### PR TITLE
fix(ci): persist exact staging Cloud live receipt

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -406,7 +406,35 @@ jobs:
         run: bun run --cwd packages/app build:web
 
       - name: Run real STAGING cloud login + provision + chat
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium
+        id: staging-cloud-smoke
+        shell: bash
+        run: |
+          set -uo pipefail
+          started_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+          echo "started_ms=$started_ms" >> "$GITHUB_OUTPUT"
+          set +e
+          bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium
+          test_status=$?
+          set -e
+          completed_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+          echo "completed_ms=$completed_ms" >> "$GITHUB_OUTPUT"
+          exit "$test_status"
+
+      - name: Write secret-free staging receipt
+        if: ${{ always() && steps.staging-cloud-smoke.outcome != 'skipped' }}
+        env:
+          TEST_OUTCOME: ${{ steps.staging-cloud-smoke.outcome }}
+          TEST_STARTED_MS: ${{ steps.staging-cloud-smoke.outputs.started_ms }}
+          TEST_COMPLETED_MS: ${{ steps.staging-cloud-smoke.outputs.completed_ms }}
+        run: |
+          node packages/scripts/write-staging-cloud-receipt.mjs \
+            --output artifacts/app-live-e2e/cloud-staging-receipt.json \
+            --source-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --outcome "$TEST_OUTCOME" \
+            --started-ms "$TEST_STARTED_MS" \
+            --completed-ms "$TEST_COMPLETED_MS"
 
       - name: Record what this lane drove
         if: ${{ always() }}
@@ -418,14 +446,15 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload cloud-live staging artifacts
-        if: ${{ always() }}
+        if: ${{ always() && steps.staging-cloud-smoke.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: app-live-e2e-cloud-staging
           path: |
+            artifacts/app-live-e2e/cloud-staging-receipt.json
             packages/app/playwright-report/
             packages/app/test-results/
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 7
 
   # Real on-device LOCAL provisioning + chat on Android: boots an emulator, builds

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -18,6 +18,8 @@ function read(path: string): string {
 
 interface WorkflowStep {
   env?: Record<string, string>;
+  id?: string;
+  if?: string;
   name?: string;
   uses?: string;
   run?: string;
@@ -244,6 +246,31 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
     );
     expect(prodUpload?.with?.name).toBe("app-live-e2e-cloud");
     expect(stagingUpload?.with?.name).toBe("app-live-e2e-cloud-staging");
+  });
+
+  test("uploads a mandatory exact-SHA, secret-free receipt for every executed smoke", () => {
+    const smoke = stagingStep(
+      "Run real STAGING cloud login + provision + chat",
+    );
+    const receipt = stagingStep("Write secret-free staging receipt");
+    const upload = stagingStep("Upload cloud-live staging artifacts");
+
+    expect(smoke.id).toBe("staging-cloud-smoke");
+    expect(smoke.run).toContain('echo "started_ms=$started_ms"');
+    expect(smoke.run).toContain('echo "completed_ms=$completed_ms"');
+    expect(receipt.if).toContain(
+      "steps.staging-cloud-smoke.outcome != 'skipped'",
+    );
+    expect(receipt.run).toContain("write-staging-cloud-receipt.mjs");
+    expect(receipt.run).toContain('--source-sha "$GITHUB_SHA"');
+    expect(receipt.run).not.toMatch(
+      /ELIZAOS_CLOUD_API_KEY|authorization|bearer/i,
+    );
+    expect(upload.if).toBe(receipt.if);
+    expect(upload.with?.path).toContain(
+      "artifacts/app-live-e2e/cloud-staging-receipt.json",
+    );
+    expect(upload.with?.["if-no-files-found"]).toBe("error");
   });
 });
 

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Contract tests for the staging Cloud live receipt's closed, secret-free schema.
+ */
+import { describe, expect, test } from "bun:test";
+import { createStagingCloudReceipt } from "../write-staging-cloud-receipt.mjs";
+
+const exactSha = "87da9c8ba169440f0fb21dc613f7bc425c8014b6";
+
+function args(overrides: Record<string, string> = {}): string[] {
+  const values = {
+    output: "/tmp/staging-cloud-receipt.json",
+    "source-sha": exactSha,
+    "run-id": "32237956456",
+    "run-attempt": "1",
+    outcome: "success",
+    "started-ms": "1787151674000",
+    "completed-ms": "1787151717600",
+    ...overrides,
+  };
+  return Object.entries(values).flatMap(([name, value]) => [
+    `--${name}`,
+    value,
+  ]);
+}
+
+describe("staging Cloud live receipt", () => {
+  test("binds successful evidence to the exact SHA, run, duration, and fixed annotations", () => {
+    expect(createStagingCloudReceipt(args())).toEqual({
+      schemaVersion: 1,
+      lane: "app-live-e2e-cloud-staging",
+      sourceSha: exactSha,
+      workflow: { runId: 32237956456, runAttempt: 1 },
+      result: {
+        outcome: "success",
+        startedAtMs: 1787151674000,
+        completedAtMs: 1787151717600,
+        durationMs: 43600,
+      },
+      annotations: {
+        cloudApiOrigin: "https://api-staging.eliza.app",
+        cloudEnvironment: "staging",
+        rendererSource: "local-checkout",
+        deployedRendererTested: false,
+        loginProvisionChatPassed: true,
+      },
+    });
+  });
+
+  test("records a failed test without claiming login, provision, or chat passed", () => {
+    const receipt = createStagingCloudReceipt(args({ outcome: "failure" }));
+    expect(receipt.result.outcome).toBe("failure");
+    expect(receipt.annotations.loginProvisionChatPassed).toBe(false);
+  });
+
+  test("rejects abbreviated SHAs, invalid outcomes, and impossible timing", () => {
+    expect(() =>
+      createStagingCloudReceipt(args({ "source-sha": exactSha.slice(0, 8) })),
+    ).toThrow("exact lowercase 40-hex commit SHA");
+    expect(() =>
+      createStagingCloudReceipt(args({ outcome: "skipped" })),
+    ).toThrow("outcome must be success or failure");
+    expect(() =>
+      createStagingCloudReceipt(
+        args({
+          "started-ms": "1787151717600",
+          "completed-ms": "1787151674000",
+        }),
+      ),
+    ).toThrow("must not precede");
+  });
+
+  test("rejects unknown inputs so credentials and raw responses cannot enter the artifact", () => {
+    expect(() =>
+      createStagingCloudReceipt([...args(), "--bearer", "secret"]),
+    ).toThrow("unsupported argument: --bearer");
+    expect(() =>
+      createStagingCloudReceipt([...args(), "--raw-response", "{}"]),
+    ).toThrow("unsupported argument: --raw-response");
+
+    const serialized = JSON.stringify(createStagingCloudReceipt(args()));
+    expect(serialized).not.toMatch(
+      /bearer|authorization|api.?key|response|reply/i,
+    );
+  });
+});

--- a/packages/scripts/write-staging-cloud-receipt.mjs
+++ b/packages/scripts/write-staging-cloud-receipt.mjs
@@ -1,0 +1,135 @@
+/**
+ * Writes the durable, secret-free receipt for the staging Cloud live lane.
+ *
+ * The schema is deliberately closed: callers provide only GitHub identity,
+ * timing, and outcome values, while Cloud annotations are fixed here. Bearer
+ * credentials, model replies, and raw HTTP bodies can never enter the file.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const EXPECTED_ARGUMENTS = new Set([
+  "output",
+  "source-sha",
+  "run-id",
+  "run-attempt",
+  "outcome",
+  "started-ms",
+  "completed-ms",
+]);
+
+function fail(message) {
+  throw new Error(`[staging-cloud-receipt] ${message}`);
+}
+
+function parseArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail("arguments must be --name value pairs");
+    }
+    const name = flag.slice(2);
+    if (!EXPECTED_ARGUMENTS.has(name)) {
+      fail(`unsupported argument: ${flag}`);
+    }
+    if (values.has(name)) {
+      fail(`duplicate argument: ${flag}`);
+    }
+    values.set(name, value);
+  }
+
+  for (const name of EXPECTED_ARGUMENTS) {
+    if (!values.has(name)) {
+      fail(`missing argument: --${name}`);
+    }
+  }
+  return values;
+}
+
+function positiveInteger(value, name) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    fail(`${name} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    fail(`${name} exceeds the safe integer range`);
+  }
+  return parsed;
+}
+
+function timestamp(value, name) {
+  if (!/^\d{13}$/.test(value)) {
+    fail(`${name} must be a 13-digit Unix timestamp in milliseconds`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    fail(`${name} exceeds the safe integer range`);
+  }
+  return parsed;
+}
+
+export function createStagingCloudReceipt(argv) {
+  const values = parseArguments(argv);
+  const sourceSha = values.get("source-sha");
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+    fail("source-sha must be an exact lowercase 40-hex commit SHA");
+  }
+
+  const outcome = values.get("outcome");
+  if (outcome !== "success" && outcome !== "failure") {
+    fail("outcome must be success or failure");
+  }
+
+  const startedAtMs = timestamp(values.get("started-ms"), "started-ms");
+  const completedAtMs = timestamp(values.get("completed-ms"), "completed-ms");
+  if (completedAtMs < startedAtMs) {
+    fail("completed-ms must not precede started-ms");
+  }
+
+  return {
+    schemaVersion: 1,
+    lane: "app-live-e2e-cloud-staging",
+    sourceSha,
+    workflow: {
+      runId: positiveInteger(values.get("run-id"), "run-id"),
+      runAttempt: positiveInteger(values.get("run-attempt"), "run-attempt"),
+    },
+    result: {
+      outcome,
+      startedAtMs,
+      completedAtMs,
+      durationMs: completedAtMs - startedAtMs,
+    },
+    annotations: {
+      cloudApiOrigin: "https://api-staging.eliza.app",
+      cloudEnvironment: "staging",
+      rendererSource: "local-checkout",
+      deployedRendererTested: false,
+      loginProvisionChatPassed: outcome === "success",
+    },
+  };
+}
+
+export async function writeStagingCloudReceipt(argv) {
+  const values = parseArguments(argv);
+  const outputPath = resolve(values.get("output"));
+  const receipt = createStagingCloudReceipt(argv);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return outputPath;
+}
+
+if (import.meta.main) {
+  try {
+    const outputPath = await writeStagingCloudReceipt(process.argv.slice(2));
+    process.stdout.write(`${outputPath}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
# Relates to

Related to #18076. This draft deliberately does not close the issue: a reviewed, authorized staging rerun must still prove the new receipt at the exact PR head.

- [x] Targets `develop` and is rebased onto exact `origin/develop` `cf75fd3b909068fe4f5029fdd8323774f5b86426` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] The predecessor live run and the remaining exact-head acceptance step are explicit below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head: `a02e4196f805f2f4143bce00fedc39abf26f6c27`
- [x] Exact base: `cf75fd3b909068fe4f5029fdd8323774f5b86426`
- [x] Clean one-commit branch; no rebase conflicts.
- [x] Exact-head `bun run verify` passes: 358/358 Turbo tasks and every repository audit.

# Risks

Low. The change is isolated to the opt-in staging Cloud live job and a deterministic receipt writer. The principal risk is an invalid receipt input causing the staging job to fail closed; the live test itself, staging origin, credential scope, and production lane are unchanged.

# Background

## What does this PR do?

The successful staging run [32237956456 / job 96022036345](https://github.com/elizaOS/eliza/actions/runs/32237956456/job/96022036345) proved the real staging origin and login/provision/chat path at `87da9c8ba169440f0fb21dc613f7bc425c8014b6`, but the artifact upload retained nothing because passing Playwright runs produced neither configured report directory and `if-no-files-found` was `ignore`.

This patch makes every executed staging smoke write a mandatory JSON receipt containing only:

- the exact 40-hex checkout SHA and numeric workflow run identity;
- measured start, completion, and duration milliseconds;
- success/failure outcome;
- fixed annotations for the staging API origin, staging environment, locally built renderer, and whether login/provision/chat passed.

The writer has a closed argument/schema allowlist. The workflow does not pass the Cloud API credential to it, and bearer, authorization, API-key, raw-response, or model-reply data cannot enter the receipt. Failure receipts explicitly set `loginProvisionChatPassed: false`. The staging upload now includes the receipt and uses `if-no-files-found: error`; optional Playwright diagnostic directories remain included when they exist.

No Cloud call, provisioning run, deployment, secret change, or issue-state mutation was performed while preparing this PR.

## What kind of change is this?

Bug fix to CI evidence retention; no production runtime or UI behavior changes.

# Documentation changes needed?

N/A - the workflow, receipt schema, and contract tests are the maintained operator contract.

# Testing

## Where should a reviewer start?

1. `.github/workflows/app-live-e2e.yml` staging smoke/receipt/upload steps.
2. `packages/scripts/write-staging-cloud-receipt.mjs` closed schema and validation.
3. `packages/scripts/__tests__/staging-cloud-receipt.test.ts` adversarial inputs.
4. `packages/scripts/__tests__/app-live-e2e-workflow.test.ts` workflow wiring.

## Exact-head verification

- `bun test packages/scripts/__tests__/staging-cloud-receipt.test.ts packages/scripts/__tests__/app-live-e2e-workflow.test.ts` — 17 pass, 0 fail, 66 assertions.
- `bunx biome check packages/scripts/write-staging-cloud-receipt.mjs packages/scripts/__tests__/staging-cloud-receipt.test.ts packages/scripts/__tests__/app-live-e2e-workflow.test.ts` — clean.
- `bun run audit:workflow-triggers` — 54 workflows verified.
- `bun run audit:scripts` — pass, no orphan/no-op/broken scripts.
- `bun run audit:scripts:inventory` — 112 scripts, zero orphan files.
- `bun run verify` — 358/358 Turbo tasks; all repository audits pass; anti-larp scanned 8,975 test files clean.
- A generated receipt was parsed with `jq`, asserted at exactly 43,600 ms, and scanned to contain none of `bearer`, `authorization`, `api key`, `raw response`, or `reply`.

# Evidence Gate

<!-- evidence-head:a02e4196f805f2f4143bce00fedc39abf26f6c27 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI evidence plumbing only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI evidence plumbing only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code changed, and an exact-head live staging rerun is intentionally deferred until independent review. The predecessor run is linked in Background as context, not exact-head acceptance.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - the renderer and frontend behavior are unchanged; this patch only retains workflow evidence.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic CI receipt generation does not invoke a language model.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact-head live receipt is intentionally pending independent review and an authorized staging dispatch; this task forbids provider/provisioning mutations.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface or text rendering changed.

# Known gaps / failures

- The predecessor run is not exact-head evidence for this implementation. After independent review, an authorized staging dispatch must download and inspect `app-live-e2e-cloud-staging` and confirm `cloud-staging-receipt.json` binds to the dispatched SHA. Until then this PR remains draft and #18076 remains open.
- The receipt proves the locally built checkout renderer against the staging API; it does not claim to test a deployed staging Pages artifact.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [staging-evidence]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
