### PR TITLE
fix(plugin-vision): populate recently-left when entities leave the scene

### DIFF
--- a/plugins/plugin-vision/src/entity-tracker.test.ts
+++ b/plugins/plugin-vision/src/entity-tracker.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Deterministic in-memory tests for EntityTracker's presence state machine.
+ * They pin the "recently left" transition: an entity active in one frame and
+ * absent in the next must surface through getRecentlyLeft(), the signal both
+ * the VISION_PERCEPTION provider and the describe action feed to the agent.
+ * The harness fakes the clock so departure timestamps and cleanup windows are
+ * exact; no runtime or native backend is involved.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EntityTracker } from "./entity-tracker";
+import type { PersonInfo } from "./types";
+
+function person(x = 100, y = 100): PersonInfo {
+  return {
+    id: "detection",
+    pose: "standing",
+    facing: "camera",
+    confidence: 0.9,
+    boundingBox: { x, y, width: 50, height: 100 },
+  };
+}
+
+describe("EntityTracker recently-left transition", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports an entity that was present then absent, with the departure time", async () => {
+    const tracker = new EntityTracker("world-1");
+
+    const [tracked] = await tracker.updateEntities([], [person()]);
+    expect(tracker.getRecentlyLeft()).toHaveLength(0);
+    expect(tracker.getActiveEntities().map((e) => e.id)).toEqual([tracked.id]);
+
+    vi.advanceTimersByTime(1000);
+    const departedAt = Date.now();
+    await tracker.updateEntities([], []);
+
+    const recentlyLeft = tracker.getRecentlyLeft();
+    expect(recentlyLeft).toHaveLength(1);
+    expect(recentlyLeft[0].entity.id).toBe(tracked.id);
+    expect(recentlyLeft[0].leftAt).toBe(departedAt);
+    expect(tracker.getActiveEntities()).toHaveLength(0);
+    expect(tracker.getStatistics().recentlyLeft).toBe(1);
+  });
+
+  it("does not report an entity that stays present across frames", async () => {
+    const tracker = new EntityTracker("world-1");
+
+    await tracker.updateEntities([], [person()]);
+    vi.advanceTimersByTime(500);
+    await tracker.updateEntities([], [person()]);
+
+    expect(tracker.getRecentlyLeft()).toHaveLength(0);
+    expect(tracker.getActiveEntities()).toHaveLength(1);
+  });
+
+  it("clears the recently-left record when the entity reappears", async () => {
+    const tracker = new EntityTracker("world-1");
+
+    const [tracked] = await tracker.updateEntities([], [person()]);
+    vi.advanceTimersByTime(500);
+    await tracker.updateEntities([], []);
+    expect(tracker.getRecentlyLeft()).toHaveLength(1);
+
+    // Reappear within the missing threshold so it re-matches the same entity.
+    vi.advanceTimersByTime(500);
+    await tracker.updateEntities([], [person()]);
+
+    expect(tracker.getRecentlyLeft()).toHaveLength(0);
+    const active = tracker.getActiveEntities();
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe(tracked.id);
+  });
+
+  it("ages recently-left records out after the cleanup threshold", async () => {
+    const tracker = new EntityTracker("world-1");
+
+    await tracker.updateEntities([], [person()]);
+    vi.advanceTimersByTime(1000);
+    await tracker.updateEntities([], []);
+    expect(tracker.getRecentlyLeft()).toHaveLength(1);
+
+    // Past CLEANUP_THRESHOLD (60s); a subsequent empty frame prunes the record.
+    vi.advanceTimersByTime(61_000);
+    await tracker.updateEntities([], []);
+
+    expect(tracker.getRecentlyLeft()).toHaveLength(0);
+    expect(tracker.getStatistics().recentlyLeft).toBe(0);
+  });
+});

--- a/plugins/plugin-vision/src/entity-tracker.ts
+++ b/plugins/plugin-vision/src/entity-tracker.ts
@@ -247,16 +247,19 @@ export class EntityTracker {
     seenEntityIds: Set<string>,
     timestamp: number,
   ): void {
+    // Snapshot the prior frame's active set before overwriting it; the
+    // departure check below compares this-frame against last-frame presence.
+    // Reading the reassigned field would reduce the guard to `!seen && seen`,
+    // a dead transition that never populates `recentlyLeft`.
+    const previouslyActive = this.worldState.activeEntities;
+
     // Update active entities
     this.worldState.activeEntities = Array.from(seenEntityIds);
     this.worldState.lastUpdate = timestamp;
 
-    // Check for entities that left
+    // Check for entities that were active last frame but are absent now.
     for (const [entityId, entity] of this.worldState.entities) {
-      if (
-        !seenEntityIds.has(entityId) &&
-        this.worldState.activeEntities.includes(entityId)
-      ) {
+      if (!seenEntityIds.has(entityId) && previouslyActive.includes(entityId)) {
         // Entity just left the scene
         this.worldState.recentlyLeft.push({
           entityId,
@@ -266,6 +269,14 @@ export class EntityTracker {
 
         logger.info(`[EntityTracker] Entity left scene: ${entityId}`);
       }
+    }
+
+    // A re-observed entity is present again, not "recently left"; drop any
+    // stale departure record so the two presence windows stay disjoint.
+    if (this.worldState.recentlyLeft.length > 0) {
+      this.worldState.recentlyLeft = this.worldState.recentlyLeft.filter(
+        (entry) => !seenEntityIds.has(entry.entityId),
+      );
     }
 
     // Recently-left entries are short-lived presence signals, not history.


### PR DESCRIPTION
# Relates to

Closes #22416

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Owning-package tests, typecheck, and lint were run; results and the one pre-existing unrelated blocker are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the before/after test output and the provider-text demonstration below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`bad793372e`); zero conflicts.
- [x] Owning package (`plugins/plugin-vision`) test + lint pass post-sync. The repo-wide `bun run verify` and `tsc` full pass are blocked only by an unrelated pre-existing issue documented under **Known gaps / failures**.

# Risks

Low. The change is scoped to one private method (`EntityTracker.updateWorldState`). No public signature, type, or contract changes. It only makes a previously-dead state transition fire; callers already handle a populated `recentlyLeft` list. Full plugin-vision suite (278 passing) is green.

# Background

## What does this PR do?

`EntityTracker.updateWorldState()` detects entities that departed the scene by comparing the current frame's seen IDs against the previous frame's active set. But it overwrote `this.worldState.activeEntities` with the **current** frame's IDs *before* running the departure loop, so the guard

```
!seenEntityIds.has(id) && this.worldState.activeEntities.includes(id)
```

collapsed to `!seen && seen` — always false. As a result `recentlyLeft` was never populated and `getRecentlyLeft()` always returned `[]`. This is a dead state-machine transition on a live perception path: the `VISION_PERCEPTION` provider (`src/provider.ts` ~L255 "Recently left:") and the describe action (`src/action.ts` ~L1080) both feed the agent a "\<name\> left \<time\> ago" signal that could never occur, so the agent silently lost all "person/entity departed" awareness.

The fix snapshots the prior active set before reassigning it and tests departure against that snapshot. It also drops a re-observed entity's stale departure record so the active and recently-left presence windows stay disjoint (a currently-present entity is never reported as "recently left").

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior now matches the already-documented `recentlyLeft` contract in `src/types.ts` and the provider/action rendering.

# Testing

## Where should a reviewer start?

`plugins/plugin-vision/src/entity-tracker.test.ts` (new). Run:

```bash
bun install --minimum-release-age=0     # local mirror enforces a release-age guard
bun run --cwd packages/core build       # tests import built @elizaos/core
cd plugins/plugin-vision && bunx vitest run src/entity-tracker.test.ts
```

## Detailed testing steps

The new suite pins the state machine with a faked clock (no runtime/native backend):
1. present in frame 1 then absent in frame 2 => `getRecentlyLeft()` has exactly the departed entity with the correct `leftAt`;
2. still-present entity across two frames => no recently-left entry;
3. re-appearance in a later frame keeps it active and clears its stale departure record;
4. entries age out after `CLEANUP_THRESHOLD`.

# Evidence Gate

<!-- evidence-head:fefb4fd19954de4142a76707cd5acc2d4997195f -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a runtime perception state-machine fix in plugins/plugin-vision (no packages/app, packages/ui, or rendered .tsx changes).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the affected output is agent-context text, demonstrated below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - full failing-before then passing-after vitest output is pasted inline in the Backend and frontend logs collapsible section below; a trusted-host artifact URL cannot be minted from this token-only fork CLI, since user-attachments needs GitHub's web uploader and the pr-evidence release needs elizaOS push access.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model/agent-decision change. The fix restores a deterministic perception signal; provider text rendering is shown below.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reproduced VISION_PERCEPTION provider Recently left perception text is pasted inline in the Screenshots section below; same trusted-host upload limitation as the backend logs row.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no prompt/model/agent-decision change.` The fix restores a deterministic perception state transition; no live model is involved in `EntityTracker`.

## Backend + frontend logs

Frontend: `N/A - no frontend involved.`

Backend — failing-before / passing-after of the regression suite against the exact source under review:

<details><summary>BEFORE (buggy <code>entity-tracker.ts</code> from origin/develop) — 3 fail</summary>

```
 × reports an entity that was present then absent, with the departure time
 × clears the recently-left record when the entity reappears
 × ages recently-left records out after the cleanup threshold
AssertionError: expected [] to have a length of 1 but got +0
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```
(The one passing test is "does not report an entity that stays present across frames", which correctly expects an empty list.)
</details>

<details><summary>AFTER (this PR) — all pass</summary>

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
</details>

<details><summary>Full plugin-vision suite (this PR)</summary>

```
 Test Files  44 passed (44)
      Tests  278 passed | 4 skipped (282)
```
</details>

<details><summary>Lint (biome) — clean</summary>

```
$ bunx @biomejs/biome check src/entity-tracker.ts src/entity-tracker.test.ts
Checked 2 files in 25ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.` The user-facing impact is agent-context text. Demonstration reproducing the provider's `src/provider.ts` ~L255 "Recently left:" rendering for a two-frame (present -> absent) scenario:

<details><summary>Provider "Recently left:" text — before vs after</summary>

```
Before this fix: getRecentlyLeft() === []  =>  (no "Recently left:" section emitted)

After this fix (same two-frame scenario, present -> absent):
Recently left:
- Unknown person left 0s ago
```
("Unknown person" and "0s ago" follow the exact provider fallback + rounding logic; the entity had no assigned name and departed <1s earlier.)
</details>

## Audio / voice walkthrough

`N/A - no audio/voice path touched.`

## Known gaps / failures

- `bun run --cwd plugins/plugin-vision typecheck` reports one **pre-existing, unrelated** error: `src/index.ts(122,9): TS2307: Cannot find module '@elizaos/plugin-computeruse/mobile/ocr-provider'` — an optional cross-plugin seam whose types resolve only when `@elizaos/plugin-computeruse` is built. I confirmed it is present on unmodified `origin/develop` (stashed my two files and re-ran `tsc`; same single error). It does not touch `entity-tracker.ts` and is outside this PR's scope.
- `bun install` on this machine's mirror enforces a minimum-release-age guard; `--minimum-release-age=0` was used for install only. No source or lockfile guard was changed.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->