### PR TITLE
fix(ui): isolate chat sheet pointer gestures

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -36,6 +36,8 @@ import {
 // The resting overlay's suggestion strip fetches model suggestions via the
 // shared client; stub it so the strip stays on its static fallback in tests.
 vi.mock("../../api/client", () => ({
+  // Voice's inert off-device diagnostics instantiate this re-export at module
+  // load; keep the class shape while replacing only the shared singleton.
   ElizaClient: class {
     fetch = vi.fn();
   },
@@ -2060,6 +2062,34 @@ describe("ChatOverlay", () => {
     // balloons up into the home widgets.
     expect(grabber.className).toContain("before:-top-6");
     expect(grabber.className).not.toContain("before:-top-16");
+    expect(grabber.className).toContain("inset-x-[4.5rem]");
+    expect(grabber.className).not.toContain("inset-x-6");
+  });
+
+  it("keeps the collapsed grabber and chat actions as exclusive gesture owners", () => {
+    const parentPointerDown = vi.fn();
+    render(
+      <div onPointerDown={parentPointerDown}>
+        <ChatOverlay controller={makeController()} />
+      </div>,
+    );
+
+    const plus = screen.getByTestId("chat-composer-plus");
+    fireEvent.pointerDown(plus, {
+      button: 0,
+      pointerId: 51,
+      pointerType: "mouse",
+    });
+    expect(parentPointerDown).not.toHaveBeenCalled();
+
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    fireEvent.pointerDown(grabber, {
+      button: 0,
+      pointerId: 52,
+      pointerType: "mouse",
+      clientY: 420,
+    });
+    expect(parentPointerDown).not.toHaveBeenCalled();
   });
 
   it("mounts an inert transcript preview during an upward drag before release", async () => {

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -4234,6 +4234,21 @@ describe("ChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(sheet.getAttribute("data-chat-state")).toBe("MAXIMIZED");
   });
 
+  it("fades the fullscreen transcript with its scroll mask instead of a painted rectangle", () => {
+    const { controller } = makeSwipeController();
+    render(<ChatOverlay controller={controller} />);
+
+    bigPullUp();
+
+    const viewport = screen.getByTestId("chat-thread-scroll");
+    const surface = screen.getByTestId("chat-sheet-surface");
+    expect(viewport.className.split(/\s+/)).toContain("scroll-fade");
+    expect(viewport.className.split(/\s+/)).not.toContain("scroll-fade-b");
+    expect(screen.queryByTestId("chat-thread-top-fade")).toBeNull();
+    expect(screen.queryByTestId("chat-sheet-top-sheen")).toBeNull();
+    expect(surface.style.backgroundImage).toBe("none");
+  });
+
   it("snaps to full-screen at 90% while held and reverses below the same line", async () => {
     const { controller } = makeSwipeController();
     render(<ChatOverlay controller={controller} />);

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -5863,11 +5863,13 @@ export function ChatOverlay({
               // catch light. Depth here is the glass rim, not a drop shadow (the
               // flat system keeps all shadow tokens none).
               boxShadow: surfaceEdgeShadow,
-              // Specular sheen: a soft radial highlight near the top-left (as if
-              // lit from above) over the faint neutral top-edge fade — the glass
-              // catches light instead of just fading. Neutral white only, NOT the
-              // warm `--surface` gradient that read as brown.
-              backgroundImage: `${LIQUID_GLASS_SHEEN}, linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 22%)`,
+              // Specular sheen belongs to the inset glass slab, where there is
+              // an edge to catch light. Fullscreen is a flat view surface; the
+              // same image became a broad gray glow across its top edge.
+              backgroundImage:
+                firstRunOpen || fullBleed
+                  ? "none"
+                  : `${LIQUID_GLASS_SHEEN}, linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 22%)`,
               // Full-bleed: extend the glass UP through the safe-area-top so the
               // dark background reaches the true top of the screen. The panel
               // height comes from visualViewport (which excludes the Android
@@ -5965,12 +5967,16 @@ export function ChatOverlay({
               }
             }}
           >
-            {/* Specular sheen — a soft light from the top edge, the liquid-glass
-                highlight. Subtle + non-interactive. */}
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-x-0 top-0 z-0 h-20 bg-gradient-to-b from-surface to-transparent"
-            />
+            {/* The top-edge sheen belongs only to the inset glass slab.
+                Fullscreen is a flat view surface; carrying this highlight into
+                full-bleed creates an unwanted gray glow across the viewport. */}
+            {!fullBleed ? (
+              <div
+                data-testid="chat-sheet-top-sheen"
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-x-0 top-0 z-0 h-20 bg-gradient-to-b from-surface to-transparent"
+              />
+            ) : null}
 
             {/* Top-bar pull-down-to-restore grab zone (#13531). Confined to the
                 safe-area + MAXIMIZE_RESTORE_ZONE_PX strip at the very top so the
@@ -6165,6 +6171,11 @@ export function ChatOverlay({
                       <MessageScrollerViewport
                         id="continuous-thread"
                         data-testid="chat-thread-scroll"
+                        // Fullscreen no longer changes flex-basis while the user
+                        // reads, so its top edge can use the real scroll mask and
+                        // dissolve into the sheet's nuanced surface. Resizable
+                        // detents retain the compositor overlay below.
+                        fade={fullBleed ? "both" : "bottom"}
                         ref={threadRef}
                         preserveScrollOnPrepend={false}
                         onScroll={handleThreadScroll}
@@ -6328,24 +6339,25 @@ export function ChatOverlay({
                     </AnimatePresence>
                   </MessageScroller>
                 </MessageScrollerProvider>
-                <motion.div
-                  data-testid="chat-thread-top-fade"
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-x-px top-px z-30 h-12"
-                  style={{
-                    opacity: threadContentOpacity,
-                    // A fixed compositor layer lets messages dissolve beneath
-                    // the floating grabber without masking the scrolling
-                    // subtree. WebKit re-rasterizes CSS-masked scrollers while
-                    // their flex basis changes, which makes the pull gesture
-                    // stutter. Hold the panel color through the grabber's
-                    // footprint before beginning the dissolve so no glyph can
-                    // ghost through the antialiased rim or the handle itself.
-                    backgroundImage: fullBleed
-                      ? "linear-gradient(to bottom, var(--bg) 0%, var(--bg) 28%, color-mix(in srgb, var(--bg) 72%, transparent) 64%, transparent 100%)"
-                      : "linear-gradient(to bottom, var(--card) 0%, var(--card) 28%, color-mix(in srgb, var(--card) 62%, transparent) 64%, transparent 100%)",
-                  }}
-                />
+                {!firstRunOpen && !fullBleed ? (
+                  <motion.div
+                    data-testid="chat-thread-top-fade"
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-x-px top-px z-30 h-12"
+                    style={{
+                      opacity: threadContentOpacity,
+                      // A fixed compositor layer lets messages dissolve beneath
+                      // the floating grabber without masking the scrolling
+                      // subtree. WebKit re-rasterizes CSS-masked scrollers while
+                      // their flex basis changes, which makes the pull gesture
+                      // stutter. Hold the panel color through the grabber's
+                      // footprint before beginning the dissolve so no glyph can
+                      // ghost through the antialiased rim or the handle itself.
+                      backgroundImage:
+                        "linear-gradient(to bottom, var(--card) 0%, var(--card) 28%, color-mix(in srgb, var(--card) 62%, transparent) 64%, transparent 100%)",
+                    }}
+                  />
+                ) : null}
               </motion.div>
             ) : null}
             {/* Cloud-agent provisioning status — rendered IN the chat, just

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -995,6 +995,13 @@ function SheetGrabber({
         if (e.cancelable) e.preventDefault();
       }}
       {...binding}
+      onPointerDown={(event) => {
+        // This handle is a complete gesture owner. In the shell it can sit over
+        // a broad home/notification pull surface, whose native listener runs
+        // independently of React; do not let this press seed both systems.
+        event.stopPropagation();
+        binding.onPointerDown(event);
+      }}
       className={cn(
         "appearance-none border-0 bg-transparent text-left",
         // ABSOLUTELY positioned over the panel top (zero layout height — it
@@ -1004,7 +1011,13 @@ function SheetGrabber({
         // open" affordance) but STAYS ABOVE the input row so it never steals
         // taps meant for the textarea / +/mic controls below it.
         // z-20 keeps it above the input row (z-10) so it always wins the drag.
-        "absolute inset-x-6 top-0.5 z-20 flex cursor-grab touch-none select-none items-center justify-center py-2 active:cursor-grabbing",
+        "absolute top-0.5 z-20 flex cursor-grab touch-none select-none items-center justify-center py-2 active:cursor-grabbing",
+        // In input mode, reserve a real gutter over BOTH edge controls. The
+        // prior full-width band began inside the + button and immediately to
+        // its right, so a tiny miss opened/flung the sheet instead of opening
+        // chat actions. Once the sheet is open, those controls are far below
+        // this top handle and the generous full-width drag lane is safe again.
+        open ? "inset-x-6" : "inset-x-[4.5rem]",
         // The invisible hit target reaches a comfortable distance ABOVE the
         // panel (a swipe-up begun in the empty field just over the composer is
         // caught) and STOPS at the handle's own bottom, so it never overlaps the
@@ -6514,6 +6527,11 @@ export function ChatOverlay({
                       aria-label="chat actions"
                       disabled={firstRunOpen}
                       data-testid="chat-composer-plus"
+                      onPointerDown={(event) => {
+                        // The action menu owns this press even when the
+                        // composer is mounted over another shell drag surface.
+                        event.stopPropagation();
+                      }}
                       // Same responsive real target and 20px mark as the
                       // SoftButton controls, so the row reads as one family.
                       className="relative grid shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1817,6 +1817,55 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
   });
 
+  it("does not let a mouse drag on chat controls pull the notification shade", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+        <button
+          type="button"
+          data-chat-gesture-surface=""
+          data-testid="chat-pull-handle"
+        >
+          Chat pull handle
+        </button>
+      </div>,
+    );
+    collapseShade();
+    const list = screen.getByTestId("home-notification-list");
+    const chatHandle = screen.getByTestId("chat-pull-handle");
+
+    fireEvent.pointerDown(chatHandle, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 32,
+      clientX: 180,
+      clientY: 300,
+    });
+    fireEvent.pointerMove(chatHandle, {
+      pointerType: "mouse",
+      pointerId: 32,
+      clientX: 180,
+      clientY: 500,
+    });
+    fireEvent.pointerUp(chatHandle, {
+      pointerType: "mouse",
+      pointerId: 32,
+      clientX: 180,
+      clientY: 500,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+  });
+
   it("keeps the priority row mounted while an outside tap fades quiet groups", () => {
     __ingestNotificationForTests(
       makeNotification({

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1817,6 +1817,24 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
   });
 
+  it("does not collapse for a portaled chat action control", () => {
+    seedTriage();
+    render(
+      <>
+        <NotificationsHomeCenter />
+        <div data-chat-overlay-control="">
+          <button type="button">Upload file</button>
+        </div>
+      </>,
+    );
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.click(screen.getByText("Upload file"), { detail: 1 });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+  });
+
   it("does not let a mouse drag on chat controls pull the notification shade", () => {
     seedTriage();
     const surfaceRef = { current: null as HTMLElement | null };
@@ -1862,6 +1880,76 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+  });
+
+  it("keeps nested chat controls isolated from touch, wheel, and pen shade gestures", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+        <button type="button" data-chat-gesture-surface="">
+          <span data-testid="nested-chat-control">Chat action icon</span>
+        </button>
+      </div>,
+    );
+    const list = collapseShade();
+    const nestedControl = screen.getByTestId("nested-chat-control");
+
+    fireEvent.touchStart(nestedControl, {
+      touches: [{ identifier: 71, clientX: 180, clientY: 250 }],
+    });
+    fireEvent.touchMove(nestedControl, {
+      touches: [{ identifier: 71, clientX: 180, clientY: 520 }],
+    });
+    fireEvent.touchEnd(nestedControl, {
+      touches: [],
+      changedTouches: [{ identifier: 71, clientX: 180, clientY: 520 }],
+    });
+    fireEvent.wheel(nestedControl, { deltaY: -(PULL_COMMIT_PX + 20) });
+    fireEvent.pointerDown(nestedControl, {
+      pointerType: "pen",
+      isPrimary: true,
+      pointerId: 72,
+      clientX: 180,
+      clientY: 250,
+    });
+    fireEvent.pointerMove(nestedControl, {
+      pointerType: "pen",
+      pointerId: 72,
+      clientX: 180,
+      clientY: 520,
+    });
+    fireEvent.pointerUp(nestedControl, {
+      pointerType: "pen",
+      pointerId: 72,
+      clientX: 180,
+      clientY: 520,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+
+    expandShade();
+    fireEvent.touchStart(nestedControl, {
+      touches: [{ identifier: 73, clientX: 180, clientY: 520 }],
+    });
+    fireEvent.touchMove(nestedControl, {
+      touches: [{ identifier: 73, clientX: 180, clientY: 220 }],
+    });
+    fireEvent.touchEnd(nestedControl, {
+      touches: [],
+      changedTouches: [{ identifier: 73, clientX: 180, clientY: 220 }],
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.hasAttribute("data-shade-dragging")).toBe(false);
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
   });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -587,7 +587,9 @@ let notificationsHomeCenterRenderObserverForTests: (() => void) | null = null;
 function isChatGestureTarget(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
-    target.closest("[data-chat-gesture-surface]") !== null
+    target.closest(
+      "[data-chat-gesture-surface], [data-chat-overlay-control]",
+    ) !== null
   );
 }
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1842,7 +1842,7 @@ export function NotificationsHomeCenter({
     };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
-      if (e.touches.length !== 1 || !t) {
+      if (e.touches.length !== 1 || !t || isChatGestureTarget(e.target)) {
         abortTouchPull();
         return;
       }
@@ -1991,6 +1991,7 @@ export function NotificationsHomeCenter({
       // surface. The home listener only fills the otherwise dead background.
       if (
         !usesEmptyBackground ||
+        isChatGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
         return;
@@ -2059,6 +2060,7 @@ export function NotificationsHomeCenter({
       if (
         event.touches.length !== 1 ||
         !touch ||
+        isChatGestureTarget(target) ||
         isInteractiveGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
@@ -2147,6 +2149,7 @@ export function NotificationsHomeCenter({
       const target = event.target;
       if (
         event.deltaY >= 0 ||
+        isChatGestureTarget(target) ||
         isInteractiveGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
@@ -2204,6 +2207,7 @@ export function NotificationsHomeCenter({
         !shadeGestureRef.current.canCollapse ||
         !(target instanceof Node) ||
         list.contains(target) ||
+        isChatGestureTarget(target) ||
         isInteractiveGestureTarget(target)
       ) {
         abort();
@@ -2333,6 +2337,7 @@ export function NotificationsHomeCenter({
       if (
         event.pointerType !== "mouse" ||
         !event.isPrimary ||
+        isChatGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
         return;

--- a/packages/ui/src/components/ui/message-scroller.tsx
+++ b/packages/ui/src/components/ui/message-scroller.tsx
@@ -73,13 +73,21 @@ function MessageScroller({
 
 function MessageScrollerViewport({
   className,
+  fade = "bottom",
   ...props
-}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport> & {
+  fade?: "both" | "bottom" | "none";
+}) {
   return (
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b overflow-y-auto overscroll-contain [contain:content]",
+        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain [contain:content]",
+        fade === "both"
+          ? "scroll-fade"
+          : fade === "bottom"
+            ? "scroll-fade-b"
+            : undefined,
         className,
       )}
       {...props}


### PR DESCRIPTION
# Relates to

Relates to #21828 and the operator's direct browser QA reports.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is rebased on the current reviewed base.
- [x] Exact final source head was built and exercised.
- [x] Focused component, app-audit, recorded-browser, and manual-review evidence is permanent.
- [ ] Independent approval must be refreshed for the final rebased head before merge.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@edfb954bd67e40ce002234e864a0962e817304bc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

- Reserves separate control gutters for the collapsed chat action and grabber.
- Gives the action control, grabber, notification shade, and portaled chat-action items exclusive pointer ownership.
- Replaces the fullscreen painted top rectangle and inset-glass sheen with the transcript scroller's real two-sided mask.
- Restoring to an inset detent restores the inset-only fade and sheen behavior.

The patch is limited to five shared UI files. It does not change provider routing, backend behavior, cloud infrastructure, native code, storage, credentials, or voice behavior.

# Sync with develop

- Exact PR head: `edfb954bd67e40ce002234e864a0962e817304bc`.
- Rebased on: `8fc430c996805550c5ed115575c29872e5aa7ebd`.
- The rebase preserved all three PR commits. One test-double conflict retained develop's `fetch`/`getBaseUrl` mock and the PR's class-shape rationale. One production conflict retained develop's onboarding/desktop-host behavior while applying the PR's fullscreen sheen/top-fade semantics.

# Testing

- `ChatOverlay.test.tsx` plus `NotificationsHomeCenter.test.tsx`: **293/293 passed**.
- Changed-file Biome (5 files) and exact `git diff --check`: passed.
- Exact app build: passed. Renderer build ID `f71e75e0a778`; manifest commit matches `edfb954bd67e...`.
- Affected app audit: **4/4** `builtin-chat` viewports passed (`good`) at desktop, mobile portrait, mobile landscape, and iPad; no console, render, overflow, hover, color, or quality failures.
- Recorded real-app Chromium lane: **8/10 passed**, including Upload file, long-thread scrolling, fullscreen maximize, three restore paths, and Escape collapse.
- Two legacy recorded-suite setup assertions did not reach this PR's target behavior: one expects collapsed-at-rest although the newly merged desktop/onboarding contract starts open; one assumes a grabber click always opens under the new detent contract. They are disclosed in the exact validation JSON.

# Evidence Gate

<!-- evidence-head:edfb954bd67e40ce002234e864a0962e817304bc -->

<!-- evidence-row:before-screenshots -->
- [x] Exact-base [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-before-desktop-b5f6de9.jpg) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-before-mobile-b5f6de9.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Exact-head affected captures: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-chat-desktop-edfb954.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-chat-mobile-edfb954.png), and [iPad](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-chat-ipad-edfb954.png).
<!-- evidence-row:walkthrough-video -->
- [x] Exact-head H.264 recordings: [fullscreen maximize](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-fullscreen-maximize-edfb954.mp4), [restore to inset](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-fullscreen-restore-edfb954.mp4), [long-thread scroll](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-long-thread-scroll-edfb954.mp4), and [portaled Upload action](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-upload-action-edfb954.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A: deterministic browser routes exercise local UI ownership/compositing; no backend, provider, credential, or protected integration is involved.
<!-- evidence-row:frontend-logs -->
- [x] [Exact renderer manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-renderer-build-edfb954.json) and [validation summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-validation-summary-edfb954.json).
<!-- evidence-row:llm-trajectory -->
- [x] N/A: these interactions do not send a message or invoke an LLM.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact affected app-audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22288-app-audit-chat-edfb954.json).
<!-- evidence-row:ocr-review -->
- [x] Manual visual review completed for all exact-head affected captures and sampled recorded end states. Packaged OCR could not start in the no-install isolated checkout because optional `sharp`/`pixelmatch` links were absent; the app audit still verified semantic readiness/readable text and image quality. No credentials, provider values, clipped controls, or fullscreen gray rectangle were present.

# Manual findings

- Exact fullscreen capture has no legacy painted top rectangle or inset glass sheen.
- Exact restore returns to the inset open sheet with transcript content intact.
- Exact Upload action opens the image chooser without beginning a sheet drag.
- Exact long-thread recording demonstrates real internal transcript scrolling.
- Deterministic fixtures contain no secrets or personal data.

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Attribution status: self-reported  
— [browser-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@edfb954bd67e40ce002234e864a0962e817304bc:packages/skills/skills/contribute-to-eliza"} -->
