### PR TITLE
fix(cloud): bound vendor fetch wrappers with timeout

### DIFF
--- a/packages/cloud/services/gateway-discord/src/hash-router.ts
+++ b/packages/cloud/services/gateway-discord/src/hash-router.ts
@@ -64,6 +64,7 @@ async function resolvePodIPs(
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
+      signal: AbortSignal.timeout(10_000),
     } as RequestInit);
 
     if (!res.ok) return [];

--- a/packages/cloud/services/gateway-webhook/src/hash-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/hash-router.ts
@@ -64,6 +64,7 @@ async function resolvePodIPs(
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
+      signal: AbortSignal.timeout(10_000),
     } as RequestInit);
 
     if (!res.ok) return [];

--- a/packages/cloud/shared/src/lib/utils/blooio-api.ts
+++ b/packages/cloud/shared/src/lib/utils/blooio-api.ts
@@ -155,6 +155,7 @@ export async function blooioApiRequest<T>(
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(10_000),
   });
 
   const responseText = await response.text();

--- a/packages/cloud/shared/src/lib/utils/telegram-api.ts
+++ b/packages/cloud/shared/src/lib/utils/telegram-api.ts
@@ -27,6 +27,7 @@ export async function telegramBotApiRequest<T>(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: params ? JSON.stringify(params) : undefined,
+    signal: AbortSignal.timeout(10_000),
   });
 
   const data = (await response.json()) as TelegramApiResponse<T>;
@@ -56,7 +57,9 @@ export async function telegramBotApiGet<T>(
     });
   }
 
-  const response = await fetch(url.toString());
+  const response = await fetch(url.toString(), {
+    signal: AbortSignal.timeout(10_000),
+  });
   const data = (await response.json()) as TelegramApiResponse<T>;
 
   if (!data.ok) {


### PR DESCRIPTION
## Relates to

- [x] Targets `develop` at current `origin/develop` with zero conflicts.
- [x] `bun install` and proportional exact-head verification were run; the unrelated local root-verify resolution blocker is recorded below.
- [x] A reviewer can confirm the repair from the exact typecheck evidence below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low. Single init-field timeout addition on already-unbounded `fetch` calls. No API change, no new helper, no retry behavior change. `AbortSignal.timeout(10_000)` fails closed on stall.

## What does this PR do?

Bounds 5 vendor/infra `fetch` sites that currently hang indefinitely when the remote stalls:

- `packages/cloud/shared/src/lib/utils/telegram-api.ts:26` `telegramBotApiRequest` (POST) and `:59` `telegramBotApiGet` (GET) — `https://api.telegram.org/bot${botToken}/${method}`
- `packages/cloud/shared/src/lib/utils/blooio-api.ts:154` `blooioApiRequest` — `${BLOOIO_API_BASE}${endpoint}` vendor helper used by every Blooio call site
- `packages/cloud/services/gateway-webhook/src/hash-router.ts:64` and `packages/cloud/services/gateway-discord/src/hash-router.ts:64` — `https://kubernetes.default.svc/apis/discovery.k8s.io/v1/.../endpointslices` pod-IP resolution for the consistent-hash ring (clones)

Each site now passes `signal: AbortSignal.timeout(10_000)` so a stalled remote aborts after 10s instead of wedging the gateway/cron.

## Testing

- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — pass
- `bun run --cwd packages/cloud/services/gateway-discord typecheck` — pass
- `git diff --check` — pass
- `git diff --stat` — 4 files, 7 insertions, 1 deletion

## Known gaps / failures

`bun run verify` reaches Turbo tasks then the local sparse setup resolves some Wrangler/drizzle peer deps through the global cache; unrelated to this diff. Package typecheck lanes above are green on the exact head. Hosted PR CI remains authoritative.

## Evidence Gate

<!-- evidence-head:4a7777f1ac -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed beyond bounded fetch timeout
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend product behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A
Attribution status: self-reported
— [cloud-ci]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A"} -->
