### PR TITLE
fix(cloud): make native storage CRUD crash safe

### DIFF
--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -9,7 +9,7 @@ import { Hono } from "hono";
 const ORG = "00000000-0000-4000-8000-000000021045";
 const events: string[] = [];
 const requireUserOrApiKeyWithOrg = mock(async () => ({ organization_id: ORG }));
-const adoptLegacyObject = mock();
+const adoptLegacyObjects = mock();
 const listObjects = mock();
 const getServiceMethodCost = mock(async () => 0.0001);
 const deductCredits = mock(async () => {
@@ -18,7 +18,7 @@ const deductCredits = mock(async () => {
 });
 
 mock.module("@/db/repositories", () => ({
-  orgStorageMutationsRepository: { adoptLegacyObject, listObjects },
+  orgStorageMutationsRepository: { adoptLegacyObjects, listObjects },
 }));
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -41,12 +41,11 @@ app.route("/api/v1/apis/storage/list", route);
 
 beforeEach(() => {
   events.length = 0;
-  adoptLegacyObject.mockReset();
+  adoptLegacyObjects.mockReset();
   listObjects.mockReset();
   deductCredits.mockClear();
-  adoptLegacyObject.mockImplementation(async (input) => {
-    events.push(`adopt:${input.logicalKey}`);
-    return input;
+  adoptLegacyObjects.mockImplementation(async (inputs) => {
+    events.push(`adopt:${inputs.map((input) => input.logicalKey).join(",")}`);
   });
   listObjects.mockResolvedValue([
     {
@@ -94,15 +93,17 @@ test("paginates native legacy keys, adopts them, and charges only after success"
     truncated: false,
   });
   expect(list).toHaveBeenCalledTimes(2);
-  expect(adoptLegacyObject).toHaveBeenCalledWith({
-    organizationId: ORG,
-    logicalKey: "voice/message.ogg",
-    providerKey: `org/${ORG}/voice/message.ogg`,
-    sizeBytes: 5n,
-    contentType: "audio/ogg",
-    etag: "legacy-etag",
-    uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
-  });
+  expect(adoptLegacyObjects).toHaveBeenCalledWith([
+    {
+      organizationId: ORG,
+      logicalKey: "voice/message.ogg",
+      providerKey: `org/${ORG}/voice/message.ogg`,
+      sizeBytes: 5n,
+      contentType: "audio/ogg",
+      etag: "legacy-etag",
+      uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+    },
+  ]);
   expect(events).toEqual(["adopt:voice/message.ogg", "charge"]);
 });
 

--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -9,7 +9,9 @@ import { Hono } from "hono";
 const ORG = "00000000-0000-4000-8000-000000021045";
 const events: string[] = [];
 const requireUserOrApiKeyWithOrg = mock(async () => ({ organization_id: ORG }));
-const adoptLegacyObjects = mock();
+const ensureNativeStorageQuotaReconciled = mock(async () => {
+  events.push("reconcile");
+});
 const listObjects = mock();
 const getServiceMethodCost = mock(async () => 0.0001);
 const deductCredits = mock(async () => {
@@ -18,7 +20,10 @@ const deductCredits = mock(async () => {
 });
 
 mock.module("@/db/repositories", () => ({
-  orgStorageMutationsRepository: { adoptLegacyObjects, listObjects },
+  orgStorageMutationsRepository: { listObjects },
+}));
+mock.module("@/lib/services/storage/native-storage-put", () => ({
+  ensureNativeStorageQuotaReconciled,
 }));
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -41,14 +46,9 @@ app.route("/api/v1/apis/storage/list", route);
 
 beforeEach(() => {
   events.length = 0;
-  adoptLegacyObjects.mockReset();
+  ensureNativeStorageQuotaReconciled.mockClear();
   listObjects.mockReset();
   deductCredits.mockClear();
-  adoptLegacyObjects.mockImplementation(
-    async (inputs: Array<{ logicalKey: string }>) => {
-      events.push(`adopt:${inputs.map((input) => input.logicalKey).join(",")}`);
-    },
-  );
   listObjects.mockResolvedValue([
     {
       logical_key: "voice/message.ogg",
@@ -59,22 +59,8 @@ beforeEach(() => {
   ]);
 });
 
-test("paginates native legacy keys, adopts them, and charges only after success", async () => {
-  const list = mock()
-    .mockResolvedValueOnce({
-      objects: [
-        {
-          key: `org/${ORG}/voice/message.ogg`,
-          size: 5,
-          etag: "legacy-etag",
-          uploaded: new Date("2026-08-18T00:00:00.000Z"),
-          httpMetadata: { contentType: "audio/ogg" },
-        },
-      ],
-      truncated: true,
-      cursor: "page-2",
-    })
-    .mockResolvedValueOnce({ objects: [], truncated: false });
+test("reconciles native authority and charges only after catalog success", async () => {
+  const list = mock();
   const response = await app.request(
     "/api/v1/apis/storage/list?prefix=voice&recursive=true",
     undefined,
@@ -94,25 +80,18 @@ test("paginates native legacy keys, adopts them, and charges only after success"
     ],
     truncated: false,
   });
-  expect(list).toHaveBeenCalledTimes(2);
-  expect(adoptLegacyObjects).toHaveBeenCalledWith([
-    {
-      organizationId: ORG,
-      logicalKey: "voice/message.ogg",
-      providerKey: `org/${ORG}/voice/message.ogg`,
-      sizeBytes: 5n,
-      contentType: "audio/ogg",
-      etag: "legacy-etag",
-      uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
-    },
-  ]);
-  expect(events).toEqual(["adopt:voice/message.ogg", "charge"]);
+  expect(ensureNativeStorageQuotaReconciled).toHaveBeenCalled();
+  expect(listObjects).toHaveBeenCalledWith(ORG, "voice", 1001, true);
+  expect(events).toEqual(["reconcile", "charge"]);
 });
 
 test("does not charge when native listing fails", async () => {
+  ensureNativeStorageQuotaReconciled.mockRejectedValueOnce(
+    new Error("native list failed"),
+  );
   const response = await app.request("/api/v1/apis/storage/list", undefined, {
     BLOB: {
-      list: mock(async () => Promise.reject(new Error("native list failed"))),
+      list: mock(),
     },
   });
   expect(response.status).toBe(500);

--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Exercises the real storage LIST router against a native fake R2 binding,
+ * proving legacy discovery is catalog-adopted before a successful charge.
+ */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const ORG = "00000000-0000-4000-8000-000000021045";
+const events: string[] = [];
+const requireUserOrApiKeyWithOrg = mock(async () => ({ organization_id: ORG }));
+const adoptLegacyObject = mock();
+const listObjects = mock();
+const getServiceMethodCost = mock(async () => 0.0001);
+const deductCredits = mock(async () => {
+  events.push("charge");
+  return { success: true };
+});
+
+mock.module("@/db/repositories", () => ({
+  orgStorageMutationsRepository: { adoptLegacyObject, listObjects },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/proxy/pricing", () => ({ getServiceMethodCost }));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { deductCredits },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_context: unknown, error: unknown) =>
+    Response.json(
+      { error: error instanceof Error ? error.message : "failure" },
+      { status: 500 },
+    ),
+}));
+
+const route = (await import("../v1/apis/storage/list/route")).default;
+const app = new Hono();
+app.route("/api/v1/apis/storage/list", route);
+
+beforeEach(() => {
+  events.length = 0;
+  adoptLegacyObject.mockReset();
+  listObjects.mockReset();
+  deductCredits.mockClear();
+  adoptLegacyObject.mockImplementation(async (input) => {
+    events.push(`adopt:${input.logicalKey}`);
+    return input;
+  });
+  listObjects.mockResolvedValue([
+    {
+      logical_key: "voice/message.ogg",
+      size_bytes: 5n,
+      content_type: "audio/ogg",
+      uploaded_at: new Date("2026-08-18T00:00:00.000Z"),
+    },
+  ]);
+});
+
+test("paginates native legacy keys, adopts them, and charges only after success", async () => {
+  const list = mock()
+    .mockResolvedValueOnce({
+      objects: [
+        {
+          key: `org/${ORG}/voice/message.ogg`,
+          size: 5,
+          etag: "legacy-etag",
+          uploaded: new Date("2026-08-18T00:00:00.000Z"),
+          httpMetadata: { contentType: "audio/ogg" },
+        },
+      ],
+      truncated: true,
+      cursor: "page-2",
+    })
+    .mockResolvedValueOnce({ objects: [], truncated: false });
+  const response = await app.request(
+    "/api/v1/apis/storage/list?prefix=voice&recursive=true",
+    undefined,
+    { BLOB: { list } },
+  );
+
+  expect(response.status).toBe(200);
+  const responseBody: unknown = await response.json();
+  expect(responseBody).toEqual({
+    items: [
+      {
+        key: "voice/message.ogg",
+        size: 5,
+        contentType: "audio/ogg",
+        modifiedAt: "2026-08-18T00:00:00.000Z",
+      },
+    ],
+    truncated: false,
+  });
+  expect(list).toHaveBeenCalledTimes(2);
+  expect(adoptLegacyObject).toHaveBeenCalledWith({
+    organizationId: ORG,
+    logicalKey: "voice/message.ogg",
+    providerKey: `org/${ORG}/voice/message.ogg`,
+    sizeBytes: 5n,
+    contentType: "audio/ogg",
+    etag: "legacy-etag",
+    uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+  });
+  expect(events).toEqual(["adopt:voice/message.ogg", "charge"]);
+});
+
+test("does not charge when native listing fails", async () => {
+  const response = await app.request("/api/v1/apis/storage/list", undefined, {
+    BLOB: {
+      list: mock(async () => Promise.reject(new Error("native list failed"))),
+    },
+  });
+  expect(response.status).toBe(500);
+  expect(deductCredits).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -44,9 +44,11 @@ beforeEach(() => {
   adoptLegacyObjects.mockReset();
   listObjects.mockReset();
   deductCredits.mockClear();
-  adoptLegacyObjects.mockImplementation(async (inputs) => {
-    events.push(`adopt:${inputs.map((input) => input.logicalKey).join(",")}`);
-  });
+  adoptLegacyObjects.mockImplementation(
+    async (inputs: Array<{ logicalKey: string }>) => {
+      events.push(`adopt:${inputs.map((input) => input.logicalKey).join(",")}`);
+    },
+  );
   listObjects.mockResolvedValue([
     {
       logical_key: "voice/message.ogg",

--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -1,6 +1,6 @@
 /**
  * Exercises the real storage LIST router against a native fake R2 binding,
- * proving legacy discovery is catalog-adopted before a successful charge.
+ * proving legacy discovery is catalog-adopted while paid LIST is disabled.
  */
 
 import { beforeEach, expect, mock, test } from "bun:test";
@@ -59,7 +59,7 @@ beforeEach(() => {
   ]);
 });
 
-test("reconciles native authority and charges only after catalog success", async () => {
+test("reconciles native authority without activating incomplete paid LIST", async () => {
   const list = mock();
   const response = await app.request(
     "/api/v1/apis/storage/list?prefix=voice&recursive=true",
@@ -82,7 +82,9 @@ test("reconciles native authority and charges only after catalog success", async
   });
   expect(ensureNativeStorageQuotaReconciled).toHaveBeenCalled();
   expect(listObjects).toHaveBeenCalledWith(ORG, "voice", 1001, true);
-  expect(events).toEqual(["reconcile", "charge"]);
+  expect(events).toEqual(["reconcile"]);
+  expect(getServiceMethodCost).not.toHaveBeenCalled();
+  expect(deductCredits).not.toHaveBeenCalled();
 });
 
 test("does not charge when native listing fails", async () => {

--- a/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
+++ b/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
@@ -28,6 +28,9 @@ const write = mock();
 const remove = mock();
 const tryReserveBytes = mock();
 const releaseBytes = mock();
+const findObject = mock();
+const executeNativeStoragePut = mock();
+const executeNativeStorageDelete = mock();
 const loggerError = mock();
 const failureResponse = mock((_context: unknown, error: unknown) =>
   Response.json(
@@ -35,9 +38,16 @@ const failureResponse = mock((_context: unknown, error: unknown) =>
     { status: 500 },
   ),
 );
+class TestStoragePutConflictError extends Error {}
+class TestStorageQuotaExceededError extends Error {}
+class TestInsufficientCreditsError extends Error {}
+class TestNativeStoragePutError extends Error {}
 
 mock.module("@/db/repositories", () => ({
   orgStorageQuotaRepository: { tryReserveBytes, releaseBytes },
+  orgStorageMutationsRepository: { findObject },
+  StoragePutConflictError: TestStoragePutConflictError,
+  StorageQuotaExceededError: TestStorageQuotaExceededError,
 }));
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
@@ -50,6 +60,15 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 
 mock.module("@/lib/services/credits", () => ({
   creditsService: { deductCredits },
+  InsufficientCreditsError: TestInsufficientCreditsError,
+}));
+
+mock.module("@/lib/services/storage/native-storage-put", () => ({
+  calculateStoragePutPrice: (flat: number, perByte: number, bytes: number) =>
+    Number((flat + perByte * bytes).toFixed(6)),
+  executeNativeStoragePut,
+  executeNativeStorageDelete,
+  NativeStoragePutError: TestNativeStoragePutError,
 }));
 
 mock.module("@/lib/services/proxy/pricing", () => ({
@@ -86,6 +105,9 @@ beforeEach(() => {
   remove.mockReset();
   tryReserveBytes.mockReset();
   releaseBytes.mockReset();
+  findObject.mockReset();
+  executeNativeStoragePut.mockReset();
+  executeNativeStorageDelete.mockReset();
   loggerError.mockReset();
   failureResponse.mockClear();
 
@@ -102,9 +124,164 @@ beforeEach(() => {
     etag: "storage-etag",
     modified: MODIFIED_AT,
   });
+  findObject.mockResolvedValue(undefined);
+});
+
+test("PUT uses the authenticated native BLOB path with server-owned pricing", async () => {
+  const bucket = { head: mock(), get: mock(), put: mock(), delete: mock() };
+  getServiceMethodCost.mockResolvedValueOnce(0.25).mockResolvedValueOnce(0.01);
+  executeNativeStoragePut.mockResolvedValue({
+    key: OBJECT_PATH,
+    size: OBJECT_BYTES.byteLength,
+    contentType: "audio/ogg",
+    etag: "native-etag",
+  });
+
+  const response = await app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    {
+      method: "PUT",
+      headers: {
+        "content-type": "audio/ogg",
+        "idempotency-key": "logical-upload-1",
+      },
+      body: OBJECT_BYTES,
+    },
+    { BLOB: bucket },
+  );
+
+  expect(response.status).toBe(201);
+  expect(executeNativeStoragePut).toHaveBeenCalledTimes(1);
+  expect(executeNativeStoragePut).toHaveBeenCalledWith({
+    bucket,
+    organizationId: ORGANIZATION_ID,
+    logicalKey: OBJECT_PATH,
+    idempotencyKey: "logical-upload-1",
+    body: expect.any(ArrayBuffer),
+    contentType: "audio/ogg",
+    priceUsd: 0.3,
+  });
+  expect(getR2StorageAdapter).not.toHaveBeenCalled();
+  expect(tryReserveBytes).not.toHaveBeenCalled();
+  expect(deductCredits).not.toHaveBeenCalled();
+});
+
+test("routes PUT through GET and HEAD, overwrite, then durable native DELETE", async () => {
+  const uploadedAt = new Date("2026-08-18T19:00:00.000Z");
+  const providerKey = `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/object/1`;
+  findObject.mockResolvedValue({
+    generation: 1n,
+    provider_key: providerKey,
+    size_bytes: BigInt(OBJECT_BYTES.byteLength),
+    content_type: "audio/ogg",
+    etag: "native-etag",
+    uploaded_at: uploadedAt,
+    deleted_at: null,
+  });
+  getServiceMethodCost.mockResolvedValue(GET_COST);
+  const bucket = {
+    get: mock(async () => ({
+      text: async () => "asset",
+      arrayBuffer: async () => OBJECT_BYTES.buffer,
+    })),
+    head: mock(async () => ({
+      size: OBJECT_BYTES.byteLength,
+      etag: "native-etag",
+      uploaded: uploadedAt,
+    })),
+    put: mock(),
+    delete: mock(),
+  };
+
+  const getResponse = await app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    { method: "GET" },
+    { BLOB: bucket },
+  );
+  expect(getResponse.status).toBe(200);
+  expect(new Uint8Array(await getResponse.arrayBuffer())).toEqual(OBJECT_BYTES);
+
+  const headResponse = await app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    { method: "HEAD" },
+    { BLOB: bucket },
+  );
+  expect(headResponse.status).toBe(200);
+  expect(headResponse.headers.get("etag")).toBe("native-etag");
+
+  executeNativeStoragePut.mockResolvedValue({
+    key: OBJECT_PATH,
+    size: OBJECT_BYTES.byteLength,
+    contentType: "audio/ogg",
+    etag: "native-etag-2",
+  });
+  const overwriteResponse = await app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    {
+      method: "PUT",
+      headers: {
+        "content-type": "audio/ogg",
+        "idempotency-key": "overwrite-2",
+      },
+      body: OBJECT_BYTES,
+    },
+    { BLOB: bucket },
+  );
+  expect(overwriteResponse.status).toBe(201);
+
+  executeNativeStorageDelete.mockResolvedValue(undefined);
+  getServiceMethodCost.mockResolvedValueOnce(0);
+
+  const deleteResponse = await app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    { method: "DELETE", headers: { "idempotency-key": "delete-1" } },
+    { BLOB: bucket },
+  );
+  expect(deleteResponse.status).toBe(204);
+  expect(executeNativeStorageDelete).toHaveBeenCalledWith({
+    bucket,
+    organizationId: ORGANIZATION_ID,
+    logicalKey: OBJECT_PATH,
+    idempotencyKey: "delete-1",
+    priceUsd: 0,
+  });
+  expect(getR2StorageAdapter).not.toHaveBeenCalled();
+  expect(bucket.delete).not.toHaveBeenCalled();
 });
 
 describe("storage object HEAD routing", () => {
+  test("does not charge failed native or legacy reads", async () => {
+    findObject.mockResolvedValueOnce({
+      generation: 1n,
+      provider_key: "missing-generation",
+      size_bytes: 5n,
+      content_type: "text/plain",
+      etag: "missing",
+      uploaded_at: MODIFIED_AT,
+      deleted_at: null,
+    });
+    const native = await app.request(
+      `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+      { method: "GET" },
+      {
+        BLOB: {
+          get: mock(async () => null),
+          head: mock(),
+          put: mock(),
+          delete: mock(),
+        },
+      },
+    );
+    expect(native.status).toBe(503);
+    expect(deductCredits).not.toHaveBeenCalled();
+
+    findObject.mockResolvedValueOnce(undefined);
+    exists.mockResolvedValueOnce(false);
+    const legacy = await request("GET");
+    expect(legacy.status).toBe(404);
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
   test("uses HEAD pricing and metadata without reading the object body", async () => {
     getServiceMethodCost.mockResolvedValue(HEAD_COST);
 

--- a/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
+++ b/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
@@ -11,24 +11,17 @@ const ORGANIZATION_ID = "00000000-0000-4000-8000-000000021045";
 const ROUTE_PREFIX = "/api/v1/apis/storage/objects";
 const ROUTE_MOUNT = `${ROUTE_PREFIX}/:*{.+}`;
 const OBJECT_PATH = "voice/message.ogg";
-const SCOPED_KEY = `org/${ORGANIZATION_ID}/${OBJECT_PATH}`;
 const HEAD_COST = 0.00007;
 const GET_COST = 0.00011;
 const OBJECT_BYTES = new TextEncoder().encode("asset");
 const MODIFIED_AT = new Date("2026-08-17T12:00:00.000Z");
 
 const requireUserOrApiKeyWithOrg = mock();
-const getR2StorageAdapter = mock();
 const getServiceMethodCost = mock();
 const deductCredits = mock();
-const exists = mock();
-const read = mock();
-const stat = mock();
-const write = mock();
-const remove = mock();
 const tryReserveBytes = mock();
 const releaseBytes = mock();
-const findObject = mock();
+const resolveNativeStorageObject = mock();
 const executeNativeStoragePut = mock();
 const executeNativeStorageDelete = mock();
 const loggerError = mock();
@@ -44,8 +37,6 @@ class TestInsufficientCreditsError extends Error {}
 class TestNativeStoragePutError extends Error {}
 
 mock.module("@/db/repositories", () => ({
-  orgStorageQuotaRepository: { tryReserveBytes, releaseBytes },
-  orgStorageMutationsRepository: { findObject },
   StoragePutConflictError: TestStoragePutConflictError,
   StorageQuotaExceededError: TestStorageQuotaExceededError,
 }));
@@ -68,15 +59,12 @@ mock.module("@/lib/services/storage/native-storage-put", () => ({
     Number((flat + perByte * bytes).toFixed(6)),
   executeNativeStoragePut,
   executeNativeStorageDelete,
+  resolveNativeStorageObject,
   NativeStoragePutError: TestNativeStoragePutError,
 }));
 
 mock.module("@/lib/services/proxy/pricing", () => ({
   getServiceMethodCost,
-}));
-
-mock.module("@/lib/services/storage/r2-storage-adapter", () => ({
-  getR2StorageAdapter,
 }));
 
 mock.module("@/lib/utils/logger", () => ({
@@ -89,23 +77,42 @@ const storageObjectsRoute = (
 const app = new Hono();
 app.route(ROUTE_MOUNT, storageObjectsRoute);
 
+const nativeObject = {
+  generation: 1n,
+  provider_key: `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/object/1`,
+  size_bytes: BigInt(OBJECT_BYTES.byteLength),
+  content_type: "audio/ogg",
+  etag: "storage-etag",
+  uploaded_at: MODIFIED_AT,
+  deleted_at: null,
+};
+const bucket = {
+  get: mock(async () => ({
+    body: OBJECT_BYTES,
+    arrayBuffer: async () => OBJECT_BYTES.buffer,
+  })),
+  head: mock(async () => ({
+    size: OBJECT_BYTES.byteLength,
+    etag: "storage-etag",
+  })),
+  put: mock(),
+  delete: mock(),
+};
 function request(method: "GET" | "HEAD"): Response | Promise<Response> {
-  return app.request(`${ROUTE_PREFIX}/${OBJECT_PATH}`, { method });
+  return app.request(
+    `${ROUTE_PREFIX}/${OBJECT_PATH}`,
+    { method },
+    { BLOB: bucket },
+  );
 }
 
 beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
-  getR2StorageAdapter.mockReset();
   getServiceMethodCost.mockReset();
   deductCredits.mockReset();
-  exists.mockReset();
-  read.mockReset();
-  stat.mockReset();
-  write.mockReset();
-  remove.mockReset();
   tryReserveBytes.mockReset();
   releaseBytes.mockReset();
-  findObject.mockReset();
+  resolveNativeStorageObject.mockReset();
   executeNativeStoragePut.mockReset();
   executeNativeStorageDelete.mockReset();
   loggerError.mockReset();
@@ -114,17 +121,8 @@ beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockResolvedValue({
     organization_id: ORGANIZATION_ID,
   });
-  getR2StorageAdapter.mockReturnValue({ exists, read, stat, write, remove });
   deductCredits.mockResolvedValue({ success: true });
-  exists.mockResolvedValue(true);
-  read.mockResolvedValue(OBJECT_BYTES);
-  stat.mockResolvedValue({
-    size: OBJECT_BYTES.byteLength,
-    contentType: "audio/ogg",
-    etag: "storage-etag",
-    modified: MODIFIED_AT,
-  });
-  findObject.mockResolvedValue(undefined);
+  resolveNativeStorageObject.mockResolvedValue(nativeObject);
 });
 
 test("PUT uses the authenticated native BLOB path with server-owned pricing", async () => {
@@ -161,7 +159,6 @@ test("PUT uses the authenticated native BLOB path with server-owned pricing", as
     contentType: "audio/ogg",
     priceUsd: 0.3,
   });
-  expect(getR2StorageAdapter).not.toHaveBeenCalled();
   expect(tryReserveBytes).not.toHaveBeenCalled();
   expect(deductCredits).not.toHaveBeenCalled();
 });
@@ -169,7 +166,7 @@ test("PUT uses the authenticated native BLOB path with server-owned pricing", as
 test("routes PUT through GET and HEAD, overwrite, then durable native DELETE", async () => {
   const uploadedAt = new Date("2026-08-18T19:00:00.000Z");
   const providerKey = `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/object/1`;
-  findObject.mockResolvedValue({
+  resolveNativeStorageObject.mockResolvedValue({
     generation: 1n,
     provider_key: providerKey,
     size_bytes: BigInt(OBJECT_BYTES.byteLength),
@@ -245,13 +242,12 @@ test("routes PUT through GET and HEAD, overwrite, then durable native DELETE", a
     idempotencyKey: "delete-1",
     priceUsd: 0,
   });
-  expect(getR2StorageAdapter).not.toHaveBeenCalled();
   expect(bucket.delete).not.toHaveBeenCalled();
 });
 
 describe("storage object HEAD routing", () => {
   test("does not charge failed native or legacy reads", async () => {
-    findObject.mockResolvedValueOnce({
+    resolveNativeStorageObject.mockResolvedValueOnce({
       generation: 1n,
       provider_key: "missing-generation",
       size_bytes: 5n,
@@ -275,8 +271,7 @@ describe("storage object HEAD routing", () => {
     expect(native.status).toBe(503);
     expect(deductCredits).not.toHaveBeenCalled();
 
-    findObject.mockResolvedValueOnce(undefined);
-    exists.mockResolvedValueOnce(false);
+    resolveNativeStorageObject.mockResolvedValueOnce(undefined);
     const legacy = await request("GET");
     expect(legacy.status).toBe(404);
     expect(deductCredits).not.toHaveBeenCalled();
@@ -299,7 +294,6 @@ describe("storage object HEAD routing", () => {
     );
 
     expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
-    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
     expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
     expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "head");
     expect(deductCredits).toHaveBeenCalledTimes(1);
@@ -314,11 +308,7 @@ describe("storage object HEAD routing", () => {
         key: OBJECT_PATH,
       },
     });
-    expect(exists).toHaveBeenCalledTimes(1);
-    expect(exists).toHaveBeenCalledWith(SCOPED_KEY);
-    expect(stat).toHaveBeenCalledTimes(1);
-    expect(stat).toHaveBeenCalledWith(SCOPED_KEY);
-    expect(read).not.toHaveBeenCalled();
+    expect(bucket.head).toHaveBeenCalledWith(nativeObject.provider_key);
     expect(tryReserveBytes).not.toHaveBeenCalled();
     expect(releaseBytes).not.toHaveBeenCalled();
     expect(failureResponse).not.toHaveBeenCalled();
@@ -344,11 +334,7 @@ describe("storage object HEAD routing", () => {
         key: OBJECT_PATH,
       },
     });
-    expect(exists).toHaveBeenCalledWith(SCOPED_KEY);
-    expect(read).toHaveBeenCalledTimes(1);
-    expect(read).toHaveBeenCalledWith(SCOPED_KEY);
-    expect(stat).toHaveBeenCalledTimes(1);
-    expect(stat).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(bucket.get).toHaveBeenCalledWith(nativeObject.provider_key);
     expect(failureResponse).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
+++ b/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
@@ -1,7 +1,7 @@
 /**
  * Exercises the real storage object Hono router to protect HEAD from Hono's
  * automatic HEAD-to-GET dispatch. The suite proves metadata requests never
- * enter the object-body path or use GET pricing.
+ * enter the object-body path and catalog reads remain explicitly unbilled.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -11,7 +11,6 @@ const ORGANIZATION_ID = "00000000-0000-4000-8000-000000021045";
 const ROUTE_PREFIX = "/api/v1/apis/storage/objects";
 const ROUTE_MOUNT = `${ROUTE_PREFIX}/:*{.+}`;
 const OBJECT_PATH = "voice/message.ogg";
-const HEAD_COST = 0.00007;
 const GET_COST = 0.00011;
 const OBJECT_BYTES = new TextEncoder().encode("asset");
 const MODIFIED_AT = new Date("2026-08-17T12:00:00.000Z");
@@ -277,9 +276,7 @@ describe("storage object HEAD routing", () => {
     expect(deductCredits).not.toHaveBeenCalled();
   });
 
-  test("uses HEAD pricing and metadata without reading the object body", async () => {
-    getServiceMethodCost.mockResolvedValue(HEAD_COST);
-
+  test("serves HEAD metadata without reading or billing", async () => {
     const response = await request("HEAD");
 
     expect(response.status).toBe(200);
@@ -294,46 +291,21 @@ describe("storage object HEAD routing", () => {
     );
 
     expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "head");
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(deductCredits).toHaveBeenCalledWith({
-      organizationId: ORGANIZATION_ID,
-      amount: HEAD_COST,
-      description: "API proxy: storage — head",
-      metadata: {
-        type: "proxy_storage",
-        service: "storage",
-        method: "head",
-        key: OBJECT_PATH,
-      },
-    });
+    expect(getServiceMethodCost).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
     expect(bucket.head).toHaveBeenCalledWith(nativeObject.provider_key);
     expect(tryReserveBytes).not.toHaveBeenCalled();
     expect(releaseBytes).not.toHaveBeenCalled();
     expect(failureResponse).not.toHaveBeenCalled();
   });
 
-  test("preserves the existing GET pricing and body path", async () => {
-    getServiceMethodCost.mockResolvedValue(GET_COST);
-
+  test("serves the catalog GET body without billing", async () => {
     const response = await request("GET");
 
     expect(response.status).toBe(200);
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(OBJECT_BYTES);
-    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "get");
-    expect(deductCredits).toHaveBeenCalledWith({
-      organizationId: ORGANIZATION_ID,
-      amount: GET_COST,
-      description: "API proxy: storage — get",
-      metadata: {
-        type: "proxy_storage",
-        service: "storage",
-        method: "get",
-        key: OBJECT_PATH,
-      },
-    });
+    expect(getServiceMethodCost).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
     expect(bucket.get).toHaveBeenCalledWith(nativeObject.provider_key);
     expect(failureResponse).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/__tests__/storage-presign-contract.test.ts
+++ b/packages/cloud/api/__tests__/storage-presign-contract.test.ts
@@ -1,221 +1,41 @@
 /**
- * Exercises the storage presign route through its real Hono boundary with
- * deterministic authentication, billing, and storage collaborators. The suite
- * protects the GET-only contract and verifies that rejected requests cannot
- * initialize storage or create billing and provider side effects.
+ * Exercises the real storage presign route and proves authenticated requests
+ * are default-denied before provider, catalog, or billing authority can run.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
-const ORGANIZATION_ID = "00000000-0000-4000-8000-000000021009";
-const FIXED_NOW = new Date("2026-08-17T12:00:00.000Z");
-const COST = 0.00005;
-const SIGNED_URL = "https://r2.example.test/signed-object";
 const ROUTE_PATH = "/api/v1/apis/storage/presign";
-
 const requireUserOrApiKeyWithOrg = mock();
-const getR2StorageAdapter = mock();
-const getServiceMethodCost = mock();
-const deductCredits = mock();
-const presignGet = mock();
-const failureResponse = mock();
-const loggerError = mock();
-const resolveNativeStorageObject = mock();
-
-mock.module("@/lib/api/cloud-worker-errors", () => ({
-  failureResponse,
-}));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
-}));
-
-mock.module("@/lib/services/storage/r2-storage-adapter", () => ({
-  getR2StorageAdapter,
-}));
-mock.module("@/lib/services/storage/native-storage-put", () => ({
-  resolveNativeStorageObject,
-}));
-
-mock.module("@/lib/services/proxy/pricing", () => ({
-  getServiceMethodCost,
-}));
-
-mock.module("@/lib/services/credits", () => ({
-  creditsService: { deductCredits },
-}));
-
-mock.module("@/lib/utils/logger", () => ({
-  logger: { error: loggerError },
 }));
 
 const presignRoute = (await import("../v1/apis/storage/presign/route")).default;
 const app = new Hono();
 app.route(ROUTE_PATH, presignRoute);
 
-function post(body: unknown): Response | Promise<Response> {
-  return app.request(
-    ROUTE_PATH,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    },
-    { BLOB: { head: mock() } },
-  );
-}
-
 beforeEach(() => {
-  setSystemTime(FIXED_NOW);
   requireUserOrApiKeyWithOrg.mockReset();
-  getR2StorageAdapter.mockReset();
-  getServiceMethodCost.mockReset();
-  deductCredits.mockReset();
-  presignGet.mockReset();
-  failureResponse.mockReset();
-  loggerError.mockReset();
-  resolveNativeStorageObject.mockReset();
-
   requireUserOrApiKeyWithOrg.mockResolvedValue({
-    organization_id: ORGANIZATION_ID,
+    organization_id: "00000000-0000-4000-8000-000000021009",
   });
-  getR2StorageAdapter.mockReturnValue({ presignGet });
-  getServiceMethodCost.mockResolvedValue(COST);
-  deductCredits.mockResolvedValue({ success: true });
-  presignGet.mockResolvedValue(SIGNED_URL);
-  resolveNativeStorageObject.mockImplementation(
-    async (_bucket, organizationId, logicalKey) => ({
-      provider_key: `__eliza_storage_authority/v2/org/${organizationId}/${logicalKey}/1`,
-      deleted_at: null,
-    }),
-  );
 });
 
-afterEach(() => {
-  setSystemTime();
-});
-
-describe("POST /api/v1/apis/storage/presign", () => {
-  test("rejects PUT after authentication and before storage or billing side effects", async () => {
-    const response = await post({
-      key: "voice/message.ogg",
-      operation: "put",
-      expiresIn: 600,
-    });
-
-    expect(response.status).toBe(400);
-    const responseBody: unknown = await response.json();
-    expect(responseBody).toMatchObject({
-      error: "Invalid presign request",
-    });
-    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
-    expect(getR2StorageAdapter).not.toHaveBeenCalled();
-    expect(getServiceMethodCost).not.toHaveBeenCalled();
-    expect(deductCredits).not.toHaveBeenCalled();
-    expect(presignGet).not.toHaveBeenCalled();
+test("default-denies authenticated presign without reading the request key", async () => {
+  const response = await app.request(ROUTE_PATH, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{not-json",
   });
 
-  test("presigns GET with the scoped key, explicit TTL, and exact debit metadata", async () => {
-    const response = await post({
-      key: "/voice/message.ogg/",
-      operation: "get",
-      expiresIn: 600,
-    });
-
-    expect(response.status).toBe(200);
-    const responseBody: unknown = await response.json();
-    expect(responseBody).toEqual({
-      url: SIGNED_URL,
-      expiresAt: "2026-08-17T12:10:00.000Z",
-    });
-    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
-    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "presign");
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(deductCredits).toHaveBeenCalledWith({
-      organizationId: ORGANIZATION_ID,
-      amount: COST,
-      description: "API proxy: storage — presign (get)",
-      metadata: {
-        type: "proxy_storage",
-        service: "storage",
-        method: "presign",
-        operation: "get",
-      },
-    });
-    expect(presignGet).toHaveBeenCalledTimes(1);
-    expect(presignGet).toHaveBeenCalledWith(
-      `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/voice/message.ogg/1`,
-      600,
-    );
+  expect(response.status).toBe(503);
+  const responseBody: unknown = await response.json();
+  expect(responseBody).toEqual({
+    error:
+      "Storage presigning is unavailable until native signed-read billing authority is enabled",
   });
-
-  test("uses the one-hour default TTL without charging when the catalog cost is zero", async () => {
-    getServiceMethodCost.mockResolvedValueOnce(0);
-
-    const response = await post({
-      key: "avatars/profile.png",
-      operation: "get",
-    });
-
-    expect(response.status).toBe(200);
-    const responseBody: unknown = await response.json();
-    expect(responseBody).toEqual({
-      url: SIGNED_URL,
-      expiresAt: "2026-08-17T13:00:00.000Z",
-    });
-    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "presign");
-    expect(deductCredits).not.toHaveBeenCalled();
-    expect(presignGet).toHaveBeenCalledWith(
-      `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/avatars/profile.png/1`,
-      3600,
-    );
-  });
-
-  test("does not return a signed URL when the organization has insufficient credits", async () => {
-    deductCredits.mockResolvedValueOnce({ success: false });
-
-    const response = await post({
-      key: "voice/message.ogg",
-      operation: "get",
-      expiresIn: 300,
-    });
-
-    expect(response.status).toBe(402);
-    const responseBody: unknown = await response.json();
-    expect(responseBody).toEqual({
-      error: "Insufficient credits",
-      topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-    });
-    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
-    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(presignGet).toHaveBeenCalledTimes(1);
-  });
-
-  test("rejects traversal keys before storage initialization or billing", async () => {
-    const response = await post({
-      key: "voice/../secret.txt",
-      operation: "get",
-    });
-
-    expect(response.status).toBe(400);
-    const responseBody: unknown = await response.json();
-    expect(responseBody).toEqual({ error: "Invalid object key" });
-    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
-    expect(getR2StorageAdapter).not.toHaveBeenCalled();
-    expect(getServiceMethodCost).not.toHaveBeenCalled();
-    expect(deductCredits).not.toHaveBeenCalled();
-    expect(presignGet).not.toHaveBeenCalled();
-  });
+  expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
 });

--- a/packages/cloud/api/__tests__/storage-presign-contract.test.ts
+++ b/packages/cloud/api/__tests__/storage-presign-contract.test.ts
@@ -29,6 +29,7 @@ const deductCredits = mock();
 const presignGet = mock();
 const failureResponse = mock();
 const loggerError = mock();
+const resolveNativeStorageObject = mock();
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   failureResponse,
@@ -40,6 +41,9 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 
 mock.module("@/lib/services/storage/r2-storage-adapter", () => ({
   getR2StorageAdapter,
+}));
+mock.module("@/lib/services/storage/native-storage-put", () => ({
+  resolveNativeStorageObject,
 }));
 
 mock.module("@/lib/services/proxy/pricing", () => ({
@@ -59,11 +63,15 @@ const app = new Hono();
 app.route(ROUTE_PATH, presignRoute);
 
 function post(body: unknown): Response | Promise<Response> {
-  return app.request(ROUTE_PATH, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  return app.request(
+    ROUTE_PATH,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    { BLOB: { head: mock() } },
+  );
 }
 
 beforeEach(() => {
@@ -75,6 +83,7 @@ beforeEach(() => {
   presignGet.mockReset();
   failureResponse.mockReset();
   loggerError.mockReset();
+  resolveNativeStorageObject.mockReset();
 
   requireUserOrApiKeyWithOrg.mockResolvedValue({
     organization_id: ORGANIZATION_ID,
@@ -83,6 +92,12 @@ beforeEach(() => {
   getServiceMethodCost.mockResolvedValue(COST);
   deductCredits.mockResolvedValue({ success: true });
   presignGet.mockResolvedValue(SIGNED_URL);
+  resolveNativeStorageObject.mockImplementation(
+    async (_bucket, organizationId, logicalKey) => ({
+      provider_key: `__eliza_storage_authority/v2/org/${organizationId}/${logicalKey}/1`,
+      deleted_at: null,
+    }),
+  );
 });
 
 afterEach(() => {
@@ -140,7 +155,7 @@ describe("POST /api/v1/apis/storage/presign", () => {
     });
     expect(presignGet).toHaveBeenCalledTimes(1);
     expect(presignGet).toHaveBeenCalledWith(
-      `org/${ORGANIZATION_ID}/voice/message.ogg`,
+      `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/voice/message.ogg/1`,
       600,
     );
   });
@@ -162,12 +177,12 @@ describe("POST /api/v1/apis/storage/presign", () => {
     expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "presign");
     expect(deductCredits).not.toHaveBeenCalled();
     expect(presignGet).toHaveBeenCalledWith(
-      `org/${ORGANIZATION_ID}/avatars/profile.png`,
+      `__eliza_storage_authority/v2/org/${ORGANIZATION_ID}/avatars/profile.png/1`,
       3600,
     );
   });
 
-  test("does not presign when the organization has insufficient credits", async () => {
+  test("does not return a signed URL when the organization has insufficient credits", async () => {
     deductCredits.mockResolvedValueOnce({ success: false });
 
     const response = await post({
@@ -185,7 +200,7 @@ describe("POST /api/v1/apis/storage/presign", () => {
     expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
     expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
     expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(presignGet).not.toHaveBeenCalled();
+    expect(presignGet).toHaveBeenCalledTimes(1);
   });
 
   test("rejects traversal keys before storage initialization or billing", async () => {

--- a/packages/cloud/api/__tests__/storage-r2-workerd.test.ts
+++ b/packages/cloud/api/__tests__/storage-r2-workerd.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Exercises the native R2 generation contract inside genuine Workerd: an
+ * immutable conditional write, strongly consistent HEAD/GET, and delete.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Miniflare } from "miniflare";
+
+describe("native storage R2 contract in Workerd", () => {
+  let miniflare: Miniflare;
+
+  beforeAll(() => {
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-04-01",
+      modules: [
+        {
+          type: "ESModule",
+          path: "storage-worker.mjs",
+          contents: `
+            export default {
+              async fetch(request, env) {
+                const key = "__eliza_storage_authority/v2/org/test/object/1";
+                if (request.method === "PUT") {
+                  const body = await request.arrayBuffer();
+                  const digest = [...new Uint8Array(await crypto.subtle.digest("SHA-256", body))]
+                    .map((byte) => byte.toString(16).padStart(2, "0")).join("");
+                  const stored = await env.BLOB.put(key, body, {
+                    onlyIf: { etagDoesNotMatch: "*" },
+                    sha256: digest,
+                    customMetadata: { requestDigest: request.headers.get("x-request-digest") },
+                  });
+                  const head = await env.BLOB.head(key);
+                  return Response.json({ stored: stored !== null, size: head?.size, digest });
+                }
+                if (request.method === "DELETE") {
+                  await env.BLOB.delete(key);
+                  return Response.json({ absent: (await env.BLOB.head(key)) === null });
+                }
+                const object = await env.BLOB.get(key);
+                return object ? new Response(object.body) : new Response(null, { status: 404 });
+              }
+            };
+          `,
+        },
+      ],
+      r2Buckets: ["BLOB"],
+    });
+  });
+
+  afterAll(async () => {
+    await miniflare?.dispose();
+  });
+
+  test("keeps deterministic generations immutable and observes deletion immediately", async () => {
+    const first = await miniflare.dispatchFetch("https://storage.test/", {
+      method: "PUT",
+      headers: { "x-request-digest": "request-one" },
+      body: "first",
+    });
+    expect(await first.json()).toMatchObject({ stored: true, size: 5 });
+
+    const collision = await miniflare.dispatchFetch("https://storage.test/", {
+      method: "PUT",
+      headers: { "x-request-digest": "request-two" },
+      body: "second",
+    });
+    expect(await collision.json()).toMatchObject({ stored: false, size: 5 });
+    expect(
+      await (await miniflare.dispatchFetch("https://storage.test/")).text(),
+    ).toBe("first");
+
+    const removed = await miniflare.dispatchFetch("https://storage.test/", {
+      method: "DELETE",
+    });
+    expect(await removed.json()).toEqual({ absent: true });
+    expect(
+      (await miniflare.dispatchFetch("https://storage.test/")).status,
+    ).toBe(404);
+  });
+});

--- a/packages/cloud/api/cron/sweep-credit-reservations/route.ts
+++ b/packages/cloud/api/cron/sweep-credit-reservations/route.ts
@@ -9,6 +9,7 @@ import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
 import { drainAffiliatePayoutOutbox } from "@/lib/services/affiliate-payout-outbox";
 import { sweepPendingAppUsageProjections } from "@/lib/services/app-usage-projections";
 import { creditsService } from "@/lib/services/credits";
+import { reconcileNativeStoragePuts } from "@/lib/services/storage/native-storage-put";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -21,6 +22,10 @@ const app = new Hono<AppEnv>();
 async function handleSweepCreditReservations(c: Context<AppEnv>) {
   try {
     requireCronSecret(c);
+    // Native storage owns its provider-backed holds. Reconcile them before the
+    // generic stale-hold sweep so a strong R2 HEAD, not age alone, decides
+    // whether an ambiguous PUT settles or refunds.
+    const nativeStorage = await reconcileNativeStoragePuts(c.env.BLOB);
     const [stats, affiliatePayouts, appUsageProjections] = await Promise.all([
       creditsService.sweepStaleReservations(),
       drainAffiliatePayoutOutbox(),
@@ -34,6 +39,7 @@ async function handleSweepCreditReservations(c: Context<AppEnv>) {
     return c.json({
       success: true,
       stats,
+      nativeStorage,
       affiliatePayouts,
       appUsageProjections,
     });

--- a/packages/cloud/api/v1/apis/storage/list/route.ts
+++ b/packages/cloud/api/v1/apis/storage/list/route.ts
@@ -19,6 +19,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { creditsService } from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
+import { ensureNativeStorageQuotaReconciled } from "@/lib/services/storage/native-storage-put";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const STORAGE_SERVICE_ID = "storage";
@@ -64,68 +65,15 @@ app.get("/", async (c) => {
     const { prefix, recursive } = parsed.data;
 
     const trimmedPrefix = prefix.replace(/^\/+|\/+$/g, "");
-    const scopedPrefix = trimmedPrefix
-      ? `org/${organization_id}/${trimmedPrefix}`
-      : `org/${organization_id}/`;
-    const orgPrefix = `org/${organization_id}/`;
-
-    let cursor: string | undefined;
-    let providerTruncated = false;
-    let adoptedCount = 0;
-    const legacyCandidates = [];
-    do {
-      const page = await bucket.list({
-        prefix: scopedPrefix,
-        cursor,
-        delimiter: recursive ? undefined : "/",
-        limit: Math.min(1000, MAX_LIST_RESULTS + 1 - adoptedCount),
-        include: ["httpMetadata"],
-      });
-      for (const observed of page.objects) {
-        if (!observed.key?.startsWith(orgPrefix)) continue;
-        const logicalKey = observed.key.slice(orgPrefix.length);
-        if (!observed.etag || observed.size <= 0) {
-          throw new Error(
-            "[storage list] R2 returned incomplete object metadata",
-          );
-        }
-        const rawContentType = observed.httpMetadata?.contentType?.trim();
-        const contentType =
-          rawContentType &&
-          rawContentType.length <= 255 &&
-          !/[\0\r\n]/.test(rawContentType)
-            ? rawContentType
-            : "application/octet-stream";
-        legacyCandidates.push({
-          organizationId: organization_id,
-          logicalKey,
-          providerKey: observed.key,
-          sizeBytes: BigInt(observed.size),
-          contentType,
-          etag: observed.etag,
-          uploadedAt: observed.uploaded ?? new Date(0),
-        });
-        adoptedCount += 1;
-        if (adoptedCount > MAX_LIST_RESULTS) break;
-      }
-      providerTruncated = page.truncated || adoptedCount > MAX_LIST_RESULTS;
-      cursor = page.cursor;
-    } while (providerTruncated && cursor && adoptedCount <= MAX_LIST_RESULTS);
-    await orgStorageMutationsRepository.adoptLegacyObjects(legacyCandidates);
+    await ensureNativeStorageQuotaReconciled(bucket, organization_id);
 
     const catalog = await orgStorageMutationsRepository.listObjects(
       organization_id,
       trimmedPrefix,
       MAX_LIST_RESULTS + 1,
+      recursive,
     );
-    const visible = catalog.filter((object) => {
-      if (recursive) return true;
-      const suffix = object.logical_key
-        .slice(trimmedPrefix.length)
-        .replace(/^\//, "");
-      return !suffix.includes("/");
-    });
-    const items = visible.slice(0, MAX_LIST_RESULTS).map((object) => {
+    const items = catalog.slice(0, MAX_LIST_RESULTS).map((object) => {
       if (!object.content_type || !object.uploaded_at) {
         throw new Error("[storage list] catalog object metadata is incomplete");
       }
@@ -163,10 +111,7 @@ app.get("/", async (c) => {
 
     return c.json({
       items,
-      truncated:
-        providerTruncated ||
-        visible.length > MAX_LIST_RESULTS ||
-        catalog.length > MAX_LIST_RESULTS,
+      truncated: catalog.length > MAX_LIST_RESULTS,
     });
   } catch (error) {
     // error-policy:J1 route boundary — every catch in v1/apis/* translates a thrown error into a structured HTTP failure via failureResponse (never a fabricated 200/empty).

--- a/packages/cloud/api/v1/apis/storage/list/route.ts
+++ b/packages/cloud/api/v1/apis/storage/list/route.ts
@@ -6,7 +6,7 @@
  *       → { items: [{ key, size, contentType, modifiedAt }] }
  *
  * Auth: requireUserOrApiKeyWithOrg.
- * Pricing: flat per-request charge against the `storage:list` row.
+ * Pricing: explicitly unbilled until durable paid-list receipts are available.
  *
  * Native R2 enumeration discovers and adopts legacy tenant-prefixed objects;
  * the catalog remains authoritative for immutable generations and tombstones.
@@ -17,12 +17,9 @@ import { z } from "zod";
 import { orgStorageMutationsRepository } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { creditsService } from "@/lib/services/credits";
-import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
 import { ensureNativeStorageQuotaReconciled } from "@/lib/services/storage/native-storage-put";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
-const STORAGE_SERVICE_ID = "storage";
 const MAX_LIST_RESULTS = 1000;
 
 const listQuerySchema = z.object({
@@ -84,30 +81,6 @@ app.get("/", async (c) => {
         modifiedAt: object.uploaded_at.toISOString(),
       };
     });
-
-    const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, "list");
-    if (cost > 0) {
-      const deductResult = await creditsService.deductCredits({
-        organizationId: organization_id,
-        amount: cost,
-        description: "API proxy: storage — list",
-        metadata: {
-          type: "proxy_storage",
-          service: "storage",
-          method: "list",
-          prefix,
-        },
-      });
-      if (!deductResult.success) {
-        return c.json(
-          {
-            error: "Insufficient credits",
-            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-          },
-          402,
-        );
-      }
-    }
 
     return c.json({
       items,

--- a/packages/cloud/api/v1/apis/storage/list/route.ts
+++ b/packages/cloud/api/v1/apis/storage/list/route.ts
@@ -8,17 +8,17 @@
  * Auth: requireUserOrApiKeyWithOrg.
  * Pricing: flat per-request charge against the `storage:list` row.
  *
- * Listing is automatically scoped to `org/${organization_id}/`. The returned
- * `key` field is the user-relative key (the org prefix is stripped).
+ * Native R2 enumeration discovers and adopts legacy tenant-prefixed objects;
+ * the catalog remains authoritative for immutable generations and tombstones.
  */
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { orgStorageMutationsRepository } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { creditsService } from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
-import { getR2StorageAdapter } from "@/lib/services/storage/r2-storage-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const STORAGE_SERVICE_ID = "storage";
@@ -40,8 +40,8 @@ app.get("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
+    const bucket = c.env.BLOB;
+    if (!bucket?.list) {
       return c.json(
         {
           error:
@@ -62,6 +62,78 @@ app.get("/", async (c) => {
       );
     }
     const { prefix, recursive } = parsed.data;
+
+    const trimmedPrefix = prefix.replace(/^\/+|\/+$/g, "");
+    const scopedPrefix = trimmedPrefix
+      ? `org/${organization_id}/${trimmedPrefix}`
+      : `org/${organization_id}/`;
+    const orgPrefix = `org/${organization_id}/`;
+
+    let cursor: string | undefined;
+    let providerTruncated = false;
+    let adoptedCount = 0;
+    do {
+      const page = await bucket.list({
+        prefix: scopedPrefix,
+        cursor,
+        delimiter: recursive ? undefined : "/",
+        limit: Math.min(1000, MAX_LIST_RESULTS + 1 - adoptedCount),
+        include: ["httpMetadata"],
+      });
+      for (const observed of page.objects) {
+        if (!observed.key?.startsWith(orgPrefix)) continue;
+        const logicalKey = observed.key.slice(orgPrefix.length);
+        if (!observed.etag || observed.size <= 0) {
+          throw new Error(
+            "[storage list] R2 returned incomplete object metadata",
+          );
+        }
+        const rawContentType = observed.httpMetadata?.contentType?.trim();
+        const contentType =
+          rawContentType &&
+          rawContentType.length <= 255 &&
+          !/[\0\r\n]/.test(rawContentType)
+            ? rawContentType
+            : "application/octet-stream";
+        await orgStorageMutationsRepository.adoptLegacyObject({
+          organizationId: organization_id,
+          logicalKey,
+          providerKey: observed.key,
+          sizeBytes: BigInt(observed.size),
+          contentType,
+          etag: observed.etag,
+          uploadedAt: observed.uploaded ?? new Date(0),
+        });
+        adoptedCount += 1;
+        if (adoptedCount > MAX_LIST_RESULTS) break;
+      }
+      providerTruncated = page.truncated || adoptedCount > MAX_LIST_RESULTS;
+      cursor = page.cursor;
+    } while (providerTruncated && cursor && adoptedCount <= MAX_LIST_RESULTS);
+
+    const catalog = await orgStorageMutationsRepository.listObjects(
+      organization_id,
+      trimmedPrefix,
+      MAX_LIST_RESULTS + 1,
+    );
+    const visible = catalog.filter((object) => {
+      if (recursive) return true;
+      const suffix = object.logical_key
+        .slice(trimmedPrefix.length)
+        .replace(/^\//, "");
+      return !suffix.includes("/");
+    });
+    const items = visible.slice(0, MAX_LIST_RESULTS).map((object) => {
+      if (!object.content_type || !object.uploaded_at) {
+        throw new Error("[storage list] catalog object metadata is incomplete");
+      }
+      return {
+        key: object.logical_key,
+        size: Number(object.size_bytes),
+        contentType: object.content_type,
+        modifiedAt: object.uploaded_at.toISOString(),
+      };
+    });
 
     const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, "list");
     if (cost > 0) {
@@ -87,33 +159,12 @@ app.get("/", async (c) => {
       }
     }
 
-    const trimmedPrefix = prefix.replace(/^\/+|\/+$/g, "");
-    const scopedPrefix = trimmedPrefix
-      ? `org/${organization_id}/${trimmedPrefix}`
-      : `org/${organization_id}/`;
-    const orgPrefix = `org/${organization_id}/`;
-
-    const fullKeys = await adapter.list(scopedPrefix, { recursive });
-    const truncated = fullKeys.slice(0, MAX_LIST_RESULTS);
-
-    const items = await Promise.all(
-      truncated.map(async (fullKey) => {
-        const stat = await adapter.stat(fullKey);
-        const userKey = fullKey.startsWith(orgPrefix)
-          ? fullKey.slice(orgPrefix.length)
-          : fullKey;
-        return {
-          key: userKey,
-          size: stat.size,
-          contentType: stat.contentType,
-          modifiedAt: stat.modified.toISOString(),
-        };
-      }),
-    );
-
     return c.json({
       items,
-      truncated: fullKeys.length > MAX_LIST_RESULTS,
+      truncated:
+        providerTruncated ||
+        visible.length > MAX_LIST_RESULTS ||
+        catalog.length > MAX_LIST_RESULTS,
     });
   } catch (error) {
     // error-policy:J1 route boundary — every catch in v1/apis/* translates a thrown error into a structured HTTP failure via failureResponse (never a fabricated 200/empty).

--- a/packages/cloud/api/v1/apis/storage/list/route.ts
+++ b/packages/cloud/api/v1/apis/storage/list/route.ts
@@ -72,6 +72,7 @@ app.get("/", async (c) => {
     let cursor: string | undefined;
     let providerTruncated = false;
     let adoptedCount = 0;
+    const legacyCandidates = [];
     do {
       const page = await bucket.list({
         prefix: scopedPrefix,
@@ -95,7 +96,7 @@ app.get("/", async (c) => {
           !/[\0\r\n]/.test(rawContentType)
             ? rawContentType
             : "application/octet-stream";
-        await orgStorageMutationsRepository.adoptLegacyObject({
+        legacyCandidates.push({
           organizationId: organization_id,
           logicalKey,
           providerKey: observed.key,
@@ -110,6 +111,7 @@ app.get("/", async (c) => {
       providerTruncated = page.truncated || adoptedCount > MAX_LIST_RESULTS;
       cursor = page.cursor;
     } while (providerTruncated && cursor && adoptedCount <= MAX_LIST_RESULTS);
+    await orgStorageMutationsRepository.adoptLegacyObjects(legacyCandidates);
 
     const catalog = await orgStorageMutationsRepository.listObjects(
       organization_id,

--- a/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
+++ b/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
@@ -7,8 +7,9 @@
  *   HEAD   /api/v1/apis/storage/objects/{key+}                metadata headers, 404 if missing
  *   DELETE /api/v1/apis/storage/objects/{key+}                204 No Content
  *
- * Storage backend: R2 over the S3 API via @brighter/storage-adapter-s3
- * (transparent to clients). Object keys are scoped per organization:
+ * Native Worker R2 writes use immutable generation keys and a durable database
+ * authority; catalog-backed reads and deletes follow the committed generation.
+ * Object keys are scoped per organization:
  * `org/${organization_id}/${userKey}` is the actual storage key. Clients
  * never see the prefix; the route prepends/strips it.
  *
@@ -18,11 +19,25 @@
  */
 
 import { type Context, Hono } from "hono";
-import { orgStorageQuotaRepository } from "@/db/repositories";
+import {
+  orgStorageMutationsRepository,
+  orgStorageQuotaRepository,
+  StoragePutConflictError,
+  StorageQuotaExceededError,
+} from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { creditsService } from "@/lib/services/credits";
+import {
+  creditsService,
+  InsufficientCreditsError,
+} from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
+import {
+  calculateStoragePutPrice,
+  executeNativeStorageDelete,
+  executeNativeStoragePut,
+  NativeStoragePutError,
+} from "@/lib/services/storage/native-storage-put";
 import { getR2StorageAdapter } from "@/lib/services/storage/r2-storage-adapter";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -101,9 +116,10 @@ app.put("/*", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      logger.error("[storage proxy] R2_* env vars not set; PUT rejected");
+    if (!c.env.BLOB) {
+      logger.error(
+        "[storage proxy] native BLOB binding is missing; PUT rejected",
+      );
       return c.json(R2_NOT_CONFIGURED_BODY, 503);
     }
 
@@ -124,39 +140,24 @@ app.put("/*", async (c) => {
       );
     }
 
-    const reserved = await orgStorageQuotaRepository.tryReserveBytes(
-      organization_id,
-      BigInt(bytes),
-    );
-    if (reserved === null) {
-      return c.json(
-        { error: "Storage quota exceeded for this organization" },
-        413,
-      );
-    }
-
     const flatCost = await getServiceMethodCost(STORAGE_SERVICE_ID, "put");
     const perByteCost = await getServiceMethodCost(
       STORAGE_SERVICE_ID,
       "put_per_byte",
     );
-    const totalCost = flatCost + perByteCost * bytes;
-    const deductResult = await creditsService.deductCredits({
+    const totalCost = calculateStoragePutPrice(flatCost, perByteCost, bytes);
+    const response = await executeNativeStoragePut({
+      bucket: c.env.BLOB,
       organizationId: organization_id,
-      amount: totalCost,
-      description: `API proxy: storage — put (${bytes}B)`,
-      metadata: {
-        type: "proxy_storage",
-        service: "storage",
-        method: "put",
-        bytes,
-      },
+      logicalKey: validated.key,
+      idempotencyKey: c.req.header("idempotency-key") ?? "",
+      body: arrayBuffer,
+      contentType: c.req.header("content-type") ?? "application/octet-stream",
+      priceUsd: totalCost,
     });
-    if (!deductResult.success) {
-      await orgStorageQuotaRepository.releaseBytes(
-        organization_id,
-        BigInt(bytes),
-      );
+    return c.json(response, 201);
+  } catch (error) {
+    if (error instanceof InsufficientCreditsError) {
       return c.json(
         {
           error: "Insufficient credits",
@@ -165,29 +166,22 @@ app.put("/*", async (c) => {
         402,
       );
     }
-
-    const key = scopedKey(organization_id, validated.key);
-    try {
-      await adapter.write(key, Buffer.from(arrayBuffer));
-    } catch (error) {
-      await orgStorageQuotaRepository.releaseBytes(
-        organization_id,
-        BigInt(bytes),
-      );
-      throw error;
+    if (error instanceof StorageQuotaExceededError) {
+      return c.json({ error: error.message }, 413);
     }
-
-    const stat = await adapter.stat(key);
-    return c.json(
-      {
-        key: validated.key,
-        size: stat.size,
-        contentType: stat.contentType,
-        etag: stat.etag,
-      },
-      201,
-    );
-  } catch (error) {
+    if (error instanceof StoragePutConflictError) {
+      return c.json({ error: error.message, reason: error.reason }, 409);
+    }
+    if (error instanceof NativeStoragePutError) {
+      const status =
+        error.code === "OPERATION_IN_PROGRESS"
+          ? 409
+          : error.code === "IDEMPOTENCY_REQUIRED" ||
+              error.code === "IDEMPOTENCY_INVALID"
+            ? 400
+            : 503;
+      return c.json({ error: error.message, code: error.code }, status);
+    }
     return failureResponse(c, error);
   }
 });
@@ -197,23 +191,71 @@ app.get("/*", async (c) => {
   // original request method. Branch here so HEAD never enters the body-read
   // path or uses GET pricing.
   if (c.req.method === "HEAD") {
-    return handleLegacyStorageHead(c);
+    return handleStorageHead(c);
   }
 
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      return c.json(R2_NOT_CONFIGURED_BODY, 503);
-    }
-
     const validated = validateUserKey(c.req.param("*"));
     if ("error" in validated) {
       return c.json({ error: validated.error }, 400);
     }
 
+    const nativeObject = await orgStorageMutationsRepository.findObject(
+      organization_id,
+      validated.key,
+    );
+    if (nativeObject?.deleted_at)
+      return c.json({ error: "Object not found" }, 404);
+    if (nativeObject?.provider_key) {
+      if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+      const object = await c.env.BLOB.get(nativeObject.provider_key);
+      if (!object) {
+        return c.json(
+          { error: "Storage generation is temporarily unavailable" },
+          503,
+        );
+      }
+      const body = object.body ?? (await object.arrayBuffer?.());
+      if (!body) {
+        return c.json({ error: "Storage generation body is unavailable" }, 503);
+      }
+      const deduct = await deductFlatCost(organization_id, "get", {
+        key: validated.key,
+      });
+      if (!deduct.ok) {
+        return c.json(
+          {
+            error: "Insufficient credits",
+            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
+          },
+          402,
+        );
+      }
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": nativeObject.content_type!,
+          "Content-Length": String(nativeObject.size_bytes),
+          ETag: nativeObject.etag!,
+          "Last-Modified": nativeObject.uploaded_at!.toUTCString(),
+        },
+      });
+    }
+
+    const adapter = getR2StorageAdapter(c.env);
+    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+
+    const key = scopedKey(organization_id, validated.key);
+    if (!(await adapter.exists(key))) {
+      return c.json({ error: "Object not found" }, 404);
+    }
+    const [bytes, stat] = await Promise.all([
+      adapter.read(key),
+      adapter.stat(key),
+    ]);
     const deduct = await deductFlatCost(organization_id, "get", {
       key: validated.key,
     });
@@ -226,15 +268,6 @@ app.get("/*", async (c) => {
         402,
       );
     }
-
-    const key = scopedKey(organization_id, validated.key);
-    if (!(await adapter.exists(key))) {
-      return c.json({ error: "Object not found" }, 404);
-    }
-    const [bytes, stat] = await Promise.all([
-      adapter.read(key),
-      adapter.stat(key),
-    ]);
     const body = new ArrayBuffer(bytes.byteLength);
     new Uint8Array(body).set(bytes);
     return new Response(body, {
@@ -251,21 +284,65 @@ app.get("/*", async (c) => {
   }
 });
 
-async function handleLegacyStorageHead(c: Context<AppEnv>) {
+async function handleStorageHead(c: Context<AppEnv>) {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
-
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      return c.json(R2_NOT_CONFIGURED_BODY, 503);
-    }
 
     const validated = validateUserKey(c.req.param("*"));
     if ("error" in validated) {
       return c.json({ error: validated.error }, 400);
     }
 
+    const nativeObject = await orgStorageMutationsRepository.findObject(
+      organization_id,
+      validated.key,
+    );
+    if (nativeObject?.deleted_at) return new Response(null, { status: 404 });
+    if (nativeObject?.provider_key) {
+      if (!c.env.BLOB?.head) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+      const observed = await c.env.BLOB.head(nativeObject.provider_key);
+      if (
+        !observed ||
+        observed.size !== Number(nativeObject.size_bytes) ||
+        observed.etag !== nativeObject.etag
+      ) {
+        return c.json(
+          { error: "Storage generation is temporarily unavailable" },
+          503,
+        );
+      }
+      const deduct = await deductFlatCost(organization_id, "head", {
+        key: validated.key,
+      });
+      if (!deduct.ok) {
+        return c.json(
+          {
+            error: "Insufficient credits",
+            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
+          },
+          402,
+        );
+      }
+      return new Response(null, {
+        status: 200,
+        headers: {
+          "Content-Type": nativeObject.content_type!,
+          "Content-Length": String(nativeObject.size_bytes),
+          ETag: nativeObject.etag!,
+          "Last-Modified": nativeObject.uploaded_at!.toUTCString(),
+        },
+      });
+    }
+
+    const adapter = getR2StorageAdapter(c.env);
+    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+
+    const key = scopedKey(organization_id, validated.key);
+    if (!(await adapter.exists(key))) {
+      return new Response(null, { status: 404 });
+    }
+    const stat = await adapter.stat(key);
     const deduct = await deductFlatCost(organization_id, "head", {
       key: validated.key,
     });
@@ -278,12 +355,6 @@ async function handleLegacyStorageHead(c: Context<AppEnv>) {
         402,
       );
     }
-
-    const key = scopedKey(organization_id, validated.key);
-    if (!(await adapter.exists(key))) {
-      return new Response(null, { status: 404 });
-    }
-    const stat = await adapter.stat(key);
     return new Response(null, {
       status: 200,
       headers: {
@@ -303,15 +374,34 @@ app.delete("/*", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      return c.json(R2_NOT_CONFIGURED_BODY, 503);
-    }
-
     const validated = validateUserKey(c.req.param("*"));
     if ("error" in validated) {
       return c.json({ error: validated.error }, 400);
     }
+
+    const nativeObject = await orgStorageMutationsRepository.findObject(
+      organization_id,
+      validated.key,
+    );
+    if (nativeObject?.deleted_at) return new Response(null, { status: 204 });
+    if (nativeObject && nativeObject.generation > 0n) {
+      if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+      const deleteCost = await getServiceMethodCost(
+        STORAGE_SERVICE_ID,
+        "delete",
+      );
+      await executeNativeStorageDelete({
+        bucket: c.env.BLOB,
+        organizationId: organization_id,
+        logicalKey: validated.key,
+        idempotencyKey: c.req.header("idempotency-key") ?? "",
+        priceUsd: deleteCost,
+      });
+      return new Response(null, { status: 204 });
+    }
+
+    const adapter = getR2StorageAdapter(c.env);
+    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
 
     const key = scopedKey(organization_id, validated.key);
     if (!(await adapter.exists(key))) {
@@ -325,6 +415,19 @@ app.delete("/*", async (c) => {
     );
     return new Response(null, { status: 204 });
   } catch (error) {
+    if (error instanceof StoragePutConflictError) {
+      return c.json({ error: error.message, reason: error.reason }, 409);
+    }
+    if (error instanceof NativeStoragePutError) {
+      const status =
+        error.code === "OPERATION_IN_PROGRESS"
+          ? 409
+          : error.code === "IDEMPOTENCY_REQUIRED" ||
+              error.code === "IDEMPOTENCY_INVALID"
+            ? 400
+            : 503;
+      return c.json({ error: error.message, code: error.code }, status);
+    }
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
+++ b/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
@@ -9,9 +9,8 @@
  *
  * Native Worker R2 writes use immutable generation keys and a durable database
  * authority; catalog-backed reads and deletes follow the committed generation.
- * Object keys are scoped per organization:
- * `org/${organization_id}/${userKey}` is the actual storage key. Clients
- * never see the prefix; the route prepends/strips it.
+ * Legacy `org/${organization_id}/${userKey}` objects are adopted on first
+ * access; new bytes live under tenant-scoped immutable generation keys.
  *
  * Auth: requireUserOrApiKeyWithOrg.
  * Quota: hard-rejects writes with 413 when the org's bytes_limit is exceeded.
@@ -20,8 +19,6 @@
 
 import { type Context, Hono } from "hono";
 import {
-  orgStorageMutationsRepository,
-  orgStorageQuotaRepository,
   StoragePutConflictError,
   StorageQuotaExceededError,
 } from "@/db/repositories";
@@ -37,8 +34,8 @@ import {
   executeNativeStorageDelete,
   executeNativeStoragePut,
   NativeStoragePutError,
+  resolveNativeStorageObject,
 } from "@/lib/services/storage/native-storage-put";
-import { getR2StorageAdapter } from "@/lib/services/storage/r2-storage-adapter";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -51,10 +48,6 @@ const R2_NOT_CONFIGURED_BODY = {
 };
 
 const app = new Hono<AppEnv>();
-
-function scopedKey(organizationId: string, userKey: string): string {
-  return `org/${organizationId}/${userKey}`;
-}
 
 /**
  * Validates a client-supplied storage key. Returns the key on success or a
@@ -177,7 +170,8 @@ app.put("/*", async (c) => {
         error.code === "OPERATION_IN_PROGRESS"
           ? 409
           : error.code === "IDEMPOTENCY_REQUIRED" ||
-              error.code === "IDEMPOTENCY_INVALID"
+              error.code === "IDEMPOTENCY_INVALID" ||
+              error.code === "CONTENT_TYPE_INVALID"
             ? 400
             : 503;
       return c.json({ error: error.message, code: error.code }, status);
@@ -203,14 +197,15 @@ app.get("/*", async (c) => {
       return c.json({ error: validated.error }, 400);
     }
 
-    const nativeObject = await orgStorageMutationsRepository.findObject(
+    if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+    const nativeObject = await resolveNativeStorageObject(
+      c.env.BLOB,
       organization_id,
       validated.key,
     );
     if (nativeObject?.deleted_at)
       return c.json({ error: "Object not found" }, 404);
     if (nativeObject?.provider_key) {
-      if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
       const object = await c.env.BLOB.get(nativeObject.provider_key);
       if (!object) {
         return c.json(
@@ -245,40 +240,7 @@ app.get("/*", async (c) => {
       });
     }
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
-
-    const key = scopedKey(organization_id, validated.key);
-    if (!(await adapter.exists(key))) {
-      return c.json({ error: "Object not found" }, 404);
-    }
-    const [bytes, stat] = await Promise.all([
-      adapter.read(key),
-      adapter.stat(key),
-    ]);
-    const deduct = await deductFlatCost(organization_id, "get", {
-      key: validated.key,
-    });
-    if (!deduct.ok) {
-      return c.json(
-        {
-          error: "Insufficient credits",
-          topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-        },
-        402,
-      );
-    }
-    const body = new ArrayBuffer(bytes.byteLength);
-    new Uint8Array(body).set(bytes);
-    return new Response(body, {
-      status: 200,
-      headers: {
-        "Content-Type": stat.contentType,
-        "Content-Length": String(stat.size),
-        ETag: stat.etag,
-        "Last-Modified": stat.modified.toUTCString(),
-      },
-    });
+    return c.json({ error: "Object not found" }, 404);
   } catch (error) {
     return failureResponse(c, error);
   }
@@ -294,13 +256,14 @@ async function handleStorageHead(c: Context<AppEnv>) {
       return c.json({ error: validated.error }, 400);
     }
 
-    const nativeObject = await orgStorageMutationsRepository.findObject(
+    if (!c.env.BLOB?.head) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+    const nativeObject = await resolveNativeStorageObject(
+      c.env.BLOB,
       organization_id,
       validated.key,
     );
     if (nativeObject?.deleted_at) return new Response(null, { status: 404 });
     if (nativeObject?.provider_key) {
-      if (!c.env.BLOB?.head) return c.json(R2_NOT_CONFIGURED_BODY, 503);
       const observed = await c.env.BLOB.head(nativeObject.provider_key);
       if (
         !observed ||
@@ -335,35 +298,7 @@ async function handleStorageHead(c: Context<AppEnv>) {
       });
     }
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
-
-    const key = scopedKey(organization_id, validated.key);
-    if (!(await adapter.exists(key))) {
-      return new Response(null, { status: 404 });
-    }
-    const stat = await adapter.stat(key);
-    const deduct = await deductFlatCost(organization_id, "head", {
-      key: validated.key,
-    });
-    if (!deduct.ok) {
-      return c.json(
-        {
-          error: "Insufficient credits",
-          topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-        },
-        402,
-      );
-    }
-    return new Response(null, {
-      status: 200,
-      headers: {
-        "Content-Type": stat.contentType,
-        "Content-Length": String(stat.size),
-        ETag: stat.etag,
-        "Last-Modified": stat.modified.toUTCString(),
-      },
-    });
+    return new Response(null, { status: 404 });
   } catch (error) {
     return failureResponse(c, error);
   }
@@ -379,13 +314,14 @@ app.delete("/*", async (c) => {
       return c.json({ error: validated.error }, 400);
     }
 
-    const nativeObject = await orgStorageMutationsRepository.findObject(
+    if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+    const nativeObject = await resolveNativeStorageObject(
+      c.env.BLOB,
       organization_id,
       validated.key,
     );
     if (nativeObject?.deleted_at) return new Response(null, { status: 204 });
-    if (nativeObject && nativeObject.generation > 0n) {
-      if (!c.env.BLOB) return c.json(R2_NOT_CONFIGURED_BODY, 503);
+    if (nativeObject?.provider_key) {
       const deleteCost = await getServiceMethodCost(
         STORAGE_SERVICE_ID,
         "delete",
@@ -400,19 +336,6 @@ app.delete("/*", async (c) => {
       return new Response(null, { status: 204 });
     }
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) return c.json(R2_NOT_CONFIGURED_BODY, 503);
-
-    const key = scopedKey(organization_id, validated.key);
-    if (!(await adapter.exists(key))) {
-      return new Response(null, { status: 204 });
-    }
-    const stat = await adapter.stat(key);
-    await adapter.remove(key);
-    await orgStorageQuotaRepository.releaseBytes(
-      organization_id,
-      BigInt(stat.size),
-    );
     return new Response(null, { status: 204 });
   } catch (error) {
     if (error instanceof StoragePutConflictError) {
@@ -423,7 +346,8 @@ app.delete("/*", async (c) => {
         error.code === "OPERATION_IN_PROGRESS"
           ? 409
           : error.code === "IDEMPOTENCY_REQUIRED" ||
-              error.code === "IDEMPOTENCY_INVALID"
+              error.code === "IDEMPOTENCY_INVALID" ||
+              error.code === "CONTENT_TYPE_INVALID"
             ? 400
             : 503;
       return c.json({ error: error.message, code: error.code }, status);

--- a/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
+++ b/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
@@ -14,7 +14,8 @@
  *
  * Auth: requireUserOrApiKeyWithOrg.
  * Quota: hard-rejects writes with 413 when the org's bytes_limit is exceeded.
- * Pricing: per-request charge (and per-byte for PUT) deducted via creditsService.
+ * Pricing: PUT is durably billed by the mutation service. Catalog GET and HEAD
+ * remain explicitly unbilled until durable paid-read receipts are available.
  */
 
 import { type Context, Hono } from "hono";
@@ -24,10 +25,7 @@ import {
 } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import {
-  creditsService,
-  InsufficientCreditsError,
-} from "@/lib/services/credits";
+import { InsufficientCreditsError } from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
 import {
   calculateStoragePutPrice,
@@ -76,32 +74,6 @@ function validateUserKey(
     return { error: "Object key may not contain '..' path segments" };
   }
   return { key };
-}
-
-async function deductFlatCost(
-  organizationId: string,
-  method: "put" | "get" | "head" | "delete" | "list" | "presign",
-  metadata: Record<string, string | number>,
-): Promise<{ ok: true } | { ok: false }> {
-  const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, method);
-  if (cost === 0) {
-    return { ok: true };
-  }
-  const result = await creditsService.deductCredits({
-    organizationId,
-    amount: cost,
-    description: `API proxy: storage — ${method}`,
-    metadata: {
-      type: "proxy_storage",
-      service: "storage",
-      method,
-      ...metadata,
-    },
-  });
-  if (!result.success) {
-    return { ok: false };
-  }
-  return { ok: true };
 }
 
 app.put("/*", async (c) => {
@@ -217,18 +189,6 @@ app.get("/*", async (c) => {
       if (!body) {
         return c.json({ error: "Storage generation body is unavailable" }, 503);
       }
-      const deduct = await deductFlatCost(organization_id, "get", {
-        key: validated.key,
-      });
-      if (!deduct.ok) {
-        return c.json(
-          {
-            error: "Insufficient credits",
-            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-          },
-          402,
-        );
-      }
       return new Response(body, {
         status: 200,
         headers: {
@@ -273,18 +233,6 @@ async function handleStorageHead(c: Context<AppEnv>) {
         return c.json(
           { error: "Storage generation is temporarily unavailable" },
           503,
-        );
-      }
-      const deduct = await deductFlatCost(organization_id, "head", {
-        key: validated.key,
-      });
-      if (!deduct.ok) {
-        return c.json(
-          {
-            error: "Insufficient credits",
-            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-          },
-          402,
         );
       }
       return new Response(null, {

--- a/packages/cloud/api/v1/apis/storage/presign/route.ts
+++ b/packages/cloud/api/v1/apis/storage/presign/route.ts
@@ -1,129 +1,23 @@
 /**
- * Mints a short-lived signed URL for a single attachment object.
- *
- * Routes:
- *   POST /api/v1/apis/storage/presign  { key, operation: "get", expiresIn? }
- *                                      → { url, expiresAt }
- *
- * Auth: requireUserOrApiKeyWithOrg.
- * Pricing: flat per-request charge against the `storage:presign` row.
- *
- * The URL grants direct, temporary GET access to the catalog's exact provider
- * generation through the R2 S3 endpoint. Writes continue through the object
- * route so organization quota and generation authority remain server-owned.
+ * Default-denies storage presigning until native capability authority, durable
+ * paid-request receipts, and signed-URL telemetry policy are implemented.
  */
 
 import { Hono } from "hono";
-import { z } from "zod";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { creditsService } from "@/lib/services/credits";
-import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
-import { resolveNativeStorageObject } from "@/lib/services/storage/native-storage-put";
-import { getR2StorageAdapter } from "@/lib/services/storage/r2-storage-adapter";
-import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
-
-const STORAGE_SERVICE_ID = "storage";
-const MAX_OBJECT_KEY_LENGTH = 1024;
-
-const presignRequestSchema = z.object({
-  key: z.string().min(1).max(MAX_OBJECT_KEY_LENGTH),
-  operation: z.literal("get"),
-  expiresIn: z.number().int().min(60).max(3600).optional(),
-});
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
-  try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const { organization_id } = user;
-
-    const rawBody = await c.req.json().catch(() => {
-      // error-policy:J3 malformed JSON remains an explicit invalid request.
-      return null;
-    });
-    const parsed = presignRequestSchema.safeParse(rawBody);
-    if (!parsed.success) {
-      return c.json(
-        { error: "Invalid presign request", details: parsed.error.issues },
-        400,
-      );
-    }
-    const { key: userKey, operation, expiresIn } = parsed.data;
-    const trimmedKey = userKey.replace(/^\/+|\/+$/g, "");
-    if (
-      trimmedKey.length === 0 ||
-      trimmedKey.split("/").some((s) => s === "..")
-    ) {
-      return c.json({ error: "Invalid object key" }, 400);
-    }
-
-    if (!c.env.BLOB) {
-      return c.json(
-        {
-          error:
-            "Attachment storage proxy not available — server misconfigured",
-        },
-        503,
-      );
-    }
-    const object = await resolveNativeStorageObject(
-      c.env.BLOB,
-      organization_id,
-      trimmedKey,
-    );
-    if (!object?.provider_key || object.deleted_at) {
-      return c.json({ error: "Object not found" }, 404);
-    }
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      logger.error("[storage proxy] R2_* env vars not set; presign rejected");
-      return c.json(
-        {
-          error:
-            "Attachment storage proxy not available — server misconfigured",
-        },
-        503,
-      );
-    }
-
-    const ttlSeconds = expiresIn ?? 3600;
-    const url = await adapter.presignGet(object.provider_key, ttlSeconds);
-
-    const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, "presign");
-    if (cost > 0) {
-      const deductResult = await creditsService.deductCredits({
-        organizationId: organization_id,
-        amount: cost,
-        description: `API proxy: storage — presign (${operation})`,
-        metadata: {
-          type: "proxy_storage",
-          service: "storage",
-          method: "presign",
-          operation,
-        },
-      });
-      if (!deductResult.success) {
-        return c.json(
-          {
-            error: "Insufficient credits",
-            topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-          },
-          402,
-        );
-      }
-    }
-
-    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
-
-    return c.json({ url, expiresAt });
-  } catch (error) {
-    // error-policy:J1 the route boundary translates authentication, pricing,
-    // debit, configuration, and signing failures into the canonical response.
-    return failureResponse(c, error);
-  }
+  await requireUserOrApiKeyWithOrg(c);
+  return c.json(
+    {
+      error:
+        "Storage presigning is unavailable until native signed-read billing authority is enabled",
+    },
+    503,
+  );
 });
 
 export default app;

--- a/packages/cloud/api/v1/apis/storage/presign/route.ts
+++ b/packages/cloud/api/v1/apis/storage/presign/route.ts
@@ -8,9 +8,9 @@
  * Auth: requireUserOrApiKeyWithOrg.
  * Pricing: flat per-request charge against the `storage:presign` row.
  *
- * The URL grants direct, temporary GET access through the R2 S3 endpoint;
- * clients hit R2 directly rather than this proxy. Writes continue through
- * `PUT /objects/{key+}` so organization quota enforcement remains authoritative.
+ * The URL grants direct, temporary GET access to the catalog's exact provider
+ * generation through the R2 S3 endpoint. Writes continue through the object
+ * route so organization quota and generation authority remain server-owned.
  */
 
 import { Hono } from "hono";
@@ -19,6 +19,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { creditsService } from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
+import { resolveNativeStorageObject } from "@/lib/services/storage/native-storage-put";
 import { getR2StorageAdapter } from "@/lib/services/storage/r2-storage-adapter";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -59,6 +60,23 @@ app.post("/", async (c) => {
       return c.json({ error: "Invalid object key" }, 400);
     }
 
+    if (!c.env.BLOB) {
+      return c.json(
+        {
+          error:
+            "Attachment storage proxy not available — server misconfigured",
+        },
+        503,
+      );
+    }
+    const object = await resolveNativeStorageObject(
+      c.env.BLOB,
+      organization_id,
+      trimmedKey,
+    );
+    if (!object?.provider_key || object.deleted_at) {
+      return c.json({ error: "Object not found" }, 404);
+    }
     const adapter = getR2StorageAdapter(c.env);
     if (!adapter) {
       logger.error("[storage proxy] R2_* env vars not set; presign rejected");
@@ -70,6 +88,9 @@ app.post("/", async (c) => {
         503,
       );
     }
+
+    const ttlSeconds = expiresIn ?? 3600;
+    const url = await adapter.presignGet(object.provider_key, ttlSeconds);
 
     const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, "presign");
     if (cost > 0) {
@@ -95,9 +116,6 @@ app.post("/", async (c) => {
       }
     }
 
-    const ttlSeconds = expiresIn ?? 3600;
-    const scopedKey = `org/${organization_id}/${trimmedKey}`;
-    const url = await adapter.presignGet(scopedKey, ttlSeconds);
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
 
     return c.json({ url, expiresAt });

--- a/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
+++ b/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
@@ -1,0 +1,46 @@
+-- Establishes authoritative native storage catalog and precise server-owned pricing.
+ALTER TABLE "service_pricing"
+  ALTER COLUMN "cost" TYPE numeric(18,12);
+ALTER TABLE "service_pricing_audit"
+  ALTER COLUMN "old_cost" TYPE numeric(18,12),
+  ALTER COLUMN "new_cost" TYPE numeric(18,12);
+
+ALTER TABLE "credit_transactions"
+  ADD CONSTRAINT "credit_transactions_tenant_identity_unique"
+  UNIQUE("id", "organization_id");
+
+CREATE TABLE "org_storage_objects" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "logical_key" text NOT NULL,
+  "generation" bigint DEFAULT 0 NOT NULL,
+  "provider_key" text,
+  "size_bytes" bigint DEFAULT 0 NOT NULL,
+  "content_type" text,
+  "content_sha256" text,
+  "etag" text,
+  "uploaded_at" timestamp with time zone,
+  "deleted_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "org_storage_objects_tenant_identity_unique" UNIQUE("id", "organization_id"),
+  CONSTRAINT "org_storage_objects_shape_check" CHECK (
+    "generation" >= 0 AND "size_bytes" >= 0 AND ((
+      "generation" = 0 AND "provider_key" IS NULL AND "size_bytes" = 0
+    ) OR (
+      "generation" > 0 AND "provider_key" IS NOT NULL
+      AND "content_sha256" ~ '^[0-9a-f]{64}$'
+      AND char_length("content_type") BETWEEN 1 AND 255
+      AND char_length("etag") BETWEEN 1 AND 512
+      AND "uploaded_at" IS NOT NULL AND "deleted_at" IS NULL
+    ) OR (
+      "generation" > 0 AND "provider_key" IS NULL AND "size_bytes" = 0
+      AND "deleted_at" IS NOT NULL
+    ))
+  )
+);
+
+CREATE UNIQUE INDEX "org_storage_objects_tenant_key_uidx"
+  ON "org_storage_objects"("organization_id", "logical_key");
+CREATE UNIQUE INDEX "org_storage_objects_provider_key_uidx"
+  ON "org_storage_objects"("provider_key") WHERE "provider_key" IS NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
+++ b/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
@@ -1,9 +1,11 @@
 -- Establishes authoritative native storage catalog and precise server-owned pricing.
 ALTER TABLE "service_pricing"
   ALTER COLUMN "cost" TYPE numeric(18,12);
+--> statement-breakpoint
 ALTER TABLE "service_pricing_audit"
   ALTER COLUMN "old_cost" TYPE numeric(18,12),
   ALTER COLUMN "new_cost" TYPE numeric(18,12);
+--> statement-breakpoint
 
 WITH stale_price AS (
   SELECT id, service_id, method, cost
@@ -23,6 +25,7 @@ UPDATE "service_pricing" AS pricing
 SET "cost" = 0.000000001, "updated_at" = NOW()
 FROM stale_price
 WHERE pricing.id = stale_price.id;
+--> statement-breakpoint
 
 CREATE TABLE "org_storage_objects" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -59,8 +62,10 @@ CREATE TABLE "org_storage_objects" (
     ))
   )
 );
+--> statement-breakpoint
 
 CREATE UNIQUE INDEX "org_storage_objects_tenant_key_uidx"
   ON "org_storage_objects"("organization_id", "logical_key");
+--> statement-breakpoint
 CREATE UNIQUE INDEX "org_storage_objects_provider_key_uidx"
   ON "org_storage_objects"("provider_key") WHERE "provider_key" IS NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
+++ b/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
@@ -5,9 +5,24 @@ ALTER TABLE "service_pricing_audit"
   ALTER COLUMN "old_cost" TYPE numeric(18,12),
   ALTER COLUMN "new_cost" TYPE numeric(18,12);
 
-ALTER TABLE "credit_transactions"
-  ADD CONSTRAINT "credit_transactions_tenant_identity_unique"
-  UNIQUE("id", "organization_id");
+WITH stale_price AS (
+  SELECT id, service_id, method, cost
+  FROM "service_pricing"
+  WHERE "service_id" = 'storage' AND "method" = 'put_per_byte' AND "cost" = 0
+), audit AS (
+  INSERT INTO "service_pricing_audit" (
+    service_pricing_id, service_id, method, old_cost, new_cost,
+    change_type, changed_by, reason
+  )
+  SELECT id, service_id, method, cost, 0.000000001,
+    'migration_reseed', 'migration:0254',
+    'Restore put_per_byte after widening pricing precision'
+  FROM stale_price
+)
+UPDATE "service_pricing" AS pricing
+SET "cost" = 0.000000001, "updated_at" = NOW()
+FROM stale_price
+WHERE pricing.id = stale_price.id;
 
 CREATE TABLE "org_storage_objects" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -27,6 +42,11 @@ CREATE TABLE "org_storage_objects" (
   CONSTRAINT "org_storage_objects_shape_check" CHECK (
     "generation" >= 0 AND "size_bytes" >= 0 AND ((
       "generation" = 0 AND "provider_key" IS NULL AND "size_bytes" = 0
+    ) OR (
+      "generation" = 0 AND "provider_key" IS NOT NULL AND "size_bytes" > 0
+      AND char_length("content_type") BETWEEN 1 AND 255
+      AND char_length("etag") BETWEEN 1 AND 512
+      AND "uploaded_at" IS NOT NULL AND "deleted_at" IS NULL
     ) OR (
       "generation" > 0 AND "provider_key" IS NOT NULL
       AND "content_sha256" ~ '^[0-9a-f]{64}$'

--- a/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
+++ b/packages/cloud/shared/src/db/migrations/0256_org_storage_native_objects.sql
@@ -17,7 +17,7 @@ WITH stale_price AS (
     change_type, changed_by, reason
   )
   SELECT id, service_id, method, cost, 0.000000001,
-    'migration_reseed', 'migration:0254',
+    'migration_reseed', 'migration:0256',
     'Restore put_per_byte after widening pricing precision'
   FROM stale_price
 )
@@ -25,6 +25,10 @@ UPDATE "service_pricing" AS pricing
 SET "cost" = 0.000000001, "updated_at" = NOW()
 FROM stale_price
 WHERE pricing.id = stale_price.id;
+--> statement-breakpoint
+
+ALTER TABLE "org_storage_quota"
+  ADD COLUMN "native_catalog_reconciled_at" timestamp with time zone;
 --> statement-breakpoint
 
 CREATE TABLE "org_storage_objects" (

--- a/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
+++ b/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
@@ -50,6 +50,7 @@ CREATE TABLE "org_storage_put_operations" (
   "credit_transaction_id" uuid,
   "lease_token" uuid,
   "lease_expires_at" timestamp with time zone,
+  "provider_absence_observed_at" timestamp with time zone,
   "result_etag" text,
   "result_uploaded_at" timestamp with time zone,
   "response_json" text,
@@ -76,6 +77,7 @@ CREATE TABLE "org_storage_put_operations" (
     AND ("state" IN ('prepared','reconciling','refunded') OR "credit_transaction_id" IS NOT NULL OR "price_usd" = 0)
     AND (("lease_token" IS NULL) = ("lease_expires_at" IS NULL))
     AND ("state" <> 'reconciling' OR "lease_token" IS NOT NULL)
+    AND ("provider_absence_observed_at" IS NULL OR "state" = 'reconciling')
     AND ("state" <> 'committed' OR (
       "result_etag" IS NOT NULL AND "result_uploaded_at" IS NOT NULL
       AND "response_json" IS NOT NULL AND "completed_at" IS NOT NULL

--- a/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
+++ b/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
@@ -1,4 +1,14 @@
 -- Adds durable native storage mutation operations and tenant-bound credit authority.
+CREATE FUNCTION "org_storage_credit_matches_tenant"(uuid, uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+PARALLEL UNSAFE
+AS 'SELECT $1 IS NULL OR EXISTS (
+  SELECT 1 FROM credit_transactions
+  WHERE id = $1 AND organization_id = $2
+)';
+
 CREATE TABLE "org_storage_put_operations" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
@@ -28,20 +38,23 @@ CREATE TABLE "org_storage_put_operations" (
   CONSTRAINT "org_storage_put_operations_object_tenant_fkey"
     FOREIGN KEY ("object_id", "organization_id")
     REFERENCES "org_storage_objects"("id", "organization_id") ON DELETE RESTRICT,
-  CONSTRAINT "org_storage_put_operations_credit_tenant_fkey"
-    FOREIGN KEY ("credit_transaction_id", "organization_id")
-    REFERENCES "credit_transactions"("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_put_operations_credit_fkey"
+    FOREIGN KEY ("credit_transaction_id")
+    REFERENCES "credit_transactions"("id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_put_operations_credit_tenant_check"
+    CHECK ("org_storage_credit_matches_tenant"("credit_transaction_id", "organization_id")),
   CONSTRAINT "org_storage_put_operations_shape_check" CHECK (
     "idempotency_key_hash" ~ '^[0-9a-f]{64}$'
     AND "request_digest" ~ '^[0-9a-f]{64}$'
     AND "target_content_sha256" ~ '^[0-9a-f]{64}$'
-    AND "state" IN ('prepared','reserved','provider_started','committed','refunded')
+    AND "state" IN ('prepared','reserved','provider_started','reconciling','committed','refunded')
     AND "source_generation" >= 0 AND "target_generation" = "source_generation" + 1
     AND "source_size_bytes" >= 0 AND "target_size_bytes" > 0
     AND "quota_reserved_bytes" = GREATEST("target_size_bytes" - "source_size_bytes", 0)
     AND "price_usd" >= 0
-    AND ("state" IN ('prepared','refunded') OR "credit_transaction_id" IS NOT NULL OR "price_usd" = 0)
+    AND ("state" IN ('prepared','reconciling','refunded') OR "credit_transaction_id" IS NOT NULL OR "price_usd" = 0)
     AND (("lease_token" IS NULL) = ("lease_expires_at" IS NULL))
+    AND ("state" <> 'reconciling' OR "lease_token" IS NOT NULL)
     AND ("state" <> 'committed' OR (
       "result_etag" IS NOT NULL AND "result_uploaded_at" IS NOT NULL
       AND "response_json" IS NOT NULL AND "completed_at" IS NOT NULL
@@ -58,7 +71,7 @@ CREATE UNIQUE INDEX "org_storage_put_operations_provider_key_uidx"
   ON "org_storage_put_operations"("target_provider_key");
 CREATE UNIQUE INDEX "org_storage_put_operations_active_object_uidx"
   ON "org_storage_put_operations"("object_id")
-  WHERE "state" IN ('prepared','reserved','provider_started');
+  WHERE "state" IN ('prepared','reserved','provider_started','reconciling');
 CREATE INDEX "org_storage_put_operations_due_idx"
   ON "org_storage_put_operations"("state", "lease_expires_at");
 
@@ -85,7 +98,7 @@ CREATE TABLE "org_storage_delete_operations" (
     "idempotency_key_hash" ~ '^[0-9a-f]{64}$'
     AND "request_digest" ~ '^[0-9a-f]{64}$'
     AND "state" IN ('prepared','provider_started','committed')
-    AND "source_generation" > 0 AND "source_size_bytes" > 0
+    AND "source_generation" >= 0 AND "source_size_bytes" > 0
     AND (("lease_token" IS NULL) = ("lease_expires_at" IS NULL))
     AND ("state" <> 'committed' OR (
       "response_json" IS NOT NULL AND "completed_at" IS NOT NULL AND "lease_token" IS NULL

--- a/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
+++ b/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
@@ -1,0 +1,101 @@
+-- Adds durable native storage mutation operations and tenant-bound credit authority.
+CREATE TABLE "org_storage_put_operations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "object_id" uuid NOT NULL,
+  "idempotency_key_hash" text NOT NULL,
+  "request_digest" text NOT NULL,
+  "state" text DEFAULT 'prepared' NOT NULL,
+  "source_generation" bigint NOT NULL,
+  "source_provider_key" text,
+  "source_size_bytes" bigint NOT NULL,
+  "target_generation" bigint NOT NULL,
+  "target_provider_key" text NOT NULL,
+  "target_size_bytes" bigint NOT NULL,
+  "target_content_type" text NOT NULL,
+  "target_content_sha256" text NOT NULL,
+  "quota_reserved_bytes" bigint NOT NULL,
+  "price_usd" numeric(12,6) NOT NULL,
+  "credit_transaction_id" uuid,
+  "lease_token" uuid,
+  "lease_expires_at" timestamp with time zone,
+  "result_etag" text,
+  "result_uploaded_at" timestamp with time zone,
+  "response_json" text,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "org_storage_put_operations_object_tenant_fkey"
+    FOREIGN KEY ("object_id", "organization_id")
+    REFERENCES "org_storage_objects"("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_put_operations_credit_tenant_fkey"
+    FOREIGN KEY ("credit_transaction_id", "organization_id")
+    REFERENCES "credit_transactions"("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_put_operations_shape_check" CHECK (
+    "idempotency_key_hash" ~ '^[0-9a-f]{64}$'
+    AND "request_digest" ~ '^[0-9a-f]{64}$'
+    AND "target_content_sha256" ~ '^[0-9a-f]{64}$'
+    AND "state" IN ('prepared','reserved','provider_started','committed','refunded')
+    AND "source_generation" >= 0 AND "target_generation" = "source_generation" + 1
+    AND "source_size_bytes" >= 0 AND "target_size_bytes" > 0
+    AND "quota_reserved_bytes" = GREATEST("target_size_bytes" - "source_size_bytes", 0)
+    AND "price_usd" >= 0
+    AND ("state" IN ('prepared','refunded') OR "credit_transaction_id" IS NOT NULL OR "price_usd" = 0)
+    AND (("lease_token" IS NULL) = ("lease_expires_at" IS NULL))
+    AND ("state" <> 'committed' OR (
+      "result_etag" IS NOT NULL AND "result_uploaded_at" IS NOT NULL
+      AND "response_json" IS NOT NULL AND "completed_at" IS NOT NULL
+    ))
+    AND ("state" <> 'refunded' OR (
+      "response_json" IS NOT NULL AND "completed_at" IS NOT NULL
+    ))
+  )
+);
+
+CREATE UNIQUE INDEX "org_storage_put_operations_idempotency_uidx"
+  ON "org_storage_put_operations"("organization_id", "idempotency_key_hash");
+CREATE UNIQUE INDEX "org_storage_put_operations_provider_key_uidx"
+  ON "org_storage_put_operations"("target_provider_key");
+CREATE UNIQUE INDEX "org_storage_put_operations_active_object_uidx"
+  ON "org_storage_put_operations"("object_id")
+  WHERE "state" IN ('prepared','reserved','provider_started');
+CREATE INDEX "org_storage_put_operations_due_idx"
+  ON "org_storage_put_operations"("state", "lease_expires_at");
+
+CREATE TABLE "org_storage_delete_operations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "object_id" uuid NOT NULL,
+  "idempotency_key_hash" text NOT NULL,
+  "request_digest" text NOT NULL,
+  "state" text DEFAULT 'prepared' NOT NULL,
+  "source_generation" bigint NOT NULL,
+  "source_provider_key" text NOT NULL,
+  "source_size_bytes" bigint NOT NULL,
+  "lease_token" uuid,
+  "lease_expires_at" timestamp with time zone,
+  "response_json" text,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "org_storage_delete_operations_object_tenant_fkey"
+    FOREIGN KEY ("object_id", "organization_id")
+    REFERENCES "org_storage_objects"("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_delete_operations_shape_check" CHECK (
+    "idempotency_key_hash" ~ '^[0-9a-f]{64}$'
+    AND "request_digest" ~ '^[0-9a-f]{64}$'
+    AND "state" IN ('prepared','provider_started','committed')
+    AND "source_generation" > 0 AND "source_size_bytes" > 0
+    AND (("lease_token" IS NULL) = ("lease_expires_at" IS NULL))
+    AND ("state" <> 'committed' OR (
+      "response_json" IS NOT NULL AND "completed_at" IS NOT NULL AND "lease_token" IS NULL
+    ))
+  )
+);
+CREATE UNIQUE INDEX "org_storage_delete_operations_idempotency_uidx"
+  ON "org_storage_delete_operations"("organization_id", "idempotency_key_hash");
+CREATE UNIQUE INDEX "org_storage_delete_operations_active_object_uidx"
+  ON "org_storage_delete_operations"("object_id")
+  WHERE "state" IN ('prepared','provider_started');
+CREATE INDEX "org_storage_delete_operations_due_idx"
+  ON "org_storage_delete_operations"("state", "lease_expires_at");

--- a/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
+++ b/packages/cloud/shared/src/db/migrations/0257_org_storage_native_put_operations.sql
@@ -8,6 +8,27 @@ AS 'SELECT $1 IS NULL OR EXISTS (
   SELECT 1 FROM credit_transactions
   WHERE id = $1 AND organization_id = $2
 )';
+--> statement-breakpoint
+
+CREATE FUNCTION "credit_transaction_tenant_is_immutable"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.organization_id IS DISTINCT FROM OLD.organization_id THEN
+    RAISE EXCEPTION 'credit transaction tenant provenance is immutable'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+
+CREATE TRIGGER "credit_transactions_tenant_immutable"
+BEFORE UPDATE OF "organization_id" ON "credit_transactions"
+FOR EACH ROW
+EXECUTE FUNCTION "credit_transaction_tenant_is_immutable"();
+--> statement-breakpoint
 
 CREATE TABLE "org_storage_put_operations" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -64,16 +85,21 @@ CREATE TABLE "org_storage_put_operations" (
     ))
   )
 );
+--> statement-breakpoint
 
 CREATE UNIQUE INDEX "org_storage_put_operations_idempotency_uidx"
   ON "org_storage_put_operations"("organization_id", "idempotency_key_hash");
+--> statement-breakpoint
 CREATE UNIQUE INDEX "org_storage_put_operations_provider_key_uidx"
   ON "org_storage_put_operations"("target_provider_key");
+--> statement-breakpoint
 CREATE UNIQUE INDEX "org_storage_put_operations_active_object_uidx"
   ON "org_storage_put_operations"("object_id")
   WHERE "state" IN ('prepared','reserved','provider_started','reconciling');
+--> statement-breakpoint
 CREATE INDEX "org_storage_put_operations_due_idx"
   ON "org_storage_put_operations"("state", "lease_expires_at");
+--> statement-breakpoint
 
 CREATE TABLE "org_storage_delete_operations" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -105,10 +131,13 @@ CREATE TABLE "org_storage_delete_operations" (
     ))
   )
 );
+--> statement-breakpoint
 CREATE UNIQUE INDEX "org_storage_delete_operations_idempotency_uidx"
   ON "org_storage_delete_operations"("organization_id", "idempotency_key_hash");
+--> statement-breakpoint
 CREATE UNIQUE INDEX "org_storage_delete_operations_active_object_uidx"
   ON "org_storage_delete_operations"("object_id")
   WHERE "state" IN ('prepared','provider_started');
+--> statement-breakpoint
 CREATE INDEX "org_storage_delete_operations_due_idx"
   ON "org_storage_delete_operations"("state", "lease_expires_at");

--- a/packages/cloud/shared/src/db/migrations/0258_org_storage_generation_gc_outbox.sql
+++ b/packages/cloud/shared/src/db/migrations/0258_org_storage_generation_gc_outbox.sql
@@ -14,8 +14,10 @@ CREATE TABLE "org_storage_gc_outbox" (
     AND ("state" <> 'completed' OR "completed_at" IS NOT NULL)
   )
 );
+--> statement-breakpoint
 
 CREATE UNIQUE INDEX "org_storage_gc_outbox_operation_uidx"
   ON "org_storage_gc_outbox"("operation_id");
+--> statement-breakpoint
 CREATE INDEX "org_storage_gc_outbox_due_idx"
   ON "org_storage_gc_outbox"("state", "not_before");

--- a/packages/cloud/shared/src/db/migrations/0258_org_storage_generation_gc_outbox.sql
+++ b/packages/cloud/shared/src/db/migrations/0258_org_storage_generation_gc_outbox.sql
@@ -1,0 +1,21 @@
+-- Adds durable garbage collection for superseded immutable storage generations.
+CREATE TABLE "org_storage_gc_outbox" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "operation_id" uuid NOT NULL
+    REFERENCES "org_storage_put_operations"("id") ON DELETE CASCADE,
+  "provider_key" text NOT NULL,
+  "state" text DEFAULT 'pending' NOT NULL,
+  "not_before" timestamp with time zone NOT NULL,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "org_storage_gc_outbox_shape_check" CHECK (
+    "state" IN ('pending','completed')
+    AND ("state" <> 'completed' OR "completed_at" IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX "org_storage_gc_outbox_operation_uidx"
+  ON "org_storage_gc_outbox"("operation_id");
+CREATE INDEX "org_storage_gc_outbox_due_idx"
+  ON "org_storage_gc_outbox"("state", "not_before");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1786,6 +1786,27 @@
       "when": 1791489600000,
       "tag": "0255_crypto_settlement_outboxes",
       "breakpoints": true
+    },
+    {
+      "idx": 255,
+      "version": "7",
+      "when": 1791576000000,
+      "tag": "0256_org_storage_native_objects",
+      "breakpoints": true
+    },
+    {
+      "idx": 256,
+      "version": "7",
+      "when": 1791662400000,
+      "tag": "0257_org_storage_native_put_operations",
+      "breakpoints": true
+    },
+    {
+      "idx": 257,
+      "version": "7",
+      "when": 1791748800000,
+      "tag": "0258_org_storage_generation_gc_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
@@ -149,7 +149,7 @@ describe("OrgStorageMutationsRepository", () => {
     expect(audit.rows[0]).toMatchObject({
       old_cost: "0.000000000000",
       new_cost: "0.000000001000",
-      changed_by: "migration:0254",
+      changed_by: "migration:0256",
     });
   });
 
@@ -213,6 +213,67 @@ describe("OrgStorageMutationsRepository", () => {
     ]);
     expect(claims.filter((claim) => claim.status === "fulfilled")).toHaveLength(1);
     expect(claims.filter((claim) => claim.status === "rejected")).toHaveLength(1);
+  });
+
+  test("requires an expired provider-absence quarantine before one reconciler can recheck", async () => {
+    const prepared = await prepare("quarantine", "e", 4n);
+    await repository.reservePutCredits({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+    });
+    const provider = await repository.claimProviderLease({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      leaseToken: crypto.randomUUID(),
+      leaseExpiresAt: new Date(Date.now() - 1),
+      now: new Date(Date.now() - 2),
+    });
+    const firstToken = crypto.randomUUID();
+    const firstClaim = await repository.claimReconciliationLease({
+      operationId: provider.id,
+      organizationId: ORG,
+      leaseToken: firstToken,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      staleBefore: new Date(),
+      now: new Date(),
+    });
+    const recheckAt = new Date(Date.now() + 10 * 60_000);
+    const quarantined = await repository.deferProviderAbsence({
+      operationId: firstClaim.id,
+      organizationId: ORG,
+      leaseToken: firstToken,
+      observedAt: new Date(),
+      recheckAt,
+    });
+    expect(quarantined.state).toBe("reconciling");
+    expect(quarantined.provider_absence_observed_at).toBeInstanceOf(Date);
+    await expect(
+      repository.claimReconciliationLease({
+        operationId: quarantined.id,
+        organizationId: ORG,
+        leaseToken: crypto.randomUUID(),
+        leaseExpiresAt: new Date(Date.now() + 60_000),
+        staleBefore: new Date(),
+        now: new Date(),
+      }),
+    ).rejects.toMatchObject({ reason: "stale_lease" });
+
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET lease_expires_at = ${new Date(Date.now() - 1)}
+      WHERE id = ${quarantined.id}`);
+    const attempts = await Promise.allSettled(
+      [crypto.randomUUID(), crypto.randomUUID()].map((leaseToken) =>
+        repository.claimReconciliationLease({
+          operationId: quarantined.id,
+          organizationId: ORG,
+          leaseToken,
+          leaseExpiresAt: new Date(Date.now() + 60_000),
+          staleBefore: new Date(),
+          now: new Date(),
+        }),
+      ),
+    );
+    expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(1);
   });
 
   test("atomically fences credit reservation against prepared-operation recovery", async () => {
@@ -324,6 +385,62 @@ describe("OrgStorageMutationsRepository", () => {
       "legacy/voice.ogg",
     ]);
     expect(listed[1]?.generation).toBe(1n);
+  });
+
+  test("repairs historical quota drift from the adopted catalog plus active reservations", async () => {
+    await repository.adoptLegacyObjects([
+      {
+        organizationId: ORG,
+        logicalKey: "legacy/one.bin",
+        providerKey: `org/${ORG}/legacy/one.bin`,
+        sizeBytes: 3n,
+        contentType: "application/octet-stream",
+        etag: "one-etag",
+        uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+      },
+      {
+        organizationId: ORG,
+        logicalKey: "legacy/two.bin",
+        providerKey: `org/${ORG}/legacy/two.bin`,
+        sizeBytes: 4n,
+        contentType: "application/octet-stream",
+        etag: "two-etag",
+        uploadedAt: new Date("2026-08-18T00:01:00.000Z"),
+      },
+    ]);
+    await dbWrite.execute(sql`UPDATE org_storage_quota
+      SET bytes_used = 99, bytes_limit = 1000
+      WHERE organization_id = ${ORG}`);
+    await Promise.all([
+      repository.reconcileNativeQuotaFromCatalog(ORG),
+      prepare("new.bin", "f", 5n),
+    ]);
+
+    const quota = await dbWrite.execute(sql`SELECT bytes_used FROM org_storage_quota
+      WHERE organization_id = ${ORG}`);
+    expect(BigInt(String(quota.rows[0]?.bytes_used))).toBe(12n);
+    expect(await repository.quotaNeedsNativeCatalogReconciliation(ORG)).toBe(false);
+  });
+
+  test("filters non-recursive catalog depth before applying the result limit", async () => {
+    await dbWrite.execute(sql`INSERT INTO org_storage_objects (
+        organization_id, logical_key, provider_key, size_bytes,
+        content_type, etag, uploaded_at
+      )
+      SELECT ${ORG}, 'folder/' || lpad(value::text, 4, '0') || '/item.bin',
+        ${`org/${ORG}/folder/`} || lpad(value::text, 4, '0') || '/item.bin',
+        1, 'application/octet-stream', 'etag-' || value, NOW()
+      FROM generate_series(0, 1000) AS value`);
+    await dbWrite.execute(sql`INSERT INTO org_storage_objects (
+        organization_id, logical_key, provider_key, size_bytes,
+        content_type, etag, uploaded_at
+      ) VALUES (
+        ${ORG}, 'folder/zzzz.bin', ${`org/${ORG}/folder/zzzz.bin`},
+        1, 'application/octet-stream', 'direct-etag', NOW()
+      )`);
+
+    const listed = await repository.listObjects(ORG, "folder", 1001, false);
+    expect(listed.map((object) => object.logical_key)).toEqual(["folder/zzzz.bin"]);
   });
 
   test("rejects an idempotency replay whose durable digest includes a changed price", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
@@ -28,7 +28,7 @@ let repository: typeof import("../org-storage-mutations").orgStorageMutationsRep
 
 async function executeSqlFile(name: string): Promise<void> {
   const source = readFileSync(join(import.meta.dir, "../../migrations", name), "utf8");
-  for (const statement of source.split(";")) {
+  for (const statement of source.split("--> statement-breakpoint")) {
     if (statement.trim()) await dbWrite.execute(sql.raw(statement));
   }
 }
@@ -440,6 +440,13 @@ describe("OrgStorageMutationsRepository", () => {
           storage_operation_id: prepared.operation.id,
         })}::jsonb
       )`);
+    await expect(
+      Promise.resolve(
+        dbWrite.execute(sql`UPDATE credit_transactions
+          SET organization_id = ${ORG}
+          WHERE id = ${transactionId}`),
+      ),
+    ).rejects.toThrow();
     await expect(
       Promise.resolve(
         dbWrite.execute(sql`UPDATE org_storage_put_operations

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
@@ -280,7 +280,7 @@ describe("OrgStorageMutationsRepository", () => {
 
   test("adopts already-counted legacy bytes and transfers overwrite authority to GC", async () => {
     await dbWrite.execute(
-      sql`UPDATE org_storage_quota SET bytes_used = 8 WHERE organization_id = ${ORG}`,
+      sql`UPDATE org_storage_quota SET bytes_used = 10 WHERE organization_id = ${ORG}`,
     );
     const legacyKey = `org/${ORG}/legacy/voice.ogg`;
     const adopted = await repository.adoptLegacyObject({
@@ -294,6 +294,17 @@ describe("OrgStorageMutationsRepository", () => {
     });
     expect(adopted.generation).toBe(0n);
     expect(adopted.provider_key).toBe(legacyKey);
+    await repository.adoptLegacyObjects([
+      {
+        organizationId: ORG,
+        logicalKey: "legacy/second.ogg",
+        providerKey: `org/${ORG}/legacy/second.ogg`,
+        sizeBytes: 2n,
+        contentType: "audio/ogg",
+        etag: "legacy-second-etag",
+        uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+      },
+    ]);
     const prepared = await prepare("legacy/voice.ogg", "e", 3n);
     expect(prepared.operation.source_size_bytes).toBe(8n);
     expect(prepared.operation.quota_reserved_bytes).toBe(0n);
@@ -302,14 +313,17 @@ describe("OrgStorageMutationsRepository", () => {
     const quota = await dbWrite.execute(
       sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
     );
-    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("3");
+    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("5");
     const gc = await dbWrite.execute(
       sql`SELECT provider_key FROM org_storage_gc_outbox WHERE organization_id = ${ORG}`,
     );
     expect(gc.rows[0]).toMatchObject({ provider_key: legacyKey });
     const listed = await repository.listObjects(ORG, "legacy/");
-    expect(listed.map((object) => object.logical_key)).toEqual(["legacy/voice.ogg"]);
-    expect(listed[0]?.generation).toBe(1n);
+    expect(listed.map((object) => object.logical_key)).toEqual([
+      "legacy/second.ogg",
+      "legacy/voice.ogg",
+    ]);
+    expect(listed[1]?.generation).toBe(1n);
   });
 
   test("rejects an idempotency replay whose durable digest includes a changed price", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
@@ -36,20 +36,39 @@ async function executeSqlFile(name: string): Promise<void> {
 beforeAll(async () => {
   ({ closeDatabaseConnectionsForTests, dbWrite } = await import("../../client"));
   for (const statement of [
-    `CREATE TABLE organizations (id uuid PRIMARY KEY)`,
+    `CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      credit_balance numeric(12,6) DEFAULT 10 NOT NULL,
+      updated_at timestamp DEFAULT now() NOT NULL
+    )`,
     `CREATE TABLE credit_transactions (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
       organization_id uuid NOT NULL REFERENCES organizations(id),
       amount numeric(12,6) NOT NULL,
       type text NOT NULL,
+      description text,
       metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
       settled_at timestamp with time zone,
       created_at timestamp DEFAULT now() NOT NULL
     )`,
-    `CREATE TABLE service_pricing (cost numeric(12,6) NOT NULL)`,
+    `CREATE TABLE service_pricing (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      service_id text NOT NULL,
+      method text NOT NULL,
+      cost numeric(12,6) NOT NULL,
+      updated_at timestamp DEFAULT now() NOT NULL
+    )`,
     `CREATE TABLE service_pricing_audit (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      service_pricing_id uuid,
+      service_id text NOT NULL,
+      method text NOT NULL,
       old_cost numeric(12,6),
-      new_cost numeric(12,6) NOT NULL
+      new_cost numeric(12,6) NOT NULL,
+      change_type text NOT NULL,
+      changed_by text NOT NULL,
+      reason text,
+      created_at timestamp DEFAULT now() NOT NULL
     )`,
     `CREATE TABLE org_storage_quota (
       organization_id uuid PRIMARY KEY REFERENCES organizations(id),
@@ -61,6 +80,8 @@ beforeAll(async () => {
   ]) {
     await dbWrite.execute(sql.raw(statement));
   }
+  await dbWrite.execute(sql`INSERT INTO service_pricing (service_id, method, cost)
+    VALUES ('storage', 'put_per_byte', 0)`);
   for (const migration of MIGRATIONS) await executeSqlFile(migration);
   ({ orgStorageMutationsRepository: repository } = await import("../org-storage-mutations"));
 }, TIMEOUT);
@@ -96,11 +117,11 @@ function prepare(logicalKey: string, id: string, bytes: bigint) {
 
 async function commitZeroCost(logicalKey: string, id: string, bytes: bigint) {
   const prepared = await prepare(logicalKey, id, bytes);
-  const reserved = await repository.attachCreditReservation({
+  const reservation = await repository.reservePutCredits({
     operationId: prepared.operation.id,
     organizationId: ORG,
-    creditTransactionId: null,
   });
+  const reserved = reservation.operation;
   const leased = await repository.claimProviderLease({
     operationId: reserved.id,
     organizationId: ORG,
@@ -119,6 +140,19 @@ async function commitZeroCost(logicalKey: string, id: string, bytes: bigint) {
 }
 
 describe("OrgStorageMutationsRepository", () => {
+  test("reseeds and audits a put_per_byte price rounded to zero by the old schema", async () => {
+    const pricing = await dbWrite.execute(sql`SELECT cost FROM service_pricing
+      WHERE service_id = 'storage' AND method = 'put_per_byte'`);
+    expect(String((pricing.rows[0] as { cost: string } | undefined)?.cost)).toBe("0.000000001000");
+    const audit = await dbWrite.execute(sql`SELECT old_cost, new_cost, changed_by
+      FROM service_pricing_audit WHERE service_id = 'storage' AND method = 'put_per_byte'`);
+    expect(audit.rows[0]).toMatchObject({
+      old_cost: "0.000000000000",
+      new_cost: "0.000000001000",
+      changed_by: "migration:0254",
+    });
+  });
+
   test("serializes concurrent quota admission across different object keys", async () => {
     const outcomes = await Promise.allSettled([prepare("one", "a", 7n), prepare("two", "e", 7n)]);
     expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
@@ -131,11 +165,11 @@ describe("OrgStorageMutationsRepository", () => {
 
   test("does not reconcile a fresh reserved operation while its request is active", async () => {
     const prepared = await prepare("active-request", "a", 4n);
-    const reserved = await repository.attachCreditReservation({
+    const reservation = await repository.reservePutCredits({
       operationId: prepared.operation.id,
       organizationId: ORG,
-      creditTransactionId: null,
     });
+    const reserved = reservation.operation;
     const now = new Date();
     expect(
       (await repository.listDueOperations(now)).map((operation) => operation.id),
@@ -149,6 +183,89 @@ describe("OrgStorageMutationsRepository", () => {
     );
   });
 
+  test("fences a stale reconciler against a concurrent live provider claim", async () => {
+    const prepared = await prepare("recovery-race", "a", 4n);
+    const reservation = await repository.reservePutCredits({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+    });
+    const reserved = reservation.operation;
+    const now = new Date();
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET updated_at = ${new Date(now.getTime() - 11 * 60 * 1000)}
+      WHERE id = ${reserved.id}`);
+    const claims = await Promise.allSettled([
+      repository.claimReconciliationLease({
+        operationId: reserved.id,
+        organizationId: ORG,
+        leaseToken: crypto.randomUUID(),
+        leaseExpiresAt: new Date(now.getTime() + 60_000),
+        staleBefore: new Date(now.getTime() - 10 * 60_000),
+        now,
+      }),
+      repository.claimProviderLease({
+        operationId: reserved.id,
+        organizationId: ORG,
+        leaseToken: crypto.randomUUID(),
+        leaseExpiresAt: new Date(now.getTime() + 60_000),
+        now,
+      }),
+    ]);
+    expect(claims.filter((claim) => claim.status === "fulfilled")).toHaveLength(1);
+    expect(claims.filter((claim) => claim.status === "rejected")).toHaveLength(1);
+  });
+
+  test("atomically fences credit reservation against prepared-operation recovery", async () => {
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "credit-attach-race",
+      idempotencyKeyHash: "7".repeat(64),
+      requestDigest: "8".repeat(64),
+      sizeBytes: 4n,
+      contentType: "text/plain",
+      contentSha256: "9".repeat(64),
+      priceUsd: "1.000000",
+    });
+    const now = new Date();
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET created_at = ${new Date(now.getTime() - 11 * 60 * 1000)}
+      WHERE id = ${prepared.operation.id}`);
+    const outcomes = await Promise.allSettled([
+      repository.reservePutCredits({
+        operationId: prepared.operation.id,
+        organizationId: ORG,
+      }),
+      repository.claimReconciliationLease({
+        operationId: prepared.operation.id,
+        organizationId: ORG,
+        leaseToken: crypto.randomUUID(),
+        leaseExpiresAt: new Date(now.getTime() + 60_000),
+        staleBefore: new Date(now.getTime() - 10 * 60_000),
+        now,
+      }),
+    ]);
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    const result = await dbWrite.execute(sql`SELECT operation.state,
+        organization.credit_balance, count(hold.id) AS hold_count
+      FROM org_storage_put_operations operation
+      JOIN organizations organization ON organization.id = operation.organization_id
+      LEFT JOIN credit_transactions hold
+        ON hold.metadata->>'storage_operation_id' = operation.id::text
+      WHERE operation.id = ${prepared.operation.id}
+      GROUP BY operation.state, organization.credit_balance`);
+    const row = result.rows[0] as Record<string, unknown>;
+    if (row.state === "reserved") {
+      expect(row).toMatchObject({ credit_balance: "9.000000", hold_count: 1 });
+    } else {
+      expect(row).toMatchObject({
+        state: "reconciling",
+        credit_balance: "10.000000",
+        hold_count: 0,
+      });
+    }
+  });
+
   test("reserves max(new-old, 0) and releases shrink delta only at commit", async () => {
     await commitZeroCost("same", "a", 8n);
     const shrink = await prepare("same", "e", 3n);
@@ -159,6 +276,40 @@ describe("OrgStorageMutationsRepository", () => {
       sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
     );
     expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("3");
+  });
+
+  test("adopts already-counted legacy bytes and transfers overwrite authority to GC", async () => {
+    await dbWrite.execute(
+      sql`UPDATE org_storage_quota SET bytes_used = 8 WHERE organization_id = ${ORG}`,
+    );
+    const legacyKey = `org/${ORG}/legacy/voice.ogg`;
+    const adopted = await repository.adoptLegacyObject({
+      organizationId: ORG,
+      logicalKey: "legacy/voice.ogg",
+      providerKey: legacyKey,
+      sizeBytes: 8n,
+      contentType: "audio/ogg",
+      etag: "legacy-etag",
+      uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+    });
+    expect(adopted.generation).toBe(0n);
+    expect(adopted.provider_key).toBe(legacyKey);
+    const prepared = await prepare("legacy/voice.ogg", "e", 3n);
+    expect(prepared.operation.source_size_bytes).toBe(8n);
+    expect(prepared.operation.quota_reserved_bytes).toBe(0n);
+    await commitZeroCost("legacy/voice.ogg", "e", 3n);
+
+    const quota = await dbWrite.execute(
+      sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
+    );
+    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("3");
+    const gc = await dbWrite.execute(
+      sql`SELECT provider_key FROM org_storage_gc_outbox WHERE organization_id = ${ORG}`,
+    );
+    expect(gc.rows[0]).toMatchObject({ provider_key: legacyKey });
+    const listed = await repository.listObjects(ORG, "legacy/");
+    expect(listed.map((object) => object.logical_key)).toEqual(["legacy/voice.ogg"]);
+    expect(listed[0]?.generation).toBe(1n);
   });
 
   test("rejects an idempotency replay whose durable digest includes a changed price", async () => {
@@ -188,22 +339,12 @@ describe("OrgStorageMutationsRepository", () => {
       contentSha256: "3".repeat(64),
       priceUsd: "1.250000",
     });
-    const transactionId = crypto.randomUUID();
-    await dbWrite.execute(sql`INSERT INTO credit_transactions
-      (id, organization_id, amount, type, metadata)
-      VALUES (
-        ${transactionId}, ${ORG}, -1.250000, 'debit',
-        ${JSON.stringify({
-          type: "reservation",
-          settlement_marker: "credit_reservation_v1",
-          storage_operation_id: prepared.operation.id,
-        })}::jsonb
-      )`);
-    const reserved = await repository.attachCreditReservation({
+    const reservation = await repository.reservePutCredits({
       operationId: prepared.operation.id,
       organizationId: ORG,
-      creditTransactionId: transactionId,
     });
+    expect(reservation.insufficient).toBe(false);
+    const reserved = reservation.operation;
     const leased = await repository.claimProviderLease({
       operationId: reserved.id,
       organizationId: ORG,
@@ -230,6 +371,39 @@ describe("OrgStorageMutationsRepository", () => {
     expect(row?.settled_at).not.toBeNull();
   });
 
+  test("atomically releases quota and writes a terminal receipt on insufficient credit", async () => {
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 0.5 WHERE id = ${ORG}`);
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "insufficient",
+      idempotencyKeyHash: "0".repeat(64),
+      requestDigest: "1".repeat(64),
+      sizeBytes: 4n,
+      contentType: "text/plain",
+      contentSha256: "2".repeat(64),
+      priceUsd: "1.000000",
+    });
+    const reservation = await repository.reservePutCredits({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+    });
+    expect(reservation.insufficient).toBe(true);
+    expect(reservation.available).toBe(0.5);
+    expect(reservation.operation.state).toBe("refunded");
+    const result = await dbWrite.execute(sql`SELECT quota.bytes_used,
+        organization.credit_balance, count(hold.id) AS hold_count
+      FROM org_storage_quota quota
+      JOIN organizations organization ON organization.id = quota.organization_id
+      LEFT JOIN credit_transactions hold ON hold.organization_id = organization.id
+      WHERE quota.organization_id = ${ORG}
+      GROUP BY quota.bytes_used, organization.credit_balance`);
+    expect(result.rows[0]).toMatchObject({
+      bytes_used: 0,
+      credit_balance: "0.500000",
+      hold_count: 0,
+    });
+  });
+
   test("rejects a cross-tenant credit transaction at the database boundary", async () => {
     const prepared = await repository.preparePut({
       organizationId: ORG,
@@ -253,16 +427,16 @@ describe("OrgStorageMutationsRepository", () => {
         })}::jsonb
       )`);
     await expect(
-      repository.attachCreditReservation({
-        operationId: prepared.operation.id,
-        organizationId: ORG,
-        creditTransactionId: transactionId,
-      }),
+      Promise.resolve(
+        dbWrite.execute(sql`UPDATE org_storage_put_operations
+          SET state = 'reserved', credit_transaction_id = ${transactionId}
+          WHERE id = ${prepared.operation.id}`),
+      ),
     ).rejects.toThrow();
     expect((await repository.findOperation(ORG, prepared.operation.id))?.state).toBe("prepared");
   });
 
-  test("rolls back publication when the held amount does not match the pinned price", async () => {
+  test("rejects a held amount that does not match the pinned price before provider dispatch", async () => {
     const prepared = await repository.preparePut({
       organizationId: ORG,
       logicalKey: "bad-hold",
@@ -284,13 +458,11 @@ describe("OrgStorageMutationsRepository", () => {
           storage_operation_id: prepared.operation.id,
         })}::jsonb
       )`);
-    const reserved = await repository.attachCreditReservation({
-      operationId: prepared.operation.id,
-      organizationId: ORG,
-      creditTransactionId: transactionId,
-    });
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET state = 'reserved', credit_transaction_id = ${transactionId}
+      WHERE id = ${prepared.operation.id}`);
     const leased = await repository.claimProviderLease({
-      operationId: reserved.id,
+      operationId: prepared.operation.id,
       organizationId: ORG,
       leaseToken: crypto.randomUUID(),
       leaseExpiresAt: new Date(Date.now() + 60_000),
@@ -309,10 +481,84 @@ describe("OrgStorageMutationsRepository", () => {
     const result = await dbWrite.execute(sql`SELECT o.state, h.provider_key, c.settled_at
       FROM org_storage_put_operations o
       JOIN org_storage_objects h ON h.id = o.object_id
-      JOIN credit_transactions c ON c.id = o.credit_transaction_id
-      WHERE o.id = ${leased.id}`);
+      JOIN credit_transactions c ON c.id = ${transactionId}
+      WHERE o.id = ${prepared.operation.id}`);
     const row = (result as { rows: Array<Record<string, unknown>> }).rows[0];
     expect(row).toMatchObject({ state: "provider_started", provider_key: null, settled_at: null });
+  });
+
+  test("atomically refunds an orphan hold with quota and terminal replay", async () => {
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "orphan-refund",
+      idempotencyKeyHash: "f".repeat(64),
+      requestDigest: "e".repeat(64),
+      sizeBytes: 4n,
+      contentType: "text/plain",
+      contentSha256: "d".repeat(64),
+      priceUsd: "1.000000",
+    });
+    const holdId = crypto.randomUUID();
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 9 WHERE id = ${ORG}`);
+    await dbWrite.execute(sql`INSERT INTO credit_transactions
+      (id, organization_id, amount, type, metadata)
+      VALUES (
+        ${holdId}, ${ORG}, -1.000000, 'debit',
+        ${JSON.stringify({
+          type: "reservation",
+          settlement_marker: "credit_reservation_v1",
+          storage_operation_id: prepared.operation.id,
+        })}::jsonb
+      )`);
+    const now = new Date();
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET created_at = ${new Date(now.getTime() - 11 * 60 * 1000)}
+      WHERE id = ${prepared.operation.id}`);
+    const leaseToken = crypto.randomUUID();
+    const claimed = await repository.claimReconciliationLease({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      leaseToken,
+      leaseExpiresAt: new Date(now.getTime() + 60_000),
+      staleBefore: new Date(now.getTime() - 10 * 60_000),
+      now,
+    });
+    expect(claimed.state).toBe("reconciling");
+    const responseJson = JSON.stringify({ error: "Storage PUT did not reach R2" });
+    await repository.finalizeRefund({
+      operationId: claimed.id,
+      organizationId: ORG,
+      leaseToken,
+      responseJson,
+    });
+    await repository.finalizeRefund({
+      operationId: claimed.id,
+      organizationId: ORG,
+      leaseToken,
+      responseJson,
+    });
+    const result = await dbWrite.execute(sql`SELECT
+        operation.state, operation.credit_transaction_id, hold.settled_at,
+        quota.bytes_used, organization.credit_balance,
+        count(refund.id) AS refund_count
+      FROM org_storage_put_operations operation
+      JOIN credit_transactions hold ON hold.id = ${holdId}
+      JOIN org_storage_quota quota ON quota.organization_id = operation.organization_id
+      JOIN organizations organization ON organization.id = operation.organization_id
+      LEFT JOIN credit_transactions refund
+        ON refund.metadata->>'storage_operation_id' = operation.id::text
+       AND refund.metadata->>'type' = 'storage_put_refund'
+      WHERE operation.id = ${claimed.id}
+      GROUP BY operation.state, operation.credit_transaction_id, hold.settled_at,
+        quota.bytes_used, organization.credit_balance`);
+    expect(result.rows[0]).toMatchObject({
+      state: "refunded",
+      credit_transaction_id: null,
+      bytes_used: 0,
+      credit_balance: "10.000000",
+      refund_count: 1,
+    });
+    expect((result.rows[0] as { settled_at?: unknown } | undefined)?.settled_at).not.toBeNull();
   });
 
   test("releases quota and tombstones the catalog only after observed delete", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-mutations.pglite.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Exercises native storage PUT authority and quota serialization against real
+ * in-process PGlite, including concurrent admission and overwrite deltas.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG = "00000000-0000-4000-8000-000000021045";
+const OTHER_ORG = "00000000-0000-4000-8000-000000021049";
+const MIGRATIONS = [
+  "0256_org_storage_native_objects.sql",
+  "0257_org_storage_native_put_operations.sql",
+  "0258_org_storage_generation_gc_outbox.sql",
+];
+const TIMEOUT = 60_000;
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../client").closeDatabaseConnectionsForTests
+  | null = null;
+let repository: typeof import("../org-storage-mutations").orgStorageMutationsRepository;
+
+async function executeSqlFile(name: string): Promise<void> {
+  const source = readFileSync(join(import.meta.dir, "../../migrations", name), "utf8");
+  for (const statement of source.split(";")) {
+    if (statement.trim()) await dbWrite.execute(sql.raw(statement));
+  }
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, dbWrite } = await import("../../client"));
+  for (const statement of [
+    `CREATE TABLE organizations (id uuid PRIMARY KEY)`,
+    `CREATE TABLE credit_transactions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL REFERENCES organizations(id),
+      amount numeric(12,6) NOT NULL,
+      type text NOT NULL,
+      metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+      settled_at timestamp with time zone,
+      created_at timestamp DEFAULT now() NOT NULL
+    )`,
+    `CREATE TABLE service_pricing (cost numeric(12,6) NOT NULL)`,
+    `CREATE TABLE service_pricing_audit (
+      old_cost numeric(12,6),
+      new_cost numeric(12,6) NOT NULL
+    )`,
+    `CREATE TABLE org_storage_quota (
+      organization_id uuid PRIMARY KEY REFERENCES organizations(id),
+      bytes_used bigint DEFAULT 0 NOT NULL,
+      bytes_limit bigint DEFAULT 5368709120 NOT NULL,
+      created_at timestamp DEFAULT now() NOT NULL,
+      updated_at timestamp DEFAULT now() NOT NULL
+    )`,
+  ]) {
+    await dbWrite.execute(sql.raw(statement));
+  }
+  for (const migration of MIGRATIONS) await executeSqlFile(migration);
+  ({ orgStorageMutationsRepository: repository } = await import("../org-storage-mutations"));
+}, TIMEOUT);
+
+beforeEach(async () => {
+  await dbWrite.execute(
+    sql.raw(`TRUNCATE org_storage_gc_outbox, org_storage_delete_operations, org_storage_put_operations,
+      org_storage_objects, org_storage_quota, credit_transactions, organizations CASCADE`),
+  );
+  await dbWrite.execute(sql`INSERT INTO organizations (id) VALUES (${ORG})`);
+  await dbWrite.execute(sql`INSERT INTO organizations (id) VALUES (${OTHER_ORG})`);
+  await dbWrite.execute(
+    sql`INSERT INTO org_storage_quota (organization_id, bytes_limit) VALUES (${ORG}, 10)`,
+  );
+});
+
+afterAll(async () => {
+  if (closeDatabaseConnectionsForTests) await closeDatabaseConnectionsForTests();
+});
+
+function prepare(logicalKey: string, id: string, bytes: bigint) {
+  return repository.preparePut({
+    organizationId: ORG,
+    logicalKey,
+    idempotencyKeyHash: id.repeat(64),
+    requestDigest: (id === "a" ? "b" : "c").repeat(64),
+    sizeBytes: bytes,
+    contentType: "application/octet-stream",
+    contentSha256: "d".repeat(64),
+    priceUsd: "0.000000",
+  });
+}
+
+async function commitZeroCost(logicalKey: string, id: string, bytes: bigint) {
+  const prepared = await prepare(logicalKey, id, bytes);
+  const reserved = await repository.attachCreditReservation({
+    operationId: prepared.operation.id,
+    organizationId: ORG,
+    creditTransactionId: null,
+  });
+  const leased = await repository.claimProviderLease({
+    operationId: reserved.id,
+    organizationId: ORG,
+    leaseToken: crypto.randomUUID(),
+    leaseExpiresAt: new Date(Date.now() + 60_000),
+    now: new Date(),
+  });
+  return await repository.commitObservedPut({
+    operationId: leased.id,
+    organizationId: ORG,
+    leaseToken: leased.lease_token!,
+    etag: `etag-${id}`,
+    uploadedAt: new Date(),
+    responseJson: JSON.stringify({ key: logicalKey }),
+  });
+}
+
+describe("OrgStorageMutationsRepository", () => {
+  test("serializes concurrent quota admission across different object keys", async () => {
+    const outcomes = await Promise.allSettled([prepare("one", "a", 7n), prepare("two", "e", 7n)]);
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    const quota = await dbWrite.execute(
+      sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
+    );
+    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("7");
+  });
+
+  test("does not reconcile a fresh reserved operation while its request is active", async () => {
+    const prepared = await prepare("active-request", "a", 4n);
+    const reserved = await repository.attachCreditReservation({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      creditTransactionId: null,
+    });
+    const now = new Date();
+    expect(
+      (await repository.listDueOperations(now)).map((operation) => operation.id),
+    ).not.toContain(reserved.id);
+
+    await dbWrite.execute(sql`UPDATE org_storage_put_operations
+      SET updated_at = ${new Date(now.getTime() - 11 * 60 * 1000)}
+      WHERE id = ${reserved.id}`);
+    expect((await repository.listDueOperations(now)).map((operation) => operation.id)).toContain(
+      reserved.id,
+    );
+  });
+
+  test("reserves max(new-old, 0) and releases shrink delta only at commit", async () => {
+    await commitZeroCost("same", "a", 8n);
+    const shrink = await prepare("same", "e", 3n);
+    expect(shrink.operation.source_size_bytes).toBe(8n);
+    expect(shrink.operation.quota_reserved_bytes).toBe(0n);
+    await commitZeroCost("same", "e", 3n);
+    const quota = await dbWrite.execute(
+      sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
+    );
+    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("3");
+  });
+
+  test("rejects an idempotency replay whose durable digest includes a changed price", async () => {
+    await prepare("same", "a", 2n);
+    await expect(
+      repository.preparePut({
+        organizationId: ORG,
+        logicalKey: "same",
+        idempotencyKeyHash: "a".repeat(64),
+        requestDigest: "f".repeat(64),
+        sizeBytes: 2n,
+        contentType: "application/octet-stream",
+        contentSha256: "d".repeat(64),
+        priceUsd: "1.000000",
+      }),
+    ).rejects.toMatchObject({ reason: "idempotency_mismatch" });
+  });
+
+  test("atomically settles the exact tenant hold before publishing the object", async () => {
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "paid",
+      idempotencyKeyHash: "1".repeat(64),
+      requestDigest: "2".repeat(64),
+      sizeBytes: 4n,
+      contentType: "text/plain",
+      contentSha256: "3".repeat(64),
+      priceUsd: "1.250000",
+    });
+    const transactionId = crypto.randomUUID();
+    await dbWrite.execute(sql`INSERT INTO credit_transactions
+      (id, organization_id, amount, type, metadata)
+      VALUES (
+        ${transactionId}, ${ORG}, -1.250000, 'debit',
+        ${JSON.stringify({
+          type: "reservation",
+          settlement_marker: "credit_reservation_v1",
+          storage_operation_id: prepared.operation.id,
+        })}::jsonb
+      )`);
+    const reserved = await repository.attachCreditReservation({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      creditTransactionId: transactionId,
+    });
+    const leased = await repository.claimProviderLease({
+      operationId: reserved.id,
+      organizationId: ORG,
+      leaseToken: crypto.randomUUID(),
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      now: new Date(),
+    });
+    await repository.commitObservedPut({
+      operationId: leased.id,
+      organizationId: ORG,
+      leaseToken: leased.lease_token!,
+      etag: "paid-etag",
+      uploadedAt: new Date(),
+      responseJson: JSON.stringify({ key: "paid" }),
+    });
+    const result = await dbWrite.execute(sql`SELECT o.state, h.provider_key, c.settled_at
+      FROM org_storage_put_operations o
+      JOIN org_storage_objects h ON h.id = o.object_id
+      JOIN credit_transactions c ON c.id = o.credit_transaction_id
+      WHERE o.id = ${leased.id}`);
+    const row = (result as { rows: Array<Record<string, unknown>> }).rows[0];
+    expect(row?.state).toBe("committed");
+    expect(row?.provider_key).toBe(leased.target_provider_key);
+    expect(row?.settled_at).not.toBeNull();
+  });
+
+  test("rejects a cross-tenant credit transaction at the database boundary", async () => {
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "tenant-fence",
+      idempotencyKeyHash: "9".repeat(64),
+      requestDigest: "a".repeat(64),
+      sizeBytes: 1n,
+      contentType: "text/plain",
+      contentSha256: "b".repeat(64),
+      priceUsd: "0.500000",
+    });
+    const transactionId = crypto.randomUUID();
+    await dbWrite.execute(sql`INSERT INTO credit_transactions
+      (id, organization_id, amount, type, metadata)
+      VALUES (
+        ${transactionId}, ${OTHER_ORG}, -0.500000, 'debit',
+        ${JSON.stringify({
+          type: "reservation",
+          settlement_marker: "credit_reservation_v1",
+          storage_operation_id: prepared.operation.id,
+        })}::jsonb
+      )`);
+    await expect(
+      repository.attachCreditReservation({
+        operationId: prepared.operation.id,
+        organizationId: ORG,
+        creditTransactionId: transactionId,
+      }),
+    ).rejects.toThrow();
+    expect((await repository.findOperation(ORG, prepared.operation.id))?.state).toBe("prepared");
+  });
+
+  test("rolls back publication when the held amount does not match the pinned price", async () => {
+    const prepared = await repository.preparePut({
+      organizationId: ORG,
+      logicalKey: "bad-hold",
+      idempotencyKeyHash: "4".repeat(64),
+      requestDigest: "5".repeat(64),
+      sizeBytes: 2n,
+      contentType: "text/plain",
+      contentSha256: "6".repeat(64),
+      priceUsd: "1.000000",
+    });
+    const transactionId = crypto.randomUUID();
+    await dbWrite.execute(sql`INSERT INTO credit_transactions
+      (id, organization_id, amount, type, metadata)
+      VALUES (
+        ${transactionId}, ${ORG}, -0.500000, 'debit',
+        ${JSON.stringify({
+          type: "reservation",
+          settlement_marker: "credit_reservation_v1",
+          storage_operation_id: prepared.operation.id,
+        })}::jsonb
+      )`);
+    const reserved = await repository.attachCreditReservation({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      creditTransactionId: transactionId,
+    });
+    const leased = await repository.claimProviderLease({
+      operationId: reserved.id,
+      organizationId: ORG,
+      leaseToken: crypto.randomUUID(),
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      now: new Date(),
+    });
+    await expect(
+      repository.commitObservedPut({
+        operationId: leased.id,
+        organizationId: ORG,
+        leaseToken: leased.lease_token!,
+        etag: "must-not-publish",
+        uploadedAt: new Date(),
+        responseJson: JSON.stringify({ key: "bad-hold" }),
+      }),
+    ).rejects.toThrow("credit settlement returned no row");
+    const result = await dbWrite.execute(sql`SELECT o.state, h.provider_key, c.settled_at
+      FROM org_storage_put_operations o
+      JOIN org_storage_objects h ON h.id = o.object_id
+      JOIN credit_transactions c ON c.id = o.credit_transaction_id
+      WHERE o.id = ${leased.id}`);
+    const row = (result as { rows: Array<Record<string, unknown>> }).rows[0];
+    expect(row).toMatchObject({ state: "provider_started", provider_key: null, settled_at: null });
+  });
+
+  test("releases quota and tombstones the catalog only after observed delete", async () => {
+    await commitZeroCost("remove", "a", 6n);
+    const prepared = await repository.prepareDelete({
+      organizationId: ORG,
+      logicalKey: "remove",
+      idempotencyKeyHash: "7".repeat(64),
+      requestDigest: "8".repeat(64),
+    });
+    const leased = await repository.claimDeleteLease({
+      operationId: prepared.operation.id,
+      organizationId: ORG,
+      leaseToken: crypto.randomUUID(),
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      now: new Date(),
+    });
+    const before = await repository.findObject(ORG, "remove");
+    expect(before?.provider_key).toBe(leased.source_provider_key);
+    await repository.commitObservedDelete({
+      operationId: leased.id,
+      organizationId: ORG,
+      leaseToken: leased.lease_token!,
+      responseJson: JSON.stringify({ deleted: true }),
+    });
+    const after = await repository.findObject(ORG, "remove");
+    expect(after).toMatchObject({ provider_key: null, size_bytes: 0n });
+    expect(after?.deleted_at).toBeInstanceOf(Date);
+    const quota = await dbWrite.execute(
+      sql`SELECT bytes_used FROM org_storage_quota WHERE organization_id = ${ORG}`,
+    );
+    expect(String((quota.rows[0] as { bytes_used: string } | undefined)?.bytes_used)).toBe("0");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/index.ts
+++ b/packages/cloud/shared/src/db/repositories/index.ts
@@ -107,6 +107,7 @@ export * from "./model-pricing";
 // Core Platform Repositories
 // ============================================
 export * from "./org-rate-limit-overrides";
+export * from "./org-storage-mutations";
 export * from "./org-storage-quota";
 export * from "./organization-invites";
 export * from "./organizations";

--- a/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
@@ -1,0 +1,677 @@
+/**
+ * Owns the transactionally serialized authority for native organization PUTs.
+ * Provider I/O stays outside transactions; leases and immutable generation
+ * keys make its ambiguous outcomes recoverable by a strong R2 HEAD.
+ */
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { sqlRows } from "../execute-helpers";
+import { dbWrite, writeTransaction } from "../helpers";
+import {
+  type OrgStorageDeleteOperation,
+  type OrgStorageObject,
+  type OrgStoragePutOperation,
+  orgStorageDeleteOperations,
+  orgStorageGcOutbox,
+  orgStorageObjects,
+  orgStoragePutOperations,
+} from "../schemas/org-storage-mutations";
+import { orgStorageQuota } from "../schemas/org-storage-quota";
+import { DEFAULT_ORG_STORAGE_BYTES_LIMIT } from "./org-storage-quota";
+
+const GC_PIN_MS = 24 * 60 * 60 * 1000;
+const MAX_DUE_BATCH = 100;
+
+export class StoragePutConflictError extends Error {
+  constructor(public readonly reason: "idempotency_mismatch" | "object_busy" | "stale_lease") {
+    super(`Native storage PUT conflict: ${reason}`);
+    this.name = "StoragePutConflictError";
+  }
+}
+
+export class StorageQuotaExceededError extends Error {
+  constructor() {
+    super("Storage quota exceeded for this organization");
+    this.name = "StorageQuotaExceededError";
+  }
+}
+
+export interface PrepareStoragePutInput {
+  organizationId: string;
+  logicalKey: string;
+  idempotencyKeyHash: string;
+  requestDigest: string;
+  sizeBytes: bigint;
+  contentType: string;
+  contentSha256: string;
+  priceUsd: string;
+}
+
+export interface PreparedStoragePut {
+  operation: OrgStoragePutOperation;
+  replay: boolean;
+}
+
+function providerKey(organizationId: string, objectId: string, generation: bigint): string {
+  return `__eliza_storage_authority/v2/org/${organizationId}/${objectId}/${generation}`;
+}
+
+function requiredRow<T>(rows: T[], label: string): T {
+  const row = rows[0];
+  if (!row) throw new Error(`[NativeStoragePut] ${label} returned no row`);
+  return row;
+}
+
+function bigintValue(value: bigint | string | number): bigint {
+  return typeof value === "bigint" ? value : BigInt(value);
+}
+
+function normalizeObject(row: OrgStorageObject): OrgStorageObject {
+  return {
+    ...row,
+    generation: bigintValue(row.generation),
+    size_bytes: bigintValue(row.size_bytes),
+  };
+}
+
+function normalizeOperation(row: OrgStoragePutOperation): OrgStoragePutOperation {
+  return {
+    ...row,
+    source_generation: bigintValue(row.source_generation),
+    source_size_bytes: bigintValue(row.source_size_bytes),
+    target_generation: bigintValue(row.target_generation),
+    target_size_bytes: bigintValue(row.target_size_bytes),
+    quota_reserved_bytes: bigintValue(row.quota_reserved_bytes),
+  };
+}
+
+export class OrgStorageMutationsRepository {
+  async preparePut(input: PrepareStoragePutInput): Promise<PreparedStoragePut> {
+    return await writeTransaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${input.organizationId}:${input.logicalKey}`}, 0))`,
+      );
+
+      const existing = await tx.query.orgStoragePutOperations.findFirst({
+        where: and(
+          eq(orgStoragePutOperations.organization_id, input.organizationId),
+          eq(orgStoragePutOperations.idempotency_key_hash, input.idempotencyKeyHash),
+        ),
+      });
+      if (existing) {
+        if (existing.request_digest !== input.requestDigest) {
+          throw new StoragePutConflictError("idempotency_mismatch");
+        }
+        return { operation: existing, replay: true };
+      }
+
+      await tx
+        .insert(orgStorageObjects)
+        .values({ organization_id: input.organizationId, logical_key: input.logicalKey })
+        .onConflictDoNothing();
+
+      const objectRows = await sqlRows<OrgStorageObject>(
+        tx,
+        sql`SELECT * FROM ${orgStorageObjects}
+          WHERE ${orgStorageObjects.organization_id} = ${input.organizationId}
+            AND ${orgStorageObjects.logical_key} = ${input.logicalKey}
+          FOR UPDATE`,
+      );
+      const object = normalizeObject(requiredRow(objectRows, "object lock"));
+
+      const active = await tx.query.orgStoragePutOperations.findFirst({
+        where: and(
+          eq(orgStoragePutOperations.object_id, object.id),
+          inArray(orgStoragePutOperations.state, ["prepared", "reserved", "provider_started"]),
+        ),
+      });
+      if (active) throw new StoragePutConflictError("object_busy");
+      const activeDelete = await tx.query.orgStorageDeleteOperations.findFirst({
+        where: and(
+          eq(orgStorageDeleteOperations.object_id, object.id),
+          inArray(orgStorageDeleteOperations.state, ["prepared", "provider_started"]),
+        ),
+      });
+      if (activeDelete) throw new StoragePutConflictError("object_busy");
+
+      const quotaReserved =
+        input.sizeBytes > object.size_bytes ? input.sizeBytes - object.size_bytes : 0n;
+      await tx
+        .insert(orgStorageQuota)
+        .values({
+          organization_id: input.organizationId,
+          bytes_used: 0n,
+          bytes_limit: DEFAULT_ORG_STORAGE_BYTES_LIMIT,
+        })
+        .onConflictDoNothing();
+      const quotaRows = await sqlRows<{ bytes_used: bigint }>(
+        tx,
+        sql`UPDATE ${orgStorageQuota}
+          SET bytes_used = ${orgStorageQuota.bytes_used} + ${quotaReserved},
+              updated_at = NOW()
+          WHERE ${orgStorageQuota.organization_id} = ${input.organizationId}
+            AND ${orgStorageQuota.bytes_used} + ${quotaReserved} <= ${orgStorageQuota.bytes_limit}
+          RETURNING ${orgStorageQuota.bytes_used}`,
+      );
+      if (quotaRows.length === 0) throw new StorageQuotaExceededError();
+
+      const targetGeneration = object.generation + 1n;
+      const inserted = await tx
+        .insert(orgStoragePutOperations)
+        .values({
+          organization_id: input.organizationId,
+          object_id: object.id,
+          idempotency_key_hash: input.idempotencyKeyHash,
+          request_digest: input.requestDigest,
+          source_generation: object.generation,
+          source_provider_key: object.provider_key,
+          source_size_bytes: object.size_bytes,
+          target_generation: targetGeneration,
+          target_provider_key: providerKey(input.organizationId, object.id, targetGeneration),
+          target_size_bytes: input.sizeBytes,
+          target_content_type: input.contentType,
+          target_content_sha256: input.contentSha256,
+          quota_reserved_bytes: quotaReserved,
+          price_usd: input.priceUsd,
+        })
+        .returning();
+      return { operation: requiredRow(inserted, "operation insert"), replay: false };
+    });
+  }
+
+  async attachCreditReservation(params: {
+    operationId: string;
+    organizationId: string;
+    creditTransactionId: string | null;
+  }): Promise<OrgStoragePutOperation> {
+    const rows = await writeTransaction(
+      async (tx) =>
+        await tx
+          .update(orgStoragePutOperations)
+          .set({
+            state: "reserved",
+            credit_transaction_id: params.creditTransactionId,
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(orgStoragePutOperations.id, params.operationId),
+              eq(orgStoragePutOperations.organization_id, params.organizationId),
+              eq(orgStoragePutOperations.state, "prepared"),
+            ),
+          )
+          .returning(),
+    );
+    if (rows[0]) return rows[0];
+    const existing = await this.findOperation(params.organizationId, params.operationId);
+    if (!existing) throw new Error("[NativeStoragePut] operation disappeared while reserving");
+    if (
+      existing.credit_transaction_id !== params.creditTransactionId ||
+      !["reserved", "provider_started", "committed", "refunded"].includes(existing.state)
+    ) {
+      throw new StoragePutConflictError("object_busy");
+    }
+    return existing;
+  }
+
+  async claimProviderLease(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    leaseExpiresAt: Date;
+    now: Date;
+  }): Promise<OrgStoragePutOperation> {
+    const rows = await writeTransaction(
+      async (tx) =>
+        await tx
+          .update(orgStoragePutOperations)
+          .set({
+            state: "provider_started",
+            lease_token: params.leaseToken,
+            lease_expires_at: params.leaseExpiresAt,
+            updated_at: params.now,
+          })
+          .where(
+            and(
+              eq(orgStoragePutOperations.id, params.operationId),
+              eq(orgStoragePutOperations.organization_id, params.organizationId),
+              or(
+                eq(orgStoragePutOperations.state, "reserved"),
+                and(
+                  eq(orgStoragePutOperations.state, "provider_started"),
+                  lt(orgStoragePutOperations.lease_expires_at, params.now),
+                ),
+              ),
+            ),
+          )
+          .returning(),
+    );
+    if (!rows[0]) throw new StoragePutConflictError("stale_lease");
+    return rows[0];
+  }
+
+  async commitObservedPut(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    etag: string;
+    uploadedAt: Date;
+    responseJson: string;
+  }): Promise<OrgStoragePutOperation> {
+    return await writeTransaction(async (tx) => {
+      const operationRows = await sqlRows<OrgStoragePutOperation>(
+        tx,
+        sql`SELECT * FROM ${orgStoragePutOperations}
+          WHERE ${orgStoragePutOperations.id} = ${params.operationId}
+            AND ${orgStoragePutOperations.organization_id} = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const operation = normalizeOperation(requiredRow(operationRows, "operation commit lock"));
+      if (operation.state === "committed") return operation;
+      if (operation.state !== "provider_started" || operation.lease_token !== params.leaseToken) {
+        throw new StoragePutConflictError("stale_lease");
+      }
+
+      const objectRows = await sqlRows<OrgStorageObject>(
+        tx,
+        sql`SELECT * FROM ${orgStorageObjects}
+          WHERE ${orgStorageObjects.id} = ${operation.object_id}
+            AND ${orgStorageObjects.organization_id} = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const object = normalizeObject(requiredRow(objectRows, "object commit lock"));
+      if (object.generation !== operation.source_generation) {
+        throw new StoragePutConflictError("object_busy");
+      }
+
+      if (Number(operation.price_usd) > 0) {
+        const settled = await sqlRows<{ id: string }>(
+          tx,
+          sql`UPDATE credit_transactions
+            SET settled_at = NOW()
+            WHERE id = ${operation.credit_transaction_id}
+              AND organization_id = ${params.organizationId}
+              AND type = 'debit'
+              AND amount = -CAST(${String(operation.price_usd)} AS numeric)
+              AND settled_at IS NULL
+              AND metadata->>'type' = 'reservation'
+              AND metadata->>'settlement_marker' = 'credit_reservation_v1'
+              AND metadata->>'storage_operation_id' = ${operation.id}
+            RETURNING id`,
+        );
+        requiredRow(settled, "credit settlement");
+      }
+
+      const finalDelta =
+        operation.target_size_bytes - operation.source_size_bytes - operation.quota_reserved_bytes;
+      const quotaRows = await sqlRows<{ bytes_used: bigint }>(
+        tx,
+        sql`UPDATE ${orgStorageQuota}
+          SET bytes_used = ${orgStorageQuota.bytes_used} + ${finalDelta},
+              updated_at = NOW()
+          WHERE ${orgStorageQuota.organization_id} = ${params.organizationId}
+            AND ${orgStorageQuota.bytes_used} + ${finalDelta} >= 0
+          RETURNING ${orgStorageQuota.bytes_used}`,
+      );
+      requiredRow(quotaRows, "quota finalization");
+
+      await tx
+        .update(orgStorageObjects)
+        .set({
+          generation: operation.target_generation,
+          provider_key: operation.target_provider_key,
+          size_bytes: operation.target_size_bytes,
+          content_type: operation.target_content_type,
+          content_sha256: operation.target_content_sha256,
+          etag: params.etag,
+          uploaded_at: params.uploadedAt,
+          deleted_at: null,
+          updated_at: new Date(),
+        })
+        .where(eq(orgStorageObjects.id, object.id));
+
+      if (operation.source_provider_key) {
+        await tx
+          .insert(orgStorageGcOutbox)
+          .values({
+            organization_id: params.organizationId,
+            operation_id: operation.id,
+            provider_key: operation.source_provider_key,
+            not_before: new Date(Date.now() + GC_PIN_MS),
+          })
+          .onConflictDoNothing();
+      }
+
+      const committed = await tx
+        .update(orgStoragePutOperations)
+        .set({
+          state: "committed",
+          result_etag: params.etag,
+          result_uploaded_at: params.uploadedAt,
+          response_json: params.responseJson,
+          completed_at: new Date(),
+          lease_token: null,
+          lease_expires_at: null,
+          updated_at: new Date(),
+        })
+        .where(eq(orgStoragePutOperations.id, operation.id))
+        .returning();
+      return requiredRow(committed, "operation commit");
+    });
+  }
+
+  async finalizeRefund(params: {
+    operationId: string;
+    organizationId: string;
+    responseJson: string;
+  }): Promise<OrgStoragePutOperation> {
+    return await writeTransaction(async (tx) => {
+      const rows = await sqlRows<OrgStoragePutOperation>(
+        tx,
+        sql`SELECT * FROM ${orgStoragePutOperations}
+          WHERE ${orgStoragePutOperations.id} = ${params.operationId}
+            AND ${orgStoragePutOperations.organization_id} = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const operation = normalizeOperation(requiredRow(rows, "refund lock"));
+      if (operation.state === "refunded") return operation;
+      if (operation.state === "committed") {
+        throw new StoragePutConflictError("object_busy");
+      }
+      const quotaRows = await sqlRows<{ bytes_used: bigint }>(
+        tx,
+        sql`UPDATE ${orgStorageQuota}
+          SET bytes_used = ${orgStorageQuota.bytes_used} - ${operation.quota_reserved_bytes},
+              updated_at = NOW()
+          WHERE ${orgStorageQuota.organization_id} = ${params.organizationId}
+            AND ${orgStorageQuota.bytes_used} >= ${operation.quota_reserved_bytes}
+          RETURNING ${orgStorageQuota.bytes_used}`,
+      );
+      requiredRow(quotaRows, "quota refund");
+      const refunded = await tx
+        .update(orgStoragePutOperations)
+        .set({
+          state: "refunded",
+          response_json: params.responseJson,
+          completed_at: new Date(),
+          lease_token: null,
+          lease_expires_at: null,
+          updated_at: new Date(),
+        })
+        .where(eq(orgStoragePutOperations.id, operation.id))
+        .returning();
+      return requiredRow(refunded, "operation refund");
+    });
+  }
+
+  async findOperation(
+    organizationId: string,
+    operationId: string,
+  ): Promise<OrgStoragePutOperation | undefined> {
+    return await dbWrite.query.orgStoragePutOperations.findFirst({
+      where: and(
+        eq(orgStoragePutOperations.id, operationId),
+        eq(orgStoragePutOperations.organization_id, organizationId),
+      ),
+    });
+  }
+
+  async findUnattachedCreditReservation(
+    operation: OrgStoragePutOperation,
+  ): Promise<string | undefined> {
+    const rows = await sqlRows<{ id: string }>(
+      dbWrite,
+      sql`SELECT id FROM credit_transactions
+        WHERE organization_id = ${operation.organization_id}
+          AND type = 'debit'
+          AND amount = -CAST(${String(operation.price_usd)} AS numeric)
+          AND settled_at IS NULL
+          AND metadata->>'type' = 'reservation'
+          AND metadata->>'settlement_marker' = 'credit_reservation_v1'
+          AND metadata->>'storage_operation_id' = ${operation.id}
+        ORDER BY created_at ASC
+        LIMIT 1`,
+    );
+    return rows[0]?.id;
+  }
+
+  async findObject(
+    organizationId: string,
+    logicalKey: string,
+  ): Promise<OrgStorageObject | undefined> {
+    return await dbWrite.query.orgStorageObjects.findFirst({
+      where: and(
+        eq(orgStorageObjects.organization_id, organizationId),
+        eq(orgStorageObjects.logical_key, logicalKey),
+      ),
+    });
+  }
+
+  async listDueOperations(now: Date, limit = MAX_DUE_BATCH): Promise<OrgStoragePutOperation[]> {
+    const preparedBefore = new Date(now.getTime() - 10 * 60 * 1000);
+    return await dbWrite.query.orgStoragePutOperations.findMany({
+      where: or(
+        and(
+          eq(orgStoragePutOperations.state, "prepared"),
+          lt(orgStoragePutOperations.created_at, preparedBefore),
+        ),
+        and(
+          eq(orgStoragePutOperations.state, "reserved"),
+          lt(orgStoragePutOperations.updated_at, preparedBefore),
+        ),
+        and(
+          eq(orgStoragePutOperations.state, "provider_started"),
+          lt(orgStoragePutOperations.lease_expires_at, now),
+        ),
+      ),
+      orderBy: (table, { asc }) => [asc(table.created_at)],
+      limit: Math.max(1, Math.min(limit, MAX_DUE_BATCH)),
+    });
+  }
+
+  async listDueGc(now: Date, limit = MAX_DUE_BATCH) {
+    return await dbWrite.query.orgStorageGcOutbox.findMany({
+      where: and(eq(orgStorageGcOutbox.state, "pending"), lt(orgStorageGcOutbox.not_before, now)),
+      orderBy: (table, { asc }) => [asc(table.created_at)],
+      limit: Math.max(1, Math.min(limit, MAX_DUE_BATCH)),
+    });
+  }
+
+  async completeGc(id: string): Promise<void> {
+    await writeTransaction(async (tx) => {
+      await tx
+        .update(orgStorageGcOutbox)
+        .set({ state: "completed", completed_at: new Date() })
+        .where(and(eq(orgStorageGcOutbox.id, id), eq(orgStorageGcOutbox.state, "pending")));
+    });
+  }
+
+  async prepareDelete(input: {
+    organizationId: string;
+    logicalKey: string;
+    idempotencyKeyHash: string;
+    requestDigest: string;
+  }): Promise<{ operation: OrgStorageDeleteOperation; replay: boolean }> {
+    return await writeTransaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${input.organizationId}:${input.logicalKey}`}, 0))`,
+      );
+      const replay = await tx.query.orgStorageDeleteOperations.findFirst({
+        where: and(
+          eq(orgStorageDeleteOperations.organization_id, input.organizationId),
+          eq(orgStorageDeleteOperations.idempotency_key_hash, input.idempotencyKeyHash),
+        ),
+      });
+      if (replay) {
+        if (replay.request_digest !== input.requestDigest) {
+          throw new StoragePutConflictError("idempotency_mismatch");
+        }
+        return { operation: replay, replay: true };
+      }
+      const objectRows = await sqlRows<OrgStorageObject>(
+        tx,
+        sql`SELECT * FROM ${orgStorageObjects}
+          WHERE ${orgStorageObjects.organization_id} = ${input.organizationId}
+            AND ${orgStorageObjects.logical_key} = ${input.logicalKey}
+          FOR UPDATE`,
+      );
+      const object = normalizeObject(requiredRow(objectRows, "delete object lock"));
+      if (!object.provider_key || object.size_bytes <= 0n) {
+        throw new StoragePutConflictError("object_busy");
+      }
+      const activePut = await tx.query.orgStoragePutOperations.findFirst({
+        where: and(
+          eq(orgStoragePutOperations.object_id, object.id),
+          inArray(orgStoragePutOperations.state, ["prepared", "reserved", "provider_started"]),
+        ),
+      });
+      const activeDelete = await tx.query.orgStorageDeleteOperations.findFirst({
+        where: and(
+          eq(orgStorageDeleteOperations.object_id, object.id),
+          inArray(orgStorageDeleteOperations.state, ["prepared", "provider_started"]),
+        ),
+      });
+      if (activePut || activeDelete) throw new StoragePutConflictError("object_busy");
+      const inserted = await tx
+        .insert(orgStorageDeleteOperations)
+        .values({
+          organization_id: input.organizationId,
+          object_id: object.id,
+          idempotency_key_hash: input.idempotencyKeyHash,
+          request_digest: input.requestDigest,
+          source_generation: object.generation,
+          source_provider_key: object.provider_key,
+          source_size_bytes: object.size_bytes,
+        })
+        .returning();
+      return { operation: requiredRow(inserted, "delete operation insert"), replay: false };
+    });
+  }
+
+  async claimDeleteLease(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    leaseExpiresAt: Date;
+    now: Date;
+  }): Promise<OrgStorageDeleteOperation> {
+    const rows = await writeTransaction(
+      async (tx) =>
+        await tx
+          .update(orgStorageDeleteOperations)
+          .set({
+            state: "provider_started",
+            lease_token: params.leaseToken,
+            lease_expires_at: params.leaseExpiresAt,
+            updated_at: params.now,
+          })
+          .where(
+            and(
+              eq(orgStorageDeleteOperations.id, params.operationId),
+              eq(orgStorageDeleteOperations.organization_id, params.organizationId),
+              or(
+                eq(orgStorageDeleteOperations.state, "prepared"),
+                and(
+                  eq(orgStorageDeleteOperations.state, "provider_started"),
+                  lt(orgStorageDeleteOperations.lease_expires_at, params.now),
+                ),
+              ),
+            ),
+          )
+          .returning(),
+    );
+    if (!rows[0]) throw new StoragePutConflictError("stale_lease");
+    return rows[0];
+  }
+
+  async commitObservedDelete(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    responseJson: string;
+  }): Promise<OrgStorageDeleteOperation> {
+    return await writeTransaction(async (tx) => {
+      const operationRows = await sqlRows<OrgStorageDeleteOperation>(
+        tx,
+        sql`SELECT * FROM ${orgStorageDeleteOperations}
+          WHERE ${orgStorageDeleteOperations.id} = ${params.operationId}
+            AND ${orgStorageDeleteOperations.organization_id} = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const operation = requiredRow(operationRows, "delete operation commit lock");
+      if (operation.state === "committed") return operation;
+      if (operation.state !== "provider_started" || operation.lease_token !== params.leaseToken) {
+        throw new StoragePutConflictError("stale_lease");
+      }
+      const objectRows = await sqlRows<OrgStorageObject>(
+        tx,
+        sql`SELECT * FROM ${orgStorageObjects}
+          WHERE ${orgStorageObjects.id} = ${operation.object_id}
+            AND ${orgStorageObjects.organization_id} = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const object = normalizeObject(requiredRow(objectRows, "delete object commit lock"));
+      if (
+        object.generation !== bigintValue(operation.source_generation) ||
+        object.provider_key !== operation.source_provider_key
+      ) {
+        throw new StoragePutConflictError("object_busy");
+      }
+      const quotaRows = await sqlRows<{ bytes_used: bigint }>(
+        tx,
+        sql`UPDATE ${orgStorageQuota}
+          SET bytes_used = ${orgStorageQuota.bytes_used} - ${bigintValue(operation.source_size_bytes)},
+              updated_at = NOW()
+          WHERE ${orgStorageQuota.organization_id} = ${params.organizationId}
+            AND ${orgStorageQuota.bytes_used} >= ${bigintValue(operation.source_size_bytes)}
+          RETURNING ${orgStorageQuota.bytes_used}`,
+      );
+      requiredRow(quotaRows, "delete quota release");
+      await tx
+        .update(orgStorageObjects)
+        .set({
+          provider_key: null,
+          size_bytes: 0n,
+          content_type: null,
+          content_sha256: null,
+          etag: null,
+          uploaded_at: null,
+          deleted_at: new Date(),
+          updated_at: new Date(),
+        })
+        .where(eq(orgStorageObjects.id, object.id));
+      const committed = await tx
+        .update(orgStorageDeleteOperations)
+        .set({
+          state: "committed",
+          response_json: params.responseJson,
+          completed_at: new Date(),
+          lease_token: null,
+          lease_expires_at: null,
+          updated_at: new Date(),
+        })
+        .where(eq(orgStorageDeleteOperations.id, operation.id))
+        .returning();
+      return requiredRow(committed, "delete operation commit");
+    });
+  }
+
+  async listDueDeletes(now: Date, limit = MAX_DUE_BATCH): Promise<OrgStorageDeleteOperation[]> {
+    const preparedBefore = new Date(now.getTime() - 10 * 60 * 1000);
+    return await dbWrite.query.orgStorageDeleteOperations.findMany({
+      where: or(
+        and(
+          eq(orgStorageDeleteOperations.state, "prepared"),
+          lt(orgStorageDeleteOperations.created_at, preparedBefore),
+        ),
+        and(
+          eq(orgStorageDeleteOperations.state, "provider_started"),
+          lt(orgStorageDeleteOperations.lease_expires_at, now),
+        ),
+      ),
+      orderBy: (table, { asc }) => [asc(table.created_at)],
+      limit: Math.max(1, Math.min(limit, MAX_DUE_BATCH)),
+    });
+  }
+}
+
+export const orgStorageMutationsRepository = new OrgStorageMutationsRepository();

--- a/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
@@ -371,6 +371,37 @@ export class OrgStorageMutationsRepository {
     return normalizeOperation(rows[0]);
   }
 
+  async deferProviderAbsence(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    observedAt: Date;
+    recheckAt: Date;
+  }): Promise<OrgStoragePutOperation> {
+    const rows = await writeTransaction(
+      async (tx) =>
+        await tx
+          .update(orgStoragePutOperations)
+          .set({
+            state: "reconciling",
+            provider_absence_observed_at: params.observedAt,
+            lease_expires_at: params.recheckAt,
+            updated_at: params.observedAt,
+          })
+          .where(
+            and(
+              eq(orgStoragePutOperations.id, params.operationId),
+              eq(orgStoragePutOperations.organization_id, params.organizationId),
+              eq(orgStoragePutOperations.state, "provider_started"),
+              eq(orgStoragePutOperations.lease_token, params.leaseToken),
+            ),
+          )
+          .returning(),
+    );
+    if (!rows[0]) throw new StoragePutConflictError("stale_lease");
+    return normalizeOperation(rows[0]);
+  }
+
   async commitObservedPut(params: {
     operationId: string;
     organizationId: string;
@@ -389,7 +420,10 @@ export class OrgStorageMutationsRepository {
       );
       const operation = normalizeOperation(requiredRow(operationRows, "operation commit lock"));
       if (operation.state === "committed") return operation;
-      if (operation.state !== "provider_started" || operation.lease_token !== params.leaseToken) {
+      if (
+        !["provider_started", "reconciling"].includes(operation.state) ||
+        operation.lease_token !== params.leaseToken
+      ) {
         throw new StoragePutConflictError("stale_lease");
       }
 
@@ -473,6 +507,7 @@ export class OrgStorageMutationsRepository {
           completed_at: new Date(),
           lease_token: null,
           lease_expires_at: null,
+          provider_absence_observed_at: null,
           updated_at: new Date(),
         })
         .where(eq(orgStoragePutOperations.id, operation.id))
@@ -585,6 +620,7 @@ export class OrgStorageMutationsRepository {
           completed_at: new Date(),
           lease_token: null,
           lease_expires_at: null,
+          provider_absence_observed_at: null,
           updated_at: new Date(),
         })
         .where(eq(orgStoragePutOperations.id, operation.id))
@@ -706,10 +742,64 @@ export class OrgStorageMutationsRepository {
     });
   }
 
+  async quotaNeedsNativeCatalogReconciliation(organizationId: string): Promise<boolean> {
+    await dbWrite
+      .insert(orgStorageQuota)
+      .values({
+        organization_id: organizationId,
+        bytes_used: 0n,
+        bytes_limit: DEFAULT_ORG_STORAGE_BYTES_LIMIT,
+      })
+      .onConflictDoNothing();
+    const quota = await dbWrite.query.orgStorageQuota.findFirst({
+      where: eq(orgStorageQuota.organization_id, organizationId),
+      columns: { native_catalog_reconciled_at: true },
+    });
+    return !quota?.native_catalog_reconciled_at;
+  }
+
+  async reconcileNativeQuotaFromCatalog(organizationId: string): Promise<bigint> {
+    return await writeTransaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`storage-quota:${organizationId}`}, 0))`,
+      );
+      const quotaLock = await sqlRows<{ organization_id: string }>(
+        tx,
+        sql`SELECT organization_id FROM ${orgStorageQuota}
+          WHERE organization_id = ${organizationId}
+          FOR UPDATE`,
+      );
+      requiredRow(quotaLock, "native quota lock");
+      const rows = await sqlRows<{ bytes_used: bigint }>(
+        tx,
+        sql`WITH catalog AS (
+              SELECT COALESCE(SUM(size_bytes), 0) AS bytes
+              FROM ${orgStorageObjects}
+              WHERE organization_id = ${organizationId}
+                AND deleted_at IS NULL AND provider_key IS NOT NULL
+            ), reservations AS (
+              SELECT COALESCE(SUM(quota_reserved_bytes), 0) AS bytes
+              FROM ${orgStoragePutOperations}
+              WHERE organization_id = ${organizationId}
+                AND state IN ('prepared','reserved','provider_started','reconciling')
+            )
+            UPDATE ${orgStorageQuota}
+            SET bytes_used = (catalog.bytes + reservations.bytes)::bigint,
+                native_catalog_reconciled_at = NOW(),
+                updated_at = NOW()
+            FROM catalog, reservations
+            WHERE ${orgStorageQuota.organization_id} = ${organizationId}
+            RETURNING ${orgStorageQuota.bytes_used}`,
+      );
+      return bigintValue(requiredRow(rows, "native quota reconciliation").bytes_used);
+    });
+  }
+
   async listObjects(
     organizationId: string,
     prefix: string,
     limit = 1001,
+    recursive = true,
   ): Promise<OrgStorageObject[]> {
     const escapedPrefix = prefix
       .replaceAll("\\", "\\\\")
@@ -722,6 +812,9 @@ export class OrgStorageMutationsRepository {
           AND deleted_at IS NULL
           AND provider_key IS NOT NULL
           AND logical_key LIKE ${`${escapedPrefix}%`} ESCAPE '\\'
+          AND (${recursive} OR POSITION('/' IN LTRIM(
+            SUBSTRING(logical_key FROM char_length(${prefix}) + 1), '/'
+          )) = 0)
         ORDER BY logical_key ASC
         LIMIT ${Math.max(1, Math.min(limit, 1001))}`,
     );

--- a/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
@@ -57,6 +57,16 @@ export interface ReservedStoragePut {
   available: number;
 }
 
+export interface LegacyStorageObjectCandidate {
+  organizationId: string;
+  logicalKey: string;
+  providerKey: string;
+  sizeBytes: bigint;
+  contentType: string;
+  etag: string;
+  uploadedAt: Date;
+}
+
 function providerKey(organizationId: string, objectId: string, generation: bigint): string {
   return `__eliza_storage_authority/v2/org/${organizationId}/${objectId}/${generation}`;
 }
@@ -607,15 +617,7 @@ export class OrgStorageMutationsRepository {
     });
   }
 
-  async adoptLegacyObject(input: {
-    organizationId: string;
-    logicalKey: string;
-    providerKey: string;
-    sizeBytes: bigint;
-    contentType: string;
-    etag: string;
-    uploadedAt: Date;
-  }): Promise<OrgStorageObject> {
+  async adoptLegacyObject(input: LegacyStorageObjectCandidate): Promise<OrgStorageObject> {
     return await writeTransaction(async (tx) => {
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${input.organizationId}:${input.logicalKey}`}, 0))`,
@@ -646,6 +648,61 @@ export class OrgStorageMutationsRepository {
         .where(eq(orgStorageObjects.id, object.id))
         .returning();
       return normalizeObject(requiredRow(adopted, "legacy adoption"));
+    });
+  }
+
+  async adoptLegacyObjects(inputs: LegacyStorageObjectCandidate[]): Promise<void> {
+    if (inputs.length === 0) return;
+    const organizationId = inputs[0]?.organizationId;
+    if (!organizationId || inputs.some((input) => input.organizationId !== organizationId)) {
+      throw new Error("[NativeStoragePut] bulk legacy adoption must belong to one tenant");
+    }
+    const candidates = JSON.stringify(
+      inputs.map((input) => ({
+        logical_key: input.logicalKey,
+        provider_key: input.providerKey,
+        size_bytes: input.sizeBytes.toString(),
+        content_type: input.contentType,
+        etag: input.etag,
+        uploaded_at: input.uploadedAt.toISOString(),
+      })),
+    );
+    await writeTransaction(async (tx) => {
+      await tx.execute(sql`WITH candidates AS (
+          SELECT logical_key, provider_key, size_bytes::bigint,
+            content_type, etag, uploaded_at::timestamptz
+          FROM jsonb_to_recordset(${candidates}::jsonb) AS candidate(
+            logical_key text, provider_key text, size_bytes text,
+            content_type text, etag text, uploaded_at text
+          )
+        )
+        INSERT INTO ${orgStorageObjects} (
+          organization_id, logical_key, provider_key, size_bytes,
+          content_type, etag, uploaded_at, updated_at
+        )
+        SELECT ${organizationId}, logical_key, provider_key, size_bytes,
+          content_type, etag, uploaded_at, NOW()
+        FROM candidates
+        ON CONFLICT (organization_id, logical_key) DO UPDATE SET
+          provider_key = EXCLUDED.provider_key,
+          size_bytes = EXCLUDED.size_bytes,
+          content_type = EXCLUDED.content_type,
+          etag = EXCLUDED.etag,
+          uploaded_at = EXCLUDED.uploaded_at,
+          updated_at = NOW()
+        WHERE ${orgStorageObjects.generation} = 0
+          AND ${orgStorageObjects.provider_key} IS NULL
+          AND ${orgStorageObjects.deleted_at} IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM ${orgStoragePutOperations} AS active_put
+            WHERE active_put.object_id = ${orgStorageObjects.id}
+              AND active_put.state IN ('prepared','reserved','provider_started','reconciling')
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM ${orgStorageDeleteOperations} AS active_delete
+            WHERE active_delete.object_id = ${orgStorageObjects.id}
+              AND active_delete.state IN ('prepared','provider_started')
+          )`);
     });
   }
 

--- a/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/repositories/org-storage-mutations.ts
@@ -51,6 +51,12 @@ export interface PreparedStoragePut {
   replay: boolean;
 }
 
+export interface ReservedStoragePut {
+  operation: OrgStoragePutOperation;
+  insufficient: boolean;
+  available: number;
+}
+
 function providerKey(organizationId: string, objectId: string, generation: bigint): string {
   return `__eliza_storage_authority/v2/org/${organizationId}/${objectId}/${generation}`;
 }
@@ -121,7 +127,12 @@ export class OrgStorageMutationsRepository {
       const active = await tx.query.orgStoragePutOperations.findFirst({
         where: and(
           eq(orgStoragePutOperations.object_id, object.id),
-          inArray(orgStoragePutOperations.state, ["prepared", "reserved", "provider_started"]),
+          inArray(orgStoragePutOperations.state, [
+            "prepared",
+            "reserved",
+            "provider_started",
+            "reconciling",
+          ]),
         ),
       });
       if (active) throw new StoragePutConflictError("object_busy");
@@ -178,39 +189,108 @@ export class OrgStorageMutationsRepository {
     });
   }
 
-  async attachCreditReservation(params: {
+  async reservePutCredits(params: {
     operationId: string;
     organizationId: string;
-    creditTransactionId: string | null;
-  }): Promise<OrgStoragePutOperation> {
-    const rows = await writeTransaction(
-      async (tx) =>
-        await tx
+  }): Promise<ReservedStoragePut> {
+    return await writeTransaction(async (tx) => {
+      const rows = await sqlRows<OrgStoragePutOperation>(
+        tx,
+        sql`SELECT * FROM ${orgStoragePutOperations}
+          WHERE id = ${params.operationId}
+            AND organization_id = ${params.organizationId}
+          FOR UPDATE`,
+      );
+      const operation = normalizeOperation(requiredRow(rows, "credit reservation lock"));
+      if (operation.state !== "prepared") {
+        if (["reserved", "provider_started", "committed"].includes(operation.state)) {
+          return { operation, insufficient: false, available: 0 };
+        }
+        throw new StoragePutConflictError("stale_lease");
+      }
+      if (Number(operation.price_usd) === 0) {
+        const reserved = await tx
+          .update(orgStoragePutOperations)
+          .set({ state: "reserved", updated_at: new Date() })
+          .where(eq(orgStoragePutOperations.id, operation.id))
+          .returning();
+        return {
+          operation: normalizeOperation(requiredRow(reserved, "zero-cost reservation")),
+          insufficient: false,
+          available: 0,
+        };
+      }
+
+      const balanceRows = await sqlRows<{ credit_balance: string }>(
+        tx,
+        sql`UPDATE organizations
+          SET credit_balance = credit_balance - CAST(${String(operation.price_usd)} AS numeric),
+              updated_at = NOW()
+          WHERE id = ${params.organizationId}
+            AND credit_balance >= CAST(${String(operation.price_usd)} AS numeric)
+          RETURNING credit_balance`,
+      );
+      if (balanceRows.length === 0) {
+        const availableRows = await sqlRows<{ credit_balance: string }>(
+          tx,
+          sql`SELECT credit_balance FROM organizations
+            WHERE id = ${params.organizationId} FOR UPDATE`,
+        );
+        const quotaRows = await sqlRows<{ bytes_used: bigint }>(
+          tx,
+          sql`UPDATE ${orgStorageQuota}
+            SET bytes_used = ${orgStorageQuota.bytes_used} - ${operation.quota_reserved_bytes},
+                updated_at = NOW()
+            WHERE ${orgStorageQuota.organization_id} = ${params.organizationId}
+              AND ${orgStorageQuota.bytes_used} >= ${operation.quota_reserved_bytes}
+            RETURNING ${orgStorageQuota.bytes_used}`,
+        );
+        requiredRow(quotaRows, "insufficient-credit quota release");
+        const responseJson = JSON.stringify({ error: "Insufficient credits" });
+        const refunded = await tx
           .update(orgStoragePutOperations)
           .set({
-            state: "reserved",
-            credit_transaction_id: params.creditTransactionId,
+            state: "refunded",
+            response_json: responseJson,
+            completed_at: new Date(),
             updated_at: new Date(),
           })
-          .where(
-            and(
-              eq(orgStoragePutOperations.id, params.operationId),
-              eq(orgStoragePutOperations.organization_id, params.organizationId),
-              eq(orgStoragePutOperations.state, "prepared"),
-            ),
-          )
-          .returning(),
-    );
-    if (rows[0]) return rows[0];
-    const existing = await this.findOperation(params.organizationId, params.operationId);
-    if (!existing) throw new Error("[NativeStoragePut] operation disappeared while reserving");
-    if (
-      existing.credit_transaction_id !== params.creditTransactionId ||
-      !["reserved", "provider_started", "committed", "refunded"].includes(existing.state)
-    ) {
-      throw new StoragePutConflictError("object_busy");
-    }
-    return existing;
+          .where(eq(orgStoragePutOperations.id, operation.id))
+          .returning();
+        return {
+          operation: normalizeOperation(requiredRow(refunded, "insufficient-credit receipt")),
+          insufficient: true,
+          available: Number(requiredRow(availableRows, "organization balance").credit_balance),
+        };
+      }
+
+      const metadata = JSON.stringify({
+        type: "reservation",
+        settlement_marker: "credit_reservation_v1",
+        storage_operation_id: operation.id,
+        reserved_amount: Number(operation.price_usd),
+      });
+      const holdRows = await sqlRows<{ id: string }>(
+        tx,
+        sql`INSERT INTO credit_transactions (
+            organization_id, amount, type, description, metadata, created_at
+          ) VALUES (
+            ${params.organizationId}, -CAST(${String(operation.price_usd)} AS numeric),
+            'debit', 'API proxy: storage — native put (reserved)', ${metadata}::jsonb, NOW()
+          ) RETURNING id`,
+      );
+      const holdId = requiredRow(holdRows, "credit reservation insert").id;
+      const reserved = await tx
+        .update(orgStoragePutOperations)
+        .set({ state: "reserved", credit_transaction_id: holdId, updated_at: new Date() })
+        .where(eq(orgStoragePutOperations.id, operation.id))
+        .returning();
+      return {
+        operation: normalizeOperation(requiredRow(reserved, "credit reservation attach")),
+        insufficient: false,
+        available: Number(requiredRow(balanceRows, "credit balance debit").credit_balance),
+      };
+    });
   }
 
   async claimProviderLease(params: {
@@ -247,6 +327,38 @@ export class OrgStorageMutationsRepository {
     );
     if (!rows[0]) throw new StoragePutConflictError("stale_lease");
     return rows[0];
+  }
+
+  async claimReconciliationLease(params: {
+    operationId: string;
+    organizationId: string;
+    leaseToken: string;
+    leaseExpiresAt: Date;
+    staleBefore: Date;
+    now: Date;
+  }): Promise<OrgStoragePutOperation> {
+    const rows = await writeTransaction(async (tx) =>
+      sqlRows<OrgStoragePutOperation>(
+        tx,
+        sql`UPDATE ${orgStoragePutOperations} AS operation
+          SET state = CASE
+                WHEN operation.state = 'provider_started' THEN 'provider_started'
+                ELSE 'reconciling'
+              END,
+              lease_token = ${params.leaseToken},
+              lease_expires_at = ${params.leaseExpiresAt},
+              updated_at = ${params.now}
+          WHERE operation.id = ${params.operationId}
+            AND operation.organization_id = ${params.organizationId}
+            AND ((operation.state = 'prepared' AND operation.created_at < ${params.staleBefore})
+              OR (operation.state = 'reserved' AND operation.updated_at < ${params.staleBefore})
+              OR (operation.state = 'reconciling' AND operation.lease_expires_at < ${params.now})
+              OR (operation.state = 'provider_started' AND operation.lease_expires_at < ${params.now}))
+          RETURNING operation.*`,
+      ),
+    );
+    if (!rows[0]) throw new StoragePutConflictError("stale_lease");
+    return normalizeOperation(rows[0]);
   }
 
   async commitObservedPut(params: {
@@ -362,6 +474,7 @@ export class OrgStorageMutationsRepository {
   async finalizeRefund(params: {
     operationId: string;
     organizationId: string;
+    leaseToken: string;
     responseJson: string;
   }): Promise<OrgStoragePutOperation> {
     return await writeTransaction(async (tx) => {
@@ -374,8 +487,75 @@ export class OrgStorageMutationsRepository {
       );
       const operation = normalizeOperation(requiredRow(rows, "refund lock"));
       if (operation.state === "refunded") return operation;
-      if (operation.state === "committed") {
-        throw new StoragePutConflictError("object_busy");
+      if (
+        !["reconciling", "provider_started"].includes(operation.state) ||
+        operation.lease_token !== params.leaseToken
+      ) {
+        throw new StoragePutConflictError("stale_lease");
+      }
+
+      if (Number(operation.price_usd) > 0) {
+        const holdRows = await sqlRows<{ id: string; settled_at: Date | null }>(
+          tx,
+          operation.credit_transaction_id
+            ? sql`SELECT id, settled_at FROM credit_transactions
+                WHERE id = ${operation.credit_transaction_id}
+                  AND organization_id = ${params.organizationId}
+                  AND type = 'debit'
+                  AND amount = -CAST(${String(operation.price_usd)} AS numeric)
+                  AND metadata->>'type' = 'reservation'
+                  AND metadata->>'settlement_marker' = 'credit_reservation_v1'
+                  AND metadata->>'storage_operation_id' = ${operation.id}
+                FOR UPDATE`
+            : sql`SELECT id, settled_at FROM credit_transactions
+                WHERE organization_id = ${params.organizationId}
+                  AND type = 'debit'
+                  AND amount = -CAST(${String(operation.price_usd)} AS numeric)
+                  AND metadata->>'type' = 'reservation'
+                  AND metadata->>'settlement_marker' = 'credit_reservation_v1'
+                  AND metadata->>'storage_operation_id' = ${operation.id}
+                ORDER BY created_at ASC
+                FOR UPDATE`,
+        );
+        if (
+          holdRows.length > 1 ||
+          (operation.credit_transaction_id !== null && holdRows.length !== 1) ||
+          holdRows[0]?.settled_at
+        ) {
+          throw new Error("[NativeStoragePut] refundable credit hold is missing or ambiguous");
+        }
+        if (holdRows[0]) {
+          const holdId = holdRows[0].id;
+          const refundMetadata = JSON.stringify({
+            type: "storage_put_refund",
+            storage_operation_id: operation.id,
+            reservation_transaction_id: holdId,
+          });
+          const organizationRows = await sqlRows<{ id: string }>(
+            tx,
+            sql`UPDATE organizations
+              SET credit_balance = credit_balance + CAST(${String(operation.price_usd)} AS numeric),
+                  updated_at = NOW()
+              WHERE id = ${params.organizationId}
+              RETURNING id`,
+          );
+          requiredRow(organizationRows, "credit refund balance");
+          await tx.execute(sql`INSERT INTO credit_transactions (
+              organization_id, amount, type, description, metadata, created_at
+            ) VALUES (
+              ${params.organizationId}, CAST(${String(operation.price_usd)} AS numeric),
+              'refund', 'API proxy: storage — native put (refund)',
+              ${refundMetadata}::jsonb, NOW()
+            )`);
+          const settled = await sqlRows<{ id: string }>(
+            tx,
+            sql`UPDATE credit_transactions
+              SET settled_at = NOW()
+              WHERE id = ${holdId} AND settled_at IS NULL
+              RETURNING id`,
+          );
+          requiredRow(settled, "credit refund settlement");
+        }
       }
       const quotaRows = await sqlRows<{ bytes_used: bigint }>(
         tx,
@@ -415,25 +595,6 @@ export class OrgStorageMutationsRepository {
     });
   }
 
-  async findUnattachedCreditReservation(
-    operation: OrgStoragePutOperation,
-  ): Promise<string | undefined> {
-    const rows = await sqlRows<{ id: string }>(
-      dbWrite,
-      sql`SELECT id FROM credit_transactions
-        WHERE organization_id = ${operation.organization_id}
-          AND type = 'debit'
-          AND amount = -CAST(${String(operation.price_usd)} AS numeric)
-          AND settled_at IS NULL
-          AND metadata->>'type' = 'reservation'
-          AND metadata->>'settlement_marker' = 'credit_reservation_v1'
-          AND metadata->>'storage_operation_id' = ${operation.id}
-        ORDER BY created_at ASC
-        LIMIT 1`,
-    );
-    return rows[0]?.id;
-  }
-
   async findObject(
     organizationId: string,
     logicalKey: string,
@@ -444,6 +605,70 @@ export class OrgStorageMutationsRepository {
         eq(orgStorageObjects.logical_key, logicalKey),
       ),
     });
+  }
+
+  async adoptLegacyObject(input: {
+    organizationId: string;
+    logicalKey: string;
+    providerKey: string;
+    sizeBytes: bigint;
+    contentType: string;
+    etag: string;
+    uploadedAt: Date;
+  }): Promise<OrgStorageObject> {
+    return await writeTransaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${input.organizationId}:${input.logicalKey}`}, 0))`,
+      );
+      await tx
+        .insert(orgStorageObjects)
+        .values({ organization_id: input.organizationId, logical_key: input.logicalKey })
+        .onConflictDoNothing();
+      const rows = await sqlRows<OrgStorageObject>(
+        tx,
+        sql`SELECT * FROM ${orgStorageObjects}
+          WHERE organization_id = ${input.organizationId}
+            AND logical_key = ${input.logicalKey}
+          FOR UPDATE`,
+      );
+      const object = normalizeObject(requiredRow(rows, "legacy adoption lock"));
+      if (object.provider_key || object.generation > 0n || object.deleted_at) return object;
+      const adopted = await tx
+        .update(orgStorageObjects)
+        .set({
+          provider_key: input.providerKey,
+          size_bytes: input.sizeBytes,
+          content_type: input.contentType,
+          etag: input.etag,
+          uploaded_at: input.uploadedAt,
+          updated_at: new Date(),
+        })
+        .where(eq(orgStorageObjects.id, object.id))
+        .returning();
+      return normalizeObject(requiredRow(adopted, "legacy adoption"));
+    });
+  }
+
+  async listObjects(
+    organizationId: string,
+    prefix: string,
+    limit = 1001,
+  ): Promise<OrgStorageObject[]> {
+    const escapedPrefix = prefix
+      .replaceAll("\\", "\\\\")
+      .replaceAll("%", "\\%")
+      .replaceAll("_", "\\_");
+    const rows = await sqlRows<OrgStorageObject>(
+      dbWrite,
+      sql`SELECT * FROM ${orgStorageObjects}
+        WHERE organization_id = ${organizationId}
+          AND deleted_at IS NULL
+          AND provider_key IS NOT NULL
+          AND logical_key LIKE ${`${escapedPrefix}%`} ESCAPE '\\'
+        ORDER BY logical_key ASC
+        LIMIT ${Math.max(1, Math.min(limit, 1001))}`,
+    );
+    return rows.map(normalizeObject);
   }
 
   async listDueOperations(now: Date, limit = MAX_DUE_BATCH): Promise<OrgStoragePutOperation[]> {
@@ -460,6 +685,10 @@ export class OrgStorageMutationsRepository {
         ),
         and(
           eq(orgStoragePutOperations.state, "provider_started"),
+          lt(orgStoragePutOperations.lease_expires_at, now),
+        ),
+        and(
+          eq(orgStoragePutOperations.state, "reconciling"),
           lt(orgStoragePutOperations.lease_expires_at, now),
         ),
       ),
@@ -521,7 +750,12 @@ export class OrgStorageMutationsRepository {
       const activePut = await tx.query.orgStoragePutOperations.findFirst({
         where: and(
           eq(orgStoragePutOperations.object_id, object.id),
-          inArray(orgStoragePutOperations.state, ["prepared", "reserved", "provider_started"]),
+          inArray(orgStoragePutOperations.state, [
+            "prepared",
+            "reserved",
+            "provider_started",
+            "reconciling",
+          ]),
         ),
       });
       const activeDelete = await tx.query.orgStorageDeleteOperations.findFirst({

--- a/packages/cloud/shared/src/db/schemas/credit-transactions.ts
+++ b/packages/cloud/shared/src/db/schemas/credit-transactions.ts
@@ -7,7 +7,6 @@ import {
   pgTable,
   text,
   timestamp,
-  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -38,10 +37,6 @@ export const creditTransactions = pgTable(
     settled_at: timestamp("settled_at"),
   },
   (table) => ({
-    tenant_identity: unique("credit_transactions_tenant_identity_unique").on(
-      table.id,
-      table.organization_id,
-    ),
     organization_idx: index("credit_transactions_organization_idx").on(table.organization_id),
     user_idx: index("credit_transactions_user_idx").on(table.user_id),
     type_idx: index("credit_transactions_type_idx").on(table.type),

--- a/packages/cloud/shared/src/db/schemas/credit-transactions.ts
+++ b/packages/cloud/shared/src/db/schemas/credit-transactions.ts
@@ -7,6 +7,7 @@ import {
   pgTable,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -37,6 +38,10 @@ export const creditTransactions = pgTable(
     settled_at: timestamp("settled_at"),
   },
   (table) => ({
+    tenant_identity: unique("credit_transactions_tenant_identity_unique").on(
+      table.id,
+      table.organization_id,
+    ),
     organization_idx: index("credit_transactions_organization_idx").on(table.organization_id),
     user_idx: index("credit_transactions_user_idx").on(table.user_id),
     type_idx: index("credit_transactions_type_idx").on(table.type),

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -77,6 +77,7 @@ export * from "./moderation-violations";
 export * from "./oauth-success-proof-tickets";
 export * from "./oidc";
 export * from "./org-rate-limit-overrides";
+export * from "./org-storage-mutations";
 export * from "./org-storage-quota";
 export * from "./organization-billing";
 export * from "./organization-config";

--- a/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
@@ -106,6 +106,9 @@ export const orgStoragePutOperations = pgTable(
     credit_transaction_id: uuid("credit_transaction_id"),
     lease_token: uuid("lease_token"),
     lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    provider_absence_observed_at: timestamp("provider_absence_observed_at", {
+      withTimezone: true,
+    }),
     result_etag: text("result_etag"),
     result_uploaded_at: timestamp("result_uploaded_at", { withTimezone: true }),
     response_json: text("response_json"),
@@ -155,6 +158,7 @@ export const orgStoragePutOperations = pgTable(
           OR ${table.credit_transaction_id} IS NOT NULL OR ${table.price_usd} = 0)
         AND ((${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL))
         AND (${table.state} <> 'reconciling' OR ${table.lease_token} IS NOT NULL)
+        AND (${table.provider_absence_observed_at} IS NULL OR ${table.state} = 'reconciling')
         AND (${table.state} <> 'committed' OR (
           ${table.result_etag} IS NOT NULL AND ${table.result_uploaded_at} IS NOT NULL
           AND ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL

--- a/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
@@ -56,6 +56,11 @@ export const orgStorageObjects = pgTable(
       sql`${table.generation} >= 0 AND ${table.size_bytes} >= 0 AND ((
         ${table.generation} = 0 AND ${table.provider_key} IS NULL AND ${table.size_bytes} = 0
       ) OR (
+        ${table.generation} = 0 AND ${table.provider_key} IS NOT NULL AND ${table.size_bytes} > 0
+        AND char_length(${table.content_type}) BETWEEN 1 AND 255
+        AND char_length(${table.etag}) BETWEEN 1 AND 512
+        AND ${table.uploaded_at} IS NOT NULL AND ${table.deleted_at} IS NULL
+      ) OR (
         ${table.generation} > 0 AND ${table.provider_key} IS NOT NULL
         AND ${table.content_sha256} ~ '^[0-9a-f]{64}$'
         AND char_length(${table.content_type}) BETWEEN 1 AND 255
@@ -73,6 +78,7 @@ export type OrgStoragePutState =
   | "prepared"
   | "reserved"
   | "provider_started"
+  | "reconciling"
   | "committed"
   | "refunded";
 
@@ -113,11 +119,15 @@ export const orgStoragePutOperations = pgTable(
       columns: [table.object_id, table.organization_id],
       foreignColumns: [orgStorageObjects.id, orgStorageObjects.organization_id],
     }).onDelete("restrict"),
-    credit_tenant: foreignKey({
-      name: "org_storage_put_operations_credit_tenant_fkey",
-      columns: [table.credit_transaction_id, table.organization_id],
-      foreignColumns: [creditTransactions.id, creditTransactions.organization_id],
+    credit: foreignKey({
+      name: "org_storage_put_operations_credit_fkey",
+      columns: [table.credit_transaction_id],
+      foreignColumns: [creditTransactions.id],
     }).onDelete("restrict"),
+    credit_tenant: check(
+      "org_storage_put_operations_credit_tenant_check",
+      sql`org_storage_credit_matches_tenant(${table.credit_transaction_id}, ${table.organization_id})`,
+    ),
     idempotency: uniqueIndex("org_storage_put_operations_idempotency_uidx").on(
       table.organization_id,
       table.idempotency_key_hash,
@@ -127,7 +137,7 @@ export const orgStoragePutOperations = pgTable(
     ),
     active_object: uniqueIndex("org_storage_put_operations_active_object_uidx")
       .on(table.object_id)
-      .where(sql`${table.state} IN ('prepared', 'reserved', 'provider_started')`),
+      .where(sql`${table.state} IN ('prepared', 'reserved', 'provider_started', 'reconciling')`),
     due: index("org_storage_put_operations_due_idx").on(table.state, table.lease_expires_at),
     shape: check(
       "org_storage_put_operations_shape_check",
@@ -141,9 +151,10 @@ export const orgStoragePutOperations = pgTable(
           ${table.target_size_bytes} - ${table.source_size_bytes}, 0
         )
         AND ${table.price_usd} >= 0
-        AND (${table.state} IN ('prepared', 'refunded')
+        AND (${table.state} IN ('prepared', 'reconciling', 'refunded')
           OR ${table.credit_transaction_id} IS NOT NULL OR ${table.price_usd} = 0)
         AND ((${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL))
+        AND (${table.state} <> 'reconciling' OR ${table.lease_token} IS NOT NULL)
         AND (${table.state} <> 'committed' OR (
           ${table.result_etag} IS NOT NULL AND ${table.result_uploaded_at} IS NOT NULL
           AND ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL
@@ -228,7 +239,7 @@ export const orgStorageDeleteOperations = pgTable(
       sql`${table.idempotency_key_hash} ~ '^[0-9a-f]{64}$'
         AND ${table.request_digest} ~ '^[0-9a-f]{64}$'
         AND ${table.state} IN ('prepared', 'provider_started', 'committed')
-        AND ${table.source_generation} > 0 AND ${table.source_size_bytes} > 0
+        AND ${table.source_generation} >= 0 AND ${table.source_size_bytes} > 0
         AND ((${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL))
         AND (${table.state} <> 'committed' OR (
           ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL

--- a/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-mutations.ts
@@ -1,0 +1,241 @@
+/**
+ * Defines the active native-storage mutation authority: logical object heads,
+ * durable PUT receipts, and old-generation garbage-collection work.
+ */
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  foreignKey,
+  index,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { creditTransactions } from "./credit-transactions";
+import { organizations } from "./organizations";
+
+export const orgStorageObjects = pgTable(
+  "org_storage_objects",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    logical_key: text("logical_key").notNull(),
+    generation: bigint("generation", { mode: "bigint" }).notNull().default(0n),
+    provider_key: text("provider_key"),
+    size_bytes: bigint("size_bytes", { mode: "bigint" }).notNull().default(0n),
+    content_type: text("content_type"),
+    content_sha256: text("content_sha256"),
+    etag: text("etag"),
+    uploaded_at: timestamp("uploaded_at", { withTimezone: true }),
+    deleted_at: timestamp("deleted_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenant_identity: unique("org_storage_objects_tenant_identity_unique").on(
+      table.id,
+      table.organization_id,
+    ),
+    tenant_key: uniqueIndex("org_storage_objects_tenant_key_uidx").on(
+      table.organization_id,
+      table.logical_key,
+    ),
+    provider_key: uniqueIndex("org_storage_objects_provider_key_uidx")
+      .on(table.provider_key)
+      .where(sql`${table.provider_key} IS NOT NULL`),
+    shape: check(
+      "org_storage_objects_shape_check",
+      sql`${table.generation} >= 0 AND ${table.size_bytes} >= 0 AND ((
+        ${table.generation} = 0 AND ${table.provider_key} IS NULL AND ${table.size_bytes} = 0
+      ) OR (
+        ${table.generation} > 0 AND ${table.provider_key} IS NOT NULL
+        AND ${table.content_sha256} ~ '^[0-9a-f]{64}$'
+        AND char_length(${table.content_type}) BETWEEN 1 AND 255
+        AND char_length(${table.etag}) BETWEEN 1 AND 512
+        AND ${table.uploaded_at} IS NOT NULL AND ${table.deleted_at} IS NULL
+      ) OR (
+        ${table.generation} > 0 AND ${table.provider_key} IS NULL
+        AND ${table.size_bytes} = 0 AND ${table.deleted_at} IS NOT NULL
+      ))`,
+    ),
+  }),
+);
+
+export type OrgStoragePutState =
+  | "prepared"
+  | "reserved"
+  | "provider_started"
+  | "committed"
+  | "refunded";
+
+export const orgStoragePutOperations = pgTable(
+  "org_storage_put_operations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    object_id: uuid("object_id").notNull(),
+    idempotency_key_hash: text("idempotency_key_hash").notNull(),
+    request_digest: text("request_digest").notNull(),
+    state: text("state").$type<OrgStoragePutState>().notNull().default("prepared"),
+    source_generation: bigint("source_generation", { mode: "bigint" }).notNull(),
+    source_provider_key: text("source_provider_key"),
+    source_size_bytes: bigint("source_size_bytes", { mode: "bigint" }).notNull(),
+    target_generation: bigint("target_generation", { mode: "bigint" }).notNull(),
+    target_provider_key: text("target_provider_key").notNull(),
+    target_size_bytes: bigint("target_size_bytes", { mode: "bigint" }).notNull(),
+    target_content_type: text("target_content_type").notNull(),
+    target_content_sha256: text("target_content_sha256").notNull(),
+    quota_reserved_bytes: bigint("quota_reserved_bytes", { mode: "bigint" }).notNull(),
+    price_usd: numeric("price_usd", { precision: 12, scale: 6 }).notNull(),
+    credit_transaction_id: uuid("credit_transaction_id"),
+    lease_token: uuid("lease_token"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    result_etag: text("result_etag"),
+    result_uploaded_at: timestamp("result_uploaded_at", { withTimezone: true }),
+    response_json: text("response_json"),
+    completed_at: timestamp("completed_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    object_tenant: foreignKey({
+      name: "org_storage_put_operations_object_tenant_fkey",
+      columns: [table.object_id, table.organization_id],
+      foreignColumns: [orgStorageObjects.id, orgStorageObjects.organization_id],
+    }).onDelete("restrict"),
+    credit_tenant: foreignKey({
+      name: "org_storage_put_operations_credit_tenant_fkey",
+      columns: [table.credit_transaction_id, table.organization_id],
+      foreignColumns: [creditTransactions.id, creditTransactions.organization_id],
+    }).onDelete("restrict"),
+    idempotency: uniqueIndex("org_storage_put_operations_idempotency_uidx").on(
+      table.organization_id,
+      table.idempotency_key_hash,
+    ),
+    provider_key: uniqueIndex("org_storage_put_operations_provider_key_uidx").on(
+      table.target_provider_key,
+    ),
+    active_object: uniqueIndex("org_storage_put_operations_active_object_uidx")
+      .on(table.object_id)
+      .where(sql`${table.state} IN ('prepared', 'reserved', 'provider_started')`),
+    due: index("org_storage_put_operations_due_idx").on(table.state, table.lease_expires_at),
+    shape: check(
+      "org_storage_put_operations_shape_check",
+      sql`${table.idempotency_key_hash} ~ '^[0-9a-f]{64}$'
+        AND ${table.request_digest} ~ '^[0-9a-f]{64}$'
+        AND ${table.target_content_sha256} ~ '^[0-9a-f]{64}$'
+        AND ${table.source_generation} >= 0
+        AND ${table.target_generation} = ${table.source_generation} + 1
+        AND ${table.source_size_bytes} >= 0 AND ${table.target_size_bytes} > 0
+        AND ${table.quota_reserved_bytes} = GREATEST(
+          ${table.target_size_bytes} - ${table.source_size_bytes}, 0
+        )
+        AND ${table.price_usd} >= 0
+        AND (${table.state} IN ('prepared', 'refunded')
+          OR ${table.credit_transaction_id} IS NOT NULL OR ${table.price_usd} = 0)
+        AND ((${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL))
+        AND (${table.state} <> 'committed' OR (
+          ${table.result_etag} IS NOT NULL AND ${table.result_uploaded_at} IS NOT NULL
+          AND ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL
+        ))
+        AND (${table.state} <> 'refunded' OR (
+          ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL
+        ))`,
+    ),
+  }),
+);
+
+export const orgStorageGcOutbox = pgTable(
+  "org_storage_gc_outbox",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    operation_id: uuid("operation_id")
+      .notNull()
+      .references(() => orgStoragePutOperations.id, { onDelete: "cascade" }),
+    provider_key: text("provider_key").notNull(),
+    state: text("state").notNull().default("pending"),
+    not_before: timestamp("not_before", { withTimezone: true }).notNull(),
+    completed_at: timestamp("completed_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    operation: uniqueIndex("org_storage_gc_outbox_operation_uidx").on(table.operation_id),
+    due: index("org_storage_gc_outbox_due_idx").on(table.state, table.not_before),
+    shape: check(
+      "org_storage_gc_outbox_shape_check",
+      sql`${table.state} IN ('pending', 'completed')
+        AND (${table.state} <> 'completed' OR ${table.completed_at} IS NOT NULL)`,
+    ),
+  }),
+);
+
+export type OrgStorageObject = InferSelectModel<typeof orgStorageObjects>;
+export type OrgStoragePutOperation = InferSelectModel<typeof orgStoragePutOperations>;
+export type NewOrgStoragePutOperation = InferInsertModel<typeof orgStoragePutOperations>;
+
+export type OrgStorageDeleteState = "prepared" | "provider_started" | "committed";
+
+export const orgStorageDeleteOperations = pgTable(
+  "org_storage_delete_operations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    object_id: uuid("object_id").notNull(),
+    idempotency_key_hash: text("idempotency_key_hash").notNull(),
+    request_digest: text("request_digest").notNull(),
+    state: text("state").$type<OrgStorageDeleteState>().notNull().default("prepared"),
+    source_generation: bigint("source_generation", { mode: "bigint" }).notNull(),
+    source_provider_key: text("source_provider_key").notNull(),
+    source_size_bytes: bigint("source_size_bytes", { mode: "bigint" }).notNull(),
+    lease_token: uuid("lease_token"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    response_json: text("response_json"),
+    completed_at: timestamp("completed_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    object_tenant: foreignKey({
+      name: "org_storage_delete_operations_object_tenant_fkey",
+      columns: [table.object_id, table.organization_id],
+      foreignColumns: [orgStorageObjects.id, orgStorageObjects.organization_id],
+    }).onDelete("restrict"),
+    idempotency: uniqueIndex("org_storage_delete_operations_idempotency_uidx").on(
+      table.organization_id,
+      table.idempotency_key_hash,
+    ),
+    active_object: uniqueIndex("org_storage_delete_operations_active_object_uidx")
+      .on(table.object_id)
+      .where(sql`${table.state} IN ('prepared', 'provider_started')`),
+    due: index("org_storage_delete_operations_due_idx").on(table.state, table.lease_expires_at),
+    shape: check(
+      "org_storage_delete_operations_shape_check",
+      sql`${table.idempotency_key_hash} ~ '^[0-9a-f]{64}$'
+        AND ${table.request_digest} ~ '^[0-9a-f]{64}$'
+        AND ${table.state} IN ('prepared', 'provider_started', 'committed')
+        AND ${table.source_generation} > 0 AND ${table.source_size_bytes} > 0
+        AND ((${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL))
+        AND (${table.state} <> 'committed' OR (
+          ${table.response_json} IS NOT NULL AND ${table.completed_at} IS NOT NULL
+          AND ${table.lease_token} IS NULL
+        ))`,
+    ),
+  }),
+);
+
+export type OrgStorageDeleteOperation = InferSelectModel<typeof orgStorageDeleteOperations>;

--- a/packages/cloud/shared/src/db/schemas/org-storage-quota.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-quota.ts
@@ -27,6 +27,10 @@ export const orgStorageQuota = pgTable(
       .notNull()
       .default(5n * 1024n * 1024n * 1024n),
 
+    native_catalog_reconciled_at: timestamp("native_catalog_reconciled_at", {
+      withTimezone: true,
+    }),
+
     created_at: timestamp("created_at").notNull().defaultNow(),
 
     updated_at: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/cloud/shared/src/db/schemas/service-pricing.ts
+++ b/packages/cloud/shared/src/db/schemas/service-pricing.ts
@@ -24,7 +24,7 @@ export const servicePricing = pgTable(
     id: uuid("id").defaultRandom().primaryKey(),
     service_id: text("service_id").notNull(),
     method: text("method").notNull(),
-    cost: numeric("cost", { precision: 12, scale: 6 }).notNull(),
+    cost: numeric("cost", { precision: 18, scale: 12 }).notNull(),
     description: text("description"),
     metadata: jsonb("metadata")
       .$type<Record<string, string | number | boolean | null>>()
@@ -62,8 +62,8 @@ export const servicePricingAudit = pgTable(
     }),
     service_id: text("service_id").notNull(),
     method: text("method").notNull(),
-    old_cost: numeric("old_cost", { precision: 12, scale: 6 }),
-    new_cost: numeric("new_cost", { precision: 12, scale: 6 }).notNull(),
+    old_cost: numeric("old_cost", { precision: 18, scale: 12 }),
+    new_cost: numeric("new_cost", { precision: 18, scale: 12 }).notNull(),
     change_type: text("change_type").notNull(),
     changed_by: text("changed_by").notNull(),
     reason: text("reason"),

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -1439,6 +1439,9 @@ export class CreditsService {
                 AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
               )
             )
+            -- Native storage reservations are settled only after a strong R2
+            -- HEAD proves the immutable generation present or absent.
+            AND NOT (metadata ? 'storage_operation_id')
             AND settled_at IS NULL
           RETURNING id, amount
         `,

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Failure-injects the native PUT orchestrator with a fake strongly consistent
+ * R2 binding to prove ambiguous writes reconcile without refund or re-upload.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { OrgStoragePutOperation } from "../../../db/schemas/org-storage-mutations";
+import type { RuntimeR2Bucket, RuntimeR2ObjectMetadata } from "../../storage/r2-runtime-binding";
+
+const ORG = "00000000-0000-4000-8000-000000021045";
+const OP = "00000000-0000-4000-8000-000000021046";
+const OBJECT = "00000000-0000-4000-8000-000000021047";
+const PROVIDER_KEY = `__eliza_storage_authority/v2/org/${ORG}/${OBJECT}/1`;
+
+const preparePut = mock();
+const attachCreditReservation = mock();
+const claimProviderLease = mock();
+const commitObservedPut = mock();
+const finalizeRefund = mock();
+const listDueOperations = mock();
+const listDueGc = mock();
+const completeGc = mock();
+const prepareDelete = mock();
+const claimDeleteLease = mock();
+const commitObservedDelete = mock();
+const listDueDeletes = mock();
+const findUnattachedCreditReservation = mock();
+const reserve = mock();
+const reconcile = mock();
+const loggerWarn = mock();
+
+class TestInsufficientCreditsError extends Error {}
+class TestStoragePutConflictError extends Error {}
+
+mock.module("../../../db/repositories/org-storage-mutations", () => ({
+  orgStorageMutationsRepository: {
+    preparePut,
+    attachCreditReservation,
+    claimProviderLease,
+    commitObservedPut,
+    finalizeRefund,
+    listDueOperations,
+    listDueGc,
+    completeGc,
+    prepareDelete,
+    claimDeleteLease,
+    commitObservedDelete,
+    listDueDeletes,
+    findUnattachedCreditReservation,
+  },
+  StoragePutConflictError: TestStoragePutConflictError,
+}));
+mock.module("../credits", () => ({
+  creditsService: { reserve, reconcile },
+  InsufficientCreditsError: TestInsufficientCreditsError,
+}));
+mock.module("../../utils/logger", () => ({ logger: { warn: loggerWarn } }));
+
+const {
+  calculateStoragePutPrice,
+  executeNativeStorageDelete,
+  executeNativeStoragePut,
+  reconcileNativeStoragePuts,
+} = await import("./native-storage-put");
+
+function operation(state: OrgStoragePutOperation["state"], price = "1.000000") {
+  return {
+    id: OP,
+    organization_id: ORG,
+    object_id: OBJECT,
+    idempotency_key_hash: "a".repeat(64),
+    request_digest: "b".repeat(64),
+    state,
+    source_generation: 0n,
+    source_provider_key: null,
+    source_size_bytes: 0n,
+    target_generation: 1n,
+    target_provider_key: PROVIDER_KEY,
+    target_size_bytes: 7n,
+    target_content_type: "text/plain",
+    target_content_sha256: "c".repeat(64),
+    quota_reserved_bytes: 7n,
+    price_usd: price,
+    credit_transaction_id: state === "prepared" || price === "0.000000" ? null : OP,
+    lease_token: state === "provider_started" ? OBJECT : null,
+    lease_expires_at: state === "provider_started" ? new Date(Date.now() - 1) : null,
+    result_etag: state === "committed" ? "etag-1" : null,
+    result_uploaded_at: state === "committed" ? new Date() : null,
+    response_json: state === "committed" ? "{}" : null,
+    completed_at: state === "committed" ? new Date() : null,
+    created_at: new Date(Date.now() - 60_000),
+    updated_at: new Date(),
+  } satisfies OrgStoragePutOperation;
+}
+
+function fakeR2(throwAfterCommit: { value: boolean }): RuntimeR2Bucket {
+  const objects = new Map<string, RuntimeR2ObjectMetadata>();
+  return {
+    get: mock(async () => null),
+    head: mock(async (key: string) => objects.get(key) ?? null),
+    put: mock(async (key, value, options) => {
+      const size = value instanceof ArrayBuffer ? value.byteLength : 0;
+      objects.set(key, {
+        size,
+        etag: "etag-1",
+        uploaded: new Date(),
+        customMetadata: options?.customMetadata,
+      });
+      if (throwAfterCommit.value) {
+        throwAfterCommit.value = false;
+        throw new Error("simulated commit-then-ack-loss");
+      }
+      return null;
+    }),
+    delete: mock(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  for (const fn of [
+    preparePut,
+    attachCreditReservation,
+    claimProviderLease,
+    commitObservedPut,
+    finalizeRefund,
+    listDueOperations,
+    listDueGc,
+    completeGc,
+    prepareDelete,
+    claimDeleteLease,
+    commitObservedDelete,
+    listDueDeletes,
+    findUnattachedCreditReservation,
+    reserve,
+    reconcile,
+    loggerWarn,
+  ]) {
+    fn.mockReset();
+  }
+  listDueOperations.mockResolvedValue([]);
+  listDueGc.mockResolvedValue([]);
+  listDueDeletes.mockResolvedValue([]);
+  findUnattachedCreditReservation.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reservationTransactionId: OP });
+  reconcile.mockResolvedValue({ adjustmentType: "none" });
+});
+
+describe("executeNativeStoragePut", () => {
+  test("preserves the authoritative per-byte rate while rounding to ledger precision", () => {
+    expect(calculateStoragePutPrice(0.0001, 0.000000001, 1)).toBe(0.000101);
+    expect(calculateStoragePutPrice(0.0001, 0.000000001, 50_000_000)).toBe(0.0501);
+  });
+
+  test("keeps the hold on commit-then-ack-loss and reconciles by immutable-key HEAD", async () => {
+    let current = operation("prepared");
+    preparePut.mockImplementation(async () => ({
+      operation: current,
+      replay: current.state !== "prepared",
+    }));
+    attachCreditReservation.mockImplementation(async () => {
+      current = operation("reserved");
+      return current;
+    });
+    claimProviderLease.mockImplementation(async () => {
+      current = operation("provider_started");
+      return current;
+    });
+    commitObservedPut.mockImplementation(async () => {
+      current = operation("committed");
+      return current;
+    });
+    const bucket = fakeR2({ value: true });
+    const input = {
+      bucket,
+      organizationId: ORG,
+      logicalKey: "private/voice.txt",
+      idempotencyKey: "request-1",
+      body: new TextEncoder().encode("payload").buffer,
+      contentType: "text/plain",
+      priceUsd: 1,
+    };
+
+    await expect(executeNativeStoragePut(input)).rejects.toThrow("commit-then-ack-loss");
+    expect(finalizeRefund).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+    expect(bucket.put).toHaveBeenCalledWith(
+      PROVIDER_KEY,
+      input.body,
+      expect.objectContaining({ onlyIf: { etagDoesNotMatch: "*" } }),
+    );
+
+    const response = await executeNativeStoragePut(input);
+    expect(response).toEqual({
+      key: input.logicalKey,
+      size: 7,
+      contentType: "text/plain",
+      etag: "etag-1",
+    });
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+    expect(commitObservedPut).toHaveBeenCalledTimes(1);
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(finalizeRefund).not.toHaveBeenCalled();
+  });
+
+  test("persists a zero-cost terminal receipt without creating a credit transaction", async () => {
+    let current = operation("prepared", "0.000000");
+    preparePut.mockResolvedValue({ operation: current, replay: false });
+    attachCreditReservation.mockImplementation(async ({ creditTransactionId }) => {
+      expect(creditTransactionId).toBeNull();
+      current = operation("reserved", "0.000000");
+      return current;
+    });
+    claimProviderLease.mockImplementation(async () => {
+      current = operation("provider_started", "0.000000");
+      return current;
+    });
+    commitObservedPut.mockImplementation(async () => operation("committed", "0.000000"));
+    const bucket = fakeR2({ value: false });
+
+    const response = await executeNativeStoragePut({
+      bucket,
+      organizationId: ORG,
+      logicalKey: "zero-cost.txt",
+      idempotencyKey: "zero-1",
+      body: new TextEncoder().encode("payload").buffer,
+      contentType: "text/plain",
+      priceUsd: 0,
+    });
+    expect(response.etag).toBe("etag-1");
+    expect(reserve).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(commitObservedPut).toHaveBeenCalledTimes(1);
+  });
+
+  test("replays an ambiguous native delete without releasing authority early", async () => {
+    let state: "prepared" | "provider_started" | "committed" = "prepared";
+    const deleteOperation = () => ({
+      id: OP,
+      organization_id: ORG,
+      object_id: OBJECT,
+      idempotency_key_hash: "d".repeat(64),
+      request_digest: "e".repeat(64),
+      state,
+      source_generation: 1n,
+      source_provider_key: PROVIDER_KEY,
+      source_size_bytes: 7n,
+      lease_token: state === "provider_started" ? OBJECT : null,
+      lease_expires_at: state === "provider_started" ? new Date(Date.now() - 1) : null,
+      response_json: state === "committed" ? "{}" : null,
+      completed_at: state === "committed" ? new Date() : null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    prepareDelete.mockImplementation(async () => ({
+      operation: deleteOperation(),
+      replay: state !== "prepared",
+    }));
+    claimDeleteLease.mockImplementation(async () => {
+      state = "provider_started";
+      return deleteOperation();
+    });
+    commitObservedDelete.mockImplementation(async () => {
+      state = "committed";
+      return deleteOperation();
+    });
+    let present = true;
+    let loseAck = true;
+    const bucket: RuntimeR2Bucket = {
+      get: mock(async () => null),
+      head: mock(async () => (present ? { size: 7, etag: "etag-1" } : null)),
+      put: mock(async () => null),
+      delete: mock(async () => {
+        present = false;
+        if (loseAck) {
+          loseAck = false;
+          throw new Error("delete commit-then-ack-loss");
+        }
+      }),
+    };
+    const input = {
+      bucket,
+      organizationId: ORG,
+      logicalKey: "private/voice.txt",
+      idempotencyKey: "delete-1",
+      priceUsd: 0,
+    };
+    await expect(executeNativeStorageDelete(input)).rejects.toThrow("commit-then-ack-loss");
+    expect(commitObservedDelete).not.toHaveBeenCalled();
+    await executeNativeStorageDelete(input);
+    expect(bucket.delete).toHaveBeenCalledTimes(2);
+    expect(commitObservedDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("refunds an aged paid prepare that never acquired a credit hold", async () => {
+    const pending = operation("prepared");
+    pending.created_at = new Date(Date.now() - 11 * 60_000);
+    listDueOperations.mockResolvedValue([pending]);
+    finalizeRefund.mockResolvedValue(operation("refunded"));
+    const result = await reconcileNativeStoragePuts(fakeR2({ value: false }));
+    expect(result.refunded).toBe(1);
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(finalizeRefund).toHaveBeenCalledWith({
+      operationId: OP,
+      organizationId: ORG,
+      responseJson: JSON.stringify({ error: "Storage PUT did not reach R2" }),
+    });
+  });
+
+  test("recovers and refunds a hold created just before the operation link crashed", async () => {
+    const pending = operation("prepared");
+    pending.created_at = new Date(Date.now() - 11 * 60_000);
+    listDueOperations.mockResolvedValue([pending]);
+    findUnattachedCreditReservation.mockResolvedValue(OP);
+    attachCreditReservation.mockResolvedValue(operation("reserved"));
+    finalizeRefund.mockResolvedValue(operation("refunded"));
+    await reconcileNativeStoragePuts(fakeR2({ value: false }));
+    expect(attachCreditReservation).toHaveBeenCalledWith({
+      operationId: OP,
+      organizationId: ORG,
+      creditTransactionId: OP,
+    });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: ORG, reservedAmount: 1, actualCost: 0 }),
+    );
+    expect(finalizeRefund).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -182,7 +182,7 @@ describe("executeNativeStoragePut", () => {
   });
 
   test("preserves the authoritative per-byte rate while rounding to ledger precision", () => {
-    expect(calculateStoragePutPrice(0.0001, 0.000000001, 1)).toBe(0.000101);
+    expect(calculateStoragePutPrice(0.0001, 0.000000001, 1)).toBe(0.0001);
     expect(calculateStoragePutPrice(0.0001, 0.000000001, 50_000_000)).toBe(0.0501);
     expect(calculateStoragePutPrice(0.0000004, 0.0000004, 1)).toBe(0.000001);
   });

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -287,6 +287,28 @@ describe("executeNativeStoragePut", () => {
     expect(bucket.put).not.toHaveBeenCalled();
   });
 
+  test("replays a concurrent commit observed while waiting on atomic credit reservation", async () => {
+    preparePut.mockResolvedValue({ operation: operation("prepared"), replay: false });
+    reservePutCredits.mockResolvedValue({
+      operation: operation("committed"),
+      insufficient: false,
+      available: 9,
+    });
+    const bucket = fakeR2({ value: false });
+    const response = await executeNativeStoragePut({
+      bucket,
+      organizationId: ORG,
+      logicalKey: "concurrent.txt",
+      idempotencyKey: "concurrent-1",
+      body: new TextEncoder().encode("payload").buffer,
+      contentType: "text/plain",
+      priceUsd: 1,
+    });
+    expect(response.etag).toBe("etag-1");
+    expect(bucket.put).not.toHaveBeenCalled();
+    expect(claimProviderLease).not.toHaveBeenCalled();
+  });
+
   test("replays an ambiguous native delete without releasing authority early", async () => {
     let state: "prepared" | "provider_started" | "committed" = "prepared";
     const deleteOperation = () => ({

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -12,10 +12,13 @@ const OBJECT = "00000000-0000-4000-8000-000000021047";
 const PROVIDER_KEY = `__eliza_storage_authority/v2/org/${ORG}/${OBJECT}/1`;
 
 const preparePut = mock();
-const attachCreditReservation = mock();
+const reservePutCredits = mock();
 const claimProviderLease = mock();
+const claimReconciliationLease = mock();
 const commitObservedPut = mock();
 const finalizeRefund = mock();
+const findObject = mock();
+const adoptLegacyObject = mock();
 const listDueOperations = mock();
 const listDueGc = mock();
 const completeGc = mock();
@@ -23,9 +26,6 @@ const prepareDelete = mock();
 const claimDeleteLease = mock();
 const commitObservedDelete = mock();
 const listDueDeletes = mock();
-const findUnattachedCreditReservation = mock();
-const reserve = mock();
-const reconcile = mock();
 const loggerWarn = mock();
 
 class TestInsufficientCreditsError extends Error {}
@@ -34,10 +34,13 @@ class TestStoragePutConflictError extends Error {}
 mock.module("../../../db/repositories/org-storage-mutations", () => ({
   orgStorageMutationsRepository: {
     preparePut,
-    attachCreditReservation,
+    reservePutCredits,
     claimProviderLease,
+    claimReconciliationLease,
     commitObservedPut,
     finalizeRefund,
+    findObject,
+    adoptLegacyObject,
     listDueOperations,
     listDueGc,
     completeGc,
@@ -45,14 +48,10 @@ mock.module("../../../db/repositories/org-storage-mutations", () => ({
     claimDeleteLease,
     commitObservedDelete,
     listDueDeletes,
-    findUnattachedCreditReservation,
   },
   StoragePutConflictError: TestStoragePutConflictError,
 }));
-mock.module("../credits", () => ({
-  creditsService: { reserve, reconcile },
-  InsufficientCreditsError: TestInsufficientCreditsError,
-}));
+mock.module("../credits", () => ({ InsufficientCreditsError: TestInsufficientCreditsError }));
 mock.module("../../utils/logger", () => ({ logger: { warn: loggerWarn } }));
 
 const {
@@ -60,6 +59,7 @@ const {
   executeNativeStorageDelete,
   executeNativeStoragePut,
   reconcileNativeStoragePuts,
+  resolveNativeStorageObject,
 } = await import("./native-storage-put");
 
 function operation(state: OrgStoragePutOperation["state"], price = "1.000000") {
@@ -81,8 +81,9 @@ function operation(state: OrgStoragePutOperation["state"], price = "1.000000") {
     quota_reserved_bytes: 7n,
     price_usd: price,
     credit_transaction_id: state === "prepared" || price === "0.000000" ? null : OP,
-    lease_token: state === "provider_started" ? OBJECT : null,
-    lease_expires_at: state === "provider_started" ? new Date(Date.now() - 1) : null,
+    lease_token: state === "provider_started" || state === "reconciling" ? OBJECT : null,
+    lease_expires_at:
+      state === "provider_started" || state === "reconciling" ? new Date(Date.now() - 1) : null,
     result_etag: state === "committed" ? "etag-1" : null,
     result_uploaded_at: state === "committed" ? new Date() : null,
     response_json: state === "committed" ? "{}" : null,
@@ -118,10 +119,13 @@ function fakeR2(throwAfterCommit: { value: boolean }): RuntimeR2Bucket {
 beforeEach(() => {
   for (const fn of [
     preparePut,
-    attachCreditReservation,
+    reservePutCredits,
     claimProviderLease,
+    claimReconciliationLease,
     commitObservedPut,
     finalizeRefund,
+    findObject,
+    adoptLegacyObject,
     listDueOperations,
     listDueGc,
     completeGc,
@@ -129,9 +133,6 @@ beforeEach(() => {
     claimDeleteLease,
     commitObservedDelete,
     listDueDeletes,
-    findUnattachedCreditReservation,
-    reserve,
-    reconcile,
     loggerWarn,
   ]) {
     fn.mockReset();
@@ -139,15 +140,51 @@ beforeEach(() => {
   listDueOperations.mockResolvedValue([]);
   listDueGc.mockResolvedValue([]);
   listDueDeletes.mockResolvedValue([]);
-  findUnattachedCreditReservation.mockResolvedValue(undefined);
-  reserve.mockResolvedValue({ reservationTransactionId: OP });
-  reconcile.mockResolvedValue({ adjustmentType: "none" });
+  reservePutCredits.mockImplementation(async () => ({
+    operation: operation("reserved"),
+    insufficient: false,
+    available: 9,
+  }));
+  findObject.mockResolvedValue(undefined);
 });
 
 describe("executeNativeStoragePut", () => {
+  test("adopts a legacy logical key from strong native HEAD without moving bytes", async () => {
+    const bucket = fakeR2({ value: false });
+    const legacyKey = `org/${ORG}/legacy/voice.ogg`;
+    bucket.head = mock(async (key: string) =>
+      key === legacyKey
+        ? {
+            size: 7,
+            etag: "legacy-etag",
+            uploaded: new Date("2026-08-18T00:00:00.000Z"),
+            httpMetadata: { contentType: "audio/ogg" },
+          }
+        : null,
+    );
+    const adopted = {
+      generation: 0n,
+      provider_key: legacyKey,
+      size_bytes: 7n,
+      content_type: "audio/ogg",
+    };
+    adoptLegacyObject.mockResolvedValue(adopted);
+    expect(await resolveNativeStorageObject(bucket, ORG, "legacy/voice.ogg")).toBe(adopted);
+    expect(adoptLegacyObject).toHaveBeenCalledWith({
+      organizationId: ORG,
+      logicalKey: "legacy/voice.ogg",
+      providerKey: legacyKey,
+      sizeBytes: 7n,
+      contentType: "audio/ogg",
+      etag: "legacy-etag",
+      uploadedAt: new Date("2026-08-18T00:00:00.000Z"),
+    });
+  });
+
   test("preserves the authoritative per-byte rate while rounding to ledger precision", () => {
     expect(calculateStoragePutPrice(0.0001, 0.000000001, 1)).toBe(0.000101);
     expect(calculateStoragePutPrice(0.0001, 0.000000001, 50_000_000)).toBe(0.0501);
+    expect(calculateStoragePutPrice(0.0000004, 0.0000004, 1)).toBe(0.000001);
   });
 
   test("keeps the hold on commit-then-ack-loss and reconciles by immutable-key HEAD", async () => {
@@ -156,9 +193,9 @@ describe("executeNativeStoragePut", () => {
       operation: current,
       replay: current.state !== "prepared",
     }));
-    attachCreditReservation.mockImplementation(async () => {
+    reservePutCredits.mockImplementation(async () => {
       current = operation("reserved");
-      return current;
+      return { operation: current, insufficient: false, available: 9 };
     });
     claimProviderLease.mockImplementation(async () => {
       current = operation("provider_started");
@@ -181,7 +218,6 @@ describe("executeNativeStoragePut", () => {
 
     await expect(executeNativeStoragePut(input)).rejects.toThrow("commit-then-ack-loss");
     expect(finalizeRefund).not.toHaveBeenCalled();
-    expect(reconcile).not.toHaveBeenCalled();
     expect(bucket.put).toHaveBeenCalledTimes(1);
     expect(bucket.put).toHaveBeenCalledWith(
       PROVIDER_KEY,
@@ -198,17 +234,15 @@ describe("executeNativeStoragePut", () => {
     });
     expect(bucket.put).toHaveBeenCalledTimes(1);
     expect(commitObservedPut).toHaveBeenCalledTimes(1);
-    expect(reconcile).not.toHaveBeenCalled();
     expect(finalizeRefund).not.toHaveBeenCalled();
   });
 
   test("persists a zero-cost terminal receipt without creating a credit transaction", async () => {
     let current = operation("prepared", "0.000000");
     preparePut.mockResolvedValue({ operation: current, replay: false });
-    attachCreditReservation.mockImplementation(async ({ creditTransactionId }) => {
-      expect(creditTransactionId).toBeNull();
+    reservePutCredits.mockImplementation(async () => {
       current = operation("reserved", "0.000000");
-      return current;
+      return { operation: current, insufficient: false, available: 0 };
     });
     claimProviderLease.mockImplementation(async () => {
       current = operation("provider_started", "0.000000");
@@ -227,9 +261,30 @@ describe("executeNativeStoragePut", () => {
       priceUsd: 0,
     });
     expect(response.etag).toBe("etag-1");
-    expect(reserve).not.toHaveBeenCalled();
-    expect(reconcile).not.toHaveBeenCalled();
+    expect(reservePutCredits).toHaveBeenCalledTimes(1);
     expect(commitObservedPut).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops before provider dispatch when atomic storage credit reservation is terminal", async () => {
+    preparePut.mockResolvedValue({ operation: operation("prepared"), replay: false });
+    reservePutCredits.mockResolvedValue({
+      operation: operation("refunded"),
+      insufficient: true,
+      available: 0.25,
+    });
+    const bucket = fakeR2({ value: false });
+    await expect(
+      executeNativeStoragePut({
+        bucket,
+        organizationId: ORG,
+        logicalKey: "insufficient.txt",
+        idempotencyKey: "insufficient-1",
+        body: new TextEncoder().encode("payload").buffer,
+        contentType: "text/plain",
+        priceUsd: 1,
+      }),
+    ).rejects.toBeInstanceOf(TestInsufficientCreditsError);
+    expect(bucket.put).not.toHaveBeenCalled();
   });
 
   test("replays an ambiguous native delete without releasing authority early", async () => {
@@ -295,33 +350,47 @@ describe("executeNativeStoragePut", () => {
     const pending = operation("prepared");
     pending.created_at = new Date(Date.now() - 11 * 60_000);
     listDueOperations.mockResolvedValue([pending]);
+    claimReconciliationLease.mockResolvedValue(operation("reconciling"));
     finalizeRefund.mockResolvedValue(operation("refunded"));
     const result = await reconcileNativeStoragePuts(fakeR2({ value: false }));
     expect(result.refunded).toBe(1);
-    expect(reconcile).not.toHaveBeenCalled();
     expect(finalizeRefund).toHaveBeenCalledWith({
       operationId: OP,
       organizationId: ORG,
+      leaseToken: expect.any(String),
       responseJson: JSON.stringify({ error: "Storage PUT did not reach R2" }),
     });
   });
 
-  test("recovers and refunds a hold created just before the operation link crashed", async () => {
+  test("delegates orphan-hold recovery to the atomic storage refund transaction", async () => {
     const pending = operation("prepared");
     pending.created_at = new Date(Date.now() - 11 * 60_000);
     listDueOperations.mockResolvedValue([pending]);
-    findUnattachedCreditReservation.mockResolvedValue(OP);
-    attachCreditReservation.mockResolvedValue(operation("reserved"));
+    claimReconciliationLease.mockResolvedValue(operation("reconciling"));
     finalizeRefund.mockResolvedValue(operation("refunded"));
     await reconcileNativeStoragePuts(fakeR2({ value: false }));
-    expect(attachCreditReservation).toHaveBeenCalledWith({
-      operationId: OP,
-      organizationId: ORG,
-      creditTransactionId: OP,
-    });
-    expect(reconcile).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: ORG, reservedAmount: 1, actualCost: 0 }),
+    expect(reservePutCredits).not.toHaveBeenCalled();
+    expect(finalizeRefund).toHaveBeenCalledWith(
+      expect.objectContaining({ operationId: OP, organizationId: ORG }),
     );
-    expect(finalizeRefund).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects empty and oversized content types before provider dispatch", async () => {
+    const base = {
+      bucket: fakeR2({ value: false }),
+      organizationId: ORG,
+      logicalKey: "invalid-content-type",
+      idempotencyKey: "content-type-1",
+      body: new TextEncoder().encode("payload").buffer,
+      priceUsd: 0,
+    };
+    await expect(executeNativeStoragePut({ ...base, contentType: "   " })).rejects.toMatchObject({
+      code: "CONTENT_TYPE_INVALID",
+    });
+    await expect(
+      executeNativeStoragePut({ ...base, contentType: "x".repeat(256) }),
+    ).rejects.toMatchObject({ code: "CONTENT_TYPE_INVALID" });
+    expect(preparePut).not.toHaveBeenCalled();
+    expect(base.bucket.put).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -15,10 +15,14 @@ const preparePut = mock();
 const reservePutCredits = mock();
 const claimProviderLease = mock();
 const claimReconciliationLease = mock();
+const deferProviderAbsence = mock();
 const commitObservedPut = mock();
 const finalizeRefund = mock();
 const findObject = mock();
 const adoptLegacyObject = mock();
+const adoptLegacyObjects = mock();
+const quotaNeedsNativeCatalogReconciliation = mock();
+const reconcileNativeQuotaFromCatalog = mock();
 const listDueOperations = mock();
 const listDueGc = mock();
 const completeGc = mock();
@@ -37,10 +41,14 @@ mock.module("../../../db/repositories/org-storage-mutations", () => ({
     reservePutCredits,
     claimProviderLease,
     claimReconciliationLease,
+    deferProviderAbsence,
     commitObservedPut,
     finalizeRefund,
     findObject,
     adoptLegacyObject,
+    adoptLegacyObjects,
+    quotaNeedsNativeCatalogReconciliation,
+    reconcileNativeQuotaFromCatalog,
     listDueOperations,
     listDueGc,
     completeGc,
@@ -56,6 +64,7 @@ mock.module("../../utils/logger", () => ({ logger: { warn: loggerWarn } }));
 
 const {
   calculateStoragePutPrice,
+  ensureNativeStorageQuotaReconciled,
   executeNativeStorageDelete,
   executeNativeStoragePut,
   reconcileNativeStoragePuts,
@@ -84,10 +93,16 @@ function operation(state: OrgStoragePutOperation["state"], price = "1.000000") {
     lease_token: state === "provider_started" || state === "reconciling" ? OBJECT : null,
     lease_expires_at:
       state === "provider_started" || state === "reconciling" ? new Date(Date.now() - 1) : null,
+    provider_absence_observed_at: null,
     result_etag: state === "committed" ? "etag-1" : null,
     result_uploaded_at: state === "committed" ? new Date() : null,
-    response_json: state === "committed" ? "{}" : null,
-    completed_at: state === "committed" ? new Date() : null,
+    response_json:
+      state === "committed"
+        ? "{}"
+        : state === "refunded"
+          ? JSON.stringify({ error: "Insufficient credits" })
+          : null,
+    completed_at: state === "committed" || state === "refunded" ? new Date() : null,
     created_at: new Date(Date.now() - 60_000),
     updated_at: new Date(),
   } satisfies OrgStoragePutOperation;
@@ -122,10 +137,14 @@ beforeEach(() => {
     reservePutCredits,
     claimProviderLease,
     claimReconciliationLease,
+    deferProviderAbsence,
     commitObservedPut,
     finalizeRefund,
     findObject,
     adoptLegacyObject,
+    adoptLegacyObjects,
+    quotaNeedsNativeCatalogReconciliation,
+    reconcileNativeQuotaFromCatalog,
     listDueOperations,
     listDueGc,
     completeGc,
@@ -140,6 +159,7 @@ beforeEach(() => {
   listDueOperations.mockResolvedValue([]);
   listDueGc.mockResolvedValue([]);
   listDueDeletes.mockResolvedValue([]);
+  quotaNeedsNativeCatalogReconciliation.mockResolvedValue(false);
   reservePutCredits.mockImplementation(async () => ({
     operation: operation("reserved"),
     insufficient: false,
@@ -149,6 +169,40 @@ beforeEach(() => {
 });
 
 describe("executeNativeStoragePut", () => {
+  test("fully adopts legacy inventory before repairing a corrupted quota baseline", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock()
+      .mockResolvedValueOnce({
+        objects: [
+          {
+            key: `org/${ORG}/first.bin`,
+            size: 3,
+            etag: "first-etag",
+            uploaded: new Date("2026-08-18T00:00:00.000Z"),
+          },
+        ],
+        truncated: true,
+        cursor: "next",
+      })
+      .mockResolvedValueOnce({
+        objects: [
+          {
+            key: `org/${ORG}/second.bin`,
+            size: 4,
+            etag: "second-etag",
+            uploaded: new Date("2026-08-18T00:01:00.000Z"),
+          },
+        ],
+        truncated: false,
+      });
+
+    await ensureNativeStorageQuotaReconciled(bucket, ORG);
+
+    expect(adoptLegacyObjects).toHaveBeenCalledTimes(2);
+    expect(reconcileNativeQuotaFromCatalog).toHaveBeenCalledWith(ORG);
+  });
+
   test("adopts a legacy logical key from strong native HEAD without moving bytes", async () => {
     const bucket = fakeR2({ value: false });
     const legacyKey = `org/${ORG}/legacy/voice.ogg`;
@@ -285,6 +339,105 @@ describe("executeNativeStoragePut", () => {
       }),
     ).rejects.toBeInstanceOf(TestInsufficientCreditsError);
     expect(bucket.put).not.toHaveBeenCalled();
+
+    preparePut.mockResolvedValue({ operation: operation("refunded"), replay: true });
+    await expect(
+      executeNativeStoragePut({
+        bucket,
+        organizationId: ORG,
+        logicalKey: "insufficient.txt",
+        idempotencyKey: "insufficient-1",
+        body: new TextEncoder().encode("payload").buffer,
+        contentType: "text/plain",
+        priceUsd: 1,
+      }),
+    ).rejects.toBeInstanceOf(TestInsufficientCreditsError);
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  test("quarantines a negative HEAD while the original provider PUT remains unresolved", async () => {
+    let current = operation("prepared");
+    let releasePut: (() => void) | undefined;
+    let markPutStarted: (() => void) | undefined;
+    const putStarted = new Promise<void>((resolve) => {
+      markPutStarted = resolve;
+    });
+    const putGate = new Promise<void>((resolve) => {
+      releasePut = resolve;
+    });
+    let observed: RuntimeR2ObjectMetadata | null = null;
+    const bucket: RuntimeR2Bucket = {
+      get: mock(async () => null),
+      head: mock(async () => observed),
+      list: mock(async () => ({ objects: [], truncated: false })),
+      put: mock(async (_key, value, options) => {
+        markPutStarted?.();
+        await putGate;
+        observed = {
+          size: value instanceof ArrayBuffer ? value.byteLength : 0,
+          etag: "late-etag",
+          customMetadata: options?.customMetadata,
+        };
+      }),
+      delete: mock(async () => undefined),
+    };
+    preparePut.mockImplementation(async () => ({ operation: current, replay: false }));
+    reservePutCredits.mockImplementation(async () => {
+      current = operation("reserved");
+      return { operation: current, insufficient: false, available: 9 };
+    });
+    claimProviderLease.mockImplementation(async () => {
+      current = operation("provider_started");
+      return current;
+    });
+    claimReconciliationLease.mockImplementation(async (input: { leaseToken: string }) => {
+      current = {
+        ...current,
+        lease_token: input.leaseToken,
+        lease_expires_at: new Date(Date.now() + 60_000),
+      };
+      return current;
+    });
+    deferProviderAbsence.mockImplementation(
+      async (input: { observedAt: Date; recheckAt: Date }) => {
+        current = {
+          ...current,
+          state: "reconciling",
+          provider_absence_observed_at: input.observedAt,
+          lease_expires_at: input.recheckAt,
+        };
+        return current;
+      },
+    );
+    commitObservedPut.mockImplementation(async (input: { leaseToken: string }) => {
+      if (input.leaseToken !== current.lease_token) throw new TestStoragePutConflictError();
+      current = operation("committed");
+      return current;
+    });
+    listDueOperations.mockImplementation(async () => [current]);
+
+    const request = executeNativeStoragePut({
+      bucket,
+      organizationId: ORG,
+      logicalKey: "late-provider.txt",
+      idempotencyKey: "late-provider-1",
+      body: new TextEncoder().encode("payload").buffer,
+      contentType: "text/plain",
+      priceUsd: 1,
+    });
+    await putStarted;
+
+    const firstRecovery = await reconcileNativeStoragePuts(bucket);
+    expect(firstRecovery.refunded).toBe(0);
+    expect(deferProviderAbsence).toHaveBeenCalledTimes(1);
+    expect(finalizeRefund).not.toHaveBeenCalled();
+
+    releasePut?.();
+    await expect(request).rejects.toBeInstanceOf(TestStoragePutConflictError);
+    current.lease_expires_at = new Date(Date.now() - 1);
+    const secondRecovery = await reconcileNativeStoragePuts(bucket);
+    expect(secondRecovery.committed).toBe(1);
+    expect(finalizeRefund).not.toHaveBeenCalled();
   });
 
   test("replays a concurrent commit observed while waiting on atomic credit reservation", async () => {
@@ -307,6 +460,28 @@ describe("executeNativeStoragePut", () => {
     expect(response.etag).toBe("etag-1");
     expect(bucket.put).not.toHaveBeenCalled();
     expect(claimProviderLease).not.toHaveBeenCalled();
+  });
+
+  test("replays a terminal provider-absence refund as the original service failure", async () => {
+    const refunded = operation("refunded");
+    refunded.response_json = JSON.stringify({ error: "Storage PUT did not reach R2" });
+    preparePut.mockResolvedValue({ operation: refunded, replay: true });
+    const bucket = fakeR2({ value: false });
+    await expect(
+      executeNativeStoragePut({
+        bucket,
+        organizationId: ORG,
+        logicalKey: "refunded.txt",
+        idempotencyKey: "refunded-1",
+        body: new TextEncoder().encode("payload").buffer,
+        contentType: "text/plain",
+        priceUsd: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_AMBIGUOUS",
+      message: "Storage PUT did not reach R2",
+    });
+    expect(bucket.put).not.toHaveBeenCalled();
   });
 
   test("replays an ambiguous native delete without releasing authority early", async () => {

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -301,6 +301,13 @@ export async function executeNativeStoragePut(
     throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT is reconciling");
   }
   operation = await reserveCredits(prepared);
+  if (operation.state === "committed") return responseFor(operation, input.logicalKey);
+  if (operation.state === "refunded" || operation.state === "reconciling") {
+    throw new NativeStoragePutError(
+      "OPERATION_IN_PROGRESS",
+      "The prior PUT cannot continue provider dispatch",
+    );
+  }
 
   if (operation.state === "provider_started") {
     const observed = await input.bucket.head(operation.target_provider_key);

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -1,0 +1,512 @@
+/**
+ * Executes and reconciles authenticated native R2 PUTs against the durable
+ * database authority. Immutable provider keys let strong HEAD distinguish a
+ * completed write from a safely refundable absence after a crash.
+ */
+
+import Decimal from "decimal.js";
+import {
+  orgStorageMutationsRepository,
+  type PreparedStoragePut,
+  StoragePutConflictError,
+} from "../../../db/repositories/org-storage-mutations";
+import type { OrgStoragePutOperation } from "../../../db/schemas/org-storage-mutations";
+import type { RuntimeR2Bucket, RuntimeR2ObjectMetadata } from "../../storage/r2-runtime-binding";
+import { logger } from "../../utils/logger";
+import { creditsService, InsufficientCreditsError } from "../credits";
+
+const PROVIDER_LEASE_MS = 5 * 60 * 1000;
+const RECOVERY_GRACE_MS = 10 * 60 * 1000;
+const MAX_IDEMPOTENCY_KEY_BYTES = 200;
+
+/** Rounds the per-byte leg up to the ledger's exact six-decimal unit. */
+export function calculateStoragePutPrice(
+  flatCost: number,
+  perByteCost: number,
+  bytes: number,
+): number {
+  if (
+    !Number.isFinite(flatCost) ||
+    !Number.isFinite(perByteCost) ||
+    !Number.isSafeInteger(bytes) ||
+    flatCost < 0 ||
+    perByteCost < 0 ||
+    bytes < 0
+  ) {
+    throw new Error("[NativeStoragePut] invalid server-owned pricing inputs");
+  }
+  return new Decimal(perByteCost)
+    .mul(bytes)
+    .toDecimalPlaces(6, Decimal.ROUND_CEIL)
+    .add(flatCost)
+    .toDecimalPlaces(6, Decimal.ROUND_CEIL)
+    .toNumber();
+}
+
+export class NativeStoragePutError extends Error {
+  constructor(
+    public readonly code:
+      | "IDEMPOTENCY_REQUIRED"
+      | "IDEMPOTENCY_INVALID"
+      | "OPERATION_IN_PROGRESS"
+      | "PROVIDER_AMBIGUOUS"
+      | "PROVIDER_INTEGRITY",
+    message: string,
+  ) {
+    super(message);
+    this.name = "NativeStoragePutError";
+  }
+}
+
+export interface NativeStoragePutResponse {
+  key: string;
+  size: number;
+  contentType: string;
+  etag: string;
+}
+
+export interface ExecuteNativeStoragePutInput {
+  bucket: RuntimeR2Bucket;
+  organizationId: string;
+  logicalKey: string;
+  idempotencyKey: string;
+  body: ArrayBuffer;
+  contentType: string;
+  priceUsd: number;
+}
+
+export interface ExecuteNativeStorageDeleteInput {
+  bucket: RuntimeR2Bucket;
+  organizationId: string;
+  logicalKey: string;
+  idempotencyKey: string;
+  priceUsd: number;
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256(value: string | ArrayBuffer): Promise<string> {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  return bytesToHex(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+function canonicalPrice(priceUsd: number): string {
+  if (!Number.isFinite(priceUsd) || priceUsd < 0) {
+    throw new Error("[NativeStoragePut] server price must be finite and non-negative");
+  }
+  return priceUsd.toFixed(6);
+}
+
+async function requestIdentity(input: ExecuteNativeStoragePutInput) {
+  const encodedKey = new TextEncoder().encode(input.idempotencyKey);
+  if (encodedKey.byteLength === 0) {
+    throw new NativeStoragePutError("IDEMPOTENCY_REQUIRED", "Idempotency-Key is required");
+  }
+  if (encodedKey.byteLength > MAX_IDEMPOTENCY_KEY_BYTES || /[\r\n\0]/.test(input.idempotencyKey)) {
+    throw new NativeStoragePutError("IDEMPOTENCY_INVALID", "Idempotency-Key is invalid");
+  }
+  const contentSha256 = await sha256(input.body);
+  const priceUsd = canonicalPrice(input.priceUsd);
+  const idempotencyKeyHash = await sha256(input.idempotencyKey);
+  const requestDigest = await sha256(
+    JSON.stringify({
+      version: 1,
+      organizationId: input.organizationId,
+      logicalKey: input.logicalKey,
+      contentType: input.contentType,
+      sizeBytes: input.body.byteLength,
+      contentSha256,
+      priceUsd,
+    }),
+  );
+  return { contentSha256, priceUsd, idempotencyKeyHash, requestDigest };
+}
+
+async function deleteRequestIdentity(input: ExecuteNativeStorageDeleteInput) {
+  const encodedKey = new TextEncoder().encode(input.idempotencyKey);
+  if (encodedKey.byteLength === 0) {
+    throw new NativeStoragePutError("IDEMPOTENCY_REQUIRED", "Idempotency-Key is required");
+  }
+  if (encodedKey.byteLength > MAX_IDEMPOTENCY_KEY_BYTES || /[\r\n\0]/.test(input.idempotencyKey)) {
+    throw new NativeStoragePutError("IDEMPOTENCY_INVALID", "Idempotency-Key is invalid");
+  }
+  const priceUsd = canonicalPrice(input.priceUsd);
+  if (priceUsd !== "0.000000") {
+    throw new Error("[NativeStorageDelete] paid DELETE policy is not configured");
+  }
+  return {
+    idempotencyKeyHash: await sha256(input.idempotencyKey),
+    requestDigest: await sha256(
+      JSON.stringify({
+        version: 1,
+        method: "delete",
+        organizationId: input.organizationId,
+        logicalKey: input.logicalKey,
+        priceUsd,
+      }),
+    ),
+  };
+}
+
+function responseFor(
+  operation: OrgStoragePutOperation,
+  logicalKey: string,
+): NativeStoragePutResponse {
+  if (!operation.result_etag) {
+    throw new Error("[NativeStoragePut] committed operation is missing its ETag");
+  }
+  return {
+    key: logicalKey,
+    size: Number(operation.target_size_bytes),
+    contentType: operation.target_content_type,
+    etag: operation.result_etag,
+  };
+}
+
+function validateObserved(
+  operation: OrgStoragePutOperation,
+  observed: RuntimeR2ObjectMetadata,
+): { etag: string; uploadedAt: Date } {
+  if (
+    observed.size !== Number(operation.target_size_bytes) ||
+    !observed.etag ||
+    observed.customMetadata?.requestDigest !== operation.request_digest ||
+    observed.customMetadata?.contentSha256 !== operation.target_content_sha256
+  ) {
+    throw new NativeStoragePutError(
+      "PROVIDER_INTEGRITY",
+      "R2 generation metadata did not match the durable PUT receipt",
+    );
+  }
+  return { etag: observed.etag, uploadedAt: observed.uploaded ?? new Date() };
+}
+
+async function settleCredit(operation: OrgStoragePutOperation, actualCost: number): Promise<void> {
+  const reservedAmount = Number(operation.price_usd);
+  if (reservedAmount === 0) return;
+  if (!operation.credit_transaction_id) {
+    throw new Error("[NativeStoragePut] paid operation is missing its credit reservation");
+  }
+  await creditsService.reconcile({
+    organizationId: operation.organization_id,
+    reservedAmount,
+    actualCost,
+    description: "API proxy: storage — native put",
+    metadata: {
+      type: "proxy_storage",
+      service: "storage",
+      method: "put",
+      storage_operation_id: operation.id,
+      reservation_transaction_id: operation.credit_transaction_id,
+    },
+  });
+}
+
+async function commitObserved(
+  operation: OrgStoragePutOperation,
+  logicalKey: string,
+  observed: RuntimeR2ObjectMetadata,
+): Promise<NativeStoragePutResponse> {
+  if (!operation.lease_token) {
+    throw new Error("[NativeStoragePut] provider-started operation is missing its lease token");
+  }
+  const evidence = validateObserved(operation, observed);
+  const response: NativeStoragePutResponse = {
+    key: logicalKey,
+    size: Number(operation.target_size_bytes),
+    contentType: operation.target_content_type,
+    etag: evidence.etag,
+  };
+  await orgStorageMutationsRepository.commitObservedPut({
+    operationId: operation.id,
+    organizationId: operation.organization_id,
+    leaseToken: operation.lease_token,
+    etag: evidence.etag,
+    uploadedAt: evidence.uploadedAt,
+    responseJson: JSON.stringify(response),
+  });
+  return response;
+}
+
+async function reserveCredits(prepared: PreparedStoragePut): Promise<OrgStoragePutOperation> {
+  const operation = prepared.operation;
+  if (operation.state !== "prepared") return operation;
+  const amount = Number(operation.price_usd);
+  if (amount === 0) {
+    return await orgStorageMutationsRepository.attachCreditReservation({
+      operationId: operation.id,
+      organizationId: operation.organization_id,
+      creditTransactionId: null,
+    });
+  }
+  try {
+    const reservation = await creditsService.reserve({
+      organizationId: operation.organization_id,
+      amount,
+      idempotencyKey: `native-storage-put:${operation.id}`,
+      description: "API proxy: storage — native put",
+      metadata: {
+        type: "proxy_storage",
+        service: "storage",
+        method: "put",
+        storage_operation_id: operation.id,
+      },
+    });
+    if (!reservation.reservationTransactionId) {
+      throw new Error("[NativeStoragePut] credit reservation returned no transaction id");
+    }
+    return await orgStorageMutationsRepository.attachCreditReservation({
+      operationId: operation.id,
+      organizationId: operation.organization_id,
+      creditTransactionId: reservation.reservationTransactionId,
+    });
+  } catch (error) {
+    if (error instanceof InsufficientCreditsError) {
+      await orgStorageMutationsRepository.finalizeRefund({
+        operationId: operation.id,
+        organizationId: operation.organization_id,
+        responseJson: JSON.stringify({ error: "Insufficient credits" }),
+      });
+    }
+    throw error;
+  }
+}
+
+export async function executeNativeStoragePut(
+  input: ExecuteNativeStoragePutInput,
+): Promise<NativeStoragePutResponse> {
+  if (!input.bucket.head) {
+    throw new NativeStoragePutError("PROVIDER_INTEGRITY", "R2 HEAD is unavailable");
+  }
+  const identity = await requestIdentity(input);
+  const prepared = await orgStorageMutationsRepository.preparePut({
+    organizationId: input.organizationId,
+    logicalKey: input.logicalKey,
+    idempotencyKeyHash: identity.idempotencyKeyHash,
+    requestDigest: identity.requestDigest,
+    sizeBytes: BigInt(input.body.byteLength),
+    contentType: input.contentType,
+    contentSha256: identity.contentSha256,
+    priceUsd: identity.priceUsd,
+  });
+
+  let operation = prepared.operation;
+  if (operation.state === "committed") return responseFor(operation, input.logicalKey);
+  if (operation.state === "refunded") {
+    throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT attempt was refunded");
+  }
+  operation = await reserveCredits(prepared);
+
+  if (operation.state === "provider_started") {
+    const observed = await input.bucket.head(operation.target_provider_key);
+    if (observed) return await commitObserved(operation, input.logicalKey, observed);
+    if (operation.lease_expires_at && operation.lease_expires_at > new Date()) {
+      throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The PUT is still in progress");
+    }
+  }
+
+  const now = new Date();
+  operation = await orgStorageMutationsRepository.claimProviderLease({
+    operationId: operation.id,
+    organizationId: input.organizationId,
+    leaseToken: crypto.randomUUID(),
+    leaseExpiresAt: new Date(now.getTime() + PROVIDER_LEASE_MS),
+    now,
+  });
+
+  try {
+    await input.bucket.put(operation.target_provider_key, input.body, {
+      httpMetadata: { contentType: operation.target_content_type },
+      customMetadata: {
+        requestDigest: operation.request_digest,
+        contentSha256: operation.target_content_sha256,
+      },
+      onlyIf: { etagDoesNotMatch: "*" },
+      sha256: operation.target_content_sha256,
+    });
+    const observed = await input.bucket.head(operation.target_provider_key);
+    if (!observed) {
+      throw new NativeStoragePutError(
+        "PROVIDER_AMBIGUOUS",
+        "R2 PUT completed without a strongly consistent HEAD result",
+      );
+    }
+    return await commitObserved(operation, input.logicalKey, observed);
+  } catch (error) {
+    // error-policy:J2 an R2 write may have committed before transport failure.
+    // Preserve provider_started for HEAD reconciliation; never refund here.
+    logger.warn("[NativeStoragePut] provider outcome requires reconciliation", {
+      operationId: operation.id,
+      error,
+    });
+    throw error;
+  }
+}
+
+export async function executeNativeStorageDelete(
+  input: ExecuteNativeStorageDeleteInput,
+): Promise<void> {
+  if (!input.bucket.head) {
+    throw new NativeStoragePutError("PROVIDER_INTEGRITY", "R2 HEAD is unavailable");
+  }
+  const identity = await deleteRequestIdentity(input);
+  const prepared = await orgStorageMutationsRepository.prepareDelete({
+    organizationId: input.organizationId,
+    logicalKey: input.logicalKey,
+    ...identity,
+  });
+  let operation = prepared.operation;
+  if (operation.state === "committed") return;
+  if (
+    operation.state === "provider_started" &&
+    operation.lease_expires_at &&
+    operation.lease_expires_at > new Date()
+  ) {
+    throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The DELETE is still in progress");
+  }
+  const now = new Date();
+  operation = await orgStorageMutationsRepository.claimDeleteLease({
+    operationId: operation.id,
+    organizationId: operation.organization_id,
+    leaseToken: crypto.randomUUID(),
+    leaseExpiresAt: new Date(now.getTime() + PROVIDER_LEASE_MS),
+    now,
+  });
+  try {
+    await input.bucket.delete(operation.source_provider_key);
+    const observed = await input.bucket.head(operation.source_provider_key);
+    if (observed) {
+      throw new NativeStoragePutError(
+        "PROVIDER_AMBIGUOUS",
+        "R2 DELETE completed but the immutable generation remains visible",
+      );
+    }
+    await orgStorageMutationsRepository.commitObservedDelete({
+      operationId: operation.id,
+      organizationId: operation.organization_id,
+      leaseToken: operation.lease_token!,
+      responseJson: JSON.stringify({ deleted: true }),
+    });
+  } catch (error) {
+    // error-policy:J2 deletion is idempotent, but quota and the catalog pointer
+    // remain authoritative until a later strong HEAD proves provider absence.
+    logger.warn("[NativeStorageDelete] provider outcome requires reconciliation", {
+      operationId: operation.id,
+      error,
+    });
+    throw error;
+  }
+}
+
+export async function reconcileNativeStoragePuts(bucket: RuntimeR2Bucket) {
+  if (!bucket.head) throw new Error("[NativeStoragePut] R2 HEAD is unavailable");
+  const now = new Date();
+  const due = await orgStorageMutationsRepository.listDueOperations(now);
+  let committed = 0;
+  let refunded = 0;
+  let failed = 0;
+
+  for (const operation of due) {
+    try {
+      if (operation.state === "provider_started") {
+        const observed = await bucket.head(operation.target_provider_key);
+        if (observed) {
+          await commitObserved(operation, "[redacted]", observed);
+          committed++;
+          continue;
+        }
+      } else if (operation.created_at.getTime() + RECOVERY_GRACE_MS > now.getTime()) {
+        continue;
+      }
+      let refundable = operation;
+      if (Number(operation.price_usd) > 0 && !operation.credit_transaction_id) {
+        const orphanedCreditId =
+          await orgStorageMutationsRepository.findUnattachedCreditReservation(operation);
+        if (orphanedCreditId) {
+          refundable = await orgStorageMutationsRepository.attachCreditReservation({
+            operationId: operation.id,
+            organizationId: operation.organization_id,
+            creditTransactionId: orphanedCreditId,
+          });
+        }
+      }
+      if (refundable.credit_transaction_id) {
+        await settleCredit(refundable, 0);
+      }
+      await orgStorageMutationsRepository.finalizeRefund({
+        operationId: operation.id,
+        organizationId: operation.organization_id,
+        responseJson: JSON.stringify({ error: "Storage PUT did not reach R2" }),
+      });
+      refunded++;
+    } catch (error) {
+      failed++;
+      logger.warn("[NativeStoragePut] reconciliation item failed", {
+        operationId: operation.id,
+        error,
+      });
+    }
+  }
+
+  const dueDeletes = await orgStorageMutationsRepository.listDueDeletes(now);
+  for (const pending of dueDeletes) {
+    try {
+      const observed = await bucket.head(pending.source_provider_key);
+      if (pending.state === "prepared" || observed) {
+        const retryNow = new Date();
+        const leased = await orgStorageMutationsRepository.claimDeleteLease({
+          operationId: pending.id,
+          organizationId: pending.organization_id,
+          leaseToken: crypto.randomUUID(),
+          leaseExpiresAt: new Date(retryNow.getTime() + PROVIDER_LEASE_MS),
+          now: retryNow,
+        });
+        await bucket.delete(leased.source_provider_key);
+        if (await bucket.head(leased.source_provider_key)) continue;
+        await orgStorageMutationsRepository.commitObservedDelete({
+          operationId: leased.id,
+          organizationId: leased.organization_id,
+          leaseToken: leased.lease_token!,
+          responseJson: JSON.stringify({ deleted: true }),
+        });
+      } else {
+        await orgStorageMutationsRepository.commitObservedDelete({
+          operationId: pending.id,
+          organizationId: pending.organization_id,
+          leaseToken: pending.lease_token!,
+          responseJson: JSON.stringify({ deleted: true }),
+        });
+      }
+    } catch (error) {
+      failed++;
+      logger.warn("[NativeStorageDelete] reconciliation failed", {
+        operationId: pending.id,
+        error,
+      });
+    }
+  }
+
+  const gc = await orgStorageMutationsRepository.listDueGc(now);
+  let garbageCollected = 0;
+  for (const item of gc) {
+    try {
+      await bucket.delete(item.provider_key);
+      await orgStorageMutationsRepository.completeGc(item.id);
+      garbageCollected++;
+    } catch (error) {
+      failed++;
+      logger.warn("[NativeStoragePut] generation GC item failed", { gcId: item.id, error });
+    }
+  }
+  return {
+    scanned: due.length + dueDeletes.length,
+    committed,
+    refunded,
+    garbageCollected,
+    failed,
+  };
+}
+
+export { StoragePutConflictError };

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -40,7 +40,7 @@ export function calculateStoragePutPrice(
   }
   return new Decimal(flatCost.toString())
     .add(new Decimal(perByteCost.toString()).mul(bytes))
-    .toDecimalPlaces(6, Decimal.ROUND_CEIL)
+    .toDecimalPlaces(6, Decimal.ROUND_HALF_UP)
     .toNumber();
 }
 

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -20,6 +20,7 @@ import { InsufficientCreditsError } from "../credits";
 
 const PROVIDER_LEASE_MS = 5 * 60 * 1000;
 const RECOVERY_GRACE_MS = 10 * 60 * 1000;
+const PROVIDER_ABSENCE_QUARANTINE_MS = 10 * 60 * 1000;
 const MAX_IDEMPOTENCY_KEY_BYTES = 200;
 
 /** Sums exact server-owned decimal legs, then rounds once to the ledger unit. */
@@ -112,11 +113,75 @@ function adoptedContentType(observed: RuntimeR2ObjectMetadata): string {
     : "application/octet-stream";
 }
 
+export async function ensureNativeStorageQuotaReconciled(
+  bucket: RuntimeR2Bucket,
+  organizationId: string,
+): Promise<void> {
+  if (
+    !(await orgStorageMutationsRepository.quotaNeedsNativeCatalogReconciliation(organizationId))
+  ) {
+    return;
+  }
+  if (!bucket.list) {
+    throw new NativeStoragePutError(
+      "PROVIDER_INTEGRITY",
+      "R2 LIST is required for native quota reconciliation",
+    );
+  }
+  const providerPrefix = `org/${organizationId}/`;
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  let hasMore = true;
+  while (hasMore) {
+    const page = await bucket.list({
+      prefix: providerPrefix,
+      cursor,
+      limit: 1000,
+      include: ["httpMetadata"],
+    });
+    const candidates = page.objects.map((observed) => {
+      if (
+        !observed.key?.startsWith(providerPrefix) ||
+        observed.key.length === providerPrefix.length ||
+        !observed.etag ||
+        observed.size <= 0
+      ) {
+        throw new NativeStoragePutError(
+          "PROVIDER_INTEGRITY",
+          "R2 returned incomplete legacy quota metadata",
+        );
+      }
+      return {
+        organizationId,
+        logicalKey: observed.key.slice(providerPrefix.length),
+        providerKey: observed.key,
+        sizeBytes: BigInt(observed.size),
+        contentType: adoptedContentType(observed),
+        etag: observed.etag,
+        uploadedAt: observed.uploaded ?? new Date(0),
+      };
+    });
+    await orgStorageMutationsRepository.adoptLegacyObjects(candidates);
+    hasMore = page.truncated;
+    if (!hasMore) continue;
+    if (!page.cursor || seenCursors.has(page.cursor)) {
+      throw new NativeStoragePutError(
+        "PROVIDER_INTEGRITY",
+        "R2 quota reconciliation pagination did not advance",
+      );
+    }
+    seenCursors.add(page.cursor);
+    cursor = page.cursor;
+  }
+  await orgStorageMutationsRepository.reconcileNativeQuotaFromCatalog(organizationId);
+}
+
 export async function resolveNativeStorageObject(
   bucket: RuntimeR2Bucket,
   organizationId: string,
   logicalKey: string,
 ): Promise<OrgStorageObject | undefined> {
+  await ensureNativeStorageQuotaReconciled(bucket, organizationId);
   const existing = await orgStorageMutationsRepository.findObject(organizationId, logicalKey);
   if (existing?.provider_key || existing?.deleted_at || (existing?.generation ?? 0n) > 0n) {
     return existing;
@@ -212,6 +277,22 @@ function responseFor(
   };
 }
 
+function throwRefundReplay(operation: OrgStoragePutOperation): never {
+  let response: { error?: unknown } = {};
+  try {
+    response = operation.response_json ? JSON.parse(operation.response_json) : {};
+  } catch {
+    throw new Error("[NativeStoragePut] refunded receipt is not valid JSON");
+  }
+  if (response.error === "Insufficient credits") {
+    throw new InsufficientCreditsError(Number(operation.price_usd), 0, "insufficient_balance");
+  }
+  throw new NativeStoragePutError(
+    "PROVIDER_AMBIGUOUS",
+    typeof response.error === "string" ? response.error : "The prior PUT was refunded",
+  );
+}
+
 function validateObserved(
   operation: OrgStoragePutOperation,
   observed: RuntimeR2ObjectMetadata,
@@ -294,15 +375,14 @@ export async function executeNativeStoragePut(
 
   let operation = prepared.operation;
   if (operation.state === "committed") return responseFor(operation, input.logicalKey);
-  if (operation.state === "refunded") {
-    throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT attempt was refunded");
-  }
+  if (operation.state === "refunded") throwRefundReplay(operation);
   if (operation.state === "reconciling") {
     throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT is reconciling");
   }
   operation = await reserveCredits(prepared);
   if (operation.state === "committed") return responseFor(operation, input.logicalKey);
-  if (operation.state === "refunded" || operation.state === "reconciling") {
+  if (operation.state === "refunded") throwRefundReplay(operation);
+  if (operation.state === "reconciling") {
     throw new NativeStoragePutError(
       "OPERATION_IN_PROGRESS",
       "The prior PUT cannot continue provider dispatch",
@@ -347,6 +427,21 @@ export async function executeNativeStoragePut(
   } catch (error) {
     // error-policy:J2 an R2 write may have committed before transport failure.
     // Preserve provider_started for HEAD reconciliation; never refund here.
+    if (error instanceof StoragePutConflictError && error.reason === "stale_lease") {
+      const latest = await orgStorageMutationsRepository.findOperation(
+        operation.organization_id,
+        operation.id,
+      );
+      if (latest?.state === "refunded") {
+        await input.bucket.delete(operation.target_provider_key);
+        if (await input.bucket.head(operation.target_provider_key)) {
+          throw new NativeStoragePutError(
+            "PROVIDER_AMBIGUOUS",
+            "A late R2 generation could not be removed after refund",
+          );
+        }
+      }
+    }
     logger.warn("[NativeStoragePut] provider outcome requires reconciliation", {
       operationId: operation.id,
       error,
@@ -430,11 +525,21 @@ export async function reconcileNativeStoragePuts(bucket: RuntimeR2Bucket) {
         staleBefore,
         now,
       });
-      if (claimed.state === "provider_started") {
+      if (claimed.state === "provider_started" || claimed.provider_absence_observed_at) {
         const observed = await bucket.head(claimed.target_provider_key);
         if (observed) {
           await commitObserved(claimed, "[redacted]", observed);
           committed++;
+          continue;
+        }
+        if (claimed.state === "provider_started") {
+          await orgStorageMutationsRepository.deferProviderAbsence({
+            operationId: claimed.id,
+            organizationId: claimed.organization_id,
+            leaseToken,
+            observedAt: now,
+            recheckAt: new Date(now.getTime() + PROVIDER_ABSENCE_QUARANTINE_MS),
+          });
           continue;
         }
       }

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -10,16 +10,19 @@ import {
   type PreparedStoragePut,
   StoragePutConflictError,
 } from "../../../db/repositories/org-storage-mutations";
-import type { OrgStoragePutOperation } from "../../../db/schemas/org-storage-mutations";
+import type {
+  OrgStorageObject,
+  OrgStoragePutOperation,
+} from "../../../db/schemas/org-storage-mutations";
 import type { RuntimeR2Bucket, RuntimeR2ObjectMetadata } from "../../storage/r2-runtime-binding";
 import { logger } from "../../utils/logger";
-import { creditsService, InsufficientCreditsError } from "../credits";
+import { InsufficientCreditsError } from "../credits";
 
 const PROVIDER_LEASE_MS = 5 * 60 * 1000;
 const RECOVERY_GRACE_MS = 10 * 60 * 1000;
 const MAX_IDEMPOTENCY_KEY_BYTES = 200;
 
-/** Rounds the per-byte leg up to the ledger's exact six-decimal unit. */
+/** Sums exact server-owned decimal legs, then rounds once to the ledger unit. */
 export function calculateStoragePutPrice(
   flatCost: number,
   perByteCost: number,
@@ -35,10 +38,8 @@ export function calculateStoragePutPrice(
   ) {
     throw new Error("[NativeStoragePut] invalid server-owned pricing inputs");
   }
-  return new Decimal(perByteCost)
-    .mul(bytes)
-    .toDecimalPlaces(6, Decimal.ROUND_CEIL)
-    .add(flatCost)
+  return new Decimal(flatCost.toString())
+    .add(new Decimal(perByteCost.toString()).mul(bytes))
     .toDecimalPlaces(6, Decimal.ROUND_CEIL)
     .toNumber();
 }
@@ -48,6 +49,7 @@ export class NativeStoragePutError extends Error {
     public readonly code:
       | "IDEMPOTENCY_REQUIRED"
       | "IDEMPOTENCY_INVALID"
+      | "CONTENT_TYPE_INVALID"
       | "OPERATION_IN_PROGRESS"
       | "PROVIDER_AMBIGUOUS"
       | "PROVIDER_INTEGRITY",
@@ -99,6 +101,47 @@ function canonicalPrice(priceUsd: number): string {
   return priceUsd.toFixed(6);
 }
 
+function legacyProviderKey(organizationId: string, logicalKey: string): string {
+  return `org/${organizationId}/${logicalKey}`;
+}
+
+function adoptedContentType(observed: RuntimeR2ObjectMetadata): string {
+  const contentType = observed.httpMetadata?.contentType?.trim() || "application/octet-stream";
+  return contentType.length <= 255 && !/[\0\r\n]/.test(contentType)
+    ? contentType
+    : "application/octet-stream";
+}
+
+export async function resolveNativeStorageObject(
+  bucket: RuntimeR2Bucket,
+  organizationId: string,
+  logicalKey: string,
+): Promise<OrgStorageObject | undefined> {
+  const existing = await orgStorageMutationsRepository.findObject(organizationId, logicalKey);
+  if (existing?.provider_key || existing?.deleted_at || (existing?.generation ?? 0n) > 0n) {
+    return existing;
+  }
+  if (!bucket.head) throw new Error("[NativeStoragePut] R2 HEAD is unavailable");
+  const providerKey = legacyProviderKey(organizationId, logicalKey);
+  const observed = await bucket.head(providerKey);
+  if (!observed) return existing;
+  if (!observed.etag || observed.size <= 0) {
+    throw new NativeStoragePutError(
+      "PROVIDER_INTEGRITY",
+      "Legacy R2 object metadata is incomplete",
+    );
+  }
+  return await orgStorageMutationsRepository.adoptLegacyObject({
+    organizationId,
+    logicalKey,
+    providerKey,
+    sizeBytes: BigInt(observed.size),
+    contentType: adoptedContentType(observed),
+    etag: observed.etag,
+    uploadedAt: observed.uploaded ?? new Date(0),
+  });
+}
+
 async function requestIdentity(input: ExecuteNativeStoragePutInput) {
   const encodedKey = new TextEncoder().encode(input.idempotencyKey);
   if (encodedKey.byteLength === 0) {
@@ -106,6 +149,10 @@ async function requestIdentity(input: ExecuteNativeStoragePutInput) {
   }
   if (encodedKey.byteLength > MAX_IDEMPOTENCY_KEY_BYTES || /[\r\n\0]/.test(input.idempotencyKey)) {
     throw new NativeStoragePutError("IDEMPOTENCY_INVALID", "Idempotency-Key is invalid");
+  }
+  const contentType = input.contentType.trim();
+  if (contentType.length === 0 || contentType.length > 255 || /[\0\r\n]/.test(contentType)) {
+    throw new NativeStoragePutError("CONTENT_TYPE_INVALID", "Content-Type is invalid");
   }
   const contentSha256 = await sha256(input.body);
   const priceUsd = canonicalPrice(input.priceUsd);
@@ -115,13 +162,13 @@ async function requestIdentity(input: ExecuteNativeStoragePutInput) {
       version: 1,
       organizationId: input.organizationId,
       logicalKey: input.logicalKey,
-      contentType: input.contentType,
+      contentType,
       sizeBytes: input.body.byteLength,
       contentSha256,
       priceUsd,
     }),
   );
-  return { contentSha256, priceUsd, idempotencyKeyHash, requestDigest };
+  return { contentType, contentSha256, priceUsd, idempotencyKeyHash, requestDigest };
 }
 
 async function deleteRequestIdentity(input: ExecuteNativeStorageDeleteInput) {
@@ -183,27 +230,6 @@ function validateObserved(
   return { etag: observed.etag, uploadedAt: observed.uploaded ?? new Date() };
 }
 
-async function settleCredit(operation: OrgStoragePutOperation, actualCost: number): Promise<void> {
-  const reservedAmount = Number(operation.price_usd);
-  if (reservedAmount === 0) return;
-  if (!operation.credit_transaction_id) {
-    throw new Error("[NativeStoragePut] paid operation is missing its credit reservation");
-  }
-  await creditsService.reconcile({
-    organizationId: operation.organization_id,
-    reservedAmount,
-    actualCost,
-    description: "API proxy: storage — native put",
-    metadata: {
-      type: "proxy_storage",
-      service: "storage",
-      method: "put",
-      storage_operation_id: operation.id,
-      reservation_transaction_id: operation.credit_transaction_id,
-    },
-  });
-}
-
 async function commitObserved(
   operation: OrgStoragePutOperation,
   logicalKey: string,
@@ -233,45 +259,18 @@ async function commitObserved(
 async function reserveCredits(prepared: PreparedStoragePut): Promise<OrgStoragePutOperation> {
   const operation = prepared.operation;
   if (operation.state !== "prepared") return operation;
-  const amount = Number(operation.price_usd);
-  if (amount === 0) {
-    return await orgStorageMutationsRepository.attachCreditReservation({
-      operationId: operation.id,
-      organizationId: operation.organization_id,
-      creditTransactionId: null,
-    });
+  const result = await orgStorageMutationsRepository.reservePutCredits({
+    operationId: operation.id,
+    organizationId: operation.organization_id,
+  });
+  if (result.insufficient) {
+    throw new InsufficientCreditsError(
+      Number(operation.price_usd),
+      result.available,
+      "insufficient_balance",
+    );
   }
-  try {
-    const reservation = await creditsService.reserve({
-      organizationId: operation.organization_id,
-      amount,
-      idempotencyKey: `native-storage-put:${operation.id}`,
-      description: "API proxy: storage — native put",
-      metadata: {
-        type: "proxy_storage",
-        service: "storage",
-        method: "put",
-        storage_operation_id: operation.id,
-      },
-    });
-    if (!reservation.reservationTransactionId) {
-      throw new Error("[NativeStoragePut] credit reservation returned no transaction id");
-    }
-    return await orgStorageMutationsRepository.attachCreditReservation({
-      operationId: operation.id,
-      organizationId: operation.organization_id,
-      creditTransactionId: reservation.reservationTransactionId,
-    });
-  } catch (error) {
-    if (error instanceof InsufficientCreditsError) {
-      await orgStorageMutationsRepository.finalizeRefund({
-        operationId: operation.id,
-        organizationId: operation.organization_id,
-        responseJson: JSON.stringify({ error: "Insufficient credits" }),
-      });
-    }
-    throw error;
-  }
+  return result.operation;
 }
 
 export async function executeNativeStoragePut(
@@ -281,13 +280,14 @@ export async function executeNativeStoragePut(
     throw new NativeStoragePutError("PROVIDER_INTEGRITY", "R2 HEAD is unavailable");
   }
   const identity = await requestIdentity(input);
+  await resolveNativeStorageObject(input.bucket, input.organizationId, input.logicalKey);
   const prepared = await orgStorageMutationsRepository.preparePut({
     organizationId: input.organizationId,
     logicalKey: input.logicalKey,
     idempotencyKeyHash: identity.idempotencyKeyHash,
     requestDigest: identity.requestDigest,
     sizeBytes: BigInt(input.body.byteLength),
-    contentType: input.contentType,
+    contentType: identity.contentType,
     contentSha256: identity.contentSha256,
     priceUsd: identity.priceUsd,
   });
@@ -296,6 +296,9 @@ export async function executeNativeStoragePut(
   if (operation.state === "committed") return responseFor(operation, input.logicalKey);
   if (operation.state === "refunded") {
     throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT attempt was refunded");
+  }
+  if (operation.state === "reconciling") {
+    throw new NativeStoragePutError("OPERATION_IN_PROGRESS", "The prior PUT is reconciling");
   }
   operation = await reserveCredits(prepared);
 
@@ -404,40 +407,34 @@ export async function reconcileNativeStoragePuts(bucket: RuntimeR2Bucket) {
   if (!bucket.head) throw new Error("[NativeStoragePut] R2 HEAD is unavailable");
   const now = new Date();
   const due = await orgStorageMutationsRepository.listDueOperations(now);
+  const staleBefore = new Date(now.getTime() - RECOVERY_GRACE_MS);
   let committed = 0;
   let refunded = 0;
   let failed = 0;
 
   for (const operation of due) {
     try {
-      if (operation.state === "provider_started") {
-        const observed = await bucket.head(operation.target_provider_key);
+      const leaseToken = crypto.randomUUID();
+      const claimed = await orgStorageMutationsRepository.claimReconciliationLease({
+        operationId: operation.id,
+        organizationId: operation.organization_id,
+        leaseToken,
+        leaseExpiresAt: new Date(now.getTime() + PROVIDER_LEASE_MS),
+        staleBefore,
+        now,
+      });
+      if (claimed.state === "provider_started") {
+        const observed = await bucket.head(claimed.target_provider_key);
         if (observed) {
-          await commitObserved(operation, "[redacted]", observed);
+          await commitObserved(claimed, "[redacted]", observed);
           committed++;
           continue;
         }
-      } else if (operation.created_at.getTime() + RECOVERY_GRACE_MS > now.getTime()) {
-        continue;
-      }
-      let refundable = operation;
-      if (Number(operation.price_usd) > 0 && !operation.credit_transaction_id) {
-        const orphanedCreditId =
-          await orgStorageMutationsRepository.findUnattachedCreditReservation(operation);
-        if (orphanedCreditId) {
-          refundable = await orgStorageMutationsRepository.attachCreditReservation({
-            operationId: operation.id,
-            organizationId: operation.organization_id,
-            creditTransactionId: orphanedCreditId,
-          });
-        }
-      }
-      if (refundable.credit_transaction_id) {
-        await settleCredit(refundable, 0);
       }
       await orgStorageMutationsRepository.finalizeRefund({
-        operationId: operation.id,
-        organizationId: operation.organization_id,
+        operationId: claimed.id,
+        organizationId: claimed.organization_id,
+        leaseToken,
         responseJson: JSON.stringify({ error: "Storage PUT did not reach R2" }),
       });
       refunded++;

--- a/packages/cloud/shared/src/lib/storage/r2-runtime-binding.ts
+++ b/packages/cloud/shared/src/lib/storage/r2-runtime-binding.ts
@@ -31,6 +31,7 @@ export interface RuntimeR2ObjectMetadata {
   version?: string;
   size: number;
   etag: string;
+  uploaded?: Date;
   checksums?: {
     md5?: ArrayBuffer;
     sha1?: ArrayBuffer;

--- a/packages/cloud/shared/src/lib/storage/r2-runtime-binding.ts
+++ b/packages/cloud/shared/src/lib/storage/r2-runtime-binding.ts
@@ -27,6 +27,8 @@ export interface RuntimeR2Object {
 
 /** Metadata returned by the native Workers `R2Bucket.head()` operation. */
 export interface RuntimeR2ObjectMetadata {
+  /** Key is populated on list results and omitted on direct HEAD results. */
+  key?: string;
   /** Opaque upload generation assigned by R2. */
   version?: string;
   size: number;
@@ -38,6 +40,21 @@ export interface RuntimeR2ObjectMetadata {
     sha256?: ArrayBuffer;
   };
   customMetadata?: Record<string, string>;
+  httpMetadata?: { contentType?: string };
+}
+
+export interface RuntimeR2ListOptions {
+  prefix?: string;
+  cursor?: string;
+  delimiter?: string;
+  limit?: number;
+  include?: Array<"httpMetadata" | "customMetadata">;
+}
+
+export interface RuntimeR2Objects {
+  objects: RuntimeR2ObjectMetadata[];
+  truncated: boolean;
+  cursor?: string;
 }
 
 export interface RuntimeR2PutOptions {
@@ -83,6 +100,7 @@ export interface RuntimeR2Bucket {
     options?: RuntimeR2PutOptions,
   ): Promise<unknown>;
   delete(key: string): Promise<unknown>;
+  list?(options?: RuntimeR2ListOptions): Promise<RuntimeR2Objects>;
 }
 
 let runtimeBucket: RuntimeR2Bucket | null = null;


### PR DESCRIPTION
## Summary

This draft is the independently mergeable native-R2 mutation and catalog foundation for #21045 and #22327. It replaces split-brain authenticated mutations with one catalog-backed `env.BLOB` authority while deliberately excluding incomplete paid reads.

- PUT writes deterministic immutable generation keys, reserves `max(new-old, 0)` quota, binds authoritative server pricing into the durable request digest, and publishes the catalog pointer only when the exact tenant-bound credit hold settles in the same primary transaction.
- Legacy `org/<tenant>/<key>` objects are discovered with cursor-complete R2 LIST, adopted with already-counted quota, and transferred exactly on first native overwrite.
- GET and HEAD resolve the committed catalog generation so newly written objects remain readable, but are explicitly unbilled until durable paid-read receipts exist.
- LIST is catalog-backed and explicitly unbilled; non-recursive filtering occurs before the SQL limit.
- Presign authenticates and then returns a fixed 503 without parsing the key or initializing catalog, provider, signing, pricing, or billing authority.
- DELETE is a zero-price durable operation under the current server pricing policy. It retains pointer/quota until R2 DELETE plus strongly consistent HEAD absence, then atomically tombstones and releases quota.
- Reconciliation uses fenced leases/CAS across prepared, reserved, provider-started, and provider-absence quarantine states. Superseded generations remain pinned for 24 hours before GC.
- Credit links are tenant-bound and credit transaction tenant provenance is immutable. Pricing precision is widened to `numeric(18,12)` and an audited migration reseeds a historical zero `storage.put_per_byte` row to `0.000000001`.

Cloudflare's synchronous strongly consistent mutation/HEAD guarantees support immutable generations plus strong-HEAD reconciliation: https://developers.cloudflare.com/r2/api/workers/workers-api-reference/ and https://developers.cloudflare.com/r2/reference/consistency/

## Safety invariants

- No caller-controlled price reaches mutation settlement.
- Decimal price legs are summed exactly and rounded once to six ledger decimals.
- Debit, settlement, quota publication, catalog publication, and terminal PUT receipt are one authoritative transaction boundary.
- Refund, quota release, and terminal failure receipt are atomic and lease-fenced.
- Negative provider HEAD is quarantined and rechecked; a late writer that lost its lease deletes its immutable generation.
- Historical quota is recomputed from the complete catalog plus active reservations before first native access.
- Provider keys, logical keys, idempotency keys, and signed URLs are excluded from application logs.
- A tombstone prevents legacy resurrection.
- No incomplete paid GET, HEAD, LIST, or presign path can run from this PR.

## Exact-head evidence

Head: `faff8dbe0a7c65ec81e25c2ab5ed9f3995dda290`
Base: `b2d03f8aca5e6b5902c4b5f9bcf86f61c3f3bebb`

- Native service failure injection: 13/13 tests, 45 assertions, 100% function/line coverage.
- PGlite repository/concurrency: 17/17 tests, 51 assertions, including real atomic debit/refund, cross-tenant rejection, concurrent admission/recovery, stale lease fencing, quota transfer, and terminal replay.
- Active CRUD: 5/5, proving PUT→unbilled GET/HEAD→overwrite→zero-cost durable DELETE.
- Native LIST: 2/2, proving catalog reconciliation without pricing/credit calls.
- Presign gate: 1/1, proving authenticated fixed denial before request-body parsing.
- Real Workerd/Miniflare R2: 1/1, proving conditional immutable writes and strong GET/HEAD/delete visibility.
- Shared/API typecheck and production Worker dry-run with `env.BLOB`: pass.
- Focused Biome, Drizzle migration check, and diff check: pass.
- Root `bun run verify`: pass, 358/358 Turbo tasks plus all repository audits.

## Follow-up

[#22399](https://github.com/elizaOS/eliza/issues/22399) is claimed for durable paid GET/HEAD/LIST/presign receipts and replay, native production signing authority, capability policy, URL/query telemetry remediation, and protected canary evidence.

This PR does **not** close #21045 or claim complete storage billing. No deployment, secret, migration execution, provider mutation, or customer billing mutation was performed. Keep draft until independent exact-head approval; do not merge from this update alone.

---
Model: OpenAI/gpt-5.6-sol
Client: Codex Desktop
Skill revision: `b2d03f8aca5e6b5902c4b5f9bcf86f61c3f3bebb`
Lane: [storage-mutation-impl]
