### PR TITLE
fix(plugin-computeruse): open Windows targets without shell parsing

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/launch-open-invocation.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/launch-open-invocation.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Pins Windows COMPUTER_USE open to a constant ShellExecute script so neither
+ * cmd nor PowerShell parses the target. Deterministic — no handler is spawned.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileMock, currentPlatformMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  currentPlatformMock: vi.fn<NodeJS.Platform>(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFile: execFileMock,
+}));
+
+vi.mock("../platform/helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../platform/helpers.js")>()),
+  currentPlatform: currentPlatformMock,
+}));
+
+import { openTarget } from "../platform/launch.js";
+
+describe("openTarget invocation", () => {
+  const hostile = "https://example.com&calc.exe";
+
+  beforeEach(() => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null);
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the Windows target out of every command-line argument", async () => {
+    currentPlatformMock.mockReturnValue("win32");
+
+    await openTarget(hostile);
+
+    expect(execFileMock).toHaveBeenCalledOnce();
+    const [command, args, options] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { env: NodeJS.ProcessEnv; timeout: number },
+    ];
+    expect(command).toBe("powershell.exe");
+    expect(command).not.toBe("cmd");
+    expect(args).not.toContain("/c");
+    expect(args).not.toContain("start");
+    expect(args.every((arg) => !arg.includes(hostile))).toBe(true);
+    expect(args.at(-1)).toContain("UseShellExecute = $true");
+    expect(args.at(-1)).toContain("SetEnvironmentVariable");
+    expect(options.env.ELIZA_COMPUTERUSE_OPEN_TARGET).toBe(hostile);
+  });
+
+  it.each([
+    ["darwin", "open"],
+    ["linux", "xdg-open"],
+  ] as const)("passes the target as one argv on %s", async (os, command) => {
+    currentPlatformMock.mockReturnValue(os);
+
+    await openTarget(hostile);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      command,
+      [hostile],
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it.each(["", "   "])("rejects an empty target", async (target) => {
+    currentPlatformMock.mockReturnValue("win32");
+    await expect(openTarget(target)).rejects.toMatchObject({
+      code: "COMPUTER_USE_OPEN_INVALID_TARGET",
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects null bytes before constructing a process environment", async () => {
+    currentPlatformMock.mockReturnValue("win32");
+    await expect(openTarget("safe\0unsafe")).rejects.toMatchObject({
+      code: "COMPUTER_USE_OPEN_INVALID_TARGET",
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/launch.ts
+++ b/plugins/plugin-computeruse/src/platform/launch.ts
@@ -7,15 +7,18 @@
  * action and pass through the approval manager like every other non-read verb.
  *
  * Implementation notes:
- *   - `open` shells the OS default-handler (`open` / `xdg-open` / `start`), so a
- *     URL opens in the browser, a file in its default app, a folder in the file
- *     manager — exactly the OS double-click behavior.
+ *   - `open` invokes the OS default handler (`open`, `xdg-open`, or Windows
+ *     ShellExecute) so URLs, files, and folders match OS double-click behavior.
+ *     Windows must not go through `cmd /c start`: `start` is a cmd builtin and
+ *     treats `&`, `|`, and `>` in the target as extra commands.
  *   - `launch` spawns the executable DETACHED and returns its pid so the caller
  *     can track / focus it. The child is unref'd so it outlives the agent turn.
  */
 
 import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { ElizaError } from "@elizaos/core";
 import { currentPlatform } from "./helpers.js";
+import { psSpawnTimeoutMs } from "./windows-timeouts.js";
 
 /** Result of a launch — the spawned process id (and the resolved command). */
 export interface LaunchResult {
@@ -25,6 +28,70 @@ export interface LaunchResult {
 }
 
 const OPEN_TIMEOUT_MS = 10_000;
+const WINDOWS_OPEN_TIMEOUT_MS = 20_000;
+const WINDOWS_OPEN_TARGET_ENV = "ELIZA_COMPUTERUSE_OPEN_TARGET";
+const WINDOWS_SHELL_EXECUTE_SCRIPT = [
+  "$target = [Environment]::GetEnvironmentVariable('ELIZA_COMPUTERUSE_OPEN_TARGET', 'Process')",
+  "[Environment]::SetEnvironmentVariable('ELIZA_COMPUTERUSE_OPEN_TARGET', $null, 'Process')",
+  "$info = [System.Diagnostics.ProcessStartInfo]::new()",
+  "$info.FileName = $target",
+  "$info.UseShellExecute = $true",
+  "[System.Diagnostics.Process]::Start($info) | Out-Null",
+].join("; ");
+
+interface OpenInvocation {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  timeoutMs: number;
+}
+
+/** Resolve the no-shell invocation used by {@link openTarget}. */
+function resolveOpenInvocation(
+  target: string,
+  os: NodeJS.Platform,
+): OpenInvocation {
+  const value = target.trim();
+  if (!value) {
+    throw new ElizaError("open requires a non-empty target", {
+      code: "COMPUTER_USE_OPEN_INVALID_TARGET",
+    });
+  }
+  if (value.includes("\0")) {
+    throw new ElizaError("open target cannot contain a null byte", {
+      code: "COMPUTER_USE_OPEN_INVALID_TARGET",
+    });
+  }
+  if (os === "darwin") {
+    return { command: "open", args: [value], timeoutMs: OPEN_TIMEOUT_MS };
+  }
+  if (os === "linux") {
+    return { command: "xdg-open", args: [value], timeoutMs: OPEN_TIMEOUT_MS };
+  }
+  if (os === "win32") {
+    // The script is constant and the untrusted target travels only through the
+    // child environment. This preserves ShellExecute's default-handler contract
+    // for URLs, files, and folders without exposing the target to cmd or the
+    // PowerShell parser. A one-shot PowerShell is slower than explorer.exe, so
+    // retain the package's Defender-aware timeout floor.
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        WINDOWS_SHELL_EXECUTE_SCRIPT,
+      ],
+      env: { [WINDOWS_OPEN_TARGET_ENV]: value },
+      timeoutMs: psSpawnTimeoutMs(WINDOWS_OPEN_TIMEOUT_MS),
+    };
+  }
+  throw new ElizaError(`open unsupported on platform "${os}"`, {
+    code: "COMPUTER_USE_OPEN_UNSUPPORTED_PLATFORM",
+    context: { platform: os },
+  });
+}
 
 /**
  * Open a file / URL / folder with the OS default handler. Resolves once the
@@ -32,32 +99,52 @@ const OPEN_TIMEOUT_MS = 10_000;
  * running). Rejects on a non-zero launcher exit.
  */
 export function openTarget(target: string): Promise<void> {
-  const value = target?.trim();
-  if (!value) {
-    return Promise.reject(new Error("open requires a non-empty target"));
+  let invocation: OpenInvocation;
+  try {
+    invocation = resolveOpenInvocation(target ?? "", currentPlatform());
+  } catch (err) {
+    return Promise.reject(
+      err instanceof ElizaError
+        ? err
+        : new ElizaError("Failed to resolve the OS open invocation", {
+            code: "COMPUTER_USE_OPEN_RESOLUTION_FAILED",
+            cause: err,
+          }),
+    );
   }
-  const os = currentPlatform();
-  let command: string;
-  let args: string[];
-  if (os === "darwin") {
-    command = "open";
-    args = [value];
-  } else if (os === "linux") {
-    command = "xdg-open";
-    args = [value];
-  } else if (os === "win32") {
-    // `start` is a cmd builtin; the empty "" is the window-title arg so a
-    // quoted path/URL isn't mistaken for the title.
-    command = "cmd";
-    args = ["/c", "start", "", value];
-  } else {
-    return Promise.reject(new Error(`open unsupported on platform "${os}"`));
-  }
+  const { command, args, env, timeoutMs } = invocation;
   return new Promise<void>((resolve, reject) => {
-    execFile(command, args, { timeout: OPEN_TIMEOUT_MS }, (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
+    try {
+      execFile(
+        command,
+        args,
+        {
+          timeout: timeoutMs,
+          ...(env ? { env: { ...process.env, ...env } } : {}),
+        },
+        (err) => {
+          if (err) {
+            // error-policy:J1 process boundary translates launcher failure.
+            reject(
+              new ElizaError(`Failed to open target with ${command}`, {
+                code: "COMPUTER_USE_OPEN_FAILED",
+                cause: err,
+                context: { command },
+              }),
+            );
+          } else resolve();
+        },
+      );
+    } catch (err) {
+      // error-policy:J1 process boundary translates synchronous spawn failure.
+      reject(
+        new ElizaError(`Failed to start target opener ${command}`, {
+          code: "COMPUTER_USE_OPEN_FAILED",
+          cause: err,
+          context: { command },
+        }),
+      );
+    }
   });
 }
 


### PR DESCRIPTION
# Relates to

Relates to #22364.

Supersedes #22378 while preserving ss251's authorship. The source closes a real
`cmd /c start` injection, but replaces it with `explorer.exe`, which does not
reliably preserve the documented default-handler behavior for arbitrary URLs,
files, and folders.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `9cf8d43850671152da915a3e190e83e3864751b7`.
- [x] Zero conflicts and clean diff.
- [x] Post-sync package gates and root verification pass.

# Risks

Low. macOS and Linux keep their existing single-argument openers. Windows now
uses the OS ShellExecute default-handler contract without exposing the target
to cmd or PowerShell parsing.

# Background

## What does this PR do?

- Passes the Windows target only through the child process environment to a
  constant PowerShell script.
- Clears that value before calling `.NET ProcessStartInfo` with
  `UseShellExecute = true`, so the launched handler does not inherit it.
- Keeps the untrusted target out of all cmd and PowerShell arguments and logs.
- Uses typed `ElizaError` values for invalid targets and launcher failures.
- Tests the production `openTarget` path without exported test seams.

## What kind of change is this?

Security bug fix; no intended public API change.

# Documentation changes needed?

No. The existing open action continues to use registered OS default handlers.

# Testing

On exact head `95facd8a0bceeae1583eab0e990252b184d6245f`:

```text
focused launch and M12 tests                              PASS, 17/17
bun run --cwd plugins/plugin-computeruse typecheck       PASS
bun run --cwd plugins/plugin-computeruse lint:check      PASS, 216 files
bun run --cwd plugins/plugin-computeruse build           PASS
git diff --check                                         PASS
bun install --frozen-lockfile                            PASS
bun run verify                                           PASS, 358/358 tasks
```

The broader plugin run completed 791 passes. Three unrelated harness failures
reproduce unchanged on the exact develop baseline.

# Evidence Gate

<!-- evidence-head:95facd8a0bceeae1583eab0e990252b184d6245f -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - process-launch boundary only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - process-launch boundary only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - deterministic command, argument, and environment behavior is covered in production-path tests.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - local OS launcher boundary; no deployed backend changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the action launches an OS handler and produces no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Known gaps / failures

Three unrelated baseline harness failures are described under Testing. No
changed-path, package gate, or repository verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza"} -->
