### PR TITLE
fix(plugin-computeruse): reject PNG IHDR pixel bombs before inflate

### DIFF
--- a/plugins/plugin-computeruse/src/scene/dhash.test.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.test.ts
@@ -21,8 +21,8 @@
  * constructible.
  */
 
-import { deflateSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { deflateSync, inflateSync } from "node:zlib";
+import { describe, expect, it, vi } from "vitest";
 import {
   type BlockGrid,
   blockGrid,
@@ -166,13 +166,19 @@ describe("decodePng", () => {
       pngChunk("IDAT", deflateSync(Buffer.from([0, 1, 2, 3]))),
       pngChunk("IEND", Buffer.alloc(0)),
     ]);
-    expect(decodePng(bomb)).toBeNull();
+    const inflate = vi.fn(() => {
+      throw new Error("inflate must not run for over-budget IHDR");
+    });
+    expect(decodePng(bomb, inflate)).toBeNull();
+    expect(inflate).not.toHaveBeenCalled();
     expect(bomb.length).toBeLessThan(128);
   });
 
   it("still decodes a last-fit screenshot-sized frame", () => {
     expect(7680 * 4320).toBeLessThanOrEqual(MAX_DECODE_PNG_PIXELS);
-    const decoded = decodePng(makePng({ width: 64, height: 48 }));
+    const inflate = vi.fn(inflateSync);
+    const decoded = decodePng(makePng({ width: 64, height: 48 }), inflate);
+    expect(inflate).toHaveBeenCalledTimes(1);
     expect(decoded).not.toBeNull();
     expect(decoded?.width).toBe(64);
     expect(decoded?.height).toBe(48);

--- a/plugins/plugin-computeruse/src/scene/dhash.test.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.test.ts
@@ -174,7 +174,7 @@ describe("decodePng", () => {
   });
 
   it("still decodes a last-fit screenshot-sized frame", () => {
-    expect(8000 * 4000).toBeLessThanOrEqual(MAX_DECODE_PNG_PIXELS);
+    expect(7680 * 4320).toBeLessThanOrEqual(MAX_DECODE_PNG_PIXELS);
     const decoded = decodePng(makePng({ width: 64, height: 48 }));
     expect(decoded).not.toBeNull();
     expect(decoded?.width).toBe(64);

--- a/plugins/plugin-computeruse/src/scene/dhash.test.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.test.ts
@@ -35,6 +35,7 @@ import {
   hamming,
   MAX_DECODE_PNG_PIXELS,
   pngDimensions,
+  pngRasterExceedsDecodeBudget,
 } from "./dhash.js";
 
 // ── parameterized PNG synthesizer ────────────────────────────────────────────
@@ -148,13 +149,15 @@ describe("decodePng", () => {
     }
   });
 
-  it("returns null without allocating for a last-overflow IHDR pixel bomb", () => {
-    const width = 65535;
-    const height = 65535;
-    expect(width * height).toBeGreaterThan(MAX_DECODE_PNG_PIXELS);
+  it("rejects an over-budget IHDR before inflate via the dimension helper", () => {
+    expect(pngRasterExceedsDecodeBudget(65535, 65535)).toBe(true);
+    expect(pngRasterExceedsDecodeBudget(7680, 4320)).toBe(false);
+    expect(pngRasterExceedsDecodeBudget(0, 1)).toBe(true);
+    const expectedScanlineBytes = (65535 * 3 + 1) * 65535;
+    expect(expectedScanlineBytes).toBeGreaterThan(MAX_DECODE_PNG_PIXELS);
     const ihdr = Buffer.alloc(13);
-    ihdr.writeUInt32BE(width, 0);
-    ihdr.writeUInt32BE(height, 4);
+    ihdr.writeUInt32BE(65535, 0);
+    ihdr.writeUInt32BE(65535, 4);
     ihdr[8] = 8;
     ihdr[9] = 2;
     const bomb = Buffer.concat([
@@ -163,13 +166,7 @@ describe("decodePng", () => {
       pngChunk("IDAT", deflateSync(Buffer.from([0, 1, 2, 3]))),
       pngChunk("IEND", Buffer.alloc(0)),
     ]);
-    let result: ReturnType<typeof decodePng> | "threw";
-    try {
-      result = decodePng(bomb);
-    } catch {
-      result = "threw";
-    }
-    expect(result).toBeNull();
+    expect(decodePng(bomb)).toBeNull();
     expect(bomb.length).toBeLessThan(128);
   });
 

--- a/plugins/plugin-computeruse/src/scene/dhash.test.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.test.ts
@@ -33,6 +33,7 @@ import {
   diffBlocks,
   frameDhash,
   hamming,
+  MAX_DECODE_PNG_PIXELS,
   pngDimensions,
 } from "./dhash.js";
 
@@ -145,6 +146,39 @@ describe("decodePng", () => {
         `${label} must decode to null without throwing`,
       ).toBeNull();
     }
+  });
+
+  it("returns null without allocating for a last-overflow IHDR pixel bomb", () => {
+    const width = 65535;
+    const height = 65535;
+    expect(width * height).toBeGreaterThan(MAX_DECODE_PNG_PIXELS);
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    const bomb = Buffer.concat([
+      SIGNATURE,
+      pngChunk("IHDR", ihdr),
+      pngChunk("IDAT", deflateSync(Buffer.from([0, 1, 2, 3]))),
+      pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+    let result: ReturnType<typeof decodePng> | "threw";
+    try {
+      result = decodePng(bomb);
+    } catch {
+      result = "threw";
+    }
+    expect(result).toBeNull();
+    expect(bomb.length).toBeLessThan(128);
+  });
+
+  it("still decodes a last-fit screenshot-sized frame", () => {
+    expect(8000 * 4000).toBeLessThanOrEqual(MAX_DECODE_PNG_PIXELS);
+    const decoded = decodePng(makePng({ width: 64, height: 48 }));
+    expect(decoded).not.toBeNull();
+    expect(decoded?.width).toBe(64);
+    expect(decoded?.height).toBe(48);
   });
 });
 

--- a/plugins/plugin-computeruse/src/scene/dhash.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.ts
@@ -17,7 +17,9 @@
  *     RGBA, 8-bit depth, non-interlaced). Anything else returns `null` and
  *     the caller falls back to a coarser whole-frame byte hash. IHDR
  *     width×height above {@link MAX_DECODE_PNG_PIXELS} is rejected before
- *     `inflateSync` / `Buffer.alloc` so a 69-byte bomb cannot throw.
+ *     `inflateSync` so a huge IHDR cannot set `maxOutputLength` to the
+ *     declared scanline budget. A tiny IDAT still fails later with
+ *     `inflated.length < expected`; the budget is the pre-inflate gate.
  *   - Pure functions, no I/O. Safe to test deterministically.
  *
  * Block-grid contract:
@@ -37,6 +39,25 @@ const PNG_SIGNATURE = Buffer.from([
 ]);
 /** Fail-closed pixel budget. IHDR is attacker-declared; 8K is 33_177_600. */
 export const MAX_DECODE_PNG_PIXELS = 50_000_000;
+
+/**
+ * True when declared IHDR width×height must not reach inflate / RGBA alloc.
+ * Uses `floor(MAX/height)` so the compare cannot overflow JS number range.
+ */
+export function pngRasterExceedsDecodeBudget(
+  width: number,
+  height: number,
+): boolean {
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return true;
+  }
+  return width > Math.floor(MAX_DECODE_PNG_PIXELS / height);
+}
 
 export interface RawImage {
   width: number;
@@ -89,7 +110,7 @@ export function decodePng(png: Buffer): RawImage | null {
   if (interlace !== 0) return null;
   if (colorType !== 2 && colorType !== 6) return null;
   if (idatChunks.length === 0) return null;
-  if (height > 0 && width > Math.floor(MAX_DECODE_PNG_PIXELS / height)) {
+  if (pngRasterExceedsDecodeBudget(width, height)) {
     return null;
   }
 
@@ -104,6 +125,8 @@ export function decodePng(png: Buffer): RawImage | null {
       maxOutputLength: expected,
     });
   } catch {
+    // error-policy:J3 malformed or over-budget compressed PNG input is
+    // sanitized to explicit null; decodePng never throws on untrusted bytes.
     return null;
   }
   if (inflated.length < expected) return null;

--- a/plugins/plugin-computeruse/src/scene/dhash.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.ts
@@ -66,12 +66,20 @@ export interface RawImage {
   rgba: Buffer;
 }
 
+/** Inflate seam for tests: prove over-budget IHDR never reaches zlib. */
+export type DecodePngInflate = typeof inflateSync;
+
 /**
  * Decode a PNG buffer to RGBA. Returns null for unsupported variants
  * (interlaced, palette-indexed, 16-bit depth) — caller handles that by
  * falling back to a non-block-grid hash strategy.
+ *
+ * `inflate` is a test seam. Production callers omit it.
  */
-export function decodePng(png: Buffer): RawImage | null {
+export function decodePng(
+  png: Buffer,
+  inflate: DecodePngInflate = inflateSync,
+): RawImage | null {
   if (png.length < PNG_SIGNATURE.length) return null;
   for (let i = 0; i < PNG_SIGNATURE.length; i += 1) {
     if (png[i] !== PNG_SIGNATURE[i]) return null;
@@ -121,7 +129,7 @@ export function decodePng(png: Buffer): RawImage | null {
 
   let inflated: Buffer;
   try {
-    inflated = inflateSync(Buffer.concat(idatChunks), {
+    inflated = inflate(Buffer.concat(idatChunks), {
       maxOutputLength: expected,
     });
   } catch {

--- a/plugins/plugin-computeruse/src/scene/dhash.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.ts
@@ -15,7 +15,9 @@
  *   - The PNG decoder here is intentionally minimal — it handles the formats
  *     produced by every screenshot path we ship (color type 2 = RGB, 6 =
  *     RGBA, 8-bit depth, non-interlaced). Anything else returns `null` and
- *     the caller falls back to a coarser whole-frame byte hash.
+ *     the caller falls back to a coarser whole-frame byte hash. IHDR
+ *     width×height above {@link MAX_DECODE_PNG_PIXELS} is rejected before
+ *     `inflateSync` / `Buffer.alloc` so a 69-byte bomb cannot throw.
  *   - Pure functions, no I/O. Safe to test deterministically.
  *
  * Block-grid contract:
@@ -33,6 +35,8 @@ import { inflateSync } from "node:zlib";
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
+/** Fail-closed pixel budget. IHDR is attacker-declared; 8K is ~33e6 pixels. */
+export const MAX_DECODE_PNG_PIXELS = 32_000_000;
 
 export interface RawImage {
   width: number;
@@ -85,11 +89,23 @@ export function decodePng(png: Buffer): RawImage | null {
   if (interlace !== 0) return null;
   if (colorType !== 2 && colorType !== 6) return null;
   if (idatChunks.length === 0) return null;
+  if (height > 0 && width > Math.floor(MAX_DECODE_PNG_PIXELS / height)) {
+    return null;
+  }
 
-  const inflated = inflateSync(Buffer.concat(idatChunks));
   const bytesPerPixel = colorType === 6 ? 4 : 3;
   const stride = width * bytesPerPixel;
+  if (stride + 1 > Number.MAX_SAFE_INTEGER / height) return null;
   const expected = (stride + 1) * height;
+
+  let inflated: Buffer;
+  try {
+    inflated = inflateSync(Buffer.concat(idatChunks), {
+      maxOutputLength: expected,
+    });
+  } catch {
+    return null;
+  }
   if (inflated.length < expected) return null;
 
   const rgba = Buffer.alloc(width * height * 4);

--- a/plugins/plugin-computeruse/src/scene/dhash.ts
+++ b/plugins/plugin-computeruse/src/scene/dhash.ts
@@ -35,8 +35,8 @@ import { inflateSync } from "node:zlib";
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
-/** Fail-closed pixel budget. IHDR is attacker-declared; 8K is ~33e6 pixels. */
-export const MAX_DECODE_PNG_PIXELS = 32_000_000;
+/** Fail-closed pixel budget. IHDR is attacker-declared; 8K is 33_177_600. */
+export const MAX_DECODE_PNG_PIXELS = 50_000_000;
 
 export interface RawImage {
   width: number;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone PNG IHDR pixel-budget gate in the computer-use dHash decoder.
Not a twin of `#22303` / `#22302` / `#22304` / `#22305`, `#22308`,
`#22311`, `#22315`, `#22320`, `#22278`, `#22262`, or the timeout family.
No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` (base `de026436678c`); not rewritten solely to chase later unrelated commits.
- [x] Focused dHash tests 20/20 at this head.
- [x] Dimension-budget helper last-fit / first-overflow plus inflater seam
      proving the 65535² fixture never reaches zlib. No 17 GB `Buffer.alloc`
      claim on a tiny IDAT.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Based on `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head focused test: 20/20 `dhash.test.ts`.
- [x] Biome on the two touched files: clean.

# Risks

Low and bounded to `plugins/plugin-computeruse/src/scene/dhash.ts`.
Frames above 50 million pixels now decode as `null` (existing fallback:
coarser byte hash). 8K (7680×4320 ≈ 33e6) still fits. Malformed frames
still return `null` — never throw. `inflate` is output-capped to the
accepted scanline budget. Optional second `inflate` argument is a test
seam; production callers omit it.

# Background

## What does this PR do?

`decodePng` trusted IHDR `width`/`height` and would call
`inflateSync(..., { maxOutputLength: expected })` where `expected` is
the declared scanline budget (`(width*bpp+1)*height`). For 65535×65535
RGB that budget is ~12.9 GiB — even when the IDAT is four compressed
bytes. Origin already returned `null` for that tiny fixture because
`inflated.length < expected` after a small inflate; it never reached
`Buffer.alloc`. The first PR body overstated that path.

This extracts `pngRasterExceedsDecodeBudget` and rejects the declared
raster **before** inflate, so an over-budget IHDR cannot set
`maxOutputLength` to the declared scanline budget. An optional `inflate`
seam proves the bomb fixture never calls zlib. A tiny IDAT still
returns `null`.

## What kind of change is this?

Bug fix (resource-bound enforcement). Addresses Shaw P1/P2 on this PR.

# Documentation changes needed?

No production API change. Optional `inflate` argument is a test seam.
Oversized frames already had a null fallback.

# Testing

## Where should a reviewer start?

`pngRasterExceedsDecodeBudget` and `decodePng` in `dhash.ts`, and the
budget + inflater-seam cases in `dhash.test.ts`.

## Detailed testing steps

```bash
bunx vitest run plugins/plugin-computeruse/src/scene/dhash.test.ts --coverage.enabled=false
```

65535×65535 exceeds the budget; 7680×4320 does not. The bomb fixture
passes a throwing `inflate` spy that must not be called. A 64×48 frame
calls the spy once and decodes. Base `de026436` also returned `null`
for that fixture after a short inflate — this head proves the
**pre-inflate** helper and seam, not a 17 GB alloc.

# Evidence Gate

<!-- evidence-head:44d3ff6bc2dc90a54d4777f9cb4970b67610742c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated decoder proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - PNG decode only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Helper 65535×65535 over budget; inflater spy not called on bomb;
      last-fit 64×48 calls inflate once; 20/20 dhash tests at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

Shaw P1: the 69-byte 65535×65535 fixture does **not** allocate 17 GB on
origin; this revision withdraws that claim. Package-wide verify was not
re-run. Focused dhash tests 20/20.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
