### PR TITLE
fix(agent): cap mobile DNS fetch inflate before Response enqueue

### DIFF
--- a/packages/agent/src/runtime/mobile-dns-decode-budget.ts
+++ b/packages/agent/src/runtime/mobile-dns-decode-budget.ts
@@ -1,0 +1,32 @@
+/**
+ * Decoded-byte budget for the mobile DNS-pinned fetch wrapper. Gzip/deflate/br
+ * inflate is credited here so a tiny compressed body cannot materialize tens
+ * of megabytes before the Response stream is handed to the caller.
+ */
+
+export const MAX_MOBILE_DNS_DECODED_BYTES = 64 * 1024 * 1024;
+
+export class MobileFetchDecodeBudgetError extends Error {
+  readonly code = "MOBILE_FETCH_DECODE_TOO_LARGE";
+  constructor(
+    readonly decodedBytes: number,
+    readonly maxBytes: number,
+  ) {
+    super(
+      `mobile DNS fetch decoded body exceeded ${maxBytes} bytes (got ${decodedBytes})`,
+    );
+    this.name = "MobileFetchDecodeBudgetError";
+  }
+}
+
+/** Credit one decoded chunk; throw before the caller enqueues past the cap. */
+export function creditDecodedBodyBytes(
+  state: { bytes: number },
+  chunkLength: number,
+  maxBytes = MAX_MOBILE_DNS_DECODED_BYTES,
+): void {
+  state.bytes += chunkLength;
+  if (state.bytes > maxBytes) {
+    throw new MobileFetchDecodeBudgetError(state.bytes, maxBytes);
+  }
+}

--- a/packages/agent/src/runtime/mobile-dns.test.ts
+++ b/packages/agent/src/runtime/mobile-dns.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic coverage for the mobile DNS-pinned fetch decode budget.
+ * The harness is real zlib (gzip of zeros) with no network and no mocked
+ * collaborators. `configureMobileDnsIfNeeded` is a no-op off mobile, so tests
+ * exercise the exported credit helper and a replica of the inflate path.
+ */
+import zlib from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  creditDecodedBodyBytes,
+  MAX_MOBILE_DNS_DECODED_BYTES,
+  MobileFetchDecodeBudgetError,
+} from "./mobile-dns-decode-budget.ts";
+
+function gzipZeros(bytes: number): Buffer {
+  return zlib.gzipSync(Buffer.alloc(bytes, 0));
+}
+
+async function gunzipWithBudget(
+  compressed: Buffer,
+  maxBytes: number,
+): Promise<Buffer> {
+  const gunzip = zlib.createGunzip();
+  const chunks: Buffer[] = [];
+  const budget = { bytes: 0 };
+  await new Promise<void>((resolve, reject) => {
+    gunzip.on("data", (chunk: Buffer) => {
+      try {
+        creditDecodedBodyBytes(budget, chunk.length, maxBytes);
+      } catch (error) {
+        gunzip.destroy();
+        reject(error);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    gunzip.on("end", () => resolve());
+    gunzip.on("error", reject);
+    gunzip.end(compressed);
+  });
+  return Buffer.concat(chunks);
+}
+
+describe("mobile DNS fetch decode budget", () => {
+  it("credits decoded chunks and rejects past the cap before more enqueue", () => {
+    const state = { bytes: 0 };
+    creditDecodedBodyBytes(state, 100, 150);
+    expect(state.bytes).toBe(100);
+    try {
+      creditDecodedBodyBytes(state, 51, 150);
+      expect.fail("expected decode-budget rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MobileFetchDecodeBudgetError);
+      expect(error).toMatchObject({
+        code: "MOBILE_FETCH_DECODE_TOO_LARGE",
+        decodedBytes: 151,
+        maxBytes: 150,
+      });
+    }
+  });
+
+  it("admits a zeros gzip whose decoded size stays inside the budget", async () => {
+    const raw = 256 * 1024;
+    const out = await gunzipWithBudget(gzipZeros(raw), raw);
+    expect(out.length).toBe(raw);
+  });
+
+  it("rejects a zeros gzip bomb before materializing the declared inflate", async () => {
+    const raw = 2 * 1024 * 1024;
+    const compressed = gzipZeros(raw);
+    expect(compressed.length).toBeLessThan(64 * 1024);
+    await expect(
+      gunzipWithBudget(compressed, 512 * 1024),
+    ).rejects.toMatchObject({
+      code: "MOBILE_FETCH_DECODE_TOO_LARGE",
+      maxBytes: 512 * 1024,
+    });
+  });
+
+  it("keeps the production cap above typical API bodies and below multi-GiB inflates", () => {
+    expect(MAX_MOBILE_DNS_DECODED_BYTES).toBe(64 * 1024 * 1024);
+  });
+});

--- a/packages/agent/src/runtime/mobile-dns.ts
+++ b/packages/agent/src/runtime/mobile-dns.ts
@@ -5,8 +5,10 @@
  * — dns.setServers, a dns.lookup patch backed by an explicit-server resolver, and
  * a globalThis.fetch wrapper that routes external requests through node:http(s)
  * (which honors the custom lookup) — so outbound cloud/inference/connector calls
- * resolve. Idempotent and a no-op off mobile; loopback and IP literals always
- * bypass the overrides.
+ * resolve. Gzip/deflate/br response bodies are credited against a decoded-byte
+ * budget before they enter the Response stream: a tiny compressed bomb otherwise
+ * materializes tens of megabytes in the agent process. Idempotent and a no-op
+ * off mobile; loopback and IP literals always bypass the overrides.
  */
 import dns, { type LookupAddress } from "node:dns";
 import http from "node:http";
@@ -14,6 +16,13 @@ import https from "node:https";
 import net from "node:net";
 import zlib from "node:zlib";
 import { isMobilePlatform } from "@elizaos/shared";
+import { creditDecodedBodyBytes } from "./mobile-dns-decode-budget.ts";
+
+export {
+  creditDecodedBodyBytes,
+  MAX_MOBILE_DNS_DECODED_BYTES,
+  MobileFetchDecodeBudgetError,
+} from "./mobile-dns-decode-budget.ts";
 
 /**
  * Public resolvers the on-device agent dials directly. Android/iOS expose no
@@ -290,9 +299,23 @@ async function fetchViaNode(
 
         const stream = new ReadableStream<Uint8Array>({
           start(controller) {
-            decoded.on("data", (chunk: Buffer) =>
-              controller.enqueue(new Uint8Array(chunk)),
-            );
+            const budget = { bytes: 0 };
+            const inflateBudget = decoded !== res;
+            decoded.on("data", (chunk: Buffer) => {
+              if (inflateBudget) {
+                try {
+                  creditDecodedBodyBytes(budget, chunk.length);
+                } catch (error) {
+                  // error-policy:J3 untrusted gzip/deflate/br inflate becomes a
+                  // typed stream error; never enqueue past the decoded budget.
+                  res.destroy();
+                  decoded.destroy();
+                  controller.error(error);
+                  return;
+                }
+              }
+              controller.enqueue(new Uint8Array(chunk));
+            });
             decoded.on("end", () => controller.close());
             decoded.on("error", (err: Error) => controller.error(err));
           },


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone mobile-fetch gzip/deflate/br inflate overflow. Not a twin of
`#22331` (X-archive ZIP central directory), `#22302` (plugin-x
`arrayBuffer`), `#22306` (PNG IHDR), `#22320` (ffmpeg child), `#22328`
(Matrix PREPARED), `#22262`, `#22278`, `#22282`, or the HTTP
fetch-timeout family. Not an ASI `#1874` reprint. HARD_SKIP has no
mobile-dns path. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Origin `createGunzip()` of a 32 KiB / 32 MiB zeros gzip
      materialized 33554432 bytes in 61ms.
- [x] Head credits decoded chunks and rejects past 64 MiB before
      enqueue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `705177498ecc` with zero conflicts.
- [x] Isolated decode-budget tests 4/4 at this head.
- [x] Biome on the three touched files: clean.

# Risks

Low and bounded to the mobile `globalThis.fetch` wrapper's gzip/deflate/br
path. Uncompressed bodies are unchanged. A legitimate decoded body under
64 MiB still streams. A zeros-gzip bomb fails with
`MobileFetchDecodeBudgetError` instead of allocating the inflate.

# Background

## What does this PR do?

`fetchViaNode` did:

```ts
const decoded =
  enc === "gzip"
    ? res.pipe(zlib.createGunzip())
    : enc === "deflate"
      ? res.pipe(zlib.createInflate())
      : enc === "br"
        ? res.pipe(zlib.createBrotliDecompress())
        : res;
decoded.on("data", (chunk) => controller.enqueue(chunk));
```

Origin replica: `gzipSync(32 MiB zeros)` is 32637 bytes;
`createGunzip()` emitted `out=33554432` in 61ms. There was no decoded
budget, so a multi-gigabyte inflate is the same path.

This credits each inflated chunk via `creditDecodedBodyBytes` and
destroys the request/decoder when the 64 MiB cap is crossed.

## What kind of change is this?

Bug fix (gzip-bomb overflow).

# Documentation changes needed?

No public HTTP API change. Hostile inflate becomes a typed stream error
(`MOBILE_FETCH_DECODE_TOO_LARGE`).

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/mobile-dns-decode-budget.ts` and
`mobile-dns.test.ts`. Wiring is the inflate `data` handler in
`mobile-dns.ts`.

## Detailed testing steps

```bash
bun test packages/agent/src/runtime/mobile-dns.test.ts
```

Origin: 32 KiB → 32 MiB in 61ms. Head: 2 MiB zeros gzip with a 512 KiB
test cap rejects `MOBILE_FETCH_DECODE_TOO_LARGE`.

# Evidence Gate

<!-- evidence-head:8b8310429060cb9e32085280072779f3f356fbd3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated zlib proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - decode budget only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin `createGunzip()` of 32 KiB / 32 MiB zeros gzip
      materialized 33554432 bytes in 61ms. Head tests 4/4 at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated
decode-budget tests 4/4 are the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
