### PR TITLE
fix(core): block credential paths on DOCUMENT import_file

### DIFF
--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -38,6 +38,7 @@ import {
 	userReferenceLogView as queryLogView,
 } from "../../utils/reference-echo.ts";
 import { addDocumentFromFilePath } from "./docs-loader.ts";
+import { isBlockedDocumentImportPath } from "./import-file-path.ts";
 import {
 	type DocumentListResult,
 	DocumentService,
@@ -1057,6 +1058,13 @@ async function handleImportFile(
 		params,
 	);
 	if (filePath) {
+		if (isBlockedDocumentImportPath(filePath)) {
+			const text =
+				"That file path is not available for document import; it is a credential or OS-private location.";
+			return result(false, text, "import_file", {
+				values: { error: "forbidden", filePath: queryLogView(filePath) },
+			});
+		}
 		if (!fs.existsSync(filePath)) {
 			const text = `No file exists at ${describeUserReference(filePath, "that path")}; tell the user it couldn't be found.`;
 			return result(false, text, "import_file", {

--- a/packages/core/src/features/documents/import-file-path.test.ts
+++ b/packages/core/src/features/documents/import-file-path.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pins DOCUMENT import_file's host-path blocklist. Deterministic: uses a fake
+ * home and real temp files/symlinks, then drives the real handler so a
+ * USER-scoped import of the SSH credential home never reaches addDocument.
+ * Does not read the operator's live secrets.
+ */
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	SearchCategoryRegistration,
+	UUID,
+} from "../../types";
+import { documentAction } from "./actions.ts";
+import {
+	defaultDocumentImportBlockedRoots,
+	isBlockedDocumentImportPath,
+} from "./import-file-path.ts";
+import { DocumentService } from "./service.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const WORLD_ID = "00000000-0000-4000-8000-00000000face" as UUID;
+
+function makeMessage(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text },
+		createdAt: Date.now(),
+	} as Memory;
+}
+
+function makeRuntime(service: {
+	addDocument: ReturnType<typeof vi.fn>;
+}): IAgentRuntime {
+	const categories = new Map<string, SearchCategoryRegistration>();
+	return {
+		agentId: AGENT_ID,
+		getService: vi.fn(<T>(type: string): T | null =>
+			type === DocumentService.serviceType ? (service as unknown as T) : null,
+		),
+		registerSearchCategory: vi.fn((reg: SearchCategoryRegistration) => {
+			categories.set(reg.category, reg);
+		}),
+		getSearchCategory: vi.fn((category: string) => {
+			const found = categories.get(category);
+			if (!found) {
+				throw new Error(`unknown category ${category}`);
+			}
+			return found;
+		}),
+		getSetting: vi.fn(() => undefined),
+		getRoom: vi.fn(async () => ({ id: ROOM_ID, worldId: WORLD_ID })),
+		getWorld: vi.fn(async () => ({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		})),
+		getRoomsForParticipants: vi.fn(async () => {
+			throw new Error("room lookup is unavailable");
+		}),
+		reportError: vi.fn(),
+		useModel: vi.fn(async () => {
+			throw new Error("useModel must not be called on the planner-trust path");
+		}),
+	} as unknown as IAgentRuntime;
+}
+
+describe("isBlockedDocumentImportPath", () => {
+	it("blocks credential homes and OS-private roots", () => {
+		const home = "/Users/fixture";
+		expect(
+			isBlockedDocumentImportPath(path.join(home, ".ssh", "id_rsa"), { home }),
+		).toBe(true);
+		expect(
+			isBlockedDocumentImportPath(path.join(home, ".aws", "credentials"), {
+				home,
+			}),
+		).toBe(true);
+		expect(isBlockedDocumentImportPath("/etc/passwd", { home })).toBe(true);
+		expect(isBlockedDocumentImportPath("/etc/shadow", { home })).toBe(true);
+	});
+
+	it("allows an ordinary workspace file", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "doc-import-ok-"));
+		const file = path.join(dir, "notes.md");
+		writeFileSync(file, "launch is friday");
+		expect(
+			isBlockedDocumentImportPath(file, { home: path.join(dir, "home") }),
+		).toBe(false);
+	});
+
+	it("blocks a symlink whose realpath is a credential file", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "doc-import-link-"));
+		const home = path.join(dir, "home");
+		mkdirSync(path.join(home, ".ssh"), { recursive: true });
+		const secret = path.join(home, ".ssh", "id_rsa");
+		writeFileSync(secret, "SECRET");
+		const decoy = path.join(dir, "notes.md");
+		symlinkSync(secret, decoy);
+		expect(isBlockedDocumentImportPath(decoy, { home })).toBe(true);
+	});
+
+	it("realpaths blocked roots so /etc and /private/etc agree", () => {
+		const roots = defaultDocumentImportBlockedRoots("/Users/fixture");
+		expect(roots).toContain("/etc");
+		expect(isBlockedDocumentImportPath("/etc/passwd")).toBe(true);
+	});
+});
+
+describe("DOCUMENT import_file handler path gate", () => {
+	it("rejects the SSH credential home before addDocument on a USER-scoped import", async () => {
+		const addDocument = vi.fn(async () => {
+			throw new Error("addDocument must not run for a blocked import_file");
+		});
+		const res = await documentAction.handler?.(
+			makeRuntime({ addDocument }),
+			makeMessage("import my key"),
+			undefined,
+			{
+				parameters: {
+					action: "import_file",
+					filePath: path.join(homedir(), ".ssh", "id_rsa"),
+				},
+			} as HandlerOptions,
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "forbidden" });
+		expect(addDocument).not.toHaveBeenCalled();
+	});
+
+	it("rejects /etc/passwd before addDocument", async () => {
+		const addDocument = vi.fn(async () => {
+			throw new Error("addDocument must not run for a blocked import_file");
+		});
+		const res = await documentAction.handler?.(
+			makeRuntime({ addDocument }),
+			makeMessage("import passwd"),
+			undefined,
+			{
+				parameters: { action: "import_file", filePath: "/etc/passwd" },
+			} as HandlerOptions,
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "forbidden" });
+		expect(addDocument).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/features/documents/import-file-path.ts
+++ b/packages/core/src/features/documents/import-file-path.ts
@@ -1,0 +1,61 @@
+/**
+ * Path policy for DOCUMENT `import_file`. That subaction is USER-role and
+ * reads the host filesystem; without a blocklist a planner can copy credential
+ * or OS-private files into the document store. `import_url` already has an
+ * SSRF guard. Roots are realpathed when they exist so macOS `/etc` →
+ * `/private/etc` cannot slip through.
+ */
+import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export function defaultDocumentImportBlockedRoots(home = homedir()): string[] {
+	return [
+		path.join(home, ".ssh"),
+		path.join(home, ".aws"),
+		path.join(home, ".gnupg"),
+		path.join(home, ".docker"),
+		path.join(home, ".kube"),
+		path.join(home, ".netrc"),
+		path.join(home, "pvt"),
+		"/etc",
+		"/proc",
+		"/sys",
+		"/dev",
+		"/root",
+	];
+}
+
+function resolveExisting(absPath: string): string {
+	try {
+		return realpathSync(absPath);
+	} catch {
+		// error-policy:J3 missing or unreadable root/file — keep the lexical
+		// absolute so a not-yet-created SSH private-key path is still blocked.
+		return path.resolve(absPath);
+	}
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+	const relative = path.relative(root, candidate);
+	return (
+		relative === "" ||
+		(!relative.startsWith("..") && !path.isAbsolute(relative))
+	);
+}
+
+export function isBlockedDocumentImportPath(
+	filePath: string,
+	options: { home?: string; roots?: readonly string[] } = {},
+): boolean {
+	const configured =
+		options.roots ?? defaultDocumentImportBlockedRoots(options.home);
+	const roots = [
+		...configured.map((root) => path.resolve(root)),
+		...configured.map((root) => resolveExisting(root)),
+	];
+	const candidates = [path.resolve(filePath), resolveExisting(filePath)];
+	return candidates.some((candidate) =>
+		roots.some((root) => isWithinRoot(candidate, root)),
+	);
+}


### PR DESCRIPTION
## Summary
- DOCUMENT `import_file` is USER-role and, on origin, read any host path with only `existsSync`.
- A planner could copy SSH keys, AWS credentials, or `/etc/passwd` into the document store. `import_url` already has an SSRF guard; `import_file` had none.
- Reject credential homes (`.ssh`, `.aws`, `.gnupg`, `.docker`, `.kube`, `.netrc`, `pvt`) and OS-private roots (`/etc`, `/proc`, `/sys`, `/dev`, `/root`), including symlink realpaths, before the read. Workspace files still import.

## What Changed
- `packages/core/src/features/documents/import-file-path.ts` — blocklist + realpath containment.
- `packages/core/src/features/documents/actions.ts` — `handleImportFile` returns `forbidden` before `existsSync` / `addDocument`.
- Tests: predicate, symlink escape, USER-scoped handler (no `addDocument`).

## Exact-head evidence
Head: `175e3cee7230bc41c7065fe7b1c4f90e89e2ce49`
Base: `origin/develop@e39e764beabae1901b8ba1d4b9023f7f7fe409ff`
Occupancy: `scannedAt=2026-08-19T05:00:11.271Z` — documents import path FREE.

## Red / green
On origin, USER-scoped `import_file` of a credential home or `/etc/passwd` reached `addDocumentFromFilePath` / `readFileSync`.

After this head:

```text
import_file SSH credential home → { error: "forbidden" }, addDocument not called
import_file /etc/passwd → { error: "forbidden" }
workspace notes.md → not blocked
symlink to a credential file → blocked
bun test import-file-path + action-context-gate + actions-echo
# 27 pass, 0 fail
```

## Verification
- [x] Targets `develop`
- [x] Focused bun test 27/27 at this head
- [x] `biome check` on the three files — clean
- [x] Not `#22262`. Not timeout-family. Not 21’s E-list. Not a twin of `#22302`–`#22357`.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — document import path policy; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:175e3cee7230bc41c7065fe7b1c4f90e89e2ce49 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
