### PR TITLE
fix(plugin-wechat): preserve multibyte UTF-8 inbound content split across TCP chunks

### DIFF
--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -47,6 +47,7 @@ plugins/plugin-wechat/
     utils/qrcode.ts           # displayQRUrl — prints QR code login URL to terminal
     index.test.ts             # Unit tests
     callback-server.test.ts   # Webhook URL/payload fail-closed tests
+    callback-utf8.test.ts     # Inbound UTF-8 TCP chunk-boundary integrity
     connector-account-provider.test.ts # Unit tests for ConnectorAccountProvider
 ```
 

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -47,6 +47,7 @@ plugins/plugin-wechat/
     utils/qrcode.ts           # displayQRUrl — prints QR code login URL to terminal
     index.test.ts             # Unit tests
     callback-server.test.ts   # Webhook URL/payload fail-closed tests
+    callback-utf8.test.ts     # Inbound UTF-8 TCP chunk-boundary integrity
     connector-account-provider.test.ts # Unit tests for ConnectorAccountProvider
 ```
 

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -87,7 +87,12 @@ export async function startCallbackServer(
       return;
     }
 
-    let body = "";
+    // Accumulate raw bytes and decode once on "end". Decoding each TCP chunk
+    // independently with Buffer.toString() corrupts any multi-byte UTF-8 code
+    // point (i.e. essentially every CJK character WeChat carries) that
+    // straddles a chunk boundary, replacing it with U+FFFD on both sides of
+    // the split (#22426).
+    const chunks: Buffer[] = [];
     let bodyBytes = 0;
     req.on("data", (chunk: Buffer) => {
       bodyBytes += chunk.length;
@@ -97,7 +102,7 @@ export async function startCallbackServer(
         req.destroy();
         return;
       }
-      body += chunk.toString();
+      chunks.push(chunk);
     });
 
     req.on("end", async () => {
@@ -105,6 +110,7 @@ export async function startCallbackServer(
         return;
       }
 
+      const body = Buffer.concat(chunks).toString("utf8");
       let payload: unknown;
       try {
         payload = JSON.parse(body);

--- a/plugins/plugin-wechat/src/callback-utf8.test.ts
+++ b/plugins/plugin-wechat/src/callback-utf8.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression coverage for #22426: the webhook body must be decoded from the
+ * concatenated raw bytes, not per TCP chunk. WeChat's primary content is CJK
+ * (multi-byte UTF-8), so a code point that straddles a TCP packet boundary was
+ * previously decoded as U+FFFD replacement characters on both sides of the
+ * split. These tests drive the real listener over a raw TCP socket and split
+ * the body mid-character to prove exact-content delivery survives fragmentation
+ * without regressing the buffered-size 413 guard. The harness is real: only the
+ * message sink is a recording array.
+ */
+
+import { connect } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { startCallbackServer } from "./callback-server";
+import type { WechatMessageContext } from "./types";
+
+const VALID_MS = 1_710_969_600_000;
+
+function payloadWith(content: string): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      data: {
+        type: 60001,
+        sender: "alice",
+        recipient: "bot",
+        content,
+        timestamp: VALID_MS,
+        msgId: "utf8-1",
+      },
+    }),
+    "utf8",
+  );
+}
+
+/**
+ * Sends a raw HTTP/1.1 POST whose body is written in multiple socket frames at
+ * the given byte offsets, so a multi-byte character can be forced to straddle a
+ * TCP chunk boundary. Resolves with the parsed status line once the server
+ * responds and closes the socket.
+ */
+function rawSplitPost(
+  port: number,
+  path: string,
+  apiKey: string,
+  body: Buffer,
+  splitOffsets: number[],
+): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, "127.0.0.1", () => {
+      const header = Buffer.from(
+        `POST ${path} HTTP/1.1\r\n` +
+          `Host: 127.0.0.1\r\n` +
+          `x-api-key: ${apiKey}\r\n` +
+          `Content-Type: application/json\r\n` +
+          `Content-Length: ${body.length}\r\n` +
+          `Connection: close\r\n\r\n`,
+        "utf8",
+      );
+      socket.write(header);
+
+      const bounds = [0, ...splitOffsets, body.length];
+      let index = 0;
+      const writeNext = () => {
+        if (index >= bounds.length - 1) {
+          return;
+        }
+        const start = bounds[index];
+        const end = bounds[index + 1];
+        index += 1;
+        socket.write(body.subarray(start, end), () => {
+          // Yield to the event loop so each slice lands as its own read on the
+          // server, reproducing genuine TCP fragmentation rather than a single
+          // coalesced buffer.
+          setTimeout(writeNext, 5);
+        });
+      };
+      writeNext();
+    });
+
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.on("end", () => {
+      const response = Buffer.concat(chunks).toString("utf8");
+      const statusMatch = /^HTTP\/1\.1 (\d{3})/.exec(response);
+      resolve({ status: statusMatch ? Number(statusMatch[1]) : 0 });
+    });
+    socket.on("error", reject);
+  });
+}
+
+describe("webhook UTF-8 chunk-boundary integrity (#22426)", () => {
+  const closers: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(closers.map((close) => close()));
+    closers.length = 0;
+  });
+
+  async function startServer(received: WechatMessageContext[]) {
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: (_accountId, msg) => {
+        received.push(msg);
+      },
+    });
+    closers.push(handle.close);
+    return handle.port;
+  }
+
+  it("delivers exact CJK content when a character is split across TCP writes", async () => {
+    const received: WechatMessageContext[] = [];
+    const port = await startServer(received);
+    const content = "价格是多少钱";
+    const body = payloadWith(content);
+
+    // The first CJK character "价" begins immediately after `"content":"` in
+    // the serialized JSON. Split one byte into it so its three UTF-8 bytes land
+    // on both sides of the boundary.
+    const contentByteStart = body.indexOf(Buffer.from(content, "utf8"));
+    expect(contentByteStart).toBeGreaterThan(0);
+
+    const res = await rawSplitPost(
+      port,
+      "/webhook/wechat/main",
+      "key-main",
+      body,
+      [contentByteStart + 1],
+    );
+
+    expect(res.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content).toBe(content);
+    expect(received[0]?.content).not.toContain("\uFFFD");
+  });
+
+  it("survives boundaries at every byte offset inside the CJK run", async () => {
+    const content = "订单号是多少";
+    const body = payloadWith(content);
+    const contentByteStart = body.indexOf(Buffer.from(content, "utf8"));
+    const runBytes = Buffer.from(content, "utf8").length;
+
+    for (let offset = 1; offset < runBytes; offset += 1) {
+      const received: WechatMessageContext[] = [];
+      const port = await startServer(received);
+      const res = await rawSplitPost(
+        port,
+        "/webhook/wechat/main",
+        "key-main",
+        body,
+        [contentByteStart + offset],
+      );
+      expect(res.status).toBe(200);
+      expect(received).toHaveLength(1);
+      expect(received[0]?.content).toBe(content);
+    }
+  });
+
+  it("reassembles a 4-byte emoji surrogate split across three writes", async () => {
+    const received: WechatMessageContext[] = [];
+    const port = await startServer(received);
+    // U+1F600 GRINNING FACE encodes to four UTF-8 bytes (F0 9F 98 80).
+    const content = "笑一个😀谢谢";
+    const body = payloadWith(content);
+    const emojiByteStart = body.indexOf(Buffer.from("😀", "utf8"));
+    expect(emojiByteStart).toBeGreaterThan(0);
+
+    const res = await rawSplitPost(
+      port,
+      "/webhook/wechat/main",
+      "key-main",
+      body,
+      [emojiByteStart + 1, emojiByteStart + 3],
+    );
+
+    expect(res.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content).toBe(content);
+    expect(received[0]?.content).not.toContain("\uFFFD");
+  });
+
+  it("still returns 413 when the buffered body exceeds maxBodyBytes", async () => {
+    const received: WechatMessageContext[] = [];
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      maxBodyBytes: 64,
+      onMessage: (_accountId, msg) => {
+        received.push(msg);
+      },
+    });
+    closers.push(handle.close);
+
+    // A body far larger than the 64-byte cap, delivered in two writes so the
+    // limit is crossed by the accumulated buffered size, not a single chunk.
+    const body = payloadWith("价格".repeat(200));
+    const res = await rawSplitPost(
+      handle.port,
+      "/webhook/wechat/main",
+      "key-main",
+      body,
+      [40],
+    );
+
+    expect(res.status).toBe(413);
+    expect(received).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #22426

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and focused package checks (test, typecheck, lint, build)
      were run after sync. `bun run verify` is a whole-repo gate; see
      **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop` (`bad793372e`); zero conflicts.
- [x] Focused package checks pass post-sync; see **Known gaps / failures** for
      the whole-repo `bun run verify` note.

# Risks

Low. The change is a ~5-line localized rewrite of how the WeChat webhook request
handler buffers the inbound HTTP body. There is no public contract change: the
same `maxBodyBytes` cap and 413 guard remain, and the decoded string is still
JSON-parsed and passed to `normalizePayload` exactly as before. The only
behavioral difference is that a correct string is now produced for bodies
fragmented across TCP reads.

# Background

## What does this PR do?

The WeChat webhook callback server in `plugins/plugin-wechat/src/callback-server.ts`
accumulated the request body with `body += chunk.toString()` inside the
`req.on("data", ...)` handler. `Buffer.prototype.toString()` decodes each TCP
chunk independently as UTF-8, so any multi-byte code point — essentially every
Chinese character, WeChat's primary content — that straddles a TCP packet
boundary was decoded as U+FFFD replacement characters on both sides of the
split. The corrupted string was then JSON-parsed and passed through
`normalizePayload` into `WechatMessageContext.content`, i.e. the inbound message
text the agent processes and stores. This is a silent data-integrity failure on
the core inbound message path (`价格是多少钱` arriving as `���格是多少钱`),
non-deterministic because it depends on TCP fragmentation.

The fix accumulates raw `Buffer` chunks and decodes once on `"end"` via
`Buffer.concat(chunks).toString("utf8")` before `JSON.parse`, keeping the
existing byte-count cap and 413 guard intact.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

Package guide layout updated: `plugins/plugin-wechat/CLAUDE.md` and its
byte-identical `AGENTS.md` now list the new `callback-utf8.test.ts`
(`bun run check:agents-claude` passes).

# Testing

## Where should a reviewer start?

`plugins/plugin-wechat/src/callback-utf8.test.ts` — a real-listener test that
opens a raw TCP socket and writes a JSON body containing CJK/emoji content in
multiple socket frames, forcing a multi-byte character to straddle the boundary,
then asserts `onMessage` receives the exact original content.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-wechat test
# focused:
plugins/plugin-wechat/node_modules/.bin/vitest run src/callback-utf8.test.ts
```

# Evidence Gate

<!-- evidence-head:ba16bd9e0a9e30aa09bbce3b6d37d37ba82382bc -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server-side message-decoding fix; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server-side message-decoding fix; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; behavior is proven by the failing-then-passing regression test below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - fork/headless run cannot mint an accepted user-attachments URL and fork-release URLs are rejected by the gate (#17600); the complete real-listener before/after and full-suite logs are pasted inline under 'Backend + frontend logs' below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a transport-layer decoding fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - see inline 'Domain artifacts' detail below; the delivered WechatMessageContext.content strings are asserted exactly by src/callback-utf8.test.ts and shown inline (same hosting constraint as backend-logs).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - transport-layer decoding fix; no model call is exercised or changed.`

## Backend + frontend logs

Real-listener regression test against the actual `startCallbackServer` server.

**BEFORE the fix** (revert only `callback-server.ts`, run the new test):

```
 FAIL  src/callback-utf8.test.ts > ... > delivers exact CJK content when a character is split across TCP writes
AssertionError: expected '\ufffd\ufffd\ufffd格是多少钱' to be '价格是多少钱'
Expected: "价格是多少钱"
Received: "���格是多少钱"
 FAIL  src/callback-utf8.test.ts > ... > survives boundaries at every byte offset inside the CJK run
AssertionError: expected '\ufffd\ufffd\ufffd单号是多少' to be '订单号是多少'
 FAIL  src/callback-utf8.test.ts > ... > reassembles a 4-byte emoji surrogate split across three writes
AssertionError: expected '笑一个\ufffd\ufffd\ufffd\ufffd谢谢' to be '笑一个😀谢谢'
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

The one passing "before" case is the 413 byte-limit guard — proving the fix does
not regress the size cap.

**AFTER the fix** (new test):

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

**Full package suite** (existing single-write `callback-server.test.ts` still
passes — the pre-existing suite only ever sent the body in one write, so it
never exercised a split and the bug was invisible to it):

```
 Test Files  5 passed (5)
      Tests  55 passed (55)
```

typecheck (`tsc --noEmit`), lint (`biome check`), and build (`tsup`) all pass.

## Domain artifacts

The domain artifact is the exact `WechatMessageContext.content` string delivered
by the real callback server when a multi-byte character is split across TCP
writes. `src/callback-utf8.test.ts` asserts these exact values:

| Case | Split | BEFORE fix (delivered) | AFTER fix (delivered) |
| --- | --- | --- | --- |
| CJK `价格是多少钱` | 1 byte into `价` (3-byte U+4EF7) | `���格是多少钱` (U+FFFD×3) | `价格是多少钱` |
| CJK `订单号是多少` | every byte offset in the run | `���单号是多少` | `订单号是多少` (exact at every offset) |
| Emoji `笑一个😀谢谢` | 4-byte U+1F600 across 3 writes | `笑一个����谢谢` (U+FFFD×4) | `笑一个😀谢谢` |
| Oversized body | 2 writes, > `maxBodyBytes` | HTTP 413, no dispatch | HTTP 413, no dispatch (guard preserved) |

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no audio/voice path.`

## Known gaps / failures

- `bun run verify` is a whole-monorepo gate that requires the full workspace to
  build; it was not run end to end on this constrained machine. The change is
  confined to `plugins/plugin-wechat`, whose `test`, `typecheck`, `lint`, and
  `build` all pass, plus repo `check:agents-claude`.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->



