### PR TITLE
fix(cloud): make crypto settlement atomic

### DIFF
--- a/packages/cloud/api/__tests__/oxapay-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/oxapay-webhook-route.test.ts
@@ -158,7 +158,7 @@ beforeEach(() => {
     trackId,
     orderId: trackId.replace("trk_", "pr_"),
     status: "paid",
-    amount: 25,
+    amount: "25",
     amountText: "25.00",
     currency: "USD",
     transactions: [],

--- a/packages/cloud/api/cron/cleanup-expired-crypto-payments/route.ts
+++ b/packages/cloud/api/cron/cleanup-expired-crypto-payments/route.ts
@@ -4,60 +4,13 @@
  */
 
 import { Hono } from "hono";
-import { cryptoPaymentsRepository } from "@/db/repositories/crypto-payments";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
-import { appChargeCallbacksService } from "@/lib/services/app-charge-callbacks";
 import { cryptoPaymentsService } from "@/lib/services/crypto-payments";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
-
-function appChargeFailureCallback(payment: {
-  id: string;
-  expected_amount: string;
-  organization_id: string;
-  user_id: string | null;
-  network: string;
-  token: string;
-  metadata: unknown;
-}) {
-  const metadata =
-    typeof payment.metadata === "object" &&
-    payment.metadata !== null &&
-    !Array.isArray(payment.metadata)
-      ? (payment.metadata as Record<string, unknown>)
-      : {};
-  const kind = metadata.kind ?? metadata.type;
-  const appId =
-    typeof metadata.app_id === "string" ? metadata.app_id : undefined;
-  const chargeRequestId =
-    typeof metadata.charge_request_id === "string"
-      ? metadata.charge_request_id
-      : undefined;
-
-  if (kind !== "app_credit_purchase" || !appId || !chargeRequestId) {
-    return null;
-  }
-
-  return {
-    appId,
-    chargeRequestId,
-    status: "failed" as const,
-    provider: "oxapay" as const,
-    providerPaymentId: payment.id,
-    amountUsd: payment.expected_amount,
-    payerUserId: payment.user_id,
-    payerOrganizationId: payment.organization_id,
-    reason: "expired",
-    metadata: {
-      crypto_payment_id: payment.id,
-      network: payment.network,
-      token: payment.token,
-    },
-  };
-}
 
 app.get("/", async (c) => {
   try {
@@ -77,11 +30,7 @@ app.get("/", async (c) => {
     let errors = 0;
     for (const payment of expiredPayments) {
       try {
-        await cryptoPaymentsRepository.markAsExpired(payment.id);
-        const callback = appChargeFailureCallback(payment);
-        if (callback) {
-          await appChargeCallbacksService.dispatch(callback);
-        }
+        await cryptoPaymentsService.expirePaymentWithCallback(payment);
         markedExpired++;
       } catch (error) {
         errors++;

--- a/packages/cloud/api/cron/process-pending-crypto-payments/route.ts
+++ b/packages/cloud/api/cron/process-pending-crypto-payments/route.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
+import { appChargeCallbacksService } from "@/lib/services/app-charge-callbacks";
 import { directWalletPaymentsService } from "@/lib/services/direct-wallet-payments";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -27,11 +28,15 @@ app.get("/", (c) =>
 app.post("/", async (c) => {
   try {
     requireCronSecret(c);
-    const stats = await directWalletPaymentsService.processBroadcastBatch(
-      c.env,
-    );
-    return c.json({ success: true, ...stats });
+    const [stats, sweeps, callbacks] = await Promise.all([
+      directWalletPaymentsService.processBroadcastBatch(c.env),
+      directWalletPaymentsService.drainSweepOutbox(c.env),
+      appChargeCallbacksService.drain(),
+    ]);
+    return c.json({ success: true, ...stats, sweeps, callbacks });
   } catch (error) {
+    // error-policy:J1 cron is the transport boundary for durable crypto
+    // verification, sweep, and callback recovery and returns retryable failure.
     logger.error("[Cron process-pending-crypto-payments] failed", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
+++ b/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
@@ -80,13 +80,6 @@ app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
       return c.json({ error: "Unauthorized" }, 403);
     }
 
-    if (payment.status === "confirmed") {
-      return c.json({
-        success: true,
-        message: "Payment already confirmed",
-        status: payment.status,
-      });
-    }
     if (payment.status === "expired") {
       return c.json({ error: "Payment has expired" }, 400);
     }

--- a/packages/cloud/api/crypto/payments/route.ts
+++ b/packages/cloud/api/crypto/payments/route.ts
@@ -31,7 +31,7 @@ const createPaymentSchema = z.object({
     .transform((value) => String(value))
     .refine((value) => Number(value) >= 1, "Minimum amount is $1")
     .refine((value) => Number(value) <= 10000, "Maximum amount is $10,000"),
-  currency: z.string().default("USD"),
+  currency: z.literal("USD").default("USD"),
   payCurrency: z.enum(SUPPORTED_PAY_CURRENCIES).default("USDT"),
   network: z
     .enum(["ERC20", "TRC20", "BEP20", "POLYGON", "SOL", "BASE", "ARB", "OP"])
@@ -92,6 +92,7 @@ app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
         INVALID_UUID: { status: 400, message: "Invalid request format" },
         AMOUNT_TOO_SMALL: { status: 400, message: "Amount too small" },
         AMOUNT_TOO_LARGE: { status: 400, message: "Amount too large" },
+        INVALID_CURRENCY: { status: 400, message: "Currency must be USD" },
         SERVICE_NOT_CONFIGURED: {
           status: 503,
           message: "Service temporarily unavailable",

--- a/packages/cloud/api/crypto/payments/route.ts
+++ b/packages/cloud/api/crypto/payments/route.ts
@@ -27,9 +27,10 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const createPaymentSchema = z.object({
   amount: z
-    .number()
-    .min(1, "Minimum amount is $1")
-    .max(10000, "Maximum amount is $10,000"),
+    .union([z.string().regex(/^(?:\d+|\d+\.\d+)$/), z.number().finite()])
+    .transform((value) => String(value))
+    .refine((value) => Number(value) >= 1, "Minimum amount is $1")
+    .refine((value) => Number(value) <= 10000, "Maximum amount is $10,000"),
   currency: z.string().default("USD"),
   payCurrency: z.enum(SUPPORTED_PAY_CURRENCIES).default("USDT"),
   network: z

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -929,7 +929,7 @@ async function handlePaymentIntentFailed(event: Stripe.Event): Promise<void> {
   });
 
   if (purchaseSource === "miniapp_app" && appId && chargeRequestId) {
-    await appChargeCallbacksService.dispatch({
+    await appChargeCallbacksService.failChargeAndEnqueue({
       appId,
       chargeRequestId,
       status: "failed",

--- a/packages/cloud/shared/src/db/crypto-payment-transaction-hash.test.ts
+++ b/packages/cloud/shared/src/db/crypto-payment-transaction-hash.test.ts
@@ -1,0 +1,23 @@
+/** Exercises the shared crypto transaction identity boundary with deterministic strings. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeCryptoTransactionHash,
+  cryptoTransactionHashesEqual,
+} from "./crypto-payment-transaction-hash";
+
+describe("crypto payment transaction hash identity", () => {
+  test("canonicalizes EVM hexadecimal casing", () => {
+    expect(canonicalizeCryptoTransactionHash(" 0xAbCd1234 ", "bsc")).toBe("0xabcd1234");
+    expect(cryptoTransactionHashesEqual("0xABCD1234", "0xabcd1234", "base")).toBe(true);
+  });
+
+  test("preserves case-sensitive Solana transaction identifiers", () => {
+    expect(canonicalizeCryptoTransactionHash("5AbCdEfGh", "solana")).toBe("5AbCdEfGh");
+    expect(cryptoTransactionHashesEqual("5AbCdEfGh", "5abcdefGh", "solana")).toBe(false);
+  });
+
+  test("rejects empty transaction identities", () => {
+    expect(() => canonicalizeCryptoTransactionHash("  ", "bsc")).toThrow("must not be empty");
+  });
+});

--- a/packages/cloud/shared/src/db/crypto-payment-transaction-hash.ts
+++ b/packages/cloud/shared/src/db/crypto-payment-transaction-hash.ts
@@ -1,0 +1,33 @@
+/**
+ * Defines the canonical transaction-hash identity shared by every crypto-payment writer.
+ * EVM-style hexadecimal hashes are case-insensitive; case-sensitive chain identifiers remain unchanged.
+ */
+
+const HEX_TRANSACTION_HASH = /^0x[0-9a-f]+$/i;
+
+export function isHexTransactionHash(transactionHash: string): boolean {
+  return HEX_TRANSACTION_HASH.test(transactionHash.trim());
+}
+
+export function canonicalizeCryptoTransactionHash(
+  transactionHash: string,
+  network?: string | null,
+): string {
+  const trimmed = transactionHash.trim();
+  if (!trimmed) throw new Error("Transaction hash must not be empty");
+  if (network?.toLowerCase() === "solana") return trimmed;
+  return isHexTransactionHash(trimmed) ? trimmed.toLowerCase() : trimmed;
+}
+
+export function cryptoTransactionHashesEqual(
+  left: string | null | undefined,
+  right: string,
+  network?: string | null,
+): boolean {
+  return (
+    left !== null &&
+    left !== undefined &&
+    canonicalizeCryptoTransactionHash(left, network) ===
+      canonicalizeCryptoTransactionHash(right, network)
+  );
+}

--- a/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
+++ b/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
@@ -61,12 +61,16 @@ CREATE TABLE IF NOT EXISTS crypto_sweep_outbox (
   last_error text,
   prepared_transaction text,
   sweep_transaction_hash text,
+  prepared_metadata jsonb,
   delivered_at timestamptz,
   terminal_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT NOW(),
   updated_at timestamptz NOT NULL DEFAULT NOW(),
   CONSTRAINT crypto_sweep_outbox_prepared_pair_check
-    CHECK ((prepared_transaction IS NULL) = (sweep_transaction_hash IS NULL))
+    CHECK (
+      (prepared_transaction IS NULL) = (sweep_transaction_hash IS NULL)
+      AND (prepared_transaction IS NULL) = (prepared_metadata IS NULL)
+    )
 );
 CREATE UNIQUE INDEX IF NOT EXISTS crypto_sweep_outbox_payment_uidx
   ON crypto_sweep_outbox(payment_id);

--- a/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
+++ b/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
@@ -35,6 +35,8 @@ CREATE TABLE IF NOT EXISTS app_charge_callback_outbox (
   claim_token uuid,
   lease_expires_at timestamptz,
   last_error text,
+  room_delivered_at timestamptz,
+  http_delivered_at timestamptz,
   delivered_at timestamptz,
   terminal_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT NOW(),

--- a/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
+++ b/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
@@ -59,11 +59,14 @@ CREATE TABLE IF NOT EXISTS crypto_sweep_outbox (
   claim_token uuid,
   lease_expires_at timestamptz,
   last_error text,
+  prepared_transaction text,
   sweep_transaction_hash text,
   delivered_at timestamptz,
   terminal_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT NOW(),
-  updated_at timestamptz NOT NULL DEFAULT NOW()
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT crypto_sweep_outbox_prepared_pair_check
+    CHECK ((prepared_transaction IS NULL) = (sweep_transaction_hash IS NULL))
 );
 CREATE UNIQUE INDEX IF NOT EXISTS crypto_sweep_outbox_payment_uidx
   ON crypto_sweep_outbox(payment_id);

--- a/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
+++ b/packages/cloud/shared/src/db/migrations/0255_crypto_settlement_outboxes.sql
@@ -1,0 +1,70 @@
+-- Fail closed if legacy active EVM hash casing already represents a double spend.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM crypto_payments
+    WHERE transaction_hash ~ '^0x[0-9A-Fa-f]+$'
+      AND status IN ('pending', 'broadcast', 'confirmed')
+    GROUP BY lower(transaction_hash)
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'active crypto payments contain duplicate EVM transaction hashes after canonicalization';
+  END IF;
+END $$;
+
+UPDATE crypto_payments
+SET transaction_hash = lower(transaction_hash), updated_at = NOW()
+WHERE transaction_hash ~ '^0x[0-9A-Fa-f]+$'
+  AND transaction_hash <> lower(transaction_hash);
+
+CREATE UNIQUE INDEX IF NOT EXISTS crypto_payments_active_evm_tx_hash_lower_uidx
+  ON crypto_payments (lower(transaction_hash))
+  WHERE transaction_hash ~ '^0x[0-9A-Fa-f]+$'
+    AND status IN ('pending', 'broadcast', 'confirmed');
+
+CREATE TABLE IF NOT EXISTS app_charge_callback_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  delivery_key text NOT NULL,
+  charge_request_id uuid NOT NULL REFERENCES crypto_payments(id) ON DELETE CASCADE,
+  payload jsonb NOT NULL,
+  payload_digest text NOT NULL,
+  state text NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'processing', 'delivered', 'terminal')),
+  attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  next_attempt_at timestamptz NOT NULL DEFAULT NOW(),
+  claim_token uuid,
+  lease_expires_at timestamptz,
+  last_error text,
+  delivered_at timestamptz,
+  terminal_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS app_charge_callback_outbox_delivery_uidx
+  ON app_charge_callback_outbox(delivery_key);
+CREATE INDEX IF NOT EXISTS app_charge_callback_outbox_due_idx
+  ON app_charge_callback_outbox(next_attempt_at, created_at)
+  WHERE state IN ('pending', 'processing');
+
+CREATE TABLE IF NOT EXISTS crypto_sweep_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  payment_id uuid NOT NULL REFERENCES crypto_payments(id) ON DELETE CASCADE,
+  payload jsonb NOT NULL,
+  payload_digest text NOT NULL,
+  state text NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'processing', 'delivered', 'terminal')),
+  attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  next_attempt_at timestamptz NOT NULL DEFAULT NOW(),
+  claim_token uuid,
+  lease_expires_at timestamptz,
+  last_error text,
+  sweep_transaction_hash text,
+  delivered_at timestamptz,
+  terminal_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS crypto_sweep_outbox_payment_uidx
+  ON crypto_sweep_outbox(payment_id);
+CREATE INDEX IF NOT EXISTS crypto_sweep_outbox_due_idx
+  ON crypto_sweep_outbox(next_attempt_at, created_at)
+  WHERE state IN ('pending', 'processing');

--- a/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
+++ b/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
@@ -1,0 +1,52 @@
+/** Applies migration 0255 to real PGlite for legacy collision and safe canonicalization proof. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+
+const databases: PGlite[] = [];
+const migration = await readFile(
+  new URL("./0255_crypto_settlement_outboxes.sql", import.meta.url),
+  "utf8",
+);
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`CREATE TABLE crypto_payments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    transaction_hash text, status text NOT NULL, updated_at timestamptz NOT NULL DEFAULT now()
+  )`);
+  return db;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0255 crypto settlement migration", () => {
+  test("fails closed when active legacy EVM casing aliases already collide", async () => {
+    const db = await database();
+    await db.exec(`INSERT INTO crypto_payments(transaction_hash, status) VALUES
+      ('0xAbCd', 'confirmed'), ('0xaBcD', 'broadcast')`);
+    await expect(db.exec(migration)).rejects.toThrow(/duplicate EVM transaction hashes/i);
+    const rows = await db.query<{ transaction_hash: string }>(
+      "SELECT transaction_hash FROM crypto_payments ORDER BY transaction_hash",
+    );
+    expect(rows.rows.map((row) => row.transaction_hash)).toEqual(["0xAbCd", "0xaBcD"]);
+  });
+
+  test("canonicalizes safe legacy EVM rows, preserves Solana case, and enforces lower uniqueness", async () => {
+    const db = await database();
+    await db.exec(`INSERT INTO crypto_payments(transaction_hash, status) VALUES
+      ('0xAbCd', 'confirmed'), ('SoLaNaCase', 'confirmed')`);
+    await db.exec(migration);
+    const rows = await db.query<{ transaction_hash: string }>(
+      "SELECT transaction_hash FROM crypto_payments ORDER BY transaction_hash",
+    );
+    expect(rows.rows.map((row) => row.transaction_hash)).toEqual(["0xabcd", "SoLaNaCase"]);
+    await expect(
+      db.exec("INSERT INTO crypto_payments(transaction_hash, status) VALUES ('0xABCD', 'pending')"),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
+++ b/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
@@ -58,6 +58,13 @@ describe("0255 crypto settlement migration", () => {
         '{}', 'digest', 'signed-transaction'
       )`),
     ).rejects.toThrow(/prepared_pair/i);
+    await db.exec(`INSERT INTO crypto_sweep_outbox(
+        payment_id, payload, payload_digest, prepared_transaction,
+        sweep_transaction_hash, prepared_metadata
+      ) VALUES (
+        (SELECT id FROM crypto_payments WHERE transaction_hash = '0xabcd'),
+        '{}', 'digest', 'signed-transaction', 'hash', '{"network":"solana"}'
+      )`);
     await expect(
       db.exec("INSERT INTO crypto_payments(transaction_hash, status) VALUES ('0xABCD', 'pending')"),
     ).rejects.toThrow();

--- a/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
+++ b/packages/cloud/shared/src/db/migrations/crypto-settlement-outboxes.test.ts
@@ -45,6 +45,19 @@ describe("0255 crypto settlement migration", () => {
       "SELECT transaction_hash FROM crypto_payments ORDER BY transaction_hash",
     );
     expect(rows.rows.map((row) => row.transaction_hash)).toEqual(["0xabcd", "SoLaNaCase"]);
+    const preparedColumn = await db.query<{ data_type: string }>(`
+      SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'crypto_sweep_outbox' AND column_name = 'prepared_transaction'
+    `);
+    expect(preparedColumn.rows).toEqual([{ data_type: "text" }]);
+    await expect(
+      db.exec(`INSERT INTO crypto_sweep_outbox(
+        payment_id, payload, payload_digest, prepared_transaction
+      ) VALUES (
+        (SELECT id FROM crypto_payments WHERE transaction_hash = '0xabcd'),
+        '{}', 'digest', 'signed-transaction'
+      )`),
+    ).rejects.toThrow(/prepared_pair/i);
     await expect(
       db.exec("INSERT INTO crypto_payments(transaction_hash, status) VALUES ('0xABCD', 'pending')"),
     ).rejects.toThrow();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1779,6 +1779,13 @@
       "when": 1791403200000,
       "tag": "0254_payment_request_provider_settlement",
       "breakpoints": true
+    },
+    {
+      "idx": 254,
+      "version": "7",
+      "when": 1791489600000,
+      "tag": "0255_crypto_settlement_outboxes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/app-earnings.ts
+++ b/packages/cloud/shared/src/db/repositories/app-earnings.ts
@@ -1,4 +1,4 @@
-// Persists app earnings records for cloud services through the shared DB boundary.
+/** Persists app earnings records for cloud services through the shared DB boundary. */
 
 import Decimal from "decimal.js";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";

--- a/packages/cloud/shared/src/db/repositories/app-earnings.ts
+++ b/packages/cloud/shared/src/db/repositories/app-earnings.ts
@@ -3,6 +3,7 @@
 import Decimal from "decimal.js";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { logger } from "../../lib/utils/logger";
+import type { DbTransaction } from "../client";
 import { dbRead, dbWrite } from "../helpers";
 import {
   type AppEarnings,
@@ -123,8 +124,9 @@ export class AppEarningsRepository {
   async findTransactionByPaymentIntent(
     appId: string,
     paymentIntentId: string,
+    transaction?: DbTransaction,
   ): Promise<AppEarningsTransaction | undefined> {
-    const result = await dbRead
+    const result = await (transaction ?? dbRead)
       .select()
       .from(appEarningsTransactions)
       .where(
@@ -330,6 +332,7 @@ export class AppEarningsRepository {
    */
   async applyCreatorMovement(
     params: ApplyCreatorMovementParams,
+    transaction?: DbTransaction,
   ): Promise<ApplyCreatorMovementResult> {
     const expectedCreatorAmount = new Decimal(params.creatorAmount);
     const platformRevenueAmount = new Decimal(params.platformRevenueAmount);
@@ -353,7 +356,7 @@ export class AppEarningsRepository {
     }
     const platformRevenueDelta = platformRevenueAmount.toFixed(6);
 
-    return dbWrite.transaction(async (tx) => {
+    const apply = async (tx: DbTransaction): Promise<ApplyCreatorMovementResult> => {
       const [redeemableLedger] = await tx
         .select({
           amount: redeemableEarningsLedger.amount,
@@ -547,7 +550,8 @@ export class AppEarningsRepository {
       }
 
       return { deduplicated: false, transaction: inserted };
-    });
+    };
+    return transaction ? await apply(transaction) : await dbWrite.transaction(apply);
   }
 
   /**
@@ -784,9 +788,15 @@ export class AppEarningsRepository {
   /**
    * Creates a new earnings transaction record.
    */
-  async createTransaction(data: NewAppEarningsTransaction): Promise<AppEarningsTransaction> {
-    const [transaction] = await dbWrite.insert(appEarningsTransactions).values(data).returning();
-    return transaction;
+  async createTransaction(
+    data: NewAppEarningsTransaction,
+    transaction?: DbTransaction,
+  ): Promise<AppEarningsTransaction> {
+    const [created] = await (transaction ?? dbWrite)
+      .insert(appEarningsTransactions)
+      .values(data)
+      .returning();
+    return created;
   }
 }
 

--- a/packages/cloud/shared/src/db/repositories/crypto-payments.ts
+++ b/packages/cloud/shared/src/db/repositories/crypto-payments.ts
@@ -1,5 +1,9 @@
 // Persists crypto payments records for cloud services through the shared DB boundary.
 import { and, desc, eq, lt, sql } from "drizzle-orm";
+import {
+  canonicalizeCryptoTransactionHash,
+  isHexTransactionHash,
+} from "../crypto-payment-transaction-hash";
 import { dbRead, dbWrite } from "../helpers";
 import {
   type CryptoPayment,
@@ -34,9 +38,17 @@ export class CryptoPaymentsRepository {
   }
 
   async findByTransactionHash(txHash: string): Promise<CryptoPayment | undefined> {
-    return await dbRead.query.cryptoPayments.findFirst({
-      where: eq(cryptoPayments.transaction_hash, txHash),
-    });
+    const canonicalTxHash = canonicalizeCryptoTransactionHash(txHash);
+    const [payment] = await dbRead
+      .select()
+      .from(cryptoPayments)
+      .where(
+        isHexTransactionHash(canonicalTxHash)
+          ? sql`lower(${cryptoPayments.transaction_hash}) = ${canonicalTxHash}`
+          : eq(cryptoPayments.transaction_hash, canonicalTxHash),
+      )
+      .limit(1);
+    return payment;
   }
 
   async findByTrackId(trackId: string): Promise<CryptoPayment | undefined> {
@@ -79,10 +91,15 @@ export class CryptoPaymentsRepository {
   // ============================================================================
 
   async create(data: NewCryptoPayment): Promise<CryptoPayment> {
+    const transactionHash =
+      typeof data.transaction_hash === "string"
+        ? canonicalizeCryptoTransactionHash(data.transaction_hash, data.network)
+        : data.transaction_hash;
     const [payment] = await dbWrite
       .insert(cryptoPayments)
       .values({
         ...data,
+        transaction_hash: transactionHash,
         created_at: new Date(),
         updated_at: new Date(),
       })
@@ -91,10 +108,15 @@ export class CryptoPaymentsRepository {
   }
 
   async update(id: string, data: Partial<NewCryptoPayment>): Promise<CryptoPayment | undefined> {
+    const transactionHash =
+      typeof data.transaction_hash === "string"
+        ? canonicalizeCryptoTransactionHash(data.transaction_hash, data.network)
+        : data.transaction_hash;
     const [payment] = await dbWrite
       .update(cryptoPayments)
       .set({
         ...data,
+        ...(data.transaction_hash !== undefined && { transaction_hash: transactionHash }),
         updated_at: new Date(),
       })
       .where(eq(cryptoPayments.id, id))
@@ -112,7 +134,7 @@ export class CryptoPaymentsRepository {
       .update(cryptoPayments)
       .set({
         status: "confirmed",
-        transaction_hash: txHash,
+        transaction_hash: canonicalizeCryptoTransactionHash(txHash),
         block_number: blockNumber,
         received_amount: receivedAmount,
         confirmed_at: new Date(),

--- a/packages/cloud/shared/src/db/repositories/crypto-payments.ts
+++ b/packages/cloud/shared/src/db/repositories/crypto-payments.ts
@@ -1,4 +1,4 @@
-// Persists crypto payments records for cloud services through the shared DB boundary.
+/** Persists crypto payments records for cloud services through the shared DB boundary. */
 import { and, desc, eq, lt, sql } from "drizzle-orm";
 import {
   canonicalizeCryptoTransactionHash,

--- a/packages/cloud/shared/src/db/schemas/crypto-payments.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-payments.ts
@@ -1,4 +1,4 @@
-// Defines the crypto payments Drizzle table shape used by cloud repositories and services.
+/** Defines the crypto payments Drizzle table shape used by cloud repositories and services. */
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { organizations } from "./organizations";

--- a/packages/cloud/shared/src/db/schemas/crypto-payments.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-payments.ts
@@ -56,9 +56,10 @@ export const cryptoPayments = pgTable(
     status_idx: index("crypto_payments_status_idx").on(table.status),
     // Uniqueness on transaction_hash is enforced by a PARTIAL unique index
     // scoped to active statuses ('pending','broadcast','confirmed'), managed
-    // via migration 0131_partial_unique_tx_hash.sql. Drizzle's schema DSL
-    // cannot express the partial WHERE clause cleanly, so we expose a plain
-    // (non-unique) lookup index here and let the migration own the constraint.
+    // via migration 0131_partial_unique_tx_hash.sql. Settlement code stores
+    // hexadecimal hashes in canonical lowercase before this constraint while
+    // preserving case-sensitive chain identifiers. Drizzle's schema DSL cannot
+    // express the partial WHERE clause cleanly, so the migration owns it.
     tx_hash_idx: index("crypto_payments_transaction_hash_idx").on(table.transaction_hash),
     network_idx: index("crypto_payments_network_idx").on(table.network),
     created_idx: index("crypto_payments_created_at_idx").on(table.created_at),

--- a/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
@@ -2,6 +2,7 @@
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   jsonb,
@@ -59,6 +60,7 @@ export const cryptoSweepOutbox = pgTable(
     claim_token: uuid("claim_token"),
     lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
     last_error: text("last_error"),
+    prepared_transaction: text("prepared_transaction"),
     sweep_transaction_hash: text("sweep_transaction_hash"),
     delivered_at: timestamp("delivered_at", { withTimezone: true }),
     terminal_at: timestamp("terminal_at", { withTimezone: true }),
@@ -70,6 +72,10 @@ export const cryptoSweepOutbox = pgTable(
     due_idx: index("crypto_sweep_outbox_due_idx")
       .on(table.next_attempt_at, table.created_at)
       .where(sql`${table.state} IN ('pending', 'processing')`),
+    prepared_pair_check: check(
+      "crypto_sweep_outbox_prepared_pair_check",
+      sql`(${table.prepared_transaction} IS NULL) = (${table.sweep_transaction_hash} IS NULL)`,
+    ),
   }),
 );
 

--- a/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
@@ -62,6 +62,7 @@ export const cryptoSweepOutbox = pgTable(
     last_error: text("last_error"),
     prepared_transaction: text("prepared_transaction"),
     sweep_transaction_hash: text("sweep_transaction_hash"),
+    prepared_metadata: jsonb("prepared_metadata").$type<Record<string, unknown>>(),
     delivered_at: timestamp("delivered_at", { withTimezone: true }),
     terminal_at: timestamp("terminal_at", { withTimezone: true }),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -74,7 +75,9 @@ export const cryptoSweepOutbox = pgTable(
       .where(sql`${table.state} IN ('pending', 'processing')`),
     prepared_pair_check: check(
       "crypto_sweep_outbox_prepared_pair_check",
-      sql`(${table.prepared_transaction} IS NULL) = (${table.sweep_transaction_hash} IS NULL)`,
+      sql`(${table.prepared_transaction} IS NULL)
+        = (${table.sweep_transaction_hash} IS NULL)
+        AND (${table.prepared_transaction} IS NULL) = (${table.prepared_metadata} IS NULL)`,
     ),
   }),
 );

--- a/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
@@ -1,0 +1,77 @@
+/** Durable post-settlement delivery intents for app callbacks and wallet sweeps. */
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { cryptoPayments } from "./crypto-payments";
+
+export const appChargeCallbackOutbox = pgTable(
+  "app_charge_callback_outbox",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    delivery_key: text("delivery_key").notNull(),
+    charge_request_id: uuid("charge_request_id")
+      .notNull()
+      .references(() => cryptoPayments.id, { onDelete: "cascade" }),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    payload_digest: text("payload_digest").notNull(),
+    state: text("state").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    next_attempt_at: timestamp("next_attempt_at", { withTimezone: true }).notNull().defaultNow(),
+    claim_token: uuid("claim_token"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    last_error: text("last_error"),
+    delivered_at: timestamp("delivered_at", { withTimezone: true }),
+    terminal_at: timestamp("terminal_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    delivery_unique: uniqueIndex("app_charge_callback_outbox_delivery_uidx").on(table.delivery_key),
+    due_idx: index("app_charge_callback_outbox_due_idx")
+      .on(table.next_attempt_at, table.created_at)
+      .where(sql`${table.state} IN ('pending', 'processing')`),
+  }),
+);
+
+export const cryptoSweepOutbox = pgTable(
+  "crypto_sweep_outbox",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    payment_id: uuid("payment_id")
+      .notNull()
+      .references(() => cryptoPayments.id, { onDelete: "cascade" }),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    payload_digest: text("payload_digest").notNull(),
+    state: text("state").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    next_attempt_at: timestamp("next_attempt_at", { withTimezone: true }).notNull().defaultNow(),
+    claim_token: uuid("claim_token"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    last_error: text("last_error"),
+    sweep_transaction_hash: text("sweep_transaction_hash"),
+    delivered_at: timestamp("delivered_at", { withTimezone: true }),
+    terminal_at: timestamp("terminal_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    payment_unique: uniqueIndex("crypto_sweep_outbox_payment_uidx").on(table.payment_id),
+    due_idx: index("crypto_sweep_outbox_due_idx")
+      .on(table.next_attempt_at, table.created_at)
+      .where(sql`${table.state} IN ('pending', 'processing')`),
+  }),
+);
+
+export type AppChargeCallbackOutboxRow = InferSelectModel<typeof appChargeCallbackOutbox>;
+export type NewAppChargeCallbackOutboxRow = InferInsertModel<typeof appChargeCallbackOutbox>;
+export type CryptoSweepOutboxRow = InferSelectModel<typeof cryptoSweepOutbox>;
+export type NewCryptoSweepOutboxRow = InferInsertModel<typeof cryptoSweepOutbox>;

--- a/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
+++ b/packages/cloud/shared/src/db/schemas/crypto-settlement-outbox.ts
@@ -29,6 +29,8 @@ export const appChargeCallbackOutbox = pgTable(
     claim_token: uuid("claim_token"),
     lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
     last_error: text("last_error"),
+    room_delivered_at: timestamp("room_delivered_at", { withTimezone: true }),
+    http_delivered_at: timestamp("http_delivered_at", { withTimezone: true }),
     delivered_at: timestamp("delivered_at", { withTimezone: true }),
     terminal_at: timestamp("terminal_at", { withTimezone: true }),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -51,6 +51,7 @@ export * from "./conversations";
 export * from "./credit-packs";
 export * from "./credit-transactions";
 export * from "./crypto-payments";
+export * from "./crypto-settlement-outbox";
 export * from "./daily-metrics";
 export * from "./device-bus";
 export * from "./discord-channels";

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
@@ -48,6 +48,7 @@ let appChargeCallbacksService: typeof import("../app-charge-callbacks").appCharg
 let callbackRoomBelongsToOrganization: typeof import("../callback-channel-authz").callbackRoomBelongsToOrganization;
 let memoriesRepository: typeof import("../../../db/repositories/agents/memories").memoriesRepository;
 let createSpy: ReturnType<typeof spyOn> | undefined;
+let findSpy: ReturnType<typeof spyOn> | undefined;
 let pgliteReady = true;
 
 async function seedCharge(creatorOrg: string, roomId: string, agentId = CHAR_A): Promise<void> {
@@ -136,6 +137,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   createSpy?.mockRestore();
+  findSpy?.mockRestore();
   if (closeDb) await closeDb();
 });
 
@@ -193,6 +195,8 @@ describe("appChargeCallbacksService.dispatch — settlement memory write is gate
   beforeEach(() => {
     if (!pgliteReady) return;
     createSpy?.mockRestore();
+    findSpy?.mockRestore();
+    findSpy = spyOn(memoriesRepository, "findById").mockResolvedValue(null);
     createSpy = spyOn(memoriesRepository, "create").mockImplementation(
       async () => ({ id: "mem", roomId: ROOM_A }) as never,
     );
@@ -215,6 +219,26 @@ describe("appChargeCallbacksService.dispatch — settlement memory write is gate
     const [memory] = createSpy.mock.calls[0] as [{ roomId: string; agentId: string }];
     expect(memory.roomId).toBe(ROOM_A);
     expect(memory.agentId).toBe(CHAR_A);
+  });
+
+  test("room callback retry reuses one deterministic memory identity", async () => {
+    if (!pgliteReady) return;
+    await seedCharge(ORG_A, ROOM_A);
+    const dispatch = {
+      appId: APP_ID,
+      chargeRequestId: CHARGE_ID,
+      status: "paid" as const,
+      provider: "stripe" as const,
+      providerPaymentId: "pi_retry_identity",
+    };
+
+    await appChargeCallbacksService.dispatch(dispatch);
+    await appChargeCallbacksService.dispatch(dispatch);
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+    const first = createSpy.mock.calls[0]?.[0] as { id: string };
+    const second = createSpy.mock.calls[1]?.[0] as { id: string };
+    expect(second.id).toBe(first.id);
   });
 
   test("same-tenant room with a mismatched callback agent → NO memory is written", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -1,0 +1,102 @@
+/** Exercises durable app-charge callback claim, retry, and replay semantics on real PGlite. */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000a1";
+const CHARGE_ID = "00000000-0000-4000-8000-0000000000a2";
+const params = {
+  appId: "00000000-0000-4000-8000-0000000000a3",
+  chargeRequestId: CHARGE_ID,
+  status: "paid" as const,
+  provider: "oxapay" as const,
+  providerPaymentId: "00000000-0000-4000-8000-0000000000a4",
+  amountUsd: "10.00",
+  payerOrganizationId: ORG_ID,
+};
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let service: typeof import("../app-charge-callbacks").appChargeCallbacksService;
+
+beforeAll(async () => {
+  ({ dbWrite, closeDatabaseConnectionsForTests: closeDb } = await import("../../../db/client"));
+  ({ appChargeCallbacksService: service } = await import("../app-charge-callbacks"));
+  await dbWrite.execute(`CREATE TABLE crypto_payments (
+    id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid,
+    payment_address text NOT NULL, token text NOT NULL, network text NOT NULL,
+    expected_amount text NOT NULL, received_amount text, credits_to_add text NOT NULL,
+    transaction_hash text, block_number text, status text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT now(), updated_at timestamp NOT NULL DEFAULT now(),
+    confirmed_at timestamp, expires_at timestamp NOT NULL, metadata jsonb DEFAULT '{}'
+  )`);
+  await dbWrite.execute(`CREATE TABLE app_charge_callback_outbox (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), delivery_key text NOT NULL UNIQUE,
+    charge_request_id uuid NOT NULL REFERENCES crypto_payments(id), payload jsonb NOT NULL,
+    payload_digest text NOT NULL, state text NOT NULL DEFAULT 'pending', attempts integer NOT NULL DEFAULT 0,
+    next_attempt_at timestamptz NOT NULL DEFAULT now(), claim_token uuid, lease_expires_at timestamptz,
+    last_error text, delivered_at timestamptz, terminal_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+  )`);
+});
+
+afterAll(async () => closeDb?.());
+
+beforeEach(async () => {
+  await dbWrite.execute("DELETE FROM app_charge_callback_outbox");
+  await dbWrite.execute("DELETE FROM crypto_payments");
+  await dbWrite.execute(`INSERT INTO crypto_payments
+    (id, organization_id, payment_address, token, network, expected_amount, credits_to_add, status, expires_at, metadata)
+    VALUES ('${CHARGE_ID}', '${ORG_ID}', 'charge', 'USD', 'internal', '10', '10', 'confirmed',
+      now() + interval '1 hour', '{"kind":"app_charge_request","app_id":"${params.appId}"}')`);
+});
+
+describe("app charge callback outbox", () => {
+  test("enqueue replay validates the immutable payload", async () => {
+    await dbWrite.transaction(async (tx) => {
+      await service.enqueue(params, tx);
+      await service.enqueue(params, tx);
+      await expect(service.enqueue({ ...params, amountUsd: "11.00" }, tx)).rejects.toThrow(
+        "does not match",
+      );
+    });
+    const rows = await dbWrite.execute(
+      "SELECT count(*)::int AS count FROM app_charge_callback_outbox",
+    );
+    expect((rows.rows[0] as { count: number }).count).toBe(1);
+  });
+
+  test("failed delivery remains durable and the active dispatcher retries it", async () => {
+    await dbWrite.transaction((tx) => service.enqueue(params, tx));
+    const original = service.dispatch.bind(service);
+    let attempts = 0;
+    service.dispatch = async () => {
+      attempts += 1;
+      return attempts === 1
+        ? { httpPosted: false, roomMessageCreated: false, errors: ["injected callback failure"] }
+        : { httpPosted: true, roomMessageCreated: false, errors: [] };
+    };
+    try {
+      const first = await service.drain();
+      expect(first.retried).toBe(1);
+      let row = await dbWrite.execute(
+        "SELECT state, attempts, last_error FROM app_charge_callback_outbox",
+      );
+      expect((row.rows[0] as { state: string }).state).toBe("pending");
+      expect((row.rows[0] as { last_error: string }).last_error).toContain("injected");
+
+      await dbWrite.execute(
+        "UPDATE app_charge_callback_outbox SET next_attempt_at=now() - interval '1 second'",
+      );
+      const second = await service.drain();
+      expect(second.delivered).toBe(1);
+      row = await dbWrite.execute("SELECT state, attempts FROM app_charge_callback_outbox");
+      expect((row.rows[0] as { state: string; attempts: number }).state).toBe("delivered");
+      expect(Number((row.rows[0] as { attempts: number }).attempts)).toBe(2);
+    } finally {
+      service.dispatch = original;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -20,13 +20,15 @@ const params = {
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let service: typeof import("../app-charge-callbacks").appChargeCallbacksService;
+let settlementService: typeof import("../app-charge-settlement").appChargeSettlementService;
 
 beforeAll(async () => {
   ({ dbWrite, closeDatabaseConnectionsForTests: closeDb } = await import("../../../db/client"));
   ({ appChargeCallbacksService: service } = await import("../app-charge-callbacks"));
+  ({ appChargeSettlementService: settlementService } = await import("../app-charge-settlement"));
   await dbWrite.execute(`CREATE TABLE crypto_payments (
     id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid,
-    payment_address text NOT NULL, token text NOT NULL, network text NOT NULL,
+    payment_address text NOT NULL, token_address text, token text NOT NULL, network text NOT NULL,
     expected_amount text NOT NULL, received_amount text, credits_to_add text NOT NULL,
     transaction_hash text, block_number text, status text NOT NULL,
     created_at timestamp NOT NULL DEFAULT now(), updated_at timestamp NOT NULL DEFAULT now(),
@@ -98,5 +100,36 @@ describe("app charge callback outbox", () => {
     } finally {
       service.dispatch = original;
     }
+  });
+
+  test("app charge status and callback intent commit together and replay recovers deletion", async () => {
+    await dbWrite.execute(`UPDATE crypto_payments SET status='pending' WHERE id='${CHARGE_ID}'`);
+    const settlement = {
+      appId: params.appId,
+      chargeRequestId: CHARGE_ID,
+      provider: "stripe" as const,
+      providerPaymentId: "pi_exact",
+      amountUsd: "10.123456789",
+      payerOrganizationId: ORG_ID,
+    };
+
+    await settlementService.markPaid(settlement);
+    let rows = await dbWrite.execute(
+      `SELECT payload, state FROM app_charge_callback_outbox WHERE charge_request_id='${CHARGE_ID}'`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect((rows.rows[0] as { payload: { amountUsd: string } }).payload.amountUsd).toBe(
+      "10.123456789",
+    );
+
+    await dbWrite.execute("DELETE FROM app_charge_callback_outbox");
+    await settlementService.markPaid(settlement);
+    rows = await dbWrite.execute(
+      `SELECT payload FROM app_charge_callback_outbox WHERE charge_request_id='${CHARGE_ID}'`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    await expect(
+      settlementService.markPaid({ ...settlement, providerPaymentId: "pi_other" }),
+    ).rejects.toThrow("already settled by another payment");
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -73,9 +73,16 @@ describe("app charge callback outbox", () => {
 
   test("failed delivery remains durable and the active dispatcher retries it", async () => {
     await dbWrite.transaction((tx) => service.enqueue(params, tx));
-    const original = service.dispatch.bind(service);
+    const dispatcher = service as unknown as {
+      dispatchSnapshot: () => Promise<{
+        httpPosted: boolean;
+        roomMessageCreated: boolean;
+        errors: string[];
+      }>;
+    };
+    const original = dispatcher.dispatchSnapshot.bind(service);
     let attempts = 0;
-    service.dispatch = async () => {
+    dispatcher.dispatchSnapshot = async () => {
       attempts += 1;
       return attempts === 1
         ? { httpPosted: false, roomMessageCreated: false, errors: ["injected callback failure"] }
@@ -99,15 +106,27 @@ describe("app charge callback outbox", () => {
       expect((row.rows[0] as { state: string; attempts: number }).state).toBe("delivered");
       expect(Number((row.rows[0] as { attempts: number }).attempts)).toBe(2);
     } finally {
-      service.dispatch = original;
+      dispatcher.dispatchSnapshot = original;
     }
   });
 
-  test("a partial callback retry does not redeliver the channel that already succeeded", async () => {
+  test("a partial retry freezes its envelope and targets across charge metadata mutation", async () => {
     await dbWrite.transaction((tx) => service.enqueue(params, tx));
-    const original = service.dispatch.bind(service);
-    const optionsSeen: Array<{ skipRoom?: boolean; skipHttp?: boolean; createdAt?: Date }> = [];
-    service.dispatch = async (_params, options = {}) => {
+    type Snapshot = {
+      envelope: { createdAt: string; charge: { amountUsd: string } };
+      target: { callbackUrl?: string; channel?: Record<string, unknown> };
+    };
+    const dispatcher = service as unknown as {
+      dispatchSnapshot: (
+        snapshot: Snapshot,
+        options?: { skipRoom?: boolean; skipHttp?: boolean },
+      ) => Promise<{ httpPosted: boolean; roomMessageCreated: boolean; errors: string[] }>;
+    };
+    const original = dispatcher.dispatchSnapshot.bind(service);
+    const optionsSeen: Array<{ skipRoom?: boolean; skipHttp?: boolean }> = [];
+    const snapshotsSeen: Snapshot[] = [];
+    dispatcher.dispatchSnapshot = async (snapshot, options = {}) => {
+      snapshotsSeen.push(snapshot);
       optionsSeen.push(options);
       return optionsSeen.length === 1
         ? { httpPosted: false, roomMessageCreated: true, errors: ["HTTP unavailable"] }
@@ -115,6 +134,12 @@ describe("app charge callback outbox", () => {
     };
     try {
       expect((await service.drain()).retried).toBe(1);
+      await dbWrite.execute(`UPDATE crypto_payments SET expected_amount='999', metadata='{
+          "kind":"app_charge_request",
+          "app_id":"${params.appId}",
+          "callback_url":"https://mutated.invalid/callback",
+          "callback_channel":{"roomId":"mutated"}
+        }'::jsonb WHERE id='${CHARGE_ID}'`);
       await dbWrite.execute(
         "UPDATE app_charge_callback_outbox SET next_attempt_at=now() - interval '1 second'",
       );
@@ -123,17 +148,17 @@ describe("app charge callback outbox", () => {
         { skipRoom: false, skipHttp: false },
         { skipRoom: true, skipHttp: false },
       ]);
-      expect(optionsSeen[0]?.createdAt).toBeInstanceOf(Date);
-      expect(optionsSeen[1]?.createdAt?.toISOString()).toBe(
-        optionsSeen[0]?.createdAt?.toISOString(),
-      );
+      expect(snapshotsSeen[1]).toEqual(snapshotsSeen[0]);
+      expect(snapshotsSeen[1]?.envelope.charge.amountUsd).toBe("10");
+      expect(snapshotsSeen[1]?.target.callbackUrl).toBeUndefined();
+      expect(snapshotsSeen[1]?.target.channel).toBeUndefined();
       const row = await dbWrite.execute(
         "SELECT room_delivered_at, http_delivered_at FROM app_charge_callback_outbox",
       );
       expect((row.rows[0] as { room_delivered_at: Date | null }).room_delivered_at).not.toBeNull();
       expect((row.rows[0] as { http_delivered_at: Date | null }).http_delivered_at).not.toBeNull();
     } finally {
-      service.dispatch = original;
+      dispatcher.dispatchSnapshot = original;
     }
   });
 
@@ -153,9 +178,9 @@ describe("app charge callback outbox", () => {
       `SELECT payload, state FROM app_charge_callback_outbox WHERE charge_request_id='${CHARGE_ID}'`,
     );
     expect(rows.rows).toHaveLength(1);
-    expect((rows.rows[0] as { payload: { amountUsd: string } }).payload.amountUsd).toBe(
-      "10.123456789",
-    );
+    expect(
+      (rows.rows[0] as { payload: { params: { amountUsd: string } } }).payload.params.amountUsd,
+    ).toBe("10.123456789");
 
     await dbWrite.execute("DELETE FROM app_charge_callback_outbox");
     await settlementService.markPaid(settlement);
@@ -181,7 +206,9 @@ describe("app charge callback outbox", () => {
     `);
     expect(rows.rows).toHaveLength(1);
     expect((rows.rows[0] as { status: string }).status).toBe("failed");
-    expect((rows.rows[0] as { payload: { status: string } }).payload.status).toBe("failed");
+    expect(
+      (rows.rows[0] as { payload: { params: { status: string } } }).payload.params.status,
+    ).toBe("failed");
     expect((rows.rows[0] as { state: string }).state).toBe("pending");
 
     await dbWrite.execute(`UPDATE crypto_payments SET status='confirmed' WHERE id='${CHARGE_ID}'`);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -163,4 +163,30 @@ describe("app charge callback outbox", () => {
       settlementService.markPaid({ ...settlement, providerPaymentId: "pi_other" }),
     ).rejects.toThrow("already settled by another payment");
   });
+
+  test("failed charge status and notification intent commit atomically", async () => {
+    await dbWrite.execute(`UPDATE crypto_payments SET status='pending' WHERE id='${CHARGE_ID}'`);
+    const failed = { ...params, status: "failed" as const, reason: "provider declined" };
+
+    expect(await service.failChargeAndEnqueue(failed)).toBe(true);
+    const rows = await dbWrite.execute(`
+      SELECT p.status, o.payload, o.state
+      FROM crypto_payments p
+      JOIN app_charge_callback_outbox o ON o.charge_request_id = p.id
+      WHERE p.id='${CHARGE_ID}'
+    `);
+    expect(rows.rows).toHaveLength(1);
+    expect((rows.rows[0] as { status: string }).status).toBe("failed");
+    expect((rows.rows[0] as { payload: { status: string } }).payload.status).toBe("failed");
+    expect((rows.rows[0] as { state: string }).state).toBe("pending");
+
+    await dbWrite.execute(`UPDATE crypto_payments SET status='confirmed' WHERE id='${CHARGE_ID}'`);
+    expect(
+      await service.failChargeAndEnqueue({ ...failed, providerPaymentId: "pi_late_failure" }),
+    ).toBe(false);
+    const late = await dbWrite.execute(
+      "SELECT count(*)::int AS count FROM app_charge_callback_outbox",
+    );
+    expect((late.rows[0] as { count: number }).count).toBe(1);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -106,7 +106,7 @@ describe("app charge callback outbox", () => {
   test("a partial callback retry does not redeliver the channel that already succeeded", async () => {
     await dbWrite.transaction((tx) => service.enqueue(params, tx));
     const original = service.dispatch.bind(service);
-    const optionsSeen: Array<{ skipRoom?: boolean; skipHttp?: boolean }> = [];
+    const optionsSeen: Array<{ skipRoom?: boolean; skipHttp?: boolean; createdAt?: Date }> = [];
     service.dispatch = async (_params, options = {}) => {
       optionsSeen.push(options);
       return optionsSeen.length === 1
@@ -119,10 +119,14 @@ describe("app charge callback outbox", () => {
         "UPDATE app_charge_callback_outbox SET next_attempt_at=now() - interval '1 second'",
       );
       expect((await service.drain()).delivered).toBe(1);
-      expect(optionsSeen).toEqual([
+      expect(optionsSeen.map(({ skipRoom, skipHttp }) => ({ skipRoom, skipHttp }))).toEqual([
         { skipRoom: false, skipHttp: false },
         { skipRoom: true, skipHttp: false },
       ]);
+      expect(optionsSeen[0]?.createdAt).toBeInstanceOf(Date);
+      expect(optionsSeen[1]?.createdAt?.toISOString()).toBe(
+        optionsSeen[0]?.createdAt?.toISOString(),
+      );
       const row = await dbWrite.execute(
         "SELECT room_delivered_at, http_delivered_at FROM app_charge_callback_outbox",
       );

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-outbox.test.ts
@@ -39,7 +39,8 @@ beforeAll(async () => {
     charge_request_id uuid NOT NULL REFERENCES crypto_payments(id), payload jsonb NOT NULL,
     payload_digest text NOT NULL, state text NOT NULL DEFAULT 'pending', attempts integer NOT NULL DEFAULT 0,
     next_attempt_at timestamptz NOT NULL DEFAULT now(), claim_token uuid, lease_expires_at timestamptz,
-    last_error text, delivered_at timestamptz, terminal_at timestamptz,
+    last_error text, room_delivered_at timestamptz, http_delivered_at timestamptz,
+    delivered_at timestamptz, terminal_at timestamptz,
     created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
   )`);
 });
@@ -97,6 +98,36 @@ describe("app charge callback outbox", () => {
       row = await dbWrite.execute("SELECT state, attempts FROM app_charge_callback_outbox");
       expect((row.rows[0] as { state: string; attempts: number }).state).toBe("delivered");
       expect(Number((row.rows[0] as { attempts: number }).attempts)).toBe(2);
+    } finally {
+      service.dispatch = original;
+    }
+  });
+
+  test("a partial callback retry does not redeliver the channel that already succeeded", async () => {
+    await dbWrite.transaction((tx) => service.enqueue(params, tx));
+    const original = service.dispatch.bind(service);
+    const optionsSeen: Array<{ skipRoom?: boolean; skipHttp?: boolean }> = [];
+    service.dispatch = async (_params, options = {}) => {
+      optionsSeen.push(options);
+      return optionsSeen.length === 1
+        ? { httpPosted: false, roomMessageCreated: true, errors: ["HTTP unavailable"] }
+        : { httpPosted: true, roomMessageCreated: false, errors: [] };
+    };
+    try {
+      expect((await service.drain()).retried).toBe(1);
+      await dbWrite.execute(
+        "UPDATE app_charge_callback_outbox SET next_attempt_at=now() - interval '1 second'",
+      );
+      expect((await service.drain()).delivered).toBe(1);
+      expect(optionsSeen).toEqual([
+        { skipRoom: false, skipHttp: false },
+        { skipRoom: true, skipHttp: false },
+      ]);
+      const row = await dbWrite.execute(
+        "SELECT room_delivered_at, http_delivered_at FROM app_charge_callback_outbox",
+      );
+      expect((row.rows[0] as { room_delivered_at: Date | null }).room_delivered_at).not.toBeNull();
+      expect((row.rows[0] as { http_delivered_at: Date | null }).http_delivered_at).not.toBeNull();
     } finally {
       service.dispatch = original;
     }

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -26,20 +26,74 @@ process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000c1";
+const OTHER_ORG_ID = "00000000-0000-4000-8000-0000000000c2";
 const PAYMENT_ID = "00000000-0000-4000-8000-0000000000d1";
+const OTHER_PAYMENT_ID = "00000000-0000-4000-8000-0000000000d2";
+const USER_ID = "00000000-0000-4000-8000-0000000000e1";
+const APP_ID = "00000000-0000-4000-8000-0000000000f1";
 const PGLITE_TIMEOUT = 60000;
 
 // Controllable invoice stub: succeeds by default; throws when armed so we can
 // exercise a post-credit failure inside the confirmation transaction.
 let invoiceCreateShouldThrow = false;
+let invoiceCreateSawTransaction = false;
+let lastInvoiceAmountPaid: string | null = null;
 mock.module("../invoices", () => ({
   invoicesService: {
     async getByStripeInvoiceId() {
       return undefined;
     },
-    async create() {
+    async create(data: { amount_paid: string }, transaction?: unknown) {
+      invoiceCreateSawTransaction = transaction !== undefined;
+      lastInvoiceAmountPaid = data.amount_paid;
       if (invoiceCreateShouldThrow) throw new Error("simulated invoice insert conflict");
       return { id: "invoice-stub" };
+    },
+  },
+}));
+let appPurchaseSawTransaction = false;
+mock.module("../app-credits", () => ({
+  appCreditsService: {
+    async processPurchase(params: { transaction?: { execute(query: string): Promise<unknown> } }) {
+      appPurchaseSawTransaction = params.transaction !== undefined;
+      await params.transaction?.execute(
+        `INSERT INTO credit_transactions
+          (organization_id, amount, type, description, metadata, stripe_payment_intent_id)
+         VALUES ('${ORG_ID}', '1', 'credit', 'app purchase sentinel', '{}', 'app-sentinel')`,
+      );
+      return {
+        success: true,
+        creditsAdded: 10,
+        platformOffset: 0,
+        creatorEarnings: 0,
+        newBalance: 0,
+      };
+    },
+  },
+}));
+mock.module("../referrals", () => ({
+  referralsService: {
+    async calculateRevenueSplitsExact() {
+      return {
+        elizaCloudAmount: "9.000000",
+        splits: [{ userId: USER_ID, role: "creator", amount: "1.000000" }],
+      };
+    },
+  },
+}));
+let referralShouldThrowAfterWrite = false;
+let referralSawTransaction = false;
+mock.module("../redeemable-earnings", () => ({
+  redeemableEarningsService: {
+    async addEarnings(params: { transaction?: { execute(query: string): Promise<unknown> } }) {
+      referralSawTransaction = params.transaction !== undefined;
+      await params.transaction?.execute(
+        `INSERT INTO credit_transactions
+          (organization_id, amount, type, description, metadata, stripe_payment_intent_id)
+         VALUES ('${ORG_ID}', '1', 'credit', 'referral sentinel', '{}', 'referral-sentinel')`,
+      );
+      if (referralShouldThrowAfterWrite) throw new Error("simulated referral failure");
+      return { success: true, newBalance: 1, ledgerEntryId: "referral-ledger" };
     },
   },
 }));
@@ -75,6 +129,7 @@ mock.module("../oxapay", () => ({
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let cryptoPaymentsRepository: typeof import("../../../db/repositories/crypto-payments").cryptoPaymentsRepository;
 let cryptoPaymentsService: typeof import("../crypto-payments").cryptoPaymentsService;
 let pgliteReady = true;
 
@@ -85,6 +140,28 @@ async function seedPendingPayment(): Promise<void> {
         expected_amount, credits_to_add, status, expires_at, metadata)
      VALUES
        ('${PAYMENT_ID}', '${ORG_ID}', NULL, '0xpay', 'USDT', 'bsc',
+        '10', '10', 'pending', now() + interval '1 hour',
+        '{"oxapay_track_id":"track-123"}'::jsonb);`,
+  );
+}
+async function seedAppPurchasePayment(): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO crypto_payments
+       (id, organization_id, user_id, payment_address, token, network,
+        expected_amount, credits_to_add, status, expires_at, metadata)
+     VALUES
+       ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay', 'USDT', 'bsc',
+        '10', '10', 'pending', now() + interval '1 hour',
+        '{"oxapay_track_id":"track-123","kind":"app_credit_purchase","app_id":"${APP_ID}"}'::jsonb);`,
+  );
+}
+async function seedReferralPayment(): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO crypto_payments
+       (id, organization_id, user_id, payment_address, token, network,
+        expected_amount, credits_to_add, status, expires_at, metadata)
+     VALUES
+       ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay', 'USDT', 'bsc',
         '10', '10', 'pending', now() + interval '1 hour',
         '{"oxapay_track_id":"track-123"}'::jsonb);`,
   );
@@ -103,10 +180,17 @@ async function paymentStatus(): Promise<string> {
   const r = await dbWrite.execute(`SELECT status FROM crypto_payments WHERE id='${PAYMENT_ID}';`);
   return (r.rows[0] as { status: string }).status;
 }
+async function paymentReceivedAmount(): Promise<string | null> {
+  const r = await dbWrite.execute(
+    `SELECT received_amount FROM crypto_payments WHERE id='${PAYMENT_ID}';`,
+  );
+  return (r.rows[0] as { received_amount: string | null }).received_amount;
+}
 
 beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ cryptoPaymentsRepository } = await import("../../../db/repositories/crypto-payments"));
     ({ cryptoPaymentsService } = await import("../crypto-payments"));
     const ddl = [
       // Full org columns — organizationsRepository.findById selects them all.
@@ -168,6 +252,10 @@ beforeAll(async () => {
         expires_at timestamp NOT NULL,
         metadata jsonb DEFAULT '{}'::jsonb
       )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS crypto_payments_active_tx_hash_unique_idx
+         ON crypto_payments (transaction_hash)
+         WHERE transaction_hash IS NOT NULL
+           AND status IN ('pending', 'broadcast', 'confirmed')`,
     ];
     for (const stmt of ddl) await dbWrite.execute(stmt);
   } catch (error) {
@@ -186,9 +274,15 @@ beforeEach(async () => {
   await dbWrite.execute(`DELETE FROM crypto_payments;`);
   await dbWrite.execute(`DELETE FROM organizations;`);
   await dbWrite.execute(
-    `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '0');`,
+    `INSERT INTO organizations (id, credit_balance) VALUES
+       ('${ORG_ID}', '0'), ('${OTHER_ORG_ID}', '0');`,
   );
   invoiceCreateShouldThrow = false;
+  invoiceCreateSawTransaction = false;
+  lastInvoiceAmountPaid = null;
+  appPurchaseSawTransaction = false;
+  referralShouldThrowAfterWrite = false;
+  referralSawTransaction = false;
 });
 
 describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
@@ -218,6 +312,45 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
   );
 
   test(
+    "rolls back app-purchase writes when the following invoice leg fails",
+    async () => {
+      if (!pgliteReady) return;
+      await seedAppPurchasePayment();
+      invoiceCreateShouldThrow = true;
+
+      await expect(
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashApp", "10", "USDT"),
+      ).rejects.toThrow("simulated invoice insert conflict");
+
+      expect(appPurchaseSawTransaction).toBe(true);
+      expect(await creditRowCount()).toBe(0);
+      expect(await orgBalance()).toBeCloseTo(0, 6);
+      expect(await paymentStatus()).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rolls back payment, org credit, invoice boundary, and referral write on referral failure",
+    async () => {
+      if (!pgliteReady) return;
+      await seedReferralPayment();
+      referralShouldThrowAfterWrite = true;
+
+      await expect(
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReferral", "10", "USDT"),
+      ).rejects.toThrow("simulated referral failure");
+
+      expect(referralSawTransaction).toBe(true);
+      expect(invoiceCreateSawTransaction).toBe(true);
+      expect(await creditRowCount()).toBe(0);
+      expect(await orgBalance()).toBeCloseTo(0, 6);
+      expect(await paymentStatus()).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "a post-credit failure inside the tx rolls the credit back (atomic) — no orphaned credit",
     async () => {
       if (!pgliteReady) return;
@@ -242,6 +375,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       expect(await creditRowCount()).toBe(1);
       expect(await orgBalance()).toBeCloseTo(10, 6);
       expect(await paymentStatus()).toBe("confirmed");
+      expect(invoiceCreateSawTransaction).toBe(true);
     },
     PGLITE_TIMEOUT,
   );
@@ -282,6 +416,142 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       expect(replayed.success).toBe(true);
       expect(await creditRowCount()).toBe(1);
       expect(await orgBalance()).toBeCloseTo(10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "preserves the provider decimal on the payment row and quantizes credits only at ledger precision",
+    async () => {
+      if (!pgliteReady) return;
+      await seedPendingPayment();
+
+      const exactProviderAmount = "10.123456789012345678";
+      await cryptoPaymentsService.confirmPayment(
+        PAYMENT_ID,
+        "0xhashExact",
+        exactProviderAmount,
+        "USDT",
+      );
+
+      expect(await paymentReceivedAmount()).toBe(exactProviderAmount);
+      expect(lastInvoiceAmountPaid).toBe("10.12");
+      const rows = await dbWrite.execute(
+        `SELECT amount::text AS amount FROM credit_transactions WHERE organization_id='${ORG_ID}';`,
+      );
+      expect((rows.rows[0] as { amount: string }).amount).toBe("10.123457");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rejects a confirmed replay whose provider amount or currency differs",
+    async () => {
+      if (!pgliteReady) return;
+      await seedPendingPayment();
+      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "10", "USDT");
+
+      await expect(
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "11", "USDT"),
+      ).rejects.toThrow("does not match");
+      await expect(
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "10", "BTC"),
+      ).rejects.toThrow("does not match");
+      expect(await creditRowCount()).toBe(1);
+      expect(await orgBalance()).toBeCloseTo(10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent webhook and manual confirmation converge on one settlement",
+    async () => {
+      if (!pgliteReady) return;
+      await seedPendingPayment();
+
+      const [webhook, manual] = await Promise.all([
+        cryptoPaymentsService.handleWebhook({
+          track_id: "track-123",
+          status: "confirmed",
+          txID: "0xhashManual",
+        }),
+        cryptoPaymentsService.verifyAndConfirmByTxHash(PAYMENT_ID, "0xhashManual"),
+      ]);
+
+      expect(webhook.success).toBe(true);
+      expect(manual.success).toBe(true);
+      expect(await paymentStatus()).toBe("confirmed");
+      expect(await creditRowCount()).toBe(1);
+      expect(await orgBalance()).toBeCloseTo(10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "hex transaction-hash casing variants cannot settle two tenants",
+    async () => {
+      if (!pgliteReady) return;
+      await seedPendingPayment();
+      await dbWrite.execute(
+        `INSERT INTO crypto_payments
+           (id, organization_id, user_id, payment_address, token, network,
+            expected_amount, credits_to_add, status, expires_at, metadata)
+         VALUES
+           ('${OTHER_PAYMENT_ID}', '${OTHER_ORG_ID}', NULL, '0xpay2', 'USDT', 'bsc',
+            '10', '10', 'pending', now() + interval '1 hour',
+            '{"oxapay_track_id":"track-456"}'::jsonb);`,
+      );
+
+      const results = await Promise.allSettled([
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xAbCd1234", "10", "USDT"),
+        cryptoPaymentsService.confirmPayment(OTHER_PAYMENT_ID, "0xaBcD1234", "10", "USDT"),
+      ]);
+
+      expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+      const rows = await dbWrite.execute(
+        `SELECT organization_id, transaction_hash FROM crypto_payments WHERE status='confirmed'`,
+      );
+      expect(rows.rows).toHaveLength(1);
+      expect((rows.rows[0] as { transaction_hash: string }).transaction_hash).toBe("0xabcd1234");
+      expect(await creditRowCount()).toBe(1);
+      const otherBalance = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id='${OTHER_ORG_ID}'`,
+      );
+      const balances = [
+        await orgBalance(),
+        Number((otherBalance.rows[0] as { credit_balance: string }).credit_balance),
+      ].sort((left, right) => left - right);
+      expect(balances).toEqual([0, 10]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "repository and settlement service share one canonical EVM transaction identity",
+    async () => {
+      if (!pgliteReady) return;
+      await cryptoPaymentsRepository.create({
+        id: OTHER_PAYMENT_ID,
+        organization_id: OTHER_ORG_ID,
+        payment_address: "0xpay2",
+        token: "USDT",
+        network: "bsc",
+        expected_amount: "10",
+        credits_to_add: "10",
+        transaction_hash: "0xABCDEF1234",
+        status: "broadcast",
+        expires_at: new Date(Date.now() + 60_000),
+        metadata: { oxapay_track_id: "track-456" },
+      });
+      await seedPendingPayment();
+
+      await expect(
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xabcdef1234", "10", "USDT"),
+      ).rejects.toThrow("another payment");
+      const existing = await cryptoPaymentsRepository.findById(OTHER_PAYMENT_ID);
+      expect(existing?.transaction_hash).toBe("0xabcdef1234");
+      expect(await creditRowCount()).toBe(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -57,12 +57,15 @@ mock.module("../invoices", () => ({
 let appPurchaseSawTransaction = false;
 mock.module("../app-credits", () => ({
   appCreditsService: {
-    async processPurchase(params: { transaction?: { execute(query: string): Promise<unknown> } }) {
+    async processPurchase(params: {
+      stripePaymentIntentId: string;
+      transaction?: { execute(query: string): Promise<unknown> };
+    }) {
       appPurchaseSawTransaction = params.transaction !== undefined;
       await params.transaction?.execute(
         `INSERT INTO credit_transactions
           (organization_id, amount, type, description, metadata, stripe_payment_intent_id)
-         VALUES ('${ORG_ID}', '1', 'credit', 'app purchase sentinel', '{}', 'app-sentinel')`,
+         VALUES ('${ORG_ID}', '1', 'credit', 'app purchase sentinel', '{}', '${params.stripePaymentIntentId}')`,
       );
       return {
         success: true,
@@ -564,6 +567,40 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
     await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xcallback", settlementEvidence());
     rows = await dbWrite.execute(`SELECT delivery_key FROM app_charge_callback_outbox`);
     expect(rows.rows).toHaveLength(1);
+    expect(await creditRowCount()).toBe(1);
+  });
+
+  test("one app charge request cannot be purchased by two crypto payments", async () => {
+    if (!pgliteReady) return;
+    await dbWrite.execute(
+      `INSERT INTO crypto_payments
+         (id, organization_id, user_id, payment_address, token, network,
+          expected_amount, credits_to_add, status, expires_at, metadata)
+       VALUES
+         ('${CHARGE_REQUEST_ID}', '${ORG_ID}', '${USER_ID}', 'app-charge', 'USD', 'internal',
+          '10', '10', 'pending', now() + interval '1 hour',
+          '{"kind":"app_charge_request","app_id":"${APP_ID}","creator_organization_id":"${ORG_ID}"}'::jsonb),
+         ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay-1', 'USDT', 'bsc',
+          '10', '10', 'pending', now() + interval '1 hour',
+          '{"oxapay_track_id":"track-123","fiat_amount":"10","fiat_currency":"USD","kind":"app_credit_purchase","app_id":"${APP_ID}","charge_request_id":"${CHARGE_REQUEST_ID}"}'::jsonb),
+         ('${OTHER_PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay-2', 'USDT', 'bsc',
+          '10', '10', 'pending', now() + interval '1 hour',
+          '{"oxapay_track_id":"track-456","fiat_amount":"10","fiat_currency":"USD","kind":"app_credit_purchase","app_id":"${APP_ID}","charge_request_id":"${CHARGE_REQUEST_ID}"}'::jsonb)`,
+    );
+
+    await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xappfirst", settlementEvidence());
+    await expect(
+      cryptoPaymentsService.confirmPayment(
+        OTHER_PAYMENT_ID,
+        "0xappsecond",
+        settlementEvidence("10", "USDT", "track-456"),
+      ),
+    ).rejects.toThrow("already settled by another payment");
+
+    const second = await dbWrite.execute(
+      `SELECT status FROM crypto_payments WHERE id='${OTHER_PAYMENT_ID}'`,
+    );
+    expect((second.rows[0] as { status: string }).status).toBe("pending");
     expect(await creditRowCount()).toBe(1);
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -286,6 +286,8 @@ beforeAll(async () => {
         claim_token uuid,
         lease_expires_at timestamptz,
         last_error text,
+        room_delivered_at timestamptz,
+        http_delivered_at timestamptz,
         delivered_at timestamptz,
         terminal_at timestamptz,
         created_at timestamptz NOT NULL DEFAULT now(),

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -31,12 +31,14 @@ const PAYMENT_ID = "00000000-0000-4000-8000-0000000000d1";
 const OTHER_PAYMENT_ID = "00000000-0000-4000-8000-0000000000d2";
 const USER_ID = "00000000-0000-4000-8000-0000000000e1";
 const APP_ID = "00000000-0000-4000-8000-0000000000f1";
+const CHARGE_REQUEST_ID = "00000000-0000-4000-8000-0000000000f2";
 const PGLITE_TIMEOUT = 60000;
 
 // Controllable invoice stub: succeeds by default; throws when armed so we can
 // exercise a post-credit failure inside the confirmation transaction.
 let invoiceCreateShouldThrow = false;
 let invoiceCreateSawTransaction = false;
+let invoiceCreateCount = 0;
 let lastInvoiceAmountPaid: string | null = null;
 mock.module("../invoices", () => ({
   invoicesService: {
@@ -44,6 +46,7 @@ mock.module("../invoices", () => ({
       return undefined;
     },
     async create(data: { amount_paid: string }, transaction?: unknown) {
+      invoiceCreateCount += 1;
       invoiceCreateSawTransaction = transaction !== undefined;
       lastInvoiceAmountPaid = data.amount_paid;
       if (invoiceCreateShouldThrow) throw new Error("simulated invoice insert conflict");
@@ -109,7 +112,10 @@ mock.module("../oxapay", () => ({
   oxaPayService: {
     async getPaymentStatus() {
       return {
+        trackId: "track-123",
         status: "confirmed",
+        amount: "10",
+        currency: "USD",
         transactions: [
           {
             txHash: "0xhashManual",
@@ -133,6 +139,15 @@ let cryptoPaymentsRepository: typeof import("../../../db/repositories/crypto-pay
 let cryptoPaymentsService: typeof import("../crypto-payments").cryptoPaymentsService;
 let pgliteReady = true;
 
+function settlementEvidence(
+  invoiceAmount = "10",
+  payCurrency = "USDT",
+  trackId = "track-123",
+  invoiceCurrency = "USD",
+) {
+  return { trackId, invoiceAmount, invoiceCurrency, payCurrency };
+}
+
 async function seedPendingPayment(): Promise<void> {
   await dbWrite.execute(
     `INSERT INTO crypto_payments
@@ -141,7 +156,7 @@ async function seedPendingPayment(): Promise<void> {
      VALUES
        ('${PAYMENT_ID}', '${ORG_ID}', NULL, '0xpay', 'USDT', 'bsc',
         '10', '10', 'pending', now() + interval '1 hour',
-        '{"oxapay_track_id":"track-123"}'::jsonb);`,
+        '{"oxapay_track_id":"track-123","fiat_amount":"10","fiat_currency":"USD"}'::jsonb);`,
   );
 }
 async function seedAppPurchasePayment(): Promise<void> {
@@ -152,7 +167,7 @@ async function seedAppPurchasePayment(): Promise<void> {
      VALUES
        ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay', 'USDT', 'bsc',
         '10', '10', 'pending', now() + interval '1 hour',
-        '{"oxapay_track_id":"track-123","kind":"app_credit_purchase","app_id":"${APP_ID}"}'::jsonb);`,
+        '{"oxapay_track_id":"track-123","fiat_amount":"10","fiat_currency":"USD","kind":"app_credit_purchase","app_id":"${APP_ID}"}'::jsonb);`,
   );
 }
 async function seedReferralPayment(): Promise<void> {
@@ -163,7 +178,7 @@ async function seedReferralPayment(): Promise<void> {
      VALUES
        ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay', 'USDT', 'bsc',
         '10', '10', 'pending', now() + interval '1 hour',
-        '{"oxapay_track_id":"track-123"}'::jsonb);`,
+        '{"oxapay_track_id":"track-123","fiat_amount":"10","fiat_currency":"USD"}'::jsonb);`,
   );
 }
 async function orgBalance(): Promise<number> {
@@ -256,6 +271,23 @@ beforeAll(async () => {
          ON crypto_payments (transaction_hash)
          WHERE transaction_hash IS NOT NULL
            AND status IN ('pending', 'broadcast', 'confirmed')`,
+      `CREATE TABLE IF NOT EXISTS app_charge_callback_outbox (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        delivery_key text NOT NULL UNIQUE,
+        charge_request_id uuid NOT NULL,
+        payload jsonb NOT NULL,
+        payload_digest text NOT NULL,
+        state text NOT NULL DEFAULT 'pending',
+        attempts integer NOT NULL DEFAULT 0,
+        next_attempt_at timestamptz NOT NULL DEFAULT now(),
+        claim_token uuid,
+        lease_expires_at timestamptz,
+        last_error text,
+        delivered_at timestamptz,
+        terminal_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )`,
     ];
     for (const stmt of ddl) await dbWrite.execute(stmt);
   } catch (error) {
@@ -270,6 +302,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   if (!pgliteReady) return;
+  await dbWrite.execute(`DELETE FROM app_charge_callback_outbox;`);
   await dbWrite.execute(`DELETE FROM credit_transactions;`);
   await dbWrite.execute(`DELETE FROM crypto_payments;`);
   await dbWrite.execute(`DELETE FROM organizations;`);
@@ -279,6 +312,7 @@ beforeEach(async () => {
   );
   invoiceCreateShouldThrow = false;
   invoiceCreateSawTransaction = false;
+  invoiceCreateCount = 0;
   lastInvoiceAmountPaid = null;
   appPurchaseSawTransaction = false;
   referralShouldThrowAfterWrite = false;
@@ -292,7 +326,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       if (!pgliteReady) return;
       await seedPendingPayment();
 
-      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashA", "10");
+      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashA", settlementEvidence());
       expect(await orgBalance()).toBeCloseTo(10, 6);
       expect(await creditRowCount()).toBe(1);
 
@@ -303,7 +337,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       await dbWrite.execute(
         `UPDATE crypto_payments SET status='pending' WHERE id='${PAYMENT_ID}';`,
       );
-      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashA", "10");
+      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashA", settlementEvidence());
 
       expect(await creditRowCount()).toBe(1);
       expect(await orgBalance()).toBeCloseTo(10, 6);
@@ -319,7 +353,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       invoiceCreateShouldThrow = true;
 
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashApp", "10", "USDT"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashApp", settlementEvidence()),
       ).rejects.toThrow("simulated invoice insert conflict");
 
       expect(appPurchaseSawTransaction).toBe(true);
@@ -338,7 +372,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       referralShouldThrowAfterWrite = true;
 
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReferral", "10", "USDT"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReferral", settlementEvidence()),
       ).rejects.toThrow("simulated referral failure");
 
       expect(referralSawTransaction).toBe(true);
@@ -359,7 +393,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       // Arm the invoice insert (which runs after the credit) to throw.
       invoiceCreateShouldThrow = true;
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashB", "10"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashB", settlementEvidence()),
       ).rejects.toThrow();
 
       // Because the credit is granted with db: tx, the invoice failure rolled it
@@ -371,7 +405,7 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
 
       // A clean reprocess now succeeds and credits exactly once.
       invoiceCreateShouldThrow = false;
-      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashB", "10");
+      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashB", settlementEvidence());
       expect(await creditRowCount()).toBe(1);
       expect(await orgBalance()).toBeCloseTo(10, 6);
       expect(await paymentStatus()).toBe("confirmed");
@@ -427,11 +461,16 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
       await seedPendingPayment();
 
       const exactProviderAmount = "10.123456789012345678";
+      await dbWrite.execute(
+        `UPDATE crypto_payments
+         SET expected_amount='${exactProviderAmount}',
+             metadata = metadata || '{"fiat_amount":"${exactProviderAmount}"}'::jsonb
+         WHERE id='${PAYMENT_ID}'`,
+      );
       await cryptoPaymentsService.confirmPayment(
         PAYMENT_ID,
         "0xhashExact",
-        exactProviderAmount,
-        "USDT",
+        settlementEvidence(exactProviderAmount),
       );
 
       expect(await paymentReceivedAmount()).toBe(exactProviderAmount);
@@ -449,19 +488,84 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
     async () => {
       if (!pgliteReady) return;
       await seedPendingPayment();
-      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "10", "USDT");
+      await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", settlementEvidence());
 
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "11", "USDT"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", settlementEvidence("11")),
       ).rejects.toThrow("does not match");
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xhashReplay", "10", "BTC"),
+        cryptoPaymentsService.confirmPayment(
+          PAYMENT_ID,
+          "0xhashReplay",
+          settlementEvidence("10", "BTC"),
+        ),
       ).rejects.toThrow("does not match");
       expect(await creditRowCount()).toBe(1);
       expect(await orgBalance()).toBeCloseTo(10, 6);
     },
     PGLITE_TIMEOUT,
   );
+
+  test("binds provider track ID, fiat amount, and fiat currency to the stored quote", async () => {
+    if (!pgliteReady) return;
+    await seedPendingPayment();
+
+    await expect(
+      cryptoPaymentsService.confirmPayment(
+        PAYMENT_ID,
+        "0xquote1",
+        settlementEvidence("10", "USDT", "wrong-track"),
+      ),
+    ).rejects.toThrow("server-stored fiat quote");
+    await expect(
+      cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xquote2", settlementEvidence("10.01")),
+    ).rejects.toThrow("server-stored fiat quote");
+    await expect(
+      cryptoPaymentsService.confirmPayment(
+        PAYMENT_ID,
+        "0xquote3",
+        settlementEvidence("10", "USDT", "track-123", "EUR"),
+      ),
+    ).rejects.toThrow("server-stored fiat quote");
+    expect(await paymentStatus()).toBe("pending");
+    expect(await creditRowCount()).toBe(0);
+  });
+
+  test("confirmed replay re-proves the canonical invoice settlement", async () => {
+    if (!pgliteReady) return;
+    await seedPendingPayment();
+    await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xinvoiceReplay", settlementEvidence());
+    expect(invoiceCreateCount).toBe(1);
+
+    await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xinvoiceReplay", settlementEvidence());
+    expect(invoiceCreateCount).toBe(2);
+    expect(await creditRowCount()).toBe(1);
+  });
+
+  test("confirmed app-purchase replay recovers a missing durable callback intent", async () => {
+    if (!pgliteReady) return;
+    await dbWrite.execute(
+      `INSERT INTO crypto_payments
+         (id, organization_id, user_id, payment_address, token, network,
+          expected_amount, credits_to_add, status, expires_at, metadata)
+       VALUES
+         ('${CHARGE_REQUEST_ID}', '${ORG_ID}', '${USER_ID}', 'app-charge', 'USD', 'internal',
+          '10', '10', 'pending', now() + interval '1 hour',
+          '{"kind":"app_charge_request","app_id":"${APP_ID}","creator_organization_id":"${ORG_ID}"}'::jsonb),
+         ('${PAYMENT_ID}', '${ORG_ID}', '${USER_ID}', '0xpay', 'USDT', 'bsc',
+          '10', '10', 'pending', now() + interval '1 hour',
+          '{"oxapay_track_id":"track-123","fiat_amount":"10","fiat_currency":"USD","kind":"app_credit_purchase","app_id":"${APP_ID}","charge_request_id":"${CHARGE_REQUEST_ID}"}'::jsonb)`,
+    );
+    await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xcallback", settlementEvidence());
+    let rows = await dbWrite.execute(`SELECT delivery_key FROM app_charge_callback_outbox`);
+    expect(rows.rows).toHaveLength(1);
+
+    await dbWrite.execute(`DELETE FROM app_charge_callback_outbox`);
+    await cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xcallback", settlementEvidence());
+    rows = await dbWrite.execute(`SELECT delivery_key FROM app_charge_callback_outbox`);
+    expect(rows.rows).toHaveLength(1);
+    expect(await creditRowCount()).toBe(1);
+  });
 
   test(
     "concurrent webhook and manual confirmation converge on one settlement",
@@ -499,12 +603,16 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
          VALUES
            ('${OTHER_PAYMENT_ID}', '${OTHER_ORG_ID}', NULL, '0xpay2', 'USDT', 'bsc',
             '10', '10', 'pending', now() + interval '1 hour',
-            '{"oxapay_track_id":"track-456"}'::jsonb);`,
+            '{"oxapay_track_id":"track-456","fiat_amount":"10","fiat_currency":"USD"}'::jsonb);`,
       );
 
       const results = await Promise.allSettled([
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xAbCd1234", "10", "USDT"),
-        cryptoPaymentsService.confirmPayment(OTHER_PAYMENT_ID, "0xaBcD1234", "10", "USDT"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xAbCd1234", settlementEvidence()),
+        cryptoPaymentsService.confirmPayment(
+          OTHER_PAYMENT_ID,
+          "0xaBcD1234",
+          settlementEvidence("10", "USDT", "track-456"),
+        ),
       ]);
 
       expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
@@ -542,12 +650,16 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
         transaction_hash: "0xABCDEF1234",
         status: "broadcast",
         expires_at: new Date(Date.now() + 60_000),
-        metadata: { oxapay_track_id: "track-456" },
+        metadata: {
+          oxapay_track_id: "track-456",
+          fiat_amount: "10",
+          fiat_currency: "USD",
+        },
       });
       await seedPendingPayment();
 
       await expect(
-        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xabcdef1234", "10", "USDT"),
+        cryptoPaymentsService.confirmPayment(PAYMENT_ID, "0xabcdef1234", settlementEvidence()),
       ).rejects.toThrow("another payment");
       const existing = await cryptoPaymentsRepository.findById(OTHER_PAYMENT_ID);
       expect(existing?.transaction_hash).toBe("0xabcdef1234");

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
@@ -80,8 +80,8 @@ mock.module("viem", () => ({
     }),
 }));
 
-// Invoice creation runs after the confirmation tx and is not under test here
-// (it has its own idempotency); stub it to avoid unrelated table DDL.
+// Invoice creation shares the confirmation transaction but has its own
+// idempotency suite; stub it here so this harness can isolate credit atomicity.
 mock.module("../invoices", () => ({
   invoicesService: {
     async getByStripeInvoiceId() {
@@ -231,6 +231,24 @@ beforeAll(async () => {
         confirmed_at timestamp,
         expires_at timestamp NOT NULL,
         metadata jsonb DEFAULT '{}'::jsonb
+      )`,
+      `CREATE TABLE IF NOT EXISTS crypto_sweep_outbox (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        payment_id uuid NOT NULL REFERENCES crypto_payments(id) ON DELETE CASCADE,
+        payload jsonb NOT NULL,
+        payload_digest text NOT NULL,
+        state text NOT NULL DEFAULT 'pending',
+        attempts integer NOT NULL DEFAULT 0,
+        next_attempt_at timestamptz NOT NULL DEFAULT NOW(),
+        claim_token uuid,
+        lease_expires_at timestamptz,
+        last_error text,
+        sweep_transaction_hash text,
+        delivered_at timestamptz,
+        terminal_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        updated_at timestamptz NOT NULL DEFAULT NOW(),
+        UNIQUE (payment_id)
       )`,
     ];
     for (const stmt of ddl) await dbWrite.execute(stmt);

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
@@ -245,6 +245,7 @@ beforeAll(async () => {
         last_error text,
         prepared_transaction text,
         sweep_transaction_hash text,
+        prepared_metadata jsonb,
         delivered_at timestamptz,
         terminal_at timestamptz,
         created_at timestamptz NOT NULL DEFAULT NOW(),

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
@@ -243,6 +243,7 @@ beforeAll(async () => {
         claim_token uuid,
         lease_expires_at timestamptz,
         last_error text,
+        prepared_transaction text,
         sweep_transaction_hash text,
         delivered_at timestamptz,
         terminal_at timestamptz,

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -374,6 +374,7 @@ beforeAll(async () => {
       last_error text,
       prepared_transaction text,
       sweep_transaction_hash text,
+      prepared_metadata jsonb,
       delivered_at timestamptz,
       terminal_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now(),
@@ -708,12 +709,24 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
         const ambiguous = await service.drainSweepOutbox(env, 1);
         expect(ambiguous.deferred).toBe(1);
         let outbox = await dbWrite.execute(
-          `SELECT state, prepared_transaction, sweep_transaction_hash FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+          `SELECT state, prepared_transaction, sweep_transaction_hash, prepared_metadata
+           FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
         );
         expect((outbox.rows[0] as { state: string }).state).toBe("pending");
         expect((outbox.rows[0] as { prepared_transaction: string }).prepared_transaction).toBe(
           submittedSweepBytes[0],
         );
+        expect(
+          (
+            outbox.rows[0] as {
+              prepared_metadata: { network: string; nonce: string; sweepTo: string };
+            }
+          ).prepared_metadata,
+        ).toEqual({
+          network: "bsc",
+          nonce: "0",
+          sweepTo: env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS,
+        });
 
         await dbWrite.execute(
           "UPDATE crypto_sweep_outbox SET next_attempt_at=now() - interval '1 second'",

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -427,7 +427,7 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
         network: "bsc",
         tokenSymbol: "USDT",
       });
-      const hash = `0x${"a".repeat(64)}`;
+      const hash = `0x${"Ab".repeat(32)}`;
       await trustPayerProof(payment);
       const attached = await service.attachTransaction(env, {
         paymentId: payment.id,
@@ -435,7 +435,7 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
         userId: USER_ID,
       });
       expect(attached.payment.status).toBe("broadcast");
-      expect(attached.payment.transaction_hash).toBe(hash);
+      expect(attached.payment.transaction_hash).toBe(hash.toLowerCase());
       expect(attached.alreadyAttached).toBe(false);
     });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -7,7 +7,7 @@
  * stubs — we drive the state machine, not the chain.
  *
  * To keep the surface tight we:
- *   - create only the `crypto_payments` table (the sole table the service writes)
+ *   - create the payment and durable sweep-outbox tables used by this boundary
  *   - mock `creditsService` and `invoicesService` with tiny stand-ins that
  *     preserve the stripePaymentIntentId idempotency contract, since that is
  *     what protects against double-credit on retry.
@@ -27,7 +27,7 @@ import {
 // undefined under bun). Register non-hoisted mocks only under Vitest, before
 // the service's dynamic import in `beforeAll`; bun-test selects a skipped
 // suite without invoking unsupported mock plumbing. The dedicated Vitest lane
-// runs all 40 state-machine cases in CI against real in-process PGlite.
+// runs the state-machine cases in CI against real in-process PGlite.
 const SUPPORTS_VITEST_MOCK_API =
   typeof vi.importActual === "function" && typeof vi.doMock === "function";
 
@@ -75,6 +75,7 @@ interface FakeTx {
 }
 
 const chainTxs = new Map<string, FakeTx>();
+let sweepSubmissions = 0;
 
 if (SUPPORTS_VITEST_MOCK_API) {
   vi.doMock("viem", async () => {
@@ -136,6 +137,12 @@ if (SUPPORTS_VITEST_MOCK_API) {
         // behaviourally identical.
         verifyTypedData: (args: Parameters<typeof actual.verifyTypedData>[0]) =>
           actual.verifyTypedData(args),
+      }),
+      createWalletClient: () => ({
+        async sendTransaction() {
+          sweepSubmissions += 1;
+          return `0x${"5".repeat(64)}`;
+        },
       }),
       parseEventLogs: ({ logs }: { logs: Array<{ address: string }> }) => {
         // Map the stub-receipt log back to a parsed Transfer event using the
@@ -246,7 +253,7 @@ if (SUPPORTS_VITEST_MOCK_API) {
     creditsService: {
       async addCredits(params: {
         organizationId: string;
-        amount: number;
+        amount: number | string;
         description: string;
         stripePaymentIntentId?: string;
         metadata?: Record<string, unknown>;
@@ -261,10 +268,10 @@ if (SUPPORTS_VITEST_MOCK_API) {
         }
         creditsLedger.push({
           organizationId: params.organizationId,
-          amount: params.amount,
+          amount: Number(params.amount),
           stripePaymentIntentId: params.stripePaymentIntentId,
         });
-        return { transaction: { id: "new" }, newBalance: params.amount };
+        return { transaction: { id: "new" }, newBalance: Number(params.amount) };
       },
     },
   }));
@@ -336,6 +343,26 @@ beforeAll(async () => {
       metadata jsonb DEFAULT '{}'::jsonb
     )
   `);
+  await dbWrite.execute(`
+    CREATE TABLE IF NOT EXISTS crypto_sweep_outbox (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      payment_id uuid NOT NULL REFERENCES crypto_payments(id) ON DELETE CASCADE,
+      payload jsonb NOT NULL,
+      payload_digest text NOT NULL,
+      state text NOT NULL DEFAULT 'pending',
+      attempts integer NOT NULL DEFAULT 0,
+      next_attempt_at timestamptz NOT NULL DEFAULT now(),
+      claim_token uuid,
+      lease_expires_at timestamptz,
+      last_error text,
+      sweep_transaction_hash text,
+      delivered_at timestamptz,
+      terminal_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE(payment_id)
+    )
+  `);
 }, 240_000);
 
 afterAll(async () => {
@@ -345,6 +372,7 @@ afterAll(async () => {
 beforeEach(() => {
   chainTxs.clear();
   creditsLedger.length = 0;
+  sweepSubmissions = 0;
 });
 
 async function resetTable() {
@@ -528,6 +556,83 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
       // Retry — idempotency by stripePaymentIntentId means no new ledger entry.
       await service.confirmPayment(env, { paymentId: payment.id, txHash: hash, userId: USER_ID });
       expect(creditsLedger).toHaveLength(1);
+    });
+
+    test("post-sweep acknowledgement crash becomes terminal without rolling back or resubmitting", async () => {
+      await resetTable();
+      const originalReceive = env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS;
+      const originalPrivateKey = env.CRYPTO_DIRECT_BSC_PRIVATE_KEY;
+      const originalSecure = env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS;
+      const matchingReceive = privateKeyToAccount(PROOF_PAYER_KEY).address;
+      env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = matchingReceive;
+      env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS = "0x2222222222222222222222222222222222222222";
+      env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = ATTACKER_KEY;
+      try {
+        const { payment } = await service.createPayment(env, {
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          accountWalletAddress: null,
+          payerAddress: PAYER_EVM,
+          amountUsd: 10,
+          network: "bsc",
+          tokenSymbol: "USDT",
+        });
+        const meta = payment.metadata as Record<string, unknown>;
+        const expectedUnits = BigInt(meta.expected_token_units as string);
+        const tokenAddress = meta.token_address as string;
+        const hash = `0x${"6".repeat(64)}`;
+        chainTxs.set(hash, {
+          from: PAYER_EVM,
+          to: tokenAddress,
+          value: 0n,
+          status: "success",
+          receiveAddress: matchingReceive,
+          erc20: {
+            tokenAddress,
+            from: PAYER_EVM,
+            to: matchingReceive,
+            value: expectedUnits,
+          },
+        });
+        await trustPayerProof(payment);
+        await service.confirmPayment(env, { paymentId: payment.id, txHash: hash, userId: USER_ID });
+        expect((await dbWrite.query.cryptoPayments.findFirst())?.status).toBe("confirmed");
+        expect(creditsLedger).toHaveLength(1);
+        const initialOutbox = await dbWrite.execute(
+          `SELECT state, last_error FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+        );
+        expect((initialOutbox.rows[0] as { state: string }).state).toBe("pending");
+        expect((initialOutbox.rows[0] as { last_error: string }).last_error).toContain(
+          "does not match the receive wallet",
+        );
+
+        env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = PROOF_PAYER_KEY;
+        await dbWrite.execute(
+          "UPDATE crypto_sweep_outbox SET state='pending', claim_token=NULL, lease_expires_at=NULL, next_attempt_at=now() - interval '1 second'",
+        );
+        const crashed = await service.drainSweepOutbox(env, 1, {
+          afterExternalSweep: async () => {
+            throw new Error("injected post-sweep database outage");
+          },
+        });
+        expect(crashed.deferred).toBe(1);
+        let outbox = await dbWrite.execute(
+          `SELECT state, last_error FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+        );
+        expect((outbox.rows[0] as { state: string }).state).toBe("terminal");
+        expect((outbox.rows[0] as { last_error: string }).last_error).toContain("post-sweep");
+        expect((await dbWrite.query.cryptoPayments.findFirst())?.status).toBe("confirmed");
+
+        const noReplay = await service.drainSweepOutbox(env, 1);
+        expect(noReplay.processed).toBe(0);
+        expect(sweepSubmissions).toBe(1);
+      } finally {
+        env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = originalReceive;
+        if (originalSecure === undefined) delete env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS;
+        else env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS = originalSecure;
+        if (originalPrivateKey === undefined) delete env.CRYPTO_DIRECT_BSC_PRIVATE_KEY;
+        else env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = originalPrivateKey;
+      }
     });
 
     test("confirmPayment rejects amount-too-low; status stays broadcast; no credits", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -76,6 +76,8 @@ interface FakeTx {
 
 const chainTxs = new Map<string, FakeTx>();
 let sweepSubmissions = 0;
+let sweepSubmitThrowsAfterAccept = false;
+const submittedSweepBytes: string[] = [];
 
 if (SUPPORTS_VITEST_MOCK_API) {
   vi.doMock("viem", async () => {
@@ -127,6 +129,15 @@ if (SUPPORTS_VITEST_MOCK_API) {
           if (!tx) throw new Error("not found");
           return { from: tx.from, to: tx.to, value: tx.value };
         },
+        async sendRawTransaction({ serializedTransaction }: { serializedTransaction: string }) {
+          sweepSubmissions += 1;
+          submittedSweepBytes.push(serializedTransaction);
+          if (sweepSubmitThrowsAfterAccept) {
+            sweepSubmitThrowsAfterAccept = false;
+            throw new Error("injected provider acknowledgement loss");
+          }
+          return actual.keccak256(serializedTransaction as `0x${string}`);
+        },
         async readContract() {
           return 18n;
         },
@@ -139,9 +150,15 @@ if (SUPPORTS_VITEST_MOCK_API) {
           actual.verifyTypedData(args),
       }),
       createWalletClient: () => ({
-        async sendTransaction() {
-          sweepSubmissions += 1;
-          return `0x${"5".repeat(64)}`;
+        async prepareTransactionRequest(input: { to: string; data: string }) {
+          return {
+            ...input,
+            chainId: 56,
+            gas: 100_000n,
+            gasPrice: 1n,
+            nonce: 0,
+            type: "legacy" as const,
+          };
         },
       }),
       parseEventLogs: ({ logs }: { logs: Array<{ address: string }> }) => {
@@ -355,6 +372,7 @@ beforeAll(async () => {
       claim_token uuid,
       lease_expires_at timestamptz,
       last_error text,
+      prepared_transaction text,
       sweep_transaction_hash text,
       delivered_at timestamptz,
       terminal_at timestamptz,
@@ -373,6 +391,8 @@ beforeEach(() => {
   chainTxs.clear();
   creditsLedger.length = 0;
   sweepSubmissions = 0;
+  sweepSubmitThrowsAfterAccept = false;
+  submittedSweepBytes.length = 0;
 });
 
 async function resetTable() {
@@ -617,15 +637,95 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
         });
         expect(crashed.deferred).toBe(1);
         let outbox = await dbWrite.execute(
-          `SELECT state, last_error FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+          `SELECT state, last_error, prepared_transaction, sweep_transaction_hash FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
         );
         expect((outbox.rows[0] as { state: string }).state).toBe("terminal");
         expect((outbox.rows[0] as { last_error: string }).last_error).toContain("post-sweep");
+        expect(
+          (outbox.rows[0] as { prepared_transaction: string }).prepared_transaction,
+        ).toBeTruthy();
+        expect(
+          (outbox.rows[0] as { sweep_transaction_hash: string }).sweep_transaction_hash,
+        ).toMatch(/^0x[0-9a-f]{64}$/);
         expect((await dbWrite.query.cryptoPayments.findFirst())?.status).toBe("confirmed");
 
         const noReplay = await service.drainSweepOutbox(env, 1);
         expect(noReplay.processed).toBe(0);
         expect(sweepSubmissions).toBe(1);
+      } finally {
+        env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = originalReceive;
+        if (originalSecure === undefined) delete env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS;
+        else env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS = originalSecure;
+        if (originalPrivateKey === undefined) delete env.CRYPTO_DIRECT_BSC_PRIVATE_KEY;
+        else env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = originalPrivateKey;
+      }
+    });
+
+    test("provider acknowledgement loss retries the exact pre-signed sweep bytes", async () => {
+      await resetTable();
+      const originalReceive = env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS;
+      const originalPrivateKey = env.CRYPTO_DIRECT_BSC_PRIVATE_KEY;
+      const originalSecure = env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS;
+      const matchingReceive = privateKeyToAccount(PROOF_PAYER_KEY).address;
+      env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = matchingReceive;
+      env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS = "0x2222222222222222222222222222222222222222";
+      env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = ATTACKER_KEY;
+      try {
+        const { payment } = await service.createPayment(env, {
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          accountWalletAddress: null,
+          payerAddress: PAYER_EVM,
+          amountUsd: 10,
+          network: "bsc",
+          tokenSymbol: "USDT",
+        });
+        const meta = payment.metadata as Record<string, unknown>;
+        const expectedUnits = BigInt(meta.expected_token_units as string);
+        const tokenAddress = meta.token_address as string;
+        const hash = `0x${"7".repeat(64)}`;
+        chainTxs.set(hash, {
+          from: PAYER_EVM,
+          to: tokenAddress,
+          value: 0n,
+          status: "success",
+          receiveAddress: matchingReceive,
+          erc20: {
+            tokenAddress,
+            from: PAYER_EVM,
+            to: matchingReceive,
+            value: expectedUnits,
+          },
+        });
+        await trustPayerProof(payment);
+        await service.confirmPayment(env, { paymentId: payment.id, txHash: hash, userId: USER_ID });
+
+        env.CRYPTO_DIRECT_BSC_PRIVATE_KEY = PROOF_PAYER_KEY;
+        await dbWrite.execute(
+          "UPDATE crypto_sweep_outbox SET state='pending', claim_token=NULL, lease_expires_at=NULL, next_attempt_at=now() - interval '1 second'",
+        );
+        sweepSubmitThrowsAfterAccept = true;
+        const ambiguous = await service.drainSweepOutbox(env, 1);
+        expect(ambiguous.deferred).toBe(1);
+        let outbox = await dbWrite.execute(
+          `SELECT state, prepared_transaction, sweep_transaction_hash FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+        );
+        expect((outbox.rows[0] as { state: string }).state).toBe("pending");
+        expect((outbox.rows[0] as { prepared_transaction: string }).prepared_transaction).toBe(
+          submittedSweepBytes[0],
+        );
+
+        await dbWrite.execute(
+          "UPDATE crypto_sweep_outbox SET next_attempt_at=now() - interval '1 second'",
+        );
+        const recovered = await service.drainSweepOutbox(env, 1);
+        expect(recovered.delivered).toBe(1);
+        expect(sweepSubmissions).toBe(2);
+        expect(submittedSweepBytes[1]).toBe(submittedSweepBytes[0]);
+        outbox = await dbWrite.execute(
+          `SELECT state FROM crypto_sweep_outbox WHERE payment_id='${payment.id}'`,
+        );
+        expect((outbox.rows[0] as { state: string }).state).toBe("delivered");
       } finally {
         env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = originalReceive;
         if (originalSecure === undefined) delete env.CRYPTO_DIRECT_BSC_SECURE_ADDRESS;

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-sweep-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-sweep-recovery.test.ts
@@ -1,0 +1,45 @@
+/** Pins the Solana signed-transaction recovery decision at the provider boundary. */
+import { describe, expect, test } from "bun:test";
+import { classifySolanaSweepRecovery } from "../direct-wallet-payments";
+
+describe("Solana sweep acknowledgement recovery", () => {
+  test("reuses the same signed transaction while an absent signature can still land", () => {
+    expect(
+      classifySolanaSweepRecovery({
+        signatureStatus: null,
+        currentBlockHeight: 500,
+        lastValidBlockHeight: 500,
+      }),
+    ).toBe("resend");
+  });
+
+  test("reprepares only after signature-history absence and definitive blockhash expiry", () => {
+    expect(
+      classifySolanaSweepRecovery({
+        signatureStatus: null,
+        currentBlockHeight: 501,
+        lastValidBlockHeight: 500,
+      }),
+    ).toBe("reprepare");
+  });
+
+  test("never resubmits or reprepares a transaction already visible in signature history", () => {
+    expect(
+      classifySolanaSweepRecovery({
+        signatureStatus: { err: null },
+        currentBlockHeight: 900,
+        lastValidBlockHeight: 500,
+      }),
+    ).toBe("landed");
+  });
+
+  test("fails closed on an on-chain failed transaction", () => {
+    expect(() =>
+      classifySolanaSweepRecovery({
+        signatureStatus: { err: { InstructionError: [0, "Custom"] } },
+        currentBlockHeight: 500,
+        lastValidBlockHeight: 500,
+      }),
+    ).toThrow("failed on chain");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/invoices-transaction-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invoices-transaction-idempotency.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Exercises invoice creation against real PGlite to prove caller-transaction
+ * reuse and strict unique-key replay validation.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000c1";
+const OTHER_ORG_ID = "00000000-0000-4000-8000-0000000000c2";
+const PGLITE_TIMEOUT = 60000;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let invoicesService: typeof import("../invoices").invoicesService;
+let pgliteReady = true;
+
+const invoice = {
+  organization_id: ORG_ID,
+  stripe_invoice_id: "OXAPAY_PAYMENT_1",
+  stripe_customer_id: "OXAPAY_CUSTOMER_1",
+  stripe_payment_intent_id: "0xpayment",
+  amount_due: "10.00",
+  amount_paid: "10.00",
+  currency: "usdt",
+  status: "paid",
+  invoice_type: "crypto_payment",
+  credits_added: "10.00",
+};
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ invoicesService } = await import("../invoices"));
+    await dbWrite.execute(`CREATE TABLE IF NOT EXISTS invoices (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      stripe_invoice_id text NOT NULL UNIQUE,
+      stripe_customer_id text NOT NULL,
+      stripe_payment_intent_id text,
+      amount_due numeric(10,2) NOT NULL,
+      amount_paid numeric(10,2) NOT NULL,
+      currency text NOT NULL DEFAULT 'usd',
+      status text NOT NULL,
+      invoice_type text NOT NULL,
+      invoice_number text,
+      invoice_pdf text,
+      hosted_invoice_url text,
+      credits_added numeric(10,2),
+      metadata jsonb DEFAULT '{}',
+      created_at timestamp NOT NULL DEFAULT now(),
+      updated_at timestamp NOT NULL DEFAULT now(),
+      due_date timestamp,
+      paid_at timestamp
+    )`);
+  } catch {
+    // The loud guard below prevents a missing database from becoming a vacuous green.
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+beforeEach(async () => {
+  if (pgliteReady) await dbWrite.execute("DELETE FROM invoices");
+});
+
+describe("invoice transaction and unique replay", () => {
+  test("reuses the caller transaction and returns the same invoice on exact replay", async () => {
+    if (!pgliteReady) return;
+    await dbWrite.transaction(async (tx) => {
+      const first = await invoicesService.create(invoice, tx);
+      const replay = await invoicesService.create(invoice, tx);
+      expect(replay.id).toBe(first.id);
+    });
+    const rows = await dbWrite.execute("SELECT count(*)::int AS count FROM invoices");
+    expect((rows.rows[0] as { count: number }).count).toBe(1);
+  });
+
+  test("rejects amount and tenant changes under the same invoice key", async () => {
+    if (!pgliteReady) return;
+    await invoicesService.create(invoice);
+    await expect(invoicesService.create({ ...invoice, amount_paid: "11.00" })).rejects.toThrow(
+      "does not match",
+    );
+    await expect(
+      invoicesService.create({ ...invoice, organization_id: OTHER_ORG_ID }),
+    ).rejects.toThrow("does not match");
+  });
+
+  test("a later failure rolls back an invoice created on the caller transaction", async () => {
+    if (!pgliteReady) return;
+    await expect(
+      dbWrite.transaction(async (tx) => {
+        await invoicesService.create(invoice, tx);
+        throw new Error("injected post-invoice failure");
+      }),
+    ).rejects.toThrow("injected post-invoice failure");
+    const rows = await dbWrite.execute("SELECT count(*)::int AS count FROM invoices");
+    expect((rows.rows[0] as { count: number }).count).toBe(0);
+  });
+});
+
+test("pglite invoice schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/invoices-transaction-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invoices-transaction-idempotency.test.ts
@@ -28,6 +28,7 @@ const invoice = {
   status: "paid",
   invoice_type: "crypto_payment",
   credits_added: "10.00",
+  metadata: { provider: "oxapay", token: "USDT", transaction_hash: "0xpayment" },
 };
 
 beforeAll(async () => {
@@ -90,6 +91,12 @@ describe("invoice transaction and unique replay", () => {
     await expect(
       invoicesService.create({ ...invoice, organization_id: OTHER_ORG_ID }),
     ).rejects.toThrow("does not match");
+    await expect(
+      invoicesService.create({
+        ...invoice,
+        metadata: { ...invoice.metadata, token: "BTC" },
+      }),
+    ).rejects.toThrow("does not match");
   });
 
   test("a later failure rolls back an invoice created on the caller transaction", async () => {
@@ -102,6 +109,15 @@ describe("invoice transaction and unique replay", () => {
     ).rejects.toThrow("injected post-invoice failure");
     const rows = await dbWrite.execute("SELECT count(*)::int AS count FROM invoices");
     expect((rows.rows[0] as { count: number }).count).toBe(0);
+  });
+
+  test("a deleted projection is rebuilt from the same canonical settlement", async () => {
+    if (!pgliteReady) return;
+    await invoicesService.create(invoice);
+    await dbWrite.execute("DELETE FROM invoices WHERE stripe_invoice_id='OXAPAY_PAYMENT_1'");
+    const recovered = await invoicesService.create(invoice);
+    expect(recovered.stripe_invoice_id).toBe("OXAPAY_PAYMENT_1");
+    expect((recovered.metadata as Record<string, unknown>).settlement_digest).toBeString();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
@@ -135,4 +135,18 @@ describe("AppChargeCallbacksService — SSRF-guarded HTTP callback", () => {
     expect(result.httpPosted).toBe(false);
     expect(result.errors[0]).toContain("500");
   });
+
+  it("retries with an immutable callback envelope", async () => {
+    seedCharge({
+      kind: "app_charge_request",
+      app_id: APP_ID,
+      callback_url: CALLBACK_URL,
+    });
+
+    await appChargeCallbacksService.dispatch(DISPATCH_PARAMS);
+    await appChargeCallbacksService.dispatch(DISPATCH_PARAMS);
+
+    expect(safeFetchCalls).toHaveLength(2);
+    expect(String(safeFetchCalls[1]?.init?.body)).toBe(String(safeFetchCalls[0]?.init?.body));
+  });
 });

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
@@ -67,7 +67,7 @@ const DISPATCH_PARAMS = {
   status: "paid" as const,
   provider: "stripe" as const,
   providerPaymentId: "pi_123",
-  amountUsd: "12.50",
+  amountUsd: "12.500000000000000001",
 };
 
 describe("AppChargeCallbacksService — SSRF-guarded HTTP callback", () => {
@@ -97,6 +97,12 @@ describe("AppChargeCallbacksService — SSRF-guarded HTTP callback", () => {
     expect(headers["Content-Type"]).toBe("application/json");
     expect(headers["X-Eliza-Event"]).toBe("app_charge.paid");
     expect(headers["X-Eliza-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+    const body = JSON.parse(String(call.init?.body)) as {
+      charge: { amountUsd: string };
+      payment: { amountUsd: string };
+    };
+    expect(body.charge.amountUsd).toBe("12.500000000000000001");
+    expect(body.payment.amountUsd).toBe("12.500000000000000001");
   });
 
   it("records a guard rejection as a dispatch error instead of throwing", async () => {

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -1,14 +1,17 @@
 /** Coordinates app-charge callback delivery and authorized room-message projection. */
 import { MemoryType } from "@elizaos/core";
 import { randomUUID } from "crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, lte, or } from "drizzle-orm";
+import { type DbTransaction, dbWrite } from "../../db/client";
 import { dbRead } from "../../db/helpers";
 import { memoriesRepository } from "../../db/repositories/agents/memories";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
+import { appChargeCallbackOutbox } from "../../db/schemas/crypto-settlement-outbox";
 import { safeFetch } from "../security/safe-fetch";
 import type { DialogueMetadata } from "../types/message-content";
 import { logger } from "../utils/logger";
 import { callbackRoomBelongsToOrganization } from "./callback-channel-authz";
+import { settlementDigest } from "./settlement-digest";
 
 export type AppChargeCallbackStatus = "paid" | "failed";
 export type AppChargeCallbackProvider = "stripe" | "oxapay";
@@ -38,6 +41,8 @@ export interface AppChargeCallbackDispatchParams {
   payerOrganizationId?: string | null;
   reason?: string;
   metadata?: Record<string, unknown>;
+  /** Stable durable-delivery identity reused across outbox retries. */
+  deliveryId?: string;
 }
 
 export interface AppChargeCallbackPayload {
@@ -64,10 +69,59 @@ export interface AppChargeCallbackPayload {
   metadata?: Record<string, unknown>;
 }
 
-interface CallbackDispatchResult {
+export interface CallbackDispatchResult {
   httpPosted: boolean;
   roomMessageCreated: boolean;
   errors: string[];
+}
+
+const CALLBACK_MAX_ATTEMPTS = 12;
+const CALLBACK_LEASE_MS = 60_000;
+
+function callbackDeliveryKey(params: AppChargeCallbackDispatchParams): string {
+  return `${params.provider}:${params.providerPaymentId}:${params.chargeRequestId}:${params.status}`;
+}
+
+export function parseAppChargeCallbackDispatchParams(
+  value: unknown,
+): AppChargeCallbackDispatchParams {
+  if (!isRecord(value)) throw new Error("App callback outbox payload is not an object");
+  const required = ["appId", "chargeRequestId", "status", "provider", "providerPaymentId"];
+  if (required.some((key) => typeof value[key] !== "string" || value[key] === "")) {
+    throw new Error("App callback outbox payload is missing required identity fields");
+  }
+  if (value.status !== "paid" && value.status !== "failed") {
+    throw new Error("App callback outbox status is invalid");
+  }
+  if (value.provider !== "stripe" && value.provider !== "oxapay") {
+    throw new Error("App callback outbox provider is invalid");
+  }
+  const optionalStrings = ["payerUserId", "payerOrganizationId", "reason", "deliveryId"];
+  if (
+    optionalStrings.some(
+      (key) => value[key] !== undefined && value[key] !== null && typeof value[key] !== "string",
+    ) ||
+    (value.amountUsd !== undefined &&
+      value.amountUsd !== null &&
+      typeof value.amountUsd !== "string" &&
+      typeof value.amountUsd !== "number") ||
+    (value.metadata !== undefined && !isRecord(value.metadata))
+  ) {
+    throw new Error("App callback outbox payload has invalid optional fields");
+  }
+  return {
+    appId: value.appId as string,
+    chargeRequestId: value.chargeRequestId as string,
+    status: value.status,
+    provider: value.provider,
+    providerPaymentId: value.providerPaymentId as string,
+    amountUsd: value.amountUsd as string | number | null | undefined,
+    payerUserId: value.payerUserId as string | null | undefined,
+    payerOrganizationId: value.payerOrganizationId as string | null | undefined,
+    reason: value.reason as string | undefined,
+    metadata: value.metadata as Record<string, unknown> | undefined,
+    deliveryId: value.deliveryId as string | undefined,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -196,6 +250,131 @@ export function createAppChargeCallbackPayload(
 }
 
 export class AppChargeCallbacksService {
+  async enqueue(
+    params: AppChargeCallbackDispatchParams,
+    transaction: DbTransaction,
+  ): Promise<void> {
+    const deliveryKey = callbackDeliveryKey(params);
+    const digest = settlementDigest(params);
+    const [inserted] = await transaction
+      .insert(appChargeCallbackOutbox)
+      .values({
+        delivery_key: deliveryKey,
+        charge_request_id: params.chargeRequestId,
+        payload: { ...params },
+        payload_digest: digest,
+      })
+      .onConflictDoNothing({ target: appChargeCallbackOutbox.delivery_key })
+      .returning();
+    if (inserted) return;
+
+    const [existing] = await transaction
+      .select()
+      .from(appChargeCallbackOutbox)
+      .where(eq(appChargeCallbackOutbox.delivery_key, deliveryKey))
+      .limit(1);
+    if (!existing || existing.payload_digest !== digest) {
+      throw new Error("App callback outbox replay does not match the committed delivery");
+    }
+  }
+
+  async drain(
+    limit = 25,
+  ): Promise<{ processed: number; delivered: number; retried: number; terminal: number }> {
+    const stats = { processed: 0, delivered: 0, retried: 0, terminal: 0 };
+    for (let index = 0; index < limit; index += 1) {
+      const claimToken = randomUUID();
+      const now = new Date();
+      const leaseExpiresAt = new Date(now.getTime() + CALLBACK_LEASE_MS);
+      const claimed = await dbWrite.transaction(async (tx) => {
+        const [candidate] = await tx
+          .select()
+          .from(appChargeCallbackOutbox)
+          .where(
+            and(
+              lte(appChargeCallbackOutbox.next_attempt_at, now),
+              or(
+                eq(appChargeCallbackOutbox.state, "pending"),
+                and(
+                  eq(appChargeCallbackOutbox.state, "processing"),
+                  lte(appChargeCallbackOutbox.lease_expires_at, now),
+                ),
+              ),
+            ),
+          )
+          .orderBy(appChargeCallbackOutbox.next_attempt_at, appChargeCallbackOutbox.created_at)
+          .for("update", { skipLocked: true })
+          .limit(1);
+        if (!candidate) return null;
+        const [row] = await tx
+          .update(appChargeCallbackOutbox)
+          .set({
+            state: "processing",
+            claim_token: claimToken,
+            lease_expires_at: leaseExpiresAt,
+            attempts: candidate.attempts + 1,
+            updated_at: now,
+          })
+          .where(eq(appChargeCallbackOutbox.id, candidate.id))
+          .returning();
+        return row ?? null;
+      });
+      if (!claimed) break;
+      stats.processed += 1;
+
+      try {
+        const params = parseAppChargeCallbackDispatchParams(claimed.payload);
+        if (settlementDigest(params) !== claimed.payload_digest) {
+          throw new Error("App callback outbox payload digest mismatch");
+        }
+        const result = await this.dispatch({ ...params, deliveryId: claimed.delivery_key });
+        if (result.errors.length > 0) throw new Error(result.errors.join("; "));
+        await dbWrite
+          .update(appChargeCallbackOutbox)
+          .set({
+            state: "delivered",
+            delivered_at: new Date(),
+            claim_token: null,
+            lease_expires_at: null,
+            last_error: null,
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(appChargeCallbackOutbox.id, claimed.id),
+              eq(appChargeCallbackOutbox.claim_token, claimToken),
+            ),
+          );
+        stats.delivered += 1;
+      } catch (error) {
+        // error-policy:J4 an expected delivery failure remains visibly pending
+        // for bounded durable retry; exhausted or corrupt rows become terminal.
+        const terminal = claimed.attempts >= CALLBACK_MAX_ATTEMPTS;
+        const delayMs = Math.min(3_600_000, 1_000 * 2 ** Math.min(claimed.attempts, 10));
+        await dbWrite
+          .update(appChargeCallbackOutbox)
+          .set({
+            state: terminal ? "terminal" : "pending",
+            terminal_at: terminal ? new Date() : null,
+            next_attempt_at: new Date(Date.now() + delayMs),
+            claim_token: null,
+            lease_expires_at: null,
+            last_error: error instanceof Error ? error.message : String(error),
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(appChargeCallbackOutbox.id, claimed.id),
+              eq(appChargeCallbackOutbox.claim_token, claimToken),
+            ),
+          );
+        if (terminal) stats.terminal += 1;
+        else stats.retried += 1;
+      }
+    }
+    return stats;
+  }
+
   async dispatch(params: AppChargeCallbackDispatchParams): Promise<CallbackDispatchResult> {
     const result: CallbackDispatchResult = {
       httpPosted: false,
@@ -235,6 +414,7 @@ export class AppChargeCallbacksService {
           chargeRequest.organization_id,
         );
       } catch (error) {
+        // error-policy:J4 durable delivery records the explicit failed room channel.
         const message = error instanceof Error ? error.message : String(error);
         result.errors.push(message);
         logger.warn("[AppChargeCallbacks] Failed to create room callback message", {
@@ -248,9 +428,15 @@ export class AppChargeCallbacksService {
     const callbackUrl = stringValue(metadata, "callback_url");
     if (callbackUrl) {
       try {
-        await this.postHttpCallback(callbackUrl, stringValue(metadata, "callback_secret"), payload);
+        await this.postHttpCallback(
+          callbackUrl,
+          stringValue(metadata, "callback_secret"),
+          payload,
+          params.deliveryId,
+        );
         result.httpPosted = true;
       } catch (error) {
+        // error-policy:J4 durable delivery records the explicit failed HTTP target.
         const message = error instanceof Error ? error.message : String(error);
         result.errors.push(message);
         logger.warn("[AppChargeCallbacks] Failed to post HTTP callback", {
@@ -279,6 +465,7 @@ export class AppChargeCallbacksService {
     callbackUrl: string,
     secret: string | undefined,
     payload: AppChargeCallbackPayload,
+    deliveryId?: string,
   ): Promise<void> {
     const body = JSON.stringify(payload);
     const timestamp = new Date().toISOString();
@@ -286,7 +473,7 @@ export class AppChargeCallbacksService {
       "Content-Type": "application/json",
       "X-Eliza-Event": payload.event,
       "X-Eliza-Timestamp": timestamp,
-      "X-Eliza-Delivery": randomUUID(),
+      "X-Eliza-Delivery": deliveryId ?? randomUUID(),
     };
 
     if (secret) {

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -1,6 +1,7 @@
 /** Coordinates app-charge callback delivery and authorized room-message projection. */
 import { MemoryType } from "@elizaos/core";
 import { randomUUID } from "crypto";
+import Decimal from "decimal.js";
 import { and, eq, lte, or } from "drizzle-orm";
 import { type DbTransaction, dbWrite } from "../../db/client";
 import { dbRead } from "../../db/helpers";
@@ -51,7 +52,7 @@ export interface AppChargeCallbackPayload {
   charge: {
     id: string;
     appId: string;
-    amountUsd: number;
+    amountUsd: string;
     status: AppChargeCallbackStatus;
     paymentContext: "verified_payer" | "any_payer";
     description?: string;
@@ -60,7 +61,7 @@ export interface AppChargeCallbackPayload {
   payment: {
     provider: AppChargeCallbackProvider;
     providerPaymentId: string;
-    amountUsd: number;
+    amountUsd: string;
     payerUserId?: string;
     payerOrganizationId?: string;
     reason?: string;
@@ -133,13 +134,16 @@ function stringValue(record: Record<string, unknown>, key: string): string | und
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function numberValue(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number.parseFloat(value);
-    if (Number.isFinite(parsed)) return parsed;
+function decimalStringValue(value: unknown, fallback?: string): string {
+  const candidate = value ?? fallback;
+  if (typeof candidate !== "string" && typeof candidate !== "number") {
+    throw new Error("App callback amount is missing");
   }
-  return fallback;
+  const amount = new Decimal(candidate);
+  if (!amount.isFinite() || amount.isNegative()) {
+    throw new Error("App callback amount is invalid");
+  }
+  return amount.toFixed();
 }
 
 function recordValue(
@@ -168,13 +172,8 @@ function agentIdFromChannel(channel: AppChargeCallbackChannel): string | undefin
   return stringValue(channel, "agentId") ?? stringValue(channel, "agent_id");
 }
 
-function formatUsd(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
+function formatUsd(amount: string): string {
+  return `$${new Decimal(amount).toDecimalPlaces(2).toFixed(2)}`;
 }
 
 async function hmacHex(secret: string, message: string): Promise<string> {
@@ -216,7 +215,7 @@ export function createAppChargeCallbackPayload(
   chargeMetadata: Record<string, unknown>,
   expectedAmount: string | number,
 ): AppChargeCallbackPayload {
-  const amount = numberValue(params.amountUsd ?? expectedAmount);
+  const amount = decimalStringValue(params.amountUsd ?? expectedAmount);
   const channel = callbackChannel(chargeMetadata);
   const metadata = {
     ...callbackMetadata(chargeMetadata),
@@ -229,7 +228,7 @@ export function createAppChargeCallbackPayload(
     charge: {
       id: params.chargeRequestId,
       appId: params.appId,
-      amountUsd: numberValue(chargeMetadata.amount_usd, amount),
+      amountUsd: decimalStringValue(chargeMetadata.amount_usd, amount),
       status: params.status,
       paymentContext:
         chargeMetadata.payment_context === "any_payer" ? "any_payer" : "verified_payer",

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -1,5 +1,5 @@
 /** Coordinates app-charge callback delivery and authorized room-message projection. */
-import { MemoryType } from "@elizaos/core";
+import { MemoryType, stringToUuid } from "@elizaos/core";
 import { randomUUID } from "crypto";
 import Decimal from "decimal.js";
 import { and, eq, lte, or } from "drizzle-orm";
@@ -214,6 +214,7 @@ export function createAppChargeCallbackPayload(
   params: AppChargeCallbackDispatchParams,
   chargeMetadata: Record<string, unknown>,
   expectedAmount: string | number,
+  createdAt = new Date().toISOString(),
 ): AppChargeCallbackPayload {
   const amount = decimalStringValue(params.amountUsd ?? expectedAmount);
   const channel = callbackChannel(chargeMetadata);
@@ -224,7 +225,7 @@ export function createAppChargeCallbackPayload(
 
   return {
     event: params.status === "paid" ? "app_charge.paid" : "app_charge.failed",
-    createdAt: new Date().toISOString(),
+    createdAt,
     charge: {
       id: params.chargeRequestId,
       appId: params.appId,
@@ -249,6 +250,24 @@ export function createAppChargeCallbackPayload(
 }
 
 export class AppChargeCallbacksService {
+  async failChargeAndEnqueue(params: AppChargeCallbackDispatchParams): Promise<boolean> {
+    return dbWrite.transaction(async (tx) => {
+      const [charge] = await tx
+        .select({ status: cryptoPayments.status })
+        .from(cryptoPayments)
+        .where(eq(cryptoPayments.id, params.chargeRequestId))
+        .for("update")
+        .limit(1);
+      if (!charge || charge.status === "confirmed") return false;
+      await tx
+        .update(cryptoPayments)
+        .set({ status: "failed", updated_at: new Date() })
+        .where(eq(cryptoPayments.id, params.chargeRequestId));
+      await this.enqueue(params, tx);
+      return true;
+    });
+  }
+
   async enqueue(
     params: AppChargeCallbackDispatchParams,
     transaction: DbTransaction,
@@ -424,7 +443,14 @@ export class AppChargeCallbacksService {
       return result;
     }
 
-    const payload = createAppChargeCallbackPayload(params, metadata, chargeRequest.expected_amount);
+    const payload = createAppChargeCallbackPayload(
+      params,
+      metadata,
+      chargeRequest.expected_amount,
+      chargeRequest.created_at instanceof Date
+        ? chargeRequest.created_at.toISOString()
+        : new Date(0).toISOString(),
+    );
 
     const channel = callbackChannel(metadata);
     if (channel && !options.skipRoom) {
@@ -551,8 +577,27 @@ export class AppChargeCallbacksService {
         ? `Payment went through for ${formatUsd(payload.payment.amountUsd)}.`
         : `Payment did not go through for ${formatUsd(payload.payment.amountUsd)}.`;
 
+    const memoryId = stringToUuid(
+      `app-charge-callback:${payload.payment.provider}:${payload.payment.providerPaymentId}:${payload.charge.id}:${payload.charge.status}`,
+    );
+    const existing = await memoriesRepository.findById(memoryId);
+    if (existing) {
+      const metadata =
+        existing.metadata && typeof existing.metadata === "object"
+          ? (existing.metadata as Record<string, unknown>)
+          : {};
+      if (
+        metadata.appChargeEvent !== payload.event ||
+        metadata.appChargeId !== payload.charge.id ||
+        metadata.providerPaymentId !== payload.payment.providerPaymentId
+      ) {
+        throw new Error("App callback deterministic room delivery identity is already bound");
+      }
+      return true;
+    }
+
     await memoriesRepository.create({
-      id: randomUUID(),
+      id: memoryId,
       roomId,
       entityId: agentId,
       agentId,

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -320,19 +320,33 @@ export class AppChargeCallbacksService {
       });
       if (!claimed) break;
       stats.processed += 1;
+      let deliveryResult: CallbackDispatchResult | null = null;
 
       try {
         const params = parseAppChargeCallbackDispatchParams(claimed.payload);
         if (settlementDigest(params) !== claimed.payload_digest) {
           throw new Error("App callback outbox payload digest mismatch");
         }
-        const result = await this.dispatch({ ...params, deliveryId: claimed.delivery_key });
-        if (result.errors.length > 0) throw new Error(result.errors.join("; "));
+        deliveryResult = await this.dispatch(
+          { ...params, deliveryId: claimed.delivery_key },
+          {
+            skipRoom: claimed.room_delivered_at !== null,
+            skipHttp: claimed.http_delivered_at !== null,
+          },
+        );
+        if (deliveryResult.errors.length > 0) {
+          throw new Error(deliveryResult.errors.join("; "));
+        }
+        const deliveredAt = new Date();
         await dbWrite
           .update(appChargeCallbackOutbox)
           .set({
             state: "delivered",
-            delivered_at: new Date(),
+            room_delivered_at:
+              claimed.room_delivered_at ?? (deliveryResult.roomMessageCreated ? deliveredAt : null),
+            http_delivered_at:
+              claimed.http_delivered_at ?? (deliveryResult.httpPosted ? deliveredAt : null),
+            delivered_at: deliveredAt,
             claim_token: null,
             lease_expires_at: null,
             last_error: null,
@@ -349,6 +363,7 @@ export class AppChargeCallbacksService {
         // error-policy:J4 an expected delivery failure remains visibly pending
         // for bounded durable retry; exhausted or corrupt rows become terminal.
         const terminal = claimed.attempts >= CALLBACK_MAX_ATTEMPTS;
+        const attemptAt = new Date();
         const delayMs = Math.min(3_600_000, 1_000 * 2 ** Math.min(claimed.attempts, 10));
         await dbWrite
           .update(appChargeCallbackOutbox)
@@ -359,7 +374,11 @@ export class AppChargeCallbacksService {
             claim_token: null,
             lease_expires_at: null,
             last_error: error instanceof Error ? error.message : String(error),
-            updated_at: new Date(),
+            room_delivered_at:
+              claimed.room_delivered_at ?? (deliveryResult?.roomMessageCreated ? attemptAt : null),
+            http_delivered_at:
+              claimed.http_delivered_at ?? (deliveryResult?.httpPosted ? attemptAt : null),
+            updated_at: attemptAt,
           })
           .where(
             and(
@@ -374,7 +393,10 @@ export class AppChargeCallbacksService {
     return stats;
   }
 
-  async dispatch(params: AppChargeCallbackDispatchParams): Promise<CallbackDispatchResult> {
+  async dispatch(
+    params: AppChargeCallbackDispatchParams,
+    options: { skipRoom?: boolean; skipHttp?: boolean } = {},
+  ): Promise<CallbackDispatchResult> {
     const result: CallbackDispatchResult = {
       httpPosted: false,
       roomMessageCreated: false,
@@ -405,7 +427,7 @@ export class AppChargeCallbacksService {
     const payload = createAppChargeCallbackPayload(params, metadata, chargeRequest.expected_amount);
 
     const channel = callbackChannel(metadata);
-    if (channel) {
+    if (channel && !options.skipRoom) {
       try {
         result.roomMessageCreated = await this.createRoomMessage(
           payload,
@@ -425,7 +447,7 @@ export class AppChargeCallbacksService {
     }
 
     const callbackUrl = stringValue(metadata, "callback_url");
-    if (callbackUrl) {
+    if (callbackUrl && !options.skipHttp) {
       try {
         await this.postHttpCallback(
           callbackUrl,

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -76,6 +76,18 @@ export interface CallbackDispatchResult {
   errors: string[];
 }
 
+interface AppChargeCallbackOutboxPayload extends Record<string, unknown> {
+  version: 1;
+  params: AppChargeCallbackDispatchParams;
+  envelope: AppChargeCallbackPayload;
+  target: {
+    organizationId: string;
+    channel?: AppChargeCallbackChannel;
+    callbackUrl?: string;
+    callbackSecret?: string;
+  };
+}
+
 const CALLBACK_MAX_ATTEMPTS = 12;
 const CALLBACK_LEASE_MS = 60_000;
 
@@ -122,6 +134,43 @@ export function parseAppChargeCallbackDispatchParams(
     reason: value.reason as string | undefined,
     metadata: value.metadata as Record<string, unknown> | undefined,
     deliveryId: value.deliveryId as string | undefined,
+  };
+}
+
+function parseAppChargeCallbackOutboxPayload(value: unknown): AppChargeCallbackOutboxPayload {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.target)) {
+    throw new Error("App callback outbox snapshot is invalid");
+  }
+  const params = parseAppChargeCallbackDispatchParams(value.params);
+  const envelope = value.envelope;
+  const target = value.target;
+  if (
+    !isRecord(envelope) ||
+    !isRecord(envelope.charge) ||
+    !isRecord(envelope.payment) ||
+    typeof target.organizationId !== "string" ||
+    (target.channel !== undefined && !isRecord(target.channel)) ||
+    (target.callbackUrl !== undefined && typeof target.callbackUrl !== "string") ||
+    (target.callbackSecret !== undefined && typeof target.callbackSecret !== "string") ||
+    envelope.event !== (params.status === "paid" ? "app_charge.paid" : "app_charge.failed") ||
+    envelope.charge.id !== params.chargeRequestId ||
+    envelope.charge.appId !== params.appId ||
+    envelope.charge.status !== params.status ||
+    envelope.payment.provider !== params.provider ||
+    envelope.payment.providerPaymentId !== params.providerPaymentId
+  ) {
+    throw new Error("App callback outbox snapshot binding is invalid");
+  }
+  return {
+    version: 1,
+    params,
+    envelope: envelope as unknown as AppChargeCallbackPayload,
+    target: {
+      organizationId: target.organizationId,
+      channel: target.channel as AppChargeCallbackChannel | undefined,
+      callbackUrl: target.callbackUrl as string | undefined,
+      callbackSecret: target.callbackSecret as string | undefined,
+    },
   };
 }
 
@@ -273,14 +322,43 @@ export class AppChargeCallbacksService {
     transaction: DbTransaction,
   ): Promise<void> {
     const deliveryKey = callbackDeliveryKey(params);
-    const digest = settlementDigest(params);
+    const [chargeRequest] = await transaction
+      .select()
+      .from(cryptoPayments)
+      .where(eq(cryptoPayments.id, params.chargeRequestId))
+      .for("update")
+      .limit(1);
+    if (!chargeRequest) throw new Error("App callback charge request not found");
+    const metadata = isRecord(chargeRequest.metadata) ? chargeRequest.metadata : {};
+    if (metadata.kind !== "app_charge_request" || metadata.app_id !== params.appId) {
+      throw new Error("App callback charge request metadata mismatch");
+    }
+    const createdAt = new Date();
+    const snapshot: AppChargeCallbackOutboxPayload = {
+      version: 1,
+      params: { ...params, deliveryId: undefined },
+      envelope: createAppChargeCallbackPayload(
+        params,
+        metadata,
+        chargeRequest.expected_amount,
+        createdAt.toISOString(),
+      ),
+      target: {
+        organizationId: chargeRequest.organization_id,
+        channel: callbackChannel(metadata),
+        callbackUrl: stringValue(metadata, "callback_url"),
+        callbackSecret: stringValue(metadata, "callback_secret"),
+      },
+    };
+    const digest = settlementDigest(snapshot);
     const [inserted] = await transaction
       .insert(appChargeCallbackOutbox)
       .values({
         delivery_key: deliveryKey,
         charge_request_id: params.chargeRequestId,
-        payload: { ...params },
+        payload: snapshot,
         payload_digest: digest,
+        created_at: createdAt,
       })
       .onConflictDoNothing({ target: appChargeCallbackOutbox.delivery_key })
       .returning();
@@ -291,7 +369,14 @@ export class AppChargeCallbacksService {
       .from(appChargeCallbackOutbox)
       .where(eq(appChargeCallbackOutbox.delivery_key, deliveryKey))
       .limit(1);
-    if (!existing || existing.payload_digest !== digest) {
+    if (!existing) {
+      throw new Error("App callback outbox replay does not match the committed delivery");
+    }
+    const existingSnapshot = parseAppChargeCallbackOutboxPayload(existing.payload);
+    if (
+      existing.payload_digest !== settlementDigest(existingSnapshot) ||
+      settlementDigest(existingSnapshot.params) !== settlementDigest(snapshot.params)
+    ) {
       throw new Error("App callback outbox replay does not match the committed delivery");
     }
   }
@@ -342,16 +427,18 @@ export class AppChargeCallbacksService {
       let deliveryResult: CallbackDispatchResult | null = null;
 
       try {
-        const params = parseAppChargeCallbackDispatchParams(claimed.payload);
-        if (settlementDigest(params) !== claimed.payload_digest) {
+        const snapshot = parseAppChargeCallbackOutboxPayload(claimed.payload);
+        if (settlementDigest(snapshot) !== claimed.payload_digest) {
           throw new Error("App callback outbox payload digest mismatch");
         }
-        deliveryResult = await this.dispatch(
-          { ...params, deliveryId: claimed.delivery_key },
+        deliveryResult = await this.dispatchSnapshot(
+          {
+            ...snapshot,
+            params: { ...snapshot.params, deliveryId: claimed.delivery_key },
+          },
           {
             skipRoom: claimed.room_delivered_at !== null,
             skipHttp: claimed.http_delivered_at !== null,
-            createdAt: claimed.created_at,
           },
         );
         if (deliveryResult.errors.length > 0) {
@@ -415,14 +502,8 @@ export class AppChargeCallbacksService {
 
   async dispatch(
     params: AppChargeCallbackDispatchParams,
-    options: { skipRoom?: boolean; skipHttp?: boolean; createdAt?: Date } = {},
+    options: { skipRoom?: boolean; skipHttp?: boolean } = {},
   ): Promise<CallbackDispatchResult> {
-    const result: CallbackDispatchResult = {
-      httpPosted: false,
-      roomMessageCreated: false,
-      errors: [],
-    };
-
     const chargeRequest = await dbRead.query.cryptoPayments.findFirst({
       where: eq(cryptoPayments.id, params.chargeRequestId),
     });
@@ -432,7 +513,7 @@ export class AppChargeCallbacksService {
         appId: params.appId,
         chargeRequestId: params.chargeRequestId,
       });
-      return result;
+      return { httpPosted: false, roomMessageCreated: false, errors: [] };
     }
 
     const metadata = isRecord(chargeRequest.metadata) ? chargeRequest.metadata : {};
@@ -441,27 +522,46 @@ export class AppChargeCallbacksService {
         appId: params.appId,
         chargeRequestId: params.chargeRequestId,
       });
-      return result;
+      return { httpPosted: false, roomMessageCreated: false, errors: [] };
     }
-
-    const payload = createAppChargeCallbackPayload(
+    const snapshot: AppChargeCallbackOutboxPayload = {
+      version: 1,
       params,
-      metadata,
-      chargeRequest.expected_amount,
-      options.createdAt instanceof Date
-        ? options.createdAt.toISOString()
-        : chargeRequest.created_at instanceof Date
+      envelope: createAppChargeCallbackPayload(
+        params,
+        metadata,
+        chargeRequest.expected_amount,
+        chargeRequest.created_at instanceof Date
           ? chargeRequest.created_at.toISOString()
           : new Date(0).toISOString(),
-    );
+      ),
+      target: {
+        organizationId: chargeRequest.organization_id,
+        channel: callbackChannel(metadata),
+        callbackUrl: stringValue(metadata, "callback_url"),
+        callbackSecret: stringValue(metadata, "callback_secret"),
+      },
+    };
+    return this.dispatchSnapshot(snapshot, options);
+  }
 
-    const channel = callbackChannel(metadata);
+  private async dispatchSnapshot(
+    snapshot: AppChargeCallbackOutboxPayload,
+    options: { skipRoom?: boolean; skipHttp?: boolean },
+  ): Promise<CallbackDispatchResult> {
+    const { params, envelope: payload, target } = snapshot;
+    const result: CallbackDispatchResult = {
+      httpPosted: false,
+      roomMessageCreated: false,
+      errors: [],
+    };
+    const channel = target.channel;
     if (channel && !options.skipRoom) {
       try {
         result.roomMessageCreated = await this.createRoomMessage(
           payload,
           channel,
-          chargeRequest.organization_id,
+          target.organizationId,
         );
       } catch (error) {
         // error-policy:J4 durable delivery records the explicit failed room channel.
@@ -475,15 +575,10 @@ export class AppChargeCallbacksService {
       }
     }
 
-    const callbackUrl = stringValue(metadata, "callback_url");
+    const callbackUrl = target.callbackUrl;
     if (callbackUrl && !options.skipHttp) {
       try {
-        await this.postHttpCallback(
-          callbackUrl,
-          stringValue(metadata, "callback_secret"),
-          payload,
-          params.deliveryId,
-        );
+        await this.postHttpCallback(callbackUrl, target.callbackSecret, payload, params.deliveryId);
         result.httpPosted = true;
       } catch (error) {
         // error-policy:J4 durable delivery records the explicit failed HTTP target.

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -351,6 +351,7 @@ export class AppChargeCallbacksService {
           {
             skipRoom: claimed.room_delivered_at !== null,
             skipHttp: claimed.http_delivered_at !== null,
+            createdAt: claimed.created_at,
           },
         );
         if (deliveryResult.errors.length > 0) {
@@ -414,7 +415,7 @@ export class AppChargeCallbacksService {
 
   async dispatch(
     params: AppChargeCallbackDispatchParams,
-    options: { skipRoom?: boolean; skipHttp?: boolean } = {},
+    options: { skipRoom?: boolean; skipHttp?: boolean; createdAt?: Date } = {},
   ): Promise<CallbackDispatchResult> {
     const result: CallbackDispatchResult = {
       httpPosted: false,
@@ -447,9 +448,11 @@ export class AppChargeCallbacksService {
       params,
       metadata,
       chargeRequest.expected_amount,
-      chargeRequest.created_at instanceof Date
-        ? chargeRequest.created_at.toISOString()
-        : new Date(0).toISOString(),
+      options.createdAt instanceof Date
+        ? options.createdAt.toISOString()
+        : chargeRequest.created_at instanceof Date
+          ? chargeRequest.created_at.toISOString()
+          : new Date(0).toISOString(),
     );
 
     const channel = callbackChannel(metadata);

--- a/packages/cloud/shared/src/lib/services/app-charge-settlement.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-settlement.ts
@@ -1,4 +1,6 @@
-// Coordinates cloud service app charge settlement behavior behind route handlers.
+/** Atomically commits app-charge status and its durable callback delivery intent. */
+import { ElizaError } from "@elizaos/core";
+import Decimal from "decimal.js";
 import { eq } from "drizzle-orm";
 import { dbWrite } from "../../db/helpers";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
@@ -32,8 +34,25 @@ function paidMetadata(params: MarkAppChargePaidParams, paidAt: Date): Record<str
 export class AppChargeSettlementService {
   async markPaid(params: MarkAppChargePaidParams): Promise<void> {
     const paidAt = new Date();
-    const amount =
-      typeof params.amountUsd === "number" ? params.amountUsd.toFixed(2) : params.amountUsd;
+    const amountDecimal = new Decimal(params.amountUsd);
+    if (!amountDecimal.isFinite() || !amountDecimal.gt(0)) {
+      throw new ElizaError("App charge settlement amount must be a positive decimal", {
+        code: "INVALID_APP_CHARGE_SETTLEMENT_AMOUNT",
+        context: { chargeRequestId: params.chargeRequestId },
+      });
+    }
+    const amount = amountDecimal.toFixed();
+    const callback = {
+      appId: params.appId,
+      chargeRequestId: params.chargeRequestId,
+      status: "paid" as const,
+      provider: params.provider,
+      providerPaymentId: params.providerPaymentId,
+      amountUsd: amount,
+      payerUserId: params.payerUserId,
+      payerOrganizationId: params.payerOrganizationId,
+      metadata: params.metadata,
+    };
     let didMarkPaid = false;
 
     await dbWrite.transaction(async (tx) => {
@@ -45,16 +64,38 @@ export class AppChargeSettlementService {
         .limit(1);
 
       if (!chargeRequest) {
-        throw new Error("Charge request not found");
+        throw new ElizaError("Charge request not found", {
+          code: "APP_CHARGE_REQUEST_NOT_FOUND",
+          context: { chargeRequestId: params.chargeRequestId },
+        });
       }
 
       const metadata = chargeRequest.metadata ?? {};
       if (metadata.kind !== "app_charge_request" || metadata.app_id !== params.appId) {
-        throw new Error("Charge request metadata mismatch");
+        throw new ElizaError("Charge request metadata mismatch", {
+          code: "APP_CHARGE_REQUEST_MISMATCH",
+          context: { appId: params.appId, chargeRequestId: params.chargeRequestId },
+        });
       }
 
       if (chargeRequest.status === "confirmed") {
+        if (
+          metadata.paid_provider !== params.provider ||
+          metadata.paid_provider_payment_id !== params.providerPaymentId
+        ) {
+          throw new ElizaError("Charge request is already settled by another payment", {
+            code: "APP_CHARGE_ALREADY_SETTLED",
+            context: { appId: params.appId, chargeRequestId: params.chargeRequestId },
+          });
+        }
+        await appChargeCallbacksService.enqueue(callback, tx);
         return;
+      }
+      if (chargeRequest.status !== "pending") {
+        throw new ElizaError("Charge request cannot be settled from its current status", {
+          code: "INVALID_APP_CHARGE_STATUS",
+          context: { chargeRequestId: params.chargeRequestId, status: chargeRequest.status },
+        });
       }
 
       await tx
@@ -72,22 +113,9 @@ export class AppChargeSettlementService {
         })
         .where(eq(cryptoPayments.id, params.chargeRequestId));
 
+      await appChargeCallbacksService.enqueue(callback, tx);
       didMarkPaid = true;
     });
-
-    if (didMarkPaid) {
-      await appChargeCallbacksService.dispatch({
-        appId: params.appId,
-        chargeRequestId: params.chargeRequestId,
-        status: "paid",
-        provider: params.provider,
-        providerPaymentId: params.providerPaymentId,
-        amountUsd: amount,
-        payerUserId: params.payerUserId,
-        payerOrganizationId: params.payerOrganizationId,
-        metadata: params.metadata,
-      });
-    }
 
     logger.info(
       didMarkPaid

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -3,18 +3,21 @@
  */
 
 import Decimal from "decimal.js";
+import { and, eq, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
 import { appEarningsRepository } from "../../db/repositories/app-earnings";
 import * as appsRepositoryModule from "../../db/repositories/apps";
 import { type App, appsRepository } from "../../db/repositories/apps";
 import { organizationsRepository } from "../../db/repositories/organizations";
 import { usersRepository } from "../../db/repositories/users";
+import { apps, appUsers } from "../../db/schemas/apps";
+import { organizations } from "../../db/schemas/organizations";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { getRequestIdempotencyKey } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import {
   computeInferenceCharge,
-  computePurchaseSplit,
   computeReconciliation,
   isAppMonetizationActive,
   parseAppMonetizationNumber,
@@ -313,8 +316,10 @@ export interface AppCreditPurchaseParams {
   appId: string;
   userId: string;
   organizationId: string;
-  purchaseAmount: number;
+  purchaseAmount: number | string;
   stripePaymentIntentId?: string; // For deduplication on webhook retries
+  /** Reuse the caller's settlement transaction so every purchase projection commits together. */
+  transaction?: DbTransaction;
 }
 
 /**
@@ -455,7 +460,18 @@ export interface AppCreditReconciliationResult {
  */
 export class AppCreditsService {
   /** The org credit balance — the single ledger app purchases fund and app inference debits (#8253). */
-  private async readOrgBalance(organizationId: string): Promise<number> {
+  private async readOrgBalance(
+    organizationId: string,
+    transaction?: DbTransaction,
+  ): Promise<number> {
+    if (transaction) {
+      const [org] = await transaction
+        .select({ creditBalance: organizations.credit_balance })
+        .from(organizations)
+        .where(eq(organizations.id, organizationId))
+        .limit(1);
+      return org ? parseOrgCreditBalance(org.creditBalance) : 0;
+    }
     const org = await organizationsRepository.findById(organizationId);
     // error-policy:J6 missing org preserves the existing no-credit result path; a present
     // org with corrupt money data must fail closed.
@@ -463,9 +479,20 @@ export class AppCreditsService {
   }
 
   async processPurchase(params: AppCreditPurchaseParams): Promise<AppCreditPurchaseResult> {
-    const { appId, userId, organizationId, purchaseAmount, stripePaymentIntentId } = params;
+    const { appId, userId, organizationId, stripePaymentIntentId, transaction } = params;
+    const purchaseAmountDecimal = new Decimal(params.purchaseAmount);
+    if (!purchaseAmountDecimal.isFinite() || !purchaseAmountDecimal.gt(0)) {
+      throw new Error("App credit purchase amount must be a positive decimal");
+    }
+    const purchaseAmount = purchaseAmountDecimal.toFixed();
+    // Preserve string-valued provider money end to end. Existing internal
+    // number callers retain their metadata shape for API compatibility.
+    const purchaseAmountValue =
+      typeof params.purchaseAmount === "string" ? purchaseAmount : purchaseAmountDecimal.toNumber();
 
-    const app = await appsRepository.findById(appId);
+    const app = transaction
+      ? (await transaction.select().from(apps).where(eq(apps.id, appId)).limit(1))[0]
+      : await appsRepository.findById(appId);
     if (!app) {
       throw new Error(`App not found: ${appId}`);
     }
@@ -474,6 +501,7 @@ export class AppCreditsService {
       const existingTransaction = await appEarningsRepository.findTransactionByPaymentIntent(
         appId,
         stripePaymentIntentId,
+        transaction,
       );
       if (existingTransaction) {
         const existingMetadata =
@@ -484,7 +512,7 @@ export class AppCreditsService {
           existingTransaction.app_id !== appId ||
           existingTransaction.user_id !== userId ||
           existingMetadata.organizationId !== organizationId ||
-          existingMetadata.purchaseAmount !== purchaseAmount ||
+          !new Decimal(String(existingMetadata.purchaseAmount)).equals(purchaseAmountDecimal) ||
           existingMetadata.stripePaymentIntentId !== stripePaymentIntentId
         ) {
           throw new Error(`App purchase projection replay mismatch for ${stripePaymentIntentId}`);
@@ -494,7 +522,7 @@ export class AppCreditsService {
           creditsAdded: 0,
           platformOffset: 0,
           creatorEarnings: 0,
-          newBalance: await this.readOrgBalance(organizationId),
+          newBalance: await this.readOrgBalance(organizationId, transaction),
         };
       }
     }
@@ -503,23 +531,37 @@ export class AppCreditsService {
     // (enabled AND not review-rejected — a ban revokes earnings); users always
     // get full credits for their purchase. Math in app-credit-math.ts.
     const monetizationActive = isAppMonetizationActive(app);
-    const quotedSplit = computePurchaseSplit(purchaseAmount, {
-      monetizationEnabled: monetizationActive,
-      platformOffsetAmount: app.platform_offset_amount,
-      purchaseSharePercentage: app.purchase_share_percentage,
-      inferenceMarkupPercentage: app.inference_markup_percentage,
-    });
     const quotedCreatorSharePercentage = monetizationActive
       ? parseAppMonetizationNumber("purchase_share_percentage", app.purchase_share_percentage, {
           min: 0,
           max: 100,
         })
       : 0;
+    const quotedPlatformOffset = monetizationActive
+      ? Decimal.min(
+          purchaseAmountDecimal,
+          new Decimal(
+            parseAppMonetizationNumber("platform_offset_amount", app.platform_offset_amount, {
+              min: 0,
+            }),
+          ),
+        )
+      : new Decimal(0);
+    const quotedCreatorEarnings = purchaseAmountDecimal
+      .minus(quotedPlatformOffset)
+      .mul(quotedCreatorSharePercentage)
+      .div(100)
+      .toDecimalPlaces(6);
+    const quotedSplit = {
+      creditsToAdd: purchaseAmountDecimal.toDecimalPlaces(6).toFixed(6),
+      platformOffset: quotedPlatformOffset.toDecimalPlaces(6).toFixed(6),
+      creatorEarnings: quotedCreatorEarnings.toFixed(6),
+    };
 
     logger.info("[AppCredits] Processing purchase", {
       appId,
       userId,
-      purchaseAmount,
+      purchaseAmount: purchaseAmountValue,
       platformOffset: quotedSplit.platformOffset,
       creatorEarnings: quotedSplit.creatorEarnings,
       creditsToAdd: quotedSplit.creditsToAdd,
@@ -532,13 +574,16 @@ export class AppCreditsService {
     // purchased credits were stranded).
     const { transaction: purchaseCredit, newBalance } = await creditsService.addCredits({
       organizationId,
-      amount: quotedSplit.creditsToAdd,
+      amount:
+        typeof params.purchaseAmount === "string"
+          ? quotedSplit.creditsToAdd
+          : purchaseAmountDecimal.toNumber(),
       description: `App credit purchase (${app.name ?? appId})`,
       metadata: {
         appId,
         userId,
         organizationId,
-        purchaseAmount,
+        purchaseAmount: purchaseAmountValue,
         creditsToAdd: quotedSplit.creditsToAdd,
         platformOffset: quotedSplit.platformOffset,
         creatorEarnings: quotedSplit.creatorEarnings,
@@ -547,6 +592,7 @@ export class AppCreditsService {
         type: "app_credit_purchase",
       },
       ...(stripePaymentIntentId && { stripePaymentIntentId }),
+      db: transaction,
     });
 
     const persistedPurchaseMetadata =
@@ -582,11 +628,11 @@ export class AppCreditsService {
       purchaseCredit.organization_id !== organizationId ||
       purchaseCredit.type !== "credit" ||
       !persistedPurchaseAmount.isFinite() ||
-      !persistedPurchaseAmount.equals(new Decimal(purchaseAmount).toDecimalPlaces(6)) ||
+      !persistedPurchaseAmount.equals(purchaseAmountDecimal.toDecimalPlaces(6)) ||
       persistedPurchaseMetadata.appId !== appId ||
       persistedPurchaseMetadata.userId !== userId ||
       persistedPurchaseMetadata.organizationId !== organizationId ||
-      !new Decimal(creditsToAdd).equals(new Decimal(purchaseAmount)) ||
+      !new Decimal(creditsToAdd).equals(purchaseAmountDecimal.toDecimalPlaces(6)) ||
       new Decimal(platformOffset).greaterThan(persistedPurchaseAmount) ||
       new Decimal(creatorEarnings).greaterThan(persistedPurchaseAmount.minus(platformOffset)) ||
       !new Decimal(creatorEarnings)
@@ -612,12 +658,18 @@ export class AppCreditsService {
     };
 
     // Track app user activity for purchase (this will create app_users record if new user)
-    await this.trackAppUserActivity(app, userId, "0.00", {
-      type: "purchase",
-      purchaseAmount,
-      creditsAdded: creditsToAdd,
-      ...(stripePaymentIntentId && { stripePaymentIntentId }),
-    });
+    await this.trackAppUserActivity(
+      app,
+      userId,
+      "0.00",
+      {
+        type: "purchase",
+        purchaseAmount: purchaseAmountValue,
+        creditsAdded: creditsToAdd,
+        ...(stripePaymentIntentId && { stripePaymentIntentId }),
+      },
+      transaction,
+    );
 
     // CRITICAL: Always create a transaction record for deduplication purposes
     // Even when monetization is disabled, we need to track the purchase
@@ -630,7 +682,7 @@ export class AppCreditsService {
         platformOffset,
         "purchase",
         {
-          purchaseAmount,
+          purchaseAmount: purchaseAmountValue,
           organizationId,
           platformOffset,
           creatorSharePercentage,
@@ -638,23 +690,27 @@ export class AppCreditsService {
           ...(stripePaymentIntentId && { stripePaymentIntentId }),
         },
         chargeTimeApp,
+        transaction,
       );
     } else if (stripePaymentIntentId) {
       // Monetization disabled but still need transaction record for deduplication
-      await appEarningsRepository.createTransaction({
-        app_id: appId,
-        user_id: userId,
-        type: "credit_purchase",
-        amount: "0", // No earnings when monetization disabled
-        description: "Credit purchase (monetization disabled)",
-        metadata: {
-          organizationId,
-          purchaseAmount,
-          creditsAdded: creditsToAdd,
-          stripePaymentIntentId,
-          monetizationDisabled: true,
+      await appEarningsRepository.createTransaction(
+        {
+          app_id: appId,
+          user_id: userId,
+          type: "credit_purchase",
+          amount: "0", // No earnings when monetization disabled
+          description: "Credit purchase (monetization disabled)",
+          metadata: {
+            organizationId,
+            purchaseAmount: purchaseAmountValue,
+            creditsAdded: creditsToAdd,
+            stripePaymentIntentId,
+            monetizationDisabled: true,
+          },
         },
-      });
+        transaction,
+      );
     }
 
     return {
@@ -1548,6 +1604,7 @@ export class AppCreditsService {
     leg: CreatorEarningsLeg,
     metadata: Record<string, unknown>,
     providedApp?: AppCreditAccountingApp,
+    transaction?: DbTransaction,
   ): Promise<{ deduplicated: boolean; commitState: CreatorEarningsCommitState }> {
     const app: AppCreditAccountingApp | undefined =
       providedApp ?? (await appsRepository.findById(appId));
@@ -1608,12 +1665,17 @@ export class AppCreditsService {
           appCreatorShadowVersion: 1,
           appPlatformRevenueDelta: new Decimal(platformRevenueAmount).toFixed(6),
         },
+        transaction,
       });
     } catch (cause) {
       // error-policy:J2 attach explicit commit state so the caller can decide
       // whether compensating the backing debit is safe.
       if (!identity.dedupeBySourceId) {
         commitState.redeemable = "unknown";
+        throw new CreatorEarningsAccountingError(commitState, cause);
+      }
+      if (transaction) {
+        commitState.redeemable = "absent";
         throw new CreatorEarningsAccountingError(commitState, cause);
       }
       try {
@@ -1678,7 +1740,7 @@ export class AppCreditsService {
     }
 
     try {
-      const projection = await appEarningsRepository.applyCreatorMovement({
+      const movement = {
         appId,
         userId,
         type,
@@ -1689,7 +1751,10 @@ export class AppCreditsService {
         metadata,
         redeemableLedgerEntryId: result.ledgerEntryId,
         redeemableDeduplicated,
-      });
+      };
+      const projection = transaction
+        ? await appEarningsRepository.applyCreatorMovement(movement, transaction)
+        : await appEarningsRepository.applyCreatorMovement(movement);
       commitState.shadowBalanceRecorded = true;
       commitState.shadowTransactionRecorded = true;
       return { deduplicated: projection.deduplicated, commitState };
@@ -1819,8 +1884,50 @@ export class AppCreditsService {
     userId: string,
     creditsUsed: string,
     metadata?: Record<string, unknown>,
+    transaction?: DbTransaction,
   ): Promise<void> {
-    await appsRepository.trackAppUserActivity(app.id, userId, creditsUsed, metadata);
+    if (!transaction) {
+      await appsRepository.trackAppUserActivity(app.id, userId, creditsUsed, metadata);
+      return;
+    }
+
+    const [existing] = await transaction
+      .select({ id: appUsers.id })
+      .from(appUsers)
+      .where(and(eq(appUsers.app_id, app.id), eq(appUsers.user_id, userId)))
+      .for("update")
+      .limit(1);
+    if (existing) {
+      await transaction
+        .update(appUsers)
+        .set({
+          total_requests: sql`${appUsers.total_requests} + 1`,
+          total_credits_used: sql`${appUsers.total_credits_used} + ${creditsUsed}`,
+          last_seen_at: new Date(),
+        })
+        .where(eq(appUsers.id, existing.id));
+    } else {
+      await transaction.insert(appUsers).values({
+        app_id: app.id,
+        user_id: userId,
+        total_requests: 1,
+        total_credits_used: creditsUsed,
+        metadata: metadata ?? {},
+      });
+      await transaction
+        .update(apps)
+        .set({ total_users: sql`${apps.total_users} + 1`, updated_at: new Date() })
+        .where(eq(apps.id, app.id));
+    }
+    await transaction
+      .update(apps)
+      .set({
+        total_requests: sql`${apps.total_requests} + 1`,
+        total_credits_used: sql`${apps.total_credits_used} + ${creditsUsed}`,
+        last_used_at: new Date(),
+        updated_at: new Date(),
+      })
+      .where(eq(apps.id, app.id));
   }
 
   async getMonetizationSettings(appId: string): Promise<{

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -107,12 +107,14 @@ export class ReservationNotFoundError extends ElizaError {
 export class InvalidCreditAmountError extends ElizaError {
   override readonly name = "InvalidCreditAmountError";
 
-  constructor(amount: number, operation: "reserve" | "reserve_and_deduct") {
+  constructor(amount: number, operation: "reserve" | "reserve_and_deduct" | "add_credits") {
     const permitsZero = operation === "reserve";
     super(
       permitsZero
         ? "Credit reservation amount must be a finite, non-negative number"
-        : "Credit deduction amount must be a positive, finite number",
+        : operation === "add_credits"
+          ? "Credit increase amount must be a positive, finite number"
+          : "Credit deduction amount must be a positive, finite number",
       {
         code: "INVALID_CREDIT_AMOUNT",
         context: { amount, operation, permitsZero },
@@ -449,6 +451,11 @@ export class CreditsService {
       stripePaymentIntentId,
       transactionType,
     } = params;
+    const amountDecimal = new Decimal(amount);
+    if (!amountDecimal.isFinite() || !amountDecimal.gt(0)) {
+      throw new InvalidCreditAmountError(Number(amount), "add_credits");
+    }
+    const amountText = amountDecimal.toDecimalPlaces(6).toFixed(6);
     const executor = params.db ?? dbWrite;
     const metadataJson = JSON.stringify(metadata ?? {});
     const stripeId = stripePaymentIntentId ?? null;
@@ -474,7 +481,7 @@ export class CreditsService {
           )
           SELECT
             org.id,
-            ${String(amount)}::numeric,
+            ${amountText}::numeric,
             ${transactionType},
             ${description},
             ${metadataJson}::jsonb,
@@ -525,7 +532,7 @@ export class CreditsService {
         updated AS (
           UPDATE organizations AS o
           SET
-            credit_balance = org.current_balance + ${String(amount)}::numeric,
+            credit_balance = org.current_balance + ${amountText}::numeric,
             settings = CASE
               WHEN ${transactionType} = 'credit'
                 THEN COALESCE(o.settings, '{}'::jsonb) - 'welcomeBonusWithheld'
@@ -568,6 +575,13 @@ export class CreditsService {
         if (!org) {
           throw new Error("Organization not found");
         }
+        if (
+          existingTransaction.organization_id !== organizationId ||
+          existingTransaction.type !== transactionType ||
+          !new Decimal(existingTransaction.amount).equals(amountText)
+        ) {
+          throw new Error("Credit idempotency replay does not match the original settlement");
+        }
         return {
           transaction: existingTransaction,
           newBalance: Number.parseFloat(String(org.credit_balance)),
@@ -575,8 +589,16 @@ export class CreditsService {
       }
     }
 
+    const transaction = toCreditTransaction(row);
+    if (
+      transaction.organization_id !== organizationId ||
+      transaction.type !== transactionType ||
+      !new Decimal(transaction.amount).equals(amountText)
+    ) {
+      throw new Error("Credit idempotency replay does not match the original settlement");
+    }
     return {
-      transaction: toCreditTransaction(row),
+      transaction,
       newBalance: parseNumeric(row.new_balance, "new_balance"),
     };
   }
@@ -657,30 +679,6 @@ export class CreditsService {
       db,
       deferCacheInvalidation = false,
     } = params;
-
-    // IDEMPOTENCY: If stripePaymentIntentId is provided, check for existing transaction
-    // This prevents race conditions when both synchronous and webhook calls try to add credits
-    if (stripePaymentIntentId && !db) {
-      const existingTransaction =
-        await this.getTransactionByStripePaymentIntent(stripePaymentIntentId);
-
-      if (existingTransaction) {
-        logger.info(
-          `[CreditsService] Idempotency: Payment intent ${stripePaymentIntentId} already processed (transaction ${existingTransaction.id})`,
-        );
-
-        // Get current balance to return consistent response
-        const org = await organizationsRepository.findById(organizationId);
-        if (!org) {
-          throw new Error("Organization not found");
-        }
-
-        return {
-          transaction: existingTransaction,
-          newBalance: Number.parseFloat(String(org.credit_balance)),
-        };
-      }
-    }
 
     const result = await this.applyCreditIncrease({
       organizationId,
@@ -1058,7 +1056,8 @@ export class CreditsService {
   }> {
     const { organizationId, amount, description, metadata, stripePaymentIntentId } = params;
 
-    if (new Decimal(String(amount)).lessThanOrEqualTo(0)) {
+    const refundAmount = new Decimal(String(amount));
+    if (!refundAmount.isFinite() || !refundAmount.gt(0)) {
       throw new Error("Refund amount must be positive");
     }
 

--- a/packages/cloud/shared/src/lib/services/crypto-payments-currency.test.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments-currency.test.ts
@@ -1,0 +1,31 @@
+/** Proves legacy crypto credit invoices reject non-USD fiat before provider or database work. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { CryptoPaymentError, cryptoPaymentsService } from "./crypto-payments";
+
+const originalMerchantKey = process.env.OXAPAY_MERCHANT_API_KEY;
+
+beforeAll(() => {
+  process.env.OXAPAY_MERCHANT_API_KEY = "test-only-key";
+});
+
+afterAll(() => {
+  if (originalMerchantKey === undefined) delete process.env.OXAPAY_MERCHANT_API_KEY;
+  else process.env.OXAPAY_MERCHANT_API_KEY = originalMerchantKey;
+});
+
+describe("legacy crypto invoice currency authority", () => {
+  test("rejects caller-selected non-USD fiat before creating an OxaPay invoice", async () => {
+    try {
+      await cryptoPaymentsService.createPayment({
+        organizationId: "10000000-0000-4000-8000-000000000001",
+        amount: "2500",
+        currency: "JPY",
+      });
+      throw new Error("Expected non-USD crypto invoice creation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CryptoPaymentError);
+      expect(error).toMatchObject({ code: "INVALID_CURRENCY" });
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/crypto-payments.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments.ts
@@ -631,7 +631,37 @@ class CryptoPaymentsService {
           throw new Error("Charge request metadata mismatch");
         }
 
-        if (chargeRequest.status === "confirmed") return;
+        const callbackSettlement: AppChargeCallbackDispatchParams = {
+          appId: appPurchase.appId,
+          chargeRequestId: appPurchase.chargeRequestId,
+          status: "paid",
+          provider: "oxapay",
+          providerPaymentId: payment.id,
+          amountUsd: creditsToAdd,
+          payerUserId: payment.user_id,
+          payerOrganizationId: payment.organization_id,
+          metadata: {
+            crypto_payment_id: payment.id,
+            transaction_hash: canonicalTxHash,
+            network: payment.network,
+            token: payCurrency,
+          },
+        };
+
+        if (chargeRequest.status === "confirmed") {
+          if (
+            chargeMetadata.paid_provider !== "oxapay" ||
+            chargeMetadata.paid_provider_payment_id !== payment.id ||
+            chargeMetadata.paid_crypto_payment_id !== payment.id
+          ) {
+            throw new Error("Charge request is already settled by another payment");
+          }
+          await appChargeCallbacksService.enqueue(callbackSettlement, tx);
+          return callbackSettlement;
+        }
+        if (chargeRequest.status !== "pending") {
+          throw new Error(`Charge request cannot settle from status ${chargeRequest.status}`);
+        }
 
         await tx
           .update(cryptoPayments)
@@ -656,22 +686,6 @@ class CryptoPaymentsService {
           })
           .where(eq(cryptoPayments.id, appPurchase.chargeRequestId));
 
-        const callbackSettlement: AppChargeCallbackDispatchParams = {
-          appId: appPurchase.appId,
-          chargeRequestId: appPurchase.chargeRequestId,
-          status: "paid",
-          provider: "oxapay",
-          providerPaymentId: payment.id,
-          amountUsd: creditsToAdd,
-          payerUserId: payment.user_id,
-          payerOrganizationId: payment.organization_id,
-          metadata: {
-            crypto_payment_id: payment.id,
-            transaction_hash: canonicalTxHash,
-            network: payment.network,
-            token: payCurrency,
-          },
-        };
         await appChargeCallbacksService.enqueue(callbackSettlement, tx);
         return callbackSettlement;
       };

--- a/packages/cloud/shared/src/lib/services/crypto-payments.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments.ts
@@ -1,14 +1,18 @@
 // Coordinates cloud service crypto payments behavior behind route handlers.
 import Decimal from "decimal.js";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { validate as uuidValidate } from "uuid";
 import { z } from "zod";
-import { dbWrite } from "../../db/client";
+import { type DbTransaction, dbWrite } from "../../db/client";
+import {
+  canonicalizeCryptoTransactionHash,
+  cryptoTransactionHashesEqual,
+  isHexTransactionHash,
+} from "../../db/crypto-payment-transaction-hash";
 import {
   type CryptoPayment,
   cryptoPaymentsRepository,
 } from "../../db/repositories/crypto-payments";
-import { organizationsRepository } from "../../db/repositories/organizations";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
 import { PAYMENT_EXPIRATION_SECONDS, validatePaymentAmount } from "../config/crypto";
 import { createCryptoCustomerId, createCryptoInvoiceId } from "../constants/invoice-ids";
@@ -19,7 +23,6 @@ import {
 } from "./app-charge-callbacks";
 import { appCreditsService } from "./app-credits";
 import { creditsService } from "./credits";
-import { discordService } from "./discord";
 import { invoicesService } from "./invoices";
 import { isOxaPayConfigured, type OxaPayNetwork, oxaPayService } from "./oxapay";
 import { redeemableEarningsService } from "./redeemable-earnings";
@@ -449,8 +452,21 @@ class CryptoPaymentsService {
       if (!payment) {
         throw new Error("Payment not found");
       }
+      const canonicalTxHash = canonicalizeCryptoTransactionHash(txHash, payment.network);
 
       if (payment.status === "confirmed") {
+        const settledCurrency =
+          typeof payment.metadata?.settlement_currency === "string"
+            ? payment.metadata.settlement_currency
+            : payment.token;
+        if (
+          !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash) ||
+          !payment.received_amount ||
+          !new Decimal(payment.received_amount).equals(receivedAmount) ||
+          settledCurrency.toLowerCase() !== (actualPayCurrency || payment.token).toLowerCase()
+        ) {
+          throw new Error("Payment confirmation replay does not match the committed settlement");
+        }
         logger.info("[Crypto Payments] Payment already confirmed", {
           paymentId: redact.paymentId(paymentId),
         });
@@ -468,13 +484,17 @@ class CryptoPaymentsService {
       const existingTx = await tx
         .select()
         .from(cryptoPayments)
-        .where(eq(cryptoPayments.transaction_hash, txHash))
+        .where(
+          isHexTransactionHash(canonicalTxHash)
+            ? sql`lower(${cryptoPayments.transaction_hash}) = ${canonicalTxHash}`
+            : eq(cryptoPayments.transaction_hash, canonicalTxHash),
+        )
         .for("update");
 
       if (existingTx.length > 0 && existingTx[0].id !== paymentId) {
         logger.error("[Crypto Payments] Double-spend attempt detected", {
           paymentId: redact.paymentId(paymentId),
-          txHash: redact.txHash(txHash),
+          txHash: redact.txHash(canonicalTxHash),
           existingPaymentId: redact.paymentId(existingTx[0].id),
         });
         throw new Error("Transaction already processed for another payment");
@@ -482,7 +502,16 @@ class CryptoPaymentsService {
 
       // Credit user the exact received amount (no fee reversal)
       const receivedDecimal = new Decimal(receivedAmount);
-      const creditsToAdd = receivedDecimal.toFixed(3);
+      if (!receivedDecimal.isFinite() || !receivedDecimal.gt(0)) {
+        throw new Error("Received payment amount must be a positive decimal");
+      }
+      const receivedAmountExact = receivedDecimal.toFixed();
+      const creditsToAdd = receivedDecimal.toDecimalPlaces(6).toFixed(6);
+      // Invoice columns are intentionally cent-denominated. Keep the provider's
+      // exact decimal on the payment and in metadata, while explicitly rounding
+      // the invoice projection to its declared database scale.
+      const invoiceAmountDue = new Decimal(payment.expected_amount).toDecimalPlaces(2).toFixed(2);
+      const invoiceAmountPaid = receivedDecimal.toDecimalPlaces(2).toFixed(2);
       const payCurrency = actualPayCurrency || payment.token;
       const appPurchase = getAppCreditPurchaseMetadata(payment.metadata);
       const confirmedAt = new Date();
@@ -504,7 +533,9 @@ class CryptoPaymentsService {
         const chargeMetadata = chargeRequest.metadata ?? {};
         if (
           chargeMetadata.kind !== "app_charge_request" ||
-          chargeMetadata.app_id !== appPurchase.appId
+          chargeMetadata.app_id !== appPurchase.appId ||
+          chargeMetadata.creator_organization_id !== chargeRequest.organization_id ||
+          !new Decimal(chargeRequest.expected_amount).equals(payment.expected_amount)
         ) {
           throw new Error("Charge request metadata mismatch");
         }
@@ -527,7 +558,7 @@ class CryptoPaymentsService {
               payer_user_id: payment.user_id ?? undefined,
               payer_organization_id: payment.organization_id,
               paid_crypto_payment_id: payment.id,
-              paid_transaction_hash: txHash,
+              paid_transaction_hash: canonicalTxHash,
               paid_network: payment.network,
               paid_token: payCurrency,
             },
@@ -545,7 +576,7 @@ class CryptoPaymentsService {
           payerOrganizationId: payment.organization_id,
           metadata: {
             crypto_payment_id: payment.id,
-            transaction_hash: txHash,
+            transaction_hash: canonicalTxHash,
             network: payment.network,
             token: payCurrency,
           },
@@ -556,10 +587,16 @@ class CryptoPaymentsService {
         .update(cryptoPayments)
         .set({
           status: "confirmed",
-          transaction_hash: txHash,
-          received_amount: receivedAmount,
+          transaction_hash: canonicalTxHash,
+          received_amount: receivedAmountExact,
           credits_to_add: creditsToAdd,
           confirmed_at: confirmedAt,
+          metadata: {
+            ...(payment.metadata ?? {}),
+            settlement_currency: payCurrency,
+            settlement_amount: receivedAmountExact,
+            settlement_transaction_hash: canonicalTxHash,
+          },
         })
         .where(eq(cryptoPayments.id, paymentId));
 
@@ -572,41 +609,45 @@ class CryptoPaymentsService {
           appId: appPurchase.appId,
           userId: payment.user_id,
           organizationId: payment.organization_id,
-          purchaseAmount: receivedDecimal.toNumber(),
+          purchaseAmount: creditsToAdd,
           stripePaymentIntentId: `crypto:${payment.id}`,
+          transaction: tx,
         });
 
         await markChargeRequestPaid();
 
-        await invoicesService.create({
-          organization_id: payment.organization_id,
-          stripe_invoice_id: createCryptoInvoiceId(payment.id),
-          stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-          stripe_payment_intent_id: txHash,
-          amount_due: payment.expected_amount,
-          amount_paid: creditsToAdd,
-          currency: payCurrency.toLowerCase(),
-          status: "paid",
-          invoice_type: "app_crypto_payment",
-          credits_added: creditsToAdd,
-          metadata: {
-            payment_method: "crypto",
-            provider: "oxapay",
-            network: payment.network,
-            token: payCurrency,
-            transaction_hash: txHash,
-            received_after_fee: receivedAmount,
-            oxapay_track_id: getTrackId(payment.metadata),
-            app_id: appPurchase.appId,
-            charge_request_id: appPurchase.chargeRequestId,
-            platform_offset: result.platformOffset,
-            creator_earnings: result.creatorEarnings,
+        await invoicesService.create(
+          {
+            organization_id: payment.organization_id,
+            stripe_invoice_id: createCryptoInvoiceId(payment.id),
+            stripe_customer_id: createCryptoCustomerId(payment.organization_id),
+            stripe_payment_intent_id: canonicalTxHash,
+            amount_due: invoiceAmountDue,
+            amount_paid: invoiceAmountPaid,
+            currency: payCurrency.toLowerCase(),
+            status: "paid",
+            invoice_type: "app_crypto_payment",
+            credits_added: invoiceAmountPaid,
+            metadata: {
+              payment_method: "crypto",
+              provider: "oxapay",
+              network: payment.network,
+              token: payCurrency,
+              transaction_hash: canonicalTxHash,
+              received_after_fee: receivedAmountExact,
+              oxapay_track_id: getTrackId(payment.metadata),
+              app_id: appPurchase.appId,
+              charge_request_id: appPurchase.chargeRequestId,
+              platform_offset: result.platformOffset,
+              creator_earnings: result.creatorEarnings,
+            },
           },
-        });
+          tx,
+        );
 
         logger.info("[Crypto Payments] App credit payment confirmed", {
           paymentId: redact.paymentId(paymentId),
-          txHash: redact.txHash(txHash),
+          txHash: redact.txHash(canonicalTxHash),
           appId: appPurchase.appId,
           creditsAdded: creditsToAdd,
           creatorEarnings: result.creatorEarnings,
@@ -618,7 +659,7 @@ class CryptoPaymentsService {
 
       await creditsService.addCredits({
         organizationId: payment.organization_id,
-        amount: receivedDecimal.toNumber(),
+        amount: creditsToAdd,
         description: `Crypto payment (${payCurrency} on ${payment.network})`,
         // Grant the credit INSIDE the confirmation transaction so it commits
         // atomically with the status="confirmed" flip: a throw later in the tx
@@ -635,10 +676,10 @@ class CryptoPaymentsService {
         db: tx,
         metadata: {
           crypto_payment_id: payment.id,
-          transaction_hash: txHash,
+          transaction_hash: canonicalTxHash,
           network: payment.network,
           token: payCurrency,
-          received_after_fee: receivedAmount,
+          received_after_fee: receivedAmountExact,
           user_paid_amount: creditsToAdd,
           oxapay_track_id: getTrackId(payment.metadata),
         },
@@ -646,62 +687,45 @@ class CryptoPaymentsService {
 
       // Create invoice with clearly namespaced IDs to distinguish from Stripe invoices.
       // These are NOT actual Stripe IDs - they use OXAPAY_* prefix for clarity.
-      await invoicesService.create({
-        organization_id: payment.organization_id,
-        stripe_invoice_id: createCryptoInvoiceId(payment.id),
-        stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-        stripe_payment_intent_id: txHash,
-        amount_due: payment.expected_amount,
-        amount_paid: creditsToAdd,
-        currency: payCurrency.toLowerCase(),
-        status: "paid",
-        invoice_type: "crypto_payment",
-        credits_added: creditsToAdd,
-        metadata: {
-          payment_method: "crypto",
-          provider: "oxapay",
-          network: payment.network,
-          token: payCurrency,
-          transaction_hash: txHash,
-          received_after_fee: receivedAmount,
-          oxapay_track_id: getTrackId(payment.metadata),
+      await invoicesService.create(
+        {
+          organization_id: payment.organization_id,
+          stripe_invoice_id: createCryptoInvoiceId(payment.id),
+          stripe_customer_id: createCryptoCustomerId(payment.organization_id),
+          stripe_payment_intent_id: canonicalTxHash,
+          amount_due: invoiceAmountDue,
+          amount_paid: invoiceAmountPaid,
+          currency: payCurrency.toLowerCase(),
+          status: "paid",
+          invoice_type: "crypto_payment",
+          credits_added: invoiceAmountPaid,
+          metadata: {
+            payment_method: "crypto",
+            provider: "oxapay",
+            network: payment.network,
+            token: payCurrency,
+            transaction_hash: canonicalTxHash,
+            received_after_fee: receivedAmountExact,
+            oxapay_track_id: getTrackId(payment.metadata),
+          },
         },
-      });
+        tx,
+      );
 
       await this.creditReferralRevenueSplits({
         payment,
-        purchaseAmount: receivedDecimal.toNumber(),
-        txHash,
+        purchaseAmount: creditsToAdd,
+        txHash: canonicalTxHash,
+        transaction: tx,
       });
 
       logger.info("[Crypto Payments] Payment confirmed and credits added", {
         paymentId: redact.paymentId(paymentId),
-        txHash: redact.txHash(txHash),
+        txHash: redact.txHash(canonicalTxHash),
         creditsAdded: creditsToAdd,
         expectedAmount: payment.expected_amount,
         receivedAmount,
         organizationId: redact.orgId(payment.organization_id),
-      });
-
-      // Log payment to Discord (fire and forget)
-      organizationsRepository.findById(payment.organization_id).then((org) => {
-        discordService
-          .logPaymentReceived({
-            paymentId: txHash,
-            amount: receivedDecimal.toNumber(),
-            currency: payCurrency,
-            credits: receivedDecimal.toNumber(),
-            organizationId: payment.organization_id,
-            organizationName: org?.name,
-            paymentMethod: "crypto",
-            paymentType: "Crypto Payment",
-            network: payment.network,
-          })
-          .catch((err) => {
-            logger.error("[Crypto Payments] Failed to log payment to Discord", {
-              error: err,
-            });
-          });
       });
     });
 
@@ -722,341 +746,76 @@ class CryptoPaymentsService {
     txHash: string,
   ): Promise<{ success: boolean; message: string }> {
     validateUuid(paymentId, "payment ID");
-    const appChargeCallbacks: AppChargeCallbackDispatchParams[] = [];
 
     try {
-      // Use a database transaction with row-level locking to prevent race conditions
-      // This ensures only one request can process the confirmation at a time
-      const result = await dbWrite.transaction(async (tx) => {
-        // Acquire a row-level lock on the payment record
-        const paymentResult = await tx
-          .select()
-          .from(cryptoPayments)
-          .where(eq(cryptoPayments.id, paymentId))
-          .for("update");
-
-        const payment = paymentResult[0];
-
-        if (!payment) {
-          return { success: false, message: "Payment not found" };
-        }
-
-        if (payment.status === "confirmed") {
-          return { success: true, message: "Payment already confirmed" };
-        }
-
-        if (payment.status === "expired") {
-          return { success: false, message: "Payment has expired" };
-        }
-
-        if (payment.status === "failed") {
-          return { success: false, message: "Payment has failed" };
-        }
-
-        // Get the OxaPay track ID to verify on-chain
-        let trackId: string;
-        try {
-          trackId = getTrackId(payment.metadata);
-        } catch {
-          logger.error("[Crypto Payments] Missing track ID for on-chain verification", {
-            paymentId: redact.paymentId(paymentId),
-            txHash: redact.txHash(txHash),
-          });
-          return {
-            success: false,
-            message: "Payment configuration error - missing track ID",
-          };
-        }
-
-        // Verify the transaction on-chain via OxaPay API
-        const oxaStatus = await oxaPayService.getPaymentStatus(trackId);
-
-        // Check if the payment is confirmed on OxaPay's side
-        if (!oxaPayService.isPaymentConfirmed(oxaStatus.status)) {
-          logger.warn("[Crypto Payments] On-chain verification failed - payment not confirmed", {
-            paymentId: redact.paymentId(paymentId),
-            txHash: redact.txHash(txHash),
-            trackId: redact.trackId(trackId),
-            oxaPayStatus: oxaStatus.status,
-          });
-          return {
-            success: false,
-            message: `Payment not yet confirmed by blockchain. Current status: ${oxaStatus.status}`,
-          };
-        }
-
-        // Verify the provided transaction hash matches one from OxaPay
-        const matchingTx = oxaStatus.transactions.find(
-          (txn) => txn.txHash.toLowerCase() === txHash.toLowerCase(),
-        );
-
-        if (!matchingTx) {
-          // List the valid transaction hashes for debugging (redacted)
-          const validHashes = oxaStatus.transactions.map((txn) => redact.txHash(txn.txHash));
-          logger.warn("[Crypto Payments] Transaction hash not found in OxaPay records", {
-            paymentId: redact.paymentId(paymentId),
-            providedTxHash: redact.txHash(txHash),
-            trackId: redact.trackId(trackId),
-            validTransactions: validHashes,
-          });
-          return {
-            success: false,
-            message:
-              "Transaction hash not found in payment records. Please ensure you submitted the correct transaction hash.",
-          };
-        }
-
-        // matchingTx.amount now correctly contains the USD credit amount (handles auto-conversion)
-        const receivedAmount = new Decimal(matchingTx.amount);
-        logger.info("[Crypto Payments] Manual verification - payment received", {
-          paymentId: redact.paymentId(paymentId),
-          txHash: redact.txHash(txHash),
-          expectedAmount: payment.expected_amount,
-          creditAmount: receivedAmount.toString(),
-          nativeAmount: matchingTx.nativeAmount,
-          usdAmount: matchingTx.usdAmount,
-          payCurrency: matchingTx.currency,
-        });
-
-        // Check if this transaction hash is already used by another payment
-        const existingTxResult = await tx
-          .select()
-          .from(cryptoPayments)
-          .where(eq(cryptoPayments.transaction_hash, txHash))
-          .for("update");
-
-        if (existingTxResult.length > 0 && existingTxResult[0].id !== paymentId) {
-          logger.error("[Crypto Payments] Double-spend attempt detected", {
-            paymentId: redact.paymentId(paymentId),
-            txHash: redact.txHash(txHash),
-            existingPaymentId: redact.paymentId(existingTxResult[0].id),
-          });
-          return {
-            success: false,
-            message: "Transaction already processed for another payment",
-          };
-        }
-
-        // Credit user the exact received amount (no fee reversal)
-        const creditsToAdd = receivedAmount.toFixed(3);
-        const payCurrency = matchingTx.currency || payment.token;
-        const appPurchase = getAppCreditPurchaseMetadata(payment.metadata);
-        const confirmedAt = new Date();
-
-        const markChargeRequestPaid = async () => {
-          if (!appPurchase?.chargeRequestId) return;
-
-          const [chargeRequest] = await tx
-            .select()
-            .from(cryptoPayments)
-            .where(eq(cryptoPayments.id, appPurchase.chargeRequestId))
-            .for("update")
-            .limit(1);
-
-          if (!chargeRequest) {
-            throw new Error("Charge request not found");
-          }
-
-          const chargeMetadata = chargeRequest.metadata ?? {};
-          if (
-            chargeMetadata.kind !== "app_charge_request" ||
-            chargeMetadata.app_id !== appPurchase.appId
-          ) {
-            throw new Error("Charge request metadata mismatch");
-          }
-
-          if (chargeRequest.status === "confirmed") return;
-
-          await tx
-            .update(cryptoPayments)
-            .set({
-              status: "confirmed",
-              received_amount: creditsToAdd,
-              credits_to_add: creditsToAdd,
-              confirmed_at: confirmedAt,
-              updated_at: confirmedAt,
-              metadata: {
-                ...chargeMetadata,
-                paid_at: confirmedAt.toISOString(),
-                paid_provider: "oxapay",
-                paid_provider_payment_id: payment.id,
-                payer_user_id: payment.user_id ?? undefined,
-                payer_organization_id: payment.organization_id,
-                paid_crypto_payment_id: payment.id,
-                paid_transaction_hash: txHash,
-                paid_network: payment.network,
-                paid_token: payCurrency,
-              },
-            })
-            .where(eq(cryptoPayments.id, appPurchase.chargeRequestId));
-
-          appChargeCallbacks.push({
-            appId: appPurchase.appId,
-            chargeRequestId: appPurchase.chargeRequestId,
-            status: "paid",
-            provider: "oxapay",
-            providerPaymentId: payment.id,
-            amountUsd: creditsToAdd,
-            payerUserId: payment.user_id,
-            payerOrganizationId: payment.organization_id,
-            metadata: {
-              crypto_payment_id: payment.id,
-              transaction_hash: txHash,
-              network: payment.network,
-              token: payCurrency,
-            },
-          });
-        };
-
-        logger.info("[Crypto Payments] On-chain verification successful", {
-          paymentId: redact.paymentId(paymentId),
-          txHash: redact.txHash(txHash),
-          trackId: redact.trackId(trackId),
-          receivedAmount: matchingTx.amount,
-          creditsToAdd,
-        });
-
-        // Update the payment record
-        await tx
-          .update(cryptoPayments)
-          .set({
-            status: "confirmed",
-            transaction_hash: txHash,
-            received_amount: matchingTx.amount.toString(),
-            credits_to_add: creditsToAdd,
-            confirmed_at: confirmedAt,
-          })
-          .where(eq(cryptoPayments.id, paymentId));
-
-        if (appPurchase) {
-          if (!payment.user_id) {
-            return {
+      const payment = await cryptoPaymentsRepository.findById(paymentId);
+      if (!payment) {
+        return { success: false, message: "Payment not found" };
+      }
+      if (payment.status === "confirmed") {
+        return cryptoTransactionHashesEqual(payment.transaction_hash, txHash, payment.network)
+          ? { success: true, message: "Payment already confirmed" }
+          : {
               success: false,
-              message: "App credit crypto payment is missing user ID",
+              message: "Payment confirmation replay does not match the committed settlement",
             };
-          }
+      }
+      if (payment.status === "expired") {
+        return { success: false, message: "Payment has expired" };
+      }
+      if (payment.status === "failed") {
+        return { success: false, message: "Payment has failed" };
+      }
 
-          const result = await appCreditsService.processPurchase({
-            appId: appPurchase.appId,
-            userId: payment.user_id,
-            organizationId: payment.organization_id,
-            purchaseAmount: receivedAmount.toNumber(),
-            stripePaymentIntentId: `crypto:${payment.id}`,
-          });
-
-          await markChargeRequestPaid();
-
-          await invoicesService.create({
-            organization_id: payment.organization_id,
-            stripe_invoice_id: createCryptoInvoiceId(payment.id),
-            stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-            stripe_payment_intent_id: txHash,
-            amount_due: payment.expected_amount,
-            amount_paid: creditsToAdd,
-            currency: payCurrency.toLowerCase(),
-            status: "paid",
-            invoice_type: "app_crypto_payment",
-            credits_added: creditsToAdd,
-            metadata: {
-              payment_method: "crypto",
-              provider: "oxapay",
-              network: payment.network,
-              token: payCurrency,
-              transaction_hash: txHash,
-              received_after_fee: matchingTx.amount.toString(),
-              oxapay_track_id: trackId,
-              app_id: appPurchase.appId,
-              charge_request_id: appPurchase.chargeRequestId,
-              platform_offset: result.platformOffset,
-              creator_earnings: result.creatorEarnings,
-            },
-          });
-
-          logger.info("[Crypto Payments] Manual app credit confirmation successful", {
-            paymentId: redact.paymentId(paymentId),
-            txHash: redact.txHash(txHash),
-            appId: appPurchase.appId,
-            creditsAdded: creditsToAdd,
-            creatorEarnings: result.creatorEarnings,
-            organizationId: redact.orgId(payment.organization_id),
-          });
-
-          return {
-            success: true,
-            message: "Payment confirmed successfully",
-          };
-        }
-
-        // Add credits based on exact received amount
-        await creditsService.addCredits({
-          organizationId: payment.organization_id,
-          amount: receivedAmount.toNumber(),
-          description: `Crypto payment (${payCurrency} on ${payment.network})`,
-          stripePaymentIntentId: `crypto:${payment.id}`,
-          db: tx,
-          metadata: {
-            crypto_payment_id: payment.id,
-            transaction_hash: txHash,
-            network: payment.network,
-            token: payCurrency,
-            received_amount: matchingTx.amount.toString(),
-            credits_added: creditsToAdd,
-            oxapay_track_id: trackId,
-          },
-        });
-
-        // Create invoice with clearly namespaced IDs to distinguish from Stripe invoices.
-        // These are NOT actual Stripe IDs - they use OXAPAY_* prefix for clarity.
-        await invoicesService.create({
-          organization_id: payment.organization_id,
-          stripe_invoice_id: createCryptoInvoiceId(payment.id),
-          stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-          stripe_payment_intent_id: txHash,
-          amount_due: payment.expected_amount,
-          amount_paid: creditsToAdd,
-          currency: payCurrency.toLowerCase(),
-          status: "paid",
-          invoice_type: "crypto_payment",
-          credits_added: creditsToAdd,
-          metadata: {
-            payment_method: "crypto",
-            provider: "oxapay",
-            network: payment.network,
-            token: payCurrency,
-            transaction_hash: txHash,
-            received_after_fee: matchingTx.amount.toString(),
-            oxapay_track_id: trackId,
-          },
-        });
-
-        await this.creditReferralRevenueSplits({
-          payment,
-          purchaseAmount: receivedAmount.toNumber(),
-          txHash,
-        });
-
-        logger.info("[Crypto Payments] Manual confirmation successful", {
+      let trackId: string;
+      try {
+        trackId = getTrackId(payment.metadata);
+      } catch {
+        // error-policy:J1 the manual-confirmation boundary reports malformed
+        // persisted provider configuration as an explicit failed result.
+        logger.error("[Crypto Payments] Missing track ID for on-chain verification", {
           paymentId: redact.paymentId(paymentId),
           txHash: redact.txHash(txHash),
-          creditsAdded: creditsToAdd,
-          organizationId: redact.orgId(payment.organization_id),
         });
-
         return {
-          success: true,
-          message: "Payment confirmed successfully",
+          success: false,
+          message: "Payment configuration error - missing track ID",
         };
-      });
+      }
 
-      await dispatchAppChargeCallbacks(appChargeCallbacks);
-      return result;
+      const oxaStatus = await oxaPayService.getPaymentStatus(trackId);
+      if (!oxaPayService.isPaymentConfirmed(oxaStatus.status)) {
+        return {
+          success: false,
+          message: `Payment not yet confirmed by blockchain. Current status: ${oxaStatus.status}`,
+        };
+      }
+
+      const matchingTx = oxaStatus.transactions.find((transaction) =>
+        cryptoTransactionHashesEqual(transaction.txHash, txHash, payment.network),
+      );
+      if (!matchingTx) {
+        return {
+          success: false,
+          message:
+            "Transaction hash not found in payment records. Please ensure you submitted the correct transaction hash.",
+        };
+      }
+
+      await this.confirmPayment(
+        payment.id,
+        matchingTx.txHash,
+        new Decimal(matchingTx.amount).toFixed(),
+        matchingTx.currency || payment.token,
+      );
+      return { success: true, message: "Payment confirmed successfully" };
     } catch (error) {
+      // error-policy:J1 the route translates this explicit failed result.
       logger.error("[Crypto Payments] Manual confirmation failed", {
         paymentId: redact.paymentId(paymentId),
         txHash: redact.txHash(txHash),
         error,
       });
-
       return {
         success: false,
         message: error instanceof Error ? error.message : "Confirmation failed",
@@ -1066,20 +825,24 @@ class CryptoPaymentsService {
 
   private async creditReferralRevenueSplits(params: {
     payment: CryptoPayment;
-    purchaseAmount: number;
+    purchaseAmount: string;
     txHash: string;
+    transaction: DbTransaction;
   }): Promise<void> {
-    const { payment, purchaseAmount, txHash } = params;
+    const { payment, purchaseAmount, txHash, transaction } = params;
     if (!payment.user_id) return;
 
-    const { splits } = await referralsService.calculateRevenueSplits(
+    const purchase = new Decimal(purchaseAmount);
+    const { splits } = await referralsService.calculateRevenueSplitsExact(
       payment.user_id,
       purchaseAmount,
+      transaction,
     );
     if (splits.length === 0) return;
 
     for (const split of splits) {
-      if (split.amount <= 0) continue;
+      const splitAmount = new Decimal(split.amount);
+      if (!splitAmount.gt(0)) continue;
       const source =
         split.role === "app_owner" ? "app_owner_revenue_share" : "creator_revenue_share";
       const sourceId = `crypto_revenue_split:${payment.id}:${split.userId}`;
@@ -1091,7 +854,7 @@ class CryptoPaymentsService {
         dedupeBySourceId: true,
         description: `${
           split.role === "app_owner" ? "App Owner" : "Creator"
-        } revenue share (${((split.amount / purchaseAmount) * 100).toFixed(0)}%) for crypto payment $${purchaseAmount.toFixed(2)}`,
+        } revenue share (${splitAmount.div(purchase).mul(100).toDecimalPlaces(0).toFixed()}%) for crypto payment $${purchase.toFixed(2)}`,
         metadata: {
           buyer_user_id: payment.user_id,
           buyer_org_id: payment.organization_id,
@@ -1099,6 +862,7 @@ class CryptoPaymentsService {
           transaction_hash: txHash,
           role: split.role,
         },
+        transaction,
       });
 
       if (!result.success) {

--- a/packages/cloud/shared/src/lib/services/crypto-payments.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service crypto payments behavior behind route handlers.
+import { ElizaError } from "@elizaos/core";
 import Decimal from "decimal.js";
 import { eq, sql } from "drizzle-orm";
 import { validate as uuidValidate } from "uuid";
@@ -14,12 +15,14 @@ import {
   cryptoPaymentsRepository,
 } from "../../db/repositories/crypto-payments";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
+import type { NewInvoice } from "../../db/schemas/invoices";
 import { PAYMENT_EXPIRATION_SECONDS, validatePaymentAmount } from "../config/crypto";
 import { createCryptoCustomerId, createCryptoInvoiceId } from "../constants/invoice-ids";
 import { logger, redact } from "../utils/logger";
 import {
   type AppChargeCallbackDispatchParams,
   appChargeCallbacksService,
+  parseAppChargeCallbackDispatchParams,
 } from "./app-charge-callbacks";
 import { appCreditsService } from "./app-credits";
 import { creditsService } from "./credits";
@@ -47,20 +50,21 @@ export type CryptoPaymentErrorCode =
  * Custom error class for crypto payment operations.
  * Provides typed error codes for clean API error handling.
  */
-export class CryptoPaymentError extends Error {
+export class CryptoPaymentError extends ElizaError {
+  override readonly name = "CryptoPaymentError";
+
   constructor(
     public readonly code: CryptoPaymentErrorCode,
     message: string,
   ) {
-    super(message);
-    this.name = "CryptoPaymentError";
+    super(message, { code, severity: "fatal" });
   }
 }
 
 export interface CreatePaymentParams {
   organizationId: string;
   userId?: string;
-  amount: number;
+  amount: string | number;
   currency?: string;
   payCurrency?: string;
   network?: OxaPayNetwork;
@@ -91,11 +95,89 @@ const paymentMetadataSchema = z
     oxapay_track_id: z.string().optional(),
     pay_link: z.string().optional(),
     fiat_currency: z.string().optional(),
-    fiat_amount: z.number().optional(),
+    fiat_amount: z.union([z.string(), z.number()]).optional(),
   })
   .passthrough();
 
 type PaymentMetadata = z.infer<typeof paymentMetadataSchema>;
+const storedInvoiceSettlementSchema = z.object({
+  organization_id: z.string().uuid(),
+  stripe_invoice_id: z.string().min(1),
+  stripe_customer_id: z.string().min(1),
+  stripe_payment_intent_id: z.string().min(1),
+  amount_due: z.string().min(1),
+  amount_paid: z.string().min(1),
+  currency: z.string().min(1),
+  status: z.string().min(1),
+  invoice_type: z.string().min(1),
+  credits_added: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+function storedInvoiceSettlement(value: unknown): NewInvoice {
+  const result = storedInvoiceSettlementSchema.safeParse(value);
+  if (!result.success) {
+    throw new ElizaError("Confirmed payment has an invalid canonical invoice settlement", {
+      code: "INVALID_CRYPTO_INVOICE_SETTLEMENT",
+      context: { issues: result.error.issues },
+    });
+  }
+  return result.data;
+}
+
+interface OxaSettlementEvidence {
+  trackId: string;
+  invoiceAmount: string;
+  invoiceCurrency: string;
+  payCurrency: string;
+}
+
+function oxaQuoteForPayment(payment: CryptoPayment): {
+  trackId: string;
+  fiatAmount: string;
+  fiatCurrency: string;
+} {
+  const metadata = extractMetadata(payment.metadata);
+  const trackId = getTrackId(metadata);
+  const rawAmount = metadata.fiat_amount ?? payment.expected_amount;
+  const fiatAmount = new Decimal(rawAmount).toFixed();
+  const fiatCurrency = metadata.fiat_currency?.trim().toUpperCase();
+  if (!fiatCurrency || !new Decimal(fiatAmount).isFinite() || !new Decimal(fiatAmount).gt(0)) {
+    throw new ElizaError("Crypto payment has an invalid stored fiat quote", {
+      code: "INVALID_CRYPTO_PAYMENT_QUOTE",
+      context: { paymentId: payment.id },
+    });
+  }
+  return { trackId, fiatAmount, fiatCurrency };
+}
+
+function validateOxaSettlementEvidence(
+  payment: CryptoPayment,
+  evidence: OxaSettlementEvidence,
+): void {
+  const quote = oxaQuoteForPayment(payment);
+  let invoiceAmount: Decimal;
+  try {
+    invoiceAmount = new Decimal(evidence.invoiceAmount);
+  } catch (cause) {
+    // error-policy:J2 convert malformed provider money into a typed settlement failure.
+    throw new ElizaError("OxaPay returned an invalid invoice amount", {
+      code: "INVALID_OXAPAY_SETTLEMENT",
+      context: { paymentId: payment.id },
+      cause,
+    });
+  }
+  if (
+    evidence.trackId !== quote.trackId ||
+    !invoiceAmount.equals(quote.fiatAmount) ||
+    evidence.invoiceCurrency.trim().toUpperCase() !== quote.fiatCurrency
+  ) {
+    throw new ElizaError("OxaPay settlement does not match the server-stored fiat quote", {
+      code: "OXAPAY_QUOTE_MISMATCH",
+      context: { paymentId: payment.id },
+    });
+  }
+}
 
 /**
  * Safely extract metadata with runtime validation.
@@ -150,14 +232,6 @@ function getAppCreditPurchaseMetadata(
     appId,
     chargeRequestId: getStringMetadata(meta, "charge_request_id"),
   };
-}
-
-async function dispatchAppChargeCallbacks(
-  callbacks: AppChargeCallbackDispatchParams[],
-): Promise<void> {
-  for (const callback of callbacks) {
-    await appChargeCallbacksService.dispatch(callback);
-  }
 }
 
 function appChargeFailureCallbackForPayment(
@@ -264,7 +338,7 @@ class CryptoPaymentsService {
     const orderId = `${organizationId.replace(/-/g, "").slice(0, 12)}_${Date.now()}_${randomSuffix}`;
 
     const oxaInvoice = await oxaPayService.createInvoice({
-      amount,
+      amount: amountDecimal.toFixed(),
       currency,
       payCurrency,
       network,
@@ -279,8 +353,8 @@ class CryptoPaymentsService {
       organization_id: organizationId,
       user_id: userId,
       payment_address: oxaInvoice.trackId,
-      expected_amount: amountDecimal.toFixed(3),
-      credits_to_add: amountDecimal.toFixed(3),
+      expected_amount: amountDecimal.toFixed(),
+      credits_to_add: amountDecimal.toFixed(),
       network: network || "AUTO",
       token: payCurrency || "AUTO",
       token_address: null,
@@ -291,7 +365,7 @@ class CryptoPaymentsService {
         oxapay_track_id: oxaInvoice.trackId,
         pay_link: oxaInvoice.payLink,
         fiat_currency: currency,
-        fiat_amount: amount,
+        fiat_amount: amountDecimal.toFixed(),
       },
     });
 
@@ -307,7 +381,7 @@ class CryptoPaymentsService {
       payLink: oxaInvoice.payLink,
       expiresAt: oxaInvoice.expiresAt,
       trackId: oxaInvoice.trackId,
-      creditsToAdd: amountDecimal.toFixed(3),
+      creditsToAdd: amountDecimal.toFixed(),
     };
   }
 
@@ -329,13 +403,6 @@ class CryptoPaymentsService {
     const payment = await cryptoPaymentsRepository.findById(paymentId);
     if (!payment) {
       throw new Error("Payment not found");
-    }
-
-    if (payment.status === "confirmed") {
-      return {
-        confirmed: true,
-        payment: this.formatPaymentStatus(payment),
-      };
     }
 
     if (payment.status === "expired" || payment.status === "failed") {
@@ -372,7 +439,12 @@ class CryptoPaymentsService {
           network: payment.network,
         });
 
-        await this.confirmPayment(payment.id, tx.txHash, receivedAmount.toString(), tx.currency);
+        await this.confirmPayment(payment.id, tx.txHash, {
+          trackId: oxaStatus.trackId,
+          invoiceAmount: oxaStatus.amount,
+          invoiceCurrency: oxaStatus.currency,
+          payCurrency: tx.currency,
+        });
 
         const confirmedPayment = await cryptoPaymentsRepository.findById(payment.id);
         if (!confirmedPayment) {
@@ -413,12 +485,18 @@ class CryptoPaymentsService {
         };
       }
     } catch (error) {
+      // error-policy:J2 preserve provider/payment context on an inner failure.
       logger.error("[Crypto Payments] Failed to check OxaPay status", {
         paymentId: redact.paymentId(paymentId),
         trackId: redact.trackId(trackId),
         error,
       });
-      throw error;
+      if (error instanceof ElizaError) throw error;
+      throw new ElizaError("Failed to verify OxaPay payment status", {
+        code: "OXAPAY_STATUS_VERIFICATION_FAILED",
+        context: { paymentId, trackId },
+        cause: error,
+      });
     }
 
     return {
@@ -434,11 +512,9 @@ class CryptoPaymentsService {
   async confirmPayment(
     paymentId: string,
     txHash: string,
-    receivedAmount: string,
-    actualPayCurrency?: string,
+    evidence: OxaSettlementEvidence,
   ): Promise<void> {
     validateUuid(paymentId, "payment ID");
-    const appChargeCallbacks: AppChargeCallbackDispatchParams[] = [];
 
     await dbWrite.transaction(async (tx) => {
       const paymentResult = await tx
@@ -452,7 +528,11 @@ class CryptoPaymentsService {
       if (!payment) {
         throw new Error("Payment not found");
       }
+      validateOxaSettlementEvidence(payment, evidence);
       const canonicalTxHash = canonicalizeCryptoTransactionHash(txHash, payment.network);
+      const receivedAmount = evidence.invoiceAmount;
+      const actualPayCurrency = evidence.payCurrency;
+      const quote = oxaQuoteForPayment(payment);
 
       if (payment.status === "confirmed") {
         const settledCurrency =
@@ -463,9 +543,18 @@ class CryptoPaymentsService {
           !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash) ||
           !payment.received_amount ||
           !new Decimal(payment.received_amount).equals(receivedAmount) ||
-          settledCurrency.toLowerCase() !== (actualPayCurrency || payment.token).toLowerCase()
+          settledCurrency.toLowerCase() !== actualPayCurrency.toLowerCase()
         ) {
           throw new Error("Payment confirmation replay does not match the committed settlement");
+        }
+        const invoiceSettlement = storedInvoiceSettlement(payment.metadata?.invoice_settlement);
+        await invoicesService.create(invoiceSettlement, tx);
+        const callbackSettlement = payment.metadata?.callback_settlement;
+        if (callbackSettlement !== undefined) {
+          await appChargeCallbacksService.enqueue(
+            parseAppChargeCallbackDispatchParams(callbackSettlement),
+            tx,
+          );
         }
         logger.info("[Crypto Payments] Payment already confirmed", {
           paymentId: redact.paymentId(paymentId),
@@ -491,11 +580,12 @@ class CryptoPaymentsService {
         )
         .for("update");
 
-      if (existingTx.length > 0 && existingTx[0].id !== paymentId) {
+      const collision = existingTx.find((candidate) => candidate.id !== paymentId);
+      if (collision) {
         logger.error("[Crypto Payments] Double-spend attempt detected", {
           paymentId: redact.paymentId(paymentId),
           txHash: redact.txHash(canonicalTxHash),
-          existingPaymentId: redact.paymentId(existingTx[0].id),
+          existingPaymentId: redact.paymentId(collision.id),
         });
         throw new Error("Transaction already processed for another payment");
       }
@@ -510,9 +600,10 @@ class CryptoPaymentsService {
       // Invoice columns are intentionally cent-denominated. Keep the provider's
       // exact decimal on the payment and in metadata, while explicitly rounding
       // the invoice projection to its declared database scale.
-      const invoiceAmountDue = new Decimal(payment.expected_amount).toDecimalPlaces(2).toFixed(2);
+      const invoiceAmountDue = new Decimal(quote.fiatAmount).toDecimalPlaces(2).toFixed(2);
       const invoiceAmountPaid = receivedDecimal.toDecimalPlaces(2).toFixed(2);
-      const payCurrency = actualPayCurrency || payment.token;
+      const payCurrency = actualPayCurrency;
+      const invoiceCurrency = quote.fiatCurrency.toLowerCase();
       const appPurchase = getAppCreditPurchaseMetadata(payment.metadata);
       const confirmedAt = new Date();
 
@@ -565,7 +656,7 @@ class CryptoPaymentsService {
           })
           .where(eq(cryptoPayments.id, appPurchase.chargeRequestId));
 
-        appChargeCallbacks.push({
+        const callbackSettlement: AppChargeCallbackDispatchParams = {
           appId: appPurchase.appId,
           chargeRequestId: appPurchase.chargeRequestId,
           status: "paid",
@@ -580,7 +671,9 @@ class CryptoPaymentsService {
             network: payment.network,
             token: payCurrency,
           },
-        });
+        };
+        await appChargeCallbacksService.enqueue(callbackSettlement, tx);
+        return callbackSettlement;
       };
 
       await tx
@@ -614,36 +707,47 @@ class CryptoPaymentsService {
           transaction: tx,
         });
 
-        await markChargeRequestPaid();
+        const callbackSettlement = await markChargeRequestPaid();
 
-        await invoicesService.create(
-          {
-            organization_id: payment.organization_id,
-            stripe_invoice_id: createCryptoInvoiceId(payment.id),
-            stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-            stripe_payment_intent_id: canonicalTxHash,
-            amount_due: invoiceAmountDue,
-            amount_paid: invoiceAmountPaid,
-            currency: payCurrency.toLowerCase(),
-            status: "paid",
-            invoice_type: "app_crypto_payment",
-            credits_added: invoiceAmountPaid,
-            metadata: {
-              payment_method: "crypto",
-              provider: "oxapay",
-              network: payment.network,
-              token: payCurrency,
-              transaction_hash: canonicalTxHash,
-              received_after_fee: receivedAmountExact,
-              oxapay_track_id: getTrackId(payment.metadata),
-              app_id: appPurchase.appId,
-              charge_request_id: appPurchase.chargeRequestId,
-              platform_offset: result.platformOffset,
-              creator_earnings: result.creatorEarnings,
-            },
+        const invoiceSettlement = {
+          organization_id: payment.organization_id,
+          stripe_invoice_id: createCryptoInvoiceId(payment.id),
+          stripe_customer_id: createCryptoCustomerId(payment.organization_id),
+          stripe_payment_intent_id: canonicalTxHash,
+          amount_due: invoiceAmountDue,
+          amount_paid: invoiceAmountPaid,
+          currency: invoiceCurrency,
+          status: "paid",
+          invoice_type: "app_crypto_payment",
+          credits_added: invoiceAmountPaid,
+          metadata: {
+            payment_method: "crypto",
+            provider: "oxapay",
+            network: payment.network,
+            token: payCurrency,
+            transaction_hash: canonicalTxHash,
+            received_after_fee: receivedAmountExact,
+            oxapay_track_id: getTrackId(payment.metadata),
+            app_id: appPurchase.appId,
+            charge_request_id: appPurchase.chargeRequestId,
+            platform_offset: result.platformOffset,
+            creator_earnings: result.creatorEarnings,
           },
-          tx,
-        );
+        };
+        await invoicesService.create(invoiceSettlement, tx);
+        await tx
+          .update(cryptoPayments)
+          .set({
+            metadata: {
+              ...(payment.metadata ?? {}),
+              settlement_currency: payCurrency,
+              settlement_amount: receivedAmountExact,
+              settlement_transaction_hash: canonicalTxHash,
+              invoice_settlement: invoiceSettlement,
+              ...(callbackSettlement && { callback_settlement: callbackSettlement }),
+            },
+          })
+          .where(eq(cryptoPayments.id, paymentId));
 
         logger.info("[Crypto Payments] App credit payment confirmed", {
           paymentId: redact.paymentId(paymentId),
@@ -687,30 +791,40 @@ class CryptoPaymentsService {
 
       // Create invoice with clearly namespaced IDs to distinguish from Stripe invoices.
       // These are NOT actual Stripe IDs - they use OXAPAY_* prefix for clarity.
-      await invoicesService.create(
-        {
-          organization_id: payment.organization_id,
-          stripe_invoice_id: createCryptoInvoiceId(payment.id),
-          stripe_customer_id: createCryptoCustomerId(payment.organization_id),
-          stripe_payment_intent_id: canonicalTxHash,
-          amount_due: invoiceAmountDue,
-          amount_paid: invoiceAmountPaid,
-          currency: payCurrency.toLowerCase(),
-          status: "paid",
-          invoice_type: "crypto_payment",
-          credits_added: invoiceAmountPaid,
-          metadata: {
-            payment_method: "crypto",
-            provider: "oxapay",
-            network: payment.network,
-            token: payCurrency,
-            transaction_hash: canonicalTxHash,
-            received_after_fee: receivedAmountExact,
-            oxapay_track_id: getTrackId(payment.metadata),
-          },
+      const invoiceSettlement = {
+        organization_id: payment.organization_id,
+        stripe_invoice_id: createCryptoInvoiceId(payment.id),
+        stripe_customer_id: createCryptoCustomerId(payment.organization_id),
+        stripe_payment_intent_id: canonicalTxHash,
+        amount_due: invoiceAmountDue,
+        amount_paid: invoiceAmountPaid,
+        currency: invoiceCurrency,
+        status: "paid",
+        invoice_type: "crypto_payment",
+        credits_added: invoiceAmountPaid,
+        metadata: {
+          payment_method: "crypto",
+          provider: "oxapay",
+          network: payment.network,
+          token: payCurrency,
+          transaction_hash: canonicalTxHash,
+          received_after_fee: receivedAmountExact,
+          oxapay_track_id: getTrackId(payment.metadata),
         },
-        tx,
-      );
+      };
+      await invoicesService.create(invoiceSettlement, tx);
+      await tx
+        .update(cryptoPayments)
+        .set({
+          metadata: {
+            ...(payment.metadata ?? {}),
+            settlement_currency: payCurrency,
+            settlement_amount: receivedAmountExact,
+            settlement_transaction_hash: canonicalTxHash,
+            invoice_settlement: invoiceSettlement,
+          },
+        })
+        .where(eq(cryptoPayments.id, paymentId));
 
       await this.creditReferralRevenueSplits({
         payment,
@@ -728,8 +842,6 @@ class CryptoPaymentsService {
         organizationId: redact.orgId(payment.organization_id),
       });
     });
-
-    await dispatchAppChargeCallbacks(appChargeCallbacks);
   }
 
   /**
@@ -752,13 +864,14 @@ class CryptoPaymentsService {
       if (!payment) {
         return { success: false, message: "Payment not found" };
       }
-      if (payment.status === "confirmed") {
-        return cryptoTransactionHashesEqual(payment.transaction_hash, txHash, payment.network)
-          ? { success: true, message: "Payment already confirmed" }
-          : {
-              success: false,
-              message: "Payment confirmation replay does not match the committed settlement",
-            };
+      if (
+        payment.status === "confirmed" &&
+        !cryptoTransactionHashesEqual(payment.transaction_hash, txHash, payment.network)
+      ) {
+        return {
+          success: false,
+          message: "Payment confirmation replay does not match the committed settlement",
+        };
       }
       if (payment.status === "expired") {
         return { success: false, message: "Payment has expired" };
@@ -802,12 +915,12 @@ class CryptoPaymentsService {
         };
       }
 
-      await this.confirmPayment(
-        payment.id,
-        matchingTx.txHash,
-        new Decimal(matchingTx.amount).toFixed(),
-        matchingTx.currency || payment.token,
-      );
+      await this.confirmPayment(payment.id, matchingTx.txHash, {
+        trackId: oxaStatus.trackId,
+        invoiceAmount: oxaStatus.amount,
+        invoiceCurrency: oxaStatus.currency,
+        payCurrency: matchingTx.currency || payment.token,
+      });
       return { success: true, message: "Payment confirmed successfully" };
     } catch (error) {
       // error-policy:J1 the route translates this explicit failed result.
@@ -901,7 +1014,7 @@ class CryptoPaymentsService {
       return { success: false, message: "Payment not found" };
     }
 
-    if (payment.status !== "pending") {
+    if (payment.status !== "pending" && payment.status !== "confirmed") {
       logger.info("[Crypto Payments] Payment already processed", {
         track_id: redact.trackId(track_id),
         status: payment.status,
@@ -948,12 +1061,12 @@ class CryptoPaymentsService {
           network: payment.network,
         });
 
-        await this.confirmPayment(
-          payment.id,
-          tx.txHash || txID || track_id,
-          receivedAmount.toString(),
-          tx.currency,
-        );
+        await this.confirmPayment(payment.id, tx.txHash || txID || track_id, {
+          trackId: oxaStatus.trackId,
+          invoiceAmount: oxaStatus.amount,
+          invoiceCurrency: oxaStatus.currency,
+          payCurrency: tx.currency,
+        });
         return { success: true, message: "Payment confirmed" };
       }
 
@@ -971,11 +1084,17 @@ class CryptoPaymentsService {
 
       return { success: true, message: "Webhook processed" };
     } catch (error) {
+      // error-policy:J2 keep webhook identity while preserving the cause for retry.
       logger.error("[Crypto Payments] Webhook processing error", {
         track_id: redact.trackId(track_id),
         error,
       });
-      throw error;
+      if (error instanceof ElizaError) throw error;
+      throw new ElizaError("Crypto payment webhook settlement failed", {
+        code: "CRYPTO_WEBHOOK_SETTLEMENT_FAILED",
+        context: { trackId: track_id },
+        cause: error,
+      });
     }
   }
 

--- a/packages/cloud/shared/src/lib/services/crypto-payments.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service crypto payments behavior behind route handlers.
+/** Coordinates atomic provider-backed crypto settlement and recovery behind route handlers. */
 import { ElizaError } from "@elizaos/core";
 import Decimal from "decimal.js";
 import { eq, sql } from "drizzle-orm";

--- a/packages/cloud/shared/src/lib/services/crypto-payments.ts
+++ b/packages/cloud/shared/src/lib/services/crypto-payments.ts
@@ -38,6 +38,7 @@ export type CryptoPaymentErrorCode =
   | "INVALID_UUID"
   | "AMOUNT_TOO_SMALL"
   | "AMOUNT_TOO_LARGE"
+  | "INVALID_CURRENCY"
   | "SERVICE_NOT_CONFIGURED"
   | "PAYMENT_NOT_FOUND"
   | "PAYMENT_ALREADY_CONFIRMED"
@@ -69,7 +70,6 @@ export interface CreatePaymentParams {
   payCurrency?: string;
   network?: OxaPayNetwork;
   description?: string;
-  callbackUrl?: string;
   returnUrl?: string;
   metadata?: Record<string, unknown>;
 }
@@ -96,6 +96,7 @@ const paymentMetadataSchema = z
     pay_link: z.string().optional(),
     fiat_currency: z.string().optional(),
     fiat_amount: z.union([z.string(), z.number()]).optional(),
+    oxapay_order_id: z.string().optional(),
   })
   .passthrough();
 
@@ -127,6 +128,7 @@ function storedInvoiceSettlement(value: unknown): NewInvoice {
 
 interface OxaSettlementEvidence {
   trackId: string;
+  orderId: string;
   invoiceAmount: string;
   invoiceCurrency: string;
   payCurrency: string;
@@ -134,11 +136,13 @@ interface OxaSettlementEvidence {
 
 function oxaQuoteForPayment(payment: CryptoPayment): {
   trackId: string;
+  orderId?: string;
   fiatAmount: string;
   fiatCurrency: string;
 } {
   const metadata = extractMetadata(payment.metadata);
   const trackId = getTrackId(metadata);
+  const orderId = metadata.oxapay_order_id?.trim();
   const rawAmount = metadata.fiat_amount ?? payment.expected_amount;
   const fiatAmount = new Decimal(rawAmount).toFixed();
   const fiatCurrency = metadata.fiat_currency?.trim().toUpperCase();
@@ -148,7 +152,7 @@ function oxaQuoteForPayment(payment: CryptoPayment): {
       context: { paymentId: payment.id },
     });
   }
-  return { trackId, fiatAmount, fiatCurrency };
+  return { trackId, orderId, fiatAmount, fiatCurrency };
 }
 
 function validateOxaSettlementEvidence(
@@ -169,6 +173,7 @@ function validateOxaSettlementEvidence(
   }
   if (
     evidence.trackId !== quote.trackId ||
+    (quote.orderId !== undefined && evidence.orderId !== quote.orderId) ||
     !invoiceAmount.equals(quote.fiatAmount) ||
     evidence.invoiceCurrency.trim().toUpperCase() !== quote.fiatCurrency
   ) {
@@ -259,14 +264,45 @@ function appChargeFailureCallbackForPayment(
   };
 }
 
-async function dispatchAppChargeFailureForPayment(
+async function persistAppChargeFailureForPayment(
   payment: CryptoPayment,
+  status: "expired" | "failed",
   reason: string,
 ): Promise<void> {
   const callback = appChargeFailureCallbackForPayment(payment, reason);
-  if (callback) {
-    await appChargeCallbacksService.dispatch(callback);
-  }
+  await dbWrite.transaction(async (tx) => {
+    const [locked] = await tx
+      .select()
+      .from(cryptoPayments)
+      .where(eq(cryptoPayments.id, payment.id))
+      .for("update")
+      .limit(1);
+    if (!locked || locked.status === "confirmed") return;
+    await tx
+      .update(cryptoPayments)
+      .set({
+        status,
+        metadata: {
+          ...(locked.metadata ?? {}),
+          failureReason: reason,
+        },
+        updated_at: new Date(),
+      })
+      .where(eq(cryptoPayments.id, payment.id));
+    if (!callback) return;
+    const [chargeRequest] = await tx
+      .select({ status: cryptoPayments.status })
+      .from(cryptoPayments)
+      .where(eq(cryptoPayments.id, callback.chargeRequestId))
+      .for("update")
+      .limit(1);
+    if (!chargeRequest || chargeRequest.status === "confirmed") return;
+    await tx
+      .update(cryptoPayments)
+      .set({ status: "failed", updated_at: new Date() })
+      .where(eq(cryptoPayments.id, callback.chargeRequestId));
+    await appChargeCallbacksService.enqueue(callback, tx);
+  });
 }
 
 /**
@@ -311,6 +347,13 @@ class CryptoPaymentsService {
       throw new CryptoPaymentError("SERVICE_NOT_CONFIGURED", "Payment service not configured");
     }
 
+    if (currency.trim().toUpperCase() !== "USD") {
+      throw new CryptoPaymentError(
+        "INVALID_CURRENCY",
+        "Crypto credit purchases are priced only in USD",
+      );
+    }
+
     const amountDecimal = new Decimal(amount);
     const validation = validatePaymentAmount(amountDecimal);
 
@@ -324,9 +367,7 @@ class CryptoPaymentsService {
     // OXAPAY_CALLBACK_URL: Override for local development with ngrok.
     // In production, falls back to NEXT_PUBLIC_APP_URL which points to the live domain.
     const callbackUrl =
-      params.callbackUrl ||
-      process.env.OXAPAY_CALLBACK_URL ||
-      `${process.env.NEXT_PUBLIC_APP_URL}/api/crypto/webhook`;
+      process.env.OXAPAY_CALLBACK_URL || `${process.env.NEXT_PUBLIC_APP_URL}/api/crypto/webhook`;
 
     const returnUrl =
       params.returnUrl ||
@@ -363,6 +404,7 @@ class CryptoPaymentsService {
       metadata: {
         ...(metadata ?? {}),
         oxapay_track_id: oxaInvoice.trackId,
+        oxapay_order_id: orderId,
         pay_link: oxaInvoice.payLink,
         fiat_currency: currency,
         fiat_amount: amountDecimal.toFixed(),
@@ -441,6 +483,7 @@ class CryptoPaymentsService {
 
         await this.confirmPayment(payment.id, tx.txHash, {
           trackId: oxaStatus.trackId,
+          orderId: oxaStatus.orderId,
           invoiceAmount: oxaStatus.amount,
           invoiceCurrency: oxaStatus.currency,
           payCurrency: tx.currency,
@@ -458,8 +501,7 @@ class CryptoPaymentsService {
       }
 
       if (oxaPayService.isPaymentExpired(oxaStatus.status)) {
-        await cryptoPaymentsRepository.markAsExpired(payment.id);
-        await dispatchAppChargeFailureForPayment(payment, "expired");
+        await persistAppChargeFailureForPayment(payment, "expired", "expired");
         const expiredPayment = await cryptoPaymentsRepository.findById(payment.id);
         if (!expiredPayment) {
           throw new Error("Failed to retrieve expired payment");
@@ -472,8 +514,7 @@ class CryptoPaymentsService {
       }
 
       if (oxaPayService.isPaymentFailed(oxaStatus.status)) {
-        await cryptoPaymentsRepository.markAsFailed(payment.id, oxaStatus.status);
-        await dispatchAppChargeFailureForPayment(payment, oxaStatus.status);
+        await persistAppChargeFailureForPayment(payment, "failed", oxaStatus.status);
         const failedPayment = await cryptoPaymentsRepository.findById(payment.id);
         if (!failedPayment) {
           throw new Error("Failed to retrieve failed payment");
@@ -931,6 +972,7 @@ class CryptoPaymentsService {
 
       await this.confirmPayment(payment.id, matchingTx.txHash, {
         trackId: oxaStatus.trackId,
+        orderId: oxaStatus.orderId,
         invoiceAmount: oxaStatus.amount,
         invoiceCurrency: oxaStatus.currency,
         payCurrency: matchingTx.currency || payment.token,
@@ -1077,6 +1119,7 @@ class CryptoPaymentsService {
 
         await this.confirmPayment(payment.id, tx.txHash || txID || track_id, {
           trackId: oxaStatus.trackId,
+          orderId: oxaStatus.orderId,
           invoiceAmount: oxaStatus.amount,
           invoiceCurrency: oxaStatus.currency,
           payCurrency: tx.currency,
@@ -1085,14 +1128,12 @@ class CryptoPaymentsService {
       }
 
       if (oxaPayService.isPaymentExpired(status)) {
-        await cryptoPaymentsRepository.markAsExpired(payment.id);
-        await dispatchAppChargeFailureForPayment(payment, "expired");
+        await persistAppChargeFailureForPayment(payment, "expired", "expired");
         return { success: true, message: "Payment marked as expired" };
       }
 
       if (oxaPayService.isPaymentFailed(status)) {
-        await cryptoPaymentsRepository.markAsFailed(payment.id, status);
-        await dispatchAppChargeFailureForPayment(payment, status);
+        await persistAppChargeFailureForPayment(payment, "failed", status);
         return { success: true, message: "Payment marked as failed" };
       }
 
@@ -1129,6 +1170,10 @@ class CryptoPaymentsService {
 
   async listExpiredPendingPayments(): Promise<CryptoPayment[]> {
     return cryptoPaymentsRepository.listExpiredPendingPayments();
+  }
+
+  async expirePaymentWithCallback(payment: CryptoPayment): Promise<void> {
+    await persistAppChargeFailureForPayment(payment, "expired", "expired");
   }
 
   private formatPaymentStatus(payment: CryptoPayment): PaymentStatus {

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -30,6 +30,11 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { base, bsc } from "viem/chains";
 import { dbWrite } from "../../db/client";
+import {
+  canonicalizeCryptoTransactionHash,
+  cryptoTransactionHashesEqual,
+  isHexTransactionHash,
+} from "../../db/crypto-payment-transaction-hash";
 import type { CryptoPayment } from "../../db/repositories/crypto-payments";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
 import type { Bindings } from "../../types/cloud-worker-env";
@@ -1327,17 +1332,25 @@ export class DirectWalletPaymentsService {
         .for("update");
       if (!payment) throw new Error("Payment not found");
       if (payment.user_id !== params.userId) throw new Error("Unauthorized");
+      const canonicalTxHash = canonicalizeCryptoTransactionHash(params.txHash, payment.network);
 
       // Already-confirmed payments don't accept new hashes — the hash is
       // already final.
       if (payment.status === "confirmed") {
+        if (
+          !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash, payment.network)
+        ) {
+          throw new Error("Payment confirmation replay does not match the committed transaction");
+        }
         return { payment, alreadyAttached: true };
       }
 
-      if (payment.transaction_hash === params.txHash) {
+      if (
+        cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash, payment.network)
+      ) {
         return { payment, alreadyAttached: true };
       }
-      if (payment.transaction_hash && payment.transaction_hash !== params.txHash) {
+      if (payment.transaction_hash) {
         throw new Error("Payment already has a different transaction hash attached");
       }
       if (payment.status !== "pending") {
@@ -1356,7 +1369,11 @@ export class DirectWalletPaymentsService {
       const existingTx = await tx
         .select()
         .from(cryptoPayments)
-        .where(eq(cryptoPayments.transaction_hash, params.txHash))
+        .where(
+          isHexTransactionHash(canonicalTxHash)
+            ? sql`lower(${cryptoPayments.transaction_hash}) = ${canonicalTxHash}`
+            : eq(cryptoPayments.transaction_hash, canonicalTxHash),
+        )
         .for("update");
       if (existingTx.length > 0 && existingTx[0].id !== payment.id) {
         throw new Error("Transaction already attached to another payment");
@@ -1365,7 +1382,7 @@ export class DirectWalletPaymentsService {
       const [updated] = await tx
         .update(cryptoPayments)
         .set({
-          transaction_hash: params.txHash,
+          transaction_hash: canonicalTxHash,
           status: "broadcast",
           ...(payerProofPatch && {
             metadata: sql`COALESCE(${cryptoPayments.metadata}, '{}'::jsonb) || ${JSON.stringify(
@@ -1458,9 +1475,16 @@ export class DirectWalletPaymentsService {
       if (payment.status === "confirmed") {
         const direct = directMetadata(payment);
         const cfg = directPaymentConfig(env, direct.network);
+        const canonicalTxHash = canonicalizeCryptoTransactionHash(params.txHash, direct.network);
+        if (
+          !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash, direct.network)
+        ) {
+          throw new Error("Payment confirmation replay does not match the committed transaction");
+        }
         return {
           payment,
           alreadyConfirmed: true,
+          transactionHash: canonicalTxHash,
           direct,
           cfg,
           amountPaid: payment.expected_amount,
@@ -1480,6 +1504,7 @@ export class DirectWalletPaymentsService {
 
       const direct = directMetadata(payment);
       const cfg = directPaymentConfig(env, direct.network);
+      const canonicalTxHash = canonicalizeCryptoTransactionHash(params.txHash, direct.network);
       requireConfigured(cfg);
 
       // Verify the HMAC-signed quote BEFORE the on-chain verify. This
@@ -1517,7 +1542,11 @@ export class DirectWalletPaymentsService {
       const existingTx = await tx
         .select()
         .from(cryptoPayments)
-        .where(eq(cryptoPayments.transaction_hash, params.txHash))
+        .where(
+          isHexTransactionHash(canonicalTxHash)
+            ? sql`lower(${cryptoPayments.transaction_hash}) = ${canonicalTxHash}`
+            : eq(cryptoPayments.transaction_hash, canonicalTxHash),
+        )
         .for("update");
       if (existingTx.length > 0 && existingTx[0].id !== payment.id) {
         throw new Error("Transaction already processed for another payment");
@@ -1528,14 +1557,14 @@ export class DirectWalletPaymentsService {
         verification = await verifySolanaTokenPayment({
           cfg,
           payerAddress: direct.payerAddress,
-          txHash: params.txHash,
+          txHash: canonicalTxHash,
           expectedUnits: direct.expectedTokenUnits,
         });
       } else if (direct.tokenKind === "native") {
         verification = await verifyEvmNativePayment({
           cfg,
           payerAddress: direct.payerAddress,
-          txHash: params.txHash,
+          txHash: canonicalTxHash,
           expectedUnits: direct.expectedTokenUnits,
           slippageBps: direct.slippageBps,
         });
@@ -1547,7 +1576,7 @@ export class DirectWalletPaymentsService {
           cfg,
           tokenAddress: direct.tokenAddress,
           payerAddress: direct.payerAddress,
-          txHash: params.txHash,
+          txHash: canonicalTxHash,
           expectedUnits: direct.expectedTokenUnits,
         });
       }
@@ -1576,7 +1605,7 @@ export class DirectWalletPaymentsService {
         .update(cryptoPayments)
         .set({
           status: "confirmed",
-          transaction_hash: params.txHash,
+          transaction_hash: canonicalTxHash,
           block_number: verification.blockNumber,
           received_amount: amountPaid.toFixed(2),
           confirmed_at: confirmedAt,
@@ -1612,7 +1641,7 @@ export class DirectWalletPaymentsService {
           crypto_payment_id: payment.id,
           payment_method: "crypto",
           provider: "wallet_native",
-          transaction_hash: params.txHash,
+          transaction_hash: canonicalTxHash,
           network: direct.network,
           token: direct.tokenSymbol,
           paid_amount_usd: amountPaid.toFixed(2),
@@ -1629,6 +1658,7 @@ export class DirectWalletPaymentsService {
       return {
         payment: confirmed ?? payment,
         alreadyConfirmed: false,
+        transactionHash: canonicalTxHash,
         direct,
         cfg,
         amountPaid: amountPaid.toFixed(2),
@@ -1646,7 +1676,7 @@ export class DirectWalletPaymentsService {
         organization_id: result.payment.organization_id,
         stripe_invoice_id: invoiceId,
         stripe_customer_id: createCryptoCustomerId(result.payment.organization_id),
-        stripe_payment_intent_id: params.txHash,
+        stripe_payment_intent_id: result.transactionHash,
         amount_due: amountPaid,
         amount_paid: amountPaid,
         currency: "usd",
@@ -1658,7 +1688,7 @@ export class DirectWalletPaymentsService {
           provider: "wallet_native",
           network: direct.network,
           token: direct.tokenSymbol,
-          transaction_hash: params.txHash,
+          transaction_hash: result.transactionHash,
           bonus_credits: direct.bonusCredits,
           sweep,
         },
@@ -1667,7 +1697,7 @@ export class DirectWalletPaymentsService {
 
     logger.info("[DirectWalletPayments] Payment confirmed", {
       paymentId: redact.paymentId(params.paymentId),
-      txHash: redact.txHash(params.txHash),
+      txHash: redact.txHash(result.transactionHash),
     });
 
     return result;

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service direct wallet payments behavior behind route handlers.
+/** Coordinates verified direct-wallet settlement, crediting, invoicing, and durable sweeping. */
 import {
   createAssociatedTokenAccountInstruction,
   createTransferCheckedInstruction,

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -5,13 +5,7 @@ import {
   getAccount,
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
-import {
-  Connection,
-  Keypair,
-  PublicKey,
-  sendAndConfirmTransaction,
-  Transaction,
-} from "@solana/web3.js";
+import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";
 import bs58 from "bs58";
 import Decimal from "decimal.js";
 import { and, eq, lte, or, sql } from "drizzle-orm";
@@ -24,6 +18,7 @@ import {
   type Hex,
   http,
   isAddress,
+  keccak256,
   parseAbiItem,
   parseEventLogs,
 } from "viem";
@@ -996,13 +991,19 @@ function evmPrivateKey(env: Bindings, network: DirectWalletNetwork): Hex | null 
   return (key.startsWith("0x") ? key : `0x${key}`) as Hex;
 }
 
-async function sweepEvmIfConfigured(params: {
+interface PreparedSweep {
+  rawTransaction: string;
+  transactionHash: string;
+  sweepTo: string;
+}
+
+async function prepareEvmSweep(params: {
   env: Bindings;
   cfg: DirectWalletNetworkConfig;
   tokenAddress: Hex | null;
   tokenDecimals: number;
   units: bigint;
-}): Promise<{ sweep_transaction_hash: string; sweep_to: string } | null> {
+}): Promise<PreparedSweep | null> {
   if (!params.tokenAddress || !params.cfg.secureAddress) return null;
   const privateKey = evmPrivateKey(params.env, params.cfg.network);
   if (!privateKey) return null;
@@ -1019,7 +1020,7 @@ async function sweepEvmIfConfigured(params: {
     chain: params.cfg.network === "base" ? base : bsc,
     transport: http(params.cfg.rpcUrl),
   });
-  const hash = await wallet.sendTransaction({
+  const request = await wallet.prepareTransactionRequest({
     to: params.tokenAddress,
     data: encodeFunctionData({
       abi: erc20Abi,
@@ -1027,7 +1028,39 @@ async function sweepEvmIfConfigured(params: {
       args: [getAddress(params.cfg.secureAddress), params.units],
     }),
   });
-  return { sweep_transaction_hash: hash, sweep_to: params.cfg.secureAddress };
+  const rawTransaction = await account.signTransaction(
+    request as Parameters<typeof account.signTransaction>[0],
+  );
+  return {
+    rawTransaction,
+    transactionHash: keccak256(rawTransaction),
+    sweepTo: params.cfg.secureAddress,
+  };
+}
+
+async function submitPreparedEvmSweep(
+  cfg: DirectWalletNetworkConfig,
+  prepared: PreparedSweep,
+): Promise<void> {
+  const client = createPublicClient({
+    chain: cfg.network === "base" ? base : bsc,
+    transport: http(cfg.rpcUrl),
+  });
+  try {
+    const existing = await client.getTransaction({
+      hash: prepared.transactionHash as Hex,
+    });
+    if (existing.hash.toLowerCase() === prepared.transactionHash.toLowerCase()) return;
+  } catch {
+    // error-policy:J4 Absence or a transient lookup error is safe because the
+    // dispatcher resends the exact same signed bytes and therefore the same hash.
+  }
+  const submitted = await client.sendRawTransaction({
+    serializedTransaction: prepared.rawTransaction as Hex,
+  });
+  if (submitted.toLowerCase() !== prepared.transactionHash.toLowerCase()) {
+    throw new Error("EVM provider returned a different sweep transaction hash");
+  }
 }
 
 function solanaKeypairFromEnv(env: Bindings): Keypair | null {
@@ -1039,11 +1072,22 @@ function solanaKeypairFromEnv(env: Bindings): Keypair | null {
   return Keypair.fromSecretKey(bs58.decode(raw));
 }
 
-async function sweepSolanaIfConfigured(params: {
+function bytesToBase64(value: Uint8Array): string {
+  let binary = "";
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function prepareSolanaSweep(params: {
   env: Bindings;
   cfg: DirectWalletNetworkConfig;
   units: bigint;
-}): Promise<{ sweep_transaction_hash: string; sweep_to: string } | null> {
+}): Promise<PreparedSweep | null> {
   if (!params.cfg.tokenMint || !params.cfg.secureAddress) return null;
   const payer = solanaKeypairFromEnv(params.env);
   if (!payer) return null;
@@ -1074,10 +1118,35 @@ async function sweepSolanaIfConfigured(params: {
       params.cfg.tokenDecimals,
     ),
   );
-  const hash = await sendAndConfirmTransaction(connection, tx, [payer], {
-    commitment: "confirmed",
+  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = payer.publicKey;
+  tx.sign(payer);
+  if (!tx.signature) throw new Error("Solana sweep transaction has no signature");
+  return {
+    rawTransaction: bytesToBase64(tx.serialize()),
+    transactionHash: bs58.encode(tx.signature),
+    sweepTo: params.cfg.secureAddress,
+  };
+}
+
+async function submitPreparedSolanaSweep(
+  cfg: DirectWalletNetworkConfig,
+  prepared: PreparedSweep,
+): Promise<void> {
+  const connection = new Connection(cfg.rpcUrl, "confirmed");
+  const existing = await connection.getSignatureStatus(prepared.transactionHash, {
+    searchTransactionHistory: true,
   });
-  return { sweep_transaction_hash: hash, sweep_to: params.cfg.secureAddress };
+  if (existing.value && !existing.value.err) return;
+  const submitted = await connection.sendRawTransaction(base64ToBytes(prepared.rawTransaction), {
+    maxRetries: 0,
+    skipPreflight: false,
+  });
+  if (submitted !== prepared.transactionHash) {
+    throw new Error("Solana provider returned a different sweep transaction signature");
+  }
+  await connection.confirmTransaction(submitted, "confirmed");
 }
 
 interface DirectSweepPayload {
@@ -1900,16 +1969,49 @@ export class DirectWalletPaymentsService {
       const cfg = directPaymentConfig(env, payload.network);
       requireConfigured(cfg);
       const units = BigInt(payload.receivedUnits);
-      const sweep: { sweep_transaction_hash: string; sweep_to: string } | null =
-        payload.network === "solana"
-          ? await sweepSolanaIfConfigured({ env, cfg, units })
-          : await sweepEvmIfConfigured({
-              env,
-              cfg,
-              tokenAddress: payload.tokenAddress,
-              tokenDecimals: payload.tokenDecimals,
-              units,
-            });
+      const prepared: PreparedSweep | null =
+        claimed.prepared_transaction && claimed.sweep_transaction_hash && cfg.secureAddress
+          ? {
+              rawTransaction: claimed.prepared_transaction,
+              transactionHash: claimed.sweep_transaction_hash,
+              sweepTo: cfg.secureAddress,
+            }
+          : payload.network === "solana"
+            ? await prepareSolanaSweep({ env, cfg, units })
+            : await prepareEvmSweep({
+                env,
+                cfg,
+                tokenAddress: payload.tokenAddress,
+                tokenDecimals: payload.tokenDecimals,
+                units,
+              });
+      if (prepared && !claimed.prepared_transaction) {
+        const [persisted] = await dbWrite
+          .update(cryptoSweepOutbox)
+          .set({
+            prepared_transaction: prepared.rawTransaction,
+            sweep_transaction_hash: prepared.transactionHash,
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(cryptoSweepOutbox.id, claimed.id),
+              eq(cryptoSweepOutbox.claim_token, claimToken),
+              sql`${cryptoSweepOutbox.prepared_transaction} IS NULL`,
+            ),
+          )
+          .returning({ id: cryptoSweepOutbox.id });
+        if (!persisted) {
+          throw new Error("Crypto sweep lease was lost before transaction preparation");
+        }
+      }
+      if (prepared) {
+        if (payload.network === "solana") {
+          await submitPreparedSolanaSweep(cfg, prepared);
+        } else {
+          await submitPreparedEvmSweep(cfg, prepared);
+        }
+      }
       externalSweepReturned = true;
       const completedAt = new Date();
       await hooks?.afterExternalSweep?.();
@@ -1931,7 +2033,7 @@ export class DirectWalletPaymentsService {
           .set({
             state: "delivered",
             delivered_at: completedAt,
-            sweep_transaction_hash: sweep?.sweep_transaction_hash ?? null,
+            sweep_transaction_hash: prepared?.transactionHash ?? null,
             claim_token: null,
             lease_expires_at: null,
             last_error: null,
@@ -1942,7 +2044,12 @@ export class DirectWalletPaymentsService {
           .update(cryptoPayments)
           .set({
             metadata: sql`COALESCE(${cryptoPayments.metadata}, '{}'::jsonb) || ${JSON.stringify({
-              sweep: sweep ?? { state: "not_configured" },
+              sweep: prepared
+                ? {
+                    sweep_transaction_hash: prepared.transactionHash,
+                    sweep_to: prepared.sweepTo,
+                  }
+                : { state: "not_configured" },
               sweep_completed_at: completedAt.toISOString(),
             })}::jsonb`,
             updated_at: completedAt,

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -991,10 +991,23 @@ function evmPrivateKey(env: Bindings, network: DirectWalletNetwork): Hex | null 
   return (key.startsWith("0x") ? key : `0x${key}`) as Hex;
 }
 
+type PreparedSweepMetadata =
+  | {
+      network: "base" | "bsc";
+      sweepTo: string;
+      nonce: string;
+    }
+  | {
+      network: "solana";
+      sweepTo: string;
+      blockhash: string;
+      lastValidBlockHeight: number;
+    };
+
 interface PreparedSweep {
   rawTransaction: string;
   transactionHash: string;
-  sweepTo: string;
+  metadata: PreparedSweepMetadata;
 }
 
 async function prepareEvmSweep(params: {
@@ -1003,8 +1016,9 @@ async function prepareEvmSweep(params: {
   tokenAddress: Hex | null;
   tokenDecimals: number;
   units: bigint;
+  sweepTo: string;
 }): Promise<PreparedSweep | null> {
-  if (!params.tokenAddress || !params.cfg.secureAddress) return null;
+  if (!params.tokenAddress) return null;
   const privateKey = evmPrivateKey(params.env, params.cfg.network);
   if (!privateKey) return null;
 
@@ -1025,16 +1039,23 @@ async function prepareEvmSweep(params: {
     data: encodeFunctionData({
       abi: erc20Abi,
       functionName: "transfer",
-      args: [getAddress(params.cfg.secureAddress), params.units],
+      args: [getAddress(params.sweepTo), params.units],
     }),
   });
+  if (request.nonce === undefined) {
+    throw new Error("Prepared EVM sweep is missing its explicit nonce");
+  }
   const rawTransaction = await account.signTransaction(
     request as Parameters<typeof account.signTransaction>[0],
   );
   return {
     rawTransaction,
     transactionHash: keccak256(rawTransaction),
-    sweepTo: params.cfg.secureAddress,
+    metadata: {
+      network: params.cfg.network === "base" ? "base" : "bsc",
+      sweepTo: params.sweepTo,
+      nonce: String(request.nonce),
+    },
   };
 }
 
@@ -1087,8 +1108,10 @@ async function prepareSolanaSweep(params: {
   env: Bindings;
   cfg: DirectWalletNetworkConfig;
   units: bigint;
+  sweepTo: string;
+  tokenMint: string;
+  tokenDecimals: number;
 }): Promise<PreparedSweep | null> {
-  if (!params.cfg.tokenMint || !params.cfg.secureAddress) return null;
   const payer = solanaKeypairFromEnv(params.env);
   if (!payer) return null;
   if (
@@ -1099,9 +1122,9 @@ async function prepareSolanaSweep(params: {
   }
 
   const connection = new Connection(params.cfg.rpcUrl, "confirmed");
-  const mint = new PublicKey(params.cfg.tokenMint);
+  const mint = new PublicKey(params.tokenMint);
   const fromAta = getAssociatedTokenAddressSync(mint, payer.publicKey);
-  const secureOwner = new PublicKey(params.cfg.secureAddress);
+  const secureOwner = new PublicKey(params.sweepTo);
   const toAta = getAssociatedTokenAddressSync(mint, secureOwner);
   const tx = new Transaction();
   const toInfo = await connection.getAccountInfo(toAta);
@@ -1115,10 +1138,10 @@ async function prepareSolanaSweep(params: {
       toAta,
       payer.publicKey,
       params.units,
-      params.cfg.tokenDecimals,
+      params.tokenDecimals,
     ),
   );
-  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
   tx.recentBlockhash = blockhash;
   tx.feePayer = payer.publicKey;
   tx.sign(payer);
@@ -1126,19 +1149,58 @@ async function prepareSolanaSweep(params: {
   return {
     rawTransaction: bytesToBase64(tx.serialize()),
     transactionHash: bs58.encode(tx.signature),
-    sweepTo: params.cfg.secureAddress,
+    metadata: {
+      network: "solana",
+      sweepTo: params.sweepTo,
+      blockhash,
+      lastValidBlockHeight,
+    },
   };
+}
+
+export type SolanaSweepRecovery = "landed" | "resend" | "reprepare";
+
+export function classifySolanaSweepRecovery(params: {
+  signatureStatus: { err: unknown } | null;
+  currentBlockHeight: number;
+  lastValidBlockHeight: number;
+}): SolanaSweepRecovery {
+  if (params.signatureStatus) {
+    if (params.signatureStatus.err) {
+      throw new Error("Solana sweep transaction failed on chain");
+    }
+    return "landed";
+  }
+  return params.currentBlockHeight > params.lastValidBlockHeight ? "reprepare" : "resend";
 }
 
 async function submitPreparedSolanaSweep(
   cfg: DirectWalletNetworkConfig,
   prepared: PreparedSweep,
-): Promise<void> {
+): Promise<"landed" | "reprepare"> {
+  if (prepared.metadata.network !== "solana") {
+    throw new Error("Prepared Solana sweep metadata is invalid");
+  }
   const connection = new Connection(cfg.rpcUrl, "confirmed");
   const existing = await connection.getSignatureStatus(prepared.transactionHash, {
     searchTransactionHistory: true,
   });
-  if (existing.value && !existing.value.err) return;
+  if (existing.value) {
+    const recovery = classifySolanaSweepRecovery({
+      signatureStatus: existing.value,
+      currentBlockHeight: 0,
+      lastValidBlockHeight: prepared.metadata.lastValidBlockHeight,
+    });
+    if (recovery !== "landed") throw new Error("Solana signature status is inconsistent");
+    return "landed";
+  }
+  const recovery = classifySolanaSweepRecovery({
+    signatureStatus: null,
+    currentBlockHeight: await connection.getBlockHeight("confirmed"),
+    lastValidBlockHeight: prepared.metadata.lastValidBlockHeight,
+  });
+  if (recovery === "landed") return "landed";
+  if (recovery === "reprepare") return "reprepare";
   const submitted = await connection.sendRawTransaction(base64ToBytes(prepared.rawTransaction), {
     maxRetries: 0,
     skipPreflight: false,
@@ -1146,7 +1208,15 @@ async function submitPreparedSolanaSweep(
   if (submitted !== prepared.transactionHash) {
     throw new Error("Solana provider returned a different sweep transaction signature");
   }
-  await connection.confirmTransaction(submitted, "confirmed");
+  await connection.confirmTransaction(
+    {
+      signature: submitted,
+      blockhash: prepared.metadata.blockhash,
+      lastValidBlockHeight: prepared.metadata.lastValidBlockHeight,
+    },
+    "confirmed",
+  );
+  return "landed";
 }
 
 interface DirectSweepPayload {
@@ -1154,8 +1224,10 @@ interface DirectSweepPayload {
   network: DirectWalletNetwork;
   tokenKind: DirectWalletTokenKind;
   tokenAddress: Hex | null;
+  tokenMint: string | null;
   tokenDecimals: number;
   receivedUnits: string;
+  sweepTo: string | null;
 }
 
 function directSweepPayload(value: unknown): DirectSweepPayload {
@@ -1171,14 +1243,71 @@ function directSweepPayload(value: unknown): DirectSweepPayload {
       payload.tokenKind !== "erc20" &&
       payload.tokenKind !== "spl") ||
     (payload.tokenAddress !== null && typeof payload.tokenAddress !== "string") ||
+    (payload.tokenMint !== null && typeof payload.tokenMint !== "string") ||
     typeof payload.tokenDecimals !== "number" ||
     !Number.isInteger(payload.tokenDecimals) ||
     typeof payload.receivedUnits !== "string" ||
-    !/^\d+$/.test(payload.receivedUnits)
+    !/^\d+$/.test(payload.receivedUnits) ||
+    (payload.sweepTo !== null && typeof payload.sweepTo !== "string")
   ) {
     throw new Error("Crypto sweep outbox payload is malformed");
   }
   return payload as unknown as DirectSweepPayload;
+}
+
+function preparedSweepFromRow(value: {
+  prepared_transaction: string | null;
+  sweep_transaction_hash: string | null;
+  prepared_metadata: Record<string, unknown> | null;
+}): PreparedSweep | null {
+  if (
+    value.prepared_transaction === null &&
+    value.sweep_transaction_hash === null &&
+    value.prepared_metadata === null
+  ) {
+    return null;
+  }
+  const metadata = value.prepared_metadata;
+  if (
+    !value.prepared_transaction ||
+    !value.sweep_transaction_hash ||
+    !metadata ||
+    typeof metadata.sweepTo !== "string"
+  ) {
+    throw new Error("Prepared crypto sweep row is incomplete");
+  }
+  if (
+    (metadata.network === "base" || metadata.network === "bsc") &&
+    typeof metadata.nonce === "string"
+  ) {
+    return {
+      rawTransaction: value.prepared_transaction,
+      transactionHash: value.sweep_transaction_hash,
+      metadata: {
+        network: metadata.network,
+        sweepTo: metadata.sweepTo,
+        nonce: metadata.nonce,
+      },
+    };
+  }
+  if (
+    metadata.network === "solana" &&
+    typeof metadata.blockhash === "string" &&
+    typeof metadata.lastValidBlockHeight === "number" &&
+    Number.isSafeInteger(metadata.lastValidBlockHeight)
+  ) {
+    return {
+      rawTransaction: value.prepared_transaction,
+      transactionHash: value.sweep_transaction_hash,
+      metadata: {
+        network: "solana",
+        sweepTo: metadata.sweepTo,
+        blockhash: metadata.blockhash,
+        lastValidBlockHeight: metadata.lastValidBlockHeight,
+      },
+    };
+  }
+  throw new Error("Prepared crypto sweep metadata is malformed");
 }
 
 function directPaymentSettlementDigest(payment: CryptoPayment): string {
@@ -1769,8 +1898,10 @@ export class DirectWalletPaymentsService {
           network: direct.network,
           tokenKind: direct.tokenKind,
           tokenAddress: direct.tokenAddress,
+          tokenMint: direct.tokenMint,
           tokenDecimals: direct.tokenDecimals,
           receivedUnits: verification.receivedUnits.toString(),
+          sweepTo: cfg.secureAddress,
         });
         return {
           payment,
@@ -1879,8 +2010,10 @@ export class DirectWalletPaymentsService {
         network: direct.network,
         tokenKind: direct.tokenKind,
         tokenAddress: direct.tokenAddress,
+        tokenMint: direct.tokenMint,
         tokenDecimals: direct.tokenDecimals,
         receivedUnits: verification.receivedUnits.toString(),
+        sweepTo: cfg.secureAddress,
       });
 
       const [confirmed] = await tx
@@ -1969,45 +2102,79 @@ export class DirectWalletPaymentsService {
       const cfg = directPaymentConfig(env, payload.network);
       requireConfigured(cfg);
       const units = BigInt(payload.receivedUnits);
-      const prepared: PreparedSweep | null =
-        claimed.prepared_transaction && claimed.sweep_transaction_hash && cfg.secureAddress
-          ? {
-              rawTransaction: claimed.prepared_transaction,
-              transactionHash: claimed.sweep_transaction_hash,
-              sweepTo: cfg.secureAddress,
-            }
-          : payload.network === "solana"
-            ? await prepareSolanaSweep({ env, cfg, units })
-            : await prepareEvmSweep({
-                env,
-                cfg,
-                tokenAddress: payload.tokenAddress,
-                tokenDecimals: payload.tokenDecimals,
-                units,
-              });
-      if (prepared && !claimed.prepared_transaction) {
+      let prepared = preparedSweepFromRow(claimed);
+      if (
+        prepared &&
+        (prepared.metadata.network !== payload.network ||
+          prepared.metadata.sweepTo !== payload.sweepTo)
+      ) {
+        throw new Error("Prepared crypto sweep does not match the immutable intent");
+      }
+      const prepare = async (): Promise<PreparedSweep | null> => {
+        if (!payload.sweepTo) return null;
+        if (payload.network === "solana") {
+          if (!payload.tokenMint) throw new Error("Solana sweep intent is missing its token mint");
+          return prepareSolanaSweep({
+            env,
+            cfg,
+            units,
+            sweepTo: payload.sweepTo,
+            tokenMint: payload.tokenMint,
+            tokenDecimals: payload.tokenDecimals,
+          });
+        }
+        return prepareEvmSweep({
+          env,
+          cfg,
+          tokenAddress: payload.tokenAddress,
+          tokenDecimals: payload.tokenDecimals,
+          units,
+          sweepTo: payload.sweepTo,
+        });
+      };
+      const persistPrepared = async (
+        next: PreparedSweep,
+        previousHash: string | null,
+      ): Promise<void> => {
         const [persisted] = await dbWrite
           .update(cryptoSweepOutbox)
           .set({
-            prepared_transaction: prepared.rawTransaction,
-            sweep_transaction_hash: prepared.transactionHash,
+            prepared_transaction: next.rawTransaction,
+            sweep_transaction_hash: next.transactionHash,
+            prepared_metadata: next.metadata,
             updated_at: new Date(),
           })
           .where(
             and(
               eq(cryptoSweepOutbox.id, claimed.id),
               eq(cryptoSweepOutbox.claim_token, claimToken),
-              sql`${cryptoSweepOutbox.prepared_transaction} IS NULL`,
+              previousHash === null
+                ? sql`${cryptoSweepOutbox.sweep_transaction_hash} IS NULL`
+                : eq(cryptoSweepOutbox.sweep_transaction_hash, previousHash),
             ),
           )
           .returning({ id: cryptoSweepOutbox.id });
         if (!persisted) {
           throw new Error("Crypto sweep lease was lost before transaction preparation");
         }
+      };
+      if (!prepared) {
+        prepared = await prepare();
+        if (prepared) await persistPrepared(prepared, null);
       }
       if (prepared) {
         if (payload.network === "solana") {
-          await submitPreparedSolanaSweep(cfg, prepared);
+          const outcome = await submitPreparedSolanaSweep(cfg, prepared);
+          if (outcome === "reprepare") {
+            const expiredHash = prepared.transactionHash;
+            const replacement = await prepare();
+            if (!replacement) throw new Error("Solana sweep replacement could not be prepared");
+            await persistPrepared(replacement, expiredHash);
+            prepared = replacement;
+            if ((await submitPreparedSolanaSweep(cfg, prepared)) === "reprepare") {
+              throw new Error("New Solana sweep blockhash expired before submission");
+            }
+          }
         } else {
           await submitPreparedEvmSweep(cfg, prepared);
         }
@@ -2047,7 +2214,7 @@ export class DirectWalletPaymentsService {
               sweep: prepared
                 ? {
                     sweep_transaction_hash: prepared.transactionHash,
-                    sweep_to: prepared.sweepTo,
+                    sweep_to: prepared.metadata.sweepTo,
                   }
                 : { state: "not_configured" },
               sweep_completed_at: completedAt.toISOString(),

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -14,7 +14,7 @@ import {
 } from "@solana/web3.js";
 import bs58 from "bs58";
 import Decimal from "decimal.js";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, lte, or, sql } from "drizzle-orm";
 import {
   createPublicClient,
   createWalletClient,
@@ -29,7 +29,7 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base, bsc } from "viem/chains";
-import { dbWrite } from "../../db/client";
+import { type DbTransaction, dbWrite } from "../../db/client";
 import {
   canonicalizeCryptoTransactionHash,
   cryptoTransactionHashesEqual,
@@ -37,6 +37,7 @@ import {
 } from "../../db/crypto-payment-transaction-hash";
 import type { CryptoPayment } from "../../db/repositories/crypto-payments";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
+import { cryptoSweepOutbox } from "../../db/schemas/crypto-settlement-outbox";
 import type { Bindings } from "../../types/cloud-worker-env";
 import { ValidationError } from "../api/cloud-worker-errors";
 import { PAYMENT_EXPIRATION_MS, validatePaymentAmount } from "../config/crypto";
@@ -54,6 +55,7 @@ import {
   verifyDirectWalletPayerProof,
 } from "./direct-wallet-payer-proof";
 import { invoicesService } from "./invoices";
+import { settlementDigest } from "./settlement-digest";
 
 export type DirectWalletNetwork = "base" | "bsc" | "solana";
 
@@ -477,6 +479,7 @@ function publicDirectPaymentConfig(
   try {
     return directPaymentConfig(env, network);
   } catch (error) {
+    // error-policy:J4 public configuration exposes this network as disabled.
     return disabledDirectPaymentConfig(network, error);
   }
 }
@@ -999,7 +1002,7 @@ async function sweepEvmIfConfigured(params: {
   tokenAddress: Hex | null;
   tokenDecimals: number;
   units: bigint;
-}): Promise<Record<string, unknown> | null> {
+}): Promise<{ sweep_transaction_hash: string; sweep_to: string } | null> {
   if (!params.tokenAddress || !params.cfg.secureAddress) return null;
   const privateKey = evmPrivateKey(params.env, params.cfg.network);
   if (!privateKey) return null;
@@ -1040,7 +1043,7 @@ async function sweepSolanaIfConfigured(params: {
   env: Bindings;
   cfg: DirectWalletNetworkConfig;
   units: bigint;
-}): Promise<Record<string, unknown> | null> {
+}): Promise<{ sweep_transaction_hash: string; sweep_to: string } | null> {
   if (!params.cfg.tokenMint || !params.cfg.secureAddress) return null;
   const payer = solanaKeypairFromEnv(params.env);
   if (!payer) return null;
@@ -1075,6 +1078,109 @@ async function sweepSolanaIfConfigured(params: {
     commitment: "confirmed",
   });
   return { sweep_transaction_hash: hash, sweep_to: params.cfg.secureAddress };
+}
+
+interface DirectSweepPayload {
+  paymentId: string;
+  network: DirectWalletNetwork;
+  tokenKind: DirectWalletTokenKind;
+  tokenAddress: Hex | null;
+  tokenDecimals: number;
+  receivedUnits: string;
+}
+
+function directSweepPayload(value: unknown): DirectSweepPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Crypto sweep outbox payload is not an object");
+  }
+  const payload = value as Record<string, unknown>;
+  if (
+    typeof payload.paymentId !== "string" ||
+    (payload.network !== "base" && payload.network !== "bsc" && payload.network !== "solana") ||
+    (payload.tokenKind !== "native" &&
+      payload.tokenKind !== "bep20" &&
+      payload.tokenKind !== "erc20" &&
+      payload.tokenKind !== "spl") ||
+    (payload.tokenAddress !== null && typeof payload.tokenAddress !== "string") ||
+    typeof payload.tokenDecimals !== "number" ||
+    !Number.isInteger(payload.tokenDecimals) ||
+    typeof payload.receivedUnits !== "string" ||
+    !/^\d+$/.test(payload.receivedUnits)
+  ) {
+    throw new Error("Crypto sweep outbox payload is malformed");
+  }
+  return payload as unknown as DirectSweepPayload;
+}
+
+function directPaymentSettlementDigest(payment: CryptoPayment): string {
+  const direct = directMetadata(payment);
+  return settlementDigest({
+    id: payment.id,
+    organizationId: payment.organization_id,
+    userId: payment.user_id,
+    expectedAmount: payment.expected_amount,
+    creditsToAdd: payment.credits_to_add,
+    expiresAt: payment.expires_at,
+    network: direct.network,
+    tokenKind: direct.tokenKind,
+    tokenAddress: direct.tokenAddress,
+    tokenMint: direct.tokenMint,
+    tokenDecimals: direct.tokenDecimals,
+    expectedTokenUnits: direct.expectedTokenUnits.toString(),
+    payerAddress: direct.payerAddress,
+    quoteSignature: direct.metadata.quote_signature,
+  });
+}
+
+async function enqueueDirectSweep(
+  transaction: DbTransaction,
+  payload: DirectSweepPayload,
+): Promise<void> {
+  if (payload.tokenKind === "native") return;
+  const digest = settlementDigest(payload);
+  const [inserted] = await transaction
+    .insert(cryptoSweepOutbox)
+    .values({ payment_id: payload.paymentId, payload: { ...payload }, payload_digest: digest })
+    .onConflictDoNothing({ target: cryptoSweepOutbox.payment_id })
+    .returning();
+  if (inserted) return;
+  const [existing] = await transaction
+    .select()
+    .from(cryptoSweepOutbox)
+    .where(eq(cryptoSweepOutbox.payment_id, payload.paymentId))
+    .limit(1);
+  if (!existing || existing.payload_digest !== digest) {
+    throw new Error("Crypto sweep replay does not match the committed sweep intent");
+  }
+}
+
+function directInvoiceSettlement(
+  payment: CryptoPayment,
+  direct: ReturnType<typeof directMetadata>,
+  transactionHash: string,
+) {
+  const amountPaid = new Decimal(payment.expected_amount).toDecimalPlaces(2).toFixed(2);
+  const creditsAdded = new Decimal(payment.credits_to_add).toDecimalPlaces(2).toFixed(2);
+  return {
+    organization_id: payment.organization_id,
+    stripe_invoice_id: createCryptoInvoiceId(payment.id),
+    stripe_customer_id: createCryptoCustomerId(payment.organization_id),
+    stripe_payment_intent_id: transactionHash,
+    amount_due: amountPaid,
+    amount_paid: amountPaid,
+    currency: "usd",
+    status: "paid",
+    invoice_type: "crypto_payment",
+    credits_added: creditsAdded,
+    metadata: {
+      payment_method: "crypto",
+      provider: "wallet_native",
+      network: direct.network,
+      token: direct.tokenSymbol,
+      transaction_hash: transactionHash,
+      bonus_credits: direct.bonusCredits,
+    },
+  } as const;
 }
 
 export class DirectWalletPaymentsService {
@@ -1375,7 +1481,7 @@ export class DirectWalletPaymentsService {
             : eq(cryptoPayments.transaction_hash, canonicalTxHash),
         )
         .for("update");
-      if (existingTx.length > 0 && existingTx[0].id !== payment.id) {
+      if (existingTx.some((candidate) => candidate.id !== payment.id)) {
         throw new Error("Transaction already attached to another payment");
       }
 
@@ -1463,6 +1569,113 @@ export class DirectWalletPaymentsService {
       payerSignature?: string;
     },
   ) {
+    const [observedPayment] = await dbWrite
+      .select()
+      .from(cryptoPayments)
+      .where(eq(cryptoPayments.id, params.paymentId))
+      .limit(1);
+    if (!observedPayment) throw new Error("Payment not found");
+    if (observedPayment.user_id !== params.userId) throw new Error("Unauthorized");
+    const observedDirect = directMetadata(observedPayment);
+    const observedConfig = directPaymentConfig(env, observedDirect.network);
+    const canonicalTxHash = canonicalizeCryptoTransactionHash(
+      params.txHash,
+      observedDirect.network,
+    );
+    requireConfigured(observedConfig);
+
+    let payerProofPatch: Record<string, unknown> | null = null;
+    let verification: { blockNumber: string; receivedUnits: bigint };
+    if (observedPayment.status === "confirmed") {
+      if (
+        !cryptoTransactionHashesEqual(
+          observedPayment.transaction_hash,
+          canonicalTxHash,
+          observedDirect.network,
+        )
+      ) {
+        throw new Error("Payment confirmation replay does not match the committed transaction");
+      }
+      const receivedUnits = metadataOf(observedPayment).received_token_units;
+      if (typeof receivedUnits !== "string" || !/^\d+$/.test(receivedUnits)) {
+        throw new Error("Confirmed payment is missing its verified token units");
+      }
+      verification = {
+        blockNumber: observedPayment.block_number ?? "",
+        receivedUnits: BigInt(receivedUnits),
+      };
+    } else {
+      if (observedPayment.status !== "pending" && observedPayment.status !== "broadcast") {
+        throw new Error(`Payment is ${observedPayment.status}`);
+      }
+      if (observedPayment.expires_at < new Date() && !params.allowExpired) {
+        throw new Error("Payment has expired");
+      }
+      if (
+        observedPayment.transaction_hash &&
+        !cryptoTransactionHashesEqual(
+          observedPayment.transaction_hash,
+          canonicalTxHash,
+          observedDirect.network,
+        )
+      ) {
+        throw new Error("Payment already has a different transaction hash attached");
+      }
+      const persistedSig = observedDirect.metadata.quote_signature;
+      if (typeof persistedSig !== "string" || persistedSig.length === 0) {
+        throw new Error("Quote signature missing — payment may have been tampered with.");
+      }
+      const sigOk = await verifyQuoteSignature(
+        env,
+        {
+          paymentId: observedPayment.id,
+          expectedTokenUnits: observedDirect.expectedTokenUnits,
+          receiveAddress: String(observedDirect.metadata.receive_address ?? ""),
+          chainId: observedConfig.chainId ?? null,
+          tokenAddress: observedDirect.tokenAddress,
+          tokenMint: observedDirect.tokenMint,
+          expiresAt: observedPayment.expires_at,
+        },
+        persistedSig,
+      );
+      if (!sigOk)
+        throw new Error("Quote signature mismatch — payment may have been tampered with.");
+
+      payerProofPatch = await verifyPayerProofOrThrow({
+        paymentId: observedPayment.id,
+        direct: observedDirect,
+        signature: params.payerSignature,
+        cfg: observedConfig,
+      });
+      if (observedDirect.network === "solana") {
+        verification = await verifySolanaTokenPayment({
+          cfg: observedConfig,
+          payerAddress: observedDirect.payerAddress,
+          txHash: canonicalTxHash,
+          expectedUnits: observedDirect.expectedTokenUnits,
+        });
+      } else if (observedDirect.tokenKind === "native") {
+        verification = await verifyEvmNativePayment({
+          cfg: observedConfig,
+          payerAddress: observedDirect.payerAddress,
+          txHash: canonicalTxHash,
+          expectedUnits: observedDirect.expectedTokenUnits,
+          slippageBps: observedDirect.slippageBps,
+        });
+      } else {
+        if (!observedDirect.tokenAddress)
+          throw new Error("Payment metadata is missing token address");
+        verification = await verifyEvmTokenPayment({
+          cfg: observedConfig,
+          tokenAddress: observedDirect.tokenAddress,
+          payerAddress: observedDirect.payerAddress,
+          txHash: canonicalTxHash,
+          expectedUnits: observedDirect.expectedTokenUnits,
+        });
+      }
+    }
+    const observedDigest = directPaymentSettlementDigest(observedPayment);
+
     const result = await dbWrite.transaction(async (tx) => {
       const [payment] = await tx
         .select()
@@ -1475,12 +1688,21 @@ export class DirectWalletPaymentsService {
       if (payment.status === "confirmed") {
         const direct = directMetadata(payment);
         const cfg = directPaymentConfig(env, direct.network);
-        const canonicalTxHash = canonicalizeCryptoTransactionHash(params.txHash, direct.network);
         if (
           !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash, direct.network)
         ) {
           throw new Error("Payment confirmation replay does not match the committed transaction");
         }
+        const invoiceSettlement = directInvoiceSettlement(payment, direct, canonicalTxHash);
+        await invoicesService.create(invoiceSettlement, tx);
+        await enqueueDirectSweep(tx, {
+          paymentId: payment.id,
+          network: direct.network,
+          tokenKind: direct.tokenKind,
+          tokenAddress: direct.tokenAddress,
+          tokenDecimals: direct.tokenDecimals,
+          receivedUnits: verification.receivedUnits.toString(),
+        });
         return {
           payment,
           alreadyConfirmed: true,
@@ -1489,7 +1711,7 @@ export class DirectWalletPaymentsService {
           cfg,
           amountPaid: payment.expected_amount,
           creditsToAdd: payment.credits_to_add,
-          sweep: metadataOf(payment).sweep,
+          sweep: metadataOf(payment).sweep ?? { state: "pending" },
         };
       }
       if (payment.status !== "pending" && payment.status !== "broadcast") {
@@ -1504,40 +1726,16 @@ export class DirectWalletPaymentsService {
 
       const direct = directMetadata(payment);
       const cfg = directPaymentConfig(env, direct.network);
-      const canonicalTxHash = canonicalizeCryptoTransactionHash(params.txHash, direct.network);
       requireConfigured(cfg);
-
-      // Verify the HMAC-signed quote BEFORE the on-chain verify. This
-      // short-circuits a tampered client that swapped expectedTokenUnits or
-      // the receive address between createPayment and confirm, so we can
-      // reject before the user's wallet popup hits the chain.
-      const persistedSig = direct.metadata.quote_signature;
-      if (typeof persistedSig !== "string" || persistedSig.length === 0) {
-        throw new Error("Quote signature missing — payment may have been tampered with.");
+      if (directPaymentSettlementDigest(payment) !== observedDigest) {
+        throw new Error("Payment quote changed while on-chain verification was in progress");
       }
-      const sigOk = await verifyQuoteSignature(
-        env,
-        {
-          paymentId: payment.id,
-          expectedTokenUnits: direct.expectedTokenUnits,
-          receiveAddress: String(direct.metadata.receive_address ?? ""),
-          chainId: cfg.chainId ?? null,
-          tokenAddress: direct.tokenAddress,
-          tokenMint: direct.tokenMint,
-          expiresAt: payment.expires_at,
-        },
-        persistedSig,
-      );
-      if (!sigOk) {
-        throw new Error("Quote signature mismatch — payment may have been tampered with.");
+      if (
+        payment.transaction_hash &&
+        !cryptoTransactionHashesEqual(payment.transaction_hash, canonicalTxHash, direct.network)
+      ) {
+        throw new Error("Payment already has a different transaction hash attached");
       }
-
-      const payerProofPatch = await verifyPayerProofOrThrow({
-        paymentId: payment.id,
-        direct,
-        signature: params.payerSignature,
-        cfg,
-      });
 
       const existingTx = await tx
         .select()
@@ -1548,59 +1746,13 @@ export class DirectWalletPaymentsService {
             : eq(cryptoPayments.transaction_hash, canonicalTxHash),
         )
         .for("update");
-      if (existingTx.length > 0 && existingTx[0].id !== payment.id) {
+      if (existingTx.some((candidate) => candidate.id !== payment.id)) {
         throw new Error("Transaction already processed for another payment");
-      }
-
-      let verification: { blockNumber: string; receivedUnits: bigint };
-      if (direct.network === "solana") {
-        verification = await verifySolanaTokenPayment({
-          cfg,
-          payerAddress: direct.payerAddress,
-          txHash: canonicalTxHash,
-          expectedUnits: direct.expectedTokenUnits,
-        });
-      } else if (direct.tokenKind === "native") {
-        verification = await verifyEvmNativePayment({
-          cfg,
-          payerAddress: direct.payerAddress,
-          txHash: canonicalTxHash,
-          expectedUnits: direct.expectedTokenUnits,
-          slippageBps: direct.slippageBps,
-        });
-      } else {
-        if (!direct.tokenAddress) {
-          throw new Error("Payment metadata is missing token address");
-        }
-        verification = await verifyEvmTokenPayment({
-          cfg,
-          tokenAddress: direct.tokenAddress,
-          payerAddress: direct.payerAddress,
-          txHash: canonicalTxHash,
-          expectedUnits: direct.expectedTokenUnits,
-        });
       }
 
       const amountPaid = new Decimal(payment.expected_amount);
       const creditsToAdd = new Decimal(payment.credits_to_add);
       const confirmedAt = new Date();
-      const sweep =
-        direct.network === "solana"
-          ? await sweepSolanaIfConfigured({ env, cfg, units: verification.receivedUnits }).catch(
-              (error) => ({ sweep_error: error instanceof Error ? error.message : String(error) }),
-            )
-          : direct.tokenKind === "native"
-            ? null
-            : await sweepEvmIfConfigured({
-                env,
-                cfg,
-                tokenAddress: direct.tokenAddress,
-                tokenDecimals: direct.tokenDecimals,
-                units: verification.receivedUnits,
-              }).catch((error) => ({
-                sweep_error: error instanceof Error ? error.message : String(error),
-              }));
-
       await tx
         .update(cryptoPayments)
         .set({
@@ -1615,7 +1767,7 @@ export class DirectWalletPaymentsService {
             ...(payerProofPatch ?? {}),
             confirmed_at: confirmedAt.toISOString(),
             received_token_units: verification.receivedUnits.toString(),
-            sweep,
+            sweep: { state: direct.tokenKind === "native" ? "not_required" : "pending" },
           },
         })
         .where(eq(cryptoPayments.id, payment.id));
@@ -1630,7 +1782,7 @@ export class DirectWalletPaymentsService {
       // dedupe in addCredits (ON CONFLICT on stripe_payment_intent_id).
       await creditsService.addCredits({
         organizationId: payment.organization_id,
-        amount: Number(creditsToAdd.toFixed(2)),
+        amount: creditsToAdd.toFixed(2),
         description:
           direct.bonusCredits > 0
             ? `Direct crypto payment (${direct.tokenSymbol} on ${cfg.displayName}) + BSC promotion`
@@ -1651,6 +1803,17 @@ export class DirectWalletPaymentsService {
         },
       });
 
+      const invoiceSettlement = directInvoiceSettlement(payment, direct, canonicalTxHash);
+      await invoicesService.create(invoiceSettlement, tx);
+      await enqueueDirectSweep(tx, {
+        paymentId: payment.id,
+        network: direct.network,
+        tokenKind: direct.tokenKind,
+        tokenAddress: direct.tokenAddress,
+        tokenDecimals: direct.tokenDecimals,
+        receivedUnits: verification.receivedUnits.toString(),
+      });
+
       const [confirmed] = await tx
         .select()
         .from(cryptoPayments)
@@ -1663,36 +1826,21 @@ export class DirectWalletPaymentsService {
         cfg,
         amountPaid: amountPaid.toFixed(2),
         creditsToAdd: creditsToAdd.toFixed(2),
-        sweep,
+        sweep: { state: direct.tokenKind === "native" ? "not_required" : "pending" },
       };
     });
 
-    const { direct, amountPaid, creditsToAdd, sweep } = result;
-
-    const invoiceId = createCryptoInvoiceId(result.payment.id);
-    const existingInvoice = await invoicesService.getByStripeInvoiceId(invoiceId);
-    if (!existingInvoice) {
-      await invoicesService.create({
-        organization_id: result.payment.organization_id,
-        stripe_invoice_id: invoiceId,
-        stripe_customer_id: createCryptoCustomerId(result.payment.organization_id),
-        stripe_payment_intent_id: result.transactionHash,
-        amount_due: amountPaid,
-        amount_paid: amountPaid,
-        currency: "usd",
-        status: "paid",
-        invoice_type: "crypto_payment",
-        credits_added: creditsToAdd,
-        metadata: {
-          payment_method: "crypto",
-          provider: "wallet_native",
-          network: direct.network,
-          token: direct.tokenSymbol,
-          transaction_hash: result.transactionHash,
-          bonus_credits: direct.bonusCredits,
-          sweep,
-        },
-      });
+    if (result.direct.tokenKind !== "native") {
+      try {
+        await this.processSweepForPayment(env, result.payment.id);
+      } catch (error) {
+        // error-policy:J4 settlement is durable and explicitly reports a
+        // pending sweep; the active cron dispatcher retries the outbox row.
+        logger.warn("[DirectWalletPayments] Post-settlement sweep deferred", {
+          paymentId: redact.paymentId(result.payment.id),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     logger.info("[DirectWalletPayments] Payment confirmed", {
@@ -1701,6 +1849,167 @@ export class DirectWalletPaymentsService {
     });
 
     return result;
+  }
+
+  private async processSweepForPayment(
+    env: Bindings,
+    paymentId: string,
+    hooks?: { afterExternalSweep?: () => Promise<void> },
+  ): Promise<boolean> {
+    const claimToken = crypto.randomUUID();
+    const now = new Date();
+    const claimed = await dbWrite.transaction(async (tx) => {
+      const [candidate] = await tx
+        .select()
+        .from(cryptoSweepOutbox)
+        .where(eq(cryptoSweepOutbox.payment_id, paymentId))
+        .for("update")
+        .limit(1);
+      if (!candidate || candidate.state === "delivered" || candidate.state === "terminal") {
+        return null;
+      }
+      if (
+        candidate.state === "processing" &&
+        candidate.lease_expires_at &&
+        candidate.lease_expires_at > now
+      ) {
+        return null;
+      }
+      if (candidate.next_attempt_at > now) return null;
+      const [row] = await tx
+        .update(cryptoSweepOutbox)
+        .set({
+          state: "processing",
+          claim_token: claimToken,
+          lease_expires_at: new Date(now.getTime() + 120_000),
+          attempts: candidate.attempts + 1,
+          updated_at: now,
+        })
+        .where(eq(cryptoSweepOutbox.id, candidate.id))
+        .returning();
+      return row ?? null;
+    });
+    if (!claimed) return false;
+
+    let externalSweepReturned = false;
+    try {
+      const payload = directSweepPayload(claimed.payload);
+      if (settlementDigest(payload) !== claimed.payload_digest) {
+        throw new Error("Crypto sweep outbox payload digest mismatch");
+      }
+      const cfg = directPaymentConfig(env, payload.network);
+      requireConfigured(cfg);
+      const units = BigInt(payload.receivedUnits);
+      const sweep: { sweep_transaction_hash: string; sweep_to: string } | null =
+        payload.network === "solana"
+          ? await sweepSolanaIfConfigured({ env, cfg, units })
+          : await sweepEvmIfConfigured({
+              env,
+              cfg,
+              tokenAddress: payload.tokenAddress,
+              tokenDecimals: payload.tokenDecimals,
+              units,
+            });
+      externalSweepReturned = true;
+      const completedAt = new Date();
+      await hooks?.afterExternalSweep?.();
+      await dbWrite.transaction(async (tx) => {
+        const [owned] = await tx
+          .select()
+          .from(cryptoSweepOutbox)
+          .where(
+            and(
+              eq(cryptoSweepOutbox.id, claimed.id),
+              eq(cryptoSweepOutbox.claim_token, claimToken),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (!owned) throw new Error("Crypto sweep lease was lost before acknowledgement");
+        await tx
+          .update(cryptoSweepOutbox)
+          .set({
+            state: "delivered",
+            delivered_at: completedAt,
+            sweep_transaction_hash: sweep?.sweep_transaction_hash ?? null,
+            claim_token: null,
+            lease_expires_at: null,
+            last_error: null,
+            updated_at: completedAt,
+          })
+          .where(eq(cryptoSweepOutbox.id, claimed.id));
+        await tx
+          .update(cryptoPayments)
+          .set({
+            metadata: sql`COALESCE(${cryptoPayments.metadata}, '{}'::jsonb) || ${JSON.stringify({
+              sweep: sweep ?? { state: "not_configured" },
+              sweep_completed_at: completedAt.toISOString(),
+            })}::jsonb`,
+            updated_at: completedAt,
+          })
+          .where(eq(cryptoPayments.id, paymentId));
+      });
+      return true;
+    } catch (error) {
+      // error-policy:J4 the outbox retains the failure and bounded retry state;
+      // the payment and credit settlement remain committed and observable.
+      // Once the provider returned a submission result, an acknowledgement
+      // failure is outcome-unknown. Never submit again automatically: doing so
+      // could sweep a later deposit with the same balance-based transfer.
+      const terminal = externalSweepReturned || claimed.attempts >= 12;
+      await dbWrite
+        .update(cryptoSweepOutbox)
+        .set({
+          state: terminal ? "terminal" : "pending",
+          terminal_at: terminal ? new Date() : null,
+          next_attempt_at: new Date(
+            Date.now() + Math.min(3_600_000, 2 ** claimed.attempts * 1_000),
+          ),
+          claim_token: null,
+          lease_expires_at: null,
+          last_error: error instanceof Error ? error.message : String(error),
+          updated_at: new Date(),
+        })
+        .where(
+          and(eq(cryptoSweepOutbox.id, claimed.id), eq(cryptoSweepOutbox.claim_token, claimToken)),
+        );
+      throw error;
+    }
+  }
+
+  async drainSweepOutbox(
+    env: Bindings,
+    limit = 25,
+    hooks?: { afterExternalSweep?: () => Promise<void> },
+  ): Promise<{ processed: number; delivered: number; deferred: number }> {
+    const due = await dbWrite
+      .select({ paymentId: cryptoSweepOutbox.payment_id })
+      .from(cryptoSweepOutbox)
+      .where(
+        and(
+          lte(cryptoSweepOutbox.next_attempt_at, new Date()),
+          or(
+            eq(cryptoSweepOutbox.state, "pending"),
+            and(
+              eq(cryptoSweepOutbox.state, "processing"),
+              lte(cryptoSweepOutbox.lease_expires_at, new Date()),
+            ),
+          ),
+        ),
+      )
+      .orderBy(cryptoSweepOutbox.next_attempt_at, cryptoSweepOutbox.created_at)
+      .limit(limit);
+    const stats = { processed: 0, delivered: 0, deferred: 0 };
+    for (const row of due) {
+      stats.processed += 1;
+      try {
+        if (await this.processSweepForPayment(env, row.paymentId, hooks)) stats.delivered += 1;
+      } catch {
+        // error-policy:J4 processSweepForPayment persisted retry/terminal state.
+        stats.deferred += 1;
+      }
+    }
+    return stats;
   }
 
   /**
@@ -1800,13 +2109,7 @@ export class DirectWalletPaymentsService {
                 last_verify_at: new Date().toISOString(),
               })}::jsonb`,
             })
-            .where(eq(cryptoPayments.id, payment.id))
-            .catch((e) => {
-              logger.warn("[DirectWalletPayments] failed to bump verify_attempts", {
-                paymentId: redact.paymentId(payment.id),
-                error: String(e),
-              });
-            });
+            .where(eq(cryptoPayments.id, payment.id));
 
         if (!terminal && attempts < MAX_VERIFY_ATTEMPTS) {
           stats.stillPending += 1;

--- a/packages/cloud/shared/src/lib/services/invoices.ts
+++ b/packages/cloud/shared/src/lib/services/invoices.ts
@@ -7,6 +7,25 @@ import { desc, eq } from "drizzle-orm";
 import { type DbTransaction, dbRead, dbWrite } from "../../db/client";
 import { type Invoice, invoices, type NewInvoice } from "../../db/schemas";
 import { logger } from "../utils/logger";
+import { settlementDigest } from "./settlement-digest";
+
+function invoiceSettlementContract(data: NewInvoice | Invoice): Record<string, unknown> {
+  const metadata = { ...((data.metadata as Record<string, unknown> | null) ?? {}) };
+  delete metadata.settlement_digest;
+  return {
+    organization_id: data.organization_id,
+    stripe_invoice_id: data.stripe_invoice_id,
+    stripe_customer_id: data.stripe_customer_id,
+    stripe_payment_intent_id: data.stripe_payment_intent_id ?? null,
+    amount_due: new Decimal(data.amount_due).toFixed(),
+    amount_paid: new Decimal(data.amount_paid).toFixed(),
+    currency: data.currency ?? "usd",
+    status: data.status,
+    invoice_type: data.invoice_type,
+    credits_added: data.credits_added == null ? null : new Decimal(data.credits_added).toFixed(),
+    metadata,
+  };
+}
 
 /**
  * Service for invoice CRUD operations.
@@ -14,10 +33,18 @@ import { logger } from "../utils/logger";
 class InvoicesService {
   async create(data: NewInvoice, transaction?: DbTransaction): Promise<Invoice> {
     const executor = transaction ?? dbWrite;
+    const digest = settlementDigest(invoiceSettlementContract(data));
+    const dataWithDigest: NewInvoice = {
+      ...data,
+      metadata: {
+        ...((data.metadata as Record<string, unknown> | null) ?? {}),
+        settlement_digest: digest,
+      },
+    };
     const [created] = await executor
       .insert(invoices)
       .values({
-        ...data,
+        ...dataWithDigest,
         created_at: new Date(),
         updated_at: new Date(),
       })
@@ -35,23 +62,9 @@ class InvoicesService {
     if (!invoice) {
       throw new Error("Invoice replay could not recover the committed invoice");
     }
-    const creditsMatch =
-      invoice.credits_added === null && data.credits_added == null
-        ? true
-        : invoice.credits_added !== null && data.credits_added != null
-          ? new Decimal(invoice.credits_added).equals(data.credits_added)
-          : false;
-    if (
-      invoice.organization_id !== data.organization_id ||
-      invoice.stripe_customer_id !== data.stripe_customer_id ||
-      invoice.stripe_payment_intent_id !== (data.stripe_payment_intent_id ?? null) ||
-      !new Decimal(invoice.amount_due).equals(data.amount_due) ||
-      !new Decimal(invoice.amount_paid).equals(data.amount_paid) ||
-      invoice.currency !== (data.currency ?? "usd") ||
-      invoice.status !== data.status ||
-      invoice.invoice_type !== data.invoice_type ||
-      !creditsMatch
-    ) {
+    const storedDigest = settlementDigest(invoiceSettlementContract(invoice));
+    const storedMetadata = (invoice.metadata as Record<string, unknown> | null) ?? {};
+    if (storedDigest !== digest || storedMetadata.settlement_digest !== digest) {
       throw new Error("Invoice idempotency replay does not match the original settlement");
     }
 

--- a/packages/cloud/shared/src/lib/services/invoices.ts
+++ b/packages/cloud/shared/src/lib/services/invoices.ts
@@ -2,8 +2,9 @@
  * Service for managing invoices from Stripe payments.
  */
 
+import Decimal from "decimal.js";
 import { desc, eq } from "drizzle-orm";
-import { dbRead, dbWrite } from "../../db/client";
+import { type DbTransaction, dbRead, dbWrite } from "../../db/client";
 import { type Invoice, invoices, type NewInvoice } from "../../db/schemas";
 import { logger } from "../utils/logger";
 
@@ -11,15 +12,48 @@ import { logger } from "../utils/logger";
  * Service for invoice CRUD operations.
  */
 class InvoicesService {
-  async create(data: NewInvoice): Promise<Invoice> {
-    const [invoice] = await dbWrite
+  async create(data: NewInvoice, transaction?: DbTransaction): Promise<Invoice> {
+    const executor = transaction ?? dbWrite;
+    const [created] = await executor
       .insert(invoices)
       .values({
         ...data,
         created_at: new Date(),
         updated_at: new Date(),
       })
+      .onConflictDoNothing({ target: invoices.stripe_invoice_id })
       .returning();
+    const invoice =
+      created ??
+      (
+        await executor
+          .select()
+          .from(invoices)
+          .where(eq(invoices.stripe_invoice_id, data.stripe_invoice_id))
+          .limit(1)
+      )[0];
+    if (!invoice) {
+      throw new Error("Invoice replay could not recover the committed invoice");
+    }
+    const creditsMatch =
+      invoice.credits_added === null && data.credits_added == null
+        ? true
+        : invoice.credits_added !== null && data.credits_added != null
+          ? new Decimal(invoice.credits_added).equals(data.credits_added)
+          : false;
+    if (
+      invoice.organization_id !== data.organization_id ||
+      invoice.stripe_customer_id !== data.stripe_customer_id ||
+      invoice.stripe_payment_intent_id !== (data.stripe_payment_intent_id ?? null) ||
+      !new Decimal(invoice.amount_due).equals(data.amount_due) ||
+      !new Decimal(invoice.amount_paid).equals(data.amount_paid) ||
+      invoice.currency !== (data.currency ?? "usd") ||
+      invoice.status !== data.status ||
+      invoice.invoice_type !== data.invoice_type ||
+      !creditsMatch
+    ) {
+      throw new Error("Invoice idempotency replay does not match the original settlement");
+    }
 
     logger.info("invoices-service", "Invoice created", {
       invoiceId: invoice.id,

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -66,6 +66,16 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
     expect(status.transactions[0].nativeAmount).toBe("0.000000010000000001");
   });
 
+  test("rejects an inquiry response for a different provider track ID", async () => {
+    stubInquiryResponse({ trackId: "trk_other" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toThrow(/track ID/i);
+  });
+
+  test("rejects a missing invoice currency", async () => {
+    stubInquiryResponse({ currency: "" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toThrow(/invoice currency/i);
+  });
+
   test("missing amount throws OxaPayApiError instead of crediting $0", async () => {
     stubInquiryResponse({ amount: undefined });
     await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -1,14 +1,4 @@
-/**
- * Fail-closed invoice-amount parsing in oxaPayService.getPaymentStatus (#13415).
- *
- * The inquiry response's `amount` string is the USD value the caller credits on
- * a confirmed payment (crypto-payments confirmPayment). The old
- * `Number.parseFloat(data.amount) || 0` coercion turned a malformed or missing
- * amount into $0, letting a CONFIRMED payment settle while crediting nothing.
- * These tests pin the strict behavior: non-finite/non-positive invoice amounts
- * throw OxaPayApiError; the audit-only native pay amount degrades to undefined
- * without failing the inquiry.
- */
+/** Pins exact decimal request and fail-closed inquiry contracts at the OxaPay boundary. */
 
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { OxaPayApiError, oxaPayService } from "./oxapay";
@@ -131,5 +121,28 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
     const status = await oxaPayService.getPaymentStatus("trk_1");
     expect(status.amount).toBe("25");
     expect(status.transactions[0].nativeAmount).toBeUndefined();
+  });
+});
+
+describe("oxaPayService.createInvoice — exact decimal request", () => {
+  test("sends and returns the caller's exact decimal without Number conversion", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          result: 100,
+          trackId: "trk_exact",
+          payLink: "https://pay.example.test/trk_exact",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const amount = "10.123456789012345678";
+    const invoice = await oxaPayService.createInvoice({ amount });
+
+    expect(requestBody?.amount).toBe(amount);
+    expect(invoice.amount).toBe(amount);
   });
 });

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -47,11 +47,23 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
   test("valid positive amount resolves and is credited verbatim", async () => {
     stubInquiryResponse({});
     const status = await oxaPayService.getPaymentStatus("trk_1");
-    expect(status.amount).toBe(25);
+    expect(status.amount).toBe("25");
     expect(status.transactions).toHaveLength(1);
-    expect(status.transactions[0].amount).toBe(25);
-    expect(status.transactions[0].usdAmount).toBe(25);
-    expect(status.transactions[0].nativeAmount).toBe(0.5);
+    expect(status.transactions[0].amount).toBe("25");
+    expect(status.transactions[0].usdAmount).toBe("25");
+    expect(status.transactions[0].nativeAmount).toBe("0.5");
+  });
+
+  test("preserves provider decimals without binary floating-point conversion", async () => {
+    stubInquiryResponse({
+      amount: "10.123456789012345678",
+      payAmount: "0.000000010000000001",
+    });
+    const status = await oxaPayService.getPaymentStatus("trk_1");
+    expect(status.amount).toBe("10.123456789012345678");
+    expect(status.transactions[0].amount).toBe("10.123456789012345678");
+    expect(status.transactions[0].usdAmount).toBe("10.123456789012345678");
+    expect(status.transactions[0].nativeAmount).toBe("0.000000010000000001");
   });
 
   test("missing amount throws OxaPayApiError instead of crediting $0", async () => {
@@ -93,21 +105,21 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
   test("malformed audit-only payAmount degrades to undefined without failing", async () => {
     stubInquiryResponse({ payAmount: "garbage" });
     const status = await oxaPayService.getPaymentStatus("trk_1");
-    expect(status.amount).toBe(25);
+    expect(status.amount).toBe("25");
     expect(status.transactions[0].nativeAmount).toBeUndefined();
   });
 
   test("partial numeric audit-only payAmount degrades to undefined without failing", async () => {
     stubInquiryResponse({ payAmount: "0.5 SOL" });
     const status = await oxaPayService.getPaymentStatus("trk_1");
-    expect(status.amount).toBe(25);
+    expect(status.amount).toBe("25");
     expect(status.transactions[0].nativeAmount).toBeUndefined();
   });
 
   test("missing payAmount degrades to undefined without failing", async () => {
     stubInquiryResponse({ payAmount: undefined });
     const status = await oxaPayService.getPaymentStatus("trk_1");
-    expect(status.amount).toBe(25);
+    expect(status.amount).toBe("25");
     expect(status.transactions[0].nativeAmount).toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service oxapay behavior behind route handlers.
+import { ElizaError } from "@elizaos/core";
 import Decimal from "decimal.js";
 import { logger } from "../utils/logger";
 
@@ -7,7 +8,7 @@ export type OxaPayNetwork = "ERC20" | "TRC20" | "BEP20" | "POLYGON" | "SOL" | "B
 export interface OxaPayInvoiceResult {
   trackId: string;
   payLink: string;
-  amount: number;
+  amount: string;
   currency: string;
   expiresAt: Date;
 }
@@ -39,14 +40,21 @@ const OXAPAY_API_BASE = "https://api.oxapay.com";
 /**
  * Custom error for OxaPay API failures.
  */
-export class OxaPayApiError extends Error {
+export class OxaPayApiError extends ElizaError {
+  override readonly name = "OxaPayApiError";
+
   constructor(
     message: string,
     public readonly statusCode?: number,
     public readonly apiResult?: number,
+    cause?: unknown,
   ) {
-    super(message);
-    this.name = "OxaPayApiError";
+    super(message, {
+      code: "OXAPAY_API_ERROR",
+      context: { statusCode, apiResult },
+      severity: "fatal",
+      cause,
+    });
   }
 }
 
@@ -59,9 +67,13 @@ async function oxaPayFetch<T>(url: string, options: RequestInit): Promise<T> {
   try {
     response = await fetch(url, options);
   } catch (error) {
+    // error-policy:J2 wrap provider transport failure and preserve its cause.
     logger.error("[OxaPay] Network error", { url, error });
     throw new OxaPayApiError(
       `Network error connecting to OxaPay: ${error instanceof Error ? error.message : "Unknown error"}`,
+      undefined,
+      undefined,
+      error,
     );
   }
 
@@ -74,8 +86,9 @@ async function oxaPayFetch<T>(url: string, options: RequestInit): Promise<T> {
   try {
     data = await response.json();
   } catch (error) {
+    // error-policy:J2 wrap malformed provider transport and preserve its cause.
     logger.error("[OxaPay] Invalid JSON response", { url, error });
-    throw new OxaPayApiError("OxaPay returned invalid JSON response");
+    throw new OxaPayApiError("OxaPay returned invalid JSON response", undefined, undefined, error);
   }
 
   return data;
@@ -119,7 +132,7 @@ class OxaPayService {
    * This returns a payLink that redirects users to OxaPay's hosted payment page.
    */
   async createInvoice(params: {
-    amount: number | string;
+    amount: string | number;
     currency?: string;
     payCurrency?: string;
     network?: OxaPayNetwork;
@@ -145,8 +158,9 @@ class OxaPayService {
       lifetime = 1800,
     } = params;
 
+    const invoiceAmount = new Decimal(amount).toFixed();
     logger.info("[OxaPay] Creating invoice", {
-      amount,
+      amount: invoiceAmount,
       currency,
       payCurrency,
       network,
@@ -155,7 +169,7 @@ class OxaPayService {
 
     const requestBody: Record<string, unknown> = {
       merchant: merchantKey,
-      amount,
+      amount: invoiceAmount,
       currency,
       lifeTime: lifetime / 60,
       feePaidByPayer: 0,
@@ -197,7 +211,7 @@ class OxaPayService {
     return {
       trackId: data.trackId,
       payLink: data.payLink,
-      amount: Number(amount),
+      amount: invoiceAmount,
       currency,
       expiresAt: new Date(Date.now() + lifetime * 1000),
     };
@@ -242,6 +256,10 @@ class OxaPayService {
       );
     }
 
+    if (data.trackId !== trackId) {
+      throw new OxaPayApiError("OxaPay inquiry track ID does not match the requested invoice");
+    }
+
     // Note: OxaPay doesn't provide blockchain confirmation counts.
     // Confirmation is determined by status ("paid" = confirmed by network).
     //
@@ -253,22 +271,15 @@ class OxaPayService {
     // amount, so a result=100 inquiry whose `amount` is missing, malformed, or
     // non-positive is a bad provider response. The parser is deliberately
     // full-string strict; parseFloat would accept corrupt prefixes like "25 USD".
-    let invoiceAmount: string;
-    try {
-      invoiceAmount = parseOxaPayInvoiceAmount(data.amount);
-    } catch (error) {
-      logger.error("[OxaPay] Invalid invoice amount in inquiry response", {
-        trackId: data.trackId,
-        status: data.status,
-        rawAmount: data.amount,
-        error,
-      });
-      throw error;
-    }
+    const invoiceAmount = parseOxaPayInvoiceAmount(data.amount);
 
     // Native pay amount is audit/debug metadata only (never credited); a
     // malformed value degrades to undefined instead of failing the inquiry.
     const nativePayAmount = parseOxaPayDecimalAmount(data.payAmount) ?? undefined;
+    const invoiceCurrency = data.currency?.trim().toUpperCase();
+    if (!invoiceCurrency) {
+      throw new OxaPayApiError("OxaPay inquiry returned an invalid invoice currency");
+    }
 
     return {
       trackId: data.trackId,
@@ -276,7 +287,7 @@ class OxaPayService {
       status: data.status,
       amount: invoiceAmount,
       amountText: data.amount.trim(),
-      currency: data.currency,
+      currency: invoiceCurrency,
       transactions: data.txID
         ? [
             {

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -132,7 +132,7 @@ class OxaPayService {
    * This returns a payLink that redirects users to OxaPay's hosted payment page.
    */
   async createInvoice(params: {
-    amount: string | number;
+    amount: string;
     currency?: string;
     payCurrency?: string;
     network?: OxaPayNetwork;

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service oxapay behavior behind route handlers.
+/** Validates exact OxaPay invoice and inquiry contracts for crypto settlement callers. */
 import { ElizaError } from "@elizaos/core";
 import Decimal from "decimal.js";
 import { logger } from "../utils/logger";

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service oxapay behavior behind route handlers.
+import Decimal from "decimal.js";
 import { logger } from "../utils/logger";
 
 export type OxaPayNetwork = "ERC20" | "TRC20" | "BEP20" | "POLYGON" | "SOL" | "BASE" | "ARB" | "OP";
@@ -15,21 +16,21 @@ export interface OxaPayPaymentStatus {
   trackId: string;
   orderId: string;
   status: string;
-  amount: number;
+  amount: string;
   amountText: string;
   currency: string;
   transactions: Array<{
     txHash: string;
     /** The amount to credit (USD value when auto-converted, native value otherwise) */
-    amount: number;
+    amount: string;
     currency: string;
     network: string;
     address: string;
     status: string;
     /** Original amount in native currency (e.g., SOL) before conversion */
-    nativeAmount?: number;
+    nativeAmount?: string;
     /** USD equivalent amount from invoice */
-    usdAmount?: number;
+    usdAmount?: string;
   }>;
 }
 
@@ -92,19 +93,19 @@ export function isOxaPayConfigured(): boolean {
   return Boolean(process.env.OXAPAY_MERCHANT_API_KEY);
 }
 
-function parseOxaPayDecimalAmount(rawAmount: string | undefined): number | null {
+function parseOxaPayDecimalAmount(rawAmount: string | undefined): string | null {
   const trimmedAmount = rawAmount?.trim();
   if (!trimmedAmount || !/^(?:\d+|\d+\.\d+|\.\d+)$/.test(trimmedAmount)) {
     return null;
   }
 
-  const amount = Number(trimmedAmount);
-  return Number.isFinite(amount) ? amount : null;
+  const amount = new Decimal(trimmedAmount);
+  return amount.isFinite() ? amount.toFixed() : null;
 }
 
-function parseOxaPayInvoiceAmount(rawAmount: string | undefined): number {
+function parseOxaPayInvoiceAmount(rawAmount: string | undefined): string {
   const amount = parseOxaPayDecimalAmount(rawAmount);
-  if (amount === null || amount <= 0) {
+  if (amount === null || !new Decimal(amount).gt(0)) {
     throw new OxaPayApiError(
       `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(rawAmount ?? null)}`,
     );
@@ -252,7 +253,7 @@ class OxaPayService {
     // amount, so a result=100 inquiry whose `amount` is missing, malformed, or
     // non-positive is a bad provider response. The parser is deliberately
     // full-string strict; parseFloat would accept corrupt prefixes like "25 USD".
-    let invoiceAmount: number;
+    let invoiceAmount: string;
     try {
       invoiceAmount = parseOxaPayInvoiceAmount(data.amount);
     } catch (error) {

--- a/packages/cloud/shared/src/lib/services/payment-adapters/oxapay.test.ts
+++ b/packages/cloud/shared/src/lib/services/payment-adapters/oxapay.test.ts
@@ -30,7 +30,7 @@ const getPaymentStatus = mock(async (trackId: string) => ({
   trackId,
   orderId: "pr_abc123",
   status: "paid",
-  amount: 25,
+  amount: "25",
   amountText: "25.00",
   currency: "USD",
   transactions: [],
@@ -38,7 +38,7 @@ const getPaymentStatus = mock(async (trackId: string) => ({
 const createInvoice = mock(async (input: { callbackUrl?: string }) => ({
   trackId: "trk_created",
   payLink: "https://pay.example.test/trk_created",
-  amount: 25,
+  amount: "25",
   currency: "USD",
   expiresAt: new Date(Date.now() + 60_000),
   input,

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -19,7 +19,7 @@
 
 import Decimal from "decimal.js";
 import { and, eq, sql } from "drizzle-orm";
-import { dbRead, dbWrite } from "../../db/client";
+import { type DbTransaction, dbRead, dbWrite } from "../../db/client";
 import { redeemableEarnings, redeemableEarningsLedger } from "../../db/schemas/redeemable-earnings";
 import { normalizeLedgerSourceId } from "../utils/ledger-source-id";
 import { logger } from "../utils/logger";
@@ -39,12 +39,14 @@ type EarningsSource =
 
 interface AddEarningsParams {
   userId: string;
-  amount: number;
+  amount: number | string;
   source: EarningsSource;
   sourceId: string;
   description: string;
   metadata?: Record<string, unknown>;
   dedupeBySourceId?: boolean;
+  /** Reuse the caller's settlement transaction when this earning is one leg of a larger unit. */
+  transaction?: DbTransaction;
 }
 
 interface AddEarningsResult {
@@ -264,6 +266,7 @@ class RedeemableEarningsService {
       description,
       metadata,
       dedupeBySourceId = false,
+      transaction,
     } = params;
 
     const inputAmount = new Decimal(amount);
@@ -300,7 +303,7 @@ class RedeemableEarningsService {
       ...(ledgerSourceId !== sourceId ? { original_source_id: sourceId } : {}),
     });
 
-    const result = await dbWrite.transaction(async (tx) => {
+    const apply = async (tx: DbTransaction) => {
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${`redeemable_earnings:${userId}`}))`,
       );
@@ -444,7 +447,8 @@ class RedeemableEarningsService {
         ledgerEntryId: ledgerEntry.id,
         deduplicated: false,
       };
-    });
+    };
+    const result = transaction ? await apply(transaction) : await dbWrite.transaction(apply);
 
     if (result.deduplicated) {
       logger.info("[RedeemableEarnings] Reused existing earning entry", {

--- a/packages/cloud/shared/src/lib/services/referrals.ts
+++ b/packages/cloud/shared/src/lib/services/referrals.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service referrals behavior behind route handlers.
+/** Coordinates referral lookup and exact revenue-split calculation behind service callers. */
 import * as crypto from "crypto";
 import Decimal from "decimal.js";
 import { eq } from "drizzle-orm";

--- a/packages/cloud/shared/src/lib/services/referrals.ts
+++ b/packages/cloud/shared/src/lib/services/referrals.ts
@@ -1,5 +1,8 @@
 // Coordinates cloud service referrals behavior behind route handlers.
 import * as crypto from "crypto";
+import Decimal from "decimal.js";
+import { eq } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
 import {
   type ReferralCode,
   type ReferralSignup,
@@ -9,6 +12,7 @@ import {
   socialShareRewardsRepository,
 } from "../../db/repositories/referrals";
 import { usersRepository } from "../../db/repositories/users";
+import { referralCodes, referralSignups } from "../../db/schemas/referrals";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
 
@@ -325,6 +329,7 @@ export class ReferralsService {
   async calculateRevenueSplits(
     userId: string,
     purchaseAmount: number,
+    transaction?: DbTransaction,
   ): Promise<{
     elizaCloudAmount: number;
     splits: Array<{
@@ -333,23 +338,63 @@ export class ReferralsService {
       amount: number;
     }>;
   }> {
-    const signup = await referralSignupsRepository.findByReferredUserId(userId);
+    const exact = await this.calculateRevenueSplitsExact(
+      userId,
+      new Decimal(purchaseAmount).toFixed(),
+      transaction,
+    );
+    return {
+      elizaCloudAmount: Number(exact.elizaCloudAmount),
+      splits: exact.splits.map((split) => ({ ...split, amount: Number(split.amount) })),
+    };
+  }
+
+  /** Exact-decimal split used by settlement code before any provider amount reaches SQL. */
+  async calculateRevenueSplitsExact(
+    userId: string,
+    purchaseAmount: string,
+    transaction?: DbTransaction,
+  ): Promise<{
+    elizaCloudAmount: string;
+    splits: Array<{
+      userId: string;
+      role: "app_owner" | "creator" | "editor";
+      amount: string;
+    }>;
+  }> {
+    const providerAmount = new Decimal(purchaseAmount);
+    if (!providerAmount.isFinite() || !providerAmount.gt(0)) {
+      throw new Error("Referral revenue split purchase amount must be positive");
+    }
+    // Settlement ledgers are six-decimal. Provider dust below that boundary is
+    // retained on the payment audit row, never manufactured into a float or a
+    // payout that the ledger cannot represent.
+    const amount = providerAmount.toDecimalPlaces(6);
+    const signup = transaction
+      ? (
+          await transaction
+            .select()
+            .from(referralSignups)
+            .where(eq(referralSignups.referred_user_id, userId))
+            .limit(1)
+        )[0]
+      : await referralSignupsRepository.findByReferredUserId(userId);
 
     // Default: 100% to ElizaCloud if no referrer
     if (!signup) {
-      return { elizaCloudAmount: purchaseAmount, splits: [] };
+      return { elizaCloudAmount: amount.toFixed(6), splits: [] };
     }
 
-    const { ELIZA_CLOUD, APP_OWNER, CREATOR, CREATOR_TIER, EDITOR_TIER } = REFERRAL_REVENUE_SPLITS;
-
-    let elizaCloudAmount = purchaseAmount * ELIZA_CLOUD;
-    const appOwnerAmount = purchaseAmount * APP_OWNER;
-    const baseCreatorAmount = purchaseAmount * CREATOR;
+    const { APP_OWNER, CREATOR, CREATOR_TIER, EDITOR_TIER } = REFERRAL_REVENUE_SPLITS;
+    const ledgerShare = (ratio: number) =>
+      amount.mul(ratio).toDecimalPlaces(6, Decimal.ROUND_DOWN).toFixed(6);
+    const appOwnerAmount = ledgerShare(APP_OWNER);
+    const baseCreatorAmount = ledgerShare(CREATOR);
 
     const splits: Array<{
       userId: string;
       role: "app_owner" | "creator" | "editor";
-      amount: number;
+      amount: string;
     }> = [];
 
     if (signup.app_owner_id) {
@@ -358,25 +403,39 @@ export class ReferralsService {
         role: "app_owner",
         amount: appOwnerAmount,
       });
-    } else {
-      elizaCloudAmount += appOwnerAmount;
     }
 
     const creatorId = signup.creator_id || signup.referrer_user_id;
 
-    const referralCode = await referralCodesRepository.findById(signup.referral_code_id);
+    const referralCode = transaction
+      ? (
+          await transaction
+            .select()
+            .from(referralCodes)
+            .where(eq(referralCodes.id, signup.referral_code_id))
+            .limit(1)
+        )[0]
+      : await referralCodesRepository.findById(signup.referral_code_id);
     if (referralCode && referralCode.parent_referral_id) {
-      const parentCode = await referralCodesRepository.findById(referralCode.parent_referral_id);
+      const parentCode = transaction
+        ? (
+            await transaction
+              .select()
+              .from(referralCodes)
+              .where(eq(referralCodes.id, referralCode.parent_referral_id))
+              .limit(1)
+          )[0]
+        : await referralCodesRepository.findById(referralCode.parent_referral_id);
       if (parentCode) {
         splits.push({
           userId: creatorId,
           role: "creator",
-          amount: purchaseAmount * CREATOR_TIER,
+          amount: ledgerShare(CREATOR_TIER),
         });
         splits.push({
           userId: parentCode.user_id,
           role: "editor",
-          amount: purchaseAmount * EDITOR_TIER,
+          amount: ledgerShare(EDITOR_TIER),
         });
       } else {
         splits.push({
@@ -393,15 +452,13 @@ export class ReferralsService {
       });
     }
 
-    const splitsSum = splits.reduce((s, x) => s + x.amount, 0);
-    const totalAllocated = elizaCloudAmount + splitsSum;
-    if (Math.abs(totalAllocated - purchaseAmount) > 1e-6) {
-      throw new Error(
-        `Referral revenue split total must equal purchaseAmount: ${totalAllocated} !== ${purchaseAmount}`,
-      );
+    const splitsSum = splits.reduce((sum, split) => sum.add(split.amount), new Decimal(0));
+    const elizaCloudAmount = amount.minus(splitsSum);
+    if (elizaCloudAmount.isNegative()) {
+      throw new Error("Referral revenue splits exceed the quantized settlement amount");
     }
 
-    return { elizaCloudAmount, splits };
+    return { elizaCloudAmount: elizaCloudAmount.toFixed(6), splits };
   }
 
   async getReferralStats(userId: string): Promise<{

--- a/packages/cloud/shared/src/lib/services/settlement-digest.ts
+++ b/packages/cloud/shared/src/lib/services/settlement-digest.ts
@@ -1,0 +1,22 @@
+/** Produces canonical replay digests for immutable billing settlement contracts. */
+import { createHash } from "node:crypto";
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (typeof value !== "object" || value === null) return value;
+  if (value instanceof Date) return value.toISOString();
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, canonicalJson(nested)]),
+  );
+}
+
+export function canonicalSettlementJson(value: unknown): string {
+  return JSON.stringify(canonicalJson(value));
+}
+
+export function settlementDigest(value: unknown): string {
+  return createHash("sha256").update(canonicalSettlementJson(value)).digest("hex");
+}


### PR DESCRIPTION
## Summary

- settle crypto payment status, organization credit, app-purchase effects, invoice projection, referral earnings, and callback intent in one caller-owned database transaction
- bind OxaPay settlement to the server-stored provider track ID, order ID, fiat amount, and fiat currency; accept only USD credit purchases
- make confirmed replay re-prove the canonical settlement and reconstruct missing invoice/callback projections without minting again
- persist immutable app-charge callback envelopes and deterministic room-message identities, with retry leases and independent room/HTTP checkpoints
- prepare and sign direct-wallet sweep transactions before provider submission, persist the exact bytes/hash, and retry only those same bytes after acknowledgement loss
- establish one transaction-hash identity across writers: EVM hashes canonicalize to lowercase, Solana identifiers retain case, and migration 0255 fails closed on active legacy collisions

## Safety properties

- failures after app writes, credits, invoice creation, referral writes, callback enqueue, or sweep enqueue roll back every database settlement leg
- concurrent webhook/manual delivery converges on one settlement; cross-tenant EVM casing aliases cannot double-spend
- provider failure/expiry status and the failed app callback intent commit atomically; a later paid state cannot be overwritten by failure
- callback retry does not repeat an already-delivered channel and reuses an immutable payload/deterministic room identity
- sweep acknowledgement loss cannot create a fresh transfer: EVM and Solana retry the persisted signed transaction only
- OxaPay settlement rebinds track/order/amount/currency to the server quote; caller-selected callback endpoints and non-USD fiat are rejected

Refs #22327

## Database

- adds `0255_crypto_settlement_outboxes.sql`, contiguous after merged migration 0254
- preflights active EVM lowercase collisions, canonicalizes safe legacy hashes, and preserves case-sensitive non-EVM identities
- adds leased callback/sweep outboxes and requires prepared transaction bytes and sweep hash to be present or absent together

## Verification

Exact PR head: `4fcaa6db6762671d40c083d58a2ecb6a4dd873a2`  
Exact base: `146a30dfa931f1bb9450bcc3faa8ca3d413c9375`

- exact-head focused billing/replay/concurrency: 86 passed / 309 assertions
- exact-head direct-wallet Vitest/PGlite integration: 42 passed
- exact-head persisted callback timestamp/retry regression: 5 passed / 26 assertions
- callback target mutation and Solana acknowledgement/expiry recovery regressions: green
- broader pre-final-rebase focused billing/replay/concurrency: 82 passed / 301 assertions; final rebase was patch-identical by `git range-diff`
- cloud shared/API typechecks, production Worker dry-run, package lints, Drizzle migration check, and diff-check: green
- prior full `bun run verify` on the patch-identical rebased head reached 285/356 Turbo tasks and stopped only on unchanged `@elizaos/cloud-test-mocks#typecheck`: `qrcode-terminal` has no declaration in `plugins/plugin-whatsapp/src/baileys/qr-code.ts`; that file is byte-identical to its base version

The aggregate Bun suites with process-global mocks are not used as evidence; owning suites were run in isolation. UI evidence is N/A because this is backend settlement/recovery.

## Attribution

- Agent: OpenAI / gpt-5.6-sol
- Tool: Codex Desktop
- Workflow: codex-crypto-settlement
