### PR TITLE
fix(plugin-coding-tools): confine shell workdir via realpath

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -3,7 +3,7 @@
  * spawned shell in a temp directory (no mocks) — command execution, session
  * tracking, and history-provider context injection.
  */
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { type IAgentRuntime, logger } from "@elizaos/core";
@@ -140,6 +140,20 @@ describePosixShell("shell plugin real local integration", () => {
       /Cannot navigate outside allowed directory|Command contains forbidden patterns/,
     );
     expect(service.getCurrentDirectory()).toBe(allowedDirectory);
+  });
+
+  it("rejects a real shell workdir symlink that resolves outside", async () => {
+    const outside = mkdtempSync(path.join(tmpdir(), "eliza-shell-outside-"));
+    try {
+      symlinkSync(outside, path.join(allowedDirectory, "escape"));
+      const result = await service.exec("pwd", { workdir: "escape" });
+
+      expect(result.status).toBe("failed");
+      expect(result.reason).toContain("outside allowed directory");
+      expect(service.getCurrentDirectory()).toBe(allowedDirectory);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it("surfaces a model-visible error instead of blank output when history retrieval throws", async () => {

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
@@ -1,14 +1,49 @@
 /**
  * Path and command-safety guards: validatePath() confines a resolved path to the
- * allowed directory, while isForbiddenCommand/isSafeCommand/extractBaseCommand
- * gate which commands the shell will run (the command-injection boundary).
- * isSafeCommand still allows one data pipe (cat | grep). It rejects active
- * shell syntax outside quoted data and a pipe into an interpreter or command
- * dispatcher because ShellService then runs the string as `shell -c`.
+ * allowed directory by realpath, while isForbiddenCommand/isSafeCommand/
+ * extractBaseCommand gate which commands the shell will run (the
+ * command-injection boundary). isSafeCommand still allows one data pipe
+ * (`cat | grep`). It rejects active shell syntax outside quoted data and a
+ * pipe into an interpreter or command dispatcher because ShellService then
+ * runs the string as `shell -c`.
+ *
+ * Lexical `path.resolve` + `path.relative` is not enough for workdir/`cd`:
+ * a symlink inside the allowed tree whose target is outside still looks
+ * contained, and spawning with that cwd follows the link.
  */
+import fs from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import { analyzeShellCommand } from "../approvals/analysis.js";
+
+/**
+ * Realpath `p`, walking up to the longest existing parent when the leaf is
+ * missing so a symlink directory cannot hide behind a not-yet-created name.
+ */
+function resolveRealPathSync(p: string): string {
+  const absolute = path.resolve(p);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // error-policy:J3 missing leaf or ancestor — walk up rather than treating
+    // the lexical path as contained.
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  for (;;) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return absolute;
+    }
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(fs.realpathSync(parent), ...tail);
+    } catch {
+      // error-policy:J3 this ancestor is also missing; keep walking.
+      current = parent;
+    }
+  }
+}
 
 export function validatePath(
   commandPath: string,
@@ -16,18 +51,18 @@ export function validatePath(
   currentDir: string,
 ): string | null {
   const resolvedPath = path.resolve(currentDir, commandPath);
-  const normalizedPath = path.normalize(resolvedPath);
-  const normalizedAllowed = path.normalize(allowedDir);
-  const relative = path.relative(normalizedAllowed, normalizedPath);
+  const realPath = resolveRealPathSync(resolvedPath);
+  const realAllowed = resolveRealPathSync(allowedDir);
+  const relative = path.relative(realAllowed, realPath);
 
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     logger.warn(
-      `Path validation failed: ${normalizedPath} is outside allowed directory ${normalizedAllowed}`,
+      `Path validation failed: ${resolvedPath} is outside allowed directory ${allowedDir}`,
     );
     return null;
   }
 
-  return normalizedPath;
+  return realPath;
 }
 
 const PIPE_INTERPRETERS = new Set([

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
@@ -16,32 +16,15 @@ import path from "node:path";
 import { logger } from "@elizaos/core";
 import { analyzeShellCommand } from "../approvals/analysis.js";
 
-/**
- * Realpath `p`, walking up to the longest existing parent when the leaf is
- * missing so a symlink directory cannot hide behind a not-yet-created name.
- */
-function resolveRealPathSync(p: string): string {
-  const absolute = path.resolve(p);
+/** Resolve an existing directory without accepting partial or lexical paths. */
+function resolveDirectoryRealPathSync(p: string): string | null {
   try {
-    return fs.realpathSync(absolute);
+    const realPath = fs.realpathSync(path.resolve(p));
+    return fs.statSync(realPath).isDirectory() ? realPath : null;
   } catch {
-    // error-policy:J3 missing leaf or ancestor — walk up rather than treating
-    // the lexical path as contained.
-  }
-  const tail: string[] = [];
-  let current = absolute;
-  for (;;) {
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return absolute;
-    }
-    tail.unshift(path.basename(current));
-    try {
-      return path.join(fs.realpathSync(parent), ...tail);
-    } catch {
-      // error-policy:J3 this ancestor is also missing; keep walking.
-      current = parent;
-    }
+    // error-policy:J3 cwd candidates are untrusted input. Missing, dangling,
+    // looping, inaccessible, and racing paths all fail closed.
+    return null;
   }
 }
 
@@ -51,11 +34,21 @@ export function validatePath(
   currentDir: string,
 ): string | null {
   const resolvedPath = path.resolve(currentDir, commandPath);
-  const realPath = resolveRealPathSync(resolvedPath);
-  const realAllowed = resolveRealPathSync(allowedDir);
+  const realPath = resolveDirectoryRealPathSync(resolvedPath);
+  const realAllowed = resolveDirectoryRealPathSync(allowedDir);
+  if (!realPath || !realAllowed) {
+    logger.warn(
+      `Path validation failed: ${resolvedPath} or its allowed directory could not be resolved as a directory`,
+    );
+    return null;
+  }
   const relative = path.relative(realAllowed, realPath);
 
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
     logger.warn(
       `Path validation failed: ${resolvedPath} is outside allowed directory ${allowedDir}`,
     );

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts
@@ -5,8 +5,10 @@
  * outside the sandbox. This harness is real filesystem, not mocked.
  */
 import {
+  closeSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -43,6 +45,13 @@ describe("validatePath — symlink workdir confinement", () => {
     expect(validatePath("sub", allowed, allowed)).toBe(realpathSync(child));
   });
 
+  it("accepts a descendant whose name begins with two dots", () => {
+    const { allowed } = sandbox();
+    const child = path.join(allowed, "..safe");
+    mkdirSync(child);
+    expect(validatePath("..safe", allowed, allowed)).toBe(realpathSync(child));
+  });
+
   it("rejects lexical .. escapes", () => {
     const { allowed } = sandbox();
     expect(validatePath("..", allowed, allowed)).toBeNull();
@@ -58,6 +67,17 @@ describe("validatePath — symlink workdir confinement", () => {
     },
   );
 
+  itSymlink(
+    "rejects a dangling outside symlink instead of treating it lexically",
+    () => {
+      const { allowed, outside } = sandbox();
+      const absentOutsideTarget = path.join(outside, "not-created");
+      symlinkSync(absentOutsideTarget, path.join(allowed, "escape"));
+
+      expect(validatePath("escape/subdir", allowed, allowed)).toBeNull();
+    },
+  );
+
   itSymlink("accepts a symlink that stays inside the allowed tree", () => {
     const { allowed } = sandbox();
     const inner = path.join(allowed, "inner");
@@ -65,5 +85,14 @@ describe("validatePath — symlink workdir confinement", () => {
     symlinkSync(inner, path.join(allowed, "alias"));
     const validated = validatePath("alias", allowed, allowed);
     expect(validated).toBe(realpathSync(inner));
+  });
+
+  it("rejects missing paths and regular files because cwd must be a directory", () => {
+    const { allowed } = sandbox();
+    expect(validatePath("missing", allowed, allowed)).toBeNull();
+
+    const file = path.join(allowed, "file.txt");
+    closeSync(openSync(file, "w"));
+    expect(validatePath("file.txt", allowed, allowed)).toBeNull();
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Real-path confinement for ShellService workdir and `cd`. Lexical
+ * `path.resolve` plus `path.relative` treats a symlink inside the allowed
+ * tree as contained; spawning with that cwd follows the link and runs
+ * outside the sandbox. This harness is real filesystem, not mocked.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePath } from "./pathUtils.ts";
+
+describe("validatePath — symlink workdir confinement", () => {
+  const temps: string[] = [];
+  afterEach(() => {
+    for (const dir of temps.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const itSymlink = process.platform === "win32" ? it.skip : it;
+
+  function sandbox(): { allowed: string; outside: string } {
+    const root = mkdtempSync(path.join(tmpdir(), "eliza-shell-validate-"));
+    temps.push(root);
+    const allowed = path.join(root, "allowed");
+    const outside = path.join(root, "outside");
+    mkdirSync(allowed);
+    mkdirSync(outside);
+    return { allowed, outside };
+  }
+
+  it("accepts a real descendant of the allowed directory", () => {
+    const { allowed } = sandbox();
+    const child = path.join(allowed, "sub");
+    mkdirSync(child);
+    expect(validatePath("sub", allowed, allowed)).toBe(realpathSync(child));
+  });
+
+  it("rejects lexical .. escapes", () => {
+    const { allowed } = sandbox();
+    expect(validatePath("..", allowed, allowed)).toBeNull();
+    expect(validatePath("../outside", allowed, allowed)).toBeNull();
+  });
+
+  itSymlink(
+    "rejects a symlink whose realpath is outside the allowed tree",
+    () => {
+      const { allowed, outside } = sandbox();
+      symlinkSync(outside, path.join(allowed, "escape"));
+      expect(validatePath("escape", allowed, allowed)).toBeNull();
+    },
+  );
+
+  itSymlink("accepts a symlink that stays inside the allowed tree", () => {
+    const { allowed } = sandbox();
+    const inner = path.join(allowed, "inner");
+    mkdirSync(inner);
+    symlinkSync(inner, path.join(allowed, "alias"));
+    const validated = validatePath("alias", allowed, allowed);
+    expect(validated).toBe(realpathSync(inner));
+  });
+});


### PR DESCRIPTION
## Problem

`ShellService` workdir and `cd` go through `validatePath()`, which confined paths with lexical `path.resolve` + `path.relative`. A symlink **inside** the allowed tree whose target is **outside** still looks contained. Spawning with that cwd follows the link.

Origin proof (macOS): `validatePath("escape", allowed, allowed)` returned `allowed/escape` (`lexicalInside: true`). `spawn({ cwd: validated })` ran in the outside directory and read `secret.txt`.

The FILE-handler sibling (`src/lib/path-utils.ts`) already realpaths. The shell workdir path did not.

## Fix

`validatePath` requires both the candidate and allowed root to realpath as existing directories, rejects every resolution failure, and returns the canonical candidate only when separator-aware containment keeps it inside the canonical root.

## Testing

```
bun run --cwd plugins/plugin-coding-tools test src/shell/utils/pathUtils.validate-path.test.ts src/lib/path-utils.test.ts
```

16 passed. Coverage includes descendants, separator-aware `..`, outside and dangling symlinks, inside symlinks, missing paths, regular files, and the existing FILE-path sibling contract.

# Evidence Gate

<!-- evidence-head:4c59f1107d1d97dc058488913b252813a8ebeaa9 -->

- [x] Before full-page screenshots — `N/A - no rendered UI; shell workdir confinement`
- [x] After full-page screenshots — `N/A - no rendered UI`
- [x] Walkthrough video — `N/A - unit proof of symlink cwd escape`
- [x] Backend logs — origin spawn leaked `SECRET`; after the fix `validatePath` returns null
- [x] Frontend logs — `N/A - no frontend`
- [x] LLM trajectory — `N/A - no model change`
- [x] Domain artifacts — `N/A`
- [x] OCR review — `N/A - no rendered visual surface`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

## Maintainer repair and exact-head evidence

The submitted longest-existing-parent fallback was held because it walked past dangling symlinks and every non-ENOENT realpath failure, then returned a lexical cwd. Exact repaired head `4c59f1107d1d97dc058488913b252813a8ebeaa9` requires both the allowed root and candidate to resolve as existing directories, fails closed on all resolution errors, and uses separator-aware containment so a legitimate `..safe` directory remains valid.

- Real-filesystem path suites: 16/16 passed.
- Real ShellService symlink-workdir production regression: 1/1 passed.
- Package typecheck and Node/declaration build: passed.
- Changed-file Biome and `git diff --check`: passed.
- The complete shell.real file currently has an unrelated current-develop baseline failure because its legacy `printf ... > file` fixture is rejected by command-syntax policy; the changed workdir test passes independently.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent
Contribution skill revision: elizaOS/eliza@39576d09f91cb72a9fb046b54a090506e7935170:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [resource-bounds-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent","skill_revision":"elizaOS/eliza@39576d09f91cb72a9fb046b54a090506e7935170:packages/skills/skills/contribute-to-eliza"} -->