### PR TITLE
fix(plugin-google-genai): recognize embedding resource-name limits

### DIFF
--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -149,10 +149,24 @@ describe("Google GenAI config", () => {
     // gemini-embedding-2 window accepts 8,192. Unmapped overrides must fall back
     // to the safe default (2,048), never the larger window.
     expect(getEmbeddingInputTokenLimit("gemini-embedding-001")).toBe(2_048);
+    expect(getEmbeddingInputTokenLimit("models/gemini-embedding-001")).toBe(
+      2_048,
+    );
     expect(getEmbeddingInputTokenLimit("gemini-embedding-2")).toBe(8_192);
+    expect(getEmbeddingInputTokenLimit("models/gemini-embedding-2")).toBe(
+      8_192,
+    );
     expect(getEmbeddingInputTokenLimit("some-unknown-model")).toBe(
       DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
     );
+    expect(getEmbeddingInputTokenLimit("models/some-unknown-model")).toBe(
+      DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
+    );
+    expect(
+      getEmbeddingInputTokenLimit(
+        "publishers/google/models/gemini-embedding-2",
+      ),
+    ).toBe(DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT);
     expect(DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT).toBe(2_048);
     // The default model's limit must equal the safe fallback so an unknown id is
     // never truncated to a window wider than the shipped default supports.

--- a/plugins/plugin-google-genai/__tests__/embedding.sdk-boundary.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.sdk-boundary.test.ts
@@ -45,11 +45,11 @@ function requestText(body: Record<string, unknown>): string {
   );
 }
 
-function createRuntime(): IAgentRuntime {
+function createRuntime(model = "gemini-embedding-001"): IAgentRuntime {
   return {
     emitEvent: vi.fn(async () => undefined),
     getSetting: vi.fn((key: string) => {
-      if (key === "GOOGLE_EMBEDDING_MODEL") return "gemini-embedding-001";
+      if (key === "GOOGLE_EMBEDDING_MODEL") return model;
       return null;
     }),
   } as unknown as IAgentRuntime;
@@ -60,71 +60,93 @@ describe("Google embedding SDK boundary", () => {
     sdk.client = undefined;
   });
 
-  it("counts with the real SDK and embeds only the provider-admitted Unicode prefix", async () => {
-    const captured: CapturedRequest[] = [];
-    const server = createServer((request, response) => {
-      const chunks: Buffer[] = [];
-      request.on("data", (chunk: Buffer) => chunks.push(chunk));
-      request.on("end", () => {
-        const body = JSON.parse(
-          Buffer.concat(chunks).toString("utf8"),
-        ) as Record<string, unknown>;
-        const text = requestText(body);
-        captured.push({ path: request.url ?? "", text });
-        response.setHeader("content-type", "application/json");
-        if (request.url?.includes(":countTokens")) {
+  it.each([
+    {
+      model: "gemini-embedding-001",
+      inputCodePoints: 1_100,
+      expectedCodePoints: 1_024,
+    },
+    {
+      model: "models/gemini-embedding-2",
+      inputCodePoints: 4_100,
+      expectedCodePoints: 4_096,
+    },
+  ])(
+    "counts with the real SDK and embeds only the provider-admitted Unicode prefix for $model",
+    async ({ model, inputCodePoints, expectedCodePoints }) => {
+      const captured: CapturedRequest[] = [];
+      const server = createServer((request, response) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => {
+          const body = JSON.parse(
+            Buffer.concat(chunks).toString("utf8"),
+          ) as Record<string, unknown>;
+          const text = requestText(body);
+          captured.push({ path: request.url ?? "", text });
+          response.setHeader("content-type", "application/json");
+          if (request.url?.includes(":countTokens")) {
+            response.end(
+              JSON.stringify({ totalTokens: Array.from(text).length * 2 }),
+            );
+            return;
+          }
+          if (
+            request.url?.includes(":embedContent") ||
+            request.url?.includes(":batchEmbedContents")
+          ) {
+            response.end(
+              JSON.stringify({
+                embeddings: [{ values: Array(768).fill(0.5) }],
+              }),
+            );
+            return;
+          }
+          response.statusCode = 404;
           response.end(
-            JSON.stringify({ totalTokens: Array.from(text).length * 2 }),
+            JSON.stringify({ error: { message: "unexpected route" } }),
           );
-          return;
-        }
-        if (
-          request.url?.includes(":embedContent") ||
-          request.url?.includes(":batchEmbedContents")
-        ) {
-          response.end(
-            JSON.stringify({
-              embeddings: [{ values: Array(768).fill(0.5) }],
-            }),
-          );
-          return;
-        }
-        response.statusCode = 404;
-        response.end(
-          JSON.stringify({ error: { message: "unexpected route" } }),
+        });
+      });
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+      );
+
+      try {
+        const { port } = server.address() as AddressInfo;
+        sdk.client = new GoogleGenAI({
+          apiKey: "deterministic-local-boundary-key",
+          httpOptions: { baseUrl: `http://127.0.0.1:${port}` },
+        });
+        const oversized = "😀".repeat(inputCodePoints);
+
+        const result = await handleTextEmbedding(
+          createRuntime(model),
+          oversized,
         );
-      });
-    });
-    await new Promise<void>((resolve) =>
-      server.listen(0, "127.0.0.1", resolve),
-    );
 
-    try {
-      const { port } = server.address() as AddressInfo;
-      sdk.client = new GoogleGenAI({
-        apiKey: "deterministic-local-boundary-key",
-        httpOptions: { baseUrl: `http://127.0.0.1:${port}` },
-      });
-      const oversized = "😀".repeat(1_100);
-
-      const result = await handleTextEmbedding(createRuntime(), oversized);
-
-      expect(result).toHaveLength(768);
-      expect(captured[0]).toMatchObject({
-        path: expect.stringContaining(":countTokens"),
-        text: oversized,
-      });
-      expect(captured.at(-1)?.path).toMatch(
-        /:embedContent|:batchEmbedContents/,
-      );
-      expect(captured.at(-2)?.path).toContain(":countTokens");
-      expect(captured.at(-2)?.text).toBe(captured.at(-1)?.text);
-      expect(Array.from(captured.at(-1)?.text ?? "")).toHaveLength(1_024);
-      expect(captured.at(-1)?.text).toBe("😀".repeat(1_024));
-    } finally {
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
-    }
-  });
+        expect(result).toHaveLength(768);
+        expect(captured[0]).toMatchObject({
+          path: expect.stringContaining(":countTokens"),
+          text: oversized,
+        });
+        expect(captured.at(-1)?.path).toMatch(
+          /:embedContent|:batchEmbedContents/,
+        );
+        expect(captured.at(-2)?.path).toContain(":countTokens");
+        expect(captured.at(-2)?.text).toBe(captured.at(-1)?.text);
+        expect(Array.from(captured.at(-1)?.text ?? "")).toHaveLength(
+          expectedCodePoints,
+        );
+        expect(captured.at(-1)?.text).toBe("😀".repeat(expectedCodePoints));
+        expect(
+          captured.every(({ path }) => !path.includes("models/models/")),
+        ).toBe(true);
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    },
+  );
 });

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -353,32 +353,41 @@ describe("Google GenAI embeddings", () => {
     expect(mocks.embedContent).not.toHaveBeenCalled();
   });
 
-  it("does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input", async () => {
-    // The same provider-tokenized input that exceeds the default model's 2,048
-    // limit remains below gemini-embedding-2's 8,192-token window.
-    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-2");
-    mocks.countEmbeddingTokens.mockImplementation(
-      async ({ contents }: { contents: string }) => ({
-        totalTokens: contents.length,
-      }),
-    );
-    const input = "a".repeat(3_000);
+  it.each(["gemini-embedding-2", "models/gemini-embedding-2"])(
+    "does NOT truncate a %s override to the smaller 2,048 limit for the same input",
+    async (model) => {
+      // The same provider-tokenized input that exceeds the default model's
+      // 2,048 limit remains below gemini-embedding-2's 8,192-token window.
+      mocks.getEmbeddingModel.mockReturnValue(model);
+      mocks.countEmbeddingTokens.mockImplementation(
+        async ({ contents }: { contents: string }) => ({
+          totalTokens: contents.length,
+        }),
+      );
+      const input = "a".repeat(3_000);
 
-    await handleTextEmbedding(createRuntime(), input);
+      await handleTextEmbedding(createRuntime(), input);
 
-    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
-    const passed = mocks.embedContent.mock.calls[0][0] as {
-      model: string;
-      contents: string;
-    };
-    expect(passed.model).toBe("gemini-embedding-2");
-    expect(passed.contents.length).toBe(3_000);
-  });
+      expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+      const passed = mocks.embedContent.mock.calls[0][0] as {
+        model: string;
+        contents: string;
+      };
+      expect(passed.model).toBe(model);
+      expect(passed.contents.length).toBe(3_000);
+      expect(
+        mocks.countEmbeddingTokens.mock.calls.every(
+          ([request]) => request.model === model,
+        ),
+      ).toBe(true);
+    },
+  );
 
   it("truncates an unmapped override to the safe 2,048-token default limit", async () => {
     // An override id not present in the limit map falls back to the safe 2,048
     // limit rather than inheriting the larger model's window.
-    mocks.getEmbeddingModel.mockReturnValue("some-unknown-embedding-model");
+    const model = "models/some-unknown-embedding-model";
+    mocks.getEmbeddingModel.mockReturnValue(model);
     mocks.countEmbeddingTokens.mockImplementation(
       async ({ contents }: { contents: string }) => ({
         totalTokens: contents.length,
@@ -388,7 +397,11 @@ describe("Google GenAI embeddings", () => {
 
     await handleTextEmbedding(createRuntime(), oversized);
 
-    const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
+    const passed = mocks.embedContent.mock.calls[0][0] as {
+      model: string;
+      contents: string;
+    };
+    expect(passed.model).toBe(model);
     expect(passed.contents.length).toBe(2_048);
   });
 

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -147,11 +147,18 @@ export const DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT = 2_048;
 
 /**
  * Resolve the documented input token limit for an embedding model id, falling
- * back to the safe default for unmapped overrides.
+ * back to the safe default for unmapped overrides. Google accepts either a
+ * bare model id or its `models/` resource name, so the optional resource prefix
+ * is ignored only for this local constraint lookup; callers still pass the
+ * configured model string unchanged to the SDK.
  */
 export function getEmbeddingInputTokenLimit(model: string): number {
+  const lookupModel = model.startsWith("models/")
+    ? model.slice("models/".length)
+    : model;
   return (
-    EMBEDDING_INPUT_TOKEN_LIMITS[model] ?? DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT
+    EMBEDDING_INPUT_TOKEN_LIMITS[lookupModel] ??
+    DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT
   );
 }
 


### PR DESCRIPTION
Closes #22095

## Summary

Completes the residual acceptance gap left after #22114: Google accepts embedding model identifiers as either bare IDs or `models/` resource names, but the local token-limit map previously recognized only the bare form. `models/gemini-embedding-2` therefore fell back to 2,048 tokens instead of its documented 8,192-token window.

This patch strips the optional `models/` prefix only for the local constraint lookup. The original configured model string remains unchanged for every provider `countTokens` and `embedContent` request. Unknown prefixed resources and non-Google publisher paths continue to use the conservative 2,048-token fallback.

## Exact-head evidence

Head: `01f1d8aa8de05731c0fadb2ed7988a4df16b4873`
Base: `e27ffd70564c8f2d69ac1dc705b011af71b7a2c6`

- Focused config, handler, and real local-SDK boundary: **33/33 passed**.
- Full package tests: **90 passed, 2 credentialed integration tests skipped**.
- Package typecheck: passed.
- Package Biome/lint: 32 files, passed.
- Node, browser, CJS, and declaration builds: passed.
- Guide parity and `git diff --check`: passed.

The real `@google/genai` client was pointed at a deterministic local HTTP server. For `models/gemini-embedding-2`, an 8,200-token Unicode input was provider-counted and truncated to exactly 8,192 tokens / 4,096 emoji before embedding. Captured SDK paths contained one `models/` segment, not `models/models/`. Handler-level assertions prove both `countTokens` and `embedContent` receive the original bare or qualified configured string unchanged.

## Evidence matrix

- Screenshots/video: N/A — provider admission logic only; no rendered UI.
- Backend/domain artifact: deterministic local SDK request paths and request bodies asserted in the owning tests.
- Live credentials: N/A — no provider/account mutation is needed; the real installed SDK is exercised against a local server.
- Model trajectory: N/A — no generation/prompt behavior changes.

## Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: `elizaOS/eliza@e27ffd70564c8f2d69ac1dc705b011af71b7a2c6:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

— [codex-cortex-security]
<!-- evidence-head:01f1d8aa8de05731c0fadb2ed7988a4df16b4873 -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e27ffd70564c8f2d69ac1dc705b011af71b7a2c6:packages/skills/skills/contribute-to-eliza"} -->