### PR TITLE
fix(corpus-tools): reject X-archive zip bombs before unzipSync

### DIFF
--- a/packages/corpus-tools/src/collectors/x-archive.test.ts
+++ b/packages/corpus-tools/src/collectors/x-archive.test.ts
@@ -9,7 +9,12 @@ import path from "node:path";
 import { zipSync } from "fflate";
 import { afterEach, describe, expect, it } from "vitest";
 import { validateCorpusTarget } from "../validator.ts";
-import { collectXArchive } from "./x-archive.ts";
+import {
+  assertXArchiveZipFileSize,
+  collectXArchive,
+  MAX_X_ARCHIVE_UNCOMPRESSED_BYTES,
+  MAX_X_ARCHIVE_ZIP_BYTES,
+} from "./x-archive.ts";
 
 const FIXTURE_DIR = path.join(import.meta.dirname, "../../fixtures/x-archive");
 const OWNER = "7777";
@@ -227,4 +232,110 @@ describe("collectXArchive", () => {
       collectXArchive({ archivePath: badJson, ownerAccountId: OWNER, outDir }),
     ).rejects.toMatchObject({ code: "X_ARCHIVE_BAD_JSON" });
   });
+
+  it("rejects a ZIP whose forged central directory declares a huge entry", async () => {
+    const zipPath = path.join(await makeTempDir(), "bomb.zip");
+    const forged = forgeUncompressedSizes(
+      await zipFixtureBytes(),
+      MAX_X_ARCHIVE_UNCOMPRESSED_BYTES + 1,
+    );
+    await fs.writeFile(zipPath, forged);
+    await expect(
+      collectXArchive({
+        archivePath: zipPath,
+        ownerAccountId: OWNER,
+        outDir: await makeTempDir(),
+      }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_ZIP_TOO_LARGE" });
+  });
+
+  it("rejects when the sum of declared entry sizes exceeds the cap", async () => {
+    const zipPath = path.join(await makeTempDir(), "sum-bomb.zip");
+    const perEntry = Math.floor(MAX_X_ARCHIVE_UNCOMPRESSED_BYTES / 2) + 1;
+    const forged = forgeUncompressedSizes(await zipFixtureBytes(), perEntry);
+    await fs.writeFile(zipPath, forged);
+    await expect(
+      collectXArchive({
+        archivePath: zipPath,
+        ownerAccountId: OWNER,
+        outDir: await makeTempDir(),
+      }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_ZIP_TOO_LARGE" });
+  });
+
+  it("rejects a buffer that is not a ZIP archive", async () => {
+    const zipPath = path.join(await makeTempDir(), "not.zip");
+    await fs.writeFile(zipPath, "this is not a zip file at all");
+    await expect(
+      collectXArchive({
+        archivePath: zipPath,
+        ownerAccountId: OWNER,
+        outDir: await makeTempDir(),
+      }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_ZIP_INVALID" });
+  });
+
+  it("rejects a ZIP whose on-disk size exceeds the compressed cap", () => {
+    try {
+      assertXArchiveZipFileSize(MAX_X_ARCHIVE_ZIP_BYTES + 1, "huge.zip");
+      expect.fail("expected compressed-size rejection");
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "X_ARCHIVE_ZIP_TOO_LARGE",
+        context: {
+          archivePath: "huge.zip",
+          declaredBytes: MAX_X_ARCHIVE_ZIP_BYTES + 1,
+          maxBytes: MAX_X_ARCHIVE_ZIP_BYTES,
+        },
+      });
+    }
+    expect(() =>
+      assertXArchiveZipFileSize(MAX_X_ARCHIVE_ZIP_BYTES, "ok.zip"),
+    ).not.toThrow();
+  });
 });
+
+/**
+ * Overwrite the uncompressed-size field of every central-directory entry,
+ * simulating a zip whose declared sizes do not match its real payload.
+ */
+function forgeUncompressedSizes(zip: Uint8Array, size: number): Uint8Array {
+  const out = new Uint8Array(zip);
+  const view = new DataView(out.buffer, out.byteOffset, out.byteLength);
+  let eocd = -1;
+  for (let i = out.length - 22; i >= 0; i--) {
+    if (
+      out[i] === 0x50 &&
+      out[i + 1] === 0x4b &&
+      out[i + 2] === 0x05 &&
+      out[i + 3] === 0x06
+    ) {
+      eocd = i;
+      break;
+    }
+  }
+  expect(eocd).toBeGreaterThanOrEqual(0);
+  const entryCount = view.getUint16(eocd + 10, true);
+  let offset = view.getUint32(eocd + 16, true);
+  for (let i = 0; i < entryCount; i++) {
+    expect(view.getUint32(offset, true)).toBe(0x02014b50);
+    view.setUint32(offset + 24, size, true);
+    offset +=
+      46 +
+      view.getUint16(offset + 28, true) +
+      view.getUint16(offset + 30, true) +
+      view.getUint16(offset + 32, true);
+  }
+  return out;
+}
+
+async function zipFixtureBytes(): Promise<Uint8Array> {
+  const dataDir = path.join(FIXTURE_DIR, "data");
+  const entries: Record<string, Uint8Array> = {};
+  for (const name of await fs.readdir(dataDir)) {
+    entries[`data/${name}`] = new Uint8Array(
+      await fs.readFile(path.join(dataDir, name)),
+    );
+  }
+  return zipSync(entries);
+}

--- a/packages/corpus-tools/src/collectors/x-archive.ts
+++ b/packages/corpus-tools/src/collectors/x-archive.ts
@@ -10,8 +10,10 @@
  * root within the archive; DMs map per conversation with direction derived from
  * senderId versus the owner id. Likes carry no timestamps in the archive, so
  * they are counted in the summary but never fabricated into message rows.
- * Raw archives belong under the gitignored `data/` tree; only synthetic
- * fixtures are committed.
+ * ZIP archives are rejected from the central directory before `unzipSync`
+ * materializes entries: a compressed zeros bomb otherwise expands to its
+ * declared size in process memory. Raw archives belong under the gitignored
+ * `data/` tree; only synthetic fixtures are committed.
  */
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
@@ -66,6 +68,18 @@ interface ArchiveFileSource {
 }
 
 const YTD_PREFIX = /^\s*window\.YTD\.[\w-]+\.part\d+\s*=\s*/;
+
+/**
+ * Compressed ZIP on disk. Official X archives sit well under this; a multi-GiB
+ * file would be allocated by `readFile` before any entry filter runs.
+ */
+export const MAX_X_ARCHIVE_ZIP_BYTES = 1 * 1024 * 1024 * 1024;
+
+/**
+ * Sum of central-directory uncompressed sizes. `unzipSync` materializes every
+ * matching entry at its declared size, so this is the peak allocation.
+ */
+export const MAX_X_ARCHIVE_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024;
 
 function stripYtdPrefix(fileName: string, raw: string): string {
   if (!YTD_PREFIX.test(raw)) {
@@ -133,10 +147,12 @@ async function openArchive(archivePath: string): Promise<ArchiveFileSource> {
       },
     };
   }
-  const bytes = await fs.readFile(archivePath);
+  assertXArchiveZipFileSize(stat.size, archivePath);
+  const zipBytes: Uint8Array = await fs.readFile(archivePath);
+  assertXArchiveZipUncompressedSize(zipBytes);
   let files: Record<string, Uint8Array>;
   try {
-    files = unzipSync(new Uint8Array(bytes), {
+    files = unzipSync(zipBytes, {
       filter: (file) =>
         file.name.startsWith("data/") && file.name.endsWith(".js"),
     });
@@ -162,6 +178,106 @@ async function openArchive(archivePath: string): Promise<ArchiveFileSource> {
 /** Matches `tweets.js`, `tweets-part1.js`, ... for baseName `tweets`. */
 function matchesPart(fileName: string, baseName: string): boolean {
   return new RegExp(`^${baseName}(-part\\d+)?\\.js$`).test(fileName);
+}
+
+/** Reject a ZIP whose on-disk size would be allocated by `readFile`. */
+export function assertXArchiveZipFileSize(
+  size: number,
+  archivePath?: string,
+): void {
+  if (size > MAX_X_ARCHIVE_ZIP_BYTES) {
+    throw new ElizaError(
+      archivePath
+        ? `X archive ZIP ${archivePath} exceeds the compressed size limit`
+        : "X archive ZIP exceeds the compressed size limit",
+      {
+        code: "X_ARCHIVE_ZIP_TOO_LARGE",
+        context: {
+          ...(archivePath ? { archivePath } : {}),
+          declaredBytes: size,
+          maxBytes: MAX_X_ARCHIVE_ZIP_BYTES,
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Sum the uncompressed sizes declared in the ZIP central directory and reject
+ * archives over MAX_X_ARCHIVE_UNCOMPRESSED_BYTES before `unzipSync` runs.
+ * Zip64 is rejected: a corpus archive under the 1 GiB compressed cap never
+ * needs it, and the 32-bit size fields would otherwise under-count a bomb.
+ */
+export function assertXArchiveZipUncompressedSize(zipBuffer: Uint8Array): void {
+  const data = zipBuffer;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  let eocd = -1;
+  const scanFloor = Math.max(0, data.length - 22 - 0xffff);
+  for (let i = data.length - 22; i >= scanFloor; i--) {
+    if (
+      data[i] === 0x50 &&
+      data[i + 1] === 0x4b &&
+      data[i + 2] === 0x05 &&
+      data[i + 3] === 0x06
+    ) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) {
+    throw new ElizaError("X archive ZIP is not a valid archive", {
+      code: "X_ARCHIVE_ZIP_INVALID",
+      context: { reason: "end of central directory not found" },
+    });
+  }
+
+  const entryCount = view.getUint16(eocd + 10, true);
+  const cdOffset = view.getUint32(eocd + 16, true);
+  if (entryCount === 0xffff || cdOffset === 0xffffffff) {
+    throw new ElizaError("X archive ZIP uses zip64, which is not supported", {
+      code: "X_ARCHIVE_ZIP_INVALID",
+      context: { reason: "zip64 central directory" },
+    });
+  }
+
+  let totalUncompressed = 0;
+  let offset = cdOffset;
+  for (let i = 0; i < entryCount; i++) {
+    if (
+      offset + 46 > data.length ||
+      view.getUint32(offset, true) !== 0x02014b50
+    ) {
+      throw new ElizaError("X archive ZIP is not a valid archive", {
+        code: "X_ARCHIVE_ZIP_INVALID",
+        context: { reason: "malformed central directory entry", entryIndex: i },
+      });
+    }
+    const declared = view.getUint32(offset + 24, true);
+    if (declared === 0xffffffff) {
+      throw new ElizaError("X archive ZIP uses zip64, which is not supported", {
+        code: "X_ARCHIVE_ZIP_INVALID",
+        context: { reason: "zip64 uncompressed size", entryIndex: i },
+      });
+    }
+    totalUncompressed += declared;
+    if (totalUncompressed > MAX_X_ARCHIVE_UNCOMPRESSED_BYTES) {
+      throw new ElizaError(
+        "X archive ZIP expands beyond the uncompressed size limit",
+        {
+          code: "X_ARCHIVE_ZIP_TOO_LARGE",
+          context: {
+            declaredBytes: totalUncompressed,
+            maxBytes: MAX_X_ARCHIVE_UNCOMPRESSED_BYTES,
+          },
+        },
+      );
+    }
+    const nameLen = view.getUint16(offset + 28, true);
+    const extraLen = view.getUint16(offset + 30, true);
+    const commentLen = view.getUint16(offset + 32, true);
+    offset += 46 + nameLen + extraLen + commentLen;
+  }
 }
 
 interface RawTweet {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone X-archive ZIP overflow: `collectXArchive` called `unzipSync`
with only a `data/*.js` path filter. Not a twin of `#22296` (skill
package streaming accumulator), `#22302` (plugin-x `arrayBuffer`),
`#22306` (PNG IHDR), `#22308` (Smithers lines), `#22320` (ffmpeg),
`#22328` (Matrix PREPARED), `#22262`, `#22278`, `#22282`, or the HTTP
fetch-timeout family. Not an ASI `#1874` reprint. HARD_SKIP has no
corpus-tools collector path. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Origin `unzipSync` of an 82 KiB / 80 MiB zeros ZIP materialized
      83886080 bytes in 716ms.
- [x] Head rejects forged central-directory bombs before `unzipSync`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `9af374938212` with zero conflicts.
- [x] Isolated collector tests 11/11 at this head.
- [x] Biome on the two touched files: clean.

# Risks

Low and bounded to the official X ZIP ingest path. A legitimate archive
under 1 GiB compressed / 2 GiB declared uncompressed still extracts.
A zip64 or forged huge central directory fails closed with
`X_ARCHIVE_ZIP_TOO_LARGE` / `X_ARCHIVE_ZIP_INVALID` instead of
materializing the declared size. Extracted-directory ingest is
unchanged.

# Background

## What does this PR do?

`openArchive` did:

```ts
const bytes = await fs.readFile(archivePath);
files = unzipSync(new Uint8Array(bytes), {
  filter: (file) =>
    file.name.startsWith("data/") && file.name.endsWith(".js"),
});
```

fflate materializes each matching entry at its declared uncompressed
size. Origin replica: `zipSync({ "data/tweets.js": 80 MiB zeros })` is
81996 bytes compressed; `unzipSync` returned `outBytes=83886080` in
716ms. A multi-gigabyte zeros bomb is the same path with no cap.

This PR stats the ZIP (1 GiB compressed cap), sums central-directory
uncompressed sizes (2 GiB cap; zip64 rejected), and only then calls
`unzipSync`.

## What kind of change is this?

Bug fix (zip-bomb overflow).

# Documentation changes needed?

No public HTTP API change. Hostile archives now throw typed
`ElizaError` codes (`X_ARCHIVE_ZIP_TOO_LARGE`, `X_ARCHIVE_ZIP_INVALID`).

# Testing

## Where should a reviewer start?

`assertXArchiveZipUncompressedSize` / `assertXArchiveZipFileSize` in
`packages/corpus-tools/src/collectors/x-archive.ts` and the four new
cases in `x-archive.test.ts`. Existing fixture ZIP/dir tests still
pass.

## Detailed testing steps

```bash
cd packages/corpus-tools && bun test src/collectors/x-archive.test.ts
```

Origin: 80 MiB zeros ZIP → 83886080 bytes / 716ms. Head: forged
`MAX+1` central-directory sizes reject `X_ARCHIVE_ZIP_TOO_LARGE`
without calling `unzipSync`.

# Evidence Gate

<!-- evidence-head:c4a1d590d54f0b7e5beb618de47deb3da67dfc6a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated collector proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - ZIP budget only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin `unzipSync` of 82 KiB / 80 MiB zeros ZIP materialized
      83886080 bytes in 716ms. Head collector tests 11/11 at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated
collector tests 11/11 are the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
