### PR TITLE
fix(views): deduplicate renderer-observed handoffs

### DIFF
--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -207,18 +207,44 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     const { ctx, json, broadcastWsToClientId } = makeNavigateCtx("calendar", {
       clientId: "seeker-rest-client",
       delivery: "completed-action",
+      completedActionHandoffId: "handoff-1234",
     });
 
     await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
 
     expect(broadcastWsToClientId).toHaveBeenCalledTimes(1);
+    expect(broadcastWsToClientId).toHaveBeenCalledWith(
+      "seeker-rest-client",
+      expect.objectContaining({ completedActionHandoffId: "handoff-1234" }),
+    );
     expect(json).toHaveBeenCalledWith(
       ctx.res,
-      expect.objectContaining({ completedActionDelivered: true }),
+      expect.objectContaining({
+        completedActionDelivered: true,
+        completedActionHandoffId: "handoff-1234",
+      }),
     );
     expect(broadcastWsToClientId.mock.invocationCallOrder[0]).toBeLessThan(
       json.mock.invocationCallOrder[0],
     );
+  });
+
+  it("drops an invalid completed-action handoff id at the HTTP boundary", async () => {
+    const { ctx, json, broadcastWsToClientId } = makeNavigateCtx("calendar", {
+      clientId: "seeker-rest-client",
+      delivery: "completed-action",
+      completedActionHandoffId: "not valid because spaces",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    const frame = broadcastWsToClientId.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(frame).not.toHaveProperty("completedActionHandoffId");
+    const response = json.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(response).not.toHaveProperty("completedActionHandoffId");
   });
 
   it("keeps the completed-action fallback when targeted delivery throws", async () => {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -35,6 +35,7 @@ import {
 } from "@elizaos/core";
 import {
   createShellNavigateViewWsFrame,
+  normalizeCompletedActionHandoffId,
   parseClampedInteger,
   type RouteHelpers,
   readJsonBody,
@@ -1104,6 +1105,7 @@ export async function handleViewsRoutes(
   //   payload: unknown     — opaque deep-link state consumed by the target view
   //   delivery: "originating-client" — realtime caller navigates its own client
   //   delivery: "completed-action" — app chat navigates from its stream result
+  //   completedActionHandoffId: string — renderer-observed transport dedupe key
   if (method === "POST" && subResource === "navigate") {
     const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
       () => null,
@@ -1248,10 +1250,13 @@ export async function handleViewsRoutes(
     // chat normally has the completed action as a reliable fallback, but when
     // its originating renderer still has a live WebSocket, deliver there now:
     // the navigate frame is emitted before the action callback can claim
-    // "Opened …", while the later completed-action handoff remains a no-op (or
-    // recovers the switch when this best-effort delivery misses).
+    // "Opened …". Supporting renderers deduplicate this frame against the
+    // caller-scoped terminal handoff by id after one path is actually handled.
     const shouldTargetCompletedAction =
       body?.delivery === "completed-action" && Boolean(originatingClientId);
+    const completedActionHandoffId = shouldTargetCompletedAction
+      ? normalizeCompletedActionHandoffId(body?.completedActionHandoffId)
+      : undefined;
     let completedActionDelivered = false;
     if (
       reportedSource !== "user" &&
@@ -1268,6 +1273,7 @@ export async function handleViewsRoutes(
         ...(alwaysOnTop ? { alwaysOnTop } : {}),
         ...layoutPayload,
         ...deepLinkPayload,
+        ...(completedActionHandoffId ? { completedActionHandoffId } : {}),
       };
       const frame = createShellNavigateViewWsFrame(navigatePayload);
       if (originatingClientId) {
@@ -1318,6 +1324,7 @@ export async function handleViewsRoutes(
       ...layoutPayload,
       ...deepLinkPayload,
       ...(shouldTargetCompletedAction ? { completedActionDelivered } : {}),
+      ...(completedActionHandoffId ? { completedActionHandoffId } : {}),
     });
     return true;
   }

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -119,6 +119,8 @@ export interface NavigateViewDetail {
   alwaysOnTop?: boolean;
   /** Opaque payload handed to the target view on navigation (deep-link state). */
   payload?: unknown;
+  /** Idempotency key shared by early WS and terminal chat navigation delivery. */
+  completedActionHandoffId?: string;
 }
 
 export type NavigateViewEvent = CustomEvent<NavigateViewDetail>;
@@ -242,6 +244,8 @@ export interface ShellNavigateViewPayload {
   alwaysOnTop?: boolean;
   /** Opaque target-view deep-link state, validated by the receiving view. */
   payload?: unknown;
+  /** Idempotency key shared by early WS and terminal chat navigation delivery. */
+  completedActionHandoffId?: string;
 }
 
 export type ShellNavigateViewWsFrame = ShellNavigateViewPayload & {
@@ -250,6 +254,17 @@ export type ShellNavigateViewWsFrame = ShellNavigateViewPayload & {
 
 function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+const COMPLETED_ACTION_HANDOFF_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export function normalizeCompletedActionHandoffId(
+  value: unknown,
+): string | undefined {
+  return typeof value === "string" &&
+    COMPLETED_ACTION_HANDOFF_ID_PATTERN.test(value)
+    ? value
+    : undefined;
 }
 
 function readViewType(value: unknown): ShellNavigateViewType | undefined {
@@ -268,6 +283,10 @@ export function normalizeShellNavigateViewPayload(
       )
     : undefined;
 
+  const completedActionHandoffId = normalizeCompletedActionHandoffId(
+    data.completedActionHandoffId,
+  );
+
   return {
     viewId: typeof data.viewId === "string" ? data.viewId : undefined,
     viewPath: typeof data.viewPath === "string" ? data.viewPath : undefined,
@@ -284,6 +303,7 @@ export function normalizeShellNavigateViewPayload(
     placement: readNonEmptyString(data.placement),
     alwaysOnTop: data.alwaysOnTop === true,
     ...(Object.hasOwn(data, "payload") ? { payload: data.payload } : {}),
+    ...(completedActionHandoffId ? { completedActionHandoffId } : {}),
   };
 }
 

--- a/packages/shared/src/events/shell-navigate-view.test.ts
+++ b/packages/shared/src/events/shell-navigate-view.test.ts
@@ -45,6 +45,7 @@ describe("shell navigate view websocket event", () => {
         layout: "split",
         placement: "right",
         alwaysOnTop: true,
+        completedActionHandoffId: "handoff-1234",
         payload: { permissionRequest: { permission: "microphone" } },
       }),
     ).toEqual({
@@ -59,6 +60,7 @@ describe("shell navigate view websocket event", () => {
       layout: "split",
       placement: "right",
       alwaysOnTop: true,
+      completedActionHandoffId: "handoff-1234",
       payload: { permissionRequest: { permission: "microphone" } },
     });
   });
@@ -72,6 +74,7 @@ describe("shell navigate view websocket event", () => {
           subview: "",
           views: [null, ""],
           alwaysOnTop: "yes",
+          completedActionHandoffId: "spaces are rejected",
         }),
       ),
     ).toEqual({

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -8,7 +8,10 @@
  */
 
 import { Capacitor } from "@capacitor/core";
-import { createNavigateViewEvent } from "@elizaos/shared/events";
+import {
+  createNavigateViewEvent,
+  NAVIGATE_VIEW_EVENT,
+} from "@elizaos/shared/events";
 import {
   act,
   cleanup,
@@ -597,6 +600,23 @@ describe("App navigate-view event wiring", () => {
     });
     expect(appState.setTab).toHaveBeenCalledTimes(2);
     expect(desktopTabsMock.openTab).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges a cancelable completed-action handoff only after handling it", () => {
+    render(<App />);
+    const event = new CustomEvent(NAVIGATE_VIEW_EVENT, {
+      cancelable: true,
+      detail: {
+        viewId: "views-manager",
+        viewPath: "/views",
+        completedActionHandoffId: "handoff-app-observed",
+      },
+    });
+
+    act(() => window.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(appState.setTab).toHaveBeenCalledWith("views");
   });
 
   it("routes a settings subview navigate to the settings tab (#9945)", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -83,6 +83,7 @@ import {
   reportUserViewSwitch,
   useSlashCommandController,
 } from "./chat/useSlashCommandController";
+import { markCompletedActionNavigationHandled } from "./completed-action-navigation";
 import { getOverlayAppLazyComponent } from "./components/apps/AppWindowRenderer.helpers";
 import { GameViewOverlay } from "./components/apps/GameViewOverlay";
 import { getOverlayApp } from "./components/apps/overlay-app-registry";
@@ -2729,9 +2730,12 @@ function AppContent() {
         setSettingsNavigatePayload(detail.payload);
         setSettingsNavigateSequence((sequence) => sequence + 1);
         setTab("settings");
+        markCompletedActionNavigationHandled(event, detail);
         return;
       }
-      baseHandler(event);
+      if (baseHandler(event)) {
+        markCompletedActionNavigationHandled(event, detail);
+      }
     };
     window.addEventListener(NAVIGATE_VIEW_EVENT, handleNavigateView);
     return () =>

--- a/packages/ui/src/app-navigate-view.ts
+++ b/packages/ui/src/app-navigate-view.ts
@@ -144,7 +144,7 @@ export function createNavigateViewHandler({
   setTab: (tab: Tab) => void;
   setTabForPath?: (tab: Tab) => void;
   setViewLayout?: (layout: ActiveViewLayout | null) => void;
-}): (event: Event) => void {
+}): (event: Event) => boolean {
   const activatePathTab = setTabForPath ?? setTab;
   const activateTabForPath = (path: string) => {
     const routeTab = tabFromPath(path);
@@ -153,7 +153,7 @@ export function createNavigateViewHandler({
 
   return (event: Event) => {
     const detail = (event as CustomEvent<NavigateViewDetail>).detail;
-    if (!detail) return;
+    if (!detail) return false;
     storeNavigateViewPayload(detail);
     if (detail.action === "close" || detail.action === "close-all") {
       setViewLayout?.(null);
@@ -166,7 +166,7 @@ export function createNavigateViewHandler({
       }
       setActiveDesktopTabId(null);
       setTab("chat");
-      return;
+      return true;
     }
     if (detail.action === "split-view" || detail.action === "tile-views") {
       const viewIds = layoutViewIdsForDetail(detail);
@@ -191,18 +191,18 @@ export function createNavigateViewHandler({
       });
       activatePathTab("views");
       navigatePath("/views");
-      return;
+      return true;
     }
     const path = pathForNavigateViewDetail(
       detail,
       availableViewsForDesktopTabs,
     );
-    if (!path) return;
+    if (!path) return false;
     setViewLayout?.(null);
     const directTab = directTabForNavigateView(detail, path);
     if (directTab) {
       setTab(directTab);
-      return;
+      return true;
     }
     if (detail.action === "open-window" && detail.viewId) {
       const entry = desktopEntryForDetail(
@@ -238,7 +238,7 @@ export function createNavigateViewHandler({
           activateTabForPath(viewPath);
           navigatePath(viewPath);
         });
-      return;
+      return true;
     }
     if (detail.viewId) {
       const entry = desktopEntryForDetail(
@@ -252,5 +252,6 @@ export function createNavigateViewHandler({
     }
     activateTabForPath(path);
     navigatePath(path);
+    return true;
   };
 }

--- a/packages/ui/src/completed-action-navigation.test.ts
+++ b/packages/ui/src/completed-action-navigation.test.ts
@@ -12,30 +12,60 @@ import {
   resetCompletedActionNavigationForTests,
 } from "./completed-action-navigation";
 import { NAVIGATE_VIEW_EVENT } from "./events";
+import { dispatchViewActionHandoffDirect } from "./view-action-handoff";
+
+function terminalDelivery(
+  completedActionHandoffId: string,
+  viewId = "calendar",
+): boolean {
+  return dispatchViewActionHandoffDirect([
+    {
+      actionName: "VIEWS",
+      success: true,
+      values: {
+        mode: "show",
+        viewId,
+        completedActionHandoffId,
+      },
+    },
+  ]);
+}
+
+function websocketDelivery(
+  completedActionHandoffId: string,
+  viewId = "calendar",
+): boolean {
+  return dispatchCompletedActionNavigation({
+    viewId,
+    completedActionHandoffId,
+  });
+}
 
 describe("completed action navigation", () => {
   beforeEach(() => window.history.replaceState(null, "", "/chat"));
   afterEach(() => resetCompletedActionNavigationForTests());
 
-  it("deduplicates WebSocket-first and terminal-first delivery after shell handling", () => {
-    const seen: string[] = [];
-    const listener = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-      seen.push(detail.viewId);
-      markCompletedActionNavigationHandled(event, detail);
-    };
-    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+  it.each([
+    ["WebSocket-first", websocketDelivery, terminalDelivery],
+    ["terminal-first", terminalDelivery, websocketDelivery],
+  ] as const)(
+    "deduplicates real %s delivery after shell handling",
+    (_order, firstDelivery, secondDelivery) => {
+      const seen: string[] = [];
+      const listener = (event: Event) => {
+        const detail = (event as CustomEvent).detail;
+        seen.push(detail.viewId);
+        markCompletedActionNavigationHandled(event, detail);
+      };
+      window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
 
-    const detail = {
-      viewId: "calendar",
-      completedActionHandoffId: "handoff-both-orders",
-    };
-    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
-    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
-    expect(seen).toEqual(["calendar"]);
+      expect(firstDelivery("handoff-both-orders")).toBe(true);
+      expect(secondDelivery("handoff-both-orders")).toBe(false);
+      expect(seen).toEqual(["calendar"]);
 
-    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
-  });
+      window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+    },
+  );
 
   it("retries at terminal delivery when the early frame had no mounted handler", () => {
     const detail = {
@@ -57,9 +87,12 @@ describe("completed action navigation", () => {
     window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
   });
 
-  it.each(["WebSocket-first", "terminal-first"])(
+  it.each([
+    ["WebSocket-first", websocketDelivery, terminalDelivery],
+    ["terminal-first", terminalDelivery, websocketDelivery],
+  ] as const)(
     "does not pull the renderer back after handled %s delivery and user navigation",
-    (order) => {
+    (order, firstDelivery, secondDelivery) => {
       const seen: string[] = [];
       const listener = (event: Event) => {
         const detail = (event as CustomEvent).detail;
@@ -67,15 +100,11 @@ describe("completed action navigation", () => {
         markCompletedActionNavigationHandled(event, detail);
       };
       window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
-      const detail = {
-        viewId: "calendar",
-        completedActionHandoffId: `handled-${order}`,
-      };
-
-      expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+      const handoffId = `handled-${order}`;
+      expect(firstDelivery(handoffId)).toBe(true);
       window.history.pushState(null, "", "/settings");
       window.dispatchEvent(new PopStateEvent("popstate"));
-      expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+      expect(secondDelivery(handoffId)).toBe(false);
       expect(window.location.pathname).toBe("/settings");
       expect(seen).toEqual(["calendar"]);
       window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
@@ -83,17 +112,19 @@ describe("completed action navigation", () => {
   );
 
   it("lets intervening user navigation win when the early frame was unhandled", () => {
-    const detail = {
-      viewId: "notes",
-      completedActionHandoffId: "unhandled-before-user-navigation",
-    };
-    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+    expect(websocketDelivery("unhandled-before-user-navigation", "notes")).toBe(
+      true,
+    );
 
     window.history.pushState(null, "", "/settings");
     const listener = vi.fn();
     window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
-    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
-    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(terminalDelivery("unhandled-before-user-navigation", "notes")).toBe(
+      false,
+    );
+    expect(websocketDelivery("unhandled-before-user-navigation", "notes")).toBe(
+      false,
+    );
     expect(window.location.pathname).toBe("/settings");
     expect(listener).not.toHaveBeenCalled();
     window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);

--- a/packages/ui/src/completed-action-navigation.test.ts
+++ b/packages/ui/src/completed-action-navigation.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Exercises renderer-observed navigation deduplication with real cancelable DOM
+ * events, including both transport arrival orders and an unhandled early frame.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchCompletedActionNavigation,
+  markCompletedActionNavigationHandled,
+  resetCompletedActionNavigationForTests,
+} from "./completed-action-navigation";
+import { NAVIGATE_VIEW_EVENT } from "./events";
+
+describe("completed action navigation", () => {
+  beforeEach(() => window.history.replaceState(null, "", "/chat"));
+  afterEach(() => resetCompletedActionNavigationForTests());
+
+  it("deduplicates WebSocket-first and terminal-first delivery after shell handling", () => {
+    const seen: string[] = [];
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      seen.push(detail.viewId);
+      markCompletedActionNavigationHandled(event, detail);
+    };
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+
+    const detail = {
+      viewId: "calendar",
+      completedActionHandoffId: "handoff-both-orders",
+    };
+    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(seen).toEqual(["calendar"]);
+
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it("retries at terminal delivery when the early frame had no mounted handler", () => {
+    const detail = {
+      viewId: "notes",
+      completedActionHandoffId: "handoff-unhandled-early",
+    };
+    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+
+    const listener = vi.fn((event: Event) => {
+      markCompletedActionNavigationHandled(
+        event,
+        (event as CustomEvent).detail,
+      );
+    });
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it.each(["WebSocket-first", "terminal-first"])(
+    "does not pull the renderer back after handled %s delivery and user navigation",
+    (order) => {
+      const seen: string[] = [];
+      const listener = (event: Event) => {
+        const detail = (event as CustomEvent).detail;
+        seen.push(detail.viewId);
+        markCompletedActionNavigationHandled(event, detail);
+      };
+      window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+      const detail = {
+        viewId: "calendar",
+        completedActionHandoffId: `handled-${order}`,
+      };
+
+      expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+      window.history.pushState(null, "", "/settings");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+      expect(window.location.pathname).toBe("/settings");
+      expect(seen).toEqual(["calendar"]);
+      window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+    },
+  );
+
+  it("lets intervening user navigation win when the early frame was unhandled", () => {
+    const detail = {
+      viewId: "notes",
+      completedActionHandoffId: "unhandled-before-user-navigation",
+    };
+    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+
+    window.history.pushState(null, "", "/settings");
+    const listener = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(window.location.pathname).toBe("/settings");
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it("uses the navigation epoch when user navigation keeps the same path", () => {
+    const detail = {
+      viewId: "notes",
+      completedActionHandoffId: "unhandled-before-same-path-navigation",
+    };
+    expect(dispatchCompletedActionNavigation(detail)).toBe(true);
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    const listener = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    expect(dispatchCompletedActionNavigation(detail)).toBe(false);
+    expect(window.location.pathname).toBe("/chat");
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it("does not deduplicate unrelated navigation without a handoff id", () => {
+    const listener = (event: Event) => {
+      markCompletedActionNavigationHandled(
+        event,
+        (event as CustomEvent).detail,
+      );
+    };
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    expect(dispatchCompletedActionNavigation({ viewId: "wallet" })).toBe(true);
+    expect(dispatchCompletedActionNavigation({ viewId: "wallet" })).toBe(true);
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it("bounds handled history and permits an evicted id to run again", () => {
+    const listener = (event: Event) => {
+      markCompletedActionNavigationHandled(
+        event,
+        (event as CustomEvent).detail,
+      );
+    };
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    for (let index = 0; index <= 256; index++) {
+      expect(
+        dispatchCompletedActionNavigation({
+          viewId: "calendar",
+          completedActionHandoffId: `bounded-${index}`,
+        }),
+      ).toBe(true);
+    }
+    expect(
+      dispatchCompletedActionNavigation({
+        viewId: "calendar",
+        completedActionHandoffId: "bounded-0",
+      }),
+    ).toBe(true);
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+});

--- a/packages/ui/src/completed-action-navigation.ts
+++ b/packages/ui/src/completed-action-navigation.ts
@@ -1,0 +1,119 @@
+/**
+ * Deduplicates the targeted-WebSocket and terminal-chat delivery paths for one
+ * completed VIEWS action. A mounted shell can acknowledge the cancelable event;
+ * an unhandled first delivery instead records its route epoch so intervening
+ * user navigation wins over a late fallback.
+ */
+
+import type { NavigateViewDetail } from "@elizaos/shared/events";
+import {
+  NAVIGATE_VIEW_EVENT,
+  normalizeCompletedActionHandoffId,
+} from "@elizaos/shared/events";
+import { getWindowNavigationPath } from "./navigation";
+
+const MAX_TRACKED_HANDOFFS = 256;
+const handledHandoffs = new Set<string>();
+const pendingHandoffs = new Map<
+  string,
+  { navigationEpoch: number; path: string }
+>();
+let navigationEpoch = 0;
+let observedWindow: Window | undefined;
+
+function advanceNavigationEpoch(): void {
+  navigationEpoch += 1;
+}
+
+function observeNavigationEpoch(): void {
+  if (typeof window === "undefined" || observedWindow === window) return;
+  observedWindow?.removeEventListener("popstate", advanceNavigationEpoch);
+  observedWindow?.removeEventListener("hashchange", advanceNavigationEpoch);
+  observedWindow = window;
+  observedWindow.addEventListener("popstate", advanceNavigationEpoch);
+  observedWindow.addEventListener("hashchange", advanceNavigationEpoch);
+}
+
+function rememberHandledHandoff(id: string): void {
+  pendingHandoffs.delete(id);
+  handledHandoffs.delete(id);
+  handledHandoffs.add(id);
+  while (handledHandoffs.size > MAX_TRACKED_HANDOFFS) {
+    const oldest = handledHandoffs.values().next().value;
+    if (typeof oldest !== "string") break;
+    handledHandoffs.delete(oldest);
+  }
+}
+
+function rememberPendingHandoff(
+  id: string,
+  snapshot: { navigationEpoch: number; path: string },
+): void {
+  pendingHandoffs.delete(id);
+  pendingHandoffs.set(id, snapshot);
+  while (pendingHandoffs.size > MAX_TRACKED_HANDOFFS) {
+    const oldest = pendingHandoffs.keys().next().value;
+    if (typeof oldest !== "string") break;
+    pendingHandoffs.delete(oldest);
+  }
+}
+
+/** Dispatch once unless the mounted shell already handled the same handoff. */
+export function dispatchCompletedActionNavigation(
+  detail: NavigateViewDetail,
+): boolean {
+  if (typeof window === "undefined") return false;
+  observeNavigationEpoch();
+  const id = normalizeCompletedActionHandoffId(detail.completedActionHandoffId);
+  if (id && handledHandoffs.has(id)) return false;
+
+  const path = getWindowNavigationPath();
+  const pending = id ? pendingHandoffs.get(id) : undefined;
+  if (
+    id &&
+    pending &&
+    (pending.navigationEpoch !== navigationEpoch || pending.path !== path)
+  ) {
+    // An unhandled transport frame is not permission to override a navigation
+    // the user made while the terminal fallback was still in flight. Retire
+    // the id so a later duplicate cannot pull the renderer back either.
+    rememberHandledHandoff(id);
+    return false;
+  }
+
+  const snapshot = { navigationEpoch, path };
+  const event = new CustomEvent<NavigateViewDetail>(NAVIGATE_VIEW_EVENT, {
+    detail,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  if (id) {
+    if (event.defaultPrevented) rememberHandledHandoff(id);
+    else if (!pending) rememberPendingHandoff(id, snapshot);
+  }
+  return true;
+}
+
+/** Mark a handoff handled from a shell listener before performing navigation. */
+export function markCompletedActionNavigationHandled(
+  event: Event,
+  detail: NavigateViewDetail | undefined,
+): void {
+  if (
+    !event.cancelable ||
+    !normalizeCompletedActionHandoffId(detail?.completedActionHandoffId)
+  ) {
+    return;
+  }
+  event.preventDefault();
+}
+
+/** Test-only reset for module-scoped renderer delivery history. */
+export function resetCompletedActionNavigationForTests(): void {
+  handledHandoffs.clear();
+  pendingHandoffs.clear();
+  observedWindow?.removeEventListener("popstate", advanceNavigationEpoch);
+  observedWindow?.removeEventListener("hashchange", advanceNavigationEpoch);
+  observedWindow = undefined;
+  navigationEpoch = 0;
+}

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -7,7 +7,6 @@
 import { MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
-  createNavigateViewEvent,
   normalizeShellNavigateViewPayload,
   SHELL_NAVIGATE_VIEW_WS_EVENT,
 } from "@elizaos/shared/events";
@@ -21,6 +20,7 @@ import {
 } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { mapServerTasksToSessions } from "../chat/coding-agent-session-state";
+import { dispatchCompletedActionNavigation } from "../completed-action-navigation";
 import { prefetchAppsCatalog } from "../components/apps/load-apps-catalog";
 import { registerDeviceControlInteractHandler } from "../components/views/device-control-interact";
 import {
@@ -488,7 +488,7 @@ export function bindReadyPhase(
     (data: Record<string, unknown>) => {
       if (typeof window === "undefined") return;
       const payload = normalizeShellNavigateViewPayload(data);
-      window.dispatchEvent(createNavigateViewEvent(payload));
+      dispatchCompletedActionNavigation(payload);
     },
   );
 

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -945,6 +945,46 @@ describe("useChatSend action handoff", () => {
     window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
   });
 
+  it("retains terminal fallback when send-count delivery has a renderer handoff id", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Opening Calendar.",
+      completed: true,
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: {
+            mode: "show",
+            viewId: "calendar",
+            completedActionDelivered: true,
+            completedActionHandoffId: "handoff-not-yet-observed",
+          },
+        },
+      ],
+    });
+    const navigations: CustomEvent[] = [];
+    const onNavigate = (event: Event) => navigations.push(event as CustomEvent);
+    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("open calendar", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(navigations).toHaveLength(1);
+    expect(navigations[0]?.detail).toMatchObject({
+      viewId: "calendar",
+      completedActionHandoffId: "handoff-not-yet-observed",
+    });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+  });
+
   it("invalidates mounted views after a successful REST-streamed action", async () => {
     mocks.client.sendConversationMessageStream.mockResolvedValue({
       text: 'Created sticky note "LP3 Demo Proof".',

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -122,7 +122,13 @@ async function handoffCompletedAction(
     // can belong to another device and is unavailable to REST-only native
     // renderers. The shell resolves the canonical path from the view id.
     try {
-      if (!viewHandoff.completedActionDelivered) {
+      // A renderer-observed handoff id is stronger than the server's legacy
+      // synchronous socket-count marker: always offer the terminal path and let
+      // the mounted shell deduplicate whichever transport it handled first.
+      if (
+        viewHandoff.completedActionHandoffId ||
+        !viewHandoff.completedActionDelivered
+      ) {
         dispatchViewActionHandoffDirect(actionResults);
       }
     } catch (err) {

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -64,10 +64,15 @@ describe("view action handoff", () => {
           values: {
             ...showCalendar.values,
             completedActionDelivered: true,
+            completedActionHandoffId: "handoff-calendar",
           },
         },
       ]),
-    ).toEqual({ viewId: "calendar", completedActionDelivered: true });
+    ).toEqual({
+      viewId: "calendar",
+      completedActionDelivered: true,
+      completedActionHandoffId: "handoff-calendar",
+    });
   });
 
   it("ignores inherited handoff fields and delivery confirmations", () => {
@@ -150,6 +155,29 @@ describe("view action handoff", () => {
       viewId: "cloud-apps",
       viewPath: "/cloud-apps",
       source: "agent",
+    });
+  });
+
+  it("carries renderer handoff identity through direct terminal dispatch", () => {
+    const dispatch = vi.fn();
+    expect(
+      dispatchViewActionHandoffDirect(
+        [
+          {
+            ...showCalendar,
+            values: {
+              ...showCalendar.values,
+              completedActionHandoffId: "handoff-calendar",
+            },
+          },
+        ],
+        dispatch,
+      ),
+    ).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith({
+      viewId: "calendar",
+      source: "agent",
+      completedActionHandoffId: "handoff-calendar",
     });
   });
 

--- a/packages/ui/src/view-action-handoff.ts
+++ b/packages/ui/src/view-action-handoff.ts
@@ -5,8 +5,10 @@
  */
 
 import { ElizaError } from "@elizaos/core";
+import { normalizeCompletedActionHandoffId } from "@elizaos/shared/events";
 import type { ChatActionResultSummary } from "./api/client-types-chat";
 import { fetchWithCsrf } from "./api/csrf-client";
+import { dispatchCompletedActionNavigation } from "./completed-action-navigation";
 import { dispatchNavigateViewEvent } from "./events";
 import { getWindowNavigationPath } from "./navigation";
 
@@ -34,6 +36,7 @@ export interface ViewActionHandoff {
   viewPath?: string;
   subview?: string;
   completedActionDelivered?: true;
+  completedActionHandoffId?: string;
 }
 
 function readString(value: unknown): string | undefined {
@@ -65,6 +68,9 @@ export function findViewActionHandoff(
     if ((mode === "show" || mode === "open") && viewId) {
       const viewPath = readString(readOwnValue(values, "viewPath"));
       const subview = readString(readOwnValue(values, "subview"));
+      const completedActionHandoffId = normalizeCompletedActionHandoffId(
+        readOwnValue(values, "completedActionHandoffId"),
+      );
       return {
         viewId,
         ...(viewPath ? { viewPath } : {}),
@@ -72,6 +78,7 @@ export function findViewActionHandoff(
         ...(readOwnValue(values, "completedActionDelivered") === true
           ? { completedActionDelivered: true }
           : {}),
+        ...(completedActionHandoffId ? { completedActionHandoffId } : {}),
       };
     }
   }
@@ -248,12 +255,19 @@ export function dispatchViewActionHandoffDirect(
 ): boolean {
   const handoff = findViewActionHandoff(actionResults);
   if (!handoff) return false;
-  dispatch({
+  const detail = {
     viewId: handoff.viewId,
     source: "agent",
     ...(handoff.viewPath ? { viewPath: handoff.viewPath } : {}),
     ...(handoff.subview ? { subview: handoff.subview } : {}),
-  });
+    ...(handoff.completedActionHandoffId
+      ? { completedActionHandoffId: handoff.completedActionHandoffId }
+      : {}),
+  } as const;
+  if (dispatch === dispatchNavigateViewEvent) {
+    return dispatchCompletedActionNavigation(detail);
+  }
+  dispatch(detail);
   return true;
 }
 

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -4,6 +4,7 @@
  * navigation; the post-tool model owns all visible wording.
  */
 
+import { randomUUID } from "node:crypto";
 import type {
 	ActionResult,
 	HandlerCallback,
@@ -377,6 +378,8 @@ interface NavigateResult {
 	subview?: string;
 	/** The server synchronously accepted delivery to the originating renderer. */
 	completedActionDelivered?: true;
+	/** Renderer-observed idempotency key echoed by a supporting server. */
+	completedActionHandoffId?: string;
 }
 
 function navigationEffectReceipt({
@@ -438,6 +441,7 @@ async function navigateToView(
 	navigationLabel = view.label,
 	delivery?: "originating-client" | "completed-action",
 	originatingClientId?: string,
+	completedActionHandoffId?: string,
 ): Promise<NavigateResult> {
 	// Emit navigate event via POST /api/views/:id/navigate (shell listens).
 	// A shell without the navigate route did not accept the requested effect.
@@ -461,6 +465,7 @@ async function navigateToView(
 					...(resolvedSubview ? { subview: resolvedSubview } : {}),
 					...(delivery ? { delivery } : {}),
 					...(originatingClientId ? { clientId: originatingClientId } : {}),
+					...(completedActionHandoffId ? { completedActionHandoffId } : {}),
 				}),
 				signal: AbortSignal.timeout(5_000),
 			},
@@ -487,6 +492,9 @@ async function navigateToView(
 				...(delivery === "completed-action" &&
 				confirmsCompletedActionDelivery(responseBody)
 					? { completedActionDelivered: true as const }
+					: {}),
+				...(responseBody?.completedActionHandoffId === completedActionHandoffId
+					? { completedActionHandoffId }
 					: {}),
 			};
 		}
@@ -638,17 +646,23 @@ export async function runViewsShow({
 		: undefined;
 	const navigationLabel =
 		canonicalTarget?.viewId === view.id ? canonicalTarget.label : view.label;
+	const completedActionDelivery =
+		!isRealtimeVoiceTurn(message) && Boolean(originatingClientId);
+	const completedActionHandoffId = completedActionDelivery
+		? randomUUID()
+		: undefined;
 	const result = await navigateToView(
 		view,
 		viewType,
 		subview ?? undefined,
 		navigationLabel,
-		isRealtimeVoiceTurn(message)
+		!completedActionDelivery && isRealtimeVoiceTurn(message)
 			? "originating-client"
-			: originatingClientId
+			: completedActionDelivery
 				? "completed-action"
 				: undefined,
 		originatingClientId,
+		completedActionHandoffId,
 	);
 
 	logger.info(
@@ -672,6 +686,9 @@ export async function runViewsShow({
 			...(result.subview ? { subview: result.subview } : {}),
 			...(confirmsCompletedActionDelivery(result)
 				? { completedActionDelivered: true }
+				: {}),
+			...(result.completedActionHandoffId
+				? { completedActionHandoffId: result.completedActionHandoffId }
 				: {}),
 		},
 		data: { view, ...(result.subview ? { subview: result.subview } : {}) },

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -480,6 +480,17 @@ async function navigateToView(
 				if (!(error instanceof SyntaxError)) throw error;
 				responseBody = null;
 			}
+			const echoedCompletedActionHandoffId =
+				completedActionHandoffId &&
+				typeof responseBody === "object" &&
+				responseBody !== null &&
+				!Array.isArray(responseBody) &&
+				Object.getOwnPropertyDescriptor(
+					responseBody,
+					"completedActionHandoffId",
+				)?.value === completedActionHandoffId
+					? completedActionHandoffId
+					: undefined;
 			return {
 				ok: true,
 				text: navigationEffectReceipt({
@@ -490,11 +501,12 @@ async function navigateToView(
 				}),
 				subview: resolvedSubview,
 				...(delivery === "completed-action" &&
-				confirmsCompletedActionDelivery(responseBody)
+				confirmsCompletedActionDelivery(responseBody) &&
+				(!completedActionHandoffId || echoedCompletedActionHandoffId)
 					? { completedActionDelivered: true as const }
 					: {}),
-				...(responseBody?.completedActionHandoffId === completedActionHandoffId
-					? { completedActionHandoffId }
+				...(echoedCompletedActionHandoffId
+					? { completedActionHandoffId: echoedCompletedActionHandoffId }
 					: {}),
 			};
 		}

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -409,12 +409,22 @@ describe("view switching — VIEWS action resolver", () => {
 
 		it("targets app-chat navigation to the client that sent the turn", async () => {
 			installNavigateCapture();
-			vi.mocked(globalThis.fetch).mockResolvedValue({
-				ok: true,
-				status: 200,
-				text: async () => "",
-				json: async () => ({ ok: true, completedActionDelivered: true }),
-			} as Response);
+			vi.mocked(globalThis.fetch).mockImplementation(async (_url, init) => {
+				const requestBody = JSON.parse(String(init?.body)) as Record<
+					string,
+					unknown
+				>;
+				return {
+					ok: true,
+					status: 200,
+					text: async () => "",
+					json: async () => ({
+						ok: true,
+						completedActionDelivered: true,
+						completedActionHandoffId: requestBody.completedActionHandoffId,
+					}),
+				} as Response;
+			});
 			const action = createViewsAction({
 				client: clientFor(REGISTRY),
 				hasOwnerAccess: vi.fn(async () => true),
@@ -438,11 +448,21 @@ describe("view switching — VIEWS action resolver", () => {
 			expect(lastCall).toBeDefined();
 			if (!lastCall) throw new Error("expected the view navigation request");
 			const [, init] = lastCall;
-			expect(JSON.parse(String(init?.body))).toMatchObject({
+			const requestBody = JSON.parse(String(init?.body)) as Record<
+				string,
+				unknown
+			>;
+			expect(requestBody).toMatchObject({
 				clientId: "seeker-client",
 				delivery: "completed-action",
 			});
-			expect(result?.values).toMatchObject({ completedActionDelivered: true });
+			expect(requestBody.completedActionHandoffId).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f-]{27}$/,
+			);
+			expect(result?.values).toMatchObject({
+				completedActionDelivered: true,
+				completedActionHandoffId: requestBody.completedActionHandoffId,
+			});
 		});
 
 		it("keeps terminal fallback enabled for a malformed success receipt", async () => {

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -465,6 +465,42 @@ describe("view switching — VIEWS action resolver", () => {
 			});
 		});
 
+		it("keeps terminal fallback enabled when an older server does not echo the handoff id", async () => {
+			installNavigateCapture();
+			vi.mocked(globalThis.fetch).mockImplementation(async () => {
+				return {
+					ok: true,
+					status: 200,
+					text: async () => "",
+					json: async () => ({
+						ok: true,
+						completedActionDelivered: true,
+					}),
+				} as Response;
+			});
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+
+			const result = await action.handler(
+				{ agentId: "agent-1" } as never,
+				{
+					...message("open calendar"),
+					content: {
+						text: "open calendar",
+						metadata: { viewClientId: "older-server-client" },
+					},
+				} as never,
+				undefined,
+				{ action: "show", view: "calendar" },
+				vi.fn(),
+			);
+
+			expect(result?.values).not.toHaveProperty("completedActionDelivered");
+			expect(result?.values).not.toHaveProperty("completedActionHandoffId");
+		});
+
 		it("keeps terminal fallback enabled for a malformed success receipt", async () => {
 			installNavigateCapture();
 			vi.mocked(globalThis.fetch).mockResolvedValue(


### PR DESCRIPTION
Closes #22273. Follow-up to merged #22245 and #22267.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f599ef7c191d176c974d656e818a81c2cce90e42:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## What changed

A synchronous WebSocket send count is not a renderer acknowledgement. This change gives every completed VIEWS handoff a bounded, validated id carried through the targeted frame and terminal result, then deduplicates only from state observed by the originating renderer.

- A mounted shell acknowledges a handled cancelable navigation event.
- An unhandled first delivery remains retryable while the renderer stays on the same route epoch.
- Explicit intervening navigation wins: if the path or popstate/hashchange epoch advances before fallback, the pending handoff is retired and cannot pull the user back.
- The same rule covers WebSocket-first and terminal-first orderings.
- Handled and pending histories are bounded to 256 entries.
- Legacy results without an id keep their existing behavior; zero-recipient/send-throw fallback, older servers, client targeting, and realtime voice remain unchanged.

## Exact-head validation

Head: `3f2a7eb66d8d03583db3bc7c3e63a60ca98cb334`/
Base: `a6b612298d68bfd42f47a1ab7f8c957ee18eaf62`/

- agent route: **24/24 passed**
- shared event contract: **3/3 passed**
- app-control: **186/186 passed**
- mounted App, hydration, renderer idempotency, UI handoff/chat: **139/139 passed**
- total focused: **352/352 passed**
- renderer idempotency sub-suite: **8/8 passed**, including handled WS-first and terminal-first followed by user navigation, unhandled early frame followed by changed-path navigation, and same-path navigation epoch advance
- shared and app-control typechecks: passed
- agent, shared, UI, and app-control production builds: passed
- Biome over all 16 changed files, guide parity, and `git diff --check`: passed

UI typecheck remains blocked by pre-existing timeout tests importing non-exported BuildBadge/load-pack symbols. Agent typecheck remains blocked by unrelated missing plugin-capacitor-bridge/plugin-wallet/plugin-video/plugin-vision/plugin-notes workspace exports. No diagnostic points to a changed file.

`bun run --cwd packages/app audit:app` was attempted on the rebased source. Its prerequisite view/core/shared builds completed, then the browser capture produced no progress under host contention and was stopped rather than held indefinitely. No rendered pixel source changed; exact-head visual/browser timing evidence remains pending and the PR stays draft.

## Evidence gate

Evidence matches exact commit `3f2a7eb66d8d03583db3bc7c3e63a60ca98cb334`./
<!-- evidence-head:3f2a7eb66d8d03583db3bc7c3e63a60ca98cb334 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered pixel source changed; this is delivery ordering and idempotency.
<!-- evidence-row:after-screenshots -->
- [ ] Pending - exact-head app audit capture did not complete under host contention.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending - attach current-head live timing capture; predecessor evidence is not restamped.
<!-- evidence-row:backend-logs -->
- [ ] Pending - hosted checks and current-head live transport logs are not yet attached.
<!-- evidence-row:frontend-logs -->
- [ ] Pending - current-head browser timing logs are not yet attached.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the transport repair does not change model planning; #22245 carries the originating trajectory but it is not current-head evidence.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - navigation changes browser shell state only.
<!-- evidence-row:ocr-review -->
- [ ] Pending - exact-head app audit did not reach final OCR/verdict inspection.

## Deterministic transport transcript

```text
Handled WebSocket-first and terminal-first handoffs navigate once; after the user moves to /settings, their duplicate delivery is suppressed and /settings remains active.
An unhandled early frame retries when the route epoch is unchanged, but a changed path before terminal fallback retires the id without dispatching into the mounted shell.
A same-path popstate epoch advance also retires the pending id, preventing history-state user navigation from being overwritten by a late transport fallback.
```

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f599ef7c191d176c974d656e818a81c2cce90e42:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/pr22245-deep-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f599ef7c191d176c974d656e818a81c2cce90e42:packages/skills/skills/contribute-to-eliza"} -->