### PR TITLE
fix(plugin-computeruse): harden browser navigation URLs

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/browser-auto-open.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-auto-open.test.ts
@@ -120,7 +120,7 @@ describe("ComputerUseService browser auto-open recovery", () => {
       url: "https://example.com",
     });
     expect(browser.openBrowser).toHaveBeenCalledTimes(1);
-    expect(browser.openBrowser).toHaveBeenCalledWith("https://example.com");
+    expect(browser.openBrowser).toHaveBeenCalledWith("https://example.com/");
     expect(browser.navigateBrowser).toHaveBeenCalledTimes(2);
   });
 

--- a/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Deterministic coverage for the computer-use browser navigation scheme gate.
+ * No Puppeteer launch; the predicate is the system under test.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assertHttpBrowserUrl,
+  BLOCKED_BROWSER_URL_SCHEME_MESSAGE,
+  BlockedBrowserUrlError,
+} from "../security/browser-url-policy.js";
+
+describe("assertHttpBrowserUrl", () => {
+  it("admits http and https URLs", () => {
+    expect(assertHttpBrowserUrl("https://example.com/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(assertHttpBrowserUrl("http://127.0.0.1:31337/")).toBe(
+      "http://127.0.0.1:31337/",
+    );
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "about:blank",
+    "not a url",
+  ])("rejects %s", (raw) => {
+    expect(() => assertHttpBrowserUrl(raw)).toThrow(BlockedBrowserUrlError);
+    expect(() => assertHttpBrowserUrl(raw)).toThrow(
+      BLOCKED_BROWSER_URL_SCHEME_MESSAGE,
+    );
+  });
+});

--- a/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-url-policy.test.ts
@@ -2,6 +2,7 @@
  * Deterministic coverage for the computer-use browser navigation scheme gate.
  * No Puppeteer launch; the predicate is the system under test.
  */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   assertHttpBrowserUrl,
@@ -17,6 +18,9 @@ describe("assertHttpBrowserUrl", () => {
     expect(assertHttpBrowserUrl("http://127.0.0.1:31337/")).toBe(
       "http://127.0.0.1:31337/",
     );
+    expect(assertHttpBrowserUrl("HTTPS://EXAMPLE.COM")).toBe(
+      "https://example.com/",
+    );
   });
 
   it.each([
@@ -24,11 +28,29 @@ describe("assertHttpBrowserUrl", () => {
     "javascript:alert(1)",
     "data:text/html,<script>alert(1)</script>",
     "about:blank",
+    "https://user@example.com/private",
+    "https://user:password@example.com/private",
     "not a url",
   ])("rejects %s", (raw) => {
     expect(() => assertHttpBrowserUrl(raw)).toThrow(BlockedBrowserUrlError);
     expect(() => assertHttpBrowserUrl(raw)).toThrow(
       BLOCKED_BROWSER_URL_SCHEME_MESSAGE,
     );
+  });
+
+  it("uses the repository's typed domain error contract", () => {
+    let thrown: unknown;
+    try {
+      assertHttpBrowserUrl("not a url");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      name: "BlockedBrowserUrlError",
+      code: "COMPUTER_USE_BROWSER_URL_BLOCKED",
+    });
+    expect((thrown as Error).cause).toBeInstanceOf(TypeError);
   });
 });

--- a/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
@@ -10,6 +10,7 @@ import os from "node:os";
 import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as browser from "../platform/browser.js";
 
 vi.mock("../platform/browser.js", () => {
   const state = (url = "about:blank") => ({
@@ -129,6 +130,33 @@ describe("ComputerUseService browser command dispatch", () => {
     >[0]);
     expect(result.success).toBe(false);
   });
+
+  it.each(["file:///etc/passwd", "https://user:password@example.com/private"])(
+    "rejects and redacts an unsafe navigation target before dispatch: %s",
+    async (url) => {
+      vi.mocked(browser.navigateBrowser).mockClear();
+
+      const result = await service.executeBrowserAction({
+        action: "navigate",
+        url,
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        error:
+          "Computer-use browser navigation requires an absolute http(s) URL without embedded credentials.",
+      });
+      expect(browser.navigateBrowser).not.toHaveBeenCalled();
+      expect(service.getRecentActions().at(-1)).toMatchObject({
+        action: "browser_navigate",
+        params: { action: "navigate" },
+        success: false,
+      });
+      expect(service.getRecentActions().at(-1)?.params).not.toHaveProperty(
+        "url",
+      );
+    },
+  );
 
   it("routes browser command strings through executeCommand", async () => {
     for (const command of [

--- a/plugins/plugin-computeruse/src/platform/browser.ts
+++ b/plugins/plugin-computeruse/src/platform/browser.ts
@@ -6,6 +6,8 @@
  * Uses puppeteer-core (not full puppeteer) to avoid bundling Chromium.
  * Auto-detects installed Chrome, Edge, or Brave at launch.
  * Each session uses a temp user data directory to prevent conflicts.
+ * Navigation is HTTP(S)-only so `file:` / `javascript:` cannot bypass the
+ * FILE-action path blocklist through the screenshot surface.
  */
 
 import { execFileSync } from "node:child_process";
@@ -15,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
 import { assertBrowserExecuteAllowed } from "../security/browser-script-policy.js";
+import { assertHttpBrowserUrl } from "../security/browser-url-policy.js";
 import type {
   BrowserInfo,
   BrowserState,
@@ -170,6 +173,7 @@ async function ensureBrowser(): Promise<Page> {
 }
 
 export async function openBrowser(url?: string): Promise<BrowserState> {
+  const target = url ? assertHttpBrowserUrl(url) : undefined;
   const pup = await getPuppeteer();
   const executablePath = detectBrowserPath();
   if (!executablePath) {
@@ -223,8 +227,8 @@ export async function openBrowser(url?: string): Promise<BrowserState> {
       const pages = await browser.pages();
       activePage = pages[0] ?? (await browser.newPage());
 
-      if (url) {
-        await activePage.goto(url, {
+      if (target) {
+        await activePage.goto(target, {
           waitUntil: "domcontentloaded",
           timeout: 30000,
         });
@@ -285,8 +289,12 @@ export async function closeBrowser(): Promise<void> {
 // ── Navigation ──────────────────────────────────────────────────────────────
 
 export async function navigateBrowser(url: string): Promise<BrowserState> {
+  const target = assertHttpBrowserUrl(url);
   const page = await ensureBrowser();
-  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.goto(target, {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
   return {
     url: page.url(),
     title: await page.title(),
@@ -532,11 +540,15 @@ export async function listBrowserTabs(): Promise<BrowserTab[]> {
 }
 
 export async function openBrowserTab(url?: string): Promise<BrowserTab> {
+  const target = url ? assertHttpBrowserUrl(url) : undefined;
   if (!browser) throw new Error("Browser not open.");
   const page = await browser.newPage();
   activePage = page;
-  if (url) {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  if (target) {
+    await page.goto(target, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
   }
   const pages = await browser.pages();
   return {

--- a/plugins/plugin-computeruse/src/security/browser-url-policy.ts
+++ b/plugins/plugin-computeruse/src/security/browser-url-policy.ts
@@ -5,15 +5,22 @@
  * into the screenshot surface.
  */
 
+import { ElizaError } from "@elizaos/core";
+
 export const BLOCKED_BROWSER_URL_SCHEME_MESSAGE =
-  "Computer-use browser navigation allows only http and https URLs.";
+  "Computer-use browser navigation requires an absolute http(s) URL without embedded credentials.";
 
-export class BlockedBrowserUrlError extends Error {
-  readonly code = "blocked_browser_url" as const;
+export class BlockedBrowserUrlError extends ElizaError {
+  override readonly name = "BlockedBrowserUrlError";
 
-  constructor(message = BLOCKED_BROWSER_URL_SCHEME_MESSAGE) {
-    super(message);
-    this.name = "BlockedBrowserUrlError";
+  constructor(options?: { cause?: unknown; protocol?: string }) {
+    super(BLOCKED_BROWSER_URL_SCHEME_MESSAGE, {
+      code: "COMPUTER_USE_BROWSER_URL_BLOCKED",
+      ...(options?.cause === undefined ? {} : { cause: options.cause }),
+      ...(options?.protocol === undefined
+        ? {}
+        : { context: { protocol: options.protocol } }),
+    });
   }
 }
 
@@ -21,12 +28,15 @@ export function assertHttpBrowserUrl(raw: string): string {
   let parsed: URL;
   try {
     parsed = new URL(raw);
-  } catch {
+  } catch (cause) {
     // error-policy:J3 untrusted navigation target; unparseable URL is denied.
-    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+    throw new BlockedBrowserUrlError({ cause });
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+    throw new BlockedBrowserUrlError({ protocol: parsed.protocol });
+  }
+  if (parsed.username || parsed.password) {
+    throw new BlockedBrowserUrlError({ protocol: parsed.protocol });
   }
   return parsed.href;
 }

--- a/plugins/plugin-computeruse/src/security/browser-url-policy.ts
+++ b/plugins/plugin-computeruse/src/security/browser-url-policy.ts
@@ -1,0 +1,32 @@
+/**
+ * HTTP(S)-only navigation policy for computer-use Puppeteer. FILE actions
+ * already refuse credential and OS-private paths; `page.goto` did not, so a
+ * `file:` or `javascript:` target bypassed that gate and loaded local bytes
+ * into the screenshot surface.
+ */
+
+export const BLOCKED_BROWSER_URL_SCHEME_MESSAGE =
+  "Computer-use browser navigation allows only http and https URLs.";
+
+export class BlockedBrowserUrlError extends Error {
+  readonly code = "blocked_browser_url" as const;
+
+  constructor(message = BLOCKED_BROWSER_URL_SCHEME_MESSAGE) {
+    super(message);
+    this.name = "BlockedBrowserUrlError";
+  }
+}
+
+export function assertHttpBrowserUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // error-policy:J3 untrusted navigation target; unparseable URL is denied.
+    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new BlockedBrowserUrlError(BLOCKED_BROWSER_URL_SCHEME_MESSAGE);
+  }
+  return parsed.href;
+}

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -123,6 +123,7 @@ import {
   type ScreenStateChange,
   ScreenStateStore,
 } from "../scene/screen-state.js";
+import { assertHttpBrowserUrl } from "../security/browser-url-policy.js";
 import type {
   ActionHistoryEntry,
   ApprovalMode,
@@ -864,7 +865,19 @@ export class ComputerUseService extends Service {
   async executeBrowserAction(
     rawParams: BrowserActionParams,
   ): Promise<BrowserActionResult> {
-    const params = this.normalizeBrowserActionParams(rawParams);
+    const action = this.normalizeBrowserAction(rawParams.action);
+    let params: BrowserActionParams;
+    try {
+      params = this.normalizeBrowserActionParams(rawParams);
+    } catch (error) {
+      // error-policy:J1 action boundary — reject an invalid navigation target
+      // before its raw value reaches action history or the approval queue.
+      const rejectedEntry = this.createEntry(`browser_${action}`, { action });
+      return this.failEntry(rejectedEntry, {
+        success: false,
+        error: errorMessage(error),
+      });
+    }
     const entry = this.createEntry(
       `browser_${params.action}`,
       this.toParamsRecord(params),
@@ -1594,6 +1607,9 @@ export class ComputerUseService extends Service {
     const tabIdCandidate = params.tabId ?? params.index ?? params.tab_index;
     return {
       ...params,
+      ...(params.url === undefined
+        ? {}
+        : { url: assertHttpBrowserUrl(params.url) }),
       tabId: tabIdCandidate !== undefined ? String(tabIdCandidate) : undefined,
       action: this.normalizeBrowserAction(params.action),
     };

--- a/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.ts
@@ -54,6 +54,6 @@ export class SnapshotStorage {
           ORDER BY idx ASC`
     );
 
-    return result.rows.map((row) => row.snapshot as SchemaSnapshot);
+    return result.rows.map((row: Record<string, unknown>) => row.snapshot as SchemaSnapshot);
   }
 }


### PR DESCRIPTION
# Relates to

Relates to #22364.

Supersedes #22370 while preserving ss251's original implementation commit and
authorship. The source identifies a real direct-navigation scheme bypass, but
its exact head is not safe to merge: it accepts embedded HTTP credentials,
uses a plain `Error`, and validates only inside the platform after raw URL
parameters have already entered action history and the approval request.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `e6f34f220ff60f410c2fcb403095cff7da153ac1`.
- [x] Zero conflicts and clean diff.
- [x] Post-sync package gates and root verification pass.

# Risks

Low to medium. Computer-use browser navigation is now limited to canonical
HTTP(S) URLs without embedded credentials. Existing legitimate web navigation
continues unchanged. Non-web schemes and credential-bearing URLs fail before
approval, history persistence, browser creation, or navigation.

# Background

## What does this PR do?

- Rejects `file:`, `javascript:`, `data:`, `about:`, malformed URLs, and HTTP(S)
  userinfo at the computer-use service boundary.
- Canonicalizes safe URLs before approval and history persistence.
- Records rejected actions with a structured error but never the unsafe raw URL.
- Uses a typed `ElizaError` with stable code, context, and preserved parse cause.
- Keeps the platform check as defense in depth at all three `page.goto` sites.
- Covers approval ordering, history redaction, routing, canonicalization, and
  browser auto-open behavior through the real service boundary.

## What kind of change is this?

Security bug fix; no intended public API change.

# Documentation changes needed?

No. Computer-use browser actions remain web-navigation actions; this closes a
path that bypassed the separately protected file surface.

# Testing

## Where should a reviewer start?

- `plugins/plugin-computeruse/src/security/browser-url-policy.ts`
- `plugins/plugin-computeruse/src/services/computer-use-service.ts`
- `plugins/plugin-computeruse/src/platform/browser.ts`

## Detailed testing steps

On exact head `2cb594cde1413a54d01b641f1fe6726c484a9111`:

```text
focused browser policy/script/routing/auto-open tests    PASS, 19/19
bun run --cwd plugins/plugin-computeruse typecheck       PASS
bun run --cwd plugins/plugin-computeruse lint:check      PASS, 215 files
bun run --cwd plugins/plugin-computeruse build           PASS
bun run --cwd plugins/plugin-sql typecheck               PASS
bun run --cwd packages/cloud/shared typecheck            PASS, fresh cache
git diff --check                                         PASS
bun install --frozen-lockfile                            PASS, no lock changes
bun run verify                                           PASS
```

The broader plugin baseline completed 785 passes and 17 skips; three unrelated
existing harness suites remain red because two import `bun:test` under Vitest
and one existing partial core mock omits `formatError`. None touches the changed
browser boundary. The focused real-service suites and repository gate are green.

# Evidence Gate

<!-- evidence-head:2cb594cde1413a54d01b641f1fe6726c484a9111 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend browser policy only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend browser policy only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - rejection ordering and persistence are deterministic service behavior.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - real service-boundary tests assert approval, history, and launch ordering without a deployed service.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or route changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, planner, or model-selection behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - rejected navigation produces no persistent domain artifact and intentionally omits the raw URL from history.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Known gaps / failures

The three unrelated baseline harness failures are described under Testing. No
changed-path, package gate, or repository verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza"} -->
