### PR TITLE
fix(security): confine physical paths with realpath ancestor walkup

### DIFF
--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -24,6 +24,27 @@ import { promises as fs } from "node:fs";
 import type http from "node:http";
 import path from "node:path";
 
+async function resolveRealPath(p: string): Promise<string> {
+	const absolute = path.resolve(p);
+	try {
+		return await fs.realpath(absolute);
+	} catch {
+		// error-policy:J3 ancestor missing — walk up to longest existing parent
+	}
+	const tail: string[] = [];
+	let current = absolute;
+	while (true) {
+		const parent = path.dirname(current);
+		if (parent === current) return absolute;
+		tail.unshift(path.basename(current));
+		try {
+			return path.join(await fs.realpath(parent), ...tail);
+		} catch {
+			current = parent;
+		}
+	}
+}
+
 import {
   EventType,
   type IAgentRuntime,
@@ -946,6 +967,25 @@ export async function handleViewsRoutes(
     ) {
       error(res, "Malformed view asset path", 400);
       return true;
+    }
+
+    // Physical containment: a bundleDir symlink to an outside folder would
+    // lexically appear inside but `fs.stat`/`readFile` follow the link.
+    try {
+      const realBundleDir = await resolveRealPath(bundleDir);
+      const realAssetPath = await resolveRealPath(assetPath);
+      const realRelative = path.relative(realBundleDir, realAssetPath);
+      if (
+        realRelative === ".." ||
+        realRelative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(realRelative) ||
+        realRelative === ""
+      ) {
+        error(res, "Malformed view asset path", 400);
+        return true;
+      }
+    } catch {
+      // error-policy:J3 realpath failed — lexical gate already passed, continue to stat
     }
 
     let stat: import("node:fs").Stats;

--- a/packages/shared/src/local-inference/paths.ts
+++ b/packages/shared/src/local-inference/paths.ts
@@ -13,8 +13,35 @@
  * path.
  */
 
+import * as fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
+
+function resolveRealPathSync(p: string): string {
+  const absolute = path.resolve(p);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // error-policy:J3 ancestor missing — walk up to longest existing parent
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) return absolute;
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(fs.realpathSync(parent), ...tail);
+    } catch {
+      current = parent;
+    }
+  }
+}
+
+function isWithin(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
 
 export function localInferenceRoot(): string {
   return path.join(resolveStateDir(), "local-inference");
@@ -40,5 +67,16 @@ export function isWithinElizaRoot(target: string): boolean {
   const root = path.resolve(localInferenceRoot());
   const resolved = path.resolve(target);
   if (resolved === root) return false;
-  return resolved.startsWith(`${root}${path.sep}`);
+  // Lexical fast-path: cheap reject before touching the filesystem.
+  if (!isWithin(resolved, root)) return false;
+  // Physical check: a subdir symlink to /etc would lexically appear inside
+  // but `fs.stat` follows the link, so we must also compare realpaths.
+  try {
+    const realRoot = resolveRealPathSync(root);
+    const realTarget = resolveRealPathSync(resolved);
+    return isWithin(realTarget, realRoot);
+  } catch {
+    // error-policy:J3 realpath failed — fall back to lexical result already computed
+    return true;
+  }
 }

--- a/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts
@@ -6,9 +6,34 @@
  * shell syntax outside quoted data and a pipe into an interpreter or command
  * dispatcher because ShellService then runs the string as `shell -c`.
  */
+import * as fs from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import { analyzeShellCommand } from "../approvals/analysis.js";
+
+function resolveRealPathSync(p: string): string {
+  const absolute = path.resolve(p);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // error-policy:J3 leaf or ancestor missing — walk up to longest existing
+    // prefix and realpath that, then rejoin the tail so a workspace
+    // directory symlink to an outside folder cannot hide behind a
+    // not-yet-created basename.
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) return absolute;
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(fs.realpathSync(parent), ...tail);
+    } catch {
+      current = parent;
+    }
+  }
+}
 
 export function validatePath(
   commandPath: string,
@@ -18,9 +43,15 @@ export function validatePath(
   const resolvedPath = path.resolve(currentDir, commandPath);
   const normalizedPath = path.normalize(resolvedPath);
   const normalizedAllowed = path.normalize(allowedDir);
-  const relative = path.relative(normalizedAllowed, normalizedPath);
 
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  // Physical containment: resolve symlinks through the longest existing
+  // ancestor so a workspace dir symlink to an outside folder cannot bypass
+  // the lexical `path.relative` check (a -> /etc, a/b lexically passes but
+  // physically is outside).
+  const realPath = resolveRealPathSync(resolvedPath);
+  const realAllowed = resolveRealPathSync(normalizedAllowed);
+  const realRelative = path.relative(realAllowed, realPath);
+  if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
     logger.warn(
       `Path validation failed: ${normalizedPath} is outside allowed directory ${normalizedAllowed}`,
     );

--- a/plugins/plugin-local-inference/src/services/paths.ts
+++ b/plugins/plugin-local-inference/src/services/paths.ts
@@ -4,8 +4,30 @@
  * so `ELIZA_STATE_DIR` relocates them. Includes the containment check used to
  * keep downloads and registry writes inside the local-inference root.
  */
+import * as fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
+
+function resolveRealPathSync(p: string): string {
+  const absolute = path.resolve(p);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // error-policy:J3 ancestor missing — walk up to longest existing parent
+  }
+  const tail: string[] = [];
+  let current = absolute;
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) return absolute;
+    tail.unshift(path.basename(current));
+    try {
+      return path.join(fs.realpathSync(parent), ...tail);
+    } catch {
+      current = parent;
+    }
+  }
+}
 
 export function localInferenceRoot(): string {
 	return path.join(resolveStateDir(), "local-inference");
@@ -26,7 +48,15 @@ export function downloadsStagingDir(): string {
 export function isWithinElizaRoot(target: string): boolean {
 	const root = path.resolve(localInferenceRoot());
 	const resolved = path.resolve(target);
-	return isSubpath(resolved, root);
+	if (!isSubpath(resolved, root)) return false;
+	try {
+		const realRoot = resolveRealPathSync(root);
+		const realTarget = resolveRealPathSync(resolved);
+		return isSubpath(realTarget, realRoot);
+	} catch {
+		// error-policy:J3 realpath failed — lexical check already passed
+		return true;
+	}
 }
 
 function isSubpath(target: string, root: string): boolean {


### PR DESCRIPTION
## Relates to

- [x] Targets `develop` at current `origin/develop` with zero conflicts.
- [x] `bun install` and proportional exact-head verification were run; the unrelated local root-verify resolution blocker is recorded below.
- [x] A reviewer can confirm the repair from the exact typecheck evidence below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low. Adds a `realpath` ancestor-walkup + physical `path.relative` check after the existing lexical gate. No API change, no new helper exported, no retry behavior change. `realpathSync`/`realpath` on a missing leaf walks up to the longest existing parent and re-joins the tail, so not-yet-created basenames are still confined. Falls back to the lexical result if `realpath` fails. Mirrors the already-merged `plugins/plugin-coding-tools/src/lib/path-utils.ts:56` async walkup and `plugins/plugin-local-inference/src/services/registry.ts:253` physical check.

## What does this PR do?

Confines 4 lexical-only containment checks that are bypassable when a workspace subdirectory is a symlink to an outside folder (`a -> /etc`, `a/b` lexically passes `!relative.startsWith("..")` but `fs.stat`/`readFile` follow the link):

- `plugins/plugin-coding-tools/src/shell/utils/pathUtils.ts:validatePath` — shell `validatePath` gates `cd` / workdir against `allowedDirectory`; callers in `src/shell/services/shellService.ts:580,1286,1328` are sync
- `packages/shared/src/local-inference/paths.ts:39` `isWithinElizaRoot` — canonical shared check re-exported to UI and plugins
- `plugins/plugin-local-inference/src/services/paths.ts:26` `isWithinElizaRoot` — plugin-local duplicate of the same check
- `packages/agent/src/api/views-routes.ts:938` view-asset serve — `GET /api/views/:id/<asset>` serves Vite chunks under `path.dirname(bundlePath)`; lexical `path.relative(bundleDir, assetPath)` is followed by `fs.stat`/`readFile`

Each site now resolves both sides through `resolveRealPath(Sync)` (tail walkup) and re-checks `path.relative(realParent, realChild)` for `..` / absolute. The lexical gate is kept as a cheap fast-path before touching the filesystem.

## Testing

- `bun run --cwd plugins/plugin-coding-tools typecheck` — pass
- `bun run --cwd packages/shared typecheck` — pass
- `bun run --cwd plugins/plugin-local-inference typecheck` — pass
- `bun run --cwd packages/agent typecheck` — pass
- `git diff --check` — pass
- `git diff --stat` — 4 files, 143 insertions, 4 deletions

## Known gaps / failures

`bun run verify` reaches Turbo tasks then the local sparse setup resolves some Wrangler/drizzle peer deps through the global cache; unrelated to this diff. Package typecheck lanes above are green on the exact head. Hosted PR CI remains authoritative.

## Evidence Gate

<!-- evidence-head:ec1575847b -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed beyond physical path confinement
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend product behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A
Attribution status: self-reported
— [coding-tools+shared+local-inference+agent-ci]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A"} -->
