### PR TITLE
fix(plugin-x): cap attachment downloads before allocate

### DIFF
--- a/plugins/plugin-x/src/fetch-media-data.test.ts
+++ b/plugins/plugin-x/src/fetch-media-data.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Overflow coverage for {@link fetchMediaData}: remote attachment URLs must
+ * go through the capped core media fetcher, and local files larger than the
+ * connector attachment cap must fail before readFile.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+  fetchRemoteMedia,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchMediaData } from "./utils";
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    fetchRemoteMedia: vi.fn(actual.fetchRemoteMedia),
+  };
+});
+
+const mockedFetchRemoteMedia = vi.mocked(fetchRemoteMedia);
+
+afterEach(() => {
+  mockedFetchRemoteMedia.mockReset();
+});
+
+describe("fetchMediaData", () => {
+  it("fetches HTTP attachments through the capped remote media helper", async () => {
+    mockedFetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from("png"),
+      contentType: "image/png",
+    });
+
+    await expect(
+      fetchMediaData([
+        {
+          id: "att-1",
+          url: "https://cdn.example/photo.png",
+        },
+      ]),
+    ).resolves.toEqual([{ data: Buffer.from("png"), mediaType: "image/png" }]);
+
+    expect(mockedFetchRemoteMedia).toHaveBeenCalledWith({
+      url: "https://cdn.example/photo.png",
+      maxBytes: DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+      timeoutMs: 30_000,
+    });
+  });
+
+  it("rejects a local file larger than the connector attachment cap before read", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "x-media-"));
+    const filePath = path.join(dir, "oversize.bin");
+    const handle = await fs.open(filePath, "w");
+    try {
+      await handle.truncate(DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES + 1);
+    } finally {
+      await handle.close();
+    }
+
+    try {
+      await expect(
+        fetchMediaData([
+          {
+            id: "att-2",
+            url: filePath,
+          },
+        ]),
+      ).rejects.toMatchObject({
+        name: "ElizaError",
+        code: "X_ATTACHMENT_TOO_LARGE",
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a local file at or under the cap", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "x-media-"));
+    const filePath = path.join(dir, "ok.bin");
+    await fs.writeFile(filePath, Buffer.from("ok"));
+
+    try {
+      await expect(
+        fetchMediaData([
+          {
+            id: "att-3",
+            url: filePath,
+          },
+        ]),
+      ).resolves.toEqual([{ data: Buffer.from("ok"), mediaType: "image/png" }]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Shared tweet-sending and media helpers for the connector: `sendTweet` (publishes
  * text, splitting into threads and honoring the max length, returning the accepted
- * `SentTweet`), `fetchMediaData` (SSRF-guarded media download for attachments), and
+ * `SentTweet`), `fetchMediaData` (SSRF-guarded, size-capped attachment download), and
  * `parseActionResponseFromText` (extracts the model's like/retweet/quote/reply
  * choice). Re-exports the shared API error handler.
  */
@@ -11,8 +11,9 @@ import type { Media } from "@elizaos/core";
 import {
   type Content,
   createUniqueUuid,
+  DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
   ElizaError,
-  fetchWithSsrfGuard,
+  fetchRemoteMedia,
   logger,
   type Memory,
   truncateToCompleteSentence,
@@ -60,9 +61,9 @@ export const isValidTweet = (tweet: Tweet): boolean => {
 
 /**
  * Fetches media data from a list of attachments, supporting both HTTP URLs and local file paths.
- *
- * @param attachments Array of Media objects containing URLs or file paths to fetch media from
- * @returns Promise that resolves with an array of MediaData objects containing the fetched media data and content type
+ * Remote URLs go through {@link fetchRemoteMedia} (SSRF guard +
+ * {@link DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES}) so a lying or missing
+ * Content-Length cannot force an unbounded `arrayBuffer()`.
  */
 export async function fetchMediaData(
   attachments: Media[],
@@ -70,34 +71,41 @@ export async function fetchMediaData(
   return Promise.all(
     attachments.map(async (attachment: Media) => {
       if (/^(http|https):\/\//.test(attachment.url)) {
-        // Handle HTTP URLs — route through the SSRF guard so a crafted
-        // attachment URL can't reach internal/metadata endpoints.
-        const { response, release } = await fetchWithSsrfGuard({
+        const { buffer, contentType } = await fetchRemoteMedia({
           url: attachment.url,
+          maxBytes: DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
           timeoutMs: 30_000,
         });
-        try {
-          if (!response.ok) {
-            throw new Error(`Failed to fetch file: ${attachment.url}`);
-          }
-          const mediaBuffer = Buffer.from(await response.arrayBuffer());
-          const mediaType = attachment.contentType || "image/png";
-          return { data: mediaBuffer, mediaType };
-        } finally {
-          await release();
-        }
+        return {
+          data: buffer,
+          mediaType: attachment.contentType || contentType || "image/png",
+        };
       }
-      if (fs.existsSync(attachment.url)) {
-        // Handle local file paths
-        const mediaBuffer = await fs.promises.readFile(
-          path.resolve(attachment.url),
+      const resolvedPath = path.resolve(attachment.url);
+      const stat = await fs.promises.stat(resolvedPath).catch(() => null);
+      if (!stat?.isFile()) {
+        throw new Error(
+          `File not found: ${attachment.url}. Make sure the path is correct.`,
         );
-        const mediaType = attachment.contentType || "image/png";
-        return { data: mediaBuffer, mediaType };
       }
-      throw new Error(
-        `File not found: ${attachment.url}. Make sure the path is correct.`,
-      );
+      if (stat.size > DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES) {
+        throw new ElizaError(
+          `X attachment exceeds ${DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES} bytes`,
+          {
+            code: "X_ATTACHMENT_TOO_LARGE",
+            context: {
+              path: resolvedPath,
+              bytes: stat.size,
+              maxBytes: DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+            },
+          },
+        );
+      }
+      const mediaBuffer = await fs.promises.readFile(resolvedPath);
+      return {
+        data: mediaBuffer,
+        mediaType: attachment.contentType || "image/png",
+      };
     }),
   );
 }


### PR DESCRIPTION
# Relates to

Occupancy-FREE overflow on X attachment downloads. No issue filed.
Stayed off `#22262`, leftover-tax, and workspace 20’s listed timeout E-family.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused plugin-x tests passed at this head.
- [x] A reviewer can confirm the unbounded `arrayBuffer()` and the capped fetch from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from current `origin/develop` (`de026436678c`).
- [x] `bun run --cwd plugins/plugin-x test -- src/fetch-media-data.test.ts src/utils.test.ts` — 8 passed.

# Risks

Low. HTTP attachments already used `fetchWithSsrfGuard`. They now use the same guard plus `fetchRemoteMedia` / `readResponseWithLimit` at `DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES` (50MB). Local files fail closed from `stat` before `readFile`. Bodies at exactly 50MB still load.

# Background

## What does this PR do?

`fetchMediaData` downloaded HTTP attachments with `response.arrayBuffer()` and local files with `readFile()`, with no size bound. On origin:

```text
arrayBuffer() of (50MB+1) → allocated=52428801
```

This PR routes HTTP URLs through `fetchRemoteMedia({ maxBytes: 50MB, timeoutMs: 30_000 })` and rejects oversize local files from `stat` before read.

Not leftover-tax. Not extra-decode. Not a cloud JSON 500 reprint. Not `#22262`. Not plugin-x `broker.ts` / `lifeops-message-adapter.ts`.

## What kind of change is this?

Bug fix (overflow).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/fetch-media-data.test.ts`, then `fetchMediaData` in `plugins/plugin-x/src/utils.ts`.

## Detailed testing steps

```text
bun run --cwd plugins/plugin-x test -- src/fetch-media-data.test.ts src/utils.test.ts
# 8 passed — HTTP path uses fetchRemoteMedia(maxBytes, timeoutMs); local oversize throws X_ATTACHMENT_TOO_LARGE; sendTweet suite unchanged
```

# Evidence Gate

<!-- evidence-head:afc56985349088b0d8ebf0b2d53bd7a2fc2e8437 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; attachment-download overflow only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; attachment-download overflow only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - overflow proved by origin arrayBuffer allocate and unit tests.
<!-- evidence-row:backend-logs -->
- [x] Red: origin `allocated=52428801`. Green: 8-pass vitest at this head.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] HTTP attachments call fetchRemoteMedia with the 50MB connector cap; local oversize throws `X_ATTACHMENT_TOO_LARGE`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/provider path.

## Backend + frontend logs

Red: origin `arrayBuffer()` of 50MB+1 allocates 52428801.
Green: vitest 8 passed at `afc56985349088b0d8ebf0b2d53bd7a2fc2e8437`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
