### PR TITLE
fix(plugin-pdf): reject declared PDF page counts before getPage hang

### DIFF
--- a/plugins/plugin-pdf/__tests__/pdf-service.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.test.ts
@@ -4,7 +4,11 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime } from "@elizaos/core";
-import { MAX_PDF_BUFFER_BYTES, PdfService } from "../services/pdf";
+import {
+	MAX_PDF_BUFFER_BYTES,
+	MAX_PDF_PAGES,
+	PdfService,
+} from "../services/pdf";
 
 const getDocumentProxyMock = vi.hoisted(() => vi.fn());
 
@@ -16,6 +20,17 @@ interface MockPageInput {
 	items: unknown;
 	width?: number;
 	height?: number;
+}
+
+function makeDeclaredPdf(numPages: number) {
+	return {
+		numPages,
+		getPage: vi.fn(async () => ({
+			getTextContent: vi.fn(async () => ({ items: [{ str: "p" }] })),
+			getViewport: vi.fn(() => ({ width: 612, height: 792 })),
+		})),
+		getMetadata: vi.fn(async () => ({ info: {} })),
+	};
 }
 
 function makePdf(
@@ -192,6 +207,52 @@ describe("PdfService", () => {
 			);
 		}
 		expect(getDocumentProxyMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects a declared page count above the page budget before getPage", async () => {
+		const pdf = makeDeclaredPdf(MAX_PDF_PAGES + 1);
+		getDocumentProxyMock.mockResolvedValue(pdf);
+
+		await expect(service().convertPdfToText(validPdfBuffer())).rejects.toThrow(
+			`PDF page count exceeds maximum of ${MAX_PDF_PAGES} pages`,
+		);
+		await expect(
+			service().convertPdfToTextWithOptions(validPdfBuffer()),
+		).resolves.toEqual({
+			success: false,
+			error: `PDF page count exceeds maximum of ${MAX_PDF_PAGES} pages`,
+		});
+		await expect(service().getDocumentInfo(validPdfBuffer())).rejects.toThrow(
+			`PDF page count exceeds maximum of ${MAX_PDF_PAGES} pages`,
+		);
+		expect(pdf.getPage).not.toHaveBeenCalled();
+	});
+
+	it("extracts a last-fit document at the page budget", async () => {
+		const pdf = makeDeclaredPdf(MAX_PDF_PAGES);
+		getDocumentProxyMock.mockResolvedValue(pdf);
+
+		await expect(service().convertPdfToText(validPdfBuffer())).resolves.toBe(
+			Array.from({ length: MAX_PDF_PAGES }, () => "p").join("\n"),
+		);
+		expect(pdf.getPage).toHaveBeenCalledTimes(MAX_PDF_PAGES);
+	});
+
+	it.each([
+		Number.POSITIVE_INFINITY,
+		1e20,
+		-1,
+		1.5,
+		Number.NaN,
+	])("rejects a hostile declared page count before getPage: %s", async (numPages) => {
+		const pdf = makeDeclaredPdf(1);
+		pdf.numPages = numPages as number;
+		getDocumentProxyMock.mockResolvedValue(pdf);
+
+		await expect(service().convertPdfToText(validPdfBuffer())).rejects.toThrow(
+			"PDF page count must be a non-negative safe integer",
+		);
+		expect(pdf.getPage).not.toHaveBeenCalled();
 	});
 
 	it("rejects oversized PDF inputs before extraction", async () => {

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -1,6 +1,10 @@
 /**
  * Implements local PDF input validation, text extraction, metadata parsing,
  * and content cleanup for the runtime PDF service.
+ *
+ * Declared page counts are fail-closed at {@link MAX_PDF_PAGES} before any
+ * per-page `getPage` work. File-size already has {@link MAX_PDF_BUFFER_BYTES};
+ * `numPages` is independent attacker-controlled work.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
@@ -18,6 +22,18 @@ import type {
 type PdfTextItem = { str: string };
 
 export const MAX_PDF_BUFFER_BYTES = 100 * 1024 * 1024;
+/** Fail-closed page budget. `numPages` is attacker-declared, not a file size. */
+export const MAX_PDF_PAGES = 2_048;
+
+function requirePdfPageCount(numPages: unknown): number {
+  if (typeof numPages !== "number" || !Number.isSafeInteger(numPages) || numPages < 0) {
+    throw new RangeError("PDF page count must be a non-negative safe integer");
+  }
+  if (numPages > MAX_PDF_PAGES) {
+    throw new RangeError(`PDF page count exceeds maximum of ${MAX_PDF_PAGES} pages`);
+  }
+  return numPages;
+}
 
 const PDF_HEADER_BYTES = [0x25, 0x50, 0x44, 0x46, 0x2d] as const;
 const PDF_HEADER_SCAN_BYTES = 1024;
@@ -143,7 +159,7 @@ export class PdfService extends Service {
   async convertPdfToText(pdfBuffer: Buffer | Uint8Array): Promise<string> {
     const uint8Array = validatePdfInput(pdfBuffer);
     const pdf = await getDocumentProxy(uint8Array);
-    const numPages = pdf.numPages;
+    const numPages = requirePdfPageCount(pdf.numPages);
 
     const textPages: string[] = [];
 
@@ -165,7 +181,7 @@ export class PdfService extends Service {
     try {
       const uint8Array = validatePdfInput(pdfBuffer);
       const pdf = await getDocumentProxy(uint8Array);
-      const numPages = pdf.numPages;
+      const numPages = requirePdfPageCount(pdf.numPages);
 
       const { startPage, endPage } = normalizeExtractionOptions(options, numPages);
 
@@ -203,7 +219,7 @@ export class PdfService extends Service {
   async getDocumentInfo(pdfBuffer: Buffer | Uint8Array): Promise<PdfDocumentInfo> {
     const uint8Array = validatePdfInput(pdfBuffer);
     const pdf = await getDocumentProxy(uint8Array);
-    const numPages = pdf.numPages;
+    const numPages = requirePdfPageCount(pdf.numPages);
 
     const metadataResult = await pdf.getMetadata();
     const info =


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone fail-before-work hang on the PDF extractor. `numPages` is
attacker-declared and was not bounded. Does not twin `#22284` (do not change
`cleanUpContent` / `split("")`), `#22303` (CUA file-op bytes), or `#22296`
(HTTP skill-package bytes). No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Focused `plugin-pdf` unit tests pass at the exact head (34/34).
- [x] A reviewer can confirm overflow is rejected before `getPage` from the
      tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head focused test: 34/34 `__tests__/pdf-service.test.ts`.
- [x] Biome on `services/pdf.ts`: clean.

# Risks

Low and bounded to `plugins/plugin-pdf/services/pdf.ts`. Documents with more
than 2048 pages now fail closed before per-page extraction. Last-fit 2048
still extracts. Hostile `numPages` (`Infinity`, `1e20`, negatives,
non-integers) reject without calling `getPage`. File-size cap
(`MAX_PDF_BUFFER_BYTES`) is unchanged.

# Background

## What does this PR do?

`PdfService.convertPdfToText`, `convertPdfToTextWithOptions`, and
`getDocumentInfo` trusted `pdf.numPages` from unpdf/pdfjs and looped
`getPage` for every declared page. Buffer size was capped at 100 MiB; a
small crafted PDF can still declare a huge page count and hang the
extractor.

This adds `requirePdfPageCount` (`MAX_PDF_PAGES = 2048`) immediately after
`getDocumentProxy` and before any `getPage`.

## What kind of change is this?

Bug fix (resource-bound enforcement).

# Documentation changes needed?

No public API change. Oversized page counts now throw a `RangeError` on the
throwing methods and become the existing structured `{ success: false }`
on `convertPdfToTextWithOptions`.

# Testing

## Where should a reviewer start?

`plugins/plugin-pdf/services/pdf.ts` and the new cases in
`__tests__/pdf-service.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-pdf test __tests__/pdf-service.test.ts
```

Origin: `for (pageNum = 1; pageNum <= pdf.numPages; pageNum++)` with no
budget — `getPage` is called once per declared page.

Head: `numPages = MAX_PDF_PAGES + 1` throws before `getPage`;
`MAX_PDF_PAGES` last-fit still extracts; hostile counts never call
`getPage`.

# Evidence Gate

<!-- evidence-head:4a2ebed26cc0ca1102afef7ec12099b6e88c1527 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated unit proof; no server process.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Unit proof at this head: overflow `getPage` call count is 0; last-fit
      calls `getPage` exactly 2048 times; 34/34 tests pass.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - extractor validation only.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`__tests__/pdf-service.integration.test.ts` is not in this proof: this
worktree cannot resolve the `unpdf` package for the real-parser suite
(pre-existing). The contract under test is the declared-`numPages` gate,
covered by the mocked unit file. `bun run verify` was not re-run for the
whole monorepo this cycle.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
