### PR TITLE
fix(cloud,lifeops): pin postMessage targetOrigin, fail closed

### DIFF
--- a/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
+++ b/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
@@ -1,0 +1,35 @@
+/** Exercises Eliza App popup target-origin validation through the real route HTML. */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import route from "./route";
+
+const app = new Hono<AppEnv>().route("/connection-success", route);
+
+async function render(configuredOrigin?: string): Promise<string> {
+  const response = await app.request(
+    "/connection-success?source=eliza-app&platform=github",
+    {},
+    { AGENT_APP_ORIGIN: configuredOrigin } as AppEnv["Bindings"],
+  );
+  expect(response.status).toBe(200);
+  return response.text();
+}
+
+describe("connection-success popup target origin", () => {
+  test("canonicalizes the configured URL to its exact origin", async () => {
+    const html = await render("https://app.eliza.how/some/path?query=1");
+    expect(html).toContain("var targetOrigin = 'https://app.eliza.how';");
+    expect(html).not.toContain("some/path");
+  });
+
+  test.each([undefined, "", "*", "data:text/html,opaque", "not a URL"])(
+    "fails closed for configured origin %p",
+    async (configuredOrigin) => {
+      const html = await render(configuredOrigin);
+      expect(html).toContain("var targetOrigin = '';");
+      expect(html).toContain("if (targetOrigin && window.opener");
+    },
+  );
+});

--- a/packages/cloud/api/eliza-app/auth/connection-success/route.ts
+++ b/packages/cloud/api/eliza-app/auth/connection-success/route.ts
@@ -1,6 +1,7 @@
 // Handles cloud API eliza app auth connection success route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
+import { normalizePostMessageTargetOrigin } from "@/lib/services/agent-github-return";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 function escapeForJsString(value: string): string {
@@ -93,7 +94,7 @@ function buildHtml(platform: string): string {
 function buildElizaAppHtml(
   provider: string,
   connectionId: string | null,
-  targetOrigin: string,
+  targetOrigin: string | null,
 ): string {
   const providerLabel = PROVIDER_LABELS[provider] ?? "Your account";
   const payload = JSON.stringify({
@@ -177,7 +178,7 @@ function buildElizaAppHtml(
   <script>
     (function () {
       const payload = ${payload};
-      var targetOrigin = '${escapeForJsString(targetOrigin)}';
+      var targetOrigin = '${escapeForJsString(targetOrigin ?? "")}';
       if (targetOrigin && window.opener && !window.opener.closed) {
         try {
           window.opener.postMessage(payload, targetOrigin);
@@ -201,10 +202,16 @@ app.get("/", (c) => {
   if (source === "eliza-app") {
     const provider = c.req.query("platform") || "connection";
     const connectionId = c.req.query("connection_id") ?? null;
-    const targetOrigin = (c.env.AGENT_APP_ORIGIN as string | undefined)?.trim() ?? "";
-    return c.body(buildElizaAppHtml(provider, connectionId, targetOrigin), 200, {
-      "Content-Type": "text/html; charset=utf-8",
-    });
+    const targetOrigin = normalizePostMessageTargetOrigin(
+      c.env.AGENT_APP_ORIGIN as string | undefined,
+    );
+    return c.body(
+      buildElizaAppHtml(provider, connectionId, targetOrigin),
+      200,
+      {
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    );
   }
 
   const platform = c.req.query("platform") || "web";

--- a/packages/cloud/api/eliza-app/auth/connection-success/route.ts
+++ b/packages/cloud/api/eliza-app/auth/connection-success/route.ts
@@ -3,6 +3,16 @@ import { Hono } from "hono";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+function escapeForJsString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/</g, "\\x3c")
+    .replace(/>/g, "\\x3e")
+    .replace(/\r?\n/g, "");
+}
+
 const PLATFORM_MESSAGES: Record<string, string> = {
   discord: "head back to Discord and send me a message.",
   telegram: "head back to Telegram and send me a message.",
@@ -83,6 +93,7 @@ function buildHtml(platform: string): string {
 function buildElizaAppHtml(
   provider: string,
   connectionId: string | null,
+  targetOrigin: string,
 ): string {
   const providerLabel = PROVIDER_LABELS[provider] ?? "Your account";
   const payload = JSON.stringify({
@@ -166,9 +177,10 @@ function buildElizaAppHtml(
   <script>
     (function () {
       const payload = ${payload};
-      if (window.opener && !window.opener.closed) {
+      var targetOrigin = '${escapeForJsString(targetOrigin)}';
+      if (targetOrigin && window.opener && !window.opener.closed) {
         try {
-          window.opener.postMessage(payload, "*");
+          window.opener.postMessage(payload, targetOrigin);
           setTimeout(function () {
             window.close();
           }, 150);
@@ -189,7 +201,8 @@ app.get("/", (c) => {
   if (source === "eliza-app") {
     const provider = c.req.query("platform") || "connection";
     const connectionId = c.req.query("connection_id") ?? null;
-    return c.body(buildElizaAppHtml(provider, connectionId), 200, {
+    const targetOrigin = (c.env.AGENT_APP_ORIGIN as string | undefined)?.trim() ?? "";
+    return c.body(buildElizaAppHtml(provider, connectionId, targetOrigin), 200, {
       "Content-Type": "text/html; charset=utf-8",
     });
   }

--- a/packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts
+++ b/packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts
@@ -13,6 +13,7 @@ const readManagedAgentGithubBinding = mock(() => null);
 
 mock.module("@/lib/services/agent-github-return", () => ({
   createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin: (value: string) => new URL(value).origin,
 }));
 mock.module("@/db/repositories/agent-sandboxes", () => ({
   agentSandboxesRepository: { findByIdAndOrg },

--- a/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
@@ -20,7 +20,10 @@
 
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { createLifeOpsGithubReturnResponse } from "@/lib/services/agent-github-return";
+import {
+  createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin,
+} from "@/lib/services/agent-github-return";
 import { managedAgentGithubService } from "@/lib/services/agent-managed-github";
 import { readManagedAgentGithubBinding } from "@/lib/services/eliza-agent-config";
 import { oauthService } from "@/lib/services/oauth";
@@ -60,14 +63,7 @@ app.get("/", async (c) => {
   const postMessage = requestedPostMessage === "1";
   const returnUrl = c.req.query("return_url") ?? null;
 
-  const targetOrigin = (() => {
-    try {
-      return new URL(baseUrl).origin;
-    } catch {
-      return null;
-    }
-  })();
-
+  const targetOrigin = normalizePostMessageTargetOrigin(baseUrl);
   const respond = (args: {
     status: "connected" | "error";
     githubUsername?: string | null;

--- a/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
@@ -60,6 +60,14 @@ app.get("/", async (c) => {
   const postMessage = requestedPostMessage === "1";
   const returnUrl = c.req.query("return_url") ?? null;
 
+  const targetOrigin = (() => {
+    try {
+      return new URL(baseUrl).origin;
+    } catch {
+      return null;
+    }
+  })();
+
   const respond = (args: {
     status: "connected" | "error";
     githubUsername?: string | null;
@@ -91,6 +99,7 @@ app.get("/", async (c) => {
         },
         postMessage,
         returnUrl,
+        targetOrigin,
       });
     }
     if (args.status === "connected") {

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.post-message.test.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.post-message.test.ts
@@ -8,6 +8,7 @@ const createLifeOpsGithubReturnResponse = mock(
 
 mock.module("@/lib/services/agent-github-return", () => ({
   createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin: (value: string) => new URL(value).origin,
 }));
 
 const route = (await import("./route")).default;

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
@@ -11,7 +11,10 @@
  */
 
 import { Hono } from "hono";
-import { createLifeOpsGithubReturnResponse } from "@/lib/services/agent-github-return";
+import {
+  createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin,
+} from "@/lib/services/agent-github-return";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -22,13 +25,7 @@ async function __hono_GET(
 ) {
   const searchParams = new URL(request.url).searchParams;
   const baseUrl = env?.NEXT_PUBLIC_APP_URL || "https://cloud.eliza.app";
-  const targetOrigin = (() => {
-    try {
-      return new URL(baseUrl).origin;
-    } catch {
-      return null;
-    }
-  })();
+  const targetOrigin = normalizePostMessageTargetOrigin(baseUrl);
   const githubConnected = searchParams.get("github_connected");
   const githubError = searchParams.get("github_error");
   const connectionId = searchParams.get("connection_id");
@@ -76,7 +73,7 @@ async function __hono_GET(
         },
         postMessage,
         returnUrl,
-      targetOrigin,
+        targetOrigin,
       });
     }
     return Response.redirect(
@@ -102,7 +99,7 @@ async function __hono_GET(
         },
         postMessage,
         returnUrl,
-      targetOrigin,
+        targetOrigin,
       });
     }
     return Response.redirect(

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
@@ -22,6 +22,13 @@ async function __hono_GET(
 ) {
   const searchParams = new URL(request.url).searchParams;
   const baseUrl = env?.NEXT_PUBLIC_APP_URL || "https://cloud.eliza.app";
+  const targetOrigin = (() => {
+    try {
+      return new URL(baseUrl).origin;
+    } catch {
+      return null;
+    }
+  })();
   const githubConnected = searchParams.get("github_connected");
   const githubError = searchParams.get("github_error");
   const connectionId = searchParams.get("connection_id");
@@ -69,6 +76,7 @@ async function __hono_GET(
         },
         postMessage,
         returnUrl,
+      targetOrigin,
       });
     }
     return Response.redirect(
@@ -94,6 +102,7 @@ async function __hono_GET(
         },
         postMessage,
         returnUrl,
+      targetOrigin,
       });
     }
     return Response.redirect(
@@ -119,6 +128,7 @@ async function __hono_GET(
       },
       postMessage,
       returnUrl,
+      targetOrigin,
     });
   }
 

--- a/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
+++ b/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
@@ -1,0 +1,33 @@
+/** Exercises PayPal popup target-origin validation through the real route HTML. */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import route from "./route";
+
+const app = new Hono<AppEnv>().route("/callback", route);
+
+async function render(configuredOrigin?: string): Promise<string> {
+  const response = await app.request("/callback?code=secret&state=state", {}, {
+    AGENT_APP_ORIGIN: configuredOrigin,
+  } as AppEnv["Bindings"]);
+  expect(response.status).toBe(200);
+  return response.text();
+}
+
+describe("PayPal popup target origin", () => {
+  test("canonicalizes the configured URL to its exact origin", async () => {
+    const html = await render("https://app.eliza.how/some/path?query=1");
+    expect(html).toContain("var targetOrigin = 'https://app.eliza.how';");
+    expect(html).not.toContain("some/path");
+  });
+
+  test.each([undefined, "", "*", "data:text/html,opaque", "not a URL"])(
+    "fails closed for configured origin %p",
+    async (configuredOrigin) => {
+      const html = await render(configuredOrigin);
+      expect(html).toContain("var targetOrigin = '';");
+      expect(html).toContain("if (targetOrigin && window.opener");
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/paypal/popup-callback/route.ts
+++ b/packages/cloud/api/v1/eliza/paypal/popup-callback/route.ts
@@ -40,7 +40,7 @@ app.get("/", (c) => {
   const errorDescription = c.req.query("error_description") ?? "";
   const agentAppOrigin = (c.env.AGENT_APP_ORIGIN as string | undefined)?.trim();
   const targetOrigin =
-    agentAppOrigin && agentAppOrigin.length > 0 ? agentAppOrigin : "*";
+    agentAppOrigin && agentAppOrigin.length > 0 ? agentAppOrigin : "";
 
   const payload = JSON.stringify({
     type: "agent-paypal-oauth",
@@ -72,7 +72,7 @@ app.get("/", (c) => {
       (function () {
         var payload = ${payload};
         try {
-          if (window.opener && !window.opener.closed) {
+          if (targetOrigin && window.opener && !window.opener.closed) {
             window.opener.postMessage(payload, '${escapeForJsString(targetOrigin)}');
           }
         } catch (err) {

--- a/packages/cloud/api/v1/eliza/paypal/popup-callback/route.ts
+++ b/packages/cloud/api/v1/eliza/paypal/popup-callback/route.ts
@@ -13,12 +13,12 @@
  * to actually exchange the code.
  *
  * The HTML enforces a strict targetOrigin so no third-party site can read
- * the code by opening this URL inside an iframe. Defaults to "*" if no
- * AGENT_APP_ORIGIN is configured (acceptable for the early integration
- * window — this is a one-shot code, not a long-lived secret).
+ * the code by opening this URL inside an iframe. It fails closed when
+ * AGENT_APP_ORIGIN is absent or invalid rather than exposing the OAuth code.
  */
 
 import { Hono } from "hono";
+import { normalizePostMessageTargetOrigin } from "@/lib/services/agent-github-return";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -38,9 +38,9 @@ app.get("/", (c) => {
   const state = c.req.query("state") ?? "";
   const error = c.req.query("error") ?? "";
   const errorDescription = c.req.query("error_description") ?? "";
-  const agentAppOrigin = (c.env.AGENT_APP_ORIGIN as string | undefined)?.trim();
-  const targetOrigin =
-    agentAppOrigin && agentAppOrigin.length > 0 ? agentAppOrigin : "";
+  const targetOrigin = normalizePostMessageTargetOrigin(
+    c.env.AGENT_APP_ORIGIN as string | undefined,
+  );
 
   const payload = JSON.stringify({
     type: "agent-paypal-oauth",
@@ -71,9 +71,10 @@ app.get("/", (c) => {
     <script>
       (function () {
         var payload = ${payload};
+        var targetOrigin = '${escapeForJsString(targetOrigin ?? "")}';
         try {
           if (targetOrigin && window.opener && !window.opener.closed) {
-            window.opener.postMessage(payload, '${escapeForJsString(targetOrigin)}');
+            window.opener.postMessage(payload, targetOrigin);
           }
         } catch (err) {
           // Cross-origin postMessage failed; user can close the window manually.

--- a/packages/cloud/shared/src/lib/services/agent-github-return.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-github-return.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Covers the opener postMessage targetOrigin pinning for LifeOps GitHub return.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin,
+} from "./agent-github-return";
+
+describe("createLifeOpsGithubReturnResponse — targetOrigin pinning", () => {
+  test.each([
+    ["https://app.eliza.how/path?query=1", "https://app.eliza.how"],
+    ["http://127.0.0.1:5173/callback", "http://127.0.0.1:5173"],
+    ["*", null],
+    ["data:text/html,opaque", null],
+    ["javascript:alert(1)", null],
+    ["not a URL", null],
+    ["", null],
+  ])("normalizes configured opener origin %p", (value, expected) => {
+    expect(normalizePostMessageTargetOrigin(value)).toBe(expected);
+  });
+  test("uses configured targetOrigin, not wildcard", async () => {
+    const res = createLifeOpsGithubReturnResponse({
+      title: "ok",
+      message: "done",
+      detail: { target: "agent", status: "connected", agentId: "a1" },
+      postMessage: true,
+      returnUrl: null,
+      targetOrigin: "https://app.eliza.how",
+    });
+    const html = await res.text();
+    expect(html).toContain("https://app.eliza.how");
+    expect(html).toContain("targetOrigin");
+    expect(html).not.toContain('postMessage(payload, "*"');
+    expect(html).not.toContain("postMessage(payload, '*'");
+  });
+
+  test("fail-closed when targetOrigin absent — no postMessage with wildcard or window.location.origin", async () => {
+    const res = createLifeOpsGithubReturnResponse({
+      title: "ok",
+      message: "done",
+      detail: { target: "agent", status: "connected", agentId: "a1" },
+      postMessage: true,
+      returnUrl: null,
+      targetOrigin: null,
+    });
+    const html = await res.text();
+    expect(html).not.toContain('postMessage(payload, "*"');
+    // When no targetOrigin, the postMessage branch is guarded by `targetOrigin &&`
+    expect(html).toContain("targetOrigin &&");
+  });
+
+  test("does not emit wildcard when postMessage disabled", async () => {
+    const res = createLifeOpsGithubReturnResponse({
+      title: "ok",
+      message: "done",
+      detail: { target: "owner", status: "error", message: "nope" },
+      postMessage: false,
+      returnUrl: null,
+    });
+    const html = await res.text();
+    expect(html).not.toContain('postMessage(payload, "*"');
+  });
+
+  test("opener postMessage routes are pinned — no wildcard, no window.location.origin fallback for PayPal", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../../../../../..");
+    const checks: Array<{ rel: string; mustContain: string; mustNotContain: string[] }> = [
+      {
+        rel: "packages/cloud/api/v1/eliza/paypal/popup-callback/route.ts",
+        mustContain: "targetOrigin && window.opener",
+        mustNotContain: [
+          'postMessage(payload, "*"',
+          "postMessage(payload, window.location.origin)",
+        ],
+      },
+      {
+        rel: "packages/cloud/api/eliza-app/auth/connection-success/route.ts",
+        mustContain: "targetOrigin && window.opener",
+        mustNotContain: [
+          'postMessage(payload, "*"',
+          "postMessage(payload, window.location.origin)",
+        ],
+      },
+      {
+        rel: "packages/cloud/shared/src/lib/services/agent-github-return.ts",
+        mustContain: "targetOrigin && window.opener",
+        mustNotContain: [
+          'postMessage(payload, "*"',
+          "postMessage(payload, window.location.origin)",
+        ],
+      },
+    ];
+    for (const { rel, mustContain, mustNotContain } of checks) {
+      const src = readFileSync(path.join(repoRoot, rel), "utf8");
+      const openerCalls = [...src.matchAll(/window\.opener\.postMessage\([^)]+\)/g)].map(
+        (m) => m[0],
+      );
+      expect(openerCalls.length).toBeGreaterThan(0);
+      for (const call of openerCalls) {
+        expect(call).not.toContain('"*"');
+        expect(call).not.toContain("'*'");
+      }
+      expect(src).toContain(mustContain);
+      for (const banned of mustNotContain) {
+        expect(src).not.toContain(banned);
+      }
+    }
+    // LifeOps agent-hosted callback is same-origin, window.location.origin is intentional and documented.
+    const lifeOpsSrc = readFileSync(
+      path.join(repoRoot, "plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts"),
+      "utf8",
+    );
+    expect(lifeOpsSrc).toContain("window.location.origin");
+    expect(lifeOpsSrc).not.toContain('postMessage(payload, "*"');
+    expect(lifeOpsSrc).toContain("same-origin");
+  });
+
+  test("paypal route fails closed when AGENT_APP_ORIGIN absent — no window.location.origin fallback", () => {
+    const src = readFileSync(
+      path.resolve(import.meta.dir, "../../../../api/v1/eliza/paypal/popup-callback/route.ts"),
+      "utf8",
+    );
+    expect(src).toContain("const targetOrigin =");
+    expect(src).toContain("targetOrigin && window.opener");
+    // No fallback to popup origin in the postMessage path — only comment may mention it
+    expect(src).not.toContain(
+      "targetOrigin = serverOrigin ? serverOrigin : window.location.origin",
+    );
+    expect(src).not.toContain("window.location.origin;");
+    // Must deliver to configured opener origin, not popup origin
+    expect(src).toContain("window.opener.postMessage(payload, targetOrigin)");
+    expect(src).not.toMatch(/:\s*"\*"/);
+  });
+
+  test("SandboxedViewFrame opaque-origin wildcard is intentionally retained", () => {
+    const src = readFileSync(
+      path.resolve(
+        import.meta.dir,
+        "../../../../../..",
+        "packages/ui/src/components/views/SandboxedViewFrame.tsx",
+      ),
+      "utf8",
+    );
+    expect(src).toContain('frameWindow.postMessage(response, "*")');
+    expect(src).toContain("Opaque-origin frames cannot be targeted by origin");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-github-return.ts
+++ b/packages/cloud/shared/src/lib/services/agent-github-return.ts
@@ -84,6 +84,7 @@ export function createLifeOpsGithubReturnResponse(args: {
   detail: LifeOpsGithubReturnDetail;
   postMessage?: boolean;
   returnUrl?: string | null;
+  targetOrigin?: string | null;
 }): Response {
   const payload = {
     type: LIFEOPS_GITHUB_POST_MESSAGE_TYPE,
@@ -166,9 +167,10 @@ export function createLifeOpsGithubReturnResponse(args: {
         const payload = ${serializeInlineScriptValue(payload)};
         const postMessageToOpener = ${args.postMessage === true ? "true" : "false"};
         const deepLink = ${serializeInlineScriptValue(deepLink)};
-        if (postMessageToOpener && window.opener && !window.opener.closed) {
+        const targetOrigin = ${serializeInlineScriptValue(args.targetOrigin ?? null)};
+        if (postMessageToOpener && targetOrigin && window.opener && !window.opener.closed) {
           try {
-            window.opener.postMessage(payload, "*");
+            window.opener.postMessage(payload, targetOrigin);
           } catch {}
         }
         if (typeof deepLink === "string" && deepLink.length > 0) {

--- a/packages/cloud/shared/src/lib/services/agent-github-return.ts
+++ b/packages/cloud/shared/src/lib/services/agent-github-return.ts
@@ -19,6 +19,23 @@ function serializeInlineScriptValue(value: unknown): string {
   return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
+export function normalizePostMessageTargetOrigin(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null;
+    }
+    return parsed.origin === "null" ? null : parsed.origin;
+  } catch {
+    // error-policy:J3 Invalid configured origins fail closed.
+    return null;
+  }
+}
+
 function readAgentDeepLinkPath(value: string): string | null {
   try {
     const parsed = new URL(value);

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -1030,7 +1030,10 @@ function writeHtml(
           },
         })};
         if (window.opener && typeof window.opener.postMessage === "function") {
-          window.opener.postMessage(payload, "*");
+          // LifeOps google-connector callback is served from the same agent host as the opener (same-origin popup).
+          // Pin to window.location.origin (agent origin) — cross-origin openers will not receive this postMessage
+          // and will rely on BroadcastChannel/localStorage fallback below. This is fail-closed, not a wildcard leak.
+          window.opener.postMessage(payload, window.location.origin);
         }
         if (typeof BroadcastChannel === "function") {
           for (const channelName of [


### PR DESCRIPTION
# Relates to

Fixes #22573.

This repairs the opener `postMessage` boundary: target origins are configured, validated as canonical HTTP(S) origins, and invalid or wildcard values fail closed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `muse/muse-spark-1.2-contributor`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was invoked for this repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The final repair commit was authored by OpenAI Codex (`codex@openai.com`) using OpenAI gpt-5.6-sol via Codex. It requires independent exact-head review before merge.

# Sync with develop

- [x] Reconstructed onto `origin/develop@cfcd7d55db00cdcf778e0536fc00816051cb944c` after a contributor overwrite, with only the intended source changes and the attributed repair.
- [x] Focused behavioral suites and changed-file gates pass on exact head `f6ad2317372aabbbce0c0dbbfaf0643002eb16b6`.

# What changed

- Pin PayPal, connection-success, GitHub OAuth, and LifeOps GitHub popup messages to the configured opener origin.
- Normalize only `http:` and `https:` URLs to their canonical `.origin`.
- Reject empty, malformed, opaque-scheme, and wildcard (`*`) values, so misconfiguration cannot reintroduce wildcard disclosure.
- Preserve the intentional opaque-origin iframe wildcard outside these opener flows.
- Add real Hono route tests for connection-success and PayPal plus shared adversarial normalization coverage.

# Risks

Misconfigured target origins now suppress opener messaging instead of leaking a payload. Users retain the existing manual-close/fallback behavior. Payloads and close timers are otherwise unchanged.

# Testing

Run each file in a separate Bun process because repository-level `mock.module` state can cross-contaminate unrelated route modules:

```text
bun test packages/cloud/shared/src/lib/services/agent-github-return.test.ts
13 pass, 0 fail

bun test packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
6 pass, 0 fail

bun test packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
6 pass, 0 fail

bun test packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts
14 pass, 0 fail

bun test packages/cloud/api/v1/eliza/lifeops/github-complete/route.post-message.test.ts
14 pass, 0 fail

Total: 53 pass, 0 fail
Changed-file Biome: 11 files checked, no fixes applied
git diff --check origin/develop...HEAD: pass
```

# Evidence Gate

<!-- evidence-head:f6ad2317372aabbbce0c0dbbfaf0643002eb16b6 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend was changed; deterministic real-route test output is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - generated callback HTML is asserted directly by route tests.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact changes.

# Known gaps

The full repository `bun run verify` lane was not rerun in this sparse isolated checkout. The affected production routes, adversarial origin values, existing identity semantics, changed-file Biome, and diff whitespace gate are covered above.
