### PR TITLE
fix(voice): bound diarization scoring resources

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.greedy.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.greedy.test.ts
@@ -129,7 +129,7 @@ describe("computeDiarizationErrorRate — greedy mapping fallback", () => {
 			seg("p", 2000, 3000), // c collapsed onto p → a confusion either arm
 		];
 		const exact = computeDiarizationErrorRate(reference, hypothesis, {
-			maxExactSpeakers: 16,
+			maxExactSpeakers: 7,
 		});
 		const greedy = computeDiarizationErrorRate(reference, hypothesis, {
 			maxExactSpeakers: 0,

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
@@ -4,6 +4,8 @@ import {
 	computeDiarizationErrorRate,
 	type DiarizationSegment,
 	diarizationWithinBudget,
+	MAX_DER_DURATION_MS,
+	MIN_DER_FRAME_MS,
 } from "./diarization-error-rate";
 
 /**
@@ -89,6 +91,29 @@ describe("computeDiarizationErrorRate", () => {
 		const result = computeDiarizationErrorRate(reference, hypothesis);
 		expect(result.missedMs).toBeCloseTo(1000, -1);
 		expect(result.der).toBeCloseTo(1000 / 3000, 2);
+	});
+
+	it("fails closed on a hostile timeline instead of allocating millions of frames", () => {
+		const started = performance.now();
+		expect(() =>
+			computeDiarizationErrorRate(
+				[seg("alice", 0, MAX_DER_DURATION_MS + 1)],
+				[seg("spk0", 0, MAX_DER_DURATION_MS + 1)],
+			),
+		).toThrow(/exceeds/);
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("fails closed on a sub-millisecond frame that would explode frame count", () => {
+		expect(() =>
+			computeDiarizationErrorRate(
+				[seg("alice", 0, 1000)],
+				[seg("spk0", 0, 1000)],
+				{
+					frameMs: MIN_DER_FRAME_MS / 10,
+				},
+			),
+		).toThrow(/frameMs/);
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
@@ -5,6 +5,11 @@ import {
 	type DiarizationSegment,
 	diarizationWithinBudget,
 	MAX_DER_DURATION_MS,
+	MAX_DER_EXACT_SPEAKERS,
+	MAX_DER_FRAMES,
+	MAX_DER_SEGMENTS,
+	MAX_DER_SPEAKERS,
+	MAX_DER_WORK_UNITS,
 	MIN_DER_FRAME_MS,
 } from "./diarization-error-rate";
 
@@ -85,6 +90,16 @@ describe("computeDiarizationErrorRate", () => {
 		expect(result.der).toBe(0); // perfectly diarized overlap
 	});
 
+	it("keeps a speaker active across overlapping segments with the same label", () => {
+		const reference = [seg("alice", 0, 200), seg("alice", 100, 300)];
+		const hypothesis = [seg("spk0", 0, 300)];
+		const result = computeDiarizationErrorRate(reference, hypothesis, {
+			frameMs: 100,
+		});
+		expect(result.totalReferenceMs).toBe(300);
+		expect(result.der).toBe(0);
+	});
+
 	it("penalizes a missed overlapping talker", () => {
 		const reference = [seg("alice", 0, 2000), seg("bob", 1000, 2000)];
 		const hypothesis = [seg("spk0", 0, 2000)]; // bob's overlapping 1000ms missed
@@ -114,6 +129,95 @@ describe("computeDiarizationErrorRate", () => {
 				},
 			),
 		).toThrow(/frameMs/);
+	});
+
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, -1])(
+		"rejects malformed frame size %s instead of substituting the default",
+		(frameMs) => {
+			expect(() =>
+				computeDiarizationErrorRate(
+					[seg("alice", 0, 1000)],
+					[seg("spk0", 0, 1000)],
+					{ frameMs },
+				),
+			).toThrow(/frameMs/);
+		},
+	);
+
+	it("bounds the duration/frame product before sweeping the timeline", () => {
+		const score = () =>
+			computeDiarizationErrorRate(
+				[seg("alice", 0, MAX_DER_FRAMES + 1)],
+				[seg("spk0", 0, MAX_DER_FRAMES + 1)],
+				{ frameMs: 1 },
+			);
+		expect(score).toThrow(new RegExp(`${MAX_DER_FRAMES} frames`));
+		try {
+			score();
+		} catch (error) {
+			expect(error).toMatchObject({ code: "DIARIZATION_SCORE_UNBOUNDED" });
+		}
+	});
+
+	it("rejects inverted segments instead of silently dropping them", () => {
+		expect(() =>
+			computeDiarizationErrorRate([seg("alice", 20, 10)], [seg("spk0", 0, 10)]),
+		).toThrow(/greater than or equal/);
+	});
+
+	it("bounds sparse segment arrays before iterating their holes", () => {
+		const sparse = new Array<DiarizationSegment>(MAX_DER_SEGMENTS + 1);
+		expect(() => computeDiarizationErrorRate(sparse, [])).toThrow(
+			new RegExp(`${MAX_DER_SEGMENTS} combined segments`),
+		);
+	});
+
+	it("bounds unique speaker cardinality before constructing the mapping matrix", () => {
+		const reference = Array.from(
+			{ length: MAX_DER_SPEAKERS / 2 + 1 },
+			(_, index) => seg(`r${index}`, 0, 0),
+		);
+		const hypothesis = Array.from(
+			{ length: MAX_DER_SPEAKERS / 2 },
+			(_, index) => seg(`h${index}`, 0, 0),
+		);
+		expect(() => computeDiarizationErrorRate(reference, hypothesis)).toThrow(
+			new RegExp(`${MAX_DER_SPEAKERS} combined speakers`),
+		);
+	});
+
+	it("bounds overlap-amplified co-occurrence work", () => {
+		const speakersPerSide = 40;
+		const frames = Math.floor(MAX_DER_WORK_UNITS / speakersPerSide ** 2) + 1;
+		const reference = Array.from({ length: speakersPerSide }, (_, index) =>
+			seg(`r${index}`, 0, frames),
+		);
+		const hypothesis = Array.from({ length: speakersPerSide }, (_, index) =>
+			seg(`h${index}`, 0, frames),
+		);
+		expect(() =>
+			computeDiarizationErrorRate(reference, hypothesis, { frameMs: 1 }),
+		).toThrow(new RegExp(`${MAX_DER_WORK_UNITS} bounded work units`));
+	});
+
+	it("keeps the factorial mapping threshold within its proven safe ceiling", () => {
+		expect(() =>
+			computeDiarizationErrorRate([seg("alice", 0, 10)], [seg("spk0", 0, 10)], {
+				maxExactSpeakers: MAX_DER_EXACT_SPEAKERS + 1,
+			}),
+		).toThrow(/maxExactSpeakers/);
+	});
+
+	it("maps prototype-like speaker labels without mutating the result object", () => {
+		const result = computeDiarizationErrorRate(
+			[seg("constructor", 0, 100)],
+			[seg("__proto__", 0, 100)],
+		);
+		expect(Object.hasOwn(result.mapping, "__proto__")).toBe(true);
+		expect(
+			Object.getOwnPropertyDescriptor(result.mapping, "__proto__")?.value,
+		).toBe("constructor");
+		expect(result.der).toBe(0);
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.ts
@@ -1,17 +1,11 @@
-// Diarization Error Rate (DER) scorer for the voice test matrix (issue #9147).
-//
-// The voice-scenario schema already carries a `maxDer` threshold and an
-// `expectedSpeakerLabel` per turn, but nothing computed DER — diarization was
-// only ever scored on the respond-decision, so a wrong speaker attribution or a
-// missed overlapping talker passed silently. This is that missing scorer: a
-// pure, frame-based DER (the standard NIST md-eval decomposition) so the
-// diarization / multi-speaker / overlapping-speech scenario classes can assert
-// per-turn labels AND enforce `maxDer`.
-//
-// Frame-based (default 10ms) so OVERLAPPING speech is handled correctly: each
-// frame compares the SET of reference speakers against the SET of hypothesis
-// speakers, after an optimal one-to-one speaker mapping that maximizes matched
-// time. Everything here is deterministic and dependency-free.
+/**
+ * Computes frame-based Diarization Error Rate for the voice workbench.
+ * Overlapping speech is scored as active-speaker sets after a one-to-one label
+ * mapping. Input, sweep, co-occurrence, and exact-search budgets bound scenario
+ * data before it can exhaust the host running a benchmark.
+ */
+
+import { ElizaError } from "@elizaos/core";
 
 export interface DiarizationSegment {
 	/** Speaker label (any stable string — ground-truth and hypothesis label
@@ -43,7 +37,8 @@ export interface DerOptions {
 	/** Frame size in ms (default 10). Smaller = more precise, more work. */
 	frameMs?: number;
 	/** Above this combined speaker count, fall back to a greedy mapping instead
-	 * of the exact permutation search (keeps it O(n) not O(n!)). Default 7. */
+	 * of the exact permutation search. Must be an integer from 0 through 7;
+	 * larger thresholds would make the exact branch factorial. Default 7. */
 	maxExactSpeakers?: number;
 }
 
@@ -51,73 +46,170 @@ export interface DerOptions {
  * would allocate tens of millions of Sets and hang the scorer. */
 export const MIN_DER_FRAME_MS = 1;
 /** Longest accepted reference/hypothesis timeline. Voice scenarios are
- * minutes; a hostile `endMs` of 1e8+ was an 8s frameize hang on origin. */
+ * minutes; this also rejects nonsensical timestamp magnitudes early. */
 export const MAX_DER_DURATION_MS = 4 * 60 * 60 * 1000;
+/** Maximum frames swept by one score. At the default 10ms resolution this
+ * still admits the full four-hour timeline. */
+export const MAX_DER_FRAMES = 1_500_000;
+/** Maximum combined reference and hypothesis segments. */
+export const MAX_DER_SEGMENTS = 100_000;
+/** Maximum combined distinct labels used to size the mapping matrix. */
+export const MAX_DER_SPEAKERS = 256;
+/** Maximum frame/pair visits across co-occurrence and final scoring sweeps. */
+export const MAX_DER_WORK_UNITS = 10_000_000;
+/** Maximum safe threshold for the factorial exact mapping branch. */
+export const MAX_DER_EXACT_SPEAKERS = 7;
+/** Speaker identifiers are labels, not an unbounded text-retention surface. */
+export const MAX_DER_SPEAKER_LABEL_CHARS = 256;
 
-function totalDurationMs(segments: readonly DiarizationSegment[]): number {
+interface ValidatedTimeline {
+	durationMs: number;
+	speakers: Set<string>;
+}
+
+function invalidDiarizationInput(
+	message: string,
+	context?: Record<string, unknown>,
+): ElizaError {
+	return new ElizaError(message, {
+		code: "DIARIZATION_INPUT_INVALID",
+		context,
+		severity: "ephemeral",
+	});
+}
+
+function unboundedDiarizationScore(
+	message: string,
+	context: Record<string, unknown>,
+): ElizaError {
+	return new ElizaError(message, {
+		code: "DIARIZATION_SCORE_UNBOUNDED",
+		context,
+		severity: "ephemeral",
+	});
+}
+
+function validateTimeline(
+	segments: readonly DiarizationSegment[],
+	name: string,
+): ValidatedTimeline {
+	if (!Array.isArray(segments)) {
+		throw invalidDiarizationInput(
+			`Diarization ${name} must be an array of segments`,
+			{ timeline: name },
+		);
+	}
 	let max = 0;
-	for (const s of segments) {
+	const speakers = new Set<string>();
+	for (let index = 0; index < segments.length; index++) {
+		const s = segments[index];
+		if (s === null || typeof s !== "object") {
+			throw invalidDiarizationInput(
+				`Diarization ${name}[${index}] must be a segment object`,
+				{ timeline: name, index },
+			);
+		}
 		if (!Number.isFinite(s.startMs) || !Number.isFinite(s.endMs)) {
-			throw new Error(
+			throw invalidDiarizationInput(
 				"Diarization segment startMs/endMs must be finite milliseconds",
+				{ timeline: name, index },
 			);
 		}
 		if (s.startMs < 0 || s.endMs < 0) {
-			throw new Error("Diarization segment startMs/endMs must be non-negative");
+			throw invalidDiarizationInput(
+				"Diarization segment startMs/endMs must be non-negative",
+				{ timeline: name, index },
+			);
 		}
+		if (s.endMs < s.startMs) {
+			throw invalidDiarizationInput(
+				"Diarization segment endMs must be greater than or equal to startMs",
+				{ timeline: name, index },
+			);
+		}
+		if (
+			typeof s.speaker !== "string" ||
+			s.speaker.length > MAX_DER_SPEAKER_LABEL_CHARS
+		) {
+			throw invalidDiarizationInput(
+				`Diarization speaker labels must be strings of at most ${MAX_DER_SPEAKER_LABEL_CHARS} characters`,
+				{ timeline: name, index, limit: MAX_DER_SPEAKER_LABEL_CHARS },
+			);
+		}
+		speakers.add(s.speaker);
 		if (s.endMs > max) max = s.endMs;
 	}
-	return max;
+	return { durationMs: max, speakers };
 }
 
-/** Per-frame active-speaker sets. `frames[f]` is the set of speakers whose
- * segment covers the start of frame `f`. */
-function frameize(
+interface FrameEvents {
+	add: string[];
+	remove: string[];
+}
+
+/** Build sparse activation events rather than allocating one Set per frame. */
+function buildFrameEvents(
 	segments: readonly DiarizationSegment[],
 	frameMs: number,
 	numFrames: number,
-): Array<Set<string>> {
-	const frames: Array<Set<string>> = Array.from(
-		{ length: numFrames },
-		() => new Set<string>(),
-	);
+): Map<number, FrameEvents> {
+	const events = new Map<number, FrameEvents>();
+	const eventAt = (frame: number): FrameEvents => {
+		let event = events.get(frame);
+		if (!event) {
+			event = { add: [], remove: [] };
+			events.set(frame, event);
+		}
+		return event;
+	};
 	for (const seg of segments) {
 		if (seg.endMs <= seg.startMs) continue;
-		const first = Math.max(0, Math.floor(seg.startMs / frameMs));
-		// A frame f (covering [f·frameMs, (f+1)·frameMs)) is active if its start
-		// time falls within [startMs, endMs).
-		const last = Math.min(numFrames - 1, Math.ceil(seg.endMs / frameMs) - 1);
-		for (let f = first; f <= last; f++) {
-			if (f * frameMs >= seg.startMs && f * frameMs < seg.endMs) {
-				frames[f].add(seg.speaker);
-			}
-		}
+		const first = Math.ceil(seg.startMs / frameMs);
+		const afterLast = Math.min(numFrames, Math.ceil(seg.endMs / frameMs));
+		if (first >= afterLast) continue;
+		eventAt(first).add.push(seg.speaker);
+		eventAt(afterLast).remove.push(seg.speaker);
 	}
-	return frames;
+	return events;
 }
 
-function uniqueSpeakers(segments: readonly DiarizationSegment[]): string[] {
-	return [...new Set(segments.map((s) => s.speaker))];
+type ActiveSpeakers = Map<string, number>;
+
+function applyFrameEvents(active: ActiveSpeakers, event?: FrameEvents): void {
+	if (!event) return;
+	for (const speaker of event.remove) {
+		const count = active.get(speaker) ?? 0;
+		if (count <= 1) active.delete(speaker);
+		else active.set(speaker, count - 1);
+	}
+	for (const speaker of event.add) {
+		active.set(speaker, (active.get(speaker) ?? 0) + 1);
+	}
 }
 
 /** Frames where reference speaker `r` and hypothesis speaker `h` are both active. */
 function coOccurrence(
-	refFrames: Array<Set<string>>,
-	hypFrames: Array<Set<string>>,
+	refEvents: Map<number, FrameEvents>,
+	hypEvents: Map<number, FrameEvents>,
+	numFrames: number,
 	refSpeakers: string[],
 	hypSpeakers: string[],
+	consumeWork: (amount: number) => void,
 ): Map<string, Map<string, number>> {
 	const co = new Map<string, Map<string, number>>();
 	for (const r of refSpeakers)
 		co.set(r, new Map(hypSpeakers.map((h) => [h, 0])));
-	for (let f = 0; f < refFrames.length; f++) {
-		const rs = refFrames[f];
-		const hs = hypFrames[f];
+	const rs: ActiveSpeakers = new Map();
+	const hs: ActiveSpeakers = new Map();
+	for (let f = 0; f < numFrames; f++) {
+		applyFrameEvents(rs, refEvents.get(f));
+		applyFrameEvents(hs, hypEvents.get(f));
+		consumeWork(1 + rs.size * hs.size);
 		if (rs.size === 0 || hs.size === 0) continue;
-		for (const r of rs) {
+		for (const r of rs.keys()) {
 			const row = co.get(r);
 			if (!row) continue;
-			for (const h of hs) row.set(h, (row.get(h) ?? 0) + 1);
+			for (const h of hs.keys()) row.set(h, (row.get(h) ?? 0) + 1);
 		}
 	}
 	return co;
@@ -135,18 +227,18 @@ function bestMapping(
 
 	if (refSpeakers.length + hypSpeakers.length <= maxExact) {
 		// Exact: try every injective assignment of hyp speakers onto ref speakers.
-		let best: Record<string, string> = {};
+		let best = new Map<string, string>();
 		let bestScore = -1;
 		const assign = (
 			i: number,
 			usedRefs: Set<string>,
-			current: Record<string, string>,
+			current: Map<string, string>,
 			running: number,
 		) => {
 			if (i === hypSpeakers.length) {
 				if (running > bestScore) {
 					bestScore = running;
-					best = { ...current };
+					best = new Map(current);
 				}
 				return;
 			}
@@ -156,14 +248,14 @@ function bestMapping(
 			for (const r of refSpeakers) {
 				if (usedRefs.has(r)) continue;
 				usedRefs.add(r);
-				current[h] = r;
+				current.set(h, r);
 				assign(i + 1, usedRefs, current, running + score(h, r));
-				delete current[h];
+				current.delete(h);
 				usedRefs.delete(r);
 			}
 		};
-		assign(0, new Set(), {}, 0);
-		return best;
+		assign(0, new Set(), new Map(), 0);
+		return Object.fromEntries(best);
 	}
 
 	// Greedy: repeatedly take the highest-scoring (h, r) pair not yet used.
@@ -174,14 +266,14 @@ function bestMapping(
 	pairs.sort((a, b) => b.s - a.s);
 	const usedHyp = new Set<string>();
 	const usedRef = new Set<string>();
-	const mapping: Record<string, string> = {};
+	const mapping = new Map<string, string>();
 	for (const { h, r, s } of pairs) {
 		if (s <= 0 || usedHyp.has(h) || usedRef.has(r)) continue;
-		mapping[h] = r;
+		mapping.set(h, r);
 		usedHyp.add(h);
 		usedRef.add(r);
 	}
-	return mapping;
+	return Object.fromEntries(mapping);
 }
 
 /**
@@ -195,31 +287,95 @@ export function computeDiarizationErrorRate(
 	options: DerOptions = {},
 ): DerResult {
 	const requestedFrame = options.frameMs;
-	const frameMs =
-		requestedFrame !== undefined && requestedFrame > 0 ? requestedFrame : 10;
+	const frameMs = requestedFrame ?? 10;
 	if (!Number.isFinite(frameMs) || frameMs < MIN_DER_FRAME_MS) {
-		throw new Error(
+		throw invalidDiarizationInput(
 			`Diarization frameMs must be a finite value ≥ ${MIN_DER_FRAME_MS}ms`,
+			{ frameMs, minimum: MIN_DER_FRAME_MS },
 		);
 	}
 	const maxExact = options.maxExactSpeakers ?? 7;
+	if (
+		!Number.isSafeInteger(maxExact) ||
+		maxExact < 0 ||
+		maxExact > MAX_DER_EXACT_SPEAKERS
+	) {
+		throw invalidDiarizationInput(
+			`Diarization maxExactSpeakers must be an integer from 0 through ${MAX_DER_EXACT_SPEAKERS}`,
+			{ maxExactSpeakers: maxExact, maximum: MAX_DER_EXACT_SPEAKERS },
+		);
+	}
+	if (!Array.isArray(reference) || !Array.isArray(hypothesis)) {
+		throw invalidDiarizationInput(
+			"Diarization reference and hypothesis must be segment arrays",
+		);
+	}
+	if (
+		reference.length > MAX_DER_SEGMENTS ||
+		hypothesis.length > MAX_DER_SEGMENTS - reference.length
+	) {
+		throw unboundedDiarizationScore(
+			`Diarization input exceeds ${MAX_DER_SEGMENTS} combined segments`,
+			{
+				limit: MAX_DER_SEGMENTS,
+				referenceSegments: reference.length,
+				hypothesisSegments: hypothesis.length,
+			},
+		);
+	}
+	const validatedReference = validateTimeline(reference, "reference");
+	const validatedHypothesis = validateTimeline(hypothesis, "hypothesis");
 	const durationMs = Math.max(
-		totalDurationMs(reference),
-		totalDurationMs(hypothesis),
+		validatedReference.durationMs,
+		validatedHypothesis.durationMs,
 	);
 	if (durationMs > MAX_DER_DURATION_MS) {
-		throw new Error(
+		throw unboundedDiarizationScore(
 			`Diarization timeline ${durationMs}ms exceeds ${MAX_DER_DURATION_MS}ms`,
+			{ durationMs, limit: MAX_DER_DURATION_MS },
 		);
 	}
 	const numFrames = Math.ceil(durationMs / frameMs);
+	if (!Number.isSafeInteger(numFrames) || numFrames > MAX_DER_FRAMES) {
+		throw unboundedDiarizationScore(
+			`Diarization score exceeds ${MAX_DER_FRAMES} frames at ${frameMs}ms resolution`,
+			{ frames: numFrames, limit: MAX_DER_FRAMES, frameMs },
+		);
+	}
 
-	const refSpeakers = uniqueSpeakers(reference);
-	const hypSpeakers = uniqueSpeakers(hypothesis);
-	const refFrames = frameize(reference, frameMs, numFrames);
-	const hypFrames = frameize(hypothesis, frameMs, numFrames);
+	const refSpeakers = [...validatedReference.speakers];
+	const hypSpeakers = [...validatedHypothesis.speakers];
+	if (refSpeakers.length + hypSpeakers.length > MAX_DER_SPEAKERS) {
+		throw unboundedDiarizationScore(
+			`Diarization input exceeds ${MAX_DER_SPEAKERS} combined speakers`,
+			{
+				limit: MAX_DER_SPEAKERS,
+				referenceSpeakers: refSpeakers.length,
+				hypothesisSpeakers: hypSpeakers.length,
+			},
+		);
+	}
+	const refEvents = buildFrameEvents(reference, frameMs, numFrames);
+	const hypEvents = buildFrameEvents(hypothesis, frameMs, numFrames);
+	let remainingWork = MAX_DER_WORK_UNITS;
+	const consumeWork = (amount: number): void => {
+		if (amount > remainingWork) {
+			throw unboundedDiarizationScore(
+				`Diarization score exceeds ${MAX_DER_WORK_UNITS} bounded work units`,
+				{ limit: MAX_DER_WORK_UNITS },
+			);
+		}
+		remainingWork -= amount;
+	};
 
-	const co = coOccurrence(refFrames, hypFrames, refSpeakers, hypSpeakers);
+	const co = coOccurrence(
+		refEvents,
+		hypEvents,
+		numFrames,
+		refSpeakers,
+		hypSpeakers,
+		consumeWork,
+	);
 	const mapping = bestMapping(co, refSpeakers, hypSpeakers, maxExact);
 	// inverse: ref speaker -> the hyp speaker mapped onto it.
 	const inverse = new Map<string, string>();
@@ -229,10 +385,13 @@ export function computeDiarizationErrorRate(
 	let falseAlarmFrames = 0;
 	let confusionFrames = 0;
 	let referenceSpeakerFrames = 0;
+	const R: ActiveSpeakers = new Map();
+	const H: ActiveSpeakers = new Map();
 
 	for (let f = 0; f < numFrames; f++) {
-		const R = refFrames[f];
-		const H = hypFrames[f];
+		applyFrameEvents(R, refEvents.get(f));
+		applyFrameEvents(H, hypEvents.get(f));
+		consumeWork(1 + R.size);
 		const nRef = R.size;
 		const nSys = H.size;
 		referenceSpeakerFrames += nRef;
@@ -240,7 +399,7 @@ export function computeDiarizationErrorRate(
 
 		// Correctly attributed: a ref speaker whose mapped hyp speaker is active.
 		let correct = 0;
-		for (const r of R) {
+		for (const r of R.keys()) {
 			const h = inverse.get(r);
 			if (h !== undefined && H.has(h)) correct += 1;
 		}

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.ts
@@ -47,8 +47,27 @@ export interface DerOptions {
 	maxExactSpeakers?: number;
 }
 
+/** Smallest accepted frame. A sub-millisecond frame with a long timeline
+ * would allocate tens of millions of Sets and hang the scorer. */
+export const MIN_DER_FRAME_MS = 1;
+/** Longest accepted reference/hypothesis timeline. Voice scenarios are
+ * minutes; a hostile `endMs` of 1e8+ was an 8s frameize hang on origin. */
+export const MAX_DER_DURATION_MS = 4 * 60 * 60 * 1000;
+
 function totalDurationMs(segments: readonly DiarizationSegment[]): number {
-	return segments.reduce((max, s) => Math.max(max, s.endMs), 0);
+	let max = 0;
+	for (const s of segments) {
+		if (!Number.isFinite(s.startMs) || !Number.isFinite(s.endMs)) {
+			throw new Error(
+				"Diarization segment startMs/endMs must be finite milliseconds",
+			);
+		}
+		if (s.startMs < 0 || s.endMs < 0) {
+			throw new Error("Diarization segment startMs/endMs must be non-negative");
+		}
+		if (s.endMs > max) max = s.endMs;
+	}
+	return max;
 }
 
 /** Per-frame active-speaker sets. `frames[f]` is the set of speakers whose
@@ -175,12 +194,24 @@ export function computeDiarizationErrorRate(
 	hypothesis: readonly DiarizationSegment[],
 	options: DerOptions = {},
 ): DerResult {
-	const frameMs = options.frameMs && options.frameMs > 0 ? options.frameMs : 10;
+	const requestedFrame = options.frameMs;
+	const frameMs =
+		requestedFrame !== undefined && requestedFrame > 0 ? requestedFrame : 10;
+	if (!Number.isFinite(frameMs) || frameMs < MIN_DER_FRAME_MS) {
+		throw new Error(
+			`Diarization frameMs must be a finite value ≥ ${MIN_DER_FRAME_MS}ms`,
+		);
+	}
 	const maxExact = options.maxExactSpeakers ?? 7;
 	const durationMs = Math.max(
 		totalDurationMs(reference),
 		totalDurationMs(hypothesis),
 	);
+	if (durationMs > MAX_DER_DURATION_MS) {
+		throw new Error(
+			`Diarization timeline ${durationMs}ms exceeds ${MAX_DER_DURATION_MS}ms`,
+		);
+	}
 	const numFrames = Math.ceil(durationMs / frameMs);
 
 	const refSpeakers = uniqueSpeakers(reference);


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI/grok-4.6`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Grok CLI via cmux`, `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@015767b4c399c918879e65df6444f84d25b5c307:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:66d4081040e743f037b10106b205cf10be755c3b -->

Closes #22701.

## Summary

Bounds the frame-based diarization scorer across every material work dimension: timeline duration, frame count, combined segment count, speaker-mapping matrix size, overlap-amplified co-occurrence work, speaker-label retention, and factorial exact mapping.

The submitted duration/minimum-frame pair was directionally useful but still admitted 14.4 million frames per timeline at the documented 4-hour/1ms combination, while retaining one `Set` per frame. The repaired implementation replaces those arrays with a sparse activation-event sweep and returns structured `DIARIZATION_INPUT_INVALID` or `DIARIZATION_SCORE_UNBOUNDED` failures. It also rejects inverted segments and unsafe `maxExactSpeakers` overrides.

## Contract research

- `pyannote.metrics` documents DER as false alarm + missed detection + speaker confusion over total reference speaker-time, with overlap included by default. The repaired sweep retains those same active-speaker-set components and the existing optimal/greedy one-to-one mapping behavior.
- The package voice workbench is the production consumer. Its real-scenario scorer and speaker-isolation harness both call this exported scorer; no alternative unbounded frameizer remains in the changed path.

## Exact-head verification

Exact repaired head `66d4081040e743f037b10106b205cf10be755c3b`, rebased on develop `f1eba5c3817ba72e412c89f3d0870ff0aca74df1`.

- Exact diarization plus all direct voice-harness consumers: **7 files / 107 tests passed**, pinned Bun 1.3.14.
- Exact scorer-focused suite: **2 files / 26 tests passed**.
- Exact package production build, declaration generation, focused Biome, and `git diff --check`: **passed**.
- Full owning-package Vitest on the identical repair tree before the base-only rebase: **277 files / 2,847 tests passed / 18 skipped**. Three unrelated environment/baseline failures remained: a `bun:test` file collected under Vitest, missing optional `phonemizer`, and the existing speaker-name inference expectation. None touches the three changed files.
- Package-wide typecheck was attempted and reached the project. This isolated checkout lacks unrelated `drizzle-orm`, `@elizaos/plugin-native-inference`, and `phonemizer` dependencies; the exact source compiles through the successful declaration build and emitted no changed-file diagnostic.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure server-side benchmark/scoring utility; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure server-side benchmark/scoring utility; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Pinned Bun production-scorer receipt:

```text
4-hour timeline, default 10ms resolution
DER=0, referenceMs=14400000, elapsed=175.1ms
Focused/consumer matrix: 107/107 passed
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent response behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic DER results cover perfect mapping, overlap, missed speech, false alarms, confusion, repeated same-label spans, prototype-like labels, and every new resource boundary.

```text
Perfect remapped labels: DER=0, confusionMs=0, mapping={spk0:alice,spk1:bob}
Overlapping reference speakers: totalReferenceMs=3000, DER=0; missed talker: missedMs=1000
Four-hour sparse-sweep receipt: DER=0, totalReferenceMs=14400000; every adversarial budget rejected with its typed code
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Provenance

Original implementation: xAI `grok-4.6` via Grok CLI/cmux. Deep review, sparse-sweep repair, structured resource boundaries, adversarial production tests, research, and exact-head verification: OpenAI `gpt-5.6-sol` via Codex Desktop multi-agent.
