### PR TITLE
fix(app-core): realign the sms-gateway template contract test and wire it into its lane

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "check:source-artifacts": "node scripts/check-source-artifacts.mjs",
     "test": "node ../scripts/run-vitest.mjs run --config vitest.config.ts && bun run test:script-suites",
-    "test:script-suites": "node --test scripts/run-mobile-build-android-app-actions.test.mjs scripts/mas-smoke.test.mjs scripts/stage-android-agent.test.mjs scripts/stage-desktop-fused-lib-staleness.test.mjs scripts/build-helpers/arm64-simd.test.mjs && bun test scripts/aosp/stage-default-models.test.mjs scripts/aosp/compile-libllama-zig-pin.test.mjs",
+    "test:script-suites": "node --test scripts/android-sms-gateway-template.test.mjs scripts/run-mobile-build-android-app-actions.test.mjs scripts/mas-smoke.test.mjs scripts/stage-android-agent.test.mjs scripts/stage-desktop-fused-lib-staleness.test.mjs scripts/build-helpers/arm64-simd.test.mjs && bun test scripts/aosp/stage-default-models.test.mjs scripts/aosp/compile-libllama-zig-pin.test.mjs",
     "test:auth": "node ../scripts/run-vitest.mjs run --config vitest.config.ts --no-file-parallelism src/api/auth src/api/auth-bootstrap-routes src/services/auth-store src/cli/program/register.auth",
     "test:local-provisioning": "node scripts/run-node-tsx.mjs scripts/check-real-local-provisioning.ts",
     "test:local-chat": "node scripts/run-node-tsx.mjs scripts/check-real-local-chat.ts",

--- a/packages/app-core/scripts/android-sms-gateway-template.test.mjs
+++ b/packages/app-core/scripts/android-sms-gateway-template.test.mjs
@@ -265,18 +265,21 @@ test("Android gateway installer supports one-command wireless pairing", () => {
     assert.match(installRunbook, new RegExp(escapeRegExp(marker)));
   }
 
+  // The readiness contract moved from GitHub Pages DNS verification to the
+  // rendered Cloudflare/Blooio surface in cc65444e1, a8a8b8d3e (#19511), and
+  // 60838c42f (#19536); assert the current admission markers instead.
   for (const marker of [
-    "GitHub Pages DNS records",
-    "sms-gateway:homepage:dns -- --apply",
-    "expectedApexRecords",
-    "expectedWwwCname",
-    "A ${expectedDomain}",
-    "CNAME www.${expectedDomain}",
+    "Cloudflare",
+    "cloudflare-origin",
+    "Text Eliza",
+    "resolveWhatsAppAdmission",
+    "WHATSAPP_PUBLIC_ENABLED",
+    "rejectedWhatsAppNumbers",
+    "+18087881821",
+    "whatsapp-fail-closed",
     "homepage-public-readiness-latest.json",
     "--evidence <path>",
     "writeEvidence",
-    "registryStatuses",
-    "delegatedNameservers",
   ]) {
     assert.match(homepageReadinessScript, new RegExp(escapeRegExp(marker)));
   }
@@ -300,16 +303,19 @@ test("Android gateway installer supports one-command wireless pairing", () => {
     assert.match(homepagePorkbunDnsScript, new RegExp(escapeRegExp(marker)));
   }
 
+  // The homepage README dropped its GitHub Pages DNS section for the Blooio
+  // WhatsApp activation contract (5a249cd99 #19532); assert the values the
+  // readiness script also enforces so the two cannot drift apart silently.
   for (const marker of [
-    "Public `eliza.app` DNS",
-    "client hold",
-    "A eliza.app",
-    "185.199.108.153",
-    "CNAME www.eliza.app",
-    "elizaos.github.io.",
-    "check-homepage-public-readiness.mjs",
-    "sms-gateway:homepage:dns",
-    "PORKBUN_API_KEY",
+    "WHATSAPP_PUBLIC_ENABLED",
+    "VITE_WHATSAPP_PHONE_NUMBER",
+    "+18087881821",
+    "wa.me",
+    "Blooio",
+    "message.received",
+    "+14155238886",
+    "+15551649988",
+    "+14159611510",
   ]) {
     assert.match(homepageReadme, new RegExp(escapeRegExp(marker)));
   }
@@ -729,6 +735,11 @@ test("BlueBubbles e2e verifier stops before retrying when validation is missing"
       verifyBlueBubblesScriptPath,
       "--bridge-url",
       bridge.url,
+      // Every sibling subtest routes evidence into the .tmp sandbox; without
+      // this the verifier writes its default .eliza-local artifact and the
+      // suite dirties the working tree.
+      "--evidence",
+      temporaryEvidencePath("bluebubbles-e2e-verifier-"),
     ]);
 
     assert.notEqual(result.code, 0);

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -164,9 +164,6 @@ export default defineConfig({
       // The runner-based suites above are excluded from vitest because they use
       // node:test/bun:test. They are executed by `bun run test:script-suites`
       // (chained from `test`) so the exclusion no longer means "runs nowhere".
-      // scripts/android-sms-gateway-template.test.mjs is deliberately not in
-      // that lane (see #22347): it asserts markers that check-homepage-public-readiness.mjs
-      // lost in cc65444e1, so it fails for a real reason tracked separately.
       // Uses Node.js built-in test runner (node:test), not vitest.
       "scripts/mobile-auth-simulator-smoke-endstate.test.mjs",
       "scripts/android-sms-gateway-template.test.mjs",


### PR DESCRIPTION
# Relates to

Closes #22347. **Stacked on #22348** (`fix/app-core-script-self-tests`, approved ×2) — the first commit here is #22348's; review only `c653c95f3`. This executes the trim-and-realign branch of the issue, with the history receipts that make restore-the-old-surface a non-option.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below — **see Known gaps: full verify delegated to PR CI per
      operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from #22348's head `2531ab5d4` (itself on `origin/develop`); rebases trivially in either merge order — both branches are mine.

# Risks

**Low.** One test file realigned to the contracts that actually exist, one list item added to `test:script-suites`, one exclusion comment updated. The realignment is not a loosening: the full rot inventory was measured mechanically (a soft-assert harness over every marker block) — **17 dead markers across exactly two blocks; every other block still passes** — and the replacements assert the *current* load-bearing contract, including the cross-file agreement both artifacts must keep (gateway number `+18087881821`, the three rejected senders) so this class of silent drift now fails the suite instead of rotting quietly.

# Background

## What does this PR do?

`scripts/android-sms-gateway-template.test.mjs` cross-checks ~15 gateway scripts, runbooks, and the homepage README for mutual consistency. Two of its marker blocks rotted when the homepage-readiness surface was rebuilt:

1. **`check-homepage-public-readiness.mjs` block — 8 dead markers** (`GitHub Pages DNS records`, `expectedApexRecords`, `expectedWwwCname`, `A ${expectedDomain}`, `CNAME www.${expectedDomain}`, `registryStatuses`, `delegatedNameservers`, `sms-gateway:homepage:dns -- --apply`). The script was rewritten to validate the rendered Cloudflare/Blooio surface in cc65444e1, a8a8b8d3e (#19511), and 60838c42f (#19536). The block now asserts the current admission contract: `cloudflare-origin`, the `Text Eliza` button, `resolveWhatsAppAdmission`, `WHATSAPP_PUBLIC_ENABLED`, `rejectedWhatsAppNumbers`, `whatsapp-fail-closed`, `+18087881821`, plus the three still-valid evidence markers.
2. **`packages/homepage/README.md` block — all 9 markers dead** (`A eliza.app`, `185.199.108.153`, `elizaos.github.io.`, `PORKBUN_API_KEY`, …). The README swapped its GitHub Pages DNS section for the Blooio WhatsApp activation contract in 5a249cd99 (#19532). The block now asserts that contract — `WHATSAPP_PUBLIC_ENABLED`, `VITE_WHATSAPP_PHONE_NUMBER`, `wa.me`, `Blooio`, `message.received`, and the same gateway/rejected numbers the readiness script enforces.

Two adjacent repairs in the same delivery:

- **Tree-clean fix:** the BlueBubbles e2e-verifier subtest was the only one not routing evidence through the suite's `.tmp` sandbox, so every run wrote `.eliza-local/bluebubbles-gateway-e2e-latest.json` into the working tree (the accident #22421 guards against). It now uses `temporaryEvidencePath` like its siblings; the suite leaves the tree clean.
- **Wiring:** the suite joins `test:script-suites` (the lane #22348 created), and the vitest exclusion comment loses its "deliberately not wired, see #22347" clause.

## What kind of change is this?

Bug fix (rotted contract test realigned and executed).

# Documentation changes needed?

None; the deciding history is cited in-code beside each realigned block.

# Testing

## Where should a reviewer start?

```bash
bun run --cwd packages/app-core test:script-suites
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:abe183a66958a3df8489bfee7ab8cd425cfc1cce -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - node:test contract suite; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - terminal-only; transcripts below are complete.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - the only servers are the suite's in-process mock bridges.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] [22484-eliza-22484-rebased-tests.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22484-eliza-22484-rebased-tests.txt)

<details>
<summary>1. Full rot inventory, measured — 17 dead markers, exactly two blocks</summary>

```
# soft-assert harness over every marker block of the suite (assert.match
# recorded instead of thrown), run against develop:
=== ROTTED MARKERS: 17 ===
  /GitHub Pages DNS records/  /sms-gateway:homepage:dns -- --apply/
  /expectedApexRecords/  /expectedWwwCname/  /A \$\{expectedDomain\}/
  /CNAME www\.\$\{expectedDomain\}/  /registryStatuses/  /delegatedNameservers/
  /Public `eliza\.app` DNS/  /client hold/  /A eliza\.app/  /185\.199\.108\.153/
  /CNAME www\.eliza\.app/  /elizaos\.github\.io\./  /check-homepage-public-readiness\.mjs/
  /sms-gateway:homepage:dns/  /PORKBUN_API_KEY/
# every other marker block passes unchanged — the rot is precisely these two.
```
</details>

<details>
<summary>2. History receipts — restore is not on the table</summary>

```
$ git log --oneline -3 -- packages/app-core/scripts/check-homepage-public-readiness.mjs
cc65444e1 fix(homepage): align readiness with Text Eliza
a8a8b8d3e feat(cloud): ship phone-first personal Eliza (#19511)
60838c42f fix(homepage): align readiness admission policy (#19536)
$ git log --oneline -2 -- packages/homepage/README.md
eee292d5a fix(discord): switch production application default (#19913) (#19916)
5a249cd99 fix(homepage): validate live Blooio readiness (#19532)
```
</details>

<details>
<summary>3. RED on develop → GREEN at head, tree clean</summary>

```
# BEFORE: first dead marker kills the contract subtest
AssertionError: The input did not match the regular expression /GitHub Pages DNS records/

# AFTER (this head):
$ node --test scripts/android-sms-gateway-template.test.mjs
ℹ tests 9   ℹ pass 9   ℹ fail 0        # exit 0
$ git status --short && ls .eliza-local
NO .eliza-local — tree clean            # e2e-verifier evidence now sandboxed
```
</details>

<details>
<summary>4. Full lane with the suite wired</summary>

```
$ bun run --cwd packages/app-core test:script-suites
ℹ tests 47   ℹ pass 46   ℹ fail 1
# the 1 failure is run-mobile-build-android-app-actions.test.mjs's machine-local
# adm-zip resolution artifact, already disclosed as #22348's known gap (declared
# dependency, resolved in bun.lock; clean CI install provides it). Identical
# failure on the #22348 baseline without this change.

$ ./node_modules/.bin/biome check <3 changed files>   # exit 0
warnings 9 -> 7 (the realignment removed two template-literal-shaped strings)
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcripts above are the artifact; the suite's HTTP servers are in-process mocks.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** Per the recorded operator hardware constraint it is delegated to this PR's CI.
- **One lane suite still fails machine-locally** (`adm-zip`, pre-existing, disclosed on #22348; CI is its prover). Zero of the nine tests in the realigned suite touch it.
- **Merge-order note:** stacked on #22348; if this merges first it carries #22348's commit, if #22348 merges first this rebases to a three-file diff. Both branches are mine, so either resolution is on me, not reviewers.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

