### PR TITLE
fix(plugin-computeruse): cap file-op reads and writes before allocate

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/file-bytes.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/file-bytes.test.ts
@@ -18,14 +18,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  appendFile,
   createDirectory,
+  decodedBase64Budget,
   directoryExists,
+  editFile,
   getFileSize,
   MAX_FILE_OP_BYTES,
   READ_FILE_CHAR_LIMIT,
   readBytes,
+  readExactWindowFromHandle,
   readFile,
   writeBytes,
+  writeFile,
 } from "../platform/file-ops.js";
 
 function writeSparseFile(file: string, size: number): void {
@@ -191,5 +196,101 @@ describe("create_dir / directory_exists / get_file_size", () => {
     expect(s.success).toBe(true);
     expect(s.size).toBe(raw.length);
     expect(s.is_file).toBe(true);
+  });
+});
+
+describe("readExactWindowFromHandle", () => {
+  it("loops short reads and slices to the bytes actually obtained", async () => {
+    const source = Buffer.from([1, 2, 3, 4]);
+    let cursor = 0;
+    const handle = {
+      read: async (
+        buf: Buffer,
+        offset: number,
+        length: number,
+        _position: number,
+      ) => {
+        if (cursor >= source.length || length <= 0) {
+          return { bytesRead: 0 };
+        }
+        buf[offset] = source[cursor] ?? 0;
+        cursor += 1;
+        return { bytesRead: 1 };
+      },
+    };
+    const got = await readExactWindowFromHandle(handle, 0, 4);
+    expect(got.equals(source)).toBe(true);
+  });
+
+  it("stops at EOF instead of returning a zero-padded allocation", async () => {
+    const source = Buffer.from([9]);
+    let calls = 0;
+    const handle = {
+      read: async (
+        buf: Buffer,
+        offset: number,
+        _length: number,
+        _position: number,
+      ) => {
+        calls += 1;
+        if (calls === 1) {
+          buf[offset] = source[0] ?? 0;
+          return { bytesRead: 1 };
+        }
+        return { bytesRead: 0 };
+      },
+    };
+    const got = await readExactWindowFromHandle(handle, 0, 4);
+    expect(got.equals(source)).toBe(true);
+    expect(got.length).toBe(1);
+  });
+});
+
+describe("editFile / appendFile same-handle budget", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cu-edit-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("edits through the opened handle without a stat-then-slurp", async () => {
+    const file = join(dir, "edit.txt");
+    await writeFile(file, "hello world");
+    const result = await editFile(file, "world", "universe");
+    expect(result.success).toBe(true);
+    const read = await readFile(file);
+    expect(read.content).toBe("hello universe");
+  });
+
+  it("appends using the size observed on the opened handle", async () => {
+    const file = join(dir, "a.txt");
+    await writeFile(file, "one");
+    const result = await appendFile(file, "two");
+    expect(result.success).toBe(true);
+    const read = await readFile(file);
+    expect(read.content).toBe("onetwo");
+  });
+});
+
+describe("decodedBase64Budget", () => {
+  it("matches padded and unpadded cap / cap+1 boundaries", () => {
+    const paddedFit = Buffer.alloc(3, 0x61).toString("base64");
+    expect(paddedFit.endsWith("=") || paddedFit.length % 4 === 0).toBe(true);
+    expect(decodedBase64Budget(paddedFit)).toBe(3);
+    expect(decodedBase64Budget("YQ")).toBe(1);
+    expect(decodedBase64Budget("YQ==")).toBe(1);
+    expect(decodedBase64Budget("YWE")).toBe(2);
+    expect(decodedBase64Budget("YWE=")).toBe(2);
+    expect(decodedBase64Budget("YWFh")).toBe(3);
+    expect(decodedBase64Budget("YWFhYQ")).toBe(4);
+    expect(decodedBase64Budget("YWFhYQ==")).toBe(4);
+    const overUnpadded = Buffer.alloc(MAX_FILE_OP_BYTES + 1, 0x61)
+      .toString("base64")
+      .replace(/=+$/, "");
+    expect(decodedBase64Budget(overUnpadded)).toBeGreaterThanOrEqual(
+      MAX_FILE_OP_BYTES + 1,
+    );
   });
 });

--- a/plugins/plugin-computeruse/src/__tests__/file-bytes.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/file-bytes.test.ts
@@ -2,9 +2,18 @@
  * Binary filesystem primitives (#9170 — trycua/cua read_bytes / write_bytes /
  * create_dir / directory_exists / get_file_size). Pure Node fs over the safe-path
  * guard, so this runs in the DEFAULT lane on Windows / Linux / macOS alike.
+ *
+ * Also covers the fail-before-allocate byte budget: origin `readBytes` slurped
+ * the whole guest file before applying offset/length.
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  closeSync,
+  ftruncateSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -12,9 +21,21 @@ import {
   createDirectory,
   directoryExists,
   getFileSize,
+  MAX_FILE_OP_BYTES,
+  READ_FILE_CHAR_LIMIT,
   readBytes,
+  readFile,
   writeBytes,
 } from "../platform/file-ops.js";
+
+function writeSparseFile(file: string, size: number): void {
+  const fd = openSync(file, "w");
+  try {
+    ftruncateSync(fd, size);
+  } finally {
+    closeSync(fd);
+  }
+}
 
 describe("binary file ops (read_bytes / write_bytes)", () => {
   let dir: string;
@@ -58,6 +79,75 @@ describe("binary file ops (read_bytes / write_bytes)", () => {
     expect(w.success).toBe(true);
     const r = await readBytes(file);
     expect(r.size).toBe(3);
+  });
+
+  it("rejects an unwindowed read larger than the file-op budget", async () => {
+    const file = join(dir, "huge.bin");
+    writeSparseFile(file, MAX_FILE_OP_BYTES + 1);
+    const r = await readBytes(file);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/file-op budget/);
+    expect(r.bytes).toBeUndefined();
+  });
+
+  it("reads a last-fit window from a file larger than the budget", async () => {
+    const file = join(dir, "window.bin");
+    writeSparseFile(file, MAX_FILE_OP_BYTES + 4096);
+    const r = await readBytes(file, 0, MAX_FILE_OP_BYTES);
+    expect(r.success).toBe(true);
+    expect(r.size).toBe(MAX_FILE_OP_BYTES);
+    expect(Buffer.from(r.bytes ?? "", "base64").length).toBe(MAX_FILE_OP_BYTES);
+  });
+
+  it("rejects the first overflowing window before allocating it", async () => {
+    const file = join(dir, "overflow.bin");
+    writeSparseFile(file, MAX_FILE_OP_BYTES + 4096);
+    const r = await readBytes(file, 0, MAX_FILE_OP_BYTES + 1);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/file-op budget/);
+    expect(r.bytes).toBeUndefined();
+  });
+
+  it("rejects hostile offset/length before any read", async () => {
+    const file = join(dir, "hostile.bin");
+    writeSparseFile(file, 64);
+    for (const length of [
+      Number.POSITIVE_INFINITY,
+      1e20,
+      -1,
+      1.5,
+      Number.NaN,
+    ]) {
+      const r = await readBytes(file, 0, length);
+      expect(r.success).toBe(false);
+      expect(r.error).toMatch(/non-negative safe integer/);
+    }
+  });
+
+  it("rejects a write_bytes payload above the budget before decode-write", async () => {
+    const file = join(dir, "too-big.bin");
+    const encoded = Buffer.alloc(MAX_FILE_OP_BYTES + 1, 0x61).toString(
+      "base64",
+    );
+    const w = await writeBytes(file, encoded);
+    expect(w.success).toBe(false);
+    expect(w.error).toMatch(/file-op budget/);
+  });
+
+  it("accepts a last-fit write_bytes payload", async () => {
+    const file = join(dir, "fit.bin");
+    const raw = Buffer.alloc(MAX_FILE_OP_BYTES, 0x62);
+    const w = await writeBytes(file, raw.toString("base64"));
+    expect(w.success).toBe(true);
+    expect(w.size).toBe(MAX_FILE_OP_BYTES);
+  });
+
+  it("readFile returns at most 10000 chars from a sparse oversized file", async () => {
+    const file = join(dir, "huge.txt");
+    writeSparseFile(file, 8 * 1024 * 1024);
+    const r = await readFile(file);
+    expect(r.success).toBe(true);
+    expect(r.content).toHaveLength(READ_FILE_CHAR_LIMIT);
   });
 });
 

--- a/plugins/plugin-computeruse/src/__tests__/file-ops.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/file-ops.real.test.ts
@@ -3,7 +3,15 @@
  * Uses temp directories — no mocks needed.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  ftruncateSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -42,6 +50,19 @@ describe("file operations (real)", () => {
       const result = await readFile(join(tempDir, "nope.txt"));
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
+    });
+
+    it("returns only the first 10000 characters without slurping a huge file", async () => {
+      const filePath = join(tempDir, "huge.txt");
+      const fd = openSync(filePath, "w");
+      try {
+        ftruncateSync(fd, 8 * 1024 * 1024);
+      } finally {
+        closeSync(fd);
+      }
+      const result = await readFile(filePath);
+      expect(result.success).toBe(true);
+      expect(result.content).toHaveLength(10000);
     });
   });
 

--- a/plugins/plugin-computeruse/src/platform/file-ops.ts
+++ b/plugins/plugin-computeruse/src/platform/file-ops.ts
@@ -6,8 +6,10 @@
  * Byte-bearing reads and writes fail closed before allocating more than
  * {@link MAX_FILE_OP_BYTES}. `readFile` still returns at most
  * {@link READ_FILE_CHAR_LIMIT} characters, but it no longer slurp-then-slices
- * the whole guest file first.
+ * the whole guest file first. Edit/append budget against the size observed on
+ * the opened handle; they do not lock out a concurrent writer.
  */
+import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { FileActionResult, FileEntry } from "../types.js";
@@ -17,12 +19,19 @@ import { resolveSafeFileTarget } from "./security.js";
 export const MAX_FILE_OP_BYTES = 10 * 1024 * 1024;
 export const READ_FILE_CHAR_LIMIT = 10_000;
 
-function decodedBase64Budget(encoded: string): number {
-  const n = encoded.length;
-  let pad = 0;
-  if (n >= 2 && encoded.endsWith("==")) pad = 2;
-  else if (n >= 1 && encoded.endsWith("=")) pad = 1;
-  return Math.floor(n / 4) * 3 - pad;
+type ReadableFileHandle = Pick<FileHandle, "read">;
+
+/**
+ * Decoded-byte ceiling for Node `Buffer.from(..., "base64")`, including
+ * unpadded input. Never underestimates: leftover 2 chars → 1 byte, leftover 3
+ * → 2 bytes, leftover 1 (invalid) still counts 1 so a cap+1 payload cannot
+ * sneak past the pre-decode check.
+ */
+export function decodedBase64Budget(encoded: string): number {
+  let n = encoded.length;
+  while (n > 0 && encoded.charCodeAt(n - 1) === 0x3d) n -= 1;
+  const rem = n % 4;
+  return Math.floor(n / 4) * 3 + (rem === 0 ? 0 : rem === 3 ? 2 : 1);
 }
 
 function budgetExceeded(op: string): FileActionResult {
@@ -50,20 +59,29 @@ function parseByteCount(
   return { ok: true, value };
 }
 
-async function readExactWindow(
-  resolvedPath: string,
+/**
+ * Fill `take` bytes from `start`, looping on short reads. Returns a slice of
+ * the bytes actually obtained (EOF stops the loop).
+ */
+export async function readExactWindowFromHandle(
+  handle: ReadableFileHandle,
   start: number,
   take: number,
 ): Promise<Buffer> {
+  if (take === 0) return Buffer.alloc(0);
   const buf = Buffer.alloc(take);
-  if (take === 0) return buf;
-  const handle = await fs.open(resolvedPath, "r");
-  try {
-    await handle.read(buf, 0, take, start);
-  } finally {
-    await handle.close();
+  let filled = 0;
+  while (filled < take) {
+    const { bytesRead } = await handle.read(
+      buf,
+      filled,
+      take - filled,
+      start + filled,
+    );
+    if (bytesRead === 0) break;
+    filled += bytesRead;
   }
-  return buf;
+  return filled === take ? buf : buf.subarray(0, filled);
 }
 
 export async function readFile(
@@ -76,18 +94,23 @@ export async function readFile(
   }
 
   try {
-    const stat = await fs.stat(check.resolvedPath);
-    if (!stat.isFile()) {
-      return { success: false, error: "Path is not a regular file." };
+    const handle = await fs.open(check.resolvedPath, "r");
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        return { success: false, error: "Path is not a regular file." };
+      }
+      const maxBytes = READ_FILE_CHAR_LIMIT * 4;
+      const take = Math.min(stat.size, maxBytes);
+      const buf = await readExactWindowFromHandle(handle, 0, take);
+      return {
+        success: true,
+        path: check.resolvedPath,
+        content: buf.toString(encoding).slice(0, READ_FILE_CHAR_LIMIT),
+      };
+    } finally {
+      await handle.close();
     }
-    const maxBytes = READ_FILE_CHAR_LIMIT * 4;
-    const take = Math.min(stat.size, maxBytes);
-    const buf = await readExactWindow(check.resolvedPath, 0, take);
-    return {
-      success: true,
-      path: check.resolvedPath,
-      content: buf.toString(encoding).slice(0, READ_FILE_CHAR_LIMIT),
-    };
   } catch (error) {
     // error-policy:J1 file-op boundary — the failure returns as a structured
     // {success:false,error} the action surfaces to the model.
@@ -139,27 +162,38 @@ export async function editFile(
   }
 
   try {
-    const stat = await fs.stat(check.resolvedPath);
-    if (stat.size > MAX_FILE_OP_BYTES) {
-      return budgetExceeded("edit");
-    }
-    const content = await fs.readFile(check.resolvedPath, "utf8");
-    if (!content.includes(oldText)) {
+    const handle = await fs.open(check.resolvedPath, "r+");
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        return { success: false, error: "Path is not a regular file." };
+      }
+      const take = Math.min(stat.size, MAX_FILE_OP_BYTES + 1);
+      const buf = await readExactWindowFromHandle(handle, 0, take);
+      if (buf.length > MAX_FILE_OP_BYTES) {
+        return budgetExceeded("edit");
+      }
+      const content = buf.toString("utf8");
+      if (!content.includes(oldText)) {
+        return {
+          success: false,
+          error: "Old text not found in file.",
+        };
+      }
+      const next = content.replace(oldText, newText);
+      if (Buffer.byteLength(next, "utf8") > MAX_FILE_OP_BYTES) {
+        return budgetExceeded("edit");
+      }
+      await handle.truncate(0);
+      await handle.write(next, 0, "utf8");
       return {
-        success: false,
-        error: "Old text not found in file.",
+        success: true,
+        path: check.resolvedPath,
+        message: "File edited.",
       };
+    } finally {
+      await handle.close();
     }
-    const next = content.replace(oldText, newText);
-    if (Buffer.byteLength(next, "utf8") > MAX_FILE_OP_BYTES) {
-      return budgetExceeded("edit");
-    }
-    await fs.writeFile(check.resolvedPath, next, "utf8");
-    return {
-      success: true,
-      path: check.resolvedPath,
-      message: "File edited.",
-    };
   } catch (error) {
     // error-policy:J1 file-op boundary — the failure returns as a structured
     // {success:false,error} the action surfaces to the model.
@@ -184,20 +218,17 @@ export async function appendFile(
     if (incoming > MAX_FILE_OP_BYTES) {
       return budgetExceeded("append");
     }
-    let existing = 0;
-    try {
-      existing = (await fs.stat(check.resolvedPath)).size;
-    } catch (error) {
-      // error-policy:J3 missing target is a create-on-append; other stat
-      // failures must not be disguised as an empty file.
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT") throw error;
-    }
-    if (existing + incoming > MAX_FILE_OP_BYTES) {
-      return budgetExceeded("append");
-    }
     await fs.mkdir(path.dirname(check.resolvedPath), { recursive: true });
-    await fs.appendFile(check.resolvedPath, content, "utf8");
+    const handle = await fs.open(check.resolvedPath, "a");
+    try {
+      const existing = (await handle.stat()).size;
+      if (existing + incoming > MAX_FILE_OP_BYTES) {
+        return budgetExceeded("append");
+      }
+      await handle.write(content, null, "utf8");
+    } finally {
+      await handle.close();
+    }
     return {
       success: true,
       path: check.resolvedPath,
@@ -364,26 +395,31 @@ export async function readBytes(
   const parsedLength = parseByteCount(length, "length");
   if (!parsedLength.ok) return parsedLength.result;
   try {
-    const stat = await fs.stat(check.resolvedPath);
-    if (!stat.isFile()) {
-      return { success: false, error: "Path is not a regular file." };
+    const handle = await fs.open(check.resolvedPath, "r");
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        return { success: false, error: "Path is not a regular file." };
+      }
+      const start = parsedOffset.value ?? 0;
+      const remaining = Math.max(0, stat.size - start);
+      const take =
+        parsedLength.value === undefined
+          ? remaining
+          : Math.min(parsedLength.value, remaining);
+      if (take > MAX_FILE_OP_BYTES) {
+        return budgetExceeded("read_bytes");
+      }
+      const buf = await readExactWindowFromHandle(handle, start, take);
+      return {
+        success: true,
+        path: check.resolvedPath,
+        bytes: buf.toString("base64"),
+        size: buf.length,
+      };
+    } finally {
+      await handle.close();
     }
-    const start = parsedOffset.value ?? 0;
-    const remaining = Math.max(0, stat.size - start);
-    const take =
-      parsedLength.value === undefined
-        ? remaining
-        : Math.min(parsedLength.value, remaining);
-    if (take > MAX_FILE_OP_BYTES) {
-      return budgetExceeded("read_bytes");
-    }
-    const buf = await readExactWindow(check.resolvedPath, start, take);
-    return {
-      success: true,
-      path: check.resolvedPath,
-      bytes: buf.toString("base64"),
-      size: buf.length,
-    };
   } catch (error) {
     // error-policy:J1 file-op boundary — the failure returns as a structured
     // {success:false,error} the action surfaces to the model.

--- a/plugins/plugin-computeruse/src/platform/file-ops.ts
+++ b/plugins/plugin-computeruse/src/platform/file-ops.ts
@@ -2,11 +2,69 @@
  * Internal file primitives (read/write/list) behind path-security checks. Not
  * exposed as an agent action — the FILE action owns user-facing file access;
  * these back internal computer-use flows only.
+ *
+ * Byte-bearing reads and writes fail closed before allocating more than
+ * {@link MAX_FILE_OP_BYTES}. `readFile` still returns at most
+ * {@link READ_FILE_CHAR_LIMIT} characters, but it no longer slurp-then-slices
+ * the whole guest file first.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { FileActionResult, FileEntry } from "../types.js";
 import { resolveSafeFileTarget } from "./security.js";
+
+/** Same working-set ceiling as the clipboard path (`CLIPBOARD_MAX_BYTES`). */
+export const MAX_FILE_OP_BYTES = 10 * 1024 * 1024;
+export const READ_FILE_CHAR_LIMIT = 10_000;
+
+function decodedBase64Budget(encoded: string): number {
+  const n = encoded.length;
+  let pad = 0;
+  if (n >= 2 && encoded.endsWith("==")) pad = 2;
+  else if (n >= 1 && encoded.endsWith("=")) pad = 1;
+  return Math.floor(n / 4) * 3 - pad;
+}
+
+function budgetExceeded(op: string): FileActionResult {
+  return {
+    success: false,
+    error: `${op} exceeds the ${MAX_FILE_OP_BYTES}-byte file-op budget.`,
+  };
+}
+
+function invalidByteCount(name: string): FileActionResult {
+  return {
+    success: false,
+    error: `${name} must be a non-negative safe integer.`,
+  };
+}
+
+function parseByteCount(
+  value: unknown,
+  name: string,
+): { ok: true; value?: number } | { ok: false; result: FileActionResult } {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    return { ok: false, result: invalidByteCount(name) };
+  }
+  return { ok: true, value };
+}
+
+async function readExactWindow(
+  resolvedPath: string,
+  start: number,
+  take: number,
+): Promise<Buffer> {
+  const buf = Buffer.alloc(take);
+  if (take === 0) return buf;
+  const handle = await fs.open(resolvedPath, "r");
+  try {
+    await handle.read(buf, 0, take, start);
+  } finally {
+    await handle.close();
+  }
+  return buf;
+}
 
 export async function readFile(
   targetPath: string,
@@ -18,11 +76,17 @@ export async function readFile(
   }
 
   try {
-    const content = await fs.readFile(check.resolvedPath, { encoding });
+    const stat = await fs.stat(check.resolvedPath);
+    if (!stat.isFile()) {
+      return { success: false, error: "Path is not a regular file." };
+    }
+    const maxBytes = READ_FILE_CHAR_LIMIT * 4;
+    const take = Math.min(stat.size, maxBytes);
+    const buf = await readExactWindow(check.resolvedPath, 0, take);
     return {
       success: true,
       path: check.resolvedPath,
-      content: String(content).slice(0, 10000),
+      content: buf.toString(encoding).slice(0, READ_FILE_CHAR_LIMIT),
     };
   } catch (error) {
     // error-policy:J1 file-op boundary — the failure returns as a structured
@@ -44,6 +108,9 @@ export async function writeFile(
   }
 
   try {
+    if (Buffer.byteLength(content, "utf8") > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("write");
+    }
     await fs.mkdir(path.dirname(check.resolvedPath), { recursive: true });
     await fs.writeFile(check.resolvedPath, content, "utf8");
     return {
@@ -72,6 +139,10 @@ export async function editFile(
   }
 
   try {
+    const stat = await fs.stat(check.resolvedPath);
+    if (stat.size > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("edit");
+    }
     const content = await fs.readFile(check.resolvedPath, "utf8");
     if (!content.includes(oldText)) {
       return {
@@ -79,11 +150,11 @@ export async function editFile(
         error: "Old text not found in file.",
       };
     }
-    await fs.writeFile(
-      check.resolvedPath,
-      content.replace(oldText, newText),
-      "utf8",
-    );
+    const next = content.replace(oldText, newText);
+    if (Buffer.byteLength(next, "utf8") > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("edit");
+    }
+    await fs.writeFile(check.resolvedPath, next, "utf8");
     return {
       success: true,
       path: check.resolvedPath,
@@ -109,6 +180,22 @@ export async function appendFile(
   }
 
   try {
+    const incoming = Buffer.byteLength(content, "utf8");
+    if (incoming > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("append");
+    }
+    let existing = 0;
+    try {
+      existing = (await fs.stat(check.resolvedPath)).size;
+    } catch (error) {
+      // error-policy:J3 missing target is a create-on-append; other stat
+      // failures must not be disguised as an empty file.
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") throw error;
+    }
+    if (existing + incoming > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("append");
+    }
     await fs.mkdir(path.dirname(check.resolvedPath), { recursive: true });
     await fs.appendFile(check.resolvedPath, content, "utf8");
     return {
@@ -272,16 +359,25 @@ export async function readBytes(
   if (!check.allowed || !check.resolvedPath) {
     return { success: false, error: check.reason ?? "Path not allowed." };
   }
+  const parsedOffset = parseByteCount(offset, "offset");
+  if (!parsedOffset.ok) return parsedOffset.result;
+  const parsedLength = parseByteCount(length, "length");
+  if (!parsedLength.ok) return parsedLength.result;
   try {
-    let buf = await fs.readFile(check.resolvedPath);
-    if (typeof offset === "number" || typeof length === "number") {
-      const start = Math.max(0, Math.floor(offset ?? 0));
-      const end =
-        typeof length === "number"
-          ? start + Math.max(0, Math.floor(length))
-          : undefined;
-      buf = buf.subarray(start, end);
+    const stat = await fs.stat(check.resolvedPath);
+    if (!stat.isFile()) {
+      return { success: false, error: "Path is not a regular file." };
     }
+    const start = parsedOffset.value ?? 0;
+    const remaining = Math.max(0, stat.size - start);
+    const take =
+      parsedLength.value === undefined
+        ? remaining
+        : Math.min(parsedLength.value, remaining);
+    if (take > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("read_bytes");
+    }
+    const buf = await readExactWindow(check.resolvedPath, start, take);
     return {
       success: true,
       path: check.resolvedPath,
@@ -308,7 +404,14 @@ export async function writeBytes(
     return { success: false, error: check.reason ?? "Path not allowed." };
   }
   try {
-    const buf = Buffer.from(base64 ?? "", "base64");
+    const encoded = base64 ?? "";
+    if (decodedBase64Budget(encoded) > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("write_bytes");
+    }
+    const buf = Buffer.from(encoded, "base64");
+    if (buf.length > MAX_FILE_OP_BYTES) {
+      return budgetExceeded("write_bytes");
+    }
     await fs.mkdir(path.dirname(check.resolvedPath), { recursive: true });
     await fs.writeFile(check.resolvedPath, buf);
     return {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone fail-before-allocate overflow on the computer-use file-op host.
No owning issue: this is a new occupancy-FREE hole on `origin/develop`, not a
Shaw-required closer. Does not twin `#22208` (surrogate-pair agent text),
`#22296` (HTTP skill-package bytes), `#22278` (Headscale TTL), or `#22262`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `plugin-computeruse` file-bytes tests pass at the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `de026436678c` (`#22296`) with zero conflicts.
- [x] Exact-head focused test: 13/13 `src/__tests__/file-bytes.test.ts`.
- [x] Exact-head Biome check on the three touched files: clean.

# Risks

Low and bounded to `plugins/plugin-computeruse/src/platform/file-ops.ts`.
Reads and writes now fail closed at 10 MiB — the same working-set as
`CLIPBOARD_MAX_BYTES`. A last-fit 10 MiB window or write still succeeds.
Windowed `read_bytes` of a larger guest file only maps that window; an
unwindowed read of a file above the budget returns a structured failure
instead of allocating the file. Hostile `offset`/`length` (`Infinity`,
`1e20`, negatives, non-integers) are rejected as invalid counts.

`readFile` still returns at most 10_000 characters; it no longer
slurp-then-slices the whole file first. `edit`/`append`/`write` refuse a
result that would exceed the same budget. Path-security checks are unchanged.

# Background

## What does this PR do?

`readBytes` used `fs.readFile` and then `subarray(offset, offset+length)`.
On `origin/develop` a 48 MiB sparse file with a 16-byte window still moved
RSS by 48.5 MiB. `readFile` had the same slurp-then-slice shape behind its
10_000-character truncation.

This PR stats first, rejects a window or write above 10 MiB, and reads only
the requested byte window through `fs.open` + `read`. `write_bytes` rejects
from the declared base64 decoded size before `Buffer.from`.

## What kind of change is this?

Bug fix (resource-bound enforcement).

# Documentation changes needed?

No public setting or API changed. File-action callers still receive
`{ success, error }` on failure.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/platform/file-ops.ts` (`readBytes`,
`writeBytes`, `readFile`) and `src/__tests__/file-bytes.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-computeruse test src/__tests__/file-bytes.test.ts
```

Origin (red): `fs.readFile` of a 48 MiB file then `subarray(0, 16)` →
`rssDeltaMB: 48.5`, `returned: 16`.

Head (green): `readBytes(path, 0, 16)` on the same 48 MiB file →
`windowOk: true`, `windowRssDeltaMB: 1.1`; unwindowed read rejected with
the file-op budget error.

# Evidence Gate

<!-- evidence-head:db580dae3cd770d052c27ed8ab9558b5e555d6f9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; Node file-op primitives only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; Node file-op primitives only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated Node proof (RSS before/after + 13 unit tests); no
      server process.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model text change; byte-budget
      only on existing file primitives.
<!-- evidence-row:domain-artifacts -->
- [x] Isolated red/green proof on a 48 MiB sparse file (16-byte window):
      origin RSS +48.5 MiB; head window RSS +1.1 MiB and unwindowed reject.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this does not change a prompt, model call, or action schema.

## Backend + frontend logs

N/A - no HTTP route. Proof is the RSS replica plus
`file-bytes.test.ts` 13/13 at `db580dae3cd770d052c27ed8ab9558b5e555d6f9`.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice/TTS change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo this cycle; the
owning package's focused file-op tests and Biome check on the touched
files passed at this head. `*.real.test.ts` is excluded from the default
plugin vitest lane; the new `readFile` huge-file case is also in
`file-bytes.test.ts` so the default lane covers it.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
