### PR TITLE
fix(cloud): restore billing migration checkpoint fixture

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -187,7 +187,29 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
     CREATE TABLE organizations (
       id uuid PRIMARY KEY,
       credit_balance numeric(16, 6) NOT NULL DEFAULT '0.000000',
+      stripe_customer_id text,
+      billing_email text,
+      stripe_payment_method_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean DEFAULT false,
+      auto_top_up_amount numeric(10, 2),
+      auto_top_up_threshold numeric(10, 2),
       CONSTRAINT credit_balance_non_negative CHECK (credit_balance >= 0)
+    );
+    CREATE TABLE organization_billing (
+      organization_id uuid NOT NULL UNIQUE
+        REFERENCES organizations(id) ON DELETE CASCADE,
+      stripe_customer_id text,
+      billing_email text,
+      tax_id_type text,
+      tax_id_value text,
+      billing_address jsonb,
+      stripe_payment_method_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean NOT NULL DEFAULT false,
+      auto_top_up_amount numeric(12, 6),
+      auto_top_up_threshold numeric(12, 6) DEFAULT '0.000000',
+      updated_at timestamp without time zone NOT NULL DEFAULT now()
     );
     CREATE TABLE credit_transactions (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -236,7 +258,20 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
       updated_at timestamp with time zone NOT NULL DEFAULT now()
     );
     CREATE TABLE payment_requests (
-      id uuid PRIMARY KEY
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+      provider text NOT NULL CHECK (
+        provider IN ('stripe', 'oxapay', 'x402', 'wallet_native')
+      ),
+      amount_cents bigint NOT NULL CHECK (amount_cents >= 0),
+      currency text NOT NULL DEFAULT 'usd',
+      provider_intent jsonb NOT NULL DEFAULT '{}'::jsonb,
+      status text NOT NULL DEFAULT 'pending' CHECK (
+        status IN ('pending', 'delivered', 'settled', 'failed', 'expired', 'canceled')
+      ),
+      settled_at timestamp with time zone,
+      settlement_tx_ref text,
+      settlement_proof jsonb
     );
     CREATE TABLE payment_request_events (
       id uuid PRIMARY KEY,
@@ -418,6 +453,162 @@ async function waitForAdvisoryLock(client: pg.Client): Promise<void> {
   throw new Error("Timed out waiting for migration advisory lock");
 }
 
+async function expectPreCheckpointPaymentRequestAuthority(
+  client: pg.Client,
+): Promise<void> {
+  const authority = await client.query<{
+    payment_columns: string[];
+    organization_id_type: string;
+    organization_id_nullable: string;
+    provider_type: string;
+    provider_nullable: string;
+    organization_fk: string;
+    provider_check: string;
+    receipt_table: string | null;
+    receipt_parent_index: string | null;
+  }>(`
+    SELECT
+      (SELECT to_json(array_agg(format('%s:%s:%s', attname,
+          format_type(atttypid, atttypmod),
+          CASE WHEN attnotnull THEN 'required' ELSE 'nullable' END)
+        ORDER BY attnum))
+        FROM pg_attribute
+        WHERE attrelid = 'payment_requests'::regclass
+          AND attnum > 0 AND NOT attisdropped) AS payment_columns,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payment_requests'
+          AND column_name = 'organization_id') AS organization_id_type,
+      (SELECT is_nullable FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payment_requests'
+          AND column_name = 'organization_id') AS organization_id_nullable,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payment_requests'
+          AND column_name = 'provider') AS provider_type,
+      (SELECT is_nullable FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payment_requests'
+          AND column_name = 'provider') AS provider_nullable,
+      (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+        WHERE conrelid = 'payment_requests'::regclass AND contype = 'f'
+          AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+            WHERE attrelid = 'payment_requests'::regclass
+              AND attname = 'organization_id')]::smallint[]) AS organization_fk,
+      (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+        WHERE conrelid = 'payment_requests'::regclass AND contype = 'c'
+          AND pg_get_constraintdef(oid) LIKE '%provider%') AS provider_check,
+      to_regclass('public.payment_request_receipts')::text AS receipt_table,
+      to_regclass('public.payment_requests_id_organization_provider_unique')::text
+        AS receipt_parent_index
+  `);
+  expect(authority.rows[0]).toEqual({
+    payment_columns: [
+      "id:uuid:required",
+      "organization_id:uuid:required",
+      "provider:text:required",
+      "amount_cents:bigint:required",
+      "currency:text:required",
+      "provider_intent:jsonb:required",
+      "status:text:required",
+      "settled_at:timestamp with time zone:nullable",
+      "settlement_tx_ref:text:nullable",
+      "settlement_proof:jsonb:nullable",
+    ],
+    organization_id_type: "uuid",
+    organization_id_nullable: "NO",
+    provider_type: "text",
+    provider_nullable: "NO",
+    organization_fk:
+      "FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE",
+    provider_check:
+      "CHECK ((provider = ANY (ARRAY['stripe'::text, 'oxapay'::text, 'x402'::text, 'wallet_native'::text])))",
+    receipt_table: null,
+    receipt_parent_index: null,
+  });
+}
+
+async function expectPreCheckpointOrganizationBillingAuthority(
+  client: pg.Client,
+): Promise<void> {
+  const authority = await client.query<{
+    organization_columns: string[];
+    billing_columns: string[];
+    organization_fk: string;
+    organization_unique: string;
+    authority_index: string | null;
+    shadow_authority_index: string | null;
+    sync_function: string | null;
+    shadow_guard: string | null;
+  }>(`
+    SELECT
+      (SELECT to_json(array_agg(format('%s:%s:%s', attname,
+          format_type(atttypid, atttypmod),
+          CASE WHEN attnotnull THEN 'required' ELSE 'nullable' END)
+        ORDER BY attnum))
+        FROM pg_attribute
+        WHERE attrelid = 'organizations'::regclass
+          AND attnum > 0 AND NOT attisdropped AND attname IN (
+            'stripe_customer_id', 'billing_email', 'stripe_payment_method_id',
+            'stripe_default_payment_method', 'auto_top_up_enabled',
+            'auto_top_up_amount', 'auto_top_up_threshold'
+          )) AS organization_columns,
+      (SELECT to_json(array_agg(format('%s:%s:%s', attname,
+          format_type(atttypid, atttypmod),
+          CASE WHEN attnotnull THEN 'required' ELSE 'nullable' END)
+        ORDER BY attnum))
+        FROM pg_attribute
+        WHERE attrelid = 'organization_billing'::regclass
+          AND attnum > 0 AND NOT attisdropped)
+        AS billing_columns,
+      (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+        WHERE conrelid = 'organization_billing'::regclass AND contype = 'f'
+          AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+            WHERE attrelid = 'organization_billing'::regclass
+              AND attname = 'organization_id')]::smallint[]) AS organization_fk,
+      (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+        WHERE conrelid = 'organization_billing'::regclass AND contype = 'u'
+          AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+            WHERE attrelid = 'organization_billing'::regclass
+              AND attname = 'organization_id')]::smallint[]) AS organization_unique,
+      to_regclass('public.organizations_stripe_customer_authority_unique')::text
+        AS authority_index,
+      to_regclass('public.org_billing_stripe_customer_authority_unique')::text
+        AS shadow_authority_index,
+      to_regprocedure('public.sync_organization_billing_shadow()')::text AS sync_function,
+      to_regprocedure('public.guard_organization_billing_shadow()')::text AS shadow_guard
+  `);
+  expect(authority.rows[0]).toEqual({
+    organization_columns: [
+      "stripe_customer_id:text:nullable",
+      "billing_email:text:nullable",
+      "stripe_payment_method_id:text:nullable",
+      "stripe_default_payment_method:text:nullable",
+      "auto_top_up_enabled:boolean:nullable",
+      "auto_top_up_amount:numeric(10,2):nullable",
+      "auto_top_up_threshold:numeric(10,2):nullable",
+    ],
+    billing_columns: [
+      "organization_id:uuid:required",
+      "stripe_customer_id:text:nullable",
+      "billing_email:text:nullable",
+      "tax_id_type:text:nullable",
+      "tax_id_value:text:nullable",
+      "billing_address:jsonb:nullable",
+      "stripe_payment_method_id:text:nullable",
+      "stripe_default_payment_method:text:nullable",
+      "auto_top_up_enabled:boolean:required",
+      "auto_top_up_amount:numeric(12,6):nullable",
+      "auto_top_up_threshold:numeric(12,6):nullable",
+      "updated_at:timestamp without time zone:required",
+    ],
+    organization_fk:
+      "FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE",
+    organization_unique: "UNIQUE (organization_id)",
+    authority_index: null,
+    shadow_authority_index: null,
+    sync_function: null,
+    shadow_guard: null,
+  });
+}
+
 describe.skipIf(!ENABLED)(
   "migrate-with-diagnostics real PostgreSQL safety",
   () => {
@@ -433,11 +624,13 @@ describe.skipIf(!ENABLED)(
         );
       }
       await admin.end();
-    }, 120_000);
+    }, 300_000);
 
     test("applies the append-only fix-forward once and passes the reusable catalog preflight", async () => {
       const database = await createDatabase();
       await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
+      await expectPreCheckpointPaymentRequestAuthority(database.client);
+      await expectPreCheckpointOrganizationBillingAuthority(database.client);
       await database.client.query(`
         INSERT INTO jobs (
           status,


### PR DESCRIPTION
# Relates to

Fixes #22475.

- [x] Targets `develop` and is based on latest `origin/develop` (`2734e4c5d60f3e86aca33854ae751d8ba3934cd0`) with zero conflicts.
- [x] A reviewer can confirm the change from the real PostgreSQL receipts below.
- [ ] `bun install` / root `bun run verify`: not run; see Known gaps.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop`; zero conflicts.
- [ ] Root verify unavailable in the explicitly lightweight no-install worktree; exact noncausal dependency blocker is below.

# Risks

Low. This changes only the real-PostgreSQL migration checkpoint fixture and its regression assertions. It does not edit schema, migration, or journal files.

# Background

## What does this PR do?

Restores the dependency-minimal historical authority that migrations 0262-0264 consume:

- `payment_requests` tenant/provider/settlement columns and constraints required before receipt projection;
- legacy organization billing authority and shadow columns required before 0264 performs its guarded cutover;
- catalog assertions proving the fixture has the historical types and bindings while 0262 receipt objects and 0264 authority indexes/functions remain absent before migration;
- a bounded 300-second fixture teardown allowance for PostgreSQL checkpoints on loaded hosts.

The applied ledger prefix remains exactly 184; no 0262-0264 object is pre-applied.

## What kind of change is this?

Bug fix to migration test infrastructure.

# Documentation changes needed?

No product documentation change is needed.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts`

## Detailed testing steps

- `RUN_REAL_POSTGRES_MIGRATION_TESTS=1 MIGRATION_TEST_DATABASE_URL=postgresql://localhost/postgres?sslmode=disable bun test packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts`
  - 10 pass, 0 fail, 49 assertions, 255.11s
  - all pending migrations through 0264 applied; replay, catalog preflight, malformed-ledger, lock-contention, and bounded-retry cases passed
  - post-suite query confirmed zero `migration_%` databases and no teardown errors
- focused exact fixture path: 1 pass, 0 fail, 10 assertions
- `bunx biome check packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts`: pass with three pre-existing undeclared-env warnings
- isolated TS6 file typecheck: pass
- `bun run --cwd packages/cloud/shared db:check-migrations`: pass
- `git diff --check`: pass
- schema/journal diff: zero files changed

# Evidence Gate

<!-- evidence-head:9a8ace8c25ba399b3aea4af7adf107e4782d9380 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend migration fixture only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend migration fixture only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only migration fixture; exact PostgreSQL receipt is in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no product data changed; real PostgreSQL migration receipt is in Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

The task required the existing local PostgreSQL 16 service and prohibited Docker or a broad install. The isolated worktree used an existing frozen dependency clone. `bun run typecheck:cloud` was attempted but stopped noncausally while building unrelated `plugin-web-search` because that lightweight clone has no `tsup` executable. The changed test file passes an isolated TS6 typecheck, Biome, Drizzle validation, and the full real-PostgreSQL suite.

AI provider/model: openai/gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
