### PR TITLE
fix(cloud): make remote pairing authority atomic

### DIFF
--- a/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Exercises remote pairing through real Hono routes and the PGlite-backed
+ * repository. Authentication is deterministic, while ownership locking,
+ * verifier persistence, supersession, and revocation use production queries.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { Hono } from "hono";
+import type { Database } from "@/db/client";
+import { RemoteSessionsRepository } from "@/db/repositories/remote-sessions-store";
+import { agentSandboxes } from "@/db/schemas/agent-sandboxes";
+import { remoteSessions } from "@/db/schemas/remote-sessions";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+setDefaultTimeout(300_000);
+
+const organizationId = "10000000-0000-4000-8000-000000000001";
+const ownerId = "20000000-0000-4000-8000-000000000001";
+const otherUserId = "20000000-0000-4000-8000-000000000002";
+const agentId = "30000000-0000-4000-8000-000000000001";
+const secret = "pglite-remote-pairing-secret-at-least-32-bytes";
+
+let authenticatedUser = { id: ownerId, organization_id: organizationId };
+const requireUserOrApiKeyWithOrg = mock(async () => authenticatedUser);
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: authenticatedUser,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+
+let repository: RemoteSessionsRepository;
+const repositoryProxy = {
+  createPendingForOwnedAgent: (
+    ...args: Parameters<RemoteSessionsRepository["createPendingForOwnedAgent"]>
+  ) => repository.createPendingForOwnedAgent(...args),
+  listActiveByOwnedAgent: (
+    ...args: Parameters<RemoteSessionsRepository["listActiveByOwnedAgent"]>
+  ) => repository.listActiveByOwnedAgent(...args),
+  revoke: (...args: Parameters<RemoteSessionsRepository["revoke"]>) =>
+    repository.revoke(...args),
+};
+mock.module("@/db/repositories/remote-sessions", () => ({
+  remoteSessionsRepository: repositoryProxy,
+}));
+
+let pglite: PGlite;
+let dbWrite: Database;
+let verifyRemotePairingCodeVerifier: typeof import("@/db/crypto/remote-pairing-code").verifyRemotePairingCodeVerifier;
+let app: Hono<AppEnv>;
+
+async function seedAgent(userId = ownerId, deleted = false): Promise<void> {
+  await dbWrite.execute(sql`
+    INSERT INTO agent_sandboxes (id, organization_id, user_id, deleted_at)
+    VALUES (${agentId}, ${organizationId}, ${userId}, ${deleted ? new Date() : null})
+  `);
+}
+
+async function pair(): Promise<Response> {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/remote/pair", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agentId,
+        organizationId: "attacker-org",
+        userId: otherUserId,
+        redirectUri: "https://attacker.example/callback",
+        purpose: "arbitrary-authority",
+      }),
+    }),
+    { REMOTE_PAIRING_HMAC_SECRET: secret } as AppEnv["Bindings"],
+  );
+}
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  dbWrite = drizzle({
+    client: pglite,
+    schema: { agentSandboxes, remoteSessions },
+  }) as unknown as Database;
+  repository = new RemoteSessionsRepository(dbWrite);
+  ({ verifyRemotePairingCodeVerifier } = await import(
+    "@/db/crypto/remote-pairing-code"
+  ));
+
+  await dbWrite.execute(sql`
+    CREATE TABLE agent_sandboxes (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      deleted_at timestamp with time zone
+    )
+  `);
+  await dbWrite.execute(sql`
+    CREATE TABLE remote_sessions (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      agent_id uuid NOT NULL,
+      status text NOT NULL,
+      requester_identity text NOT NULL,
+      pairing_token_hash text,
+      ingress_url text,
+      ingress_reason text,
+      created_at timestamp with time zone NOT NULL DEFAULT now(),
+      updated_at timestamp with time zone NOT NULL DEFAULT now(),
+      ended_at timestamp with time zone
+    )
+  `);
+
+  const { default: pairRoute } = await import("./route");
+  const { default: sessionsRoute } = await import("../sessions/route");
+  const { default: revokeRoute } = await import(
+    "../sessions/[id]/revoke/route"
+  );
+  app = new Hono<AppEnv>();
+  app.route("/api/v1/remote/pair", pairRoute);
+  app.route("/api/v1/remote/sessions", sessionsRoute);
+  app.route("/api/v1/remote/sessions/:id/revoke", revokeRoute);
+}, 180_000);
+
+beforeEach(async () => {
+  authenticatedUser = { id: ownerId, organization_id: organizationId };
+  await dbWrite.delete(remoteSessions);
+  await dbWrite.execute(sql`DELETE FROM agent_sandboxes`);
+}, 180_000);
+
+afterAll(async () => {
+  if (pglite) await pglite.close();
+}, 180_000);
+
+describe("remote pairing real persistence boundary", () => {
+  test("persists a verifier bound to authoritative tenant, owner, agent, and session", async () => {
+    await seedAgent();
+
+    const response = await pair();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    const body = (await response.json()) as {
+      data: { sessionId: string; code: string; expiresAt: string };
+    };
+    const [row] = await dbWrite.select().from(remoteSessions);
+    expect(row?.requester_identity).toBe(ownerId);
+    expect(row?.pairing_token_hash).toMatch(
+      /^hmac-sha256-v2:\d{13}:[0-9a-f]{64}$/,
+    );
+    expect(row?.pairing_token_hash).not.toContain(body.data.code);
+
+    const context = {
+      organizationId,
+      userId: ownerId,
+      agentId,
+      sessionId: body.data.sessionId,
+    };
+    const verifier = row?.pairing_token_hash ?? "";
+    const beforeExpiry = new Date(Date.parse(body.data.expiresAt) - 1);
+    expect(
+      await verifyRemotePairingCodeVerifier(
+        secret,
+        context,
+        body.data.code,
+        verifier,
+        beforeExpiry,
+      ),
+    ).toBe(true);
+    for (const foreignContext of [
+      { ...context, organizationId: "10000000-0000-4000-8000-000000000002" },
+      { ...context, userId: otherUserId },
+      { ...context, agentId: "30000000-0000-4000-8000-000000000002" },
+      { ...context, sessionId: "40000000-0000-4000-8000-000000000002" },
+    ]) {
+      expect(
+        await verifyRemotePairingCodeVerifier(
+          secret,
+          foreignContext,
+          body.data.code,
+          verifier,
+          beforeExpiry,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("rejects foreign and deleted agents without creating state", async () => {
+    await seedAgent(otherUserId);
+    expect((await pair()).status).toBe(404);
+    expect(await dbWrite.select().from(remoteSessions)).toHaveLength(0);
+
+    await dbWrite.execute(sql`DELETE FROM agent_sandboxes`);
+    await seedAgent(ownerId, true);
+    expect((await pair()).status).toBe(404);
+    expect(await dbWrite.select().from(remoteSessions)).toHaveLength(0);
+  });
+
+  test("serializes concurrent issuers and leaves exactly one current challenge", async () => {
+    await seedAgent();
+
+    const responses = await Promise.all([pair(), pair(), pair(), pair()]);
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    const bodies = await Promise.all(
+      responses.map(
+        async (response) =>
+          (await response.json()) as {
+            data: { sessionId: string; code: string };
+          },
+      ),
+    );
+    const rows = await dbWrite.select().from(remoteSessions);
+    expect(rows).toHaveLength(4);
+    expect(rows.filter((row) => row.status === "pending")).toHaveLength(1);
+    expect(rows.filter((row) => row.status === "denied")).toHaveLength(3);
+    const pending = rows.find((row) => row.status === "pending");
+    const pendingResponse = bodies.find(
+      (body) => body.data.sessionId === pending?.id,
+    );
+    expect(pendingResponse).toBeDefined();
+    expect(pending?.ended_at).toBeNull();
+    expect(
+      rows
+        .filter((row) => row.status === "denied")
+        .every((row) => row.ended_at),
+    ).toBe(true);
+  });
+
+  test("an ownership transfer hides the old grant and prevents its revocation path", async () => {
+    await seedAgent();
+    const pairResponse = await pair();
+    const pairBody = (await pairResponse.json()) as {
+      data: { sessionId: string };
+    };
+
+    await dbWrite.execute(
+      sql`UPDATE agent_sandboxes SET user_id = ${otherUserId} WHERE id = ${agentId}`,
+    );
+
+    const listResponse = await app.request(
+      `https://api.example.test/api/v1/remote/sessions?agentId=${agentId}`,
+    );
+    expect(listResponse.status).toBe(404);
+    const revokeResponse = await app.request(
+      `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+      { method: "POST" },
+    );
+    expect(revokeResponse.status).toBe(404);
+    const [stored] = await dbWrite.select().from(remoteSessions);
+    expect(stored?.status).toBe("pending");
+  });
+
+  test("serializes concurrent revocations as one transition and idempotent replays", async () => {
+    await seedAgent();
+    const pairResponse = await pair();
+    const pairBody = (await pairResponse.json()) as {
+      data: { sessionId: string };
+    };
+
+    const responses = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        app.request(
+          `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+          { method: "POST" },
+        ),
+      ),
+    );
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    const bodies = await Promise.all(
+      responses.map(
+        async (response) =>
+          (await response.json()) as { data: { alreadyEnded: boolean } },
+      ),
+    );
+    expect(
+      bodies.filter((body) => body.data.alreadyEnded === false),
+    ).toHaveLength(1);
+    expect(
+      bodies.filter((body) => body.data.alreadyEnded === true),
+    ).toHaveLength(3);
+    const [stored] = await dbWrite.select().from(remoteSessions);
+    expect(stored?.status).toBe("revoked");
+    expect(stored?.ended_at).not.toBeNull();
+  });
+});

--- a/packages/cloud/api/v1/remote/pair/route.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.test.ts
@@ -14,22 +14,17 @@ import {
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const requireUserOrApiKeyWithOrg = mock(async () => ({
-  id: "11111111-1111-4111-8111-111111111111",
-  organization_id: "22222222-2222-4222-8222-222222222222",
+  id: userId,
+  organization_id: organizationId,
 }));
-const findByIdAndOrg = mock();
-const create = mock();
+const createPendingForOwnedAgent = mock();
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
 
-mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { findByIdAndOrg },
-}));
-
 mock.module("@/db/repositories/remote-sessions", () => ({
-  remoteSessionsRepository: { create },
+  remoteSessionsRepository: { createPendingForOwnedAgent },
 }));
 
 const { default: pairingRoute } = await import("./route");
@@ -38,7 +33,13 @@ const app = new Hono<AppEnv>();
 app.route("/api/v1/remote/pair", pairingRoute);
 
 const secret = "a-dedicated-remote-pairing-secret-with-32-bytes";
+const userId = "11111111-1111-4111-8111-111111111111";
+const organizationId = "22222222-2222-4222-8222-222222222222";
 const agentId = "33333333-3333-4333-8333-333333333333";
+
+function verifierContext(sessionId: string) {
+  return { organizationId, userId, agentId, sessionId };
+}
 
 async function postPair(
   body: string,
@@ -59,13 +60,8 @@ async function postPair(
 describe("remote pairing route", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockClear();
-    findByIdAndOrg.mockReset();
-    create.mockReset();
-    findByIdAndOrg.mockResolvedValue({
-      id: agentId,
-      user_id: "11111111-1111-4111-8111-111111111111",
-    });
-    create.mockImplementation(async (data) => ({
+    createPendingForOwnedAgent.mockReset();
+    createPendingForOwnedAgent.mockImplementation(async (data) => ({
       ...data,
       created_at: new Date(),
       updated_at: new Date(),
@@ -97,8 +93,8 @@ describe("remote pairing route", () => {
       startedAt + 299_000,
     );
 
-    expect(create).toHaveBeenCalledTimes(1);
-    const persisted = create.mock.calls[0]?.[0] as {
+    expect(createPendingForOwnedAgent).toHaveBeenCalledTimes(1);
+    const persisted = createPendingForOwnedAgent.mock.calls[0]?.[0] as {
       id: string;
       requester_identity: string;
       pairing_token_hash: string;
@@ -110,41 +106,57 @@ describe("remote pairing route", () => {
     expect(persisted.pairing_token_hash).toBe(
       await deriveRemotePairingCodeVerifier(
         secret,
-        body.data.sessionId,
+        verifierContext(body.data.sessionId),
         body.data.code,
         new Date(body.data.expiresAt),
       ),
     );
     expect(persisted.pairing_token_hash).toMatch(
-      /^hmac-sha256-v1:\d{13}:[0-9a-f]{64}$/,
+      /^hmac-sha256-v2:\d{13}:[0-9a-f]{64}$/,
     );
     expect(persisted.pairing_token_hash).not.toBe(body.data.code);
   });
 
-  test("binds the verifier to both the session id and dedicated secret", async () => {
+  test("binds the verifier to every authority identity and dedicated secret", async () => {
     const expiry = new Date("2026-08-18T20:00:00.000Z");
+    const context = verifierContext("44444444-4444-4444-8444-444444444444");
     const first = await deriveRemotePairingCodeVerifier(
       secret,
-      "44444444-4444-4444-8444-444444444444",
+      context,
       "123456",
       expiry,
     );
     const otherSession = await deriveRemotePairingCodeVerifier(
       secret,
-      "55555555-5555-4555-8555-555555555555",
+      { ...context, sessionId: "55555555-5555-4555-8555-555555555555" },
       "123456",
       expiry,
     );
     const otherSecret = await deriveRemotePairingCodeVerifier(
       "another-dedicated-remote-pairing-secret-value",
-      "44444444-4444-4444-8444-444444444444",
+      context,
       "123456",
       expiry,
     );
 
-    expect(first).toMatch(/^hmac-sha256-v1:\d{13}:[0-9a-f]{64}$/);
+    expect(first).toMatch(/^hmac-sha256-v2:\d{13}:[0-9a-f]{64}$/);
     expect(otherSession).not.toBe(first);
     expect(otherSecret).not.toBe(first);
+    for (const changedContext of [
+      { ...context, organizationId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+      { ...context, userId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
+      { ...context, agentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" },
+    ]) {
+      expect(
+        await verifyRemotePairingCodeVerifier(
+          secret,
+          changedContext,
+          "123456",
+          first,
+          new Date(expiry.getTime() - 1),
+        ),
+      ).toBe(false);
+    }
     expect(isRemotePairingVerifierCurrent(first, expiry.getTime() - 1)).toBe(
       true,
     );
@@ -168,7 +180,7 @@ describe("remote pairing route", () => {
     expect(
       await verifyRemotePairingCodeVerifier(
         secret,
-        "44444444-4444-4444-8444-444444444444",
+        context,
         "123456",
         first,
         new Date(expiry.getTime() - 1),
@@ -177,7 +189,7 @@ describe("remote pairing route", () => {
     expect(
       await verifyRemotePairingCodeVerifier(
         secret,
-        "44444444-4444-4444-8444-444444444444",
+        context,
         "123457",
         first,
         new Date(expiry.getTime() - 1),
@@ -186,7 +198,7 @@ describe("remote pairing route", () => {
     expect(
       await verifyRemotePairingCodeVerifier(
         secret,
-        "44444444-4444-4444-8444-444444444444",
+        context,
         "123456",
         first,
         expiry,
@@ -195,7 +207,7 @@ describe("remote pairing route", () => {
     expect(
       await verifyRemotePairingCodeVerifier(
         secret,
-        "44444444-4444-4444-8444-444444444444",
+        context,
         "123456",
         first,
         new Date(Number.NaN),
@@ -204,7 +216,7 @@ describe("remote pairing route", () => {
     await expect(
       verifyRemotePairingCodeVerifier(
         "too-short",
-        "44444444-4444-4444-8444-444444444444",
+        context,
         "123456",
         first,
         new Date(expiry.getTime() - 1),
@@ -220,35 +232,42 @@ describe("remote pairing route", () => {
       success: false,
       code: "REMOTE_PAIRING_NOT_CONFIGURED",
     });
-    expect(findByIdAndOrg).not.toHaveBeenCalled();
-    expect(create).not.toHaveBeenCalled();
+    expect(createPendingForOwnedAgent).not.toHaveBeenCalled();
   });
 
   test("rejects malformed JSON without fabricating an empty request", async () => {
     const response = await postPair("{");
 
     expect(response.status).toBe(400);
-    expect(create).not.toHaveBeenCalled();
+    expect(createPendingForOwnedAgent).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed agent identifier before deriving or persisting authority", async () => {
+    const response = await postPair(JSON.stringify({ agentId: "not-a-uuid" }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "agentId must be a UUID",
+    });
+    expect(createPendingForOwnedAgent).not.toHaveBeenCalled();
   });
 
   test("does not create a pairing session for another organization agent", async () => {
-    findByIdAndOrg.mockResolvedValue(undefined);
+    createPendingForOwnedAgent.mockResolvedValue(undefined);
 
     const response = await postPair(JSON.stringify({ agentId }));
 
     expect(response.status).toBe(404);
-    expect(create).not.toHaveBeenCalled();
+    expect(createPendingForOwnedAgent).toHaveBeenCalledTimes(1);
   });
 
   test("does not create a pairing session for another user in the organization", async () => {
-    findByIdAndOrg.mockResolvedValue({
-      id: agentId,
-      user_id: "66666666-6666-4666-8666-666666666666",
-    });
+    createPendingForOwnedAgent.mockResolvedValue(undefined);
 
     const response = await postPair(JSON.stringify({ agentId }));
 
     expect(response.status).toBe(404);
-    expect(create).not.toHaveBeenCalled();
+    expect(createPendingForOwnedAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/remote/pair/route.ts
+++ b/packages/cloud/api/v1/remote/pair/route.ts
@@ -17,8 +17,10 @@
  */
 
 import { Hono } from "hono";
-import { deriveRemotePairingCodeVerifier } from "@/db/crypto/remote-pairing-code";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  deriveRemotePairingCodeVerifier,
+  isRemotePairingUuid,
+} from "@/db/crypto/remote-pairing-code";
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -79,13 +81,8 @@ app.post("/", async (c) => {
     if (!agentId) {
       return c.json({ success: false, error: "agentId is required" }, 400);
     }
-
-    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
-      agentId,
-      user.organization_id,
-    );
-    if (!sandbox || sandbox.user_id !== user.id) {
-      return c.json({ success: false, error: "Agent not found" }, 404);
+    if (!isRemotePairingUuid(agentId)) {
+      return c.json({ success: false, error: "agentId must be a UUID" }, 400);
     }
 
     const code = generatePairingCode();
@@ -93,12 +90,17 @@ app.post("/", async (c) => {
     const expiresAt = new Date(Date.now() + PAIRING_CODE_TTL_SECONDS * 1000);
     const tokenHash = await deriveRemotePairingCodeVerifier(
       pairingSecret,
-      sessionId,
+      {
+        organizationId: user.organization_id,
+        userId: user.id,
+        agentId,
+        sessionId,
+      },
       code,
       expiresAt,
     );
 
-    const session = await remoteSessionsRepository.create({
+    const session = await remoteSessionsRepository.createPendingForOwnedAgent({
       id: sessionId,
       organization_id: user.organization_id,
       user_id: user.id,
@@ -107,6 +109,9 @@ app.post("/", async (c) => {
       requester_identity: user.id,
       pairing_token_hash: tokenHash,
     });
+    if (!session) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
 
     c.header(
       "Cache-Control",

--- a/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
@@ -1,4 +1,4 @@
-// Handles v1 cloud API v1 remote sessions id revoke route traffic with route-local auth expectations.
+/** Handles owner-scoped remote-session revocation at the HTTP boundary. */
 import { Hono } from "hono";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -6,8 +6,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 /**
  * POST /api/v1/remote/sessions/:id/revoke
  *
- * T9a — Revokes an active or pending remote session. Only the owning
- * organization can revoke.
+ * T9a — Revokes an active or pending remote session. Only the current
+ * authenticated agent owner can revoke it.
  */
 
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
@@ -25,12 +25,12 @@ async function __hono_POST(
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
-    const existing = await remoteSessionsRepository.findByIdAndOwner(
+    const result = await remoteSessionsRepository.revoke(
       id,
       user.organization_id,
       user.id,
     );
-    if (!existing) {
+    if (!result) {
       return applyCorsHeaders(
         Response.json(
           { success: false, error: "Session not found" },
@@ -40,31 +40,18 @@ async function __hono_POST(
       );
     }
 
-    if (existing.status === "revoked" || existing.status === "denied") {
+    const { alreadyEnded, session } = result;
+    if (alreadyEnded) {
       return applyCorsHeaders(
         Response.json({
           success: true,
           data: {
-            id: existing.id,
-            status: existing.status,
-            alreadyEnded: true,
+            id: session.id,
+            status: session.status,
+            alreadyEnded,
+            endedAt: session.ended_at,
           },
         }),
-        CORS_METHODS,
-      );
-    }
-
-    const revoked = await remoteSessionsRepository.revoke(
-      id,
-      user.organization_id,
-      user.id,
-    );
-    if (!revoked) {
-      return applyCorsHeaders(
-        Response.json(
-          { success: false, error: "Revoke failed" },
-          { status: 409 },
-        ),
         CORS_METHODS,
       );
     }
@@ -73,14 +60,16 @@ async function __hono_POST(
       Response.json({
         success: true,
         data: {
-          id: revoked.id,
-          status: revoked.status,
-          endedAt: revoked.ended_at,
+          id: session.id,
+          status: session.status,
+          alreadyEnded,
+          endedAt: session.ended_at,
         },
       }),
       CORS_METHODS,
     );
   } catch (error) {
+    // error-policy:J1 the HTTP boundary translates typed/internal failures.
     return applyCorsHeaders(errorToResponse(error), CORS_METHODS);
   }
 }

--- a/packages/cloud/api/v1/remote/sessions/owner-boundary.test.ts
+++ b/packages/cloud/api/v1/remote/sessions/owner-boundary.test.ts
@@ -20,22 +20,16 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
 const requireAuthOrApiKeyWithOrg = mock(async () => ({
   user: { id: ownerId, organization_id: organizationId },
 }));
-const findByIdAndOrg = mock();
-const findByIdAndOwner = mock();
-const listActiveByAgent = mock();
+const listActiveByOwnedAgent = mock();
 const revoke = mock();
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
 mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
-mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { findByIdAndOrg },
-}));
 mock.module("@/db/repositories/remote-sessions", () => ({
   remoteSessionsRepository: {
-    findByIdAndOwner,
-    listActiveByAgent,
+    listActiveByOwnedAgent,
     revoke,
   },
 }));
@@ -49,12 +43,9 @@ app.route("/api/v1/remote/sessions/:id/revoke", revokeRoute);
 
 describe("remote session owner boundaries", () => {
   beforeEach(() => {
-    findByIdAndOrg.mockReset();
-    findByIdAndOwner.mockReset();
-    listActiveByAgent.mockReset();
+    listActiveByOwnedAgent.mockReset();
     revoke.mockReset();
-    findByIdAndOrg.mockResolvedValue({ id: agentId, user_id: ownerId });
-    listActiveByAgent.mockResolvedValue([]);
+    listActiveByOwnedAgent.mockResolvedValue([]);
   });
 
   test("lists sessions through organization and authenticated-owner scope", async () => {
@@ -63,7 +54,7 @@ describe("remote session owner boundaries", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(listActiveByAgent).toHaveBeenCalledWith(
+    expect(listActiveByOwnedAgent).toHaveBeenCalledWith(
       agentId,
       organizationId,
       ownerId,
@@ -71,30 +62,33 @@ describe("remote session owner boundaries", () => {
   });
 
   test("hides another same-organization user's agent sessions", async () => {
-    findByIdAndOrg.mockResolvedValue({
-      id: agentId,
-      user_id: "55555555-5555-4555-8555-555555555555",
-    });
+    listActiveByOwnedAgent.mockResolvedValue(undefined);
 
     const response = await app.request(
       `/api/v1/remote/sessions?agentId=${agentId}`,
     );
 
     expect(response.status).toBe(404);
-    expect(listActiveByAgent).not.toHaveBeenCalled();
+    expect(listActiveByOwnedAgent).toHaveBeenCalledWith(
+      agentId,
+      organizationId,
+      ownerId,
+    );
   });
 
-  test("looks up and revokes a session through authenticated-owner scope", async () => {
+  test("revokes a session through one atomic authenticated-owner operation", async () => {
     const active = {
       id: sessionId,
       status: "active",
       ended_at: null,
     };
-    findByIdAndOwner.mockResolvedValue(active);
     revoke.mockResolvedValue({
-      ...active,
-      status: "revoked",
-      ended_at: new Date("2026-08-18T20:00:00.000Z"),
+      alreadyEnded: false,
+      session: {
+        ...active,
+        status: "revoked",
+        ended_at: new Date("2026-08-18T20:00:00.000Z"),
+      },
     });
 
     const response = await app.request(
@@ -103,16 +97,32 @@ describe("remote session owner boundaries", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(findByIdAndOwner).toHaveBeenCalledWith(
-      sessionId,
-      organizationId,
-      ownerId,
-    );
     expect(revoke).toHaveBeenCalledWith(sessionId, organizationId, ownerId);
   });
 
+  test("reports a repeated revocation as idempotent success", async () => {
+    revoke.mockResolvedValue({
+      alreadyEnded: true,
+      session: {
+        id: sessionId,
+        status: "revoked",
+        ended_at: new Date("2026-08-18T20:00:00.000Z"),
+      },
+    });
+
+    const response = await app.request(
+      `/api/v1/remote/sessions/${sessionId}/revoke`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { id: sessionId, status: "revoked", alreadyEnded: true },
+    });
+  });
+
   test("does not reveal or revoke another owner's session", async () => {
-    findByIdAndOwner.mockResolvedValue(undefined);
+    revoke.mockResolvedValue(undefined);
 
     const response = await app.request(
       `/api/v1/remote/sessions/${sessionId}/revoke`,
@@ -120,6 +130,6 @@ describe("remote session owner boundaries", () => {
     );
 
     expect(response.status).toBe(404);
-    expect(revoke).not.toHaveBeenCalled();
+    expect(revoke).toHaveBeenCalledWith(sessionId, organizationId, ownerId);
   });
 });

--- a/packages/cloud/api/v1/remote/sessions/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { Hono } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -26,19 +25,14 @@ app.get("/", async (c) => {
       );
     }
 
-    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
-      agentId,
-      user.organization_id,
-    );
-    if (!sandbox || sandbox.user_id !== user.id) {
-      return c.json({ success: false, error: "Agent not found" }, 404);
-    }
-
-    const sessions = await remoteSessionsRepository.listActiveByAgent(
+    const sessions = await remoteSessionsRepository.listActiveByOwnedAgent(
       agentId,
       user.organization_id,
       user.id,
     );
+    if (!sessions) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
 
     return c.json({
       success: true,

--- a/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
@@ -1,14 +1,28 @@
 /**
  * Defines the versioned keyed verifier stored for human-entered remote
- * pairing codes. The signed payload binds the code to one session and expiry;
- * callers must still atomically consume the corresponding pending row.
+ * pairing codes. The signed payload binds one challenge to its tenant, owner,
+ * agent, session, purpose, and expiry; callers must still atomically consume
+ * the corresponding pending row.
  */
 
-const VERIFIER_PREFIX = "hmac-sha256-v1";
-const VERIFIER_PATTERN = /^hmac-sha256-v1:(\d{13}):([0-9a-f]{64})$/;
-const SESSION_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const VERIFIER_PREFIX = "hmac-sha256-v2";
+const VERIFIER_PATTERN = /^hmac-sha256-v2:(\d{13}):([0-9a-f]{64})$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const CODE_PATTERN = /^\d{6}$/;
+const PAIRING_PURPOSE = "remote-control";
+
+/** Authoritative database identities covered by one pairing verifier. */
+export interface RemotePairingVerifierContext {
+  organizationId: string;
+  userId: string;
+  agentId: string;
+  sessionId: string;
+}
+
+/** Reports whether an untrusted pairing identifier is a canonical UUID. */
+export function isRemotePairingUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
 
 function textBuffer(value: string): ArrayBuffer {
   const encoded = new TextEncoder().encode(value);
@@ -25,10 +39,26 @@ function assertSecret(secret: string): ArrayBuffer {
   return secretBytes;
 }
 
-function assertInputs(sessionId: string, code: string, expiresAtMs: number): void {
-  if (!SESSION_ID_PATTERN.test(sessionId)) {
-    throw new TypeError("remote pairing session id must be a canonical UUID");
+function assertContext(context: RemotePairingVerifierContext): void {
+  const entries = [
+    ["organization", context.organizationId],
+    ["user", context.userId],
+    ["agent", context.agentId],
+    ["session", context.sessionId],
+  ] as const;
+  for (const [name, value] of entries) {
+    if (!isRemotePairingUuid(value)) {
+      throw new TypeError(`remote pairing ${name} id must be a canonical UUID`);
+    }
   }
+}
+
+function assertInputs(
+  context: RemotePairingVerifierContext,
+  code: string,
+  expiresAtMs: number,
+): void {
+  assertContext(context);
   if (!CODE_PATTERN.test(code)) {
     throw new TypeError("remote pairing code must contain exactly six digits");
   }
@@ -37,8 +67,23 @@ function assertInputs(sessionId: string, code: string, expiresAtMs: number): voi
   }
 }
 
-function signingPayload(sessionId: string, code: string, expiresAtMs: number): ArrayBuffer {
-  return textBuffer(`eliza.remote-pairing.v1\0${sessionId}\0${expiresAtMs}\0${code}`);
+function signingPayload(
+  context: RemotePairingVerifierContext,
+  code: string,
+  expiresAtMs: number,
+): ArrayBuffer {
+  return textBuffer(
+    [
+      "eliza.remote-pairing.v2",
+      PAIRING_PURPOSE,
+      context.organizationId,
+      context.userId,
+      context.agentId,
+      context.sessionId,
+      String(expiresAtMs),
+      code,
+    ].join("\0"),
+  );
 }
 
 function bytesToHex(bytes: ArrayBuffer): string {
@@ -93,17 +138,17 @@ export function isRemotePairingSessionCurrent(
 /** Derives the versioned verifier persisted instead of the six-digit code. */
 export async function deriveRemotePairingCodeVerifier(
   secret: string,
-  sessionId: string,
+  context: RemotePairingVerifierContext,
   code: string,
   expiresAt: Date,
 ): Promise<string> {
   const expiresAtMs = expiresAt.getTime();
-  assertInputs(sessionId, code, expiresAtMs);
+  assertInputs(context, code, expiresAtMs);
   const key = await importHmacKey(secret, "sign");
   const signature = await crypto.subtle.sign(
     "HMAC",
     key,
-    signingPayload(sessionId, code, expiresAtMs),
+    signingPayload(context, code, expiresAtMs),
   );
   return `${VERIFIER_PREFIX}:${expiresAtMs}:${bytesToHex(signature)}`;
 }
@@ -111,7 +156,7 @@ export async function deriveRemotePairingCodeVerifier(
 /** Verifies the code, session binding, signature, and expiry without exposing the code. */
 export async function verifyRemotePairingCodeVerifier(
   secret: string,
-  sessionId: string,
+  context: RemotePairingVerifierContext,
   code: string,
   verifier: string,
   now: Date,
@@ -124,7 +169,7 @@ export async function verifyRemotePairingCodeVerifier(
     return false;
   }
   try {
-    assertInputs(sessionId, code, expiresAtMs);
+    assertInputs(context, code, expiresAtMs);
   } catch {
     // error-policy:J3 untrusted pairing material is an explicit invalid result.
     return false;
@@ -134,6 +179,6 @@ export async function verifyRemotePairingCodeVerifier(
     "HMAC",
     key,
     hexToBuffer(match[2]),
-    signingPayload(sessionId, code, expiresAtMs),
+    signingPayload(context, code, expiresAtMs),
   );
 }

--- a/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
@@ -1,0 +1,183 @@
+/**
+ * Persists remote-control sessions while keeping every authorization-sensitive
+ * operation bound to the current primary-database owner of the target agent.
+ * The injectable database keeps the same production queries testable against
+ * an isolated real PostgreSQL-compatible engine.
+ */
+
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { Database } from "../client";
+import { isRemotePairingSessionCurrent } from "../crypto/remote-pairing-code";
+import { agentSandboxes } from "../schemas/agent-sandboxes";
+import {
+  type NewRemoteSession,
+  type RemoteSession,
+  type RemoteSessionStatus,
+  remoteSessions,
+} from "../schemas/remote-sessions";
+
+const ACTIVE_STATUSES: RemoteSessionStatus[] = ["pending", "active"];
+
+export interface RevokeRemoteSessionResult {
+  session: RemoteSession;
+  alreadyEnded: boolean;
+}
+
+export class RemoteSessionsRepository {
+  constructor(private readonly database: Database) {}
+
+  /**
+   * Creates the sole pending challenge for an agent under a row lock. The lock
+   * serializes ownership changes and concurrent issuers; a newer challenge
+   * denies every older pending challenge before it becomes visible.
+   */
+  async createPendingForOwnedAgent(data: NewRemoteSession): Promise<RemoteSession | undefined> {
+    if (
+      data.status !== "pending" ||
+      data.requester_identity !== data.user_id ||
+      !data.id ||
+      !data.organization_id ||
+      !data.user_id ||
+      !data.agent_id ||
+      !data.pairing_token_hash
+    ) {
+      throw new TypeError("Pending remote session input violates its ownership contract");
+    }
+
+    return this.database.transaction(async (tx) => {
+      const [ownedAgent] = await tx
+        .select({ id: agentSandboxes.id })
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.id, data.agent_id),
+            eq(agentSandboxes.organization_id, data.organization_id),
+            eq(agentSandboxes.user_id, data.user_id),
+            isNull(agentSandboxes.deleted_at),
+          ),
+        )
+        .for("update");
+      if (!ownedAgent) return undefined;
+
+      const now = new Date();
+      await tx
+        .update(remoteSessions)
+        .set({ status: "denied", updated_at: now, ended_at: now })
+        .where(
+          and(
+            eq(remoteSessions.agent_id, data.agent_id),
+            eq(remoteSessions.organization_id, data.organization_id),
+            eq(remoteSessions.user_id, data.user_id),
+            eq(remoteSessions.status, "pending"),
+          ),
+        );
+
+      const [row] = await tx.insert(remoteSessions).values(data).returning();
+      if (!row) throw new Error("Failed to create remote session");
+      return row;
+    });
+  }
+
+  async listActiveByOwnedAgent(
+    agentId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<RemoteSession[] | undefined> {
+    return this.database.transaction(async (tx) => {
+      const [ownedAgent] = await tx
+        .select({ id: agentSandboxes.id })
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.id, agentId),
+            eq(agentSandboxes.organization_id, orgId),
+            eq(agentSandboxes.user_id, userId),
+            isNull(agentSandboxes.deleted_at),
+          ),
+        )
+        .for("share");
+      if (!ownedAgent) return undefined;
+
+      const rows = await tx
+        .select()
+        .from(remoteSessions)
+        .where(
+          and(
+            eq(remoteSessions.agent_id, agentId),
+            eq(remoteSessions.organization_id, orgId),
+            eq(remoteSessions.user_id, userId),
+            inArray(remoteSessions.status, ACTIVE_STATUSES),
+          ),
+        )
+        .orderBy(desc(remoteSessions.created_at));
+      const nowMs = Date.now();
+      return rows.filter((row) =>
+        isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
+      );
+    });
+  }
+
+  async revoke(
+    id: string,
+    orgId: string,
+    userId: string,
+  ): Promise<RevokeRemoteSessionResult | undefined> {
+    const now = new Date();
+    return this.database.transaction(async (tx) => {
+      const [authorized] = await tx
+        .select({ agentId: remoteSessions.agent_id })
+        .from(remoteSessions)
+        .innerJoin(
+          agentSandboxes,
+          and(
+            eq(agentSandboxes.id, remoteSessions.agent_id),
+            eq(agentSandboxes.organization_id, remoteSessions.organization_id),
+            eq(agentSandboxes.user_id, remoteSessions.user_id),
+            isNull(agentSandboxes.deleted_at),
+          ),
+        )
+        .where(
+          and(
+            eq(remoteSessions.id, id),
+            eq(remoteSessions.organization_id, orgId),
+            eq(remoteSessions.user_id, userId),
+          ),
+        )
+        .for("update", { of: agentSandboxes });
+      if (!authorized) return undefined;
+
+      const [current] = await tx
+        .select()
+        .from(remoteSessions)
+        .where(
+          and(
+            eq(remoteSessions.id, id),
+            eq(remoteSessions.organization_id, orgId),
+            eq(remoteSessions.user_id, userId),
+            eq(remoteSessions.agent_id, authorized.agentId),
+          ),
+        )
+        .for("update");
+      if (!current) return undefined;
+      if (current.status === "revoked" || current.status === "denied") {
+        return { session: current, alreadyEnded: true };
+      }
+
+      const [row] = await tx
+        .update(remoteSessions)
+        .set({ status: "revoked", updated_at: now, ended_at: now })
+        .where(
+          and(
+            eq(remoteSessions.id, id),
+            eq(remoteSessions.organization_id, orgId),
+            eq(remoteSessions.user_id, userId),
+            eq(remoteSessions.agent_id, authorized.agentId),
+            inArray(remoteSessions.status, ACTIVE_STATUSES),
+          ),
+        )
+        .returning();
+      if (!row) throw new Error("Locked remote session could not be revoked");
+      return { session: row, alreadyEnded: false };
+    });
+  }
+}

--- a/packages/cloud/shared/src/db/repositories/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions.ts
@@ -1,85 +1,16 @@
-// Persists remote sessions records for cloud services through the shared DB boundary.
-import { and, desc, eq, inArray } from "drizzle-orm";
-import { isRemotePairingSessionCurrent } from "../crypto/remote-pairing-code";
-import { dbRead, dbWrite } from "../helpers";
-import {
-  type NewRemoteSession,
-  type RemoteSession,
-  type RemoteSessionStatus,
-  remoteSessions,
+/** Exposes the production remote-session repository at its stable import path. */
+
+import { dbWrite } from "../helpers";
+import { RemoteSessionsRepository } from "./remote-sessions-store";
+
+export type {
+  NewRemoteSession,
+  RemoteSession,
+  RemoteSessionStatus,
 } from "../schemas/remote-sessions";
+export {
+  RemoteSessionsRepository,
+  type RevokeRemoteSessionResult,
+} from "./remote-sessions-store";
 
-export type { NewRemoteSession, RemoteSession, RemoteSessionStatus };
-
-const ACTIVE_STATUSES: RemoteSessionStatus[] = ["pending", "active"];
-
-export class RemoteSessionsRepository {
-  async create(data: NewRemoteSession): Promise<RemoteSession> {
-    const [row] = await dbWrite.insert(remoteSessions).values(data).returning();
-    if (!row) {
-      throw new Error("Failed to create remote session");
-    }
-    return row;
-  }
-
-  async findByIdAndOwner(
-    id: string,
-    orgId: string,
-    userId: string,
-  ): Promise<RemoteSession | undefined> {
-    const [row] = await dbRead
-      .select()
-      .from(remoteSessions)
-      .where(
-        and(
-          eq(remoteSessions.id, id),
-          eq(remoteSessions.organization_id, orgId),
-          eq(remoteSessions.user_id, userId),
-        ),
-      )
-      .limit(1);
-    return row;
-  }
-
-  async listActiveByAgent(
-    agentId: string,
-    orgId: string,
-    userId: string,
-  ): Promise<RemoteSession[]> {
-    const rows = await dbRead
-      .select()
-      .from(remoteSessions)
-      .where(
-        and(
-          eq(remoteSessions.agent_id, agentId),
-          eq(remoteSessions.organization_id, orgId),
-          eq(remoteSessions.user_id, userId),
-          inArray(remoteSessions.status, ACTIVE_STATUSES),
-        ),
-      )
-      .orderBy(desc(remoteSessions.created_at));
-    const nowMs = Date.now();
-    return rows.filter((row) =>
-      isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
-    );
-  }
-
-  async revoke(id: string, orgId: string, userId: string): Promise<RemoteSession | undefined> {
-    const now = new Date();
-    const [row] = await dbWrite
-      .update(remoteSessions)
-      .set({ status: "revoked", updated_at: now, ended_at: now })
-      .where(
-        and(
-          eq(remoteSessions.id, id),
-          eq(remoteSessions.organization_id, orgId),
-          eq(remoteSessions.user_id, userId),
-          inArray(remoteSessions.status, ACTIVE_STATUSES),
-        ),
-      )
-      .returning();
-    return row;
-  }
-}
-
-export const remoteSessionsRepository = new RemoteSessionsRepository();
+export const remoteSessionsRepository = new RemoteSessionsRepository(dbWrite);


### PR DESCRIPTION
## Summary

Follow-up hardening for the bounded remote pairing work merged in #22129.

- bind the pairing verifier to purpose, tenant, user, agent, session, expiry, and code
- authorize ownership on the primary database inside the same transaction that creates, lists, or revokes a session
- serialize concurrent challenge creation so only one pending challenge remains per agent
- make concurrent revocation atomic and idempotent
- validate agent UUIDs and keep client-supplied authority/redirect fields out of the verifier context

This remains intentionally scoped to challenge issuance/list/revoke. No consume or device-grant endpoint exists yet, so this does not claim end-to-end production pairing.

## Verification

- `bun test packages/cloud/api/v1/remote` — 17 pass, 0 fail, including real Hono + PGlite concurrency, ownership-transfer, replay, and verifier-binding coverage
- `bun run --cwd packages/cloud/shared typecheck` — pass
- Cloud API `tsc --noEmit` — pass
- `bunx biome check` on all changed files — pass
- `git diff --check` — pass
- root `bun run verify` — reached 209/211 successful tasks, then failed in the Cloud API Wrangler bundle on an unrelated current-develop stub-export defect: `truncateWellFormed` is imported by shared Discord/Telegram helpers but absent from `packages/cloud/api/src/stubs/elizaos-core.ts`

Refs #21784

## Contribution provenance

- Model: OpenAI/gpt-5.6-sol
- Client: Codex Desktop multi-agent review