### PR TITLE
fix(ui): make bake-view-icons refuse to bake from a missing or empty source

### DIFF
--- a/packages/ui/scripts/bake-view-icons.mjs
+++ b/packages/ui/scripts/bake-view-icons.mjs
@@ -30,11 +30,30 @@ const out = join(
 );
 const assetDir = join(here, "..", "src", "components", "views", "view-icons");
 
-const files = existsSync(srcDir)
-  ? readdirSync(srcDir)
-      .filter((f) => f.endsWith(".png"))
-      .sort()
-  : [];
+// Fail closed before the destructive rewrite below: on any machine that has
+// not run gen-view-icons.mjs (or passed an explicit srcDir), the source
+// directory is absent, and proceeding would delete every committed icon and
+// bake an empty VIEW_ICONS map with a zero exit status.
+if (!existsSync(srcDir)) {
+  console.error(
+    `[bake-view-icons] source directory ${srcDir} does not exist; ` +
+      "run scripts/gen-view-icons.mjs first (FAL_KEY required) or pass the icon directory as an argument. " +
+      "Refusing to delete the committed icons under src/components/views/view-icons.",
+  );
+  process.exit(1);
+}
+
+const files = readdirSync(srcDir)
+  .filter((f) => f.endsWith(".png"))
+  .sort();
+
+if (files.length === 0) {
+  console.error(
+    `[bake-view-icons] ${srcDir} contains no .png files; ` +
+      "refusing to replace the committed icon set with an empty bake.",
+  );
+  process.exit(1);
+}
 
 rmSync(assetDir, { force: true, recursive: true });
 mkdirSync(assetDir, { recursive: true });

--- a/packages/ui/test/bake-view-icons.test.mjs
+++ b/packages/ui/test/bake-view-icons.test.mjs
@@ -5,8 +5,8 @@
  * copies the actual script into a temp package mirror and executes it as a
  * subprocess, so path resolution and the destructive rewrite are exercised for
  * real — against sandboxed assets, never the repository copies. Deterministic;
- * no network. The best-effort Biome pass inside the script is inert here (no
- * bunx in the mirror root) and is not under test.
+ * no network. The harness removes PATH from the subprocess environment so the
+ * script's best-effort Biome pass fails immediately and is not under test.
  */
 import { execFileSync } from "node:child_process";
 import {
@@ -59,9 +59,18 @@ function makeMirror() {
 }
 
 function runBake(script, args) {
+  // The production script formats its output through a best-effort `bunx`
+  // subprocess. Keep this contract test offline and independent of the host's
+  // global tools/cache: process.execPath is absolute, while an empty PATH makes
+  // the optional formatter fail immediately on every platform.
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"),
+  );
+  env.PATH = "";
   try {
     const stdout = execFileSync(process.execPath, [script, ...args], {
       encoding: "utf8",
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     return { status: 0, stdout, stderr: "" };

--- a/packages/ui/test/bake-view-icons.test.mjs
+++ b/packages/ui/test/bake-view-icons.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * Contract tests for scripts/bake-view-icons.mjs: the bake must refuse to run
+ * when its source icon directory is missing or empty, because it deletes the
+ * committed icon assets before writing the new set. Real harness: each case
+ * copies the actual script into a temp package mirror and executes it as a
+ * subprocess, so path resolution and the destructive rewrite are exercised for
+ * real — against sandboxed assets, never the repository copies. Deterministic;
+ * no network. The best-effort Biome pass inside the script is inert here (no
+ * bunx in the mirror root) and is not under test.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const realScript = join(here, "..", "scripts", "bake-view-icons.mjs");
+
+const cleanups = [];
+afterEach(() => {
+  while (cleanups.length > 0) {
+    rmSync(cleanups.pop(), { force: true, recursive: true });
+  }
+});
+
+/** Build a temp mirror of the package layout the script resolves against. */
+function makeMirror() {
+  const root = mkdtempSync(join(tmpdir(), "bake-view-icons-"));
+  cleanups.push(root);
+  const scriptsDir = join(root, "pkg", "scripts");
+  const viewsDir = join(root, "pkg", "src", "components", "views");
+  const assetDir = join(viewsDir, "view-icons");
+  mkdirSync(scriptsDir, { recursive: true });
+  mkdirSync(assetDir, { recursive: true });
+  cpSync(realScript, join(scriptsDir, "bake-view-icons.mjs"));
+  // Committed-state stand-ins the script must not destroy on refusal.
+  writeFileSync(join(assetDir, "chat.png"), "png-bytes-chat");
+  writeFileSync(join(assetDir, "default.png"), "png-bytes-default");
+  writeFileSync(
+    join(viewsDir, "view-icons.generated.ts"),
+    "export const VIEW_ICONS = { committed: true };\n",
+  );
+  return {
+    script: join(scriptsDir, "bake-view-icons.mjs"),
+    assetDir,
+    generated: join(viewsDir, "view-icons.generated.ts"),
+  };
+}
+
+function runBake(script, args) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (error) {
+    // error-policy:J3 — subprocess failure is the observable contract under
+    // test; capture its exit status and stderr as an explicit result.
+    return {
+      status: error.status ?? -1,
+      stdout: String(error.stdout ?? ""),
+      stderr: String(error.stderr ?? ""),
+    };
+  }
+}
+
+describe("bake-view-icons fail-closed contract", () => {
+  it("refuses when the source directory does not exist and leaves committed assets untouched", () => {
+    const mirror = makeMirror();
+    const missing = join(dirname(mirror.assetDir), "no-such-source-dir");
+    const result = runBake(mirror.script, [missing]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("does not exist");
+    expect(result.stderr).toContain("gen-view-icons.mjs");
+    expect(readdirSync(mirror.assetDir).sort()).toEqual([
+      "chat.png",
+      "default.png",
+    ]);
+    expect(readFileSync(mirror.generated, "utf8")).toContain("committed: true");
+  });
+
+  it("refuses when the source directory exists but holds no .png files", () => {
+    const mirror = makeMirror();
+    const empty = join(dirname(mirror.assetDir), "empty-source");
+    mkdirSync(empty, { recursive: true });
+    writeFileSync(join(empty, "notes.txt"), "not an icon");
+    const result = runBake(mirror.script, [empty]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("no .png files");
+    expect(readdirSync(mirror.assetDir).sort()).toEqual([
+      "chat.png",
+      "default.png",
+    ]);
+    expect(readFileSync(mirror.generated, "utf8")).toContain("committed: true");
+  });
+
+  it("bakes a populated source directory, replacing the committed set", () => {
+    const mirror = makeMirror();
+    const source = join(dirname(mirror.assetDir), "fresh-icons");
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, "alpha.png"), "png-bytes-alpha");
+    writeFileSync(join(source, "beta.png"), "png-bytes-beta");
+    const result = runBake(mirror.script, [source]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("packaged 2 icons");
+    expect(readdirSync(mirror.assetDir).sort()).toEqual([
+      "alpha.png",
+      "beta.png",
+    ]);
+    // Assert via the asset URL paths: the script's trailing best-effort Biome
+    // pass may reformat key quoting when a global bunx is on PATH.
+    const generated = readFileSync(mirror.generated, "utf8");
+    expect(generated).toContain("./view-icons/alpha.png");
+    expect(generated).toContain("./view-icons/beta.png");
+    expect(existsSync(join(mirror.assetDir, "chat.png"))).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #22403. `bun run --cwd packages/ui generate:view-icons` on any machine that hasn't run the FAL-backed icon generator deletes all 52 committed launcher icons and bakes an empty `VIEW_ICONS` map — with exit 0.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below — **see Known gaps: full verify delegated to PR CI per
      operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`b2d03f8ac`).
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Low.** Two refusal gates added before the script's destructive `rmSync`; the populated-source path is byte-for-byte the old behavior (proved by the happy-path contract test, which re-bakes a sandboxed mirror successfully). The only flows that now exit 1 are the ones that previously destroyed committed state: a missing source directory and a png-free source directory. There is no legitimate zero-icon bake — the committed map carries 52 entries and `viewIconDataUri()` depends on `VIEW_ICONS.default` existing.

# Background

## What does this PR do?

`packages/ui/scripts/bake-view-icons.mjs` copies icons from a source directory (default `/tmp/view-icons`, produced by `scripts/gen-view-icons.mjs`, which needs `FAL_KEY` and fails fast without it) into the committed package assets, deleting the old set first. A missing source directory silently became an empty file list, so the delete still ran:

```js
const files = existsSync(srcDir) ? readdirSync(srcDir).filter(...) : [];  // silently []
rmSync(assetDir, { force: true, recursive: true });                       // committed icons gone
```

Result on a fresh checkout: all 52 committed PNGs deleted, `view-icons.generated.ts` rewritten with an empty map (`viewIconDataUri()` then returns `""` for every view, `default` fallback included), `packaged 0 icons`, exit 0.

Now the script fails closed **before** the `rmSync`, with an actionable message naming the upstream generator and the `[srcDir]` argument — mirroring the fail-fast its upstream half already has — and refuses an existing-but-png-free source the same way. Same shape as #22336 (approved): a generator must not exit 0 while silently truncating or destroying its committed output.

Added `packages/ui/test/bake-view-icons.test.mjs` (the `test/**/*.test.mjs` lane the vitest config already includes for script logic): it copies the real script into a temp package mirror and runs it as a subprocess, so the destructive rewrite is exercised for real against sandboxed assets — never the repository copies.

## What kind of change is this?

Bug fix (destructive fail-open in a build script).

# Documentation changes needed?

None; the refusal message itself documents the required upstream step.

# Testing

## Where should a reviewer start?

```bash
bun run --cwd packages/ui generate:view-icons
```

On a machine without `/tmp/view-icons` this previously deleted `packages/ui/src/components/views/view-icons/` (52 files) and emptied the generated map; it now exits 1 with the remediation and leaves the tree clean. Then:

```bash
bun run --cwd packages/ui test -- test/bake-view-icons.test.mjs
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ca477aea285b1663f1ddc968123088ff1d93d6aa -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - build-script guard; no rendered UI surface changes (the fix prevents icon destruction, it does not alter any rendered state).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user flow; a script refusal path.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs; the transcripts below are the artifact.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

<details>
<summary>1. BEFORE — one command on a clean develop worktree destroys the committed icon set, exit 0</summary>

```
$ ls /tmp/view-icons
ls: /tmp/view-icons: No such file or directory
$ bun run --cwd packages/ui generate:view-icons        # unpatched script
packaged 0 icons -> .../src/components/views/view-icons + .../view-icons.generated.ts
$ git status --short
 M packages/ui/src/components/views/view-icons.generated.ts
 D packages/ui/src/components/views/view-icons/activity.png
 D packages/ui/src/components/views/view-icons/advanced.png
 D packages/ui/src/components/views/view-icons/apps.png
 ... (all 52 committed PNGs deleted; VIEW_ICONS rewritten empty)
```
</details>

<details>
<summary>2. AFTER — same command refuses before touching anything</summary>

```
$ bun run --cwd packages/ui generate:view-icons
[bake-view-icons] source directory /tmp/view-icons does not exist; run
scripts/gen-view-icons.mjs first (FAL_KEY required) or pass the icon directory
as an argument. Refusing to delete the committed icons under
src/components/views/view-icons.
error: script "generate:view-icons" exited with code 1
$ git status --short          # (only this PR's two files)
 M packages/ui/scripts/bake-view-icons.mjs
?? packages/ui/test/bake-view-icons.test.mjs
```
</details>

<details>
<summary>3. Failing-test-first — contract test red on the unpatched script, green at head</summary>

```
# RED (fix stashed, test present): the unpatched script exits 0 in both refusal cases
 × refuses when the source directory does not exist and leaves committed assets untouched
 × refuses when the source directory exists but holds no .png files
   AssertionError: expected +0 not to be +0
 Test Files  1 failed (1)   Tests  3 failed (3)

# GREEN at head, plus the nearest consumer test
 Test Files  2 passed (2)   Tests  6 passed (6)
   test/bake-view-icons.test.mjs                       3 passed
   src/components/views/view-icon-aliases.test.ts      3 passed
```
</details>

<details>
<summary>4. Happy path is unchanged — a populated source still bakes (from the contract test)</summary>

```
 ✓ bakes a populated source directory, replacing the committed set
   - exit 0, "packaged 2 icons"
   - sandbox assetDir replaced: [alpha.png, beta.png]
   - generated map contains ./view-icons/alpha.png and ./view-icons/beta.png
```
</details>

<details>
<summary>5. Lint clean</summary>

```
$ ./node_modules/.bin/biome check packages/ui/scripts/bake-view-icons.mjs packages/ui/test/bake-view-icons.test.mjs
Checked 2 files in 9ms. No fixes applied.
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcripts above are the executable artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** Per the recorded operator hardware constraint it is delegated to this PR's CI.
- **The script's trailing best-effort Biome pass is not under test.** It is unchanged by this PR and explicitly documented in the script as non-fatal; the contract test asserts via icon URL paths so a globally-installed `bunx` reformatting key quoting cannot flake it.
- **The FAL-backed happy path with real generated icons was not run** (`gen-view-icons.mjs` needs a fal.ai key this environment does not have). The populated-source path is covered by the sandboxed contract test instead, which exercises the identical copy/emit code.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
