### PR TITLE
fix(plugin-computeruse): do not open Windows targets through cmd start

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/launch-kill-invocation.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/launch-kill-invocation.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins kill_app to exact pid/name argv. Origin used `pkill -f` (regex over
+ * the full command line) and Windows `/IM` with unfiltered names. Deterministic.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveKillInvocation } from "../platform/launch.js";
+
+describe("resolveKillInvocation", () => {
+  it("kills a positive pid without a process-group signal", () => {
+    expect(resolveKillInvocation("4242", "linux")).toEqual({
+      command: "kill",
+      args: ["-9", "4242"],
+      isPid: true,
+      value: "4242",
+    });
+    expect(resolveKillInvocation("4242", "win32")).toEqual({
+      command: "taskkill",
+      args: ["/F", "/PID", "4242"],
+      isPid: true,
+      value: "4242",
+    });
+  });
+
+  it("refuses pid 0", () => {
+    expect(() => resolveKillInvocation("0", "linux")).toThrow(/pid 0/i);
+    expect(() => resolveKillInvocation("0", "win32")).toThrow(/pid 0/i);
+  });
+
+  it("uses exact-name pkill, not -f regex", () => {
+    const unix = resolveKillInvocation("Safari", "darwin");
+    expect(unix).toEqual({
+      command: "pkill",
+      args: ["-x", "Safari"],
+      isPid: false,
+      value: "Safari",
+    });
+    expect(unix.args).not.toContain("-f");
+  });
+
+  it("rejects regex and wildcard process names", () => {
+    for (const name of [".", ".*", "*", "eliza|node", "foo bar", "../x"]) {
+      expect(() => resolveKillInvocation(name, "linux")).toThrow(
+        /exact executable name/,
+      );
+      expect(() => resolveKillInvocation(name, "win32")).toThrow(
+        /exact executable name/,
+      );
+    }
+  });
+
+  it("Windows IM is a single .exe name with no wildcard", () => {
+    expect(resolveKillInvocation("notepad", "win32")).toEqual({
+      command: "taskkill",
+      args: ["/F", "/IM", "notepad.exe"],
+      isPid: false,
+      value: "notepad",
+    });
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/launch.ts
+++ b/plugins/plugin-computeruse/src/platform/launch.ts
@@ -219,45 +219,62 @@ export interface KillResult {
  * routes through the approval manager like every other non-read verb. Uses
  * `execFile` (no shell) so the target can't inject a command.
  *
- *   - Windows: `taskkill /F /PID <n>` or `/F /IM <name>.exe`.
- *   - macOS / Linux: `kill -9 <pid>` or `pkill -f <name>`.
+ *   - Windows: `taskkill /F /PID <n>` or `/F /IM <exact>.exe`.
+ *   - macOS / Linux: `kill -9 <pid>` or `pkill -x <exact name>`.
+ *     Never `pkill -f`: that treats the target as a regex over the full
+ *     command line, so `.` or `eliza` would match this process and others.
  *
  * Rejects when the target does not exist (non-zero exit) so the caller gets
  * clear feedback rather than a silent no-op.
  */
-export function killApp(target: string): Promise<KillResult> {
+
+const SAFE_PROCESS_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\.exe)?$/i;
+
+export function resolveKillInvocation(
+  target: string,
+  os: NodeJS.Platform,
+): { command: string; args: string[]; isPid: boolean; value: string } {
   const value = String(target ?? "").trim();
   if (!value) {
-    return Promise.reject(
-      new Error("kill_app requires a non-empty target (pid or app name)"),
-    );
+    throw new Error("kill_app requires a non-empty target (pid or app name)");
   }
   const isPid = /^\d+$/.test(value);
-  const os = currentPlatform();
-  let command: string;
-  let args: string[];
-  if (os === "win32") {
-    command = "taskkill";
-    args = isPid
-      ? ["/F", "/PID", value]
-      : [
-          "/F",
-          "/IM",
-          value.toLowerCase().endsWith(".exe") ? value : `${value}.exe`,
-        ];
-  } else if (os === "darwin" || os === "linux") {
-    if (isPid) {
-      command = "kill";
-      args = ["-9", value];
-    } else {
-      command = "pkill";
-      args = ["-f", value];
+  if (isPid) {
+    // `kill -9 0` signals the whole process group. Require a real pid.
+    if (value === "0") {
+      throw new Error("kill_app refuses pid 0 (process-group signal)");
     }
-  } else {
-    return Promise.reject(
-      new Error(`kill_app unsupported on platform "${os}"`),
+    if (os === "win32") {
+      return { command: "taskkill", args: ["/F", "/PID", value], isPid, value };
+    }
+    if (os === "darwin" || os === "linux") {
+      return { command: "kill", args: ["-9", value], isPid, value };
+    }
+    throw new Error(`kill_app unsupported on platform "${os}"`);
+  }
+  if (!SAFE_PROCESS_NAME.test(value)) {
+    throw new Error(
+      "kill_app process name must be a single exact executable name",
     );
   }
+  if (os === "win32") {
+    const image = value.toLowerCase().endsWith(".exe") ? value : `${value}.exe`;
+    return { command: "taskkill", args: ["/F", "/IM", image], isPid, value };
+  }
+  if (os === "darwin" || os === "linux") {
+    return { command: "pkill", args: ["-x", value], isPid, value };
+  }
+  throw new Error(`kill_app unsupported on platform "${os}"`);
+}
+
+export function killApp(target: string): Promise<KillResult> {
+  let invocation: ReturnType<typeof resolveKillInvocation>;
+  try {
+    invocation = resolveKillInvocation(target, currentPlatform());
+  } catch (err) {
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+  const { command, args, isPid, value } = invocation;
   return new Promise<KillResult>((resolve, reject) => {
     execFile(command, args, { timeout: OPEN_TIMEOUT_MS }, (err) => {
       if (err) {


### PR DESCRIPTION
## Summary
- `#22379` (lalalune) landed the Windows `open` / `cmd /c start` unit. This PR no longer reprints that.
- Remaining unit: `kill_app` on origin still uses `pkill -f <target>` (regex over the full command line) and Windows `taskkill /IM` with unfiltered names. Pid `0` is a process-group signal.
- Require a real pid or one exact executable name (`pkill -x` / `taskkill /IM name.exe`).

## What Changed
- `plugins/plugin-computeruse/src/platform/launch.ts` — `resolveKillInvocation` only. Shaw's `openTarget` / ShellExecute path is untouched.
- `plugins/plugin-computeruse/src/__tests__/launch-kill-invocation.test.ts`

## Exact-head evidence
Head: `db68157027b0d7ab81493d9beb26f48a6ebf01ce`
Base: `origin/develop@c3ae523db997` (`#22379`)
Occupancy: `launch.ts` after `#22379` — this PR adds only the kill argv.

## Red / green
On origin after `#22379`:

```text
unix kill_app: pkill -f .
win32 kill_app: taskkill /F /IM *.exe
kill pid 0: kill -9 0
```

After this head:

```text
kill pid 0 → rejected
kill "." / "*" / "eliza|node" → rejected
kill Safari → pkill -x Safari
kill notepad → taskkill /F /IM notepad.exe
bun test launch-kill-invocation + launch-open-invocation
# 11 passed (Shaw open 6 + kill 5)
```

## Verification
- [x] Targets `develop`
- [x] Focused tests 11/11 at this head
- [x] `biome check` on the two files — clean
- [x] Not `#22262`. Not leftover-tax. Not 21’s E-list. Not a twin of `#22379` open.

## N/A evidence
- Before/after screenshots, walkthrough video, frontend/backend logs, live-model trajectory: N/A — kill_app name policy; no product UI pixel change.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:db68157027b0d7ab81493d9beb26f48a6ebf01ce -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
