### PR TITLE
fix(agent): reject ReDoS VFS grep patterns before line test

### DIFF
--- a/packages/agent/src/services/vfs-builtin-shell.test.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.test.ts
@@ -118,6 +118,22 @@ describe("runVfsBuiltinShell", () => {
     expect(files.stdout).toContain("src/nested/b.ts");
   });
 
+  it("rejects nested-quantifier grep patterns before testing VFS lines", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "redos" });
+    await vfs.initialize();
+    await vfs.writeFile("src/bomb.ts", `${"a".repeat(28)}!\n`);
+
+    const startedAt = Date.now();
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://redos/src",
+      command: "grep",
+      args: ["(a+)+$", "."],
+    });
+    expect(Date.now() - startedAt).toBeLessThan(200);
+    expect(result).toMatchObject({ exitCode: 2, stdout: "" });
+    expect(result.stderr).toContain("unsafe regular expression");
+  });
+
   it("keeps command separators inside quoted arguments", async () => {
     const result = await runVfsBuiltinShell({
       cwdUri: "vfs://quoted/",

--- a/packages/agent/src/services/vfs-builtin-shell.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.ts
@@ -6,9 +6,16 @@
  * single command. Supported commands: echo, printf, pwd, cat, ls, mkdir, rm, and
  * grep/rg implemented over the VFS export (no host ripgrep). Unknown commands
  * exit 127; all paths stay inside the project root and symlinks are rejected.
+ *
+ * grep/rg compile the caller pattern with `compileVfsSearchPattern` before any
+ * line is tested. JS `RegExp` is synchronous and cannot be aborted, so a
+ * nested-quantifier pattern (`(a+)+$`) against ordinary VFS lines hangs the
+ * agent process — origin replica: 20 × 28-`a` lines took ~9s on Bun and a
+ * single line hung Node past 8s.
  */
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { compileVfsSearchPattern } from "./vfs-search-pattern.ts";
 import { createVirtualFilesystemService } from "./virtual-filesystem.ts";
 
 interface VfsBuiltinShellRequest {
@@ -392,16 +399,15 @@ async function searchTargets(
   options: SearchOptions,
   targets: SearchTarget[],
 ): Promise<VfsBuiltinCommandResult> {
-  let matcher: RegExp;
-  try {
-    matcher = new RegExp(pattern, options.ignoreCase ? "i" : "");
-  } catch (error) {
+  const compiled = compileVfsSearchPattern(pattern, options.ignoreCase);
+  if (!compiled.ok) {
     return {
       exitCode: 2,
       stdout: "",
-      stderr: `${tool}: ${error instanceof Error ? error.message : String(error)}\n`,
+      stderr: `${tool}: ${compiled.error}\n`,
     };
   }
+  const matcher = compiled.matcher;
 
   const lines: string[] = [];
   for (const target of targets) {

--- a/packages/agent/src/services/vfs-search-pattern.test.ts
+++ b/packages/agent/src/services/vfs-search-pattern.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Isolated compile-gate tests for VFS grep/rg ReDoS rejection. Does not boot
+ * VirtualFilesystemService; hang/last-fit cases run against the helper only.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  compileVfsSearchPattern,
+  MAX_VFS_SEARCH_PATTERN_LENGTH,
+  vfsSearchPatternIsUnsafe,
+} from "./vfs-search-pattern.ts";
+
+describe("compileVfsSearchPattern", () => {
+  it("accepts last-fit linear patterns", () => {
+    expect(vfsSearchPatternIsUnsafe("needle")).toBe(false);
+    expect(vfsSearchPatternIsUnsafe("foo+")).toBe(false);
+    expect(vfsSearchPatternIsUnsafe("(needle)+")).toBe(false);
+    expect(vfsSearchPatternIsUnsafe("[a+]+")).toBe(false);
+    expect(vfsSearchPatternIsUnsafe("foo|bar")).toBe(false);
+    expect(compileVfsSearchPattern("Needles?", true)).toMatchObject({
+      ok: true,
+    });
+    const compiled = compileVfsSearchPattern("needle", false);
+    expect(compiled.ok).toBe(true);
+    if (compiled.ok) {
+      expect(compiled.matcher.test("a needle here")).toBe(true);
+    }
+  });
+
+  it("rejects nested quantifiers, quantified alternation, and oversize patterns", () => {
+    expect(vfsSearchPatternIsUnsafe("(a+)+$")).toBe(true);
+    expect(vfsSearchPatternIsUnsafe("(a*)*")).toBe(true);
+    expect(vfsSearchPatternIsUnsafe("(a|aa)+")).toBe(true);
+    expect(vfsSearchPatternIsUnsafe("(?:a+)+")).toBe(true);
+    expect(
+      vfsSearchPatternIsUnsafe("x".repeat(MAX_VFS_SEARCH_PATTERN_LENGTH + 1)),
+    ).toBe(false);
+    const overflow = compileVfsSearchPattern(
+      "x".repeat(MAX_VFS_SEARCH_PATTERN_LENGTH + 1),
+    );
+    expect(overflow).toEqual({
+      ok: false,
+      error: `pattern longer than ${MAX_VFS_SEARCH_PATTERN_LENGTH} characters`,
+    });
+    const nested = compileVfsSearchPattern("(a+)+$");
+    expect(nested.ok).toBe(false);
+    if (!nested.ok) {
+      expect(nested.error).toContain("unsafe regular expression");
+    }
+  });
+});

--- a/packages/agent/src/services/vfs-search-pattern.ts
+++ b/packages/agent/src/services/vfs-search-pattern.ts
@@ -1,0 +1,145 @@
+/**
+ * Compile-time ReDoS gate for in-process VFS grep/rg patterns.
+ *
+ * `RegExp#test` is synchronous and cannot be aborted. Nested quantifiers and
+ * quantified alternation (`(a+)+$`, `(a|aa)+`) hang the agent on ordinary
+ * file lines — origin: 20 × 28-`a` lines took ~9s on Bun; one line hung Node
+ * past 8s. Character classes are skipped so `[a+]+` stays legal.
+ */
+
+/** Longest grep/rg pattern accepted before compile. */
+export const MAX_VFS_SEARCH_PATTERN_LENGTH = 512;
+
+export type CompiledVfsSearchPattern =
+  | { ok: true; matcher: RegExp }
+  | { ok: false; error: string };
+
+/**
+ * Compile a VFS grep/rg pattern, rejecting nested quantifiers and quantified
+ * alternation that would backtrack catastrophically on ordinary file lines.
+ */
+export function compileVfsSearchPattern(
+  pattern: string,
+  ignoreCase = false,
+): CompiledVfsSearchPattern {
+  if (pattern.length > MAX_VFS_SEARCH_PATTERN_LENGTH) {
+    return {
+      ok: false,
+      error: `pattern longer than ${MAX_VFS_SEARCH_PATTERN_LENGTH} characters`,
+    };
+  }
+  if (vfsSearchPatternIsUnsafe(pattern)) {
+    return {
+      ok: false,
+      error:
+        "unsafe regular expression (nested quantifiers or quantified alternation)",
+    };
+  }
+  try {
+    return { ok: true, matcher: new RegExp(pattern, ignoreCase ? "i" : "") };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * True when a group that already has a quantifier or alternation is itself
+ * quantified — the star-height > 1 shape that makes `(a+)+$` and `(a|aa)+`
+ * hang a synchronous `RegExp#test`.
+ */
+export function vfsSearchPatternIsUnsafe(source: string): boolean {
+  type Frame = { quantifiedAtom: boolean; alternation: boolean };
+  const stack: Frame[] = [{ quantifiedAtom: false, alternation: false }];
+  let escaped = false;
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const frame = stack[stack.length - 1];
+    if (frame === undefined) return true;
+    if (escaped) {
+      escaped = false;
+      i += 1;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "(") {
+      stack.push({ quantifiedAtom: false, alternation: false });
+      if (source.startsWith("?", i + 1)) {
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === ")") {
+      if (stack.length <= 1) {
+        i += 1;
+        continue;
+      }
+      const closed = stack.pop();
+      i += 1;
+      if (closed === undefined) return true;
+      if (isQuantifierStart(source[i])) {
+        if (closed.quantifiedAtom || closed.alternation) return true;
+        const parent = stack[stack.length - 1];
+        if (parent) parent.quantifiedAtom = true;
+        i = skipQuantifier(source, i);
+      }
+      continue;
+    }
+    if (ch === "[") {
+      i = skipCharacterClass(source, i);
+      continue;
+    }
+    if (ch === "|" && stack.length > 1) {
+      frame.alternation = true;
+      i += 1;
+      continue;
+    }
+    if (isQuantifierStart(ch)) {
+      frame.quantifiedAtom = true;
+      i = skipQuantifier(source, i);
+      continue;
+    }
+    i += 1;
+  }
+  return false;
+}
+
+function isQuantifierStart(ch: string | undefined): boolean {
+  return ch === "*" || ch === "+" || ch === "?" || ch === "{";
+}
+
+function skipCharacterClass(source: string, index: number): number {
+  let i = index + 1;
+  if (source[i] === "^") i += 1;
+  if (source[i] === "]") i += 1;
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (source[i] === "]") return i + 1;
+    i += 1;
+  }
+  return source.length;
+}
+
+function skipQuantifier(source: string, index: number): number {
+  const ch = source[index];
+  if (ch === "*" || ch === "+" || ch === "?") {
+    const next = index + 1;
+    return source[next] === "?" ? next + 1 : next;
+  }
+  if (ch !== "{") return index + 1;
+  const close = source.indexOf("}", index + 1);
+  if (close < 0) return source.length;
+  return source[close + 1] === "?" ? close + 2 : close + 1;
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone in-process VFS grep/rg ReDoS hang. The builtin shell compiled the
caller pattern with `new RegExp` and tested every exported line synchronously.
Not a twin of `#22308` (Smithers stdout byte cap), `#22306` (PNG pixels),
`#22303`/`#22302` (file/HTTP slurps), `#22304`/`#22305`, `#22278`, `#22262`,
or the fetch-timeout family. HARD_SKIP is `parent-context-routes.ts`, not
this shell. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Helper last-fit / first-reject proved at this head.
- [x] A reviewer can confirm origin hung (~9s Bun / Node >8s) and the
      compile gate now rejects in 0ms.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head helper proof: linear patterns compile; `(a+)+$` /
      `(a|aa)+` / oversize reject.
- [x] Biome on the four touched files: clean.

# Risks

Low and bounded to `packages/agent/src/services/vfs-builtin-shell.ts`
grep/rg compile. Nested-quantifier and quantified-alternation patterns now
exit 2 with `unsafe regular expression` instead of hanging the agent.
Legitimate searches (`needle`, `foo+`, `(needle)+`, `[a+]+`) stay accepted.
Character classes are skipped so a `+` inside `[]` is not treated as a
group quantifier.

# Background

## What does this PR do?

`searchTargets` did `new RegExp(pattern)` and `matcher.test(line)` for every
VFS-exported line. JS regex is synchronous and cannot be aborted.

Origin replica: `(a+)+$` against 20 lines of 28 `a`s + `!` took **8984ms**
on Bun 1.3.14. The same pattern against one line hung Node past 8s.

This introduces `compileVfsSearchPattern` with a star-height check
(`MAX_VFS_SEARCH_PATTERN_LENGTH = 512`). Unsafe or oversize patterns fail
closed before any line is tested.

## What kind of change is this?

Bug fix (resource-bound / hang prevention).

# Documentation changes needed?

No public HTTP API change. Oversized or catastrophic grep patterns are a
new stderr from the existing exit-2 compile path.

# Testing

## Where should a reviewer start?

`compileVfsSearchPattern` in `vfs-search-pattern.ts` and
`vfs-search-pattern.test.ts`. Wiring is the `searchTargets` compile call.

## Detailed testing steps

```bash
bun test packages/agent/src/services/vfs-search-pattern.test.ts
```

Origin: 20 × `(a+)+$` on 28-`a` lines → 8984ms Bun; Node one line >8s.
Head: compile rejects in 0ms; last-fit `needle` still matches.

# Evidence Gate

<!-- evidence-head:0de91a47c0975e64ba93623319136f89643e5b37 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated Node/Bun proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - grep compile only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin 20-line `(a+)+$` replica 8984ms Bun; Node one line hung
      >8s. Head compile last-fit/reject proof at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

Worktree `bun test` of `vfs-builtin-shell.test.ts` cannot import
`@elizaos/core` (`uuid` / `@noble/hashes` / `markdown-it` not resolvable
through this worktree's `node_modules` symlink). Isolated helper tests
passed (2/2). Isolated `bun -e` helper proof is the recorded suite at
this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
