### PR TITLE
fix(computeruse): bound PNG decompression with pixel budget and maxOutputLength

### DIFF
--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
@@ -3,13 +3,74 @@
  * screenshot evidence lanes from empty or visually blank PNG captures.
  *
  * Synthetic metrics lock the empty floor, single-color rule, and dominant-color
- * threshold without depending on live display capture.
+ * threshold without depending on live display capture. Additional cases pin the
+ * bounded PNG decompression guards that prevent a 69-byte IHDR bomb from driving
+ * an unbounded inflateSync allocation — pixel budget, stride overflow, and
+ * maxOutputLength + length-mismatch checks mirror scene/dhash.ts.
  */
+
+import { deflateSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import {
+  analyzePngScreenshot,
   type ScreenshotQuality,
   screenshotQualityIssues,
 } from "./screenshot-quality";
+
+// ── PNG synthesizer (crc32 + chunk + minimal IHDR/IDAT/IEND) ─────────────
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) {
+    crc ^= buf[i] ?? 0;
+    for (let k = 0; k < 8; k += 1) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+function pngChunk(type: string, data: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const t = Buffer.from(type, "ascii");
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([t, data])));
+  return Buffer.concat([len, t, data, crc]);
+}
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+function makePng(
+  opts: {
+    width?: number;
+    height?: number;
+    colorType?: number;
+    pixel?: (x: number, y: number) => number;
+  } = {},
+): Buffer {
+  const w = opts.width ?? 32;
+  const h = opts.height ?? 32;
+  const colorType = opts.colorType ?? 2;
+  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : 1;
+  const pixel = opts.pixel ?? ((x: number) => (x * 8) % 255);
+  const rows: number[] = [];
+  for (let y = 0; y < h; y += 1) {
+    rows.push(0);
+    for (let x = 0; x < w; x += 1) {
+      const v = pixel(x, y) & 0xff;
+      for (let ch = 0; ch < channels; ch += 1) rows.push(ch === 3 ? 255 : v);
+    }
+  }
+  const idat = deflateSync(Buffer.from(rows));
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8;
+  ihdr[9] = colorType;
+  return Buffer.concat([
+    PNG_SIG,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", idat),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
 
 const quality = (o: Partial<ScreenshotQuality>): ScreenshotQuality => ({
   width: 100,
@@ -62,3 +123,90 @@ describe("screenshotQualityIssues", () => {
     ).toEqual([]);
   });
 });
+
+describe("analyzePngScreenshot: bounded decompression", () => {
+  it("decodes a valid 1x1 PNG without throwing", () => {
+    const buf = makePng({ width: 1, height: 1 });
+    const q = analyzePngScreenshot(buf);
+    expect(q.width).toBe(1);
+    expect(q.height).toBe(1);
+    expect(q.sampledPixels).toBe(1);
+  });
+
+  it("decodes a synthesized multi-color PNG and reports sane metrics", () => {
+    const buf = makePng({ width: 4, height: 4 });
+    const q = analyzePngScreenshot(buf);
+    expect(q.width).toBe(4);
+    expect(q.height).toBe(4);
+    expect(q.sampledPixels).toBe(16);
+    expect(q.colorBuckets).toBeGreaterThan(1);
+  });
+
+  it("throws for a pixel-budget-exceeding IHDR (bomb header)", () => {
+    const budget = 7_680 * 4_320;
+    // 65535x65535 >> budget, bomb is <128 bytes.
+    const w = 65535;
+    const h = 65535;
+    expect(w * h).toBeGreaterThan(budget);
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(w, 0);
+    ihdr.writeUInt32BE(h, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    const bomb = Buffer.concat([
+      PNG_SIG,
+      pngChunk("IHDR", ihdr),
+      pngChunk("IDAT", deflateSync(Buffer.from([0, 1, 2, 3]))),
+      pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+    expect(bomb.length).toBeLessThan(128);
+    expect(() => analyzePngScreenshot(bomb)).toThrow(/exceed.*pixel budget/);
+  });
+
+  it("throws on decompression length mismatch", () => {
+    // Valid IHDR 2x2 but IDAT only inflates to 2 rows instead of 2*(stride+1).
+    const w = 2;
+    const h = 2;
+    // Build a truncated IDAT (only 1 row).
+    const rows = [0, 10, 20, 30, 40, 50, 60];
+    const idat = deflateSync(Buffer.from(rows));
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(w, 0);
+    ihdr.writeUInt32BE(h, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    const truncated = Buffer.concat([
+      PNG_SIG,
+      pngChunk("IHDR", ihdr),
+      pngChunk("IDAT", idat),
+      pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+    expect(() => analyzePngScreenshot(truncated)).toThrow(
+      /decompression failed|length mismatch/,
+    );
+  });
+
+  it("caps inflateSync via maxOutputLength (bomb with claimed large dims but tiny body)", () => {
+    const w = 100;
+    const h = 100;
+    // IHDR claims 100x100 RGB (stride 300, expected 30100) but IDAT inflates to far larger.
+    // Craft an IDAT that would inflate to >expected if unbounded — repetition compresses well.
+    const huge = Buffer.alloc(50_000, 0xaa);
+    const idat = deflateSync(huge);
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(w, 0);
+    ihdr.writeUInt32BE(h, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    const bomb = Buffer.concat([
+      PNG_SIG,
+      pngChunk("IHDR", ihdr),
+      pngChunk("IDAT", idat),
+      pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+    expect(() => analyzePngScreenshot(bomb)).toThrow(
+      /decompression failed|length mismatch/,
+    );
+  });
+});
+

--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
@@ -80,7 +80,6 @@ const quality = (o: Partial<ScreenshotQuality>): ScreenshotQuality => ({
   dominantRatio: 0.2,
   ...o,
 });
-
 describe("screenshotQualityIssues", () => {
   it("flags an empty screenshot", () => {
     const issues = screenshotQualityIssues(
@@ -182,7 +181,7 @@ describe("analyzePngScreenshot: bounded decompression", () => {
       pngChunk("IEND", Buffer.alloc(0)),
     ]);
     expect(() => analyzePngScreenshot(truncated)).toThrow(
-      /decompression failed|length mismatch/,
+      /PNG decompression length mismatch/,
     );
   });
 
@@ -204,9 +203,10 @@ describe("analyzePngScreenshot: bounded decompression", () => {
       pngChunk("IDAT", idat),
       pngChunk("IEND", Buffer.alloc(0)),
     ]);
+    // This distinguishes the allocation cap from the later length check: if
+    // maxOutputLength is removed, inflate succeeds and reports a mismatch.
     expect(() => analyzePngScreenshot(bomb)).toThrow(
-      /decompression failed|length mismatch/,
+      /PNG decompression failed/,
     );
   });
 });
-

--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.ts
@@ -106,7 +106,35 @@ export function analyzePngScreenshot(buffer: Buffer): ScreenshotQuality {
 
   const bpp = bytesPerPixel(colorType);
   const stride = width * bpp;
-  const inflated = inflateSync(Buffer.concat(idatChunks));
+  // Fail-closed pixel budget mirrors scene/dhash.ts. IHDR is attacker-declared
+  // so a 69-byte bomb cannot drive an unbounded inflateSync allocation.
+  const MAX_DECODE_PNG_PIXELS = 7_680 * 4_320;
+  if (height > 0 && width > Math.floor(MAX_DECODE_PNG_PIXELS / height)) {
+    throw new Error(
+      `PNG dimensions exceed pixel budget: ${width}x${height} > ${MAX_DECODE_PNG_PIXELS}`,
+    );
+  }
+  if (stride + 1 > Number.MAX_SAFE_INTEGER / height) {
+    throw new Error(`PNG stride overflows: ${width}x${height} bpp=${bpp}`);
+  }
+  const expected = (stride + 1) * height;
+  let inflated: Buffer;
+  try {
+    inflated = inflateSync(Buffer.concat(idatChunks), {
+      maxOutputLength: expected,
+    });
+  } catch (error) {
+    // error-policy:J3 Malformed or bomb-compressed PNG produces an explicit
+    // invalid result rather than an unbounded allocation.
+    throw new Error(
+      `PNG decompression failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (inflated.length !== expected) {
+    throw new Error(
+      `PNG decompression length mismatch: expected ${expected}, got ${inflated.length}`,
+    );
+  }
   const buckets = new Map<string, number>();
   let previous: Buffer<ArrayBufferLike> = Buffer.alloc(stride);
   let cursor = 0;


### PR DESCRIPTION
# Relates to

Closes #22556

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is mergeable with the current base.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` passed on exact head `f4632e8afbc165fb4df63a28c4aecfc0d4895e5b`.
- [x] A reviewer can confirm the changed path from the focused behavioral suite below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `muse-spark-1.2-contributor`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Background

## What does this PR do?

- Adds a `7680 * 4320` decoded-pixel budget before allocating scanline storage.
- Guards stride arithmetic before computing the expected inflated byte length.
- Passes the exact expected byte length as zlib's `maxOutputLength` and converts malformed or overlong compressed data into an explicit invalid-PNG error.
- Rejects truncated streams whose inflated length is smaller than the declared image requires.
- Adds behavioral tests for valid decoding, oversized IHDR dimensions, truncated data, and an over-expanding compressed payload.

The final review repair removes a formatter defect and makes the over-expansion assertion distinguish zlib's allocation cap from the later length-mismatch check. The PR is intentionally limited to `screenshot-quality.ts` and its test.

## What kind of change is this?

Bug fix (non-breaking).

# Risks

Low and fail-closed. Valid 8-bit grayscale, RGB, and RGBA screenshots within the existing 8K pixel budget retain their current behavior. Unsupported, malformed, oversized, truncated, or over-expanding PNGs now fail explicitly before unbounded decompression.

# Documentation changes needed?

N/A — internal parser hardening with no public API or configuration change.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts`, then `plugins/plugin-computeruse/src/platform/screenshot-quality.ts`.

## Exact-head verification

```text
bun test plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
9 pass, 0 fail

bun run --cwd plugins/plugin-computeruse format:check
Checked 217 files. No fixes applied.

bun run --cwd plugins/plugin-computeruse lint:check
Checked 217 files. No fixes applied.

bun run verify
Tasks: 358 successful, 358 total
anti-larp: scanned 8997 test files; clean

git diff --check
(no output — pass)
```

# Evidence Gate

<!-- evidence-head:f4632e8afbc165fb4df63a28c4aecfc0d4895e5b -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A — deterministic parser hardening; exact focused and repository verification is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database or persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface changed.

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported  
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->

