### PR TITLE
fix(plugin-mcp): reject hostile MCP JSON Schemas before Ajv compile

### DIFF
--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -65,4 +65,35 @@ describe("validateJsonSchema", () => {
     const result = validateJsonSchema({ name: 123 }, schema);
     expect(result.success).toBe(false);
   });
+
+  it("does not throw when an MCP tool inputSchema is the allOf $ref bomb", () => {
+    const bomb = {
+      $id: "http://evil/mcp-schema-bomb",
+      type: "object",
+      allOf: [{ $ref: "#" }, { $ref: "#" }],
+    };
+    const result = validateJsonSchema({}, bomb);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/two \$refs to #/);
+    }
+  });
+
+  it("does not poison a process-wide Ajv cache when two schemas share $id", () => {
+    const first = {
+      $id: "http://example.com/shared-tool",
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    };
+    const second = {
+      $id: "http://example.com/shared-tool",
+      type: "object",
+      properties: { b: { type: "number" } },
+      required: ["b"],
+    };
+    expect(validateJsonSchema({ a: "ok" }, first).success).toBe(true);
+    const again = validateJsonSchema({ b: 1 }, second);
+    expect(again.success).toBe(true);
+  });
 });

--- a/plugins/plugin-mcp/src/utils/__tests__/mcp-schema-budget.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/mcp-schema-budget.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Deterministic tests for the MCP JSON Schema compile budget. Harness is local
+ * and dependency-free: the walker rejects the Ajv allOf/$ref bomb and admits
+ * ordinary tool schemas, including a single recursive $ref for tree data.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  assertMcpJsonSchemaBudget,
+  MAX_MCP_SCHEMA_DEPTH,
+  MAX_MCP_SCHEMA_JSON_BYTES,
+  McpSchemaTooComplexError,
+} from "../mcp-schema-budget";
+
+const ALLOF_REF_BOMB = {
+  $id: "http://evil/mcp-schema-bomb",
+  type: "object",
+  allOf: [{ $ref: "#" }, { $ref: "#" }],
+} as const;
+
+describe("assertMcpJsonSchemaBudget", () => {
+  it("admits a typical MCP tool object schema", () => {
+    expect(() =>
+      assertMcpJsonSchemaBudget({
+        type: "object",
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      })
+    ).not.toThrow();
+  });
+
+  it("admits a single recursive $ref used as a tree node", () => {
+    expect(() =>
+      assertMcpJsonSchemaBudget({
+        $defs: {
+          node: {
+            type: "object",
+            properties: { child: { $ref: "#/$defs/node" } },
+          },
+        },
+        $ref: "#/$defs/node",
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects a 75-byte allOf of two $ref: '#' documents", () => {
+    expect(() => assertMcpJsonSchemaBudget(ALLOF_REF_BOMB)).toThrow(McpSchemaTooComplexError);
+    expect(() => assertMcpJsonSchemaBudget(ALLOF_REF_BOMB)).toThrow(/two \$refs to #/);
+    expect(Buffer.byteLength(JSON.stringify(ALLOF_REF_BOMB))).toBeLessThan(120);
+  });
+
+  it("rejects definitions that allOf-ref themselves twice", () => {
+    expect(() =>
+      assertMcpJsonSchemaBudget({
+        definitions: {
+          a: {
+            allOf: [{ $ref: "#/definitions/a" }, { $ref: "#/definitions/a" }],
+          },
+        },
+        $ref: "#/definitions/a",
+      })
+    ).toThrow(/two \$refs to #\/definitions\/a/);
+  });
+
+  it("rejects a serialized schema larger than the byte budget", () => {
+    const huge = { type: "string", description: "x".repeat(MAX_MCP_SCHEMA_JSON_BYTES) };
+    expect(() => assertMcpJsonSchemaBudget(huge)).toThrow(/serialized size/);
+  });
+
+  it("rejects nesting deeper than the depth budget", () => {
+    let schema: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < MAX_MCP_SCHEMA_DEPTH + 4; i++) {
+      schema = { type: "object", properties: { n: schema } };
+    }
+    expect(() => assertMcpJsonSchemaBudget(schema)).toThrow(/nesting depth/);
+  });
+});

--- a/plugins/plugin-mcp/src/utils/json.ts
+++ b/plugins/plugin-mcp/src/utils/json.ts
@@ -3,9 +3,14 @@
  * selections: parseJSON strips code fences and surrounding prose then parses with
  * JSON5 leniency, and validateJsonSchema gates a value against a JSON Schema via
  * Ajv. Used on the untrusted-model-output boundary in the selection flow.
+ *
+ * MCP tool `inputSchema` is attacker-controlled. Compile it on a fresh Ajv
+ * (untrusted `$id` must not poison a process-wide cache) after the budget in
+ * `mcp-schema-budget.ts` rejects the allOf/$ref RangeError bomb.
  */
 import Ajv from "ajv";
 import JSON5 from "json5";
+import { assertMcpJsonSchemaBudget, McpSchemaTooComplexError } from "./mcp-schema-budget";
 
 export function parseJSON<T>(input: string): T {
   let cleanedInput = input.replace(/^```(?:json)?\s*|\s*```$/g, "").trim();
@@ -21,10 +26,6 @@ export function parseJSON<T>(input: string): T {
 
   return JSON5.parse(cleanedInput) as T;
 }
-
-const ajv = new Ajv({
-  allErrors: true,
-});
 
 interface AjvErrorLike {
   readonly instancePath?: string;
@@ -46,16 +47,33 @@ export function validateJsonSchema<T>(
   data: unknown,
   schema: Readonly<Record<string, unknown>>
 ): { success: true; data: T } | { success: false; error: string } {
-  const validate = ajv.compile(schema);
-  const valid = validate(data);
-
-  if (!valid) {
-    const errors = validate.errors ?? [];
-    const errorMessage = formatAjvErrors(errors);
-    return { success: false, error: errorMessage };
+  try {
+    assertMcpJsonSchemaBudget(schema);
+  } catch (error) {
+    // error-policy:J3 untrusted MCP inputSchema — reject as invalid, never compile
+    if (error instanceof McpSchemaTooComplexError) {
+      return { success: false, error: error.message };
+    }
+    throw error;
   }
 
-  return { success: true, data: data as T };
+  try {
+    const isolated = new Ajv({ allErrors: true });
+    const validate = isolated.compile(schema);
+    const valid = validate(data);
+
+    if (!valid) {
+      const errors = validate.errors ?? [];
+      const errorMessage = formatAjvErrors(errors);
+      return { success: false, error: errorMessage };
+    }
+
+    return { success: true, data: data as T };
+  } catch (error) {
+    // error-policy:J3 Ajv.compile of untrusted schema must not 500 the loop
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: `schema compile failed: ${message}` };
+  }
 }
 
 export function stringifyJSON(value: unknown): string {

--- a/plugins/plugin-mcp/src/utils/mcp-schema-budget.ts
+++ b/plugins/plugin-mcp/src/utils/mcp-schema-budget.ts
@@ -1,0 +1,109 @@
+/**
+ * Preflight budget for untrusted MCP tool `inputSchema` documents before Ajv
+ * compiles them. Connected MCP servers supply that JSON Schema; a 75-byte
+ * `allOf: [{ $ref: "#" }, { $ref: "#" }]` document makes Ajv recurse until
+ * `RangeError`, and a shared Ajv cache 500s when two tools reuse the same `$id`.
+ *
+ * This walker is dependency-free so the bomb shape can be proven without
+ * pulling Ajv or `@elizaos/core` into the unit.
+ */
+
+export const MAX_MCP_SCHEMA_JSON_BYTES = 256 * 1024;
+export const MAX_MCP_SCHEMA_DEPTH = 32;
+export const MAX_MCP_SCHEMA_NODES = 2048;
+
+export class McpSchemaTooComplexError extends Error {
+  readonly code = "MCP_SCHEMA_TOO_COMPLEX";
+
+  constructor(reason: string) {
+    super(`MCP JSON schema rejected: ${reason}`);
+    this.name = "McpSchemaTooComplexError";
+  }
+}
+
+const COMPOSITION_KEYS = ["allOf", "anyOf", "oneOf"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalRefTarget(ref: string): string {
+  if (ref === "#" || ref === "#/") {
+    return "#";
+  }
+  return ref;
+}
+
+function assertCompositionDoesNotDoubleRefSelf(
+  record: Record<string, unknown>,
+  keyword: (typeof COMPOSITION_KEYS)[number]
+): void {
+  const items = record[keyword];
+  if (!Array.isArray(items)) {
+    return;
+  }
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    if (!isRecord(item) || typeof item.$ref !== "string") {
+      continue;
+    }
+    const target = canonicalRefTarget(item.$ref);
+    const next = (counts.get(target) ?? 0) + 1;
+    counts.set(target, next);
+    if (next >= 2) {
+      throw new McpSchemaTooComplexError(
+        `${keyword} contains two $refs to ${target} (Ajv compile recurses until RangeError)`
+      );
+    }
+  }
+}
+
+function walk(node: unknown, depth: number, acc: { nodes: number }): void {
+  if (depth > MAX_MCP_SCHEMA_DEPTH) {
+    throw new McpSchemaTooComplexError(`nesting depth exceeds ${MAX_MCP_SCHEMA_DEPTH}`);
+  }
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+  acc.nodes += 1;
+  if (acc.nodes > MAX_MCP_SCHEMA_NODES) {
+    throw new McpSchemaTooComplexError(`node count exceeds ${MAX_MCP_SCHEMA_NODES}`);
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walk(item, depth + 1, acc);
+    }
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  for (const keyword of COMPOSITION_KEYS) {
+    assertCompositionDoesNotDoubleRefSelf(record, keyword);
+  }
+  for (const value of Object.values(record)) {
+    walk(value, depth + 1, acc);
+  }
+}
+
+/**
+ * Throw {@link McpSchemaTooComplexError} when `schema` is not a bounded JSON
+ * document or contains the Ajv compile bomb (composition of two `$ref`s to
+ * the same target). Callers map the typed error to an invalid-schema result.
+ */
+export function assertMcpJsonSchemaBudget(schema: unknown): void {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(schema);
+  } catch {
+    throw new McpSchemaTooComplexError("schema is not JSON-serializable");
+  }
+  if (typeof serialized !== "string") {
+    throw new McpSchemaTooComplexError("schema is not JSON-serializable");
+  }
+  const bytes = Buffer.byteLength(serialized);
+  if (bytes > MAX_MCP_SCHEMA_JSON_BYTES) {
+    throw new McpSchemaTooComplexError(
+      `serialized size ${bytes} exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`
+    );
+  }
+  walk(schema, 0, { nodes: 0 });
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standalone MCP tool-schema compile 500: `validateJsonSchema` compiled
untrusted MCP `inputSchema` on a process-wide Ajv singleton with no
budget. A 75-byte `allOf: [{ $ref: "#" }, { $ref: "#" }]` document
RangeErrors; a second tool that reuses `$id` throws
`schema already exists`. Not a twin of `#22311` (VFS ReDoS), `#22305`
(GBNF repeat), `#22345` (first-run body), `#22341` (local-trust),
`#22262`, `#22278`, `#22282`, or the HTTP fetch-timeout family. Not an
ASI `#1874` reprint. HARD_SKIP is `routes-mcp.ts`, not
`utils/json.ts`. No invented owning issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Origin `ajv.compile(inputSchema)` on the module singleton can
      `RangeError` or throw `$id` collision.
- [x] Head rejects the 75-byte bomb before compile and compiles each
      schema on a fresh Ajv.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` `e39e764beaba` with zero conflicts.
- [x] Isolated MCP schema tests 19/19 at this head.
- [x] Biome on the four touched files: clean.

# Risks

Low and bounded to MCP tool-argument validation. Ordinary object
schemas and a single recursive `$ref` for tree data still compile.
Hostile composition `$ref`s return `{ success: false }` instead of
taking down the process.

# Background

## What does this PR do?

Origin did:

```ts
const ajv = new Ajv({ allErrors: true });
export function validateJsonSchema(data, schema) {
  const validate = ajv.compile(schema);
  return validate(data) ? { success: true, data } : { success: false, error };
}
```

`toolInputSchema` is the connected MCP server's `inputSchema`. There
was no complexity check and no isolation. A malicious server can
advertise:

```json
{ "$id": "http://evil/s", "type": "object", "allOf": [{ "$ref": "#" }, { "$ref": "#" }] }
```

Ajv recurse-compiles that until `RangeError: Maximum call stack size
exceeded` (observed on origin). Two tools that copy the same `$id`
throw `schema with key or id already exists` on the singleton.

Head walks the document in `assertMcpJsonSchemaBudget` and rejects
composition of two `$ref`s to the same target, plus byte/depth/node
caps. Compile runs on a fresh Ajv. Compile throws become
`{ success: false }` (J3), not a 500.

## What kind of change is this?

Bug fix (untrusted-schema compile 500).

# Documentation changes needed?

No public field change. Hostile tool schemas fail validation instead
of crashing the agent.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/src/utils/mcp-schema-budget.ts` and
`plugins/plugin-mcp/src/utils/json.ts`. Tests:
`src/utils/__tests__/mcp-schema-budget.test.ts` and
`src/utils/__tests__/json.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-mcp test src/utils/__tests__/mcp-schema-budget.test.ts src/utils/__tests__/json.test.ts
```

Origin: shared `ajv.compile` of the 75-byte bomb RangeErrors; two
`$id`s collide. Head: bomb returns `success: false` and never throws;
two tools may share `$id`.

# Evidence Gate

<!-- evidence-head:0f87233bf5a846e6456a2c35897f5fa315e8c9c4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated Ajv compile proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - schema compile only; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Origin 75-byte allOf/$ref bomb RangeErrors. Head tests 19/19 at this SHA.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt or model change.

## Backend + frontend logs

N/A - isolated compile proof.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run for the whole monorepo. Isolated MCP
schema tests 19/19 are the recorded suite at this head.

`bun run --cwd plugins/plugin-mcp test src/utils/__tests__/mcp-schema-budget.test.ts src/utils/__tests__/json.test.ts` at 0f87233bf -> exit 0 (2026-08-19T04:07:10.667Z)

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
