### PR TITLE
fix(core): terminate interaction button-row chunking

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -375,6 +375,24 @@ describe("layout", () => {
 		});
 	});
 
+	it("rejects non-positive maxButtonsPerRow instead of hanging", () => {
+		const block: ChoiceInteraction = {
+			kind: "choice",
+			id: "i",
+			scope: "s",
+			prompt: "Pick",
+			options: [
+				{ value: "a", label: "A" },
+				{ value: "b", label: "B" },
+			],
+		};
+		for (const perRow of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(() =>
+				toNeutralLayout(block, { maxButtonsPerRow: perRow }),
+			).toThrow(RangeError);
+		}
+	});
+
 	it("marks allowCustom choices as needing a free-text fallback", () => {
 		const block: ChoiceInteraction = {
 			kind: "choice",

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -92,7 +92,20 @@ function firstNonBlankText(
 	return undefined;
 }
 
+function resolveButtonsPerRow(value: number | undefined): number {
+	if (value === undefined) return 3;
+	if (!Number.isInteger(value) || value < 1) {
+		throw new RangeError(
+			"maxButtonsPerRow must be a finite integer of at least 1",
+		);
+	}
+	return value;
+}
+
 function chunk<T>(items: T[], size: number): T[][] {
+	if (!Number.isInteger(size) || size < 1) {
+		throw new RangeError("chunk size must be a finite integer of at least 1");
+	}
 	const rows: T[][] = [];
 	for (let i = 0; i < items.length; i += size)
 		rows.push(items.slice(i, i + size));
@@ -127,7 +140,7 @@ export function toNeutralLayout(
 	block: InteractionBlock,
 	opts: LayoutOptions = {},
 ): NeutralLayout {
-	const perRow = opts.maxButtonsPerRow ?? 3;
+	const perRow = resolveButtonsPerRow(opts.maxButtonsPerRow);
 	const resolveUrl = opts.resolveUrl;
 	const maxCallbackBytes = opts.maxCallbackBytes;
 


### PR DESCRIPTION
# Relates to

Closes #22290
Stayed off `#22262` and `#22278` (`headscale-client.ts`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused package tests passed at this head.
- [x] A reviewer can confirm the hang and the terminate from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run --cwd packages/core test -- src/messaging/interactions/interactions.test.ts` — 75 passed.

# Risks

Low. Discord (5) and Telegram (8) pass a positive `maxButtonsPerRow`. The default remains 3. Invalid sizes now throw `RangeError` instead of hanging the render loop.

# Background

## What does this PR do?

`toNeutralLayout` builds platform-neutral button rows for `[CHOICE]` / `[FOLLOWUPS]` blocks. It forwarded `maxButtonsPerRow` into `chunk()` as `for (i = 0; i < n; i += size)`. `0 ?? 3` is `0`, so `maxButtonsPerRow: 0` (or any negative integer) never advances and hangs the Discord/Telegram interaction render path.

On origin the isolated loop exits 142 under a 2s alarm for sizes `0` and `-1`. This PR rejects non-integer and `< 1` row sizes with `RangeError` so every iteration consumes at least one button.

Not leftover-tax. Not extra-decode. Not a cloud JSON 500 reprint. Not `#22262` telegram text chunking. Not `#22278` Headscale TTL `parseInt`.

## What kind of change is this?

Bug fix (hang).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/messaging/interactions/interactions.test.ts`

## Detailed testing steps

On origin:

```text
chunk(["a","b","c"], 0)   # hang, alarm exit 142
chunk(["a","b","c"], -1)  # hang, alarm exit 142
```

After this commit:

```text
bun run --cwd packages/core test -- src/messaging/interactions/interactions.test.ts
# 75 passed
# 0 / -1 / 1.5 / NaN / Infinity throw RangeError
```

# Evidence Gate

<!-- evidence-head:631f362328faf053939eef82de23bea9b542df1a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; layout projector hang only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; layout projector hang only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - hang proved by 2s alarm (exit 142) and unit tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure synchronous layout projection; no backend process, request, or log surface is involved.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted memory, database row, task, file, wallet, or external domain artifact is produced by button-row chunking.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/provider path.

## Backend + frontend logs

Red: isolated `chunk(..., 0)` / `chunk(..., -1)` SIGALRM 142.
Green: vitest 75 passed at `b96f134b5d3c`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
