### PR TITLE
fix(plugin-coding-tools): reject shell command chaining at the injection gate

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/__tests__/isSafeCommand.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/isSafeCommand.test.ts
@@ -27,6 +27,27 @@ describe("isSafeCommand", () => {
   it("rejects command substitution and backticks", () => {
     expect(isSafeCommand("echo $(whoami)")).toBe(false);
     expect(isSafeCommand("echo `id`")).toBe(false);
+    expect(isSafeCommand("echo `'id'`")).toBe(false);
+  });
+
+  it("rejects semicolon chaining that would run under shell -c", () => {
+    expect(isSafeCommand("echo hi; touch /tmp/eliza-shell-semicolon")).toBe(
+      false,
+    );
+    expect(isSafeCommand("echo hi ;id")).toBe(false);
+    expect(isSafeCommand("x ; sudo y")).toBe(false);
+  });
+
+  it("rejects a line break used as a command separator", () => {
+    expect(isSafeCommand("echo hi\nid")).toBe(false);
+    expect(isSafeCommand("echo hi\r\nid")).toBe(false);
+  });
+
+  it("rejects a single pipe into a shell or interpreter", () => {
+    expect(isSafeCommand("echo id | sh")).toBe(false);
+    expect(isSafeCommand("echo id | bash")).toBe(false);
+    expect(isSafeCommand("cat script.py | python3")).toBe(false);
+    expect(isSafeCommand("cat file.txt | grep needle")).toBe(true);
   });
 
   it("rejects sudo chained after a pipe or semicolon", () => {

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
@@ -2,6 +2,9 @@
  * Path and command-safety guards: validatePath() confines a resolved path to the
  * allowed directory, while isForbiddenCommand/isSafeCommand/extractBaseCommand
  * gate which commands the shell will run (the command-injection boundary).
+ * isSafeCommand still allows one data pipe (cat | grep). It rejects command
+ * separators, backticks, $(), and a pipe into a shell/interpreter because
+ * ShellService then runs the string as `shell -c`.
  */
 import path from "node:path";
 import { logger } from "@elizaos/core";
@@ -26,17 +29,32 @@ export function validatePath(
   return normalizedPath;
 }
 
+const PIPE_TO_INTERPRETER =
+  /\|\s*(?:sh|bash|zsh|dash|ksh|csh|tcsh|fish|python\d*|perl|ruby|node|nodejs|osascript|pwsh|powershell|cmd)(?:\s|$)/i;
+
 export function isSafeCommand(command: string): boolean {
   const pathTraversalPatterns = [/\.\.\//g, /\.\.\\/g, /\/\.\./g, /\\\.\./g];
 
   const dangerousPatterns = [
     /\$\(/g,
-    /`[^']*`/g,
     /\|\s*sudo/g,
-    /;\s*sudo/g,
     /&\s*&/g,
     /\|\s*\|/g,
+    PIPE_TO_INTERPRETER,
   ];
+
+  if (/[\n\r]/.test(command)) {
+    logger.warn(`Line break detected in command: ${command}`);
+    return false;
+  }
+  if (command.includes(";")) {
+    logger.warn(`Command chaining detected in command: ${command}`);
+    return false;
+  }
+  if (command.includes("`")) {
+    logger.warn(`Backtick substitution detected in command: ${command}`);
+    return false;
+  }
 
   for (const pattern of pathTraversalPatterns) {
     if (pattern.test(command)) {


### PR DESCRIPTION
## Summary
- `ShellService` runs the operator/agent command as `shell -c` after `isSafeCommand`.
- On `origin/develop` that gate blocked `$( )`, `&&`, and `; sudo`, but still allowed `;` lists, line breaks, quoted backticks, and a single pipe into `sh`/`bash`/`python`. Those execute as extra commands.
- Reject those injection forms. Keep one data pipe (`cat file | grep needle`). This is the existing ShellService injection boundary, not leftover-tax, not a timeout hunt, not 21’s E-list.

## What Changed
- `plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts` — `isSafeCommand` rejects `;`, `\n`/`\r`, any backtick, and a pipe into a shell/interpreter.
- `plugins/plugin-coding-tools/src/shell/__tests__/isSafeCommand.test.ts` — pins the origin-allowed bypasses.

## Exact-head evidence
Head: `9f4497a3f96d8dd0650adb0b3fdd604b6b463912`
Base: `origin/develop@e39e764beabae1901b8ba1d4b9023f7f7fe409ff`
Occupancy: `scannedAt=2026-08-19T04:50:46.312Z` — `plugin-coding-tools/src/shell` FREE.

## Red / green
On origin:

```text
isSafeCommand("echo hi; touch /tmp/eliza-shell-semicolon") → ALLOW
isSafeCommand("echo id | sh") → ALLOW
isSafeCommand("echo id | bash") → ALLOW
isSafeCommand("echo `'id'`") → ALLOW
isSafeCommand("echo hi\\nid") → ALLOW
# then spawn(shell, [...shellArgs, command])
```

After this head:

```text
those five → DENY
isSafeCommand("echo hello") → ALLOW
isSafeCommand("cat file.txt | grep needle") → ALLOW
bun run --cwd plugins/plugin-coding-tools test src/shell/__tests__/isSafeCommand.test.ts src/shell/__tests__/isSafeBinUsage.test.ts src/shell/__tests__/approvals-analysis.test.ts
# Test Files  3 passed; Tests  35 passed
```

## Verification
- [x] Targets `develop`
- [x] Focused vitest 35/35 at this head
- [x] `biome check` on the two files — clean
- [x] Not `#22262`. Not timeout-family. Not 21’s E-list. Not a twin of `#22302`–`#22354`.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — command-injection gate; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9f4497a3f96d8dd0650adb0b3fdd604b6b463912 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
