### PR TITLE
fix(scripts): fail closed when an action-audit scan root is missing

### DIFF
--- a/packages/scripts/audit-action-availability.mjs
+++ b/packages/scripts/audit-action-availability.mjs
@@ -7,7 +7,7 @@
  * intent/keyword based instead of hard state based.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import ts from "typescript";
 
@@ -52,10 +52,14 @@ const roots = process.argv
   .filter((arg) => !arg.startsWith("--"))
   .filter(Boolean);
 
+if (args.has("--self-test")) {
+  process.exit(selfTest());
+}
+
 const keywordKeys = loadKeywordKeys();
-const files = (roots.length > 0 ? roots : DEFAULT_ROOTS).flatMap((root) =>
-  walk(join(ROOT, root)),
-);
+const scanRoots = roots.length > 0 ? roots : DEFAULT_ROOTS;
+requireExistingRoots(scanRoots);
+const files = scanRoots.flatMap((root) => walk(join(ROOT, root)));
 const actions = files
   .flatMap(scanFile)
   .sort((a, b) => a.name.localeCompare(b.name) || a.file.localeCompare(b.file));
@@ -516,4 +520,65 @@ function capitalizeAscii(value) {
 
 function escapeCell(value) {
   return String(value).replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+/**
+ * Fail closed when a configured scan root is absent.
+ *
+ * `walk()` swallows a missing directory and returns no files, so a renamed or
+ * moved root previously reduced the action inventory silently. The generator
+ * that consumes this audit (`generate-action-search-keywords.mjs`) writes a
+ * committed keyword artifact and only observes a nonzero exit, so a silent
+ * shrink republished that artifact with entries missing and no diagnostic.
+ */
+function requireExistingRoots(scanRoots) {
+  const missing = scanRoots.filter((root) => !existsSync(join(ROOT, root)));
+  if (missing.length === 0) return;
+  console.error(
+    `[audit-action-availability] configured scan root(s) do not exist: ${missing.join(", ")}. ` +
+      "Update the root list (or pass existing paths) instead of scanning nothing.",
+  );
+  process.exit(1);
+}
+
+/** Prove the missing-root gate fires, and that a present root still scans. */
+function selfTest() {
+  const cases = [
+    {
+      name: "missing root is refused",
+      roots: ["definitely/not/a/real/root"],
+      expectMissing: true,
+    },
+    {
+      name: "present root is accepted",
+      roots: ["packages/scripts"],
+      expectMissing: false,
+    },
+    {
+      name: "one missing among present roots is refused",
+      roots: ["packages/scripts", "nope/missing"],
+      expectMissing: true,
+    },
+  ];
+  let failed = 0;
+  for (const testCase of cases) {
+    const missing = testCase.roots.filter(
+      (root) => !existsSync(join(ROOT, root)),
+    );
+    const gotMissing = missing.length > 0;
+    if (gotMissing !== testCase.expectMissing) {
+      failed += 1;
+      console.error(
+        `  \u2717 ${testCase.name}: expected missing=${testCase.expectMissing}, got ${gotMissing}`,
+      );
+    } else {
+      console.log(`  \u2713 ${testCase.name}`);
+    }
+  }
+  if (failed > 0) {
+    console.error(`\nself-test FAILED (${failed}/${cases.length})`);
+    return 1;
+  }
+  console.log(`\nself-test PASSED (${cases.length}/${cases.length})`);
+  return 0;
 }

--- a/packages/scripts/audit-action-availability.mjs
+++ b/packages/scripts/audit-action-availability.mjs
@@ -7,7 +7,7 @@
  * intent/keyword based instead of hard state based.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import ts from "typescript";
 
@@ -58,7 +58,7 @@ if (args.has("--self-test")) {
 
 const keywordKeys = loadKeywordKeys();
 const scanRoots = roots.length > 0 ? roots : DEFAULT_ROOTS;
-requireExistingRoots(scanRoots);
+requireReadableDirectoryRoots(scanRoots);
 const files = scanRoots.flatMap((root) => walk(join(ROOT, root)));
 const actions = files
   .flatMap(scanFile)
@@ -523,7 +523,7 @@ function escapeCell(value) {
 }
 
 /**
- * Fail closed when a configured scan root is absent.
+ * Fail closed when a configured scan root cannot be enumerated as a directory.
  *
  * `walk()` swallows a missing directory and returns no files, so a renamed or
  * moved root previously reduced the action inventory silently. The generator
@@ -531,45 +531,74 @@ function escapeCell(value) {
  * committed keyword artifact and only observes a nonzero exit, so a silent
  * shrink republished that artifact with entries missing and no diagnostic.
  */
-function requireExistingRoots(scanRoots) {
-  const missing = scanRoots.filter((root) => !existsSync(join(ROOT, root)));
-  if (missing.length === 0) return;
+function requireReadableDirectoryRoots(scanRoots) {
+  const invalid = findInvalidScanRoots(scanRoots);
+  if (invalid.length === 0) return;
   console.error(
-    `[audit-action-availability] configured scan root(s) do not exist: ${missing.join(", ")}. ` +
+    `[audit-action-availability] configured scan root(s) are not readable directories: ${invalid.join(", ")}. ` +
       "Update the root list (or pass existing paths) instead of scanning nothing.",
   );
   process.exit(1);
 }
 
-/** Prove the missing-root gate fires, and that a present root still scans. */
+/** Return actionable findings for roots that the production walker cannot scan. */
+function findInvalidScanRoots(scanRoots) {
+  const invalid = [];
+  for (const root of scanRoots) {
+    const absolute = join(ROOT, root);
+    let stat;
+    try {
+      stat = statSync(absolute);
+    } catch (error) {
+      // error-policy:J3 invalid configured input is reported explicitly.
+      invalid.push(`${root} (${error.code ?? "unreadable"})`);
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      invalid.push(`${root} (not a directory)`);
+      continue;
+    }
+    try {
+      readdirSync(absolute);
+    } catch (error) {
+      // error-policy:J3 an unreadable root is an explicit invalid result.
+      invalid.push(`${root} (${error.code ?? "unreadable"})`);
+    }
+  }
+  return invalid;
+}
+
+/** Prove the production root validator rejects every silent-empty shape. */
 function selfTest() {
   const cases = [
     {
       name: "missing root is refused",
       roots: ["definitely/not/a/real/root"],
-      expectMissing: true,
+      expectInvalid: true,
     },
     {
       name: "present root is accepted",
       roots: ["packages/scripts"],
-      expectMissing: false,
+      expectInvalid: false,
+    },
+    {
+      name: "regular file root is refused",
+      roots: ["package.json"],
+      expectInvalid: true,
     },
     {
       name: "one missing among present roots is refused",
       roots: ["packages/scripts", "nope/missing"],
-      expectMissing: true,
+      expectInvalid: true,
     },
   ];
   let failed = 0;
   for (const testCase of cases) {
-    const missing = testCase.roots.filter(
-      (root) => !existsSync(join(ROOT, root)),
-    );
-    const gotMissing = missing.length > 0;
-    if (gotMissing !== testCase.expectMissing) {
+    const gotInvalid = findInvalidScanRoots(testCase.roots).length > 0;
+    if (gotInvalid !== testCase.expectInvalid) {
       failed += 1;
       console.error(
-        `  \u2717 ${testCase.name}: expected missing=${testCase.expectMissing}, got ${gotMissing}`,
+        `  \u2717 ${testCase.name}: expected invalid=${testCase.expectInvalid}, got ${gotInvalid}`,
       );
     } else {
       console.log(`  \u2713 ${testCase.name}`);


### PR DESCRIPTION
# Relates to

Closes #22335. A renamed action scan root silently shrank the committed action-search keyword artifact.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below — **see Known gaps: full verify delegated to PR CI per
      operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`9af374938`).
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Low, and bounded by a fact I checked first: all four current `DEFAULT_ROOTS` exist**, so a healthy tree behaves exactly as before (160 actions, exit 0, markdown and `--json` unchanged). The only new failure mode is the one being added deliberately — a configured root that does not exist now stops the run instead of scanning nothing. One file changed; no consumer contract altered beyond the exit code on a genuinely broken configuration.

# Background

## What does this PR do?

`walk()` returns an empty list for a directory it cannot read, so a renamed or moved `DEFAULT_ROOTS` entry contributed zero files with no diagnostic and a zero exit. `generate-action-search-keywords.mjs` consumes this audit through `execFileSync` — which only throws on a nonzero exit — and writes the committed `packages/shared/src/i18n/keywords/action-search.generated.keywords.json`. A silent shrink therefore republished that artifact with entries missing.

This adds `requireExistingRoots()`, which checks every configured scan root (default or explicitly passed) before walking and exits 1 naming the missing one(s). It also adds a `--self-test` mode, matching the convention already used by `audit-ui-determinism`, `audit-focused-skipped-tests`, and `type-duplication-audit`.

## What kind of change is this?

Bug fix (tooling, non-breaking for a healthy tree).

# Documentation changes needed?

None; the failure message states the cause and the remedy.

# Testing

## Where should a reviewer start?

```bash
node packages/scripts/audit-action-availability.mjs --self-test
node packages/scripts/audit-action-availability.mjs --json some/missing/root   # exits 1
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c5d4b7c0a2f72e446cc33374addbbf8194bff5a9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - headless tooling change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user flow; a script exit-code guard.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs; the transcripts below are the artifact.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the silent shrink reproduced on the parent, then closed at this head:

<details>
<summary>1. BEFORE — a renamed root silently drops 11 committed keyword entries</summary>

```
# parent commit, all roots present
$ node packages/scripts/audit-action-availability.mjs --json | jq '.actions|length'
160
$ node packages/scripts/generate-action-search-keywords.mjs
Generated 140 action keyword entries at .../action-search.generated.keywords.json

# parent commit, packages/agent/src/actions renamed to actionz
$ node packages/scripts/audit-action-availability.mjs --json packages/agent/src/actionz | jq '.actions|length'
0                      # and exit 0
$ node packages/scripts/generate-action-search-keywords.mjs
Generated 129 action keyword entries at .../action-search.generated.keywords.json
$ echo $?
0
```

140 → 129 entries, success reported at every step. The directory was renamed with `mv` and restored afterwards; the working tree was verified clean.
</details>

<details>
<summary>2. AFTER — the same rename now fails closed, and the artifact is left intact</summary>

```
$ mv packages/agent/src/actions packages/agent/src/actionz
$ node packages/scripts/generate-action-search-keywords.mjs
[audit-action-availability] configured scan root(s) are not readable directories: packages/agent/src/actions. Update the root list (or pass existing paths) instead of scanning nothing.
...
$ echo $?
1
$ jq '.entries|length' packages/shared/src/i18n/keywords/action-search.generated.keywords.json
114                    # unchanged - not republished at a shrunken size
```

The actionable message is printed first; `execFileSync`'s own "Command failed" wrapper follows it. Directory restored, tree clean.

Direct invocation is equally explicit:

```
$ node packages/scripts/audit-action-availability.mjs --json packages/agent/src/actionz
[audit-action-availability] configured scan root(s) are not readable directories: packages/agent/src/actionz. Update the root list (or pass existing paths) instead of scanning nothing.
$ echo $?
1
```
</details>

<details>
<summary>3. Healthy tree unchanged, and the new self-test</summary>

```
$ node packages/scripts/audit-action-availability.mjs --json | jq '.actions|length'
160                                        # identical to parent

$ node packages/scripts/audit-action-availability.mjs | head -1
# Action Availability Audit                # markdown mode unchanged

$ node packages/scripts/generate-action-search-keywords.mjs
Generated 140 action keyword entries      # identical to parent

$ node packages/scripts/audit-action-availability.mjs --self-test
  ✓ missing root is refused
  ✓ present root is accepted
  ✓ regular file root is refused
  ✓ one missing among present roots is refused

self-test PASSED (4/4)
```
</details>

<details>
<summary>4. Repo gates</summary>

```
$ node packages/scripts/audit-scripts.mjs
[audit-scripts] OK — no orphan/no-op/broken scripts.

$ bunx @biomejs/biome check packages/scripts/audit-action-availability.mjs
Checked 1 file. No fixes applied.
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcripts above are the executable artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** Per the recorded operator hardware constraint it is delegated to this PR's CI; the proportional local evidence is the before/after reproduction, the healthy-tree equivalence check, the new self-test, `audit-scripts`, and Biome above.
- **Observed while measuring, deliberately not changed here:** a clean `generate-action-search-keywords.mjs` run on `develop` produces **140** entries while the committed artifact holds **114**, so the committed keyword data appears to lag the current action surface by 26 entries independent of this bug. That is a separate question (regenerate, or gate the artifact's freshness in CI) and I did not touch the artifact in this PR — the diff is one script file. Happy to follow up if you want the artifact refreshed or a freshness check added.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c5d4b7c0a2f72e446cc33374addbbf8194bff5a9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root/review_lane_c]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@c5d4b7c0a2f72e446cc33374addbbf8194bff5a9:packages/skills/skills/contribute-to-eliza"} -->


