### PR TITLE
fix(face-cpp): fail closed on GGUF length fields that wrap pointer math

### DIFF
--- a/packages/native/plugins/face-cpp/AGENTS.md
+++ b/packages/native/plugins/face-cpp/AGENTS.md
@@ -24,7 +24,7 @@ src/face_nms.c                  detection suppression
 src/face_kernels.c              scalar kernels
 scripts/blazeface_to_gguf.py    detector converter
 scripts/face_embed_to_gguf.py   embedder converter
-test/                           ABI, runtime, alignment, distance, and parity
+test/                           ABI, runtime, alignment, distance, hostile GGUF, and parity
 ```
 
 The detector converter is pinned to `hollance/BlazeFace-PyTorch@2c5b59d`. The shipped embedding family is `facenet_128`, pinned to `facenet-pytorch==2.5.3`; `arcface_mini_128` remains an ABI-compatible identifier, not the default artifact.

--- a/packages/native/plugins/face-cpp/CLAUDE.md
+++ b/packages/native/plugins/face-cpp/CLAUDE.md
@@ -24,7 +24,7 @@ src/face_nms.c                  detection suppression
 src/face_kernels.c              scalar kernels
 scripts/blazeface_to_gguf.py    detector converter
 scripts/face_embed_to_gguf.py   embedder converter
-test/                           ABI, runtime, alignment, distance, and parity
+test/                           ABI, runtime, alignment, distance, hostile GGUF, and parity
 ```
 
 The detector converter is pinned to `hollance/BlazeFace-PyTorch@2c5b59d`. The shipped embedding family is `facenet_128`, pinned to `facenet-pytorch==2.5.3`; `arcface_mini_128` remains an ABI-compatible identifier, not the default artifact.

--- a/packages/native/plugins/face-cpp/CMakeLists.txt
+++ b/packages/native/plugins/face-cpp/CMakeLists.txt
@@ -91,6 +91,12 @@ target_include_directories(face_embed_runtime_test PRIVATE test src)
 target_compile_options(face_embed_runtime_test PRIVATE -O2 -Wall -Wextra -Wno-unused-parameter)
 add_test(NAME face_embed_runtime_test COMMAND face_embed_runtime_test)
 
+add_executable(face_gguf_hostile_test test/face_gguf_hostile_test.c)
+target_link_libraries(face_gguf_hostile_test PRIVATE face)
+target_include_directories(face_gguf_hostile_test PRIVATE src)
+target_compile_options(face_gguf_hostile_test PRIVATE -O2 -Wall -Wextra)
+add_test(NAME face_gguf_hostile_test COMMAND face_gguf_hostile_test)
+
 # Optional Python-driven parity test against MediaPipe / hollance/BlazeFace-PyTorch.
 # Skips itself when torch / Pillow / the reference checkpoint are unavailable so it
 # never blocks the C-only build but always runs in the dev environment.

--- a/packages/native/plugins/face-cpp/CMakeLists.txt
+++ b/packages/native/plugins/face-cpp/CMakeLists.txt
@@ -94,6 +94,7 @@ add_test(NAME face_embed_runtime_test COMMAND face_embed_runtime_test)
 add_executable(face_gguf_hostile_test test/face_gguf_hostile_test.c)
 target_link_libraries(face_gguf_hostile_test PRIVATE face)
 target_include_directories(face_gguf_hostile_test PRIVATE src)
+target_compile_definitions(face_gguf_hostile_test PRIVATE _POSIX_C_SOURCE=200809L)
 target_compile_options(face_gguf_hostile_test PRIVATE -O2 -Wall -Wextra)
 add_test(NAME face_gguf_hostile_test COMMAND face_gguf_hostile_test)
 

--- a/packages/native/plugins/face-cpp/src/face_gguf.c
+++ b/packages/native/plugins/face-cpp/src/face_gguf.c
@@ -23,12 +23,17 @@
  *     dtype (u32)
  *     offset (u64, relative to start of tensor data section)
  *   tensor data section, aligned to general.alignment (default 32).
+ *
+ * Length fields are untrusted. Cursor advances compare against remaining
+ * bytes — never `ptr + u64` — so a 32-byte file that declares UINT64_MAX
+ * key length cannot wrap pointer arithmetic and memcpy-crash the process.
  */
 
 #include "face_internal.h"
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -113,20 +118,36 @@ typedef struct {
     int            err;
 } cur_t;
 
+static size_t cur_remaining(const cur_t *c) {
+    if (!c->p || !c->end || c->p > c->end) return 0;
+    return (size_t)(c->end - c->p);
+}
+
+static int cur_need(cur_t *c, size_t n) {
+    if (cur_remaining(c) < n) { c->err = -EINVAL; return -EINVAL; }
+    return 0;
+}
+
+static int cur_skip(cur_t *c, uint64_t n) {
+    if (n > cur_remaining(c)) { c->err = -EINVAL; return -EINVAL; }
+    c->p += (size_t)n;
+    return 0;
+}
+
 static uint8_t  cur_u8(cur_t *c) {
-    if (c->p + 1 > c->end) { c->err = -EINVAL; return 0; }
+    if (cur_need(c, 1) != 0) return 0;
     uint8_t v = *c->p; c->p += 1; return v;
 }
 static uint16_t cur_u16(cur_t *c) {
-    if (c->p + 2 > c->end) { c->err = -EINVAL; return 0; }
+    if (cur_need(c, 2) != 0) return 0;
     uint16_t v; memcpy(&v, c->p, 2); c->p += 2; return v;
 }
 static uint32_t cur_u32(cur_t *c) {
-    if (c->p + 4 > c->end) { c->err = -EINVAL; return 0; }
+    if (cur_need(c, 4) != 0) return 0;
     uint32_t v; memcpy(&v, c->p, 4); c->p += 4; return v;
 }
 static uint64_t cur_u64(cur_t *c) {
-    if (c->p + 8 > c->end) { c->err = -EINVAL; return 0; }
+    if (cur_need(c, 8) != 0) return 0;
     uint64_t v; memcpy(&v, c->p, 8); c->p += 8; return v;
 }
 static int32_t  cur_i32(cur_t *c) { uint32_t v = cur_u32(c); int32_t r; memcpy(&r, &v, 4); return r; }
@@ -137,14 +158,14 @@ static double   cur_f64(cur_t *c) { uint64_t v = cur_u64(c); double   r; memcpy(
 static char *cur_string_owned(cur_t *c, const char **raw_p, uint64_t *raw_len) {
     uint64_t n = cur_u64(c);
     if (c->err) return NULL;
-    if (c->p + n > c->end) { c->err = -EINVAL; return NULL; }
-    char *s = (char *)malloc(n + 1);
+    if (n > cur_remaining(c)) { c->err = -EINVAL; return NULL; }
+    char *s = (char *)malloc((size_t)n + 1);
     if (!s) { c->err = -ENOMEM; return NULL; }
-    memcpy(s, c->p, n);
+    memcpy(s, c->p, (size_t)n);
     s[n] = '\0';
     if (raw_p) *raw_p = (const char *)c->p;
     if (raw_len) *raw_len = n;
-    c->p += n;
+    c->p += (size_t)n;
     return s;
 }
 
@@ -191,16 +212,21 @@ static int parse_value(cur_t *c, face_gguf_kv *out, uint32_t type) {
             if (etype == GGUF_TYPE_STRING) {
                 for (uint64_t i = 0; i < alen; ++i) {
                     uint64_t en = cur_u64(c);
-                    if (c->err || c->p + en > c->end) { c->err = -EINVAL; return c->err; }
-                    c->p += en;
+                    if (c->err || cur_skip(c, en) != 0) {
+                        c->err = -EINVAL;
+                        return c->err;
+                    }
                 }
             } else if (etype == GGUF_TYPE_ARRAY) {
                 return -EINVAL;
             } else {
                 size_t esz;
                 if (gguf_dtype_size(etype, &esz) != 0) return -EINVAL;
-                if (c->p + esz * alen > c->end) { c->err = -EINVAL; return c->err; }
-                c->p += esz * alen;
+                if (esz != 0 && alen > (uint64_t)SIZE_MAX / esz) {
+                    c->err = -EINVAL;
+                    return -EINVAL;
+                }
+                if (cur_skip(c, (uint64_t)esz * alen) != 0) return c->err;
             }
             return 0;
         }
@@ -245,6 +271,17 @@ face_gguf *face_gguf_open(const char *path, int *err) {
         if (err) *err = c.err;
         munmap(map, map_size); close(fd);
         return NULL;
+    }
+    /* Each KV / tensor record starts with a u64 length. A count larger
+     * than the remaining bytes cannot be honest; calloc would otherwise
+     * try to allocate terabytes from a 24-byte file. */
+    {
+        size_t rem = cur_remaining(&c);
+        if (n_kvs > rem || n_tensors > rem) {
+            if (err) *err = -EINVAL;
+            munmap(map, map_size); close(fd);
+            return NULL;
+        }
     }
 
     face_gguf *g = (face_gguf *)calloc(1, sizeof(face_gguf));
@@ -301,7 +338,14 @@ face_gguf *face_gguf_open(const char *path, int *err) {
         g->tensors[i].data_off  = off;
 
         uint64_t elems = 1;
-        for (int d = 0; d < g->tensors[i].ndim; ++d) elems *= (uint64_t)g->tensors[i].dims[d];
+        for (int d = 0; d < g->tensors[i].ndim; ++d) {
+            uint64_t dim = (uint64_t)g->tensors[i].dims[d];
+            if (dim > 0 && elems > UINT64_MAX / dim) {
+                if (err) *err = -EINVAL;
+                goto fail;
+            }
+            elems *= dim;
+        }
         size_t esz;
         if (g->tensors[i].dtype == GGML_TYPE_F32) esz = 4;
         else if (g->tensors[i].dtype == GGML_TYPE_F16) esz = 2;
@@ -309,7 +353,11 @@ face_gguf *face_gguf_open(const char *path, int *err) {
             if (err) *err = -EINVAL;
             goto fail;
         }
-        g->tensors[i].n_bytes = elems * esz;
+        if (esz != 0 && elems > UINT64_MAX / (uint64_t)esz) {
+            if (err) *err = -EINVAL;
+            goto fail;
+        }
+        g->tensors[i].n_bytes = elems * (uint64_t)esz;
     }
 
     uint64_t cur_off = (uint64_t)((const uint8_t *)c.p - (const uint8_t *)map);
@@ -317,8 +365,13 @@ face_gguf *face_gguf_open(const char *path, int *err) {
     g->tensor_data_off = cur_off + pad;
 
     for (uint64_t i = 0; i < n_tensors; ++i) {
+        if (g->tensors[i].data_off > UINT64_MAX - g->tensor_data_off) {
+            if (err) *err = -EINVAL;
+            goto fail;
+        }
         g->tensors[i].data_off += g->tensor_data_off;
-        if (g->tensors[i].data_off + g->tensors[i].n_bytes > map_size) {
+        if (g->tensors[i].n_bytes > map_size ||
+            g->tensors[i].data_off > (uint64_t)map_size - g->tensors[i].n_bytes) {
             if (err) *err = -EINVAL;
             goto fail;
         }

--- a/packages/native/plugins/face-cpp/src/face_gguf.c
+++ b/packages/native/plugins/face-cpp/src/face_gguf.c
@@ -253,7 +253,7 @@ face_gguf *face_gguf_open(const char *path, int *err) {
         .err = 0,
     };
 
-    if (c.p + 4 > c.end || memcmp(c.p, GGUF_MAGIC, 4) != 0) {
+    if (cur_need(&c, 4) != 0 || memcmp(c.p, GGUF_MAGIC, 4) != 0) {
         if (err) *err = -EINVAL;
         munmap(map, map_size); close(fd);
         return NULL;

--- a/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
+++ b/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
@@ -1,0 +1,105 @@
+/**
+ * Hostile GGUF fixtures for `face_gguf_open`. A 32-byte file that declares
+ * UINT64_MAX key length must fail closed with `-EINVAL` instead of wrapping
+ * `ptr + u64` and memcpy-crashing the process. Contrast: a well-formed empty
+ * GGUF (zero KVs, zero tensors) still opens.
+ */
+
+#include "face_internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int write_bytes(const char *path, const void *data, size_t n) {
+    FILE *fp = fopen(path, "wb");
+    if (!fp) return -1;
+    size_t wrote = fwrite(data, 1, n, fp);
+    fclose(fp);
+    return wrote == n ? 0 : -1;
+}
+
+static int write_empty_gguf(const char *path) {
+    unsigned char buf[24];
+    memcpy(buf, "GGUF", 4);
+    uint32_t ver = 3;
+    uint64_t zero = 0;
+    memcpy(buf + 4, &ver, 4);
+    memcpy(buf + 8, &zero, 8);
+    memcpy(buf + 16, &zero, 8);
+    return write_bytes(path, buf, sizeof buf);
+}
+
+static int write_keylen_bomb(const char *path, uint64_t key_len) {
+    unsigned char buf[32];
+    memcpy(buf, "GGUF", 4);
+    uint32_t ver = 3;
+    uint64_t n_tensors = 0;
+    uint64_t n_kvs = 1;
+    memcpy(buf + 4, &ver, 4);
+    memcpy(buf + 8, &n_tensors, 8);
+    memcpy(buf + 16, &n_kvs, 8);
+    memcpy(buf + 24, &key_len, 8);
+    return write_bytes(path, buf, sizeof buf);
+}
+
+static char *make_tmp(void) {
+    char *path = strdup("/tmp/face-gguf-hostile-XXXXXX");
+    if (!path) return NULL;
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        free(path);
+        return NULL;
+    }
+    close(fd);
+    return path;
+}
+
+int main(void) {
+    int failures = 0;
+
+    char *empty_path = make_tmp();
+    char *bomb_path = make_tmp();
+    if (!empty_path || !bomb_path) {
+        fprintf(stderr, "[face-gguf-hostile] mkstemp failed\n");
+        return 2;
+    }
+
+    if (write_empty_gguf(empty_path) != 0) {
+        fprintf(stderr, "[face-gguf-hostile] write empty failed\n");
+        return 2;
+    }
+    int err = 0;
+    face_gguf *empty = face_gguf_open(empty_path, &err);
+    if (!empty || err != 0) {
+        fprintf(stderr, "[face-gguf-hostile] empty GGUF rejected (g=%p err=%d)\n",
+            (void *)empty, err);
+        ++failures;
+    }
+    if (empty) face_gguf_close(empty);
+
+    if (write_keylen_bomb(bomb_path, UINT64_MAX) != 0) {
+        fprintf(stderr, "[face-gguf-hostile] write bomb failed\n");
+        return 2;
+    }
+    err = 0;
+    face_gguf *bomb = face_gguf_open(bomb_path, &err);
+    if (bomb != NULL || err != -EINVAL) {
+        fprintf(stderr,
+            "[face-gguf-hostile] UINT64_MAX key length returned g=%p err=%d, expected NULL/-EINVAL\n",
+            (void *)bomb, err);
+        ++failures;
+    }
+    if (bomb) face_gguf_close(bomb);
+
+    unlink(empty_path);
+    unlink(bomb_path);
+    free(empty_path);
+    free(bomb_path);
+
+    printf("[face-gguf-hostile] failures=%d\n", failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
+++ b/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
@@ -100,10 +100,31 @@ int main(void) {
     }
     if (bomb) face_gguf_close(bomb);
 
+    char *short_path = make_tmp();
+    if (!short_path) {
+        fprintf(stderr, "[face-gguf-hostile] mkstemp short failed\n");
+        return 2;
+    }
+    if (write_bytes(short_path, "GGU", 3) != 0) {
+        fprintf(stderr, "[face-gguf-hostile] write 3-byte stub failed\n");
+        return 2;
+    }
+    err = 0;
+    face_gguf *too_short = face_gguf_open(short_path, &err);
+    if (too_short != NULL || err != -EINVAL) {
+        fprintf(stderr,
+            "[face-gguf-hostile] 3-byte file returned g=%p err=%d, expected NULL/-EINVAL\n",
+            (void *)too_short, err);
+        ++failures;
+    }
+    if (too_short) face_gguf_close(too_short);
+
     unlink(empty_path);
     unlink(bomb_path);
+    unlink(short_path);
     free(empty_path);
     free(bomb_path);
+    free(short_path);
 
     printf("[face-gguf-hostile] failures=%d\n", failures);
     return failures == 0 ? 0 : 1;

--- a/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
+++ b/packages/native/plugins/face-cpp/test/face_gguf_hostile_test.c
@@ -3,7 +3,12 @@
  * UINT64_MAX key length must fail closed with `-EINVAL` instead of wrapping
  * `ptr + u64` and memcpy-crashing the process. Contrast: a well-formed empty
  * GGUF (zero KVs, zero tensors) still opens.
+ *
+ * `_POSIX_C_SOURCE` must precede every system header. The package builds
+ * C11 with extensions off, so `strdup` / `mkstemp` are otherwise implicit
+ * on glibc and the returned pointer is truncated to `int`.
  */
+#define _POSIX_C_SOURCE 200809L
 
 #include "face_internal.h"
 


### PR DESCRIPTION
# Relates to

Standalone overflow on `origin/develop` in the product face-cpp GGUF loader (`face_gguf_open`), consumed by `@elizaos/plugin-vision` via `face-detector-ggml.ts` / `face-recognition-ggml.ts`. No invented issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from `146a30dfa931` (`#22383`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from latest `origin/develop` (`146a30dfa931`); zero conflicts.
- [ ] `bun run verify` is recorded as not run in **Known gaps / failures** — this is a C-only native package change.

# Risks

**Low.** Invalid GGUF files that previously crashed the process now return `-EINVAL`. Honest empty and synthetic BlazeFace / embed GGUFs still open. No UI, no wire protocol, no auth change.

# Background

## What does this PR do?

`face_gguf_open` treated GGUF string lengths as trusted `u64` and checked them with `ptr + n > end`. On a 32-byte file that declares `UINT64_MAX` key length, that addition wraps (UBSan: unsigned offset overflow) and `memcpy` is called with size `-1` (ASan: `negative-size-param`). The process aborts.

The product path is real: `plugin-vision` `dlopen`s this library and calls `face_embed_open` / `face_detect_open` on a GGUF path. A hostile model file at the configured weights path takes down the host.

This PR compares declared lengths against remaining mapped bytes (never `ptr + u64`), rejects KV/tensor counts larger than the remaining file, and fail-closes dim-product / range overflows.

## What kind of change is this?

Bug fix (non-breaking). Fail-closed input boundary on untrusted GGUF length fields.

## Why are we doing this? Any context or related work?

Complete bar: overflow / process abort on origin, proven with ASan+UBSan before the patch. Not a fetch/WS timeout leftover. Not a PNG leftover of `#22306`. Not zip/gzip leftover. Not AOSP GGUF. Not a width-only ASI preflight. One host: `face_gguf.c`. Did not twin `doctr_gguf.c`.

# Documentation changes needed?

Source-map line in `packages/native/plugins/face-cpp/AGENTS.md` / `CLAUDE.md` (identical) now mentions the hostile GGUF test.

# Testing

## Where should a reviewer start?

1. Origin proof: compile `origin/develop` `face_gguf.c` + a 32-byte `UINT64_MAX` key-length bomb under `-fsanitize=address,undefined` → ASan abort at `cur_string_owned` / `memcpy`.
2. This head: `face_gguf_hostile_test` → empty GGUF opens; bomb returns `NULL` / `-EINVAL`; no sanitizer report.
3. Existing C suite still green (7/7, parity test excluded — needs torch fixtures).

## Detailed testing steps

Automated. Hostile fixture is 32 bytes; no model weights required.

```bash
cmake -B packages/native/plugins/face-cpp/build -S packages/native/plugins/face-cpp
cmake --build packages/native/plugins/face-cpp/build -j
ctest --test-dir packages/native/plugins/face-cpp/build --output-on-failure -E face_parity_test
```

# Evidence Gate

<!-- evidence-head:060456055c3d1e4abcfb9575d2188521082c59d8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; C GGUF loader only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; C GGUF loader only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface; C GGUF loader only.
<!-- evidence-row:backend-logs -->
- [x] Origin ASan abort vs patched fail-closed `-EINVAL` pasted below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend / HTTP path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / schedule / wallet artifact; the domain artifact is the 32-byte GGUF bomb + ctest.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Origin `develop` (`146a30dfa931`) + ASan/UBSan, 32-byte bomb `key_len=UINT64_MAX`:

```
opening bomb key_len=18446744073709551615
face_gguf.c:140:14: runtime error: addition of unsigned offset overflowed
AddressSanitizer: negative-size-param: (size=-1)
    #2 cur_string_owned face_gguf.c:143
    #3 face_gguf_open face_gguf.c:262
ABORTING
exit=134
```

This head (`060456055c3d1e4abcfb9575d2188521082c59d8`) + same bomb:

```
NEW g=0x0 err=-22
new_bomb_exit=0
[face-gguf-hostile] failures=0
```

ctest at this head (ASan/UBSan build): **7/7 passed** (`face_abi_smoke`, `face_anchor_test`, `face_align_test`, `face_distance_test`, `face_runtime_test`, `face_embed_runtime_test`, `face_gguf_hostile_test`). `face_parity_test` excluded — requires torch / upstream checkpoints, unchanged by this loader bound.

Frontend: N/A - no frontend.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- Did not run root `bun install` / `bun run verify`. This diff is C-only under `packages/native/plugins/face-cpp` (plus identical AGENTS/CLAUDE source-map line). Proof is the ASan origin abort and the ASan ctest 7/7 at this head.
- Did not twin `packages/native/plugins/doctr-cpp/src/doctr_gguf.c` (same cursor pattern; not the plugin-vision face loader).
- `face_parity_test` not run (torch/checkpoint fixture; not this bound).

# Additional context

Occupancy-FREE at scan. One complete logical unit. No leftover-tax. Stay off `#22262`. No twin of `#22278`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
