### PR TITLE
fix(plugin-imessage): enforce IMESSAGE_GROUP_POLICY on inbound poll path

### DIFF
--- a/plugins/plugin-imessage/src/group-policy.test.ts
+++ b/plugins/plugin-imessage/src/group-policy.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression coverage for the inbound poll access gate: verifies that
+ * `IMessageService.pollForNewMessagesInner` enforces `IMESSAGE_GROUP_POLICY`
+ * for group rows (open/allowlist/disabled) while leaving the DM policy path
+ * unchanged. Drives the private poll method against a stub `chatDb` and a
+ * recording runtime, asserting on the emitted `MESSAGE_RECEIVED` events — the
+ * observable signal that a message was dispatched to the agent. The harness is
+ * deterministic and offline; chat.db and Contacts are stubbed.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatDbMessage, ChatDbReader } from "./chatdb-reader";
+import { IMessageService } from "./service";
+import type { IMessageSettings } from "./types";
+
+function makeRow(overrides: Partial<ChatDbMessage> = {}): ChatDbMessage {
+  return {
+    rowId: 1,
+    guid: "guid-1",
+    text: "hello there",
+    kind: "text",
+    handle: "+15551234567",
+    chatId: "chat-abc",
+    chatType: "direct",
+    displayName: null,
+    timestamp: 1_700_000_000_000,
+    isFromMe: false,
+    service: "iMessage",
+    isSent: false,
+    isDelivered: true,
+    isRead: false,
+    dateRead: 0,
+    dateEdited: 0,
+    dateRetracted: 0,
+    replyToGuid: null,
+    reaction: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+interface Harness {
+  service: IMessageService;
+  events: string[];
+}
+
+function makeHarness(row: ChatDbMessage, settings: Partial<IMessageSettings>): Harness {
+  const events: string[] = [];
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn(() => null),
+    emitEvent: vi.fn((type: string) => {
+      events.push(type);
+    }),
+    ensureConnection: vi.fn(async () => {}),
+    createMemory: vi.fn(async () => {}),
+    reportError: vi.fn(() => {}),
+  } as unknown as IAgentRuntime;
+
+  const service = new IMessageService(runtime);
+
+  const chatDb: Pick<ChatDbReader, "fetchNewMessages"> = {
+    fetchNewMessages: vi.fn((sinceRowId: number) => (row.rowId > sinceRowId ? [row] : [])),
+  };
+
+  const internal = service as unknown as {
+    runtime: IAgentRuntime;
+    chatDb: unknown;
+    lastRowId: number;
+    contactsLoadAttempted: boolean;
+    settings: IMessageSettings;
+  };
+  internal.runtime = runtime;
+  internal.chatDb = chatDb;
+  internal.lastRowId = 0;
+  // Skip the lazy Apple Contacts load so the harness stays offline.
+  internal.contactsLoadAttempted = true;
+  internal.settings = {
+    cliPath: "imsg",
+    pollIntervalMs: 5000,
+    heartbeatIntervalMs: 60_000,
+    dmPolicy: "pairing",
+    groupPolicy: "allowlist",
+    allowFrom: [],
+    enabled: true,
+    ...settings,
+  };
+
+  return { service, events };
+}
+
+async function poll(service: IMessageService): Promise<void> {
+  await (
+    service as unknown as { pollForNewMessagesInner(): Promise<void> }
+  ).pollForNewMessagesInner();
+}
+
+describe("inbound poll gate — group policy enforcement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not dispatch a group message when groupPolicy=disabled", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "group", handle: "+15550000001" }),
+      { groupPolicy: "disabled", allowFrom: [] }
+    );
+    await poll(service);
+    expect(events).not.toContain("MESSAGE_RECEIVED");
+  });
+
+  it("dispatches a group message when groupPolicy=open even with an empty allowlist", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "group", handle: "+15550000002" }),
+      { groupPolicy: "open", allowFrom: [] }
+    );
+    await poll(service);
+    expect(events).toContain("MESSAGE_RECEIVED");
+  });
+
+  it("does not dispatch a group message under allowlist when the sender is not listed", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "group", handle: "+15550000003" }),
+      { groupPolicy: "allowlist", allowFrom: ["+15559999999"] }
+    );
+    await poll(service);
+    expect(events).not.toContain("MESSAGE_RECEIVED");
+  });
+
+  it("dispatches a group message under allowlist when the sender is listed", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "group", handle: "+15550000004" }),
+      { groupPolicy: "allowlist", allowFrom: ["+15550000004"] }
+    );
+    await poll(service);
+    expect(events).toContain("MESSAGE_RECEIVED");
+  });
+
+  it("does not let a permissive dmPolicy admit a group message that groupPolicy forbids", async () => {
+    // The original defect: dmPolicy=open (allow) leaked group rows through
+    // regardless of groupPolicy=disabled.
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "group", handle: "+15550000005" }),
+      { dmPolicy: "open", groupPolicy: "disabled", allowFrom: [] }
+    );
+    await poll(service);
+    expect(events).not.toContain("MESSAGE_RECEIVED");
+  });
+});
+
+describe("inbound poll gate — DM policy regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches a DM when dmPolicy=open", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "direct", handle: "+15551110001" }),
+      { dmPolicy: "open", allowFrom: [] }
+    );
+    await poll(service);
+    expect(events).toContain("MESSAGE_RECEIVED");
+  });
+
+  it("does not dispatch a DM when dmPolicy=disabled", async () => {
+    const { service, events } = makeHarness(
+      makeRow({ chatType: "direct", handle: "+15551110002" }),
+      { dmPolicy: "disabled", allowFrom: [] }
+    );
+    await poll(service);
+    expect(events).not.toContain("MESSAGE_RECEIVED");
+  });
+
+  it("honors dmPolicy=allowlist for DM senders", async () => {
+    const listed = makeHarness(makeRow({ chatType: "direct", handle: "+15551110003" }), {
+      dmPolicy: "allowlist",
+      allowFrom: ["+15551110003"],
+    });
+    await poll(listed.service);
+    expect(listed.events).toContain("MESSAGE_RECEIVED");
+
+    const unlisted = makeHarness(makeRow({ chatType: "direct", handle: "+15551110004" }), {
+      dmPolicy: "allowlist",
+      allowFrom: ["+15559999999"],
+    });
+    await poll(unlisted.service);
+    expect(unlisted.events).not.toContain("MESSAGE_RECEIVED");
+  });
+
+  it("admits a group message under groupPolicy=allowlist while denying the same handle in a disabled group", async () => {
+    // Confirms the group branch reads groupPolicy, not dmPolicy: same handle,
+    // same allowlist, different group policy => different outcome.
+    const admitted = makeHarness(makeRow({ chatType: "group", handle: "+15551110005" }), {
+      dmPolicy: "disabled",
+      groupPolicy: "allowlist",
+      allowFrom: ["+15551110005"],
+    });
+    await poll(admitted.service);
+    expect(admitted.events).toContain("MESSAGE_RECEIVED");
+
+    const denied = makeHarness(makeRow({ chatType: "group", handle: "+15551110005" }), {
+      dmPolicy: "open",
+      groupPolicy: "disabled",
+      allowFrom: ["+15551110005"],
+    });
+    await poll(denied.service);
+    expect(denied.events).not.toContain("MESSAGE_RECEIVED");
+  });
+});

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -1449,17 +1449,24 @@ export class IMessageService extends Service implements IIMessageService {
         continue;
       }
 
-      // Policy gate: DM allowlist, pairing handshake, disabled, etc.
-      const dmAccess = await this.checkDmAccess(row.handle);
-      if (!dmAccess.allowed) {
+      // Policy gate: group rows are gated by IMESSAGE_GROUP_POLICY, DM rows by
+      // the DM/pairing policy. A group chat is never subject to the DM pairing
+      // handshake, so its decision is synchronous and never carries a pairing
+      // reply. Routing group rows through checkDmAccess (the previous behavior)
+      // silently ignored groupPolicy: with the default dmPolicy=pairing every
+      // group message was held, and with dmPolicy=open every group message
+      // leaked through regardless of groupPolicy=disabled/allowlist (#22283).
+      const access: { allowed: boolean; pairingReplyMessage?: string } =
+        row.chatType === "group"
+          ? this.checkGroupAccess(row.handle)
+          : await this.checkDmAccess(row.handle);
+      if (!access.allowed) {
         // A fresh pairing request carries a code for the owner-approval
         // handshake. Delivering it is an autonomous outbound text, so it
         // follows the same IMESSAGE_AUTO_REPLY consent gate as agent replies.
-        if (dmAccess.pairingReplyMessage && this.isAutoReplyEnabled()) {
-          const sendResult = await this.sendViaAppleScript(
-            row.handle,
-            dmAccess.pairingReplyMessage
-          );
+        // Only the DM pairing path produces one; group denials never do.
+        if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
+          const sendResult = await this.sendViaAppleScript(row.handle, access.pairingReplyMessage);
           if (!sendResult.success) {
             logger.warn(
               `[imessage] Pairing reply send failed for handle=${row.handle}: ${sendResult.error}`
@@ -1917,6 +1924,35 @@ export class IMessageService extends Service implements IIMessageService {
       !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
       (autoReplyRaw === true || autoReplyRaw === "true")
     );
+  }
+
+  /**
+   * Evaluates the group access policy (IMESSAGE_GROUP_POLICY) for an inbound
+   * group-chat sender. Group chats have no pairing handshake, so this decision
+   * is synchronous: `open` admits every sender, `disabled` rejects the whole
+   * chat, and `allowlist` requires the sender handle to appear in
+   * IMESSAGE_ALLOW_FROM (the same case-insensitive matching the DM allowlist
+   * uses). This is the live enforcement point the inbound poll path previously
+   * skipped by gating group rows through the DM-only `checkDmAccess` (#22283).
+   */
+  private checkGroupAccess(handle: string): { allowed: boolean } {
+    if (!this.settings) {
+      return { allowed: false };
+    }
+
+    if (this.settings.groupPolicy === "open") {
+      return { allowed: true };
+    }
+
+    if (this.settings.groupPolicy === "disabled") {
+      return { allowed: false };
+    }
+
+    // allowlist — only handles present in IMESSAGE_ALLOW_FROM may participate.
+    const inAllowlist = this.settings.allowFrom.some(
+      (allowed) => allowed.toLowerCase() === handle.toLowerCase()
+    );
+    return { allowed: inAllowlist };
   }
 
   /**


### PR DESCRIPTION
# Relates to

Closes #22283

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test/typecheck/lint) pass. See **Known gaps** for the `bun run verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b5f6de93355b0cc18bad42971861b9e431110d81:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`origin/develop` unchanged during work).
- [ ] `bun run verify` passes post-sync — see **Known gaps** (repo-wide gate not run on this constrained host; focused package gates pass).

# Risks

Low. The change is scoped to the iMessage inbound poll access gate. Group rows now consult `IMESSAGE_GROUP_POLICY`; DM rows keep the existing DM/pairing path byte-for-byte. Failure mode is fail-closed (an unset/unknown policy denies). The only behavior change is that group messages are now correctly filtered — the previously-broken safety control now works as documented.

# Background

## What does this PR do?

The iMessage service loads `groupPolicy` from `IMESSAGE_GROUP_POLICY` (default `allowlist`) but the inbound polling path never consulted it. `pollForNewMessagesInner` gated **every** chat.db row through `checkDmAccess(handle)`, which branches only on `dmPolicy` and takes no `chatType`/group argument. As a result the documented group controls were dead:

- With the default `dmPolicy=pairing`, every group message was held by the DM pairing handshake regardless of `groupPolicy`.
- With `dmPolicy=open`, every group message was dispatched to the agent **even when `IMESSAGE_GROUP_POLICY=disabled`** — an access-control/safety control that did nothing.
- `IMESSAGE_GROUP_POLICY=allowlist` was never checked.

This PR routes group rows through a new `checkGroupAccess` that enforces `groupPolicy`:

- `open` → allow every sender,
- `disabled` → deny the whole chat,
- `allowlist` → require the sender handle in `IMESSAGE_ALLOW_FROM` (same case-insensitive match the DM allowlist uses).

DM rows keep the existing `checkDmAccess` (open/pairing/allowlist/disabled) path unchanged. Runtime now matches the README/CLAUDE.md "Group Policies" table, so no doc change was required.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. The README and CLAUDE.md already document the intended Group Policy semantics (`open`/`allowlist`/`disabled`); this fix makes the runtime match the existing docs.

# Testing

## Where should a reviewer start?

`plugins/plugin-imessage/src/group-policy.test.ts` drives the private `pollForNewMessagesInner` against a stub `chatDb` and a recording runtime, asserting on emitted `MESSAGE_RECEIVED` events (the observable dispatch signal).

## Detailed testing steps

```bash
cd plugins/plugin-imessage
npx vitest run src/group-policy.test.ts
```

The suite fails on `develop` (3 failures) and passes after the fix (9/9). Full package suite: 231/231.

# Evidence Gate

<!-- evidence-head:513b747765734c8c8a8a0226d2ccdc44c4ef3ef1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side connector access-control change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side connector access-control change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow; behavior is a poll-path access gate proven by the deterministic Vitest reproduction below.
<!-- evidence-row:backend-logs -->
- [x] Deterministic reproduction of the real `pollForNewMessagesInner` gate (console output):
<details><summary>Backend logs — group-policy Vitest reproduction (before fails / after passes)</summary>

```
### BEFORE FIX (develop code) — npx vitest run src/group-policy.test.ts
 ❯ src/group-policy.test.ts (9 tests | 3 failed)
   × dispatches a group message when groupPolicy=open even with an empty allowlist
     AssertionError: expected [] to include 'MESSAGE_RECEIVED'
   × does not let a permissive dmPolicy admit a group message that groupPolicy forbids
     AssertionError: expected [ 'WORLD_JOINED', 'ENTITY_JOINED', 'MESSAGE_RECEIVED', 'MESSAGE_RECEIVED' ] to not include 'MESSAGE_RECEIVED'
   × admits a group message under groupPolicy=allowlist while denying the same handle in a disabled group
     AssertionError: expected [] to include 'MESSAGE_RECEIVED'
 Tests  3 failed | 6 passed (9)

### AFTER FIX — npx vitest run src/group-policy.test.ts
 ✓ group policy enforcement > does not dispatch a group message when groupPolicy=disabled
 ✓ group policy enforcement > dispatches a group message when groupPolicy=open even with an empty allowlist
 ✓ group policy enforcement > does not dispatch a group message under allowlist when the sender is not listed
 ✓ group policy enforcement > dispatches a group message under allowlist when the sender is listed
 ✓ group policy enforcement > does not let a permissive dmPolicy admit a group message that groupPolicy forbids
 ✓ DM policy regression > dispatches a DM when dmPolicy=open
 ✓ DM policy regression > does not dispatch a DM when dmPolicy=disabled
 ✓ DM policy regression > honors dmPolicy=allowlist for DM senders
 ✓ DM policy regression > admits a group message under groupPolicy=allowlist while denying the same handle in a disabled group
 Tests  9 passed (9)
Full package suite (bun run --cwd plugins/plugin-imessage test): 18 files, 231 tests passed.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this gates whether a message reaches the agent at all.
<!-- evidence-row:domain-artifacts -->
- [x] Emitted core-event list for one inbound group row (`groupPolicy=disabled`, `dmPolicy=open`):
<details><summary>Domain artifact — emitted event list output (before / after)</summary>

```
Scenario: group row, isFromMe=false, kind=text; dmPolicy=open, groupPolicy=disabled, allowFrom=[]
BEFORE FIX: emitted events = [ 'WORLD_JOINED', 'ENTITY_JOINED', 'MESSAGE_RECEIVED', 'MESSAGE_RECEIVED' ]
            => group message dispatched to the agent despite groupPolicy=disabled.
AFTER FIX : emitted events = [ ]
            => group row denied at the poll-path gate; no MESSAGE_RECEIVED emitted.
Also verified: groupPolicy=open + empty allowlist => dispatched; allowlist listed => dispatched;
               allowlist not-listed => denied; DM path (open/disabled/allowlist) unchanged.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Deterministic reproduction of the real `IMessageService.pollForNewMessagesInner` gate.

**Before the fix (on `develop` code) — 3 failures**, including the adversarial safety leak (`dmPolicy=open`, `groupPolicy=disabled`):

```
❯ src/group-policy.test.ts (9 tests | 3 failed)
  × dispatches a group message when groupPolicy=open even with an empty allowlist
    AssertionError: expected [] to include 'MESSAGE_RECEIVED'
  × does not let a permissive dmPolicy admit a group message that groupPolicy forbids
    AssertionError: expected [ 'WORLD_JOINED', 'ENTITY_JOINED', 'MESSAGE_RECEIVED', 'MESSAGE_RECEIVED' ] to not include 'MESSAGE_RECEIVED'
  × admits a group message under groupPolicy=allowlist while denying the same handle in a disabled group
    AssertionError: expected [] to include 'MESSAGE_RECEIVED'
 Test Files  1 failed (1)
      Tests  3 failed | 6 passed (9)
```

**After the fix — 9/9 pass:**

```
 ✓ inbound poll gate — group policy enforcement > does not dispatch a group message when groupPolicy=disabled
 ✓ inbound poll gate — group policy enforcement > dispatches a group message when groupPolicy=open even with an empty allowlist
 ✓ inbound poll gate — group policy enforcement > does not dispatch a group message under allowlist when the sender is not listed
 ✓ inbound poll gate — group policy enforcement > dispatches a group message under allowlist when the sender is listed
 ✓ inbound poll gate — group policy enforcement > does not let a permissive dmPolicy admit a group message that groupPolicy forbids
 ✓ inbound poll gate — DM policy regression > dispatches a DM when dmPolicy=open
 ✓ inbound poll gate — DM policy regression > does not dispatch a DM when dmPolicy=disabled
 ✓ inbound poll gate — DM policy regression > honors dmPolicy=allowlist for DM senders
 ✓ inbound poll gate — DM policy regression > admits a group message under groupPolicy=allowlist while denying the same handle in a disabled group
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Full package suite (`bun run --cwd plugins/plugin-imessage test`): **18 files, 231 tests passed**. `typecheck` and `lint:check` both clean.

## Screenshots (before / after) + video walkthrough

### Before
N/A - server-side connector access-control change; no rendered UI surface.

### After
N/A - server-side connector access-control change; no rendered UI surface.

### Walkthrough video
N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Domain artifacts — emitted event list for a group row (`groupPolicy=disabled`, `dmPolicy=open`)

- **Before:** `[ 'WORLD_JOINED', 'ENTITY_JOINED', 'MESSAGE_RECEIVED', 'MESSAGE_RECEIVED' ]` — the group message was dispatched to the agent despite `groupPolicy=disabled`.
- **After:** `[]` — no lifecycle or `MESSAGE_RECEIVED` events; the group row is denied at the gate.

## Known gaps / failures

- `bun run verify` (repo-wide gate) was **not** run on this host: the environment enforces a package `minimumReleaseAge` install policy and running the full monorepo verify lane is out of scope for this constrained worktree. The owning package's `test` (231/231), `typecheck`, and `lint:check` all pass, and `@elizaos/core` was built to run the suite. This is not a blocker for a change isolated to one plugin's access gate.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@b5f6de93355b0cc18bad42971861b9e431110d81:packages/skills/skills/contribute-to-eliza"} -->