### PR TITLE
fix(agent): time out hung audio-redaction ffmpeg/ffprobe children

### DIFF
--- a/packages/agent/src/api/audio-redaction-child.test.ts
+++ b/packages/agent/src/api/audio-redaction-child.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Isolated hang/overflow tests for the audio-redaction child runner. Spawns
+ * real `sleep` / `node` processes; does not import ffmpeg or the media store.
+ */
+import { describe, expect, it } from "vitest";
+import { runAudioRedactionChild } from "./audio-redaction-child.ts";
+
+describe("runAudioRedactionChild", () => {
+  it("kills a hung child at the timeout instead of waiting forever", async () => {
+    const startedAt = Date.now();
+    await expect(
+      runAudioRedactionChild("sleep", ["8"], { timeoutMs: 200 }),
+    ).rejects.toMatchObject({
+      name: "AudioRedactionChildError",
+      code: "AUDIO_REDACTION_TIMEOUT",
+    });
+    expect(Date.now() - startedAt).toBeLessThan(1500);
+  });
+
+  it("rejects a child that dumps more than the stdio budget", async () => {
+    await expect(
+      runAudioRedactionChild(
+        process.execPath,
+        ["-e", "process.stdout.write('x'.repeat(4096))"],
+        { timeoutMs: 2000, maxStdioBytes: 1024 },
+      ),
+    ).rejects.toMatchObject({
+      name: "AudioRedactionChildError",
+      code: "AUDIO_REDACTION_STDIO_OVERFLOW",
+    });
+  });
+
+  it("returns stdout from a last-fit short child", async () => {
+    const result = await runAudioRedactionChild(
+      process.execPath,
+      ["-e", "process.stdout.write('ok')"],
+      { timeoutMs: 2000, maxStdioBytes: 1024 },
+    );
+    expect(result).toMatchObject({ code: 0, stdout: "ok" });
+  });
+});

--- a/packages/agent/src/api/audio-redaction-child.ts
+++ b/packages/agent/src/api/audio-redaction-child.ts
@@ -1,0 +1,98 @@
+/**
+ * Timed, stdio-capped spawn used by the audio-redaction ffmpeg/ffprobe lane.
+ *
+ * Origin `run()` waited forever on a hung child and concatenated every stdout
+ * and stderr byte. A crafted or stuck container (or a replica `sleep`) never
+ * returns. The timeout SIGKILLs the child; an oversize pipe fails closed
+ * instead of growing for the whole timeout window.
+ */
+
+import { spawn } from "node:child_process";
+
+/** Default wall-clock budget for one ffprobe/ffmpeg invocation. */
+export const AUDIO_REDACTION_CHILD_TIMEOUT_MS = 30_000;
+
+/** Combined stdout+stderr budget before the child is killed. */
+export const MAX_AUDIO_REDACTION_STDIO_BYTES = 1_048_576;
+
+export type AudioRedactionChildResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type AudioRedactionChildErrorCode =
+  | "AUDIO_REDACTION_TIMEOUT"
+  | "AUDIO_REDACTION_STDIO_OVERFLOW";
+
+export class AudioRedactionChildError extends Error {
+  readonly code: AudioRedactionChildErrorCode;
+
+  constructor(message: string, code: AudioRedactionChildErrorCode) {
+    super(message);
+    this.name = "AudioRedactionChildError";
+    this.code = code;
+  }
+}
+
+/**
+ * Spawn `bin` and collect utf8 stdio until exit, timeout, or the byte cap.
+ */
+export function runAudioRedactionChild(
+  bin: string,
+  args: readonly string[],
+  options: { timeoutMs?: number; maxStdioBytes?: number } = {},
+): Promise<AudioRedactionChildResult> {
+  const timeoutMs = options.timeoutMs ?? AUDIO_REDACTION_CHILD_TIMEOUT_MS;
+  const maxStdioBytes =
+    options.maxStdioBytes ?? MAX_AUDIO_REDACTION_STDIO_BYTES;
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { windowsHide: true });
+    let stdout = "";
+    let stderr = "";
+    let stdioBytes = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      fail(
+        new AudioRedactionChildError(
+          `audio redaction child timed out after ${timeoutMs}ms`,
+          "AUDIO_REDACTION_TIMEOUT",
+        ),
+      );
+    }, timeoutMs);
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(error);
+    };
+
+    const append = (target: "stdout" | "stderr", chunk: Buffer) => {
+      stdioBytes += chunk.byteLength;
+      if (stdioBytes > maxStdioBytes) {
+        fail(
+          new AudioRedactionChildError(
+            `audio redaction child exceeded ${maxStdioBytes} bytes of stdio`,
+            "AUDIO_REDACTION_STDIO_OVERFLOW",
+          ),
+        );
+        return;
+      }
+      const text = chunk.toString("utf8");
+      if (target === "stdout") stdout += text;
+      else stderr += text;
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
+    child.once("error", fail);
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}

--- a/packages/agent/src/api/audio-redaction.ts
+++ b/packages/agent/src/api/audio-redaction.ts
@@ -28,16 +28,20 @@
  * error (WAV keeps working via the pure-TS lane), and any post-redaction
  * duration drift beyond the per-container tolerance throws
  * `AUDIO_REDACTION_DURATION_DRIFT` instead of storing a variant whose anchors
- * would lie.
+ * would lie. The ffmpeg/ffprobe child is timed and stdio-capped so a hung
+ * binary cannot pin the agent process.
  */
 
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { ElizaError, logger } from "@elizaos/core";
 import type { AudioRedactionSpan } from "@elizaos/shared/audio-redaction";
+import {
+  AudioRedactionChildError,
+  runAudioRedactionChild,
+} from "./audio-redaction-child.ts";
 
 /** How a window is made inaudible. */
 export type AudioRedactionMode = "mute" | "bleep";
@@ -344,46 +348,17 @@ interface SpawnResult {
   stderr: string;
 }
 
-function run(bin: string, args: readonly string[]): Promise<SpawnResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(bin, args, { windowsHide: true });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    const rejectOnce = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    };
-    const stdoutEnded = new Promise<void>((streamResolve, streamReject) => {
-      child.stdout.once("end", streamResolve);
-      child.stdout.once("error", streamReject);
-    });
-    const stderrEnded = new Promise<void>((streamResolve, streamReject) => {
-      child.stderr.once("end", streamResolve);
-      child.stderr.once("error", streamReject);
-    });
-    const closed = new Promise<number | null>((closeResolve) => {
-      child.once("close", closeResolve);
-    });
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.once("error", rejectOnce);
-    Promise.all([closed, stdoutEnded, stderrEnded])
-      .then(([code]) => {
-        if (settled) return;
-        settled = true;
-        resolve({ code, stdout, stderr });
-      })
-      .catch((error: unknown) => {
-        // error-policy:J2 Preserve subprocess stream failures for the caller.
-        rejectOnce(error instanceof Error ? error : new Error(String(error)));
-      });
-  });
+async function run(bin: string, args: readonly string[]): Promise<SpawnResult> {
+  try {
+    return await runAudioRedactionChild(bin, args);
+  } catch (error) {
+    // error-policy:J2 wrap the isolated child failure as the typed domain error
+    // the redaction lanes already surface to callers.
+    if (error instanceof AudioRedactionChildError) {
+      throw new ElizaError(error.message, { code: error.code });
+    }
+    throw error;
+  }
 }
 
 /** Probed stream geometry of an audio file. */


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone ffmpeg/ffprobe process hang in audio PII redaction. Origin `run()`
spawned the child with no timeout and concatenated every stdio byte. Not a
twin of `#22308` (Smithers NDJSON lines), `#22311` (VFS ReDoS), `#22315`
(CORS), `#22306`/`#22303`/`#22302`, `#22278`, `#22262`, or the HTTP
fetch-timeout family. HARD_SKIP is cloud `voice/tts/route.ts`, not this
executor. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Timeout / last-fit / stdio-overflow proved at this head.
- [x] A reviewer can confirm origin `sleep 8` was still running at 1.5s
      and the head kills at 200ms.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `de026436678c` with zero conflicts.
- [x] Isolated helper tests 3/3 at this head.
- [x] Biome on the three touched files: clean.

# Risks

Low and bounded to the ffmpeg/ffprobe spawn used by the lossy-container
redaction lane. A hung or bomb child now throws
`AUDIO_REDACTION_TIMEOUT` / `AUDIO_REDACTION_STDIO_OVERFLOW` instead of
pinning the agent. Legitimate probes stay tiny JSON and finish in
milliseconds. The pure-TS WAV lane is unchanged.

# Background

## What does this PR do?

`probeAudioFile` / the ffmpeg filtergraph lane called an internal `run()`
that `spawn`ed ffprobe/ffmpeg and waited for `close` with **no timeout**
and unbounded `stdout +=` / `stderr +=`. Origin replica of that shape:
`sleep 8` was still running at 1509ms.

This extracts `runAudioRedactionChild` with
`AUDIO_REDACTION_CHILD_TIMEOUT_MS = 30_000` (SIGKILL) and
`MAX_AUDIO_REDACTION_STDIO_BYTES = 1_048_576`.

## What kind of change is this?

Bug fix (process hang / overflow).

# Documentation changes needed?

No public HTTP API change. Oversized or hung ffmpeg/ffprobe is a new
typed error on the existing redaction path.

# Testing

## Where should a reviewer start?

`runAudioRedactionChild` in `audio-redaction-child.ts` and
`audio-redaction-child.test.ts`. Wiring is `run()` in `audio-redaction.ts`.

## Detailed testing steps

```bash
bun test packages/agent/src/api/audio-redaction-child.test.ts
```

Origin: `sleep 8` still running at 1.5s. Head: 200ms timeout; 4 KiB dump
overflows a 1 KiB cap; `ok` last-fit.

# Evidence Gate

<!-- evidence-head:e8c64e84eb32b37ffb106fb9874df9538e18c1d8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated child proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - ffmpeg spawn only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin `sleep 8` still-running at 1509ms. Head timeout / overflow /
      last-fit helper proof at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - redaction executor only; no voice UX change.

## Known gaps / failures

Worktree cannot run the full `audio-redaction.test.ts` suite (core import
graph). Isolated child tests 3/3 and `bun -e` helper proof are the
recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
