### PR TITLE
fix(ui): show email code only when Steward delivers it

### DIFF
--- a/packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts
@@ -138,9 +138,18 @@ for (const viewport of VIEWPORTS) {
         body: JSON.stringify({
           ok: true,
           expiresAt: "2099-01-01T00:00:00.000Z",
+          challengeId: "link-only-challenge",
+          pollSecret: "link-only-poll-secret",
         }),
       });
     });
+    await page.route("**/auth/email/status", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, status: "pending" }),
+      }),
+    );
 
     let optionsMode: "discoverable" | "server-error" = "discoverable";
     await page.route("**/auth/passkey/login/options", (route) => {
@@ -269,8 +278,16 @@ for (const viewport of VIEWPORTS) {
     await page.getByRole("button", { name: /^Passkey$/ }).click();
     await page.getByRole("button", { name: "Use Magic Link" }).click();
     await expect(page.getByText("Check your email")).toBeVisible();
+    await expect(
+      page.getByText("Check your inbox and open the magic link to sign in."),
+    ).toBeVisible();
+    await expect(page.getByLabel("Six-digit code")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Verify code" })).toHaveCount(
+      0,
+    );
     expect(magicLinkSendCount, "explicit Magic Link intent sends once").toBe(1);
     expect(otpSendCount).toBe(1);
+    await screenshot(page, testInfo, `${viewport.name}-4-link-only-email`);
 
     const logPath = testInfo.outputPath(`${viewport.name}-frontend.log`);
     await writeFile(logPath, `${frontendEvents.join("\n")}\n`, "utf8");

--- a/packages/ui/src/cloud/public-pages/lib/steward-email-login.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-email-login.test.ts
@@ -30,6 +30,7 @@ describe("steward email sign-in adapter", () => {
           expiresAt: "2026-07-17T12:10:00.000Z",
           challengeId: "challenge-1",
           pollSecret: "poll-secret",
+          codeAvailable: true,
         },
       }),
     );
@@ -47,6 +48,7 @@ describe("steward email sign-in adapter", () => {
       expiresAt: "2026-07-17T12:10:00.000Z",
       challengeId: "challenge-1",
       pollSecret: "poll-secret",
+      codeAvailable: true,
     });
 
     expect(fetchImpl).toHaveBeenCalledWith(
@@ -79,6 +81,32 @@ describe("steward email sign-in adapter", () => {
       expiresAt: "2026-07-17T12:10:00.000Z",
       challengeId: undefined,
       pollSecret: undefined,
+      codeAvailable: false,
+    });
+  });
+
+  it("does not infer code delivery from polling credentials", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        data: {
+          expiresAt: "2026-07-17T12:10:00.000Z",
+          challengeId: "challenge-1",
+          pollSecret: "poll-secret",
+        },
+      }),
+    );
+
+    await expect(
+      startStewardEmailLogin(
+        { baseUrl: "/steward", tenantId: "elizacloud", fetchImpl },
+        "person@example.com",
+      ),
+    ).resolves.toEqual({
+      expiresAt: "2026-07-17T12:10:00.000Z",
+      challengeId: "challenge-1",
+      pollSecret: "poll-secret",
+      codeAvailable: false,
     });
   });
 

--- a/packages/ui/src/cloud/public-pages/lib/steward-email-login.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-email-login.ts
@@ -20,6 +20,8 @@ export interface StewardEmailLoginChallenge {
   expiresAt: string | number;
   challengeId?: string;
   pollSecret?: string;
+  /** True only when Steward explicitly confirms that the email contains a code. */
+  codeAvailable: boolean;
 }
 
 interface StewardEmailLoginOptions {
@@ -171,9 +173,10 @@ export async function startStewardEmailLogin(
       502,
     );
   }
-  // challengeId/pollSecret are additive in Steward #242. Their absence keeps
-  // the existing magic-link-only UI working during a rolling deployment.
-  return { expiresAt, challengeId, pollSecret };
+  // Polling credentials do not describe the email's contents. Default to the
+  // link-only contract unless Steward explicitly confirms code delivery.
+  const codeAvailable = data.codeAvailable === true;
+  return { expiresAt, challengeId, pollSecret, codeAvailable };
 }
 
 export async function verifyStewardEmailSignInCode(

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
@@ -150,6 +150,13 @@ async function startEmailLogin() {
   await screen.findByLabelText("Six-digit code");
 }
 
+async function submitEmailLogin() {
+  const input = await screen.findByPlaceholderText("you@example.com");
+  fireEvent.change(input, { target: { value: "person@example.com" } });
+  fireEvent.click(screen.getByRole("button", { name: /Magic Link/i }));
+  await screen.findByText("Check your email");
+}
+
 describe("StewardLoginSection email magic-link companion code", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -158,6 +165,7 @@ describe("StewardLoginSection email magic-link companion code", () => {
       expiresAt: Date.now() + 600_000,
       challengeId: "challenge-1",
       pollSecret: "poll-secret",
+      codeAvailable: true,
     });
     emailLoginSpies.verify.mockResolvedValue({
       token: "session-token",
@@ -178,14 +186,44 @@ describe("StewardLoginSection email magic-link companion code", () => {
     vi.useRealTimers();
   });
 
-  it("redeems only six digits and establishes the session from the verify response", async () => {
+  it("keeps polling credentials link-only without an explicit code-delivery signal", async () => {
+    emailLoginSpies.start.mockResolvedValue({
+      expiresAt: Date.now() + 600_000,
+      challengeId: "challenge-1",
+      pollSecret: "poll-secret",
+      codeAvailable: false,
+    });
+    renderSection();
+    await submitEmailLogin();
+
+    expect(
+      screen.getByText("Check your inbox and open the magic link to sign in."),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Six-digit code")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Verify code/i })).toBeNull();
+    expect(screen.queryByText(/old code/i)).toBeNull();
+    expect(screen.queryByText("Waiting for the link or code.")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(emailLoginSpies.poll).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://api.example.test/steward",
+        tenantId: "elizacloud",
+      },
+      "challenge-1",
+      "poll-secret",
+    );
+  });
+
+  it("auto-redeems exactly six digits and establishes the session from the verify response", async () => {
     renderSection();
     await startEmailLogin();
 
     const codeInput = screen.getByLabelText("Six-digit code");
     fireEvent.change(codeInput, { target: { value: "12a345678" } });
     expect((codeInput as HTMLInputElement).value).toBe("123456");
-    fireEvent.click(screen.getByRole("button", { name: /Verify code/i }));
 
     await waitFor(() =>
       expect(emailLoginSpies.verify).toHaveBeenCalledWith(
@@ -273,6 +311,7 @@ describe("StewardLoginSection email magic-link companion code", () => {
       expiresAt: Date.now() + 600_000,
       challengeId: "challenge-2",
       pollSecret: "poll-secret-2",
+      codeAvailable: true,
     });
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "other@example.com" } });
@@ -436,6 +475,7 @@ describe("StewardLoginSection email magic-link companion code", () => {
       expiresAt: Date.now() + 600_000,
       challengeId: "challenge-2",
       pollSecret: "poll-secret-2",
+      codeAvailable: true,
     });
     emailLoginSpies.poll.mockResolvedValueOnce("expired");
     sessionSpies.sync.mockResolvedValue(undefined);

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -161,6 +161,7 @@ describe("StewardLoginSection passkey capability gating", () => {
       expiresAt: "2026-07-17T12:10:00.000Z",
       challengeId: "challenge-1",
       pollSecret: "poll-secret",
+      codeAvailable: true,
     });
     emailLoginSpies.verify.mockResolvedValue({
       token: "email-token",

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -912,7 +912,9 @@ export default function StewardLoginSection() {
           setError(
             describeEmailLoginError(
               pollError,
-              "Could not check that sign-in email. You can still enter the code.",
+              emailChallenge.codeAvailable
+                ? "Could not check that sign-in email. You can still enter the code."
+                : "Could not check that sign-in email. Open the magic link from the email to continue.",
             ),
           );
         }
@@ -1238,8 +1240,8 @@ export default function StewardLoginSection() {
     setLoading(null);
   }
 
-  async function handleVerifyEmailCode() {
-    const code = sanitizeOneTimeCode(emailCode);
+  async function handleVerifyEmailCode(candidateCode = emailCode) {
+    const code = sanitizeOneTimeCode(candidateCode);
     if (code.length !== 6) {
       setError("Enter the six-digit code from your email.");
       return;
@@ -1520,9 +1522,7 @@ export default function StewardLoginSection() {
     );
   }
   if (step === "email-sent") {
-    const hasCompanionCode = Boolean(
-      emailChallenge?.challengeId && emailChallenge.pollSecret,
-    );
+    const hasCompanionCode = emailChallenge?.codeAvailable === true;
     const resendDisabled = loading !== null || resendRemainingSeconds > 0;
     const checkEmailTitle =
       emailCheckState === "approved"
@@ -1589,9 +1589,17 @@ export default function StewardLoginSection() {
               placeholder="123456"
               aria-describedby="email-sign-in-code-hint"
               value={emailCode}
-              onChange={(e) =>
-                setEmailCode(sanitizeOneTimeCode(e.target.value))
-              }
+              onChange={(e) => {
+                const nextCode = sanitizeOneTimeCode(e.target.value);
+                setEmailCode(nextCode);
+                if (
+                  nextCode.length === 6 &&
+                  loading === null &&
+                  emailCheckState === "pending"
+                ) {
+                  void handleVerifyEmailCode(nextCode);
+                }
+              }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleVerifyEmailCode();
               }}
@@ -1614,7 +1622,7 @@ export default function StewardLoginSection() {
           <Button
             variant="ghost"
             type="button"
-            onClick={handleVerifyEmailCode}
+            onClick={() => handleVerifyEmailCode()}
             disabled={
               loading !== null ||
               emailCode.length !== 6 ||


### PR DESCRIPTION
Closes #19213

# Relates to

- Closes #19213
- [x] Targets `develop` and was rebased onto `origin/develop@492bc62904f0641a2598c7cf6bcff7de46539c29` with zero conflicts.
- [x] `bun install --offline --frozen-lockfile --ignore-scripts` completed.
- [x] Reviewers can confirm behavior from desktop/mobile recordings, screenshots, frontend logs, and deterministic contract tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest fetched `origin/develop`; zero conflicts.
- [ ] Root `bun run verify` is not claimed. Exact focused UI contracts, Biome, diff-check, and the real Chromium desktop/mobile flow pass; see Known gaps.

# Risks

Low. The change narrows when the six-digit factor UI appears. Explicit-code responses retain the existing path; link-only responses keep polling with opaque challenge credentials but never invent a code factor.

# Background

## What does this PR do?

The login client now treats `codeAvailable: true` as the sole authority that a companion six-digit factor was delivered. Polling credentials no longer imply code delivery. Link-only responses show only magic-link copy while continuing status polling. Explicit-code challenges auto-redeem after six sanitized digits.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. This repairs the UI interpretation of the existing Steward response contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/public-pages/lib/steward-email-login.ts`
- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`
- `packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts`

## Detailed testing steps

1. Run the three focused Vitest files; expect 35/35.
2. Run the passkey recovery Chromium smoke; expect desktop and mobile green.
3. Inspect control screenshots: explicit `codeAvailable: true` renders the code field.
4. Inspect after screenshots: a link-only response that still contains challenge polling credentials does not render a code label/button/hint, while the status endpoint is polled.

# Evidence Gate

<!-- evidence-head:80a5f22603ab4454f26b294b349352952bd32d7e -->

<!-- evidence-row:before-screenshots -->
- [x] Before/control screenshots: [desktop explicit-code control](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/desktop-3-setup-otp-66a8fa1e6a3b307bbe2f4b44ecea543efbca6585.png), [mobile explicit-code control](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/mobile-3-setup-otp-1b995509ad9baa593799c23b54d50f2b213a213f.png).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [desktop link-only](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/desktop-4-link-only-email-95739d975273b687c228a17ca5b7cca284e8fccd.png), [mobile link-only](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/mobile-4-link-only-email-232a13286b214821c55727b5348a7219f240d52e.png).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthroughs: [desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/desktop-walkthrough-24f38733602ddf1ea5cec8f46e9778d6e7a355d0.mp4), [mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/mobile-walkthrough-6690801b7017cf960c73b19a68ef36056b1fbd00.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - browser contract interpretation only; mocked HTTP is the boundary under test and no server code changes.
<!-- evidence-row:frontend-logs -->
- [x] [Desktop frontend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/desktop-frontend-log-1bf5a90bdb6a271f7069bfd1d16429c65a33ad24.log), [mobile frontend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/mobile-frontend-log-cd89fc3665bdc540c0266efc3c201e43198d5fb2.log). Network assertions verify `/auth/email/send` returns polling credentials without `codeAvailable` and `/auth/email/status` is still called.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain state changes.
<!-- evidence-row:ocr-review -->
- [x] OCR artifacts: [desktop link-only OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/19213-desktop-link-only-ocr.txt), [mobile link-only OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/19213-mobile-link-only-ocr.txt). Both extract the magic-link-only copy and no code label, button, or companion-code hint.

# Evidence Details

## Known gaps / failures

- Root `bun run verify` was not completed before opening this draft. Proportional exact-head gates are green: Vitest 35/35, Biome on all six changed files, `git diff --check`, and Chromium desktop/mobile 2/2.
- The browser run executed immediately before the final conflict-free rebase. All six PR file blobs remained unchanged by that rebase; exact-head unit/Biome/diff gates were rerun afterward.
- The flow intentionally uses deterministic HTTP fixtures because the defect is a rolling-deployment response-shape contract. No live email was sent and no credential was used.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->

