### PR TITLE
fix(agent): make plugin staging trees self-contained

### DIFF
--- a/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Real-fs tests for plugin staging copies that must not follow out-of-tree
+ * symlinks. Origin `fs.cp({ dereference: true })` materialized host file
+ * bytes into the staged tree. Deterministic temp directories, no mocks.
+ */
+
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  confinedStagingSymlinkTarget,
+  copyPluginTreeWithoutEscapingSymlinks,
+} from "./plugin-resolver.ts";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    dirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeDir(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  dirs.push(dir);
+  return fs.realpathSync(dir);
+}
+
+describe("copyPluginTreeWithoutEscapingSymlinks", () => {
+  it("copies regular files and in-tree symlinks", async () => {
+    const src = await makeDir("plugin-copy-src-");
+    const dst = await makeDir("plugin-copy-dst-");
+    await fsp.writeFile(path.join(src, "ok.txt"), "inside");
+    await fsp.symlink(path.join(src, "ok.txt"), path.join(src, "alias.txt"));
+
+    const target = path.join(dst, "tree");
+    await copyPluginTreeWithoutEscapingSymlinks(src, target);
+
+    expect(await fsp.readFile(path.join(target, "ok.txt"), "utf8")).toBe(
+      "inside",
+    );
+    const alias = path.join(target, "alias.txt");
+    expect((await fsp.lstat(alias)).isSymbolicLink()).toBe(true);
+    expect(await fsp.readFile(alias, "utf8")).toBe("inside");
+  });
+
+  it("does not materialize a host file behind an out-of-tree symlink", async () => {
+    const secretDir = await makeDir("plugin-copy-secret-");
+    const secret = path.join(secretDir, "secret.txt");
+    await fsp.writeFile(secret, "HOST-SECRET");
+
+    const src = await makeDir("plugin-copy-src-");
+    const dst = await makeDir("plugin-copy-dst-");
+    await fsp.writeFile(path.join(src, "ok.txt"), "inside");
+    await fsp.symlink(secret, path.join(src, "leaked.txt"));
+
+    const target = path.join(dst, "tree");
+    await copyPluginTreeWithoutEscapingSymlinks(src, target);
+
+    expect(await fsp.readFile(path.join(target, "ok.txt"), "utf8")).toBe(
+      "inside",
+    );
+    await expect(
+      fsp.lstat(path.join(target, "leaked.txt")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("confinedStagingSymlinkTarget", () => {
+  it("rejects a symlink whose realpath is outside the workspace", async () => {
+    const secretDir = await makeDir("plugin-link-secret-");
+    const secret = path.join(secretDir, "secret.txt");
+    await fsp.writeFile(secret, "HOST-SECRET");
+    const src = await makeDir("plugin-link-src-");
+    const link = path.join(src, "escape");
+    await fsp.symlink(secret, link);
+    expect(await confinedStagingSymlinkTarget(link)).toBeNull();
+  });
+
+  it("accepts a symlink that stays inside the source tree", async () => {
+    const src = await makeDir("plugin-link-src-");
+    const file = path.join(src, "ok.txt");
+    await fsp.writeFile(file, "inside");
+    const link = path.join(src, "alias");
+    await fsp.symlink(file, link);
+    expect(await confinedStagingSymlinkTarget(link, src)).toBe(
+      fs.realpathSync(file),
+    );
+  });
+});

--- a/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
@@ -1,22 +1,23 @@
 /**
- * Real-fs tests for plugin staging copies that must not follow out-of-tree
- * symlinks. Origin `fs.cp({ dereference: true })` materialized host file
- * bytes into the staged tree. Deterministic temp directories, no mocks.
+ * Real-filesystem tests for self-contained plugin staging trees. The harness
+ * exercises production copy and package-link helpers with deterministic temp
+ * directories and no filesystem mocks.
  */
 
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  confinedStagingSymlinkTarget,
   copyPluginTreeWithoutEscapingSymlinks,
+  copySymlinkedPackageForStaging,
 } from "./plugin-resolver.ts";
 
 const dirs: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(
     dirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })),
   );
@@ -43,6 +44,8 @@ describe("copyPluginTreeWithoutEscapingSymlinks", () => {
     );
     const alias = path.join(target, "alias.txt");
     expect((await fsp.lstat(alias)).isSymbolicLink()).toBe(true);
+    expect(path.isAbsolute(await fsp.readlink(alias))).toBe(false);
+    await fsp.rm(src, { recursive: true, force: true });
     expect(await fsp.readFile(alias, "utf8")).toBe("inside");
   });
 
@@ -66,27 +69,94 @@ describe("copyPluginTreeWithoutEscapingSymlinks", () => {
       fsp.lstat(path.join(target, "leaked.txt")),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
-});
 
-describe("confinedStagingSymlinkTarget", () => {
-  it("rejects a symlink whose realpath is outside the workspace", async () => {
-    const secretDir = await makeDir("plugin-link-secret-");
-    const secret = path.join(secretDir, "secret.txt");
-    await fsp.writeFile(secret, "HOST-SECRET");
-    const src = await makeDir("plugin-link-src-");
-    const link = path.join(src, "escape");
-    await fsp.symlink(secret, link);
-    expect(await confinedStagingSymlinkTarget(link)).toBeNull();
+  it("does not treat a configured workspace sibling as part of the package", async () => {
+    const workspace = await makeDir("plugin-copy-workspace-");
+    const src = path.join(workspace, "package");
+    const secretDir = path.join(workspace, "secrets");
+    const target = path.join(workspace, "staged");
+    await fsp.mkdir(src);
+    await fsp.mkdir(secretDir);
+    await fsp.writeFile(path.join(secretDir, "token"), "HOST-SECRET");
+    await fsp.symlink(path.join(secretDir, "token"), path.join(src, "leak"));
+    vi.stubEnv("ELIZA_WORKSPACE_ROOT", workspace);
+
+    await copyPluginTreeWithoutEscapingSymlinks(src, target);
+
+    await expect(fsp.lstat(path.join(target, "leak"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
-  it("accepts a symlink that stays inside the source tree", async () => {
-    const src = await makeDir("plugin-link-src-");
-    const file = path.join(src, "ok.txt");
-    await fsp.writeFile(file, "inside");
-    const link = path.join(src, "alias");
-    await fsp.symlink(file, link);
-    expect(await confinedStagingSymlinkTarget(link, src)).toBe(
-      fs.realpathSync(file),
+  it("rejects a relative symlink that traverses an in-tree link to the host", async () => {
+    const secretDir = await makeDir("plugin-copy-secret-");
+    await fsp.writeFile(path.join(secretDir, "secret.txt"), "HOST-SECRET");
+    const src = await makeDir("plugin-copy-src-");
+    await fsp.symlink(secretDir, path.join(src, "redirect"));
+    await fsp.symlink("redirect/secret.txt", path.join(src, "nested-leak"));
+    const target = path.join(await makeDir("plugin-copy-dst-"), "tree");
+
+    await copyPluginTreeWithoutEscapingSymlinks(src, target);
+
+    await expect(
+      fsp.lstat(path.join(target, "redirect")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fsp.lstat(path.join(target, "nested-leak")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("copySymlinkedPackageForStaging", () => {
+  it("rejects a package symlink whose manifest name does not match", async () => {
+    const secretDir = await makeDir("plugin-link-secret-");
+    await fsp.writeFile(
+      path.join(secretDir, "package.json"),
+      JSON.stringify({ name: "host-secret" }),
     );
+    const src = await makeDir("plugin-link-src-");
+    const link = path.join(src, "escape");
+    const dst = path.join(await makeDir("plugin-link-dst-"), "package");
+    await fsp.symlink(secretDir, link);
+    expect(
+      await copySymlinkedPackageForStaging(link, dst, "expected-package"),
+    ).toBe(false);
+    await expect(fsp.lstat(dst)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("copies a name-bound package instead of planting its live symlink", async () => {
+    const packageRoot = await makeDir("plugin-link-package-");
+    await fsp.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "expected-package" }),
+    );
+    await fsp.writeFile(path.join(packageRoot, "index.js"), "export default 1");
+    const src = await makeDir("plugin-link-src-");
+    const link = path.join(src, "expected-package");
+    const dst = path.join(await makeDir("plugin-link-dst-"), "package");
+    await fsp.symlink(packageRoot, link);
+
+    expect(
+      await copySymlinkedPackageForStaging(link, dst, "expected-package"),
+    ).toBe(true);
+    expect((await fsp.lstat(dst)).isSymbolicLink()).toBe(false);
+    await fsp.rm(packageRoot, { recursive: true, force: true });
+    expect(await fsp.readFile(path.join(dst, "index.js"), "utf8")).toBe(
+      "export default 1",
+    );
+  });
+
+  it("rejects malformed manifests before creating the staged package", async () => {
+    const packageRoot = await makeDir("plugin-link-package-");
+    await fsp.writeFile(path.join(packageRoot, "package.json"), "{not-json");
+    const src = await makeDir("plugin-link-src-");
+    const link = path.join(src, "expected-package");
+    const dst = path.join(await makeDir("plugin-link-dst-"), "package");
+    await fsp.symlink(packageRoot, link);
+
+    expect(
+      await copySymlinkedPackageForStaging(link, dst, "expected-package"),
+    ).toBe(false);
+    await expect(fsp.lstat(dst)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });

--- a/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-copy-tree.test.ts
@@ -105,6 +105,33 @@ describe("copyPluginTreeWithoutEscapingSymlinks", () => {
       fsp.lstat(path.join(target, "nested-leak")),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it.each([
+    { name: "the staged root", replacement: "../.." },
+    { name: "a staged ancestor", replacement: ".." },
+  ])(
+    "removes a symlink swapped after copy to point at $name",
+    async ({ replacement }) => {
+      const src = await makeDir("plugin-copy-src-");
+      const nested = path.join(src, "nested", "deeper");
+      await fsp.mkdir(nested, { recursive: true });
+      await fsp.writeFile(path.join(nested, "target.txt"), "inside");
+      await fsp.symlink("target.txt", path.join(nested, "alias"));
+      const target = path.join(await makeDir("plugin-copy-dst-"), "tree");
+
+      await copyPluginTreeWithoutEscapingSymlinks(src, target, {
+        afterCopyBeforeAudit: async () => {
+          const stagedAlias = path.join(target, "nested", "deeper", "alias");
+          await fsp.unlink(stagedAlias);
+          await fsp.symlink(replacement, stagedAlias);
+        },
+      });
+
+      await expect(
+        fsp.lstat(path.join(target, "nested", "deeper", "alias")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 });
 
 describe("copySymlinkedPackageForStaging", () => {
@@ -156,6 +183,35 @@ describe("copySymlinkedPackageForStaging", () => {
 
     expect(
       await copySymlinkedPackageForStaging(link, dst, "expected-package"),
+    ).toBe(false);
+    await expect(fsp.lstat(dst)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("revalidates staged identity after an atomic source replacement", async () => {
+    const container = await makeDir("plugin-link-race-");
+    const packageRoot = path.join(container, "package");
+    await fsp.mkdir(packageRoot);
+    await fsp.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "expected-package" }),
+    );
+    await fsp.writeFile(path.join(packageRoot, "index.js"), "trusted");
+    const link = path.join(container, "expected-package");
+    const dst = path.join(await makeDir("plugin-link-dst-"), "package");
+    await fsp.symlink(packageRoot, link);
+
+    expect(
+      await copySymlinkedPackageForStaging(link, dst, "expected-package", {
+        beforeCopy: async () => {
+          await fsp.rename(packageRoot, path.join(container, "original"));
+          await fsp.mkdir(packageRoot);
+          await fsp.writeFile(
+            path.join(packageRoot, "package.json"),
+            JSON.stringify({ name: "replacement-package" }),
+          );
+          await fsp.writeFile(path.join(packageRoot, "index.js"), "raced");
+        },
+      }),
     ).toBe(false);
     await expect(fsp.lstat(dst)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -1114,6 +1114,7 @@ export async function copySymlinkedPackageForStaging(
   sourcePath: string,
   targetPath: string,
   expectedPackageName: string,
+  options?: { beforeCopy?: () => Promise<void> },
 ): Promise<boolean> {
   const packageRoot = await resolveSymlinkTargetIfPresent(sourcePath);
   if (!packageRoot) return false;
@@ -1121,7 +1122,16 @@ export async function copySymlinkedPackageForStaging(
     if (!(await fs.stat(packageRoot)).isDirectory()) return false;
     const manifest = await readPluginPackageManifest(packageRoot);
     if (manifest?.name !== expectedPackageName) return false;
+    await options?.beforeCopy?.();
     await copyPluginTreeWithoutEscapingSymlinks(packageRoot, targetPath);
+    // The source path is not held open across the recursive copy. Bind the
+    // identity again from the self-contained staged bytes so an atomic source
+    // replacement cannot smuggle a different package under the approved name.
+    const stagedManifest = await readPluginPackageManifest(targetPath);
+    if (stagedManifest?.name !== expectedPackageName) {
+      await fs.rm(targetPath, { recursive: true, force: true });
+      return false;
+    }
     return true;
   } catch (error) {
     // error-policy:J3 malformed or racing package links are skipped rather
@@ -1130,6 +1140,7 @@ export async function copySymlinkedPackageForStaging(
       (error as NodeJS.ErrnoException).code === "ENOENT" ||
       error instanceof SyntaxError
     ) {
+      await fs.rm(targetPath, { recursive: true, force: true });
       return false;
     }
     throw error;
@@ -1192,7 +1203,11 @@ async function removeEscapingStagedSymlinks(
     if (!entry.isSymbolicLink()) continue;
     try {
       const realTarget = await fs.realpath(stagedPath);
-      if (!isPathInsideRoot(realTarget, targetRoot))
+      if (
+        realTarget === targetRoot ||
+        !isPathInsideRoot(realTarget, targetRoot) ||
+        isPathInsideRoot(stagedPath, realTarget)
+      )
         await fs.unlink(stagedPath);
     } catch (error) {
       // error-policy:J3 broken or racing copied symlinks are removed before the
@@ -1217,7 +1232,10 @@ async function removeEscapingStagedSymlinks(
 export async function copyPluginTreeWithoutEscapingSymlinks(
   sourcePath: string,
   targetPath: string,
-  options?: { filter?: (src: string) => boolean },
+  options?: {
+    filter?: (src: string) => boolean;
+    afterCopyBeforeAudit?: () => Promise<void>;
+  },
 ): Promise<void> {
   const sourceRoot = await fs.realpath(sourcePath);
   try {
@@ -1243,6 +1261,7 @@ export async function copyPluginTreeWithoutEscapingSymlinks(
       },
     });
     await rewriteAbsoluteStagingSymlinks(sourceRoot, targetPath, targetPath);
+    await options?.afterCopyBeforeAudit?.();
     await removeEscapingStagedSymlinks(targetPath, targetPath);
   } catch (error) {
     try {

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -6,9 +6,9 @@
  * directories. Each plugin is wrapped in an error boundary so a single
  * failing plugin cannot crash the agent startup.
  *
- * Staging copies of node_modules trees must not dereference or re-plant
- * symlinks whose realpath leaves the workspace — `fs.cp({ dereference: true })`
- * materializes host files (for example `/etc/passwd`) into the staged plugin.
+ * Staged package trees are self-contained: nested links remain within the
+ * copied package and symlinked dependency entries are copied only after their
+ * manifest identity is bound to the requested package name.
  *
  * @module plugin-resolver
  */
@@ -127,6 +127,7 @@ function sanitizePluginCacheSegment(value: string): string {
 }
 
 type PluginPackageManifest = {
+  name?: unknown;
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
@@ -257,12 +258,11 @@ async function stageDependencyIntoNodeModules(params: {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
   const stat = await fs.lstat(sourcePath);
   if (stat.isSymbolicLink()) {
-    const linkTarget = await confinedStagingSymlinkTarget(sourcePath);
-    if (!linkTarget) {
-      return false;
-    }
-    await fs.symlink(linkTarget, targetPath);
-    return true;
+    return copySymlinkedPackageForStaging(
+      sourcePath,
+      targetPath,
+      params.dependencyName,
+    );
   }
   if (!stat.isDirectory()) {
     return false;
@@ -1070,47 +1070,143 @@ function isPathInsideRoot(child: string, parent: string): boolean {
   );
 }
 
-async function pluginStagingConfinementRoots(
-  extraRoot?: string,
-): Promise<string[]> {
-  const roots = new Set<string>();
-  const add = async (candidate: string | undefined) => {
-    if (!candidate) return;
-    try {
-      roots.add(await fs.realpath(candidate));
-    } catch {
-      // error-policy:J3 missing extra roots are omitted, not invented.
+/**
+ * Resolve a symlink only when both its literal target and final realpath stay
+ * inside the tree being staged. The lexical check keeps a later verbatim copy
+ * self-contained; the realpath check catches an in-tree path that traverses a
+ * second symlink out of the tree.
+ */
+async function confinedTreeSymlinkTarget(
+  sourcePath: string,
+  sourceRoot: string,
+): Promise<string | null> {
+  try {
+    const rawTarget = await fs.readlink(sourcePath);
+    const lexicalTarget = path.resolve(path.dirname(sourcePath), rawTarget);
+    if (
+      lexicalTarget === sourceRoot ||
+      !isPathInsideRoot(lexicalTarget, sourceRoot)
+    ) {
+      return null;
     }
-  };
-  await add(process.cwd());
-  await add(process.env.ELIZA_WORKSPACE_ROOT?.trim());
-  await add(extraRoot);
-  return [...roots];
-}
-
-async function realpathAllowedForPluginStaging(
-  real: string,
-  extraRoot?: string,
-): Promise<boolean> {
-  const roots = await pluginStagingConfinementRoots(extraRoot);
-  return roots.some((root) => real === root || isPathInsideRoot(real, root));
+    const realTarget = await fs.realpath(sourcePath);
+    if (
+      realTarget === sourceRoot ||
+      !isPathInsideRoot(realTarget, sourceRoot) ||
+      isPathInsideRoot(sourcePath, realTarget)
+    ) {
+      return null;
+    }
+    return realTarget;
+  } catch (error) {
+    // error-policy:J3 broken or racing symlinks are rejected, not staged.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 /**
- * Realpath of a staging source symlink, or null when it is missing or points
- * outside the workspace. Re-planting an escaping realpath as a symlink in the
- * staged tree would let later reads follow it to host files.
+ * Copy a package reached through node_modules only after binding the resolved
+ * package name. Copying the validated tree avoids planting a live absolute
+ * workspace symlink in the staged runtime.
  */
-export async function confinedStagingSymlinkTarget(
+export async function copySymlinkedPackageForStaging(
   sourcePath: string,
-  extraRoot?: string,
-): Promise<string | null> {
-  const linkTarget = await resolveSymlinkTargetIfPresent(sourcePath);
-  if (!linkTarget) return null;
-  if (!(await realpathAllowedForPluginStaging(linkTarget, extraRoot))) {
-    return null;
+  targetPath: string,
+  expectedPackageName: string,
+): Promise<boolean> {
+  const packageRoot = await resolveSymlinkTargetIfPresent(sourcePath);
+  if (!packageRoot) return false;
+  try {
+    if (!(await fs.stat(packageRoot)).isDirectory()) return false;
+    const manifest = await readPluginPackageManifest(packageRoot);
+    if (manifest?.name !== expectedPackageName) return false;
+    await copyPluginTreeWithoutEscapingSymlinks(packageRoot, targetPath);
+    return true;
+  } catch (error) {
+    // error-policy:J3 malformed or racing package links are skipped rather
+    // than copied under an unverified dependency name.
+    if (
+      (error as NodeJS.ErrnoException).code === "ENOENT" ||
+      error instanceof SyntaxError
+    ) {
+      return false;
+    }
+    throw error;
   }
-  return linkTarget;
+}
+
+async function rewriteAbsoluteStagingSymlinks(
+  sourceRoot: string,
+  targetRoot: string,
+  currentTarget: string,
+): Promise<void> {
+  const entries = await fs.readdir(currentTarget, { withFileTypes: true });
+  for (const entry of entries) {
+    const stagedPath = path.join(currentTarget, entry.name);
+    if (entry.isDirectory()) {
+      await rewriteAbsoluteStagingSymlinks(sourceRoot, targetRoot, stagedPath);
+      continue;
+    }
+    if (!entry.isSymbolicLink()) continue;
+    const rawTarget = await fs.readlink(stagedPath);
+    if (!path.isAbsolute(rawTarget)) continue;
+    if (!isPathInsideRoot(rawTarget, sourceRoot)) {
+      await fs.unlink(stagedPath);
+      continue;
+    }
+    const mappedTarget = path.join(
+      targetRoot,
+      path.relative(sourceRoot, rawTarget),
+    );
+    const relativeTarget = path.relative(
+      path.dirname(stagedPath),
+      mappedTarget,
+    );
+    const sourceTarget = await fs.stat(rawTarget);
+    const isDirectory = sourceTarget.isDirectory();
+    const rewrittenTarget =
+      process.platform === "win32" && isDirectory
+        ? mappedTarget
+        : relativeTarget || ".";
+    await fs.unlink(stagedPath);
+    await fs.symlink(
+      rewrittenTarget,
+      stagedPath,
+      isDirectory && process.platform === "win32" ? "junction" : "file",
+    );
+  }
+}
+
+async function removeEscapingStagedSymlinks(
+  targetRoot: string,
+  currentTarget: string,
+): Promise<void> {
+  const entries = await fs.readdir(currentTarget, { withFileTypes: true });
+  for (const entry of entries) {
+    const stagedPath = path.join(currentTarget, entry.name);
+    if (entry.isDirectory()) {
+      await removeEscapingStagedSymlinks(targetRoot, stagedPath);
+      continue;
+    }
+    if (!entry.isSymbolicLink()) continue;
+    try {
+      const realTarget = await fs.realpath(stagedPath);
+      if (!isPathInsideRoot(realTarget, targetRoot))
+        await fs.unlink(stagedPath);
+    } catch (error) {
+      // error-policy:J3 broken or racing copied symlinks are removed before the
+      // staged tree becomes importable.
+      if (
+        (error as NodeJS.ErrnoException).code === "ENOENT" ||
+        (error as NodeJS.ErrnoException).code === "ELOOP"
+      ) {
+        await fs.unlink(stagedPath);
+        continue;
+      }
+      throw error;
+    }
+  }
 }
 
 /**
@@ -1124,23 +1220,41 @@ export async function copyPluginTreeWithoutEscapingSymlinks(
   options?: { filter?: (src: string) => boolean },
 ): Promise<void> {
   const sourceRoot = await fs.realpath(sourcePath);
-  await fs.cp(sourcePath, targetPath, {
-    recursive: true,
-    force: true,
-    dereference: false,
-    filter: async (src) => {
-      if (options?.filter && !options.filter(src)) return false;
-      try {
-        const stat = await fs.lstat(src);
-        if (!stat.isSymbolicLink()) return true;
-        const real = await fs.realpath(src);
-        return realpathAllowedForPluginStaging(real, sourceRoot);
-      } catch {
-        // error-policy:J3 broken or unresolvable symlink is skipped, not copied.
-        return false;
-      }
-    },
-  });
+  try {
+    await fs.cp(sourceRoot, targetPath, {
+      recursive: true,
+      force: true,
+      dereference: false,
+      verbatimSymlinks: true,
+      filter: async (src) => {
+        const logicalSource = path.join(
+          sourcePath,
+          path.relative(sourceRoot, src),
+        );
+        if (options?.filter && !options.filter(logicalSource)) return false;
+        try {
+          const stat = await fs.lstat(src);
+          if (!stat.isSymbolicLink()) return true;
+          return (await confinedTreeSymlinkTarget(src, sourceRoot)) !== null;
+        } catch {
+          // error-policy:J3 broken or unresolvable symlink is skipped, not copied.
+          return false;
+        }
+      },
+    });
+    await rewriteAbsoluteStagingSymlinks(sourceRoot, targetPath, targetPath);
+    await removeEscapingStagedSymlinks(targetPath, targetPath);
+  } catch (error) {
+    try {
+      await fs.rm(targetPath, { recursive: true, force: true });
+    } catch (cleanupError) {
+      // error-policy:J6 failed staging is unusable; cleanup failure is secondary.
+      logger.warn(
+        `[eliza] Failed to remove rejected plugin staging tree: ${formatError(cleanupError)}`,
+      );
+    }
+    throw error;
+  }
 }
 
 async function stageNodeModulesEntries(params: {
@@ -1174,10 +1288,11 @@ async function stageNodeModulesEntries(params: {
           continue;
         }
         if (scopedEntry.isSymbolicLink()) {
-          const linkTarget =
-            await confinedStagingSymlinkTarget(scopedSourcePath);
-          if (!linkTarget) continue;
-          await fs.symlink(linkTarget, scopedTargetPath);
+          await copySymlinkedPackageForStaging(
+            scopedSourcePath,
+            scopedTargetPath,
+            `${entry.name}/${scopedEntry.name}`,
+          );
           continue;
         }
         if (!scopedEntry.isDirectory()) {
@@ -1195,9 +1310,7 @@ async function stageNodeModulesEntries(params: {
       continue;
     }
     if (entry.isSymbolicLink()) {
-      const linkTarget = await confinedStagingSymlinkTarget(sourcePath);
-      if (!linkTarget) continue;
-      await fs.symlink(linkTarget, targetPath);
+      await copySymlinkedPackageForStaging(sourcePath, targetPath, entry.name);
       continue;
     }
     if (!entry.isDirectory()) {

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -6,6 +6,10 @@
  * directories. Each plugin is wrapped in an error boundary so a single
  * failing plugin cannot crash the agent startup.
  *
+ * Staging copies of node_modules trees must not dereference or re-plant
+ * symlinks whose realpath leaves the workspace — `fs.cp({ dereference: true })`
+ * materializes host files (for example `/etc/passwd`) into the staged plugin.
+ *
  * @module plugin-resolver
  */
 import crypto from "node:crypto";
@@ -253,7 +257,7 @@ async function stageDependencyIntoNodeModules(params: {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
   const stat = await fs.lstat(sourcePath);
   if (stat.isSymbolicLink()) {
-    const linkTarget = await resolveSymlinkTargetIfPresent(sourcePath);
+    const linkTarget = await confinedStagingSymlinkTarget(sourcePath);
     if (!linkTarget) {
       return false;
     }
@@ -264,11 +268,7 @@ async function stageDependencyIntoNodeModules(params: {
     return false;
   }
 
-  await fs.cp(sourcePath, targetPath, {
-    recursive: true,
-    force: true,
-    dereference: true,
-  });
+  await copyPluginTreeWithoutEscapingSymlinks(sourcePath, targetPath);
   return true;
 }
 
@@ -422,10 +422,7 @@ async function stageWorkspaceSourceDependencyIntoNodeModules(params: {
   }
 
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
-  await fs.cp(resolvedSourcePath, targetPath, {
-    recursive: true,
-    force: true,
-    dereference: true,
+  await copyPluginTreeWithoutEscapingSymlinks(resolvedSourcePath, targetPath, {
     filter: (src) => {
       const relativePath = path.relative(resolvedSourcePath, src);
       if (!relativePath) return true;
@@ -1061,6 +1058,91 @@ async function resolveSymlinkTargetIfPresent(
   }
 }
 
+/** Separator-aware containment so `..safe.js` is a name, not a traversal. */
+function isPathInsideRoot(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  const rel = path.relative(parent, child);
+  return (
+    rel.length > 0 &&
+    rel !== ".." &&
+    !rel.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rel)
+  );
+}
+
+async function pluginStagingConfinementRoots(
+  extraRoot?: string,
+): Promise<string[]> {
+  const roots = new Set<string>();
+  const add = async (candidate: string | undefined) => {
+    if (!candidate) return;
+    try {
+      roots.add(await fs.realpath(candidate));
+    } catch {
+      // error-policy:J3 missing extra roots are omitted, not invented.
+    }
+  };
+  await add(process.cwd());
+  await add(process.env.ELIZA_WORKSPACE_ROOT?.trim());
+  await add(extraRoot);
+  return [...roots];
+}
+
+async function realpathAllowedForPluginStaging(
+  real: string,
+  extraRoot?: string,
+): Promise<boolean> {
+  const roots = await pluginStagingConfinementRoots(extraRoot);
+  return roots.some((root) => real === root || isPathInsideRoot(real, root));
+}
+
+/**
+ * Realpath of a staging source symlink, or null when it is missing or points
+ * outside the workspace. Re-planting an escaping realpath as a symlink in the
+ * staged tree would let later reads follow it to host files.
+ */
+export async function confinedStagingSymlinkTarget(
+  sourcePath: string,
+  extraRoot?: string,
+): Promise<string | null> {
+  const linkTarget = await resolveSymlinkTargetIfPresent(sourcePath);
+  if (!linkTarget) return null;
+  if (!(await realpathAllowedForPluginStaging(linkTarget, extraRoot))) {
+    return null;
+  }
+  return linkTarget;
+}
+
+/**
+ * Copy a plugin/package tree without materializing host files behind
+ * out-of-tree symlinks. `fs.cp({ dereference: true })` followed those links
+ * and wrote the target bytes into the staged install.
+ */
+export async function copyPluginTreeWithoutEscapingSymlinks(
+  sourcePath: string,
+  targetPath: string,
+  options?: { filter?: (src: string) => boolean },
+): Promise<void> {
+  const sourceRoot = await fs.realpath(sourcePath);
+  await fs.cp(sourcePath, targetPath, {
+    recursive: true,
+    force: true,
+    dereference: false,
+    filter: async (src) => {
+      if (options?.filter && !options.filter(src)) return false;
+      try {
+        const stat = await fs.lstat(src);
+        if (!stat.isSymbolicLink()) return true;
+        const real = await fs.realpath(src);
+        return realpathAllowedForPluginStaging(real, sourceRoot);
+      } catch {
+        // error-policy:J3 broken or unresolvable symlink is skipped, not copied.
+        return false;
+      }
+    },
+  });
+}
+
 async function stageNodeModulesEntries(params: {
   sourceNodeModulesDir: string;
   targetNodeModulesDir: string;
@@ -1093,7 +1175,7 @@ async function stageNodeModulesEntries(params: {
         }
         if (scopedEntry.isSymbolicLink()) {
           const linkTarget =
-            await resolveSymlinkTargetIfPresent(scopedSourcePath);
+            await confinedStagingSymlinkTarget(scopedSourcePath);
           if (!linkTarget) continue;
           await fs.symlink(linkTarget, scopedTargetPath);
           continue;
@@ -1101,11 +1183,10 @@ async function stageNodeModulesEntries(params: {
         if (!scopedEntry.isDirectory()) {
           continue;
         }
-        await fs.cp(scopedSourcePath, scopedTargetPath, {
-          recursive: true,
-          force: true,
-          dereference: true,
-        });
+        await copyPluginTreeWithoutEscapingSymlinks(
+          scopedSourcePath,
+          scopedTargetPath,
+        );
       }
       continue;
     }
@@ -1114,7 +1195,7 @@ async function stageNodeModulesEntries(params: {
       continue;
     }
     if (entry.isSymbolicLink()) {
-      const linkTarget = await resolveSymlinkTargetIfPresent(sourcePath);
+      const linkTarget = await confinedStagingSymlinkTarget(sourcePath);
       if (!linkTarget) continue;
       await fs.symlink(linkTarget, targetPath);
       continue;
@@ -1122,11 +1203,7 @@ async function stageNodeModulesEntries(params: {
     if (!entry.isDirectory()) {
       continue;
     }
-    await fs.cp(sourcePath, targetPath, {
-      recursive: true,
-      force: true,
-      dereference: true,
-    });
+    await copyPluginTreeWithoutEscapingSymlinks(sourcePath, targetPath);
   }
 }
 
@@ -1373,12 +1450,11 @@ async function populateStagedImportRoot(
       ? path.join(stagedInstallRoot, ...params.packageRelativePath)
       : stagedInstallRoot;
   await fs.mkdir(path.dirname(stagedPackageRoot), { recursive: true });
-  await fs.cp(params.packageRoot, stagedPackageRoot, {
-    recursive: true,
-    force: true,
-    dereference: false,
-    filter: createPluginPackageStageFilter(params.packageRoot),
-  });
+  await copyPluginTreeWithoutEscapingSymlinks(
+    params.packageRoot,
+    stagedPackageRoot,
+    { filter: createPluginPackageStageFilter(params.packageRoot) },
+  );
 
   const installNodeModulesPath = path.join(params.installRoot, "node_modules");
   try {


### PR DESCRIPTION
Closes #22708.

## Problem

Plugin staging dereferenced package-tree links and could copy host-file bytes into a staged plugin. The submitted repair stopped the direct `/tmp` escape, but still treated the process working directory or `ELIZA_WORKSPACE_ROOT` as a valid confinement root, preserved absolute source-tree links in the staged result, and re-planted top-level `node_modules` links without binding the target package identity.

That was not a self-contained staging contract: a runtime launched from a broad workspace could retain links to sibling secrets, and a staged cache could depend on mutable source paths.

## Final change

- Copy package trees with `dereference: false` and verbatim link text.
- Admit a nested link only when both its lexical target and final realpath stay inside that package root; reject ancestor cycles, broken chains, and indirect escapes.
- Remap valid absolute in-package aliases into the staged destination, then perform a second destination-realpath audit before the tree becomes importable.
- On any copy/audit failure, remove the rejected partial staging tree and rethrow the original failure.
- For symlinked `node_modules` entries, resolve the target once, require a directory with a `package.json` name exactly matching the requested dependency, and copy it as a self-contained package instead of planting a live host link.
- Exercise the production helpers with real-filesystem adversarial cases rather than mocked path predicates.

## Exact-head evidence

<!-- evidence-head:d03e9c9c8248da1433374ed63876a0793d4ac8f0 -->
Evidence head: `d03e9c9c8248da1433374ed63876a0793d4ac8f0`

- Production resolver/copy/staging-cache suites: 3 files, 24 tests passed.
- `@elizaos/agent` distribution build passed.
- Full agent source Biome: 966 files clean.
- `git diff --check`: clean.
- [Detailed exact-head filesystem transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22476-pr22476-domain-v2.txt).

Package typecheck was attempted; the isolated checkout lacks unrelated optional/workspace modules and emitted no changed-file diagnostic. The missing-module baseline is disclosed in the attached transcript rather than represented as a passing gate.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered surface; this is a server-side staging filesystem boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface; this is a server-side staging filesystem boundary.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow; real filesystem artifacts and production tests are attached.
<!-- evidence-row:backend-logs -->
- [x] N/A - staging runs before the agent backend is active; the real-filesystem production helper transcript is attached as the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Real-filesystem staged-tree artifact assertions](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22476-pr22476-domain-v2.txt).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Attribution

Original contribution: xAI / grok-4.6 via Grok CLI.

Maintainer repair and review: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux; Codex Desktop multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent
Attribution status: AI-assisted maintainer repair
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

## Independent-audit blocker repair

The first repaired head was held after independent review found two residual TOCTOU windows. Exact head `d03e9c9c8248da1433374ed63876a0793d4ac8f0` now revalidates package identity from the copied `target/package.json` and deletes mismatched/malformed staging trees. Its final destination audit also removes links resolving to the stage root or any ancestor. Deterministic source-swap and post-copy symlink-swap regressions bring the exact real-filesystem family to 27/27. Owning-package production build, changed-file Biome, and diff-check pass.

Repair attribution: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.