### PR TITLE
fix(computeruse): restore Vitest package lane

### DIFF
--- a/plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts
@@ -1,5 +1,5 @@
 /** Exercises canonical and malformed Wayland portal file URI decoding. */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 import { portalFileUriToPath } from "./wayland-portal.ts";
 
 describe("wayland portal file URI encoding", () => {

--- a/plugins/plugin-computeruse/src/routes/computer-use-compat-local-trust.test.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-compat-local-trust.test.ts
@@ -1,5 +1,5 @@
 /** Exercises the real shared trust classifier through the computer-use policy wrapper. */
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isTrustedComputerUseLocalRequest } from "./computer-use-compat-local-trust.js";
 
 function req(

--- a/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.encoding.test.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.encoding.test.ts
@@ -6,10 +6,6 @@ import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@elizaos/core", () => ({
-  resolveAliasedEnvValue: () => undefined,
-}));
-
 const { handleComputerUseCompatRoutes } = await import(
   "./computer-use-compat-routes.js"
 );

--- a/plugins/plugin-computeruse/vitest.config.ts
+++ b/plugins/plugin-computeruse/vitest.config.ts
@@ -9,6 +9,7 @@ import { defineConfig } from "vitest/config";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coreSrcRoot = path.resolve(__dirname, "../../packages/core/src");
 const loggerSrcRoot = path.resolve(__dirname, "../../packages/logger/src");
+const sharedSrcRoot = path.resolve(__dirname, "../../packages/shared/src");
 const cloudRoutingSrcRoot = path.resolve(
   __dirname,
   "../../packages/cloud/routing/src",
@@ -52,6 +53,14 @@ export default defineConfig({
       {
         find: /^@elizaos\/logger\/(.*)$/,
         replacement: path.join(loggerSrcRoot, "$1"),
+      },
+      {
+        find: /^@elizaos\/shared$/,
+        replacement: path.join(sharedSrcRoot, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/shared\/(.*)$/,
+        replacement: path.join(sharedSrcRoot, "$1"),
       },
     ],
   },


### PR DESCRIPTION
# Relates to

Closes #22429.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is rebased on `origin/develop@0717f457296ec031e42f540b2229de166dbc64ae`.
- [x] Root `bun run verify` passed on the final tree.
- [x] The complete package suite passes without prebuilt `packages/shared/dist` output.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

- Uses Vitest imports in the two package tests that incorrectly imported `bun:test` even though the package's declared runner is Vitest.
- Removes the incomplete whole-module `@elizaos/core` mock from the approval-route encoding test so transitive real exports remain available.
- Aliases `@elizaos/shared` to source in the Vitest config, matching core/logger/cloud-routing so fresh checkouts do not require prebuilt shared output before collection.

No runtime or production code changes.

# Risks

Very low. The diff only repairs test-harness wiring and makes previously dead suites execute under the canonical package runner.

# Exact verification

Exact head `f4376a09f24d2e78a341cd8d5e8e9d7711b75adc`:

```text
bun run --cwd plugins/plugin-computeruse test
with packages/shared/dist temporarily absent
Test Files  93 passed | 1 skipped (94)
Tests       826 passed | 17 skipped (843)

bun run --cwd plugins/plugin-computeruse typecheck
passed

bun run --cwd plugins/plugin-computeruse lint:check
Checked 217 files. No fixes applied.

bun run --cwd plugins/plugin-computeruse format:check
Checked 217 files. No fixes applied.

bun run verify
Tasks: 358 successful, 358 total
anti-larp: scanned 8993 test files; clean

git diff --check
no output - pass
```

# Evidence Gate

<!-- evidence-head:f4376a09f24d2e78a341cd8d5e8e9d7711b75adc -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic test-harness repair; exact test output is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Review notes

The rebase and source alias changed the exact head, so previous approvals should be treated as stale until reviewers confirm this revision. This author has not self-approved or self-merged the PR.

— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->
