### PR TITLE
fix(plugin-app-manager): do not execute SVG app heroes on the dashboard origin

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -407,4 +407,113 @@ describe("handleAppsRoutes", () => {
       await rm(packageDir, { recursive: true, force: true });
     }
   });
+
+  it("serves plugin SVG heroes as attachments so they cannot execute on the dashboard origin", async () => {
+    const packageDir = await mkdtemp(
+      path.join(os.tmpdir(), "app-manager-hero-svg-"),
+    );
+    try {
+      await mkdir(path.join(packageDir, "assets"));
+      await writeFile(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-demo",
+          elizaos: { app: { heroImage: "assets/hero.svg" } },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, "assets", "hero.svg"),
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>document.cookie</script></svg>',
+      );
+
+      const getPluginManager = () =>
+        ({
+          installPlugin: vi.fn(),
+          getInstalledPlugins: vi.fn(async () => []),
+          searchPlugins: vi.fn(async () => []),
+          refreshRegistry: vi.fn(
+            async () =>
+              new Map([
+                [
+                  "@elizaos/plugin-demo",
+                  {
+                    name: "@elizaos/plugin-demo",
+                    npm: { package: "@elizaos/plugin-demo" },
+                    localPath: packageDir,
+                    appMeta: { heroImage: "assets/hero.svg" },
+                  },
+                ],
+              ]),
+          ),
+        }) as never;
+
+      const result = await callRoute({
+        method: "GET",
+        pathname: "/api/apps/hero/demo",
+        appManager: createAppManager(),
+        getPluginManager,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.headers["Content-Type"]).toBe("image/svg+xml");
+      expect(result.res.headers["Content-Disposition"]).toBe("attachment");
+      expect(result.res.headers["X-Content-Type-Options"]).toBe("nosniff");
+      expect(String(result.res.body)).toContain("<script>");
+    } finally {
+      await rm(packageDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps raster hero images inline", async () => {
+    const packageDir = await mkdtemp(
+      path.join(os.tmpdir(), "app-manager-hero-png-"),
+    );
+    try {
+      await mkdir(path.join(packageDir, "assets"));
+      await writeFile(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-demo",
+          elizaos: { app: { heroImage: "assets/hero.png" } },
+        }),
+      );
+      await writeFile(path.join(packageDir, "assets", "hero.png"), "png");
+
+      const getPluginManager = () =>
+        ({
+          installPlugin: vi.fn(),
+          getInstalledPlugins: vi.fn(async () => []),
+          searchPlugins: vi.fn(async () => []),
+          refreshRegistry: vi.fn(
+            async () =>
+              new Map([
+                [
+                  "@elizaos/plugin-demo",
+                  {
+                    name: "@elizaos/plugin-demo",
+                    npm: { package: "@elizaos/plugin-demo" },
+                    localPath: packageDir,
+                    appMeta: { heroImage: "assets/hero.png" },
+                  },
+                ],
+              ]),
+          ),
+        }) as never;
+
+      const result = await callRoute({
+        method: "GET",
+        pathname: "/api/apps/hero/demo",
+        appManager: createAppManager(),
+        getPluginManager,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.headers["Content-Type"]).toBe("image/png");
+      expect(result.res.headers["Content-Disposition"]).toBeUndefined();
+    } finally {
+      await rm(packageDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -8,6 +8,9 @@
  * Consumed by @elizaos/agent's API server. The AppManager service, plugin
  * manager, favorites store, and runtime arrive through AppsRouteContext so
  * tests can substitute mocks (see apps-routes.test.ts).
+ *
+ * `/api/apps/hero/:slug` is reachable without an owner role. SVG heroes are
+ * XML and can carry script; they must not execute on the dashboard origin.
  */
 import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
@@ -186,6 +189,26 @@ interface LocalAppPackageJson {
   };
 }
 
+function heroResponseHeaders(
+  contentType: string,
+  byteLength: number,
+): Record<string, string | number> {
+  const headers: Record<string, string | number> = {
+    "Content-Type": contentType,
+    "Content-Length": byteLength,
+    "Cache-Control": "public, max-age=300",
+    "X-Content-Type-Options": "nosniff",
+  };
+  const mime = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  if (mime === "image/svg+xml") {
+    // Same stored-XSS rule as the content-addressed media store: SVG is an
+    // XML document. Navigating to /api/apps/hero/<slug> must download, not
+    // execute, plugin-supplied or generated markup on the dashboard origin.
+    headers["Content-Disposition"] = "attachment";
+  }
+  return headers;
+}
+
 async function streamAppHero(
   res: http.ServerResponse,
   absolutePath: string,
@@ -211,16 +234,13 @@ async function streamAppHero(
     setHeader?: (name: string, value: string | number) => void;
     end?: (chunk?: unknown) => void;
   };
+  const headers = heroResponseHeaders(contentType, data.byteLength);
   if (typeof response.writeHead === "function") {
-    response.writeHead(200, {
-      "Content-Type": contentType,
-      "Content-Length": data.byteLength,
-      "Cache-Control": "public, max-age=300",
-    });
+    response.writeHead(200, headers);
   } else if (typeof response.setHeader === "function") {
-    response.setHeader("Content-Type", contentType);
-    response.setHeader("Content-Length", data.byteLength);
-    response.setHeader("Cache-Control", "public, max-age=300");
+    for (const [name, value] of Object.entries(headers)) {
+      response.setHeader(name, value);
+    }
   }
   response.end?.(data);
 }
@@ -235,16 +255,13 @@ function sendGeneratedAppHero(res: http.ServerResponse, svg: string): void {
     setHeader?: (name: string, value: string | number) => void;
     end?: (chunk?: unknown) => void;
   };
+  const headers = heroResponseHeaders("image/svg+xml", data.byteLength);
   if (typeof response.writeHead === "function") {
-    response.writeHead(200, {
-      "Content-Type": "image/svg+xml",
-      "Content-Length": data.byteLength,
-      "Cache-Control": "public, max-age=300",
-    });
+    response.writeHead(200, headers);
   } else if (typeof response.setHeader === "function") {
-    response.setHeader("Content-Type", "image/svg+xml");
-    response.setHeader("Content-Length", data.byteLength);
-    response.setHeader("Cache-Control", "public, max-age=300");
+    for (const [name, value] of Object.entries(headers)) {
+      response.setHeader(name, value);
+    }
   }
   response.end?.(data);
 }


### PR DESCRIPTION
## Summary
- `GET /api/apps/hero/:slug` has no owner-role gate. Origin served plugin and generated SVG as `image/svg+xml` with no `Content-Disposition`.
- SVG is XML and can carry `<script>`. Navigating the hero URL on the dashboard origin would execute plugin-supplied markup. The content-addressed media store already treats SVG as attachment; this route did not.
- Force `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff` for `image/svg+xml`. Raster heroes stay inline.

## What Changed
- `plugins/plugin-app-manager/src/api/apps-routes.ts` — shared hero response headers.
- `plugins/plugin-app-manager/src/api/apps-routes.test.ts` — SVG attachment; PNG stays inline.

## Exact-head evidence
Head: `17cf9292d959f420ffed1dc7a2b9cc5e9f6a1cc2`
Base: `origin/develop@4bbee9861350`
Occupancy: `scannedAt=2026-08-19T05:42:18.633Z` — `plugin-app-manager` `apps-routes.ts` FREE.

## Red / green
On origin, `streamAppHero` / `sendGeneratedAppHero` wrote:

```text
Content-Type: image/svg+xml
Content-Length: …
Cache-Control: public, max-age=300
```

After this head:

```text
plugin SVG with <script> → 200, Content-Type image/svg+xml, Content-Disposition attachment, nosniff
raster PNG → 200, no Content-Disposition
bun run --cwd plugins/plugin-app-manager test src/api/apps-routes.test.ts
# 16 pass, 0 fail
```

## Verification
- [x] Targets `develop`
- [x] Focused apps-routes tests 16/16 at this head
- [x] `biome check` on the two files — clean
- [x] Not `#22262`. Not leftover-tax. Not 21’s E-list. Not a twin of `#22365` / `#22366`.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — hero response headers; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:17cf9292d959f420ffed1dc7a2b9cc5e9f6a1cc2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
