### PR TITLE
fix(plugin-anthropic): time out hung claude -p and cap stdio

### DIFF
--- a/plugins/plugin-anthropic/__tests__/claude-cli.budget.test.ts
+++ b/plugins/plugin-anthropic/__tests__/claude-cli.budget.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Deterministic hang/overflow coverage for `claude -p` stdio collection.
+ * The harness builds real ReadableStreams (no live CLI). Origin
+ * `new Response(proc.stdout).text()` stayed pending at 401ms when the
+ * stream never closed; the collector must fail closed on that class.
+ */
+import { describe, expect, it, mock } from "bun:test";
+import {
+  CLAUDE_CLI_MAX_STDIO_BYTES,
+  collectClaudeCliOutput,
+  readClaudeCliStreamBudget,
+} from "../utils/claude-cli";
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      if (text.length > 0) {
+        controller.enqueue(new TextEncoder().encode(text));
+      }
+      controller.close();
+    },
+  });
+}
+
+function hungProcess() {
+  let closeStdout: (() => void) | undefined;
+  let resolveExit: ((code: number) => void) | undefined;
+  const stdout = new ReadableStream<Uint8Array>({
+    start(controller) {
+      closeStdout = () => {
+        try {
+          controller.close();
+        } catch {
+          // already closed by a prior kill
+        }
+      };
+    },
+  });
+  const kill = mock(() => {
+    closeStdout?.();
+    resolveExit?.(143);
+  });
+  return {
+    stdout,
+    stderr: streamOf(""),
+    exited: new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    }),
+    kill,
+  };
+}
+
+describe("claude CLI stdio budget", () => {
+  it("rejects a never-ending stdout stream instead of awaiting text() forever", async () => {
+    const proc = hungProcess();
+    const started = Date.now();
+    await expect(collectClaudeCliOutput(proc, { timeoutMs: 40, maxBytes: 1024 })).rejects.toThrow(
+      /timed out after 40ms/
+    );
+    expect(Date.now() - started).toBeLessThan(400);
+    expect(proc.kill).toHaveBeenCalled();
+  });
+
+  it("rejects stdout that exceeds the decoded-byte cap before JSON.parse", async () => {
+    const overflow = "x".repeat(128);
+    const proc = {
+      stdout: streamOf(overflow),
+      stderr: streamOf(""),
+      exited: Promise.resolve(0),
+      kill: mock(() => undefined),
+    };
+    await expect(collectClaudeCliOutput(proc, { timeoutMs: 1_000, maxBytes: 64 })).rejects.toThrow(
+      /stdout exceeded 64 bytes/
+    );
+  });
+
+  it("admits a small result inside the budget", async () => {
+    const proc = {
+      stdout: streamOf('{"result":"ok"}'),
+      stderr: streamOf(""),
+      exited: Promise.resolve(0),
+      kill: mock(() => undefined),
+    };
+    const collected = await collectClaudeCliOutput(proc, {
+      timeoutMs: 1_000,
+      maxBytes: 1024,
+    });
+    expect(collected.output).toBe('{"result":"ok"}');
+    expect(collected.exitCode).toBe(0);
+  });
+
+  it("credits stream chunks and rejects past the helper cap", async () => {
+    await expect(readClaudeCliStreamBudget(streamOf("abcdefghij"), 4, "stdout")).rejects.toThrow(
+      /stdout exceeded 4 bytes/
+    );
+    expect(CLAUDE_CLI_MAX_STDIO_BYTES).toBe(8 * 1024 * 1024);
+  });
+});

--- a/plugins/plugin-anthropic/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/error-policy.shape.test.ts
@@ -52,6 +52,7 @@ function fakeBun(stdout: string, stderr: string, exitCode: number) {
       stdout: streamOf(stdout),
       stderr: streamOf(stderr),
       exited: Promise.resolve(exitCode),
+      kill: vi.fn(),
     })),
   };
 }

--- a/plugins/plugin-anthropic/utils/claude-cli.ts
+++ b/plugins/plugin-anthropic/utils/claude-cli.ts
@@ -1,8 +1,11 @@
 /**
  * CLI auth mode: `generateViaCli` / `streamViaCli` shell out to `claude -p` via
  * `Bun.spawn` when `ANTHROPIC_AUTH_MODE=claude-cli`, parsing the CLI's JSON
- * result into text plus token usage and emitting a usage event. Bun-only (fails
- * on Node runtimes); does not support `messages`, `tools`, `toolChoice`, or
+ * result into text plus token usage and emitting a usage event. The child is
+ * killed if it never exits, and stdout/stderr are credited against a byte
+ * budget before they become a string — origin `new Response(proc.stdout).text()`
+ * never settled when the stream stayed open. Bun-only (fails on Node
+ * runtimes); does not support `messages`, `tools`, `toolChoice`, or
  * `responseSchema`.
  */
 import type { IAgentRuntime, ModelTypeName, TextStreamResult } from "@elizaos/core";
@@ -86,18 +89,24 @@ function parseUsage(
   };
 }
 
+/** Wall-clock bound for one `claude -p` child. Real generations stay under this. */
+export const CLAUDE_CLI_TIMEOUT_MS = 180_000;
+
+/** Peak stdout or stderr materialized from the child before kill. */
+export const CLAUDE_CLI_MAX_STDIO_BYTES = 8 * 1024 * 1024;
+
+interface ClaudeCliProcess {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill(): void;
+}
+
 function getBunRuntime() {
   const bunRuntime = (
     globalThis as typeof globalThis & {
       Bun?: {
-        spawn(
-          args: string[],
-          options: { stdout: "pipe"; stderr: "pipe" }
-        ): {
-          stdout: ReadableStream<Uint8Array>;
-          stderr: ReadableStream<Uint8Array>;
-          exited: Promise<number>;
-        };
+        spawn(args: string[], options: { stdout: "pipe"; stderr: "pipe" }): ClaudeCliProcess;
       };
     }
   ).Bun;
@@ -107,6 +116,65 @@ function getBunRuntime() {
   }
 
   return bunRuntime;
+}
+
+/** Read a child stream and reject before the allocation exceeds `maxBytes`. */
+export async function readClaudeCliStreamBudget(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes = CLAUDE_CLI_MAX_STDIO_BYTES,
+  label = "stdio"
+): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error(`[Anthropic CLI] ${label} exceeded ${maxBytes} bytes (got ${total})`);
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(out);
+}
+
+/**
+ * Collect stdout/stderr from a `claude -p` child and kill it if it never
+ * exits. Tests pass a short timeout so a never-ending stream fails closed
+ * without waiting the production 180s.
+ */
+export async function collectClaudeCliOutput(
+  proc: ClaudeCliProcess,
+  options?: { timeoutMs?: number; maxBytes?: number }
+): Promise<{ output: string; stderr: string; exitCode: number }> {
+  const timeoutMs = options?.timeoutMs ?? CLAUDE_CLI_TIMEOUT_MS;
+  const maxBytes = options?.maxBytes ?? CLAUDE_CLI_MAX_STDIO_BYTES;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+  try {
+    const [output, stderr, exitCode] = await Promise.all([
+      readClaudeCliStreamBudget(proc.stdout, maxBytes, "stdout"),
+      readClaudeCliStreamBudget(proc.stderr, maxBytes, "stderr"),
+      proc.exited,
+    ]);
+    if (timedOut) {
+      throw new Error(`[Anthropic CLI] claude -p timed out after ${timeoutMs}ms`);
+    }
+    return { output, stderr, exitCode };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -130,11 +198,7 @@ export async function generateViaCli(
   logger.debug(`[Anthropic CLI] ${modelType} → ${modelName}`);
 
   const proc = getBunRuntime().spawn(args, { stdout: "pipe", stderr: "pipe" });
-  const [output, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  const exitCode = await proc.exited;
+  const { output, stderr, exitCode } = await collectClaudeCliOutput(proc);
 
   if (exitCode !== 0) {
     throw new Error(`[Anthropic CLI] claude -p failed (exit ${exitCode}): ${stderr.slice(0, 500)}`);
@@ -196,6 +260,11 @@ export function streamViaCli(
   logger.debug(`[Anthropic CLI] streaming ${modelType} → ${modelName}`);
 
   const proc = getBunRuntime().spawn(args, { stdout: "pipe", stderr: "pipe" });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, CLAUDE_CLI_TIMEOUT_MS);
 
   let fullText = "";
   let usageResolved = false;
@@ -223,11 +292,20 @@ export function streamViaCli(
     const decoder = new TextDecoder();
     let lineBuf = "";
     let streamFailed = false;
+    let decodedBytes = 0;
 
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
+        decodedBytes += value.byteLength;
+        if (decodedBytes > CLAUDE_CLI_MAX_STDIO_BYTES) {
+          await reader.cancel();
+          proc.kill();
+          throw new Error(
+            `[Anthropic CLI] stdout exceeded ${CLAUDE_CLI_MAX_STDIO_BYTES} bytes (got ${decodedBytes})`
+          );
+        }
 
         lineBuf += decoder.decode(value, { stream: true });
         const lines = lineBuf.split("\n");
@@ -286,16 +364,26 @@ export function streamViaCli(
       // the consumer sees the real error instead of a fabricated "end_turn"
       // with zero chunks (#9324: throw, never fabricate).
       const exitCode = await proc.exited;
+      if (timedOut) {
+        streamFailed = true;
+        throw new Error(`[Anthropic CLI] claude -p timed out after ${CLAUDE_CLI_TIMEOUT_MS}ms`);
+      }
       if (exitCode !== 0) {
         streamFailed = true;
         // error-policy:J6 best-effort diagnostics on an already-failed process —
         // the typed failure below throws regardless of stderr readability.
-        const stderrText = await new Response(proc.stderr).text().catch(() => "");
+        const stderrText = await readClaudeCliStreamBudget(
+          proc.stderr,
+          CLAUDE_CLI_MAX_STDIO_BYTES,
+          "stderr"
+        ).catch(() => "");
+        // error-policy:J6 stderr is diagnostics on an already-failed stream.
         throw new Error(
           `[Anthropic CLI] claude -p stream failed (exit ${exitCode}): ${stderrText.slice(0, 500)}`
         );
       }
     } finally {
+      clearTimeout(timer);
       resolveText(fullText);
       if (!usageResolved) resolveUsage(undefined);
       if (!finishResolved) resolveFinish(streamFailed ? "error" : "end_turn");


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone Anthropic CLI model-path hang: `generateViaCli` awaited
`new Response(proc.stdout).text()` with no kill and no byte budget.
Not a twin of `#22320` (ffmpeg/ffprobe), `#22333` (mobile gzip),
`#22331` (X-archive ZIP), `#22328` (Matrix PREPARED), `#22308`
(Smithers lines), `#22262`, `#22278`, `#22282`, or the HTTP
fetch-timeout family. Contrast: `plugin-cli-inference` `claude-cli.ts`
already has a spawn timeout; this file did not. Not an ASI `#1874`
reprint. HARD_SKIP is plugin-openai audio/image, not this path. No
invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Origin `Response.text()` on a never-ending stream stayed
      **still-running at 403ms**.
- [x] Head collector rejects hang in <400ms and overflow before parse.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `705177498ecc` with zero conflicts.
- [x] Isolated collector tests 4/4 at this head.
- [x] Biome on the three touched files: clean.

# Risks

Low and bounded to `ANTHROPIC_AUTH_MODE=claude-cli`. A healthy `claude -p`
under 180s and 8 MiB stdio is unchanged. A hung or bomb-stdout child is
killed instead of pinning the model call. API-key / OAuth paths are
untouched.

# Background

## What does this PR do?

`generateViaCli` did:

```ts
const proc = getBunRuntime().spawn(args, { stdout: "pipe", stderr: "pipe" });
const [output, stderr] = await Promise.all([
  new Response(proc.stdout).text(),
  new Response(proc.stderr).text(),
]);
const exitCode = await proc.exited;
```

Origin replica: `new Response(neverEndingStream).text()` stayed
**still-running at 403ms**. A `claude -p` that never closes stdout hangs
the model call forever; a huge stdout allocates before `JSON.parse`.

This collects through `collectClaudeCliOutput`: 180s watchdog (`kill`)
and 8 MiB stdout/stderr budget. Streaming has the same wall-clock and
byte bounds.

## What kind of change is this?

Bug fix (process hang + stdio overflow).

# Documentation changes needed?

No public HTTP API change. Hung/oversize CLI runs throw typed errors.

# Testing

## Where should a reviewer start?

`collectClaudeCliOutput` / `readClaudeCliStreamBudget` in
`plugins/plugin-anthropic/utils/claude-cli.ts` and
`__tests__/claude-cli.budget.test.ts`.

## Detailed testing steps

```bash
cd plugins/plugin-anthropic && bun test __tests__/claude-cli.budget.test.ts
```

Origin: never-ending `Response.text()` still-running at 403ms. Head:
40ms budget rejects hang in 42ms; 128-byte stdout vs 64-byte cap
rejects before parse.

# Evidence Gate

<!-- evidence-head:2480347f7d377e1f00c46a3703d66b73d2e0dfa0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated stream proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CLI collector only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin `Response.text()` still-running at 403ms. Head collector
      tests 4/4 at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - no HTTP route.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated
collector tests 4/4 are the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
