### PR TITLE
fix(ui): fail closed on oversized omi BLE audio frames

### DIFF
--- a/packages/ui/src/pendant/omi-protocol.test.ts
+++ b/packages/ui/src/pendant/omi-protocol.test.ts
@@ -443,6 +443,51 @@ describe("OmiFrameReassembler", () => {
     expect(overflow.metrics.emittedFrames).toBe(0);
     expect(8 * chunk).toBeLessThanOrEqual(MAX_OMI_REASSEMBLED_FRAME_BYTES);
     expect(9 * chunk).toBeGreaterThan(MAX_OMI_REASSEMBLED_FRAME_BYTES);
+
+    const recovery = pushAll(r, [
+      notif(9, 0, [10, 11]),
+      notif(10, 0, [12, 13]),
+    ]);
+    expect(emittedPayloads(recovery)).toEqual([[10, 11]]);
+  });
+
+  it("accepts the exact reassembled-frame byte limit", () => {
+    const r = new OmiFrameReassembler();
+    const fullPayload = MAX_OMI_NOTIFICATION_BYTES - OMI_PACKET_HEADER_SIZE;
+    const remainder = MAX_OMI_REASSEMBLED_FRAME_BYTES - 4 * fullPayload;
+    const results = pushAll(r, [
+      notif(0, 0, payload(fullPayload, 1)),
+      notif(1, 1, payload(fullPayload, 2)),
+      notif(2, 2, payload(fullPayload, 3)),
+      notif(3, 3, payload(fullPayload, 4)),
+      notif(4, 4, payload(remainder, 5)),
+      notif(5, 0, [6]),
+    ]);
+
+    const frames = results.flatMap((result) => result.frames);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]?.data).toHaveLength(MAX_OMI_REASSEMBLED_FRAME_BYTES);
+    expect(diagnostics(results)).not.toContain("dropped-buffered-frame");
+  });
+
+  it("removes deferred retransmit bytes from the frame budget", () => {
+    const r = new OmiFrameReassembler();
+    const fullPayload = MAX_OMI_NOTIFICATION_BYTES - OMI_PACKET_HEADER_SIZE;
+    const repeated = payload(fullPayload, 1);
+    const results = pushAll(r, [
+      notif(10, 0, repeated),
+      notif(10, 1, repeated),
+      notif(11, 1, payload(fullPayload, 2)),
+      notif(12, 2, payload(fullPayload, 3)),
+      notif(13, 3, payload(100, 4)),
+      notif(14, 0, [5]),
+    ]);
+
+    expect(diagnostics(results)).toContain("duplicate-notification");
+    expect(diagnostics(results)).not.toContain("dropped-buffered-frame");
+    expect(results.flatMap((result) => result.frames)[0]?.data).toHaveLength(
+      3 * fullPayload + 100,
+    );
   });
 
   it("still reassembles an honest multi-chunk Opus-sized frame", () => {

--- a/packages/ui/src/pendant/omi-protocol.test.ts
+++ b/packages/ui/src/pendant/omi-protocol.test.ts
@@ -6,6 +6,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_OMI_NOTIFICATION_BYTES,
+  MAX_OMI_REASSEMBLED_FRAME_BYTES,
   OMI_CODEC,
   OMI_PACKET_HEADER_SIZE,
   OmiFrameReassembler,
@@ -407,5 +409,49 @@ describe("OmiFrameReassembler", () => {
 
   it("exposes the DK1 Opus codec id as 20", () => {
     expect(OMI_CODEC.OPUS_16K).toBe(20);
+  });
+
+  it("rejects an oversized GATT notification instead of holding megabytes", () => {
+    const r = new OmiFrameReassembler();
+    const bomb = new Uint8Array(MAX_OMI_NOTIFICATION_BYTES + 1);
+    bomb[2] = 0;
+    const result = r.pushDetailed(bomb, 1000);
+    expect(result.frames).toEqual([]);
+    expect(diagnostics([result])).toEqual(["oversized-notification"]);
+    expect(result.metrics.malformedNotifications).toBe(1);
+    expect(result.metrics.emittedFrames).toBe(0);
+    expect(r.push(notif(1, 0, [1, 2, 3]))).toEqual([]);
+    expect(
+      r.push(notif(2, 0, [4, 5, 6])).map((frame) => [...frame.data]),
+    ).toEqual([[1, 2, 3]]);
+  });
+
+  it("drops a continuation that would emit an oversized reassembled frame", () => {
+    const r = new OmiFrameReassembler();
+    const chunk = 2_000;
+    expect(chunk + OMI_PACKET_HEADER_SIZE).toBeLessThanOrEqual(
+      MAX_OMI_NOTIFICATION_BYTES,
+    );
+    r.pushDetailed(notif(0, 0, payload(chunk, 1)), 1000);
+    for (let i = 1; i < 8; i += 1) {
+      r.pushDetailed(notif(i, i, payload(chunk, i + 1)), 1000 + i * 10);
+    }
+    const overflow = r.pushDetailed(notif(8, 8, payload(chunk, 9)), 1080);
+    expect(overflow.frames).toEqual([]);
+    expect(diagnostics([overflow])).toContain("dropped-buffered-frame");
+    expect(overflow.metrics.droppedFrames).toBe(1);
+    expect(overflow.metrics.emittedFrames).toBe(0);
+    expect(8 * chunk).toBeLessThanOrEqual(MAX_OMI_REASSEMBLED_FRAME_BYTES);
+    expect(9 * chunk).toBeGreaterThan(MAX_OMI_REASSEMBLED_FRAME_BYTES);
+  });
+
+  it("still reassembles an honest multi-chunk Opus-sized frame", () => {
+    const r = new OmiFrameReassembler();
+    const body = payload(80, 9);
+    const results = pushAll(r, [
+      ...sequenceFrame(10, chunks(body, 40)),
+      notif(12, 0, [1]),
+    ]);
+    expect(emittedPayloads(results)).toEqual([body]);
   });
 });

--- a/packages/ui/src/pendant/omi-protocol.ts
+++ b/packages/ui/src/pendant/omi-protocol.ts
@@ -92,8 +92,9 @@ export const OMI_OPUS_FRAME_SAMPLES = 160 as const;
 export const OMI_PACKET_HEADER_SIZE = 3 as const;
 
 /**
- * Hard ceiling on one GATT notification, header included. Larger than any
- * Bluetooth LE ATT MTU we ship against (typically 185–517, rarely 1024).
+ * Defensive ceiling on one GATT notification, header included. It leaves
+ * compatibility room above the 517-byte ATT MTU used by current Android while
+ * containing malformed native-bridge or test-transport payloads.
  */
 export const MAX_OMI_NOTIFICATION_BYTES = 4096 as const;
 
@@ -102,7 +103,7 @@ export const MAX_OMI_NOTIFICATION_BYTES = 4096 as const;
  * ~256 ms of 16 kHz PCM16 or hundreds of 10 ms Opus frames; honest firmware
  * emits one ~40–80 byte Opus packet per notify.
  */
-export const MAX_OMI_REASSEMBLED_FRAME_BYTES = (16 * 1024) as const;
+export const MAX_OMI_REASSEMBLED_FRAME_BYTES = 16_384 as const;
 
 /** Device advertising name prefixes we accept (currently "Friend", soon "eliza"). */
 export const OMI_NAME_PREFIXES = ["Friend", "Omi", "eliza"] as const;
@@ -525,6 +526,7 @@ export class OmiFrameReassembler {
       const previous = this.buffer.chunks[this.buffer.chunks.length - 2];
       if (last && previous && payloadsEqual(last, previous)) {
         this.buffer.chunks.pop();
+        this.buffer.byteLength -= last.length;
         this.buffer.expectedChunkIndex -= 1;
         this.metrics.duplicates += 1;
         diagnostics.push({

--- a/packages/ui/src/pendant/omi-protocol.ts
+++ b/packages/ui/src/pendant/omi-protocol.ts
@@ -38,6 +38,11 @@
  * The uint16 notification sequence wraps at 65536; we track wraps to detect dropped
  * packets (BLE notifications are lossy) so we can log gaps without corrupting
  * the decoder (Opus tolerates whole-frame loss — a gap just drops audio).
+ *
+ * Notifications and reassembled frames are untrusted device bytes. GATT MTU is
+ * typically 185–517 bytes; a 10 ms Opus frame is ~40–80 bytes. Caps below fail
+ * closed so a hostile notify cannot hold tens of megabytes in the reassembler
+ * (the cloud voice session already rejects uplink audio frames above 64 KiB).
  */
 
 /** omi audio GATT service. Also the Web Bluetooth `filters`/`optionalServices` id. */
@@ -86,6 +91,19 @@ export const OMI_OPUS_FRAME_SAMPLES = 160 as const;
 /** `NET_BUFFER_HEADER_SIZE` — the 3-byte packet/frame index prefix. */
 export const OMI_PACKET_HEADER_SIZE = 3 as const;
 
+/**
+ * Hard ceiling on one GATT notification, header included. Larger than any
+ * Bluetooth LE ATT MTU we ship against (typically 185–517, rarely 1024).
+ */
+export const MAX_OMI_NOTIFICATION_BYTES = 4096 as const;
+
+/**
+ * Hard ceiling on one reassembled audio frame (header stripped). 16 KiB is
+ * ~256 ms of 16 kHz PCM16 or hundreds of 10 ms Opus frames; honest firmware
+ * emits one ~40–80 byte Opus packet per notify.
+ */
+export const MAX_OMI_REASSEMBLED_FRAME_BYTES = (16 * 1024) as const;
+
 /** Device advertising name prefixes we accept (currently "Friend", soon "eliza"). */
 export const OMI_NAME_PREFIXES = ["Friend", "Omi", "eliza"] as const;
 
@@ -103,6 +121,7 @@ export type OmiWireMode = "unknown" | "notification-sequence" | "frame-id";
 export type OmiFrameDiagnosticCode =
   | "duplicate-notification"
   | "malformed-notification"
+  | "oversized-notification"
   | "missing-notification"
   | "missing-chunk"
   | "out-of-order"
@@ -145,6 +164,7 @@ interface BufferedFrame {
   readonly startUnwrappedIndex: number;
   readonly droppedBefore: number;
   readonly chunks: Uint8Array[];
+  byteLength: number;
   expectedChunkIndex: number;
   lastRawIndex: number;
   lastUnwrappedIndex: number;
@@ -249,6 +269,35 @@ export class OmiFrameReassembler {
     const diagnostics: OmiFrameDiagnostic[] = [];
     const frames: ReassembledFrame[] = [];
     this.recordNotification(notification, receivedAtMs);
+
+    if (notification.length > MAX_OMI_NOTIFICATION_BYTES) {
+      const packetIndex =
+        notification.length >= 2
+          ? notification[0] | (notification[1] << 8)
+          : null;
+      const chunkIndex = notification.length >= 3 ? notification[2] : null;
+      this.metrics.malformedNotifications += 1;
+      if (this.buffer) {
+        this.dropBuffered(
+          diagnostics,
+          packetIndex,
+          chunkIndex,
+          "dropped-buffered-frame",
+          "Buffered frame dropped because an oversized notification interrupted it.",
+        );
+      }
+      diagnostics.push({
+        code: "oversized-notification",
+        packetIndex,
+        chunkIndex,
+        detail: `Notification of ${notification.length} bytes exceeds the ${MAX_OMI_NOTIFICATION_BYTES}-byte BLE payload budget.`,
+      });
+      this.lastNotification = notification.slice(
+        0,
+        Math.min(notification.length, OMI_PACKET_HEADER_SIZE),
+      );
+      return this.result(frames, diagnostics);
+    }
 
     if (this.isExactDuplicate(notification)) {
       this.metrics.duplicates += 1;
@@ -541,13 +590,13 @@ export class OmiFrameReassembler {
           this.mode = "frame-id";
         }
       }
-      this.appendChunk(rawIndex, unwrappedIndex, payload);
+      this.appendChunk(rawIndex, unwrappedIndex, payload, diagnostics);
       return;
     }
 
     if (nextNotification) {
       if (this.mode === "unknown") this.mode = "notification-sequence";
-      this.appendChunk(rawIndex, unwrappedIndex, payload);
+      this.appendChunk(rawIndex, unwrappedIndex, payload, diagnostics);
       return;
     }
 
@@ -577,6 +626,7 @@ export class OmiFrameReassembler {
       startUnwrappedIndex: unwrappedIndex,
       droppedBefore,
       chunks: [payload],
+      byteLength: payload.length,
       expectedChunkIndex: 1,
       lastRawIndex: rawIndex,
       lastUnwrappedIndex: unwrappedIndex,
@@ -587,9 +637,24 @@ export class OmiFrameReassembler {
     rawIndex: number,
     unwrappedIndex: number,
     payload: Uint8Array,
+    diagnostics: OmiFrameDiagnostic[],
   ): void {
     if (!this.buffer) return;
+    if (
+      this.buffer.byteLength + payload.length >
+      MAX_OMI_REASSEMBLED_FRAME_BYTES
+    ) {
+      this.dropBuffered(
+        diagnostics,
+        rawIndex,
+        this.buffer.expectedChunkIndex,
+        "dropped-buffered-frame",
+        `Reassembled frame would exceed the ${MAX_OMI_REASSEMBLED_FRAME_BYTES}-byte audio budget.`,
+      );
+      return;
+    }
     this.buffer.chunks.push(payload);
+    this.buffer.byteLength += payload.length;
     this.buffer.expectedChunkIndex += 1;
     this.buffer.lastRawIndex = rawIndex;
     this.buffer.lastUnwrappedIndex = unwrappedIndex;


### PR DESCRIPTION
# Relates to

Occupancy-FREE complete unit: bounded omi pendant BLE notification and frame reassembly. No issue was filed; this PR targets `develop`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Original model: `xAI/grok-4.6`
- Reviewer/repair model: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Original agent tooling: `Grok CLI via cmux`
- Reviewer/repair tooling: `Codex Desktop multi-agent`

# Summary

The omi pendant reassembler accepted arbitrarily large notification bodies and accumulated arbitrarily large multi-notification frames before forwarding them to the audio decoder. This change bounds both trust boundaries:

- notifications, including the three-byte header, are limited to 4,096 bytes;
- a reassembled frame is limited to 16,384 bytes;
- oversized input drops the pending frame and emits a typed diagnostic without retaining or copying the oversized body;
- the next valid chunk-0 notification recovers normally.

The limits preserve substantial compatibility margin. The Bluetooth ATT attribute-value maximum is 512 octets, Android 14 requests ATT MTU 517, and the verified DK1 firmware contract emits one 10 ms Opus frame of roughly 40–80 bytes per notification. Both Web Bluetooth and Capacitor/native transports pass one exact DataView notification window into this production reassembler.

# Review repair

The original exact head did not typecheck because TypeScript rejects `(16 * 1024) as const` (TS1355). Review repaired the constant to the equivalent literal `16_384 as const`, corrected the MTU comment to avoid an inaccurate generalization, added exact-limit acceptance coverage, and proved recovery after an overflow drop. Adversarial review also found that resolving a deferred retransmit popped its payload without decrementing the new byte counter; the repair now preserves that accounting invariant and includes a near-limit regression.

# Exact-head verification

Exact repaired head: `c64a6162d8e93bc6f827a6b985f3109e8a62969b`

- Pinned Bun 1.3.14 / Vitest production-path suite: 4 files, 77/77 tests green (`omi-protocol`, native BLE transport, Web Bluetooth transport, `PendantConnection`).
- Protocol boundary suite: 29/29 tests, including 4,097-byte notification rejection, continuation overflow, recovery, exact 16,384-byte acceptance, deferred-retransmit accounting, and honest Opus-sized multi-chunk reassembly.
- `bun run --cwd packages/ui typecheck`: green after pinned frozen-lockfile install and canonical core/cloud-routing builds.
- Strict standalone TypeScript proof for the changed protocol module: green.
- Biome on both changed files: green.
- `git diff --check upstream/develop...HEAD`: green.
- Package/core dependency builds used for type resolution: green.
- Working tree and diff: clean.

Real pendant hardware was not available in this review environment. Compatibility is therefore evidenced by the official Bluetooth/Android transport limits, the repository's verified DK1 wire contract, and the real production transport/connection test paths; no hardware behavior is claimed beyond those contracts.

<!-- evidence-head:c64a6162d8e93bc6f827a6b985f3109e8a62969b -->

# Evidence Gate

Original attribution: xAI / grok-4.6, Grok CLI via cmux, self-reported by the contributor.

Review and repair attribution: OpenAI / gpt-5.6-sol, Codex Desktop multi-agent.

This is a nonvisual protocol/resource-bound change; screenshots and video are N/A because no rendered UI changes.