### PR TITLE
fix(plugin-personal-assistant): sort interaction gaps before taking follow-up cadence median

### DIFF
--- a/plugins/plugin-personal-assistant/src/followup/followup-tracker.test.ts
+++ b/plugins/plugin-personal-assistant/src/followup/followup-tracker.test.ts
@@ -89,4 +89,67 @@ describe("computeOverdueFollowups passive recency", () => {
       daysOverdue: 4,
     });
   });
+
+  it("uses the statistical median (not the temporal-middle gap) for irregular cadence", async () => {
+    // Chronological interaction gaps are [1d, 30d, 2d]. The gaps array derived
+    // from time-sorted interactions is itself in temporal order, so the middle
+    // element (30d) is not the median. The true median is 2d, which clamps to
+    // the 3-day floor. A regression here (issue #22444) reads 30d and fails to
+    // flag a contact that has been silent for 7 days.
+    const runtime = runtimeWithContacts([
+      contact({
+        entityId: "10000000-0000-0000-0000-000000000003" as UUID,
+        customFields: { displayName: "Robin" },
+        lastInteractionAt: "2026-06-03T12:00:00.000Z",
+        interactions: [
+          { occurredAt: "2026-05-01T12:00:00.000Z" },
+          { occurredAt: "2026-05-02T12:00:00.000Z" },
+          { occurredAt: "2026-06-01T12:00:00.000Z" },
+          { occurredAt: "2026-06-03T12:00:00.000Z" },
+        ],
+      }),
+    ]);
+
+    const now = Date.parse("2026-06-10T12:00:00.000Z");
+    const digest = await computeOverdueFollowups(runtime, now, 30);
+
+    expect(digest.overdue).toHaveLength(1);
+    expect(digest.overdue[0]).toMatchObject({
+      displayName: "Robin",
+      thresholdDays: 3,
+      daysOverdue: 4,
+    });
+  });
+
+  it("holds the median at the low floor when one outlier gap sits in the temporal middle", async () => {
+    // Chronological gaps [2d, 2d, 40d, 2d, 2d]: the temporal-middle element is
+    // the 40d outlier, but the sorted median is 2d (clamped to the 3-day floor).
+    // The buggy positional-middle read would set a 40d threshold and leave a
+    // 10-day-silent contact unflagged.
+    const runtime = runtimeWithContacts([
+      contact({
+        entityId: "10000000-0000-0000-0000-000000000004" as UUID,
+        customFields: { displayName: "Sasha" },
+        lastInteractionAt: "2026-05-19T12:00:00.000Z",
+        interactions: [
+          { occurredAt: "2026-04-01T12:00:00.000Z" },
+          { occurredAt: "2026-04-03T12:00:00.000Z" },
+          { occurredAt: "2026-04-05T12:00:00.000Z" },
+          { occurredAt: "2026-05-15T12:00:00.000Z" },
+          { occurredAt: "2026-05-17T12:00:00.000Z" },
+          { occurredAt: "2026-05-19T12:00:00.000Z" },
+        ],
+      }),
+    ]);
+
+    const now = Date.parse("2026-05-29T12:00:00.000Z");
+    const digest = await computeOverdueFollowups(runtime, now, 30);
+
+    expect(digest.overdue).toHaveLength(1);
+    expect(digest.overdue[0]).toMatchObject({
+      displayName: "Sasha",
+      thresholdDays: 3,
+      daysOverdue: 7,
+    });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/followup/followup-tracker.ts
+++ b/plugins/plugin-personal-assistant/src/followup/followup-tracker.ts
@@ -193,6 +193,13 @@ function resolveLearnedCadenceDays(contact: ContactInfo): number | null {
   }
   if (gaps.length === 0) return null;
 
+  // Sort gaps ascending before indexing: the gaps are derived from
+  // chronologically-ordered interactionTimes and so are themselves in temporal
+  // order, not value order. Without this sort `gaps[middle]` is the middle gap
+  // in time, not the statistical median, which skews the learned threshold for
+  // any contact with irregular cadence (issue #22444).
+  gaps.sort((a, b) => a - b);
+
   const middle = Math.floor(gaps.length / 2);
   const median =
     gaps.length % 2 === 1


### PR DESCRIPTION
# Relates to

Closes #22444

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; owning-package test/typecheck/lint pass (see below). `bun run verify` is a full-repo gate not completed on this constrained machine — the exact blocker is recorded in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ae9bb7b21f5dce095c88ef21b064f0b8d5417730:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` — see **Known gaps / failures** (full-repo gate not completed on this machine; scoped package gates pass).

# Risks

Low. The change is a single `Array.prototype.sort` insertion inside the private
`resolveLearnedCadenceDays` helper. It only affects the *learned* cadence path
(contacts with no explicit `followupThresholdDays` override and ≥2 recorded
interactions). Even-cadence contacts are unaffected because a sorted and an
already-monotonic gap array coincide there, which the retained existing test
pins.

# Background

## What does this PR do?

`resolveLearnedCadenceDays()` in
`plugins/plugin-personal-assistant/src/followup/followup-tracker.ts` computes the
median interaction gap to derive a contact's follow-up threshold. It builds the
`gaps` array from **chronologically-sorted** `interactionTimes`, so the gaps are
in *temporal* order, not value order — yet it indexed `gaps[middle]` **without
sorting the gaps**. For any contact with irregular cadence it therefore returned
the temporal-middle gap, not the statistical median, producing a wrong learned
threshold. That wrong threshold flags contacts overdue too early or — as
reproduced — fails to flag a genuinely overdue contact, and the value propagates
onto the emitted `followup_overdue_digest` memory, the `LIST_OVERDUE_FOLLOWUPS`
action, and the background planner snapshot.

Fix: sort `gaps` ascending before computing `middle`/`median` (one line plus an
intent comment).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/followup/followup-tracker.test.ts` — two
new cases pin the statistical-median contract; the existing even-cadence case is
retained to prove no regression on the path where sorted and unsorted order
coincide.

## Detailed testing steps

```bash
bun install --linker hoisted   # environment note in Known gaps
cd plugins/plugin-personal-assistant
npx vitest run --config vitest.config.ts src/followup/followup-tracker.test.ts
bun run typecheck
bunx @biomejs/biome check src/followup/followup-tracker.ts src/followup/followup-tracker.test.ts
```

# Evidence Gate

<!-- evidence-head:c01c0a1c1f891ae374123d80fe91d3968fc74dee -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - no UI surface; change is a pure computation in a background tracker helper`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - no UI surface; change is a pure computation in a background tracker helper`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no UI/user flow; behavior is exercised by the vitest regression below`.
<!-- evidence-row:backend-logs -->
- [x] Backend/domain code path (`computeOverdueFollowups`) fired end to end through the vitest regression; transcript inline below and mirrored at [22450-followup-median-evidence.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence/22450-followup-median-evidence.txt).
<details><summary>vitest — computeOverdueFollowups (fix applied, full suite)</summary>

```
 RUN  v4.1.5 plugins/plugin-personal-assistant
 ✓ computeOverdueFollowups passive recency > uses RelationshipsService lastInteractionAt written by real message ingestion 5ms
 ✓ computeOverdueFollowups passive recency > learns cadence from observed interaction intervals when no override exists 3ms
 ✓ computeOverdueFollowups passive recency > uses the statistical median (not the temporal-middle gap) for irregular cadence 1ms
 ✓ computeOverdueFollowups passive recency > holds the median at the low floor when one outlier gap sits in the temporal middle 1ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — `N/A - no frontend request/response involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change; the fix is a deterministic median computation`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact under test is the digest `thresholdDays`/`overdue`; failing-before / passing-after transcript inline below and mirrored at [22450-followup-median-evidence.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence/22450-followup-median-evidence.txt).
<details><summary>vitest — same two median cases, fix reverted (regression proof)</summary>

```
 ✓ computeOverdueFollowups passive recency > uses RelationshipsService lastInteractionAt written by real message ingestion 5ms
 ✓ computeOverdueFollowups passive recency > learns cadence from observed interaction intervals when no override exists 3ms
 × computeOverdueFollowups passive recency > uses the statistical median (not the temporal-middle gap) for irregular cadence 8ms
 × computeOverdueFollowups passive recency > holds the median at the low floor when one outlier gap sits in the temporal middle 2ms
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic, non-LLM code path.`

## Backend + frontend logs

Frontend: `N/A - no frontend surface`.

Backend / domain: the tracker helper is driven through the public
`computeOverdueFollowups` entry point in the regression suite. See below.

## Domain artifacts (failing-before / passing-after)

**Before the fix** (sort line reverted) — the two new median cases fail because
the unsorted median returns the temporal-middle gap (30d / 40d), so the overdue
contact is not flagged:

<details><summary>vitest — fix reverted</summary>

```
 ✓ ... > uses RelationshipsService lastInteractionAt written by real message ingestion
 ✓ ... > learns cadence from observed interaction intervals when no override exists
 × ... > uses the statistical median (not the temporal-middle gap) for irregular cadence
 × ... > holds the median at the low floor when one outlier gap sits in the temporal middle
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

The probe used during investigation showed `digest.overdue` empty (length 0):
with gaps `[1d,30d,2d]` the unsorted median returned `gaps[1] = 30d`, so a
7-days-silent contact (`7d < 30d`) was treated as not overdue.

</details>

**After the fix** — sorting the gaps yields the true median (2d, clamped to the
3-day floor), the contact is flagged overdue, and `thresholdDays === 3`:

<details><summary>vitest — fix applied (full followup-tracker suite)</summary>

```
 ✓ ... > uses RelationshipsService lastInteractionAt written by real message ingestion 5ms
 ✓ ... > learns cadence from observed interaction intervals when no override exists 3ms
 ✓ ... > uses the statistical median (not the temporal-middle gap) for irregular cadence 1ms
 ✓ ... > holds the median at the low floor when one outlier gap sits in the temporal middle 1ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

</details>

<details><summary>typecheck + lint (owning package)</summary>

```
$ tsc --noEmit -p tsconfig.build.json
EXIT 0

$ bunx @biomejs/biome check src/followup/followup-tracker.ts src/followup/followup-tracker.test.ts
Checked 2 files in 43ms. No fixes applied.
EXIT 0
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- **`bun run verify` (full-repo gate):** not completed on this constrained
  Raspberry Pi environment. Two environment-only notes (neither affects the
  shipped diff): (1) the global registry `minimumReleaseAge` blocked a few
  unrelated transitive deps (`viem`, `smthrs`, `pepr`) during install; (2) the
  package `vitest.config.ts` resolves `fs-extra` from the hoisted tree, so
  `bun install --linker hoisted` was used and `packages/core` keyword codegen
  (`node packages/shared/scripts/generate-keywords.mjs`) was run before tests.
  The scoped owning-package gates — `test`, `typecheck`, `lint` — all pass, as
  shown above.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@ae9bb7b21f5dce095c88ef21b064f0b8d5417730:packages/skills/skills/contribute-to-eliza"} -->


