### PR TITLE
fix(agent-skills): bound catalog fetches with timeout

### DIFF
--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -1863,6 +1863,7 @@ export class AgentSkillsService extends Service {
 				const url = `${this.apiBase}/api/v1/skills?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`;
 				const response = await fetch(url, {
 					headers: { Accept: "application/json" },
+					signal: AbortSignal.timeout(10_000),
 				});
 
 				if (!response.ok) {
@@ -1955,6 +1956,7 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/search?q=${encodeURIComponent(query)}&limit=${limit}`;
 			const response = await fetch(url, {
 				headers: { Accept: "application/json" },
+				signal: AbortSignal.timeout(10_000),
 			});
 
 			if (!response.ok) {
@@ -1995,6 +1997,7 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/skills/${safeSlug}`;
 			const response = await fetch(url, {
 				headers: { Accept: "application/json" },
+				signal: AbortSignal.timeout(10_000),
 			});
 
 			if (!response.ok) {
@@ -2207,7 +2210,7 @@ export class AgentSkillsService extends Service {
 
 			// Download
 			const downloadUrl = `${this.apiBase}/api/v1/download?slug=${safeSlug}&version=${resolvedVersion}`;
-			const response = await fetch(downloadUrl);
+			const response = await fetch(downloadUrl, { signal: AbortSignal.timeout(10_000) });
 
 			if (!response.ok) {
 				throw new Error(`Download failed: ${response.status}`);
@@ -2326,7 +2329,7 @@ export class AgentSkillsService extends Service {
 
 			// Download SKILL.md
 			const skillMdUrl = `${rawBase}SKILL.md`;
-			const response = await fetch(skillMdUrl);
+			const response = await fetch(skillMdUrl, { signal: AbortSignal.timeout(10_000) });
 
 			if (!response.ok) {
 				throw new Error(
@@ -2344,7 +2347,7 @@ export class AgentSkillsService extends Service {
 			// Try to fetch README.md if it exists (optional)
 			try {
 				const readmeUrl = `${rawBase}README.md`;
-				const readmeResponse = await fetch(readmeUrl);
+				const readmeResponse = await fetch(readmeUrl, { signal: AbortSignal.timeout(10_000) });
 				if (readmeResponse.ok) {
 					const readmeContent = await readCappedSkillText(readmeResponse);
 					files.push({ name: "README.md", content: readmeContent });
@@ -2400,7 +2403,7 @@ export class AgentSkillsService extends Service {
 		options: InstallSkillOptions & { slug?: string } = {},
 	): Promise<boolean> {
 		try {
-			const response = await fetch(url);
+			const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
 
 			if (!response.ok) {
 				throw new Error(`Failed to fetch: ${response.status}`);


### PR DESCRIPTION
## Relates to

- [x] Targets `develop` at current `origin/develop` with zero conflicts.
- [x] `bun install` and proportional exact-head verification were run; the unrelated local root-verify resolution blocker is recorded below.
- [x] A reviewer can confirm the repair from the exact typecheck evidence below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low. Single init-field timeout addition on already-unbounded `fetch` calls. No API change, no helper refactor, no retry behavior change. `AbortSignal.timeout(10_000)` fails closed on stall. Sibling of already-merged `pluginRegistryService` bound-fetch fix (#22224).

## What does this PR do?

Bounds 7 `fetch` sites in `plugins/plugin-agent-skills/src/services/skills.ts` that currently hang indefinitely when the registry/raw host stalls:

- `fetchCatalog` (cursor-paginated): `${apiBase}/api/v1/skills?limit=100` (+ cursor) — `Accept: application/json`
- `search` : `${apiBase}/api/v1/search?q=...`
- `getSkillDetails` : `${apiBase}/api/v1/skills/${safeSlug}`
- `downloadSkill` : `${apiBase}/api/v1/download?slug=&version=`
- `fetchSkillMd` : `https://raw.githubusercontent.com/.../SKILL.md`
- `fetchReadme` : `https://raw.githubusercontent.com/.../README.md` (optional, inside try)
- `installFromUrl` : caller-controlled `url` — direct `fetch(url)` with capped `readCappedSkillPackage`/`readCappedSkillText` bytes but no time cap

Each site now passes `signal: AbortSignal.timeout(10_000)` so a stalled registry or raw host aborts after 10s instead of wedging the skills install/sync path.

## Testing

- `bun run --cwd plugins/plugin-agent-skills typecheck` — pass
- `git diff --check` — pass
- `git diff --stat` — 1 file, 7 insertions, 4 deletions

## Known gaps / failures

`bun run verify` reaches Turbo tasks then the local sparse setup resolves some Wrangler/drizzle peer deps through the global cache; unrelated to this diff. Package typecheck lane above is green on the exact head. Hosted PR CI remains authoritative.

## Evidence Gate

<!-- evidence-head:63348fcd8e -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed beyond bounded fetch timeout
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend product behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A
Attribution status: self-reported
— [skills-ci]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A"} -->
