### PR TITLE
fix(plugin-discord): keep surrogate pairs intact in splitMessage fallback

### DIFF
--- a/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for the outbound Discord `splitMessage` fallback
+ * (`utils.ts`, used by the connector delivery and retry paths): a raw-limit
+ * slice must never split a UTF-16 surrogate pair (emoji) across chunks, and a
+ * chunk limit that cannot make UTF-16 progress must reject instead of
+ * spinning. Pure-function assertions on the real exported `splitMessage`.
+ */
+import { describe, expect, it } from "vitest";
+import { splitMessage } from "../utils";
+
+const MAX_DISCORD_MESSAGE_LENGTH = 2000;
+
+function expectWellFormedLossless(chunks: string[], original: string): void {
+	expect(chunks.length).toBeGreaterThan(1);
+	for (const chunk of chunks) {
+		expect(chunk.length).toBeGreaterThan(0);
+		expect(chunk.isWellFormed()).toBe(true);
+	}
+	expect(chunks.join("")).toBe(original);
+}
+
+describe("splitMessage surrogate-safe chunking", () => {
+	it("keeps surrogate pairs intact and lossless across the limit", () => {
+		// A leading single-width char shifts the emoji run onto an odd offset,
+		// so the raw-limit fallback cut lands between a pair's high and low
+		// surrogate instead of coincidentally on a pair boundary.
+		const text = `b${"🎉".repeat(MAX_DISCORD_MESSAGE_LENGTH)}`;
+
+		const chunks = splitMessage(text, MAX_DISCORD_MESSAGE_LENGTH);
+
+		expectWellFormedLossless(chunks, text);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(MAX_DISCORD_MESSAGE_LENGTH);
+		}
+	});
+
+	it("splits on whitespace when available and stays well-formed", () => {
+		const firstLine = "y".repeat(MAX_DISCORD_MESSAGE_LENGTH - 1);
+		const text = `${firstLine} z`;
+
+		const chunks = splitMessage(text, MAX_DISCORD_MESSAGE_LENGTH);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.isWellFormed()).toBe(true);
+		}
+	});
+
+	it("returns the original text unchanged when under the limit", () => {
+		expect(splitMessage("hello world", MAX_DISCORD_MESSAGE_LENGTH)).toEqual([
+			"hello world",
+		]);
+	});
+
+	it("rejects a chunk limit that cannot make UTF-16 progress", () => {
+		// maxLength=1 cannot hold the lead half of an emoji without stranding it.
+		expect(() => splitMessage(`😀${"x".repeat(10)}`, 1)).toThrow(RangeError);
+	});
+});

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -19,6 +19,7 @@ import {
 	type ReplyToMode,
 	type SsrfPolicy,
 	trimTokens,
+	truncateWellFormed,
 } from "@elizaos/core";
 import {
 	ActionRowBuilder,
@@ -924,8 +925,19 @@ export function splitMessage(
 				splitIdx = lastSpace;
 			}
 
-			chunks.push(line.slice(0, splitIdx));
-			line = line.slice(splitIdx).trimStart();
+			// A raw slice() can land between the two UTF-16 code units of a
+			// surrogate pair (most emoji), leaving a lone surrogate at the
+			// chunk boundary that corrupts the character in the delivered
+			// message. truncateWellFormed backs the cut off by one unit
+			// instead.
+			const head = truncateWellFormed(line, splitIdx);
+			if (head.length === 0) {
+				throw new RangeError(
+					"Discord message chunk limit made no UTF-16 progress",
+				);
+			}
+			chunks.push(head);
+			line = line.slice(head.length).trimStart();
 		}
 		chunks.push(line);
 		return chunks;


### PR DESCRIPTION
# Relates to

Companion fix to #22209 (same bug shape in `plugins/plugin-discord`, already
open): that PR hardens `chunkDiscordText`/`splitLongLine`
(`messaging.ts`); this PR covers the remaining unfixed path —
`splitMessage` (`utils.ts`), the fallback used by the connector's outbound
delivery and retry/dedupe paths.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash-free`
<!-- attribution-row:client -->
- Agent tooling: `opencode`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`256c755448`); zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One call site changed (`splitMessage`'s raw-limit fallback cut in
`plugins/plugin-discord/utils.ts`, used by `sendToChannel` and the outbound
retry/dedupe path at `service.ts`). Pure string logic, no new dependency, no
public API change. The whitespace-break and newline preference paths are
untouched; the only behavior change is that a cut that would land between a
surrogate pair backs off by one UTF-16 code unit, and a chunk limit too small
to make UTF-16 progress rejects with a `RangeError` instead of spinning
indefinitely or emitting a lone surrogate.

# Background

## What does this PR do?

`splitMessage` (`plugins/plugin-discord/utils.ts`) chunks outbound Discord
text over `MAX_MESSAGE_LENGTH` (2000), preferring a space break point near the
limit and falling back to a raw cut at the exact limit when no whitespace
break is found. That fallback used `line.slice(0, splitIdx)` — a plain UTF-16
code-unit slice — which can land between the two code units of a surrogate
pair (most emoji), tearing the pair into two lone-surrogate chunks. The
delivered Discord message then carries malformed UTF-16 (`isWellFormed() ===
false`), corrupting the emoji on the wire, and the split is lossy.

This swaps that one cut point for core's `truncateWellFormed`
(`packages/core/src/utils/well-formed.ts`), which backs the cut off by one
code unit when it would otherwise split a pair, and throws a `RangeError`
when a caller-supplied limit is too small to consume even one well-formed
unit (matching the fail-closed contract already merged for the Telegram
connector and `plugin-slack`). Same helper, same fix pattern as #22204
(plugin-telegram), #22222 (plugin-slack), #22221 (plugin-instagram), #22220
(plugin-imessage), #22223 (plugin-signal), and the open companion #22209
(plugin-discord `chunkDiscordText`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts` (4
  tests) — drives the real exported `splitMessage`: surrogate-pair integrity
  and losslessness across the 2000-char limit, whitespace-break behavior,
  under-limit passthrough, and the fail-closed `RangeError` for a limit that
  cannot make UTF-16 progress.

## Detailed testing steps

None: Automated tests are acceptable. Every assertion drives the real exported
`splitMessage` — no mock stands in for the system under test.

- `bun run --cwd plugins/plugin-discord test -- __tests__/messaging-chunk-surrogate.test.ts` (4 tests)
- Full plugin-discord suite (648 passed; the only 4 failures are the
  pre-existing macOS-only `discord-local-oauth-timeout.test.ts` gate,
  reproduced identically on clean `develop` — see Known gaps)
- `bun run --cwd plugins/plugin-discord typecheck`
- `bunx biome check .` (159 files, no issues)

I also verified the new tests are load-bearing: the same test file run against
the pre-fix `splitMessage` (plain `slice`) fails the surrogate-integrity test.

# Evidence Gate

<!-- evidence-head:add1f088919e42446d2cf33c87fe33ee0a0d4edf -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure Discord text chunking has no rendered app UI
<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure Discord text chunking has no rendered app UI
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic pure-function regression covers the changed delivery helper
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend process or transport integration is changed

<details>
<summary>Backend logs — current head (truncateWellFormed applied), plus control run against pre-fix code</summary>

```
$ bun run --cwd plugins/plugin-discord test -- __tests__/messaging-chunk-surrogate.test.ts

 Test Files  1 passed (1)
      Tests  4 passed (4)

$ bun run --cwd plugins/plugin-discord test   # full plugin suite

 Test Files  1 failed | 81 passed (82)
      Tests  4 failed | 648 passed (652)
      # the 4 failures are the pre-existing macOS-only
      # discord-local-oauth-timeout.test.ts gate (see Known gaps)

$ bun run --cwd plugins/plugin-discord typecheck
(no output — clean)

$ bunx biome check .
Checked 159 files in 406ms. No fixes applied.

--- Standalone reproduction, current head ---
$ node --experimental-strip-types repro.mjs
chunkDiscordText: chunks=3 illFormed=0 lossless=true
splitMessage: chunks=3 illFormed=0 lossless=true

--- Control: same input against pre-fix splitMessage (plain slice) ---
splitMessage: chunk 0 NOT well-formed
splitMessage: chunk 1 NOT well-formed
splitMessage: chunk 2 NOT well-formed
splitMessage count: 3 lossless: false
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network path is changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior is changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact-head chunk arrays and UTF-16 well-formedness are asserted by the focused test

<details>
<summary>Domain artifact — well-formed/lossless proof, run against the current head</summary>

```
import { chunkDiscordText } from "plugins/plugin-discord/messaging.ts";
import { splitMessage } from "plugins/plugin-discord/utils.ts";

const text = `a${"🙂".repeat(2200)}`;
const chunks1 = chunkDiscordText(text, { maxChars: 2000 });
let bad1 = 0;
for (const c of chunks1) if (!c.isWellFormed()) bad1++;
console.log(`chunkDiscordText: chunks=${chunks1.length} illFormed=${bad1} lossless=${chunks1.join("") === text}`);

const text2 = `b${"🎉".repeat(2200)}`;
const chunks2 = splitMessage(text2, 2000);
let bad2 = 0;
for (const c of chunks2) if (!c.isWellFormed()) bad2++;
console.log(`splitMessage: chunks=${chunks2.length} illFormed=${bad2} lossless=${chunks2.join("") === text2}`);
```

Output:

```
chunkDiscordText: chunks=3 illFormed=0 lossless=true
splitMessage: chunks=3 illFormed=0 lossless=true
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text or UI surface is changed

# Evidence Details

## Known gaps / failures

- `bun run verify` reports one failure, `@elizaos/cloud-test-mocks#typecheck`:
  `plugins/plugin-whatsapp/src/baileys/qr-code.ts(6,33): error TS7016: Could
  not find a declaration file for module 'qrcode-terminal'`. Reproduced
  identically on clean `origin/develop` — unrelated to this change (this PR
  touches `plugins/plugin-discord` only).
- 4 failures in `__tests__/discord-local-oauth-timeout.test.ts`
  (`Discord local connector currently supports macOS only`) on this Linux
  host; reproduced identically with this PR's changes stashed, so they are
  pre-existing environment gates, not regressions.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: deepseek / deepseek-v4-flash-free
Client / agent tooling: opencode
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-bugfix]
<!-- slop-contribution-attribution:v1 {"provider":"deepseek","model":"deepseek-v4-flash-free","client":"opencode","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0CBCJZ3DP3AAZK69R2976T3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-19T06:29:55.299Z","completed_at":"2026-08-19T07:14:46.745Z","skill_sha256":"1587e294dc58a3e45ee6dcf5dd4d4aeb21f17e394b6137f33775caa9a2c063c7","usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d5cd81423a56d61df6a2f76c54f284906f08146002419a5e18ff539362509dd5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e0de0604-b56d-4bec-9709-b967b27ba6bc","object_id":"sha256:d5cd81423a56d61df6a2f76c54f284906f08146002419a5e18ff539362509dd5","sha256":"d5cd81423a56d61df6a2f76c54f284906f08146002419a5e18ff539362509dd5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"V-8hrgyt4p8o3hWCiYOJ0ix7UExnas-YbzpHVUHrm3jTgmk2CI6HcC-XOaCYQJTF7w74fWTJpzfr_hZW0-CCCA"}} -->


