### PR TITLE
fix(cloud): model browser origin in cookie-auth e2e

### DIFF
--- a/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
+++ b/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
@@ -69,6 +69,9 @@ describe("e2e _helpers isLocalTarget", () => {
     expect(
       sameOriginBrowserHeaders({ Origin: "https://attacker.example" }),
     ).toEqual({ Origin: "https://attacker.example" });
+    expect(
+      sameOriginBrowserHeaders({ origin: "https://attacker.example" }),
+    ).toEqual({ origin: "https://attacker.example" });
   });
 
   test("does not add Origin to ordinary API helper requests", async () => {

--- a/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
+++ b/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
@@ -1,6 +1,11 @@
 // Exercises cloud API tests e2e helpers local target.test behavior with deterministic Worker route fixtures.
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { getBaseUrl, isLocalTarget } from "../test/e2e/_helpers/api";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  api,
+  getBaseUrl,
+  isLocalTarget,
+  sameOriginBrowserHeaders,
+} from "../test/e2e/_helpers/api";
 
 /**
  * Pins the shared isLocalTarget() e2e helper (test/e2e/_helpers/api.ts) that
@@ -47,5 +52,34 @@ describe("e2e _helpers isLocalTarget", () => {
   ])("false for deployed/lookalike target %s", (baseUrl) => {
     process.env.TEST_API_BASE_URL = baseUrl;
     expect(isLocalTarget()).toBe(false);
+  });
+
+  test("adds the configured target origin only when explicitly requested", () => {
+    process.env.TEST_API_BASE_URL = "https://staging-api.elizacloud.ai/api";
+
+    expect(sameOriginBrowserHeaders({ Cookie: "session=test" })).toEqual({
+      Origin: "https://staging-api.elizacloud.ai",
+      Cookie: "session=test",
+    });
+  });
+
+  test("preserves an explicit cross-origin value for negative coverage", () => {
+    process.env.TEST_API_BASE_URL = "https://staging-api.elizacloud.ai";
+
+    expect(
+      sameOriginBrowserHeaders({ Origin: "https://attacker.example" }),
+    ).toEqual({ Origin: "https://attacker.example" });
+  });
+
+  test("does not add Origin to ordinary API helper requests", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    await api.post("/api/csrf-negative", { test: true });
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(new Headers(requestInit?.headers).has("Origin")).toBe(false);
+    fetchSpy.mockRestore();
   });
 });

--- a/packages/cloud/api/test/e2e/_helpers/api.ts
+++ b/packages/cloud/api/test/e2e/_helpers/api.ts
@@ -38,6 +38,22 @@ export function url(path: string): string {
 }
 
 /**
+ * Adds the Origin a browser sends for a same-origin request.
+ *
+ * This is deliberately opt-in so CSRF tests can continue exercising missing
+ * and hostile origins. Explicit caller headers win, including an intentional
+ * cross-origin Origin used by negative coverage.
+ */
+export function sameOriginBrowserHeaders(
+  headers: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    Origin: new URL(getBaseUrl()).origin,
+    ...headers,
+  };
+}
+
+/**
  * True when the e2e target is a LOCAL dev Worker (which shares our `.env`, so
  * INTERNAL_SECRET / test-only routes line up). Against a DEPLOYED target
  * (staging/prod) the Worker's INTERNAL_SECRET is a server-side secret we can't

--- a/packages/cloud/api/test/e2e/_helpers/api.ts
+++ b/packages/cloud/api/test/e2e/_helpers/api.ts
@@ -47,6 +47,9 @@ export function url(path: string): string {
 export function sameOriginBrowserHeaders(
   headers: Record<string, string> = {},
 ): Record<string, string> {
+  if (Object.keys(headers).some((name) => name.toLowerCase() === "origin")) {
+    return { ...headers };
+  }
   return {
     Origin: new URL(getBaseUrl()).origin,
     ...headers,

--- a/packages/cloud/api/test/e2e/agent-token-flow.test.ts
+++ b/packages/cloud/api/test/e2e/agent-token-flow.test.ts
@@ -28,6 +28,7 @@ import {
   exchangeApiKeyForSession,
   getBaseUrl,
   isServerReachable,
+  sameOriginBrowserHeaders,
 } from "./_helpers/api";
 
 const serverReachable = await isServerReachable();
@@ -126,7 +127,7 @@ describeE2E("Foundation: agent token flow", () => {
         description: "Foundation e2e test — created and revoked in afterAll.",
         rate_limit: 60,
       },
-      { headers: { Cookie: sessionCookie } },
+      { headers: sameOriginBrowserHeaders({ Cookie: sessionCookie }) },
     );
 
     expect(createRes.status).toBe(201);


### PR DESCRIPTION
Follow-up source repair for the protected staging acceptance path tracked in #22183. This PR does not close that issue.

## Why

Cloud CF Deploy run [32191021391](https://github.com/elizaOS/eliza/actions/runs/32191021391) passed database migrations, then stopped in `agent-token-flow.test.ts`: its Node client used an ambient session cookie for `POST /api/v1/api-keys` without the `Origin` that a same-origin browser supplies, so the fail-closed CSRF guard correctly returned 403.

## Change

- Add an explicit opt-in `sameOriginBrowserHeaders()` E2E helper.
- Use it only for the browser-semantic session-cookie API-key creation step.
- Preserve explicit caller `Origin` overrides case-insensitively, including hostile origins used by negative coverage.
- Keep ordinary `api.*` requests unchanged, so missing-Origin CSRF coverage remains real.

No Worker guard, workflow, database, protected environment, or deployment is changed.

## Independent exact-head evidence

<!-- evidence-head:36ecfabca97372c1e6ff71e52df84fa2995913eb -->

Head: `36ecfabca97372c1e6ff71e52df84fa2995913eb`
Base: `develop@6ac9ca350e7630d871d51f6050d2a39a6533a793`

- [x] Helper contract suite: 13 passed, 0 failed.
- [x] Same-origin derivation strips a configured path to the URL origin.
- [x] Explicit `Origin` and lowercase `origin` overrides win.
- [x] Raw `api.post` still omits Origin.
- [x] Cloud API standalone TypeScript check passes.
- [x] Biome over all three changed files and diff integrity pass.
- [x] No deployment, database, credential, or protected-resource mutation performed.

The next protected staging deployment remains an owner-authorized operational gate. #22183 must remain open until that deployment succeeds and its exact receipt is attached.

## Provenance

AI provider/model: OpenAI / gpt-5.6-sol

Client / agent tooling: Codex Desktop

Contribution skill revision: elizaOS/eliza@6ac9ca350e7630d871d51f6050d2a39a6533a793:packages/skills/skills/contribute-to-eliza

Attribution status: self-reported

— [codex/pr22269-independent-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6ac9ca350e7630d871d51f6050d2a39a6533a793:packages/skills/skills/contribute-to-eliza"} -->
