### PR TITLE
fix(ci): bypass hosted apt for protoc bootstrap

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -214,6 +214,7 @@ runs:
       env:
         FORCE_PROTOC_GITHUB_FALLBACK: ${{ inputs.force-protoc-github-fallback }}
         PROTOC_RUNNER_ARCH: ${{ runner.arch }}
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
       run: |
         if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" != "true" ] && command -v protoc >/dev/null 2>&1; then
           echo "protoc already installed: $(protoc --version)"
@@ -222,10 +223,16 @@ runs:
         apt_ok=""
         if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" = "true" ]; then
           echo "forcing protoc GitHub fallback for setup action self-test"
+        elif [ "${RUNNER_ENVIRONMENT}" != "self-hosted" ]; then
+          # GitHub-hosted Ubuntu mirrors can wedge apt-get update until the
+          # entire job timeout. The release fallback below is pinned by version
+          # and checksum, needs no elevated package-manager state, and is the
+          # deterministic hosted-runner install path.
+          echo "using pinned protoc release on GitHub-hosted runner"
         elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-          # GitHub-hosted Ubuntu images include Microsoft feeds that are unrelated
-          # to our protoc install. If those feeds return 403, apt-get update fails
-          # before it can use the Ubuntu repositories we actually need.
+          # Some persistent Ubuntu images include Microsoft feeds that are
+          # unrelated to our protoc install. If those feeds return 403,
+          # apt-get update fails before it can use the Ubuntu repositories.
           while IFS= read -r source_file; do
             if [[ "${source_file}" == *.disabled ]]; then
               echo "Microsoft apt source already disabled: ${source_file}"
@@ -245,11 +252,12 @@ runs:
           done
         fi
         if [ -z "$apt_ok" ]; then
-          # Sudo-free fallback: fetch the pinned protoc release into a user-writable
-          # dir and put it on PATH. Works on self-hosted runners without passwordless
-          # sudo or when Ubuntu mirrors fail. The checksum keeps the privileged
-          # build dependency from trusting an unauthenticated release asset.
-          echo "apt unavailable/failed; installing protoc from GitHub release (sudo-free)"
+          # Package-manager-free fallback: fetch the pinned protoc release into a
+          # user-writable dir and put it on PATH. This is the normal hosted-runner
+          # path and also covers self-hosted runners without usable apt. The
+          # checksum keeps the build dependency from trusting an unauthenticated
+          # release asset.
+          echo "installing protoc from pinned GitHub release"
           protoc_version=27.3
           case "${PROTOC_RUNNER_ARCH}" in
             X64)

--- a/packages/scripts/__tests__/ci-setup-bun-workspace-protoc.test.ts
+++ b/packages/scripts/__tests__/ci-setup-bun-workspace-protoc.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the composite workspace setup's protoc bootstrap policy. GitHub-hosted
+ * lanes must bypass apt and use the checksummed release, while self-hosted
+ * runners retain the bounded apt path and the same release fallback.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const actionPath = fileURLToPath(
+  new URL(
+    "../../../.github/actions/setup-bun-workspace/action.yml",
+    import.meta.url,
+  ),
+);
+const action = readFileSync(actionPath, "utf8");
+const runnerEnvironmentExpression = "$" + "{{ runner.environment }}";
+const runnerEnvironmentVariable = "$" + "{RUNNER_ENVIRONMENT}";
+const protocChecksumVariable = "$" + "{protoc_sha256}";
+
+describe("setup-bun-workspace protoc bootstrap", () => {
+  test("routes hosted runners directly to the pinned release", () => {
+    expect(action).toContain(
+      `RUNNER_ENVIRONMENT: ${runnerEnvironmentExpression}`,
+    );
+    expect(action).toContain(
+      `elif [ "${runnerEnvironmentVariable}" != "self-hosted" ]; then`,
+    );
+    expect(action).toContain(
+      "using pinned protoc release on GitHub-hosted runner",
+    );
+
+    const hostedBranch = action.indexOf(
+      `elif [ "${runnerEnvironmentVariable}" != "self-hosted" ]; then`,
+    );
+    const aptBranch = action.indexOf(
+      "elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then",
+    );
+    expect(hostedBranch).toBeGreaterThan(-1);
+    expect(aptBranch).toBeGreaterThan(hostedBranch);
+  });
+
+  test("keeps the fallback version and both architecture checksums pinned", () => {
+    expect(action).toContain("protoc_version=27.3");
+    expect(action).toContain(
+      "6dab2adab83f915126cab53540d48957c40e9e9023969c3e84d44bfb936c7741",
+    );
+    expect(action).toContain(
+      "bdad36f3ad7472281d90568c4956ea2e203c216e0de005c6bd486f1920f2751c",
+    );
+    expect(action).toContain(
+      `echo "${protocChecksumVariable}  $dest/protoc.zip" | sha256sum -c -`,
+    );
+  });
+});


### PR DESCRIPTION
Refs #18076

## Summary

- route GitHub-hosted Linux runners directly to the existing version-pinned, SHA-256-verified protoc release
- retain the bounded apt path for self-hosted runners and the same release fallback when apt is unavailable
- add a deterministic contract test for hosted routing, pinned version, architecture checksums, and checksum verification

## Why

App Live E2E staging run 32229709334 hung twice inside setup-bun-workspace before Bun installation. Attempt 1 logs show apt update waiting on Ubuntu mirror traffic from 07:55 until the 45-minute job timeout. The product/auth path never ran. GitHub-hosted runners do not need mutable apt state for protoc because this action already carries a pinned release and checksums.

## Exact-head evidence

- Head: `f2d1db29799a94178afb4114c143fbbdd7985175`
- Base: `bad793372ea9a08fd91c97c8cd9dfc34fc84a24c`
- `bun install --frozen-lockfile`: PASS
- focused contract: 2/2 PASS
- targeted Biome: PASS
- `git diff --check`: PASS
- `bun run verify`: PASS, 358/358 Turbo tasks; anti-larp 8,973 files clean

No staging credential, deployment, provider, or product behavior changed. The real acceptance remains a fresh staging lane after merge.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [billing-root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->