### PR TITLE
fix(plugin-app-manager): prevent SVG hero script navigation

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -407,4 +407,113 @@ describe("handleAppsRoutes", () => {
       await rm(packageDir, { recursive: true, force: true });
     }
   });
+
+  it("serves plugin SVG heroes as attachments so they cannot execute on the dashboard origin", async () => {
+    const packageDir = await mkdtemp(
+      path.join(os.tmpdir(), "app-manager-hero-svg-"),
+    );
+    try {
+      await mkdir(path.join(packageDir, "assets"));
+      await writeFile(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-demo",
+          elizaos: { app: { heroImage: "assets/hero.svg" } },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, "assets", "hero.svg"),
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>document.cookie</script></svg>',
+      );
+
+      const getPluginManager = () =>
+        ({
+          installPlugin: vi.fn(),
+          getInstalledPlugins: vi.fn(async () => []),
+          searchPlugins: vi.fn(async () => []),
+          refreshRegistry: vi.fn(
+            async () =>
+              new Map([
+                [
+                  "@elizaos/plugin-demo",
+                  {
+                    name: "@elizaos/plugin-demo",
+                    npm: { package: "@elizaos/plugin-demo" },
+                    localPath: packageDir,
+                    appMeta: { heroImage: "assets/hero.svg" },
+                  },
+                ],
+              ]),
+          ),
+        }) as never;
+
+      const result = await callRoute({
+        method: "GET",
+        pathname: "/api/apps/hero/demo",
+        appManager: createAppManager(),
+        getPluginManager,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.headers["Content-Type"]).toBe("image/svg+xml");
+      expect(result.res.headers["Content-Disposition"]).toBe("attachment");
+      expect(result.res.headers["X-Content-Type-Options"]).toBe("nosniff");
+      expect(String(result.res.body)).toContain("<script>");
+    } finally {
+      await rm(packageDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps raster hero images inline", async () => {
+    const packageDir = await mkdtemp(
+      path.join(os.tmpdir(), "app-manager-hero-png-"),
+    );
+    try {
+      await mkdir(path.join(packageDir, "assets"));
+      await writeFile(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-demo",
+          elizaos: { app: { heroImage: "assets/hero.png" } },
+        }),
+      );
+      await writeFile(path.join(packageDir, "assets", "hero.png"), "png");
+
+      const getPluginManager = () =>
+        ({
+          installPlugin: vi.fn(),
+          getInstalledPlugins: vi.fn(async () => []),
+          searchPlugins: vi.fn(async () => []),
+          refreshRegistry: vi.fn(
+            async () =>
+              new Map([
+                [
+                  "@elizaos/plugin-demo",
+                  {
+                    name: "@elizaos/plugin-demo",
+                    npm: { package: "@elizaos/plugin-demo" },
+                    localPath: packageDir,
+                    appMeta: { heroImage: "assets/hero.png" },
+                  },
+                ],
+              ]),
+          ),
+        }) as never;
+
+      const result = await callRoute({
+        method: "GET",
+        pathname: "/api/apps/hero/demo",
+        appManager: createAppManager(),
+        getPluginManager,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.headers["Content-Type"]).toBe("image/png");
+      expect(result.res.headers["Content-Disposition"]).toBeUndefined();
+    } finally {
+      await rm(packageDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -8,6 +8,9 @@
  * Consumed by @elizaos/agent's API server. The AppManager service, plugin
  * manager, favorites store, and runtime arrive through AppsRouteContext so
  * tests can substitute mocks (see apps-routes.test.ts).
+ *
+ * `/api/apps/hero/:slug` is reachable without an owner role. SVG heroes are
+ * XML and can carry script; they must not execute on the dashboard origin.
  */
 import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
@@ -186,6 +189,26 @@ interface LocalAppPackageJson {
   };
 }
 
+function heroResponseHeaders(
+  contentType: string,
+  byteLength: number,
+): Record<string, string | number> {
+  const headers: Record<string, string | number> = {
+    "Content-Type": contentType,
+    "Content-Length": byteLength,
+    "Cache-Control": "public, max-age=300",
+    "X-Content-Type-Options": "nosniff",
+  };
+  const mime = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  if (mime === "image/svg+xml") {
+    // Same stored-XSS rule as the content-addressed media store: SVG is an
+    // XML document. Navigating to /api/apps/hero/<slug> must download, not
+    // execute, plugin-supplied or generated markup on the dashboard origin.
+    headers["Content-Disposition"] = "attachment";
+  }
+  return headers;
+}
+
 async function streamAppHero(
   res: http.ServerResponse,
   absolutePath: string,
@@ -211,16 +234,13 @@ async function streamAppHero(
     setHeader?: (name: string, value: string | number) => void;
     end?: (chunk?: unknown) => void;
   };
+  const headers = heroResponseHeaders(contentType, data.byteLength);
   if (typeof response.writeHead === "function") {
-    response.writeHead(200, {
-      "Content-Type": contentType,
-      "Content-Length": data.byteLength,
-      "Cache-Control": "public, max-age=300",
-    });
+    response.writeHead(200, headers);
   } else if (typeof response.setHeader === "function") {
-    response.setHeader("Content-Type", contentType);
-    response.setHeader("Content-Length", data.byteLength);
-    response.setHeader("Cache-Control", "public, max-age=300");
+    for (const [name, value] of Object.entries(headers)) {
+      response.setHeader(name, value);
+    }
   }
   response.end?.(data);
 }
@@ -235,16 +255,13 @@ function sendGeneratedAppHero(res: http.ServerResponse, svg: string): void {
     setHeader?: (name: string, value: string | number) => void;
     end?: (chunk?: unknown) => void;
   };
+  const headers = heroResponseHeaders("image/svg+xml", data.byteLength);
   if (typeof response.writeHead === "function") {
-    response.writeHead(200, {
-      "Content-Type": "image/svg+xml",
-      "Content-Length": data.byteLength,
-      "Cache-Control": "public, max-age=300",
-    });
+    response.writeHead(200, headers);
   } else if (typeof response.setHeader === "function") {
-    response.setHeader("Content-Type", "image/svg+xml");
-    response.setHeader("Content-Length", data.byteLength);
-    response.setHeader("Cache-Control", "public, max-age=300");
+    for (const [name, value] of Object.entries(headers)) {
+      response.setHeader(name, value);
+    }
   }
   response.end?.(data);
 }


### PR DESCRIPTION
# Relates to

Relates to #22364.

Supersedes #22367 while preserving ss251's original commit authorship. The
source code was independently found correct; this replacement rebases it onto
current `develop`, records complete validation, and supplies the explicit
evidence rows required by repository policy.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Preserves the original contributor as commit author.
- [x] Package tests, typecheck, lint, build, frozen install, and root verify pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `eee99bd98ab6514b4928c9bda03e104bbdef91c9`.
- [x] Zero conflicts and clean diff.
- [x] Post-sync package gates and root verification pass.

# Risks

Low. SVG app heroes now download on top-level navigation while remaining usable
as image resources. Raster heroes retain their existing inline behavior. This
changes only response headers on the unauthenticated hero route.

# Background

## What does this PR do?

`GET /api/apps/hero/:slug` serves plugin-provided content from the dashboard
origin without an owner-role gate. SVG can contain script, so direct navigation
to a hero URL previously allowed plugin markup to execute in that origin. The
shared response-header helper now adds `Content-Disposition: attachment` for a
normalized `image/svg+xml` type and `X-Content-Type-Options: nosniff` for all
heroes. PNG and other raster images remain inline.

## What kind of change is this?

Security bug fix; no public API change.

# Documentation changes needed?

No. This aligns app heroes with the existing content-addressed media treatment
of SVG and does not change a documented user workflow.

# Testing

## Where should a reviewer start?

- `plugins/plugin-app-manager/src/api/apps-routes.ts`
- `plugins/plugin-app-manager/src/api/apps-routes.test.ts`

## Detailed testing steps

On exact head `b7de23d6f163ba46913fbb31efde0b7c10045d85`:

```text
bun run --cwd plugins/plugin-app-manager test         PASS, 37/37
bun run --cwd plugins/plugin-app-manager typecheck    PASS
bun run --cwd plugins/plugin-app-manager lint:check   PASS
bun run --cwd plugins/plugin-app-manager build        PASS
git diff --check                                      PASS
bun install --frozen-lockfile                         PASS, no lock changes
bun run verify                                        PASS
```

An adversarial Chromium smoke loaded the SVG as an `<img>` (20x20 image load)
while direct navigation produced a download and did not execute embedded script.

# Evidence Gate

<!-- evidence-head:b7de23d6f163ba46913fbb31efde0b7c10045d85 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - response headers only; no rendered product UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - response headers only; no rendered product UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - route security headers have no intended visual delta.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic route tests and Chromium navigation evidence exercise the boundary without a deployed backend.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed; direct-navigation behavior was inspected in Chromium.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - header enforcement produces no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Known gaps / failures

None at the exact head. The source PR's code was correct; its stale base and
malformed combined evidence row are corrected by this replacement.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza"} -->
