### PR TITLE
fix(plugin-workflow): cap Smithers protocol lines before parent buffer hang

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/smithers-protocol-line.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-protocol-line.test.ts
@@ -1,0 +1,38 @@
+/** Unit coverage for the Smithers parent protocol line budget. */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  appendSmithersProtocolChunk,
+  MAX_PROTOCOL_LINE_BYTES,
+} from '../../src/services/smithers-runtime';
+
+describe('appendSmithersProtocolChunk', () => {
+  test('splits complete lines and keeps the incomplete tail', () => {
+    const first = appendSmithersProtocolChunk('', 'hello\nwor');
+    expect(first.overflow).toBe(false);
+    expect(first.lines).toEqual(['hello']);
+    expect(first.buffer).toBe('wor');
+    const second = appendSmithersProtocolChunk(first.buffer, 'ld\n');
+    expect(second.overflow).toBe(false);
+    expect(second.lines).toEqual(['world']);
+    expect(second.buffer).toBe('');
+  });
+
+  test('accepts a last-fit incomplete line and rejects the first overflowing tail', () => {
+    const fit = 'x'.repeat(MAX_PROTOCOL_LINE_BYTES);
+    const lastFit = appendSmithersProtocolChunk('', fit);
+    expect(lastFit.overflow).toBe(false);
+    expect(lastFit.buffer.length).toBe(MAX_PROTOCOL_LINE_BYTES);
+
+    const overflow = appendSmithersProtocolChunk(fit, 'y');
+    expect(overflow.overflow).toBe(true);
+    expect(overflow.lines).toEqual([]);
+    expect(overflow.buffer).toBe('');
+  });
+
+  test('rejects a complete line above the budget before the parent keeps it', () => {
+    const bomb = `${'z'.repeat(MAX_PROTOCOL_LINE_BYTES + 1)}\n`;
+    const result = appendSmithersProtocolChunk('', bomb);
+    expect(result.overflow).toBe(true);
+  });
+});

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -3,6 +3,10 @@
  * and streams native Smithers progress events back to the owning elizaOS
  * runtime. The child speaks a private stdout protocol; there is no Smithers
  * Gateway, HTTP sidecar, or foreign workflow translation layer.
+ *
+ * Incomplete stdout lines are fail-closed at {@link MAX_PROTOCOL_LINE_BYTES}
+ * before the parent concatenates them. A worker that never emits `\n` used to
+ * grow `stdoutBuffer` without bound for the whole run timeout.
  */
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -22,11 +26,32 @@ const PROTOCOL_PREFIX = '__ELIZA_SMTHRS__';
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1_000;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const MAX_STDERR_CHARS = 8_192;
+/** Fail-closed ceiling for one protocol line (complete or incomplete). */
+export const MAX_PROTOCOL_LINE_BYTES = 1_048_576;
 const WORKER_TERMINATION_GRACE_MS = 1_000;
 const WORKER_STDIO_DRAIN_GRACE_MS = 1_000;
 const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-type WorkerTerminationCause = 'abort' | 'timeout';
+type WorkerTerminationCause = 'abort' | 'timeout' | 'overflow';
+
+export function appendSmithersProtocolChunk(
+  buffer: string,
+  chunk: string,
+  maxBytes: number = MAX_PROTOCOL_LINE_BYTES
+): { buffer: string; lines: string[]; overflow: boolean } {
+  const next = `${buffer}${chunk}`;
+  const parts = next.split('\n');
+  const incomplete = parts.pop() ?? '';
+  if (Buffer.byteLength(incomplete, 'utf8') > maxBytes) {
+    return { buffer: '', lines: [], overflow: true };
+  }
+  for (const line of parts) {
+    if (Buffer.byteLength(line, 'utf8') > maxBytes) {
+      return { buffer: '', lines: [], overflow: true };
+    }
+  }
+  return { buffer: incomplete, lines: parts, overflow: false };
+}
 
 interface WorkerEventMessage {
   kind: 'event';
@@ -522,10 +547,13 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
 
   worker.stdout?.setEncoding('utf8');
   worker.stdout?.on('data', (chunk: string) => {
-    stdoutBuffer += chunk;
-    const lines = stdoutBuffer.split('\n');
-    stdoutBuffer = lines.pop() ?? '';
-    for (const line of lines) {
+    const appended = appendSmithersProtocolChunk(stdoutBuffer, chunk);
+    if (appended.overflow) {
+      terminate('overflow');
+      return;
+    }
+    stdoutBuffer = appended.buffer;
+    for (const line of appended.lines) {
       lineProcessing = lineProcessing.then(() => consumeLine(line));
     }
   });
@@ -605,7 +633,9 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       // terminal pipe or one whose close event was withheld by inherited child descriptors.
     }
   }
-  if (stdoutBuffer) lineProcessing = lineProcessing.then(() => consumeLine(stdoutBuffer));
+  if (stdoutBuffer && terminationCause !== 'overflow') {
+    lineProcessing = lineProcessing.then(() => consumeLine(stdoutBuffer));
+  }
   let lineProcessingFailed = false;
   let lineProcessingError: unknown;
   const observedLineProcessing = lineProcessing.catch((error) => {
@@ -647,6 +677,16 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       code: 'SMTHRS_WORKFLOW_TIMEOUT',
       context: { timeoutMs, exitCode: outcome.exitCode, workflowId: request.workflow.id },
       severity: 'ephemeral',
+    });
+  }
+  if (terminationCause === 'overflow') {
+    throw new ElizaError('Smithers worker protocol line exceeded the byte budget', {
+      code: 'SMTHRS_PROTOCOL_OVERFLOW',
+      context: {
+        limit: MAX_PROTOCOL_LINE_BYTES,
+        exitCode: outcome.exitCode,
+        workflowId: request.workflow.id,
+      },
     });
   }
   if (workerError) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone parent-process overflow on the Smithers worker stdout protocol.
Not a twin of `#22303`/`#22302` (file/HTTP byte slurps), `#22306` (PNG
IHDR inflate), `#22304`/`#22305`, `#22278`, `#22262`, or the fetch-timeout
family. HARD_SKIP is `workbench-todos.ts`, not this runtime. No invented
owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Protocol-line helper last-fit / first-overflow proved at this head.
- [x] A reviewer can confirm a 40 MiB no-newline dump used to grow RSS
      40 MiB and now overflows at 1 MiB.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head helper proof: last-fit 1 MiB accepted; +1 and a complete
      oversize line overflow.
- [x] Biome on the two touched files: clean.

# Risks

Low and bounded to `plugins/plugin-workflow/src/services/smithers-runtime.ts`.
A worker line (complete or incomplete) above 1 MiB now kills the child and
throws `SMTHRS_PROTOCOL_OVERFLOW`. Legitimate protocol JSON events stay
well under that. Stderr remains independently clipped at 8 KiB.

# Background

## What does this PR do?

`runSmithersWorkflow` did `stdoutBuffer += chunk` and only split on `\n`.
Stderr was already clipped; stdout was not. Origin replica: concatenating
40 MiB without a newline moved RSS +40.1 MiB for the whole run timeout
(default 30 min).

This introduces `appendSmithersProtocolChunk` with
`MAX_PROTOCOL_LINE_BYTES = 1_048_576`. Overflow terminates the worker
(`overflow`) and fails closed with `SMTHRS_PROTOCOL_OVERFLOW`.

## What kind of change is this?

Bug fix (resource-bound enforcement).

# Documentation changes needed?

No public HTTP API change. Oversized worker stdout is a new typed error.

# Testing

## Where should a reviewer start?

`appendSmithersProtocolChunk` in `smithers-runtime.ts` and
`__tests__/unit/smithers-protocol-line.test.ts`.

## Detailed testing steps

```bash
bun test plugins/plugin-workflow/__tests__/unit/smithers-protocol-line.test.ts
```

Origin: `stdoutBuffer += "x".repeat(40<<20)` → rssDeltaMB 40.1.
Head: last-fit 1 MiB keeps; +1 overflow; complete oversize line overflow.

# Evidence Gate

<!-- evidence-head:eb55e03de844f6cfa55206f92971220d4de9a9aa -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated Node proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - protocol buffer only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin 40 MiB no-newline dump +40.1 MiB RSS. Head last-fit/overflow
      helper proof at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Root `bun test`
prints a huge coverage table for this package; the three new unit cases
passed. Isolated helper proof is the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
