### PR TITLE
fix(plugin-capacitor-bridge): guard every path-component decode, not just transcripts

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.path-encoding.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.path-encoding.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Malformed percent-encoding in a path component must produce a 400, not an
+ * exception escaping the request.
+ *
+ * `bridge.transcripts.encoding.test.ts` already pins this for
+ * `/api/transcripts/:id`. Nothing wraps the bridge's route dispatch, so every
+ * other path parameter needs the same guard: an unguarded
+ * `decodeURIComponent` throws `URIError` straight out of the request.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	fetchBackendStream,
+	handleDirectCoreRoute,
+	type IosBridgeBackend,
+	type StreamEmitFrame,
+} from "./bridge.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+/** The tokens the transcripts encoding suite already treats as malformed. */
+const MALFORMED = ["%", "%2", "%ZZ", "%E0%A4"] as const;
+
+function makeBackend(): IosBridgeBackend {
+	return {
+		runtime: {
+			agentId: AGENT_ID,
+			character: { name: "TestAgent" },
+			async getMemories() {
+				return [];
+			},
+			async getMemoryById() {
+				return null;
+			},
+			async createMemory() {
+				return AGENT_ID;
+			},
+			async deleteMemory() {},
+			async updateMemory() {
+				return true;
+			},
+		} as unknown as IAgentRuntime,
+		dispatchRoute: async () => null,
+		conversations: new Map(),
+		close: async () => {},
+	};
+}
+
+describe("iOS bridge — malformed path-component encoding", () => {
+	it.each(MALFORMED)(
+		"browser-workspace tab id %s is rejected with 400",
+		async (token) => {
+			const res = await handleDirectCoreRoute(
+				makeBackend(),
+				"DELETE",
+				`/api/browser-workspace/tabs/${token}`,
+				{},
+			);
+			expect(res?.status).toBe(400);
+			expect(JSON.parse(res?.body ?? "{}")).toMatchObject({
+				error: expect.stringMatching(/malformed URL encoding/),
+			});
+		},
+	);
+
+	it.each(MALFORMED)(
+		"conversation message id %s is rejected with 400",
+		async (token) => {
+			const res = await handleDirectCoreRoute(
+				makeBackend(),
+				"POST",
+				`/api/conversations/${token}/messages`,
+				{},
+			);
+			expect(res?.status).toBe(400);
+		},
+	);
+
+	it.each(MALFORMED)(
+		"buffered conversation stream id %s is rejected with 400",
+		async (token) => {
+			const res = await handleDirectCoreRoute(
+				makeBackend(),
+				"POST",
+				`/api/conversations/${token}/messages/stream`,
+				{},
+			);
+			expect(res?.status).toBe(400);
+		},
+	);
+
+	it.each(MALFORMED)(
+		"local-inference verify model id %s is rejected with 400",
+		async (token) => {
+			const res = await handleDirectCoreRoute(
+				makeBackend(),
+				"POST",
+				`/api/local-inference/installed/${token}/verify`,
+				{},
+			);
+			expect(res?.status).toBe(400);
+		},
+	);
+
+	it.each(MALFORMED)(
+		"streaming conversation id %s emits a 400 rather than throwing",
+		async (token) => {
+			const events: StreamEmitFrame[] = [];
+			const result = await fetchBackendStream(
+				makeBackend(),
+				{ path: `/api/conversations/${token}/messages/stream`, method: "POST" },
+				"stream-1",
+				async (event: StreamEmitFrame) => {
+					events.push(event);
+				},
+			);
+			expect(result).toEqual({ streamId: "stream-1", done: true });
+			const response = events.find((e) => e.kind === "response");
+			expect(response).toMatchObject({ status: 400 });
+			// The stream must still be closed out, not abandoned mid-flight.
+			expect(events.some((e) => e.kind === "complete")).toBe(true);
+		},
+	);
+
+	it("a canonical percent-encoded id still reaches its route", async () => {
+		// %2D is a well-formed encoding of "-": it must decode, not 400.
+		const res = await handleDirectCoreRoute(
+			makeBackend(),
+			"DELETE",
+			"/api/browser-workspace/tabs/btab%2Dmissing",
+			{},
+		);
+		expect(res?.status).toBe(404);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1007,7 +1007,30 @@ export async function fetchBackendStream(
 		return { streamId, done: true };
 	}
 
-	const conversationId = decodeURIComponent(match[1] ?? "");
+	const conversationId = decodePathComponent(match[1] ?? "");
+	if (conversationId === null) {
+		// Mirror the buffered route's 400 as stream frames rather than throwing
+		// out of the emitter, which would abandon the stream with no response.
+		await emit({
+			streamId,
+			kind: "response",
+			status: 400,
+			statusText: statusTextForCode(400),
+			headers: { "content-type": "application/json; charset=utf-8" },
+		});
+		await emit({
+			streamId,
+			kind: "chunk",
+			dataBase64: Buffer.from(
+				JSON.stringify({
+					error: "invalid conversation id: malformed URL encoding",
+				}),
+				"utf8",
+			).toString("base64"),
+		});
+		await emit({ streamId, kind: "complete", error: null });
+		return { streamId, done: true };
+	}
 	const body = parseRequestBody(payload);
 	await streamConversationMessageResponse(
 		backend,
@@ -1608,13 +1631,25 @@ async function persistTranscript(
 	return transcript;
 }
 
-function decodeTranscriptId(raw: string): UUID | null {
+/**
+ * Decode one path component, or null when the percent-encoding is malformed.
+ *
+ * `decodeURIComponent` throws a `URIError` on input like `%`, `%2`, or `%ZZ`.
+ * Nothing wraps the bridge's route dispatch, so an unguarded decode turns a
+ * malformed request path into an exception escaping the whole request instead
+ * of the 400 every other invalid path input produces.
+ */
+function decodePathComponent(raw: string): string | null {
 	try {
-		return decodeURIComponent(raw) as UUID;
+		return decodeURIComponent(raw);
 	} catch {
-		// error-policy:J3 Malformed transcript encoding is invalid path input.
+		// error-policy:J3 Malformed encoding is invalid path input, not a fault.
 		return null;
 	}
+}
+
+function decodeTranscriptId(raw: string): UUID | null {
+	return decodePathComponent(raw) as UUID | null;
 }
 
 async function handleTranscriptsRoute(
@@ -1796,7 +1831,13 @@ function handleBrowserWorkspaceRoute(
 	);
 	if (!match) return null;
 
-	const tabId = decodeURIComponent(match[1] ?? "").trim();
+	const decodedTabId = decodePathComponent(match[1] ?? "");
+	if (decodedTabId === null) {
+		return jsonResponse(400, {
+			error: "invalid browser tab id: malformed URL encoding",
+		});
+	}
+	const tabId = decodedTabId.trim();
 	const action = match[2] ?? null;
 	const index = iosBrowserWorkspaceTabs.findIndex((tab) => tab.id === tabId);
 	if (index < 0) {
@@ -3845,7 +3886,12 @@ async function handleNativeIosLocalInferenceRoute(
 		/^\/api\/local-inference\/installed\/([^/]+)\/verify$/,
 	);
 	if (method === "POST" && verifyMatch?.[1]) {
-		const id = decodeURIComponent(verifyMatch[1]);
+		const id = decodePathComponent(verifyMatch[1] ?? "");
+		if (id === null) {
+			return jsonResponse(400, {
+				error: "invalid model id: malformed URL encoding",
+			});
+		}
 		const model = readInstalledModels().find((entry) => entry.id === id);
 		if (!model)
 			return jsonResponse(404, { error: `Model not installed: ${id}` });
@@ -4463,7 +4509,12 @@ export async function handleDirectCoreRoute(
 		return jsonResponse(200, { messages: [] });
 	}
 	if (method === "POST" && messageStreamMatch) {
-		const conversationId = decodeURIComponent(messageStreamMatch[1] ?? "");
+		const conversationId = decodePathComponent(messageStreamMatch[1] ?? "");
+		if (conversationId === null) {
+			return jsonResponse(400, {
+				error: "invalid conversation id: malformed URL encoding",
+			});
+		}
 		const conversation = backend.conversations.get(conversationId);
 		if (!conversation) {
 			return jsonResponse(404, { error: "Conversation not found" });
@@ -4475,7 +4526,12 @@ export async function handleDirectCoreRoute(
 		return bufferedConversationStreamResponse(result);
 	}
 	if (method === "POST" && messageMatch) {
-		const conversationId = decodeURIComponent(messageMatch[1] ?? "");
+		const conversationId = decodePathComponent(messageMatch[1] ?? "");
+		if (conversationId === null) {
+			return jsonResponse(400, {
+				error: "invalid conversation id: malformed URL encoding",
+			});
+		}
 		const conversation = backend.conversations.get(conversationId);
 		if (!conversation) {
 			return jsonResponse(404, { error: "Conversation not found" });


### PR DESCRIPTION
## Problem

`decodeURIComponent` throws `URIError` on malformed percent-encoding. Nothing wraps the bridge's route dispatch — `fetchBackendResponse` awaits `handleDirectCoreRoute` with no `try`/`catch` — so an unguarded decode turns a malformed request path into an exception escaping the entire request instead of the 400 every other invalid path input produces.

`/api/transcripts/:id` was already fixed for this, and `bridge.transcripts.encoding.test.ts` pins the contract: malformed tokens yield **400 before lookup**. The guard was never applied to the other five decoders in the same file:

- `/api/browser-workspace/tabs/:id`
- `/api/conversations/:id/messages`
- `/api/conversations/:id/messages/stream` (buffered)
- `/api/local-inference/installed/:id/verify`
- `/api/conversations/:id/messages/stream` (streaming, `fetchBackendStream`)

## Fix

`decodeTranscriptId` is generalised into `decodePathComponent`, returning null on malformed encoding, and every site answers 400 with the same "malformed URL encoding" shape as transcripts.

The streaming entry needs different handling: returning a response object is not available there, so it emits the 400 as `response` and `chunk` frames and still emits `complete`. Throwing out of the emitter would abandon the stream with no response at all, which is what happens today.

After the change the only `decodeURIComponent` left in the file is the one inside the guard.

## Exact-head evidence

Exact reviewed head: `2687cbb3684bf7efbc69576c5dc534b813c7c53f`, rebased on current `develop` `9e5299cab`.

`src/ios/bridge.path-encoding.test.ts` drives the real exported `handleDirectCoreRoute` and `fetchBackendStream`, over the same four malformed tokens the transcripts suite uses (`%`, `%2`, `%ZZ`, `%E0%A4`) across all five sites:

| | at HEAD (`bad793372`) | with fix |
| --- | --- | --- |
| 20 malformed-token assertions | **FAIL** — `URIError: URI malformed` | pass |
| canonical `%2D` still decodes and routes | pass | pass |

Only the malformed cases move. The canonical-encoding assertion holds at **both** heads, which is the point of including it: it proves the guard cannot have over-corrected into rejecting valid ids. The streaming assertion additionally checks a `complete` frame is still emitted, so a rejected stream is closed rather than abandoned.

- iOS bridge suite — **71 passed**, 6/6 files
- `biome check` — clean

Fixes #22442


Maintainer review: deep caller and transport audit, exact 21/21 regression plus 71/71 iOS bridge suite, package typecheck and publishable build, Biome, and diff-check green. No model, prompt, planner, or rendered UI behavior changes; live-model and visual evidence are N/A.

Review attribution: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.

<!-- evidence-head:2687cbb3684bf7efbc69576c5dc534b813c7c53f -->

AI provider/model: anthropic / claude-opus-5[1m]
Client / agent tooling: Claude Code
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5[1m]","client":"Claude Code"} -->


