### PR TITLE
fix(cloud): do not reflect untrusted Origins on the agent router

### DIFF
--- a/packages/cloud/scripts/admin/daemons/agent-router.test.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.test.ts
@@ -9,9 +9,11 @@ import { PassThrough } from "node:stream";
 import {
   buildProxyHeaders,
   buildUnresolvedAgentResponse,
+  corsHeaders,
   extractAgentIdFromHost,
   handleRequest,
   isBridgeHostFallbackEnabled,
+  isCredentialedAgentRouterOrigin,
   resolveSandboxRouting,
   selectAgentProxyTarget,
   sendResponse,
@@ -337,6 +339,38 @@ describe("buildUnresolvedAgentResponse — CORS-bearing failure (#15347)", () =>
       undefined,
     );
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  it("does not reflect an untrusted Origin with credentials", () => {
+    const res = buildUnresolvedAgentResponse(
+      { status: "running", headscale_ip: null, web_ui_port: 20001 },
+      "https://evil.example",
+    );
+    expect(res.status).toBe(503);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(res.headers.get("vary")).toBe("origin");
+  });
+});
+
+describe("corsHeaders — credentialed origin allowlist", () => {
+  it("reflects first-party origins with credentials and rejects evil.example", () => {
+    expect(isCredentialedAgentRouterOrigin("https://cloud.eliza.app")).toBe(
+      true,
+    );
+    expect(isCredentialedAgentRouterOrigin("https://evil.example")).toBe(false);
+    const trusted = corsHeaders("https://cloud.eliza.app");
+    expect(trusted["access-control-allow-origin"]).toBe(
+      "https://cloud.eliza.app",
+    );
+    expect(trusted["access-control-allow-credentials"]).toBe("true");
+    const evil = corsHeaders("https://evil.example");
+    expect(evil["access-control-allow-origin"]).toBeUndefined();
+    expect(evil["access-control-allow-credentials"]).toBeUndefined();
+    const none = corsHeaders(undefined);
+    expect(none["access-control-allow-origin"]).toBe("*");
+    expect(none["access-control-allow-credentials"]).toBeUndefined();
   });
 });
 
@@ -390,6 +424,16 @@ describe("handleRequest — agent-host CORS preflight (#15347)", () => {
       fakeReq("GET", "cp-internal.example"),
     );
     expect(res.status).toBe(404);
+  });
+
+  it("OPTIONS from an untrusted Origin does not reflect credentials", async () => {
+    const res = await handleRequest(
+      new URL(`http://${HOST}/api/agents`),
+      fakeReq("OPTIONS", HOST, "https://evil.example"),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
   });
 
   it("rejects an untrusted forwarded host instead of falling back to an agent Host", async () => {

--- a/packages/cloud/scripts/admin/daemons/agent-router.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.ts
@@ -7,7 +7,8 @@
  * wildcard subdomain router. Routing requires a persisted headscale_ip by default;
  * legacy bridge-host fallback is opt-in because public host + dynamic port
  * metadata is not a reliable ingress target after the Hetzner/control-plane
- * split.
+ * split. Browser CORS on this hop is first-party + credentials only — an
+ * untrusted Origin is not reflected.
  *
  * Usage:
  *   npx tsx packages/cloud/scripts/admin/daemons/agent-router.ts
@@ -23,6 +24,11 @@ import * as path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import {
+  APP_SCHEME_ORIGIN_RE,
+  CAPACITOR_WEBVIEW_ORIGIN,
+  isLocalDevLoopbackOrigin,
+} from "../../../shared/src/lib/cors-constants.ts";
 import { loadLocalEnv } from "./shared/load-env";
 
 type Logger = typeof import("@elizaos/cloud-shared/lib/utils/logger").logger;
@@ -321,23 +327,74 @@ export function buildProxyHeaders(
 }
 
 /**
+ * First-party dashboard / app origins that may ride cookies across the nginx
+ * agent-host hop. Tenant agent subdomains are intentionally absent: they must
+ * not borrow a visitor's Cloud session against a different agent. Same list
+ * family as `packages/cloud/shared/src/lib/utils/cors.ts`.
+ */
+const CREDENTIALED_AGENT_ROUTER_ORIGINS = new Set([
+  "https://eliza.app",
+  "https://cloud.eliza.app",
+  "https://staging.eliza.app",
+  "https://cloud-staging.eliza.app",
+  "https://eliza.ai",
+  "https://www.eliza.ai",
+  "https://elizacloud.ai",
+  "https://www.elizacloud.ai",
+  "https://app.elizacloud.ai",
+  "https://app-staging.elizacloud.ai",
+  "https://develop.eliza-app.pages.dev",
+  "capacitor://localhost",
+]);
+
+/**
+ * True when `origin` may be reflected with `Allow-Credentials: true`.
+ * `https://evil.example` must stay false — origin + credentials is an
+ * auth-bind (any site can read cookie-authenticated router JSON).
+ */
+export function isCredentialedAgentRouterOrigin(origin: string): boolean {
+  if (CREDENTIALED_AGENT_ROUTER_ORIGINS.has(origin)) return true;
+  if (
+    process.env.NEXT_PUBLIC_APP_URL &&
+    origin === process.env.NEXT_PUBLIC_APP_URL
+  ) {
+    return true;
+  }
+  if (origin === CAPACITOR_WEBVIEW_ORIGIN) return true;
+  if (APP_SCHEME_ORIGIN_RE.test(origin)) return true;
+  if (isLocalDevLoopbackOrigin(origin)) {
+    return process.env.ENVIRONMENT !== "production";
+  }
+  return false;
+}
+
+/**
  * CORS headers for the browser-facing agent-proxy path. nginx forwards the
  * request here verbatim and injects nothing, so an error we return with no
  * `access-control-allow-origin` reaches the browser as an opaque
  * "No 'Access-Control-Allow-Origin'" failure that hides the real status (#15347).
- * The agent's own responses already carry CORS (its `resolveCorsOrigin` reflects
- * any origin when provisioned), so we mirror that by reflecting the caller's
- * Origin — `*` only for a header-less (non-browser) caller, where credentials
- * are moot.
+ *
+ * Credentialed reflection is first-party only. A missing Origin (non-browser)
+ * still gets `*` without credentials. An untrusted Origin gets Vary and the
+ * method/header allow-list but no ACAO — fail closed, no cookie ride.
  */
-function corsHeaders(origin: string | undefined): Record<string, string> {
-  return {
-    "access-control-allow-origin": origin || "*",
+export function corsHeaders(
+  origin: string | undefined,
+): Record<string, string> {
+  const headers: Record<string, string> = {
     vary: "origin",
-    "access-control-allow-credentials": "true",
     "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
     "access-control-allow-headers": "authorization,content-type,x-api-key",
   };
+  if (!origin) {
+    headers["access-control-allow-origin"] = "*";
+    return headers;
+  }
+  if (isCredentialedAgentRouterOrigin(origin)) {
+    headers["access-control-allow-origin"] = origin;
+    headers["access-control-allow-credentials"] = "true";
+  }
+  return headers;
 }
 
 /**


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone credentialed CORS reflection on the nginx agent-router hop.
`corsHeaders` echoed any `Origin` with `Allow-Credentials: true`, so a
foreign page could read cookie-authenticated router JSON. Not a twin of
`#22311` (VFS ReDoS), `#22308` (Smithers lines), `#22306`/`#22303`/`#22302`,
`#22278`, `#22262`, or the fetch-timeout family. HARD_SKIP is cloud JSON
route reprints, not this daemon. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] First-party last-fit / evil-origin reject proved at this head.
- [x] A reviewer can confirm origin reflected `https://evil.example` with
      credentials and the head no longer does.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `de026436678c` with zero conflicts.
- [x] Exact-head helper + 27/27 `agent-router.test.ts` (including the new
      untrusted-Origin cases).
- [x] Biome format clean on the two touched files.

# Risks

Low and bounded to `packages/cloud/scripts/admin/daemons/agent-router.ts`.
First-party dashboard / app origins still get credentialed reflection
(same allowlist family as `cloud-shared` `getCorsHeaders`). Untrusted
origins get `Vary: Origin` but no ACAO, so a hostile page cannot read
the body. Header-less (non-browser) callers still get `*` without
credentials. Tenant agent subdomains are not first-party — they must not
borrow a Cloud session against a different agent.

# Background

## What does this PR do?

`corsHeaders(origin)` did:

```ts
"access-control-allow-origin": origin || "*",
"access-control-allow-credentials": "true",
```

nginx forwards the agent-host request here verbatim. Any site that can
make the victim's browser send a request to `*.cloud.eliza.app` received
a reflected ACAO plus credentials — the classic CORS auth-bind.

This allowlists first-party origins (eliza.app / cloud.eliza.app /
legacy elizacloud.ai / Capacitor / app schemes / non-production
loopback). Untrusted Origins are not reflected.

## What kind of change is this?

Bug fix (auth-bind / CORS).

# Documentation changes needed?

No public HTTP API change. Hostile origins now see an opaque CORS
failure instead of readable credentialed JSON.

# Testing

## Where should a reviewer start?

`corsHeaders` / `isCredentialedAgentRouterOrigin` in `agent-router.ts`
and the new cases in `agent-router.test.ts`.

## Detailed testing steps

```bash
bun test packages/cloud/scripts/admin/daemons/agent-router.test.ts
```

Origin: `corsHeaders("https://evil.example")` → ACAO evil + credentials.
Head: ACAO omitted; `https://cloud.eliza.app` still reflected +
credentials; missing Origin still `*` without credentials.

# Evidence Gate

<!-- evidence-head:9e5acc9372785aca30b626dc23f720564a3c468b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated helper + unit proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CORS header policy only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin helper reflected `https://evil.example` with credentials.
      Head reject / first-party last-fit / 27/27 unit tests at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route in the app UI.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Focused
`agent-router.test.ts` is 27/27 at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
