### PR TITLE
fix(plugin-browser): confine workspace file paths via realpath

### DIFF
--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -3,7 +3,6 @@
  */
 
 import * as fsp from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -522,57 +521,63 @@ describe("browser workspace HTTP routes", () => {
   });
 
   it("round trips web user state without leaking across later mutations", async () => {
-    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "plugin-browser-"));
-    const statePath = path.join(dir, "browser-state.json");
-    const tab = await openBrowserWorkspaceTab({
-      show: true,
-      url: "about:blank",
-    });
-    await executeBrowserWorkspaceCommand({
-      id: tab.id,
-      networkAction: "route",
-      responseBody: "<!doctype html><title>State</title>",
-      subaction: "network",
-      url: "**",
-    });
-    await executeBrowserWorkspaceCommand({
-      id: tab.id,
-      subaction: "navigate",
-      url: "https://example.com/state",
-    });
+    const dir = await fsp.mkdtemp(
+      path.join(process.cwd(), "plugin-browser-state-"),
+    );
+    try {
+      const statePath = path.join(dir, "browser-state.json");
+      const tab = await openBrowserWorkspaceTab({
+        show: true,
+        url: "about:blank",
+      });
+      await executeBrowserWorkspaceCommand({
+        id: tab.id,
+        networkAction: "route",
+        responseBody: "<!doctype html><title>State</title>",
+        subaction: "network",
+        url: "**",
+      });
+      await executeBrowserWorkspaceCommand({
+        id: tab.id,
+        subaction: "navigate",
+        url: "https://example.com/state",
+      });
 
-    await executeBrowserWorkspaceCommand({
-      clipboardAction: "write",
-      id: tab.id,
-      subaction: "clipboard",
-      value: "saved clipboard",
-    });
-    await executeBrowserWorkspaceCommand({
-      filePath: statePath,
-      id: tab.id,
-      subaction: "state",
-    });
-    await executeBrowserWorkspaceCommand({
-      clipboardAction: "write",
-      id: tab.id,
-      subaction: "clipboard",
-      value: "mutated clipboard",
-    });
+      await executeBrowserWorkspaceCommand({
+        clipboardAction: "write",
+        id: tab.id,
+        subaction: "clipboard",
+        value: "saved clipboard",
+      });
+      await executeBrowserWorkspaceCommand({
+        filePath: statePath,
+        id: tab.id,
+        subaction: "state",
+      });
+      await executeBrowserWorkspaceCommand({
+        clipboardAction: "write",
+        id: tab.id,
+        subaction: "clipboard",
+        value: "mutated clipboard",
+      });
 
-    await executeBrowserWorkspaceCommand({
-      filePath: statePath,
-      id: tab.id,
-      stateAction: "load",
-      subaction: "state",
-    });
-    const restored = await executeBrowserWorkspaceCommand({
-      id: tab.id,
-      subaction: "state",
-    });
+      await executeBrowserWorkspaceCommand({
+        filePath: statePath,
+        id: tab.id,
+        stateAction: "load",
+        subaction: "state",
+      });
+      const restored = await executeBrowserWorkspaceCommand({
+        id: tab.id,
+        subaction: "state",
+      });
 
-    expect(restored.value).toMatchObject({
-      clipboard: "saved clipboard",
-      url: "https://example.com/state",
-    });
+      expect(restored.value).toMatchObject({
+        clipboard: "saved clipboard",
+        url: "https://example.com/state",
+      });
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -99,6 +99,7 @@ function statusFromBrowserWorkspaceErrorCode(
         : 409;
     case "script_forbidden":
     case "connector_secret_export_forbidden":
+    case "path_forbidden":
       return 403;
     case "timeout":
       return 504;

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
@@ -71,6 +71,12 @@ describe("classifyBrowserWorkspaceErrorCode", () => {
       ),
     ],
     [
+      "path_forbidden",
+      new Error(
+        "browser workspace file path escapes the workspace root: /etc/passwd",
+      ),
+    ],
+    [
       "unknown_element_ref",
       new Error(
         "Unknown browser snapshot element ref e7. Run snapshot or inspect again before reusing element refs.",

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-file-path.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-file-path.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Real-fs tests for browser-workspace command path confinement.
+ *
+ * Origin `writeBrowserWorkspaceFile` resolved + mkdir recursive with no root,
+ * so screenshot/state/pdf/baseline paths wrote through symlink parents and
+ * absolute paths outside cwd. These tests use a real temp root, not mocks.
+ */
+
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isBrowserWorkspaceError } from "../browser-workspace-errors.ts";
+import {
+  resolveBrowserWorkspaceFilePath,
+  writeBrowserWorkspaceFile,
+} from "../browser-workspace-helpers.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeRoot(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "bw-file-path-"));
+  roots.push(dir);
+  return fs.realpathSync(dir);
+}
+
+describe("resolveBrowserWorkspaceFilePath", () => {
+  it("accepts a descendant of the workspace root", async () => {
+    const root = await makeRoot();
+    const inside = path.join(root, "nested", "ok.txt");
+    expect(resolveBrowserWorkspaceFilePath(inside, root)).toBe(inside);
+  });
+
+  it("accepts a sibling named ..safe.js (not a traversal)", async () => {
+    const root = await makeRoot();
+    const sibling = path.join(root, "..safe.js");
+    expect(resolveBrowserWorkspaceFilePath(sibling, root)).toBe(sibling);
+  });
+
+  it("rejects lexical .. that leaves the root", async () => {
+    const root = await makeRoot();
+    expect(() =>
+      resolveBrowserWorkspaceFilePath(
+        path.join(root, "..", "outside.txt"),
+        root,
+      ),
+    ).toThrow(/escapes the workspace root/);
+  });
+
+  it("rejects an absolute path outside the root", async () => {
+    const root = await makeRoot();
+    expect(() => resolveBrowserWorkspaceFilePath("/etc/passwd", root)).toThrow(
+      /escapes the workspace root/,
+    );
+  });
+
+  it("rejects empty, NUL, and UNC paths", () => {
+    expect(() => resolveBrowserWorkspaceFilePath("  ")).toThrow(
+      /empty file path/,
+    );
+    expect(() => resolveBrowserWorkspaceFilePath("foo\0bar")).toThrow(/NUL/);
+    expect(() => resolveBrowserWorkspaceFilePath("//server/share")).toThrow(
+      /UNC/,
+    );
+  });
+
+  it("rejects a path whose parent is a symlink out of the root", async () => {
+    const root = await makeRoot();
+    const outside = await makeRoot();
+    await fsp.symlink(outside, path.join(root, "link"));
+    expect(() =>
+      resolveBrowserWorkspaceFilePath(
+        path.join(root, "link", "pwned.txt"),
+        root,
+      ),
+    ).toThrow(/escapes the workspace root/);
+  });
+});
+
+describe("writeBrowserWorkspaceFile", () => {
+  it("writes a descendant and does not mkdir through a symlink parent", async () => {
+    const root = await makeRoot();
+    const outside = await makeRoot();
+    await fsp.symlink(outside, path.join(root, "link"));
+
+    const inside = await writeBrowserWorkspaceFile(
+      path.join(root, "nested", "ok.txt"),
+      "inside",
+      root,
+    );
+    expect(await fsp.readFile(inside, "utf8")).toBe("inside");
+
+    await expect(
+      writeBrowserWorkspaceFile(
+        path.join(root, "link", "nested", "pwned.txt"),
+        "escaped",
+        root,
+      ),
+    ).rejects.toThrow(/escapes the workspace root/);
+    await expect(
+      fsp.stat(path.join(outside, "nested", "pwned.txt")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("throws a path_forbidden BrowserWorkspaceError", async () => {
+    const root = await makeRoot();
+    try {
+      await writeBrowserWorkspaceFile("/etc/passwd", "no", root);
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(isBrowserWorkspaceError(error)).toBe(true);
+      if (isBrowserWorkspaceError(error)) {
+        expect(error.browserWorkspaceErrorCode).toBe("path_forbidden");
+      }
+    }
+  });
+});

--- a/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
@@ -29,6 +29,8 @@ export type BrowserWorkspaceErrorCode =
   | "script_forbidden"
   /** A connector session tried to export raw cookies/tokens/storage/state. */
   | "connector_secret_export_forbidden"
+  /** Command filePath/outputPath/baselinePath escaped the workspace root. */
+  | "path_forbidden"
   /** A snapshot element ref is stale/unknown (re-snapshot needed). */
   | "unknown_element_ref"
   /** The operation exceeded its timeout. */
@@ -118,6 +120,13 @@ export function classifyBrowserWorkspaceErrorCode(
     /do not allow raw cookie, token, storage, or state export/i.test(message)
   ) {
     return "connector_secret_export_forbidden";
+  }
+  if (
+    /escapes the workspace root|rejected an empty file path|rejected a NUL in file path|rejected a UNC file path/i.test(
+      message,
+    )
+  ) {
+    return "path_forbidden";
   }
   if (/Unknown browser snapshot element ref/i.test(message)) {
     return "unknown_element_ref";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -1,7 +1,13 @@
 /**
- * Shared browser workspace utilities for command normalization, tabs, and URLs.
+ * Shared browser workspace utilities for command normalization, tabs, URLs,
+ * and workspace-rooted file reads/writes.
+ *
+ * Command `filePath` / `outputPath` / `baselinePath` values are confined with a
+ * realpath ancestor walk so a symlink parent cannot smuggle a write or state
+ * load outside the process working directory.
  */
 
+import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";
@@ -204,11 +210,100 @@ export async function sleep(ms: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Separator-aware containment: `..safe.js` is a sibling name, not a traversal.
+ * Compare realpaths so macOS `/var` vs `/private/var` is not a false escape.
+ */
+export function isWithinBrowserWorkspaceRoot(
+  child: string,
+  parent: string,
+): boolean {
+  if (child === parent) return true;
+  const rel = path.relative(parent, child);
+  return (
+    rel.length > 0 &&
+    rel !== ".." &&
+    !rel.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rel)
+  );
+}
+
+/**
+ * Realpath the longest existing ancestor, then rejoin the missing tail so a
+ * workspace symlink-to-elsewhere cannot hide behind a not-yet-created basename.
+ */
+export function resolveBrowserWorkspaceRealPath(target: string): string {
+  const absolute = path.resolve(target);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // error-policy:J3 missing leaf — walk up to the longest existing prefix.
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  for (;;) {
+    const parent = path.dirname(current);
+    if (parent === current) return absolute;
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(fs.realpathSync(parent), ...tail);
+    } catch {
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Confine a command-supplied filesystem path to `root` (default: process cwd).
+ * Rejects UNC, NUL, empty, lexical `..`, and symlink-parent escapes.
+ */
+export function resolveBrowserWorkspaceFilePath(
+  filePath: string,
+  root: string = process.cwd(),
+): string {
+  const trimmed = typeof filePath === "string" ? filePath.trim() : "";
+  if (!trimmed) {
+    throw createBrowserWorkspaceError(
+      "path_forbidden",
+      "file_path",
+      "browser workspace rejected an empty file path",
+    );
+  }
+  if (trimmed.includes("\0")) {
+    throw createBrowserWorkspaceError(
+      "path_forbidden",
+      "file_path",
+      "browser workspace rejected a NUL in file path",
+    );
+  }
+  if (trimmed.startsWith("\\\\") || trimmed.startsWith("//")) {
+    throw createBrowserWorkspaceError(
+      "path_forbidden",
+      "file_path",
+      "browser workspace rejected a UNC file path",
+    );
+  }
+  const rootReal = resolveBrowserWorkspaceRealPath(root);
+  const resolved = resolveBrowserWorkspaceRealPath(trimmed);
+  if (
+    resolved !== rootReal &&
+    !isWithinBrowserWorkspaceRoot(resolved, rootReal)
+  ) {
+    throw createBrowserWorkspaceError(
+      "path_forbidden",
+      "file_path",
+      `browser workspace file path escapes the workspace root: ${trimmed}`,
+    );
+  }
+  return resolved;
+}
+
 export async function writeBrowserWorkspaceFile(
   filePath: string,
   contents: string | Uint8Array,
+  root: string = process.cwd(),
 ): Promise<string> {
-  const resolved = path.resolve(filePath);
+  const resolved = resolveBrowserWorkspaceFilePath(filePath, root);
   await fsp.mkdir(path.dirname(resolved), { recursive: true });
   await fsp.writeFile(resolved, contents);
   return resolved;

--- a/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
@@ -3,7 +3,6 @@
  */
 
 import * as fsp from "node:fs/promises";
-import * as path from "node:path";
 import {
   browserWorkspaceTextMatches,
   buildBrowserWorkspaceElementSelector,
@@ -41,6 +40,7 @@ import {
   DEFAULT_WAIT_INTERVAL_MS,
   normalizeBrowserWorkspaceText,
   resolveBrowserWorkspaceCommandElementRefs,
+  resolveBrowserWorkspaceFilePath,
   sleep,
   writeBrowserWorkspaceFile,
 } from "./browser-workspace-helpers.js";
@@ -212,7 +212,7 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
         if (command.filePath?.trim() || command.outputPath?.trim()) {
           const targetPath =
             command.filePath?.trim() || command.outputPath?.trim() || "";
-          await writeBrowserWorkspaceFile(
+          const resolvedPath = await writeBrowserWorkspaceFile(
             targetPath,
             Buffer.from(data, "base64"),
           );
@@ -220,7 +220,7 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
             mode: "web",
             subaction: command.subaction,
             snapshot: { data },
-            value: { path: path.resolve(targetPath) },
+            value: { path: resolvedPath },
           };
         }
         return {
@@ -546,14 +546,14 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
           if (command.filePath?.trim() || command.outputPath?.trim()) {
             const targetPath =
               command.filePath?.trim() || command.outputPath?.trim() || "";
-            await writeBrowserWorkspaceFile(
+            const resolvedPath = await writeBrowserWorkspaceFile(
               targetPath,
               JSON.stringify(har, null, 2),
             );
             return {
               mode: "web",
               subaction: command.subaction,
-              value: { path: path.resolve(targetPath), ...har },
+              value: { path: resolvedPath, ...har },
             };
           }
           return { mode: "web", subaction: command.subaction, value: har };
@@ -721,7 +721,7 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
             );
           const baseline = command.baselinePath?.trim()
             ? await fsp.readFile(
-                path.resolve(command.baselinePath.trim()),
+                resolveBrowserWorkspaceFilePath(command.baselinePath.trim()),
                 "base64",
               )
             : runtime.lastScreenshotData;
@@ -739,7 +739,7 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
         const baseline = command.baselinePath?.trim()
           ? (JSON.parse(
               await fsp.readFile(
-                path.resolve(command.baselinePath.trim()),
+                resolveBrowserWorkspaceFilePath(command.baselinePath.trim()),
                 "utf8",
               ),
             ) as import("./browser-workspace-types.js").BrowserWorkspaceSnapshotRecord)
@@ -755,14 +755,14 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
           if (command.filePath?.trim() || command.outputPath?.trim()) {
             const targetPath =
               command.filePath?.trim() || command.outputPath?.trim() || "";
-            await writeBrowserWorkspaceFile(
+            const resolvedPath = await writeBrowserWorkspaceFile(
               targetPath,
               JSON.stringify(traceValue, null, 2),
             );
             return {
               mode: "web",
               subaction: command.subaction,
-              value: { path: path.resolve(targetPath), ...traceValue },
+              value: { path: resolvedPath, ...traceValue },
             };
           }
           return {
@@ -789,14 +789,14 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
           if (command.filePath?.trim() || command.outputPath?.trim()) {
             const targetPath =
               command.filePath?.trim() || command.outputPath?.trim() || "";
-            await writeBrowserWorkspaceFile(
+            const resolvedPath = await writeBrowserWorkspaceFile(
               targetPath,
               JSON.stringify(profileValue, null, 2),
             );
             return {
               mode: "web",
               subaction: command.subaction,
-              value: { path: path.resolve(targetPath), ...profileValue },
+              value: { path: resolvedPath, ...profileValue },
             };
           }
           return {
@@ -834,7 +834,10 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
             );
           }
           const payload = JSON.parse(
-            await fsp.readFile(path.resolve(filePath), "utf8"),
+            await fsp.readFile(
+              resolveBrowserWorkspaceFilePath(filePath),
+              "utf8",
+            ),
           ) as Record<string, unknown>;
           applyBrowserWorkspaceStateToWebDocument(document, payload);
           if (payload.settings && typeof payload.settings === "object") {
@@ -871,14 +874,14 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
         };
         const filePath = command.filePath?.trim() || command.outputPath?.trim();
         if (filePath) {
-          await writeBrowserWorkspaceFile(
+          const resolvedPath = await writeBrowserWorkspaceFile(
             filePath,
             JSON.stringify(payload, null, 2),
           );
           return {
             mode: "web",
             subaction: command.subaction,
-            value: { path: path.resolve(filePath), ...payload },
+            value: { path: resolvedPath, ...payload },
           };
         }
         return { mode: "web", subaction: command.subaction, value: payload };

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -17,7 +17,6 @@
  */
 
 import * as fsp from "node:fs/promises";
-import * as path from "node:path";
 
 export type {
   AcquireBrowserWorkspaceConnectorSessionRequest,
@@ -111,6 +110,7 @@ import {
   inferBrowserWorkspaceTitle,
   normalizeBrowserWorkspaceCommand,
   resolveBrowserWorkspaceCommandPartition,
+  resolveBrowserWorkspaceFilePath,
   resolveConnectorBrowserWorkspacePartition,
   sleep,
   writeBrowserWorkspaceFile,
@@ -948,7 +948,7 @@ export async function executeBrowserWorkspaceCommand(
         const currentData = screenshot.data;
         const baseline = command.baselinePath?.trim()
           ? await fsp.readFile(
-              path.resolve(command.baselinePath.trim()),
+              resolveBrowserWorkspaceFilePath(command.baselinePath.trim()),
               "base64",
             )
           : runtime.lastScreenshotData;
@@ -993,7 +993,7 @@ export async function executeBrowserWorkspaceCommand(
       const baseline = command.baselinePath?.trim()
         ? (JSON.parse(
             await fsp.readFile(
-              path.resolve(command.baselinePath.trim()),
+              resolveBrowserWorkspaceFilePath(command.baselinePath.trim()),
               "utf8",
             ),
           ) as import("./browser-workspace-types.js").BrowserWorkspaceSnapshotRecord)
@@ -1022,14 +1022,14 @@ export async function executeBrowserWorkspaceCommand(
         const payload = { entries: target.entries };
         const filePath = command.filePath?.trim() || command.outputPath?.trim();
         if (filePath) {
-          await writeBrowserWorkspaceFile(
+          const resolvedPath = await writeBrowserWorkspaceFile(
             filePath,
             JSON.stringify(payload, null, 2),
           );
           return {
             mode: "desktop",
             subaction: command.subaction,
-            value: { path: path.resolve(filePath), ...payload },
+            value: { path: resolvedPath, ...payload },
           };
         }
         return {
@@ -1070,7 +1070,7 @@ export async function executeBrowserWorkspaceCommand(
           );
         }
         const payload = JSON.parse(
-          await fsp.readFile(path.resolve(filePath), "utf8"),
+          await fsp.readFile(resolveBrowserWorkspaceFilePath(filePath), "utf8"),
         ) as Record<string, unknown>;
         await loadDesktopBrowserWorkspaceSessionState(command, payload, env);
         return {
@@ -1085,14 +1085,14 @@ export async function executeBrowserWorkspaceCommand(
       );
       const filePath = command.filePath?.trim() || command.outputPath?.trim();
       if (filePath) {
-        await writeBrowserWorkspaceFile(
+        const resolvedPath = await writeBrowserWorkspaceFile(
           filePath,
           JSON.stringify(payload, null, 2),
         );
         return {
           mode: "desktop",
           subaction: command.subaction,
-          value: { path: path.resolve(filePath), ...payload },
+          value: { path: resolvedPath, ...payload },
         };
       }
       return { mode: "desktop", subaction: command.subaction, value: payload };


### PR DESCRIPTION
## Problem

Browser workspace screenshot, state, PDF, HAR, trace, profiler, and diff `filePath` / `outputPath` / `baselinePath` values went through `path.resolve` + `mkdir(..., { recursive: true })` with **no workspace root**. A command-supplied absolute path wrote anywhere the process could write. A symlink **inside** cwd whose target is **outside** still looked like a descendant; recursive mkdir followed it.

Origin proof (macOS):

- `writeBrowserWorkspaceFile("/var/folders/.../eliza-bw-escape-*/pwned.txt", "escaped-absolute")` created that file (`outsideStartsWithCwd: false`).
- After `cwd/link -> outsideDir`, `writeBrowserWorkspaceFile("link/nested/pwned.txt", "via-symlink")` created `outsideDir/nested/pwned.txt`.

State save also dumps cookies/localStorage to that path; state load `readFile`s it. Prompt-injected agent commands can write or read outside the workspace.

## Fix

`resolveBrowserWorkspaceFilePath` realpaths the longest existing ancestor, then rejects anything that is not inside `process.cwd()` (separator-aware so `..safe.js` is not traversal). `writeBrowserWorkspaceFile` and every command `filePath` / `outputPath` / `baselinePath` read go through that helper. Escapes return HTTP 403 `path_forbidden`.

## Testing

```
bun run --cwd plugins/plugin-browser test src/workspace/__tests__/browser-workspace-file-path.test.ts src/workspace/__tests__/browser-workspace-errors.test.ts src/routes/workspace-routes.test.ts
```

59 passed. New tests: descendant accepted, `..safe.js` accepted, `..` rejected, absolute outside rejected, empty/NUL/UNC rejected, symlink parent rejected, write does not mkdir through a symlink.

# Evidence Gate

<!-- evidence-head:efcd1c009d661e8c4f7f468d3b3b452ce4b97472 -->

- [x] Before full-page screenshots — `N/A - no rendered UI; filesystem confinement`
- [x] After full-page screenshots — `N/A - no rendered UI`
- [x] Walkthrough video — `N/A - unit proof of symlink/absolute write escape`
- [x] Backend logs — origin write created `outsideDir/nested/pwned.txt`; after the fix `writeBrowserWorkspaceFile` throws `path_forbidden` and the outside path is ENOENT
- [x] Frontend logs — `N/A - no frontend`
- [x] LLM trajectory — `N/A - no model change`
- [x] Domain artifacts — `N/A`
- [x] OCR review — `N/A - no rendered visual surface`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
