### PR TITLE
fix(cloud): port truncateWellFormed into the workerd core stub

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -1919,3 +1919,25 @@ export default {
   Semaphore,
   BM25,
 };
+
+/**
+ * Worker-safe port of core's `truncateWellFormed` (utils/well-formed.ts):
+ * `text.slice(0, maxLength)` that never splits a surrogate pair — when the
+ * cut would end on a high surrogate, the boundary backs off one code unit.
+ * Pre-existing lone surrogates pass through unchanged, matching core.
+ */
+export function truncateWellFormed(text: string, maxLength: number): string {
+  if (!Number.isFinite(maxLength) || maxLength <= 0) {
+    return "";
+  }
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const lead = text.charCodeAt(maxLength - 1);
+  const trail = text.charCodeAt(maxLength);
+  const end =
+    lead >= 0xd800 && lead <= 0xdbff && trail >= 0xdc00 && trail <= 0xdfff
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+}


### PR DESCRIPTION
# Relates to

#22183 — next blocker in the staging-train chain, surfaced by receipt attempt run 32201980203 (migrations green again; Worker job failed in `typecheck → check:worker-bundle`). cc @lalalune (cloud territory; shipped directly on nubs's standing authorization to keep the frozen train moving).

# What changed

`packages/cloud/shared/src/lib/utils/telegram-helpers.ts` imports `truncateWellFormed` from `@elizaos/core`, but the workerd bundle resolves core through `packages/cloud/api/src/stubs/elizaos-core.ts`, which lacked the export — so `check:worker-bundle` fails and every staging Cloud CF release dies before deploying. This ports the surrogate-safe truncation into the stub exactly as core defines it (`utils/well-formed.ts`), same pattern as the `readResponseWithLimit` stub port (#21364). One additive export; no behavior change for anything already resolving.

# Evidence

- Before: run 32201980203 Worker job — `../shared/src/lib/utils/telegram-helpers.ts:1:9: import { truncateWellFormed } from "@elizaos/core"` unresolved → `check:worker-bundle` exit 1.
- After (this head, local): `check:worker-bundle` completes to its dry-run exit and `bun run typecheck` is clean in `packages/cloud/api`.
- PR CI remains starved repo-wide (HQ 18059089) — local receipts are the verification.

Chain status: migrations ✓ (#22070/#22199), e2e harness Origin ✓ (#22269) — this stub port is the next gate; whatever train carries all three becomes the #22183 closure receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
