### PR TITLE
fix(cloud): bound provisioning requeue authority

### DIFF
--- a/packages/cloud/shared/src/db/job-retryable-requeues-migration.test.ts
+++ b/packages/cloud/shared/src/db/job-retryable-requeues-migration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Proves the retryable-requeue authority migration against real PGlite,
+ * including replay, defaulting, and its nonnegative database invariant.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const migration = readFileSync(
+  join(import.meta.dir, "migrations", "0253_job_retryable_requeues.sql"),
+  "utf8",
+);
+const databases: PGlite[] = [];
+
+async function databaseWithJobs(): Promise<PGlite> {
+  const database = new PGlite();
+  databases.push(database);
+  await database.exec(`CREATE TABLE jobs (
+    id uuid PRIMARY KEY,
+    status text NOT NULL,
+    attempts integer NOT NULL DEFAULT 0
+  )`);
+  return database;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((database) => database.close()));
+});
+
+describe("0253 job retryable requeues", () => {
+  test("adds without an eager validation scan, then validates explicitly", () => {
+    expect(migration).toContain('CHECK ("retryable_requeues" >= 0) NOT VALID');
+    expect(migration).toContain('VALIDATE CONSTRAINT "jobs_retryable_requeues_nonnegative_check"');
+  });
+
+  test("is replay-safe and defaults existing and new rows to zero", async () => {
+    const database = await databaseWithJobs();
+    await database.exec(
+      `INSERT INTO jobs (id, status) VALUES
+       ('00000000-0000-4000-8000-000000000001', 'pending')`,
+    );
+
+    await database.exec(migration);
+    await database.exec(migration);
+    await database.exec(
+      `INSERT INTO jobs (id, status) VALUES
+       ('00000000-0000-4000-8000-000000000002', 'pending')`,
+    );
+
+    const result = await database.query<{ retryable_requeues: number }>(
+      `SELECT retryable_requeues FROM jobs ORDER BY id`,
+    );
+    expect(result.rows).toEqual([{ retryable_requeues: 0 }, { retryable_requeues: 0 }]);
+  });
+
+  test("rejects negative retry authority", async () => {
+    const database = await databaseWithJobs();
+    await database.exec(migration);
+
+    await expect(
+      database.exec(
+        `INSERT INTO jobs (id, status, retryable_requeues) VALUES
+         ('00000000-0000-4000-8000-000000000003', 'pending', -1)`,
+      ),
+    ).rejects.toThrow("jobs_retryable_requeues_nonnegative_check");
+  });
+
+  test("does not mistake another table's same-named constraint for the jobs invariant", async () => {
+    const database = await databaseWithJobs();
+    await database.exec(`
+      CREATE TABLE migration_decoy (retryable_requeues integer NOT NULL);
+      ALTER TABLE migration_decoy ADD CONSTRAINT jobs_retryable_requeues_nonnegative_check
+        CHECK (retryable_requeues >= 0);
+    `);
+
+    await database.exec(migration);
+
+    await expect(
+      database.exec(
+        `INSERT INTO jobs (id, status, retryable_requeues) VALUES
+         ('00000000-0000-4000-8000-000000000004', 'pending', -1)`,
+      ),
+    ).rejects.toThrow("jobs_retryable_requeues_nonnegative_check");
+  });
+});

--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -65,6 +65,9 @@ const BACKUP_CATALOGUE_MIGRATION_TAGS = [
   "0248_agent_vault_key_seed_receipts",
   "0249_agent_backup_restore_receipts",
   "0250_agent_restore_receipt_guards",
+  "0251_agent_backup_restore_operations",
+  "0252_agent_backup_restore_operation_guard",
+  "0253_job_retryable_requeues",
 ] as const;
 
 function journalEntries(): JournalEntry[] {

--- a/packages/cloud/shared/src/db/migrations/0253_job_retryable_requeues.sql
+++ b/packages/cloud/shared/src/db/migrations/0253_job_retryable_requeues.sql
@@ -1,0 +1,19 @@
+-- Adds database-owned retry accounting for attempt-preserving job requeues.
+
+ALTER TABLE "jobs"
+  ADD COLUMN IF NOT EXISTS "retryable_requeues" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'jobs_retryable_requeues_nonnegative_check'
+      AND conrelid = 'jobs'::regclass
+  ) THEN
+    ALTER TABLE "jobs" ADD CONSTRAINT
+      "jobs_retryable_requeues_nonnegative_check"
+      CHECK ("retryable_requeues" >= 0) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "jobs"
+  VALIDATE CONSTRAINT "jobs_retryable_requeues_nonnegative_check";

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1765,6 +1765,13 @@
       "when": 1790884800000,
       "tag": "0252_agent_backup_restore_operation_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 252,
+      "version": "7",
+      "when": 1790971200000,
+      "tag": "0253_job_retryable_requeues",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -78,6 +78,7 @@ beforeAll(async () => {
 				attempts integer NOT NULL DEFAULT 0,
 				max_attempts integer NOT NULL DEFAULT 3,
 				execution_interruptions integer NOT NULL DEFAULT 0,
+				retryable_requeues integer NOT NULL DEFAULT 0,
 				organization_id uuid NOT NULL,
 				user_id uuid,
 				api_key_id uuid,
@@ -281,6 +282,172 @@ describe("completed_at terminal-timestamp contract", () => {
       const job = await getJob(id);
       expect(job?.status).toBe("pending");
       expect(job?.completed_at).toBeNull();
+    });
+
+    test("requires and accepts the fresh row after an intermediate result write", async () => {
+      const id = "00000000-0000-4900-8000-000000000031";
+      const generation = "b0000000-0000-4000-8000-000000000031";
+      const ownerId = "owner-fresh";
+      await seedJob({ id, maxAttempts: 3 });
+      await dbWrite.update(jobs).set({ execution_generation: generation }).where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      const fresh = await repo.updateForExecution(
+        claimed,
+        { result: { error: "transport unresolved" } },
+        ownerId,
+      );
+      const staleTransition = await repo.retryLaterWithoutIncrementingAttempts(
+        claimed,
+        "transport unresolved",
+        5000,
+        ownerId,
+        { maxRequeues: 5 },
+      );
+      expect(staleTransition).toBeUndefined();
+
+      const transitioned = await repo.retryLaterWithoutIncrementingAttempts(
+        fresh,
+        "transport unresolved",
+        5000,
+        ownerId,
+        { maxRequeues: 5 },
+      );
+      expect(transitioned).toMatchObject({
+        status: "pending",
+        attempts: 0,
+        retryable_requeues: 1,
+        result: { error: "transport unresolved" },
+      });
+    });
+
+    test("allows the exact bounded requeue before terminal exhaustion", async () => {
+      const id = "00000000-0000-4900-8000-000000000035";
+      const generation = "b0000000-0000-4000-8000-000000000035";
+      const ownerId = "owner-bound-edge";
+      await seedJob({ id, maxAttempts: 3 });
+      await dbWrite
+        .update(jobs)
+        .set({ execution_generation: generation, retryable_requeues: 4 })
+        .where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      const transitioned = await repo.retryLaterWithoutIncrementingAttempts(
+        claimed,
+        "last bounded retry",
+        5000,
+        ownerId,
+        { maxRequeues: 5 },
+      );
+
+      expect(transitioned).toMatchObject({
+        status: "pending",
+        retryable_requeues: 5,
+        completed_at: null,
+      });
+    });
+
+    test("settles terminally with its dependent write when the bound is exhausted", async () => {
+      const id = "00000000-0000-4900-8000-000000000032";
+      const generation = "b0000000-0000-4000-8000-000000000032";
+      const ownerId = "owner-bound";
+      await seedJob({ id, maxAttempts: 3 });
+      await dbWrite
+        .update(jobs)
+        .set({ execution_generation: generation, retryable_requeues: 5 })
+        .where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      const transitioned = await repo.retryLaterWithoutIncrementingAttempts(
+        claimed,
+        "transport still unresolved",
+        5000,
+        ownerId,
+        {
+          maxRequeues: 5,
+          onExhaustedInTx: async (tx, failedJob) => {
+            expect(failedJob).toMatchObject({ status: "failed", retryable_requeues: 6 });
+            await tx
+              .update(jobs)
+              .set({ webhook_status: "dependent-settled" })
+              .where(eq(jobs.id, failedJob.id));
+          },
+        },
+      );
+
+      expect(transitioned).toMatchObject({ status: "failed", retryable_requeues: 6 });
+      const persisted = await getJob(id);
+      expect(persisted).toMatchObject({
+        status: "failed",
+        attempts: 0,
+        retryable_requeues: 6,
+        webhook_status: "dependent-settled",
+      });
+      expect(persisted?.completed_at).not.toBeNull();
+    });
+
+    test("rolls the terminal transition back when its dependent write fails", async () => {
+      const id = "00000000-0000-4900-8000-000000000034";
+      const generation = "b0000000-0000-4000-8000-000000000034";
+      const ownerId = "owner-bound-rollback";
+      await seedJob({ id, maxAttempts: 3 });
+      await dbWrite
+        .update(jobs)
+        .set({ execution_generation: generation, retryable_requeues: 5 })
+        .where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      await expect(
+        repo.retryLaterWithoutIncrementingAttempts(
+          claimed,
+          "transport still unresolved",
+          5000,
+          ownerId,
+          {
+            maxRequeues: 5,
+            onExhaustedInTx: async () => {
+              throw new Error("dependent write rejected");
+            },
+          },
+        ),
+      ).rejects.toThrow("dependent write rejected");
+
+      expect(await getJob(id)).toMatchObject({
+        status: "in_progress",
+        retryable_requeues: 5,
+        completed_at: null,
+      });
+    });
+
+    test("lets only one contender spend a bounded transition", async () => {
+      const id = "00000000-0000-4900-8000-000000000033";
+      const generation = "b0000000-0000-4000-8000-000000000033";
+      const ownerId = "owner-race";
+      await seedJob({ id, maxAttempts: 3 });
+      await dbWrite.update(jobs).set({ execution_generation: generation }).where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      const transitions = await Promise.all([
+        repo.retryLaterWithoutIncrementingAttempts(claimed, "retry", 5000, ownerId, {
+          maxRequeues: 5,
+        }),
+        repo.retryLaterWithoutIncrementingAttempts(claimed, "retry", 5000, ownerId, {
+          maxRequeues: 5,
+        }),
+      ]);
+
+      expect(transitions.filter(Boolean)).toHaveLength(1);
+      expect(await getJob(id)).toMatchObject({ status: "pending", retryable_requeues: 1 });
     });
   });
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -199,6 +199,7 @@ beforeAll(async () => {
 				attempts integer NOT NULL DEFAULT 0,
 				max_attempts integer NOT NULL DEFAULT 3,
 				execution_interruptions integer NOT NULL DEFAULT 0,
+				retryable_requeues integer NOT NULL DEFAULT 0,
 				organization_id uuid NOT NULL,
 				user_id uuid,
 				api_key_id uuid,

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
@@ -41,6 +41,7 @@ beforeAll(async () => {
         attempts integer NOT NULL DEFAULT 0,
         max_attempts integer NOT NULL DEFAULT 3,
         execution_interruptions integer NOT NULL DEFAULT 0,
+        retryable_requeues integer NOT NULL DEFAULT 0,
         organization_id uuid NOT NULL,
         user_id uuid,
         api_key_id uuid,

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -255,6 +255,7 @@ function retryPayloadFence(job: Job) {
     AND ${jobs.attempts} = ${job.attempts}
     AND ${jobs.max_attempts} = ${job.max_attempts}
     AND ${jobs.execution_interruptions} = ${job.execution_interruptions}
+    AND ${jobs.retryable_requeues} = ${job.retryable_requeues}
     AND ${jobs.execution_generation} IS NOT DISTINCT FROM ${job.execution_generation}
     AND ${msWindowTimestampMatch(jobs.execution_quiesced_at, job.execution_quiesced_at)}
     AND ${msWindowTimestampMatch(jobs.started_at, job.started_at)}
@@ -297,6 +298,7 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
     left.attempts === right.attempts &&
     left.max_attempts === right.max_attempts &&
     left.execution_interruptions === right.execution_interruptions &&
+    left.retryable_requeues === right.retryable_requeues &&
     left.execution_generation === right.execution_generation &&
     sameTimestamp(left.execution_quiesced_at, right.execution_quiesced_at) &&
     sameTimestamp(left.started_at, right.started_at) &&
@@ -1232,6 +1234,7 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             eq(jobs.execution_interruptions, params.job.execution_interruptions),
+            eq(jobs.retryable_requeues, params.job.retryable_requeues),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
             msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),
@@ -1273,6 +1276,7 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             eq(jobs.execution_interruptions, params.job.execution_interruptions),
+            eq(jobs.retryable_requeues, params.job.retryable_requeues),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
             msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),
@@ -1725,14 +1729,23 @@ export class JobsRepository {
    * Requeues a job after a transient worker-side ambiguity without consuming
    * its finite retry budget. This is for cases where the job left the target
    * resource in a recoverable in-between state and a later worker pass should
-   * re-check/adopt that state instead of counting it as a failed attempt.
+   * re-check/adopt that state instead of counting it as a failed attempt. A
+   * bounded transition atomically advances database-owned requeue authority
+   * and runs its dependent failure writeback in the terminal transaction.
    */
   async retryLaterWithoutIncrementingAttempts(
     claimedJob: Job,
     error: string,
     delayMs: number,
     executionOwnerId?: string,
+    bounded?: {
+      maxRequeues: number;
+      onExhaustedInTx?: JobFailureWriteback;
+    },
   ): Promise<Job | undefined> {
+    if (bounded && (!Number.isSafeInteger(bounded.maxRequeues) || bounded.maxRequeues < 0)) {
+      throw new Error(`Invalid retryable requeue bound for job ${claimedJob.id}`);
+    }
     const requiresExecutionLease = hasDetachedProvisioningExecution(claimedJob.type);
     if (requiresExecutionLease && !executionOwnerId) {
       throw new Error(`Execution owner is required to requeue claimed job ${claimedJob.id}`);
@@ -1754,6 +1767,9 @@ export class JobsRepository {
     );
 
     const generation = requireExecutionGeneration(claimedJob);
+    const nextRequeues = bounded ? claimedJob.retryable_requeues + 1 : undefined;
+    const exhausted =
+      bounded !== undefined && nextRequeues !== undefined && nextRequeues > bounded.maxRequeues;
     const updated = await dbWrite.transaction(async (tx) => {
       if (hasAgentLifecycleFence(claimedJob)) {
         await configureElizaLifecycleTransaction(tx);
@@ -1786,12 +1802,13 @@ export class JobsRepository {
       const [row] = await tx
         .update(jobs)
         .set({
-          status: "pending",
+          status: exhausted ? "failed" : "pending",
           ...payload,
-          completed_at: null,
+          ...(nextRequeues === undefined ? {} : { retryable_requeues: nextRequeues }),
+          completed_at: exhausted ? new Date() : null,
           execution_quiesced_at: new Date(),
           updated_at: new Date(),
-          scheduled_for: scheduledFor,
+          scheduled_for: exhausted ? claimedJob.scheduled_for : scheduledFor,
         })
         .where(
           and(
@@ -1816,6 +1833,18 @@ export class JobsRepository {
         )
         .returning();
       if (!row) return undefined;
+      if (exhausted && bounded?.onExhaustedInTx) {
+        // The claimed snapshot already owns hydrated payloads. Do not call
+        // hydrateJob while lifecycle locks are held because R2-backed fields
+        // can require provider I/O.
+        await bounded.onExhaustedInTx(tx, {
+          ...claimedJob,
+          ...row,
+          data: claimedJob.data,
+          result: claimedJob.result,
+          error,
+        });
+      }
       if (requiresExecutionLease && executionOwnerId) {
         await tx
           .delete(jobExecutionLeases)

--- a/packages/cloud/shared/src/db/schemas/jobs.ts
+++ b/packages/cloud/shared/src/db/schemas/jobs.ts
@@ -1,7 +1,7 @@
 // Defines the jobs Drizzle table shape used by cloud repositories and services.
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { check, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { apiKeys } from "./api-keys";
 import { generations } from "./generations";
 import { organizations } from "./organizations";
@@ -35,6 +35,10 @@ export const jobs = pgTable(
     // Column shipped ahead of this entry in 0185/0194 (#17476) so readers only
     // deploy against databases that already have it.
     execution_interruptions: integer("execution_interruptions").notNull().default(0),
+    // Retryable target/provider outcomes requeued without spending an ordinary
+    // execution attempt. This is database-owned execution authority, not job
+    // input, and is bounded atomically by the repository transition.
+    retryable_requeues: integer("retryable_requeues").notNull().default(0),
     organization_id: uuid("organization_id")
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
@@ -79,6 +83,10 @@ export const jobs = pgTable(
       .where(
         sql`${table.execution_generation} IS NOT NULL AND ${table.execution_quiesced_at} IS NULL AND ${table.agent_id} IS NOT NULL`,
       ),
+    retryable_requeues_nonnegative_check: check(
+      "jobs_retryable_requeues_nonnegative_check",
+      sql`${table.retryable_requeues} >= 0`,
+    ),
   }),
 );
 

--- a/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
@@ -52,6 +52,7 @@ beforeAll(async () => {
         attempts integer NOT NULL DEFAULT 0,
         max_attempts integer NOT NULL DEFAULT 3,
         execution_interruptions integer NOT NULL DEFAULT 0,
+        retryable_requeues integer NOT NULL DEFAULT 0,
         organization_id uuid NOT NULL,
         user_id uuid,
         api_key_id uuid,

--- a/packages/cloud/shared/src/lib/services/pii-scrub-jobs.test.ts
+++ b/packages/cloud/shared/src/lib/services/pii-scrub-jobs.test.ts
@@ -128,6 +128,7 @@ beforeAll(async () => {
         attempts integer NOT NULL DEFAULT 0,
         max_attempts integer NOT NULL DEFAULT 3,
         execution_interruptions integer NOT NULL DEFAULT 0,
+        retryable_requeues integer NOT NULL DEFAULT 0,
         organization_id uuid NOT NULL,
         user_id uuid,
         api_key_id uuid,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -60,6 +60,8 @@ function makeJob(
     error_key: null,
     attempts: 1,
     max_attempts: 3,
+    execution_interruptions: 0,
+    retryable_requeues: 0,
     execution_generation: "55555555-5555-4555-8555-555555555555",
     execution_quiesced_at: null,
     organization_id: ORG,
@@ -119,7 +121,11 @@ function harness(job: Job) {
   const retryLaterSpy = spyOn(
     jobsRepository,
     "retryLaterWithoutIncrementingAttempts",
-  ).mockResolvedValue(job);
+  ).mockImplementation(async (retrySnapshot, _error, _delayMs, _owner, bounded) => ({
+    ...retrySnapshot,
+    status: "pending",
+    retryable_requeues: retrySnapshot.retryable_requeues + (bounded ? 1 : 0),
+  }));
   return {
     job,
     claimSpy,
@@ -744,6 +750,36 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     }
   });
 
+  test("agent_provision retryable transport settles when the database bound is exhausted", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_PROVISION, {}, { retryable_requeues: 5 }));
+    ctx.retryLaterSpy.mockImplementation(async (retrySnapshot) => ({
+      ...retrySnapshot,
+      status: "failed",
+      retryable_requeues: 6,
+      completed_at: new Date(),
+    }));
+    stub("provision", {
+      success: false,
+      retryable: true,
+      error: "readiness probe transport_unresolved",
+      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "provisioning" },
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_PROVISION);
+      expect(res).toMatchObject({ retried: 0, failed: 1 });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[4]).toMatchObject({ maxRequeues: 5 });
+      expect(typeof ctx.retryLaterSpy.mock.calls[0]?.[4]?.onExhaustedInTx).toBe("function");
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
   test("agent_restart transient snapshot failure → requeued without burning an attempt", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_RESTART));
     stub("executeRestart", {
@@ -784,10 +820,14 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       const res = await run(JOB_TYPES.AGENT_PROVISION);
       expect(res).toMatchObject({ claimed: 1, retried: 0, failed: 0 });
       expect(ctx.retryLaterSpy).toHaveBeenCalledWith(
-        ctx.job,
+        expect.objectContaining({
+          id: ctx.job.id,
+          result: expect.objectContaining({ error: "readiness probe transport_unresolved" }),
+        }),
         "readiness probe transport_unresolved",
         expect.any(Number),
         expect.any(String),
+        expect.objectContaining({ maxRequeues: 5 }),
       );
       expect(ctx.incrementSpy).not.toHaveBeenCalled();
     } finally {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -967,6 +967,9 @@ export const PER_JOB_TIMEOUT_MS = parsePositiveIntEnv(
  *  operators enable the lane. */
 const SNAPSHOT_GATE_RETRY_DELAY_MS = 10 * 60 * 1000;
 const PROVISION_TRANSPORT_RETRY_DELAY_MS = 2 * 60 * 1000;
+/** Retryable provider/transport outcomes allowed before the logical job is
+ * settled terminally without restarting its ordinary-attempt ladder. */
+const PROVISION_TRANSPORT_MAX_FREE_RETRIES = 5;
 /** How many times a transient pre-deletion capture may requeue WITHOUT
  *  consuming the delete's attempt budget. At the transport retry delay above
  *  this is ~20 minutes of tolerance for a capture outage; past it the failure
@@ -1083,9 +1086,14 @@ export class UpgradeFailedError extends Error {
 }
 
 class RetryableProvisionTransportError extends Error {
-  constructor(message: string) {
+  readonly retrySnapshot: Job;
+  readonly maxRequeues: number;
+
+  constructor(message: string, retrySnapshot: Job, maxRequeues: number) {
     super(message);
     this.name = "RetryableProvisionTransportError";
+    this.retrySnapshot = retrySnapshot;
+    this.maxRequeues = maxRequeues;
   }
 }
 
@@ -1107,6 +1115,7 @@ class PreDeleteCaptureExhaustedError extends Error {
 
 class RetryableReplacementCleanupError extends Error {
   readonly retrySnapshot: Job;
+  readonly maxRequeues = PROVISION_TRANSPORT_MAX_FREE_RETRIES;
 
   constructor(message: string, retrySnapshot: Job, options?: { cause?: unknown }) {
     super(message, options);
@@ -3330,21 +3339,32 @@ export class ProvisioningJobService {
       err instanceof RetryableProvisionTransportError ||
       err instanceof RetryableReplacementCleanupError
     ) {
-      const retrySnapshot =
-        err instanceof RetryableReplacementCleanupError ? err.retrySnapshot : job;
-      const requeued = await this.retryOwnedWrite(job, "retry-later", () =>
+      const retrySnapshot = err.retrySnapshot;
+      const onExhaustedInTx = this.buildPermanentFailureWriteback(retrySnapshot, errorMsg);
+      const transition = await this.retryOwnedWrite(job, "retry-later", () =>
         jobsRepository.retryLaterWithoutIncrementingAttempts(
           retrySnapshot,
           errorMsg,
           PROVISION_TRANSPORT_RETRY_DELAY_MS,
           this.executionOwnerId,
+          { maxRequeues: err.maxRequeues, onExhaustedInTx },
         ),
       );
-      if (requeued) {
+      if (transition?.status === "pending") {
         if (result) result.retried++;
         logger.warn("[provisioning-jobs] Requeued retryable provision transport failure", {
           jobId: job.id,
           delayMs: PROVISION_TRANSPORT_RETRY_DELAY_MS,
+          requeues: transition.retryable_requeues,
+          maxRequeues: err.maxRequeues,
+          error: errorMsg,
+        });
+      } else if (transition?.status === "failed") {
+        if (result) result.failed++;
+        logger.error("[provisioning-jobs] Retryable failure exhausted its requeue budget", {
+          jobId: job.id,
+          requeues: transition.retryable_requeues,
+          maxRequeues: err.maxRequeues,
           error: errorMsg,
         });
       } else {
@@ -4225,7 +4245,7 @@ export class ProvisioningJobService {
     if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 
     if (!result.success) {
-      await this.updateClaimedExecution(job, {
+      const retrySnapshot = await this.updateClaimedExecution(job, {
         result: agentRestartJobResultToRecord({
           cloudAgentId: data.agentId,
           containerStopped: result.containerStopped,
@@ -4236,6 +4256,8 @@ export class ProvisioningJobService {
       if (result.retryable) {
         throw new RetryableProvisionTransportError(
           result.error ?? "Snapshot capture temporarily unavailable",
+          retrySnapshot,
+          PROVISION_TRANSPORT_MAX_FREE_RETRIES,
         );
       }
       throw new Error(result.error ?? "Unknown agent_restart failure");
@@ -5043,7 +5065,7 @@ export class ProvisioningJobService {
     }
 
     if (!result.success) {
-      await this.updateClaimedExecution(job, {
+      const retrySnapshot = await this.updateClaimedExecution(job, {
         result: agentSnapshotJobResultToRecord({
           cloudAgentId: data.agentId,
           error: result.error,
@@ -5052,6 +5074,8 @@ export class ProvisioningJobService {
       if (result.retryable) {
         throw new RetryableProvisionTransportError(
           result.error ?? "Snapshot capture temporarily unavailable",
+          retrySnapshot,
+          PROVISION_TRANSPORT_MAX_FREE_RETRIES,
         );
       }
       throw new Error(result.error ?? "Unknown agent_snapshot failure");
@@ -5111,13 +5135,16 @@ export class ProvisioningJobService {
       // transient would requeue forever and a user-requested delete would
       // become an immortal — still billed — agent. Count the free requeues on
       // the job result and escalate past the cap.
-      const priorCaptureRetries = readAgentDeleteCaptureRetryCount(job.result);
+      const priorCaptureRetries = Math.max(
+        job.retryable_requeues,
+        readAgentDeleteCaptureRetryCount(job.result),
+      );
       const captureRetryExhausted =
         delResult.retryable && priorCaptureRetries >= PRE_DELETE_CAPTURE_MAX_FREE_RETRIES;
       const captureRetryCount = delResult.retryable ? priorCaptureRetries + 1 : priorCaptureRetries;
       // Persist a partial result and rethrow so the jobs runner counts an
       // attempt and retries (or marks failed on exhaustion).
-      await this.updateClaimedExecution(job, {
+      const retrySnapshot = await this.updateClaimedExecution(job, {
         result: agentDeleteJobResultToRecord({
           cloudAgentId: data.agentId,
           containerStopped: delResult.containerStopped,
@@ -5133,6 +5160,8 @@ export class ProvisioningJobService {
         // budget and strand the deletion (#18517).
         throw new RetryableProvisionTransportError(
           delResult.error ?? "Pre-deletion capture temporarily unavailable",
+          retrySnapshot,
+          PRE_DELETE_CAPTURE_MAX_FREE_RETRIES,
         );
       }
       if (captureRetryExhausted) {
@@ -5200,7 +5229,7 @@ export class ProvisioningJobService {
     if (await this.completeIfAgentGone(job, provResult, data.agentId)) return;
 
     if (!provResult.success) {
-      await this.updateClaimedExecution(job, {
+      const retrySnapshot = await this.updateClaimedExecution(job, {
         result: agentProvisionJobResultToRecord({
           cloudAgentId: data.agentId,
           status: provResult.sandboxRecord?.status ?? "error",
@@ -5208,7 +5237,11 @@ export class ProvisioningJobService {
         }),
       });
       if (provResult.retryable) {
-        throw new RetryableProvisionTransportError(provResult.error);
+        throw new RetryableProvisionTransportError(
+          provResult.error,
+          retrySnapshot,
+          PROVISION_TRANSPORT_MAX_FREE_RETRIES,
+        );
       }
       throw new Error(provResult.error);
     }


### PR DESCRIPTION
# Relates to

Closes #22321.

- [x] Targets `develop` and is rebased onto `origin/develop@705177498eccaa34871bfbbfdbc8c02f066420a2` with zero conflicts.
- [x] `bun install` completed with Bun 1.3.14; focused owning gates pass. Root `bun run verify` reached 355/358 Turbo tasks before the unrelated UI baseline failure recorded below.
- [x] The real PGlite evidence below exercises the database contract directly.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop` at implementation review time; zero conflicts.
- [ ] Root `bun run verify` is fully green. Exact unrelated baseline failure is documented below.

# Risks

Medium. This changes durable provisioning-job retry authority and adds migration 0253. The failure boundary is intentionally database-owned and compare-and-swap fenced; exhaustion and dependent-row settlement occur in one transaction. Provider-backed payload hydration remains outside locked transactions.

# Background

## What does this PR do?

Fixes the surviving failure mode from closed PR #18834: a worker could persist an intermediate result, throw a retryable transport error, then try to requeue with the stale claim-time row. The repository correctly rejected that stale snapshot, leaving the job `in_progress`. Retryable transport outcomes also had no durable upper bound.

This change:

- carries the fresh row returned by each intermediate execution write into the retry transition;
- adds a nonnegative, database-owned `retryable_requeues` counter;
- atomically allows five transport requeues (ten for pre-delete capture compatibility), then fails the job and settles its dependent row in the same transaction;
- keeps provider-backed hydration outside lifecycle/job-lock transactions;
- retains exact snapshot, execution-owner, lease, generation, and lifecycle fences.

## What kind of change is this?

Bug fix (non-breaking) with an append-only database migration.

# Documentation changes needed?

No public documentation change is needed; this repairs an internal durable-worker invariant.

# Testing

## Where should a reviewer start?

Start in `JobsRepository.retryLaterWithoutIncrementingAttempts`, then follow `RetryableProvisionTransportError` through `ProvisioningJobService.handleExecutionFailure`.

## Detailed testing steps

Exact head: `b925ab921133fc435601e78bc90f7e89d531392e`

- `bun test ...job-retryable-requeues-migration.test.ts ...migration-journal-registration.test.ts` — 9 pass, 0 fail.
- Real PGlite `jobs-completed-at.test.ts` — 21 pass, 0 fail, including stale-row rejection, exact 4-to-5 boundary, 5-to-6 exhaustion, dependent-write rollback, and duplicate contenders.
- `provisioning-jobs-execute-dispatch.test.ts` — 48 pass, 0 fail.
- Adjacent recovery/limit/PII/container tests — 51 pass, 0 fail.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- scoped Biome and `git diff --check` — pass.
- `bun run verify` — stopped at an unrelated existing `@elizaos/ui#typecheck` failure after 355/358 Turbo tasks; details below.

# Evidence Gate

<!-- evidence-head:b925ab921133fc435601e78bc90f7e89d531392e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - database repository and worker control-flow change only.
<!-- evidence-row:backend-logs -->
- [x] N/A - no protected cloud credentials were used; exact deterministic worker logs and real PGlite results are summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite rows prove stale CAS rejection, one-winner duplicate settlement, exact exhaustion, terminal timestamping, atomic dependent settlement, and rollback on dependent-write failure.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

Backend: focused deterministic worker suite 48/48 and real PGlite repository suite 21/21. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice changes.

## Known gaps / failures

Root `bun run verify` reached 355 successful of 358 Turbo tasks and failed only in untouched UI baseline tests that import non-exported symbols:

- `packages/ui/src/components/shell/BuildBadge-timeout.test.ts`: `BUILD_BADGE_JSON_TIMEOUT_MS`, `BUILD_INFO_URL`, `getBuildInfoJsonWithFetch`.
- `packages/ui/src/content-packs/load-pack-timeout.test.ts`: `CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS`, `getContentPackManifestJsonWithFetch`.

This PR does not modify either source or test (`git diff origin/develop --` is empty for all four files). The owning cloud-shared typecheck and all exact changed-path gates pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@705177498eccaa34871bfbbfdbc8c02f066420a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@705177498eccaa34871bfbbfdbc8c02f066420a2:packages/skills/skills/contribute-to-eliza"} -->
