### PR TITLE
fix(cloud): send a first-party Origin from the e2e client for the cookie-mutation guard

### DIFF
--- a/packages/cloud/api/test/e2e/_helpers/api.ts
+++ b/packages/cloud/api/test/e2e/_helpers/api.ts
@@ -141,7 +141,15 @@ async function request(
     const init: RequestInit = {
       method,
       signal: timeoutSignal(),
-      headers: { ...(opts.headers ?? {}) },
+      headers: {
+        // The cookie-mutation CSRF guard requires a first-party browser
+        // origin on cookie-authenticated mutations. Browsers always attach
+        // Origin on POST; this Node client must send the same-origin value a
+        // real browser would. Listed first so a test that sets its own
+        // Origin (e.g. an adversarial-origin case) still overrides it.
+        Origin: new URL(getBaseUrl()).origin,
+        ...(opts.headers ?? {}),
+      },
     };
     if (opts.body !== undefined) {
       (init.headers as Record<string, string>)["Content-Type"] ??=


### PR DESCRIPTION
# Relates to

#22183 — the last blocker before the staging deploy receipt. cc @lalalune (cloud territory; nubs authorized shipping this directly since it unblocks the frozen staging train).

# What changed

One header in the e2e client (`test/e2e/_helpers/api.ts`): default `Origin: <base URL origin>` on every request, listed before caller-supplied headers so any test that sets its own Origin still overrides.

**Why:** the wave-10 cookie-mutation CSRF guard (`4da82caac8` + `22086323ef`) correctly requires a first-party browser origin on cookie-authenticated mutations. Browsers always attach `Origin` on POST; the Node e2e client attached none, so every cookie-authed step — first hit: agent-token-flow's "session cookie can create a new API key" — failed `403 forbidden_origin` (`missing_origin_and_referer`) and killed the Worker pre-deploy e2e gate on every staging train. The guard is behaving as designed; only the harness was un-browser-like.

# Evidence

- Local harness (same wrangler-dev + PGlite path that reproduced the CI failure), at develop `98d6a3b99a` + this commit: `[api-e2e] PASS test/e2e/agent-token-flow.test.ts` (was: `Expected: 201, Received: 403` — CI run 32191021391, where Run Database Migrations already passed post-#22070/#22199).
- Biome clean; no Worker/source change — test harness only.

Known context: pull_request CI is still starved repo-wide (HQ 18059089) — zero lanes here means "not run". The local pass above is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
