### PR TITLE
fix(app): resolve packaged branding from typed boot config

### DIFF
--- a/packages/app/src/cloud-only-branding.test.ts
+++ b/packages/app/src/cloud-only-branding.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exercises the deterministic pre-render branding resolver with real shared
+ * cloud-only policy and literal packaged, hosted, and compatibility inputs.
+ */
+import {
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/ui/config";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveAppCloudOnlyBranding } from "./cloud-only-branding";
+
+afterEach(() => {
+  setBootConfig(DEFAULT_BOOT_CONFIG);
+});
+
+describe("resolveAppCloudOnlyBranding", () => {
+  it("uses the packaged desktop typed boot API base", () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      apiBase: "http://127.0.0.1:56120",
+    });
+
+    expect(
+      resolveAppCloudOnlyBranding({
+        isDev: false,
+        bootApiBase: getBootConfig().apiBase,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps production hosted web cloud-only without an injected backend", () => {
+    expect(resolveAppCloudOnlyBranding({ isDev: false })).toBe(true);
+  });
+
+  it("preserves the legacy branded-global API-base fallback", () => {
+    expect(
+      resolveAppCloudOnlyBranding({
+        isDev: false,
+        legacyInjectedApiBase: "http://127.0.0.1:31337",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps explicit desktop cloud mode authoritative over a boot API base", () => {
+    expect(
+      resolveAppCloudOnlyBranding({
+        isDev: false,
+        bootApiBase: "http://127.0.0.1:31337",
+        desktopRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/app/src/cloud-only-branding.ts
+++ b/packages/app/src/cloud-only-branding.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolves the app shell's cloud-only brand from pre-render boot inputs.
+ * Packaged desktop builds seed the typed boot config before renderer modules
+ * evaluate; legacy branded globals remain a compatibility fallback.
+ */
+import { shouldUseCloudOnlyBranding } from "@elizaos/shared";
+
+export interface AppCloudOnlyBrandingInputs {
+  isDev: boolean;
+  bootApiBase?: string | null;
+  legacyInjectedApiBase?: string | null;
+  isNativePlatform?: boolean;
+  nativeRuntimeMode?: string | null;
+  desktopRuntimeMode?: string | null;
+}
+
+export function resolveAppCloudOnlyBranding(
+  inputs: AppCloudOnlyBrandingInputs,
+): boolean {
+  const bootApiBase = inputs.bootApiBase?.trim();
+  const legacyInjectedApiBase = inputs.legacyInjectedApiBase?.trim();
+
+  return shouldUseCloudOnlyBranding({
+    isDev: inputs.isDev,
+    injectedApiBase: bootApiBase || legacyInjectedApiBase,
+    isNativePlatform: inputs.isNativePlatform,
+    nativeRuntimeMode: inputs.nativeRuntimeMode,
+    desktopRuntimeMode: inputs.desktopRuntimeMode,
+  });
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -89,7 +89,6 @@ import {
   type AppBootConfig,
   getBootConfig,
   setBootConfig,
-  shouldUseCloudOnlyBranding,
 } from "@elizaos/ui/config";
 import {
   AGENT_READY_EVENT,
@@ -187,6 +186,7 @@ import { renderBootFailure } from "./boot-failure";
 import { startVoiceModuleLoad } from "./boot-voice-load";
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
+import { resolveAppCloudOnlyBranding } from "./cloud-only-branding";
 import { isTrustedAppLink } from "./deep-link-handler";
 import {
   buildAssistantLaunchHashRoute,
@@ -374,7 +374,7 @@ function isShareTargetQueue(value: unknown): value is ShareTargetPayload[] {
   return Array.isArray(value);
 }
 
-function getInjectedAppApiBase(): string | undefined {
+function getLegacyInjectedAppApiBase(): string | undefined {
   const brandedApiBase: unknown = Reflect.get(
     window,
     BRANDED_WINDOW_KEYS.apiBase,
@@ -408,15 +408,16 @@ function getInjectedDesktopRuntimeMode(): string | undefined {
 const APP_BRANDING: Partial<BrandingConfig> = {
   ...APP_BRANDING_BASE,
   theme: ELIZA_DEFAULT_THEME,
-  // The hosted web bundle stays cloud-only in production. Desktop shells and
-  // other hosts inject an explicit API base before React boots, and that host
-  // backend should control first-run capabilities instead — UNLESS the desktop
-  // shell explicitly opted into cloud-only mode (desktopRuntimeMode === "cloud"),
-  // which forces cloud-only regardless of the injected loopback proxy base.
-  cloudOnly: shouldUseCloudOnlyBranding({
+  // The hosted web bundle stays cloud-only in production. Desktop shells seed
+  // the typed boot config before renderer modules evaluate (with the branded
+  // window key retained as a legacy fallback), and that host backend should
+  // control first-run capabilities instead — UNLESS the desktop shell explicitly
+  // opted into cloud-only mode, which remains authoritative over a loopback base.
+  cloudOnly: resolveAppCloudOnlyBranding({
     isDev: import.meta.env.DEV ?? false,
-    injectedApiBase:
-      typeof window === "undefined" ? undefined : getInjectedAppApiBase(),
+    bootApiBase: getBootConfig().apiBase,
+    legacyInjectedApiBase:
+      typeof window === "undefined" ? undefined : getLegacyInjectedAppApiBase(),
     isNativePlatform: Capacitor.isNativePlatform(),
     desktopRuntimeMode: getInjectedDesktopRuntimeMode(),
   }),


### PR DESCRIPTION
# Relates to

Closes #21880.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Focused typed-store behavior, Biome, and diff checks pass at the exact head.
- [ ] Packaged Electrobun and app visual evidence still require an independent machine with sufficient disk/runtime-copy capacity.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `develop@6ac9ca350e763`; zero conflicts.
- [x] Exact candidate head: `d0eed105b96b1`.

# Risks

The change is limited to pre-render branding selection. Explicit desktop cloud mode still wins, hosted production web remains cloud-only, and both legacy API-base globals remain supported. The new resolver reads the typed boot-config API base that Electrobun already injects before renderer evaluation.

# Background

## What does this PR do?

Packaged Electrobun injects `apiBase` into the canonical `AppBootConfig` mirror and symbol store, but `main.tsx` previously decided `branding.cloudOnly` from removed legacy globals only. A fresh packaged profile therefore entered the Cloud authentication pill state even though its local/external API base was present.

This PR moves the decision into a small deterministic resolver. `main.tsx` passes `getBootConfig().apiBase` first and retains the branded/global API-base value as a compatibility fallback. The shared policy still makes explicit `desktopRuntimeMode: "cloud"` authoritative.

## What kind of change is this?

Bug fix.

# Testing

## Where should a reviewer start?

- `packages/app/src/cloud-only-branding.ts`
- `packages/app/src/cloud-only-branding.test.ts`
- the `APP_BRANDING.cloudOnly` wiring in `packages/app/src/main.tsx`

## Exact-head checks

```
bun test --config=/dev/null packages/app/src/cloud-only-branding.test.ts
4 pass, 0 fail, 4 assertions

bunx biome check packages/app/src/main.tsx packages/app/src/cloud-only-branding.ts packages/app/src/cloud-only-branding.test.ts
Checked 3 files. No fixes applied.

git diff --check origin/develop...HEAD
clean
```

`bun run --cwd packages/app typecheck` reaches one unrelated sparse-checkout baseline error in untouched `packages/cloud/shared/src/lib/utils/logger.ts`: its `@elizaos/core/edge` alias is absent from the app typecheck paths. No diagnostic references any changed file.

# Evidence Gate

<!-- evidence-head:d0eed105b96b1 -->

<!-- evidence-row:before-screenshots -->
- [x] The issue contains the packaged pre-fix runtime artifact: typed boot `apiBase` present while the pill remains `Sign in with Eliza Cloud`.
<!-- evidence-row:after-screenshots -->
- [ ] Blocked - exact-head packaged build/capture is not safe with the host Data volume at 1.7 GiB free.
<!-- evidence-row:walkthrough-video -->
- [ ] Blocked - requires the exact packaged Electrobun app.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic resolver run is included above: 4/4 passed.
<!-- evidence-row:frontend-logs -->
- [ ] Blocked - requires exact packaged renderer execution.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real typed boot-store test proves packaged API base => non-cloud brand; hosted web => cloud-only; legacy base => non-cloud; explicit desktop cloud => cloud-only.
<!-- evidence-row:ocr-review -->
- [ ] Blocked - `audit:app`/packaged OCR requires an exact build and sufficient disk.

## Known gaps / failures

- The load-bearing `electrobun-bottom-bar.e2e.spec.ts` and `audit:app` remain pending. The issue already documents the nightly runtime-copy build failure; this host additionally has insufficient free disk for a safe fresh desktop package.
- This PR is intentionally draft until an independent reviewer runs those exact-head packaged gates or supplies an equivalent isolated execution artifact.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->