### PR TITLE
fix(core): reject oversized regex repeat counts before GBNF expand

### DIFF
--- a/packages/core/src/runtime/__tests__/response-grammar.test.ts
+++ b/packages/core/src/runtime/__tests__/response-grammar.test.ts
@@ -17,6 +17,7 @@ import {
 	buildResponseGrammar,
 	buildSpanSamplerPlan,
 	clearResponseGrammarCache,
+	MAX_SIMPLE_REGEX_REPEAT,
 	withGuidedDecodeProviderOptions,
 } from "../response-grammar";
 import type { ResponseHandlerFieldEvaluator } from "../response-handler-field-evaluator";
@@ -722,6 +723,79 @@ describe("buildPlannerActionGrammarStrict — single-call per-action union gramm
 		expect(r.grammar).toMatch(
 			/paramsofaction-CODE-p-code ::= "\\"code\\":" \[A-Z\] \[A-Z\] \[0-9\] \[0-9\] \[0-9\] \[0-9\]/,
 		);
+	});
+
+	it("expands a last-fit exact repeat and refuses the first overflowing count", () => {
+		clearResponseGrammarCache();
+		const atoms = Array.from(
+			{ length: MAX_SIMPLE_REGEX_REPEAT },
+			() => "\\[A-Z\\]",
+		).join(" ");
+		const fit = buildPlannerActionGrammarStrict([
+			makeAction("FIT", {
+				parameters: [
+					{
+						name: "code",
+						description: "code",
+						required: true,
+						schema: {
+							type: "string",
+							pattern: `^[A-Z]{${MAX_SIMPLE_REGEX_REPEAT}}$`,
+						},
+					},
+				],
+			}),
+		]);
+		if (fit === null) throw new Error("expected grammar");
+		expect(fit.grammar).toMatch(
+			new RegExp(`paramsofaction-FIT-p-code ::= "\\\\"code\\\\":" ${atoms}`),
+		);
+
+		const overflow = buildPlannerActionGrammarStrict([
+			makeAction("OVERFLOW", {
+				parameters: [
+					{
+						name: "code",
+						description: "code",
+						required: true,
+						schema: {
+							type: "string",
+							pattern: `^[A-Z]{${MAX_SIMPLE_REGEX_REPEAT + 1}}$`,
+						},
+					},
+				],
+			}),
+		]);
+		if (overflow === null) throw new Error("expected grammar");
+		expect(overflow.grammar).toMatch(
+			/paramsofaction-OVERFLOW-p-code ::= "\\"code\\":" jsonstring/,
+		);
+	});
+
+	it("refuses an unsafe exact-repeat count before allocating GBNF atoms", () => {
+		clearResponseGrammarCache();
+		const started = performance.now();
+		const r = buildPlannerActionGrammarStrict([
+			makeAction("BOMB", {
+				parameters: [
+					{
+						name: "code",
+						description: "code",
+						required: true,
+						schema: {
+							type: "string",
+							pattern: `^A{${"9".repeat(16)}}$`,
+						},
+					},
+				],
+			}),
+		]);
+		expect(performance.now() - started).toBeLessThan(100);
+		if (r === null) throw new Error("expected grammar");
+		expect(r.grammar).toMatch(
+			/paramsofaction-BOMB-p-code ::= "\\"code\\":" jsonstring/,
+		);
+		expect(r.grammar ?? "").not.toContain("A A A A A");
 	});
 
 	it("falls back to validation-backed string grammar for unsupported regex features", () => {

--- a/packages/core/src/runtime/response-grammar.ts
+++ b/packages/core/src/runtime/response-grammar.ts
@@ -29,6 +29,10 @@
  * derived from the field-registry signature + the context-id set + the channel
  * flag + the action set). A small process-wide cache is kept here keyed on that
  * id.
+ *
+ * Simple regex `{n}` / `{n,m}` expansion is fail-closed at
+ * {@link MAX_SIMPLE_REGEX_REPEAT}. Exact `{1000000}` used to pass the span
+ * check (`max-min === 0`) and then allocate n GBNF atoms.
  */
 
 import {
@@ -192,6 +196,9 @@ interface SimpleRegexParserState {
 	index: number;
 	end: number;
 }
+
+/** Exact-repeat and range-span ceiling for simple regex → GBNF expansion. */
+export const MAX_SIMPLE_REGEX_REPEAT = 32;
 
 function compileSimplePatternToGbnf(pattern: string): string | null {
 	if (pattern.length < 2 || pattern[0] !== "^" || pattern.at(-1) !== "$") {
@@ -550,7 +557,11 @@ function parseSimpleRegexBracedQuantifier(
 		state.index = start;
 		return null;
 	}
-	if (max !== null && max - min > 32) {
+	if (min > MAX_SIMPLE_REGEX_REPEAT) {
+		state.index = start;
+		return null;
+	}
+	if (max !== null && max - min > MAX_SIMPLE_REGEX_REPEAT) {
 		state.index = start;
 		return null;
 	}
@@ -563,7 +574,10 @@ function parseSimpleRegexDecimal(state: SimpleRegexParserState): number | null {
 		state.index += 1;
 	}
 	if (state.index === start) return null;
-	return Number.parseInt(state.source.slice(start, state.index), 10);
+	const digits = state.source.slice(start, state.index);
+	const value = Number(digits);
+	if (!Number.isSafeInteger(value)) return null;
+	return value;
 }
 
 function compileSimpleRegexNode(node: SimpleRegexNode): string {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone fail-before-allocate hang in guided-decode GBNF compilation.
Action JSON-schema `pattern` values like `^A{1000000}$` and
`^A{9999999999999999}$` compiled to n GBNF atoms. The existing span check
only rejected `max-min > 32`, so an exact `{n}` (where max === min) skipped
it. Not a twin of `#22284`, `#22303`, `#22304`, `#22302`, or the timeout
family. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Focused `response-grammar.test.ts` 78/78 at the exact head.
- [x] A reviewer can confirm last-fit `{32}` still expands and `{33}` /
      unsafe `{999…9}` fall back without allocating atoms.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head focused test: 78/78.
- [x] Biome on the two touched files: clean.

# Risks

Low and bounded to `packages/core/src/runtime/response-grammar.ts`.
Exact repeats and ranges above 32 now fail the simple-regex compiler and
fall back to the existing `jsonstring` rule (server-side validation still
applies). `{2}` / `{4}` in the existing CODE fixture still expand. Unsafe
digit strings no longer become a `parseInt` loop bound.

# Background

## What does this PR do?

`parseSimpleRegexBracedQuantifier` accepted `{n}` whenever `max-min <= 32`.
`compileSimpleRegexRepeat` then pushed `n` atoms. `{1000000}` allocated a
million tokens; `{9999999999999999}` became a non-safe `parseInt` bound.

This requires a safe integer and rejects `min > 32` (same ceiling as the
existing span check) before expansion.

## What kind of change is this?

Bug fix (resource-bound enforcement).

# Documentation changes needed?

No public API change. Oversized patterns keep working as unforced strings.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/response-grammar.ts`
(`parseSimpleRegexBracedQuantifier`, `parseSimpleRegexDecimal`) and the new
cases in `response-grammar.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core test src/runtime/__tests__/response-grammar.test.ts
```

Origin: `{200000}` exact-repeat expansion produced a 1.2M-character GBNF
fragment. Head: `{33}` and `{9999999999999999}` compile to `jsonstring` in
<100ms; `{32}` still expands 32 atoms.

# Evidence Gate

<!-- evidence-head:a2a379290cfebf910bc1babf3237384da6f3c2f9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated unit proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - grammar compiler only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] 78/78 `response-grammar.test.ts` at this head, including last-fit
      `{32}`, overflow `{33}`, and unsafe 16-nines count <100ms.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo this cycle. The
owning file's focused grammar suite passed at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
