### PR TITLE
fix(cloud): bound detached gateway Kubernetes wake requests

### DIFF
--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -23,6 +23,9 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   files are absent (e.g. a developer laptop outside a cluster) and cache the
   first result. `__resetServiceAccountCacheForTests()` clears that cache for
   tests only.
+- `src/k8s-deployment-wake.ts` (`./k8s-deployment-wake`) — performs a bounded
+  Kubernetes Deployment scale PATCH and composes an optional caller abort
+  signal with the operation deadline.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
 - `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -23,6 +23,9 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   files are absent (e.g. a developer laptop outside a cluster) and cache the
   first result. `__resetServiceAccountCacheForTests()` clears that cache for
   tests only.
+- `src/k8s-deployment-wake.ts` (`./k8s-deployment-wake`) — performs a bounded
+  Kubernetes Deployment scale PATCH and composes an optional caller abort
+  signal with the operation deadline.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
 - `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -10,6 +10,7 @@
     ".": "./src/index.ts",
     "./logger": "./src/logger.ts",
     "./k8s-service-account": "./src/k8s-service-account.ts",
+    "./k8s-deployment-wake": "./src/k8s-deployment-wake.ts",
     "./identity-link-code": "./src/identity-link-code.ts",
     "./gateway-auth": "./src/gateway-auth.ts",
     "./response-attempts": "./src/response-attempts.ts",

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -13,6 +13,11 @@ export {
   identityLinkReply,
 } from "./identity-link-code";
 export {
+  DEFAULT_K8S_WAKE_TIMEOUT_MS,
+  type K8sDeploymentWakeOptions,
+  patchK8sDeploymentScale,
+} from "./k8s-deployment-wake";
+export {
   __resetServiceAccountCacheForTests,
   readServiceAccountCaCert,
   readServiceAccountToken,

--- a/packages/cloud/services/_common/src/k8s-deployment-wake.ts
+++ b/packages/cloud/services/_common/src/k8s-deployment-wake.ts
@@ -1,0 +1,43 @@
+/**
+ * Issues a bounded Kubernetes Deployment scale request for gateway wake-up
+ * paths while preserving an optional caller cancellation signal.
+ */
+
+export const DEFAULT_K8S_WAKE_TIMEOUT_MS = 15_000;
+
+export interface K8sDeploymentWakeOptions {
+  serverName: string;
+  namespace: string;
+  token: string;
+  caCert: string | null;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+  createTimeoutSignal?: (timeoutMs: number) => AbortSignal;
+}
+
+export async function patchK8sDeploymentScale(
+  options: K8sDeploymentWakeOptions,
+): Promise<Response> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const createTimeoutSignal =
+    options.createTimeoutSignal ?? AbortSignal.timeout.bind(AbortSignal);
+  const timeoutSignal = createTimeoutSignal(
+    options.timeoutMs ?? DEFAULT_K8S_WAKE_TIMEOUT_MS,
+  );
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+  const apiUrl = `https://kubernetes.default.svc/apis/apps/v1/namespaces/${options.namespace}/deployments/${options.serverName}/scale`;
+
+  return fetchFn(apiUrl, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      "Content-Type": "application/strategic-merge-patch+json",
+    },
+    body: JSON.stringify({ spec: { replicas: 1 } }),
+    signal,
+    tls: { ca: options.caCert ?? undefined },
+  } as RequestInit);
+}

--- a/packages/cloud/services/_common/tests/k8s-deployment-wake.test.ts
+++ b/packages/cloud/services/_common/tests/k8s-deployment-wake.test.ts
@@ -1,0 +1,98 @@
+/** Exercises the shared Kubernetes wake PATCH against deterministic transport boundaries. */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  DEFAULT_K8S_WAKE_TIMEOUT_MS,
+  patchK8sDeploymentScale,
+} from "../src/k8s-deployment-wake";
+
+const baseOptions = {
+  serverName: "agent-server-1",
+  namespace: "agents",
+  token: "test-token",
+  caCert: "test-ca",
+};
+
+describe("patchK8sDeploymentScale", () => {
+  test("sends the scale payload with the shared deadline", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const createTimeoutSignal = mock(() => timeoutSignal);
+    const fetchFn = mock(async () => new Response(null, { status: 200 }));
+
+    const response = await patchK8sDeploymentScale({
+      ...baseOptions,
+      fetchFn: fetchFn as typeof fetch,
+      createTimeoutSignal,
+    });
+
+    expect(response.status).toBe(200);
+    expect(createTimeoutSignal).toHaveBeenCalledWith(
+      DEFAULT_K8S_WAKE_TIMEOUT_MS,
+    );
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://kubernetes.default.svc/apis/apps/v1/namespaces/agents/deployments/agent-server-1/scale",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ spec: { replicas: 1 } }),
+        signal: timeoutSignal,
+      }),
+    );
+  });
+
+  test("aborts a never-settling PATCH at the injected deadline", async () => {
+    const fetchFn = mock(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    await expect(
+      patchK8sDeploymentScale({
+        ...baseOptions,
+        timeoutMs: 5,
+        fetchFn: fetchFn as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  test("composes explicit caller cancellation with the deadline", async () => {
+    const caller = new AbortController();
+    const fetchFn = mock(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+    const pending = patchK8sDeploymentScale({
+      ...baseOptions,
+      signal: caller.signal,
+      timeoutMs: 60_000,
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    caller.abort(new DOMException("caller cancelled", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test("returns non-2xx responses for the owning service to classify", async () => {
+    const response = await patchK8sDeploymentScale({
+      ...baseOptions,
+      fetchFn: mock(
+        async () => new Response("denied", { status: 403 }),
+      ) as typeof fetch,
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("denied");
+  });
+});

--- a/packages/cloud/services/gateway-discord/src/server-router.ts
+++ b/packages/cloud/services/gateway-discord/src/server-router.ts
@@ -1,5 +1,7 @@
 /** Routes Discord messages to registered cloud agent servers. */
+
 import { readFileSync } from "node:fs";
+import { patchK8sDeploymentScale } from "@elizaos/cloud-services-common/k8s-deployment-wake";
 import { getHashTargets, refreshHashRing } from "./hash-router";
 import { logger } from "./logger";
 
@@ -96,48 +98,74 @@ function isDirectServerUrl(serverUrl: string): boolean {
   }
 }
 
-async function wakeServer(
+export interface WakeServerDependencies {
+  getToken?: () => string | null;
+  getCaCert?: () => string | null;
+  fetchFn?: typeof fetch;
+  createTimeoutSignal?: (timeoutMs: number) => AbortSignal;
+  logError?: (message: string, context: Record<string, unknown>) => void;
+}
+
+export async function wakeServer(
   serverName: string,
   serverUrl: string,
+  dependencies: WakeServerDependencies = {},
 ): Promise<void> {
+  const logError = dependencies.logError ?? logger.error.bind(logger);
   // Hetzner containers (direct host:port URLs) are already running; there is
   // no K8s Deployment to scale. The gateways run on Railway, not K8s, so the
   // service-account token below is also absent there. Skip explicitly to
   // avoid both a pointless K8s API call and misleading error logs.
   if (isDirectServerUrl(serverUrl)) return;
 
-  const token = getK8sToken();
+  const token = (dependencies.getToken ?? getK8sToken)();
   if (!token) return;
 
   const namespace = parseNamespaceFromUrl(serverUrl);
   if (!namespace) return;
 
-  const apiUrl = `https://kubernetes.default.svc/apis/apps/v1/namespaces/${namespace}/deployments/${serverName}/scale`;
-
   try {
-    const res = await fetch(apiUrl, {
-      method: "PATCH",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/strategic-merge-patch+json",
-      },
-      body: JSON.stringify({ spec: { replicas: 1 } }),
-      tls: { ca: getK8sCaCert() ?? undefined },
-    } as RequestInit);
+    const res = await patchK8sDeploymentScale({
+      serverName,
+      namespace,
+      token,
+      caCert: (dependencies.getCaCert ?? getK8sCaCert)(),
+      fetchFn: dependencies.fetchFn,
+      createTimeoutSignal: dependencies.createTimeoutSignal,
+    });
     if (!res.ok) {
       const text = await res.text();
-      logger.error("wakeServer failed", {
+      logError("wakeServer failed", {
         serverName,
         status: res.status,
         body: text,
       });
     }
   } catch (err) {
-    logger.error("wakeServer error", {
+    // error-policy:J1 Detached wake failures terminate at this logged boundary.
+    logError("wakeServer error", {
       serverName,
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+export function observeWakeServer(
+  promise: Promise<void>,
+  serverName: string,
+  logError: (
+    message: string,
+    context: Record<string, unknown>,
+  ) => void = logger.error.bind(logger),
+): void {
+  // error-policy:J5 wakeServer observes expected failures internally; this
+  // terminal observer records only an unexpected residual rejection.
+  void promise.catch((err) => {
+    logError("wakeServer unhandled error", {
+      serverName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 /**
@@ -188,7 +216,7 @@ export async function forwardToServer(
     if (targets.length === 0) {
       if (!woken) {
         woken = true;
-        wakeServer(serverName, serverUrl);
+        observeWakeServer(wakeServer(serverName, serverUrl), serverName);
       }
       lastError = new Error("No pods available (scaled to zero)");
       continue;
@@ -207,7 +235,7 @@ export async function forwardToServer(
     lastError = result.error;
     if (!woken && result.isConnectionError) {
       woken = true;
-      wakeServer(serverName, serverUrl);
+      observeWakeServer(wakeServer(serverName, serverUrl), serverName);
     }
   }
 

--- a/packages/cloud/services/gateway-discord/tests/server-router-wake.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/server-router-wake.test.ts
@@ -1,0 +1,101 @@
+/** Exercises Discord gateway wake behavior through the real bounded PATCH helper. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { observeWakeServer, wakeServer } from "../src/server-router";
+
+const serverUrl = "http://agent-server.agents.svc:3000";
+const dependencies = {
+  getToken: () => "test-token",
+  getCaCert: () => "test-ca",
+};
+
+describe("gateway-discord wakeServer", () => {
+  test("preserves successful wake behavior", async () => {
+    const logError = mock(() => undefined);
+    const fetchFn = mock(async () => new Response(null, { status: 200 }));
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: fetchFn as typeof fetch,
+      logError,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  test("logs a non-2xx response exactly once", async () => {
+    const logError = mock(() => undefined);
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: mock(
+        async () => new Response("forbidden", { status: 403 }),
+      ) as typeof fetch,
+      logError,
+    });
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith("wakeServer failed", {
+      serverName: "agent-server",
+      status: 403,
+      body: "forbidden",
+    });
+  });
+
+  test("aborts a stalled PATCH and observes the failure once", async () => {
+    const logError = mock(() => undefined);
+    const fetchFn = mock(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: fetchFn as typeof fetch,
+      createTimeoutSignal: () => AbortSignal.timeout(5),
+      logError,
+    });
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0]?.[0]).toBe("wakeServer error");
+    expect(logError.mock.calls[0]?.[1]).toMatchObject({
+      serverName: "agent-server",
+      error: expect.any(String),
+    });
+  });
+
+  test("observes an unexpected detached rejection without an empty catch", async () => {
+    const logError = mock(() => undefined);
+
+    observeWakeServer(
+      Promise.reject(new Error("unexpected")),
+      "agent-server",
+      logError,
+    );
+    await Promise.resolve();
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith("wakeServer unhandled error", {
+      serverName: "agent-server",
+      error: "unexpected",
+    });
+  });
+
+  test("does not contact Kubernetes for a direct server", async () => {
+    const fetchFn = mock(async () => new Response(null, { status: 200 }));
+
+    await wakeServer("agent-server", "http://agent.example:3000", {
+      ...dependencies,
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-wake.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-wake.test.ts
@@ -1,0 +1,90 @@
+/** Exercises webhook gateway wake behavior through the real bounded PATCH helper. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { observeWakeServer, wakeServer } from "../src/server-router";
+
+const serverUrl = "http://agent-server.agents.svc:3000";
+const dependencies = {
+  getToken: () => "test-token",
+  getCaCert: () => "test-ca",
+};
+
+describe("gateway-webhook wakeServer", () => {
+  test("preserves successful wake behavior", async () => {
+    const logError = mock(() => undefined);
+    const fetchFn = mock(async () => new Response(null, { status: 200 }));
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: fetchFn as typeof fetch,
+      logError,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  test("logs a non-2xx response exactly once", async () => {
+    const logError = mock(() => undefined);
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: mock(
+        async () => new Response("forbidden", { status: 403 }),
+      ) as typeof fetch,
+      logError,
+    });
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith("wakeServer failed", {
+      serverName: "agent-server",
+      status: 403,
+      body: "forbidden",
+    });
+  });
+
+  test("aborts a stalled PATCH and observes the failure once", async () => {
+    const logError = mock(() => undefined);
+    const fetchFn = mock(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    await wakeServer("agent-server", serverUrl, {
+      ...dependencies,
+      fetchFn: fetchFn as typeof fetch,
+      createTimeoutSignal: () => AbortSignal.timeout(5),
+      logError,
+    });
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0]?.[0]).toBe("wakeServer error");
+    expect(logError.mock.calls[0]?.[1]).toMatchObject({
+      serverName: "agent-server",
+      error: expect.any(String),
+    });
+  });
+
+  test("observes an unexpected detached rejection without an empty catch", async () => {
+    const logError = mock(() => undefined);
+
+    observeWakeServer(
+      Promise.reject(new Error("unexpected")),
+      "agent-server",
+      logError,
+    );
+    await Promise.resolve();
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith("wakeServer unhandled error", {
+      serverName: "agent-server",
+      error: "unexpected",
+    });
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -1,5 +1,7 @@
 /** Routes authenticated connector traffic to cloud identities and agent servers. */
+
 import { readFileSync } from "node:fs";
+import { patchK8sDeploymentScale } from "@elizaos/cloud-services-common/k8s-deployment-wake";
 import { reacquireAuthHeader } from "./auth";
 import { getHashTargets, refreshHashRing } from "./hash-router";
 import { logger } from "./logger";
@@ -308,42 +310,68 @@ function parseNamespaceFromUrl(serverUrl: string): string | null {
   return match?.[1] ?? null;
 }
 
-async function wakeServer(
+export interface WakeServerDependencies {
+  getToken?: () => string | null;
+  getCaCert?: () => string | null;
+  fetchFn?: typeof fetch;
+  createTimeoutSignal?: (timeoutMs: number) => AbortSignal;
+  logError?: (message: string, context: Record<string, unknown>) => void;
+}
+
+export async function wakeServer(
   serverName: string,
   serverUrl: string,
+  dependencies: WakeServerDependencies = {},
 ): Promise<void> {
-  const token = getK8sToken();
+  const logError = dependencies.logError ?? logger.error.bind(logger);
+  const token = (dependencies.getToken ?? getK8sToken)();
   if (!token) return;
 
   const namespace = parseNamespaceFromUrl(serverUrl);
   if (!namespace) return;
 
-  const apiUrl = `https://kubernetes.default.svc/apis/apps/v1/namespaces/${namespace}/deployments/${serverName}/scale`;
-
   try {
-    const res = await fetch(apiUrl, {
-      method: "PATCH",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/strategic-merge-patch+json",
-      },
-      body: JSON.stringify({ spec: { replicas: 1 } }),
-      tls: { ca: getK8sCaCert() ?? undefined },
-    } as RequestInit);
+    const res = await patchK8sDeploymentScale({
+      serverName,
+      namespace,
+      token,
+      caCert: (dependencies.getCaCert ?? getK8sCaCert)(),
+      fetchFn: dependencies.fetchFn,
+      createTimeoutSignal: dependencies.createTimeoutSignal,
+    });
     if (!res.ok) {
       const text = await res.text();
-      logger.error("wakeServer failed", {
+      logError("wakeServer failed", {
         serverName,
         status: res.status,
         body: text,
       });
     }
   } catch (err) {
-    logger.error("wakeServer error", {
+    // error-policy:J1 Detached wake failures terminate at this logged boundary.
+    logError("wakeServer error", {
       serverName,
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+export function observeWakeServer(
+  promise: Promise<void>,
+  serverName: string,
+  logError: (
+    message: string,
+    context: Record<string, unknown>,
+  ) => void = logger.error.bind(logger),
+): void {
+  // error-policy:J5 wakeServer observes expected failures internally; this
+  // terminal observer records only an unexpected residual rejection.
+  void promise.catch((err) => {
+    logError("wakeServer unhandled error", {
+      serverName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 /**
@@ -652,10 +680,7 @@ async function forwardWithRetry(
     if (targets.length === 0) {
       if (!woken) {
         woken = true;
-        // error-policy:J5 fire-and-forget wake; wakeServer catches and logs
-        // every real failure internally (server-router.ts:191-214), so this
-        // only suppresses a residual pre-guard rejection.
-        wakeServer(serverName, serverUrl).catch(() => {});
+        observeWakeServer(wakeServer(serverName, serverUrl), serverName);
       }
       lastError = new Error("No pods available (scaled to zero)");
       continue;
@@ -716,10 +741,7 @@ async function forwardWithRetry(
     lastError = result.error;
     if (!woken && result.isConnectionError) {
       woken = true;
-      // error-policy:J5 fire-and-forget wake; wakeServer catches and logs
-      // every real failure internally (server-router.ts:191-214), so this
-      // only suppresses a residual pre-guard rejection.
-      wakeServer(serverName, serverUrl).catch(() => {});
+      observeWakeServer(wakeServer(serverName, serverUrl), serverName);
     }
   }
 


### PR DESCRIPTION
# Relates to

Fixes #22324.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the changed behavior from the deterministic behavioral evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ae395884285bb645a9824056e39871ef3be3dbfb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `ae395884285bb645a9824056e39871ef3be3dbfb`, the latest `origin/develop` at final push; zero conflicts.
- [ ] Root `bun run verify` was not run in the isolated sparse repair worktree; exact package gates and the known full-lane failures are documented below.

# Risks

Low. The change is limited to the two gateway wake paths and a dependency-free shared helper. A bounded abort can stop a Kubernetes scale PATCH after 15 seconds instead of leaving its request resources alive indefinitely. Non-2xx responses and aborts remain observable exactly once at the owning service boundary.

# Background

## What does this PR do?

- Consolidates the Discord and webhook Kubernetes scale PATCH into `@elizaos/cloud-services-common/k8s-deployment-wake`.
- Applies a 15-second deadline and composes it with an optional caller signal through `AbortSignal.any`.
- Adds injectable fetch, deadline, credential, and logger seams without exporting test-only mutable credential setters.
- Replaces empty detached catches with a J5 terminal observer that records unexpected residual rejections; expected operation failures are caught and logged at the service boundary.
- Adds Bun behavioral tests for the real helper/service code covering request shape, success, non-2xx, stalled-request abort, caller cancellation, detached residual rejection, and direct-server bypass.

The original impact statement was corrected: callers intentionally detach `wakeServer`, so a stalled PATCH did not block the retry loop. The defect was an indefinitely live background request and retained resources.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The shared-service package guide and its byte-identical `AGENTS.md` pair now document the new export.

# Testing

## Where should a reviewer start?

Review `packages/cloud/services/_common/src/k8s-deployment-wake.ts`, then the two `server-router-wake.test.ts` suites and the detached observer call sites.

## Detailed testing steps

Exact head: `1f5d0f6773fcd10b518e6b28602b4f43d3a69df2`

```text
bun test packages/cloud/services/_common/tests/k8s-deployment-wake.test.ts
4 pass, 0 fail; helper 100% function/line coverage

bun test packages/cloud/services/gateway-discord/tests/server-router-wake.test.ts
5 pass, 0 fail

bun test packages/cloud/services/gateway-webhook/__tests__/server-router-wake.test.ts
4 pass, 0 fail

bun run --cwd packages/cloud/services/_common typecheck
PASS

bun x tsc --noEmit --customConditions eliza-source -p packages/cloud/services/gateway-discord/tsconfig.json
PASS

bun run --cwd packages/cloud/services/gateway-webhook typecheck
PASS

bun run --cwd packages/cloud/services/gateway-discord build
PASS - bundled 747 modules

bun run --cwd packages/cloud/services/gateway-webhook build
PASS - bundled 197 modules

biome check <10 touched source, test, manifest, and guide files>
PASS - 8 applicable files checked, no fixes

cmp -s packages/cloud/services/_common/CLAUDE.md packages/cloud/services/_common/AGENTS.md
PASS

git diff --check
PASS
```

# Evidence Gate

<!-- evidence-head:1f5d0f6773fcd10b518e6b28602b4f43d3a69df2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only Kubernetes transport path with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only Kubernetes transport path with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no rendered or interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no cluster credential or safe live scale target is available in this isolated review environment; deterministic tests execute the production request, abort, response-classification, and logging boundaries.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, scheduled-task, wallet, media, or generated-file output.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior.

## Backend + frontend logs

The focused Bun output above is the reproducible behavioral evidence. It proves that a never-settling injected transport is aborted, both service boundaries observe/log it exactly once, and a residual detached rejection is explicitly observed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only transport behavior.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

- Root `bun install` and `bun run verify` were not run because this repair was performed in an isolated sparse worktree to preserve the dirty shared checkout. Focused package typechecks/builds/tests and formatting passed on the exact head; CI must supply repository-wide validation.
- `_common` full package lane passed: 33 pass, 0 fail.
- Discord full package lane reached 132 pass and 2 unrelated failures: the sandboxed sparse checkout omitted `packages/scripts/rm-path-recursive.mjs` and denied `/dev/null` for `deploy-railway.test.ts`; the pre-existing mock Upstash test timed out at 5 seconds. The focused wake suite, typecheck, and build pass.
- Webhook full package lane reached 167 pass and 3 unrelated failures: an existing billing parity assertion (`Expected 0, Received 0.0075`) plus pre-existing startup-routing and mock-Redis 5-second timeouts. The focused wake suite, typecheck, and build pass.
- No live Kubernetes scale target was used; the exact production helper and both service boundaries were exercised with injected deterministic transport and abort signals.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@ae395884285bb645a9824056e39871ef3be3dbfb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61-new-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@ae395884285bb645a9824056e39871ef3be3dbfb:packages/skills/skills/contribute-to-eliza"} -->
