### PR TITLE
fix(plugin-native-canvas): accept eval replies only from the web view

### DIFF
--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -162,3 +162,34 @@ describe("CanvasWeb validation", () => {
     },
   );
 });
+
+describe("CanvasWeb eval message source", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("ignores a spoofed eliza:evalResult from a window that is not the web view", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "about:blank" });
+    const iframe = document.querySelector("iframe");
+    const webView = iframe?.contentWindow;
+    expect(webView).toBeTruthy();
+
+    const evalPromise = canvas.eval({ script: "1+1" });
+    // Same-page attacker: window.postMessage delivers source === window.
+    window.postMessage({ type: "eliza:evalResult", result: "pwned" }, "*");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "eliza:evalResult", result: "2" },
+        origin: "null",
+        source: webView,
+      }),
+    );
+
+    await expect(evalPromise).resolves.toEqual({ result: "2" });
+  });
+});

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -5,7 +5,8 @@
  * `<canvas>` elements (composited as absolute-positioned DOM siblings so
  * z-ordering follows CSS `z-index`) and backs the embedded web view with an
  * iframe (inline/fullscreen) or a `window.open` popup, including the
- * `eliza://` deep-link intercept and the A2UI postMessage bridge.
+ * `eliza://` deep-link intercept and the A2UI postMessage bridge. Eval
+ * replies are accepted only from the web-view window that received the script.
  */
 
 import { WebPlugin } from "@capacitor/core";
@@ -1163,8 +1164,14 @@ export class CanvasWeb extends WebPlugin {
       }, timeoutMs);
 
       const handler = (event: MessageEvent) => {
-        const msg = event.data as WebViewIncomingMessage;
-        if (msg?.type === "eliza:evalResult" && msg.result !== undefined) {
+        // The request is posted with targetOrigin "*". Any same-page window
+        // can therefore emit `eliza:evalResult`; only the web view that
+        // received the script is allowed to complete this eval.
+        if (event.source !== target) return;
+        const data = event.data;
+        if (!data || typeof data !== "object") return;
+        const msg = data as WebViewIncomingMessage;
+        if (msg.type === "eliza:evalResult" && msg.result !== undefined) {
           clearTimeout(timeout);
           window.removeEventListener("message", handler);
           resolve({ result: String(msg.result) });


### PR DESCRIPTION
## Summary
- `CanvasWeb.evalViaPostMessage` posted `{type:"eliza:eval"}` with `targetOrigin: "*"` and then treated **any** window `message` of type `eliza:evalResult` as the script result.
- A same-page attacker (`window.postMessage({type:"eliza:evalResult",result:"pwned"},"*")`) could complete `eval()` with a spoofed value. That is an auth-bind on the web-view eval channel, not leftover-tax / timeout / extra-decode.
- Bind the reply to `event.source ===` the web-view window that received the script. Object-shaped payloads only.

## What Changed
- `plugins/plugin-native-canvas/src/web.ts` — `evalViaPostMessage` ignores messages whose `source` is not the target web view.
- `plugins/plugin-native-canvas/src/web.test.ts` — spoof from `window` is ignored; only a `MessageEvent` sourced at the iframe window resolves.

## Exact-head evidence
Head: `4932fe62b122931ab81bc08357e156e4a85d7116`
Base: `origin/develop@9af374938212f5481975f067fd0cbc06d30e3fb6`
Occupancy: `scannedAt=2026-08-19T03:10:30.176Z` — `plugins/plugin-native-canvas/src/web.ts` FREE.

## Red / green
On origin the listener had no `event.source` check. After this head:

```text
bun run --cwd plugins/plugin-native-canvas test src/web.test.ts
# Test Files  1 passed; Tests  17 passed
```

The new case posts a spoofed `eliza:evalResult` from `window` (would have resolved `"pwned"`), then a real event from the iframe `contentWindow`, and expects `{ result: "2" }`.

## Verification
- [x] Targets `develop`
- [x] Focused vitest 17/17
- [x] `biome check` on both files — clean
- [x] Not `#22262`. Not timeout-family. Not 21’s E-list. Not a twin of `#22302`–`#22328`.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — jsdom postMessage source bind; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4932fe62b122931ab81bc08357e156e4a85d7116 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-issues-ladder]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
