### PR TITLE
fix(plugin-computeruse): make kill_app targets exact

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/launch-kill-invocation.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/launch-kill-invocation.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Exercises kill_app's production process boundary without terminating a real
+ * process, including process-group, regex, wildcard, and path adversarial cases.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileMock, currentPlatformMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  currentPlatformMock: vi.fn<NodeJS.Platform>(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFile: execFileMock,
+}));
+
+vi.mock("../platform/helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../platform/helpers.js")>()),
+  currentPlatform: currentPlatformMock,
+}));
+
+import { killApp } from "../platform/launch.js";
+
+describe("killApp invocation", () => {
+  beforeEach(() => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null);
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["0", "00", "000"])(
+    "rejects process-group pid spelling %s",
+    async (target) => {
+      currentPlatformMock.mockReturnValue("linux");
+      await expect(killApp(target)).rejects.toMatchObject({
+        code: "COMPUTER_USE_KILL_INVALID_TARGET",
+      });
+      expect(execFileMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("normalizes a positive pid before invoking kill", async () => {
+    currentPlatformMock.mockReturnValue("linux");
+    await expect(killApp("004242")).resolves.toMatchObject({ pid: 4242 });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "kill",
+      ["-9", "4242"],
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it.each(["2147483648", "999999999999999999999999999"])(
+    "rejects an out-of-range Unix pid %s",
+    async (target) => {
+      currentPlatformMock.mockReturnValue("linux");
+      await expect(killApp(target)).rejects.toMatchObject({
+        code: "COMPUTER_USE_KILL_INVALID_TARGET",
+      });
+      expect(execFileMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("escapes a Unix process name before exact regex matching", async () => {
+    currentPlatformMock.mockReturnValue("linux");
+    await killApp("node.js");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "pkill",
+      ["-x", "node\\.js"],
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it("passes a Windows image name with spaces as one argv", async () => {
+    currentPlatformMock.mockReturnValue("win32");
+    await killApp("My App");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "taskkill",
+      ["/F", "/IM", "My App.exe"],
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it.each(["*.exe", "node?.exe", "../node", "dir\\node", "bad\nname"])(
+    "rejects unsafe Windows image target %s",
+    async (target) => {
+      currentPlatformMock.mockReturnValue("win32");
+      await expect(killApp(target)).rejects.toMatchObject({
+        code: "COMPUTER_USE_KILL_INVALID_TARGET",
+      });
+      expect(execFileMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/platform/launch.ts
+++ b/plugins/plugin-computeruse/src/platform/launch.ts
@@ -219,60 +219,160 @@ export interface KillResult {
  * routes through the approval manager like every other non-read verb. Uses
  * `execFile` (no shell) so the target can't inject a command.
  *
- *   - Windows: `taskkill /F /PID <n>` or `/F /IM <name>.exe`.
- *   - macOS / Linux: `kill -9 <pid>` or `pkill -f <name>`.
+ *   - Windows: `taskkill /F /PID <n>` or `/F /IM <exact>.exe`.
+ *   - macOS / Linux: `kill -9 <pid>` or `pkill -x <escaped exact name>`.
+ *     Never use `pkill -f`: it treats the input as a regular expression over
+ *     full command lines and can terminate unrelated processes.
  *
  * Rejects when the target does not exist (non-zero exit) so the caller gets
  * clear feedback rather than a silent no-op.
  */
-export function killApp(target: string): Promise<KillResult> {
+interface KillInvocation {
+  command: string;
+  args: string[];
+  isPid: boolean;
+  value: string;
+}
+
+function escapeProcessNamePattern(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function resolveKillInvocation(
+  target: string,
+  os: NodeJS.Platform,
+): KillInvocation {
   const value = String(target ?? "").trim();
   if (!value) {
-    return Promise.reject(
-      new Error("kill_app requires a non-empty target (pid or app name)"),
+    throw new ElizaError(
+      "kill_app requires a non-empty target (pid or app name)",
+      { code: "COMPUTER_USE_KILL_INVALID_TARGET" },
     );
   }
   const isPid = /^\d+$/.test(value);
-  const os = currentPlatform();
-  let command: string;
-  let args: string[];
-  if (os === "win32") {
-    command = "taskkill";
-    args = isPid
-      ? ["/F", "/PID", value]
-      : [
-          "/F",
-          "/IM",
-          value.toLowerCase().endsWith(".exe") ? value : `${value}.exe`,
-        ];
-  } else if (os === "darwin" || os === "linux") {
-    if (isPid) {
-      command = "kill";
-      args = ["-9", value];
-    } else {
-      command = "pkill";
-      args = ["-f", value];
+  if (isPid) {
+    const maxPid = os === "win32" ? 4_294_967_295n : 2_147_483_647n;
+    if (value.length > 10) {
+      throw new ElizaError("kill_app pid is outside the supported range", {
+        code: "COMPUTER_USE_KILL_INVALID_TARGET",
+      });
+    }
+    const pid = BigInt(value);
+    if (pid === 0n) {
+      throw new ElizaError(
+        "kill_app refuses pid 0 because it signals the process group",
+        { code: "COMPUTER_USE_KILL_INVALID_TARGET" },
+      );
+    }
+    if (pid > maxPid) {
+      throw new ElizaError("kill_app pid is outside the supported range", {
+        code: "COMPUTER_USE_KILL_INVALID_TARGET",
+      });
+    }
+    const normalizedPid = pid.toString();
+    if (os === "win32") {
+      return {
+        command: "taskkill",
+        args: ["/F", "/PID", normalizedPid],
+        isPid,
+        value: normalizedPid,
+      };
+    }
+    if (os === "darwin" || os === "linux") {
+      return {
+        command: "kill",
+        args: ["-9", normalizedPid],
+        isPid,
+        value: normalizedPid,
+      };
     }
   } else {
+    const hasControlCharacter = [...value].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    });
+    if (value.includes("/") || value.includes("\\") || hasControlCharacter) {
+      throw new ElizaError(
+        "kill_app process name must be one executable name, not a path",
+        { code: "COMPUTER_USE_KILL_INVALID_TARGET" },
+      );
+    }
+    if (os === "win32") {
+      if (/[*?]/.test(value)) {
+        throw new ElizaError(
+          "kill_app does not allow wildcards in a Windows image name",
+          { code: "COMPUTER_USE_KILL_INVALID_TARGET" },
+        );
+      }
+      const image = value.toLowerCase().endsWith(".exe")
+        ? value
+        : `${value}.exe`;
+      return {
+        command: "taskkill",
+        args: ["/F", "/IM", image],
+        isPid,
+        value,
+      };
+    }
+    if (os === "darwin" || os === "linux") {
+      return {
+        command: "pkill",
+        args: ["-x", escapeProcessNamePattern(value)],
+        isPid,
+        value,
+      };
+    }
+  }
+  throw new ElizaError(`kill_app unsupported on platform "${os}"`, {
+    code: "COMPUTER_USE_KILL_UNSUPPORTED_PLATFORM",
+    context: { platform: os },
+  });
+}
+
+export function killApp(target: string): Promise<KillResult> {
+  let invocation: KillInvocation;
+  try {
+    invocation = resolveKillInvocation(target, currentPlatform());
+  } catch (err) {
     return Promise.reject(
-      new Error(`kill_app unsupported on platform "${os}"`),
+      err instanceof ElizaError
+        ? err
+        : new ElizaError("Failed to resolve the kill_app invocation", {
+            code: "COMPUTER_USE_KILL_RESOLUTION_FAILED",
+            cause: err,
+          }),
     );
   }
+  const { command, args, isPid, value } = invocation;
   return new Promise<KillResult>((resolve, reject) => {
-    execFile(command, args, { timeout: OPEN_TIMEOUT_MS }, (err) => {
-      if (err) {
-        reject(
-          new Error(
-            `kill_app failed for "${value}": ${err.message} (target may not be running)`,
-          ),
-        );
-      } else {
-        resolve({
-          target: value,
-          ...(isPid ? { pid: Number(value) } : {}),
-          killed: true,
-        });
-      }
-    });
+    try {
+      execFile(command, args, { timeout: OPEN_TIMEOUT_MS }, (err) => {
+        if (err) {
+          // error-policy:J1 process boundary translates taskkill/kill failure.
+          reject(
+            new ElizaError("kill_app failed; the target may not be running", {
+              code: "COMPUTER_USE_KILL_FAILED",
+              cause: err,
+              context: { command },
+            }),
+          );
+        } else {
+          resolve({
+            target: value,
+            ...(isPid ? { pid: Number(value) } : {}),
+            killed: true,
+          });
+        }
+      });
+    } catch (err) {
+      // error-policy:J1 process boundary translates synchronous spawn failure.
+      reject(
+        new ElizaError(`Failed to start ${command}`, {
+          code: "COMPUTER_USE_KILL_FAILED",
+          cause: err,
+          context: { command },
+        }),
+      );
+    }
   });
 }


### PR DESCRIPTION
# Relates to

Relates to #22364 and completes the useful `kill_app` delta from #22378 after
the safe Windows open implementation landed in #22379.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `256c755448dd82a5b652fdc451e25b12f4c3aa4e`.
- [x] Zero conflicts and clean diff.
- [x] Post-sync package gates and root verification pass.

# Risks

Low. `kill_app` now accepts only a bounded positive PID or one validated exact
process name. Existing valid PID and name targets remain supported.

# Background

## What does this PR do?

- Parses decimal PIDs with bounded `BigInt` normalization and rejects every
  spelling of PID zero, preventing Unix process-group signaling.
- Escapes Unix process names before passing them to `pkill -x`, so dots and
  other regex syntax remain literal.
- Rejects Windows image-name wildcards, paths, and control characters while
  retaining valid spaced names.
- Uses typed `ElizaError` failures and keeps the resolver private.
- Tests the production kill path and the M12 metacharacter contract.

## What kind of change is this?

Security bug fix; no intended public API change.

# Documentation changes needed?

No. This enforces the existing exact PID/name contract.

# Testing

On exact head `09a2041f73cef5cdb8053721a041f16ddbf0054a`:

```text
focused kill_app and M12 tests                            PASS, 24/24
bun run --cwd plugins/plugin-computeruse typecheck       PASS
bun run --cwd plugins/plugin-computeruse lint:check      PASS, 217 files
bun run --cwd plugins/plugin-computeruse build           PASS
git diff --check                                         PASS
bun install --frozen-lockfile                            PASS
bun run verify                                           PASS, 358/358 tasks
```

# Evidence Gate

<!-- evidence-head:09a2041f73cef5cdb8053721a041f16ddbf0054a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - local process-control boundary only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - local process-control boundary only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - deterministic process invocation is asserted in production-path tests.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - local OS process boundary; no deployed backend changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - process termination creates no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Known gaps / failures

None in the changed scope.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@231972ee2df2e337737355cb93af1f7d099ece06:packages/skills/skills/contribute-to-eliza"} -->
