### PR TITLE
fix: deduplicate completed-action navigation fallback

### DIFF
--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -221,6 +221,30 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     );
   });
 
+  it("keeps the completed-action fallback when targeted delivery throws", async () => {
+    const { ctx, json, error, broadcastWs, broadcastWsToClientId } =
+      makeNavigateCtx("notes", {
+        clientId: "closing-rest-client",
+        delivery: "completed-action",
+      });
+    broadcastWsToClientId.mockImplementation(() => {
+      throw new Error("socket closed during targeted send");
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        ok: true,
+        viewId: "notes",
+        completedActionDelivered: false,
+      }),
+    );
+  });
+
   it("delivers app-chat navigation only to its originating client", async () => {
     const { ctx, broadcastWs, broadcastWsToClientId } = makeNavigateCtx(
       "browser",

--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -195,7 +195,26 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     });
     expect(json).toHaveBeenCalledWith(
       ctx.res,
-      expect.objectContaining({ ok: true, viewId: "calendar" }),
+      expect.objectContaining({
+        ok: true,
+        viewId: "calendar",
+        completedActionDelivered: false,
+      }),
+    );
+  });
+
+  it("reports when the originating renderer accepted completed-action delivery", async () => {
+    const { ctx, json, broadcastWsToClientId } = makeNavigateCtx("calendar", {
+      clientId: "seeker-rest-client",
+      delivery: "completed-action",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWsToClientId).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ completedActionDelivered: true }),
     );
     expect(broadcastWsToClientId.mock.invocationCallOrder[0]).toBeLessThan(
       json.mock.invocationCallOrder[0],

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -1216,6 +1216,7 @@ export async function handleViewsRoutes(
     // recovers the switch when this best-effort delivery misses).
     const shouldTargetCompletedAction =
       body?.delivery === "completed-action" && Boolean(originatingClientId);
+    let completedActionDelivered = false;
     if (
       reportedSource !== "user" &&
       (!callerOwnedDelivery || shouldTargetCompletedAction)
@@ -1238,6 +1239,10 @@ export async function handleViewsRoutes(
           originatingClientId,
           frame,
         );
+        completedActionDelivered =
+          shouldTargetCompletedAction &&
+          typeof delivered === "number" &&
+          delivered > 0;
         if (
           !shouldTargetCompletedAction &&
           (delivered === undefined || delivered <= 0)
@@ -1264,6 +1269,7 @@ export async function handleViewsRoutes(
       ...(alwaysOnTop ? { alwaysOnTop } : {}),
       ...layoutPayload,
       ...deepLinkPayload,
+      ...(shouldTargetCompletedAction ? { completedActionDelivered } : {}),
     });
     return true;
   }

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -1235,10 +1235,22 @@ export async function handleViewsRoutes(
       };
       const frame = createShellNavigateViewWsFrame(navigatePayload);
       if (originatingClientId) {
-        const delivered = ctx.broadcastWsToClientId?.(
-          originatingClientId,
-          frame,
-        );
+        let delivered: number | undefined;
+        if (shouldTargetCompletedAction) {
+          try {
+            delivered = ctx.broadcastWsToClientId?.(originatingClientId, frame);
+          } catch (err) {
+            // error-policy:J4 the terminal completed-action result remains the
+            // visible, caller-scoped navigation fallback when this optional
+            // early WebSocket optimization fails unexpectedly.
+            logger.warn(
+              { src: "ViewsRoutes", err, viewId: id },
+              "[ViewsRoutes] Early completed-action navigation delivery failed",
+            );
+          }
+        } else {
+          delivered = ctx.broadcastWsToClientId?.(originatingClientId, frame);
+        }
         completedActionDelivered =
           shouldTargetCompletedAction &&
           typeof delivered === "number" &&

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -869,6 +869,41 @@ describe("useChatSend action handoff", () => {
     window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
   });
 
+  it("does not repeat navigation already delivered to the originating renderer", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Opening Calendar.",
+      completed: true,
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: {
+            mode: "show",
+            viewId: "calendar",
+            completedActionDelivered: true,
+          },
+        },
+      ],
+    });
+    const navigations: CustomEvent[] = [];
+    const onNavigate = (event: Event) => navigations.push(event as CustomEvent);
+    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("open calendar", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(navigations).toHaveLength(0);
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+  });
+
   it("invalidates mounted views after a successful REST-streamed action", async () => {
     mocks.client.sendConversationMessageStream.mockResolvedValue({
       text: 'Created sticky note "LP3 Demo Proof".',

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -114,14 +114,17 @@ async function handoffCompletedAction(
       "agent",
     );
   }
-  if (findViewActionHandoff(actionResults)) {
+  const viewHandoff = findViewActionHandoff(actionResults);
+  if (viewHandoff) {
     // The completed stream result is scoped to this exact caller and contains
     // the validated target returned by the successful VIEWS action. Dispatch it
     // directly instead of consulting process-global `/api/views/current`, which
     // can belong to another device and is unavailable to REST-only native
     // renderers. The shell resolves the canonical path from the view id.
     try {
-      dispatchViewActionHandoffDirect(actionResults);
+      if (!viewHandoff.completedActionDelivered) {
+        dispatchViewActionHandoffDirect(actionResults);
+      }
     } catch (err) {
       // error-policy:J4 the chat turn succeeded, so preserve it while surfacing a
       // distinct navigation failure instead of fabricating an opened view.

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -56,6 +56,20 @@ describe("view action handoff", () => {
     ).toEqual({ viewId: "calendar" });
   });
 
+  it("preserves a confirmed originating-renderer delivery marker", () => {
+    expect(
+      findViewActionHandoff([
+        {
+          ...showCalendar,
+          values: {
+            ...showCalendar.values,
+            completedActionDelivered: true,
+          },
+        },
+      ]),
+    ).toEqual({ viewId: "calendar", completedActionDelivered: true });
+  });
+
   it("dispatches the canonical current view when WebSockets are unavailable", async () => {
     const dispatch = vi.fn();
 

--- a/packages/ui/src/view-action-handoff.ts
+++ b/packages/ui/src/view-action-handoff.ts
@@ -33,6 +33,7 @@ export interface ViewActionHandoff {
   viewId: string;
   viewPath?: string;
   subview?: string;
+  completedActionDelivered?: true;
 }
 
 function readString(value: unknown): string | undefined {
@@ -60,6 +61,9 @@ export function findViewActionHandoff(
         viewId,
         ...(viewPath ? { viewPath } : {}),
         ...(subview ? { subview } : {}),
+        ...(result.values?.completedActionDelivered === true
+          ? { completedActionDelivered: true }
+          : {}),
       };
     }
   }

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -374,6 +374,8 @@ interface NavigateResult {
 	text: string;
 	/** Resolved sub-section the renderer was asked to focus (settings only). */
 	subview?: string;
+	/** The server synchronously accepted delivery to the originating renderer. */
+	completedActionDelivered?: true;
 }
 
 /**
@@ -431,12 +433,20 @@ async function navigateToView(
 		);
 		const sectionSuffix = resolvedSubview ? ` — ${resolvedSubview}` : "";
 		const openedText = `Opened ${navigationLabel}${sectionSuffix}.`;
-		if (resp.ok)
+		if (resp.ok) {
+			const responseBody = (await resp.json().catch(() => null)) as Record<
+				string,
+				unknown
+			> | null;
 			return {
 				ok: true,
 				text: openedText,
 				subview: resolvedSubview,
+				...(responseBody?.completedActionDelivered === true
+					? { completedActionDelivered: true as const }
+					: {}),
 			};
+		}
 		// 501/404 = navigation route unsupported by this shell; opening succeeds.
 		if (resp.status === 501 || resp.status === 404)
 			return {
@@ -605,6 +615,9 @@ export async function runViewsShow({
 			viewType: view.viewType ?? viewType ?? "gui",
 			label: navigationLabel,
 			...(result.subview ? { subview: result.subview } : {}),
+			...(result.completedActionDelivered
+				? { completedActionDelivered: true }
+				: {}),
 		},
 		data: { view, ...(result.subview ? { subview: result.subview } : {}) },
 	};

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -407,12 +407,18 @@ describe("view switching — VIEWS action resolver", () => {
 
 		it("targets app-chat navigation to the client that sent the turn", async () => {
 			installNavigateCapture();
+			vi.mocked(globalThis.fetch).mockResolvedValue({
+				ok: true,
+				status: 200,
+				text: async () => "",
+				json: async () => ({ ok: true, completedActionDelivered: true }),
+			} as Response);
 			const action = createViewsAction({
 				client: clientFor(REGISTRY),
 				hasOwnerAccess: vi.fn(async () => true),
 			});
 
-			await action.handler(
+			const result = await action.handler(
 				{ agentId: "agent-1" } as never,
 				{
 					...message("open calendar"),
@@ -434,6 +440,7 @@ describe("view switching — VIEWS action resolver", () => {
 				clientId: "seeker-client",
 				delivery: "completed-action",
 			});
+			expect(result?.values).toMatchObject({ completedActionDelivered: true });
 		});
 
 		it("resolves an explicit view option without verb parsing", async () => {


### PR DESCRIPTION
Closes #22266. Follow-up to #22239 / #22245.

## What changed

- Records whether the early completed-action navigation reached at least one targeted socket.
- Propagates that marker through the app-control action result and UI handoff boundary.
- Suppresses the terminal navigation only after confirmed early delivery, preventing duplicate navigation.
- Retains terminal caller-scoped fallback when delivery reports zero or throws.
- Keeps ordinary originating-client navigation strict.

## Exact-head validation

Head: `4c7c785cda4e4e088e29bda83b28a640ea42d411`

- `bunx vitest run packages/agent/src/api/views-routes.navigate-broadcast.test.ts` — 23 passed
- `bunx vitest run packages/ui/src/view-action-handoff.test.ts packages/ui/src/state/useChatSend.test.tsx` — 95 passed
- `bunx vitest run plugins/plugin-app-control/src/actions/views-switching.test.ts` — 186 passed
- `bunx @biomejs/biome@2.5.7 check <8 affected files>` — passed
- `git diff --check origin/develop...HEAD` — passed

The real browser timing artifacts attached to #22245 establish the underlying successful early-navigation path. This corrective change adds deterministic coverage for the newly identified delivery/deduplication boundary; it does not alter the successful event ordering.

## Provenance

Preserves the post-review repair authored in `7f09e763` and adds the synchronous-send fallback correction discovered during independent exact-head review.
