### PR TITLE
fix(app-core): reject oversized first-run POST bodies before allocate

### DIFF
--- a/packages/app-core/src/api/first-run-routes-body.test.ts
+++ b/packages/app-core/src/api/first-run-routes-body.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Deterministic overflow coverage for the first-run POST body reader.
+ * The harness is a real Readable stream (no network). Origin concatenated
+ * every chunk before JSON.parse; a body over the cap must reject first.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type http from "node:http";
+import { Readable } from "node:stream";
+import {
+  FirstRunBodyTooLargeError,
+  MAX_FIRST_RUN_BODY_BYTES,
+  readFirstRunRawBody,
+} from "./first-run-routes-body.ts";
+
+function bodyStream(raw: string): http.IncomingMessage {
+  return Readable.from([
+    Buffer.from(raw, "utf8"),
+  ]) as unknown as http.IncomingMessage;
+}
+
+describe("readFirstRunRawBody", () => {
+  it("admits a small object body", async () => {
+    const raw = await readFirstRunRawBody(bodyStream('{"name":"Eliza"}'));
+    expect(raw).toBe('{"name":"Eliza"}');
+  });
+
+  it("rejects a body past the cap before concat of the full stream", async () => {
+    const overflow = "x".repeat(128);
+    await expect(
+      readFirstRunRawBody(bodyStream(overflow), 64),
+    ).rejects.toBeInstanceOf(FirstRunBodyTooLargeError);
+  });
+
+  it("keeps the production cap at 1 MiB", () => {
+    expect(MAX_FIRST_RUN_BODY_BYTES).toBe(1_048_576);
+  });
+});

--- a/packages/app-core/src/api/first-run-routes-body.ts
+++ b/packages/app-core/src/api/first-run-routes-body.ts
@@ -1,0 +1,40 @@
+/**
+ * Bounded reader for `POST /api/first-run`. Origin concatenated the entire
+ * request stream before JSON.parse, so a multi-megabyte body was allocated
+ * before the handler could reject it. Fail closed at the byte cap.
+ */
+import type http from "node:http";
+
+export const MAX_FIRST_RUN_BODY_BYTES = 1_048_576;
+
+export class FirstRunBodyTooLargeError extends Error {
+  readonly code = "FIRST_RUN_BODY_TOO_LARGE";
+  constructor(
+    readonly receivedBytes: number,
+    readonly maxBytes: number,
+  ) {
+    super(
+      `first-run request body exceeded ${maxBytes} bytes (got ${receivedBytes})`,
+    );
+    this.name = "FirstRunBodyTooLargeError";
+  }
+}
+
+/** Read the raw POST body and throw before the allocation exceeds the cap. */
+export async function readFirstRunRawBody(
+  req: http.IncomingMessage,
+  maxBytes = MAX_FIRST_RUN_BODY_BYTES,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    total += buf.length;
+    if (total > maxBytes) {
+      req.destroy();
+      throw new FirstRunBodyTooLargeError(total, maxBytes);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString("utf8").trim();
+}

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -13,7 +13,9 @@
  * boot; cloud/remote targets deliberately leave the process runtime-less.
  *
  * Untrusted request JSON is parsed before any persist: syntax errors and
- * non-object bodies return 400 and never report `{ ok: true }`.
+ * non-object bodies return 400 and never report `{ ok: true }`. The raw
+ * body is credited against MAX_FIRST_RUN_BODY_BYTES so a multi-megabyte
+ * POST cannot be materialized before that parse.
  *
  * A defensive delayed resave (`scheduleCloudApiKeyResave`) re-writes
  * `cloud.apiKey` if a concurrent config write clobbers it — a best-effort
@@ -44,6 +46,10 @@ import {
   isRuntimeBootDeferred,
   triggerDeferredRuntimeBoot,
 } from "./deferred-runtime-boot";
+import {
+  FirstRunBodyTooLargeError,
+  readFirstRunRawBody,
+} from "./first-run-routes-body.ts";
 import { sendJson as sendJsonResponse } from "./response";
 import {
   deriveFirstRunReplayBody,
@@ -201,18 +207,21 @@ export async function handleFirstRunRoute(
     return true;
   }
 
-  const chunks: Buffer[] = [];
+  let rawBody: string;
   try {
-    for await (const chunk of req) {
-      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-    }
+    rawBody = await readFirstRunRawBody(req);
   } catch (err) {
+    // error-policy:J1 first-run POST is the transport boundary — overflow
+    // is 413, a broken stream is 400, never a fabricated onboarding success.
+    if (err instanceof FirstRunBodyTooLargeError) {
+      sendJsonResponse(res, 413, { error: err.message });
+      return true;
+    }
     sendJsonResponse(res, 400, {
       error: `failed to read onboarding request body: ${err instanceof Error ? err.message : String(err)}`,
     });
     return true;
   }
-  const rawBody = Buffer.concat(chunks).toString("utf8").trim();
   let parsed: unknown;
   try {
     parsed = rawBody === "" ? undefined : JSON.parse(rawBody);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone first-run onboarding overflow: `POST /api/first-run`
concatenated the entire request stream before `JSON.parse`. Not a twin
of `#22302` (plugin-x download `arrayBuffer`), `#22303` (file-ops),
`#22341` (local-trust), `#22337` (claude CLI), `#22333` (gzip),
`#22331` (zip), `#22262`, `#22278`, `#22282`, or the HTTP fetch-timeout
family. Not an ASI `#1874` reprint. HARD_SKIP is `server.ts`, not this
route. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Origin concatenated every chunk with no cap (4 MiB replica
      allocated 4194304 bytes).
- [x] Head rejects a 128-byte body against a 64-byte test cap before
      full concat.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `95eba8440d80` with zero conflicts.
- [x] Isolated body-reader tests 3/3 at this head.
- [x] Biome on the three touched files: clean.

# Risks

Low and bounded to `POST /api/first-run`. A canonical onboarding JSON
object stays well under 1 MiB. A multi-megabyte POST is 413 instead of
an in-process allocation.

# Background

## What does this PR do?

Origin did:

```ts
const chunks: Buffer[] = [];
for await (const chunk of req) {
  chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
}
const rawBody = Buffer.concat(chunks).toString("utf8").trim();
```

There was no running total. A hostile onboarding POST could send
gigabytes and only then fail JSON.parse.

Head credits each chunk in `readFirstRunRawBody` and throws
`FirstRunBodyTooLargeError` at 1 MiB (HTTP 413). Syntax errors remain
400.

## What kind of change is this?

Bug fix (request-body overflow).

# Documentation changes needed?

No public field change. Oversized bodies are a new 413.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/first-run-routes-body.ts` and
`first-run-routes-body.test.ts`. Wiring is `handleFirstRunRoute`.

## Detailed testing steps

```bash
bun test packages/app-core/src/api/first-run-routes-body.test.ts
```

Origin: unbounded concat. Head: 128 vs 64 cap rejects
`FirstRunBodyTooLargeError`; small `{"name":"Eliza"}` still reads.

# Evidence Gate

<!-- evidence-head:6932835fb79e8784cd7ef4fb18aac8afa00f7ed3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated body-reader proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - body cap only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin unbounded concat. Head tests 3/3 at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - isolated reader proof.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated
body-reader tests 3/3 are the recorded suite at this head.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
