### PR TITLE
fix(capacitor-screencapture): exclude in-progress pause from reported recording duration

### DIFF
--- a/plugins/plugin-native-screencapture/src/web.test.ts
+++ b/plugins/plugin-native-screencapture/src/web.test.ts
@@ -4,6 +4,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ScreenRecordingState } from "./definitions";
 import { ScreenCaptureWeb } from "./web";
 
 type MediaRecorderEventHandler = ((event: Event) => void) | null;
@@ -486,6 +487,111 @@ describe("ScreenCaptureWeb", () => {
       duration: 0,
       fileSize: 5,
     });
+  });
+
+  it("excludes an in-progress pause from the stopped recording duration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+
+    const videoTrack = new FakeTrack("video");
+    const displayStream = new FakeStream([videoTrack]);
+    const getDisplayMedia = vi.fn(
+      async () => displayStream as unknown as MediaStream,
+    );
+    setNavigator({
+      mediaDevices: { getDisplayMedia } as unknown as MediaDevices,
+    });
+
+    const plugin = new ScreenCaptureWeb();
+    const states: ScreenRecordingState[] = [];
+    await plugin.addListener("recordingState", (event) => {
+      states.push(event as ScreenRecordingState);
+    });
+    await plugin.startRecording();
+
+    // Two seconds of active capture, then pause and stop ten seconds later
+    // without ever resuming: only the 2s of recorded content must be reported,
+    // not the 12s of wall-clock time that elapsed.
+    vi.setSystemTime(2_000);
+    await plugin.pauseRecording();
+    vi.setSystemTime(12_000);
+
+    const result = await plugin.stopRecording();
+    expect(result.duration).toBe(2);
+    expect(states[states.length - 1]).toEqual({
+      isRecording: false,
+      duration: 2,
+      fileSize: 0,
+    });
+  });
+
+  it("freezes the polled recording duration while paused", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+
+    const videoTrack = new FakeTrack("video");
+    const displayStream = new FakeStream([videoTrack]);
+    const getDisplayMedia = vi.fn(
+      async () => displayStream as unknown as MediaStream,
+    );
+    setNavigator({
+      mediaDevices: { getDisplayMedia } as unknown as MediaDevices,
+    });
+
+    const plugin = new ScreenCaptureWeb();
+    await plugin.startRecording();
+
+    vi.setSystemTime(3_000);
+    await plugin.pauseRecording();
+
+    // While paused the reported duration must stay frozen at the active capture
+    // length regardless of how much wall-clock time passes between polls.
+    vi.setSystemTime(5_000);
+    await expect(plugin.getRecordingState()).resolves.toMatchObject({
+      isRecording: true,
+      duration: 3,
+    });
+    vi.setSystemTime(9_000);
+    await expect(plugin.getRecordingState()).resolves.toMatchObject({
+      isRecording: true,
+      duration: 3,
+    });
+
+    await plugin.stopRecording();
+  });
+
+  it("counts only active capture across a pause and resume before stopping", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+
+    const videoTrack = new FakeTrack("video");
+    const displayStream = new FakeStream([videoTrack]);
+    const getDisplayMedia = vi.fn(
+      async () => displayStream as unknown as MediaStream,
+    );
+    setNavigator({
+      mediaDevices: { getDisplayMedia } as unknown as MediaDevices,
+    });
+
+    const plugin = new ScreenCaptureWeb();
+    await plugin.startRecording();
+
+    // 2s active, 5s paused, 3s active, then stop: the 5s pause must be excluded
+    // so the result reports 5s of recorded content.
+    vi.setSystemTime(2_000);
+    await plugin.pauseRecording();
+    vi.setSystemTime(7_000);
+    await plugin.resumeRecording();
+    vi.setSystemTime(10_000);
+
+    const result = await plugin.stopRecording();
+    expect(result.duration).toBe(5);
   });
 
   it("surfaces an error event when auto-stop on track end fails", async () => {

--- a/plugins/plugin-native-screencapture/src/web.ts
+++ b/plugins/plugin-native-screencapture/src/web.ts
@@ -81,6 +81,21 @@ export class ScreenCaptureWeb extends WebPlugin {
     callback: (event: ScreenCaptureEventData) => void;
   }> = [];
 
+  /**
+   * Active-capture length in seconds. MediaRecorder emits no data while paused,
+   * so an in-progress pause segment is subtracted alongside the already-
+   * accumulated `pausedDuration`; otherwise stopping while paused would count
+   * paused wall-clock time as recorded content and desync `duration` from the
+   * stored media length.
+   */
+  private elapsedSeconds(): number {
+    const pausedNow = this.isPaused ? Date.now() - this.pauseStartTime : 0;
+    return (
+      (Date.now() - this.recordingStartTime - this.pausedDuration - pausedNow) /
+      1000
+    );
+  }
+
   async isSupported(): Promise<{ supported: boolean; features: string[] }> {
     const supported = hasDisplayMedia();
     const features: string[] = [];
@@ -280,8 +295,7 @@ export class ScreenCaptureWeb extends WebPlugin {
     this.recordingStateInterval = setInterval(() => {
       if (!this.isRecording || this.isPaused || autoStopping) return;
 
-      const duration =
-        (Date.now() - this.recordingStartTime - this.pausedDuration) / 1000;
+      const duration = this.elapsedSeconds();
       const fileSize = this.recordedChunks.reduce(
         (acc, chunk) => acc + chunk.size,
         0,
@@ -321,8 +335,7 @@ export class ScreenCaptureWeb extends WebPlugin {
         return;
       }
 
-      const duration =
-        (Date.now() - this.recordingStartTime - this.pausedDuration) / 1000;
+      const duration = this.elapsedSeconds();
 
       this.mediaRecorder.onstop = () => {
         if (this.recordingStateInterval) {
@@ -389,8 +402,7 @@ export class ScreenCaptureWeb extends WebPlugin {
     this.isPaused = true;
     this.pauseStartTime = Date.now();
 
-    const duration =
-      (Date.now() - this.recordingStartTime - this.pausedDuration) / 1000;
+    const duration = this.elapsedSeconds();
     const fileSize = this.recordedChunks.reduce(
       (acc, chunk) => acc + chunk.size,
       0,
@@ -418,9 +430,7 @@ export class ScreenCaptureWeb extends WebPlugin {
   }
 
   async getRecordingState(): Promise<ScreenRecordingState> {
-    const duration = this.isRecording
-      ? (Date.now() - this.recordingStartTime - this.pausedDuration) / 1000
-      : 0;
+    const duration = this.isRecording ? this.elapsedSeconds() : 0;
     const fileSize = this.recordedChunks.reduce(
       (acc, chunk) => acc + chunk.size,
       0,


### PR DESCRIPTION
# Relates to

Closes #22360

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package `test`, `typecheck`, `lint`, and `build` pass (evidence below). `bun run verify` is a full-repo gate not completable on this constrained machine; the owning-package gates are green — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the failing-before / passing-after test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a3f9fc07179b067ebe8e1db2e6bece3b0f3cffa8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (base `a3f9fc0717`); zero conflicts.
- [x] Owning-package gates pass post-sync; see **Known gaps / failures** for the full-repo `bun run verify` note.

# Risks

Low. Self-contained change within `plugins/plugin-native-screencapture/src/web.ts`. No public contract change — the `ScreenRecordingResult`/`ScreenRecordingState` shapes are unchanged; only the computed `duration` value is corrected. Behavior when never pausing, or pausing then resuming before stop, is unchanged (covered by the existing regression test).

# Background

## What does this PR do?

`ScreenCaptureWeb` tracked paused time lazily: `pauseRecording()` records `pauseStartTime` but only folds the elapsed pause into `pausedDuration` when `resumeRecording()` runs. Every duration was computed as `(Date.now() - recordingStartTime - pausedDuration) / 1000`, which does **not** subtract the in-progress pause segment. So pausing and then stopping without resuming (a normal "pause, decide to save" flow) counted all paused wall-clock time as recorded content, even though `MediaRecorder` emits no data while paused. `getRecordingState()` had the same defect — while paused the reported duration kept climbing. The stored recording's reported `duration` therefore diverged from its actual media length, a data-integrity mismatch consumed by the browser path and the Electrobun desktop shell that render/seek on `result.duration`.

The fix adds a private `elapsedSeconds()` helper that also subtracts the current in-progress pause segment, and routes `stopRecording()`, `getRecordingState()`, `pauseRecording()`'s notify, and the `recordingState` poll interval through it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. The documented contract (`ScreenRecordingResult.duration` = recorded length) is unchanged; this fix makes the implementation match it.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-screencapture/src/web.test.ts` — three added tests exercise the changed contract using the file's existing fake `MediaRecorder`/`getDisplayMedia` doubles and `vi.useFakeTimers`.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-native-screencapture test
```

Added tests:
1. **stop-while-paused** — start, pause after 2s, stop 10s later without resuming: asserts `result.duration === 2` and the final `recordingState` event duration `=== 2`.
2. **frozen-while-paused** — start, pause after 3s, poll `getRecordingState()` at two later fake-clock times: asserts the reported duration stays `3`.
3. **pause→resume→stop regression guard** — 2s active, 5s paused, 3s active, stop: asserts `result.duration === 5`.

# Evidence Gate

<!-- evidence-head:e95711ebfc92ab300ed1341e9b0926533674e556 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this package is a Capacitor primitive with no rendered view. The change is a numeric `duration` computation.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface (see above).
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; change is a headless duration computation verified by deterministic unit tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/runtime log path; `ScreenCaptureWeb` is a browser Capacitor implementation with no structured logger. The code path is proven by the failing-before/passing-after tests below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no request/response cycle; the change is a local computation with no network activity.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted DB row, file, or on-chain output; the corrected duration values (12s wall-clock before, 2s active-only after) are demonstrated inline in the failing-before/passing-after vitest transcript under Backend + frontend logs
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Failing-before (reproduction on the current code, before the fix — new tests only):

```
FAIL  src/web.test.ts > ScreenCaptureWeb > excludes an in-progress pause from the stopped recording duration
AssertionError: expected 12 to be 2 // Object.is equality
- Expected
+ Received
- 2
+ 12

FAIL  src/web.test.ts > ScreenCaptureWeb > freezes the polled recording duration while paused
AssertionError: expected { ... } to match object { isRecording: true, duration: 3 }
-   "duration": 3,
+   "duration": 5,

 Test Files  1 failed (1)
      Tests  2 failed | 20 passed (22)
```

Passing-after (with the fix applied — full package suite green):

```
$ vitest run
 RUN  v4.1.5 plugins/plugin-native-screencapture

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  546ms
```

typecheck + lint + build:

```
$ tsc --noEmit -p tsconfig.json        # (no output: clean)
$ bunx @biomejs/biome check .          # Checked 7 files. No fixes applied.
$ bun run build:unlocked               # created dist/plugin.js, dist/plugin.cjs.js
```

## Screenshots (before / after) + video walkthrough

N/A - no UI change; this Capacitor primitive renders nothing.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` (full-repo parity/dependency/type/lint/audit gate) is not completable on this constrained Raspberry Pi environment and is unrelated to this one-file fix. The owning-package gates — `test` (22 passed), `typecheck`, `lint`, and `build` — all pass and are shown above. CI will run the full `verify` gate on this PR.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@a3f9fc07179b067ebe8e1db2e6bece3b0f3cffa8:packages/skills/skills/contribute-to-eliza"} -->

