### PR TITLE
fix(cloud): honor complete numeric Headscale pre-auth TTLs

### DIFF
--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -1027,9 +1027,10 @@ ELIZA_APP_WHATSAPP_PHONE_NUMBER=
 # HEADSCALE_API_URL=http://localhost:8081
 # HEADSCALE_API_KEY=your_headscale_api_key_here
 # HEADSCALE_USER=agent
-# Pre-auth key validity window (minutes). Must outlive container boot + VPN
-# enrollment; 10 min looped slow boots on re-auth. Default 60 (prod-verified).
-# HEADSCALE_PREAUTH_TTL_MIN=60
+# Pre-auth key validity window (minutes). Exact positive decimal, no spaces.
+# Range [1, 43200] (30 days). Default 1440 (24h). Must outlive container boot
+# + VPN enrollment; 10 min looped slow boots on re-auth.
+# HEADSCALE_PREAUTH_TTL_MIN=1440
 # VPN registration wait before a container is considered enrolled (ms). Default 180000.
 # VPN_REGISTRATION_TIMEOUT_MS=180000
 

--- a/packages/cloud/shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.test.ts
@@ -1,6 +1,11 @@
 // Exercises headscale client behavior with deterministic cloud-shared lib fixtures.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_PREAUTH_TTL_MIN, HeadscaleClient, resolvePreAuthTtlMs } from "./headscale-client";
+import {
+  DEFAULT_PREAUTH_TTL_MIN,
+  HeadscaleClient,
+  MAX_PREAUTH_TTL_MIN,
+  resolvePreAuthTtlMs,
+} from "./headscale-client";
 
 const originalFetch = globalThis.fetch;
 
@@ -44,16 +49,35 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
     }
   });
 
-  it("honors complete JS numeric minutes instead of parseInt prefix coercion", () => {
-    process.env.HEADSCALE_PREAUTH_TTL_MIN = "1e3";
-    expect(resolvePreAuthTtlMs()).toBe(1000 * 60 * 1000);
-  });
-
-  it("rejects prefix-coerced and overflowing minute strings", () => {
-    for (const bad of ["90abc", "1e20"]) {
+  it("rejects exponent, hex, fractional, subnormal, and prefix-garbage forms", () => {
+    for (const bad of [
+      "1e3",
+      "1e10",
+      "1e20",
+      "0x10",
+      "1.5",
+      "5e-324",
+      "90abc",
+      "007",
+      "144000000000",
+    ]) {
       process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
       expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
     }
+  });
+
+  it("honors the operational max and rejects one minute past it", () => {
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = String(MAX_PREAUTH_TTL_MIN);
+    expect(resolvePreAuthTtlMs()).toBe(MAX_PREAUTH_TTL_MIN * 60 * 1000);
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = String(MAX_PREAUTH_TTL_MIN + 1);
+    expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
+  });
+
+  it("keeps Date.now() + ttl inside TimeClip", () => {
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = "90";
+    const expirationMs = Date.now() + resolvePreAuthTtlMs();
+    expect(() => new Date(expirationMs).toISOString()).not.toThrow();
+    expect(Number.isFinite(Date.parse(new Date(expirationMs).toISOString()))).toBe(true);
   });
 });
 
@@ -91,6 +115,45 @@ describe("HeadscaleClient upstream errors", () => {
         "Headscale API POST /api/v1/preauthkey failed: 502 Bad Gateway; error body could not be read",
       cause: expect.objectContaining({ message: "body stream failed" }),
     });
+  });
+
+  it("sends a TimeClip-safe ISO expiration from the env TTL", async () => {
+    const originalTtl = process.env.HEADSCALE_PREAUTH_TTL_MIN;
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = "90";
+    const bodies: Array<{ expiration?: string }> = [];
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      if (init?.body) {
+        bodies.push(JSON.parse(String(init.body)) as { expiration?: string });
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          preAuthKey: { key: "hskey", expiration: "unused" },
+        }),
+        text: async () => "{}",
+        headers: new Headers({ "content-type": "application/json" }),
+      } as Response;
+    }) as typeof fetch;
+    try {
+      const before = Date.now();
+      const client = new HeadscaleClient({
+        apiUrl: "https://headscale.example",
+        apiKey: "secret",
+        user: "1",
+      });
+      await client.createPreAuthKey();
+      const after = Date.now();
+      expect(bodies).toHaveLength(1);
+      const expiration = Date.parse(bodies[0]?.expiration ?? "");
+      expect(Number.isFinite(expiration)).toBe(true);
+      expect(expiration).toBeGreaterThanOrEqual(before + 90 * 60 * 1000 - 5_000);
+      expect(expiration).toBeLessThanOrEqual(after + 90 * 60 * 1000 + 5_000);
+    } finally {
+      if (originalTtl === undefined) delete process.env.HEADSCALE_PREAUTH_TTL_MIN;
+      else process.env.HEADSCALE_PREAUTH_TTL_MIN = originalTtl;
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.test.ts
@@ -43,6 +43,18 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
       expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
     }
   });
+
+  it("honors complete JS numeric minutes instead of parseInt prefix coercion", () => {
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = "1e3";
+    expect(resolvePreAuthTtlMs()).toBe(1000 * 60 * 1000);
+  });
+
+  it("rejects prefix-coerced and overflowing minute strings", () => {
+    for (const bad of ["90abc", "1e20"]) {
+      process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
+      expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
+    }
+  });
 });
 
 describe("HeadscaleClient upstream errors", () => {

--- a/packages/cloud/shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.test.ts
@@ -2,8 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PREAUTH_TTL_MIN,
+  ECMA_TIME_CLIP_MS,
   HeadscaleClient,
   MAX_PREAUTH_TTL_MIN,
+  resolvePreAuthExpirationIso,
   resolvePreAuthTtlMs,
 } from "./headscale-client";
 
@@ -66,6 +68,13 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
     }
   });
 
+  it("rejects leading or trailing whitespace instead of trimming it", () => {
+    for (const bad of [" 90", "90 ", " 90 ", "\t90", "90\n", "90\r\n"]) {
+      process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
+      expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
+    }
+  });
+
   it("honors the operational max and rejects one minute past it", () => {
     process.env.HEADSCALE_PREAUTH_TTL_MIN = String(MAX_PREAUTH_TTL_MIN);
     expect(resolvePreAuthTtlMs()).toBe(MAX_PREAUTH_TTL_MIN * 60 * 1000);
@@ -75,9 +84,8 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
 
   it("keeps Date.now() + ttl inside TimeClip", () => {
     process.env.HEADSCALE_PREAUTH_TTL_MIN = "90";
-    const expirationMs = Date.now() + resolvePreAuthTtlMs();
-    expect(() => new Date(expirationMs).toISOString()).not.toThrow();
-    expect(Number.isFinite(Date.parse(new Date(expirationMs).toISOString()))).toBe(true);
+    const iso = resolvePreAuthExpirationIso();
+    expect(Number.isFinite(Date.parse(iso))).toBe(true);
   });
 });
 
@@ -154,6 +162,34 @@ describe("HeadscaleClient upstream errors", () => {
       if (originalTtl === undefined) delete process.env.HEADSCALE_PREAUTH_TTL_MIN;
       else process.env.HEADSCALE_PREAUTH_TTL_MIN = originalTtl;
     }
+  });
+
+  it("does not fetch when even the fallback expiration is above TimeClip", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    vi.spyOn(Date, "now").mockReturnValue(ECMA_TIME_CLIP_MS - 1000);
+    const client = new HeadscaleClient({
+      apiUrl: "https://headscale.example",
+      apiKey: "secret",
+      user: "1",
+    });
+    await expect(client.createPreAuthKey()).rejects.toThrow(/TimeClip/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when even the fallback expiration is below TimeClip", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    vi.spyOn(Date, "now").mockReturnValue(
+      -ECMA_TIME_CLIP_MS - DEFAULT_PREAUTH_TTL_MIN * 60 * 1000 - 1,
+    );
+    const client = new HeadscaleClient({
+      apiUrl: "https://headscale.example",
+      apiKey: "secret",
+      user: "1",
+    });
+    await expect(client.createPreAuthKey()).rejects.toThrow(/TimeClip/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -55,7 +55,7 @@ const PREAUTH_TTL_MINUTES_GRAMMAR = /^[1-9]\d*$/;
 export const MAX_PREAUTH_TTL_MIN = 43_200;
 
 /** ECMA-262 TimeClip magnitude. */
-const ECMA_TIME_CLIP_MS = 8.64e15;
+export const ECMA_TIME_CLIP_MS = 8.64e15;
 
 /**
  * Pre-auth key TTL window (ms): how long a freshly-created key stays valid for a
@@ -78,7 +78,8 @@ const ECMA_TIME_CLIP_MS = 8.64e15;
  */
 export function resolvePreAuthTtlMs(): number {
   const fallback = DEFAULT_PREAUTH_TTL_MIN * 60 * 1000;
-  const raw = (process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "").trim();
+  // Literal grammar: do not trim. Padded " 90 " is not an exact positive decimal.
+  const raw = process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "";
   if (!PREAUTH_TTL_MINUTES_GRAMMAR.test(raw)) {
     return fallback;
   }
@@ -87,21 +88,43 @@ export function resolvePreAuthTtlMs(): number {
     return fallback;
   }
   const ms = minutes * 60 * 1000;
-  const expirationMs = Date.now() + ms;
-  if (
-    !Number.isFinite(ms) ||
-    !Number.isFinite(expirationMs) ||
-    Math.abs(expirationMs) > ECMA_TIME_CLIP_MS
-  ) {
-    return fallback;
-  }
-  try {
-    new Date(expirationMs).toISOString();
-  } catch {
-    // error-policy:J3 out-of-range Date is invalid TTL, not a crash.
+  if (!Number.isFinite(ms)) {
     return fallback;
   }
   return ms;
+}
+
+function isoExpirationOrThrow(nowMs: number, ttlMs: number): string {
+  const expirationMs = nowMs + ttlMs;
+  if (!Number.isFinite(expirationMs) || Math.abs(expirationMs) > ECMA_TIME_CLIP_MS) {
+    throw new Error("[headscale] pre-auth expiration is outside TimeClip");
+  }
+  try {
+    return new Date(expirationMs).toISOString();
+  } catch (error) {
+    // error-policy:J2 TimeClip-invalid Date must not reach Headscale.
+    throw new Error("[headscale] pre-auth expiration is outside TimeClip", {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Build the ISO expiration used by {@link HeadscaleClient.createPreAuthKey}.
+ * Tries the env TTL, then the 24h fallback. Throws (fetch must not run) if
+ * even the fallback instant is outside TimeClip.
+ */
+export function resolvePreAuthExpirationIso(nowMs: number = Date.now()): string {
+  const envTtl = resolvePreAuthTtlMs();
+  const fallback = DEFAULT_PREAUTH_TTL_MIN * 60 * 1000;
+  try {
+    return isoExpirationOrThrow(nowMs, envTtl);
+  } catch (error) {
+    if (envTtl === fallback) {
+      throw error;
+    }
+    return isoExpirationOrThrow(nowMs, fallback);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -338,7 +361,7 @@ export class HeadscaleClient {
     // VPN enrollment; 10 min was too tight on slow boots (key expired mid-
     // registration -> container re-auth loop). Default 24h, env-overridable
     // via HEADSCALE_PREAUTH_TTL_MIN (see resolvePreAuthTtlMs).
-    const expirationTime = expiration ?? new Date(Date.now() + resolvePreAuthTtlMs()).toISOString();
+    const expirationTime = expiration ?? resolvePreAuthExpirationIso();
 
     const userId = ensureUser ? await this.ensureUser(user) : await this.resolveUserId(user);
 

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -63,8 +63,18 @@ export const DEFAULT_PREAUTH_TTL_MIN = 1440;
  * daemon redeploy and ops can retune without a code change.
  */
 export function resolvePreAuthTtlMs(): number {
-  const minutes = Number.parseInt(process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "", 10);
-  return (Number.isFinite(minutes) && minutes > 0 ? minutes : DEFAULT_PREAUTH_TTL_MIN) * 60 * 1000;
+  const raw = process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "";
+  const minutes = Number(raw);
+  const ms = minutes * 60 * 1000;
+  if (
+    !Number.isFinite(minutes) ||
+    minutes <= 0 ||
+    !Number.isFinite(ms) ||
+    ms > Number.MAX_SAFE_INTEGER
+  ) {
+    return DEFAULT_PREAUTH_TTL_MIN * 60 * 1000;
+  }
+  return ms;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -44,6 +44,19 @@ function escapeRegExp(value: string): string {
 /** Default pre-auth key TTL (minutes) when `HEADSCALE_PREAUTH_TTL_MIN` is unset. */
 export const DEFAULT_PREAUTH_TTL_MIN = 1440;
 
+/** Exact positive-decimal minutes. Rejects exponent, hex, fraction, and 0-prefix. */
+const PREAUTH_TTL_MINUTES_GRAMMAR = /^[1-9]\d*$/;
+
+/**
+ * Operational ceiling (30 days). Longer reusable keys baked into Docker env
+ * become multi-millennial credentials; larger values also overflow TimeClip
+ * in `new Date(Date.now() + ms).toISOString()`.
+ */
+export const MAX_PREAUTH_TTL_MIN = 43_200;
+
+/** ECMA-262 TimeClip magnitude. */
+const ECMA_TIME_CLIP_MS = 8.64e15;
+
 /**
  * Pre-auth key TTL window (ms): how long a freshly-created key stays valid for a
  * container to boot AND finish VPN enrollment. 10 min proved too tight on slow
@@ -59,20 +72,34 @@ export const DEFAULT_PREAUTH_TTL_MIN = 1440;
  * fix an already-baked expired key on its own (the durable fix is the
  * reconnect-first + re-key entrypoint), but it widens the window in which a
  * freshly provisioned agent can survive a delayed first boot or an early
- * reboot. Env-overridable via `HEADSCALE_PREAUTH_TTL_MIN` so it survives a
- * daemon redeploy and ops can retune without a code change.
+ * reboot. Env-overridable via `HEADSCALE_PREAUTH_TTL_MIN` (exact positive
+ * decimal minutes in `[1, MAX_PREAUTH_TTL_MIN]`) so it survives a daemon
+ * redeploy and ops can retune without a code change.
  */
 export function resolvePreAuthTtlMs(): number {
-  const raw = process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "";
+  const fallback = DEFAULT_PREAUTH_TTL_MIN * 60 * 1000;
+  const raw = (process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "").trim();
+  if (!PREAUTH_TTL_MINUTES_GRAMMAR.test(raw)) {
+    return fallback;
+  }
   const minutes = Number(raw);
+  if (!Number.isSafeInteger(minutes) || minutes < 1 || minutes > MAX_PREAUTH_TTL_MIN) {
+    return fallback;
+  }
   const ms = minutes * 60 * 1000;
+  const expirationMs = Date.now() + ms;
   if (
-    !Number.isFinite(minutes) ||
-    minutes <= 0 ||
     !Number.isFinite(ms) ||
-    ms > Number.MAX_SAFE_INTEGER
+    !Number.isFinite(expirationMs) ||
+    Math.abs(expirationMs) > ECMA_TIME_CLIP_MS
   ) {
-    return DEFAULT_PREAUTH_TTL_MIN * 60 * 1000;
+    return fallback;
+  }
+  try {
+    new Date(expirationMs).toISOString();
+  } catch {
+    // error-policy:J3 out-of-range Date is invalid TTL, not a crash.
+    return fallback;
   }
   return ms;
 }


### PR DESCRIPTION
# Relates to

Closes #22289.

Occupancy-FREE auth-TTL bind on Headscale pre-auth keys. Stayed off `#22262`. Not a twin PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused package tests passed at this head (23).
- [x] A reviewer can confirm prefix-coercion, exact grammar, and TimeClip fail-closed from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run --cwd packages/cloud/shared test:vitest -- src/lib/services/headscale-client.test.ts` — 23 passed.

# Risks

Low. Unset env still defaults to 1440 minutes. Exact `"90"` still wins. Padded / exponent / hex / fractional strings fall back to 1440. Expiration is computed atomically at `createPreAuthKey`; if even the 24h fallback is outside TimeClip, the helper throws and fetch is not called.

# Background

## What does this PR do?

`resolvePreAuthTtlMs` used `Number.parseInt`, so `HEADSCALE_PREAUTH_TTL_MIN=1e3` became a 1-minute key (176-restart crash-loop class). This head accepts only the literal positive-decimal grammar `^[1-9]\d*$` in `[1, 43200]` (no trim). Exponent / hex / fraction / `007` / padded `" 90 "` are rejected. `createPreAuthKey` uses `resolvePreAuthExpirationIso()` so a TimeClip-invalid instant fails closed before the Headscale request.

## What kind of change is this?

Bug fix (auth-TTL bind + TimeClip fail-closed).

# Documentation changes needed?

`.env.example` now documents default 1440, exact grammar, and the 30-day ceiling.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/headscale-client.test.ts`

## Detailed testing steps

```text
bun run --cwd packages/cloud/shared test:vitest -- src/lib/services/headscale-client.test.ts
# 23 passed
# "90" → 90 minutes; " 90 " / 1e3 / 0x10 → 1440
# TimeClip upper/lower edges: createPreAuthKey throws, fetch not called
```

# Evidence Gate

<!-- evidence-head:e5eddbed202ec90772f585ba126afab598d11987 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; Headscale TTL helper only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; Headscale TTL helper only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - grammar and TimeClip proved by unit tests.
<!-- evidence-row:backend-logs -->
- [x] [22278-pr22278-focused-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22278-pr22278-focused-tests.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] [22278-pr22278-expiration-payload.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22278-pr22278-expiration-payload.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/provider path.

## Backend + frontend logs

Green: vitest 23 passed at `e5eddbed202e`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


