### PR TITLE
fix(plugin-computeruse): allow only http(s) browser navigation

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Deterministic coverage for the computer-use browser navigation scheme gate.
+ * No Puppeteer launch; the predicate is the system under test.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assertHttpBrowserUrl,
+  BLOCKED_BROWSER_URL_SCHEME_MESSAGE,
+  BlockedBrowserUrlError,
+} from "../security/browser-url-policy.js";
+
+describe("assertHttpBrowserUrl", () => {
+  it("admits http and https URLs", () => {
+    expect(assertHttpBrowserUrl("https://example.com/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(assertHttpBrowserUrl("http://127.0.0.1:31337/")).toBe(
+      "http://127.0.0.1:31337/",
+    );
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "about:blank",
+    "not a url",
+  ])("rejects %s", (raw) => {
+    expect(() => assertHttpBrowserUrl(raw)).toThrow(BlockedBrowserUrlError);
+    expect(() => assertHttpBrowserUrl(raw)).toThrow(
+      BLOCKED_BROWSER_URL_SCHEME_MESSAGE,
+    );
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/browser.ts
+++ b/plugins/plugin-computeruse/src/platform/browser.ts
@@ -6,6 +6,8 @@
  * Uses puppeteer-core (not full puppeteer) to avoid bundling Chromium.
  * Auto-detects installed Chrome, Edge, or Brave at launch.
  * Each session uses a temp user data directory to prevent conflicts.
+ * Navigation is HTTP(S)-only so `file:` / `javascript:` cannot bypass the
+ * FILE-action path blocklist through the screenshot surface.
  */
 
 import { execFileSync } from "node:child_process";
@@ -15,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
 import { assertBrowserExecuteAllowed } from "../security/browser-script-policy.js";
+import { assertHttpBrowserUrl } from "../security/browser-url-policy.js";
 import type {
   BrowserInfo,
   BrowserState,
@@ -170,6 +173,7 @@ async function ensureBrowser(): Promise<Page> {
 }
 
 export async function openBrowser(url?: string): Promise<BrowserState> {
+  const target = url ? assertHttpBrowserUrl(url) : undefined;
   const pup = await getPuppeteer();
   const executablePath = detectBrowserPath();
   if (!executablePath) {
@@ -223,8 +227,8 @@ export async function openBrowser(url?: string): Promise<BrowserState> {
       const pages = await browser.pages();
       activePage = pages[0] ?? (await browser.newPage());
 
-      if (url) {
-        await activePage.goto(url, {
+      if (target) {
+        await activePage.goto(target, {
           waitUntil: "domcontentloaded",
           timeout: 30000,
         });
@@ -285,8 +289,12 @@ export async function closeBrowser(): Promise<void> {
 // ── Navigation ──────────────────────────────────────────────────────────────
 
 export async function navigateBrowser(url: string): Promise<BrowserState> {
+  const target = assertHttpBrowserUrl(url);
   const page = await ensureBrowser();
-  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.goto(target, {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
   return {
     url: page.url(),
     title: await page.title(),
@@ -532,11 +540,15 @@ export async function listBrowserTabs(): Promise<BrowserTab[]> {
 }
 
 export async function openBrowserTab(url?: string): Promise<BrowserTab> {
+  const target = url ? assertHttpBrowserUrl(url) : undefined;
   if (!browser) throw new Error("Browser not open.");
   const page = await browser.newPage();
   activePage = page;
-  if (url) {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  if (target) {
+    await page.goto(target, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
   }
   const pages = await browser.pages();
   return {

--- a/plugins/plugin-computeruse/src/security/browser-url-policy.ts
+++ b/plugins/plugin-computeruse/src/security/browser-url-policy.ts
@@ -1,0 +1,32 @@
+/**
+ * HTTP(S)-only navigation policy for computer-use Puppeteer. FILE actions
+ * already refuse credential and OS-private paths; `page.goto` did not, so a
+ * `file:` or `javascript:` target bypassed that gate and loaded local bytes
+ * into the screenshot surface.
+ */
+
+export const BLOCKED_BROWSER_URL_SCHEME_MESSAGE =
+  "Computer-use browser navigation allows only http and https URLs.";
+
+export class BlockedBrowserUrlError extends Error {
+  readonly code = "blocked_browser_url" as const;
+
+  constructor(message = BLOCKED_BROWSER_URL_SCHEME_MESSAGE) {
+    super(message);
+    this.name = "BlockedBrowserUrlError";
+  }
+}
+
+export function assertHttpBrowserUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // error-policy:J3 untrusted navigation target; unparseable URL is denied.
+    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+  }
+  return parsed.href;
+}


### PR DESCRIPTION
## Summary
- Computer-use FILE actions already refuse credential and OS-private paths. `page.goto` did not.
- On origin, `navigateBrowser` / `openBrowser` / `openBrowserTab` forwarded any scheme to Puppeteer. A `file:` or `javascript:` target loads local bytes (or script) into the screenshot surface and bypasses the FILE gate.
- Reject non-http(s) URLs before launch, navigate, and new-tab.

## What Changed
- `plugins/plugin-computeruse/src/security/browser-url-policy.ts` — `assertHttpBrowserUrl`.
- `plugins/plugin-computeruse/src/platform/browser.ts` — all three `goto` sites.
- `plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts` — http(s) admit; file/javascript/data/about/junk deny.

## Exact-head evidence
Head: `719e6f033f0453aab41c99b1f8ab8ff5e4ec1d69`
Base: `origin/develop@9f58f10f994f`
Occupancy: `scannedAt=2026-08-19T05:52:23.030Z` — `plugin-computeruse` `browser.ts` FREE.

## Red / green
On origin, `browser.ts` has three `page.goto(url)` calls and no scheme check (`file:` does not appear in the file).

After this head:

```text
https://example.com/path → admitted
file: / javascript: / data: / about:blank / junk → BlockedBrowserUrlError
bun test browser-url-policy + browser-script-policy + service-browser-routing
# 10 pass, 0 fail
```

## Verification
- [x] Targets `develop`
- [x] Focused tests 10/10 at this head
- [x] `biome check` on the three files — clean
- [x] Not `#22262`. Not 21’s E-list. Not a twin of `#22365` file-ops. Not leftover-tax.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — navigation scheme policy; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:719e6f033f0453aab41c99b1f8ab8ff5e4ec1d69 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
