### PR TITLE
fix(plugin-capacitor-bridge): scope transcript DELETE to transcripts

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Object-scope contract for the transcripts routes.
+ *
+ * `/api/transcripts/:id` addresses transcripts. GET and PUT already enforce
+ * that by refusing an id whose memory is not a transcript, so DELETE must
+ * refuse the same ids rather than acting as a delete primitive for the whole
+ * memory store.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { handleDirectCoreRoute, type IosBridgeBackend } from "./bridge.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+function createFakeRuntime(): IAgentRuntime {
+	const tables = new Map<string, Memory[]>();
+	return {
+		agentId: AGENT_ID,
+		character: { name: "TestAgent" },
+		async getMemories(params: {
+			tableName: string;
+			count?: number;
+			limit?: number;
+		}): Promise<Memory[]> {
+			const rows = [...(tables.get(params.tableName) ?? [])];
+			rows.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+			const cap = params.count ?? params.limit;
+			return typeof cap === "number" ? rows.slice(0, cap) : rows;
+		},
+		async getMemoryById(id: UUID): Promise<Memory | null> {
+			for (const rows of tables.values()) {
+				const found = rows.find((m) => m.id === id);
+				if (found) return found;
+			}
+			return null;
+		},
+		async createMemory(memory: Memory, tableName: string): Promise<UUID> {
+			const rows = tables.get(tableName) ?? [];
+			rows.push(memory);
+			tables.set(tableName, rows);
+			return memory.id as UUID;
+		},
+		async deleteMemory(id: UUID): Promise<void> {
+			for (const rows of tables.values()) {
+				const idx = rows.findIndex((m) => m.id === id);
+				if (idx >= 0) rows.splice(idx, 1);
+			}
+		},
+		async updateMemory(): Promise<boolean> {
+			return true;
+		},
+	} as unknown as IAgentRuntime;
+}
+
+function makeBackend(runtime: IAgentRuntime): IosBridgeBackend {
+	return {
+		runtime,
+		dispatchRoute: async () => null,
+		conversations: new Map(),
+		close: async () => {},
+	};
+}
+
+async function call(
+	backend: IosBridgeBackend,
+	method: string,
+	rawPath: string,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+	const res = await handleDirectCoreRoute(backend, method, rawPath, {});
+	if (!res) throw new Error(`route returned null: ${method} ${rawPath}`);
+	return { status: res.status, json: JSON.parse(res.body) };
+}
+
+describe("iOS bridge — transcripts route object scope", () => {
+	let runtime: IAgentRuntime;
+	let backend: IosBridgeBackend;
+	const MESSAGE_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
+
+	beforeEach(async () => {
+		runtime = createFakeRuntime();
+		backend = makeBackend(runtime);
+		// A plain message: not a transcript, addressed by the same id space.
+		await runtime.createMemory(
+			{
+				id: MESSAGE_ID,
+				entityId: AGENT_ID,
+				roomId: AGENT_ID,
+				agentId: AGENT_ID,
+				createdAt: 1_000,
+				content: { text: "an ordinary message" },
+			} as Memory,
+			"messages",
+		);
+	});
+
+	it("GET refuses an id that is not a transcript", async () => {
+		const { status } = await call(
+			backend,
+			"GET",
+			`/api/transcripts/${MESSAGE_ID}`,
+		);
+		expect(status).toBe(404);
+	});
+
+	it("DELETE refuses an id that is not a transcript, and does not delete it", async () => {
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${MESSAGE_ID}`,
+		);
+		expect(status).toBe(404);
+		// The unrelated memory must survive.
+		expect(await runtime.getMemoryById(MESSAGE_ID)).not.toBeNull();
+	});
+
+	it("DELETE still removes a real transcript", async () => {
+		const created = await handleDirectCoreRoute(
+			backend,
+			"POST",
+			"/api/transcripts",
+			{
+				body: JSON.stringify({
+					segments: [
+						{
+							id: "s1",
+							speakerLabel: "Speaker 1",
+							startMs: 0,
+							endMs: 10,
+							text: "hello",
+							words: [],
+						},
+					],
+				}),
+			},
+		);
+		if (!created) throw new Error("create returned null");
+		const id = (JSON.parse(created.body) as { transcript: { id: string } })
+			.transcript.id;
+
+		const { status } = await call(backend, "DELETE", `/api/transcripts/${id}`);
+		expect(status).toBe(200);
+		expect(await runtime.getMemoryById(id as UUID)).toBeNull();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1704,6 +1704,13 @@ async function handleTranscriptsRoute(
 	}
 
 	if (method === "DELETE") {
+		// `/api/transcripts/:id` addresses transcripts only. GET and PUT already
+		// refuse an id whose memory is not one; deleting without the same check
+		// turned this route into a delete primitive for every memory the agent
+		// owns, since any message, fact, or document id would be accepted here
+		// and removed with a 200.
+		const existing = await getTranscript(runtime, id);
+		if (!existing) return jsonResponse(404, { error: "not found" });
 		await runtime.deleteMemory(id);
 		return jsonResponse(200, { ok: true });
 	}


### PR DESCRIPTION
## Problem

`DELETE /api/transcripts/:id` called `runtime.deleteMemory(id)` with no check that the id belonged to a transcript, so the transcripts endpoint deleted any memory the agent owned — a message, fact, or document — and answered `200 {ok:true}` as though it had removed a transcript.

The guard is asymmetric on the same route. `rowToTranscript` returns `null` unless the row carries a JSON `content.transcript`, so GET and PUT both resolve through `getTranscript` and refuse a non-transcript id with 404. Only DELETE skipped it, which made the transcripts route a delete primitive for the whole memory store.

| method on `/api/transcripts/:id` | non-transcript memory id |
| --- | --- |
| GET | 404 — guarded |
| PUT | 404 — guarded |
| DELETE | **deletes it, returns 200** |

Same shape as #22338, where `read()`/`list()` enforced an invariant `write()` did not.

## Fix

DELETE resolves the transcript first and 404s when the id is not one, matching PUT. Seven added lines in one branch of one handler. **No successful-response shape changes** — the fix only turns an incorrect 200 into the 404 the sibling methods already return, so no existing contract assertion moves.

## Evidence

`src/ios/bridge.transcript-scope.test.ts` drives the real exported `handleDirectCoreRoute` against a fake runtime holding one ordinary message (no `content.transcript`):

| assertion | at HEAD (`bad793372`) | with fix |
| --- | --- | --- |
| GET refuses a non-transcript id | pass — already guarded | pass |
| DELETE refuses it and leaves it intact | **FAIL** — `expected 200 to be 404`, message destroyed | pass |
| DELETE still removes a real transcript | pass | pass |

Only the DELETE assertion moves between the two heads, so the coverage is load-bearing on exactly this change while pinning both the existing guard and the positive path against regression.

- iOS bridge suite — **53 passed**, 6/6 files
- `biome check` — clean

Fixes #22440

AI provider/model: anthropic / claude-opus-5[1m]
Client / agent tooling: Claude Code
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5[1m]","client":"Claude Code"} -->
