### PR TITLE
test(scenarios): classify certification evidence

### DIFF
--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -166,7 +166,12 @@ export default {
 } satisfies ScenarioDefinition;
 ```
 
-Loader discovers files recursively; entries starting with `_` are ignored. The `list` command reads only static metadata via TypeScript AST (no runtime import), so `id` must be a string literal.
+Loader discovers files recursively; entries starting with `_` are ignored. The
+`list` command reads only static metadata via TypeScript AST (no runtime
+import), so `id` and `title` must be string literals. Any authored `lane`,
+`executionProfile`, `evidenceClass`, and `certificationClass` must also be string
+literals. Top-level object spreads and computed property names are rejected
+because they could conceal or override certification metadata.
 
 ## Turn kinds
 

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -166,7 +166,12 @@ export default {
 } satisfies ScenarioDefinition;
 ```
 
-Loader discovers files recursively; entries starting with `_` are ignored. The `list` command reads only static metadata via TypeScript AST (no runtime import), so `id` must be a string literal.
+Loader discovers files recursively; entries starting with `_` are ignored. The
+`list` command reads only static metadata via TypeScript AST (no runtime
+import), so `id` and `title` must be string literals. Any authored `lane`,
+`executionProfile`, `evidenceClass`, and `certificationClass` must also be string
+literals. Top-level object spreads and computed property names are rejected
+because they could conceal or override certification metadata.
 
 ## Turn kinds
 

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -70,6 +70,31 @@ export default {
 **Final checks** (after all turns, in `finalChecks` array):
 `actionCalled`, `selectedAction`, `judgeRubric`, `connectorDispatchOccurred`, `memoryWriteOccurred`, `approvalRequestExists`, `browserTaskCompleted`, `messageDelivered`, and more — see `schema/index.js` for the full list.
 
+### Evidence and certification classes
+
+Scenario metadata separates what a run observed from what its title or report
+may certify:
+
+- `evidenceClass`: `simulated`, `runtime-observed`, `provider-observed`,
+  `native-device-observed`, or `webhook-ingress-observed`.
+- `certificationClass`: `none`, `runtime-contract`, `provider`,
+  `native-device`, or `webhook-ingress`.
+
+Missing metadata remains compatible for definitions that make no certification
+claim: it resolves to simulated evidence with class `none`. An id or title that
+says certify, certified, or certification is a deliberate exception and must
+declare its bounded class explicitly. A deterministic lane may certify a
+runtime contract, but it cannot claim provider, native/device, or real webhook
+evidence. External certification additionally requires `executionProfile:
+"provider-qualified"`; classification alone never makes a report publishable.
+Use `runtime-observed` + `runtime-contract` for real-runtime scenarios backed by
+fixture or simulated connectors.
+
+Because corpus validation does not import scenario modules, `id`, `title`, and
+any authored lane/profile/class fields must be string literals. Top-level object
+spreads and computed property names are rejected because they could conceal or
+override the certification boundary.
+
 ## CLI flags
 
 ```

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -497,6 +497,20 @@ export type ScenarioLane = "pr-deterministic" | "live-only";
  * backed by trusted durable/provider observers and hashed trajectories.
  */
 export type ScenarioExecutionProfile = "simulated" | "provider-qualified";
+/** Observable boundary that produced a scenario's evidence. */
+export type ScenarioEvidenceClass =
+  | "simulated"
+  | "runtime-observed"
+  | "provider-observed"
+  | "native-device-observed"
+  | "webhook-ingress-observed";
+/** Highest semantic certification a passing scenario is allowed to claim. */
+export type ScenarioCertificationClass =
+  | "none"
+  | "runtime-contract"
+  | "provider"
+  | "native-device"
+  | "webhook-ingress";
 export type ScenarioTier = "T1" | "T2" | "T3" | "T4";
 
 /**
@@ -583,6 +597,20 @@ export type ScenarioDefinition = {
    */
   executionProfile?: ScenarioExecutionProfile;
   /**
+   * Boundary actually observed by this scenario. Absent legacy definitions
+   * resolve to `simulated` (or `provider-observed` for an explicitly
+   * `provider-qualified` execution profile).
+   */
+  evidenceClass?: ScenarioEvidenceClass;
+  /**
+   * Highest certification label this definition may use. This is authoring
+   * metadata, not proof that a run qualified; reports and external observers
+   * remain authoritative. Absent means `none`; definitions whose id or title
+   * says certify/certified/certification must declare the bounded class
+   * explicitly.
+   */
+  certificationClass?: ScenarioCertificationClass;
+  /**
    * Platform-gated deferral. Present only on `live-only` scenarios that cannot
    * run in any current lane because the platform/runner they need does not exist
    * yet (e.g. a macOS SelfControl shard awaiting an `eliza-e2e-macos` runner).
@@ -624,6 +652,12 @@ export declare const DEFAULT_SCENARIO_LANE: ScenarioLane;
 /** Execution profile assumed for legacy scenario definitions. */
 export declare const DEFAULT_SCENARIO_EXECUTION_PROFILE: "simulated";
 
+/** Evidence class assumed when no explicit class is authored. */
+export declare const DEFAULT_SCENARIO_EVIDENCE_CLASS: "simulated";
+
+/** Certification class assumed when no explicit claim is authored. */
+export declare const DEFAULT_SCENARIO_CERTIFICATION_CLASS: "none";
+
 /** Resolve a scenario's effective lane, applying {@link DEFAULT_SCENARIO_LANE}. */
 export declare function scenarioLane(value: ScenarioDefinition): ScenarioLane;
 
@@ -640,6 +674,19 @@ export declare function isScenarioExecutionProfile(
 export declare function scenarioExecutionProfile(
   value: ScenarioDefinition,
 ): ScenarioExecutionProfile;
+
+/** Resolve and validate a scenario's observable evidence boundary. */
+export declare function scenarioEvidenceClass(
+  value: ScenarioDefinition,
+): ScenarioEvidenceClass;
+
+/**
+ * Resolve and validate a scenario's maximum certification claim against its
+ * lane, execution profile, and evidence class.
+ */
+export declare function scenarioCertificationClass(
+  value: ScenarioDefinition,
+): ScenarioCertificationClass;
 
 /** Resolve and validate the optional persona-scenario complexity tier. */
 export declare function scenarioTier(

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -203,11 +203,42 @@ export const DEFAULT_SCENARIO_LANE = "live-only";
  */
 export const DEFAULT_SCENARIO_EXECUTION_PROFILE = "simulated";
 
+/** Evidence boundary assumed for legacy simulated scenario definitions. */
+export const DEFAULT_SCENARIO_EVIDENCE_CLASS = "simulated";
+
+/** Certification claim assumed when a scenario does not declare one. */
+export const DEFAULT_SCENARIO_CERTIFICATION_CLASS = "none";
+
 const SCENARIO_LANES = new Set(["pr-deterministic", "live-only"]);
 const SCENARIO_EXECUTION_PROFILES = new Set([
   "simulated",
   "provider-qualified",
 ]);
+const SCENARIO_EVIDENCE_CLASSES = new Set([
+  "simulated",
+  "runtime-observed",
+  "provider-observed",
+  "native-device-observed",
+  "webhook-ingress-observed",
+]);
+const SCENARIO_CERTIFICATION_CLASSES = new Set([
+  "none",
+  "runtime-contract",
+  "provider",
+  "native-device",
+  "webhook-ingress",
+]);
+const EXTERNAL_SCENARIO_EVIDENCE_CLASSES = new Set([
+  "provider-observed",
+  "native-device-observed",
+  "webhook-ingress-observed",
+]);
+const REQUIRED_EVIDENCE_CLASS_BY_CERTIFICATION = {
+  "runtime-contract": "runtime-observed",
+  provider: "provider-observed",
+  "native-device": "native-device-observed",
+  "webhook-ingress": "webhook-ingress-observed",
+};
 const SCENARIO_TIERS = new Set(["T1", "T2", "T3", "T4"]);
 const SCENARIO_STATUSES = new Set(["active", "pending"]);
 
@@ -253,6 +284,74 @@ export function scenarioExecutionProfile(value) {
     );
   }
   return executionProfile;
+}
+
+/** Resolve and validate the boundary that produced a scenario's evidence. */
+export function scenarioEvidenceClass(value) {
+  const evidenceClass = value?.evidenceClass;
+  if (evidenceClass === undefined) {
+    return scenarioExecutionProfile(value) === "provider-qualified"
+      ? "provider-observed"
+      : DEFAULT_SCENARIO_EVIDENCE_CLASS;
+  }
+  if (!SCENARIO_EVIDENCE_CLASSES.has(evidenceClass)) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid evidenceClass "${evidenceClass}"; expected one of ${[...SCENARIO_EVIDENCE_CLASSES].join(", ")}`,
+    );
+  }
+  return evidenceClass;
+}
+
+/**
+ * Resolve and validate the highest certification a passing scenario may
+ * describe. Classification never substitutes for signed or live evidence.
+ */
+export function scenarioCertificationClass(value) {
+  const certificationClass =
+    value?.certificationClass ?? DEFAULT_SCENARIO_CERTIFICATION_CLASS;
+  if (!SCENARIO_CERTIFICATION_CLASSES.has(certificationClass)) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid certificationClass "${certificationClass}"; expected one of ${[...SCENARIO_CERTIFICATION_CLASSES].join(", ")}`,
+    );
+  }
+
+  const evidenceClass = scenarioEvidenceClass(value);
+  const lane = scenarioLane(value);
+  const executionProfile = scenarioExecutionProfile(value);
+  if (
+    lane === "pr-deterministic" &&
+    EXTERNAL_SCENARIO_EVIDENCE_CLASSES.has(evidenceClass)
+  ) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" declares ${evidenceClass} evidence in lane "pr-deterministic"; deterministic scenarios cannot claim provider, native-device, or webhook-ingress evidence`,
+    );
+  }
+  if (
+    EXTERNAL_SCENARIO_EVIDENCE_CLASSES.has(evidenceClass) &&
+    executionProfile !== "provider-qualified"
+  ) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" evidenceClass "${evidenceClass}" requires executionProfile "provider-qualified"`,
+    );
+  }
+  const certificationLanguage = `${value?.id ?? ""} ${value?.title ?? ""}`;
+  if (
+    certificationClass === "none" &&
+    /\bcertif(?:y|ies|ied|ication)\b/i.test(certificationLanguage)
+  ) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" uses certification language but does not declare certificationClass`,
+    );
+  }
+
+  const requiredEvidenceClass =
+    REQUIRED_EVIDENCE_CLASS_BY_CERTIFICATION[certificationClass];
+  if (requiredEvidenceClass && evidenceClass !== requiredEvidenceClass) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" certificationClass "${certificationClass}" requires evidenceClass "${requiredEvidenceClass}", received "${evidenceClass}"`,
+    );
+  }
+  return certificationClass;
 }
 
 /** Resolve and validate the optional persona-scenario complexity tier. */
@@ -377,6 +476,8 @@ export function scenario(value) {
     scenarioLane(value);
     // Provider evidence cannot be claimed by a deterministic execution profile.
     scenarioExecutionProfile(value);
+    // Certification labels must match the evidence and execution boundaries.
+    scenarioCertificationClass(value);
     // Validate optional LifeOps/persona tier metadata when authored.
     scenarioTier(value);
     // Validate pending/active inventory status before loader filtering relies on it.

--- a/packages/scenario-runner/src/execution-profile-schema.test.ts
+++ b/packages/scenario-runner/src/execution-profile-schema.test.ts
@@ -4,10 +4,14 @@
  */
 
 import {
+  DEFAULT_SCENARIO_CERTIFICATION_CLASS,
+  DEFAULT_SCENARIO_EVIDENCE_CLASS,
   DEFAULT_SCENARIO_EXECUTION_PROFILE,
   isScenarioExecutionProfile,
   type ScenarioDefinition,
   scenario,
+  scenarioCertificationClass,
+  scenarioEvidenceClass,
   scenarioExecutionProfile,
 } from "@elizaos/scenario-runner/schema";
 import { describe, expect, it } from "vitest";
@@ -64,6 +68,107 @@ describe("scenario execution profile", () => {
         } as unknown as ScenarioDefinition),
       ).toThrow(/invalid executionProfile/);
     }
+  });
+});
+
+describe("scenario evidence and certification classes", () => {
+  it("keeps legacy scenarios explicitly non-certifying", () => {
+    expect(DEFAULT_SCENARIO_EVIDENCE_CLASS).toBe("simulated");
+    expect(DEFAULT_SCENARIO_CERTIFICATION_CLASS).toBe("none");
+    expect(scenarioEvidenceClass(base)).toBe("simulated");
+    expect(scenarioCertificationClass(base)).toBe("none");
+  });
+
+  it("accepts deterministic runtime-contract coverage without inflating it to provider proof", () => {
+    const definition = {
+      ...base,
+      lane: "pr-deterministic" as const,
+      evidenceClass: "runtime-observed" as const,
+      certificationClass: "runtime-contract" as const,
+    };
+    expect(scenario(definition)).toBe(definition);
+    expect(scenarioCertificationClass(definition)).toBe("runtime-contract");
+  });
+
+  it("rejects deterministic scenarios that claim external evidence", () => {
+    for (const [evidenceClass, certificationClass] of [
+      ["provider-observed", "provider"],
+      ["native-device-observed", "native-device"],
+      ["webhook-ingress-observed", "webhook-ingress"],
+    ] as const) {
+      expect(() =>
+        scenario({
+          ...base,
+          lane: "pr-deterministic",
+          evidenceClass,
+          certificationClass,
+        } as ScenarioDefinition),
+      ).toThrow(/deterministic scenarios cannot claim/);
+    }
+  });
+
+  it("rejects external certification labels on simulated or mismatched evidence", () => {
+    expect(() =>
+      scenario({
+        ...base,
+        evidenceClass: "provider-observed",
+        certificationClass: "provider",
+      }),
+    ).toThrow(/evidenceClass "provider-observed" requires executionProfile/);
+    expect(() =>
+      scenario({
+        ...base,
+        evidenceClass: "runtime-observed",
+        certificationClass: "webhook-ingress",
+      } as ScenarioDefinition),
+    ).toThrow(/requires evidenceClass "webhook-ingress-observed"/);
+    expect(() =>
+      scenario({
+        ...base,
+        evidenceClass: "native-device-observed",
+        certificationClass: "native-device",
+      }),
+    ).toThrow(
+      /evidenceClass "native-device-observed" requires executionProfile "provider-qualified"/,
+    );
+  });
+
+  it("requires certification language to carry an explicit bounded class", () => {
+    expect(() =>
+      scenario({
+        ...base,
+        id: "fixture.certify-provider",
+        title: "Certify provider delivery",
+      }),
+    ).toThrow(
+      /uses certification language but does not declare certificationClass/,
+    );
+  });
+
+  it("accepts an explicitly provider-qualified webhook contract", () => {
+    const definition = {
+      ...base,
+      lane: "live-only" as const,
+      executionProfile: "provider-qualified" as const,
+      evidenceClass: "webhook-ingress-observed" as const,
+      certificationClass: "webhook-ingress" as const,
+    };
+    expect(scenario(definition)).toBe(definition);
+  });
+
+  it("fails closed on unknown evidence and certification strings", () => {
+    expect(() =>
+      scenario({
+        ...base,
+        evidenceClass: "provider-ish",
+      } as unknown as ScenarioDefinition),
+    ).toThrow(/invalid evidenceClass/);
+    expect(() =>
+      scenario({
+        ...base,
+        certificationClass: "certified",
+      } as unknown as ScenarioDefinition),
+    ).toThrow(/invalid certificationClass/);
   });
 });
 

--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -88,6 +88,10 @@ describe("scenario executor wait turns", () => {
     );
 
     expect(report.status).toBe("passed");
+    expect(report).toMatchObject({
+      evidenceClass: "simulated",
+      certificationClass: "none",
+    });
     expect(handleMessage).not.toHaveBeenCalled();
     expect(runtime.useModel).not.toHaveBeenCalled();
     expect(report.turns[0]).toMatchObject({

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -41,6 +41,8 @@ import {
   type ScenarioLane,
   type ScenarioTurn,
   type ScenarioTurnExecution,
+  scenarioCertificationClass,
+  scenarioEvidenceClass,
   scenarioLane,
 } from "@elizaos/scenario-runner/schema";
 import { actionMatchesScenarioExpectation } from "./action-families.ts";
@@ -2243,6 +2245,9 @@ export async function runScenario(
   const startedAt = Date.now();
   const executionProfile =
     opts.executionProfile ?? DEFAULT_SCENARIO_EXECUTION_PROFILE;
+  const effectiveScenario = { ...scenario, executionProfile };
+  const evidenceClass = scenarioEvidenceClass(effectiveScenario);
+  const certificationClass = scenarioCertificationClass(effectiveScenario);
   let logicalNow = new Date();
   const ctx: RunnerContext = {
     scenarioId: scenario.id,
@@ -2275,6 +2280,8 @@ export async function runScenario(
     failedAssertions: [],
     providerName: opts.providerName,
     executionProfile,
+    evidenceClass,
+    certificationClass,
     evidence:
       executionProfile === "simulated"
         ? {

--- a/packages/scenario-runner/src/loader.ts
+++ b/packages/scenario-runner/src/loader.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SCENARIO_LANE,
   type ScenarioDefinition,
   type ScenarioLane,
+  scenarioCertificationClass,
   scenarioLane,
   scenario as validateScenarioDefinition,
 } from "@elizaos/scenario-runner/schema";
@@ -55,6 +56,12 @@ export interface ScenarioMetadata {
   tier?: string;
   /** CI lane as declared in the file; absent means the default lane. */
   lane?: string;
+  /** Evidence boundary as declared in the file. */
+  evidenceClass?: string;
+  /** Maximum certification claim as declared in the file. */
+  certificationClass?: string;
+  /** Execution profile as declared in the file. */
+  executionProfile?: string;
   edgeVariant?: string;
   baseScenarioId?: string;
 }
@@ -299,6 +306,56 @@ function getStaticStringProperty(
   return undefined;
 }
 
+function getOptionalStaticStringProperty(
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string,
+  file: string,
+): string | undefined {
+  for (const property of objectLiteral.properties) {
+    if (
+      ts.isShorthandPropertyAssignment(property) &&
+      property.name.text === propertyName
+    ) {
+      throw new Error(
+        `[scenario-loader] ${file}: ${propertyName} must be a statically readable string literal`,
+      );
+    }
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = propertyNameText(property.name);
+    if (name !== propertyName) continue;
+    const value = staticStringValue(property.initializer);
+    if (value === undefined) {
+      throw new Error(
+        `[scenario-loader] ${file}: ${propertyName} must be a statically readable string literal`,
+      );
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function assertStaticScenarioMetadataObject(
+  objectLiteral: ts.ObjectLiteralExpression,
+  file: string,
+): void {
+  for (const property of objectLiteral.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      throw new Error(
+        `[scenario-loader] ${file}: scenario metadata cannot use object spreads because certification fields would not be statically auditable`,
+      );
+    }
+    if (
+      "name" in property &&
+      property.name &&
+      ts.isComputedPropertyName(property.name)
+    ) {
+      throw new Error(
+        `[scenario-loader] ${file}: scenario metadata cannot use computed property names because certification fields would not be statically auditable`,
+      );
+    }
+  }
+}
+
 function scenarioObjectFromExpression(
   expression: ts.Expression,
 ): ts.ObjectLiteralExpression | null {
@@ -360,20 +417,50 @@ export async function loadScenarioMetadataFile(
       `[scenario-loader] ${file}: no statically readable scenario object in default export or exported 'scenario' value.`,
     );
   }
+  assertStaticScenarioMetadataObject(objectLiteral, file);
   const id = getStaticStringProperty(objectLiteral, "id");
   if (!id) {
     throw new Error(
       `[scenario-loader] ${file}: no statically readable scenario id in default export or exported 'scenario' value.`,
     );
   }
-  return {
+  const title = getOptionalStaticStringProperty(objectLiteral, "title", file);
+  if (!title) {
+    throw new Error(
+      `[scenario-loader] ${file}: no statically readable scenario title in default export or exported 'scenario' value.`,
+    );
+  }
+  const metadata = {
     file,
     id,
-    title: getStaticStringProperty(objectLiteral, "title"),
+    title,
     status: getStaticStringProperty(objectLiteral, "status"),
     tier: getStaticStringProperty(objectLiteral, "tier"),
-    lane: getStaticStringProperty(objectLiteral, "lane"),
+    lane: getOptionalStaticStringProperty(objectLiteral, "lane", file),
+    evidenceClass: getOptionalStaticStringProperty(
+      objectLiteral,
+      "evidenceClass",
+      file,
+    ),
+    certificationClass: getOptionalStaticStringProperty(
+      objectLiteral,
+      "certificationClass",
+      file,
+    ),
+    executionProfile: getOptionalStaticStringProperty(
+      objectLiteral,
+      "executionProfile",
+      file,
+    ),
   };
+  try {
+    scenarioCertificationClass(metadata as unknown as ScenarioDefinition);
+  } catch (err) {
+    throw new Error(
+      `[scenario-loader] ${file}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return metadata;
 }
 
 export async function discoverScenarios(root: string): Promise<string[]> {

--- a/packages/scenario-runner/src/loader.ts
+++ b/packages/scenario-runner/src/loader.ts
@@ -338,6 +338,7 @@ function assertStaticScenarioMetadataObject(
   objectLiteral: ts.ObjectLiteralExpression,
   file: string,
 ): void {
+  const authoredPropertyNames = new Set<string>();
   for (const property of objectLiteral.properties) {
     if (ts.isSpreadAssignment(property)) {
       throw new Error(
@@ -352,6 +353,15 @@ function assertStaticScenarioMetadataObject(
       throw new Error(
         `[scenario-loader] ${file}: scenario metadata cannot use computed property names because certification fields would not be statically auditable`,
       );
+    }
+    if ("name" in property && property.name) {
+      const name = propertyNameText(property.name);
+      if (name && authoredPropertyNames.has(name)) {
+        throw new Error(
+          `[scenario-loader] ${file}: scenario metadata cannot declare duplicate property "${name}" because static and runtime classification could disagree`,
+        );
+      }
+      if (name) authoredPropertyNames.add(name);
     }
   }
 }

--- a/packages/scenario-runner/src/scenario-expansion.test.ts
+++ b/packages/scenario-runner/src/scenario-expansion.test.ts
@@ -136,6 +136,91 @@ describe("scenario-runner edge expansion", () => {
     );
   });
 
+  it("rejects a static corpus entry that inflates simulated evidence to provider certification", async () => {
+    const dir = await makeTempScenarioDir();
+    await writeScenarioFile(dir, "inflated.scenario.ts", [
+      "export default {",
+      '  id: "fixture.inflated",',
+      '  title: "Inflated provider claim",',
+      '  domain: "fixture",',
+      '  lane: "live-only",',
+      '  evidenceClass: "provider-observed",',
+      '  certificationClass: "provider",',
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+
+    await expect(validateScenarioCorpus(dir)).rejects.toThrow(
+      'evidenceClass "provider-observed" requires executionProfile "provider-qualified"',
+    );
+  });
+
+  it("rejects non-literal certification metadata without importing the module", async () => {
+    const dir = await makeTempScenarioDir();
+    await writeScenarioFile(dir, "dynamic.scenario.ts", [
+      'const evidenceClass = "provider-observed";',
+      "export default {",
+      '  id: "fixture.dynamic",',
+      '  title: "Dynamic evidence claim",',
+      '  domain: "fixture",',
+      "  evidenceClass,",
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+
+    await expect(validateScenarioCorpus(dir)).rejects.toThrow(
+      "evidenceClass must be a statically readable string literal",
+    );
+  });
+
+  it("rejects object spreads that could hide certification metadata", async () => {
+    const dir = await makeTempScenarioDir();
+    await writeScenarioFile(dir, "spread.scenario.ts", [
+      'const hidden = { evidenceClass: "provider-observed", certificationClass: "provider" };',
+      "export default {",
+      "  ...hidden,",
+      '  id: "fixture.spread",',
+      '  title: "Spread metadata",',
+      '  domain: "fixture",',
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+
+    await expect(validateScenarioCorpus(dir)).rejects.toThrow(
+      "scenario metadata cannot use object spreads",
+    );
+  });
+
+  it("rejects computed certification fields and non-literal titles", async () => {
+    const computedDir = await makeTempScenarioDir();
+    await writeScenarioFile(computedDir, "computed.scenario.ts", [
+      "export default {",
+      '  id: "fixture.computed",',
+      '  title: "Computed metadata",',
+      '  domain: "fixture",',
+      '  ["certificationClass"]: "provider",',
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+    await expect(validateScenarioCorpus(computedDir)).rejects.toThrow(
+      "scenario metadata cannot use computed property names",
+    );
+
+    const dynamicTitleDir = await makeTempScenarioDir();
+    await writeScenarioFile(dynamicTitleDir, "title.scenario.ts", [
+      'const title = "Certify hidden provider behavior";',
+      "export default {",
+      '  id: "fixture.dynamic-title",',
+      "  title,",
+      '  domain: "fixture",',
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+    await expect(validateScenarioCorpus(dynamicTitleDir)).rejects.toThrow(
+      "title must be a statically readable string literal",
+    );
+  });
+
   it("only appends edge context to non-blank message-like turn text", () => {
     const expanded = expandScenarioDefinition("fixture.scenario.ts", {
       id: "fixture.mixed",

--- a/packages/scenario-runner/src/scenario-expansion.test.ts
+++ b/packages/scenario-runner/src/scenario-expansion.test.ts
@@ -221,6 +221,25 @@ describe("scenario-runner edge expansion", () => {
     );
   });
 
+  it("rejects duplicate metadata whose static and runtime values could disagree", async () => {
+    const dir = await makeTempScenarioDir();
+    await writeScenarioFile(dir, "duplicate.scenario.ts", [
+      "export default {",
+      '  id: "fixture.duplicate",',
+      '  title: "Duplicate metadata",',
+      '  evidenceClass: "runtime-observed",',
+      '  certificationClass: "runtime-contract",',
+      '  evidenceClass: "provider-observed",',
+      '  domain: "fixture",',
+      '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
+      "};",
+    ]);
+
+    await expect(validateScenarioCorpus(dir)).rejects.toThrow(
+      'scenario metadata cannot declare duplicate property "evidenceClass"',
+    );
+  });
+
   it("only appends edge context to non-blank message-like turn text", () => {
     const expanded = expandScenarioDefinition("fixture.scenario.ts", {
       id: "fixture.mixed",

--- a/packages/scenario-runner/src/types.ts
+++ b/packages/scenario-runner/src/types.ts
@@ -13,7 +13,9 @@ import type {
   CapturedConnectorDispatch,
   CapturedMemoryWrite,
   CapturedStateTransition,
+  ScenarioCertificationClass,
   ScenarioContext,
+  ScenarioEvidenceClass,
   ScenarioExecutionProfile,
   ScenarioTurnExecution,
 } from "@elizaos/scenario-runner/schema";
@@ -304,6 +306,16 @@ export interface ScenarioReport {
    * rather than relabeling them simulated.
    */
   executionProfile?: ScenarioExecutionProfile;
+  /**
+   * Observable boundary declared by the scenario and validated against the
+   * effective execution profile. Optional only for legacy report producers.
+   */
+  evidenceClass?: ScenarioEvidenceClass;
+  /**
+   * Maximum certification claim supported by the declared evidence boundary.
+   * This is classification metadata, not a provider qualification decision.
+   */
+  certificationClass?: ScenarioCertificationClass;
   /**
    * Trusted, hashed evidence captured outside the action-result/model-prose
    * path. The reporter validates profile agreement, provenance references, and

--- a/packages/test/scenarios/connector-certification/_factory.ts
+++ b/packages/test/scenarios/connector-certification/_factory.ts
@@ -1,14 +1,17 @@
 /** Builds connector-certification scenarios against scenario-runner's real runtime. */
-import type {
-  ScenarioFinalCheck,
-  ScenarioSeedStep,
-} from "@elizaos/scenario-runner/schema";
-import { scenario } from "@elizaos/scenario-runner/schema";
+
 import {
   expectScenarioToCallAction,
   expectTurnToCallAction,
   judgeRubric,
 } from "@elizaos/scenario-runner/scenario-assertions";
+import type {
+  ScenarioCertificationClass,
+  ScenarioEvidenceClass,
+  ScenarioFinalCheck,
+  ScenarioSeedStep,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
 
 export const CONNECTOR_CERTIFICATION_AXES = [
   "core",
@@ -60,6 +63,10 @@ type ConnectorCertificationScenarioConfig = {
   axis: ConnectorCertificationAxis;
   /** CI lane; defaults to `live-only` (certification exercises real connectors). */
   lane?: "pr-deterministic" | "live-only";
+  /** Boundary observed; these fixtures exercise the runtime with simulated connectors. */
+  evidenceClass: ScenarioEvidenceClass;
+  /** Scope of the word "certification" in this corpus. */
+  certificationClass: ScenarioCertificationClass;
   tags?: string[];
   description: string;
   roomSource?: string;
@@ -97,6 +104,8 @@ export function buildConnectorCertificationScenario(
     title: config.title,
     domain: "connector-certification",
     lane: config.lane ?? "live-only",
+    evidenceClass: config.evidenceClass,
+    certificationClass: config.certificationClass,
     tags: [
       "connector-certification",
       config.connector,

--- a/packages/test/scenarios/connector-certification/connector.browser-portal.certify-blocked-resume.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.browser-portal.certify-blocked-resume.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.browser-portal.certify-blocked-resume",
   title: "Certify browser blocked-resume intervention handling",

--- a/packages/test/scenarios/connector-certification/connector.browser-portal.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.browser-portal.certify-core.scenario.ts
@@ -1,17 +1,18 @@
 /** Scenario fixture for connector browser portal certify core; runs through scenario-runner with deterministic services unless the scenario name marks an external-service gate. */
-import { scenario } from "@elizaos/scenario-runner/schema";
+
 import {
+  expectScenarioBrowserTask,
   expectScenarioToCallAction,
+  expectTurnBrowserTask,
   expectTurnToCallAction,
   judgeRubric,
 } from "@elizaos/scenario-runner/scenario-assertions";
-import {
-  expectScenarioBrowserTask,
-  expectTurnBrowserTask,
-} from "@elizaos/scenario-runner/scenario-assertions";
+import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   id: "connector.browser-portal.certify-core",
   title: "Certify browser and portal upload flows",
   domain: "connector-certification",

--- a/packages/test/scenarios/connector-certification/connector.calendly.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.calendly.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.calendly.certify-core",
   title: "Certify Calendly availability and booking-link flows",

--- a/packages/test/scenarios/connector-certification/connector.calendly.certify-disconnected.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.calendly.certify-disconnected.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.calendly.certify-disconnected",
   title: "Certify Calendly disconnected degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.discord.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.discord.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.discord.certify-core",
   title: "Certify Discord inbound and reply delivery",

--- a/packages/test/scenarios/connector-certification/connector.discord.certify-disconnected.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.discord.certify-disconnected.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.discord.certify-disconnected",
   title: "Certify Discord disconnected degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.gmail.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.gmail.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.gmail.certify-core",
   title: "Certify Gmail read, draft, and send-after-approval",

--- a/packages/test/scenarios/connector-certification/connector.gmail.certify-missing-scope.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.gmail.certify-missing-scope.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.gmail.certify-missing-scope",
   title: "Certify Gmail missing-scope degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.google-calendar.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.google-calendar.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.google-calendar.certify-core",
   title: "Certify Google Calendar availability and lifecycle actions",

--- a/packages/test/scenarios/connector-certification/connector.google-calendar.certify-rate-limited.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.google-calendar.certify-rate-limited.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.google-calendar.certify-rate-limited",
   title: "Certify Google Calendar rate-limit degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.google-drive-docs-sheets.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.google-drive-docs-sheets.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.google-drive-docs-sheets.certify-core",
   title: "Certify Google Drive, Docs, and Sheets document ops",

--- a/packages/test/scenarios/connector-certification/connector.google-drive-docs-sheets.certify-missing-scope.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.google-drive-docs-sheets.certify-missing-scope.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.google-drive-docs-sheets.certify-missing-scope",
   title: "Certify Drive and Docs missing-scope degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.imessage.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.imessage.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.imessage.certify-core",
   title: "Certify iMessage bridge health and delivery",

--- a/packages/test/scenarios/connector-certification/connector.imessage.certify-helper-disconnected.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.imessage.certify-helper-disconnected.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.imessage.certify-helper-disconnected",
   title: "Certify iMessage helper-disconnected degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.notifications.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.notifications.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.notifications.certify-core",
   title: "Certify desktop and mobile notification synchronization",

--- a/packages/test/scenarios/connector-certification/connector.notifications.certify-transport-offline.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.notifications.certify-transport-offline.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.notifications.certify-transport-offline",
   title: "Certify push transport-offline degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.signal.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.signal.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.signal.certify-core",
   title: "Certify Signal inbound and delivery behavior",

--- a/packages/test/scenarios/connector-certification/connector.signal.certify-session-revoked.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.signal.certify-session-revoked.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.signal.certify-session-revoked",
   title: "Certify Signal revoked-session degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.slack.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.slack.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.slack.certify-core",
   title: "Certify Slack inbound and reply delivery",

--- a/packages/test/scenarios/connector-certification/connector.slack.certify-disconnected.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.slack.certify-disconnected.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.slack.certify-disconnected",
   title: "Certify Slack disconnected degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.telegram.certify-auth-expired.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.telegram.certify-auth-expired.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.telegram.certify-auth-expired",
   title: "Certify Telegram expired-auth degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.telegram.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.telegram.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.telegram.certify-core",
   title: "Certify Telegram inbound and reply delivery",

--- a/packages/test/scenarios/connector-certification/connector.travel-booking.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.travel-booking.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.travel-booking.certify-core",
   title: "Certify travel booking adapter search and approval gating",

--- a/packages/test/scenarios/connector-certification/connector.travel-booking.certify-hold-expired.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.travel-booking.certify-hold-expired.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.travel-booking.certify-hold-expired",
   title: "Certify travel booking expired-hold degradation handling",

--- a/packages/test/scenarios/connector-certification/connector.twilio-sms.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.twilio-sms.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.twilio-sms.certify-core",
   title: "Certify Twilio SMS send-after-approval",

--- a/packages/test/scenarios/connector-certification/connector.twilio-sms.certify-retry-idempotent.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.twilio-sms.certify-retry-idempotent.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.twilio-sms.certify-retry-idempotent",
   title: "Certify Twilio SMS retry-safe idempotent send handling",

--- a/packages/test/scenarios/connector-certification/connector.twilio-voice.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.twilio-voice.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.twilio-voice.certify-core",
   title: "Certify Twilio voice approval and outcome tracking",

--- a/packages/test/scenarios/connector-certification/connector.twilio-voice.certify-retry-idempotent.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.twilio-voice.certify-retry-idempotent.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.twilio-voice.certify-retry-idempotent",
   title: "Certify Twilio voice retry-safe idempotent call handling",

--- a/packages/test/scenarios/connector-certification/connector.whatsapp.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.whatsapp.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.whatsapp.certify-core",
   title: "Certify WhatsApp inbound and delivery behavior",

--- a/packages/test/scenarios/connector-certification/connector.whatsapp.certify-delivery-degraded.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.whatsapp.certify-delivery-degraded.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.whatsapp.certify-delivery-degraded",
   title: "Certify WhatsApp degraded-delivery handling",

--- a/packages/test/scenarios/connector-certification/connector.x-dm.certify-core.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.x-dm.certify-core.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.x-dm.certify-core",
   title: "Certify X DM inbox reads and response drafting",

--- a/packages/test/scenarios/connector-certification/connector.x-dm.certify-disconnected.scenario.ts
+++ b/packages/test/scenarios/connector-certification/connector.x-dm.certify-disconnected.scenario.ts
@@ -2,6 +2,8 @@
 import { buildConnectorCertificationScenario } from "./_factory.ts";
 
 export default buildConnectorCertificationScenario({
+  evidenceClass: "runtime-observed",
+  certificationClass: "runtime-contract",
   lane: "live-only",
   id: "connector.x-dm.certify-disconnected",
   title: "Certify X DM disconnected degradation handling",


### PR DESCRIPTION
# Relates to

Relates to #22293. This draft implements only semantic evidence/certification classification and corpus validation; it does not close the 311-scenario repair epic.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai / gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d048800b6d23dfe627118386adcf66b2abe3db93:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased without conflicts onto observed `origin/develop` `9ffa072c89829807eff56fd1ad55afa8ac2ee185`.
- [x] Exact PR head is `d048800b6d23dfe627118386adcf66b2abe3db93`.
- [ ] Root build/verify remains required before merge; the focused exact-head package gates are recorded below.

# Risks

Medium-low. Legacy scenarios that make no certification claim keep the compatible simulated/none defaults. Definitions whose id or title explicitly uses certify/certified/certification must now declare a bounded class, and static corpus metadata can no longer hide behind top-level spreads, computed properties, or dynamic literals. This intentionally turns previously ambiguous certification authoring into a loud validation failure.

# Background

## What does this PR do?

- Adds closed, typed `evidenceClass` and `certificationClass` scenario metadata.
- Keeps ordinary legacy definitions compatible as simulated evidence with no certification claim; explicitly provider-qualified definitions retain their provider-observed default.
- Fails closed when deterministic or simulated definitions claim provider, native/device, or webhook certification, or when the certification and evidence boundaries disagree.
- Makes static corpus validation reject non-literal critical metadata, object spreads, and computed fields that could conceal certification claims without importing scenario modules.
- Classifies all 32 current connector-certification scenarios honestly as `runtime-observed` / `runtime-contract`; these labels do not claim provider certification.
- Documents the authoring and static-validation contract in the package README and byte-identical guides.

Explicitly out of scope: #14550 evidence-bundle/reviewer plumbing, #15887 live-information evaluation, #16972 voice/device workbench evidence, provider deployment/credentials, scenario semantic repairs, and external qualification artifacts.

## What kind of change is this?

Testing-contract hardening and truthful corpus metadata.

# Testing

## Where should a reviewer start?

Start with `packages/scenario-runner/schema/index.js`, then `src/loader.ts`, the adversarial schema/loader tests, and the connector-certification factory classifications.

## Exact-head results

```text
bun install
PASS

bun run --cwd packages/scenario-runner test
40 files, 390 tests passed

bun run --cwd packages/test test
3,421 expanded scenarios valid; 3,421 unique IDs

bun run --cwd packages/scenario-runner typecheck
PASS

bun run --cwd packages/test typecheck
PASS

bun run --cwd packages/scenario-runner build
PASS

bunx biome check <38 changed source files>
PASS

bun run check:agents-claude
PASS (155 guide pairs)

git diff --check origin/develop...HEAD
PASS
```

The root workspace build was attempted after install and interrupted after five minutes of silent host contention (exit 130). It produced enough dependency builds for both previously blocked owning typechecks to pass, but it is not represented as a successful root build or `bun run verify`.

# Evidence Gate

<!-- evidence-head:d048800b6d23dfe627118386adcf66b2abe3db93 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - schema/corpus validation only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - schema/corpus validation only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic receipts.

<details><summary>Exact-head package transcript</summary>

```text
scenario-runner test: 40 files passed, 390 tests passed
scenario-runner typecheck: PASS
packages/test corpus: 3,421 expanded scenarios valid; 3,421 unique IDs
packages/test typecheck: PASS
scenario-runner build: PASS
Biome: PASS
guide parity: 155 pairs PASS
diff check: PASS
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, routing, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head classification artifact.

```text
connector-certification inventory: 32/32 runtime-observed + runtime-contract
adversarial rejection: simulated provider/native/webhook claims
adversarial rejection: mismatched evidence/certification classes
adversarial rejection: dynamic literals, object spreads, computed fields
legacy compatibility: simulated + no certification
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

- No provider, native/device, or real-webhook certification is claimed or produced by this PR; those require independently qualified external evidence.
- This slice does not repair the remaining scenario assertions, authoritative side-effect observations, gateway ingress paths, personality evaluation, or provider controller work in #22293.
- Root `bun run verify` and a complete root build remain required before merge.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d048800b6d23dfe627118386adcf66b2abe3db93:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex-22293-certification]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d048800b6d23dfe627118386adcf66b2abe3db93:packages/skills/skills/contribute-to-eliza"} -->

