### PR TITLE
fix(ui): keep loopback trust browser bundles fail closed

### DIFF
--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
@@ -8,6 +8,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
 import { stubElizaCore, stubNodeBuiltins } from "./esbuild-stubs";
@@ -131,5 +132,24 @@ describe("stubNodeBuiltins", () => {
     )() as string;
 
     expect(evaluated).toBe("eliza-browser-fixture");
+  });
+
+  it("bundles shared loopback trust while keeping browser CIDR checks fail closed", async () => {
+    const loopbackTrustPath = fileURLToPath(
+      new URL("../../../../shared/src/loopback-trust.ts", import.meta.url),
+    );
+    const bundle = await bundleWithNodeStub(`
+      import { isRemoteAddressInCidrList } from ${JSON.stringify(loopbackTrustPath)};
+      export const observed = isRemoteAddressInCidrList(
+        "172.17.0.1",
+        "172.17.0.0/16",
+      );
+    `);
+
+    const evaluated = new Function(
+      `${bundle}; return fixture.observed;`,
+    )() as boolean;
+
+    expect(evaluated).toBe(false);
   });
 });

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
@@ -148,6 +148,12 @@ export const mkdir = anyfn;
 export const stat = anyfn;
 export const readdir = () => [];
 export const isIP = () => 0;
+// Browser fixtures never admit operator CIDRs. Keep the Node BlockList surface
+// available to transitive shared imports while making every check fail closed.
+export class BlockList {
+  addSubnet() {}
+  check() { return false; }
+}
 export const statfsSync = anyfn;
 export const cp = anyfn;
 export class AsyncLocalStorage {


### PR DESCRIPTION
Fixes #22456

## Relates to

- [x] Targets `develop` at current `origin/develop` with zero conflicts.
- [x] `bun install` and proportional exact-head verification were run; the unrelated local root-verify resolution blocker is recorded below.
- [x] A reviewer can confirm the repair from the exact browser bundle and Chromium evidence below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low. The production Node loopback/CIDR implementation is unchanged. The new browser-fixture `BlockList` deliberately rejects every check, so an accidentally reached server-only CIDR path fails closed.

## What does this PR do?

The Client Perf Gate could not bundle the real chat overlay because its browser builtin stub exposed `node:net.isIP` but not the `BlockList` now imported transitively by `@elizaos/shared/loopback-trust`. This adds the missing browser-only surface with no-op writes and always-false checks, then bundles the actual shared module in a regression test and proves CIDR admission stays disabled.

## Testing

- `bun test packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts` — 5 pass, including a real esbuild bundle of `packages/shared/src/loopback-trust.ts`
- `bun test packages/shared/src/loopback-trust.test.ts` — 85 pass, 119 assertions across loopback, proxy spoofing, CIDR, origin/host, and per-consumer policy gates
- `bun run --cwd packages/ui test:perf-gate-e2e` — PASS in real Chromium; CLS teeth injection detected, all scroll/maximize/restore frame gates green, CLS 0.0000, zero page errors, video/screenshots produced locally
- `bun run --cwd packages/ui typecheck` — pass
- `bun run --cwd packages/ui lint:check` — pass with 8 pre-existing `document.cookie` warnings in unrelated SSO tests
- `git diff --check` — pass

## Known gaps / failures

`bun run verify` reached 209/211 Turbo tasks, then the local sparse/shared-node_modules setup made Wrangler resolve `drizzle-orm` through Bun's global cache and fail to resolve peer packages `pg` and `@electric-sql/pglite`. This is outside the two-file diff; Cloud Tests lint/types and both real-PostgreSQL migration suites are green on the exact base SHA. Hosted PR CI remains authoritative.

## Evidence Gate

<!-- evidence-head:54a7535f1352f6acea7cae32051ed19a085aa4df -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test harness and browser stub only; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test harness and browser stub only; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed; the automated perf harness video is local test output
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend product behavior changed; real Chromium reported zero page errors
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [ui-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
