### PR TITLE
fix(plugin-native-llama): reject multi-parent token-tree DAGs

### DIFF
--- a/plugins/plugin-native-llama/src/token-tree-codec.test.ts
+++ b/plugins/plugin-native-llama/src/token-tree-codec.test.ts
@@ -8,6 +8,8 @@
  *     subtrees)
  *   - the encoder is deterministic across runs
  *   - the decoder rejects malformed inputs rather than producing garbage
+ *   - a multi-parent complete DAG (origin hang: 26 nodes / 1.5 KiB → 33M paths)
+ *     is rejected immediately instead of exploding `collectLeaves`
  */
 
 import { describe, expect, it } from "vitest";
@@ -100,4 +102,54 @@ describe("token-tree-codec", () => {
     const out = deserializeTokenTree(serializeTokenTree(input));
     expect(out.path).toBe("résumé.fields[0]");
   });
+
+  it("rejects a multi-parent DAG instead of exploding collectLeaves", () => {
+    // Every node points at every later node. Origin collectLeaves on 26
+    // nodes / 1551 bytes expanded 33,554,431 paths (~2.3s). The encoder
+    // never emits a second inbound edge.
+    const bomb = buildCompleteForwardDag(26);
+    expect(bomb.byteLength).toBe(1551);
+    const started = performance.now();
+    expect(() => deserializeTokenTree(bomb)).toThrow(/multiple parents/);
+    expect(performance.now() - started).toBeLessThan(50);
+  });
 });
+
+/** Hostile RTKT v1 buffer: node i children = i+1..n-1. */
+function buildCompleteForwardDag(n: number): Uint8Array {
+  const MAGIC = 0x544b5452;
+  const ROOT_TOKEN_ID = -1;
+  const pathBytes = new TextEncoder().encode("x");
+  let body = 4;
+  for (let i = 0; i < n; i++) {
+    body += 9 + (n - 1 - i) * 4;
+  }
+  const buf = new ArrayBuffer(12 + pathBytes.length + body);
+  const view = new DataView(buf);
+  const bytes = new Uint8Array(buf);
+  let offset = 0;
+  view.setUint32(offset, MAGIC, true);
+  offset += 4;
+  view.setUint32(offset, 1, true);
+  offset += 4;
+  view.setUint32(offset, pathBytes.length, true);
+  offset += 4;
+  bytes.set(pathBytes, offset);
+  offset += pathBytes.length;
+  view.setUint32(offset, n, true);
+  offset += 4;
+  for (let i = 0; i < n; i++) {
+    view.setInt32(offset, i === 0 ? ROOT_TOKEN_ID : i, true);
+    offset += 4;
+    view.setUint8(offset, 1);
+    offset += 1;
+    const childCount = n - 1 - i;
+    view.setUint32(offset, childCount, true);
+    offset += 4;
+    for (let j = i + 1; j < n; j++) {
+      view.setUint32(offset, j, true);
+      offset += 4;
+    }
+  }
+  return bytes;
+}

--- a/plugins/plugin-native-llama/src/token-tree-codec.ts
+++ b/plugins/plugin-native-llama/src/token-tree-codec.ts
@@ -21,7 +21,10 @@
  * The "child_ptrs" entries point into the same flat node array — the sampler
  * walks by index, never by allocation. Pre-order traversal guarantees parent
  * index < child index, so a single forward pass can resolve every pointer
- * without a second materialisation step.
+ * without a second materialisation step. The encoder emits a tree (in-degree
+ * ≤ 1). The decoder rejects a second inbound edge: `collectLeaves` copies the
+ * path at every visit, so a 1.5 KiB complete DAG (every node points at every
+ * later node) expands to tens of millions of paths.
  *
  * Round-trip invariants:
  *   - `deserializeTokenTree(serializeTokenTree(d))` is structurally equal to
@@ -37,6 +40,8 @@ import type { TokenSequence, TokenTreeDescriptor } from "./definitions";
 const MAGIC = 0x544b5452; // "RTKT" (Runtime Token Tree)
 const VERSION = 1;
 const ROOT_TOKEN_ID = -1;
+/** Speculative-decode tries are tiny; a larger count is hostile, not a model. */
+const MAX_TOKEN_TREE_NODES = 65_536;
 
 interface TrieNode {
   tokenId: number;
@@ -192,7 +197,9 @@ function collectLeaves(flat: FlatNode[], rootIdx: number): TokenSequence[] {
  * the native sampler), so callers needing the original names should keep
  * the source-side descriptor around alongside the bytes.
  *
- * Throws on truncated input, unknown magic, or unsupported version.
+ * Throws on truncated input, unknown magic, unsupported version, or a
+ * multi-parent DAG (the encoder never emits one; a second inbound edge is
+ * a hang bomb for `collectLeaves`).
  */
 export function deserializeTokenTree(input: Uint8Array): TokenTreeDescriptor {
   if (input.byteLength < 16) {
@@ -225,6 +232,11 @@ export function deserializeTokenTree(input: Uint8Array): TokenTreeDescriptor {
   offset += pathLen;
   const totalNodes = view.getUint32(offset, true);
   offset += 4;
+  if (totalNodes > MAX_TOKEN_TREE_NODES) {
+    throw new Error(
+      `deserializeTokenTree: node count ${totalNodes} exceeds ${MAX_TOKEN_TREE_NODES}`,
+    );
+  }
 
   const flat: FlatNode[] = [];
   for (let i = 0; i < totalNodes; i++) {
@@ -260,6 +272,18 @@ export function deserializeTokenTree(input: Uint8Array): TokenTreeDescriptor {
     throw new Error(
       "deserializeTokenTree: root node missing or has non-sentinel tokenId",
     );
+  }
+
+  const inbound = new Uint32Array(flat.length);
+  for (let i = 0; i < flat.length; i++) {
+    for (const ptr of flat[i].childPtrs) {
+      inbound[ptr] += 1;
+      if (inbound[ptr] > 1) {
+        throw new Error(
+          `deserializeTokenTree: node ${ptr} has multiple parents`,
+        );
+      }
+    }
   }
 
   const leaves = collectLeaves(flat, 0);


### PR DESCRIPTION
# Relates to

Standalone hang on `origin/develop` in `deserializeTokenTree` (`plugins/plugin-native-llama/src/token-tree-codec.ts`), the public RTKT v1 codec for the native speculative-decode sampler. No invented issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from `146a30dfa931` (`#22383`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from latest `origin/develop` (`146a30dfa931`); zero conflicts.
- [ ] `bun run verify` is recorded as not run in **Known gaps / failures** — this is a two-file codec change with an isolated bun:test.

# Risks

**Low.** The encoder already emits a tree (in-degree ≤ 1). Honest `serializeTokenTree` payloads still round-trip. Hostile multi-parent buffers that previously hung now throw.

# Background

## What does this PR do?

`deserializeTokenTree` accepted any forward child pointer (`ptr > self && ptr < n`). It did not require a tree. `collectLeaves` copies the token path at every visit, so a complete DAG — every node points at every later node — expands exponentially.

On origin `146a30dfa931`, a **1551-byte** 26-node complete DAG made origin `collectLeaves` emit **33,554,431** paths in **2268 ms**. A 24-node / 1337-byte sibling was 8.3M paths / 557 ms.

This PR:
- rejects a second inbound edge before the walk
- rejects `totalNodes > 65536` (speculative-decode tries are tiny)

The 1551-byte bomb now throws `multiple parents` in **< 1 ms**.

## What kind of change is this?

Bug fix (non-breaking). Fail-closed input boundary on an untrusted binary codec.

## Why are we doing this? Any context or related work?

Complete bar: hang on origin, proven before the patch. Not a fetch/WS leftover. Not a GGUF leftover of `#22386`. Not PNG/zip/gzip/body/symlink. One host: `token-tree-codec.ts`.

# Documentation changes needed?

None. Codec contract is unchanged for encoder-produced trees.

# Testing

## Where should a reviewer start?

1. Origin proof: 26-node complete-forward DAG, 1551 bytes → 33,554,431 leaves / 2268 ms.
2. This head: `bun test plugins/plugin-native-llama/src/token-tree-codec.test.ts` — 8/8, hostile case throws `/multiple parents/` in < 50 ms.
3. Existing round-trip / prefix-share / truncated / bad-magic cases still pass.

## Detailed testing steps

```bash
bun test plugins/plugin-native-llama/src/token-tree-codec.test.ts
```

# Evidence Gate

<!-- evidence-head:7fc43d192187496257f3723de1052c35e76d6af1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; binary codec only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; binary codec only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface; binary codec only.
<!-- evidence-row:backend-logs -->
- [x] Origin hang timing vs patched reject pasted below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend / HTTP path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - domain artifact is the 1551-byte RTKT bomb + bun:test; not a DB/wallet/audio artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Origin `develop` (`146a30dfa931`) `collectLeaves` on a 26-node complete-forward RTKT v1 buffer:

```
{"n":26,"ms":2268.4,"leaves":33554431,"bytes":1551}
{"n":24,"ms":556.6,"leaves":8388607,"bytes":1337}
{"n":22,"ms":580.1,"leaves":2097151,"bytes":1139}
```

This head (`7fc43d192187496257f3723de1052c35e76d6af1`):

```
(pass) token-tree-codec > rejects a multi-parent DAG instead of exploding collectLeaves [0.62ms]
8 pass, 0 fail
```

Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- Did not run root `bun install` / `bun run verify`. Diff is two files under `plugins/plugin-native-llama/src/`. Proof is the origin hang timing and isolated bun:test 8/8 at this head.
- Did not change the native C++ sampler (encoder still emits a tree; decoder now matches that contract).

# Additional context

Occupancy-FREE at scan. One complete logical unit. No leftover-tax. Stay off `#22262`. No twin of `#22278`. No twin of `#22386` GGUF.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
