### PR TITLE
fix(plugin-vision): fail closed on malformed PNG dims in OCR service adapters

### DIFF
--- a/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
+++ b/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
@@ -35,6 +35,7 @@ import {
   type OcrWithCoordsResult,
   type OcrWithCoordsService,
   type OcrWithCoordsWord,
+  readPngDimensionsOrNull,
 } from "./ocr-with-coords.js";
 import type { BoundingBox } from "./types.js";
 
@@ -345,22 +346,16 @@ function runTesseract(imagePath: string): Promise<string> {
  * Read width/height from the PNG IHDR chunk so the semantic-position thirds are
  * computed against the real tile dimensions (the TSV carries word boxes but no
  * page size header we can trust across versions). PNG signature is 8 bytes;
- * IHDR width/height are big-endian uint32 at offsets 16 and 20.
+ * IHDR width/height are big-endian uint32 at offsets 16 and 20. Bytes that are
+ * not a well-formed PNG with positive dimensions fail closed to zero-sized dims
+ * (the mapper treats non-positive dims as unknown) instead of feeding garbage
+ * into semantic-position math.
  */
 function readPngDimensions(pngBytes: Uint8Array): {
   width: number;
   height: number;
 } {
-  if (pngBytes.byteLength < 24) return { width: 0, height: 0 };
-  const view = new DataView(
-    pngBytes.buffer,
-    pngBytes.byteOffset,
-    pngBytes.byteLength,
-  );
-  return {
-    width: view.getUint32(16, false),
-    height: view.getUint32(20, false),
-  };
+  return readPngDimensionsOrNull(pngBytes) ?? { width: 0, height: 0 };
 }
 
 export class LinuxTesseractOcrService implements OcrWithCoordsService {

--- a/plugins/plugin-vision/src/ocr-service-paddleocr.ts
+++ b/plugins/plugin-vision/src/ocr-service-paddleocr.ts
@@ -43,6 +43,7 @@ import {
   type OcrWithCoordsInput,
   type OcrWithCoordsResult,
   type OcrWithCoordsService,
+  readPngDimensionsOrNull,
 } from "./ocr-with-coords.js";
 import type { BoundingBox } from "./types.js";
 
@@ -220,22 +221,16 @@ export function mapPaddleOcrJsonToResult(
 /**
  * Read width/height from the PNG IHDR chunk (big-endian uint32 at offsets 16/20)
  * so the semantic-position thirds use the real tile dimensions. Mirrors the
- * Tesseract provider's reader.
+ * Tesseract provider's reader and the strict `ocr-with-coords` reader: bytes
+ * that are not a well-formed PNG with positive dimensions fail closed to
+ * zero-sized dims rather than feeding garbage into semantic-position math
+ * (callers already treat non-positive dims as unknown).
  */
 function readPngDimensions(pngBytes: Uint8Array): {
   width: number;
   height: number;
 } {
-  if (pngBytes.byteLength < 24) return { width: 0, height: 0 };
-  const view = new DataView(
-    pngBytes.buffer,
-    pngBytes.byteOffset,
-    pngBytes.byteLength,
-  );
-  return {
-    width: view.getUint32(16, false),
-    height: view.getUint32(20, false),
-  };
+  return readPngDimensionsOrNull(pngBytes) ?? { width: 0, height: 0 };
 }
 
 let availabilityCache: boolean | null = null;

--- a/plugins/plugin-vision/src/ocr-with-coords.test.ts
+++ b/plugins/plugin-vision/src/ocr-with-coords.test.ts
@@ -25,6 +25,7 @@ import {
   type OcrWithCoordsBlock,
   RapidOcrCoordAdapter,
   readPngDimensions,
+  readPngDimensionsOrNull,
 } from "./ocr-with-coords";
 import type { OCRResult } from "./types";
 
@@ -167,8 +168,48 @@ describe("readPngDimensions", () => {
 
   it("rejects non-PNG inputs", async () => {
     await expect(readPngDimensions(new Uint8Array(64))).rejects.toThrow(
-      /PNG signature/,
+      /not a well-formed PNG/,
     );
+  });
+});
+
+// ── readPngDimensionsOrNull (fail-closed OCR-adapter reader) ─────────────────
+
+describe("readPngDimensionsOrNull", () => {
+  it("parses a synthesized 320x240 PNG", () => {
+    expect(readPngDimensionsOrNull(makePng(320, 240))).toEqual({
+      width: 320,
+      height: 240,
+    });
+  });
+
+  it("returns null for non-PNG bytes instead of garbage dimensions", () => {
+    // A JPEG/arbitrary buffer at >= 24 bytes previously yielded whatever the
+    // bytes at offsets 16/20 happened to hold, silently poisoning the
+    // semantic-position thirds. Now it must fail closed.
+    expect(readPngDimensionsOrNull(new Uint8Array(64))).toBeNull();
+  });
+
+  it("returns null for input shorter than a PNG header", () => {
+    expect(readPngDimensionsOrNull(new Uint8Array(12))).toBeNull();
+  });
+
+  it("returns null when the first chunk is not IHDR", () => {
+    const withSignature = new Uint8Array(64);
+    PNG_SIG.forEach((b, i) => {
+      withSignature[i] = b;
+    });
+    // Signature present but the first chunk type is "XXXX", not "IHDR".
+    withSignature[12] = 0x58;
+    withSignature[13] = 0x58;
+    withSignature[14] = 0x58;
+    withSignature[15] = 0x58;
+    expect(readPngDimensionsOrNull(withSignature)).toBeNull();
+  });
+
+  it("returns null for non-positive dimensions", () => {
+    expect(readPngDimensionsOrNull(makePng(0, 240))).toBeNull();
+    expect(readPngDimensionsOrNull(makePng(320, 0))).toBeNull();
   });
 });
 

--- a/plugins/plugin-vision/src/ocr-with-coords.ts
+++ b/plugins/plugin-vision/src/ocr-with-coords.ts
@@ -223,6 +223,47 @@ function shiftBbox(b: BoundingBox, dx: number, dy: number): BoundingBox {
 }
 
 /**
+ * Strictly validate a PNG header and return its IHDR width/height, or null
+ * when the bytes are not a well-formed PNG with positive dimensions. This is
+ * the fail-closed reader the OCR service adapters use so a malformed frame
+ * degrades to "unknown dims" instead of feeding garbage width/height into
+ * semantic-position thirds.
+ */
+export function readPngDimensionsOrNull(
+  pngBytes: Uint8Array,
+): { width: number; height: number } | null {
+  if (pngBytes.byteLength < 24) {
+    return null;
+  }
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  for (let i = 0; i < sig.length; i += 1) {
+    if (pngBytes[i] !== sig[i]) {
+      return null;
+    }
+  }
+  // IHDR type bytes at offset 12..16 must be "IHDR".
+  if (
+    pngBytes[12] !== 0x49 ||
+    pngBytes[13] !== 0x48 ||
+    pngBytes[14] !== 0x44 ||
+    pngBytes[15] !== 0x52
+  ) {
+    return null;
+  }
+  const view = new DataView(
+    pngBytes.buffer,
+    pngBytes.byteOffset,
+    pngBytes.byteLength,
+  );
+  const width = view.getUint32(16, false);
+  const height = view.getUint32(20, false);
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+/**
  * Read width/height from the PNG IHDR chunk without pulling in sharp on the
  * test path. PNG signature is 8 bytes; IHDR begins at offset 8 with a 4-byte
  * length, 4-byte type ("IHDR"), then 4-byte width and 4-byte height (BE).
@@ -233,33 +274,11 @@ function shiftBbox(b: BoundingBox, dx: number, dy: number): BoundingBox {
 export async function readPngDimensions(
   pngBytes: Uint8Array,
 ): Promise<{ width: number; height: number }> {
-  if (pngBytes.byteLength < 24) {
-    throw new Error("readPngDimensions: input too short to be a PNG");
+  const dims = readPngDimensionsOrNull(pngBytes);
+  if (dims === null) {
+    throw new Error(
+      "readPngDimensions: input is not a well-formed PNG with positive dimensions",
+    );
   }
-  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
-  for (let i = 0; i < sig.length; i += 1) {
-    if (pngBytes[i] !== sig[i]) {
-      throw new Error("readPngDimensions: missing PNG signature");
-    }
-  }
-  // IHDR type bytes at offset 12..16 must be "IHDR".
-  if (
-    pngBytes[12] !== 0x49 ||
-    pngBytes[13] !== 0x48 ||
-    pngBytes[14] !== 0x44 ||
-    pngBytes[15] !== 0x52
-  ) {
-    throw new Error("readPngDimensions: first chunk is not IHDR");
-  }
-  const view = new DataView(
-    pngBytes.buffer,
-    pngBytes.byteOffset,
-    pngBytes.byteLength,
-  );
-  const width = view.getUint32(16, false);
-  const height = view.getUint32(20, false);
-  if (width <= 0 || height <= 0) {
-    throw new Error(`readPngDimensions: invalid dimensions ${width}x${height}`);
-  }
-  return { width, height };
+  return dims;
 }


### PR DESCRIPTION
# Relates to

Hardens the same malformed-frame class the OCR stack already treats as a
contract elsewhere: the strict `readPngDimensions` in
`ocr-with-coords.ts` validates the PNG signature, the IHDR chunk type, and
positive dimensions, and the vision pipeline bounds decode via
`limitInputPixels`. The PaddleOCR and Linux-Tesseract OCR adapters duplicated
that header read without any of the validation, so a malformed frame silently
fed garbage width/height into semantic-position thirds.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash-free`
<!-- attribution-row:client -->
- Agent tooling: `opencode`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`1ca8f0bc06`); zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds one exported helper (`readPngDimensionsOrNull`) to
`plugins/plugin-vision/src/ocr-with-coords.ts`, keeps the existing throwing
`readPngDimensions` contract (same tests still pass), and rewires the two OCR
adapter readers (PaddleOCR, Linux Tesseract) to it. On malformed frames the
adapters now return `{ width: 0, height: 0 }` instead of garbage; their
mappers already treat non-positive dims as unknown (`safeWidth`/`safeHeight`),
so behavior for every valid PNG is byte-for-byte unchanged.

# Background

## What does this PR do?

`PaddleOcrService` and `LinuxTesseractOcrService` each carried a private
`readPngDimensions` that returned whatever big-endian uint32s sat at offsets
16/20 of the input — with no PNG signature check, no IHDR chunk-type check,
and no positivity check. A malformed or non-PNG frame therefore produced
silent garbage dimensions (a 32-byte corrupted buffer reads as
`4294967295×4294967295`) that fed straight into `computeSemanticPosition`
(third-based screen regions used for click coordinates). The same frame shape
already fails closed everywhere else in the OCR stack, including the strict
`readPngDimensions` in `ocr-with-coords.ts`.

This PR introduces one shared validated reader,
`readPngDimensionsOrNull` (signature + IHDR type + positive dimensions),
rewires both OCR adapters to it, and keeps the strict throwing reader in
`ocr-with-coords.ts` delegating to the same checks.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-vision/src/ocr-with-coords.test.ts` — new
  `readPngDimensionsOrNull` suite (5 cases): valid PNG parse, non-PNG bytes
  return `null`, short input, non-IHDR first chunk, and non-positive
  dimensions. The existing `readPngDimensions` suite (throwing contract) still
  passes unchanged in spirit (assertion regex updated to the generalized
  message).

## Detailed testing steps

None: Automated tests are acceptable. Every assertion drives the real exported
`readPngDimensionsOrNull` / `readPngDimensions` — no mock stands in for the
system under test.

- `bun run --cwd plugins/plugin-vision test -- src/ocr-with-coords.test.ts src/ocr-service-paddleocr.test.ts src/ocr-service-linux-tesseract.test.ts`
  → 3 files, 40 tests, all pass
- Control: the pre-fix adapter reader on a 32-byte all-`0xFF` buffer returns
  `{ width: 4294967295, height: 4294967295 }`; the fixed reader returns `null`
  and the adapter degrades to zero-sized dims
- `bun run --cwd plugins/plugin-vision typecheck` (clean)
- `bunx biome check` on the four touched files (clean)

# Evidence Gate

<!-- evidence-head:93954e3f9ddbaaa1708b318e6b3cfb0b312e7841 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only OCR pipeline logic, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only OCR pipeline logic, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [ ] N/A - real Vitest run at current head (3 files, 40 tests) plus pre-fix control against corrupted frame, inline in Evidence Details

<details>
<summary>Backend logs — current head, plus pre-fix control</summary>

```
$ bun run --cwd plugins/plugin-vision test -- src/ocr-with-coords.test.ts src/ocr-service-paddleocr.test.ts src/ocr-service-linux-tesseract.test.ts

 Test Files  3 passed (3)
      Tests  40 passed (40)

--- Control: pre-fix adapter reader on a 32-byte all-0xFF corrupted frame ---

pre-fix reader: {"width":4294967295,"height":4294967295}
  # garbage dims -> every semantic-position third collapses to top-left

post-fix readPngDimensionsOrNull: null  # adapter degrades to {0,0} (unknown)

$ bun run --cwd plugins/plugin-vision typecheck
(no output — clean)

$ bunx biome check src/ocr-with-coords.ts src/ocr-with-coords.test.ts src/ocr-service-paddleocr.ts src/ocr-service-linux-tesseract.ts
Checked 4 files in 33ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed; pure binary-header parsing
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - standalone reproduction proving garbage dims before and null/degrade after, inline in Evidence Details

<details>
<summary>Domain artifact — before/after PNG header read on corrupted bytes</summary>

```
// pre-fix (no signature/IHDR/positivity validation):
const corrupted = new Uint8Array(32).fill(0xff);
oldReader(corrupted);        // { width: 4294967295, height: 4294967295 }

// post-fix (shared validated reader):
readPngDimensionsOrNull(corrupted); // null  -> adapter uses {0,0} (unknown)
```

A valid PNG parses identically before and after:
`readPngDimensionsOrNull(makePng(320, 240))` → `{ width: 320, height: 240 }`.
</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface; OCR behavior verified by unit tests

# Evidence Details

## Known gaps / failures

- `bun run verify` reports one failure, `@elizaos/cloud-test-mocks#typecheck`:
  `plugins/plugin-whatsapp/src/baileys/qr-code.ts(6,33): error TS7016: Could
  not find a declaration file for module 'qrcode-terminal'`. Reproduced
  identically on clean `origin/develop` — unrelated to this change.
- The Linux Tesseract and PaddleOCR `describe()` paths need their platform
  binaries/python to run end-to-end; they are gated on availability and the
  pure mappers (`mapTesseractTsvToResult`, `mapPaddleOcrJsonToResult`) are
  unit-tested against fixed fixtures as in the existing suites.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: deepseek / deepseek-v4-flash-free
Client / agent tooling: opencode
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-bugfix-png-dims]
<!-- slop-contribution-attribution:v1 {"provider":"deepseek","model":"deepseek-v4-flash-free","client":"opencode","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0CGPS7WRRSG70CB2K7FVFAE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-19T08:02:52.284Z","completed_at":"2026-08-19T08:05:24.979Z","skill_sha256":"1587e294dc58a3e45ee6dcf5dd4d4aeb21f17e394b6137f33775caa9a2c063c7","usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0caee45eaf63e150c97b5814bf8df37ae65ca82ec9e749d1807255371f245ebf","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a0c54d15-52ba-4792-8000-6dc2a58e8ba3","object_id":"sha256:0caee45eaf63e150c97b5814bf8df37ae65ca82ec9e749d1807255371f245ebf","sha256":"0caee45eaf63e150c97b5814bf8df37ae65ca82ec9e749d1807255371f245ebf"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"pyqjIAKDq1a6EWXKthdd_K074VE-wuvGf5a0jqislT0PkeYRQKgvnI-baYYBRnVeyn6apPwPrqRoI5BOAc0lAA"}} -->
