### PR TITLE
fix(cloud): frame vault stdin provisioning

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -437,9 +437,9 @@ describe("resolveVpnTeardown (#16565)", () => {
 });
 
 describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
-  // Runs the EXACT shell command the provider sends over SSH, against a real
-  // local /bin/sh and a real temp "agent volume" directory — the same
-  // read-or-create the deployed node executes.
+  // The real-process cases run the exact shell program sent over SSH against
+  // local /bin/sh and a temp agent volume. They cover shell mutation and trap
+  // behavior, but not SSH channel or supported-node behavior.
   const shExecStdin = async (cmd: string, input: string, _timeoutMs: number): Promise<string> => {
     const { spawn } = await import("node:child_process");
     return await new Promise<string>((resolve, reject) => {
@@ -532,6 +532,46 @@ describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
       expect(command).not.toContain(override ?? "operator-secret-value");
       fs.rmSync(volume, { recursive: true, force: true });
     }
+  });
+
+  test("signal interruption during frame upload removes staged secret bytes", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const volume = await makeVolume();
+    const override = "interrupted-operator-secret";
+    let command = "";
+    let validFrame = "";
+    await ensureVolumeVaultPassphrase(
+      async (cmd, input) => {
+        command = cmd;
+        validFrame = input;
+        return "";
+      },
+      volume,
+      5_000,
+      override,
+    );
+
+    const child = spawn("/bin/sh", ["-c", command], { detached: true });
+    const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr.on("data", (chunk) => (output += chunk.toString()));
+    child.stdin.write(validFrame.slice(0, -8));
+    for (
+      let attempt = 0;
+      attempt < 100 && !fs.readdirSync(volume).some((entry) => entry.includes(".stdin."));
+      attempt++
+    ) {
+      await Bun.sleep(10);
+    }
+    expect(fs.readdirSync(volume).some((entry) => entry.includes(".stdin."))).toBe(true);
+
+    process.kill(-child.pid!, "SIGTERM");
+    await closed;
+    expect(output).not.toContain(override);
+    expect(fs.readdirSync(volume)).toEqual([]);
+    fs.rmSync(volume, { recursive: true, force: true });
   });
 
   test("maps an invalid frame to a non-secret typed boundary error", async () => {

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -436,7 +436,7 @@ describe("resolveVpnTeardown (#16565)", () => {
   });
 });
 
-describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
+describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
   // Runs the EXACT shell command the provider sends over SSH, against a real
   // local /bin/sh and a real temp "agent volume" directory — the same
   // read-or-create the deployed node executes.
@@ -479,7 +479,9 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     );
     expect(command).not.toContain(override);
     expect(command).not.toContain("ELIZA_VAULT_PASSPHRASE");
-    expect(input).toBe(override);
+    expect(input).toContain(override);
+    expect(input).toMatch(/^ELIZA_VAULT_STDIN_V1 \d+\n/);
+    expect(input).toEndWith("\nELIZA_VAULT_STDIN_V1_END\n");
     expect("ssh transport unavailable").not.toContain(override);
     const fs = await import("node:fs");
     fs.rmSync(volume, { recursive: true, force: true });
@@ -495,6 +497,131 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     expect(fs.readFileSync(keyPath, "utf-8")).toBe(key);
     expect(fs.statSync(keyPath).mode & 0o777).toBe(0o600);
     fs.rmSync(volume, { recursive: true, force: true });
+  });
+
+  test("rejects malformed framed stdin before first-provision mutation", async () => {
+    const fs = await import("node:fs");
+    for (const override of [undefined, "operator-secret-value"] as const) {
+      const volume = await makeVolume();
+      let command = "";
+      let validFrame = "";
+      await ensureVolumeVaultPassphrase(
+        async (cmd, input) => {
+          command = cmd;
+          validFrame = input;
+          return "";
+        },
+        volume,
+        5_000,
+        override,
+      );
+      const terminator = validFrame.split("\n").at(-2);
+      expect(terminator).toBe("ELIZA_VAULT_STDIN_V1_END");
+      const malformedFrames = [
+        validFrame.slice(0, -1),
+        `${validFrame}x`,
+        `${validFrame}${terminator}\n`,
+      ];
+
+      for (const malformedFrame of malformedFrames) {
+        await expect(shExecStdin(command, malformedFrame, 5_000)).rejects.toMatchObject({
+          code: 44,
+        });
+        expect(fs.readdirSync(volume)).toEqual([]);
+      }
+      expect(command).not.toContain(override ?? "operator-secret-value");
+      fs.rmSync(volume, { recursive: true, force: true });
+    }
+  });
+
+  test("maps an invalid frame to a non-secret typed boundary error", async () => {
+    const fs = await import("node:fs");
+    const volume = await makeVolume();
+    const override = "operator-secret-value";
+    let failure: unknown;
+    try {
+      await ensureVolumeVaultPassphrase(
+        async () => {
+          throw Object.assign(new Error("shell exited 44"), { code: 44 });
+        },
+        volume,
+        5_000,
+        override,
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toMatchObject({
+      code: "SANDBOX_VAULT_PASSPHRASE_STDIN_INCOMPLETE",
+      context: { volumePath: volume },
+    });
+    expect(String(failure)).not.toContain(override);
+    expect(JSON.stringify((failure as { context?: unknown }).context)).not.toContain(override);
+    expect(fs.readdirSync(volume)).toEqual([]);
+    fs.rmSync(volume, { recursive: true, force: true });
+  });
+
+  test("frames a multibyte override by byte length and rejects truncation", async () => {
+    const fs = await import("node:fs");
+    const volume = await makeVolume();
+    const override = "operator-🔐-密钥-value";
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, override);
+    const keyPath = getVolumeVaultPassphrasePath(volume);
+    expect(fs.readFileSync(keyPath, "utf-8")).toBe(override);
+
+    await expect(
+      ensureVolumeVaultPassphrase(
+        async (command, input, timeoutMs) => shExecStdin(command, input.slice(0, -1), timeoutMs),
+        volume,
+        5_000,
+        override,
+      ),
+    ).rejects.toMatchObject({ code: "SANDBOX_VAULT_PASSPHRASE_STDIN_INCOMPLETE" });
+    expect(fs.readFileSync(keyPath, "utf-8")).toBe(override);
+    expect(fs.readdirSync(volume)).toEqual([".vault-passphrase"]);
+    fs.rmSync(volume, { recursive: true, force: true });
+  });
+
+  test("rejects malformed framed stdin before inspecting an existing volume", async () => {
+    const fs = await import("node:fs");
+    for (const override of [undefined, "operator-secret-value"] as const) {
+      const volume = await makeVolume();
+      await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, override);
+      const keyPath = getVolumeVaultPassphrasePath(volume);
+      const persisted = fs.readFileSync(keyPath);
+      const mode = fs.statSync(keyPath).mode & 0o777;
+      let command = "";
+      let validFrame = "";
+      await ensureVolumeVaultPassphrase(
+        async (cmd, input) => {
+          command = cmd;
+          validFrame = input;
+          return "";
+        },
+        volume,
+        5_000,
+        override,
+      );
+      const terminator = validFrame.split("\n").at(-2);
+      expect(terminator).toBe("ELIZA_VAULT_STDIN_V1_END");
+      const malformedFrames = [
+        validFrame.slice(0, -1),
+        `${validFrame}x`,
+        `${validFrame}${terminator}\n`,
+      ];
+
+      for (const malformedFrame of malformedFrames) {
+        await expect(shExecStdin(command, malformedFrame, 5_000)).rejects.toMatchObject({
+          code: 44,
+        });
+        expect(fs.readFileSync(keyPath)).toEqual(persisted);
+        expect(fs.statSync(keyPath).mode & 0o777).toBe(mode);
+        expect(fs.readdirSync(volume)).toEqual([".vault-passphrase"]);
+      }
+      expect(command).not.toContain(override ?? "operator-secret-value");
+      fs.rmSync(volume, { recursive: true, force: true });
+    }
   });
 
   test("replacement container B over the same volume derives the SAME key from a newly constructed env", async () => {

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -492,6 +492,9 @@ export function getVolumePath(agentId: string): string {
  */
 export const CONTAINER_DURABLE_STATE_DIR = "/root/.eliza";
 
+const VOLUME_VAULT_STDIN_FRAME_VERSION = "ELIZA_VAULT_STDIN_V1";
+const VOLUME_VAULT_STDIN_FRAME_END = "ELIZA_VAULT_STDIN_V1_END";
+
 /** Host-side path of the persisted per-agent vault master passphrase. */
 export function getVolumeVaultPassphrasePath(volumePath: string): string {
   return `${volumePath}/.vault-passphrase`;
@@ -499,25 +502,56 @@ export function getVolumeVaultPassphrasePath(volumePath: string): string {
 
 /**
  * Shell command that establishes and validates the per-agent vault master
- * passphrase persisted on the host volume. An optional operator seed arrives
- * only on stdin; the command emits no passphrase bytes. Replacement containers
- * therefore derive the same per-volume key without exposing it to the caller.
+ * passphrase persisted on the host volume. A versioned frame containing an
+ * optional operator seed arrives only on stdin; the command emits no
+ * passphrase bytes. Replacement containers therefore derive the same
+ * per-volume key without exposing it to the caller.
  */
-export function buildVolumeVaultPassphraseCommand(volumePath: string): string {
+export function buildVolumeVaultPassphraseCommand(
+  volumePath: string,
+  overrideByteLength = 0,
+): string {
+  if (!Number.isSafeInteger(overrideByteLength) || overrideByteLength < 0) {
+    throw new Error("Vault passphrase override byte length must be a non-negative integer.");
+  }
   const keyPath = getVolumeVaultPassphrasePath(volumePath);
   const keyFile = shellQuote(keyPath);
+  const stdinFile = `${shellQuote(`${keyPath}.stdin`)}.$$`;
   const overrideFile = `${shellQuote(`${keyPath}.override`)}.$$`;
   const generatedFile = `${shellQuote(`${keyPath}.generated`)}.$$`;
   const normalizedFile = `${shellQuote(`${keyPath}.normalized`)}.$$`;
+  const expectedHeader = `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${overrideByteLength}`;
+  const expectedFrameByteLength =
+    Buffer.byteLength(expectedHeader) +
+    1 +
+    overrideByteLength +
+    1 +
+    Buffer.byteLength(VOLUME_VAULT_STDIN_FRAME_END) +
+    1;
   return [
     "set -eu",
+    `stdin_file=${stdinFile}`,
     `override_file=${overrideFile}`,
     `generated_file=${generatedFile}`,
     `normalized_file=${normalizedFile}`,
-    'trap \'rm -f "$override_file" "$generated_file" "$normalized_file"\' EXIT',
+    'trap \'rm -f "$stdin_file" "$override_file" "$generated_file" "$normalized_file"\' EXIT',
     "trap 'exit 1' HUP INT TERM",
     "umask 077",
-    'cat > "$override_file"',
+    'cat > "$stdin_file"',
+    `stdin_length=$(wc -c < "$stdin_file" | tr -d ' ')`,
+    `if test "$stdin_length" != ${expectedFrameByteLength}; then exit 44; fi`,
+    `frame_header=$(sed -n '1p' "$stdin_file")`,
+    `if test "$frame_header" != ${shellQuote(expectedHeader)}; then exit 44; fi`,
+    "frame_lines=$(awk 'END { print NR }' \"$stdin_file\")",
+    'if test "$frame_lines" != 3; then exit 44; fi',
+    `if test "$(tail -n 1 "$stdin_file")" != ${shellQuote(VOLUME_VAULT_STDIN_FRAME_END)}; then exit 44; fi`,
+    'sed \'1d;$d\' "$stdin_file" > "$override_file"',
+    "override_framed_length=$(wc -c < \"$override_file\" | tr -d ' ')",
+    'if test "$override_framed_length" -lt 1; then exit 44; fi',
+    'truncate -s -1 "$override_file"',
+    "override_length=$(wc -c < \"$override_file\" | tr -d ' ')",
+    `if test "$override_length" != ${overrideByteLength}; then exit 44; fi`,
+    'if test -s "$override_file"; then override_safe_length=$(LC_ALL=C tr -d \'[:space:][:cntrl:]\' < "$override_file" | wc -c | tr -d \' \'); if test "$override_length" -lt 12 || test "$override_length" != "$override_safe_length"; then exit 43; fi; fi',
     `if test ! -s ${keyFile}; then if test -s "$override_file"; then candidate_file="$override_file"; else head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \\n' > "$generated_file"; candidate_file="$generated_file"; fi; if ln "$candidate_file" ${keyFile} 2>/dev/null; then :; elif test -s ${keyFile}; then :; else exit 43; fi; fi`,
     // A shell variable cannot represent NUL bytes: command substitution would
     // silently delete them and rewrite the durable key. Validate the raw file
@@ -589,8 +623,14 @@ export async function ensureVolumeVaultPassphrase(
       },
     );
   }
+  const overrideBytes = Buffer.byteLength(override ?? "", "utf8");
+  const framedOverride = `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${overrideBytes}\n${override ?? ""}\n${VOLUME_VAULT_STDIN_FRAME_END}\n`;
   try {
-    await execStdin(buildVolumeVaultPassphraseCommand(volumePath), override ?? "", timeoutMs);
+    await execStdin(
+      buildVolumeVaultPassphraseCommand(volumePath, overrideBytes),
+      framedOverride,
+      timeoutMs,
+    );
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);
     const exitCode =
@@ -612,6 +652,16 @@ export async function ensureVolumeVaultPassphrase(
         `[docker-sandbox] persisted vault passphrase at ${getVolumeVaultPassphrasePath(volumePath)} is unusable; refusing to mint a fresh per-launch key`,
         {
           code: "SANDBOX_VAULT_PASSPHRASE_UNUSABLE",
+          context: { volumePath },
+          cause,
+        },
+      );
+    }
+    if (exitCode === 44 || message.includes("exited with code 44")) {
+      throw new ElizaError(
+        `[docker-sandbox] vault passphrase transport to ${getVolumeVaultPassphrasePath(volumePath)} was incomplete or invalid; refusing to change durable vault state`,
+        {
+          code: "SANDBOX_VAULT_PASSPHRASE_STDIN_INCOMPLETE",
           context: { volumePath },
           cause,
         },


### PR DESCRIPTION
# Relates to

Relates to #22060.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest GitHub `develop` with zero conflicts.
- [x] `bun install` was run after sync; the proportional `bun run verify` limitation is recorded below.
- [ ] A reviewer can confirm the remote SSH transport behavior from live-node evidence. The exact local `/bin/sh` process path is covered, but live-node evidence remains outstanding, so this PR is draft.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6dd430c8c664ef2302500dabebc9e72bac6437a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto GitHub `develop` at `b5f6de93355b0cc18bad42971861b9e431110d81`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It was attempted, but this checkout's `origin/develop` is a stale local mirror at `63bce535e3`, so base-sensitive audits treated 477 unrelated upstream files as this branch's diff. Focused and owning-package gates pass below.

# Risks

Medium security-sensitive shell/transport change. The affected surface is limited to the already-stdin-only vault passphrase bootstrap. Incorrect framing could reject valid provisioning or persist an incomplete first key. Exact byte-count, suffix, mutation-order, cleanup, concurrency, Unicode, and replacement regressions cover those risks.

# Background

## What does this PR do?

Adds a versioned, non-secret header with a declared byte length and terminal marker to every vault-passphrase stdin payload, including intentional empty input. The remote shell stages the complete frame under `umask 077`, verifies the command-known exact total byte length, exact header, three-line shape, and terminator, and only then extracts the candidate payload. Truncated, extended, or duplicated-terminator streams fail with a typed error before key comparison, generation, or atomic linking.

The change preserves the stdin-only secret transport, atomic create-if-absent behavior, persisted raw-byte validation, 0600 durable-key permissions, mismatch handling, and signal/exit cleanup merged in #22104, #22137, and #22147.

## What kind of change is this?

Bug fix (security-sensitive transport-integrity hardening).

# Documentation changes needed?

No project documentation change is required; this tightens an internal provisioning protocol without changing its public/operator interface.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts`
- `packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts`

## Detailed testing steps

1. Run `bun test --reporter=dots --coverage-reporter=lcov packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-*.test.ts`.
2. Confirm 165 tests pass across 11 files.
3. Run `bun run --cwd packages/cloud/shared typecheck`.
4. Run `bun run --cwd packages/cloud/shared lint:check`.
5. Review the malformed-frame matrix: first provision and existing volume, with and without overrides, each reject truncation, appended bytes, and duplicated terminators without durable mutation or temporary residue.

# Evidence Gate

<!-- evidence-head:6dd430c8c664ef2302500dabebc9e72bac6437a2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [ ] Live SSH-node backend logs remain outstanding; deterministic tests execute the exact generated command through a real local `/bin/sh` process without emitting passphrase bytes.

```text
local process transport: exact generated command executed by /bin/sh
adversarial result: truncated, extended, and duplicate-terminator frames exited 44 before mutation
non-disclosure result: command, typed boundary error, stdout, and stderr contained no operator passphrase
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The real-process tests inspect durable key bytes, 0600 mode, atomic replacement behavior, and exact absence of temporary residue after adversarial failures.

```text
focused vault utilities: 48 passed, 0 failed
Docker provider owning composite: 165 passed across 11 files, 0 failed
artifacts inspected: durable key bytes and mode unchanged; volume directory contained only .vault-passphrase
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Backend: the focused suite drives the exact generated shell command through `/bin/sh`, including successful generation/override/replacement, transport truncation, extra bytes, duplicate terminator injection, typed exit-44 translation, concurrency, Unicode byte lengths, permissions, cleanup, and non-disclosure. Live remote SSH-node capture remains outstanding.

Frontend: N/A - no frontend changes.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- Live supported-node SSH/process evidence is not attached; the PR remains draft and uses `Relates to #22060`.
- `bun run verify` could not produce a meaningful branch-scoped result because repository scripts resolve these worktrees' configured `origin/develop`, a stale local mirror at `63bce535e3`, instead of the fetched GitHub base `b5f6de9335`; a proportional attempt entered base-sensitive audits with hundreds of unrelated changed files and was stopped.
- Post-sync focused result: 48/48 vault utility tests pass.
- Post-sync owning Docker provider composite: 165/165 tests pass across 11 files.
- Post-sync `packages/cloud/shared` typecheck and full package Biome check pass.
- Independent security review of exact head `6dd430c8c664ef2302500dabebc9e72bac6437a2` found no source blocker: total-byte/header/shape/terminator validation precedes extraction or durable-key inspection/mutation; UTF-8 byte length is rechecked; malformed cases preserve bytes, mode, and residue; exit-44 translation contains no passphrase. Remaining live SSH interruption evidence keeps this PR draft.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6dd430c8c664ef2302500dabebc9e72bac6437a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-22060-frame]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6dd430c8c664ef2302500dabebc9e72bac6437a2:packages/skills/skills/contribute-to-eliza"} -->
