### PR TITLE
fix(core): fail closed on nested TTS stage-direction peels

### DIFF
--- a/packages/core/src/spoken-text.test.ts
+++ b/packages/core/src/spoken-text.test.ts
@@ -78,6 +78,19 @@ describe("sanitizeSpeechText", () => {
 		);
 	});
 
+	it.each(["*", "**"])(
+		"does not expose deeply nested %s directions after the peel budget",
+		(marker) => {
+			let nested = `${marker}pause${marker}`;
+			for (let depth = 0; depth < 12; depth += 1) {
+				nested = `${marker}secret-${depth} ${nested} tail-${depth}${marker}`;
+			}
+			expect(sanitizeSpeechText(`Say this. ${nested} Done.`)).toBe(
+				"Say this. Done.",
+			);
+		},
+	);
+
 	it("keeps legacy unmatched-direction text while dropping its delimiter", () => {
 		expect(sanitizeSpeechText("Say this (perhaps later")).toBe(
 			"Say this perhaps later",

--- a/packages/core/src/spoken-text.test.ts
+++ b/packages/core/src/spoken-text.test.ts
@@ -64,10 +64,23 @@ describe("sanitizeSpeechText", () => {
 
 	it("fail-closes a nested-delimiter peel bomb without hanging TTS", () => {
 		const nested = `(${"(".repeat(40_000)}hello${")".repeat(40_000)})`;
-		const started = performance.now();
 		const spoken = sanitizeSpeechText(`Say this. ${nested} Done.`);
-		const elapsedMs = performance.now() - started;
-		expect(elapsedMs).toBeLessThan(50);
 		expect(spoken).toBe("Say this. Done.");
+	});
+
+	it("does not expose text from outer layers after the peel budget", () => {
+		let nested = "(pause)";
+		for (let depth = 0; depth < 12; depth += 1) {
+			nested = `(secret-${depth} ${nested})`;
+		}
+		expect(sanitizeSpeechText(`Say this. ${nested} Done.`)).toBe(
+			"Say this. Done.",
+		);
+	});
+
+	it("keeps legacy unmatched-direction text while dropping its delimiter", () => {
+		expect(sanitizeSpeechText("Say this (perhaps later")).toBe(
+			"Say this perhaps later",
+		);
 	});
 });

--- a/packages/core/src/spoken-text.test.ts
+++ b/packages/core/src/spoken-text.test.ts
@@ -55,4 +55,19 @@ describe("sanitizeSpeechText", () => {
 			sanitizeSpeechText("*whispers* Wait!!! (pause) Are you sure??"),
 		).toBe("Wait! Are you sure?");
 	});
+
+	it("keeps speech around a few nested stage-direction layers", () => {
+		expect(
+			sanitizeSpeechText("Hello (aside (whisper) still aside) world."),
+		).toBe("Hello world.");
+	});
+
+	it("fail-closes a nested-delimiter peel bomb without hanging TTS", () => {
+		const nested = `(${"(".repeat(40_000)}hello${")".repeat(40_000)})`;
+		const started = performance.now();
+		const spoken = sanitizeSpeechText(`Say this. ${nested} Done.`);
+		const elapsedMs = performance.now() - started;
+		expect(elapsedMs).toBeLessThan(50);
+		expect(spoken).toBe("Say this. Done.");
+	});
 });

--- a/packages/core/src/spoken-text.ts
+++ b/packages/core/src/spoken-text.ts
@@ -10,7 +10,10 @@
  * rescan is O(remaining), so an uncapped `((((…hello…))))` bomb hangs TTS.
  * {@link MAX_NON_SPEECH_STRIP_PASSES} bounds the compatibility peel. If it
  * exhausts that budget, a linear interval scan removes every remaining
- * balanced direction rather than exposing text from the outer layers.
+ * balanced direction rather than exposing text from the outer layers. Lines
+ * with more star markers than that budget can represent are removed between
+ * their outer markers before peeling, preventing emphasis nesting from
+ * exposing alternating layers without rescans.
  */
 
 function collapseWhitespace(input: string): string {
@@ -39,8 +42,9 @@ function stripThinkingAndMarkup(input: string): string {
 	return text;
 }
 
-const NON_SPEECH_SEGMENT_PATTERNS = [
-	/\*{1,2}[^*\n]+\*{1,2}/g,
+const STAR_DIRECTION_PATTERN = /\*{1,2}[^*\n]+\*{1,2}/g;
+
+const BALANCED_DIRECTION_PATTERNS = [
 	/\([^()]*\)/g,
 	/\[[^[\]]*\]/g,
 	/\{[^{}]*\}/g,
@@ -107,12 +111,39 @@ function stripResidualBalancedDirections(input: string): string {
 	return parts.join("");
 }
 
+/** Fail-closes lines whose emphasis markers exceed the peel budget. */
+function stripExcessiveStarDirections(input: string): string {
+	return input
+		.split("\n")
+		.map((line) => {
+			let markerCount = 0;
+			let first = -1;
+			let last = -1;
+			for (let index = 0; index < line.length; ) {
+				if (line[index] !== "*") {
+					index += 1;
+					continue;
+				}
+				if (first < 0) first = index;
+				const runStart = index;
+				while (line[index] === "*") index += 1;
+				markerCount += Math.ceil((index - runStart) / 2);
+				last = index - 1;
+			}
+			return markerCount > MAX_NON_SPEECH_STRIP_PASSES * 2 && last > first
+				? `${line.slice(0, first)} ${line.slice(last + 1)}`
+				: line;
+		})
+		.join("\n");
+}
+
 function stripNonSpeechDirections(input: string): string {
-	let text = input;
+	let text = stripExcessiveStarDirections(input);
 	let stabilized = false;
 	for (let pass = 0; pass < MAX_NON_SPEECH_STRIP_PASSES; pass += 1) {
 		const previous = text;
-		for (const pattern of NON_SPEECH_SEGMENT_PATTERNS) {
+		text = text.replace(STAR_DIRECTION_PATTERN, " ");
+		for (const pattern of BALANCED_DIRECTION_PATTERNS) {
 			text = text.replace(pattern, " ");
 		}
 		if (text === previous) {

--- a/packages/core/src/spoken-text.ts
+++ b/packages/core/src/spoken-text.ts
@@ -8,8 +8,9 @@
  * Stage-direction stripping peels one innermost `()` / `[]` / `{}` / `**`
  * layer per pass. Honest asides nest a handful of delimiters; each miss
  * rescan is O(remaining), so an uncapped `((((…hello…))))` bomb hangs TTS.
- * {@link MAX_NON_SPEECH_STRIP_PASSES} fail-closes the peel; leftover
- * delimiter glyphs are then dropped in a single linear pass.
+ * {@link MAX_NON_SPEECH_STRIP_PASSES} bounds the compatibility peel. If it
+ * exhausts that budget, a linear interval scan removes every remaining
+ * balanced direction rather than exposing text from the outer layers.
  */
 
 function collapseWhitespace(input: string): string {
@@ -49,16 +50,78 @@ const NON_SPEECH_SEGMENT_PATTERNS = [
  * O(remaining); uncapped nested `((((…))))` hangs TTS. */
 export const MAX_NON_SPEECH_STRIP_PASSES = 8 as const;
 
+const DIRECTION_OPENERS = new Map([
+	["(", ")"],
+	["[", "]"],
+	["{", "}"],
+] as const);
+
+const DIRECTION_CLOSERS = new Map([
+	[")", "("],
+	["]", "["],
+	["}", "{"],
+] as const);
+
+/**
+ * Removes all balanced bracket regions in linear time. Independent stacks
+ * preserve the legacy sanitizer's permissive handling of crossed delimiter
+ * types while ensuring that a deeply nested outer direction cannot become
+ * speech merely because the compatibility peel reached its pass budget.
+ */
+function stripResidualBalancedDirections(input: string): string {
+	const removals = new Int32Array(input.length + 1);
+	const openerStacks = new Map<string, number[]>(
+		[...DIRECTION_OPENERS.keys()].map((opener) => [opener, []]),
+	);
+
+	for (let index = 0; index < input.length; index += 1) {
+		const char = input[index] ?? "";
+		if (DIRECTION_OPENERS.has(char as "(" | "[" | "{")) {
+			openerStacks.get(char)?.push(index);
+			continue;
+		}
+		const opener = DIRECTION_CLOSERS.get(char as ")" | "]" | "}");
+		if (!opener) continue;
+		const start = openerStacks.get(opener)?.pop();
+		if (start === undefined) continue;
+		removals[start] = (removals[start] ?? 0) + 1;
+		removals[index + 1] = (removals[index + 1] ?? 0) - 1;
+	}
+
+	const parts: string[] = [];
+	let activeIntervals = 0;
+	let visibleStart = 0;
+	for (let index = 0; index < input.length; index += 1) {
+		const previous = activeIntervals;
+		activeIntervals += removals[index] ?? 0;
+		if (previous === 0 && activeIntervals > 0) {
+			if (visibleStart < index) parts.push(input.slice(visibleStart, index));
+			parts.push(" ");
+		} else if (previous > 0 && activeIntervals === 0) {
+			visibleStart = index;
+		}
+	}
+	if (activeIntervals === 0 && visibleStart < input.length) {
+		parts.push(input.slice(visibleStart));
+	}
+	return parts.join("");
+}
+
 function stripNonSpeechDirections(input: string): string {
 	let text = input;
+	let stabilized = false;
 	for (let pass = 0; pass < MAX_NON_SPEECH_STRIP_PASSES; pass += 1) {
 		const previous = text;
 		for (const pattern of NON_SPEECH_SEGMENT_PATTERNS) {
 			text = text.replace(pattern, " ");
 		}
 		if (text === previous) {
+			stabilized = true;
 			break;
 		}
+	}
+	if (!stabilized) {
+		text = stripResidualBalancedDirections(text);
 	}
 	return text.replace(/[*()[\]{}]+/g, " ");
 }

--- a/packages/core/src/spoken-text.ts
+++ b/packages/core/src/spoken-text.ts
@@ -4,6 +4,12 @@
  * analysis / tool tags, code fences and inline code, markdown links, raw HTML,
  * and URLs, removes parenthetical and bracketed stage directions, normalizes
  * punctuation and unusual glyphs, and collapses whitespace.
+ *
+ * Stage-direction stripping peels one innermost `()` / `[]` / `{}` / `**`
+ * layer per pass. Honest asides nest a handful of delimiters; each miss
+ * rescan is O(remaining), so an uncapped `((((…hello…))))` bomb hangs TTS.
+ * {@link MAX_NON_SPEECH_STRIP_PASSES} fail-closes the peel; leftover
+ * delimiter glyphs are then dropped in a single linear pass.
  */
 
 function collapseWhitespace(input: string): string {
@@ -39,9 +45,13 @@ const NON_SPEECH_SEGMENT_PATTERNS = [
 	/\{[^{}]*\}/g,
 ];
 
+/** Honest stage directions nest a handful of delimiters. Each peel rescan is
+ * O(remaining); uncapped nested `((((…))))` hangs TTS. */
+export const MAX_NON_SPEECH_STRIP_PASSES = 8 as const;
+
 function stripNonSpeechDirections(input: string): string {
 	let text = input;
-	while (true) {
+	for (let pass = 0; pass < MAX_NON_SPEECH_STRIP_PASSES; pass += 1) {
 		const previous = text;
 		for (const pattern of NON_SPEECH_SEGMENT_PATTERNS) {
 			text = text.replace(pattern, " ");

--- a/packages/shared/src/spoken-text.test.ts
+++ b/packages/shared/src/spoken-text.test.ts
@@ -99,10 +99,23 @@ describe("sanitizeSpeechText", () => {
 
   it("fail-closes a nested-delimiter peel bomb without hanging TTS", () => {
     const nested = `(${"(".repeat(40_000)}hello${")".repeat(40_000)})`;
-    const started = performance.now();
     const spoken = sanitizeSpeechText(`Say this. ${nested} Done.`);
-    const elapsedMs = performance.now() - started;
-    expect(elapsedMs).toBeLessThan(50);
     expect(spoken).toBe("Say this. Done.");
+  });
+
+  it("does not expose text from outer layers after the peel budget", () => {
+    let nested = "(pause)";
+    for (let depth = 0; depth < 12; depth += 1) {
+      nested = `(secret-${depth} ${nested})`;
+    }
+    expect(sanitizeSpeechText(`Say this. ${nested} Done.`)).toBe(
+      "Say this. Done.",
+    );
+  });
+
+  it("keeps legacy unmatched-direction text while dropping its delimiter", () => {
+    expect(sanitizeSpeechText("Say this (perhaps later")).toBe(
+      "Say this perhaps later",
+    );
   });
 });

--- a/packages/shared/src/spoken-text.test.ts
+++ b/packages/shared/src/spoken-text.test.ts
@@ -90,4 +90,19 @@ describe("sanitizeSpeechText", () => {
       sanitizeSpeechText("*whispers* Wait!!! (pause) Are you sure??"),
     ).toBe("Wait! Are you sure?");
   });
+
+  it("keeps speech around a few nested stage-direction layers", () => {
+    expect(
+      sanitizeSpeechText("Hello (aside (whisper) still aside) world."),
+    ).toBe("Hello world.");
+  });
+
+  it("fail-closes a nested-delimiter peel bomb without hanging TTS", () => {
+    const nested = `(${"(".repeat(40_000)}hello${")".repeat(40_000)})`;
+    const started = performance.now();
+    const spoken = sanitizeSpeechText(`Say this. ${nested} Done.`);
+    const elapsedMs = performance.now() - started;
+    expect(elapsedMs).toBeLessThan(50);
+    expect(spoken).toBe("Say this. Done.");
+  });
 });

--- a/packages/shared/src/spoken-text.test.ts
+++ b/packages/shared/src/spoken-text.test.ts
@@ -113,6 +113,19 @@ describe("sanitizeSpeechText", () => {
     );
   });
 
+  it.each(["*", "**"])(
+    "does not expose deeply nested %s directions after the peel budget",
+    (marker) => {
+      let nested = `${marker}pause${marker}`;
+      for (let depth = 0; depth < 12; depth += 1) {
+        nested = `${marker}secret-${depth} ${nested} tail-${depth}${marker}`;
+      }
+      expect(sanitizeSpeechText(`Say this. ${nested} Done.`)).toBe(
+        "Say this. Done.",
+      );
+    },
+  );
+
   it("keeps legacy unmatched-direction text while dropping its delimiter", () => {
     expect(sanitizeSpeechText("Say this (perhaps later")).toBe(
       "Say this perhaps later",

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -188,6 +188,27 @@ describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
     expect(JSON.stringify(upstream[0].body)).not.toContain("secret-");
   });
 
+  test.each(["*", "**"])(
+    "keeps deeply nested %s directions out of the upstream speech request",
+    async (marker) => {
+      let nestedDirection = `${marker}pause${marker}`;
+      for (let layer = 0; layer < 12; layer += 1) {
+        nestedDirection = `${marker}secret-${layer} ${nestedDirection} tail-${layer}${marker}`;
+      }
+
+      const { res, state } = fakeRes();
+      await handleCloudTtsPreviewRoute(
+        fakeReq(JSON.stringify({ text: `Say this. ${nestedDirection} Done.` })),
+        res,
+      );
+
+      expect(state.statusCode).toBe(200);
+      expect(upstream).toHaveLength(1);
+      expect(upstream[0].body).toMatchObject({ text: "Say this. Done." });
+      expect(JSON.stringify(upstream[0].body)).not.toContain("secret-");
+    },
+  );
+
   test("honors a host pre-parsed JSON body when the stream is already drained (#16348)", async () => {
     const { res, state } = fakeRes();
     await handleCloudTtsPreviewRoute(

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -170,6 +170,24 @@ describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
     expect(upstream[0].body).toMatchObject({ text: "bill me once" });
   });
 
+  test("keeps deeply nested stage directions out of the upstream speech request", async () => {
+    let nestedDirection = "";
+    for (let layer = 0; layer < 12; layer += 1) {
+      nestedDirection = `(secret-${layer} ${nestedDirection})`;
+    }
+
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: `Say this. ${nestedDirection} Done.` })),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    expect(upstream).toHaveLength(1);
+    expect(upstream[0].body).toMatchObject({ text: "Say this. Done." });
+    expect(JSON.stringify(upstream[0].body)).not.toContain("secret-");
+  });
+
   test("honors a host pre-parsed JSON body when the stream is already drained (#16348)", async () => {
     const { res, state } = fakeRes();
     await handleCloudTtsPreviewRoute(


### PR DESCRIPTION
# Relates to

Standalone denial-of-service in the production speech sanitizer: repeated innermost stage-direction regex peels made deeply nested balanced delimiters quadratic. No invented issue.

# Sync with develop

- [x] Rebased without conflicts onto `origin/develop` `282a6cf538c43a75317090c61d297792e90e97aa`.
- [x] Exact repaired head: `9411be3308f8383abcf4d407b6bf1d6d468981c2`.

# What changed

`sanitizeSpeechText` keeps the eight-pass compatibility peel for ordinary `()`, `[]`, `{}`, and emphasis directions. If all eight passes are consumed, it now performs one linear balanced-interval scan and removes the remaining balanced directions as a unit. This is fail-closed: text in outer layers cannot become audible merely because the peel budget was reached. Unmatched legacy text remains speakable with only its delimiter removed. Lines whose star-marker count exceeds the same peel budget fail closed between their outer markers, preventing alternating emphasis layers from becoming speech.

The shared entry remains the canonical `@elizaos/core/client-public` re-export. The production `/api/tts/cloud` handler is covered directly and proves the server forwards only the sanitized result upstream.

# Risk and compatibility

Low. No UI, wire-format, auth, or provider change. Ordinary asides retain their prior fixed-point semantics. The residual scanner is linear in input length and uses bounded per-input storage; the cloud proxy request path is authenticated and forwarded speech is capped at 5,000 characters.

# Testing

Exact head `9411be3308f8383abcf4d407b6bf1d6d468981c2`, pinned Bun 1.3.14:

- Core/shared sanitizer and re-export parity: 61/61.
- Real `handleCloudTtsPreviewRoute` node request/response path with stubbed upstream fetch: 20/20. Twelve-layer bracket, single-star, and double-star directions containing per-layer secret markers all forward exactly `Say this. Done.` and no secret marker.
- `packages/core` typecheck: green.
- `plugin-elizacloud` typecheck: green.
- Full core Node/browser/edge/testing/declaration build and packed-edge verification: green.
- Changed-file Biome and `git diff --check`: green.

The 40,000-layer deterministic regression returns `Say this. Done.`; adversarial text placed in every layer remains silent. The former submitted implementation was not accepted as-is because after eight layers it exposed outer direction text.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
N/A — deterministic server/runtime text transformation; no UI changed.

<!-- evidence-row:after-screenshots -->
N/A — no UI changed.

<!-- evidence-row:before-mobile -->
N/A — no UI changed.

<!-- evidence-row:after-mobile -->
N/A — no UI changed.

<!-- evidence-row:walkthrough-video -->
N/A — no visual interaction. The production HTTP handler test is the executable artifact.

<!-- evidence-row:backend-logs -->
Exact-head production-path receipt: HTTP 200; upstream JSON `text` equals `Say this. Done.`; serialized upstream body contains no `secret-` marker. Focused suites 81/81 total.

<!-- evidence-row:frontend-console -->
N/A — no frontend change.

<!-- evidence-row:network-logs -->
The real proxy handler test captures the outbound request body before returning deterministic audio; no external credential or capability is used.

<!-- evidence-row:live-model-trajectories -->
N/A — no model decision behavior; sanitizer is deterministic and tested with adversarial model-shaped output.

# Known gaps / failures

The monorepo-wide `bun run verify` was not run. Exact owning-package tests, both affected typechecks, the full core build, Biome, and diff checks are green.

# Changelog

Keep deeply nested TTS stage directions silent without unbounded regex rescans.

# Contribution provenance

Original contribution attribution is preserved below. The cross-caller repair, production-path regression, rebase, and validation were performed with OpenAI `gpt-5.6-sol` in Codex Desktop.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux; Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: original self-reported; repair attributed in commit/body

<!-- evidence-head:9411be3308f8383abcf4d407b6bf1d6d468981c2 -->

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"none"} -->

