### PR TITLE
fix(agent): page sparse memory browse incrementally

### DIFF
--- a/packages/agent/src/api/memory-browse-pagination.test.ts
+++ b/packages/agent/src/api/memory-browse-pagination.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Exercises memory viewer pagination at the real route boundary with a
+ * deterministic adapter-shaped store. The harness honors database predicates,
+ * offsets, and limits so sparse post-filters and multi-table ordering are
+ * verified without replacing the route logic under test.
+ */
+
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, test, vi } from "vitest";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+import { handleMemoryRoutes } from "./memory-routes.ts";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111" as UUID;
+const ENTITY = "22222222-2222-4222-8222-222222222222" as UUID;
+const OTHER = "33333333-3333-4333-8333-333333333333" as UUID;
+const ROOM = "44444444-4444-4444-8444-444444444444" as UUID;
+
+function makeRow(
+  i: number,
+  text: string,
+  entityId: UUID = OTHER,
+  createdAt = 2_000_000 - i,
+): Memory {
+  return {
+    id: `00000000-0000-4000-8000-${String(i).padStart(12, "0")}` as UUID,
+    entityId,
+    roomId: ROOM,
+    agentId: AGENT_ID,
+    createdAt,
+    content: { text },
+  } as Memory;
+}
+
+type MemoryQuery = {
+  tableName: string;
+  limit: number;
+  offset?: number;
+  roomId?: UUID;
+  end?: number;
+  textContains?: string;
+};
+
+function makeRuntime(tables: Record<string, Memory[]>): {
+  runtime: AgentRuntime;
+  getMemories: ReturnType<typeof vi.fn>;
+} {
+  const getMemories = vi.fn(async (query: MemoryQuery) => {
+    let rows = tables[query.tableName] ?? [];
+    if (query.roomId) rows = rows.filter((row) => row.roomId === query.roomId);
+    if (query.end !== undefined) {
+      const end = query.end;
+      rows = rows.filter((row) => (row.createdAt ?? 0) <= end);
+    }
+    if (query.textContains) {
+      const needle = query.textContains.toLowerCase();
+      rows = rows.filter((row) =>
+        ((row.content as { text?: string }).text ?? "")
+          .toLowerCase()
+          .includes(needle),
+      );
+    }
+    return rows
+      .slice(query.offset ?? 0, (query.offset ?? 0) + query.limit)
+      .map((row) => ({ ...row }));
+  });
+  return {
+    runtime: {
+      agentId: AGENT_ID,
+      character: { name: "Eliza" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+    } as unknown as AgentRuntime,
+    getMemories,
+  };
+}
+
+async function get(
+  runtime: AgentRuntime,
+  path: string,
+): Promise<Record<string, unknown>> {
+  const url = new URL(`https://agent.test${path}`);
+  let output: unknown;
+  const context: MemoryRouteContext = {
+    req: {} as never,
+    res: {} as never,
+    method: "GET",
+    pathname: url.pathname,
+    url,
+    runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      output = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => ({}) as T,
+  };
+  expect(await handleMemoryRoutes(context)).toBe(true);
+  return output as Record<string, unknown>;
+}
+
+const ids = (response: Record<string, unknown>): string[] =>
+  (response.memories as Array<{ id: string }>).map((memory) => memory.id);
+
+function buildSparseRows(): Memory[] {
+  return Array.from({ length: 1_000 }, (_, i) =>
+    makeRow(
+      i,
+      i % 10 === 0 ? `needle row ${i}` : `hay row ${i}`,
+      i % 20 === 0 ? ENTITY : OTHER,
+    ),
+  );
+}
+
+describe("memory viewer incremental pagination (#22061)", () => {
+  test("reaches every sparse OR-query match through bounded pages", async () => {
+    const { runtime, getMemories } = makeRuntime({
+      messages: buildSparseRows(),
+    });
+    const seen = new Set<string>();
+    let offset = 0;
+    let finalTotal = 0;
+
+    for (;;) {
+      const firstCall = getMemories.mock.calls.length;
+      const page = await get(
+        runtime,
+        `/api/memories/browse?type=messages&q=needle%20missing&limit=25&offset=${offset}`,
+      );
+      const pageCalls = getMemories.mock.calls
+        .slice(firstCall)
+        .map(([query]) => query as MemoryQuery);
+      expect(pageCalls[0]?.offset).toBe(0);
+      for (let i = 1; i < pageCalls.length; i++) {
+        expect(pageCalls[i]?.offset).toBe(
+          (pageCalls[i - 1]?.offset ?? 0) +
+            Math.min(
+              pageCalls[i - 1]?.limit ?? 0,
+              1_000 - (pageCalls[i - 1]?.offset ?? 0),
+            ),
+        );
+      }
+      for (const id of ids(page)) seen.add(id);
+      finalTotal = page.total as number;
+      expect(page.totalIsExact).toBe(false);
+      if (page.hasMore === false) break;
+      offset += 25;
+    }
+
+    expect(seen.size).toBe(100);
+    expect(finalTotal).toBe(100);
+    expect(
+      getMemories.mock.calls.every(
+        ([query]) => (query as MemoryQuery).textContains === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  test("pushes a single keyword into the adapter and labels totals incomplete", async () => {
+    const { runtime, getMemories } = makeRuntime({
+      messages: buildSparseRows(),
+    });
+    const page = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=needle&limit=50",
+    );
+    expect(ids(page)).toHaveLength(50);
+    expect(page.total).toBe(100);
+    expect(page).toMatchObject({ totalIsExact: false, hasMore: true });
+    expect(getMemories).toHaveBeenCalledTimes(1);
+    const firstQuery = getMemories.mock.calls[0]?.[0] as
+      | MemoryQuery
+      | undefined;
+    expect(firstQuery?.textContains).toBe("needle");
+  });
+
+  test("returns all sparsely represented entity rows after true exhaustion", async () => {
+    const { runtime } = makeRuntime({ messages: buildSparseRows() });
+    const response = await get(
+      runtime,
+      `/api/memories/by-entity/${ENTITY}?type=messages&limit=50`,
+    );
+    expect(ids(response)).toHaveLength(50);
+    expect(response.total).toBe(50);
+    expect(response).toMatchObject({ totalIsExact: false, hasMore: false });
+  });
+
+  test("finds older feed rows beyond a long empty-content run", async () => {
+    const rows = Array.from({ length: 1_000 }, (_, i) =>
+      makeRow(i, i < 30 || i >= 900 ? `text ${i}` : ""),
+    );
+    const { runtime } = makeRuntime({ messages: rows });
+    const response = await get(
+      runtime,
+      "/api/memories/feed?type=messages&limit=50",
+    );
+    expect(response).toMatchObject({ count: 50, hasMore: true });
+  });
+
+  test("terminates after one request when a table is truly exhausted", async () => {
+    const { runtime, getMemories } = makeRuntime({
+      messages: [makeRow(0, "needle"), makeRow(1, "hay")],
+    });
+    const response = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=needle%20missing&limit=50",
+    );
+    expect(response.total).toBe(1);
+    expect(response).toMatchObject({ totalIsExact: false, hasMore: false });
+    expect(getMemories).toHaveBeenCalledTimes(1);
+  });
+
+  test("serves an unfiltered page beyond the rejected fixed scan cap", async () => {
+    const rows = Array.from({ length: 20_120 }, (_, i) =>
+      makeRow(i, `row ${i}`),
+    );
+    const { runtime, getMemories } = makeRuntime({ messages: rows });
+    const response = await get(
+      runtime,
+      "/api/memories/browse?type=messages&limit=20&offset=20000",
+    );
+    expect(ids(response)).toHaveLength(20);
+    expect(response.total).toBe(20_120);
+
+    const calls = getMemories.mock.calls.map(([query]) => query as MemoryQuery);
+    for (let i = 1; i < calls.length; i++) {
+      expect(calls[i]?.offset).toBe(
+        (calls[i - 1]?.offset ?? 0) + (calls[i - 1]?.limit ?? 0),
+      );
+    }
+    expect(calls.reduce((sum, query) => sum + query.limit, 0)).toBeLessThan(
+      26_000,
+    );
+  });
+
+  test("reads only enough from every table for a correct global page", async () => {
+    const messages = Array.from({ length: 800 }, (_, i) =>
+      makeRow(i, `message ${i}`, OTHER, 3_000_000 - i * 2),
+    );
+    const facts = Array.from({ length: 800 }, (_, i) =>
+      makeRow(10_000 + i, `fact ${i}`, OTHER, 2_999_999 - i * 2),
+    );
+    const { runtime } = makeRuntime({ messages, facts });
+    const response = await get(
+      runtime,
+      "/api/memories/browse?limit=20&offset=250",
+    );
+    expect(ids(response)).toHaveLength(20);
+    expect(response).toMatchObject({
+      total: 1_200,
+      totalIsExact: false,
+      hasMore: true,
+    });
+
+    const expected = [...messages, ...facts]
+      .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+      .slice(250, 270)
+      .map((row) => row.id);
+    expect(ids(response)).toEqual(expected);
+  });
+});

--- a/packages/agent/src/api/memory-browse-pagination.test.ts
+++ b/packages/agent/src/api/memory-browse-pagination.test.ts
@@ -5,7 +5,12 @@
  * verified without replacing the route logic under test.
  */
 
-import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  compareMemoryIds,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import { describe, expect, test, vi } from "vitest";
 import type { MemoryRouteContext } from "./memory-routes.ts";
 import { handleMemoryRoutes } from "./memory-routes.ts";
@@ -64,7 +69,7 @@ function makeRuntime(tables: Record<string, Memory[]>): {
       const timeOrder = (b.createdAt ?? 0) - (a.createdAt ?? 0);
       return timeOrder !== 0
         ? timeOrder
-        : (b.id ?? "").localeCompare(a.id ?? "");
+        : compareMemoryIds(b.id ?? "", a.id ?? "");
     });
     if (query.cursor) {
       const cursor = query.cursor;
@@ -72,7 +77,8 @@ function makeRuntime(tables: Record<string, Memory[]>): {
         const createdAt = row.createdAt ?? 0;
         return (
           createdAt < cursor.createdAt ||
-          (createdAt === cursor.createdAt && (row.id ?? "") < cursor.id)
+          (createdAt === cursor.createdAt &&
+            compareMemoryIds(row.id ?? "", cursor.id) < 0)
         );
       });
     }

--- a/packages/agent/src/api/memory-browse-pagination.test.ts
+++ b/packages/agent/src/api/memory-browse-pagination.test.ts
@@ -35,6 +35,7 @@ type MemoryQuery = {
   tableName: string;
   limit: number;
   offset?: number;
+  cursor?: { createdAt: number; id: UUID };
   roomId?: UUID;
   end?: number;
   textContains?: string;
@@ -58,6 +59,22 @@ function makeRuntime(tables: Record<string, Memory[]>): {
           .toLowerCase()
           .includes(needle),
       );
+    }
+    rows = rows.slice().sort((a, b) => {
+      const timeOrder = (b.createdAt ?? 0) - (a.createdAt ?? 0);
+      return timeOrder !== 0
+        ? timeOrder
+        : (b.id ?? "").localeCompare(a.id ?? "");
+    });
+    if (query.cursor) {
+      const cursor = query.cursor;
+      rows = rows.filter((row) => {
+        const createdAt = row.createdAt ?? 0;
+        return (
+          createdAt < cursor.createdAt ||
+          (createdAt === cursor.createdAt && (row.id ?? "") < cursor.id)
+        );
+      });
     }
     return rows
       .slice(query.offset ?? 0, (query.offset ?? 0) + query.limit)
@@ -131,15 +148,10 @@ describe("memory viewer incremental pagination (#22061)", () => {
       const pageCalls = getMemories.mock.calls
         .slice(firstCall)
         .map(([query]) => query as MemoryQuery);
-      expect(pageCalls[0]?.offset).toBe(0);
+      expect(pageCalls[0]?.cursor).toBeUndefined();
       for (let i = 1; i < pageCalls.length; i++) {
-        expect(pageCalls[i]?.offset).toBe(
-          (pageCalls[i - 1]?.offset ?? 0) +
-            Math.min(
-              pageCalls[i - 1]?.limit ?? 0,
-              1_000 - (pageCalls[i - 1]?.offset ?? 0),
-            ),
-        );
+        expect(pageCalls[i]?.cursor).toBeDefined();
+        expect(pageCalls[i]?.offset).toBeUndefined();
       }
       for (const id of ids(page)) seen.add(id);
       finalTotal = page.total as number;
@@ -224,11 +236,10 @@ describe("memory viewer incremental pagination (#22061)", () => {
     expect(response.total).toBe(20_120);
 
     const calls = getMemories.mock.calls.map(([query]) => query as MemoryQuery);
-    for (let i = 1; i < calls.length; i++) {
-      expect(calls[i]?.offset).toBe(
-        (calls[i - 1]?.offset ?? 0) + (calls[i - 1]?.limit ?? 0),
-      );
-    }
+    expect(calls[0]?.cursor).toBeUndefined();
+    expect(calls.slice(1).every((query) => query.cursor !== undefined)).toBe(
+      true,
+    );
     expect(calls.reduce((sum, query) => sum + query.limit, 0)).toBeLessThan(
       26_000,
     );
@@ -258,5 +269,37 @@ describe("memory viewer incremental pagination (#22061)", () => {
       .slice(250, 270)
       .map((row) => row.id);
     expect(ids(response)).toEqual(expected);
+  });
+
+  test("does not duplicate or skip rows when earlier rows mutate between windows", async () => {
+    const rows = Array.from({ length: 650 }, (_, i) =>
+      makeRow(i, i % 10 === 0 ? `needle ${i}` : `hay ${i}`),
+    );
+    const { runtime, getMemories } = makeRuntime({ messages: rows });
+    getMemories.mockImplementationOnce(async (query: MemoryQuery) => {
+      const first = rows.slice(0, query.limit).map((row) => ({ ...row }));
+      rows.unshift(makeRow(9_000, "newer insertion", OTHER, 3_000_000));
+      rows.splice(20, 1);
+      rows.splice(40, 1);
+      return first;
+    });
+
+    const response = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=needle%20missing&limit=50",
+    );
+    const resultIds = ids(response);
+    expect(resultIds).toHaveLength(50);
+    expect(new Set(resultIds).size).toBe(50);
+    expect(resultIds).not.toContain(makeRow(9_000, "").id);
+    expect(resultIds).toEqual(
+      Array.from({ length: 50 }, (_, index) => makeRow(index * 10, "").id),
+    );
+    expect(
+      getMemories.mock.calls.slice(1).every(([query]) => {
+        const typed = query as MemoryQuery;
+        return typed.cursor !== undefined && typed.offset === undefined;
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/agent/src/api/memory-browse-pagination.test.ts
+++ b/packages/agent/src/api/memory-browse-pagination.test.ts
@@ -308,4 +308,46 @@ describe("memory viewer incremental pagination (#22061)", () => {
       }),
     ).toBe(true);
   });
+
+  test("fails closed when an adapter accepts but ignores the keyset cursor", async () => {
+    const rows = Array.from({ length: 450 }, (_, i) =>
+      makeRow(i, i >= 420 ? `needle ${i}` : `hay ${i}`),
+    );
+    const { runtime, getMemories } = makeRuntime({ messages: rows });
+    const cursorAware = getMemories.getMockImplementation() as
+      | ((query: MemoryQuery) => Promise<Memory[]>)
+      | undefined;
+    expect(cursorAware).toBeDefined();
+    getMemories.mockImplementation((query: MemoryQuery) =>
+      cursorAware?.({ ...query, cursor: undefined }),
+    );
+
+    await expect(
+      get(
+        runtime,
+        "/api/memories/browse?type=messages&q=needle%20missing&limit=20",
+      ),
+    ).rejects.toMatchObject({ code: "MEMORY_BROWSE_CURSOR_NO_PROGRESS" });
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
+  test("fails closed at a request-wide sparse scan bound", async () => {
+    const rows = Array.from({ length: 25_001 }, (_, i) =>
+      makeRow(i, `hay ${i}`),
+    );
+    const { runtime, getMemories } = makeRuntime({ messages: rows });
+
+    await expect(
+      get(
+        runtime,
+        "/api/memories/browse?type=messages&q=needle%20missing&limit=20",
+      ),
+    ).rejects.toMatchObject({ code: "MEMORY_BROWSE_SCAN_LIMIT" });
+    expect(
+      getMemories.mock.calls.reduce(
+        (sum, [query]) => sum + (query as MemoryQuery).limit,
+        0,
+      ),
+    ).toBe(25_000);
+  });
 });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -790,9 +790,15 @@ const memoryCreatedAt = (memory: { createdAt?: number }): number =>
 
 /** Newest-first comparator shared by the browse/search/feed list routes. */
 const byNewestFirst = (
-  a: { createdAt?: number },
-  b: { createdAt?: number },
-): number => memoryCreatedAt(b) - memoryCreatedAt(a);
+  a: { createdAt?: number; id?: string; _table?: string },
+  b: { createdAt?: number; id?: string; _table?: string },
+): number => {
+  const timestampOrder = memoryCreatedAt(b) - memoryCreatedAt(a);
+  if (timestampOrder !== 0) return timestampOrder;
+  const idOrder = (b.id ?? "").localeCompare(a.id ?? "");
+  if (idOrder !== 0) return idOrder;
+  return (a._table ?? "").localeCompare(b._table ?? "");
+};
 
 function memoryToBrowseItem(memory: TaggedMemory): MemoryBrowseItem {
   const content = memory.content as Record<string, unknown> | undefined;
@@ -843,7 +849,7 @@ async function fetchMemoriesFromTables(
   const tableResults = await Promise.all(
     tables.map(async (tableName) => {
       const eligible: TaggedMemory[] = [];
-      let offset = 0;
+      let cursor: { createdAt: number; id: UUID } | undefined;
       let batchSize = 200;
 
       for (;;) {
@@ -852,12 +858,11 @@ async function fetchMemoriesFromTables(
           roomId: params.roomId,
           tableName,
           limit: batchSize,
-          offset,
+          cursor,
           end: params.before,
           textContains,
           includeEmbedding: false, // browse feed discards embeddings
         });
-        offset += memories.length;
 
         for (const memory of memories) {
           const tagged = { ...memory, _table: tableName };
@@ -892,6 +897,17 @@ async function fetchMemoriesFromTables(
         if (eligible.length >= params.target) {
           return eligible;
         }
+        const last = memories.at(-1);
+        if (!last?.id) {
+          throw new ElizaError(
+            "A paged memory row did not contain the required id",
+            {
+              code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
+              context: { tableName },
+            },
+          );
+        }
+        cursor = { createdAt: memoryCreatedAt(last), id: last.id };
         batchSize = Math.min(batchSize * 2, 5_000);
       }
     }),

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -63,6 +63,7 @@ const QUICK_CONTEXT_DOCUMENTS_THRESHOLD = 0.2;
 
 const MEMORY_BROWSE_DEFAULT_LIMIT = 50;
 const MEMORY_BROWSE_MAX_LIMIT = 200;
+const MEMORY_BROWSE_MAX_SCAN_ROWS = 25_000;
 const MEMORY_FEED_DEFAULT_LIMIT = 50;
 const MEMORY_FEED_MAX_LIMIT = 100;
 const MEMORY_TABLE_NAMES = [
@@ -842,28 +843,91 @@ async function fetchMemoriesFromTables(
   // matchesKeyword has OR semantics for multi-token queries, so only a
   // single token can be pushed into the adapter without excluding valid rows.
   const textContains = searchTerms.length === 1 ? searchTerms[0] : undefined;
+  const maxScannedRowsPerTable = Math.max(
+    1,
+    Math.floor(MEMORY_BROWSE_MAX_SCAN_ROWS / Math.max(tables.length, 1)),
+  );
 
   // Tables are independent and remain concurrent, but each table advances an
-  // offset cursor instead of repeatedly reading a larger prefix. Requiring the
-  // target from every non-exhausted table makes a bounded final cross-table
-  // merge safe without draining an unbounded store merely to compute a total.
+  // exclusive keyset cursor instead of repeatedly reading a larger prefix.
+  // Requiring the target from every non-exhausted table makes the final
+  // cross-table merge safe. The request-wide row budget fails closed when a
+  // filter is too sparse to prove the page without draining an unbounded store.
   const tableResults = await Promise.all(
     tables.map(async (tableName) => {
       const eligible: TaggedMemory[] = [];
       let cursor: { createdAt: number; id: UUID } | undefined;
       let batchSize = 200;
+      let scannedRows = 0;
 
       for (;;) {
+        const queryLimit = Math.min(
+          batchSize,
+          maxScannedRowsPerTable - scannedRows,
+        );
+        if (queryLimit <= 0) {
+          throw new ElizaError(
+            "Memory browse exceeded its bounded scan budget before proving the page",
+            {
+              code: "MEMORY_BROWSE_SCAN_LIMIT",
+              context: {
+                tableName,
+                scannedRows,
+                maxScannedRows: maxScannedRowsPerTable,
+                target: params.target,
+              },
+            },
+          );
+        }
         const memories = await runtime.getMemories({
           agentId: runtime.agentId as UUID,
           roomId: params.roomId,
           tableName,
-          limit: batchSize,
+          limit: queryLimit,
           cursor,
           end: params.before,
           textContains,
           includeEmbedding: false, // browse feed discards embeddings
         });
+        scannedRows += memories.length;
+
+        let nextCursor = cursor;
+        for (const memory of memories) {
+          if (!memory.id) {
+            throw new ElizaError(
+              "A paged memory row did not contain the required id",
+              {
+                code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
+                context: { tableName },
+              },
+            );
+          }
+          const candidate = {
+            createdAt: memoryCreatedAt(memory),
+            id: memory.id,
+          };
+          if (
+            nextCursor &&
+            (candidate.createdAt > nextCursor.createdAt ||
+              (candidate.createdAt === nextCursor.createdAt &&
+                compareMemoryIds(candidate.id, nextCursor.id) >= 0))
+          ) {
+            throw new ElizaError(
+              "Memory adapter did not advance the requested keyset cursor",
+              {
+                code: "MEMORY_BROWSE_CURSOR_NO_PROGRESS",
+                context: {
+                  tableName,
+                  cursorCreatedAt: nextCursor.createdAt,
+                  cursorId: nextCursor.id,
+                  returnedCreatedAt: candidate.createdAt,
+                  returnedId: candidate.id,
+                },
+              },
+            );
+          }
+          nextCursor = candidate;
+        }
 
         for (const memory of memories) {
           const tagged = { ...memory, _table: tableName };
@@ -892,23 +956,27 @@ async function fetchMemoriesFromTables(
           eligible.push(tagged);
         }
 
-        if (memories.length < batchSize) {
+        if (memories.length < queryLimit) {
           return eligible;
         }
         if (eligible.length >= params.target) {
           return eligible;
         }
-        const last = memories.at(-1);
-        if (!last?.id) {
+        if (scannedRows >= maxScannedRowsPerTable) {
           throw new ElizaError(
-            "A paged memory row did not contain the required id",
+            "Memory browse exceeded its bounded scan budget before proving the page",
             {
-              code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
-              context: { tableName },
+              code: "MEMORY_BROWSE_SCAN_LIMIT",
+              context: {
+                tableName,
+                scannedRows,
+                maxScannedRows: maxScannedRowsPerTable,
+                target: params.target,
+              },
             },
           );
         }
-        cursor = { createdAt: memoryCreatedAt(last), id: last.id };
+        cursor = nextCursor;
         batchSize = Math.min(batchSize * 2, 5_000);
       }
     }),

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -820,48 +820,83 @@ async function fetchMemoriesFromTables(
     entityIds?: UUID[];
     roomId?: UUID;
     tables?: readonly string[];
-    limit?: number;
+    /** Stop after this many eligible rows per table. */
+    target: number;
     before?: number;
+    searchQuery?: string;
   },
 ): Promise<TaggedMemory[]> {
   const tables = params.tables ?? MEMORY_TABLE_NAMES;
-  const perTableLimit = Math.max(
-    Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2),
-    200,
-  );
-  // Read every table concurrently — they are independent queries, and a
-  // sequential loop would make the feed's first paint wait on N round-trips.
-  // Promise.all preserves input order, so the flattened result is order-stable.
-  const perTableMemories = await Promise.all(
+  const entityIds = params.entityIds?.length
+    ? new Set<string>(params.entityIds)
+    : undefined;
+  const searchQuery = params.searchQuery?.trim() ?? "";
+  const searchTerms = searchQuery.split(/\s+/).filter(Boolean);
+  // matchesKeyword has OR semantics for multi-token queries, so only a
+  // single token can be pushed into the adapter without excluding valid rows.
+  const textContains = searchTerms.length === 1 ? searchTerms[0] : undefined;
+
+  // Tables are independent and remain concurrent, but each table advances an
+  // offset cursor instead of repeatedly reading a larger prefix. Requiring the
+  // target from every non-exhausted table makes a bounded final cross-table
+  // merge safe without draining an unbounded store merely to compute a total.
+  const tableResults = await Promise.all(
     tables.map(async (tableName) => {
-      const memories = await runtime.getMemories({
-        agentId: runtime.agentId as UUID,
-        roomId: params.roomId,
-        tableName,
-        limit: perTableLimit,
-        includeEmbedding: false, // browse feed discards embeddings (memoryToBrowseItem)
-      });
-      return memories.map((m) => Object.assign(m, { _table: tableName }));
+      const eligible: TaggedMemory[] = [];
+      let offset = 0;
+      let batchSize = 200;
+
+      for (;;) {
+        const memories = await runtime.getMemories({
+          agentId: runtime.agentId as UUID,
+          roomId: params.roomId,
+          tableName,
+          limit: batchSize,
+          offset,
+          end: params.before,
+          textContains,
+          includeEmbedding: false, // browse feed discards embeddings
+        });
+        offset += memories.length;
+
+        for (const memory of memories) {
+          const tagged = { ...memory, _table: tableName };
+          if (!hasBrowsableContent(tagged)) continue;
+          if (
+            entityIds &&
+            (!tagged.entityId || !entityIds.has(tagged.entityId))
+          ) {
+            continue;
+          }
+          if (
+            params.before !== undefined &&
+            memoryCreatedAt(tagged) >= params.before
+          ) {
+            continue;
+          }
+          if (
+            searchQuery &&
+            !matchesKeyword(
+              (tagged.content as { text?: string } | undefined)?.text ?? "",
+              searchQuery,
+            )
+          ) {
+            continue;
+          }
+          eligible.push(tagged);
+        }
+
+        if (memories.length < batchSize) {
+          return eligible;
+        }
+        if (eligible.length >= params.target) {
+          return eligible;
+        }
+        batchSize = Math.min(batchSize * 2, 5_000);
+      }
     }),
   );
-  const allMemories: TaggedMemory[] = perTableMemories.flat();
-
-  // The DB adapter ignores entityId in getMemories (used only for RLS
-  // context). Post-filter here so person-centric views actually work.
-  const entitySet = params.entityIds;
-  let filtered = allMemories;
-  if (entitySet && entitySet.length > 0) {
-    const ids = new Set<string>(entitySet);
-    filtered = allMemories.filter((m) => m.entityId && ids.has(m.entityId));
-  }
-
-  filtered = filtered.filter(hasBrowsableContent);
-
-  const beforeTs = params.before;
-  if (beforeTs !== undefined) {
-    return filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
-  }
-  return filtered;
+  return tableResults.flat();
 }
 
 /**
@@ -1058,7 +1093,7 @@ export async function handleMemoryRoutes(
 
     const allMemories = await fetchMemoriesFromTables(runtime, {
       tables,
-      limit: limit * 2,
+      target: limit + 1,
       before,
     });
 
@@ -1108,25 +1143,23 @@ export async function handleMemoryRoutes(
       tables,
       entityIds,
       roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
-      limit: limit + offset + 100,
+      searchQuery,
+      target: offset + limit + 1,
     });
 
     allMemories.sort(byNewestFirst);
-
-    let filtered = allMemories;
-    if (searchQuery) {
-      filtered = allMemories.filter((m) => {
-        const text = (m.content as { text?: string } | undefined)?.text ?? "";
-        return matchesKeyword(text, searchQuery);
-      });
-    }
-
-    const total = filtered.length;
-    const page = filtered.slice(offset, offset + limit).map(memoryToBrowseItem);
+    const total = allMemories.length;
+    const page = allMemories
+      .slice(offset, offset + limit)
+      .map(memoryToBrowseItem);
 
     json(res, {
       memories: page,
       total,
+      // Adapter calls do not share a transactional snapshot, so even an
+      // exhausted offset scan cannot promise an exact total under mutation.
+      totalIsExact: false,
+      hasMore: allMemories.length > offset + limit,
       limit,
       offset,
     });
@@ -1174,7 +1207,7 @@ export async function handleMemoryRoutes(
     const allMemories = await fetchMemoriesFromTables(runtime, {
       entityIds,
       tables,
-      limit: limit + offset + 100,
+      target: offset + limit + 1,
     });
 
     allMemories.sort(byNewestFirst);
@@ -1187,6 +1220,8 @@ export async function handleMemoryRoutes(
       entityId: primaryEntityId,
       memories: page,
       total,
+      totalIsExact: false,
+      hasMore: allMemories.length > offset + limit,
       limit,
       offset,
     });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -16,6 +16,7 @@ import {
   type AgentRuntime,
   BM25,
   ChannelType,
+  compareMemoryIds,
   composePrompt,
   createMessageMemory,
   ElizaError,
@@ -795,7 +796,7 @@ const byNewestFirst = (
 ): number => {
   const timestampOrder = memoryCreatedAt(b) - memoryCreatedAt(a);
   if (timestampOrder !== 0) return timestampOrder;
-  const idOrder = (b.id ?? "").localeCompare(a.id ?? "");
+  const idOrder = compareMemoryIds(b.id ?? "", a.id ?? "");
   if (idOrder !== 0) return idOrder;
   return (a._table ?? "").localeCompare(b._table ?? "");
 };

--- a/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
@@ -6,6 +6,7 @@
 
 import { expect, test } from "@playwright/test";
 import {
+  hideChatOverlay,
   installDefaultAppRoutes,
   openAppPath,
   seedAppStorage,
@@ -68,6 +69,11 @@ test("memory viewer queries memory data and the Browse toggle switches the surfa
   page,
 }, testInfo) => {
   const memoryRequests: string[] = [];
+
+  // This test owns the memory surface itself. Hide the shell's independent
+  // chat overlay so pointer interception cannot turn the pagination contract
+  // into a test of chat-overlay geometry.
+  await hideChatOverlay(page);
 
   await page.route("**/api/memories/browse**", async (route) => {
     const memories = Array.from({ length: 50 }, (_, index) => ({

--- a/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
@@ -1,10 +1,8 @@
-// Real interaction coverage for the built-in diagnostic page-views (logs,
-// memories). all-pages-clicksafe only proves these routes *render* without a
-// crash; the view-interaction ratchet only covers plugin-manifest views, so
-// their actual controls were never clicked or asserted. This spec drives the
-// controls and asserts they DO something — search filters, refresh re-queries —
-// against the deterministic stub, closing the "diagnostic buttons never clicked"
-// gap in the keyless lane.
+/**
+ * Real interaction coverage for the built-in logs and memories pages. The
+ * deterministic browser harness verifies that their controls query, filter,
+ * paginate, and expose truthful result counts rather than merely rendering.
+ */
 
 import { expect, test } from "@playwright/test";
 import {
@@ -68,8 +66,34 @@ test("logs page re-queries the log source on a poll", async ({ page }) => {
 
 test("memory viewer queries memory data and the Browse toggle switches the surface", async ({
   page,
-}) => {
+}, testInfo) => {
   const memoryRequests: string[] = [];
+
+  await page.route("**/api/memories/browse**", async (route) => {
+    const memories = Array.from({ length: 50 }, (_, index) => ({
+      id: `memory-browse-${index}`,
+      type: "messages",
+      text: `Bounded memory result ${index + 1}`,
+      entityId: "entity-smoke-memory",
+      roomId: "room-smoke-memory",
+      agentId: "agent-smoke-memory",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z") - index,
+      metadata: null,
+      source: "ui-smoke",
+    }));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        memories,
+        total: 51,
+        totalIsExact: false,
+        hasMore: true,
+        limit: 50,
+        offset: 0,
+      }),
+    });
+  });
   page.on("request", (req) => {
     if (/\/api\/memories\//.test(req.url())) memoryRequests.push(req.url());
   });
@@ -97,4 +121,13 @@ test("memory viewer queries memory data and the Browse toggle switches the surfa
           .length,
     )
     .toBeGreaterThan(browseBefore);
+  await expect(page.getByText("1–50 of at least 51")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next" })).toBeEnabled();
+
+  if (process.env.E2E_RECORD === "1") {
+    await page.screenshot({
+      path: testInfo.outputPath("memory-browse-incomplete-total.png"),
+      fullPage: true,
+    });
+  }
 });

--- a/packages/core/src/__tests__/turn-read-coalescing.test.ts
+++ b/packages/core/src/__tests__/turn-read-coalescing.test.ts
@@ -295,10 +295,26 @@ describe("room messages-scan coalescing", () => {
 			unique: false,
 			textContains: "message 3",
 		});
-		expect(counts.messagesScans).toBe(3);
+		const cursor = await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 5,
+			unique: false,
+			cursor: {
+				createdAt: rows[15]?.createdAt as number,
+				id: rows[15]?.id as UUID,
+			},
+		});
+		expect(counts.messagesScans).toBe(4);
 		expect(ascending[0]?.id).toBe(rows[0]?.id); // oldest-first honored
 		expect(keyword.every((m) => m.content.text?.includes("message 3"))).toBe(
 			true,
+		);
+		expect(cursor.map((memory) => memory.id)).toEqual(
+			rows
+				.slice(10, 15)
+				.reverse()
+				.map((memory) => memory.id),
 		);
 	});
 });

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -289,6 +289,7 @@ export abstract class DatabaseAdapter<DB extends object = object>
 		limit?: number;
 		count?: number;
 		offset?: number;
+		cursor?: { createdAt: number; id: UUID };
 		unique?: boolean;
 		tableName: string;
 		start?: number;

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -78,6 +78,21 @@ export function validateQueryEntitiesPagination(params: {
 }
 
 /**
+ * Compares UUID-backed memory ids in the same order as PostgreSQL's `uuid`
+ * type. PostgreSQL normalizes hexadecimal case before ordering, so in-memory
+ * adapters and cross-table merges must do the same instead of using the
+ * locale-sensitive `localeCompare`; otherwise a valid uppercase UUID can be
+ * skipped or repeated at a keyset boundary.
+ */
+export function compareMemoryIds(left: string, right: string): number {
+	const normalizedLeft = left.toLowerCase();
+	const normalizedRight = right.toLowerCase();
+	if (normalizedLeft < normalizedRight) return -1;
+	if (normalizedLeft > normalizedRight) return 1;
+	return 0;
+}
+
+/**
  * Abstract base class for database adapters.
  *
  * WHY this exists as an abstract class (not just the IDatabaseAdapter interface):

--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -155,6 +155,53 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		]);
 	});
 
+	it("uses an exclusive tuple cursor that stays stable across earlier mutations", async () => {
+		const ids = [
+			"00000000-0000-0000-0000-0000000000a1",
+			"00000000-0000-0000-0000-0000000000a2",
+			"00000000-0000-0000-0000-0000000000a3",
+			"00000000-0000-0000-0000-0000000000a4",
+			"00000000-0000-0000-0000-0000000000a5",
+		] as UUID[];
+		const adapter = await seed(
+			ids.map((id, index) => msg(`m${index}`, 1_000, id)),
+		);
+		const first = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			limit: 2,
+		});
+		expect(first.map((memory) => memory.id)).toEqual([ids[4], ids[3]]);
+
+		await adapter.deleteMemories([ids[4]]);
+		await adapter.createMemories([
+			{
+				memory: msg(
+					"inserted ahead",
+					2_000,
+					"00000000-0000-0000-0000-0000000000ff",
+				),
+				tableName: "messages",
+			},
+		]);
+		const second = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			limit: 2,
+			cursor: { createdAt: 1_000, id: ids[3] },
+		});
+		expect(second.map((memory) => memory.id)).toEqual([ids[2], ids[1]]);
+
+		await expect(
+			adapter.getMemories({
+				roomId,
+				tableName: "messages",
+				offset: 0,
+				cursor: { createdAt: 1_000, id: ids[3] },
+			}),
+		).rejects.toThrow("cursor and offset are mutually exclusive");
+	});
+
 	it("stays bounded: a keyword scan over many messages returns only matches, quickly", async () => {
 		const many: Memory[] = [];
 		for (let i = 0; i < 20000; i++) {

--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -202,6 +202,33 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		).rejects.toThrow("cursor and offset are mutually exclusive");
 	});
 
+	it("matches PostgreSQL UUID ordering across hexadecimal case at cursor boundaries", async () => {
+		const ids = [
+			"A0000000-0000-0000-0000-000000000001",
+			"a0000000-0000-0000-0000-000000000002",
+			"A0000000-0000-0000-0000-000000000003",
+			"a0000000-0000-0000-0000-000000000004",
+		] as UUID[];
+		const adapter = await seed(
+			ids.map((id, index) => msg(`case ${index}`, 1_000, id)),
+		);
+
+		const first = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			limit: 2,
+		});
+		expect(first.map((memory) => memory.id)).toEqual([ids[3], ids[2]]);
+
+		const second = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			limit: 2,
+			cursor: { createdAt: 1_000, id: ids[2] },
+		});
+		expect(second.map((memory) => memory.id)).toEqual([ids[1], ids[0]]);
+	});
+
 	it("stays bounded: a keyword scan over many messages returns only matches, quickly", async () => {
 		const many: Memory[] = [];
 		for (let i = 0; i < 20000; i++) {

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -930,6 +930,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		limit?: number;
 		count?: number;
 		offset?: number;
+		cursor?: { createdAt: number; id: UUID };
 		unique?: boolean;
 		tableName: string;
 		start?: number;
@@ -943,6 +944,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		includeEmbedding?: boolean;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
+		if (params.cursor && params.offset !== undefined) {
+			throw new Error("getMemories cursor and offset are mutually exclusive");
+		}
 		const effectiveLimit = params.limit ?? params.count ?? Infinity;
 		const tableName = params.tableName;
 		let all =
@@ -1016,6 +1020,21 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				? aId.localeCompare(bId)
 				: bId.localeCompare(aId);
 		});
+
+		if (params.cursor) {
+			const cursor = params.cursor;
+			all = all.filter((memory) => {
+				const createdAt =
+					typeof memory.createdAt === "number" ? memory.createdAt : 0;
+				const id = typeof memory.id === "string" ? memory.id : "";
+				if (createdAt !== cursor.createdAt) {
+					return direction === "asc"
+						? createdAt > cursor.createdAt
+						: createdAt < cursor.createdAt;
+				}
+				return direction === "asc" ? id > cursor.id : id < cursor.id;
+			});
+		}
 
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		return all.slice(

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -13,7 +13,11 @@
  * containment all mirror the SQL adapters. Persistence is process-local and
  * lost on restart.
  */
-import { DatabaseAdapter, validateQueryEntitiesPagination } from "../database";
+import {
+	compareMemoryIds,
+	DatabaseAdapter,
+	validateQueryEntitiesPagination,
+} from "../database";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -1017,8 +1021,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const aId = typeof a.id === "string" ? a.id : "";
 			const bId = typeof b.id === "string" ? b.id : "";
 			return direction === "asc"
-				? aId.localeCompare(bId)
-				: bId.localeCompare(aId);
+				? compareMemoryIds(aId, bId)
+				: compareMemoryIds(bId, aId);
 		});
 
 		if (params.cursor) {
@@ -1032,7 +1036,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 						? createdAt > cursor.createdAt
 						: createdAt < cursor.createdAt;
 				}
-				return direction === "asc" ? id > cursor.id : id < cursor.id;
+				const idOrder = compareMemoryIds(id, cursor.id);
+				return direction === "asc" ? idOrder > 0 : idOrder < 0;
 			});
 		}
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11096,6 +11096,7 @@ ${section_end}`;
 		limit?: number;
 		count?: number;
 		offset?: number;
+		cursor?: { createdAt: number; id: UUID };
 		unique?: boolean;
 		tableName: string;
 		start?: number;
@@ -11145,6 +11146,7 @@ ${section_end}`;
 		limit?: number;
 		count?: number;
 		offset?: number;
+		cursor?: { createdAt: number; id: UUID };
 		unique?: boolean;
 		tableName: string;
 		start?: number;
@@ -11164,6 +11166,7 @@ ${section_end}`;
 			params.worldId !== undefined ||
 			params.unique ||
 			(params.offset !== undefined && params.offset !== 0) ||
+			params.cursor !== undefined ||
 			params.end !== undefined ||
 			params.metadata !== undefined ||
 			params.textContains !== undefined ||

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1050,6 +1050,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	 * @param params.metadata Filter by metadata fields (partial object match)
 	 * @param params.limit Max results to return
 	 * @param params.offset Skip first N results for pagination
+	 * @param params.cursor Exclusive keyset cursor in the requested order. When
+	 * provided, results start strictly after `(createdAt, id)` and `offset` must
+	 * not be used. This keeps multi-query scans stable when earlier rows mutate.
 	 * @param params.tableName Memory type/table (required)
 	 */
 	getMemories(params: {
@@ -1058,6 +1061,7 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		limit?: number;
 		count?: number;
 		offset?: number;
+		cursor?: { createdAt: number; id: UUID };
 		unique?: boolean;
 		tableName: string;
 		start?: number;

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -675,7 +675,12 @@ export interface MemoryBrowseQuery {
 
 export interface MemoryBrowseResponse {
   memories: MemoryBrowseItem[];
+  /** Number of eligible rows observed while assembling this page. */
   total: number;
+  /** Whether `total` is complete rather than a lower bound. */
+  totalIsExact?: boolean;
+  /** Whether another page is known to exist. */
+  hasMore?: boolean;
   limit: number;
   offset: number;
 }

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -833,6 +833,8 @@ function handleLocalMemoriesRoute(
     return json({
       memories: items.slice(offset, offset + limit),
       total: items.length,
+      totalIsExact: true,
+      hasMore: offset + limit < items.length,
       limit,
       offset,
     });
@@ -857,7 +859,15 @@ function handleLocalMemoriesRoute(
     );
     const offset = positiveIntegerParam(url.searchParams.get("offset"), 0);
     // No entity graph in iOS local mode — no memory is attributed to an entity.
-    return json({ entityId, memories: [], total: 0, limit, offset });
+    return json({
+      entityId,
+      memories: [],
+      total: 0,
+      totalIsExact: true,
+      hasMore: false,
+      limit,
+      offset,
+    });
   }
 
   return null;

--- a/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
@@ -154,4 +154,36 @@ describe("MemoryViewerView interface contract", () => {
     fireEvent.click(screen.getByRole("button", { name: "Ask Eliza" }));
     expect(dispatchChatOpen).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps pagination enabled while presenting an incomplete total honestly", async () => {
+    clientMock.browseMemories.mockResolvedValue({
+      memories: [
+        {
+          id: "mem-browse-1",
+          type: "messages",
+          text: "bounded browse result",
+          source: "client_chat",
+          createdAt: Date.now(),
+          entityId: "entity-1",
+          roomId: "room-1",
+        },
+      ],
+      total: 51,
+      totalIsExact: false,
+      hasMore: true,
+      limit: 50,
+      offset: 0,
+    });
+
+    const user = userEvent.setup();
+    render(<MemoryViewerView />);
+    await user.click(await screen.findByTestId("memory-view-browse"));
+
+    expect(await screen.findByText("bounded browse result")).not.toBeNull();
+    expect(screen.getByText("1–1 of at least 51")).not.toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Next" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
 });

--- a/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
@@ -106,6 +106,21 @@ afterEach(() => {
 });
 
 describe("MemoryViewerView interface contract", () => {
+  it("keeps memory content scrollable above the persistent chat overlay", async () => {
+    const { container } = render(<MemoryViewerView />);
+
+    await screen.findByTestId("memory-card-mem-1");
+
+    const scroller = container.querySelector(".eliza-chat-scroll");
+    expect(scroller).not.toBeNull();
+    expect(scroller?.className).toContain(
+      "pb-[var(--eliza-chat-clearance,5.25rem)]",
+    );
+    expect(scroller?.className).toContain(
+      "pe-[var(--eliza-chat-side-clearance,0px)]",
+    );
+  });
+
   it("stacks memory cards and exposes expand state", async () => {
     render(<MemoryViewerView />);
 

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -1192,7 +1192,7 @@ export function MemoryViewerView({
               contentHeader={contentHeader}
               data-testid="memory-viewer-view"
             >
-              <div className="flex min-h-0 flex-1 flex-col gap-5">
+              <div className="eliza-chat-scroll flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto pb-[var(--eliza-chat-clearance,5.25rem)] pe-[var(--eliza-chat-side-clearance,0px)]">
                 <div className="flex w-full flex-col items-start gap-3">
                   <div
                     ref={viewModeControl.ref}

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -638,12 +638,19 @@ function MemoryBrowserPanel({
         <>
           <div className="flex items-center justify-between gap-3 text-xs-tight text-muted">
             <span className="tabular-nums">
-              {t("memoryviewer.pageRange", {
-                start: offset + 1,
-                end: offset + result.memories.length,
-                total: result.total,
-                defaultValue: "{{start}}–{{end}} of {{total}}",
-              })}
+              {result.totalIsExact === false
+                ? t("memoryviewer.pageRangeIncomplete", {
+                    start: offset + 1,
+                    end: offset + result.memories.length,
+                    total: result.total,
+                    defaultValue: "{{start}}–{{end}} of at least {{total}}",
+                  })
+                : t("memoryviewer.pageRange", {
+                    start: offset + 1,
+                    end: offset + result.memories.length,
+                    total: result.total,
+                    defaultValue: "{{start}}–{{end}} of {{total}}",
+                  })}
             </span>
             <div className="flex gap-2">
               <Button
@@ -664,7 +671,11 @@ function MemoryBrowserPanel({
                 size="sm"
                 variant="ghost"
                 className={MEMORY_FOCUS_CLASS}
-                disabled={offset + BROWSE_PAGE_SIZE >= result.total}
+                disabled={
+                  result.hasMore === undefined
+                    ? offset + BROWSE_PAGE_SIZE >= result.total
+                    : !result.hasMore
+                }
                 onClick={() => handlePage("next")}
                 {...nextControl.agentProps}
               >

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -5774,6 +5774,7 @@
   "memoryviewer.loadOlder": "Load older",
   "memoryviewer.searchMemoryText": "Search memory text…",
   "memoryviewer.pageRange": "{{start}}–{{end}} of {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} of at least {{total}}",
   "memoryviewer.prev": "Prev",
   "memoryviewer.next": "Next",
   "memoryviewer.total": "Total",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -5258,6 +5258,7 @@
   "memoryviewer.loadOlder": "Cargar más antiguos",
   "memoryviewer.searchMemoryText": "Buscar en la memoria…",
   "memoryviewer.pageRange": "{{start}}–{{end}} de {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} de al menos {{total}}",
   "memoryviewer.prev": "Anterior",
   "memoryviewer.next": "Siguiente",
   "memoryviewer.total": "Total",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -5251,6 +5251,7 @@
   "memoryviewer.loadOlder": "古いものを読み込む",
   "memoryviewer.searchMemoryText": "メモリテキストを検索…",
   "memoryviewer.pageRange": "{{start}}–{{end}} / {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} / {{total}}件以上",
   "memoryviewer.prev": "前へ",
   "memoryviewer.next": "次へ",
   "memoryviewer.total": "合計",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -5251,6 +5251,7 @@
   "memoryviewer.loadOlder": "이전 항목 불러오기",
   "memoryviewer.searchMemoryText": "메모리 텍스트 검색…",
   "memoryviewer.pageRange": "{{total}}개 중 {{start}}–{{end}}",
+  "memoryviewer.pageRangeIncomplete": "최소 {{total}}개 중 {{start}}–{{end}}",
   "memoryviewer.prev": "이전",
   "memoryviewer.next": "다음",
   "memoryviewer.total": "전체",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -5251,6 +5251,7 @@
   "memoryviewer.loadOlder": "Carregar anteriores",
   "memoryviewer.searchMemoryText": "Buscar no texto das memórias…",
   "memoryviewer.pageRange": "{{start}}–{{end}} de {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} de pelo menos {{total}}",
   "memoryviewer.prev": "Anterior",
   "memoryviewer.next": "Próximo",
   "memoryviewer.total": "Total",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -5244,6 +5244,7 @@
   "memoryviewer.loadOlder": "Mag-load ng mas luma",
   "memoryviewer.searchMemoryText": "Maghanap sa teksto ng alaala…",
   "memoryviewer.pageRange": "{{start}}–{{end}} sa {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} sa hindi bababa sa {{total}}",
   "memoryviewer.prev": "Nakaraan",
   "memoryviewer.next": "Susunod",
   "memoryviewer.total": "Kabuuan",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -5244,6 +5244,7 @@
   "memoryviewer.loadOlder": "Tải cũ hơn",
   "memoryviewer.searchMemoryText": "Tìm kiếm văn bản bộ nhớ…",
   "memoryviewer.pageRange": "{{start}}–{{end}} trong {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} trong ít nhất {{total}}",
   "memoryviewer.prev": "Trước",
   "memoryviewer.next": "Tiếp",
   "memoryviewer.total": "Tổng",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -5251,6 +5251,7 @@
   "memoryviewer.loadOlder": "加载更早",
   "memoryviewer.searchMemoryText": "搜索记忆内容…",
   "memoryviewer.pageRange": "{{start}}–{{end}} / {{total}}",
+  "memoryviewer.pageRangeIncomplete": "{{start}}–{{end}} / 至少 {{total}}",
   "memoryviewer.prev": "上一页",
   "memoryviewer.next": "下一页",
   "memoryviewer.total": "总计",

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -36,17 +36,35 @@ function createFakeRuntime(): IAgentRuntime {
 			count?: number;
 			orderBy?: "createdAt";
 			orderDirection?: "asc" | "desc";
+			offset?: number;
+			end?: number;
+			textContains?: string;
 		}): Promise<Memory[]> {
 			let rows = [...(tables.get(params.tableName) ?? [])];
 			if (params.roomId) {
 				rows = rows.filter((m) => m.roomId === params.roomId);
+			}
+			if (params.end !== undefined) {
+				const end = params.end;
+				rows = rows.filter((m) => (m.createdAt ?? 0) <= end);
+			}
+			if (params.textContains) {
+				const needle = params.textContains.toLowerCase();
+				rows = rows.filter((m) =>
+					((m.content as { text?: string }).text ?? "")
+						.toLowerCase()
+						.includes(needle),
+				);
 			}
 			if (params.orderBy === "createdAt") {
 				const dir = params.orderDirection === "asc" ? 1 : -1;
 				rows.sort((a, b) => dir * ((a.createdAt ?? 0) - (b.createdAt ?? 0)));
 			}
 			const cap = params.count ?? params.limit;
-			return typeof cap === "number" ? rows.slice(0, cap) : rows;
+			const offset = params.offset ?? 0;
+			return typeof cap === "number"
+				? rows.slice(offset, offset + cap)
+				: rows.slice(offset);
 		},
 		async getMemoryById(id: UUID): Promise<Memory | null> {
 			for (const rows of tables.values()) {
@@ -234,7 +252,13 @@ describe("iOS bridge — memories view routes", () => {
 		await seedMemory("facts", "alpha echo", 3_000);
 
 		const all = await call(backend, "GET", "/api/memories/browse");
-		expect(all.json).toMatchObject({ total: 3, limit: 50, offset: 0 });
+		expect(all.json).toMatchObject({
+			total: 3,
+			totalIsExact: false,
+			hasMore: false,
+			limit: 50,
+			offset: 0,
+		});
 
 		const search = await call(backend, "GET", "/api/memories/browse?q=alpha");
 		const texts = (search.json.memories as Array<{ text: string }>).map(
@@ -250,6 +274,22 @@ describe("iOS bridge — memories view routes", () => {
 		);
 		expect((page.json.memories as unknown[]).length).toBe(1);
 		expect(page.json).toMatchObject({ total: 3, limit: 1, offset: 1 });
+	});
+
+	it("finds sparse matches beyond the first adapter window", async () => {
+		for (let i = 0; i < 450; i++) {
+			await seedMemory("messages", i >= 420 ? `needle ${i}` : `hay ${i}`, i);
+		}
+		const result = await call(
+			backend,
+			"GET",
+			"/api/memories/browse?type=messages&q=needle%20missing&limit=20",
+		);
+		expect((result.json.memories as unknown[]).length).toBe(20);
+		expect(result.json).toMatchObject({
+			totalIsExact: false,
+			hasMore: true,
+		});
 	});
 
 	it("stats totals per table", async () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -12,7 +12,12 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+	compareMemoryIds,
+	type IAgentRuntime,
+	type Memory,
+	type UUID,
+} from "@elizaos/core";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -62,7 +67,7 @@ function createFakeRuntime(): IAgentRuntime {
 				const timeOrder = dir * ((a.createdAt ?? 0) - (b.createdAt ?? 0));
 				return timeOrder !== 0
 					? timeOrder
-					: dir * (a.id ?? "").localeCompare(b.id ?? "");
+					: dir * compareMemoryIds(a.id ?? "", b.id ?? "");
 			});
 			if (params.cursor) {
 				const cursor = params.cursor;
@@ -70,7 +75,8 @@ function createFakeRuntime(): IAgentRuntime {
 					const createdAt = row.createdAt ?? 0;
 					return (
 						createdAt < cursor.createdAt ||
-						(createdAt === cursor.createdAt && (row.id ?? "") < cursor.id)
+						(createdAt === cursor.createdAt &&
+							compareMemoryIds(row.id ?? "", cursor.id) < 0)
 					);
 				});
 			}

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -37,6 +37,7 @@ function createFakeRuntime(): IAgentRuntime {
 			orderBy?: "createdAt";
 			orderDirection?: "asc" | "desc";
 			offset?: number;
+			cursor?: { createdAt: number; id: UUID };
 			end?: number;
 			textContains?: string;
 		}): Promise<Memory[]> {
@@ -56,9 +57,22 @@ function createFakeRuntime(): IAgentRuntime {
 						.includes(needle),
 				);
 			}
-			if (params.orderBy === "createdAt") {
-				const dir = params.orderDirection === "asc" ? 1 : -1;
-				rows.sort((a, b) => dir * ((a.createdAt ?? 0) - (b.createdAt ?? 0)));
+			const dir = params.orderDirection === "asc" ? 1 : -1;
+			rows.sort((a, b) => {
+				const timeOrder = dir * ((a.createdAt ?? 0) - (b.createdAt ?? 0));
+				return timeOrder !== 0
+					? timeOrder
+					: dir * (a.id ?? "").localeCompare(b.id ?? "");
+			});
+			if (params.cursor) {
+				const cursor = params.cursor;
+				rows = rows.filter((row) => {
+					const createdAt = row.createdAt ?? 0;
+					return (
+						createdAt < cursor.createdAt ||
+						(createdAt === cursor.createdAt && (row.id ?? "") < cursor.id)
+					);
+				});
 			}
 			const cap = params.count ?? params.limit;
 			const offset = params.offset ?? 0;

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -298,7 +298,7 @@ describe("iOS bridge — memories view routes", () => {
 
 	it("finds sparse matches beyond the first adapter window", async () => {
 		for (let i = 0; i < 450; i++) {
-			await seedMemory("messages", i >= 420 ? `needle ${i}` : `hay ${i}`, i);
+			await seedMemory("messages", i < 30 ? `needle ${i}` : `hay ${i}`, i);
 		}
 		const result = await call(
 			backend,
@@ -310,6 +310,58 @@ describe("iOS bridge — memories view routes", () => {
 			totalIsExact: false,
 			hasMore: true,
 		});
+	});
+
+	it("fails closed when an adapter ignores the keyset cursor", async () => {
+		for (let i = 0; i < 450; i++) {
+			await seedMemory("messages", i < 30 ? `needle ${i}` : `hay ${i}`, i);
+		}
+		const cursorAware = runtime.getMemories.bind(runtime);
+		runtime.getMemories = vi.fn((params) =>
+			cursorAware({ ...params, cursor: undefined }),
+		);
+
+		await expect(
+			call(
+				backend,
+				"GET",
+				"/api/memories/browse?type=messages&q=needle%20missing&limit=20",
+			),
+		).rejects.toMatchObject({ code: "MEMORY_BROWSE_CURSOR_NO_PROGRESS" });
+		expect(runtime.getMemories).toHaveBeenCalledTimes(2);
+	});
+
+	it("fails closed at the shared request-wide sparse scan bound", async () => {
+		let sequence = 0;
+		const getMemories = vi.fn(
+			async (params: { limit?: number }): Promise<Memory[]> =>
+				Array.from({ length: params.limit ?? 0 }, () => {
+					const index = sequence++;
+					return {
+						id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}` as UUID,
+						entityId: AGENT_ID,
+						roomId: AGENT_ID,
+						agentId: AGENT_ID,
+						createdAt: 1_000_000 - index,
+						content: { text: `hay ${index}` },
+					} as Memory;
+				}),
+		);
+		runtime.getMemories = getMemories as IAgentRuntime["getMemories"];
+
+		await expect(
+			call(
+				backend,
+				"GET",
+				"/api/memories/browse?type=messages&q=needle%20missing&limit=20",
+			),
+		).rejects.toMatchObject({ code: "MEMORY_BROWSE_SCAN_LIMIT" });
+		expect(
+			getMemories.mock.calls.reduce(
+				(sum, [params]) => sum + (params.limit ?? 0),
+				0,
+			),
+		).toBe(25_000);
 	});
 
 	it("stats totals per table", async () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -14,6 +14,7 @@ import process from "node:process";
 import { Readable } from "node:stream";
 import {
 	ChannelType,
+	compareMemoryIds,
 	createMessageMemory,
 	ElizaError,
 	type GenerateTextParams,
@@ -1175,7 +1176,7 @@ function byNewestFirst(
 ): number {
 	const timestampOrder = memoryCreatedAt(b) - memoryCreatedAt(a);
 	if (timestampOrder !== 0) return timestampOrder;
-	const idOrder = (b.id ?? "").localeCompare(a.id ?? "");
+	const idOrder = compareMemoryIds(b.id ?? "", a.id ?? "");
 	if (idOrder !== 0) return idOrder;
 	return (a._table ?? "").localeCompare(b._table ?? "");
 }

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -15,6 +15,7 @@ import { Readable } from "node:stream";
 import {
 	ChannelType,
 	createMessageMemory,
+	ElizaError,
 	type GenerateTextParams,
 	type IAgentRuntime,
 	type Memory,
@@ -1169,10 +1170,14 @@ function memoryCreatedAt(memory: { createdAt?: number }): number {
 
 /** Newest-first comparator shared by the browse/feed list routes. */
 function byNewestFirst(
-	a: { createdAt?: number },
-	b: { createdAt?: number },
+	a: { createdAt?: number; id?: string; _table?: string },
+	b: { createdAt?: number; id?: string; _table?: string },
 ): number {
-	return memoryCreatedAt(b) - memoryCreatedAt(a);
+	const timestampOrder = memoryCreatedAt(b) - memoryCreatedAt(a);
+	if (timestampOrder !== 0) return timestampOrder;
+	const idOrder = (b.id ?? "").localeCompare(a.id ?? "");
+	if (idOrder !== 0) return idOrder;
+	return (a._table ?? "").localeCompare(b._table ?? "");
 }
 
 function memoryToBrowseItem(memory: TaggedMemory): MemoryBrowseItem {
@@ -1239,7 +1244,7 @@ async function fetchMemoriesFromTables(
 	const perTableMemories = await Promise.all(
 		tables.map(async (tableName) => {
 			const eligible: TaggedMemory[] = [];
-			let offset = 0;
+			let cursor: { createdAt: number; id: UUID } | undefined;
 			let batchSize = 200;
 			for (;;) {
 				const memories = await runtime.getMemories({
@@ -1247,12 +1252,11 @@ async function fetchMemoriesFromTables(
 					roomId: params.roomId,
 					tableName,
 					limit: batchSize,
-					offset,
+					cursor,
 					end: params.before,
 					textContains,
 					includeEmbedding: false,
 				});
-				offset += memories.length;
 				for (const memory of memories) {
 					const tagged = { ...memory, _table: tableName };
 					if (!hasBrowsableContent(tagged)) continue;
@@ -1282,6 +1286,17 @@ async function fetchMemoriesFromTables(
 				if (memories.length < batchSize || eligible.length >= params.target) {
 					return eligible;
 				}
+				const last = memories.at(-1);
+				if (!last?.id) {
+					throw new ElizaError(
+						"A paged memory row did not contain the required id",
+						{
+							code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
+							context: { tableName },
+						},
+					);
+				}
+				cursor = { createdAt: memoryCreatedAt(last), id: last.id };
 				batchSize = Math.min(batchSize * 2, 5_000);
 			}
 		}),

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1224,43 +1224,69 @@ async function fetchMemoriesFromTables(
 		entityIds?: UUID[];
 		roomId?: UUID;
 		tables?: readonly string[];
-		limit?: number;
+		target: number;
 		before?: number;
+		searchQuery?: string;
 	},
 ): Promise<TaggedMemory[]> {
 	const tables = params.tables ?? MEMORY_TABLE_NAMES;
-	const perTableLimit = Math.max(
-		Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2),
-		200,
-	);
+	const entityIds = params.entityIds?.length
+		? new Set<string>(params.entityIds)
+		: undefined;
+	const searchQuery = params.searchQuery?.trim() ?? "";
+	const searchTerms = searchQuery.split(/\s+/).filter(Boolean);
+	const textContains = searchTerms.length === 1 ? searchTerms[0] : undefined;
 	const perTableMemories = await Promise.all(
 		tables.map(async (tableName) => {
-			const memories = await runtime.getMemories({
-				agentId: runtime.agentId as UUID,
-				roomId: params.roomId,
-				tableName,
-				limit: perTableLimit,
-				includeEmbedding: false,
-			});
-			return memories.map((m) => Object.assign(m, { _table: tableName }));
+			const eligible: TaggedMemory[] = [];
+			let offset = 0;
+			let batchSize = 200;
+			for (;;) {
+				const memories = await runtime.getMemories({
+					agentId: runtime.agentId as UUID,
+					roomId: params.roomId,
+					tableName,
+					limit: batchSize,
+					offset,
+					end: params.before,
+					textContains,
+					includeEmbedding: false,
+				});
+				offset += memories.length;
+				for (const memory of memories) {
+					const tagged = { ...memory, _table: tableName };
+					if (!hasBrowsableContent(tagged)) continue;
+					if (
+						entityIds &&
+						(!tagged.entityId || !entityIds.has(tagged.entityId))
+					) {
+						continue;
+					}
+					if (
+						params.before !== undefined &&
+						memoryCreatedAt(tagged) >= params.before
+					) {
+						continue;
+					}
+					if (
+						searchQuery &&
+						!matchesMemoryKeyword(
+							(tagged.content as { text?: string } | undefined)?.text ?? "",
+							searchQuery,
+						)
+					) {
+						continue;
+					}
+					eligible.push(tagged);
+				}
+				if (memories.length < batchSize || eligible.length >= params.target) {
+					return eligible;
+				}
+				batchSize = Math.min(batchSize * 2, 5_000);
+			}
 		}),
 	);
-	const allMemories: TaggedMemory[] = perTableMemories.flat();
-
-	let filtered = allMemories;
-	const entitySet = params.entityIds;
-	if (entitySet && entitySet.length > 0) {
-		const ids = new Set<string>(entitySet);
-		filtered = allMemories.filter((m) => m.entityId && ids.has(m.entityId));
-	}
-
-	filtered = filtered.filter(hasBrowsableContent);
-
-	const beforeTs = params.before;
-	if (beforeTs !== undefined) {
-		return filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
-	}
-	return filtered;
+	return perTableMemories.flat();
 }
 
 async function handleMemoriesFeedRoute(
@@ -1282,7 +1308,7 @@ async function handleMemoriesFeedRoute(
 
 	const allMemories = await fetchMemoriesFromTables(runtime, {
 		tables,
-		limit: limit * 2,
+		target: limit + 1,
 		before,
 	});
 
@@ -1326,25 +1352,22 @@ async function handleMemoriesBrowseRoute(
 		tables,
 		entityIds,
 		roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
-		limit: limit + offset + 100,
+		target: limit + offset + 1,
+		searchQuery,
 	});
 
 	allMemories.sort(byNewestFirst);
 
-	let filtered = allMemories;
-	if (searchQuery) {
-		filtered = allMemories.filter((m) => {
-			const text = (m.content as { text?: string } | undefined)?.text ?? "";
-			return matchesMemoryKeyword(text, searchQuery);
-		});
-	}
-
-	const total = filtered.length;
-	const page = filtered.slice(offset, offset + limit).map(memoryToBrowseItem);
+	const total = allMemories.length;
+	const page = allMemories
+		.slice(offset, offset + limit)
+		.map(memoryToBrowseItem);
 
 	return jsonResponse(200, {
 		memories: page,
 		total,
+		totalIsExact: false,
+		hasMore: allMemories.length > offset + limit,
 		limit,
 		offset,
 	});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1141,6 +1141,7 @@ function parsePositiveInteger(value: string | null, fallback: number): number {
 
 const MEMORY_BROWSE_DEFAULT_LIMIT = 50;
 const MEMORY_BROWSE_MAX_LIMIT = 200;
+const MEMORY_BROWSE_MAX_SCAN_ROWS = 25_000;
 const MEMORY_FEED_DEFAULT_LIMIT = 50;
 const MEMORY_FEED_MAX_LIMIT = 100;
 const MEMORY_TABLE_NAMES = [
@@ -1242,22 +1243,84 @@ async function fetchMemoriesFromTables(
 	const searchQuery = params.searchQuery?.trim() ?? "";
 	const searchTerms = searchQuery.split(/\s+/).filter(Boolean);
 	const textContains = searchTerms.length === 1 ? searchTerms[0] : undefined;
+	const maxScannedRowsPerTable = Math.max(
+		1,
+		Math.floor(MEMORY_BROWSE_MAX_SCAN_ROWS / Math.max(tables.length, 1)),
+	);
 	const perTableMemories = await Promise.all(
 		tables.map(async (tableName) => {
 			const eligible: TaggedMemory[] = [];
 			let cursor: { createdAt: number; id: UUID } | undefined;
 			let batchSize = 200;
+			let scannedRows = 0;
 			for (;;) {
+				const queryLimit = Math.min(
+					batchSize,
+					maxScannedRowsPerTable - scannedRows,
+				);
+				if (queryLimit <= 0) {
+					throw new ElizaError(
+						"Memory browse exceeded its bounded scan budget before proving the page",
+						{
+							code: "MEMORY_BROWSE_SCAN_LIMIT",
+							context: {
+								tableName,
+								scannedRows,
+								maxScannedRows: maxScannedRowsPerTable,
+								target: params.target,
+							},
+						},
+					);
+				}
 				const memories = await runtime.getMemories({
 					agentId: runtime.agentId as UUID,
 					roomId: params.roomId,
 					tableName,
-					limit: batchSize,
+					limit: queryLimit,
 					cursor,
 					end: params.before,
 					textContains,
 					includeEmbedding: false,
 				});
+				scannedRows += memories.length;
+
+				let nextCursor = cursor;
+				for (const memory of memories) {
+					if (!memory.id) {
+						throw new ElizaError(
+							"A paged memory row did not contain the required id",
+							{
+								code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
+								context: { tableName },
+							},
+						);
+					}
+					const candidate = {
+						createdAt: memoryCreatedAt(memory),
+						id: memory.id,
+					};
+					if (
+						nextCursor &&
+						(candidate.createdAt > nextCursor.createdAt ||
+							(candidate.createdAt === nextCursor.createdAt &&
+								compareMemoryIds(candidate.id, nextCursor.id) >= 0))
+					) {
+						throw new ElizaError(
+							"Memory adapter did not advance the requested keyset cursor",
+							{
+								code: "MEMORY_BROWSE_CURSOR_NO_PROGRESS",
+								context: {
+									tableName,
+									cursorCreatedAt: nextCursor.createdAt,
+									cursorId: nextCursor.id,
+									returnedCreatedAt: candidate.createdAt,
+									returnedId: candidate.id,
+								},
+							},
+						);
+					}
+					nextCursor = candidate;
+				}
 				for (const memory of memories) {
 					const tagged = { ...memory, _table: tableName };
 					if (!hasBrowsableContent(tagged)) continue;
@@ -1284,20 +1347,24 @@ async function fetchMemoriesFromTables(
 					}
 					eligible.push(tagged);
 				}
-				if (memories.length < batchSize || eligible.length >= params.target) {
+				if (memories.length < queryLimit || eligible.length >= params.target) {
 					return eligible;
 				}
-				const last = memories.at(-1);
-				if (!last?.id) {
+				if (scannedRows >= maxScannedRowsPerTable) {
 					throw new ElizaError(
-						"A paged memory row did not contain the required id",
+						"Memory browse exceeded its bounded scan budget before proving the page",
 						{
-							code: "MEMORY_BROWSE_CURSOR_MISSING_ID",
-							context: { tableName },
+							code: "MEMORY_BROWSE_SCAN_LIMIT",
+							context: {
+								tableName,
+								scannedRows,
+								maxScannedRows: maxScannedRowsPerTable,
+								target: params.target,
+							},
 						},
 					);
 				}
-				cursor = { createdAt: memoryCreatedAt(last), id: last.id };
+				cursor = nextCursor;
 				batchSize = Math.min(batchSize * 2, 5_000);
 			}
 		}),

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -19,6 +19,7 @@ import {
   type Component,
   type Content,
   canRequesterMutateDocument,
+  compareMemoryIds,
   DatabaseAdapter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
   type DocumentCompareAndSwapParams,
@@ -824,7 +825,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (ta !== tb) return direction === "asc" ? ta - tb : tb - ta;
       const aId = typeof a.id === "string" ? a.id : "";
       const bId = typeof b.id === "string" ? b.id : "";
-      return direction === "asc" ? aId.localeCompare(bId) : bId.localeCompare(aId);
+      return direction === "asc" ? compareMemoryIds(aId, bId) : compareMemoryIds(bId, aId);
     });
 
     if (params.cursor) {
@@ -835,7 +836,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         if (createdAt !== cursor.createdAt) {
           return direction === "asc" ? createdAt > cursor.createdAt : createdAt < cursor.createdAt;
         }
-        return direction === "asc" ? id > cursor.id : id < cursor.id;
+        const idOrder = compareMemoryIds(id, cursor.id);
+        return direction === "asc" ? idOrder > 0 : idOrder < 0;
       });
     }
 

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -775,6 +775,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     limit?: number;
     count?: number;
     offset?: number;
+    cursor?: { createdAt: number; id: UUID };
     unique?: boolean;
     tableName: string;
     start?: number;
@@ -788,6 +789,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     includeEmbedding?: boolean;
     accessContext?: AccessContext;
   }): Promise<Memory[]> {
+    if (params.cursor && params.offset !== undefined) {
+      throw new Error("getMemories cursor and offset are mutually exclusive");
+    }
     const textContains = params.textContains?.trim().toLowerCase();
     let memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
       if (params.entityId && m.entityId !== params.entityId) return false;
@@ -822,6 +826,18 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       const bId = typeof b.id === "string" ? b.id : "";
       return direction === "asc" ? aId.localeCompare(bId) : bId.localeCompare(aId);
     });
+
+    if (params.cursor) {
+      const cursor = params.cursor;
+      memories = memories.filter((memory) => {
+        const createdAt = typeof memory.createdAt === "number" ? memory.createdAt : 0;
+        const id = typeof memory.id === "string" ? memory.id : "";
+        if (createdAt !== cursor.createdAt) {
+          return direction === "asc" ? createdAt > cursor.createdAt : createdAt < cursor.createdAt;
+        }
+        return direction === "asc" ? id > cursor.id : id < cursor.id;
+      });
+    }
 
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? params.count;

--- a/plugins/plugin-inmemorydb/memory-cursor-order.test.ts
+++ b/plugins/plugin-inmemorydb/memory-cursor-order.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Exercises the real ephemeral adapter's memory keyset order, including UUID
+ * hexadecimal case that PostgreSQL normalizes before comparing.
+ */
+
+import type { Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const agentId = "10000000-0000-4000-8000-000000000001" as UUID;
+const entityId = "20000000-0000-4000-8000-000000000001" as UUID;
+const roomId = "30000000-0000-4000-8000-000000000001" as UUID;
+
+describe("memory keyset ordering", () => {
+  it("does not skip or repeat mixed-case UUIDs at a cursor boundary", async () => {
+    const storage = new MemoryStorage();
+    await storage.init();
+    const adapter = new InMemoryDatabaseAdapter(storage, agentId);
+    await adapter.init();
+    const ids = [
+      "A0000000-0000-0000-0000-000000000001",
+      "a0000000-0000-0000-0000-000000000002",
+      "A0000000-0000-0000-0000-000000000003",
+      "a0000000-0000-0000-0000-000000000004",
+    ] as UUID[];
+    const memories: Memory[] = ids.map((id, index) => ({
+      id,
+      agentId,
+      entityId,
+      roomId,
+      createdAt: 1_000,
+      content: { text: `case ${index}` },
+    }));
+    await adapter.createMemories(memories.map((memory) => ({ memory, tableName: "messages" })));
+
+    const first = await adapter.getMemories({
+      roomId,
+      tableName: "messages",
+      limit: 2,
+    });
+    expect(first.map((memory) => memory.id)).toEqual([ids[3], ids[2]]);
+
+    const second = await adapter.getMemories({
+      roomId,
+      tableName: "messages",
+      limit: 2,
+      cursor: { createdAt: 1_000, id: ids[2] },
+    });
+    expect(second.map((memory) => memory.id)).toEqual([ids[1], ids[0]]);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -617,6 +617,56 @@ describe("Memory Integration Tests", () => {
       expect(allIds.length).toBe(uniqueIds.size);
     });
 
+    it("should page by an exclusive createdAt/id cursor across earlier mutations", async () => {
+      const createdAt = 1_750_000_000_000;
+      const ids = [
+        "00000000-0000-4000-8000-0000000000a1",
+        "00000000-0000-4000-8000-0000000000a2",
+        "00000000-0000-4000-8000-0000000000a3",
+        "00000000-0000-4000-8000-0000000000a4",
+        "00000000-0000-4000-8000-0000000000a5",
+      ] as UUID[];
+      for (const [index, id] of ids.entries()) {
+        await adapter.createMemory(
+          { ...createTestMemory({ text: `cursor ${index}` }), id, createdAt },
+          "memories"
+        );
+      }
+
+      const first = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+      });
+      expect(first.map((memory) => memory.id)).toEqual([ids[4], ids[3]]);
+
+      await adapter.deleteMemories([ids[4]]);
+      await adapter.createMemory(
+        {
+          ...createTestMemory({ text: "inserted ahead" }),
+          id: "00000000-0000-4000-8000-0000000000ff" as UUID,
+          createdAt: createdAt + 1,
+        },
+        "memories"
+      );
+      const second = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+        cursor: { createdAt, id: ids[3] },
+      });
+      expect(second.map((memory) => memory.id)).toEqual([ids[2], ids[1]]);
+
+      await expect(
+        adapter.getMemories({
+          roomId: testRoomId,
+          tableName: "memories",
+          offset: 0,
+          cursor: { createdAt, id: ids[3] },
+        })
+      ).rejects.toThrow("cursor and offset are mutually exclusive");
+    });
+
     it("should handle offset without count parameter", async () => {
       for (let i = 0; i < 5; i++) {
         await adapter.createMemory(createTestMemory({ text: `mem${i}` }), "memories");

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -667,6 +667,52 @@ describe("Memory Integration Tests", () => {
       ).rejects.toThrow("cursor and offset are mutually exclusive");
     });
 
+    it("does not skip rows whose database timestamps differ below cursor precision", async () => {
+      const ids = [
+        "00000000-0000-4000-8000-0000000000b1",
+        "00000000-0000-4000-8000-0000000000b2",
+        "00000000-0000-4000-8000-0000000000b3",
+        "00000000-0000-4000-8000-0000000000b4",
+      ] as UUID[];
+      const db = adapter.getDatabase() as DrizzleDatabase;
+      for (const [index, id] of ids.entries()) {
+        const micros = 400 - index * 100;
+        await db.execute(sql`
+          INSERT INTO ${memoryTable}
+            (id, type, created_at, content, entity_id, agent_id, room_id, world_id, "unique", metadata)
+          VALUES
+            (
+              ${id}::uuid,
+              'memories',
+              ('2025-01-01T00:00:00.123000Z'::timestamptz + ${micros} * interval '1 microsecond'),
+              ${JSON.stringify({ text: `sub-millisecond ${index}` })}::jsonb,
+              ${testEntityId}::uuid,
+              ${testAgentId}::uuid,
+              ${testRoomId}::uuid,
+              ${testWorldId}::uuid,
+              false,
+              '{}'::jsonb
+            )
+        `);
+      }
+
+      const first = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+      });
+      expect(first.map((memory) => memory.id)).toEqual([ids[3], ids[2]]);
+      expect(new Set(first.map((memory) => memory.createdAt))).toHaveLength(1);
+
+      const second = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+        cursor: { createdAt: first[1].createdAt as number, id: ids[2] },
+      });
+      expect(second.map((memory) => memory.id)).toEqual([ids[1], ids[0]]);
+    });
+
     it("should handle offset without count parameter", async () => {
       for (let i = 0; i < 5; i++) {
         await adapter.createMemory(createTestMemory({ text: `mem${i}` }), "memories");

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -316,6 +316,7 @@ import {
   count,
   desc,
   eq,
+  gt,
   gte,
   inArray,
   isNotNull,
@@ -2315,6 +2316,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     limit?: number;
     count?: number;
     offset?: number;
+    cursor?: { createdAt: number; id: UUID };
     unique?: boolean;
     tableName: string;
     start?: number;
@@ -2333,7 +2335,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     includeEmbedding?: boolean;
     accessContext?: AccessContext;
   }): Promise<Memory[]> {
-    const { entityId, agentId, roomId, worldId, unique, start, end, offset } = params;
+    const { entityId, agentId, roomId, worldId, unique, start, end, offset, cursor } = params;
     const includeEmbedding = params.includeEmbedding !== false;
     const tableName = params.tableName;
     // tableName is required by the IDatabaseAdapter contract (there is no
@@ -2356,6 +2358,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     if (offset !== undefined && offset < 0) {
       throw new Error("offset must be a non-negative number");
     }
+    if (cursor && offset !== undefined) {
+      throw new Error("getMemories cursor and offset are mutually exclusive");
+    }
 
     return this.withEntityContext(entityId ?? null, async (tx) => {
       const conditions = [eq(memoryTable.type, tableName)];
@@ -2377,6 +2382,21 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
       if (end !== undefined) {
         conditions.push(lte(memoryTable.createdAt, new Date(end)));
+      }
+
+      if (cursor) {
+        const cursorTimestamp = new Date(cursor.createdAt);
+        const cursorCondition =
+          params.orderDirection === "asc"
+            ? or(
+                gt(memoryTable.createdAt, cursorTimestamp),
+                and(eq(memoryTable.createdAt, cursorTimestamp), gt(memoryTable.id, cursor.id))
+              )
+            : or(
+                lt(memoryTable.createdAt, cursorTimestamp),
+                and(eq(memoryTable.createdAt, cursorTimestamp), lt(memoryTable.id, cursor.id))
+              );
+        if (cursorCondition) conditions.push(cursorCondition);
       }
 
       if (unique) {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -316,7 +316,6 @@ import {
   count,
   desc,
   eq,
-  gt,
   gte,
   inArray,
   isNotNull,
@@ -2350,10 +2349,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     const effectiveLimit = params.limit ?? params.count;
     // Default newest-first; `orderDirection: "asc"` powers around-message paging
     // (load the messages immediately *after* an anchor, not the newest tail).
+    // `Memory.createdAt` is a JavaScript millisecond timestamp. PostgreSQL
+    // stores microseconds, so keyset ordering must truncate to the precision
+    // represented by the cursor; comparing the raw column to a reconstructed
+    // Date would skip rows later in the same millisecond.
+    const cursorCreatedAt = sql`date_trunc('milliseconds', ${memoryTable.createdAt})`;
     const order =
       params.orderDirection === "asc"
-        ? [asc(memoryTable.createdAt), asc(memoryTable.id)]
-        : [desc(memoryTable.createdAt), desc(memoryTable.id)];
+        ? [asc(cursorCreatedAt), asc(memoryTable.id)]
+        : [desc(cursorCreatedAt), desc(memoryTable.id)];
 
     if (offset !== undefined && offset < 0) {
       throw new Error("offset must be a non-negative number");
@@ -2385,18 +2389,20 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       }
 
       if (cursor) {
-        const cursorTimestamp = new Date(cursor.createdAt);
-        const cursorCondition =
+        const cursorTimestamp = sql`(
+          timestamp 'epoch' + ${cursor.createdAt} * interval '1 millisecond'
+        )`;
+        conditions.push(
           params.orderDirection === "asc"
-            ? or(
-                gt(memoryTable.createdAt, cursorTimestamp),
-                and(eq(memoryTable.createdAt, cursorTimestamp), gt(memoryTable.id, cursor.id))
-              )
-            : or(
-                lt(memoryTable.createdAt, cursorTimestamp),
-                and(eq(memoryTable.createdAt, cursorTimestamp), lt(memoryTable.id, cursor.id))
-              );
-        if (cursorCondition) conditions.push(cursorCondition);
+            ? sql`(
+                ${cursorCreatedAt} > ${cursorTimestamp}
+                OR (${cursorCreatedAt} = ${cursorTimestamp} AND ${memoryTable.id} > ${cursor.id}::uuid)
+              )`
+            : sql`(
+                ${cursorCreatedAt} < ${cursorTimestamp}
+                OR (${cursorCreatedAt} = ${cursorTimestamp} AND ${memoryTable.id} < ${cursor.id}::uuid)
+              )`
+        );
       }
 
       if (unique) {


### PR DESCRIPTION
# Relates to

Closes #22061 when merged.

The pagination implementation and global-chat clearance integration are repaired and verified. The Memory view now uses the established `eliza-chat-scroll` contract and the shell-published bottom/side clearance variables, so content remains scrollable above the overlay in desktop, mobile, and compact-landscape layouts.

# Root cause and approach

The original failure was not merely an undersized fetch limit: sparse multi-token search was post-filtering a fixed prefix and therefore could silently skip matches. The repaired implementation uses stable descending `(createdAt, id)` keyset scans across the selected memory tables, stops once it can prove the requested page plus `hasMore`, and reports observed lower-bound totals rather than fabricated exact totals.

Reviewer-driven hardening on this head also:

- aligns UUID tie-breaking across in-memory, SQL, server-merge, and Capacitor adapters;
- normalizes PostgreSQL cursor comparisons to JavaScript millisecond precision, preventing same-millisecond rows from being skipped;
- rejects adapter pages that ignore the cursor or omit cursor IDs instead of looping or duplicating rows;
- caps total request scan work at 25,000 rows, divided across selected tables, and fails explicitly when that bound prevents a conclusive answer;
- keeps server and Capacitor behavior in parity and drives the UI from `hasMore` plus an explicitly incomplete total.

# Sync status

- Verified head: `c2eacc4d4f383a99052a53a1aa219d95fa9a6629`.
- This head was rebased without conflicts onto settled `origin/develop@a95d1f44fa4e`.
- Hosted Quality (Extended) run 32300473261 passed on this exact head.

# Exact-head verification

- `bun install --frozen-lockfile` — PASS.
- `bun run verify` — PASS (358/358 workspace build/typecheck tasks plus repository audits).
- Core in-memory cursor suite — PASS, 8/8.
- Agent pagination suite — PASS, 10/10.
- Real PGlite memory integration suite — PASS, 45/45.
- UI Memory viewer contract suite — PASS, 4/4.
- Capacitor bridge route suite — PASS, 20/20.
- Dedicated Chromium pagination interaction — PASS, 1/1; shows 50 rows, `1–50 of at least 51`, and an enabled Next control.
- `git diff --check` — PASS.

Broader diagnostic runs:

- Full Core suite: 6,804 passed, 13 skipped.
- Full App script/Vitest lanes: 817 passed / 1 skipped and 803/803 passed; app build passed.
- Full UI aggregate was not green: 10,982 passed, 35 failed, 7 skipped. Failures were broad untouched timeout/baseline failures under host load; the changed Memory contract suite passed.
- Full Capacitor bridge aggregate had 167 passing tests plus one unrelated collection failure where an existing test imports `bun:test` under Vitest; the changed bridge route suite passed.

# Visual evidence and overlay repair

- [Exact-head pagination screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr22254-1d28593c-memory-pagination.jpg) — SHA-256 `7f2f010bf83b7ebe857d2dd328f7fd41c590ad1dfb1b4749d5dc97105063d713`.
- [Exact-head interaction video](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr22254-1d28593c-memory-pagination.mp4) — SHA-256 `73a83a18decb68a3b263edc2d834700a3e4ee64a8b850be804c8cc7507fd0e47`.
- Full `packages/app` visual audit: 218/219 captures passed, `broken=0`; three unrelated mobile-landscape minimalism baselines failed.
- Memory OCR was verified in all four viewport captures with no regression.
- That captured blocker is repaired on the current head by applying the repository's established chat-aware scroll/clearance contract to the Memory content container. The focused interface suite passes 5/5 and asserts the shell integration classes; Biome and exact-head hosted Quality are green.

# Disposition

**REPAIRED / READY.** Pagination remains fail-fast and bounded, the production overlay collision is resolved through the shared shell contract, the branch is rebased, and exact-head validation is green.

# Contribution provenance

- AI assistance: yes
- Model: OpenAI / `gpt-5.6-sol`
- Client: Codex Desktop
- Status: self-reported

No model prompt, provider, action, or planner behavior changed, so live-model trajectory evidence is not applicable.