### PR TITLE
fix(plugin-capacitor-bridge): count memory stats without row scans

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -86,6 +86,9 @@ function createFakeRuntime(): IAgentRuntime {
 				? rows.slice(offset, offset + cap)
 				: rows.slice(offset);
 		},
+		async countMemories(params: { tableName?: string }): Promise<number> {
+			return (tables.get(params.tableName ?? "messages") ?? []).length;
+		},
 		async getMemoryById(id: UUID): Promise<Memory | null> {
 			for (const rows of tables.values()) {
 				const found = rows.find((m) => m.id === id);
@@ -375,6 +378,34 @@ describe("iOS bridge — memories view routes", () => {
 			total: 3,
 			byType: { messages: 2, memories: 0, facts: 1, documents: 0 },
 		});
+	});
+
+	it("stats uses exact counts without materializing capped row windows", async () => {
+		runtime.getMemories = vi.fn(async () => {
+			throw new Error("stats must not read rows");
+		});
+		const values: Record<string, number> = {
+			messages: 25_000,
+			memories: 4,
+			facts: 3,
+			documents: 2,
+		};
+		runtime.countMemories = vi.fn(
+			async ({ tableName }) => values[tableName ?? "messages"] ?? 0,
+		);
+
+		const { status, json } = await call(backend, "GET", "/api/memories/stats");
+		expect(status).toBe(200);
+		expect(json).toEqual({ total: 25_009, byType: values });
+		expect(runtime.countMemories).toHaveBeenCalledTimes(4);
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
+
+	it("stats fails closed on an invalid adapter count", async () => {
+		runtime.countMemories = vi.fn(async () => Number.NaN);
+		await expect(
+			call(backend, "GET", "/api/memories/stats"),
+		).rejects.toMatchObject({ code: "MEMORY_STATS_INVALID_COUNT" });
 	});
 });
 

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -407,6 +407,27 @@ describe("iOS bridge — memories view routes", () => {
 			call(backend, "GET", "/api/memories/stats"),
 		).rejects.toMatchObject({ code: "MEMORY_STATS_INVALID_COUNT" });
 	});
+
+	it("stats fails closed when individually safe counts overflow in aggregate", async () => {
+		runtime.getMemories = vi.fn(async () => {
+			throw new Error("stats must not fall back to reading rows");
+		});
+		const values: Record<string, number> = {
+			messages: Number.MAX_SAFE_INTEGER,
+			memories: 1,
+			facts: 0,
+			documents: 0,
+		};
+		runtime.countMemories = vi.fn(
+			async ({ tableName }) => values[tableName ?? "messages"] ?? 0,
+		);
+
+		await expect(
+			call(backend, "GET", "/api/memories/stats"),
+		).rejects.toMatchObject({ code: "MEMORY_STATS_INVALID_COUNT" });
+		expect(runtime.countMemories).toHaveBeenCalledTimes(4);
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
 });
 
 describe("iOS bridge — transcripts view routes", () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1488,21 +1488,34 @@ async function handleMemoriesBrowseRoute(
 async function handleMemoriesStatsRoute(
 	runtime: IAgentRuntime,
 ): Promise<BufferedHttpResponse> {
-	const counts: Record<string, number> = {};
-	let total = 0;
-
-	for (const tableName of MEMORY_TABLE_NAMES) {
-		const memories = await runtime.getMemories({
-			agentId: runtime.agentId as UUID,
-			tableName,
-			limit: 10000,
-			includeEmbedding: false,
+	// `countMemories` is a required IAgentRuntime contract and maps to SQL COUNT
+	// in production. Do not hide an adapter failure behind a bulk row read: that
+	// would both mask the outage and reintroduce the resource problem this route
+	// is meant to remove.
+	const entries = await Promise.all(
+		MEMORY_TABLE_NAMES.map(async (tableName) => {
+			const count = await runtime.countMemories({
+				tableName,
+				agentId: runtime.agentId as UUID,
+			});
+			if (!Number.isSafeInteger(count) || count < 0) {
+				throw new ElizaError("Memory adapter returned an invalid count", {
+					code: "MEMORY_STATS_INVALID_COUNT",
+					context: { tableName, count },
+				});
+			}
+			return [tableName, count] as const;
+		}),
+	);
+	const byType = Object.fromEntries(entries) as Record<string, number>;
+	const total = entries.reduce((sum, [, count]) => sum + count, 0);
+	if (!Number.isSafeInteger(total)) {
+		throw new ElizaError("Memory total exceeds the safe integer range", {
+			code: "MEMORY_STATS_INVALID_COUNT",
+			context: { total },
 		});
-		counts[tableName] = memories.length;
-		total += memories.length;
 	}
-
-	return jsonResponse(200, { total, byType: counts });
+	return jsonResponse(200, { total, byType });
 }
 
 // ── Transcript routes (mirror plugin-local-inference TranscriptStore) ─────────


### PR DESCRIPTION
## Problem

The iOS memory stats route materialized up to 10,000 complete rows from each of four tables and reported each capped array length as an exact count. Large tables therefore saturated silently at 10,000 while a stats request could load 40,000 row bodies just to compute lengths.

The submitted feed/browse work is no longer part of this PR: current `develop` already superseded it with bounded `(createdAt,id)` keyset pagination, no-progress validation, and a shared 25,000-row scan ceiling. Reintroducing the submitted exponential exact-search drain would weaken those protections.

## Final fix

- Use the required `IAgentRuntime.countMemories` contract for all four tables; production plugin-sql implements this as filtered SQL `COUNT(*)`.
- Run the independent counts concurrently.
- Require every count and their sum to be non-negative safe integers; malformed adapter output fails closed with `MEMORY_STATS_INVALID_COUNT`.
- Preserve the existing `{ total, byType }` response shape.
- Do not catch count failures or fall back to bulk row reads, which would mask a database outage and recreate the resource problem.

## Exact-head evidence

Exact repaired head: `ce74b672f8e7ead25d7ecb559857b5b422d2d9e3`, based on `develop` `4765731de71b8915cc3860ce997c6ade06eb824e`.

- Production route suite: 23/23 green, including 25,009 rows counted with zero `getMemories` calls, invalid individual counts, and individually-safe counts whose aggregate exceeds `Number.MAX_SAFE_INTEGER`.
- iOS bridge lane was exercised across all six files; focused exact route output is the acceptance receipt.
- Package typecheck: green.
- Publishable package build and declaration generation: green.
- Biome on both changed files and `git diff --check`: green.
- Real SQL implementation inspected: `countMemories` applies table and agent predicates and emits `COUNT(*)`; no row content is selected.

This is a nonvisual, deterministic in-process stats boundary. Screenshots, video, model trajectories, and native-device interaction are N/A because no rendered UI, model/planner behavior, or platform API changed.

Relates to #22061

## Contribution provenance

- Original contribution AI assistance: yes
- Original provider/model: anthropic / claude-opus-5[1m]
- Original tooling: Claude Code
- Maintainer repair provider/model: OpenAI / gpt-5.6-sol
- Maintainer tooling: Codex Desktop multi-agent
- Attribution status: self-reported

<!-- evidence-head:ce74b672f8e7ead25d7ecb559857b5b422d2d9e3 -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent"} -->