### PR TITLE
fix(ui): confine persisted GLSL to compiled presets

### DIFF
--- a/packages/ui/src/backgrounds/shader-schema.test.ts
+++ b/packages/ui/src/backgrounds/shader-schema.test.ts
@@ -159,6 +159,11 @@ describe("shader-schema — isPlausibleFragmentSource (static safety gate)", () 
         "void main(){ for (int i = 0; i < 200000; i++) {} gl_FragColor = vec4(1.0); }",
       ),
     ).toBe(false);
+    expect(
+      isPlausibleFragmentSource(
+        "void main(){ for(int i=99999;i>0;i--){} gl_FragColor = vec4(1.0); }",
+      ),
+    ).toBe(false);
   });
   it("still accepts the preset-style 5-iter for", () => {
     expect(

--- a/packages/ui/src/backgrounds/shader-schema.test.ts
+++ b/packages/ui/src/backgrounds/shader-schema.test.ts
@@ -144,5 +144,27 @@ describe("shader-schema — isPlausibleFragmentSource (static safety gate)", () 
         "void main(){ do { } while(true); gl_FragColor = vec4(1.0); }",
       ),
     ).toBe(false);
+    expect(
+      isPlausibleFragmentSource(
+        "void main(){ for(;;){} gl_FragColor = vec4(1.0); }",
+      ),
+    ).toBe(false);
+    expect(
+      isPlausibleFragmentSource(
+        "void main(){ for(;true;){} gl_FragColor = vec4(1.0); }",
+      ),
+    ).toBe(false);
+    expect(
+      isPlausibleFragmentSource(
+        "void main(){ for (int i = 0; i < 200000; i++) {} gl_FragColor = vec4(1.0); }",
+      ),
+    ).toBe(false);
+  });
+  it("still accepts the preset-style 5-iter for", () => {
+    expect(
+      isPlausibleFragmentSource(
+        "void main(){ for(int i=0;i<5;i++){} gl_FragColor = vec4(1.0); }",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/ui/src/backgrounds/shader-schema.test.ts
+++ b/packages/ui/src/backgrounds/shader-schema.test.ts
@@ -172,4 +172,23 @@ describe("shader-schema — isPlausibleFragmentSource (static safety gate)", () 
       ),
     ).toBe(true);
   });
+
+  it("fails closed on alternate and multiplicative for-loop spellings", () => {
+    const wrap = (loop: string) =>
+      `void main(){ ${loop} gl_FragColor = vec4(1.0); }`;
+    expect(isPlausibleFragmentSource(wrap("for(int i=0;i<1e9;i++){}"))).toBe(
+      false,
+    );
+    expect(
+      isPlausibleFragmentSource(
+        wrap("const int N=200000; for(int i=0;i<N;i++){}"),
+      ),
+    ).toBe(false);
+    expect(isPlausibleFragmentSource(wrap("for/**/(;;){}"))).toBe(false);
+    expect(
+      isPlausibleFragmentSource(
+        wrap("for(int i=0;i<64;i++){ for(int j=0;j<64;j++){} }"),
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/ui/src/backgrounds/shader-schema.ts
+++ b/packages/ui/src/backgrounds/shader-schema.ts
@@ -3,12 +3,13 @@
  * GLSL background (#10694).
  *
  * Arbitrary GLSL is untrusted GPU code and the uniform values arrive from
- * untrusted places (the agent, persisted localStorage, chat). Everything here
- * coerces those inputs into a safe, finite, clamped shape so a hostile or
- * malformed value can never NaN the render or push the GPU into a hang —
- * including `for(;;)` / huge-literal `for` that used to slip past the
- * `while`/`do` check. This module is deliberately three.js-free so it
- * unit-tests without a WebGL context.
+ * untrusted places (the agent, persisted localStorage, chat). Uniforms are
+ * clamped to a finite schema. Fragment source is size-bounded and scanned
+ * for hang-prone loops (`while`/`do`, empty-condition `for`, huge numeric
+ * literals in a `for` init or condition). Named constants, uniforms, and
+ * nested loops can still compile; the renderer's 5-slow-frame watchdog is
+ * the backstop. This module is three.js-free so it unit-tests without a
+ * WebGL context.
  */
 
 /** The tunable uniforms the user/agent can drive. Standard `u_time` /
@@ -123,18 +124,27 @@ export const MAX_SHADER_SOURCE_BYTES = 16 * 1024;
  * long before the renderer's 5-slow-frame watchdog. */
 export const MAX_SHADER_LOOP_ITERS = 64;
 
+/** True when a clause carries a decimal literal above {@link MAX_SHADER_LOOP_ITERS}. */
+function clauseHasHugeLiteral(clause: string): boolean {
+  for (const digits of clause.match(/\d+/g) ?? []) {
+    if (Number(digits) > MAX_SHADER_LOOP_ITERS) return true;
+  }
+  return false;
+}
+
 /** True when a `for` header has an empty/`true`/`1` condition or a numeric
- * literal above {@link MAX_SHADER_LOOP_ITERS}. */
+ * literal above {@link MAX_SHADER_LOOP_ITERS} in the init or condition. */
 function hasUnboundedForLoop(source: string): boolean {
   const header = /\bfor\s*\(([^;]*);([^;]*);/g;
   let match = header.exec(source);
   while (match !== null) {
+    const init = match[1];
     const condition = match[2].replace(/\s+/g, "");
     if (condition === "" || condition === "true" || condition === "1") {
       return true;
     }
-    for (const digits of condition.match(/\d+/g) ?? []) {
-      if (Number(digits) > MAX_SHADER_LOOP_ITERS) return true;
+    if (clauseHasHugeLiteral(init) || clauseHasHugeLiteral(match[2])) {
+      return true;
     }
     match = header.exec(source);
   }
@@ -143,10 +153,11 @@ function hasUnboundedForLoop(source: string): boolean {
 
 /**
  * Cheap static safety gate applied BEFORE the authoritative GL compile-validate
- * in the renderer. Bounds the size and rejects hang-prone loops (`while`/`do`,
- * empty-condition `for`, and `for` with a huge literal bound). Preset shaders
- * use `for(int i=0;i<5;i++)` only, so this never rejects a legitimate
- * background. Persistence (`normalizeBackgroundConfig`) is the product sink.
+ * in the renderer. Defence in depth ahead of the 5-slow-frame watchdog: size
+ * bound, no `while`/`do`, no empty-condition `for`, no huge decimal literal in
+ * a `for` init or condition. Named constants, uniforms, and nested loops are
+ * not closed by this regex. Presets use `for(int i=0;i<5;i++)` only.
+ * Persistence (`normalizeBackgroundConfig`) is the product sink.
  */
 export function isPlausibleFragmentSource(source: unknown): source is string {
   if (typeof source !== "string") return false;

--- a/packages/ui/src/backgrounds/shader-schema.ts
+++ b/packages/ui/src/backgrounds/shader-schema.ts
@@ -5,11 +5,10 @@
  * Arbitrary GLSL is untrusted GPU code and the uniform values arrive from
  * untrusted places (the agent, persisted localStorage, chat). Uniforms are
  * clamped to a finite schema. Fragment source is size-bounded and scanned
- * for hang-prone loops (`while`/`do`, empty-condition `for`, huge numeric
- * literals in a `for` init or condition). Named constants, uniforms, and
- * nested loops can still compile; the renderer's 5-slow-frame watchdog is
- * the backstop. This module is three.js-free so it unit-tests without a
- * WebGL context.
+ * for hang-prone loops (`while`/`do` and every `for` except the single
+ * literal-bounded form used by compiled-in presets). The renderer's
+ * 5-slow-frame watchdog remains the backstop. This module is three.js-free so
+ * it unit-tests without a WebGL context.
  */
 
 /** The tunable uniforms the user/agent can drive. Standard `u_time` /
@@ -124,39 +123,35 @@ export const MAX_SHADER_SOURCE_BYTES = 16 * 1024;
  * long before the renderer's 5-slow-frame watchdog. */
 export const MAX_SHADER_LOOP_ITERS = 64;
 
-/** True when a clause carries a decimal literal above {@link MAX_SHADER_LOOP_ITERS}. */
-function clauseHasHugeLiteral(clause: string): boolean {
-  for (const digits of clause.match(/\d+/g) ?? []) {
-    if (Number(digits) > MAX_SHADER_LOOP_ITERS) return true;
-  }
-  return false;
-}
+/**
+ * The only loop form used by the compiled-in preset corpus. Accepting a
+ * general GLSL expression here would make a regex-based gate fail open on
+ * aliases, scientific notation, macros, or multiplicative nested loops.
+ */
+const SAFE_PRESET_FOR_LOOP =
+  /\bfor\s*\(\s*int\s+([A-Za-z_]\w*)\s*=\s*0\s*;\s*\1\s*<\s*(\d+)\s*;\s*\1\s*\+\+\s*\)/g;
 
-/** True when a `for` header has an empty/`true`/`1` condition or a numeric
- * literal above {@link MAX_SHADER_LOOP_ITERS} in the init or condition. */
-function hasUnboundedForLoop(source: string): boolean {
-  const header = /\bfor\s*\(([^;]*);([^;]*);/g;
-  let match = header.exec(source);
-  while (match !== null) {
-    const init = match[1];
-    const condition = match[2].replace(/\s+/g, "");
-    if (condition === "" || condition === "true" || condition === "1") {
-      return true;
-    }
-    if (clauseHasHugeLiteral(init) || clauseHasHugeLiteral(match[2])) {
-      return true;
-    }
-    match = header.exec(source);
-  }
-  return false;
+/** True unless every `for` token is the single literal-bounded preset form. */
+function hasUnsupportedForLoop(source: string): boolean {
+  let safeLoopCount = 0;
+  const withoutSafeLoops = source.replace(
+    SAFE_PRESET_FOR_LOOP,
+    (_header, _variable: string, literal: string) => {
+      safeLoopCount += 1;
+      return Number(literal) <= MAX_SHADER_LOOP_ITERS ? "" : "for";
+    },
+  );
+  // The shipped corpus has one five-iteration noise loop. Rejecting multiple
+  // loops also prevents individually-small bounds from multiplying GPU work.
+  return safeLoopCount > 1 || /\bfor\b/.test(withoutSafeLoops);
 }
 
 /**
  * Cheap static safety gate applied BEFORE the authoritative GL compile-validate
  * in the renderer. Defence in depth ahead of the 5-slow-frame watchdog: size
- * bound, no `while`/`do`, no empty-condition `for`, no huge decimal literal in
- * a `for` init or condition. Named constants, uniforms, and nested loops are
- * not closed by this regex. Presets use `for(int i=0;i<5;i++)` only.
+ * bound, no `while`/`do`, and at most one literal-bounded preset-style `for`.
+ * General expressions, macros, comments between tokens, and nested loops fail
+ * closed because a regex cannot prove their total GPU work.
  * Persistence (`normalizeBackgroundConfig`) is the product sink.
  */
 export function isPlausibleFragmentSource(source: unknown): source is string {
@@ -173,6 +168,6 @@ export function isPlausibleFragmentSource(source: unknown): source is string {
   }
   // Unbounded GPU loops hang a frame; presets use a 5-iter `for` only.
   if (/\bwhile\b/.test(source) || /\bdo\b/.test(source)) return false;
-  if (hasUnboundedForLoop(source)) return false;
+  if (hasUnsupportedForLoop(source)) return false;
   return true;
 }

--- a/packages/ui/src/backgrounds/shader-schema.ts
+++ b/packages/ui/src/backgrounds/shader-schema.ts
@@ -5,8 +5,10 @@
  * Arbitrary GLSL is untrusted GPU code and the uniform values arrive from
  * untrusted places (the agent, persisted localStorage, chat). Everything here
  * coerces those inputs into a safe, finite, clamped shape so a hostile or
- * malformed value can never NaN the render or push the GPU into a hang. This
- * module is deliberately three.js-free so it unit-tests without a WebGL context.
+ * malformed value can never NaN the render or push the GPU into a hang —
+ * including `for(;;)` / huge-literal `for` that used to slip past the
+ * `while`/`do` check. This module is deliberately three.js-free so it
+ * unit-tests without a WebGL context.
  */
 
 /** The tunable uniforms the user/agent can drive. Standard `u_time` /
@@ -116,11 +118,35 @@ export function hexToRgb(hex: string): [number, number, number] {
  * reaches the GPU compiler. */
 export const MAX_SHADER_SOURCE_BYTES = 16 * 1024;
 
+/** Largest literal iteration bound a persisted `for` may carry. Presets use
+ * `for(int i=0;i<5;i++)` only; a 200000-iter bomb compiles and stalls a frame
+ * long before the renderer's 5-slow-frame watchdog. */
+export const MAX_SHADER_LOOP_ITERS = 64;
+
+/** True when a `for` header has an empty/`true`/`1` condition or a numeric
+ * literal above {@link MAX_SHADER_LOOP_ITERS}. */
+function hasUnboundedForLoop(source: string): boolean {
+  const header = /\bfor\s*\(([^;]*);([^;]*);/g;
+  let match = header.exec(source);
+  while (match !== null) {
+    const condition = match[2].replace(/\s+/g, "");
+    if (condition === "" || condition === "true" || condition === "1") {
+      return true;
+    }
+    for (const digits of condition.match(/\d+/g) ?? []) {
+      if (Number(digits) > MAX_SHADER_LOOP_ITERS) return true;
+    }
+    match = header.exec(source);
+  }
+  return false;
+}
+
 /**
  * Cheap static safety gate applied BEFORE the authoritative GL compile-validate
- * in the renderer. Bounds the size and rejects the one construct a hang-prone
- * shader needs (`while` — an unbounded GPU loop). Preset shaders use bounded
- * `for` loops only, so this never rejects a legitimate background.
+ * in the renderer. Bounds the size and rejects hang-prone loops (`while`/`do`,
+ * empty-condition `for`, and `for` with a huge literal bound). Preset shaders
+ * use `for(int i=0;i<5;i++)` only, so this never rejects a legitimate
+ * background. Persistence (`normalizeBackgroundConfig`) is the product sink.
  */
 export function isPlausibleFragmentSource(source: unknown): source is string {
   if (typeof source !== "string") return false;
@@ -134,7 +160,8 @@ export function isPlausibleFragmentSource(source: unknown): source is string {
   ) {
     return false;
   }
-  // `while`/`do` can spin unbounded on the GPU — reject (presets use bounded for).
+  // Unbounded GPU loops hang a frame; presets use a 5-iter `for` only.
   if (/\bwhile\b/.test(source) || /\bdo\b/.test(source)) return false;
+  if (hasUnboundedForLoop(source)) return false;
   return true;
 }

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
@@ -42,11 +42,10 @@ afterEach(() => {
   __setAppValueForTests(null);
 });
 
-/** A GPU bomb: a bounded `for` loop with a pathological literal bound. It
- * passes the static gate (writes gl_FragColor, no while/do, < 16KB) AND the
- * GL compile — one frame of it can stall the GPU long before the frame-time
- * watchdog's 5-slow-frame threshold. The channel must refuse raw GLSL text
- * outright; presets are the only source of shader code (#11088). */
+/** A GPU bomb: a bounded `for` loop with a pathological literal bound. The
+ * static gate now rejects huge-literal `for` (and empty-condition `for`). The
+ * channel still refuses raw GLSL text outright; presets are the only source
+ * of shader code (#11088). */
 const FOR_BOMB = `precision highp float;
 void main(){
   float acc = 0.0;
@@ -55,8 +54,8 @@ void main(){
 }`;
 
 describe("useBackgroundApplyChannel — raw GLSL source is not a sink (#11088)", () => {
-  it("sanity: the for-bomb slips past the static gate (why the channel must drop it)", () => {
-    expect(isPlausibleFragmentSource(FOR_BOMB)).toBe(true);
+  it("sanity: the for-bomb is rejected by the static gate", () => {
+    expect(isPlausibleFragmentSource(FOR_BOMB)).toBe(false);
   });
 
   it("ignores a payload carrying raw GLSL `source` text (glsl mode)", () => {

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -6,6 +6,7 @@
  * `localStorage`.
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { getShaderPreset } from "../backgrounds/shader-presets";
 import {
   loadBackgroundConfig,
   normalizeBackgroundConfig,
@@ -74,16 +75,17 @@ describe("background config persistence", () => {
     });
   });
 
-  it("keeps a glsl config with a plausible fragment source and clamps its uniforms", () => {
-    const source =
-      "precision highp float; void main(){ gl_FragColor = vec4(1.0); }";
+  it("restores a glsl preset from the compiled corpus and clamps its uniforms", () => {
+    const preset = getShaderPreset("lava");
+    expect(preset).toBeDefined();
+    if (!preset) throw new Error("lava preset missing from test corpus");
     expect(
       normalizeBackgroundConfig({
         mode: "glsl",
         color: "#123456",
         shader: {
           presetId: "lava",
-          source,
+          source: "void main(){ for(;;){} gl_FragColor=vec4(1.0);}",
           uniforms: { u_speed: 999, u_scale: 2, u_intensity: 1, u_seed: 5 },
         },
       }),
@@ -92,14 +94,14 @@ describe("background config persistence", () => {
       color: "#123456",
       shader: {
         presetId: "lava",
-        source,
+        source: preset.source,
         // u_speed clamped from 999 → 3 (schema max); others kept.
         uniforms: { u_speed: 3, u_scale: 2, u_intensity: 1, u_seed: 5 },
       },
     });
   });
 
-  it("collapses a glsl config with a missing/hostile source to the color field (safety)", () => {
+  it("collapses a glsl config without a known preset id to the color field", () => {
     // no shader payload
     expect(
       normalizeBackgroundConfig({ mode: "glsl", color: "#123456" }),
@@ -107,46 +109,39 @@ describe("background config persistence", () => {
       mode: "shader",
       color: "#123456",
     });
-    // unbounded-loop source is rejected by the static gate → color field
+    // Arbitrary source never becomes a WebGL capability, even when plausible.
     expect(
       normalizeBackgroundConfig({
         mode: "glsl",
         color: "#123456",
         shader: {
-          source: "void main(){ while(true){} gl_FragColor=vec4(1.0);}",
+          source: "void main(){ gl_FragColor=vec4(1.0);}",
         },
       }),
     ).toEqual({ mode: "shader", color: "#123456" });
-    // empty-condition / huge-literal `for` used to pass the while/do gate
+    // Unknown preset ids also fail closed instead of trusting their source.
     expect(
       normalizeBackgroundConfig({
         mode: "glsl",
         color: "#123456",
         shader: {
+          presetId: "not-a-preset",
           source: "void main(){ for(;;){} gl_FragColor=vec4(1.0);}",
-        },
-      }),
-    ).toEqual({ mode: "shader", color: "#123456" });
-    expect(
-      normalizeBackgroundConfig({
-        mode: "glsl",
-        color: "#123456",
-        shader: {
-          source:
-            "void main(){ for(int i=0;i<200000;i++){} gl_FragColor=vec4(1.0);}",
         },
       }),
     ).toEqual({ mode: "shader", color: "#123456" });
   });
 
   it("round-trips a glsl config through localStorage", () => {
+    const preset = getShaderPreset("aurora");
+    expect(preset).toBeDefined();
+    if (!preset) throw new Error("aurora preset missing from test corpus");
     const config = {
       mode: "glsl" as const,
       color: "#0a0a0a",
       shader: {
         presetId: "aurora",
-        source:
-          "precision highp float; void main(){ gl_FragColor = vec4(1.0); }",
+        source: preset.source,
         uniforms: { u_speed: 1, u_scale: 1, u_intensity: 1, u_seed: 0 },
       },
     };

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -117,6 +117,26 @@ describe("background config persistence", () => {
         },
       }),
     ).toEqual({ mode: "shader", color: "#123456" });
+    // empty-condition / huge-literal `for` used to pass the while/do gate
+    expect(
+      normalizeBackgroundConfig({
+        mode: "glsl",
+        color: "#123456",
+        shader: {
+          source: "void main(){ for(;;){} gl_FragColor=vec4(1.0);}",
+        },
+      }),
+    ).toEqual({ mode: "shader", color: "#123456" });
+    expect(
+      normalizeBackgroundConfig({
+        mode: "glsl",
+        color: "#123456",
+        shader: {
+          source:
+            "void main(){ for(int i=0;i<200000;i++){} gl_FragColor=vec4(1.0);}",
+        },
+      }),
+    ).toEqual({ mode: "shader", color: "#123456" });
   });
 
   it("round-trips a glsl config through localStorage", () => {

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -7,6 +7,7 @@ import { logger } from "@elizaos/logger";
 import { asRecord } from "@elizaos/shared";
 import { fetchWithCsrf } from "../api/csrf-client";
 import { isTerminalIosNativeAgentBootErrorMessage } from "../api/ios-local-agent-transport";
+import { getShaderPreset } from "../backgrounds/shader-presets";
 import {
   isPlausibleFragmentSource,
   normalizeUniforms,
@@ -207,23 +208,23 @@ export function normalizeBackgroundConfig(value: unknown): BackgroundConfig {
   if (record.mode === "image" && imageUrl) {
     return { mode: "image", color, imageUrl };
   }
-  // GLSL mode requires a plausible fragment source; a malformed/oversized/absent
-  // source (or a hostile persisted value) falls back to the color field so a bad
-  // shader can never wedge the background on load.
+  // Persisted GLSL is a preset capability, not an arbitrary source channel.
+  // Resolve the id back to the compiled-in corpus so a hand-edited localStorage
+  // source cannot reach WebGL and an older saved preset self-heals after updates.
   if (record.mode === "glsl") {
     const shaderRecord = asRecord(record.shader);
-    const source = shaderRecord?.source;
-    if (isPlausibleFragmentSource(source)) {
-      const presetId =
-        typeof shaderRecord?.presetId === "string"
-          ? shaderRecord.presetId
-          : undefined;
+    const preset = getShaderPreset(
+      typeof shaderRecord?.presetId === "string"
+        ? shaderRecord.presetId
+        : undefined,
+    );
+    if (preset && isPlausibleFragmentSource(preset.source)) {
       return {
         mode: "glsl",
         color,
         shader: {
-          presetId,
-          source,
+          presetId: preset.id,
+          source: preset.source,
           uniforms: normalizeUniforms(shaderRecord?.uniforms),
         },
       };


### PR DESCRIPTION
Closes #22763

# Relates to

Standalone GPU-hang on `origin/develop` in `isPlausibleFragmentSource` (`packages/ui/src/backgrounds/shader-schema.ts`), the static gate that `normalizeBackgroundConfig` uses before persisted GLSL can reach WebGL. No invented issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from `bad793372ea9` (`#22230`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from latest `origin/develop` (`bad793372ea9`); zero conflicts.
- [ ] `bun run verify` is recorded as not run in **Known gaps / failures** — this is a static GLSL gate with isolated vitest.

# Risks

**Low.** Preset shaders already use `for(int i=0;i<5;i++)` only and still pass the gate. Honest small-literal `for` still loads. Hostile empty-condition / huge-literal `for` that previously loaded as `mode:"glsl"` now falls back to the color field.

# Background

## What does this PR do?

The cheap static safety gate rejected `while` / `do` but admitted:

- `for(;;){}`
- `for(;true;){}`
- `for (int i = 0; i < 200000; i++)`

The apply channel already refuses raw agent GLSL (#11088). Persistence does not. `normalizeBackgroundConfig` loads a stored `mode:"glsl"` payload whenever `isPlausibleFragmentSource(source)` is true, so a hostile localStorage value compiled and could stall a GPU frame long before the 5-slow-frame watchdog.

On origin `bad793372ea9`, isolated bun import of the origin gate:

```
FOR_EVER true
FOR_TRUE true
FOR_BOMB true
PRESET true
WHILE false
ORIGIN_RED: static gate admits unbounded for(;;) and for(i<200000)
```

This PR rejects empty / `true` / `1` for-conditions and any numeric literal above 64 in the for-header. Preset `for(int i=0;i<5;i++)` still passes. The same bomb now fails the gate and persisted GLSL falls back to `mode:"shader"`.

## What kind of change is this?

Bug fix (non-breaking). Fail-closed input boundary on untrusted persisted GLSL.

## Why are we doing this? Any context or related work?

Complete bar: GPU hang on origin, proven before the patch. Not leftover of `#22302`–`#22394`. Not fetch/WS timeout. Not a GGUF leftover of `#22386`. Not a token-tree leftover of `#22392`. Not PNG/zip/gzip/child/CORS/ReDoS/symlink leftover. Occupancy-FREE at post time (`shader-schema.ts` unclaimed).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/backgrounds/shader-schema.ts` — `hasUnboundedForLoop` + `isPlausibleFragmentSource`. Then `packages/ui/src/state/persistence.ts` `normalizeBackgroundConfig` (unchanged caller; the gate is the sink).

## Detailed testing steps

Origin red (isolated bun import of origin `isPlausibleFragmentSource`):

```
FOR_EVER true
FOR_TRUE true
FOR_BOMB true
PRESET true
WHILE false
ORIGIN_RED: static gate admits unbounded for(;;) and for(i<200000)
```

Branch green (same payloads against this head):

```
FOR_EVER false
FOR_TRUE false
FOR_BOMB false
PRESET true
WHILE false
BRANCH_GREEN: gate rejects unbounded for, keeps preset 5-iter
PERSIST_GREEN: hostile for falls back; preset/good stay glsl
```

Isolated vitest at this head (`proof-run` recorded):

```
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/backgrounds/shader-schema.test.ts \
  src/backgrounds/shader-presets.test.ts \
  src/backgrounds/useBackgroundApplyChannel.test.tsx
# Test Files  3 passed (3)
# Tests  32 passed (32)
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:1a05a051642a1c9b2c10fe0887667f1ab974769d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - static fail-closed GLSL validator; no rendered rest-state surface change
<!-- evidence-row:after-screenshots -->
- [x] N/A - presets still pass the five-iter for; no visual rest-state change
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible happy-path flow change; hang sink is persisted localStorage load
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fragment validator; no server request path
<!-- evidence-row:frontend-logs -->
- [x] Isolated bun origin-red and branch-green prints are in Testing above; no network path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - not an agent action provider prompt or model change
<!-- evidence-row:domain-artifacts -->
- [x] Isolated bun proof plus vitest 32/32 at this head are in Testing above
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; product files are TypeScript validators

# Evidence Details

## Real LLM-call trajectory

N/A - not an agent action provider prompt or model change.

## Backend + frontend logs

Backend: N/A - client-side fragment validator; no server request path.

Frontend: origin-red / branch-green bun prints in Testing. Persist contract: hostile `for` returns `shader`; preset/good stay `glsl`.

## Screenshots (before / after) + video walkthrough

N/A - static fail-closed GLSL validator; no rendered rest-state surface change.

## Audio / voice walkthrough

N/A - not a voice transcript TTS or STT change.

## Known gaps / failures

- `bun run verify` not run. Scope is the static GLSL gate plus tests. Isolated vitest 32/32 and isolated bun origin-red / branch-green are recorded at this head via factory `proof-run.mjs`.
- `persistence.background.test.ts` could not be executed in this worktree because Vite could not resolve `file-type` through the hoist; the persist contract is the same `isPlausibleFragmentSource` call and was proven in isolated bun. CI has full workspace deps.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->



## Maintainer repair and exact-head correction

The submitted numeric-header regex was not a complete GPU-work boundary: exact probes showed scientific-notation bounds, named constants, comment-separated headers, and multiplicative nested loops still passed. The repaired exact head fails closed on every general `for` form and allows only the one literal-bounded loop shape used by the compiled preset corpus. More importantly, persisted GLSL is now resolved by known `presetId` back to the compiled-in source; a forged or stale localStorage `source` is ignored, and unknown ids fall back to the color field.

Exact repaired head: `1a05a051642a1c9b2c10fe0887667f1ab974769d`, rebased on develop `c238162fca59b9d4be8024b4a7b00a96b4d691e0`.

- Focused UI Vitest: 4 files / 52 tests pass.
- Direct production-boundary receipt: shipped preset accepted; scientific, named, comment-separated, and nested bombs all rejected; forged persisted source canonicalized; unknown preset rejected.
- UI typecheck: pass.
- Publishable UI build: pass (1,952 rewrites / 46 runtime exports).
- Biome on 4 changed files and `git diff --check`: pass.
- App audit and independent exact-head review: pending; merge remains held until both complete.

Repair provenance: OpenAI / gpt-5.6-sol via Codex desktop; AI-authored repair commit `1a05a051642a1c9b2c10fe0887667f1ab974769d`.

