### PR TITLE
fix(shared): bind loopback Origin to Host including port

### DIFF
--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -320,6 +320,134 @@ describe("isTrustedLocalRequest — shared host/origin classification", () => {
           ),
         ).toBe(false);
       });
+
+      it("rejects same-site fetch metadata even when Origin matches Host", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                origin: "http://localhost:31337",
+                "sec-fetch-site": "same-site",
+              },
+            }),
+            options,
+          ),
+        ).toBe(false);
+      });
+
+      it("rejects a loopback Origin on a different port than Host", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                origin: "http://localhost:5173",
+                "sec-fetch-site": "same-site",
+              },
+            }),
+            options,
+          ),
+        ).toBe(false);
+      });
+
+      it("rejects the same hostname on a different port even if fetch metadata claims same-origin", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "127.0.0.1:31337",
+                origin: "http://127.0.0.1:5173",
+                "sec-fetch-site": "same-origin",
+              },
+            }),
+            options,
+          ),
+        ).toBe(false);
+      });
+
+      it("rejects a matching-port Origin whose hostname does not match Host", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                origin: "http://127.0.0.1:31337",
+                "sec-fetch-site": "same-origin",
+              },
+            }),
+            options,
+          ),
+        ).toBe(false);
+      });
+
+      it("rejects a loopback Referer on a different port when no Origin is present", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                referer: "http://localhost:5173/app",
+              },
+            }),
+            options,
+          ),
+        ).toBe(false);
+      });
+
+      it("admits an Origin that matches Host including port", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                origin: "http://localhost:31337",
+                "sec-fetch-site": "same-origin",
+              },
+            }),
+            options,
+          ),
+        ).toBe(true);
+      });
+
+      it("admits Sec-Fetch-Site none on an originless loopback request", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                "sec-fetch-site": "none",
+              },
+            }),
+            options,
+          ),
+        ).toBe(true);
+      });
+
+      it("still admits an originless direct loopback client", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: { host: "localhost:31337" },
+            }),
+            options,
+          ),
+        ).toBe(true);
+      });
+
+      it("still admits a matching-port Referer when no Origin is present", () => {
+        expect(
+          isTrustedLocalRequest(
+            makeReq({
+              headers: {
+                host: "localhost:31337",
+                referer: "http://localhost:31337/dashboard",
+              },
+            }),
+            options,
+          ),
+        ).toBe(true);
+      });
     });
   }
 });

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -24,6 +24,12 @@
  * `127.0.0.1.evil.com`), which the strict parser correctly rejects. The change
  * can only ever turn a previously-trusted request into an untrusted one, never
  * the reverse.
+ *
+ * A loopback Origin hostname is not enough. An http(s) Origin or Referer must
+ * match Host including port; a present `Sec-Fetch-Site` may only be
+ * `same-origin` or `none`. Native app schemes and originless loopback clients
+ * stay admitted. `same-site` on a different local port is a CSRF, not a
+ * dashboard.
  */
 
 import type http from "node:http";
@@ -310,18 +316,68 @@ const LOCAL_APP_PROTOCOLS = new Set([
   "electrobun:",
 ]);
 
-function isTrustedLocalOrigin(raw: string): boolean {
+function parseHostAuthority(host: string): {
+  hostname: string;
+  port: string | null;
+} {
+  const trimmed = host.trim().toLowerCase();
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return { hostname: trimmed, port: null };
+    const hostname = trimmed.slice(1, end);
+    const after = trimmed.slice(end + 1);
+    const port =
+      after.startsWith(":") && after.length > 1 ? after.slice(1) : null;
+    return { hostname, port };
+  }
+  const colon = trimmed.lastIndexOf(":");
+  if (colon === -1) return { hostname: trimmed, port: null };
+  return { hostname: trimmed.slice(0, colon), port: trimmed.slice(colon + 1) };
+}
+
+function parseHttpSiteAuthority(
+  raw: string,
+): { hostname: string; port: string } | null {
+  try {
+    const parsed = new URL(raw.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    const hostname = parsed.hostname.trim().toLowerCase();
+    if (!hostname) return null;
+    const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+    return { hostname, port };
+  } catch {
+    // error-policy:J3 untrusted Origin/Referer; unparseable site is invalid.
+    return null;
+  }
+}
+
+function isNativeOrOpaqueOrigin(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed || trimmed === "null") return true;
   try {
-    const parsed = new URL(trimmed);
-    if (LOCAL_APP_PROTOCOLS.has(parsed.protocol)) {
-      return true;
-    }
-    return isLoopbackBindHost(parsed.hostname);
+    return LOCAL_APP_PROTOCOLS.has(new URL(trimmed).protocol);
   } catch {
     return false;
   }
+}
+
+/**
+ * Native / opaque origins stay trusted. An http(s) Origin or Referer must be a
+ * loopback host and must match the request Host including port. A missing Host
+ * cannot prove that bind, so the request fails closed.
+ */
+function isTrustedBrowserSite(raw: string, host: string | null): boolean {
+  if (isNativeOrOpaqueOrigin(raw)) return true;
+  const site = parseHttpSiteAuthority(raw);
+  if (!site || !isLoopbackBindHost(site.hostname)) return false;
+  if (!host) return false;
+  const hostAuth = parseHostAuthority(host);
+  if (!isLoopbackBindHost(hostAuth.hostname)) return false;
+  if (site.hostname !== hostAuth.hostname) return false;
+  const hostPort = hostAuth.port ?? "80";
+  return site.port === hostPort;
 }
 
 function cloudBlocksLocalTrust(cloudCheck: "env" | "container"): boolean {
@@ -343,8 +399,9 @@ function localAuthRequired(options: LoopbackTrustOptions): boolean {
 
 /**
  * Same-machine dashboard access. Intentionally stricter than a bare
- * `remoteAddress` check: the browser must also target a loopback Host and must
- * not present cross-site browser metadata or proxy client-IP headers.
+ * `remoteAddress` check: the browser must also target a loopback Host, an
+ * http(s) Origin/Referer must match that Host including port, and present
+ * fetch metadata may only be `same-origin` or `none`.
  *
  * Each consumer supplies {@link LoopbackTrustOptions} matching its historical
  * policy gates; the host/origin/proxy classification is identical for all.
@@ -376,13 +433,19 @@ export function isTrustedLocalRequest(
   const secFetchSite = firstHeaderValue(
     req.headers["sec-fetch-site"],
   )?.toLowerCase();
-  if (secFetchSite === "cross-site") return false;
+  if (
+    secFetchSite &&
+    secFetchSite !== "same-origin" &&
+    secFetchSite !== "none"
+  ) {
+    return false;
+  }
 
   const origin = firstHeaderValue(req.headers.origin);
-  if (origin && !isTrustedLocalOrigin(origin)) return false;
+  if (origin && !isTrustedBrowserSite(origin, host)) return false;
 
   const referer = firstHeaderValue(req.headers.referer);
-  if (!origin && referer && !isTrustedLocalOrigin(referer)) return false;
+  if (!origin && referer && !isTrustedBrowserSite(referer, host)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary
- Canonical `@elizaos/shared` `isTrustedLocalRequest` is the trunk local-trust gate for `@elizaos/app-core` and `@elizaos/agent` (`/api` including `/api/sandbox/exec`).
- On origin it admitted a loopback peer whose Host was `localhost:31337` and whose Origin was `http://localhost:5173` with `Sec-Fetch-Site: same-site`.
- A local page on another port is not the dashboard. Bind http(s) Origin and Referer to Host including port. If fetch metadata is present, allow only `same-origin` or `none`.
- Native app schemes (`capacitor:`, `file:`, `app:`, …) and originless loopback clients stay admitted.
- Not a twin of `#22341` (plugin-computeruse local copy, now merged). This is the shared helper those wrappers call.

## What Changed
- `packages/shared/src/loopback-trust.ts` — Origin/Referer must match Host hostname+port; `Sec-Fetch-Site` other than `same-origin`/`none` is denied.
- `packages/shared/src/loopback-trust.test.ts` — Shaw different-port / same-site cases under both app-core and agent option bundles.

## Exact-head evidence
Head: `9815d06b673268c3db2d4923d26e76b4785425ca`
Base: `origin/develop@623e6b2cb19e26fd75a75af284dcae4776a66420`
Occupancy: `scannedAt=2026-08-19T05:18:40.997Z` — `packages/shared/src/loopback-trust.ts` FREE.

## Red / green
On origin (`623e6b2cb19e` / previous `a3f9fc07179b`):

```text
shaw-attack true
exact-origin true
originless true
```

After this head:

```text
shaw-attack false
exact-origin true
originless true
native true
same-site-matching-origin false
bun test packages/shared/src/loopback-trust.test.ts
# 97 pass, 0 fail
```

## Verification
- [x] Targets `develop`
- [x] Focused bun test 97/97 at this head
- [x] `biome check` on the two files — clean
- [x] Rebased onto `#22341` merge. Not `#22262`. Not timeout-family. Not leftover-tax. Not 21’s E-list.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — shared request-trust helper; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9815d06b673268c3db2d4923d26e76b4785425ca -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
