### PR TITLE
fix(plugin-matrix): time out hung initial PREPARED sync

### DIFF
--- a/plugins/plugin-matrix/src/__tests__/matrix-sync.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/matrix-sync.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Isolated PREPARED-wait tests for Matrix connect. Uses a fake emitter; no
+ * live homeserver and no MatrixService boot.
+ */
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { waitForMatrixPrepared } from "../matrix-sync.js";
+import { MatrixSyncTimeoutError } from "../types.js";
+
+describe("waitForMatrixPrepared", () => {
+  it("resolves when PREPARED arrives before the budget", async () => {
+    const client = new EventEmitter();
+    const pending = waitForMatrixPrepared(client, "sync", 500);
+    queueMicrotask(() => client.emit("sync", "PREPARED"));
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("rejects a hung homeserver that never emits PREPARED", async () => {
+    const client = new EventEmitter();
+    const startedAt = Date.now();
+    await expect(waitForMatrixPrepared(client, "sync", 80)).rejects.toBeInstanceOf(
+      MatrixSyncTimeoutError
+    );
+    expect(Date.now() - startedAt).toBeLessThan(400);
+  });
+});

--- a/plugins/plugin-matrix/src/matrix-sync.ts
+++ b/plugins/plugin-matrix/src/matrix-sync.ts
@@ -1,0 +1,47 @@
+/**
+ * Timed wait for the Matrix client's first PREPARED sync.
+ *
+ * `connect()` used to `startClient` then wait forever for that event. A
+ * hung or accept-and-hold homeserver never emits PREPARED, so service
+ * initialize never returns. Origin replica of that waiter stayed pending
+ * past 400ms.
+ */
+
+import { MatrixSyncTimeoutError } from "./types.js";
+
+/** Default wall-clock budget for the first PREPARED after startClient. */
+export const MATRIX_INITIAL_SYNC_TIMEOUT_MS = 30_000;
+
+export interface MatrixSyncEmitter {
+  on(event: string, listener: (syncState: string) => void): void;
+  removeListener(event: string, listener: (syncState: string) => void): void;
+}
+
+/**
+ * Resolve when `syncEvent` reports PREPARED; reject with
+ * {@link MatrixSyncTimeoutError} if the budget elapses first.
+ */
+export function waitForMatrixPrepared(
+  client: MatrixSyncEmitter,
+  syncEvent: string,
+  timeoutMs: number = MATRIX_INITIAL_SYNC_TIMEOUT_MS
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      client.removeListener(syncEvent, listener);
+      if (error) reject(error);
+      else resolve();
+    };
+    const listener = (syncState: string) => {
+      if (syncState === "PREPARED") finish();
+    };
+    const timer = setTimeout(() => {
+      finish(new MatrixSyncTimeoutError(`Matrix initial sync timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    client.on(syncEvent, listener);
+  });
+}

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -2,6 +2,8 @@
  * Matrix service implementation for ElizaOS.
  *
  * This service provides Matrix messaging capabilities using matrix-js-sdk.
+ * Initial `/sync` waits for PREPARED with a wall-clock budget so a hung
+ * homeserver cannot pin `initialize()`.
  */
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
@@ -48,6 +50,7 @@ import {
   resolveDefaultMatrixAccountId,
   resolveMatrixAccountSettings,
 } from "./accounts.js";
+import { waitForMatrixPrepared } from "./matrix-sync.js";
 import {
   getMatrixLocalpart,
   type IMatrixService,
@@ -1425,16 +1428,7 @@ export class MatrixService extends Service implements IMatrixService {
     await state.client.startClient({ initialSyncLimit: 10 });
     state.connected = true;
 
-    // Wait for initial sync
-    await new Promise<void>((resolve) => {
-      const listener = (syncState: string) => {
-        if (syncState === "PREPARED") {
-          state.client.removeListener(sdk.ClientEvent.Sync, listener);
-          resolve();
-        }
-      };
-      state.client.on(sdk.ClientEvent.Sync, listener);
-    });
+    await waitForMatrixPrepared(state.client, sdk.ClientEvent.Sync);
 
     // Join configured rooms
     for (const room of state.settings.rooms) {

--- a/plugins/plugin-matrix/src/types.ts
+++ b/plugins/plugin-matrix/src/types.ts
@@ -349,3 +349,11 @@ export class MatrixApiError extends MatrixPluginError {
     this.errcode = errcode;
   }
 }
+
+/** Error when the initial `/sync` never reaches PREPARED. */
+export class MatrixSyncTimeoutError extends MatrixPluginError {
+  constructor(message: string = "Matrix initial sync timed out") {
+    super(message);
+    this.name = "MatrixSyncTimeoutError";
+  }
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone Matrix service-start hang: `connect()` waited forever for the
first `PREPARED` sync. Not a twin of `#22320` (ffmpeg child), `#22308`
(Smithers lines), `#22311` (VFS ReDoS), `#22315` (CORS), `#22306`,
`#22303`, `#22278`, `#22262`, `#22282`, or the HTTP fetch-timeout family.
Not an ASI `#1874` reprint. HARD_SKIP has no Matrix service path. No
invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] PREPARED last-fit / timeout proved at this head.
- [x] A reviewer can confirm origin's waiter stayed pending at 401ms.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `ae395884285b` with zero conflicts.
- [x] Isolated helper tests 2/2 at this head.
- [x] Biome on the four touched files: clean.

# Risks

Low and bounded to `MatrixService.connect`. A homeserver that never
emits `PREPARED` now fails with `MatrixSyncTimeoutError` after 30s
instead of pinning plugin initialize. A healthy first sync still
resolves on `PREPARED`. `startClient` itself is unchanged.

# Background

## What does this PR do?

`connect()` did `startClient({ initialSyncLimit: 10 })` then:

```ts
await new Promise<void>((resolve) => {
  const listener = (syncState: string) => {
    if (syncState === "PREPARED") resolve();
  };
  state.client.on(sdk.ClientEvent.Sync, listener);
});
```

Origin replica of that waiter stayed **still-running at 401ms** when no
event fired. `initialize()` awaits `connect()`, so a hung homeserver
never finishes service start.

This extracts `waitForMatrixPrepared` with
`MATRIX_INITIAL_SYNC_TIMEOUT_MS = 30_000`.

## What kind of change is this?

Bug fix (process hang).

# Documentation changes needed?

No public HTTP API change. A hung initial sync is a new typed error.

# Testing

## Where should a reviewer start?

`waitForMatrixPrepared` in `matrix-sync.ts` and
`__tests__/matrix-sync.test.ts`. Wiring is `connect()` in `service.ts`.

## Detailed testing steps

```bash
bunx vitest run plugins/plugin-matrix/src/__tests__/matrix-sync.test.ts --coverage.enabled=false
```

Origin: waiter still pending at 401ms. Head: fake emitter PREPARED
resolves; 80ms budget rejects `MatrixSyncTimeoutError` in <400ms.

# Evidence Gate

<!-- evidence-head:1063edf6729cd639d8a96d9490b0936baa231f56 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated emitter proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - sync waiter only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin waiter still-running at 401ms. Head last-fit / timeout
      helper proof at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated
PREPARED-wait tests 2/2 are the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
