### PR TITLE
fix(cloud): extend migration checkpoint fixture for payment request tenant authority

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -187,7 +187,30 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
     CREATE TABLE organizations (
       id uuid PRIMARY KEY,
       credit_balance numeric(16, 6) NOT NULL DEFAULT '0.000000',
+      stripe_customer_id text,
+      billing_email text,
+      stripe_payment_method_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean DEFAULT false,
+      auto_top_up_amount numeric(12, 6),
+      auto_top_up_threshold numeric(12, 6),
       CONSTRAINT credit_balance_non_negative CHECK (credit_balance >= 0)
+    );
+    CREATE TABLE organization_billing (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      stripe_customer_id text,
+      billing_email text,
+      tax_id_type text,
+      tax_id_value text,
+      billing_address jsonb,
+      stripe_payment_method_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean NOT NULL DEFAULT false,
+      auto_top_up_amount numeric(12, 6),
+      auto_top_up_threshold numeric(12, 6),
+      updated_at timestamp with time zone NOT NULL DEFAULT now(),
+      CONSTRAINT organization_billing_organization_id_unique UNIQUE (organization_id)
     );
     CREATE TABLE credit_transactions (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -236,7 +259,16 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
       updated_at timestamp with time zone NOT NULL DEFAULT now()
     );
     CREATE TABLE payment_requests (
-      id uuid PRIMARY KEY
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      provider text NOT NULL,
+      amount_cents bigint NOT NULL,
+      currency text NOT NULL DEFAULT 'usd',
+      status text NOT NULL DEFAULT 'pending',
+      provider_intent jsonb NOT NULL DEFAULT '{}'::jsonb,
+      settled_at timestamp with time zone,
+      settlement_tx_ref text,
+      settlement_proof jsonb
     );
     CREATE TABLE payment_request_events (
       id uuid PRIMARY KEY,
@@ -499,6 +531,75 @@ describe.skipIf(!ENABLED)(
         data_type: "text",
         is_nullable: "NO",
         column_default: "'open'::text",
+      });
+
+      // 0262 pivots payment receipts on the historical (id, organization_id,
+      // provider) tenant authority of payment_requests. If the pre-0185
+      // checkpoint fixture regresses back to the id-only shape, 0262 fails with
+      // 42703 before this index exists, so asserting both the columns and the
+      // unique index guards the fixture against that drift.
+      const paymentRequestAuthority = await database.client.query<{
+        organization_id: string;
+        provider: string;
+        tenant_authority_index: string;
+      }>(`
+        SELECT
+          (SELECT count(*)::text
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'payment_requests'
+             AND column_name = 'organization_id') AS organization_id,
+          (SELECT count(*)::text
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'payment_requests'
+             AND column_name = 'provider') AS provider,
+          (SELECT count(*)::text
+           FROM pg_indexes
+           WHERE schemaname = 'public' AND tablename = 'payment_requests'
+             AND indexname
+               = 'payment_requests_id_organization_provider_unique')
+             AS tenant_authority_index
+      `);
+      expect(paymentRequestAuthority.rows[0]).toEqual({
+        organization_id: "1",
+        provider: "1",
+        tenant_authority_index: "1",
+      });
+
+      // 0264 folds the organization_billing shadow into organizations, so the
+      // pre-0185 checkpoint must already carry the historical shadow table plus
+      // the organizations billing-authority columns. If the fixture drops them,
+      // 0264 aborts with 42P01/42703 before this row can be observed.
+      const billingAuthority = await database.client.query<{
+        shadow_table: string;
+        shadow_auto_top_up_amount: string;
+        organizations_stripe_customer_id: string;
+        organizations_auto_top_up_amount: string;
+      }>(`
+        SELECT
+          (SELECT count(*)::text
+           FROM information_schema.tables
+           WHERE table_schema = 'public'
+             AND table_name = 'organization_billing') AS shadow_table,
+          (SELECT count(*)::text
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'organization_billing'
+             AND column_name = 'auto_top_up_amount') AS shadow_auto_top_up_amount,
+          (SELECT count(*)::text
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'organizations'
+             AND column_name = 'stripe_customer_id')
+             AS organizations_stripe_customer_id,
+          (SELECT count(*)::text
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'organizations'
+             AND column_name = 'auto_top_up_amount')
+             AS organizations_auto_top_up_amount
+      `);
+      expect(billingAuthority.rows[0]).toEqual({
+        shadow_table: "1",
+        shadow_auto_top_up_amount: "1",
+        organizations_stripe_customer_id: "1",
+        organizations_auto_top_up_amount: "1",
       });
 
       const second = await runScript(MIGRATOR, database.url);


### PR DESCRIPTION
# Relates to

Closes #22475

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`). `HEAD...origin/develop` = `0 0` at push time.
- [x] `bun install` was run after sync. Full `bun run verify` was not run on this ARM contributor host (see Known gaps); the owning real-PostgreSQL suite, Biome check, and Biome format all pass.
- [x] A reviewer can confirm the change works without reading the code, from the before/after real-PostgreSQL suite output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2734e4c5d60f3e86aca33854ae751d8ba3934cd0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`0 0`).
- [ ] `bun run verify` passes post-sync — not run in full on this host; the exact scope and the checks that were run are documented in **Known gaps / failures**.

# Risks

Low. The change is confined to a single real-PostgreSQL test fixture helper
(`seedPreCheckpointSchema`) plus two catalog assertions in the same test file.
No production migration SQL, journal, schema, or runtime code is touched. The
fixture only gains historical columns/tables that pending migrations already
require, so it cannot mask a real production defect — it makes the checkpoint
faithfully reflect the pre-0185 catalog the migrator runs against.

# Background

## What does this PR do?

The real-PostgreSQL migration-fencing suite
`packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts` seeds a
dependency-minimal **pre-0185 catalog checkpoint** and then runs every pending
migration forward against it in five modes (historical / hash / timestamp /
hybrid / contention). The checkpoint fixture had drifted behind the pending
migration tail:

1. `payment_requests` was declared with only `id uuid PRIMARY KEY`. Pending
   `0262_payment_request_receipts` statement 1/8 creates
   `payment_requests_id_organization_provider_unique ("id","organization_id","provider")`
   and a later composite FK targeting `("id","organization_id","provider")`,
   so it aborted with PostgreSQL `42703` `column "organization_id" does not
   exist`, cascading into the remaining migrations and teardown.
2. Once 0262/0263 could apply, the freshly merged
   `0264_organization_billing_authority` (#22460) then failed with `42P01`
   `relation "organization_billing" does not exist`, because the pre-0185
   fixture never carried the historical `organization_billing` shadow table or
   the `organizations` billing-authority columns that 0264 folds into
   `organizations`.

The real production schemas already have these columns/tables — this is
**checkpoint-fixture drift, not a production migration defect**. The fix extends
only the fixture with the historical, dependency-minimal inputs the pending
0262–0264 tail actually references:

- `payment_requests`: `organization_id`, `provider`, `amount_cents`, `currency`,
  `status`, `provider_intent`, `settled_at`, `settlement_tx_ref`,
  `settlement_proof` (as created historically by `0116_add_payment_requests`,
  in the checkpoint prefix). Event-side columns that 0263 reads are added by the
  pending `0254_payment_request_provider_settlement` and are intentionally left
  out of the fixture.
- `organizations`: the historical billing-authority columns
  (`stripe_customer_id`, `billing_email`, `stripe_payment_method_id`,
  `stripe_default_payment_method`, `auto_top_up_enabled`, `auto_top_up_amount`,
  `auto_top_up_threshold`).
- a minimal historical `organization_billing` shadow table (from `0049`) with
  only the columns/unique constraint 0264 depends on.

No journal checkpoint is advanced and **no post-checkpoint 0264 DDL** (its
authority unique indexes, sync/guard triggers) is pre-applied — the migrator
still creates all of that. Two catalog assertions were added to the existing
`applies the append-only fix-forward once …` test: one guarding the
`payment_requests` tenant/provider authority (columns + the 0262 unique index),
one guarding the `organization_billing` shadow and `organizations`
billing-authority columns. Either assertion fails if the fixture regresses to
its prior shape. This matches the maintainer scope-update comment on the issue.

## What kind of change is this?

Bug fix (non-breaking; test-fixture correctness for the migration-fencing
suite).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts` — the
`seedPreCheckpointSchema` fixture (the `payment_requests`, `organizations`, and
new `organization_billing` blocks) and the two catalog assertions in the first
test.

## Detailed testing steps

With a real PostgreSQL (superuser/createdb role) reachable:

```bash
cd packages/cloud
RUN_REAL_POSTGRES_MIGRATION_TESTS=1 \
TEST_DATABASE_URL=postgres://<user>:<pass>@localhost:5432/postgres \
bun test scripts/admin/migrate-with-diagnostics.postgres.test.ts
```

Reproduced on a disposable `postgres:16` (aarch64) container.

# Evidence Gate

<!-- evidence-head:ad9338a51553fd69f84d467b77382af30ba84e9a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — `N/A - no UI/rendered surface; change is a real-PostgreSQL test fixture and assertions.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — `N/A - no UI/rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — `N/A - CLI/test-only change; before/after suite output attached below.`
<!-- evidence-row:backend-logs -->
- [x] Backend migrator logs (real `[db:migrate]` path end to end): BEFORE/failing full log https://gist.github.com/agent-cortex/d874ecbf488aefbffc3fda955e7bf5ac — key excerpts inline below. (Off the CI gate's `user-attachments`/`releases/download/pr-evidence` host allowlist; see Known gaps.)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs — `N/A - no frontend surface.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Real-PostgreSQL migration run (catalog `information_schema`/`pg_indexes` assertions on `payment_requests`, `organizations`, `organization_billing`): AFTER/passing full log https://gist.github.com/agent-cortex/27ac6fcd9b957cc003fcee0cb58b0573 — 10/10 pass, 0 leaked DBs. (Off the CI gate host allowlist; see Known gaps.)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Frontend: `N/A - no frontend surface.`

Backend — real-PostgreSQL migrator output.

**BEFORE (id-only `payment_requests` fixture, `main` fixture shape): 0262 aborts, 7 fail**
<details><summary>migrator + suite excerpt (before)</summary>

```
[db:migrate] applying 0262_payment_request_receipts (8 statements, attempt 1/20)
[db:migrate] failed 0262_payment_request_receipts statement 1/8
[db:migrate] sql: ... CREATE UNIQUE INDEX IF NOT EXISTS "payment_requests_id_organization_provider_unique" ON "payment_requests" ("id", "organization_id", "provider");
[db:migrate] error: message=column "organization_id" does not exist code=42703
[db:migrate] fatal: message=column "organization_id" does not exist code=42703
...
 3 pass
 7 fail
Ran 10 tests across 1 file.
```
</details>

**AFTER (extended fixture): all 10 tests green in every mode, 0 leaked databases**
<details><summary>suite result (after)</summary>

```
(pass) applies the append-only fix-forward once and passes the reusable catalog preflight
(pass) accepts historical production hash drift but enforces hashes from the checkpoint forward
(pass) accepts production timestamp order when legacy journal indexes invert
(pass) accepts historical journal order when legacy timestamps invert
(pass) accepts the production hybrid order with late historical backfills
(pass) accepts production schema history missing ledger rows before the checkpoint
(pass) rejects historical rows appended after the immutable checkpoint
(pass) rejects incompatible catalog drift and malformed ledger prefixes
(pass) serializes concurrent migrators and recovers from table-lock contention
(pass) fails observably after bounded table-lock retries without partial state

 10 pass
 0 fail
 49 expect() calls
Ran 10 tests across 1 file.

# leaked test databases after run: 0
```
</details>

Full before/after logs attached as inline artifacts.

## Screenshots (before / after) + video walkthrough

### Before
`N/A - no UI change.`
### After
`N/A - no UI change.`
### Walkthrough video
`N/A - CLI/test-only change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- Full `bun run verify` was not run on this ARM contributor host (the whole-repo
  gate builds every workspace and is impractical here). The **owning** checks
  were run and pass: the real-PostgreSQL suite
  (`bun test scripts/admin/migrate-with-diagnostics.postgres.test.ts`, 10/10),
  `bunx @biomejs/biome check` (only 3 pre-existing `noUndeclaredEnvVars`
  warnings on untouched lines 49–54; none introduced by this diff), and
  `bunx @biomejs/biome format` (clean). The file is intentionally excluded from
  the package `tsc` project (`**/*.test.ts`) and executes cleanly under
  `bun:test`.
- The suite requires `RUN_REAL_POSTGRES_MIGRATION_TESTS=1` and a createdb-capable
  `TEST_DATABASE_URL`; verified against a disposable `postgres:16` (aarch64)
  container. `pg_database LIKE 'migration_%'` = 0 after the run (no leaked DBs).
- **Evidence-gate host allowlist:** the automated gate accepts only
  `github.com/user-attachments/...` (minted by GitHub's browser comment-box
  uploader) or `elizaOS/eliza/releases/download/pr-evidence` assets. From this
  fork-contributor environment the browser uploader needs an interactive 2FA
  session and the upstream release-asset upload returns HTTP 404 (no upstream
  write), so the `backend-logs` and `domain-artifacts` rows link the real full
  logs as public gists instead. The same output is also inline above in the
  `<details>` blocks. A maintainer can re-bind these to accepted hosts if the
  gate must pass green; the artifacts themselves are real and fetchable.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@2734e4c5d60f3e86aca33854ae751d8ba3934cd0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@2734e4c5d60f3e86aca33854ae751d8ba3934cd0:packages/skills/skills/contribute-to-eliza"} -->


