### PR TITLE
docs: repoint seven relative links whose targets moved

### DIFF
--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -115,7 +115,7 @@ task creation is modeled as opening the LifeOps task feature.
 
 Build-time flag set: `VITE_ELIZA_ANDROID_RUNTIME_MODE=cloud`. The
 renderer reads this via
-[`packages/ui/src/platform/android-runtime.ts`](../../../../ui/src/platform/android-runtime.ts)
+[`packages/ui/src/platform/android-runtime.ts`](../../../ui/src/platform/android-runtime.ts)
 and the `RuntimeSettingsSection` hides the Local picker option so users
 cannot try to provision an on-device agent that physically isn't there.
 

--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -11,7 +11,7 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). **Ap
 
 **Why a dedicated script:** Electrobun needs a renderer URL, often a running API, and (in dev) a root `dist/` bundle. Starting each piece by hand drifts on ports and env vars; one orchestrator keeps **startup and shutdown** symmetric.
 
-**Full guide (WHYs for signals, `detached`, HMR vs Rollup watch, multiple `bun` PIDs):** [Desktop local development](../docs/apps/desktop-local-development.md)
+**Full guide (WHYs for signals, `detached`, HMR vs Rollup watch, multiple `bun` PIDs):** [Desktop local development](../../docs/apps/desktop-local-development.md)
 
 ### Production and staging Cloud targets
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -68,8 +68,8 @@ and the SEV-SNP/TDX hardware-attestation requirement.
 
 | Component | Code | Infra |
 |---|---|---|
-| Control plane VM | [`packages/cloud/scripts/admin/daemons/provisioning-worker.ts`](../../../../../scripts/cloud/admin/daemons/provisioning-worker.ts) | [Terraform: `control-plane/`](./control-plane/) |
-| Agent router | [`packages/cloud/scripts/admin/daemons/agent-router.ts`](../../../../../scripts/cloud/admin/daemons/agent-router.ts) | systemd unit on control-plane VM |
+| Control plane VM | [`packages/cloud/scripts/admin/daemons/provisioning-worker.ts`](../../../../scripts/admin/daemons/provisioning-worker.ts) | [Terraform: `control-plane/`](./control-plane/) |
+| Agent router | [`packages/cloud/scripts/admin/daemons/agent-router.ts`](../../../../scripts/admin/daemons/agent-router.ts) | systemd unit on control-plane VM |
 | Data plane autoscaler | [`packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts`](../../../../shared/src/lib/services/containers/node-autoscaler.ts) | Hetzner Cloud API at runtime |
 | Sandbox provisioning | [`packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts`](../../../../shared/src/lib/services/docker-sandbox-provider.ts) | SSH from control plane to data plane |
 

--- a/plugins/plugin-local-inference/native/verify/M6-gemma-kv-geometry-and-fa.md
+++ b/plugins/plugin-local-inference/native/verify/M6-gemma-kv-geometry-and-fa.md
@@ -1,6 +1,6 @@
 # M6 — Gemma KV geometry, flash-attention, and kernel re-opt status
 
-> Milestone **M6** of the [Gemma 4 cutover](../docs/gemma4-cutover-plan.md):
+> Milestone **M6** of the [Gemma 4 cutover](../../docs/gemma4-cutover-plan.md):
 > kernel re-optimization for Gemma's geometry. This doc is the *measured*
 > evidence behind the plan's claim that **QJL/Polar KV-quant is low-ROI on Gemma
 > and the head_dim=128 KV kernels are dimensionally inapplicable** — plus the FA

--- a/plugins/plugin-local-inference/native/verify/M7-gemma-cpu-verification-2026-06-22.md
+++ b/plugins/plugin-local-inference/native/verify/M7-gemma-cpu-verification-2026-06-22.md
@@ -1,6 +1,6 @@
 # M7 — Gemma 4 verification on Linux x64 (CPU + Vulkan GPU)
 
-> Milestone **M7** of the [Gemma 4 cutover](../docs/gemma4-cutover-plan.md).
+> Milestone **M7** of the [Gemma 4 cutover](../../docs/gemma4-cutover-plan.md).
 > Host: linux-x64, AMD CPU + **RTX 5080 Laptop GPU via Vulkan** (CUDA runtime is
 > blocked — see "Blocked platforms" — but Vulkan drives the GPU; see the GPU
 > section). Fork build: `c849143c9` (`b10028`, M3-seam branch) for CPU; the

--- a/plugins/plugin-local-inference/native/verify/ROADMAP.md
+++ b/plugins/plugin-local-inference/native/verify/ROADMAP.md
@@ -160,7 +160,7 @@ GPU-runner or the existing device-lab.
 **Current state.** No on-device runner. `vulkan_verify` is a
 desktop/lavapipe binary; cross-compile against the NDK Vulkan headers
 already works (the cmake flags in
-[`../../app-core/scripts/build-llama-cpp-mtp.mjs:670–689`](../../app-core/scripts/build-llama-cpp-mtp.mjs)
+[`../../app-core/scripts/build-llama-cpp-mtp.mjs:670–689`](../../../../packages/app-core/scripts/build-llama-cpp-mtp.mjs)
 do exactly this for `android-arm64-vulkan`), but the `verify/Makefile`
 doesn't have an `android-vulkan` recipe.
 
@@ -232,7 +232,7 @@ blocker #1).
 **Status:** blocks `27b-256k` tier entirely (no target exists today).
 
 **Current state.** `SUPPORTED_TARGETS` in
-[`../../app-core/scripts/build-llama-cpp-mtp.mjs:82`](../../app-core/scripts/build-llama-cpp-mtp.mjs)
+[`../../app-core/scripts/build-llama-cpp-mtp.mjs:82`](../../../../packages/app-core/scripts/build-llama-cpp-mtp.mjs)
 has no `linux-aarch64-*` triple. `parseTarget` would happily split
 `linux-aarch64-cuda` into the right shape, but the array doesn't
 include it.


### PR DESCRIPTION
# Relates to

Relates to #22422 (full inventory of the 43 broken relative-link occurrences the sweep found). This PR fixes the purely mechanical subset — seven links whose targets verifiably moved to exactly one surviving location — and changes no prose. The 30 occurrences needing owner decisions stay enumerated in the issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [x] Documentation-only change; guide parity and link/path validation both run below.
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`bad793372`).

# Risks

**None beyond intent.** Six markdown files, link hrefs only. Every new target was verified two ways before repointing: it is the *only* file with that basename in `git ls-files`, and its content matches the link's intent (headers checked — e.g. the moved runtime file still opens with "Android runtime mode resolution", the moved doc still titles "Desktop local development"). Relative paths were computed with `os.path.relpath`, not hand-arithmetic, and the post-fix sweep confirms all seven resolve.

# Background

## What does this PR do?

Repoints seven broken relative links whose targets moved during repo restructures:

| Doc | Old (broken) | New |
|---|---|---|
| `packages/app-core/platforms/android/README.md` | `../../../../ui/src/platform/android-runtime.ts` | `../../../ui/src/platform/android-runtime.ts` |
| `packages/app-core/scripts/README.md` | `../docs/apps/desktop-local-development.md` | `../../docs/apps/desktop-local-development.md` |
| `packages/cloud/.../hetzner/ARCHITECTURE.md` | `../../../../../scripts/cloud/admin/daemons/provisioning-worker.ts` | `../../../../scripts/admin/daemons/provisioning-worker.ts` |
| `packages/cloud/.../hetzner/ARCHITECTURE.md` | same pattern, `agent-router.ts` | `../../../../scripts/admin/daemons/agent-router.ts` |
| `plugin-local-inference/native/verify/M6…md` | `../docs/gemma4-cutover-plan.md` | `../../docs/gemma4-cutover-plan.md` |
| `plugin-local-inference/native/verify/M7…md` | `../docs/gemma4-cutover-plan.md` | `../../docs/gemma4-cutover-plan.md` |
| `plugin-local-inference/native/verify/ROADMAP.md` | `../../app-core/scripts/build-llama-cpp-mtp.mjs` (×2) | `../../../../packages/app-core/scripts/build-llama-cpp-mtp.mjs` |

These paths sit outside every existing link gate — `launch-qa/check-docs.mjs --scope=docs` reports 0 errors while all of them were broken.

## What kind of change is this?

Docs fix (link rot repair, mechanical subset only).

# Documentation changes needed?

This is the documentation change.

# Testing

## Where should a reviewer start?

Click any repointed link on the PR diff view, or re-run the sweep:

```bash
git ls-files "*.md" | xargs grep -l "gemma4-cutover-plan\|android-runtime\|desktop-local-development\|provisioning-worker\|build-llama-cpp-mtp"
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:1ed0cd8cdac4baf7a252878c1f3c950244d98c08 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - markdown link hrefs; no rendered UI surface in the product.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - link href edits; the sweep transcript below is complete.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

<details>
<summary>Sweep before/after + target verification + required docs gates</summary>

```
# BEFORE (develop): existence sweep over tracked *.md (fences stripped;
# templates/fixtures/__tests__/changelogs excluded)
broken occurrences: 43

# target verification (unique-basename + content match), e.g.:
$ head packages/ui/src/platform/android-runtime.ts        # "Android runtime mode resolution"
$ head packages/docs/apps/desktop-local-development.md    # title: Desktop local development
$ head plugins/plugin-local-inference/docs/gemma4-cutover-plan.md  # "Status doc for the Gemma 4 cutover"

# AFTER (this head): same sweep
remaining broken (non-CHANGELOG): 30      # exactly the #22422 inventory; all 7 repoints resolve

# required docs gates
$ node scripts/assert-agents-claude-identical.mjs
PASS: 155 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
$ node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json
errorCount: 0
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the sweep transcript above is the artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Only the mechanical subset is fixed.** The other 30 broken occurrences point at deleted or never-committed targets in areas owned by other teams (training, local-inference verify notes, cloud e2e); repairing them means editorial decisions, so they are inventoried in #22422 instead of guessed at here.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->