### PR TITLE
fix(plugin-wallet): resolve x402 fee-leg asset address for symbol assets (Closes #22381)

### DIFF
--- a/plugins/plugin-wallet/src/sdk/x402/client.fee-leg.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.fee-leg.test.ts
@@ -3,9 +3,10 @@
  * assets to their on-chain address, exactly like the payment leg. A 402 that
  * names its asset by symbol ("USDC") previously forwarded the raw string to
  * `agentTransferToken`, which ABI-encodes it as an `address` and throws
- * `InvalidAddressError`. This drives the private `executePayment` path through
- * a mocked wallet-core and asserts BOTH transfer legs receive the resolved
- * address, never the symbol.
+ * `InvalidAddressError`. This drives both the private `executePayment` path and
+ * the public `fetch` entry point through a mocked wallet-core, asserting BOTH
+ * transfer legs receive the resolved address and that the recorded transaction
+ * is logged against the resolved address, never the symbol.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentWallet } from "../wallet-core";
@@ -89,5 +90,44 @@ describe("X402Client fee leg asset resolution (#22381)", () => {
     // recorded against what was actually transferred, not the raw symbol.
     expect(result.token).toBe(USDC_BASE);
     expect(result.txHash).toBe(TX_HASH);
+  });
+
+  it("records the resolved address in the transaction log via the public fetch path", async () => {
+    // Drive the real contract boundary — `fetch` consuming a 402 — so the
+    // second half of the fix (the caller using the returned token) is pinned.
+    // A regression that logs `selected.asset` instead of the resolved token
+    // would surface here as a symbol in the recorded transaction.
+    const paymentRequired = {
+      x402Version: 1,
+      resource: {
+        url: "https://api.example.com/resource",
+        description: "",
+        mimeType: "application/json",
+      },
+      accepts: [symbolRequirement()],
+    };
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(paymentRequired), { status: 402 }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    try {
+      const client = new X402Client(createWallet());
+      const response = await client.fetch("https://api.example.com/resource");
+
+      expect(response.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const log = client.getTransactionLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].token).toBe(USDC_BASE);
+      expect(log[0].token).not.toBe("USDC");
+      expect(log[0].txHash).toBe(TX_HASH);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });

--- a/plugins/plugin-wallet/src/sdk/x402/client.fee-leg.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.fee-leg.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression for #22381 — the x402 protocol-fee leg must resolve symbol-form
+ * assets to their on-chain address, exactly like the payment leg. A 402 that
+ * names its asset by symbol ("USDC") previously forwarded the raw string to
+ * `agentTransferToken`, which ABI-encodes it as an `address` and throws
+ * `InvalidAddressError`. This drives the private `executePayment` path through
+ * a mocked wallet-core and asserts BOTH transfer legs receive the resolved
+ * address, never the symbol.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentWallet } from "../wallet-core";
+import { X402Client } from "./client";
+import type { X402PaymentRequirements } from "./types";
+
+const { agentTransferToken, checkBudget } = vi.hoisted(() => ({
+  agentTransferToken: vi.fn(),
+  checkBudget: vi.fn(),
+}));
+
+vi.mock("../wallet-core.js", () => ({
+  agentTransferToken,
+  checkBudget,
+}));
+
+// USDC on Base (chainId 8453) — the address the symbol must resolve to.
+const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const TX_HASH =
+  "0x0000000000000000000000000000000000000000000000000000000000000abc";
+
+function createWallet(): AgentWallet {
+  return {
+    address: "0x0000000000000000000000000000000000000001",
+  } as unknown as AgentWallet;
+}
+
+function symbolRequirement(): X402PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "base:8453",
+    // Symbol form, NOT an address — this is the case #22381 regressed on.
+    asset: "USDC",
+    // Large enough that the 0.77% fee floors to a non-zero base-unit amount.
+    amount: "1000000",
+    payTo: "0x0000000000000000000000000000000000000002",
+    maxTimeoutSeconds: 60,
+    extra: {},
+  };
+}
+
+describe("X402Client fee leg asset resolution (#22381)", () => {
+  beforeEach(() => {
+    agentTransferToken.mockReset();
+    checkBudget.mockReset();
+    checkBudget.mockResolvedValue({
+      token: USDC_BASE,
+      perTxLimit: 10_000_000n,
+      remainingInPeriod: 10_000_000n,
+    });
+    agentTransferToken.mockResolvedValue(TX_HASH);
+  });
+
+  it("resolves the symbol on BOTH the fee leg and the payment leg", async () => {
+    const client = new X402Client(createWallet());
+    const executePayment = (
+      client as unknown as {
+        executePayment: (
+          req: X402PaymentRequirements,
+        ) => Promise<{ txHash: string; token: string }>;
+      }
+    ).executePayment.bind(client);
+
+    const result = await executePayment(symbolRequirement());
+
+    // Fee leg + payment leg = two transfers, both with a resolved address.
+    expect(agentTransferToken).toHaveBeenCalledTimes(2);
+    for (const call of agentTransferToken.mock.calls) {
+      const params = call[1] as { token: string; amount: bigint };
+      expect(params.token).toBe(USDC_BASE);
+      expect(params.token).not.toBe("USDC");
+    }
+
+    // Fee is 0.77% (77 bps) of the amount; payment leg sends the full amount.
+    const feeCall = agentTransferToken.mock.calls[0][1] as { amount: bigint };
+    const payCall = agentTransferToken.mock.calls[1][1] as { amount: bigint };
+    expect(feeCall.amount).toBe((1_000_000n * 77n) / 10_000n);
+    expect(payCall.amount).toBe(1_000_000n);
+
+    // The returned token is the resolved address, so the transaction log is
+    // recorded against what was actually transferred, not the raw symbol.
+    expect(result.token).toBe(USDC_BASE);
+    expect(result.txHash).toBe(TX_HASH);
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/x402/client.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.ts
@@ -112,6 +112,7 @@ export class X402Client {
 
     // Execute payment
     const paymentResult = await this.executePayment(selected);
+    const resolvedToken = paymentResult.token;
 
     // Build payment payload
     const paymentPayload: X402PaymentPayload = {
@@ -130,7 +131,7 @@ export class X402Client {
       service,
       url: urlStr,
       amount,
-      token: selected.asset as Address,
+      token: resolvedToken,
       recipient: selected.payTo as Address,
       txHash: paymentResult.txHash,
       network: selected.network,
@@ -246,7 +247,7 @@ export class X402Client {
    */
   private async executePayment(
     req: X402PaymentRequirements,
-  ): Promise<{ txHash: Hash }> {
+  ): Promise<{ txHash: Hash; token: Address }> {
     // Resolve the actual contract address for the requested asset
     const resolvedAddress = resolveAssetAddress(req.asset, req.network);
     if (!resolvedAddress) {
@@ -281,7 +282,7 @@ export class X402Client {
 
     if (feeAmount > 0n) {
       await agentTransferToken(this.wallet, {
-        token: req.asset as Address,
+        token: resolvedAddress,
         to: FEE_COLLECTOR,
         amount: feeAmount,
       });
@@ -294,7 +295,7 @@ export class X402Client {
       amount,
     });
 
-    return { txHash };
+    return { txHash, token: resolvedAddress };
   }
 
   // ─── Budget Access ───


### PR DESCRIPTION
# Relates to

Closes #22381

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package `test`/`typecheck`/`lint` were run; unrelated pre-existing failures are recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the failing-then-passing regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@dd2d8802dc994f993234216c5d0e20a6d07bcef4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`a98d9641ab`); zero conflicts.
- [ ] `bun run verify` — not run to completion on this constrained machine; scoped package checks were run instead (see **Known gaps / failures**).

# Risks

Low. The change is confined to `plugins/plugin-wallet/src/sdk/x402/client.ts`: it swaps a raw
symbol string for the already-computed resolved on-chain address on the protocol-fee transfer leg
(matching the existing payment leg) and threads that resolved address into the transaction log.
No public API, no registry behavior, and no fail-closed guard changes. No funds are at risk — the
prior behavior threw before any transaction was sent.

# Background

## What does this PR do?

`X402Client.executePayment()` resolved the payment asset to an on-chain address via the
`TokenRegistry` and used it for the **payment leg**, but passed the raw, unresolved `req.asset`
to the **protocol-fee leg**:

```ts
if (feeAmount > 0n) {
  await agentTransferToken(this.wallet, {
    token: req.asset as Address,   // BUG: unresolved symbol
    to: FEE_COLLECTOR,
    amount: feeAmount,
  });
}
```

When a 402 response names its asset by symbol (e.g. `"USDC"`) — a form `resolveAssetAddress()`
explicitly accepts — the string `"USDC"` reached `agentTransferToken`, which ABI-encodes `token`
as an `address` via viem and throws `InvalidAddressError: Address "USDC" is invalid`. This fired
whenever `feeAmount > 0n` (i.e. `amount * 77 / 10000 > 0`, roughly `amount >= 130` base units),
so **every symbol-named 402 payment failed before any transaction was sent**.

This PR:
1. Uses the already-resolved `resolvedAddress` on the fee leg (matching the payment leg).
2. Returns the resolved address from `executePayment` so the `X402TransactionLog.token` field
   records the token that was actually transferred, instead of the raw symbol.
3. Adds focused regression tests: one drives `executePayment` with a symbol asset and asserts
   both transfer legs receive the resolved on-chain address; a second drives the public
   `X402Client.fetch()` boundary through a mocked 402 and asserts `X402TransactionLog.token` is
   the resolved address, not the symbol.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The fix restores the documented
symbol-or-address asset contract of `resolveAssetAddress()`; behavior now matches existing docs.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/sdk/x402/client.fee-leg.test.ts` — a new regression that mocks
`agentTransferToken`/`checkBudget` from wallet-core, invokes the private `executePayment` with a
symbol requirement (`asset: "USDC"` on `base:8453`), and asserts BOTH the fee leg and the payment
leg receive the resolved address `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, never `"USDC"`.

## Detailed testing steps

```bash
cd plugins/plugin-wallet
bunx vitest run src/sdk/x402/                 # full x402 suite (10 tests) green
bunx vitest run src/sdk/x402/client.fee-leg.test.ts
```

# Evidence Gate

<!-- evidence-head:64dd54817cbd03a8dd5d1abaacfd91cd53281b34 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; SDK payment-path defect in x402 client`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; SDK payment-path defect in x402 client`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no rendered UI surface; SDK payment-path defect in x402 client`.
<!-- evidence-row:backend-logs -->
- [x] Real code path firing end to end — the regressions drive the real `executePayment` path (fee/payment legs) and the real public `X402Client.fetch()` path (transaction log). Failing-then-passing transcript captured on the current rebased head `64dd54817cbd03a8dd5d1abaacfd91cd53281b34`:
  ```
  # 1) Mutation A — fee leg reverted to raw req.asset "USDC" — private-path test FAILS
     × resolves the symbol on BOTH the fee leg and the payment leg
  AssertionError: expected 'USDC' to be '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA…'

  # 2) Mutation B — caller (client.ts:134) reverted to selected.asset — public-path test FAILS
     × records the resolved address in the transaction log via the public fetch path
  AssertionError: expected 'USDC' to be '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA…'

  # 3) With the fix (resolved address on both legs + threaded into the log) — full x402 suite PASSES
   Test Files  2 passed (2)
        Tests  10 passed (10)
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend surface; SDK payment-path defect`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; pure SDK asset-resolution fix`.
<!-- evidence-row:domain-artifacts -->
- [x] On-chain transfer arguments the regression asserts `agentTransferToken` would submit for a symbol-form 402 (`asset:"USDC"`, `base:8453`, `amount:"1000000"`):
  ```
  resolved token (both legs): 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913  (USDC on Base 8453)
  fee leg     token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913  amount=7700     (= 1000000*77/10000)
  payment leg token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913  amount=1000000
  before fix: fee leg submitted token="USDC" → viem InvalidAddressError before any tx is sent
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; pure SDK asset-resolution fix.`

## Backend + frontend logs

Failing-then-passing regression transcript (the test drives the real `executePayment` path;
wallet-core transfer legs are mocked to capture their arguments).

<details>
<summary>1) Mutation A — fee leg reverted to raw <code>req.asset</code> — private-path test FAILS</summary>

```
     × resolves the symbol on BOTH the fee leg and the payment leg 16ms
⫰⫰⫰⫰⫰⫰⫰ Failed Tests 1 ⫰⫰⫰⫰⫰⫰⫰
AssertionError: expected 'USDC' to be '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA…' // Object.is equality
      Tests  1 failed | 1 passed (2)
```
</details>

<details>
<summary>2) Mutation B — caller (<code>client.ts:134</code>) reverted to <code>selected.asset</code> — public-path test FAILS</summary>

```
     × records the resolved address in the transaction log via the public fetch path 40ms
⫰⫰⫰⫰⫰⫰⫰ Failed Tests 1 ⫰⫰⫰⫰⫰⫰⫰
AssertionError: expected 'USDC' to be '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA…' // Object.is equality
      Tests  1 failed | 1 passed (2)
```
</details>

<details>
<summary>3) With the fix — full x402 suite PASSES on the rebased head</summary>

```
 RUN  v4.1.5 .../plugins/plugin-wallet

 Test Files  2 passed (2)
      Tests  10 passed (10)
```
</details>

Frontend logs: `N/A - no frontend surface`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface; SDK payment-path defect in the x402 client.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface.`

## Known gaps / failures

- `bun run verify` (root) was not run to completion on this constrained Raspberry Pi environment;
  scoped package checks were run instead on the rebased head `64dd54817cbd03a8dd5d1abaacfd91cd53281b34`:
  `bun run test src/sdk/x402/` (10 passed), targeted typecheck (no errors in `src/sdk/x402/*`), and
  Biome `check` on the two changed files (clean).
- Package-wide `bun run typecheck` and `bun run test` report failures **only in unrelated files**
  (`src/ui/*` and `src/chains/evm/routes/sign.test.ts`) caused by unbuilt `@elizaos/ui` workspace
  declarations and a pre-existing EVM sign-route error-message assertion. Verified pre-existing by
  stashing this change and reproducing the identical failures on clean `origin/develop`. None
  reference the modified `src/sdk/x402/` files.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@dd2d8802dc994f993234216c5d0e20a6d07bcef4:packages/skills/skills/contribute-to-eliza"} -->