### PR TITLE
fix(scenario-runner): honor attachInterceptor idempotency contract

### DIFF
--- a/packages/scenario-runner/src/interceptor.test.ts
+++ b/packages/scenario-runner/src/interceptor.test.ts
@@ -1,11 +1,39 @@
 /**
- * Unit tests for the connector-dispatch capture in interceptor.ts, exercising
- * `captureConnectorDispatchesFromAction` directly (no runtime) to pin down when
- * a dispatch is marked delivered.
+ * Unit tests for interceptor.ts. Covers the connector-dispatch delivered
+ * default (`captureConnectorDispatchesFromAction`, no runtime) and the public
+ * `attachInterceptor` idempotency contract against a light fake runtime: a
+ * re-attach must return the live wrapper (whose closures the wrapped handlers
+ * push into) and `detach()` must restore the original handlers.
  */
+import type { IAgentRuntime } from "@elizaos/core";
 import type { CapturedConnectorDispatch } from "@elizaos/scenario-runner/schema";
 import { describe, expect, it } from "vitest";
-import { captureConnectorDispatchesFromAction } from "./interceptor.ts";
+import {
+  attachInterceptor,
+  captureConnectorDispatchesFromAction,
+} from "./interceptor.ts";
+
+interface FakeRuntime {
+  actions: Array<{ name: string; handler: (...args: unknown[]) => unknown }>;
+  createMemory: (...args: unknown[]) => Promise<unknown>;
+  createTask: (...args: unknown[]) => Promise<unknown>;
+}
+
+function makeFakeRuntime(): FakeRuntime {
+  return {
+    actions: [
+      {
+        name: "DO_THING",
+        handler: async () => ({ success: true, data: {} }),
+      },
+    ],
+    createMemory: async () => "memory-id",
+    createTask: async () => "task-id",
+  };
+}
+
+const asRuntime = (rt: FakeRuntime): IAgentRuntime =>
+  rt as unknown as IAgentRuntime;
 
 describe("captureConnectorDispatchesFromAction delivered default", () => {
   it("marks delivered=true only when the action reports success: true", () => {
@@ -44,5 +72,83 @@ describe("captureConnectorDispatchesFromAction delivered default", () => {
       { data: {} },
     );
     expect(dispatches[0]!.delivered).toBe(false);
+  });
+});
+
+describe("attachInterceptor idempotency contract", () => {
+  it("returns the existing wrapper on re-attach and captures fired actions", async () => {
+    const rt = makeFakeRuntime();
+    const first = attachInterceptor(asRuntime(rt));
+    // Docstring: "re-attaching the interceptor to the same runtime returns the
+    // existing wrapper." The returned object must observe captures.
+    const second = attachInterceptor(asRuntime(rt));
+    expect(second).toBe(first);
+
+    await rt.actions[0]!.handler(rt, {}, undefined, { foo: "bar" }, undefined);
+
+    // Both references point at the same live capture arrays.
+    expect(first.actions).toHaveLength(1);
+    expect(second.actions).toHaveLength(1);
+    expect(second.actions[0]!.actionName).toBe("DO_THING");
+    expect(second.actions[0]!.parameters).toEqual({ foo: "bar" });
+
+    first.detach();
+  });
+
+  it("restores the original handler on detach after a re-attach (no leak)", async () => {
+    const rt = makeFakeRuntime();
+    const original = rt.actions[0]!.handler;
+    attachInterceptor(asRuntime(rt));
+    const second = attachInterceptor(asRuntime(rt));
+
+    // The wrapper replaced the handler on attach.
+    expect(rt.actions[0]!.handler).not.toBe(original);
+
+    // detach() from the re-attached reference must restore the original,
+    // rather than being a silent no-op that leaks the wrapper permanently.
+    second.detach();
+    expect(rt.actions[0]!.handler).toBe(original);
+  });
+
+  it("attach -> detach -> attach yields a fresh, functional interceptor", async () => {
+    const rt = makeFakeRuntime();
+    const original = rt.actions[0]!.handler;
+
+    const firstAttach = attachInterceptor(asRuntime(rt));
+    firstAttach.detach();
+    expect(rt.actions[0]!.handler).toBe(original);
+
+    // A brand-new attach after detach must rebuild working wiring.
+    const secondAttach = attachInterceptor(asRuntime(rt));
+    expect(secondAttach).not.toBe(firstAttach);
+
+    await rt.actions[0]!.handler(rt, {}, undefined, {}, undefined);
+    expect(secondAttach.actions).toHaveLength(1);
+    // The stale first interceptor must not receive the new capture.
+    expect(firstAttach.actions).toHaveLength(0);
+
+    secondAttach.detach();
+    expect(rt.actions[0]!.handler).toBe(original);
+  });
+
+  it("observes createMemory/createTask through the re-attached wrapper and restores them", async () => {
+    const rt = makeFakeRuntime();
+    const originalCreateMemory = rt.createMemory;
+    const originalCreateTask = rt.createTask;
+
+    attachInterceptor(asRuntime(rt));
+    const second = attachInterceptor(asRuntime(rt));
+
+    await rt.createMemory(
+      { entityId: "e1", roomId: "r1", content: { text: "hi" } },
+      "messages",
+    );
+    expect(second.memoryWrites).toHaveLength(1);
+    expect(second.memoryWrites[0]!.table).toBe("messages");
+    expect(second.memoryWrites[0]!.entityId).toBe("e1");
+
+    second.detach();
+    expect(rt.createMemory).toBe(originalCreateMemory);
+    expect(rt.createTask).toBe(originalCreateTask);
   });
 });

--- a/packages/scenario-runner/src/interceptor.test.ts
+++ b/packages/scenario-runner/src/interceptor.test.ts
@@ -131,6 +131,34 @@ describe("attachInterceptor idempotency contract", () => {
     expect(rt.actions[0]!.handler).toBe(original);
   });
 
+  it("a stale detach of an already-detached interceptor must not evict the live one", async () => {
+    const rt = makeFakeRuntime();
+    const original = rt.actions[0]!.handler;
+
+    const first = attachInterceptor(asRuntime(rt));
+    first.detach();
+    expect(rt.actions[0]!.handler).toBe(original);
+
+    // Re-attach installs a fresh live interceptor and re-wraps the handler.
+    const second = attachInterceptor(asRuntime(rt));
+    expect(second).not.toBe(first);
+    expect(rt.actions[0]!.handler).not.toBe(original);
+
+    // A stale detach of the ALREADY-detached first interceptor must be a no-op
+    // for the cache: the identity guard in detach() sees the live `second`
+    // instance in the cache slot and refuses to evict it. Without that guard an
+    // unconditional delete would drop the live cache entry while `second`'s
+    // wrapped handler stays installed, so the next attach would skip re-wrapping
+    // and hand back a distinct, permanently-empty interceptor.
+    first.detach();
+
+    const third = attachInterceptor(asRuntime(rt));
+    expect(third).toBe(second);
+
+    second.detach();
+    expect(rt.actions[0]!.handler).toBe(original);
+  });
+
   it("observes createMemory/createTask through the re-attached wrapper and restores them", async () => {
     const rt = makeFakeRuntime();
     const originalCreateMemory = rt.createMemory;

--- a/packages/scenario-runner/src/interceptor.ts
+++ b/packages/scenario-runner/src/interceptor.ts
@@ -28,6 +28,13 @@ import { redactedSensitiveActionResult } from "./redaction.js";
 import { toRecord } from "./utils.js";
 
 const INTERCEPTOR_MARKER = Symbol.for("scenario-runner.interceptor-wrapped");
+// The live interceptor is cached on the runtime under this symbol so that a
+// re-attach returns the SAME wrapper whose capture arrays the wrapped handlers
+// actually push into. Without this, re-attaching (handlers already marked)
+// skips re-wrapping and hands back a distinct, permanently-empty interceptor
+// whose detach() cannot restore anything. `detach()` clears this so the next
+// attach rebuilds a fresh, functional wrapper.
+const INTERCEPTOR_INSTANCE = Symbol.for("scenario-runner.interceptor-instance");
 
 interface WrappedHandler {
   (...args: unknown[]): Promise<unknown>;
@@ -385,6 +392,14 @@ export function captureConnectorDispatchesFromAction(
 }
 
 export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
+  // Idempotency: if a live interceptor is already attached to this runtime,
+  // return that exact instance. Its closures are the ones the wrapped handlers
+  // push into, so returning a new object here would observe nothing.
+  const existing = Reflect.get(runtime, INTERCEPTOR_INSTANCE);
+  if (existing) {
+    return existing as ActionInterceptor;
+  }
+
   const actions: CapturedAction[] = [];
   const approvalRequests: CapturedApprovalRequest[] = [];
   const connectorDispatches: CapturedConnectorDispatch[] = [];
@@ -565,7 +580,7 @@ export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
     }
   }
 
-  return {
+  const interceptor: ActionInterceptor = {
     actions,
     approvalRequests,
     connectorDispatches,
@@ -583,6 +598,15 @@ export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
     detach(): void {
       for (const restore of restoreFns) restore();
       restoreFns.length = 0;
+      // Clearing the cache lets a subsequent attach rebuild a fresh wrapper.
+      // The restore fns above already reinstated the original (unmarked)
+      // handlers and createMemory/createTask, so no per-handler markers linger.
+      if (Reflect.get(runtime, INTERCEPTOR_INSTANCE) === interceptor) {
+        Reflect.deleteProperty(runtime, INTERCEPTOR_INSTANCE);
+      }
     },
   };
+
+  Reflect.set(runtime, INTERCEPTOR_INSTANCE, interceptor);
+  return interceptor;
 }

--- a/packages/scenario-runner/src/interceptor.ts
+++ b/packages/scenario-runner/src/interceptor.ts
@@ -27,6 +27,11 @@ import type {
 import { redactedSensitiveActionResult } from "./redaction.js";
 import { toRecord } from "./utils.js";
 
+// Both keys use `Symbol.for` (global registry), not module-local `Symbol()`,
+// deliberately: a runtime resolved through two module instances (dual ESM/CJS
+// resolution, or a duplicated package in the graph) must still map to one
+// marker and one interceptor. A module-local symbol would split-brain the cache
+// under a duplicated dependency, so do not "tidy" these to `Symbol()`.
 const INTERCEPTOR_MARKER = Symbol.for("scenario-runner.interceptor-wrapped");
 // The live interceptor is cached on the runtime under this symbol so that a
 // re-attach returns the SAME wrapper whose capture arrays the wrapped handlers


### PR DESCRIPTION
# Relates to

Closes #22461

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` is a full-repo gate; the
      owning-package focused gates were run and are recorded below. Pre-existing
      unrelated blockers (unbuilt cross-package artifacts, e2e OOM on a 16GB host)
      are documented in **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the before/after test evidence
      attached below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5ce4d5931c3e322c8e8c8c5c4f8e73e6887c708a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch is based on the latest `origin/develop` (`5ce4d5931c`); zero conflicts.
- [x] Focused owning-package gates pass post-sync; unrelated blockers documented
      in **Known gaps / failures**.

# Risks

Low. The change is confined to `packages/scenario-runner/src/interceptor.ts`
(one public function) plus its unit test. It caches the live interceptor on the
runtime under a new symbol and returns/clears it. The in-repo consumer
(`executor.runScenario`, which always calls `detach()` before each re-attach) is
behaviorally unchanged — `detach()` clears the cache, so the next `attach()`
still builds a fresh, functional interceptor. Verified by running the existing
executor + interceptor suites green.

# Background

## What does this PR do?

`attachInterceptor(runtime)` documents an idempotency contract:

> The wrapping is idempotent and per-runtime: re-attaching the interceptor to
> the same runtime returns the existing wrapper.

The implementation violated it. On re-attach (handlers already carry
`INTERCEPTOR_MARKER`), every action's `if (alreadyWrapped) continue;` skipped
re-wrapping, so the newly-returned `ActionInterceptor` was a **distinct** object
whose capture arrays (`actions`/`memoryWrites`/`connectorDispatches`/`artifacts`/…)
were **never** populated — the live wrapped handlers still pushed into the FIRST
interceptor's closures. Worse, the second interceptor's `restoreFns` stayed
empty, so its `detach()` was a silent no-op that could not restore the original
handlers, permanently leaking the wrapper on the runtime.

The fix caches the created interceptor on the runtime under
`Symbol.for("scenario-runner.interceptor-instance")`. On entry, if that instance
is present, `attachInterceptor` returns it (true idempotency = "returns the
existing wrapper"). `detach()` clears the cache after restoring the original
handlers/`createMemory`/`createTask`, so a subsequent `attach()` rebuilds a
fresh, functional interceptor. This preserves the executor's `detach();attach()`
pattern while eliminating the dead-interceptor + no-op-detach trap for any
external/plugin consumer that follows the docstring and re-attaches without
detaching.

## What kind of change is this?

Bug fix (non-breaking change which fixes a documented public-API contract break
and a handler/state leak).

# Documentation changes needed?

None. The existing docstring already describes the correct (now-honored)
behavior; no user-facing doc change is required.

# Testing

## Where should a reviewer start?

`packages/scenario-runner/src/interceptor.test.ts` — the new
`attachInterceptor idempotency contract` describe block, and the fix in
`packages/scenario-runner/src/interceptor.ts`.

## Detailed testing steps

Automated. Four new regression tests exercise the real exported API against a
light fake runtime (pattern already used by the existing file):

1. Re-attach without detach → returned interceptor is the existing wrapper
   (`second === first`) and captures a fired action (`actions.length === 1`).
2. Re-attach then `detach()` → original handler restored (no leak).
3. `attach → detach → attach → fire` → the fresh interceptor captures once and
   the stale one stays empty.
4. `createMemory`/`createTask` wrappers stay observable through the re-attached
   wrapper and are restored on detach.

```bash
bun run --cwd packages/scenario-runner test          # 40 files, 383 tests pass
cd packages/scenario-runner && npx vitest run src/interceptor.test.ts
```

# Evidence Gate

<!-- evidence-head:6098e1c8a377ccd89940ca1a93ed0d63a5840b3b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a scenario-runner library function.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a scenario-runner library function.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; library contract change proven by unit tests below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - failing-before/passing-after vitest output is inline in the PR body (Backend + frontend logs details block); fork account cannot upload release assets to elizaOS/eliza (uploads API returns HTTP 404).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; this is a
      pure interceptor-wiring fix with deterministic unit coverage.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - reproduction artifact is inline in the PR body; same release-asset upload restriction.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model/agent behavior changes. The fix is deterministic interceptor
wiring; coverage is unit-level against a fake runtime.`

## Backend + frontend logs

Frontend: `N/A - no frontend`.

Backend / code-path proof — the same new tests run **before** the fix (against
`HEAD~1`'s `interceptor.ts`) fail exactly on the documented contradiction, and
pass **after** the fix:

<details>
<summary>BEFORE the fix (pre-fix interceptor.ts) — 3 failed</summary>

```
 ❯ src/interceptor.test.ts (7 tests | 3 failed) 28ms
     × returns the existing wrapper on re-attach and captures fired actions
     × restores the original handler on detach after a re-attach (no leak)
     × observes createMemory/createTask through the re-attached wrapper and restores them

 FAIL  attachInterceptor idempotency contract > returns the existing wrapper on re-attach and captures fired actions
   AssertionError: expected { actions: [], …(7) } to be { actions: [], …(7) } // Object.is equality
     85|     expect(second).toBe(first);

 FAIL  attachInterceptor idempotency contract > restores the original handler on detach after a re-attach (no leak)
   AssertionError: expected [AsyncFunction wrapped] to be [AsyncFunction handler] // Object.is equality
    110|     expect(rt.actions[0]!.handler).toBe(original);

 FAIL  attachInterceptor idempotency contract > observes createMemory/createTask through the re-attached wrapper and restores them
   AssertionError: expected [] to have a length of 1 but got +0
    147|     expect(second.memoryWrites[0]!.table).toBe("messages");

 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
```
</details>

<details>
<summary>AFTER the fix — 8 passed (adds the review-requested detach identity-guard test)</summary>

```
 ✓ captureConnectorDispatchesFromAction delivered default > marks delivered=true only when the action reports success: true
 ✓ captureConnectorDispatchesFromAction delivered default > marks delivered=false when the action reports success: false
 ✓ captureConnectorDispatchesFromAction delivered default > defaults delivered to false when no boolean success is present
 ✓ attachInterceptor idempotency contract > returns the existing wrapper on re-attach and captures fired actions
 ✓ attachInterceptor idempotency contract > restores the original handler on detach after a re-attach (no leak)
 ✓ attachInterceptor idempotency contract > attach -> detach -> attach yields a fresh, functional interceptor
 ✓ attachInterceptor idempotency contract > a stale detach of an already-detached interceptor must not evict the live one
 ✓ attachInterceptor idempotency contract > observes createMemory/createTask through the re-attached wrapper and restores them
 Test Files  1 passed (1)
      Tests  8 passed (8)
```
</details>

<details>
<summary>Mutation proof for the new detach identity-guard test</summary>

Replacing the guard in `detach()`

```ts
if (Reflect.get(runtime, INTERCEPTOR_INSTANCE) === interceptor) {
  Reflect.deleteProperty(runtime, INTERCEPTOR_INSTANCE);
}
```

with an unconditional `Reflect.deleteProperty(runtime, INTERCEPTOR_INSTANCE)`
fails exactly and only the new test, confirming it is not redundant:

```
 ❯ src/interceptor.test.ts (8 tests | 1 failed) 23ms
     × a stale detach of an already-detached interceptor must not evict the live one
 Test Files  1 failed (1)
      Tests  1 failed | 7 passed (8)
```
</details>

<details>
<summary>Full package test suite — 383 passed (executor detach();attach() path unchanged)</summary>

```
 Test Files  40 passed (40)
      Tests  383 passed (383)
   Duration  139.32s
```

Focused executor + interceptor subset (proves the in-repo `detach();attach()`
consumer is unaffected):

```
 Test Files  3 passed (3)   (executor.test.ts, executor-cleanup.test.ts, interceptor.test.ts)
      Tests  42 passed (42)
```
</details>

<details>
<summary>Typecheck</summary>

`bun run --cwd packages/scenario-runner typecheck` reports 0 errors under
`packages/scenario-runner/src`. The 135 reported errors are all pre-existing and
identical with and without this change (unbuilt cross-package artifacts such as
`@elizaos/plugin-phone/twilio`, `@elizaos/plugin-health/*`, `plugin-vision`);
count is 135 on the clean `HEAD~1` baseline and 135 with this change — this PR
adds zero type errors. Biome `check` on both changed files exits 0.
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/audio change.`

## Known gaps / failures

- **`bun run verify` / full-repo build not run to completion:** several
  cross-package typecheck errors and the `test:deterministic:e2e` lane require a
  full workspace build; on this 16GB host the e2e lane was `SIGKILL`ed (OOM)
  while booting the full runtime + PGLite + plugin graph. These are environment
  limits unrelated to the one-function change. The change's correctness is fully
  covered by the deterministic unit suite, and the executor path that exercises
  it in-repo (`detach();attach()`) is green.
- **Typecheck 135 errors:** pre-existing and identical on the baseline (unbuilt
  dependency artifacts); none originate in `packages/scenario-runner/src`.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@5ce4d5931c3e322c8e8c8c5c4f8e73e6887c708a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@5ce4d5931c3e322c8e8c8c5c4f8e73e6887c708a:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer exact-head review

Rebased cleanly onto develop `5ce4d5931cbb4b16d6bbc822871665a427560366`; reviewed head `6098e1c8a377ccd89940ca1a93ed0d63a5840b3b`. The documented per-runtime idempotency bug is real, and the cache/identity-guard approach matches the existing executor detach/reattach lifecycle. Exact-head evidence: interceptor production-boundary suite 8/8; scenario-runner production build passed; focused Biome and diff-check passed. Package typecheck was attempted and reached only sparse-checkout missing workspace/external dependency errors, with no diagnostic in the two changed files. No rendered, model, connector, or external-service surface changed.

Repair/review attribution: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.
