### PR TITLE
fix(plugin-pty): confine cwd through symlink parents

### DIFF
--- a/plugins/plugin-pty/services/pty-session-store.ts
+++ b/plugins/plugin-pty/services/pty-session-store.ts
@@ -1,10 +1,15 @@
 /**
  * PTY session store and console bridge for web-terminal sessions.
- * It confines child process environment/cwd, buffers output for late subscribers, selects Bun or Node PTY backends, and emits the bridge events consumed by the agent server.
+ * It confines child process environment/cwd through symlink parents, buffers
+ * output for late subscribers, selects Bun or Node PTY backends, and emits the
+ * bridge events consumed by the agent server. Lexical `path.resolve` is not
+ * enough: a cwd that is a symlink inside the allowed root must not spawn a
+ * session whose real working directory is outside the jail.
  */
 
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { promises as fs } from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import { bunTruePtySpawn, isBunRuntime } from "./bun-pty-spawn";
@@ -92,6 +97,35 @@ function buildPtyEnv(
   env.PWD = cwd;
   env.TERM = specEnv?.TERM ?? process.env.TERM ?? "xterm-256color";
   return env;
+}
+
+/**
+ * Realpath the longest existing prefix and rejoin the missing tail. A cwd
+ * symlink that already exists must resolve to its target; a not-yet-created
+ * basename under a jail symlink must not hide that target.
+ */
+async function resolveThroughSymlinkParents(input: string): Promise<string> {
+  const absolute = path.resolve(input);
+  try {
+    return await fs.realpath(absolute);
+  } catch {
+    // error-policy:J3 missing leaf or ancestor — walk up to the longest
+    // existing prefix and realpath that, then rejoin the tail.
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return absolute;
+    }
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(await fs.realpath(parent), ...tail);
+    } catch {
+      current = parent;
+    }
+  }
 }
 
 /** Resolves the node-pty `spawn` implementation lazily (native, optional dep). */
@@ -221,23 +255,25 @@ export class PtySessionStore {
   /**
    * Reject a cwd that escapes the allowed root (defense in depth — the route
    * and spec builder already resolve a safe cwd, but the store is the last gate
-   * before spawning a real process).
+   * before spawning a real process). Compare realpath of the longest existing
+   * prefix so a symlink inside the jail cannot hide an outside directory.
    */
-  private confineCwd(cwd: string): string {
+  private async confineCwd(cwd: string): Promise<string> {
     const resolved = path.resolve(cwd);
     const root = this.opts.allowedRoot
       ? path.resolve(this.opts.allowedRoot)
       : null;
-    if (root) {
-      const rel = path.relative(root, resolved);
-      if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) {
-        return resolved;
-      }
-      throw new Error(
-        `PTY cwd "${resolved}" is outside the allowed root "${root}".`,
-      );
+    if (!root) return resolved;
+
+    const realCwd = await resolveThroughSymlinkParents(resolved);
+    const realRoot = await resolveThroughSymlinkParents(root);
+    const rel = path.relative(realRoot, realCwd);
+    if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) {
+      return realCwd;
     }
-    return resolved;
+    throw new Error(
+      `PTY cwd "${resolved}" is outside the allowed root "${root}".`,
+    );
   }
 
   /** Spawn a new interactive session and start streaming its output. */
@@ -247,7 +283,7 @@ export class PtySessionStore {
         `PTY session limit reached (${this.maxSessions}); stop a session before starting another.`,
       );
     }
-    const cwd = this.confineCwd(spec.cwd);
+    const cwd = await this.confineCwd(spec.cwd);
     if (!this.resolvedSpawn) {
       this.resolvedSpawn = await this.resolveSpawn();
     }

--- a/plugins/plugin-pty/test/pty-session-store.test.ts
+++ b/plugins/plugin-pty/test/pty-session-store.test.ts
@@ -4,6 +4,16 @@
  * cwd confinement, and idle/exit reaping — driven with an injected fake PTY
  * (`makeFakeSpawn`), no OS process.
  */
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionOutputEvent } from "../services/pty-contract";
 import {
@@ -179,6 +189,33 @@ describe("PtySessionStore.start", () => {
     await expect(store.start(spec({ cwd: "/etc" }))).rejects.toThrow(
       /outside the allowed root/i,
     );
+  });
+
+  it("rejects a cwd that is a symlink to a directory outside the allowed root", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "pty-jail-"));
+    const outside = mkdtempSync(path.join(tmpdir(), "pty-outside-"));
+    writeFileSync(path.join(outside, "marker.txt"), "outside-jail");
+    const link = path.join(root, "escape");
+    symlinkSync(outside, link);
+
+    try {
+      const { store, fake } = makeStore({ allowedRoot: root });
+      await expect(store.start(spec({ cwd: link }))).rejects.toThrow(
+        /outside the allowed root/i,
+      );
+      expect(fake.calls).toHaveLength(0);
+
+      const inside = path.join(root, "ok");
+      mkdirSync(inside);
+      const innerLink = path.join(root, "alias");
+      symlinkSync(inside, innerLink);
+      await store.start(spec({ cwd: innerLink }));
+      expect(fake.calls).toHaveLength(1);
+      expect(fake.calls[0].opts.cwd).toBe(realpathSync(inside));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- `PtySessionStore.confineCwd` is the last jail before a web-terminal session is spawned.
- On origin it used lexical `path.resolve` only. A cwd that was a symlink inside the allowed root spawned a session whose real working directory was outside the jail (`PWD` and the child process follow the target).
- Realpath the longest existing prefix of cwd and of the allowed root, then compare. Inside-jail aliases still spawn. Missing paths under the root stay admitted.

## What Changed
- `plugins/plugin-pty/services/pty-session-store.ts` — `resolveThroughSymlinkParents` + async `confineCwd`.
- `plugins/plugin-pty/test/pty-session-store.test.ts` — outside-jail symlink rejected; inside-jail alias admitted.

## Exact-head evidence
Head: `bc07b37cf2a2b3b890bbd97cdcf88bc7b5c9829e`
Base: `origin/develop@623e6b2cb19e26fd75a75af284dcae4776a66420`
Occupancy: `scannedAt=2026-08-19T05:33:21.560Z` — `plugins/plugin-pty` FREE.

## Red / green
On origin (`confineCwd` = `path.resolve` + `path.relative`):

```text
lexical /etc → admitted false
symlink inside jail → outside dir → admitted true, escaped true
```

After this head:

```text
outside-jail symlink cwd → throws /outside the allowed root/, spawn not called
inside-jail alias cwd → spawn cwd = realpath(inside)
lexical /etc still rejected
bun run --cwd plugins/plugin-pty test test/pty-session-store.test.ts test/pty-service.test.ts
# 40 pass, 0 fail
```

## Verification
- [x] Targets `develop`
- [x] Focused plugin-pty tests 40/40 at this head
- [x] `biome check` on the two files — clean
- [x] Not `#22262`. Not timeout-family. Not leftover-tax. Not 21’s E-list. Not a twin of `#22344` (coding-tools sandbox paths).

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — PTY cwd jail; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bc07b37cf2a2b3b890bbd97cdcf88bc7b5c9829e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
