### PR TITLE
fix(cloud): make telegram connector chunking terminate

### DIFF
--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -267,10 +267,46 @@ async function telegramApi<T>(
   return data.result as T;
 }
 
+function assertValidTelegramChunkLength(maxLength: number): void {
+  if (
+    !Number.isFinite(maxLength) ||
+    !Number.isInteger(maxLength) ||
+    maxLength < 2
+  ) {
+    throw new RangeError(
+      "maxLength must be a finite integer of at least 2 UTF-16 code units",
+    );
+  }
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
+/**
+ * `text.slice(0, maxLength)` that never ends on the lead half of a surrogate
+ * pair. Combined with {@link assertValidTelegramChunkLength}, the chunk loop
+ * always consumes at least one code unit.
+ */
+function truncateWellFormedTelegram(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  const end =
+    isHighSurrogate(text.charCodeAt(maxLength - 1)) &&
+    isLowSurrogate(text.charCodeAt(maxLength))
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+}
+
 export function splitTelegramMessage(
   text: string,
   maxLength = MAX_MESSAGE_LENGTH,
 ): string[] {
+  assertValidTelegramChunkLength(maxLength);
   const chunks: string[] = [];
   if (!text) return chunks;
   let current = "";
@@ -286,8 +322,12 @@ export function splitTelegramMessage(
     }
     let remaining = line;
     while (remaining.length > maxLength) {
-      chunks.push(remaining.slice(0, maxLength));
-      remaining = remaining.slice(maxLength);
+      const head = truncateWellFormedTelegram(remaining, maxLength);
+      if (head.length === 0) {
+        throw new RangeError("telegram chunk limit made no UTF-16 progress");
+      }
+      chunks.push(head);
+      remaining = remaining.slice(head.length);
     }
     current = remaining;
   }

--- a/packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts
@@ -45,6 +45,22 @@ describe("splitTelegramMessage surrogate-safe chunking", () => {
     }
   });
 
+  test("rejects a zero limit immediately instead of spinning", () => {
+    const started = performance.now();
+    expect(() => splitTelegramMessage("hello", 0)).toThrow(RangeError);
+    expect(performance.now() - started).toBeLessThan(100);
+  });
+
+  test("backs off an odd limit so a straddling emoji stays well-formed", () => {
+    const text = `${"x".repeat(4)}😀${"y".repeat(4)}`;
+    const chunks = splitTelegramMessage(text, 5);
+    expect(chunks.join("")).toBe(text);
+    expect(chunks.every((chunk) => chunk.length > 0 && chunk.length <= 5)).toBe(
+      true,
+    );
+    expect(chunks.every((chunk) => chunk.toWellFormed() === chunk)).toBe(true);
+  });
+
   test("still splits ASCII lines at the default Telegram limit", () => {
     const chunks = splitTelegramMessage(`${"a".repeat(4096)}\nb`);
     expect(chunks).toEqual(["a".repeat(4096), "b"]);

--- a/packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Deterministic tests for Telegram connector chunk limits: lone-surrogate
+ * slices and non-advancing maxLength used to hang or emit ill-formed UTF-16.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { splitTelegramMessage } from "../src/telegram-connector";
+
+const INVALID_LIMITS = [
+  1,
+  0,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.NEGATIVE_INFINITY,
+];
+
+describe("splitTelegramMessage surrogate-safe chunking", () => {
+  test("keeps surrogate pairs intact across the Telegram 4096-unit limit", () => {
+    const text = `a${"🙂".repeat(4096)}`;
+    const chunks = splitTelegramMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.toWellFormed()).toBe(chunk);
+    }
+  });
+
+  test("makes nonempty, lossless progress at the minimum limit", () => {
+    const text = "😀😀x";
+    const chunks = splitTelegramMessage(text, 2);
+    expect(chunks.join("")).toBe(text);
+    expect(chunks.every((chunk) => chunk.length > 0 && chunk.length <= 2)).toBe(
+      true,
+    );
+    expect(chunks.every((chunk) => chunk.toWellFormed() === chunk)).toBe(true);
+  });
+
+  test("rejects unsafe chunk limits before splitting", () => {
+    for (const limit of INVALID_LIMITS) {
+      expect(() => splitTelegramMessage("😀x", limit)).toThrow(RangeError);
+    }
+  });
+
+  test("still splits ASCII lines at the default Telegram limit", () => {
+    const chunks = splitTelegramMessage(`${"a".repeat(4096)}\nb`);
+    expect(chunks).toEqual(["a".repeat(4096), "b"]);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #22264.

Owning issue for the Cloud Telegram connector hang / lone-surrogate slice
on `splitTelegramMessage`. Distinct from closed `plugin-telegram` #22203
and from #22250 (`packages/cloud/shared`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and was rebased onto `origin/develop` `b5f6de93355b`
      with zero conflicts.
- [x] Owning-package tests and Biome were run at this exact head.
- [x] A reviewer can confirm the change from the red/green probes below
      without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux (fix commit); Cursor (CR tests, issue, this body)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `b5f6de93355b0cc18bad42971861b9e431110d81` with zero conflicts.
- [x] Exact-head package suite and Biome recorded below.

# Risks

Low. Fail-closed `RangeError` on non-integer / `< 2` chunk limits. Default
Telegram send path still uses 4096. ASCII split at 4096 is unchanged. Package
stays dependency-free.

# Background

## What does this PR do?

`splitTelegramMessage` is the chunker used by `sendTelegramReply` on the
Cloudflare edge and Railway gateway Telegram paths
(`@elizaos/cloud-services-common/telegram-connector`). On `origin/develop` it
sliced UTF-16 by `maxLength`, so a long emoji line emitted lone surrogates.
`maxLength <= 0` never advanced `remaining` and hung (2s alarm → exit 142).

This PR rejects unsafe limits (`finite integer >= 2`) and truncates on
surrogate-pair boundaries so the loop always makes progress. Helpers stay
local so the package remains dependency-free. The CR head also proves a
zero-limit throw finishes immediately and an odd cut does not tear a pair.

This is not `#22250` (`packages/cloud/shared` helpers). Those files do not
serve this connector. Gateway-webhook and `eliza-app/webhook/_telegram-edge`
import this module.

## What kind of change is this?

Bug fix (non-breaking for the default 4096 send path; invalid caller limits
now throw instead of hanging).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts`
and `bun run --cwd packages/cloud/services/_common test`.

## Detailed testing steps

At exact head `3b9c906d0eab49812d548fb5adce326a1813b768`.

On `origin/develop` `b5f6de93355b0cc18bad42971861b9e431110d81` the live
function still uses `remaining.slice(0, maxLength)`:

```text
splitTelegramMessage("a" + "🙂".repeat(4096), 4096)
# SURROGATE_SPLIT true; last codes ["de42"]

perl -e 'alarm 2; exec @ARGV' bun -e 'splitTelegramMessage("hello", 0)'
# hang_probe_exit=142
```

After this head:

```text
bun run --cwd packages/cloud/services/_common test
# 29 pass / 0 fail / 75 expect() / 5 files

bun run --cwd packages/cloud/services/_common lint:check
# Checked 15 files. No fixes applied.

bunx tsc --noEmit --ignoreConfig --strict packages/cloud/services/_common/src/telegram-connector.ts
# exit 0

splitTelegramMessage("hello", 0) → RangeError in <100ms
splitTelegramMessage("xxxx😀yyyy", 5) well-formed and lossless
splitTelegramMessage("a"+"🙂".repeat(4096), 4096)
# SURROGATE_SPLIT false; joinOk true
```

Changed-file SHA-256 at this head:

- `packages/cloud/services/_common/src/telegram-connector.ts`
  `228feefde861dfecbb105306a465085e265e1ff5c9363f4d4bd04e435099dd3c`
- `packages/cloud/services/_common/tests/telegram-connector-chunking.test.ts`
  `ced61f912bce755ea8dbfe4dcadd6fe9ca09e20b291cada5c072125285c74074`

# Evidence Gate

<!-- evidence-head:3b9c906d0eab49812d548fb5adce326a1813b768 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; connector chunker only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; connector chunker only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; hang/split proved by the probes and package tests.
<!-- evidence-row:backend-logs -->
- [x] Exact-head package suite 29/29, Biome clean, isolated source tsc, red/green probes.

```text
$ bun run --cwd packages/cloud/services/_common test
29 pass / 0 fail / 75 expect() / 5 files
$ bun run --cwd packages/cloud/services/_common lint:check
Checked 15 files in 72ms. No fixes applied.
$ bunx tsc --noEmit --ignoreConfig --strict packages/cloud/services/_common/src/telegram-connector.ts
exit 0
develop hang_probe_exit=142
head LIMIT0_THREW RangeError
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt provider or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head chunker output vs origin/develop on the same emoji line.

```text
origin/develop splitTelegramMessage("a"+"🙂"*4096, 4096)
SURROGATE_SPLIT true lastCodes ["de42"] joinOk true chunkCount 3
exact-head 3b9c906d0eab49812d548fb5adce326a1813b768
SURROGATE_SPLIT false joinOk true; zero-limit throw <100ms; odd limit 5 well-formed
ASCII default split: ["a"*4096, "b"]
```
<!-- evidence-row:ocr-review -->
- [x] N/A - final diff has no rendered visual surface.

# Evidence Details

## Backend + domain artifact

Red (develop `splitTelegramMessage` body): emoji line produces a lone
low-surrogate tail (`de42`) and `maxLength=0` does not return within 2s.

Green (this head): same emoji line is well-formed and lossless; invalid
limits throw before the loop; odd limit 5 does not tear a pair; package
suite 29/29.

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Screenshots + video

N/A - final diff contains no rendered UI changes.

## Known gaps / failures

- Root `bun run verify` was not run; this worktree has no workspace
  `node_modules`. The owning package test, Biome, and isolated source
  `tsc --strict` are the contract for `@elizaos/cloud-services-common`.
- Package `tsc --noEmit` via `bunx tsc --ignoreConfig` on the test file
  fails for missing `bun:test` types. Isolated source typecheck is clean.
- Disposable `review-sandbox.sh` was started (`oven/bun:1.3.14`,
  `--network=none` intended). The full-tree archive hit `No space left
  on device` after the trusted lockfile install. Independent execution
  of the untrusted full tree in that container did not complete. Host
  package suite + Biome + source tsc at this SHA are what ran.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->