### PR TITLE
fix(plugin-phone): do not replay ambiguous Twilio create outcomes

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/messaging-helpers.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/messaging-helpers.ts
@@ -167,7 +167,10 @@ export async function prepareCrossChannelSend(args: {
       }
       return {
         provider: "sms",
-        supportsProviderIdempotency: true,
+        // Twilio's Messages create endpoint has no documented client-side
+        // idempotency contract. Ambiguous outcomes require reconciliation and
+        // must not be treated as safely replayable at the provider boundary.
+        supportsProviderIdempotency: false,
         dispatch: async (providerIdempotencyKey) => {
           const result = await sendTwilioSms({
             credentials,

--- a/plugins/plugin-personal-assistant/test/approval-messaging-boundary.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-messaging-boundary.test.ts
@@ -12,6 +12,24 @@ import {
 import type { LifeOpsService } from "../src/lifeops/service.js";
 
 describe("approval messaging boundary", () => {
+  it("does not claim provider idempotency for Twilio SMS", async () => {
+    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
+    vi.stubEnv("TWILIO_AUTH_TOKEN", "token");
+    vi.stubEnv("TWILIO_PHONE_NUMBER", "+15550000000");
+    try {
+      const prepared = await prepareCrossChannelSend({
+        runtime: {} as IAgentRuntime,
+        service: {} as LifeOpsService,
+        channel: "sms",
+        target: "+15551234567",
+        body: "hello",
+      });
+      expect(prepared.supportsProviderIdempotency).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("does not fall back after Telegram accepted-then-timeout", async () => {
     const fallback = vi.fn();
     const telegram = vi.fn(async () => {

--- a/plugins/plugin-phone/src/twilio.test.ts
+++ b/plugins/plugin-phone/src/twilio.test.ts
@@ -71,8 +71,10 @@ describe("Twilio transport", () => {
       expect.objectContaining({
         method: "POST",
         body: "To=%2B15551112222&From=%2B15550000000&Body=hello",
-        headers: expect.objectContaining({
-          "I-Twilio-Idempotency-Token": "approval:req-123:twilio",
+        headers: expect.not.objectContaining({
+          // This is an inbound Twilio webhook retry identifier, not a
+          // documented outbound Messages/Calls idempotency request header.
+          "I-Twilio-Idempotency-Token": expect.anything(),
         }),
       }),
     );
@@ -146,22 +148,19 @@ describe("Twilio transport", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    vi.useFakeTimers();
-    const promise = sendTwilioSms({
-      credentials,
-      to: "+15551112222",
-      body: "hello",
-    });
-    await vi.advanceTimersByTimeAsync(3_000);
-
-    await expect(promise).resolves.toMatchObject({
+    await expect(
+      sendTwilioSms({
+        credentials,
+        to: "+15551112222",
+        body: "hello",
+      }),
+    ).resolves.toMatchObject({
       ok: false,
       status: 503,
       error: "HTTP 503",
-      retryCount: 2,
+      retryCount: 0,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    vi.useRealTimers();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps hostile SMS body bytes inside the form-encoded Body field", async () => {
@@ -244,101 +243,79 @@ describe("Twilio transport", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  function idempotencyTokensFromCalls(
-    fetchMock: ReturnType<typeof vi.fn>,
-  ): Array<string | undefined> {
-    const calls = fetchMock.mock.calls as unknown as Array<
-      [string, RequestInit]
-    >;
-    return calls.map(([, init]) => {
-      const headers = (init?.headers ?? {}) as Record<string, string>;
-      return headers["I-Twilio-Idempotency-Token"];
-    });
-  }
-
-  it("reuses one generated idempotency token across an SMS network-retry", async () => {
-    // Regression for #22382: a post-send network drop then a 201 must not
-    // deliver a duplicate, doubly-billed SMS. Both /Messages.json POSTs have
-    // to carry the SAME generated I-Twilio-Idempotency-Token so Twilio
-    // deduplicates the retry, even though the caller supplied no key.
+  it("does not replay an SMS create after an ambiguous network failure", async () => {
     process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
-    let attempt = 0;
     const fetchMock = vi.fn(async () => {
-      attempt += 1;
-      if (attempt === 1) {
-        throw new Error("network timeout after send");
-      }
-      return Response.json({ sid: "SM123" }, { status: 201 });
+      throw new Error("network timeout after send");
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    vi.useFakeTimers();
-    const promise = sendTwilioSms({
-      credentials,
-      to: "+15551112222",
-      body: "hello",
+    await expect(
+      sendTwilioSms({
+        credentials,
+        to: "+15551112222",
+        body: "hello",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: null,
+      error: "network timeout after send",
+      retryCount: 0,
     });
-    await vi.advanceTimersByTimeAsync(3_000);
-    const result = await promise;
-    vi.useRealTimers();
-
-    expect(result).toMatchObject({ ok: true, status: 201, retryCount: 1 });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const paths = (
-      fetchMock.mock.calls as unknown as Array<[string, RequestInit]>
-    ).map(([url]) => url);
-    expect(paths).toEqual([
-      "https://twilio.test/2010-04-01/Accounts/AC123/Messages.json",
-      "https://twilio.test/2010-04-01/Accounts/AC123/Messages.json",
-    ]);
-    const tokens = idempotencyTokensFromCalls(fetchMock);
-    expect(tokens[0]).toBeTruthy();
-    expect(tokens[0]).toBe(tokens[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reuses one generated idempotency token across a voice network-retry", async () => {
+  it("does not replay a voice create after an ambiguous network failure", async () => {
     process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
-    let attempt = 0;
     const fetchMock = vi.fn(async () => {
-      attempt += 1;
-      if (attempt === 1) {
-        throw new Error("network timeout after send");
-      }
-      return Response.json({ sid: "CA123" }, { status: 201 });
+      throw new Error("network timeout after send");
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    vi.useFakeTimers();
-    const promise = sendTwilioVoiceCall({
-      credentials,
-      to: "+15551112222",
-      message: "reminder",
+    await expect(
+      sendTwilioVoiceCall({
+        credentials,
+        to: "+15551112222",
+        message: "reminder",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: null,
+      error: "network timeout after send",
+      retryCount: 0,
     });
-    await vi.advanceTimersByTimeAsync(3_000);
-    const result = await promise;
-    vi.useRealTimers();
-
-    expect(result).toMatchObject({ ok: true, status: 201, retryCount: 1 });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const paths = (
-      fetchMock.mock.calls as unknown as Array<[string, RequestInit]>
-    ).map(([url]) => url);
-    expect(paths).toEqual([
-      "https://twilio.test/2010-04-01/Accounts/AC123/Calls.json",
-      "https://twilio.test/2010-04-01/Accounts/AC123/Calls.json",
-    ]);
-    const tokens = idempotencyTokensFromCalls(fetchMock);
-    expect(tokens[0]).toBeTruthy();
-    expect(tokens[0]).toBe(tokens[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps a stable idempotency token across all 5xx retry attempts", async () => {
+  it("does not replay a create when a successful response has no receipt", async () => {
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    const fetchMock = vi.fn(
+      async () => new Response("accepted", { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      sendTwilioSms({
+        credentials,
+        to: "+15551112222",
+        body: "hello",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: null,
+      error: "Twilio accepted the request without a valid receipt",
+      retryCount: 0,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries only an explicit known-not-processed 429 response", async () => {
     process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
     let attempt = 0;
     const fetchMock = vi.fn(async () => {
       attempt += 1;
       if (attempt < 3) {
-        return Response.json({ message: "overloaded" }, { status: 503 });
+        return Response.json({ message: "rate limited" }, { status: 429 });
       }
       return Response.json({ sid: "SM999" }, { status: 201 });
     });
@@ -356,44 +333,5 @@ describe("Twilio transport", () => {
 
     expect(result).toMatchObject({ ok: true, status: 201, retryCount: 2 });
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    const tokens = idempotencyTokensFromCalls(fetchMock);
-    expect(tokens[0]).toBeTruthy();
-    expect(new Set(tokens).size).toBe(1);
-  });
-
-  it("honors a caller-supplied idempotency token verbatim", async () => {
-    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
-    const fetchMock = vi.fn(async () =>
-      Response.json({ sid: "SM123" }, { status: 201 }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await sendTwilioSms({
-      credentials,
-      to: "+15551112222",
-      body: "hello",
-      idempotencyKey: "approval:req-123:twilio",
-    });
-
-    expect(idempotencyTokensFromCalls(fetchMock)).toEqual([
-      "approval:req-123:twilio",
-    ]);
-  });
-
-  it("assigns distinct tokens to two independent SMS sends", async () => {
-    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
-    const fetchMock = vi.fn(async () =>
-      Response.json({ sid: "SM123" }, { status: 201 }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await sendTwilioSms({ credentials, to: "+15551112222", body: "one" });
-    await sendTwilioSms({ credentials, to: "+15551112222", body: "two" });
-
-    const tokens = idempotencyTokensFromCalls(fetchMock);
-    expect(tokens).toHaveLength(2);
-    expect(tokens[0]).toBeTruthy();
-    expect(tokens[1]).toBeTruthy();
-    expect(tokens[0]).not.toBe(tokens[1]);
   });
 });

--- a/plugins/plugin-phone/src/twilio.test.ts
+++ b/plugins/plugin-phone/src/twilio.test.ts
@@ -309,6 +309,35 @@ describe("Twilio transport", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["missing", {}],
+    ["blank", { sid: "   " }],
+    ["non-string", { sid: 123 }],
+  ])(
+    "rejects a successful response with a %s SID without replaying the create",
+    async (_label, receipt) => {
+      process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+      const fetchMock = vi.fn(async () =>
+        Response.json(receipt, { status: 201 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        sendTwilioSms({
+          credentials,
+          to: "+15551112222",
+          body: "hello",
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        status: null,
+        error: "Twilio accepted the request without a valid receipt",
+        retryCount: 0,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("retries only an explicit known-not-processed 429 response", async () => {
     process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
     let attempt = 0;

--- a/plugins/plugin-phone/src/twilio.test.ts
+++ b/plugins/plugin-phone/src/twilio.test.ts
@@ -243,4 +243,157 @@ describe("Twilio transport", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  function idempotencyTokensFromCalls(
+    fetchMock: ReturnType<typeof vi.fn>,
+  ): Array<string | undefined> {
+    const calls = fetchMock.mock.calls as unknown as Array<
+      [string, RequestInit]
+    >;
+    return calls.map(([, init]) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      return headers["I-Twilio-Idempotency-Token"];
+    });
+  }
+
+  it("reuses one generated idempotency token across an SMS network-retry", async () => {
+    // Regression for #22382: a post-send network drop then a 201 must not
+    // deliver a duplicate, doubly-billed SMS. Both /Messages.json POSTs have
+    // to carry the SAME generated I-Twilio-Idempotency-Token so Twilio
+    // deduplicates the retry, even though the caller supplied no key.
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("network timeout after send");
+      }
+      return Response.json({ sid: "SM123" }, { status: 201 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.useFakeTimers();
+    const promise = sendTwilioSms({
+      credentials,
+      to: "+15551112222",
+      body: "hello",
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toMatchObject({ ok: true, status: 201, retryCount: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const paths = (
+      fetchMock.mock.calls as unknown as Array<[string, RequestInit]>
+    ).map(([url]) => url);
+    expect(paths).toEqual([
+      "https://twilio.test/2010-04-01/Accounts/AC123/Messages.json",
+      "https://twilio.test/2010-04-01/Accounts/AC123/Messages.json",
+    ]);
+    const tokens = idempotencyTokensFromCalls(fetchMock);
+    expect(tokens[0]).toBeTruthy();
+    expect(tokens[0]).toBe(tokens[1]);
+  });
+
+  it("reuses one generated idempotency token across a voice network-retry", async () => {
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("network timeout after send");
+      }
+      return Response.json({ sid: "CA123" }, { status: 201 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.useFakeTimers();
+    const promise = sendTwilioVoiceCall({
+      credentials,
+      to: "+15551112222",
+      message: "reminder",
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toMatchObject({ ok: true, status: 201, retryCount: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const paths = (
+      fetchMock.mock.calls as unknown as Array<[string, RequestInit]>
+    ).map(([url]) => url);
+    expect(paths).toEqual([
+      "https://twilio.test/2010-04-01/Accounts/AC123/Calls.json",
+      "https://twilio.test/2010-04-01/Accounts/AC123/Calls.json",
+    ]);
+    const tokens = idempotencyTokensFromCalls(fetchMock);
+    expect(tokens[0]).toBeTruthy();
+    expect(tokens[0]).toBe(tokens[1]);
+  });
+
+  it("keeps a stable idempotency token across all 5xx retry attempts", async () => {
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt += 1;
+      if (attempt < 3) {
+        return Response.json({ message: "overloaded" }, { status: 503 });
+      }
+      return Response.json({ sid: "SM999" }, { status: 201 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.useFakeTimers();
+    const promise = sendTwilioSms({
+      credentials,
+      to: "+15551112222",
+      body: "hello",
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toMatchObject({ ok: true, status: 201, retryCount: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const tokens = idempotencyTokensFromCalls(fetchMock);
+    expect(tokens[0]).toBeTruthy();
+    expect(new Set(tokens).size).toBe(1);
+  });
+
+  it("honors a caller-supplied idempotency token verbatim", async () => {
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    const fetchMock = vi.fn(async () =>
+      Response.json({ sid: "SM123" }, { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendTwilioSms({
+      credentials,
+      to: "+15551112222",
+      body: "hello",
+      idempotencyKey: "approval:req-123:twilio",
+    });
+
+    expect(idempotencyTokensFromCalls(fetchMock)).toEqual([
+      "approval:req-123:twilio",
+    ]);
+  });
+
+  it("assigns distinct tokens to two independent SMS sends", async () => {
+    process.env.ELIZA_MOCK_TWILIO_BASE = "https://twilio.test";
+    const fetchMock = vi.fn(async () =>
+      Response.json({ sid: "SM123" }, { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendTwilioSms({ credentials, to: "+15551112222", body: "one" });
+    await sendTwilioSms({ credentials, to: "+15551112222", body: "two" });
+
+    const tokens = idempotencyTokensFromCalls(fetchMock);
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).toBeTruthy();
+    expect(tokens[1]).toBeTruthy();
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
 });

--- a/plugins/plugin-phone/src/twilio.ts
+++ b/plugins/plugin-phone/src/twilio.ts
@@ -1,14 +1,14 @@
 /**
  * Twilio transport helpers for outbound SMS and voice calls: reads credentials
- * from the environment, sends via the Twilio REST API with bounded retry, and
- * computes the segment-based SMS billing breakdown (raw cost + markup).
+ * from the environment, sends via the Twilio REST API with retry only for
+ * explicitly known-not-processed responses, and computes the segment-based SMS
+ * billing breakdown (raw cost + markup).
  *
  * These are standalone helpers held here for the future VOICE_CALL provider
  * migration; no action in this package wires them today — outbound dispatch is
  * owned by the PA-hosted VOICE_CALL action.
  */
 
-import { randomUUID } from "node:crypto";
 import { logger } from "@elizaos/core";
 
 export interface TwilioCredentials {
@@ -115,11 +115,11 @@ function getTwilioBaseUrl(): string {
   return process.env.ELIZA_MOCK_TWILIO_BASE ?? "https://api.twilio.com";
 }
 
-function isTransientFailure(result: TwilioDeliveryResult): boolean {
-  if (result.status !== null && result.status >= 400 && result.status < 500) {
-    return false;
-  }
-  return true;
+function isSafeToRetry(result: TwilioDeliveryResult): boolean {
+  // Twilio documents 429 as not processed and therefore safe to retry. Network
+  // errors, malformed success receipts, and 5xx outcomes are ambiguous for the
+  // non-idempotent Messages/Calls create endpoints and must not be replayed.
+  return result.status === 429;
 }
 
 function validationFailure(error: string): TwilioDeliveryResult {
@@ -161,9 +161,8 @@ async function sendTwilioRequest(args: {
   credentials: TwilioCredentials;
   path: string;
   payload: URLSearchParams;
-  idempotencyKey?: string;
 }): Promise<TwilioDeliveryResult> {
-  const { credentials, path, payload, idempotencyKey } = args;
+  const { credentials, path, payload } = args;
   const url = `${getTwilioBaseUrl()}/2010-04-01/Accounts/${encodeURIComponent(
     credentials.accountSid,
   )}${path}`;
@@ -197,9 +196,6 @@ async function sendTwilioRequest(args: {
             credentials.authToken,
           )}`,
           "Content-Type": "application/x-www-form-urlencoded",
-          ...(idempotencyKey
-            ? { "I-Twilio-Idempotency-Token": idempotencyKey }
-            : {}),
         },
         body: payload.toString(),
         signal: AbortSignal.timeout(12_000),
@@ -247,7 +243,7 @@ async function sendTwilioRequest(args: {
           error: errorMsg,
           retryCount: attempt,
         };
-        if (!isTransientFailure(lastResult)) {
+        if (!isSafeToRetry(lastResult)) {
           return lastResult;
         }
         continue;
@@ -280,6 +276,10 @@ async function sendTwilioRequest(args: {
         error: errorMsg,
         retryCount: attempt,
       };
+      // A transport failure can happen after Twilio accepted the create. The
+      // provider exposes no documented client idempotency key for these
+      // endpoints, so replaying here could duplicate delivery and billing.
+      break;
     }
   }
 
@@ -290,6 +290,7 @@ export async function sendTwilioSms(args: {
   credentials: TwilioCredentials;
   to: string;
   body: string;
+  /** @deprecated Twilio Messages does not document a client idempotency key. */
   idempotencyKey?: string;
 }): Promise<TwilioDeliveryResult> {
   const { credentials, to, body } = args;
@@ -301,14 +302,6 @@ export async function sendTwilioSms(args: {
   });
   if (validationError) return validationFailure(validationError);
 
-  // Twilio's /Messages.json is a non-idempotent create endpoint, but
-  // sendTwilioRequest retries transient failures (network throw/timeout, 5xx).
-  // Without a stable idempotency token a post-send timeout or retryable 5xx
-  // after acceptance would re-POST and deliver a duplicate, doubly-billed SMS.
-  // Default one token per logical send so every retry attempt deduplicates,
-  // while distinct logical sends still get distinct tokens.
-  const idempotencyKey = args.idempotencyKey ?? randomUUID();
-
   const result = await sendTwilioRequest({
     credentials,
     path: "/Messages.json",
@@ -317,7 +310,6 @@ export async function sendTwilioSms(args: {
       From: credentials.fromPhoneNumber,
       Body: body,
     }),
-    idempotencyKey,
   });
 
   if (!result.ok) {
@@ -343,6 +335,7 @@ export async function sendTwilioVoiceCall(args: {
   credentials: TwilioCredentials;
   to: string;
   message: string;
+  /** @deprecated Twilio Calls does not document a client idempotency key. */
   idempotencyKey?: string;
 }): Promise<TwilioDeliveryResult> {
   const { credentials, to, message } = args;
@@ -354,11 +347,6 @@ export async function sendTwilioVoiceCall(args: {
   });
   if (validationError) return validationFailure(validationError);
 
-  // /Calls.json is a non-idempotent create endpoint under the same retrying
-  // transport, so default an idempotency token to keep retries from placing a
-  // duplicate, doubly-billed voice call. See sendTwilioSms for the rationale.
-  const idempotencyKey = args.idempotencyKey ?? randomUUID();
-
   return sendTwilioRequest({
     credentials,
     path: "/Calls.json",
@@ -367,6 +355,5 @@ export async function sendTwilioVoiceCall(args: {
       From: credentials.fromPhoneNumber,
       Twiml: `<Response><Say>${escapeXml(message)}</Say></Response>`,
     }),
-    idempotencyKey,
   });
 }

--- a/plugins/plugin-phone/src/twilio.ts
+++ b/plugins/plugin-phone/src/twilio.ts
@@ -8,6 +8,7 @@
  * owned by the PA-hosted VOICE_CALL action.
  */
 
+import { randomUUID } from "node:crypto";
 import { logger } from "@elizaos/core";
 
 export interface TwilioCredentials {
@@ -300,6 +301,14 @@ export async function sendTwilioSms(args: {
   });
   if (validationError) return validationFailure(validationError);
 
+  // Twilio's /Messages.json is a non-idempotent create endpoint, but
+  // sendTwilioRequest retries transient failures (network throw/timeout, 5xx).
+  // Without a stable idempotency token a post-send timeout or retryable 5xx
+  // after acceptance would re-POST and deliver a duplicate, doubly-billed SMS.
+  // Default one token per logical send so every retry attempt deduplicates,
+  // while distinct logical sends still get distinct tokens.
+  const idempotencyKey = args.idempotencyKey ?? randomUUID();
+
   const result = await sendTwilioRequest({
     credentials,
     path: "/Messages.json",
@@ -308,7 +317,7 @@ export async function sendTwilioSms(args: {
       From: credentials.fromPhoneNumber,
       Body: body,
     }),
-    ...(args.idempotencyKey ? { idempotencyKey: args.idempotencyKey } : {}),
+    idempotencyKey,
   });
 
   if (!result.ok) {
@@ -345,6 +354,11 @@ export async function sendTwilioVoiceCall(args: {
   });
   if (validationError) return validationFailure(validationError);
 
+  // /Calls.json is a non-idempotent create endpoint under the same retrying
+  // transport, so default an idempotency token to keep retries from placing a
+  // duplicate, doubly-billed voice call. See sendTwilioSms for the rationale.
+  const idempotencyKey = args.idempotencyKey ?? randomUUID();
+
   return sendTwilioRequest({
     credentials,
     path: "/Calls.json",
@@ -353,6 +367,6 @@ export async function sendTwilioVoiceCall(args: {
       From: credentials.fromPhoneNumber,
       Twiml: `<Response><Say>${escapeXml(message)}</Say></Response>`,
     }),
-    ...(args.idempotencyKey ? { idempotencyKey: args.idempotencyKey } : {}),
+    idempotencyKey,
   });
 }

--- a/plugins/plugin-phone/src/twilio.ts
+++ b/plugins/plugin-phone/src/twilio.ts
@@ -248,11 +248,17 @@ async function sendTwilioRequest(args: {
         }
         continue;
       }
+      const receiptSid = typeof data.sid === "string" ? data.sid.trim() : "";
+      if (receiptSid.length === 0) {
+        // error-policy:J3 A 2xx create without a usable resource identifier is
+        // an ambiguous success. Do not report success or replay the POST.
+        throw new Error("Twilio accepted the request without a valid receipt");
+      }
       span.success({ statusCode: response.status });
       return {
         ok: true,
         status: response.status,
-        sid: data.sid,
+        sid: receiptSid,
         retryCount: attempt,
       };
     } catch (error) {


### PR DESCRIPTION
# Relates to

Closes #22382

# Background

Twilio `/Messages.json` and `/Calls.json` are non-idempotent create endpoints.
The previous implementation automatically retried network/timeout failures and
all 5xx responses, so an accepted request whose acknowledgement was lost could
be sent again, duplicating delivery and billing.

The initially submitted repair repeated `I-Twilio-Idempotency-Token` across
attempts. Independent provider research found that this is not a documented
client-side deduplication contract: Twilio documents that header on outbound
webhook callbacks so *receivers* can distinguish Twilio's callback retries.
Neither the Messages nor Calls create-resource reference documents it as a
supported client request header:

- https://www.twilio.com/docs/usage/webhooks/webhooks-connection-overrides
- https://www.twilio.com/docs/messaging/api/message-resource
- https://www.twilio.com/docs/voice/api/call-resource
- https://www.twilio.com/docs/usage/rest-api-best-practices

# Repair

- Do not automatically replay a Messages/Calls create after a network error,
  timeout, malformed successful receipt, or 5xx. Those outcomes are ambiguous.
- Retry only HTTP 429, which Twilio documents as not processed and safe to
  retry, retaining the existing bounded exponential backoff.
- Stop emitting the webhook-only `I-Twilio-Idempotency-Token` on outbound API
  requests. The legacy optional input remains temporarily for source
  compatibility and is marked deprecated.
- Mark the personal-assistant SMS connector as not supporting provider
  idempotency, so orchestration metadata does not claim a nonexistent provider
  guarantee.

# Verification

Exact repaired head: `f984797a9e614049460186167d21b8da7dcd69ce`

- `plugin-phone` focused Twilio suite: **15/15 passed**.
- Changed-file Biome: clean.
- `git diff --check origin/develop...HEAD`: clean.
- Regression coverage proves one POST only for SMS network failure, voice
  network failure, 5xx, and accepted-without-valid-receipt; bounded retry remains
  for 429 and succeeds on the third attempt.
- Personal-assistant boundary regression pins
  `supportsProviderIdempotency === false`. Its local execution is blocked in
  this sparse shared install by the unrelated missing `ai` workspace package;
  the changed test and source pass Biome.

The wider phone suite reached **59 passing tests** before five unrelated UI
suites failed import because this isolated worktree lacks Capacitor/lucide
packages. Package typecheck is likewise blocked by missing generated core i18n
data and unrelated sparse-install packages. No dependency or lockfile changes
are included.

# Evidence Gate

<!-- evidence-head:f984797a9e614049460186167d21b8da7dcd69ce -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; transport policy only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; transport policy only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live Twilio credentials were used; exact-head deterministic transport tests passed 15/15 and assert HTTP call counts.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/action/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external artifact is produced; focused tests pin transport call counts and returned delivery receipts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text.

# Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Attribution status: self-reported


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f984797a9e614049460186167d21b8da7dcd69ce:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f984797a9e614049460186167d21b8da7dcd69ce:packages/skills/skills/contribute-to-eliza"} -->

