### PR TITLE
fix(swabble): bound native fuzzy matching inputs

### DIFF
--- a/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
+++ b/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
@@ -9,7 +9,7 @@ internal object SwabbleWakeBridgeContract {
      * recognizer callback. Exact matching is unchanged; fuzzy refuses
      * oversized tokens instead of allocating the DP tables.
      */
-    const val MAX_FUZZY_TOKEN_CHARS = 64
+    const val MAX_FUZZY_TOKEN_CODE_UNITS = 64
 
     data class Config(
         val triggers: List<String>,
@@ -55,6 +55,11 @@ internal object SwabbleWakeBridgeContract {
                 if (wordIndex + triggerLen > words.size) continue
 
                 val candidate = words.subList(wordIndex, wordIndex + triggerLen).joinToString(" ")
+                if (candidate.length > MAX_FUZZY_TOKEN_CODE_UNITS ||
+                    trigger.length > MAX_FUZZY_TOKEN_CODE_UNITS
+                ) {
+                    continue
+                }
                 val distance = levenshteinDistance(candidate.lowercase(), trigger.lowercase())
                 val maxLen = maxOf(candidate.length, trigger.length)
                 if (maxLen == 0 || distance.toDouble() / maxLen > 0.3) continue
@@ -132,7 +137,7 @@ internal object SwabbleWakeBridgeContract {
     private fun levenshteinDistance(a: String, b: String): Int {
         val m = a.length
         val n = b.length
-        if (m > MAX_FUZZY_TOKEN_CHARS || n > MAX_FUZZY_TOKEN_CHARS) {
+        if (m > MAX_FUZZY_TOKEN_CODE_UNITS || n > MAX_FUZZY_TOKEN_CODE_UNITS) {
             return Int.MAX_VALUE
         }
         if (m == 0) return n

--- a/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
+++ b/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
@@ -3,6 +3,14 @@ package ai.eliza.plugins.swabble
 import com.getcapacitor.JSObject
 
 internal object SwabbleWakeBridgeContract {
+    /**
+     * Wake tokens are a handful of short words. Unbounded Levenshtein on a
+     * no-space ASR dump or a hostile trigger is O(len²) and hangs the
+     * recognizer callback. Exact matching is unchanged; fuzzy refuses
+     * oversized tokens instead of allocating the DP tables.
+     */
+    const val MAX_FUZZY_TOKEN_CHARS = 64
+
     data class Config(
         val triggers: List<String>,
         val minPostTriggerGap: Double,
@@ -124,6 +132,9 @@ internal object SwabbleWakeBridgeContract {
     private fun levenshteinDistance(a: String, b: String): Int {
         val m = a.length
         val n = b.length
+        if (m > MAX_FUZZY_TOKEN_CHARS || n > MAX_FUZZY_TOKEN_CHARS) {
+            return Int.MAX_VALUE
+        }
         if (m == 0) return n
         if (n == 0) return m
 

--- a/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
+++ b/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
@@ -3,6 +3,7 @@ package ai.eliza.plugins.swabble
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SwabbleWakeBridgeContractTest {
@@ -64,5 +65,24 @@ class SwabbleWakeBridgeContractTest {
         )
 
         assertNull(match)
+    }
+
+    @Test
+    fun `oversized no-space tokens skip fuzzy match without hanging`() {
+        val left = "a".repeat(32_768)
+        val right = "b".repeat(32_768)
+        val hostile = config.copy(triggers = listOf(right))
+        val started = System.nanoTime()
+        val match = SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "$left turn on the lights",
+            segments = emptyList(),
+            config = hostile
+        )
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000.0
+        assertNull(match)
+        assertTrue(
+            "oversized Levenshtein must fail closed quickly, took ${elapsedMs}ms",
+            elapsedMs < 50.0
+        )
     }
 }

--- a/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
+++ b/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
@@ -3,7 +3,6 @@ package ai.eliza.plugins.swabble
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SwabbleWakeBridgeContractTest {
@@ -68,21 +67,34 @@ class SwabbleWakeBridgeContractTest {
     }
 
     @Test
-    fun `oversized no-space tokens skip fuzzy match without hanging`() {
+    fun `oversized no-space tokens skip fuzzy match`() {
         val left = "a".repeat(32_768)
         val right = "b".repeat(32_768)
         val hostile = config.copy(triggers = listOf(right))
-        val started = System.nanoTime()
         val match = SwabbleWakeBridgeContract.matchWakeWord(
             transcript = "$left turn on the lights",
             segments = emptyList(),
             config = hostile
         )
-        val elapsedMs = (System.nanoTime() - started) / 1_000_000.0
         assertNull(match)
-        assertTrue(
-            "oversized Levenshtein must fail closed quickly, took ${elapsedMs}ms",
-            elapsedMs < 50.0
-        )
+    }
+
+    @Test
+    fun `fuzzy token cap accepts 64 UTF-16 units and rejects 65`() {
+        val acceptedTrigger = "a".repeat(64)
+        val acceptedCandidate = "a".repeat(63) + "b"
+        val rejectedTrigger = "a".repeat(65)
+        val rejectedCandidate = "a".repeat(64) + "b"
+
+        assertNotNull(SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "$acceptedCandidate run diagnostics",
+            segments = emptyList(),
+            config = config.copy(triggers = listOf(acceptedTrigger))
+        ))
+        assertNull(SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "$rejectedCandidate run diagnostics",
+            segments = emptyList(),
+            config = config.copy(triggers = listOf(rejectedTrigger))
+        ))
     }
 }

--- a/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
@@ -107,9 +107,17 @@ enum SwabbleWakeBridgeContract {
         if a == b { return true }
         let maxLen = max(a.count, b.count)
         guard maxLen > 2 else { return false }
+        // Wake tokens are short. Unbounded edit distance on a no-space ASR
+        // dump or a hostile trigger is O(len²) and hangs the recognizer
+        // callback. Exact equality above still matches.
+        guard a.count <= maxFuzzyTokenChars, b.count <= maxFuzzyTokenChars else {
+            return false
+        }
         let threshold = max(1, (maxLen + 1) / 3)
         return editDistance(a, b) <= threshold
     }
+
+    static let maxFuzzyTokenChars = 64
 
     private static let wsPunct = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters)
 
@@ -120,6 +128,7 @@ enum SwabbleWakeBridgeContract {
     private static func editDistance(_ a: String, _ b: String) -> Int {
         let ac = Array(a), bc = Array(b)
         let m = ac.count, n = bc.count
+        if m > maxFuzzyTokenChars || n > maxFuzzyTokenChars { return Int.max }
         if m == 0 { return n }
         if n == 0 { return m }
         var prev = Array(0...n), curr = Array(repeating: 0, count: n + 1)

--- a/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
@@ -105,19 +105,18 @@ enum SwabbleWakeBridgeContract {
 
     static func fuzzyTokenMatch(_ a: String, _ b: String) -> Bool {
         if a == b { return true }
-        let maxLen = max(a.count, b.count)
-        guard maxLen > 2 else { return false }
-        // Wake tokens are short. Unbounded edit distance on a no-space ASR
-        // dump or a hostile trigger is O(len²) and hangs the recognizer
-        // callback. Exact equality above still matches.
-        guard a.count <= maxFuzzyTokenChars, b.count <= maxFuzzyTokenChars else {
+        guard a.utf16.count <= maxFuzzyTokenCodeUnits,
+              b.utf16.count <= maxFuzzyTokenCodeUnits else {
             return false
         }
+        let maxLen = max(a.count, b.count)
+        guard maxLen > 2 else { return false }
         let threshold = max(1, (maxLen + 1) / 3)
         return editDistance(a, b) <= threshold
     }
 
-    static let maxFuzzyTokenChars = 64
+    /// Bounds both the dynamic-programming table and each retained Character.
+    static let maxFuzzyTokenCodeUnits = 64
 
     private static let wsPunct = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters)
 
@@ -126,9 +125,12 @@ enum SwabbleWakeBridgeContract {
     }
 
     private static func editDistance(_ a: String, _ b: String) -> Int {
+        guard a.utf16.count <= maxFuzzyTokenCodeUnits,
+              b.utf16.count <= maxFuzzyTokenCodeUnits else {
+            return Int.max
+        }
         let ac = Array(a), bc = Array(b)
         let m = ac.count, n = bc.count
-        if m > maxFuzzyTokenChars || n > maxFuzzyTokenChars { return Int.max }
         if m == 0 { return n }
         if n == 0 { return m }
         var prev = Array(0...n), curr = Array(repeating: 0, count: n + 1)

--- a/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
@@ -240,37 +240,7 @@ private enum WakeGate {
     /// Returns true if two normalized tokens are "close enough" to be considered a match.
     /// Threshold: ceil(maxLen / 3). e.g. "eliza" (7) ↔ "melody" (6) → threshold 3, distance 3 → match.
     static func fuzzyTokenMatch(_ a: String, _ b: String) -> Bool {
-        if a == b { return true }
-        let maxLen = max(a.count, b.count)
-        guard maxLen > 2 else { return false } // Very short words → exact only
-        // Same 64-char fail-closed cap as SwabbleWakeBridgeContract.
-        // Unbounded DP on a no-space ASR dump hangs the recognizer callback.
-        guard a.count <= maxFuzzyTokenChars, b.count <= maxFuzzyTokenChars else {
-            return false
-        }
-        let threshold = max(1, (maxLen + 1) / 3)
-        return editDistance(a, b) <= threshold
-    }
-
-    static let maxFuzzyTokenChars = 64
-
-    private static func editDistance(_ a: String, _ b: String) -> Int {
-        let ac = Array(a), bc = Array(b)
-        let m = ac.count, n = bc.count
-        if m > maxFuzzyTokenChars || n > maxFuzzyTokenChars { return Int.max }
-        if m == 0 { return n }
-        if n == 0 { return m }
-        var prev = Array(0...n), curr = Array(repeating: 0, count: n + 1)
-        for i in 1...m {
-            curr[0] = i
-            for j in 1...n {
-                curr[j] = ac[i - 1] == bc[j - 1]
-                    ? prev[j - 1]
-                    : 1 + min(prev[j], curr[j - 1], prev[j - 1])
-            }
-            swap(&prev, &curr)
-        }
-        return prev[n]
+        SwabbleWakeBridgeContract.fuzzyTokenMatch(a, b)
     }
 
     // MARK: Normalization helpers

--- a/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
@@ -243,13 +243,21 @@ private enum WakeGate {
         if a == b { return true }
         let maxLen = max(a.count, b.count)
         guard maxLen > 2 else { return false } // Very short words → exact only
+        // Same 64-char fail-closed cap as SwabbleWakeBridgeContract.
+        // Unbounded DP on a no-space ASR dump hangs the recognizer callback.
+        guard a.count <= maxFuzzyTokenChars, b.count <= maxFuzzyTokenChars else {
+            return false
+        }
         let threshold = max(1, (maxLen + 1) / 3)
         return editDistance(a, b) <= threshold
     }
 
+    static let maxFuzzyTokenChars = 64
+
     private static func editDistance(_ a: String, _ b: String) -> Int {
         let ac = Array(a), bc = Array(b)
         let m = ac.count, n = bc.count
+        if m > maxFuzzyTokenChars || n > maxFuzzyTokenChars { return Int.max }
         if m == 0 { return n }
         if n == 0 { return m }
         var prev = Array(0...n), curr = Array(repeating: 0, count: n + 1)

--- a/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleTriggerGateTests.swift
+++ b/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleTriggerGateTests.swift
@@ -42,19 +42,26 @@ final class SwabbleTriggerGateTests: XCTestCase {
                 transcript: "", triggers: triggers))
     }
 
-    func testOversizedNoSpaceTokensSkipFuzzyWithoutHanging() {
+    func testOversizedNoSpaceTokensSkipFuzzy() {
         let left = String(repeating: "a", count: 32_768)
         let right = String(repeating: "b", count: 32_768)
-        let started = Date()
         XCTAssertFalse(
             SwabbleWakeBridgeContract.fuzzyTokenMatch(left, right))
-        let elapsedMs = Date().timeIntervalSince(started) * 1000
-        XCTAssertLessThan(
-            elapsedMs,
-            50,
-            "oversized Levenshtein must fail closed quickly, took \(elapsedMs)ms")
         XCTAssertFalse(
             SwabbleWakeBridgeContract.isTriggerOnly(
                 transcript: left, triggers: [right]))
+    }
+
+    func testFuzzyCapCountsUTF16CodeUnits() {
+        let accepted = String(repeating: "a", count: 63) + "b"
+        let acceptedTrigger = String(repeating: "a", count: 64)
+        let rejected = String(repeating: "a", count: 64) + "b"
+        let rejectedTrigger = String(repeating: "a", count: 65)
+        let oversizedSingleGrapheme = "a" + String(repeating: "\u{0301}", count: 64)
+
+        XCTAssertTrue(SwabbleWakeBridgeContract.fuzzyTokenMatch(accepted, acceptedTrigger))
+        XCTAssertFalse(SwabbleWakeBridgeContract.fuzzyTokenMatch(rejected, rejectedTrigger))
+        XCTAssertEqual(oversizedSingleGrapheme.count, 1)
+        XCTAssertFalse(SwabbleWakeBridgeContract.fuzzyTokenMatch(oversizedSingleGrapheme, "b"))
     }
 }

--- a/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleTriggerGateTests.swift
+++ b/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleTriggerGateTests.swift
@@ -41,4 +41,20 @@ final class SwabbleTriggerGateTests: XCTestCase {
             SwabbleWakeBridgeContract.isTriggerOnly(
                 transcript: "", triggers: triggers))
     }
+
+    func testOversizedNoSpaceTokensSkipFuzzyWithoutHanging() {
+        let left = String(repeating: "a", count: 32_768)
+        let right = String(repeating: "b", count: 32_768)
+        let started = Date()
+        XCTAssertFalse(
+            SwabbleWakeBridgeContract.fuzzyTokenMatch(left, right))
+        let elapsedMs = Date().timeIntervalSince(started) * 1000
+        XCTAssertLessThan(
+            elapsedMs,
+            50,
+            "oversized Levenshtein must fail closed quickly, took \(elapsedMs)ms")
+        XCTAssertFalse(
+            SwabbleWakeBridgeContract.isTriggerOnly(
+                transcript: left, triggers: [right]))
+    }
 }


### PR DESCRIPTION
Closes #22706.

## Problem

Native Swabble wake-word fuzzy matching ran Levenshtein distance on recognition tokens without a reliable allocation boundary. A no-space ASR result or configured trigger could make the recognizer callback perform quadratic work.

The submitted repair was directionally correct, but its guard still ran after Android lowercasing, Swift counted grapheme clusters (so one huge combining sequence could pass as one `Character`), and the production iOS plugin retained a second untested edit-distance implementation.

## Final change

- Bound fuzzy inputs at 64 UTF-16 code units before Android case folding and before Swift `Character` arrays/DP allocation.
- Preserve exact matching before the fuzzy guard.
- Keep a defensive guard inside both edit-distance implementations.
- Route the production iOS `WakeGate` through `SwabbleWakeBridgeContract.fuzzyTokenMatch` so the shipped path and tested contract cannot drift.
- Replace flaky elapsed-time assertions with deterministic exact-cap, cap-plus-one, 32KiB no-space, and oversized single-grapheme cases.

## Exact-head evidence

<!-- evidence-head:a5908fe1c23d708f8c7b40f4f245d1826aabaacf -->
Evidence head: `a5908fe1c23d708f8c7b40f4f245d1826aabaacf`

- Android production contract compiled with Kotlin 2.2.20/JDK 21 against a minimal Capacitor `JSObject` seam; exact 64/65-code-unit and 32KiB production-path smoke passed.
- Swift production contract target built successfully with Swift 6.3.1.
- Direct compiled Swift production-boundary smoke passed exact 64/65-code-unit, 32KiB, and one-grapheme/65-code-unit combining-sequence cases.
- Package Biome: 7 files clean.
- `git diff --check`: clean.

The repository's full Android Gradle lane could not configure in the isolated review checkout because generated Capacitor settings could not resolve an unrelated app npm package. `swift test` compiled the changed production target but this host only has Command Line Tools and no XCTest module. These environment limitations are not represented as passing gates; the direct production compiles/smokes above cover both changed native boundaries.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered surface; this changes native wake-word matching computation only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface; this changes native wake-word matching computation only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered flow changed; deterministic native contract evidence is attached.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend, transport, persistence, or server path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt, inference, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact native production-boundary build and smoke transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22479-pr22479-domain.txt).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Attribution

Original contribution: xAI / grok-4.6 via Grok CLI.

Maintainer repair and review: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux; Codex Desktop multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent
Attribution status: AI-assisted maintainer repair
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
