### PR TITLE
chore: gitignore the repo-root .eliza-local state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1040,6 +1040,12 @@ packages/ui/src/components/shell/__e2e__/output-home-locale/
 /fused-lib/
 /.fused-lib/
 
+# Repo-root local state written by app-core scripts (run-mobile-build.mjs
+# artifacts, bluebubbles/homepage evidence JSON, and
+# .eliza-local/bluebubbles-bridge.env, which can hold a gateway secret).
+# Machine-local by design and easy to sweep into a commit (#22348 review).
+/.eliza-local/
+
 # App-create scaffolds: the workspace app root the APP create flow builds into
 # (<checkout>/eliza/apps/<dir>). Generated per-user app workdirs, never repo code.
 /eliza/


### PR DESCRIPTION
# Relates to

Follow-up flagged in #22348's Known gaps: the repo-root `.eliza-local/` state directory is not gitignored, and one of the files written there can hold a gateway secret.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [x] One-line ignore entry; the verification is the `git check-ignore` transcript below.
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`bad793372`).

# Risks

**None beyond intent.** One anchored ignore entry (`/.eliza-local/`). Nothing under that path is tracked today (`git ls-files | grep eliza-local` is empty), so no tracked file's status changes; the entry only prevents future accidental staging.

# Background

## What does this PR do?

Several `packages/app-core` scripts write machine-local state to `<repoRoot>/.eliza-local/`, all anchored to the repo root via their own `repoRoot` resolution:

- `run-mobile-build.mjs:251` — `.eliza-local/artifacts`
- `check-homepage-public-readiness.mjs` — `.eliza-local/homepage-public-readiness-latest.json`
- `validate-bluebubbles-outbound.mjs` — `.eliza-local/bluebubbles-outbound-validation-latest.json`
- `verify-cloud-sms-onboarding-flow.mjs` — reads `.eliza-local/bluebubbles-bridge.env`, documented as a place the **gateway secret** lives
- `scripts/android-sms-gateway-template.test.mjs` — writes `.eliza-local/bluebubbles-gateway-e2e-latest.json` when run (this is the one that nearly landed in #22348's commit)

None of that is repo content, and the un-ignored directory sits one broad `git add` away from being committed — including the secret-bearing env file. This adds the anchored ignore entry with a comment naming the writers, in the established commented style of the surrounding entries.

## What kind of change is this?

Chore (ignore machine-local state; prevents accidental secret/artifact commits).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

```bash
mkdir -p .eliza-local && touch .eliza-local/probe.json && git status --short && git check-ignore -v .eliza-local/probe.json
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ff7ebb82a9f39f05e4fdd0e74b5a9d97d8462d40 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - .gitignore entry; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - one ignore entry; the transcript below is complete.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

<details>
<summary>Ignore entry verified against a real artifact; nothing tracked is affected</summary>

```
$ mkdir -p .eliza-local && echo '{"probe":true}' > .eliza-local/probe.json
$ git status --short
 M .gitignore                      # only this PR's change; probe.json not listed
$ git check-ignore -v .eliza-local/probe.json
.gitignore:1047:/.eliza-local/	.eliza-local/probe.json
$ git ls-files | grep -c "eliza-local"
0                                  # nothing tracked under the path today
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcript above is the artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

None. The change is a single anchored ignore entry verified against a live probe artifact.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->