### PR TITLE
fix(plugin-x): stop outgoing sendTweet from advancing the mention cursor

### DIFF
--- a/plugins/plugin-x/src/interactions-mention-cursor.test.ts
+++ b/plugins/plugin-x/src/interactions-mention-cursor.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression test for #22433: an outgoing publish (`sendTweet`) must not advance
+ * the incoming @mention cursor, so a mention that arrived before a scheduled post
+ * is still processed by `processMentionTweets` instead of being silently skipped.
+ * The harness wires the real `sendTweet` and `TwitterInteractionClient` against a
+ * deterministic in-memory cursor and a mocked runtime/messageService.
+ */
+import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "./base";
+import type { Tweet } from "./client";
+import { TwitterInteractionClient } from "./interactions";
+import type { TwitterClientState } from "./types";
+import { sendTweet } from "./utils";
+
+// The plugin test shim for `@elizaos/core` omits prompt helpers the mention flow
+// depends on. Use the node source entry, matching the sibling interactions suites.
+vi.mock("@elizaos/core", async () => {
+  const node = await import("@elizaos/core/node");
+  return node;
+});
+
+const PROFILE_ID = "bot-user";
+
+function createRuntime(settings: Record<string, string> = {}) {
+  const cache = new Map<string, unknown>();
+  const createMemory = vi.fn(async () => undefined);
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+    character: { name: "Agent", templates: {} },
+    composeState: vi.fn(async () => ({ values: {}, data: {}, text: "" })),
+    createMemory,
+    emitEvent: vi.fn(),
+    ensureConnection: vi.fn(async () => undefined),
+    ensureRoomExists: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    updateWorld: vi.fn(async () => undefined),
+    cache,
+    getCache: vi.fn(async (key: string) => cache.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    deleteCache: vi.fn(async (key: string) => cache.delete(key)),
+    getMemoryById: vi.fn(async () => null),
+    getMemories: vi.fn(async () => []),
+    getSetting: vi.fn((key: string) => settings[key]),
+    reportError: vi.fn(),
+    useModel: vi.fn(async () => ""),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    messageService: {
+      handleMessage: vi.fn(async () => ({ responseMessages: [] })),
+    },
+  };
+  return runtime as unknown as IAgentRuntime & typeof runtime;
+}
+
+/**
+ * Build a ClientBase whose mention cursor is a real, monotonic in-memory value
+ * updated through the same `record`/`get` methods the production code uses, so
+ * both `sendTweet` and `processMentionTweets` observe one shared cursor.
+ */
+function createClient(runtime: IAgentRuntime, send: ReturnType<typeof vi.fn>) {
+  let cursor: bigint | null = null;
+  const authenticatedProfile = {
+    id: PROFILE_ID,
+    username: "bot",
+    screenName: "Bot",
+    bio: "",
+    nicknames: [],
+  };
+  const twitterClient = {
+    sendTweet: send,
+    getTweetsV2: vi.fn(async () => []),
+  };
+  const client = {
+    accountId: "default",
+    runtime,
+    profile: authenticatedProfile,
+    twitterClient,
+    withAuthenticatedSession: vi.fn(
+      async (operation: (session: unknown) => Promise<unknown>) =>
+        operation({
+          client: twitterClient,
+          profile: authenticatedProfile,
+          revision: 1,
+        }),
+    ),
+    isAuthenticatedSessionCurrent: vi.fn(() => true),
+    getLatestCheckedTweetId: vi.fn((profileId: string) =>
+      profileId === PROFILE_ID ? cursor : null,
+    ),
+    recordLatestCheckedTweetId: vi.fn((profileId: string, id: bigint) => {
+      if (profileId !== PROFILE_ID) return;
+      if (cursor !== null && id <= cursor) return;
+      cursor = id;
+    }),
+    cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+    cacheTweet: vi.fn(async () => undefined),
+  };
+  return client as unknown as ClientBase;
+}
+
+function mention(overrides: Partial<Tweet> = {}): Tweet {
+  return {
+    id: "1000000000000000500",
+    userId: "user-1",
+    username: "alice",
+    name: "Alice",
+    conversationId: "1000000000000000500",
+    text: "@bot are you there?",
+    timestamp: Date.now(),
+    thread: [],
+    permanentUrl: "https://x.com/alice/status/1000000000000000500",
+    ...overrides,
+  } as Tweet;
+}
+
+describe("outgoing post vs. incoming mention cursor (#22433)", () => {
+  beforeEach(() => {
+    logger.log = vi.fn();
+    logger.info = vi.fn();
+    logger.warn = vi.fn();
+    logger.error = vi.fn();
+  });
+
+  it("still processes a pre-existing mention after a scheduled post publishes a newer tweet", async () => {
+    const runtime = createRuntime();
+    const send = vi.fn().mockResolvedValue({
+      data: { data: { id: "1000000000000001000", text: "gm" } },
+    });
+    const client = createClient(runtime, send);
+    const interactions = new TwitterInteractionClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    );
+
+    // A mention arrived and the interactions loop has advanced the cursor to a
+    // point strictly below it (e.g. the previous run stopped just before it).
+    const mentionId = "1000000000000000500";
+    const startingCursor = 1_000_000_000_000_000_400n;
+    client.recordLatestCheckedTweetId(PROFILE_ID, startingCursor);
+    // Sanity: with this cursor the mention is considered new.
+    expect(client.getLatestCheckedTweetId(PROFILE_ID)).toBe(startingCursor);
+    expect(BigInt(mentionId) > startingCursor).toBe(true);
+
+    // A scheduled post fires first and publishes a much newer tweet id.
+    await sendTweet(client, "gm");
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // The cursor must be unchanged by the outgoing publish (the core of #22433).
+    // Had it advanced to the outgoing id, the older mention would be skipped.
+    expect(client.getLatestCheckedTweetId(PROFILE_ID)).toBe(startingCursor);
+
+    // Now the interactions loop runs and must process the pending mention.
+    await interactions.processMentionTweets([mention({ id: mentionId })]);
+
+    // The incoming mention was saved as a memory (handled, not skipped) ...
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    const savedMemory = vi.mocked(runtime.createMemory).mock.calls[0]?.[0] as
+      | { content: { text: string } }
+      | undefined;
+    expect(savedMemory?.content.text).toBe("@bot are you there?");
+    // ... and it was routed through the message service for a reply decision.
+    expect(runtime.messageService?.handleMessage).toHaveBeenCalledTimes(1);
+    // ... and only now does the cursor advance to the processed mention id.
+    expect(client.getLatestCheckedTweetId(PROFILE_ID)).toBe(BigInt(mentionId));
+  });
+
+  it("skips a mention already at or below the cursor without a send in between", async () => {
+    const runtime = createRuntime();
+    const send = vi.fn();
+    const client = createClient(runtime, send);
+    const interactions = new TwitterInteractionClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    );
+
+    const mentionId = "1000000000000000500";
+    // The interactions loop legitimately owns the cursor and has already passed
+    // this mention id; it must not be reprocessed.
+    client.recordLatestCheckedTweetId(PROFILE_ID, BigInt(mentionId));
+
+    await interactions.processMentionTweets([mention({ id: mentionId })]);
+
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService?.handleMessage).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-x/src/utils.test.ts
+++ b/plugins/plugin-x/src/utils.test.ts
@@ -24,11 +24,114 @@ function profile(id: string): TwitterProfile {
 }
 
 describe("sendTweet", () => {
-  it("returns the accepted tweet when local cache bookkeeping fails after publish", async () => {
+  it("does not advance the mention cursor when publishing an outgoing tweet", async () => {
+    // Regression for #22433: an outgoing post must never move the incoming
+    // mention cursor (`lastCheckedTweetId`). The published tweet always carries
+    // the newest snowflake id, so advancing the cursor here would silently skip
+    // every unprocessed @mention older than this post.
+    const authenticatedProfile = profile("account-a");
+    const setCache = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache,
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    // A mention arrived earlier and the interactions loop has already advanced
+    // the cursor to it. The outgoing post below carries a strictly newer id.
+    const pendingMentionCursor = 1_000_000_000_000_000_500n;
+    client.profile = authenticatedProfile;
+    client.recordLatestCheckedTweetId(
+      authenticatedProfile.id,
+      pendingMentionCursor,
+    );
+    const send = vi.fn().mockResolvedValue({
+      data: { data: { id: "1000000000000001000", text: "gm" } },
+    });
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: {} as never,
+        profile: authenticatedProfile,
+        revision: 1,
+      });
+    client.isAuthenticatedSessionCurrent = () => true;
+
+    await expect(sendTweet(client, "gm")).resolves.toMatchObject({
+      id: "1000000000000001000",
+      text: "gm",
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    // The cursor is unchanged even though the published id is much newer.
+    expect(client.getLatestCheckedTweetId(authenticatedProfile.id)).toBe(
+      pendingMentionCursor,
+    );
+    // No cursor persistence write happened for the outgoing publish.
+    expect(
+      setCache.mock.calls.some(([key]) =>
+        String(key).endsWith("latest_checked_tweet_id"),
+      ),
+    ).toBe(false);
+    // The tweet itself is still cached for later reference.
+    expect(setCache).toHaveBeenCalledWith(
+      "twitter/tweets/1000000000000001000",
+      expect.objectContaining({
+        id: "1000000000000001000",
+        userId: "account-a",
+        username: "account-a",
+      }),
+    );
+  });
+
+  it("leaves a null mention cursor untouched after publishing", async () => {
+    // With no prior mention checkpoint, a send must not seed the cursor either;
+    // the interactions loop, not the poster, owns the very first checkpoint.
+    const authenticatedProfile = profile("account-a");
+    const setCache = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache,
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    client.profile = authenticatedProfile;
+    expect(client.getLatestCheckedTweetId(authenticatedProfile.id)).toBeNull();
+    client.twitterClient = {
+      sendTweet: vi.fn().mockResolvedValue({
+        data: { data: { id: "1000000000000002000", text: "hello" } },
+      }),
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: {} as never,
+        profile: authenticatedProfile,
+        revision: 1,
+      });
+    client.isAuthenticatedSessionCurrent = () => true;
+
+    await sendTweet(client, "hello");
+
+    expect(client.getLatestCheckedTweetId(authenticatedProfile.id)).toBeNull();
+    expect(
+      setCache.mock.calls.some(([key]) =>
+        String(key).endsWith("latest_checked_tweet_id"),
+      ),
+    ).toBe(false);
+  });
+
+  it("reports a local receipt failure without advancing the cursor when tweet caching fails", async () => {
     const authenticatedProfile = profile("account-a");
     const reportError = vi.fn();
     const setCache = vi.fn(async (key: string) => {
-      if (key.endsWith("latest_checked_tweet_id")) {
+      if (key.startsWith("twitter/tweets/")) {
         throw new Error("cache unavailable");
       }
     });
@@ -61,18 +164,13 @@ describe("sendTweet", () => {
       text: "hello",
     });
     expect(send).toHaveBeenCalledTimes(1);
-    expect(setCache).toHaveBeenCalledWith(
-      "twitter/default/account-a/latest_checked_tweet_id",
-      "123",
-    );
     expect(reportError).toHaveBeenCalledWith(
       "X.sendTweet.localReceipt",
       expect.any(Error),
       { accountId: "default", tweetId: "123" },
     );
-    expect(
-      setCache.mock.calls.some(([key]) => String(key) === "twitter/tweets/123"),
-    ).toBe(false);
+    // Even on the failure path the cursor stays untouched.
+    expect(client.getLatestCheckedTweetId(authenticatedProfile.id)).toBeNull();
   });
 
   it("does not let a delayed account A receipt overwrite account B's cursor", async () => {

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -255,8 +255,14 @@ export async function sendTweet(
     }
 
     try {
-      client.recordLatestCheckedTweetId(profile.id, BigInt(tweetResult.id));
-      await client.cacheLatestCheckedTweetId(profile);
+      // Do NOT advance the mention cursor (`lastCheckedTweetId`) on an outgoing
+      // publish. That cursor is the primary gate `processMentionTweets` uses to
+      // decide which incoming @mentions are new; because a freshly-published
+      // tweet always has the newest snowflake id, moving it here would silently
+      // skip every unprocessed mention that arrived before this post. The
+      // interactions loop owns and persists the cursor, and the self-tweet
+      // filter (`tweet.userId !== profileId`) already prevents self-replies, so
+      // the only local bookkeeping a send needs is caching the tweet itself.
       await client.cacheTweet({
         ...tweetResult,
         userId: profile.id,


### PR DESCRIPTION
# Relates to

Closes #22433

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; focused package gates (test, typecheck,
      lint) pass. `bun run verify` is a whole-repo gate; see **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@87da9c8ba169440f0fb21dc613f7bc425c8014b6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`cf75fd3b90`); zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** (whole-repo
      gate not run on this constrained machine; focused plugin-x gates pass).

# Risks

Low. The change *removes* an incorrect side effect from `sendTweet` (it no longer
mutates the shared mention cursor). No public type, export, or signature changes.
The cursor remains owned and persisted by the interactions loop exactly as before;
self-replies are still prevented by the existing `tweet.userId !== profileId`
filter. Worst case if wrong: the agent could re-observe its own outgoing tweet as a
"new" mention — but that path is already guarded by the self-tweet filter, so there
is no new re-entrancy.

# Background

## What does this PR do?

Fixes a silent mention-drop in `@elizaos/plugin-x`. `sendTweet` (`src/utils.ts`)
advanced `client.lastCheckedTweetId` to the id of **every outgoing tweet** it
published (posts, replies, chunked threads) and persisted it via
`cacheLatestCheckedTweetId()`. That same field is the primary gate the
mention-processing loop uses to decide which incoming @mentions are new
(`processMentionTweets`, `src/interactions.ts`):

```ts
const lastCheckedTweetId = this.client.getLatestCheckedTweetId(profileId);
if (lastCheckedTweetId === null || BigInt(tweet.id) > lastCheckedTweetId) { /* handle */ }
```

Because a freshly published tweet always carries the newest snowflake id, any
scheduled post drove the cursor forward to "now". Every @mention that arrived
before the agent's most recent outgoing tweet and had not yet been processed was
silently skipped — and the skip happens **before** the per-tweet memory/dedup
check, so there was no other backstop.

The fix removes the send-side cursor mutation and its `cacheLatestCheckedTweetId()`
persist, keeping only the `cacheTweet(...)` receipt. The mention cursor is owned
and persisted by the interactions loop (it records per processed mention and caches
at the end of each run), and the self-tweet filter already prevents self-replies, so
the removed update served no purpose.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. No documented
contract described the removed side effect; the cursor's documented owner (the
interactions loop) is unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/utils.ts` — the removed cursor mutation inside `sendTweet`.
Then the two regression suites:
- `plugins/plugin-x/src/utils.test.ts` (unit: cursor unchanged after publishing)
- `plugins/plugin-x/src/interactions-mention-cursor.test.ts` (end-to-end of the
  post → mention interaction against the real `sendTweet` + `TwitterInteractionClient`)

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-x test        # vitest run
bun run --cwd plugins/plugin-x typecheck
bun run --cwd plugins/plugin-x lint:check
```

# Evidence Gate

<!-- evidence-head:d4af739cdbbd060aa88a5e13d6050941d74e4f17 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend connector change, no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend connector change, no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no UI/user flow; behavior is a server-side polling loop.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — focused plugin-x regression, failing-before / passing-after (full copy also at https://gist.github.com/agent-cortex/078ccaae62dae129b4aa6ca7ffa634a5):

```
=== FAILING-BEFORE (fix reverted) ===
 x interactions-mention-cursor > still processes a pre-existing mention after a scheduled post publishes a newer tweet
 x utils > sendTweet > does not advance the mention cursor when publishing an outgoing tweet
 x utils > sendTweet > leaves a null mention cursor untouched after publishing
 x utils > sendTweet > reports a local receipt failure without advancing the cursor when tweet caching fails
 Test Files  2 failed (2)
      Tests  4 failed | 5 passed (9)
=== PASSING-AFTER (fix applied) ===
 ok interactions-mention-cursor > still processes a pre-existing mention after a scheduled post publishes a newer tweet
 ok interactions-mention-cursor > skips a mention already at or below the cursor without a send in between
 ok utils > sendTweet > does not advance the mention cursor when publishing an outgoing tweet
 ok utils > sendTweet > leaves a null mention cursor untouched after publishing
 ok utils > sendTweet > reports a local receipt failure without advancing the cursor when tweet caching fails
 Test Files  2 passed (2)
      Tests  9 passed (9)
 typecheck: tsc --noEmit -p tsconfig.json  -> exit 0, no output
 lint:check: biome check . -> Checked 92 files. No fixes applied.
```
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the fix removes a bookkeeping side effect and does not change any prompt, model, action-selection, or provider path; the mention gate is a pure BigInt comparison exercised deterministically below.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — before/after mention-freshness gate trace for the same mention id (full copy at https://gist.github.com/agent-cortex/c33eeb54b2bfbd7af27c3f5609f02ff8):

```
cursor (interactions loop checkpoint) = 1000000000000000400
pending incoming mention id           = 1000000000000000500
unrelated outgoing scheduled post id  = 1000000000000001000
--- BEFORE FIX (buggy: outgoing post advances the cursor, mention dropped) ---
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(before send)=PROCESS
[trace] outgoing post id=1000000000000001000 published
[trace] cursor=1000000000000001000 mention=1000000000000000500 gate(after send)=SKIP
--- AFTER FIX (outgoing post leaves cursor untouched, mention still processed) ---
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(before send)=PROCESS
[trace] outgoing post id=1000000000000001000 published
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(after send)=PROCESS
```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes. The changed contract
is the mention-freshness gate, a deterministic BigInt comparison covered by the tests
below.`

## Backend + frontend logs

**Before/after mention-gate trace for the same mention id** (produced with a throwaway
harness that drives the real `sendTweet` and mirrors the `processMentionTweets` gate;
harness removed after capture). Cursor starts at `…400`, a pending mention is `…500`,
and an unrelated outgoing post is `…1000`:

Before the fix (buggy — outgoing post advances the cursor and the older mention is dropped):

```
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(before send)=PROCESS
[trace] outgoing post id=1000000000000001000 published
[trace] cursor=1000000000000001000 mention=1000000000000000500 gate(after send)=SKIP
```

After the fix (outgoing post leaves the cursor untouched; the older mention is still processed):

```
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(before send)=PROCESS
[trace] outgoing post id=1000000000000001000 published
[trace] cursor=1000000000000000400 mention=1000000000000000500 gate(after send)=PROCESS
```

**Failing-before / passing-after focused tests.** With the fix reverted, the new
regression cases fail (4 failed / 5 passed):

```
❯ src/interactions-mention-cursor.test.ts (2 tests | 1 failed)
  × still processes a pre-existing mention after a scheduled post publishes a newer tweet
❯ src/utils.test.ts (7 tests | 3 failed)
  × does not advance the mention cursor when publishing an outgoing tweet
  × leaves a null mention cursor untouched after publishing
  × reports a local receipt failure without advancing the cursor when tweet caching fails
 Test Files  2 failed (2)
      Tests  4 failed | 5 passed (9)
```

Example assertion failure (buggy cursor moved to the outgoing id):

```
FAIL  src/utils.test.ts > sendTweet > leaves a null mention cursor untouched after publishing
AssertionError: expected 1000000000000002000n to be null
```

With the fix in place, all pass:

```
✓ src/interactions-mention-cursor.test.ts > … > still processes a pre-existing mention after a scheduled post publishes a newer tweet
✓ src/interactions-mention-cursor.test.ts > … > skips a mention already at or below the cursor without a send in between
✓ src/utils.test.ts > sendTweet > does not advance the mention cursor when publishing an outgoing tweet
✓ src/utils.test.ts > sendTweet > leaves a null mention cursor untouched after publishing
✓ src/utils.test.ts > sendTweet > reports a local receipt failure without advancing the cursor when tweet caching fails
✓ src/utils.test.ts > sendTweet > does not let a delayed account A receipt overwrite account B's cursor
✓ src/utils.test.ts > sendTweet > never regresses a same-account cursor when sends settle out of order
✓ src/utils.test.ts > sendTweet > keeps a chunked thread on one captured session and captured profile
✓ src/utils.test.ts > sendTweet > aborts a chunked thread before another egress when its captured session rotates
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

**Full package suite** (unrelated pre-existing failure noted in Known gaps):

```
 Test Files  1 failed | 33 passed | 1 skipped (35)
      Tests  239 passed | 13 skipped (252)
```

**Typecheck + lint (clean):**

```
$ bun run --cwd plugins/plugin-x typecheck
$ tsc --noEmit -p tsconfig.json      # exit 0, no output

$ bun run --cwd plugins/plugin-x lint:check
$ bunx @biomejs/biome check .
Checked 92 files in 529ms. No fixes applied.
```

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - backend connector polling-loop change with no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/audio path touched.`

## Known gaps / failures

- `bun run verify` (whole-repo gate) was not run on this constrained machine; the
  owning package's focused gates (test, typecheck, lint) all pass and are shown above.
- One pre-existing, unrelated suite fails in the full package run:
  `src/lifeops-message-adapter.encoding.test.ts` imports from `bun:test` (it is a
  `bun test` file, not a vitest file) and additionally requires a built
  `@elizaos/core/node`. It is unmodified by this PR (no diff vs `origin/develop`) and
  fails identically on a clean checkout, so it is not a blocker for this change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@87da9c8ba169440f0fb21dc613f7bc425c8014b6:packages/skills/skills/contribute-to-eliza"} -->