### PR TITLE
fix(elizaos): make the min-plugin scaffold pass its own verification standalone

### DIFF
--- a/packages/elizaos/src/__tests__/min-plugin-build-contract.test.ts
+++ b/packages/elizaos/src/__tests__/min-plugin-build-contract.test.ts
@@ -14,6 +14,8 @@ const rootPackageJson = JSON.parse(
   readFileSync(resolve(templateDir, "../../../../package.json"), "utf8"),
 ) as { devDependencies: Record<string, string> };
 const canonicalBiomeVersion = rootPackageJson.devDependencies["@biomejs/biome"];
+const canonicalTsc6Version =
+  rootPackageJson.devDependencies["@typescript/typescript6"];
 
 describe("min-plugin build contract", () => {
   it("uses an emitting build config and requires the loadable build step", () => {
@@ -28,7 +30,15 @@ describe("min-plugin build contract", () => {
     ) as { compilerOptions?: Record<string, unknown>; include?: string[] };
     const scaffold = readFileSync(resolve(templateDir, "SCAFFOLD.md"), "utf8");
 
-    expect(packageJson.scripts?.build).toContain("tsconfig.build.json");
+    expect(packageJson.scripts?.build).toBe(
+      "tsc6 --noCheck -p tsconfig.build.json",
+    );
+    // The tsc6 bin only exists when the scaffold itself depends on the
+    // renamed-bin package; the monorepo root provides it here, but a
+    // standalone `bun install` of the scaffold does not (#16655 gap).
+    expect(packageJson.devDependencies?.["@typescript/typescript6"]).toBe(
+      canonicalTsc6Version,
+    );
     expect(packageJson.scripts?.lint).toBe("biome check src/");
     expect(packageJson.scripts?.["lint:check"]).toBe("biome check src/");
     expect(packageJson.scripts?.lint).not.toContain("||");
@@ -42,6 +52,13 @@ describe("min-plugin build contract", () => {
       rootDir: "src",
     });
     expect(buildConfig.include).toContain("src/**/*.tsx");
+    // Without a shipped biome config, a standalone `biome check src/` runs on
+    // Biome defaults (tab indentation) and rejects the scaffold's own source.
+    const biomeConfig = JSON.parse(
+      readFileSync(resolve(templateDir, "biome.json"), "utf8"),
+    ) as { $schema?: string; formatter?: { indentStyle?: string } };
+    expect(biomeConfig.$schema).toContain(canonicalBiomeVersion);
+    expect(biomeConfig.formatter?.indentStyle).toBe("space");
     expect(scaffold).toContain("bun install");
     expect(scaffold).toContain("bun run build");
     expect(scaffold).toContain("bundlePath");

--- a/packages/elizaos/templates/min-plugin/biome.json
+++ b/packages/elizaos/templates/min-plugin/biome.json
@@ -1,0 +1,38 @@
+{
+  "root": true,
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/**/*.ts", "src/**/*.tsx"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "correctness": {
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "complexity": {
+        "noUselessConstructor": "warn",
+        "noStaticOnlyClass": "off"
+      },
+      "a11y": {
+        "useButtonType": "off"
+      }
+    }
+  }
+}

--- a/packages/elizaos/templates/min-plugin/package.json
+++ b/packages/elizaos/templates/min-plugin/package.json
@@ -32,6 +32,7 @@
     "@biomejs/biome": "2.5.7",
     "@types/node": "^25.0.6",
     "@typescript/native": "npm:typescript@^7.0.2",
+    "@typescript/typescript6": "^6.0.2",
     "typescript": "^6.0.3",
     "vitest": "^4.0.0"
   },

--- a/packages/elizaos/templates/min-plugin/src/providers/info.ts
+++ b/packages/elizaos/templates/min-plugin/src/providers/info.ts
@@ -10,11 +10,7 @@ const PLUGIN_NAME = "__PLUGIN_NAME__";
 export const infoProvider: Provider = {
   name: "__PLUGIN_NAME___INFO",
   description: `Static info provider for the ${PLUGIN_NAME} plugin.`,
-  get: async (
-    _runtime: IAgentRuntime,
-    _message: Memory,
-    _state: State | undefined,
-  ) => {
+  get: async (_runtime: IAgentRuntime, _message: Memory, _state: State | undefined) => {
     const text = `[${PLUGIN_NAME}] active`;
     return { text, values: { pluginName: PLUGIN_NAME }, data: {} };
   },


### PR DESCRIPTION
# Relates to

Closes #22411. A standalone scaffold of the `min-plugin` template fails 2 of the 4 verification commands its own SCAFFOLD.md declares mandatory (`tsc6: command not found` on build; Biome-defaults formatting rejection on lint).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below — **see Known gaps: full verify delegated to PR CI per
      operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`b2d03f8ac`).
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Low, and scoped to the template.** Three template files change (a new dependency line, a new `biome.json`, one formatting-only source touch) plus stronger assertions in the existing contract test. In-checkout behavior is unchanged — `tsc6` already resolved there via root bin hoisting, and the repository-level Biome pass ignores `packages/elizaos/templates/**` entirely (verified: "No files were processed … ignored"), so the shipped config cannot conflict with the repo gate. The dependency is pinned to the root's canonical range and the contract test now enforces that coupling, so the template can't drift from the root again silently.

# Background

## What does this PR do?

`SCAFFOLD.md` § 4 tells the plugin-create agent: run `bun run typecheck && lint && test && build`, "All four must exit zero," then emit `PLUGIN_CREATE_DONE`; the orchestrator retries on failure (capped by `ELIZA_APP_VERIFICATION_MAX_RETRIES`). As shipped, a standalone scaffold can never satisfy that:

1. **build** ran `tsc6`, whose bin comes only from the monorepo root's `@typescript/typescript6` devDependency. df2c5b15a (#16655) rewrote the template's script from `tsc --noCheck` to `tsc6 --noCheck` without carrying the dependency into the template — and no shipped dependency can provide it (`typescript@6` and the `@typescript/native` alias both bin as `tsc`; aliases never rename bins). Standalone: exit 127.
2. **lint** ran `biome check src/` with no shipped `biome.json` — sibling templates `min-project` and `plugin` both ship one — so a standalone scaffold lints under Biome defaults (tabs) and rejects the template's own space-indented source.

The fix: add `"@typescript/typescript6": "^6.0.2"` (the root's canonical range) to the template devDependencies; ship a `biome.json` mirroring `min-project`'s; format `src/` under that config (one file changed, formatting only). The existing `min-plugin-build-contract.test.ts` — which string-matched `toContain("tsconfig.build.json")` and so could not catch a nonexistent binary — now pins the build script verbatim, requires the tsc6-providing dependency at the root canonical version (same pattern as its existing `canonicalBiomeVersion` check), and requires the shipped Biome config.

## What kind of change is this?

Bug fix (broken scaffold verification contract).

# Documentation changes needed?

None; SCAFFOLD.md's instructions are unchanged — they now actually work.

# Testing

## Where should a reviewer start?

Standalone reproduction (the real path):

```bash
cp -R packages/elizaos/templates/min-plugin /tmp/scaffold-proof && cd /tmp/scaffold-proof
grep -rl __PLUGIN_ /tmp/scaffold-proof | xargs sed -i '' -e 's/__PLUGIN_NAME__/@proof\/plugin-x/g' -e 's/__PLUGIN_DISPLAY_NAME__/Proof/g'
bun install && bun run typecheck && bun run lint && bun run test && bun run build
```

Then the contract test: `bun run --cwd packages/elizaos test -- src/__tests__/min-plugin-build-contract.test.ts`

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f3fa961a61ae4e162dd986b82c003463df9fe005 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - CLI scaffold template; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - terminal-only flow; transcripts below are complete.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs; the transcripts below are the artifact.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes; the template an agent consumes is repaired, not the agent.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

<details>
<summary>1. BEFORE — standalone scaffold of the shipped template fails build and lint</summary>

```
# scaffold copied, placeholders replaced, bun install: 157 packages
$ bun run typecheck   # PASS
$ bun run test        # PASS (1 passed)
$ bun run lint
src/index.ts format ━━━
  × Formatter would have printed the following content:
    11 │ - ··name:·PLUGIN_NAME,
       │ + → name:·PLUGIN_NAME,
error: script "lint" exited with code 1
$ bun run build
$ tsc6 --noCheck -p tsconfig.build.json
/bin/bash: tsc6: command not found
error: script "build" exited with code 127
$ npm view tsc6 version
npm error 404 Not Found - GET https://registry.npmjs.org/tsc6
$ ls node_modules/.bin | grep tsc
tsc                    # only bin present; @typescript/native (typescript@7.0.2) won the name
```
</details>

<details>
<summary>2. Root cause receipts</summary>

```
$ git show df2c5b15a -- packages/elizaos/templates/min-plugin/package.json
-    "build": "tsc --noCheck -p tsconfig.build.json",
+    "build": "tsc6 --noCheck -p tsconfig.build.json",
+    "@typescript/native": "npm:typescript@^7.0.2",
# (no @typescript/typescript6 added to the template)

# the bin exists only via the monorepo root:
$ readlink node_modules/.bin/tsc6        # repo root
../@typescript/typescript6/bin/tsc6

# repo-level Biome never checks template files (why the lint gap was invisible in CI):
$ biome check packages/elizaos/templates/min-plugin/
  × No files were processed in the specified paths.  (paths ignored)
```
</details>

<details>
<summary>3. AFTER — clean standalone scaffold of the fixed template: all four commands pass, loadable dist emitted</summary>

```
$ bun install
158 packages installed
$ for c in typecheck lint test build; do bun run $c && echo "$c: PASS"; done
typecheck: PASS
lint: PASS
test: PASS
build: PASS
$ ls dist/index.js dist/index.d.ts
dist/index.d.ts
dist/index.js          # matches package.json main/types; SCAFFOLD's loadable-build requirement
```
</details>

<details>
<summary>4. Failing-test-first — strengthened contract test red on the shipped template, green at head</summary>

```
# RED (template fixes stashed, strengthened test present)
 × uses an emitting build config and requires the loadable build step
AssertionError: expected undefined to be '^6.0.2'
 Tests  1 failed (1)

# GREEN at head, plus the other template consumer
 Test Files  2 passed (2)   Tests  2 passed (2)
   src/__tests__/min-plugin-build-contract.test.ts
   src/__tests__/min-plugin-viewkind-contract.test.ts
```
</details>

<details>
<summary>5. Lint clean on changed files</summary>

```
$ ./node_modules/.bin/biome check packages/elizaos/src/__tests__/min-plugin-build-contract.test.ts
Checked 1 file in 54ms. No fixes applied.
# template files are repo-Biome-ignored; they are formatted by the shipped template config:
$ cd packages/elizaos/templates/min-plugin && biome check src/   # under the new biome.json
Checked 2 files. No fixes applied.
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcripts above are the executable artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** Per the recorded operator hardware constraint it is delegated to this PR's CI.
- **The strengthened contract test is still static.** It now pins the exact build script, the tsc6-providing dependency (at the root canonical version, so root upgrades force the template to move in lockstep), and the shipped Biome config — which catches this entire regression class — but it does not scaffold+install+execute; the end-to-end proof above is this PR's evidence, not a CI job. If maintainers want a periodic real-scaffold smoke, I'll take that as a follow-up.
- **The in-checkout runtime create flow (`packages/core` plugin-manager) was not re-run live.** It was unbroken before (root bin hoisting) and is unchanged by this PR; the standalone path is the one repaired.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
