### PR TITLE
fix(plugin-agent-skills): cap skill package downloads before allocate

### DIFF
--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -35,7 +35,9 @@ function streamOf(
 	);
 }
 
-function openOverflowStream(onCancel: () => void): Response {
+function openOverflowStream(
+	onCancel: () => void | Promise<void>,
+): Response {
 	return new Response(
 		new ReadableStream<Uint8Array>({
 			start(controller) {
@@ -79,11 +81,33 @@ describe("readCappedSkillPackage", () => {
 		const cancel = vi.fn();
 		const response = openOverflowStream(cancel);
 
-		await expect(readCappedSkillPackage(response)).rejects.toThrow(
-			"Package too large (max 10MB)",
-		);
+		await expect(readCappedSkillPackage(response)).rejects.toMatchObject({
+			message: "Package too large (max 10MB)",
+			code: "SKILL_PACKAGE_TOO_LARGE",
+			context: {
+				maxBytes: MAX_SKILL_PACKAGE_BYTES,
+				receivedBytes: MAX_SKILL_PACKAGE_BYTES + 1,
+			},
+		});
 		expect(cancel).toHaveBeenCalledOnce();
 		expect(response.body?.locked).toBe(false);
+	});
+
+	it("does not let cancellation failure mask the typed size error", async () => {
+		const cancel = vi.fn(async () => {
+			throw new Error("transport cancel failed");
+		});
+
+		await expect(
+			readCappedSkillPackage(openOverflowStream(cancel)),
+		).rejects.toMatchObject({ code: "SKILL_PACKAGE_TOO_LARGE" });
+		expect(cancel).toHaveBeenCalledOnce();
+	});
+
+	it("returns empty bytes for a response without a body", async () => {
+		await expect(
+			readCappedSkillPackage(new Response(null)),
+		).resolves.toEqual(new Uint8Array());
 	});
 
 	it("decodes a capped SKILL.md body as UTF-8", async () => {
@@ -91,6 +115,16 @@ describe("readCappedSkillPackage", () => {
 			new Response("name: demo\n", { headers: { "content-type": "text/markdown" } }),
 		);
 		expect(text).toBe("name: demo\n");
+	});
+
+	it("rejects malformed UTF-8 instead of changing skill instructions", async () => {
+		await expect(
+			readCappedSkillText(new Response(new Uint8Array([0xc3, 0x28]))),
+		).rejects.toMatchObject({
+			code: "SKILL_PACKAGE_INVALID_UTF8",
+			context: { byteLength: 2 },
+			cause: expect.any(TypeError),
+		});
 	});
 
 	it("fails a real direct-URL install and cancels before saving an oversized body", async () => {

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Overflow coverage for {@link readCappedSkillPackage}: an oversize install
+ * body must be rejected before the full payload is retained, and a body at
+ * the cap must still be accepted.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	MAX_SKILL_PACKAGE_BYTES,
+	readCappedSkillPackage,
+	readCappedSkillText,
+} from "./skill-package-bytes";
+
+function streamOf(bytes: Uint8Array, chunkSize = 64 * 1024): Response {
+	let offset = 0;
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (offset >= bytes.byteLength) {
+					controller.close();
+					return;
+				}
+				const end = Math.min(offset + chunkSize, bytes.byteLength);
+				controller.enqueue(bytes.subarray(offset, end));
+				offset = end;
+			},
+		}),
+	);
+}
+
+describe("readCappedSkillPackage", () => {
+	it("accepts a package at the 10MB cap", async () => {
+		const body = new Uint8Array(MAX_SKILL_PACKAGE_BYTES);
+		body[0] = 80;
+		body[1] = 75;
+		const got = await readCappedSkillPackage(streamOf(body));
+		expect(got.byteLength).toBe(MAX_SKILL_PACKAGE_BYTES);
+		expect(got[0]).toBe(80);
+		expect(got[1]).toBe(75);
+	});
+
+	it("rejects one byte past the cap without retaining the overflow", async () => {
+		const body = new Uint8Array(MAX_SKILL_PACKAGE_BYTES + 1);
+		await expect(readCappedSkillPackage(streamOf(body))).rejects.toThrow(
+			"Package too large (max 10MB)",
+		);
+	});
+
+	it("decodes a capped SKILL.md body as UTF-8", async () => {
+		const text = await readCappedSkillText(
+			new Response("name: demo\n", { headers: { "content-type": "text/markdown" } }),
+		);
+		expect(text).toBe("name: demo\n");
+	});
+});

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -1,17 +1,24 @@
 /**
- * Overflow coverage for {@link readCappedSkillPackage}: an oversize install
- * body must be rejected before the full payload is retained, and a body at
- * the cap must still be accepted.
+ * Overflow coverage for Agent Skills package downloads. The deterministic
+ * stream harness proves exact-cap acceptance, overflow cancellation and lock
+ * release, UTF-8 decoding, and the real direct-URL installer's fail-closed
+ * behavior without touching the network or filesystem.
  */
 
-import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemorySkillStore } from "../storage";
 import {
 	MAX_SKILL_PACKAGE_BYTES,
 	readCappedSkillPackage,
 	readCappedSkillText,
 } from "./skill-package-bytes";
+import { AgentSkillsService } from "./skills";
 
-function streamOf(bytes: Uint8Array, chunkSize = 64 * 1024): Response {
+function streamOf(
+	bytes: Uint8Array,
+	chunkSize = 64 * 1024,
+): Response {
 	let offset = 0;
 	return new Response(
 		new ReadableStream<Uint8Array>({
@@ -28,6 +35,35 @@ function streamOf(bytes: Uint8Array, chunkSize = 64 * 1024): Response {
 	);
 }
 
+function openOverflowStream(onCancel: () => void): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(MAX_SKILL_PACKAGE_BYTES + 1));
+			},
+			cancel() {
+				onCancel();
+			},
+		}),
+	);
+}
+
+function createRuntime(): IAgentRuntime {
+	return {
+		getSetting: vi.fn(() => undefined),
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
 describe("readCappedSkillPackage", () => {
 	it("accepts a package at the 10MB cap", async () => {
 		const body = new Uint8Array(MAX_SKILL_PACKAGE_BYTES);
@@ -40,10 +76,14 @@ describe("readCappedSkillPackage", () => {
 	});
 
 	it("rejects one byte past the cap without retaining the overflow", async () => {
-		const body = new Uint8Array(MAX_SKILL_PACKAGE_BYTES + 1);
-		await expect(readCappedSkillPackage(streamOf(body))).rejects.toThrow(
+		const cancel = vi.fn();
+		const response = openOverflowStream(cancel);
+
+		await expect(readCappedSkillPackage(response)).rejects.toThrow(
 			"Package too large (max 10MB)",
 		);
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(response.body?.locked).toBe(false);
 	});
 
 	it("decodes a capped SKILL.md body as UTF-8", async () => {
@@ -51,5 +91,26 @@ describe("readCappedSkillPackage", () => {
 			new Response("name: demo\n", { headers: { "content-type": "text/markdown" } }),
 		);
 		expect(text).toBe("name: demo\n");
+	});
+
+	it("fails a real direct-URL install and cancels before saving an oversized body", async () => {
+		const cancel = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => openOverflowStream(cancel)),
+		);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.installFromUrl("https://skills.example/oversized.md", {
+				slug: "oversized",
+			}),
+		).resolves.toBe(false);
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("oversized")).toBeUndefined();
 	});
 });

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -1,0 +1,70 @@
+/**
+ * Bounded install-download reader for Agent Skills packages.
+ * Cancels the response stream as soon as {@link MAX_SKILL_PACKAGE_BYTES} is
+ * exceeded so a lying or missing Content-Length cannot force an unbounded
+ * `arrayBuffer()` / `text()` allocation.
+ */
+
+/** Maximum zip / SKILL.md download size (10MB). */
+export const MAX_SKILL_PACKAGE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Read a skill install body under {@link MAX_SKILL_PACKAGE_BYTES}.
+ * Throws `Package too large (max 10MB)` once the running total exceeds the cap.
+ */
+export async function readCappedSkillPackage(
+	response: Response,
+): Promise<Uint8Array> {
+	const tooLarge = (): Error =>
+		new Error(
+			`Package too large (max ${MAX_SKILL_PACKAGE_BYTES / 1024 / 1024}MB)`,
+		);
+	const body = response.body;
+	if (!body) {
+		const fallback = new Uint8Array(await response.arrayBuffer());
+		if (fallback.byteLength > MAX_SKILL_PACKAGE_BYTES) {
+			throw tooLarge();
+		}
+		return fallback;
+	}
+	const reader = body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value?.byteLength) continue;
+			total += value.byteLength;
+			if (total > MAX_SKILL_PACKAGE_BYTES) {
+				try {
+					await reader.cancel();
+				} catch {
+					// error-policy:J6 cancel is best-effort after the byte-cap failure.
+				}
+				throw tooLarge();
+			}
+			chunks.push(value);
+		}
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {
+			// error-policy:J6 stream lock release is teardown-only.
+		}
+	}
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return out;
+}
+
+/** Decode a capped install download as UTF-8 text (SKILL.md / README.md). */
+export async function readCappedSkillText(
+	response: Response,
+): Promise<string> {
+	return new TextDecoder().decode(await readCappedSkillPackage(response));
+}

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -5,6 +5,8 @@
  * `arrayBuffer()` / `text()` allocation.
  */
 
+import { ElizaError } from "@elizaos/core";
+
 /** Maximum zip / SKILL.md download size (10MB). */
 export const MAX_SKILL_PACKAGE_BYTES = 10 * 1024 * 1024;
 
@@ -15,17 +17,20 @@ export const MAX_SKILL_PACKAGE_BYTES = 10 * 1024 * 1024;
 export async function readCappedSkillPackage(
 	response: Response,
 ): Promise<Uint8Array> {
-	const tooLarge = (): Error =>
-		new Error(
+	const tooLarge = (receivedBytes: number): ElizaError =>
+		new ElizaError(
 			`Package too large (max ${MAX_SKILL_PACKAGE_BYTES / 1024 / 1024}MB)`,
+			{
+				code: "SKILL_PACKAGE_TOO_LARGE",
+				context: {
+					maxBytes: MAX_SKILL_PACKAGE_BYTES,
+					receivedBytes,
+				},
+			},
 		);
 	const body = response.body;
 	if (!body) {
-		const fallback = new Uint8Array(await response.arrayBuffer());
-		if (fallback.byteLength > MAX_SKILL_PACKAGE_BYTES) {
-			throw tooLarge();
-		}
-		return fallback;
+		return new Uint8Array();
 	}
 	const reader = body.getReader();
 	const chunks: Uint8Array[] = [];
@@ -42,7 +47,7 @@ export async function readCappedSkillPackage(
 				} catch {
 					// error-policy:J6 cancel is best-effort after the byte-cap failure.
 				}
-				throw tooLarge();
+				throw tooLarge(total);
 			}
 			chunks.push(value);
 		}
@@ -66,5 +71,16 @@ export async function readCappedSkillPackage(
 export async function readCappedSkillText(
 	response: Response,
 ): Promise<string> {
-	return new TextDecoder().decode(await readCappedSkillPackage(response));
+	const bytes = await readCappedSkillPackage(response);
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	} catch (cause) {
+		// error-policy:J2 malformed authored instructions are rejected without
+		// silently replacing invalid bytes and changing the package contents.
+		throw new ElizaError("Skill package text is not valid UTF-8", {
+			code: "SKILL_PACKAGE_INVALID_UTF8",
+			context: { byteLength: bytes.byteLength },
+			cause,
+		});
+	}
 }

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -15,6 +15,10 @@
  * 4. plugin - Plugin-contributed skills
  * 5. extra - Extra directories from config
  *
+ * Zip / SKILL.md downloads are read through {@link readCappedSkillPackage}
+ * so a lying or missing Content-Length cannot force an unbounded allocation
+ * before the 10MB package cap is applied.
+ *
  * @see https://agentskills.io/specification
  */
 
@@ -53,6 +57,10 @@ import type {
 } from "../types";
 import { SKILL_SOURCE_PRECEDENCE } from "../types";
 import { binaryExistsInPath } from "./bin-lookup";
+import {
+	readCappedSkillPackage,
+	readCappedSkillText,
+} from "./skill-package-bytes";
 
 // ============================================================
 // CONSTANTS
@@ -81,9 +89,6 @@ class CatalogPaginationError extends Error {
 		this.name = "CatalogPaginationError";
 	}
 }
-
-/** Maximum package size for downloads */
-const MAX_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
 
 /** Default auto-refresh interval (5 seconds) */
 const DEFAULT_AUTO_REFRESH_INTERVAL = 5000;
@@ -2208,18 +2213,13 @@ export class AgentSkillsService extends Service {
 				throw new Error(`Download failed: ${response.status}`);
 			}
 
-			const zipBuffer = await response.arrayBuffer();
-			if (zipBuffer.byteLength > MAX_PACKAGE_SIZE) {
-				throw new Error(
-					`Package too large (max ${MAX_PACKAGE_SIZE / 1024 / 1024}MB)`,
-				);
-			}
+			const zipBuffer = await readCappedSkillPackage(response);
 
 			// Extract and save based on storage type
 			if (this.storage instanceof MemorySkillStore) {
 				await (this.storage as MemorySkillStore).loadFromZip(
 					safeSlug,
-					new Uint8Array(zipBuffer),
+					zipBuffer,
 				);
 			} else if (this.storage instanceof FileSystemSkillStore) {
 				await (this.storage as FileSystemSkillStore).saveFromZip(
@@ -2334,7 +2334,7 @@ export class AgentSkillsService extends Service {
 				);
 			}
 
-			const skillMdContent = await response.text();
+			const skillMdContent = await readCappedSkillText(response);
 
 			// Create a minimal skill package
 			const files: Array<{ name: string; content: string | Uint8Array }> = [
@@ -2346,7 +2346,7 @@ export class AgentSkillsService extends Service {
 				const readmeUrl = `${rawBase}README.md`;
 				const readmeResponse = await fetch(readmeUrl);
 				if (readmeResponse.ok) {
-					const readmeContent = await readmeResponse.text();
+					const readmeContent = await readCappedSkillText(readmeResponse);
 					files.push({ name: "README.md", content: readmeContent });
 				}
 			} catch {
@@ -2422,27 +2422,22 @@ export class AgentSkillsService extends Service {
 
 			if (contentType.includes("application/zip") || url.endsWith(".zip")) {
 				// Handle zip package
-				const zipBuffer = await response.arrayBuffer();
-				if (zipBuffer.byteLength > MAX_PACKAGE_SIZE) {
-					throw new Error(
-						`Package too large (max ${MAX_PACKAGE_SIZE / 1024 / 1024}MB)`,
-					);
-				}
+				const zipBuffer = await readCappedSkillPackage(response);
 
 				if (this.storage instanceof MemorySkillStore) {
 					await (this.storage as MemorySkillStore).loadFromZip(
 						safeSlug,
-						new Uint8Array(zipBuffer),
+						zipBuffer,
 					);
 				} else if (this.storage instanceof FileSystemSkillStore) {
 					await (this.storage as FileSystemSkillStore).saveFromZip(
 						safeSlug,
-						new Uint8Array(zipBuffer),
+						zipBuffer,
 					);
 				}
 			} else {
 				// Assume it's a SKILL.md file
-				const content = await response.text();
+				const content = await readCappedSkillText(response);
 
 				const files: Array<{ name: string; content: string | Uint8Array }> = [
 					{ name: "SKILL.md", content },


### PR DESCRIPTION
# Relates to

Closes #22297.

Scoped to the Agent Skills package-download byte boundary. This does not add a
request timeout or downstream-request cancellation; a response that stalls
before exceeding the cap remains governed by the existing fetch lifecycle and
is tracked separately by #22300.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop`.
- [x] Focused cancellation/caller proof and the complete package gates pass at the exact head.
- [x] A reviewer can verify exact-cap acceptance, overflow cancellation, and caller failure from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `9ffa072c89829807eff56fd1ad55afa8ac2ee185` with zero conflicts.
- [x] Exact-head focused test: 7/7.
- [x] Exact-head complete package test: 252/252.
- [x] Exact-head typecheck, Biome lint, build/declaration emit, and `git diff --check`: clean.

# Risks

Low and bounded. Catalog and direct-URL zip installs retain the existing 10 MiB
compressed-package limit; GitHub `SKILL.md`/optional `README.md` and direct-URL
text installs now receive that same byte cap. A body exactly at 10 MiB remains
accepted. On overflow the reader is canceled best-effort and its lock is
released before the typed `SKILL_PACKAGE_TOO_LARGE` failure returns with the
established `Package too large (max 10MB)` message. A cancellation failure is
teardown-only and cannot mask that owning error. Text packages are decoded as
strict UTF-8 and malformed authored instructions fail with the typed
`SKILL_PACKAGE_INVALID_UTF8` error instead of acquiring replacement characters.

The reader bounds retained download growth; it is not a fetch deadline. A body
that stops producing bytes below the cap can still wait on the existing fetch,
and caller disconnects are not newly propagated as abort signals.

# Background

## What does this PR do?

`AgentSkillsService` materialized catalog and direct-URL zips with
`response.arrayBuffer()` and GitHub/direct-URL text with `response.text()`.
Catalog/direct-URL zips checked the 10 MiB limit only after allocation, while
the GitHub text paths had no equivalent size check.

This PR introduces one bounded response reader and uses it for catalog zip,
GitHub `SKILL.md`, optional GitHub `README.md`, and direct-URL text/zip installs.
The reader counts decoded response bytes, accepts the exact cap, cancels on the
first overflow chunk, releases the lock, and only then concatenates accepted
chunks. A missing response body becomes an empty byte sequence. Existing zip
path sanitization and the 100 MiB declared uncompressed archive limit remain
unchanged.

## What kind of change is this?

Bug fix (resource-bound enforcement).

# Documentation changes needed?

No public setting or API changed. The package's existing install surface keeps
the same 10 MiB package-error contract, now applied consistently to text
packages as well.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts`

The suite now proves:

1. exactly 10 MiB is accepted;
2. 10 MiB + 1 byte rejects, calls the stream's cancellation hook, and releases the reader lock;
3. cancellation rejection cannot mask the typed size failure;
4. a missing body produces empty bytes;
5. valid text is decoded as UTF-8 and malformed bytes fail with a typed error; and
6. the real `AgentSkillsService.installFromUrl` caller returns `false`, cancels the stream, and does not save a package.

# Evidence Gate

<!-- evidence-head:becbdfb9269b5df7548d1a94fca0bb55a254c861 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; server-side package-download boundary only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; server-side package-download boundary only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered interaction; behavior is captured by the exact-head stream and installer tests.

<!-- evidence-row:backend-logs -->
- [x] Exact-head focused and complete package gates.
<details><summary>Exact-head backend test and build transcript</summary><pre>
$ bun x vitest run src/services/skill-package-bytes.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)
$ bun run test
Test Files  24 passed (24)
Tests       252 passed (252)
$ bun run typecheck
$ tsc --noEmit
exit 0
$ bun run lint:check
Checked 63 files in 61ms. No fixes applied.
$ bun run build
ESM Build success; declaration emit exit 0
$ git diff --check origin/develop...HEAD
exit 0
</pre></details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - the frontend is not involved in package response consumption.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-planning, or agent trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Exact-cap, overflow teardown, and real installer results at this head.
<details><summary>Bounded download domain artifact</summary><pre>
exact_cap_bytes=10485760 accepted=true
overflow_bytes=10485761 error="Package too large (max 10MB)"
overflow_error_code=SKILL_PACKAGE_TOO_LARGE
overflow_cancel_hook_calls=1
overflow_reader_locked_after_rejection=false
cancel_rejection_masked_owning_error=false
missing_body_bytes=0
malformed_utf8_error_code=SKILL_PACKAGE_INVALID_UTF8
direct_url_installer_result=false
direct_url_cancel_hook_calls=1
stored_package_after_failure=undefined
archive_path_sanitization_and_uncompressed_limit_tests=green
</pre></details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or screenshots changed.

# Known gaps / failures

- Root `bun run verify` was not run in the sparse disposable review checkout.
  The owning package's complete test, typecheck, lint, build/declaration, and
  diff gates pass at the exact head.
- No timeout was added. A response that stalls below 10 MiB remains subject to
  the pre-existing fetch lifecycle; #22300 owns that residual. This PR
  specifically closes unbounded byte accumulation before the size check.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
