### PR TITLE
fix(cloud): add provider-neutral payment receipts

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
+++ b/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
@@ -1,7 +1,7 @@
 -- Provider payment receipts are immutable projections, not tax or legal invoices.
 
-CREATE UNIQUE INDEX IF NOT EXISTS "payment_requests_id_organization_unique"
-  ON "payment_requests" ("id", "organization_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "payment_requests_id_organization_provider_unique"
+  ON "payment_requests" ("id", "organization_id", "provider");
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "payment_request_receipts" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -24,9 +24,9 @@ CREATE TABLE IF NOT EXISTS "payment_request_receipts" (
     UNIQUE ("organization_id", "payment_request_id", "provider", "provider_tx_ref"),
   CONSTRAINT "payment_request_receipts_provider_transaction_unique"
     UNIQUE ("provider", "provider_tx_ref"),
-  CONSTRAINT "payment_request_receipts_request_organization_fkey"
-    FOREIGN KEY ("payment_request_id", "organization_id")
-    REFERENCES "payment_requests" ("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "payment_request_receipts_request_organization_provider_fkey"
+    FOREIGN KEY ("payment_request_id", "organization_id", "provider")
+    REFERENCES "payment_requests" ("id", "organization_id", "provider") ON DELETE RESTRICT,
   CONSTRAINT "payment_request_receipts_shape_check" CHECK ((
     "receipt_type" = 'provider_payment_receipt'
     AND "provider" IN ('stripe', 'oxapay')
@@ -41,3 +41,46 @@ CREATE TABLE IF NOT EXISTS "payment_request_receipts" (
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "payment_request_receipts_org_created_idx"
   ON "payment_request_receipts" ("organization_id", "created_at");
+--> statement-breakpoint
+INSERT INTO "payment_request_receipts" (
+  "organization_id", "payment_request_id", "provider", "provider_tx_ref",
+  "provider_event_id", "amount_cents", "currency", "settled_at",
+  "payload_digest", "settlement_proof"
+)
+SELECT
+  request."organization_id", request."id", request."provider", request."settlement_tx_ref",
+  event."provider_event_id", request."amount_cents", upper(request."currency"),
+  request."settled_at", event."payload_digest", request."settlement_proof"
+FROM "payment_requests" AS request
+JOIN "payment_request_events" AS event
+  ON event."payment_request_id" = request."id"
+ AND event."event_name" = 'webhook.received'
+ AND event."provider_disposition" = 'settled'
+ AND event."provider" = request."provider"
+ AND event."provider_tx_ref" = request."settlement_tx_ref"
+WHERE request."status" = 'settled'
+  AND request."provider" IN ('stripe', 'oxapay')
+ON CONFLICT DO NOTHING;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "reject_payment_request_receipt_mutation"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'payment request receipt is immutable' USING ERRCODE = '55000';
+END;
+$$;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "payment_request_receipts_immutable"
+  ON "payment_request_receipts";
+--> statement-breakpoint
+CREATE TRIGGER "payment_request_receipts_immutable"
+  BEFORE UPDATE OR DELETE ON "payment_request_receipts"
+  FOR EACH ROW EXECUTE FUNCTION "reject_payment_request_receipt_mutation"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "payment_request_receipts_truncate_guard"
+  ON "payment_request_receipts";
+--> statement-breakpoint
+CREATE TRIGGER "payment_request_receipts_truncate_guard"
+  BEFORE TRUNCATE ON "payment_request_receipts"
+  FOR EACH STATEMENT EXECUTE FUNCTION "reject_payment_request_receipt_mutation"();

--- a/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
+++ b/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
@@ -42,26 +42,6 @@ CREATE TABLE IF NOT EXISTS "payment_request_receipts" (
 CREATE INDEX IF NOT EXISTS "payment_request_receipts_org_created_idx"
   ON "payment_request_receipts" ("organization_id", "created_at");
 --> statement-breakpoint
-INSERT INTO "payment_request_receipts" (
-  "organization_id", "payment_request_id", "provider", "provider_tx_ref",
-  "provider_event_id", "amount_cents", "currency", "settled_at",
-  "payload_digest", "settlement_proof"
-)
-SELECT
-  request."organization_id", request."id", request."provider", request."settlement_tx_ref",
-  event."provider_event_id", request."amount_cents", upper(request."currency"),
-  request."settled_at", event."payload_digest", request."settlement_proof"
-FROM "payment_requests" AS request
-JOIN "payment_request_events" AS event
-  ON event."payment_request_id" = request."id"
- AND event."event_name" = 'webhook.received'
- AND event."provider_disposition" = 'settled'
- AND event."provider" = request."provider"
- AND event."provider_tx_ref" = request."settlement_tx_ref"
-WHERE request."status" = 'settled'
-  AND request."provider" IN ('stripe', 'oxapay')
-ON CONFLICT DO NOTHING;
---> statement-breakpoint
 CREATE OR REPLACE FUNCTION "reject_payment_request_receipt_mutation"()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
+++ b/packages/cloud/shared/src/db/migrations/0262_payment_request_receipts.sql
@@ -1,0 +1,43 @@
+-- Provider payment receipts are immutable projections, not tax or legal invoices.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "payment_requests_id_organization_unique"
+  ON "payment_requests" ("id", "organization_id");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "payment_request_receipts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "organization_id" uuid NOT NULL
+    REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "payment_request_id" uuid NOT NULL,
+  "receipt_type" text NOT NULL DEFAULT 'provider_payment_receipt',
+  "provider" text NOT NULL,
+  "provider_tx_ref" text NOT NULL,
+  "provider_event_id" text NOT NULL,
+  "amount_cents" bigint NOT NULL,
+  "currency" text NOT NULL,
+  "settled_at" timestamptz NOT NULL,
+  "payload_digest" text NOT NULL,
+  "settlement_proof" jsonb NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "payment_request_receipts_request_unique"
+    UNIQUE ("payment_request_id"),
+  CONSTRAINT "payment_request_receipts_key_unique"
+    UNIQUE ("organization_id", "payment_request_id", "provider", "provider_tx_ref"),
+  CONSTRAINT "payment_request_receipts_provider_transaction_unique"
+    UNIQUE ("provider", "provider_tx_ref"),
+  CONSTRAINT "payment_request_receipts_request_organization_fkey"
+    FOREIGN KEY ("payment_request_id", "organization_id")
+    REFERENCES "payment_requests" ("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "payment_request_receipts_shape_check" CHECK ((
+    "receipt_type" = 'provider_payment_receipt'
+    AND "provider" IN ('stripe', 'oxapay')
+    AND "amount_cents" > 0
+    AND "currency" ~ '^[A-Z]{3,8}$'
+    AND "provider_tx_ref" = btrim("provider_tx_ref")
+    AND octet_length("provider_tx_ref") BETWEEN 1 AND 512
+    AND "provider_event_id" = btrim("provider_event_id")
+    AND octet_length("provider_event_id") BETWEEN 1 AND 512
+    AND "payload_digest" ~ '^[a-f0-9]{64}$') IS TRUE)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payment_request_receipts_org_created_idx"
+  ON "payment_request_receipts" ("organization_id", "created_at");

--- a/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
+++ b/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
@@ -6,7 +6,37 @@ BEGIN
     SELECT 1
     FROM "payment_requests" AS request
     LEFT JOIN LATERAL (
-      SELECT count(*) AS authority_count
+      SELECT
+        count(*) AS candidate_count,
+        count(*) FILTER (WHERE
+          (request."provider" = 'stripe'
+            AND request."settlement_proof"->>'stripe_event_id' = event."provider_event_id"
+            AND request."settlement_proof"->>'stripe_event_type' = 'checkout.session.completed'
+            AND request."settlement_proof"->>'stripe_session_id'
+              = request."provider_intent"->>'stripe_session_id'
+            AND request."settlement_proof"->>'stripe_payment_intent_id'
+              = request."settlement_tx_ref"
+            AND jsonb_typeof(request."settlement_proof"->'stripe_amount_total') = 'number'
+            AND request."settlement_proof"->>'stripe_amount_total'
+              = request."amount_cents"::text
+            AND upper(request."settlement_proof"->>'stripe_currency')
+              = upper(request."currency")
+            AND request."settlement_proof"->>'stripe_payment_status' = 'paid')
+          OR
+          (request."provider" = 'oxapay'
+            AND request."settlement_proof"->>'provider' = 'oxapay'
+            AND request."settlement_proof"->>'oxapay_track_id'
+              = request."provider_intent"->>'oxapay_track_id'
+            AND request."settlement_proof"->>'oxapay_track_id'
+              = request."settlement_tx_ref"
+            AND request."settlement_proof"->>'oxapay_order_id' = request."id"::text
+            AND request."settlement_proof"->>'oxapay_status' = 'paid'
+            AND jsonb_typeof(request."settlement_proof"->'oxapay_amount_cents') = 'number'
+            AND request."settlement_proof"->>'oxapay_amount_cents'
+              = request."amount_cents"::text
+            AND upper(request."settlement_proof"->>'oxapay_currency')
+              = upper(request."currency"))
+        ) AS authority_count
       FROM "payment_request_events" AS event
       WHERE event."payment_request_id" = request."id"
         AND event."event_name" = 'webhook.received'
@@ -27,6 +57,7 @@ BEGIN
         request."settled_at" IS NULL
         OR request."settlement_tx_ref" IS NULL
         OR jsonb_typeof(request."settlement_proof") IS DISTINCT FROM 'object'
+        OR authority.candidate_count <> 1
         OR authority.authority_count <> 1
         OR EXISTS (
           SELECT 1

--- a/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
+++ b/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
@@ -1,0 +1,123 @@
+-- Reconciles every eligible settled request to one exact provider receipt or aborts.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "payment_requests" AS request
+    LEFT JOIN LATERAL (
+      SELECT count(*) AS authority_count
+      FROM "payment_request_events" AS event
+      WHERE event."payment_request_id" = request."id"
+        AND event."event_name" = 'webhook.received'
+        AND event."provider_disposition" = 'settled'
+        AND event."provider" = request."provider"
+        AND event."provider_tx_ref" = request."settlement_tx_ref"
+        AND event."provider_event_id" = event."redacted_payload"->>'providerEventId'
+        AND event."payload_digest" ~ '^[a-f0-9]{64}$'
+        AND event."redacted_payload"->>'paymentRequestId' = request."id"::text
+        AND event."redacted_payload"->>'provider' = request."provider"
+        AND event."redacted_payload"->>'txRef' = request."settlement_tx_ref"
+        AND event."redacted_payload"->>'amountCents' = request."amount_cents"::text
+        AND event."redacted_payload"->>'currency' = upper(request."currency")
+    ) AS authority ON true
+    WHERE request."status" = 'settled'
+      AND request."provider" IN ('stripe', 'oxapay')
+      AND (
+        request."settled_at" IS NULL
+        OR request."settlement_tx_ref" IS NULL
+        OR jsonb_typeof(request."settlement_proof") IS DISTINCT FROM 'object'
+        OR authority.authority_count <> 1
+        OR EXISTS (
+          SELECT 1
+          FROM jsonb_each(CASE
+            WHEN jsonb_typeof(request."settlement_proof") = 'object'
+              THEN request."settlement_proof"
+            ELSE '{}'::jsonb
+          END) AS proof(key, value)
+          WHERE jsonb_typeof(proof.value) NOT IN ('string', 'number', 'null')
+            OR (request."provider" = 'stripe' AND proof.key NOT IN (
+              'stripe_event_id', 'stripe_event_type', 'stripe_session_id',
+              'stripe_payment_intent_id', 'stripe_amount_total', 'stripe_currency',
+              'stripe_payment_status'
+            ))
+            OR (request."provider" = 'oxapay' AND proof.key NOT IN (
+              'provider', 'oxapay_track_id', 'oxapay_order_id', 'oxapay_status',
+              'oxapay_amount_cents', 'oxapay_currency', 'oxapay_callback_currency',
+              'oxapay_type'
+            ))
+        )
+        OR (request."provider" = 'stripe' AND (
+          request."settlement_proof"->>'stripe_payment_intent_id'
+            IS DISTINCT FROM request."settlement_tx_ref"
+          OR request."settlement_proof"->>'stripe_payment_status' IS DISTINCT FROM 'paid'
+          OR nullif(btrim(request."settlement_proof"->>'stripe_session_id'), '') IS NULL
+        ))
+        OR (request."provider" = 'oxapay' AND (
+          request."settlement_proof"->>'oxapay_track_id'
+            IS DISTINCT FROM request."settlement_tx_ref"
+          OR request."settlement_proof"->>'oxapay_order_id' IS DISTINCT FROM request."id"::text
+          OR request."settlement_proof"->>'oxapay_status' IS DISTINCT FROM 'paid'
+        ))
+      )
+  ) THEN
+    RAISE EXCEPTION 'settled payment request lacks one curated authoritative provider event';
+  END IF;
+END;
+$$;
+--> statement-breakpoint
+INSERT INTO "payment_request_receipts" (
+  "organization_id", "payment_request_id", "provider", "provider_tx_ref",
+  "provider_event_id", "amount_cents", "currency", "settled_at",
+  "payload_digest", "settlement_proof"
+)
+SELECT
+  request."organization_id", request."id", request."provider", request."settlement_tx_ref",
+  event."provider_event_id", request."amount_cents", upper(request."currency"),
+  request."settled_at", event."payload_digest", request."settlement_proof"
+FROM "payment_requests" AS request
+JOIN "payment_request_events" AS event
+  ON event."payment_request_id" = request."id"
+ AND event."event_name" = 'webhook.received'
+ AND event."provider_disposition" = 'settled'
+ AND event."provider" = request."provider"
+ AND event."provider_tx_ref" = request."settlement_tx_ref"
+WHERE request."status" = 'settled'
+  AND request."provider" IN ('stripe', 'oxapay')
+  AND NOT EXISTS (
+    SELECT 1 FROM "payment_request_receipts" AS receipt
+    WHERE receipt."payment_request_id" = request."id"
+  );
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "payment_requests" AS request
+    JOIN "payment_request_events" AS event
+      ON event."payment_request_id" = request."id"
+     AND event."event_name" = 'webhook.received'
+     AND event."provider_disposition" = 'settled'
+     AND event."provider" = request."provider"
+     AND event."provider_tx_ref" = request."settlement_tx_ref"
+    LEFT JOIN "payment_request_receipts" AS receipt
+      ON receipt."payment_request_id" = request."id"
+    WHERE request."status" = 'settled'
+      AND request."provider" IN ('stripe', 'oxapay')
+      AND (
+        receipt."id" IS NULL
+        OR receipt."organization_id" IS DISTINCT FROM request."organization_id"
+        OR receipt."provider" IS DISTINCT FROM request."provider"
+        OR receipt."provider_tx_ref" IS DISTINCT FROM request."settlement_tx_ref"
+        OR receipt."provider_event_id" IS DISTINCT FROM event."provider_event_id"
+        OR receipt."amount_cents" IS DISTINCT FROM request."amount_cents"
+        OR receipt."currency" IS DISTINCT FROM upper(request."currency")
+        OR receipt."settled_at" IS DISTINCT FROM request."settled_at"
+        OR receipt."payload_digest" IS DISTINCT FROM event."payload_digest"
+        OR receipt."settlement_proof" IS DISTINCT FROM request."settlement_proof"
+      )
+  ) THEN
+    RAISE EXCEPTION 'payment request receipt backfill postcondition failed';
+  END IF;
+END;
+$$;

--- a/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
+++ b/packages/cloud/shared/src/db/migrations/0263_payment_request_receipt_backfill.sql
@@ -74,8 +74,7 @@ BEGIN
             ))
             OR (request."provider" = 'oxapay' AND proof.key NOT IN (
               'provider', 'oxapay_track_id', 'oxapay_order_id', 'oxapay_status',
-              'oxapay_amount_cents', 'oxapay_currency', 'oxapay_callback_currency',
-              'oxapay_type'
+              'oxapay_amount_cents', 'oxapay_currency'
             ))
         )
         OR (request."provider" = 'stripe' AND (

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1835,6 +1835,13 @@
       "when": 1792094400000,
       "tag": "0262_payment_request_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 262,
+      "version": "7",
+      "when": 1792180800000,
+      "tag": "0263_payment_request_receipt_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1828,6 +1828,13 @@
       "when": 1792008000000,
       "tag": "0261_stripe_checkout_orders",
       "breakpoints": true
+    },
+    {
+      "idx": 261,
+      "version": "7",
+      "when": 1792094400000,
+      "tag": "0262_payment_request_receipts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
@@ -34,7 +34,8 @@ async function database(): Promise<PGlite> {
       status text NOT NULL,
       settled_at timestamptz,
       settlement_tx_ref text,
-      settlement_proof jsonb
+      settlement_proof jsonb,
+      provider_intent jsonb NOT NULL DEFAULT '{}'
     );
     CREATE TABLE payment_request_events (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -54,17 +55,35 @@ async function database(): Promise<PGlite> {
 }
 
 async function seedHistoricalRequest(db: PGlite, proof?: string): Promise<void> {
+  const defaultProof = JSON.stringify({
+    stripe_event_id: "evt_a",
+    stripe_event_type: "checkout.session.completed",
+    stripe_session_id: "cs_a",
+    stripe_payment_intent_id: "pi_a",
+    stripe_amount_total: 2500,
+    stripe_currency: "usd",
+    stripe_payment_status: "paid",
+  });
   await db.exec(`
     INSERT INTO payment_requests (
       id, organization_id, provider, amount_cents, currency, status,
-      settled_at, settlement_tx_ref, settlement_proof
+      settled_at, settlement_tx_ref, settlement_proof, provider_intent
     ) VALUES (
       '${REQUEST_A}', '${ORG_A}', 'stripe', 2500, 'usd', 'settled',
       '2026-08-19T08:00:00.000Z', 'pi_a',
-      '${
-        proof ??
-        '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
-      }'
+      '${proof ?? defaultProof}', '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a"}'
+    );
+  `);
+}
+
+async function seedHistoricalOxapayRequest(db: PGlite, proof: string): Promise<void> {
+  await db.exec(`
+    INSERT INTO payment_requests (
+      id, organization_id, provider, amount_cents, currency, status,
+      settled_at, settlement_tx_ref, settlement_proof, provider_intent
+    ) VALUES (
+      '${REQUEST_A}', '${ORG_A}', 'oxapay', 2500, 'usd', 'settled',
+      '2026-08-19T08:00:00.000Z', 'trk_a', '${proof}', '{"oxapay_track_id":"trk_a"}'
     );
   `);
 }
@@ -89,6 +108,28 @@ async function seedAuthority(db: PGlite, eventId = "evt_a", digest = "a".repeat(
       '${REQUEST_A}', 'webhook.received', '${callback}',
       'stripe', '${eventId}', 'pi_a', 'settled', '${digest}',
       '2026-08-19T08:00:00.000Z'
+    );
+  `);
+}
+
+async function seedOxapayAuthority(db: PGlite): Promise<void> {
+  const callback = JSON.stringify({
+    name: "PaymentSettled",
+    paymentRequestId: REQUEST_A,
+    provider: "oxapay",
+    providerEventId: "trk_a:paid",
+    txRef: "trk_a",
+    amountCents: 2500,
+    currency: "USD",
+    occurredAt: "2026-08-19T08:00:00.000Z",
+  });
+  await db.exec(`
+    INSERT INTO payment_request_events (
+      payment_request_id, event_name, redacted_payload, provider, provider_event_id,
+      provider_tx_ref, provider_disposition, payload_digest, occurred_at
+    ) VALUES (
+      '${REQUEST_A}', 'webhook.received', '${callback}', 'oxapay', 'trk_a:paid',
+      'trk_a', 'settled', '${"b".repeat(64)}', '2026-08-19T08:00:00.000Z'
     );
   `);
 }
@@ -134,8 +175,12 @@ describe("0262-0263 payment request receipts migrations", () => {
         currency: "USD",
         payload_digest: "a".repeat(64),
         settlement_proof: {
+          stripe_event_id: "evt_a",
+          stripe_event_type: "checkout.session.completed",
           stripe_session_id: "cs_a",
           stripe_payment_intent_id: "pi_a",
+          stripe_amount_total: 2500,
+          stripe_currency: "usd",
           stripe_payment_status: "paid",
         },
       },
@@ -203,7 +248,7 @@ describe("0262-0263 payment request receipts migrations", () => {
     const uncurated = await database();
     await seedHistoricalRequest(
       uncurated,
-      '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid","raw_webhook":"must-not-copy"}',
+      '{"stripe_event_id":"evt_a","stripe_event_type":"checkout.session.completed","stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_amount_total":2500,"stripe_currency":"usd","stripe_payment_status":"paid","raw_webhook":"must-not-copy"}',
     );
     await seedAuthority(uncurated);
     await uncurated.exec(schemaMigration);
@@ -223,6 +268,54 @@ describe("0262-0263 payment request receipts migrations", () => {
       '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
     )`);
     await expect(conflicting.exec(backfillMigration)).rejects.toThrow(/postcondition failed/i);
+  });
+
+  test("rejects contradictory provider event, provider, amount, and currency proof", async () => {
+    const stripeProof = {
+      stripe_event_id: "evt_a",
+      stripe_event_type: "checkout.session.completed",
+      stripe_session_id: "cs_a",
+      stripe_payment_intent_id: "pi_a",
+      stripe_amount_total: 2500,
+      stripe_currency: "usd",
+      stripe_payment_status: "paid",
+    };
+    const oxapayProof = {
+      provider: "oxapay",
+      oxapay_track_id: "trk_a",
+      oxapay_order_id: REQUEST_A,
+      oxapay_status: "paid",
+      oxapay_amount_cents: 2500,
+      oxapay_currency: "USD",
+    };
+    const cases: Array<{
+      provider: "stripe" | "oxapay";
+      proof: Record<string, unknown>;
+    }> = [
+      { provider: "stripe", proof: { ...stripeProof, stripe_event_id: "evt_wrong" } },
+      { provider: "stripe", proof: { ...stripeProof, stripe_amount_total: 2499 } },
+      { provider: "stripe", proof: { ...stripeProof, stripe_currency: "EUR" } },
+      { provider: "oxapay", proof: { ...oxapayProof, provider: "stripe" } },
+      { provider: "oxapay", proof: { ...oxapayProof, oxapay_amount_cents: 2499 } },
+      { provider: "oxapay", proof: { ...oxapayProof, oxapay_currency: "EUR" } },
+    ];
+
+    for (const input of cases) {
+      const db = await database();
+      if (input.provider === "stripe") {
+        await seedHistoricalRequest(db, JSON.stringify(input.proof));
+        await seedAuthority(db);
+      } else {
+        await seedHistoricalOxapayRequest(db, JSON.stringify(input.proof));
+        await seedOxapayAuthority(db);
+      }
+      await db.exec(schemaMigration);
+      await expect(db.exec(backfillMigration)).rejects.toThrow(/lacks one curated/i);
+      const receipts = await db.query<{ count: number }>(
+        "SELECT count(*)::int AS count FROM payment_request_receipts",
+      );
+      expect(receipts.rows).toEqual([{ count: 0 }]);
+    }
   });
 
   test("fails closed instead of accepting a colliding partial table", async () => {

--- a/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
@@ -298,6 +298,14 @@ describe("0262-0263 payment request receipts migrations", () => {
       { provider: "oxapay", proof: { ...oxapayProof, provider: "stripe" } },
       { provider: "oxapay", proof: { ...oxapayProof, oxapay_amount_cents: 2499 } },
       { provider: "oxapay", proof: { ...oxapayProof, oxapay_currency: "EUR" } },
+      {
+        provider: "oxapay",
+        proof: { ...oxapayProof, oxapay_callback_currency: "POL" },
+      },
+      {
+        provider: "oxapay",
+        proof: { ...oxapayProof, oxapay_type: "payer@example.invalid" },
+      },
     ];
 
     for (const input of cases) {

--- a/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Applies migration 0262 to real PGlite and proves deterministic backfill,
+ * replay safety, immutable retention, and tenant/provider binding.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+
+const ORG_A = "10000000-0000-4000-8000-000000000001";
+const ORG_B = "10000000-0000-4000-8000-000000000002";
+const REQUEST_A = "20000000-0000-4000-8000-000000000001";
+const REQUEST_B = "20000000-0000-4000-8000-000000000002";
+const migration = await readFile(
+  new URL("./0262_payment_request_receipts.sql", import.meta.url),
+  "utf8",
+);
+const databases: PGlite[] = [];
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE payment_requests (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL REFERENCES organizations(id),
+      provider text NOT NULL,
+      amount_cents bigint NOT NULL,
+      currency text NOT NULL,
+      status text NOT NULL,
+      settled_at timestamptz,
+      settlement_tx_ref text,
+      settlement_proof jsonb
+    );
+    CREATE TABLE payment_request_events (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      payment_request_id uuid NOT NULL REFERENCES payment_requests(id),
+      event_name text NOT NULL,
+      redacted_payload jsonb NOT NULL DEFAULT '{}',
+      provider text,
+      provider_event_id text,
+      provider_tx_ref text,
+      provider_disposition text,
+      payload_digest text,
+      occurred_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX payment_request_events_settled_provider_tx_unique
+      ON payment_request_events(provider, provider_tx_ref)
+      WHERE event_name='webhook.received' AND provider_disposition='settled';
+    INSERT INTO organizations(id) VALUES ('${ORG_A}'), ('${ORG_B}');
+  `);
+  return db;
+}
+
+async function seedHistoricalSettlement(db: PGlite): Promise<void> {
+  await db.exec(`
+    INSERT INTO payment_requests (
+      id, organization_id, provider, amount_cents, currency, status,
+      settled_at, settlement_tx_ref, settlement_proof
+    ) VALUES (
+      '${REQUEST_A}', '${ORG_A}', 'stripe', 2500, 'usd', 'settled',
+      '2026-08-19T08:00:00.000Z', 'pi_a',
+      '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
+    );
+    INSERT INTO payment_request_events (
+      payment_request_id, event_name, redacted_payload, provider, provider_event_id,
+      provider_tx_ref, provider_disposition, payload_digest, occurred_at
+    ) VALUES (
+      '${REQUEST_A}', 'webhook.received', '{"raw_webhook":"must-not-copy"}',
+      'stripe', 'evt_a', 'pi_a', 'settled', '${"a".repeat(64)}',
+      '2026-08-19T08:00:00.000Z'
+    );
+  `);
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0262 payment request receipts migration", () => {
+  test("backfills one curated receipt and replays without changing it", async () => {
+    const db = await database();
+    await seedHistoricalSettlement(db);
+    await db.exec(migration);
+    await db.exec(migration);
+
+    const receipts = await db.query<{
+      organization_id: string;
+      payment_request_id: string;
+      provider: string;
+      provider_event_id: string;
+      amount_cents: string;
+      currency: string;
+      payload_digest: string;
+      settlement_proof: Record<string, unknown>;
+    }>(`SELECT organization_id::text, payment_request_id::text, provider,
+        provider_event_id, amount_cents::text, currency, payload_digest, settlement_proof
+      FROM payment_request_receipts`);
+    expect(receipts.rows).toEqual([
+      {
+        organization_id: ORG_A,
+        payment_request_id: REQUEST_A,
+        provider: "stripe",
+        provider_event_id: "evt_a",
+        amount_cents: "2500",
+        currency: "USD",
+        payload_digest: "a".repeat(64),
+        settlement_proof: {
+          stripe_session_id: "cs_a",
+          stripe_payment_intent_id: "pi_a",
+          stripe_payment_status: "paid",
+        },
+      },
+    ]);
+    expect(JSON.stringify(receipts.rows)).not.toContain("must-not-copy");
+
+    const triggers = await db.query<{ count: number }>(`
+      SELECT count(*)::int AS count FROM pg_trigger
+      WHERE tgname IN (
+        'payment_request_receipts_immutable',
+        'payment_request_receipts_truncate_guard'
+      ) AND NOT tgisinternal
+    `);
+    expect(triggers.rows).toEqual([{ count: 2 }]);
+  });
+
+  test("rejects mutation, deletion, truncation, and cross-authority inserts", async () => {
+    const db = await database();
+    await seedHistoricalSettlement(db);
+    await db.exec(migration);
+
+    await expect(db.exec("UPDATE payment_request_receipts SET amount_cents=1")).rejects.toThrow(
+      /immutable/i,
+    );
+    await expect(db.exec("DELETE FROM payment_request_receipts")).rejects.toThrow(/immutable/i);
+    await expect(db.exec("TRUNCATE payment_request_receipts")).rejects.toThrow(/immutable/i);
+
+    await db.exec(`INSERT INTO payment_requests (
+      id, organization_id, provider, amount_cents, currency, status
+    ) VALUES ('${REQUEST_B}', '${ORG_A}', 'stripe', 100, 'usd', 'delivered')`);
+    for (const [requestId, organizationId, provider, txRef] of [
+      [REQUEST_A, ORG_B, "stripe", "pi_cross_tenant"],
+      [REQUEST_B, ORG_A, "oxapay", "trk_cross_provider"],
+    ]) {
+      await expect(
+        db.exec(`INSERT INTO payment_request_receipts (
+          organization_id, payment_request_id, provider, provider_tx_ref,
+          provider_event_id, amount_cents, currency, settled_at, payload_digest,
+          settlement_proof
+        ) VALUES (
+          '${organizationId}', '${requestId}', '${provider}', '${txRef}', 'evt_cross',
+          100, 'USD', now(), '${"b".repeat(64)}', '{}'
+        )`),
+      ).rejects.toThrow();
+    }
+  });
+
+  test("fails closed instead of accepting a colliding partial table", async () => {
+    const db = await database();
+    await db.exec("CREATE TABLE payment_request_receipts (id uuid PRIMARY KEY)");
+    await expect(db.exec(migration)).rejects.toThrow();
+    const columns = await db.query<{ column_name: string }>(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name='payment_request_receipts'
+    `);
+    expect(columns.rows).toEqual([{ column_name: "id" }]);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/payment-request-receipts.test.ts
@@ -1,5 +1,5 @@
 /**
- * Applies migration 0262 to real PGlite and proves deterministic backfill,
+ * Applies migrations 0262-0263 to real PGlite and proves deterministic backfill,
  * replay safety, immutable retention, and tenant/provider binding.
  */
 import { afterEach, describe, expect, test } from "bun:test";
@@ -10,8 +10,12 @@ const ORG_A = "10000000-0000-4000-8000-000000000001";
 const ORG_B = "10000000-0000-4000-8000-000000000002";
 const REQUEST_A = "20000000-0000-4000-8000-000000000001";
 const REQUEST_B = "20000000-0000-4000-8000-000000000002";
-const migration = await readFile(
+const schemaMigration = await readFile(
   new URL("./0262_payment_request_receipts.sql", import.meta.url),
+  "utf8",
+);
+const backfillMigration = await readFile(
+  new URL("./0263_payment_request_receipt_backfill.sql", import.meta.url),
   "utf8",
 );
 const databases: PGlite[] = [];
@@ -44,15 +48,12 @@ async function database(): Promise<PGlite> {
       payload_digest text,
       occurred_at timestamptz NOT NULL DEFAULT now()
     );
-    CREATE UNIQUE INDEX payment_request_events_settled_provider_tx_unique
-      ON payment_request_events(provider, provider_tx_ref)
-      WHERE event_name='webhook.received' AND provider_disposition='settled';
     INSERT INTO organizations(id) VALUES ('${ORG_A}'), ('${ORG_B}');
   `);
   return db;
 }
 
-async function seedHistoricalSettlement(db: PGlite): Promise<void> {
+async function seedHistoricalRequest(db: PGlite, proof?: string): Promise<void> {
   await db.exec(`
     INSERT INTO payment_requests (
       id, organization_id, provider, amount_cents, currency, status,
@@ -60,14 +61,33 @@ async function seedHistoricalSettlement(db: PGlite): Promise<void> {
     ) VALUES (
       '${REQUEST_A}', '${ORG_A}', 'stripe', 2500, 'usd', 'settled',
       '2026-08-19T08:00:00.000Z', 'pi_a',
-      '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
+      '${
+        proof ??
+        '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
+      }'
     );
+  `);
+}
+
+async function seedAuthority(db: PGlite, eventId = "evt_a", digest = "a".repeat(64)) {
+  const callback = JSON.stringify({
+    name: "PaymentSettled",
+    paymentRequestId: REQUEST_A,
+    provider: "stripe",
+    providerEventId: eventId,
+    txRef: "pi_a",
+    amountCents: 2500,
+    currency: "USD",
+    occurredAt: "2026-08-19T08:00:00.000Z",
+    raw_webhook: "must-not-copy",
+  });
+  await db.exec(`
     INSERT INTO payment_request_events (
       payment_request_id, event_name, redacted_payload, provider, provider_event_id,
       provider_tx_ref, provider_disposition, payload_digest, occurred_at
     ) VALUES (
-      '${REQUEST_A}', 'webhook.received', '{"raw_webhook":"must-not-copy"}',
-      'stripe', 'evt_a', 'pi_a', 'settled', '${"a".repeat(64)}',
+      '${REQUEST_A}', 'webhook.received', '${callback}',
+      'stripe', '${eventId}', 'pi_a', 'settled', '${digest}',
       '2026-08-19T08:00:00.000Z'
     );
   `);
@@ -77,12 +97,20 @@ afterEach(async () => {
   await Promise.all(databases.splice(0).map((db) => db.close()));
 });
 
-describe("0262 payment request receipts migration", () => {
+describe("0262-0263 payment request receipts migrations", () => {
   test("backfills one curated receipt and replays without changing it", async () => {
     const db = await database();
-    await seedHistoricalSettlement(db);
-    await db.exec(migration);
-    await db.exec(migration);
+    await seedHistoricalRequest(db);
+    await seedAuthority(db);
+    await db.exec(schemaMigration);
+    const [precondition, insert] = backfillMigration.split("--> statement-breakpoint");
+    if (!precondition || !insert) throw new Error("0263 migration prefix is incomplete");
+    await db.exec(precondition);
+    await db.exec(insert);
+    // Simulate interruption after insert but before the exact postcondition.
+    await db.exec(backfillMigration);
+    await db.exec(schemaMigration);
+    await db.exec(backfillMigration);
 
     const receipts = await db.query<{
       organization_id: string;
@@ -126,8 +154,10 @@ describe("0262 payment request receipts migration", () => {
 
   test("rejects mutation, deletion, truncation, and cross-authority inserts", async () => {
     const db = await database();
-    await seedHistoricalSettlement(db);
-    await db.exec(migration);
+    await seedHistoricalRequest(db);
+    await seedAuthority(db);
+    await db.exec(schemaMigration);
+    await db.exec(backfillMigration);
 
     await expect(db.exec("UPDATE payment_request_receipts SET amount_cents=1")).rejects.toThrow(
       /immutable/i,
@@ -155,10 +185,50 @@ describe("0262 payment request receipts migration", () => {
     }
   });
 
+  test("rejects missing or ambiguous historical settlement authority", async () => {
+    const missing = await database();
+    await seedHistoricalRequest(missing);
+    await missing.exec(schemaMigration);
+    await expect(missing.exec(backfillMigration)).rejects.toThrow(/lacks one curated/i);
+
+    const ambiguous = await database();
+    await seedHistoricalRequest(ambiguous);
+    await seedAuthority(ambiguous);
+    await seedAuthority(ambiguous, "evt_b", "b".repeat(64));
+    await ambiguous.exec(schemaMigration);
+    await expect(ambiguous.exec(backfillMigration)).rejects.toThrow(/lacks one curated/i);
+  });
+
+  test("rejects an uncurated stored proof and a valid-shaped wrong existing row", async () => {
+    const uncurated = await database();
+    await seedHistoricalRequest(
+      uncurated,
+      '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid","raw_webhook":"must-not-copy"}',
+    );
+    await seedAuthority(uncurated);
+    await uncurated.exec(schemaMigration);
+    await expect(uncurated.exec(backfillMigration)).rejects.toThrow(/lacks one curated/i);
+
+    const conflicting = await database();
+    await seedHistoricalRequest(conflicting);
+    await seedAuthority(conflicting);
+    await conflicting.exec(schemaMigration);
+    await conflicting.exec(`INSERT INTO payment_request_receipts (
+      organization_id, payment_request_id, provider, provider_tx_ref,
+      provider_event_id, amount_cents, currency, settled_at, payload_digest,
+      settlement_proof
+    ) VALUES (
+      '${ORG_A}', '${REQUEST_A}', 'stripe', 'pi_a', 'evt_a', 2499, 'USD',
+      '2026-08-19T08:00:00.000Z', '${"a".repeat(64)}',
+      '{"stripe_session_id":"cs_a","stripe_payment_intent_id":"pi_a","stripe_payment_status":"paid"}'
+    )`);
+    await expect(conflicting.exec(backfillMigration)).rejects.toThrow(/postcondition failed/i);
+  });
+
   test("fails closed instead of accepting a colliding partial table", async () => {
     const db = await database();
     await db.exec("CREATE TABLE payment_request_receipts (id uuid PRIMARY KEY)");
-    await expect(db.exec(migration)).rejects.toThrow();
+    await expect(db.exec(schemaMigration)).rejects.toThrow();
     const columns = await db.query<{ column_name: string }>(`
       SELECT column_name FROM information_schema.columns
       WHERE table_name='payment_request_receipts'

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -84,6 +84,8 @@ export * from "./organization-config";
 export * from "./organization-encryption-keys";
 export * from "./organization-invites";
 export * from "./organizations";
+export * from "./payment-request-receipts";
+export * from "./payment-requests";
 export * from "./personal-account-convergences";
 export * from "./phone-gateway-devices";
 export * from "./pii-scrub-markers";

--- a/packages/cloud/shared/src/db/schemas/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/db/schemas/payment-request-receipts.ts
@@ -1,0 +1,86 @@
+/**
+ * Defines the provider-neutral receipt projection for settled payment requests.
+ * These rows prove provider payment and are deliberately not tax or legal invoices.
+ */
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+import { type PaymentRequestProvider, paymentRequests } from "./payment-requests";
+
+export const PAYMENT_REQUEST_RECEIPT_TYPES = ["provider_payment_receipt"] as const;
+export type PaymentRequestReceiptType = (typeof PAYMENT_REQUEST_RECEIPT_TYPES)[number];
+
+export const paymentRequestReceipts = pgTable(
+  "payment_request_receipts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    payment_request_id: uuid("payment_request_id").notNull(),
+    receipt_type: text("receipt_type")
+      .$type<PaymentRequestReceiptType>()
+      .notNull()
+      .default("provider_payment_receipt"),
+    provider: text("provider")
+      .$type<Extract<PaymentRequestProvider, "stripe" | "oxapay">>()
+      .notNull(),
+    provider_tx_ref: text("provider_tx_ref").notNull(),
+    provider_event_id: text("provider_event_id").notNull(),
+    amount_cents: bigint("amount_cents", { mode: "bigint" }).notNull(),
+    currency: text("currency").notNull(),
+    settled_at: timestamp("settled_at", { withTimezone: true }).notNull(),
+    payload_digest: text("payload_digest").notNull(),
+    settlement_proof: jsonb("settlement_proof").$type<Record<string, unknown>>().notNull(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    request_unique: unique("payment_request_receipts_request_unique").on(table.payment_request_id),
+    receipt_key_unique: unique("payment_request_receipts_key_unique").on(
+      table.organization_id,
+      table.payment_request_id,
+      table.provider,
+      table.provider_tx_ref,
+    ),
+    provider_transaction_unique: unique("payment_request_receipts_provider_transaction_unique").on(
+      table.provider,
+      table.provider_tx_ref,
+    ),
+    organization_created_idx: index("payment_request_receipts_org_created_idx").on(
+      table.organization_id,
+      table.created_at,
+    ),
+    request_organization_fk: foreignKey({
+      name: "payment_request_receipts_request_organization_fkey",
+      columns: [table.payment_request_id, table.organization_id],
+      foreignColumns: [paymentRequests.id, paymentRequests.organization_id],
+    }).onDelete("restrict"),
+    shape_check: check(
+      "payment_request_receipts_shape_check",
+      sql`(${table.receipt_type} = 'provider_payment_receipt'
+        AND ${table.provider} IN ('stripe', 'oxapay')
+        AND ${table.amount_cents} > 0
+        AND ${table.currency} ~ '^[A-Z]{3,8}$'
+        AND ${table.provider_tx_ref} = btrim(${table.provider_tx_ref})
+        AND octet_length(${table.provider_tx_ref}) BETWEEN 1 AND 512
+        AND ${table.provider_event_id} = btrim(${table.provider_event_id})
+        AND octet_length(${table.provider_event_id}) BETWEEN 1 AND 512
+        AND ${table.payload_digest} ~ '^[a-f0-9]{64}$') IS TRUE`,
+    ),
+  }),
+);
+
+export type PaymentRequestReceipt = InferSelectModel<typeof paymentRequestReceipts>;
+export type NewPaymentRequestReceipt = InferInsertModel<typeof paymentRequestReceipts>;

--- a/packages/cloud/shared/src/db/schemas/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/db/schemas/payment-request-receipts.ts
@@ -62,10 +62,14 @@ export const paymentRequestReceipts = pgTable(
       table.organization_id,
       table.created_at,
     ),
-    request_organization_fk: foreignKey({
-      name: "payment_request_receipts_request_organization_fkey",
-      columns: [table.payment_request_id, table.organization_id],
-      foreignColumns: [paymentRequests.id, paymentRequests.organization_id],
+    request_organization_provider_fk: foreignKey({
+      name: "payment_request_receipts_request_organization_provider_fkey",
+      columns: [table.payment_request_id, table.organization_id, table.provider],
+      foreignColumns: [
+        paymentRequests.id,
+        paymentRequests.organization_id,
+        paymentRequests.provider,
+      ],
     }).onDelete("restrict"),
     shape_check: check(
       "payment_request_receipts_shape_check",

--- a/packages/cloud/shared/src/db/schemas/payment-requests.ts
+++ b/packages/cloud/shared/src/db/schemas/payment-requests.ts
@@ -10,6 +10,7 @@ import {
   pgTable,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -113,6 +114,10 @@ export const paymentRequests = pgTable(
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
   },
   (table) => ({
+    id_organization_unique: unique("payment_requests_id_organization_unique").on(
+      table.id,
+      table.organization_id,
+    ),
     org_created_idx: index("idx_payment_requests_org_created").on(
       table.organization_id,
       table.created_at,

--- a/packages/cloud/shared/src/db/schemas/payment-requests.ts
+++ b/packages/cloud/shared/src/db/schemas/payment-requests.ts
@@ -10,7 +10,6 @@ import {
   pgTable,
   text,
   timestamp,
-  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -114,10 +113,9 @@ export const paymentRequests = pgTable(
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
   },
   (table) => ({
-    id_organization_unique: unique("payment_requests_id_organization_unique").on(
-      table.id,
-      table.organization_id,
-    ),
+    id_organization_provider_unique: uniqueIndex(
+      "payment_requests_id_organization_provider_unique",
+    ).on(table.id, table.organization_id, table.provider),
     org_created_idx: index("idx_payment_requests_org_created").on(
       table.organization_id,
       table.created_at,

--- a/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
@@ -183,8 +183,12 @@ function stripeEvent(input?: {
     amountCents: input?.amountCents ?? 2500,
     currency: input?.currency ?? "usd",
     proof: {
+      stripe_event_id: input?.eventId ?? "evt_a",
+      stripe_event_type: "checkout.session.completed",
       stripe_session_id: `cs_${requestId}`,
       stripe_payment_intent_id: txRef,
+      stripe_amount_total: input?.amountCents ?? 2500,
+      stripe_currency: input?.currency ?? "usd",
       stripe_payment_status: disposition === "settled" ? "paid" : "unpaid",
     },
     error: disposition === "failed" ? "card failed" : undefined,
@@ -210,9 +214,12 @@ function oxapayEvent(input?: {
     amountCents: input?.amountCents ?? 4301,
     currency: "usd",
     proof: {
+      provider: "oxapay",
       oxapay_track_id: txRef,
       oxapay_order_id: requestId,
       oxapay_status: "paid",
+      oxapay_amount_cents: input?.amountCents ?? 4301,
+      oxapay_currency: "USD",
     },
   };
 }
@@ -362,7 +369,7 @@ describe("durable payment request settlement", () => {
         ...stripe.proof,
         raw_webhook: "must-not-copy",
         email: "must-not-copy@example.invalid",
-        stripe_event_id: { arbitrary: "nested" },
+        arbitrary: { nested: "must-not-copy" },
       },
     });
     await processPaymentProviderEvent({
@@ -390,6 +397,49 @@ describe("durable payment request settlement", () => {
     expect(JSON.stringify({ requests, receipts: await receiptRows() })).not.toContain(
       "must-not-copy",
     );
+  });
+
+  test("rejects contradictory provider event, provider, amount, and currency proof", async () => {
+    await insertRequest({ txRef: "pi_a" });
+    await insertRequest({
+      id: REQUEST_B,
+      orgId: ORG_B,
+      provider: "oxapay",
+      txRef: "trk_b",
+      amountCents: 4301,
+    });
+    const stripe = stripeEvent();
+    const oxapay = oxapayEvent();
+    const contradictoryEvents = [
+      { ...stripe, proof: { ...stripe.proof, stripe_event_id: "evt_wrong" } },
+      {
+        ...stripe,
+        proof: { ...stripe.proof, stripe_event_type: "payment_intent.succeeded" },
+      },
+      { ...stripe, proof: { ...stripe.proof, stripe_amount_total: 2499 } },
+      { ...stripe, proof: { ...stripe.proof, stripe_currency: "EUR" } },
+      { ...oxapay, proof: { ...oxapay.proof, provider: "stripe" } },
+      { ...oxapay, proof: { ...oxapay.proof, oxapay_amount_cents: 4300 } },
+      { ...oxapay, proof: { ...oxapay.proof, oxapay_currency: "EUR" } },
+    ];
+
+    for (const event of contradictoryEvents) {
+      await expect(processPaymentProviderEvent(event)).rejects.toThrow(
+        "does not match provider settlement authority",
+      );
+    }
+
+    expect(await receiptRows()).toHaveLength(0);
+    const balances = await sqlRows<{ credit_balance: string }>(
+      dbWrite,
+      sql`SELECT credit_balance FROM organizations ORDER BY id`,
+    );
+    expect(balances).toEqual([{ credit_balance: "0.000000" }, { credit_balance: "0.000000" }]);
+    const requests = await sqlRows<{ status: string }>(
+      dbWrite,
+      sql`SELECT status FROM payment_requests ORDER BY id`,
+    );
+    expect(requests).toEqual([{ status: "delivered" }, { status: "delivered" }]);
   });
 
   test("invalidates credit caches only after the settlement transaction commits", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
@@ -19,11 +19,13 @@ let dispatchPaymentCallbacks: typeof import("../payment-request-settlement").dis
 let formatUsdFromCents: typeof import("../payment-request-settlement").formatUsdFromCents;
 let creditsService: typeof import("../credits").creditsService;
 let pglite: PGlite;
-let receiptMigration: string;
+let receiptMigrations: string[];
 
-async function applyReceiptMigration(): Promise<void> {
-  for (const statement of receiptMigration.split("--> statement-breakpoint")) {
-    if (statement.trim()) await pglite.exec(statement);
+async function applyReceiptMigrations(): Promise<void> {
+  for (const migration of receiptMigrations) {
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      if (statement.trim()) await pglite.exec(statement);
+    }
   }
 }
 
@@ -103,10 +105,12 @@ beforeAll(async () => {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await pglite.exec(statement);
   }
-  receiptMigration = await Bun.file(
-    new URL("../../../db/migrations/0262_payment_request_receipts.sql", import.meta.url),
-  ).text();
-  await applyReceiptMigration();
+  receiptMigrations = await Promise.all(
+    ["0262_payment_request_receipts.sql", "0263_payment_request_receipt_backfill.sql"].map((file) =>
+      Bun.file(new URL(`../../../db/migrations/${file}`, import.meta.url)).text(),
+    ),
+  );
+  await applyReceiptMigrations();
 });
 
 afterAll(async () => {
@@ -125,7 +129,7 @@ beforeEach(async () => {
     VALUES ('${ORG_A}', 'A', 'a', 0), ('${ORG_B}', 'B', 'b', 0)
   `),
   );
-  await applyReceiptMigration();
+  await applyReceiptMigrations();
 });
 
 async function insertRequest(input?: {
@@ -339,6 +343,53 @@ describe("durable payment request settlement", () => {
       { id: ORG_A, credit_balance: "25.000000" },
       { id: ORG_B, credit_balance: "43.010000" },
     ]);
+  });
+
+  test("persists only provider-allowlisted scalar settlement proof", async () => {
+    await insertRequest({ txRef: "pi_a" });
+    await insertRequest({
+      id: REQUEST_B,
+      orgId: ORG_B,
+      provider: "oxapay",
+      txRef: "trk_b",
+      amountCents: 4301,
+    });
+    const stripe = stripeEvent();
+    const oxapay = oxapayEvent();
+    await processPaymentProviderEvent({
+      ...stripe,
+      proof: {
+        ...stripe.proof,
+        raw_webhook: "must-not-copy",
+        email: "must-not-copy@example.invalid",
+        stripe_event_id: { arbitrary: "nested" },
+      },
+    });
+    await processPaymentProviderEvent({
+      ...oxapay,
+      proof: {
+        ...oxapay.proof,
+        raw_webhook: "must-not-copy",
+        arbitrary: ["nested"],
+        oxapay_type: { arbitrary: "nested" },
+      },
+    });
+
+    const requests = await sqlRows<{ id: string; settlement_proof: Record<string, unknown> }>(
+      dbWrite,
+      sql`SELECT id, settlement_proof FROM payment_requests ORDER BY id`,
+    );
+    expect(requests).toEqual([
+      { id: REQUEST_A, settlement_proof: stripe.proof },
+      { id: REQUEST_B, settlement_proof: oxapay.proof },
+    ]);
+    expect((await receiptRows()).map((receipt) => receipt.settlement_proof)).toEqual([
+      stripe.proof,
+      oxapay.proof,
+    ]);
+    expect(JSON.stringify({ requests, receipts: await receiptRows() })).not.toContain(
+      "must-not-copy",
+    );
   });
 
   test("invalidates credit caches only after the settlement transaction commits", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
@@ -1,6 +1,6 @@
 /**
- * Proves unified provider settlement against a real PGlite transaction,
- * including rollback after the ledger write and same-key concurrency.
+ * Proves unified provider settlement and receipt projection against a real
+ * PGlite transaction, including rollback and same-key concurrency.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
@@ -93,6 +93,12 @@ beforeAll(async () => {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await pglite.exec(statement);
   }
+  const receiptMigration = await Bun.file(
+    new URL("../../../db/migrations/0262_payment_request_receipts.sql", import.meta.url),
+  ).text();
+  for (const statement of receiptMigration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await pglite.exec(statement);
+  }
 });
 
 afterAll(async () => {
@@ -100,6 +106,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  await dbWrite.execute(sql`DELETE FROM payment_request_receipts`);
   await dbWrite.execute(sql`DELETE FROM payment_request_events`);
   await dbWrite.execute(sql`DELETE FROM credit_transactions`);
   await dbWrite.execute(sql`DELETE FROM payment_requests`);
@@ -171,6 +178,53 @@ function stripeEvent(input?: {
   };
 }
 
+function oxapayEvent(input?: {
+  requestId?: string;
+  eventId?: string;
+  txRef?: string;
+  amountCents?: number;
+  digest?: string;
+}) {
+  const requestId = input?.requestId ?? REQUEST_B;
+  const txRef = input?.txRef ?? "trk_b";
+  return {
+    provider: "oxapay" as const,
+    providerEventId: input?.eventId ?? "oxa_evt_b",
+    paymentRequestId: requestId,
+    disposition: "settled" as const,
+    providerTxRef: txRef,
+    payloadDigest: input?.digest ?? "b".repeat(64),
+    amountCents: input?.amountCents ?? 4301,
+    currency: "usd",
+    proof: {
+      oxapay_track_id: txRef,
+      oxapay_order_id: requestId,
+      oxapay_status: "paid",
+    },
+  };
+}
+
+async function receiptRows() {
+  return sqlRows<{
+    organization_id: string;
+    payment_request_id: string;
+    receipt_type: string;
+    provider: string;
+    provider_tx_ref: string;
+    provider_event_id: string;
+    amount_cents: string;
+    currency: string;
+    payload_digest: string;
+    settlement_proof: Record<string, unknown>;
+  }>(
+    dbWrite,
+    sql`SELECT organization_id, payment_request_id, receipt_type, provider,
+          provider_tx_ref, provider_event_id, amount_cents::text AS amount_cents,
+          currency, payload_digest, settlement_proof
+        FROM payment_request_receipts ORDER BY organization_id`,
+  );
+}
+
 async function moneyRows() {
   const balance = await sqlRows<{ credit_balance: string }>(
     dbWrite,
@@ -222,6 +276,60 @@ describe("durable payment request settlement", () => {
       stripe_payment_intent_id: "pi_a",
     });
     expect(rows.request[0]).toMatchObject({ status: "settled", settlement_tx_ref: "pi_a" });
+    const receipts = await receiptRows();
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]).toMatchObject({
+      organization_id: ORG_A,
+      payment_request_id: REQUEST_A,
+      receipt_type: "provider_payment_receipt",
+      provider: "stripe",
+      provider_tx_ref: "pi_a",
+      provider_event_id: "evt_a",
+      amount_cents: "2500",
+      currency: "USD",
+      payload_digest: "a".repeat(64),
+    });
+  });
+
+  test("projects Stripe and OxaPay receipts with organization isolation", async () => {
+    await insertRequest({ txRef: "pi_a" });
+    await insertRequest({
+      id: REQUEST_B,
+      orgId: ORG_B,
+      provider: "oxapay",
+      txRef: "trk_b",
+      amountCents: 4301,
+    });
+
+    await processPaymentProviderEvent(stripeEvent());
+    await processPaymentProviderEvent(oxapayEvent());
+
+    expect(await receiptRows()).toEqual([
+      expect.objectContaining({
+        organization_id: ORG_A,
+        payment_request_id: REQUEST_A,
+        provider: "stripe",
+        provider_tx_ref: "pi_a",
+        amount_cents: "2500",
+        currency: "USD",
+      }),
+      expect.objectContaining({
+        organization_id: ORG_B,
+        payment_request_id: REQUEST_B,
+        provider: "oxapay",
+        provider_tx_ref: "trk_b",
+        amount_cents: "4301",
+        currency: "USD",
+      }),
+    ]);
+    const balances = await sqlRows<{ id: string; credit_balance: string }>(
+      dbWrite,
+      sql`SELECT id, credit_balance FROM organizations ORDER BY id`,
+    );
+    expect(balances).toEqual([
+      { id: ORG_A, credit_balance: "25.000000" },
+      { id: ORG_B, credit_balance: "43.010000" },
+    ]);
   });
 
   test("invalidates credit caches only after the settlement transaction commits", async () => {
@@ -263,6 +371,7 @@ describe("durable payment request settlement", () => {
       expect(rows.balance[0]?.credit_balance).toBe("0.000000");
       expect(rows.credits).toHaveLength(0);
       expect(rows.request[0]?.status).toBe("delivered");
+      expect(await receiptRows()).toHaveLength(0);
 
       await expect(processPaymentProviderEvent(stripeEvent())).resolves.toMatchObject({
         replay: false,
@@ -270,6 +379,7 @@ describe("durable payment request settlement", () => {
       rows = await moneyRows();
       expect(rows.balance[0]?.credit_balance).toBe("25.000000");
       expect(rows.credits).toHaveLength(1);
+      expect(await receiptRows()).toHaveLength(1);
     } finally {
       creditsService.addCredits = realAddCredits;
     }
@@ -315,6 +425,29 @@ describe("durable payment request settlement", () => {
       processPaymentProviderEvent(stripeEvent({ digest: "d".repeat(64) })),
     ).rejects.toThrow("different payload binding");
     expect((await moneyRows()).credits).toHaveLength(1);
+  });
+
+  test("receipt replay conflicts roll back credit fulfillment", async () => {
+    await insertRequest({ txRef: "pi_a" });
+    await dbWrite.execute(sql`
+      INSERT INTO payment_request_receipts (
+        organization_id, payment_request_id, provider, provider_tx_ref,
+        provider_event_id, amount_cents, currency, settled_at, payload_digest,
+        settlement_proof
+      ) VALUES (
+        ${ORG_A}, ${REQUEST_A}, 'stripe', 'pi_a', 'evt_a', 2499, 'USD', now(),
+        ${"a".repeat(64)}, ${stripeEvent().proof}
+      )
+    `);
+
+    await expect(processPaymentProviderEvent(stripeEvent())).rejects.toThrow(
+      "conflicts with immutable settlement metadata",
+    );
+    const money = await moneyRows();
+    expect(money.balance[0]?.credit_balance).toBe("0.000000");
+    expect(money.credits).toHaveLength(0);
+    expect(money.request[0]?.status).toBe("delivered");
+    expect(await receiptRows()).toHaveLength(1);
   });
 
   test("callback outbox claims once and retries a failed SSRF-safe delivery", async () => {
@@ -385,5 +518,8 @@ describe("durable payment request settlement", () => {
       sql`SELECT credit_balance FROM organizations WHERE id=${ORG_B}`,
     );
     expect(other[0]?.credit_balance).toBe("0.000000");
+    expect(
+      (await receiptRows()).filter((receipt) => receipt.organization_id === ORG_B),
+    ).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
@@ -378,7 +378,8 @@ describe("durable payment request settlement", () => {
         ...oxapay.proof,
         raw_webhook: "must-not-copy",
         arbitrary: ["nested"],
-        oxapay_type: { arbitrary: "nested" },
+        oxapay_callback_currency: "POL",
+        oxapay_type: "payer@example.invalid",
       },
     });
 
@@ -396,6 +397,10 @@ describe("durable payment request settlement", () => {
     ]);
     expect(JSON.stringify({ requests, receipts: await receiptRows() })).not.toContain(
       "must-not-copy",
+    );
+    expect(JSON.stringify({ requests, receipts: await receiptRows() })).not.toContain("POL");
+    expect(JSON.stringify({ requests, receipts: await receiptRows() })).not.toContain(
+      "payer@example.invalid",
     );
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
@@ -3,6 +3,7 @@
  * PGlite transaction, including rollback and same-key concurrency.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
 import { sql } from "drizzle-orm";
 import { sqlRows } from "../../../db/execute-helpers";
 
@@ -17,6 +18,14 @@ let processPaymentProviderEvent: typeof import("../payment-request-settlement").
 let dispatchPaymentCallbacks: typeof import("../payment-request-settlement").dispatchPaymentCallbacks;
 let formatUsdFromCents: typeof import("../payment-request-settlement").formatUsdFromCents;
 let creditsService: typeof import("../credits").creditsService;
+let pglite: PGlite;
+let receiptMigration: string;
+
+async function applyReceiptMigration(): Promise<void> {
+  for (const statement of receiptMigration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await pglite.exec(statement);
+  }
+}
 
 beforeAll(async () => {
   process.env.DATABASE_URL = "pglite://memory";
@@ -29,8 +38,9 @@ beforeAll(async () => {
   ));
   ({ creditsService } = await import("../credits"));
 
-  const pglite = client.getPgliteClientForTests();
-  if (!pglite) throw new Error("PGlite test client was not initialized");
+  const testClient = client.getPgliteClientForTests();
+  if (!testClient) throw new Error("PGlite test client was not initialized");
+  pglite = testClient;
   await pglite.exec(`
     CREATE TABLE organizations (
       id uuid PRIMARY KEY,
@@ -93,12 +103,10 @@ beforeAll(async () => {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await pglite.exec(statement);
   }
-  const receiptMigration = await Bun.file(
+  receiptMigration = await Bun.file(
     new URL("../../../db/migrations/0262_payment_request_receipts.sql", import.meta.url),
   ).text();
-  for (const statement of receiptMigration.split("--> statement-breakpoint")) {
-    if (statement.trim()) await pglite.exec(statement);
-  }
+  await applyReceiptMigration();
 });
 
 afterAll(async () => {
@@ -106,7 +114,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await dbWrite.execute(sql`DELETE FROM payment_request_receipts`);
+  await dbWrite.execute(sql`DROP TABLE IF EXISTS payment_request_receipts`);
   await dbWrite.execute(sql`DELETE FROM payment_request_events`);
   await dbWrite.execute(sql`DELETE FROM credit_transactions`);
   await dbWrite.execute(sql`DELETE FROM payment_requests`);
@@ -117,6 +125,7 @@ beforeEach(async () => {
     VALUES ('${ORG_A}', 'A', 'a', 0), ('${ORG_B}', 'B', 'b', 0)
   `),
   );
+  await applyReceiptMigration();
 });
 
 async function insertRequest(input?: {
@@ -425,6 +434,68 @@ describe("durable payment request settlement", () => {
       processPaymentProviderEvent(stripeEvent({ digest: "d".repeat(64) })),
     ).rejects.toThrow("different payload binding");
     expect((await moneyRows()).credits).toHaveLength(1);
+  });
+
+  test("distinct transaction replay repairs one receipt from persisted settlement authority", async () => {
+    await insertRequest({ txRef: "pi_a" });
+    const canonical = stripeEvent();
+    const callback = {
+      name: "PaymentSettled",
+      paymentRequestId: REQUEST_A,
+      provider: "stripe",
+      providerEventId: canonical.providerEventId,
+      txRef: canonical.providerTxRef,
+      amountCents: canonical.amountCents,
+      currency: "USD",
+      occurredAt: "2026-08-19T08:00:00.000Z",
+    };
+    await dbWrite.execute(sql`
+      UPDATE payment_requests
+      SET status='settled', settled_at='2026-08-19T08:00:00.000Z',
+          settlement_tx_ref=${canonical.providerTxRef}, settlement_proof=${canonical.proof}
+      WHERE id=${REQUEST_A}
+    `);
+    await dbWrite.execute(sql`
+      INSERT INTO payment_request_events (
+        payment_request_id, event_name, redacted_payload, provider, provider_event_id,
+        provider_tx_ref, provider_disposition, payload_digest, callback_state, occurred_at
+      ) VALUES (
+        ${REQUEST_A}, 'webhook.received', ${callback}, 'stripe', ${canonical.providerEventId},
+        ${canonical.providerTxRef}, 'settled', ${canonical.payloadDigest}, 'dispatched',
+        '2026-08-19T08:00:00.000Z'
+      )
+    `);
+
+    expect(await receiptRows()).toHaveLength(0);
+    const distinctWithUnretainedField = stripeEvent({
+      eventId: "evt_distinct_b",
+      digest: "b".repeat(64),
+    });
+    await Promise.all([
+      processPaymentProviderEvent({
+        ...distinctWithUnretainedField,
+        proof: { ...distinctWithUnretainedField.proof, raw_webhook: "must-not-copy" },
+      }),
+      processPaymentProviderEvent(
+        stripeEvent({ eventId: "evt_distinct_c", digest: "c".repeat(64) }),
+      ),
+    ]);
+
+    expect(await receiptRows()).toEqual([
+      expect.objectContaining({
+        payment_request_id: REQUEST_A,
+        provider_event_id: canonical.providerEventId,
+        payload_digest: canonical.payloadDigest,
+        settlement_proof: canonical.proof,
+      }),
+    ]);
+    expect(JSON.stringify(await receiptRows())).not.toContain("must-not-copy");
+    const events = await sqlRows<{ provider_event_id: string }>(
+      dbWrite,
+      sql`SELECT provider_event_id FROM payment_request_events
+          WHERE event_name='webhook.received'`,
+    );
+    expect(events).toEqual([{ provider_event_id: canonical.providerEventId }]);
   });
 
   test("receipt replay conflicts roll back credit fulfillment", async () => {

--- a/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
@@ -23,6 +23,47 @@ export interface ProjectPaymentRequestReceiptInput {
   settlementProof: Record<string, unknown>;
 }
 
+const SETTLEMENT_PROOF_FIELDS = {
+  stripe: [
+    "stripe_event_id",
+    "stripe_event_type",
+    "stripe_session_id",
+    "stripe_payment_intent_id",
+    "stripe_amount_total",
+    "stripe_currency",
+    "stripe_payment_status",
+  ],
+  oxapay: [
+    "provider",
+    "oxapay_track_id",
+    "oxapay_order_id",
+    "oxapay_status",
+    "oxapay_amount_cents",
+    "oxapay_currency",
+    "oxapay_callback_currency",
+    "oxapay_type",
+  ],
+} as const satisfies Record<"stripe" | "oxapay", readonly string[]>;
+
+/** Retains only provider-defined scalar fields that are safe for durable settlement records. */
+export function curatePaymentRequestSettlementProof(
+  provider: "stripe" | "oxapay",
+  proof: Record<string, unknown>,
+): Record<string, string | number | null> {
+  const curated: Record<string, string | number | null> = {};
+  for (const field of SETTLEMENT_PROOF_FIELDS[provider]) {
+    const value = proof[field];
+    if (
+      value === null ||
+      typeof value === "string" ||
+      (typeof value === "number" && Number.isFinite(value))
+    ) {
+      curated[field] = value;
+    }
+  }
+  return curated;
+}
+
 export class PaymentRequestReceiptConflictError extends ElizaError {
   override readonly name = "PaymentRequestReceiptConflictError";
 
@@ -39,6 +80,25 @@ export async function projectPaymentRequestReceipt(
   input: ProjectPaymentRequestReceiptInput,
 ): Promise<PaymentRequestReceipt> {
   const amountCents = BigInt(input.amountCents);
+  const settlementProof = curatePaymentRequestSettlementProof(
+    input.provider,
+    input.settlementProof,
+  );
+  if (
+    (input.provider === "stripe" &&
+      (settlementProof.stripe_payment_intent_id !== input.providerTxRef ||
+        settlementProof.stripe_payment_status !== "paid" ||
+        typeof settlementProof.stripe_session_id !== "string" ||
+        !settlementProof.stripe_session_id.trim())) ||
+    (input.provider === "oxapay" &&
+      (settlementProof.oxapay_track_id !== input.providerTxRef ||
+        settlementProof.oxapay_order_id !== input.paymentRequestId ||
+        settlementProof.oxapay_status !== "paid"))
+  ) {
+    throw new PaymentRequestReceiptConflictError(
+      "Payment receipt proof does not match provider settlement authority",
+    );
+  }
   const [inserted] = await tx
     .insert(paymentRequestReceipts)
     .values({
@@ -52,7 +112,7 @@ export async function projectPaymentRequestReceipt(
       currency: input.currency,
       settled_at: input.settledAt,
       payload_digest: input.payloadDigest,
-      settlement_proof: input.settlementProof,
+      settlement_proof: settlementProof,
     })
     .onConflictDoNothing()
     .returning();
@@ -73,7 +133,7 @@ export async function projectPaymentRequestReceipt(
         eq(paymentRequestReceipts.currency, input.currency),
         eq(paymentRequestReceipts.settled_at, input.settledAt),
         eq(paymentRequestReceipts.payload_digest, input.payloadDigest),
-        eq(paymentRequestReceipts.settlement_proof, input.settlementProof),
+        eq(paymentRequestReceipts.settlement_proof, settlementProof),
       ),
     )
     .limit(1);

--- a/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
@@ -40,8 +40,6 @@ const SETTLEMENT_PROOF_FIELDS = {
     "oxapay_status",
     "oxapay_amount_cents",
     "oxapay_currency",
-    "oxapay_callback_currency",
-    "oxapay_type",
   ],
 } as const satisfies Record<"stripe" | "oxapay", readonly string[]>;
 

--- a/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
@@ -80,20 +80,30 @@ export async function projectPaymentRequestReceipt(
   input: ProjectPaymentRequestReceiptInput,
 ): Promise<PaymentRequestReceipt> {
   const amountCents = BigInt(input.amountCents);
+  const currency = input.currency.trim().toUpperCase();
   const settlementProof = curatePaymentRequestSettlementProof(
     input.provider,
     input.settlementProof,
   );
   if (
     (input.provider === "stripe" &&
-      (settlementProof.stripe_payment_intent_id !== input.providerTxRef ||
+      (settlementProof.stripe_event_id !== input.providerEventId ||
+        settlementProof.stripe_event_type !== "checkout.session.completed" ||
+        settlementProof.stripe_payment_intent_id !== input.providerTxRef ||
+        settlementProof.stripe_amount_total !== input.amountCents ||
+        typeof settlementProof.stripe_currency !== "string" ||
+        settlementProof.stripe_currency.trim().toUpperCase() !== currency ||
         settlementProof.stripe_payment_status !== "paid" ||
         typeof settlementProof.stripe_session_id !== "string" ||
         !settlementProof.stripe_session_id.trim())) ||
     (input.provider === "oxapay" &&
-      (settlementProof.oxapay_track_id !== input.providerTxRef ||
+      (settlementProof.provider !== input.provider ||
+        settlementProof.oxapay_track_id !== input.providerTxRef ||
         settlementProof.oxapay_order_id !== input.paymentRequestId ||
-        settlementProof.oxapay_status !== "paid"))
+        settlementProof.oxapay_status !== "paid" ||
+        settlementProof.oxapay_amount_cents !== input.amountCents ||
+        typeof settlementProof.oxapay_currency !== "string" ||
+        settlementProof.oxapay_currency.trim().toUpperCase() !== currency))
   ) {
     throw new PaymentRequestReceiptConflictError(
       "Payment receipt proof does not match provider settlement authority",
@@ -109,7 +119,7 @@ export async function projectPaymentRequestReceipt(
       provider_tx_ref: input.providerTxRef,
       provider_event_id: input.providerEventId,
       amount_cents: amountCents,
-      currency: input.currency,
+      currency,
       settled_at: input.settledAt,
       payload_digest: input.payloadDigest,
       settlement_proof: settlementProof,
@@ -130,7 +140,7 @@ export async function projectPaymentRequestReceipt(
         eq(paymentRequestReceipts.provider_tx_ref, input.providerTxRef),
         eq(paymentRequestReceipts.provider_event_id, input.providerEventId),
         eq(paymentRequestReceipts.amount_cents, amountCents),
-        eq(paymentRequestReceipts.currency, input.currency),
+        eq(paymentRequestReceipts.currency, currency),
         eq(paymentRequestReceipts.settled_at, input.settledAt),
         eq(paymentRequestReceipts.payload_digest, input.payloadDigest),
         eq(paymentRequestReceipts.settlement_proof, settlementProof),

--- a/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-receipts.ts
@@ -1,0 +1,100 @@
+/**
+ * Projects settled provider payments into tenant-bound purchase receipts.
+ * Exact retries return the existing row; any changed settlement authority fails.
+ */
+import { ElizaError } from "@elizaos/core";
+import { and, eq, or } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
+import {
+  type PaymentRequestReceipt,
+  paymentRequestReceipts,
+} from "../../db/schemas/payment-request-receipts";
+
+export interface ProjectPaymentRequestReceiptInput {
+  organizationId: string;
+  paymentRequestId: string;
+  provider: "stripe" | "oxapay";
+  providerTxRef: string;
+  providerEventId: string;
+  amountCents: number;
+  currency: string;
+  settledAt: Date;
+  payloadDigest: string;
+  settlementProof: Record<string, unknown>;
+}
+
+export class PaymentRequestReceiptConflictError extends ElizaError {
+  override readonly name = "PaymentRequestReceiptConflictError";
+
+  constructor(message: string) {
+    super(message, {
+      code: "PAYMENT_REQUEST_RECEIPT_CONFLICT",
+      severity: "fatal",
+    });
+  }
+}
+
+export async function projectPaymentRequestReceipt(
+  tx: DbTransaction,
+  input: ProjectPaymentRequestReceiptInput,
+): Promise<PaymentRequestReceipt> {
+  const amountCents = BigInt(input.amountCents);
+  const [inserted] = await tx
+    .insert(paymentRequestReceipts)
+    .values({
+      organization_id: input.organizationId,
+      payment_request_id: input.paymentRequestId,
+      receipt_type: "provider_payment_receipt",
+      provider: input.provider,
+      provider_tx_ref: input.providerTxRef,
+      provider_event_id: input.providerEventId,
+      amount_cents: amountCents,
+      currency: input.currency,
+      settled_at: input.settledAt,
+      payload_digest: input.payloadDigest,
+      settlement_proof: input.settlementProof,
+    })
+    .onConflictDoNothing()
+    .returning();
+  if (inserted) return inserted;
+
+  const [exactReplay] = await tx
+    .select()
+    .from(paymentRequestReceipts)
+    .where(
+      and(
+        eq(paymentRequestReceipts.organization_id, input.organizationId),
+        eq(paymentRequestReceipts.payment_request_id, input.paymentRequestId),
+        eq(paymentRequestReceipts.receipt_type, "provider_payment_receipt"),
+        eq(paymentRequestReceipts.provider, input.provider),
+        eq(paymentRequestReceipts.provider_tx_ref, input.providerTxRef),
+        eq(paymentRequestReceipts.provider_event_id, input.providerEventId),
+        eq(paymentRequestReceipts.amount_cents, amountCents),
+        eq(paymentRequestReceipts.currency, input.currency),
+        eq(paymentRequestReceipts.settled_at, input.settledAt),
+        eq(paymentRequestReceipts.payload_digest, input.payloadDigest),
+        eq(paymentRequestReceipts.settlement_proof, input.settlementProof),
+      ),
+    )
+    .limit(1);
+  if (exactReplay) return exactReplay;
+
+  const [conflictingReceipt] = await tx
+    .select({ id: paymentRequestReceipts.id })
+    .from(paymentRequestReceipts)
+    .where(
+      or(
+        eq(paymentRequestReceipts.payment_request_id, input.paymentRequestId),
+        and(
+          eq(paymentRequestReceipts.provider, input.provider),
+          eq(paymentRequestReceipts.provider_tx_ref, input.providerTxRef),
+        ),
+      ),
+    )
+    .limit(1);
+  throw new PaymentRequestReceiptConflictError(
+    conflictingReceipt
+      ? "Payment receipt replay conflicts with immutable settlement metadata"
+      : "Payment receipt insert conflicted without a matching settlement authority",
+  );
+}

--- a/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
@@ -336,6 +336,31 @@ export async function processPaymentProviderEvent(
             "Provider transaction was replayed with a different settlement binding",
           );
         }
+        if (
+          request.status !== "settled" ||
+          request.settlement_tx_ref !== event.providerTxRef ||
+          !request.settled_at ||
+          !request.settlement_proof ||
+          !existingTransaction.provider_event_id ||
+          !existingTransaction.payload_digest ||
+          !amount
+        ) {
+          throw new PaymentProviderEventConflictError(
+            "Existing provider transaction has incomplete settlement authority",
+          );
+        }
+        await projectPaymentRequestReceipt(tx, {
+          organizationId: request.organization_id,
+          paymentRequestId: request.id,
+          provider: event.provider,
+          providerTxRef: event.providerTxRef,
+          providerEventId: existingTransaction.provider_event_id,
+          amountCents: amount.amountCents,
+          currency: amount.currency,
+          settledAt: request.settled_at,
+          payloadDigest: existingTransaction.payload_digest,
+          settlementProof: request.settlement_proof,
+        });
         return {
           callback: callbackFromPayload(payload, existingTransaction.callback_state),
           callbackState: existingTransaction.callback_state ?? "pending",

--- a/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
@@ -18,7 +18,10 @@ import {
 import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
-import { projectPaymentRequestReceipt } from "./payment-request-receipts";
+import {
+  curatePaymentRequestSettlementProof,
+  projectPaymentRequestReceipt,
+} from "./payment-request-receipts";
 
 const MAX_CALLBACK_ATTEMPTS = 12;
 
@@ -252,6 +255,7 @@ export async function processPaymentProviderEvent(
     paymentRequestId: requiredText(rawEvent.paymentRequestId, "paymentRequestId"),
     providerTxRef: requiredText(rawEvent.providerTxRef, "providerTxRef"),
     payloadDigest: rawEvent.payloadDigest.toLowerCase(),
+    proof: curatePaymentRequestSettlementProof(rawEvent.provider, rawEvent.proof),
   };
   if (!/^[a-f0-9]{64}$/.test(event.payloadDigest)) {
     throw new PaymentProviderEventConflictError("payloadDigest must be a SHA-256 hex digest");

--- a/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
+++ b/packages/cloud/shared/src/lib/services/payment-request-settlement.ts
@@ -18,6 +18,7 @@ import {
 import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
+import { projectPaymentRequestReceipt } from "./payment-request-receipts";
 
 const MAX_CALLBACK_ATTEMPTS = 12;
 
@@ -366,15 +367,31 @@ export async function processPaymentProviderEvent(
     const replay = Boolean(existingEvent);
 
     if (event.disposition === "settled") {
+      if (!amount) {
+        throw new PaymentProviderEventConflictError("Settled provider event has no amount");
+      }
       if (request.status === "settled" && request.settlement_tx_ref !== event.providerTxRef) {
         throw new PaymentProviderEventConflictError(
           "Payment request was already settled by another provider transaction",
         );
       }
 
+      await projectPaymentRequestReceipt(tx, {
+        organizationId: request.organization_id,
+        paymentRequestId: request.id,
+        provider: event.provider,
+        providerTxRef: event.providerTxRef,
+        providerEventId: event.providerEventId,
+        amountCents: amount.amountCents,
+        currency: amount.currency,
+        settledAt: request.settled_at ?? occurredAt,
+        payloadDigest: event.payloadDigest,
+        settlementProof: event.proof,
+      });
+
       const credit = await creditsService.addCredits({
         organizationId: request.organization_id,
-        amount: formatUsdFromCents(amount?.amountCents ?? 0),
+        amount: formatUsdFromCents(amount.amountCents),
         description: `${event.provider} payment request credit purchase`,
         metadata: {
           type: "payment_request_topup",
@@ -382,8 +399,8 @@ export async function processPaymentProviderEvent(
           provider: event.provider,
           providerEventId: event.providerEventId,
           providerTxRef: event.providerTxRef,
-          amountCents: amount?.amountCents,
-          currency: amount?.currency,
+          amountCents: amount.amountCents,
+          currency: amount.currency,
         },
         stripePaymentIntentId:
           event.provider === "stripe"
@@ -397,14 +414,14 @@ export async function processPaymentProviderEvent(
         credit.transaction.organization_id !== request.organization_id ||
         credit.transaction.type !== "credit" ||
         !new Decimal(String(credit.transaction.amount)).eq(
-          formatUsdFromCents(amount?.amountCents ?? 0),
+          formatUsdFromCents(amount.amountCents),
         ) ||
         creditMetadata.type !== "payment_request_topup" ||
         creditMetadata.paymentRequestId !== request.id ||
         creditMetadata.provider !== event.provider ||
         creditMetadata.providerTxRef !== event.providerTxRef ||
-        creditMetadata.amountCents !== amount?.amountCents ||
-        creditMetadata.currency !== amount?.currency
+        creditMetadata.amountCents !== amount.amountCents ||
+        creditMetadata.currency !== amount.currency
       ) {
         throw new PaymentProviderEventConflictError(
           "Existing credit idempotency row does not match payment settlement",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22353.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change adds a migration and an atomic write to a money-settlement path.
The main risks are migration compatibility and rejecting legitimate retries;
PGlite integration coverage exercises migration application, concurrent replay,
rollback, provider parity, and tenant isolation.

# Background

## What does this PR do?

Adds a provider-neutral `payment_request_receipts` projection for settled Stripe
and OxaPay payment requests. Each row is bound to its organization, payment
request, provider event, and provider transaction; preserves exact settled cents,
currency, time, payload digest, and provider proof; and is inserted in the same
transaction as credit fulfillment. Exact retries reuse the row while conflicting
settlement metadata aborts the transaction.

The projection is explicitly typed as a `provider_payment_receipt`. It does not
claim tax or legal invoice semantics and does not fabricate Stripe identifiers in
the legacy `invoices` table.

## What kind of change is this?

Bug fix (non-breaking change that completes provider-neutral receipt coverage for
the unified payment-request settlement flow).

# Documentation changes needed?

No project documentation change is required. The schema, migration, and service
headers document the provider-receipt boundary and its separation from tax/legal
invoices.

# Testing

## Where should a reviewer start?

Start with
`packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts`,
then inspect `payment-request-receipts.ts` in the schema and service directories.

## Detailed testing steps

Run with Node 24.15.0 and Bun 1.3.14:

```bash
fnm exec --using 24.15.0 -- bun test /absolute/path/to/packages/cloud/shared/src/lib/services/__tests__/payment-request-settlement.pglite.test.ts
fnm exec --using 24.15.0 -- bun run --cwd packages/cloud/shared typecheck
fnm exec --using 24.15.0 -- bun run --cwd packages/cloud/shared lint:check
fnm exec --using 24.15.0 -- bun run --cwd packages/cloud/shared db:check-migrations
```

Observed results: 10 tests passed, 0 failed, 47 assertions; TypeScript completed
with zero errors; Biome checked 2,084 files with no errors or fixes; Drizzle
reported `Everything's fine`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:replace-with-current-40-character-head-sha -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a database and backend settlement change with no UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the projection intentionally emits no new runtime log; direct database
      row assertions provide the relevant backend evidence below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider-model, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] PGlite integration evidence: Stripe and OxaPay settlement produced exactly
      one tenant-bound receipt each with exact cents/currency, while rollback and
      replay-conflict cases produced no credit or settlement mutation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider-model, or model behavior changes.

## Backend + frontend logs

Backend: N/A - the receipt projector has no logging side effect; the focused
PGlite suite directly reads receipt, ledger, organization-balance, and payment
request rows after the real transaction commits or rolls back.

Frontend: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

### Before

N/A - no UI surface changed.

### After

N/A - no UI surface changed.

### Walkthrough video

N/A - no UI flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- `bun install` was attempted after syncing. The first attempt could not use the
  sandbox temp directory; after setting `BUN_TMPDIR` and `TMPDIR` to a writable
  `/private/tmp` directory, installation reached dependency resolution but failed
  because registry network access is blocked (`ConnectionRefused` /
  `FailedToOpenSocket`). No tracked files changed, and all scoped gates were rerun
  successfully afterward.
- Root `bun run verify` was not run because the full monorepo gate is expected to
  exceed the task's approximately 20-minute limit. The owning package's focused
  PGlite test, typecheck, lint, and migration checks all passed post-sync.
- No live Stripe or OxaPay webhook was exercised because external provider secrets
  and network access are unavailable. Provider parity and durable database effects
  are covered through the real PGlite transaction boundary with provider-shaped
  events.


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 5559499 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [synapz-org]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0CJXR7D7CKSYHCGEJ2XMH25","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-19T08:41:37.773Z","completed_at":"2026-08-19T08:53:22.645Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":182673,"output_tokens":30522,"cache_creation_tokens":0,"cache_read_tokens":5346304,"total_tokens":5559499,"cost_micro_usd":"4502177","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhZH18YZOumLzScna2ZyDOP25JOBwpTrTwX6qb9ZqbbE","device_key_id":"ea68406aa2e612b80483e71bd39662955ca6099e58f9ac01e63d6c629dab20d0","device_signature":"UgJNPsfohx-KzCOybEmWquPjeVvd9I_kjL3hs06loPMjSuSfcBtmY7Ha-gfGWGKckI5YM6nLbdj6ppW6oPGYCQ"}} -->
