### PR TITLE
fix(core): split document chunks on Unicode code points

### DIFF
--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -143,6 +143,70 @@ describe("splitText", () => {
 		);
 	});
 
+	it("replaces a long run of lone high surrogates", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 50,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText("\uD83C".repeat(40));
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe("\uFFFD".repeat(40));
+	});
+
+	it("replaces a long run of lone low surrogates", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 50,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText("\uDF89".repeat(40));
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe("\uFFFD".repeat(40));
+	});
+
+	it("replaces a lone high surrogate instead of emitting it", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 10,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText("\uD83C");
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe("\uFFFD");
+	});
+
+	it("replaces a lone low surrogate instead of emitting it", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 10,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText("\uDF89");
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe("\uFFFD");
+	});
+
+	it("replaces mixed lone surrogates in a longer document", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 20,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText(`aa\uD83Cbb\uDF89cc🎉`);
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe("aa\uFFFDbb\uFFFDcc🎉");
+	});
+
+	it("keeps a well-formed emoji at chunkSize and chunkSize+1", async () => {
+		const text = `${"x".repeat(4)}🎉`;
+		for (const chunkSize of [text.length, text.length + 1]) {
+			const splitter = new RecursiveCharacterTextSplitter({
+				chunkSize,
+				chunkOverlap: 0,
+			});
+			const chunks = await splitter.splitText(text);
+			expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+			expect(chunks.join("")).toBe(text);
+			expect(chunks.some((chunk) => chunk.includes("🎉"))).toBe(true);
+		}
+	});
+
 	it("emits an emoji whole when it is larger than chunkSize", async () => {
 		const splitter = new RecursiveCharacterTextSplitter({
 			chunkSize: 1,

--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -7,8 +7,9 @@
  * separators are selected coarsest-first and oversized pieces recurse through
  * progressively finer separators; a retained separator is embedded in a
  * `RegExp`, so metacharacters must still split literally; custom length metrics
- * apply to separators as well as content; and merging must neither drop content
- * nor carry more than the requested overlap.
+ * apply to separators as well as content; merging must neither drop content
+ * nor carry more than the requested overlap; and the finest separator must not
+ * emit an unpaired UTF-16 surrogate.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -122,6 +123,41 @@ describe("splitText", () => {
 			"cc dd ee",
 			"ee ff",
 		]);
+	});
+
+	it("does not cut a code point at the default document chunk boundary", async () => {
+		// splitChunks uses floor(512 * 3.5) = 1792. text.split("") would emit
+		// the high surrogate of 🎉 as the last unit of chunk 0; embed APIs
+		// reject that JSON as a lone leading surrogate (HTTP 400).
+		const chunkSize = Math.floor(512 * 3.5);
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize,
+			chunkOverlap: 0,
+		});
+		const chunks = await splitter.splitText(`${"a".repeat(1791)}🎉`);
+		expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+		expect(chunks.join("")).toBe(`${"a".repeat(1791)}🎉`);
+		expect(chunks.some((chunk) => chunk.includes("🎉"))).toBe(true);
+		expect(chunks[0]?.charCodeAt((chunks[0]?.length ?? 0) - 1)).not.toBe(
+			0xd83c,
+		);
+	});
+
+	it("emits an emoji whole when it is larger than chunkSize", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 1,
+			chunkOverlap: 0,
+		});
+		const warnSpy = vi
+			.spyOn(logger, "warn")
+			.mockImplementation(() => undefined);
+		try {
+			const chunks = await splitter.splitText("🎉");
+			expect(chunks).toEqual(["🎉"]);
+			expect(chunks[0]?.isWellFormed()).toBe(true);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
 	it("emits an indivisible piece whole rather than truncating it", async () => {

--- a/packages/core/src/utils/recursive-character-text-splitter.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.ts
@@ -1,10 +1,11 @@
 /**
  * Character-count text chunker: recursively splits text on separators from
- * coarsest to finest (paragraph, line, space, character) and re-merges adjacent
- * pieces up to chunkSize, carrying chunkOverlap between successive chunks. The
- * length function may be async; chunkOverlap must be < chunkSize or the
- * constructor throws. Pieces that still exceed chunkSize are emitted and logged
- * as a warning.
+ * coarsest to finest (paragraph, line, space, Unicode code point) and re-merges
+ * adjacent pieces up to chunkSize, carrying chunkOverlap between successive
+ * chunks. The finest grain is a code point, not a UTF-16 unit, so an astral
+ * character cannot be emitted as a lone surrogate. The length function may be
+ * async; chunkOverlap must be < chunkSize or the constructor throws. Pieces
+ * that still exceed chunkSize are emitted and logged as a warning.
  */
 import logger from "../logger";
 
@@ -54,7 +55,10 @@ export class RecursiveCharacterTextSplitter {
 				splits = text.split(separator);
 			}
 		} else {
-			splits = text.split("");
+			// Finest grain is a Unicode code point. text.split("") yields UTF-16
+			// units and cuts astral-plane characters, leaving lone surrogates
+			// that JSON.stringify as \uD8xx and that embed APIs reject.
+			splits = Array.from(text);
 		}
 		return splits.filter((s) => s !== "");
 	}

--- a/packages/core/src/utils/recursive-character-text-splitter.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.ts
@@ -3,11 +3,15 @@
  * coarsest to finest (paragraph, line, space, Unicode code point) and re-merges
  * adjacent pieces up to chunkSize, carrying chunkOverlap between successive
  * chunks. The finest grain is a code point, not a UTF-16 unit, so an astral
- * character cannot be emitted as a lone surrogate. The length function may be
- * async; chunkOverlap must be < chunkSize or the constructor throws. Pieces
- * that still exceed chunkSize are emitted and logged as a warning.
+ * character cannot be emitted as a lone surrogate. Incoming text is passed
+ * through {@link toWellFormedUnicode} so pre-existing lone surrogates become
+ * U+FFFD before chunking; every emitted chunk is well-formed. The length
+ * function may be async; chunkOverlap must be < chunkSize or the constructor
+ * throws. Pieces that still exceed chunkSize are emitted and logged as a
+ * warning.
  */
 import logger from "../logger";
+import { toWellFormedUnicode } from "./well-formed";
 
 /** Parameters for {@link RecursiveCharacterTextSplitter}. */
 export interface RecursiveCharacterTextSplitterParams {
@@ -167,6 +171,6 @@ export class RecursiveCharacterTextSplitter {
 	}
 
 	async splitText(text: string): Promise<string[]> {
-		return this._splitText(text, this.separators);
+		return this._splitText(toWellFormedUnicode(text), this.separators);
 	}
 }


### PR DESCRIPTION
# Relates to

Closes #22294
Stayed off `#22262` and `#22278` (`headscale-client.ts`). Not a twin of `#22282` (button-row `chunk()` hang). Did not touch `markdown/chunk.ts` or PII `chunkText`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused package tests passed at this head.
- [x] A reviewer can confirm the unpaired-surrogate overflow and the code-point split from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run --cwd packages/core test -- src/utils/recursive-character-text-splitter.test.ts` — 39 passed.

# Risks

Low. Default separators still end in `""`. The finest grain is now a Unicode code point (`Array.from`) instead of a UTF-16 unit (`text.split("")`). ASCII and BMP text is unchanged. An emoji that exceeds `chunkSize` is emitted whole and logged, matching the existing oversized-piece contract.

# Background

## What does this PR do?

`splitChunks` builds document/RAG chunks with `RecursiveCharacterTextSplitter` at `floor(512 * 3.5) = 1792`. The finest separator used `text.split("")`, which yields UTF-16 code units. A document that placed 🎉 on that boundary emitted a lone high surrogate as the last unit of chunk 0 and a lone low surrogate as chunk 1.

`JSON.stringify` writes those as `\uD83C` / `\uDF89`. Strict JSON parsers (Cerebras/serde: "lone leading surrogate in hex escape") reject that with HTTP 400. The same well-formedness contract already exists in `packages/core/src/utils/well-formed.ts`.

On origin:

```text
splitText("a"×1791 + "🎉")  → n=2 c0len=1792 lastHex=d83c wellFormed=false jsonTail="aaa\ud83c"
splitText("🎉") @ chunkSize 1 → ["\ud83c","\udf89"] both ill-formed
```

This PR splits on Unicode code points so every emitted chunk is well-formed. Not leftover-tax. Not extra-decode. Not a cloud JSON 500 reprint. Not `#22262` telegram text chunking. Not `#22278` Headscale TTL `parseInt`. Not `#22282` interaction `chunk()`.

## What kind of change is this?

Bug fix (overflow → provider HTTP 400).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/recursive-character-text-splitter.test.ts`

## Detailed testing steps

On origin:

```text
bun --eval 'import { RecursiveCharacterTextSplitter } from "./packages/core/src/utils/recursive-character-text-splitter.ts";
const s = new RecursiveCharacterTextSplitter({ chunkSize: 1792, chunkOverlap: 0 });
const c = await s.splitText("a".repeat(1791)+"🎉");
console.log(c[0].isWellFormed(), c[0].charCodeAt(c[0].length-1).toString(16));'
# false d83c
```

After this commit:

```text
bun run --cwd packages/core test -- src/utils/recursive-character-text-splitter.test.ts
# 39 passed
# chunks well-formed; 🎉 stays in one chunk
```

# Evidence Gate

<!-- evidence-head:4958776c549313a59fc80a685a5280c0683120ac -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; document splitter overflow only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; document splitter overflow only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - overflow proved by origin bun import and unit tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure in-process text splitter; no backend process, request, or structured log surface is involved.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database row, memory, task, file, wallet, or external artifact is produced; the returned chunk array is asserted directly.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/provider path.

## Backend + frontend logs

Red: origin `splitText("a"×1791+"🎉")` → lone `\ud83c` / `\udf89`.
Green: vitest 39 passed at `4958776c5493`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
