### PR TITLE
fix(ui): preserve non-ok response abort identity

### DIFF
--- a/packages/ui/src/api/client-base-body-lifecycle.test.ts
+++ b/packages/ui/src/api/client-base-body-lifecycle.test.ts
@@ -1,5 +1,5 @@
 /** Verifies JSON response-body deadlines and caller cancellation with a real ReadableStream and stubbed transport. */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ElizaClient } from "./client-base";
 import { ApiError } from "./client-types";
 import type { AgentRequestTransport } from "./transport";
@@ -10,7 +10,7 @@ function makeClient(request: AgentRequestTransport["request"]): ElizaClient {
   return client;
 }
 
-function makeStalledResponse() {
+function makeStalledResponse(status = 200) {
   let markReadStarted: (() => void) | undefined;
   const readStarted = new Promise<void>((resolve) => {
     markReadStarted = resolve;
@@ -29,13 +29,17 @@ function makeStalledResponse() {
     cancel,
     readStarted,
     response: new Response(body, {
-      status: 200,
+      status,
       headers: { "content-type": "application/json" },
     }),
   };
 }
 
 describe("ElizaClient JSON response-body lifecycle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("cancels a stalled body when its read budget expires", async () => {
     const stalled = makeStalledResponse();
     const request = vi.fn<AgentRequestTransport["request"]>(
@@ -83,6 +87,90 @@ describe("ElizaClient JSON response-body lifecycle", () => {
       cause: callerReason,
     });
     expect(stalled.cancel).toHaveBeenCalledWith(callerReason);
+  });
+
+  it("preserves a non-2xx body deadline and cancels the owned reader", async () => {
+    const stalled = makeStalledResponse(418);
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => stalled.response,
+    );
+
+    const result = makeClient(request).fetch("/api/teapot", undefined, {
+      timeoutMs: 20,
+    });
+    await stalled.readStarted;
+
+    await expect(result).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+      path: "/api/teapot",
+      status: 418,
+      message: "Response body timed out after 20ms",
+    });
+    expect(stalled.cancel).toHaveBeenCalledTimes(1);
+    expect(stalled.cancel).toHaveBeenCalledWith("elizaos-json-body-timeout");
+  });
+
+  it("preserves caller cancellation after non-2xx headers and cancels the owned reader", async () => {
+    const stalled = makeStalledResponse(418);
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => stalled.response,
+    );
+    const controller = new AbortController();
+    const callerReason = new Error("view unmounted");
+
+    const result = makeClient(request).fetch(
+      "/api/teapot",
+      { signal: controller.signal },
+      { timeoutMs: 1_000 },
+    );
+    await stalled.readStarted;
+    controller.abort(callerReason);
+
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      kind: "network",
+      path: "/api/teapot",
+      status: 418,
+      message: "Request aborted",
+      cause: callerReason,
+    });
+    expect(stalled.cancel).toHaveBeenCalledTimes(1);
+    expect(stalled.cancel).toHaveBeenCalledWith(callerReason);
+  });
+
+  it("reads a complete non-2xx body before surfacing its HTTP error and clears the deadline", async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    const cancel = vi.fn(async () => undefined);
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"error":"short and stout"}'));
+          controller.close();
+        },
+        cancel,
+      }),
+      { status: 418 },
+    );
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => response,
+    );
+
+    await expect(
+      makeClient(request).fetch("/api/teapot", undefined, {
+        timeoutMs: 20,
+      }),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "http",
+      path: "/api/teapot",
+      status: 418,
+      message: "short and stout",
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("decodes a successful fragmented JSON body without cancelling it", async () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1454,7 +1454,7 @@ export class ElizaClient {
         path,
         options?.timeoutMs,
         init,
-      ).catch(() => "");
+      );
       let body: Record<string, unknown> | null = null;
       if (rawText) {
         try {


### PR DESCRIPTION
# Relates to

Relates to #21757.

This draft addresses only residual 1 from the latest acceptance-audit comment: the shared `ElizaClient` non-2xx response-body path. The View Manager and AEC ownership/cancellation residuals remain open and are intentionally outside this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; broader validation limitations are recorded below.
- [x] A reviewer can confirm the changed transport contract from the exact-head real-stream regression test described below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7891d402db51dce0ce607050f2ce1025a2a77d7e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `33bc36f5e93f056f9e96a1ebdab75cd4650458a7`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It was not completed for this narrow draft; exact blockers and completed proportional gates are documented below.

# Risks

Low. The change stops replacing response-body read failures with a fabricated HTTP error on non-2xx responses. Callers that previously observed the wrong `kind: "http"` fallback will now receive the existing typed timeout/network `ApiError`. Normal completed non-2xx bodies retain their parsed HTTP error behavior.

# Background

## What does this PR do?

Removes the blanket rejection swallow around the shared client's bounded non-2xx body reader. A stalled body now preserves its timeout or caller-abort `ApiError`, while the reader still owns cancellation and lock release.

The regression suite uses real `ReadableStream` bodies after response headers have arrived. It verifies timeout identity, exact caller abort cause, one transport cancellation, completed error-body parsing, no cancellation of completed bodies, and deadline cleanup.

## What kind of change is this?

Bug fix (non-breaking correction to response error identity and cancellation observability).

# Documentation changes needed?

No. This corrects an internal shared-client lifecycle contract already documented by the source and issue acceptance audit.

# Testing

## Where should a reviewer start?

- `packages/ui/src/api/client-base.ts`: non-2xx body classification path.
- `packages/ui/src/api/client-base-body-lifecycle.test.ts`: real-stream adversarial coverage.

## Detailed testing steps

From repository root at the evidence head:

```bash
PATH=/Users/shawwalters/.bun/bin:$PATH bun test packages/ui/src/api/client-base-body-lifecycle.test.ts
PATH=/Users/shawwalters/.bun/bin:$PATH bunx @biomejs/biome check packages/ui/src/api/client-base.ts packages/ui/src/api/client-base-body-lifecycle.test.ts
git diff --check origin/develop...HEAD
```

Expected: 6 tests pass; Biome and diff check pass.

# Evidence Gate

<!-- evidence-head:7891d402db51dce0ce607050f2ce1025a2a77d7e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes; the diff is a TypeScript HTTP client lifecycle correction plus tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive user flow or visual state change.
<!-- evidence-row:backend-logs -->
- [x] N/A - the changed path is a client-side response reader exercised deterministically with real streams, not a backend route.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the regression is transport error identity and reader cancellation, captured by exact-head assertions rather than browser console/network output.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, generated-file, audio, or other domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - the applicable evidence is the real `ReadableStream` transport contract test. At exact head it reports 6 passing tests, including non-2xx timeout and caller cancellation after headers.

## Screenshots (before / after) + video walkthrough

N/A - no `.tsx`, CSS, SVG, layout, or rendered state changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- `bun test packages/ui/src/api/client-base-body-lifecycle.test.ts`: PASS at exact head (6 tests, 17 assertions).
- Targeted Biome: PASS at exact head (2 files).
- `git diff --check origin/develop...HEAD`: PASS at exact head.
- `bun run --cwd packages/ui lint:check`: PASS before the final develop rebase with 8 pre-existing `noDocumentCookie` warnings and no errors; the touched files also pass exact-head targeted Biome.
- `bun run --cwd packages/ui build`: PASS before the final develop rebase. The exact-head repeat was interrupted after more than 70 seconds without compiler output under shared-host build-lock contention; it had not reported a source error.
- `bun run --cwd packages/ui typecheck`: blocked before the final rebase by unrelated current-tree errors: missing `@elizaos/core/edge` / `@elizaos/cloud-routing` build artifacts and unrelated test-only exports in `BuildBadge-timeout.test.ts` and `load-pack-timeout.test.ts`.
- `bun run verify`: not completed for this narrow draft because the broader UI typecheck was already blocked as above. This PR remains draft and does not claim the two other #21757 residuals or native/browser end-to-end evidence.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7891d402db51dce0ce607050f2ce1025a2a77d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-21757-residual]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7891d402db51dce0ce607050f2ce1025a2a77d7e:packages/skills/skills/contribute-to-eliza"} -->
