### PR TITLE
fix(plugin-computeruse): fail closed on unbounded Sway tree walks

### DIFF
--- a/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
@@ -7,7 +7,7 @@
  * The Sway walk is also exercised against a 40k-deep nest that used to
  * stack-overflow after JSON.parse succeeded.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   MAX_SWAY_TREE_DEPTH,
   MAX_SWAY_TREE_VISIT,
@@ -184,6 +184,56 @@ describe("parseSwayTree", () => {
     const out = parseSwayTree(json);
     expect(out.length).toBeLessThanOrEqual(MAX_SWAY_TREE_VISIT);
     expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("does not inspect a wide child array beyond the work budget", () => {
+    const child = { type: "con" };
+    let reads = 0;
+    const nodes = new Proxy(
+      Array.from({ length: MAX_SWAY_TREE_VISIT + 500 }, () => child),
+      {
+        get(target, property, receiver) {
+          if (typeof property === "string" && /^\d+$/.test(property))
+            reads += 1;
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    const parse = vi.spyOn(JSON, "parse").mockReturnValue({
+      type: "root",
+      nodes,
+    });
+    try {
+      parseSwayTree("{}");
+      expect(reads).toBeLessThan(MAX_SWAY_TREE_VISIT);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it("keeps depth-first order without preloading later root siblings", () => {
+    const json = JSON.stringify({
+      type: "root",
+      nodes: [
+        {
+          type: "con",
+          nodes: [
+            {
+              type: "con",
+              window: 1,
+              app_id: "first-subtree",
+              rect: { x: 0, y: 0, width: 1, height: 1 },
+            },
+          ],
+        },
+        ...Array.from({ length: MAX_SWAY_TREE_VISIT + 500 }, () => ({
+          type: "con",
+        })),
+      ],
+    });
+    expect(parseSwayTree(json).map((node) => node.label)).toContain(
+      "first-subtree",
+    );
   });
 
   it("does not recurse past the depth budget", () => {

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
@@ -4,9 +4,16 @@
  *
  * Both parsers are pure adapters over `hyprctl clients -j` and
  * `swaymsg -t get_tree`, so fixture assertions can run on any CI host.
+ * The Sway walk is also exercised against a 40k-deep nest that used to
+ * stack-overflow after JSON.parse succeeded.
  */
 import { describe, expect, it } from "vitest";
-import { parseHyprlandClients, parseSwayTree } from "./a11y-provider.js";
+import {
+  MAX_SWAY_TREE_DEPTH,
+  MAX_SWAY_TREE_VISIT,
+  parseHyprlandClients,
+  parseSwayTree,
+} from "./a11y-provider.js";
 
 describe("parseHyprlandClients", () => {
   it("maps each client to a window node with display-absolute bbox", () => {
@@ -149,5 +156,41 @@ describe("parseSwayTree", () => {
   it("returns [] on invalid JSON or a null tree", () => {
     expect(parseSwayTree("{bad")).toEqual([]);
     expect(parseSwayTree("null")).toEqual([]);
+  });
+
+  it("does not stack-overflow a 40k-deep nest after JSON.parse succeeds", () => {
+    const leaf = '{"type":"con","app_id":"x","window":1}';
+    const depth = 40_000;
+    const json =
+      '{"type":"root","nodes":['.repeat(depth) + leaf + "]}".repeat(depth);
+    expect(() => JSON.parse(json)).not.toThrow();
+    const started = performance.now();
+    const out = parseSwayTree(json);
+    expect(performance.now() - started).toBeLessThan(50);
+    expect(out).toEqual([]);
+  });
+
+  it("stops walking after the visit budget instead of materializing every sibling", () => {
+    const child = {
+      type: "con",
+      window: 1,
+      app_id: "x",
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    };
+    const json = JSON.stringify({
+      type: "root",
+      nodes: Array.from({ length: MAX_SWAY_TREE_VISIT + 500 }, () => child),
+    });
+    const out = parseSwayTree(json);
+    expect(out.length).toBeLessThanOrEqual(MAX_SWAY_TREE_VISIT);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("does not recurse past the depth budget", () => {
+    const json =
+      '{"type":"root","nodes":['.repeat(MAX_SWAY_TREE_DEPTH + 8) +
+      '{"type":"con","app_id":"deep","window":1}' +
+      "]}".repeat(MAX_SWAY_TREE_DEPTH + 8);
+    expect(parseSwayTree(json)).toEqual([]);
   });
 });

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -376,63 +376,85 @@ export function parseSwayTree(text: string): SceneAxNode[] {
     node: SwayNode;
     currentOutput: string;
     depth: number;
-  }> = [{ node: raw, currentOutput: "", depth: 0 }];
-  let visited = 0;
+    entered: boolean;
+    nodeIndex: number;
+    floatingIndex: number;
+  }> = [
+    {
+      node: raw,
+      currentOutput: "",
+      depth: 0,
+      entered: false,
+      nodeIndex: 0,
+      floatingIndex: 0,
+    },
+  ];
+  let work = 0;
 
-  while (stack.length > 0) {
-    if (visited >= MAX_SWAY_TREE_VISIT) break;
-    const frame = stack.pop();
-    if (!frame) break;
+  while (stack.length > 0 && work < MAX_SWAY_TREE_VISIT) {
+    const frame = stack[stack.length - 1];
     const { node, depth } = frame;
-    let currentOutput = frame.currentOutput;
-    visited += 1;
+    if (!frame.entered) {
+      frame.entered = true;
+      work += 1;
+      if (node.type === "output" && typeof node.name === "string") {
+        if (!outputToDisplay.has(node.name)) {
+          outputToDisplay.set(node.name, outputToDisplay.size);
+        }
+        frame.currentOutput = node.name;
+      }
+      if (node.type === "con" || node.type === "floating_con") {
+        if (node.window !== undefined || node.app_id) {
+          const displayId = outputToDisplay.get(frame.currentOutput) ?? 0;
+          seq += 1;
+          const rect = node.rect ?? {};
+          out.push({
+            id: `a${displayId}-${seq}`,
+            role: "window",
+            label: node.name || node.app_id || "unknown",
+            bbox: [
+              Number(rect.x ?? 0),
+              Number(rect.y ?? 0),
+              Number(rect.width ?? 0),
+              Number(rect.height ?? 0),
+            ],
+            actions: ["focus", "close"],
+            displayId,
+          });
+        }
+      }
+      if (depth >= MAX_SWAY_TREE_DEPTH) {
+        stack.pop();
+        continue;
+      }
+    }
 
-    if (node.type === "output" && typeof node.name === "string") {
-      if (!outputToDisplay.has(node.name)) {
-        outputToDisplay.set(node.name, outputToDisplay.size);
-      }
-      currentOutput = node.name;
-    }
-    if (node.type === "con" || node.type === "floating_con") {
-      if (node.window !== undefined || node.app_id) {
-        const displayId = outputToDisplay.get(currentOutput) ?? 0;
-        seq += 1;
-        const rect = node.rect ?? {};
-        out.push({
-          id: `a${displayId}-${seq}`,
-          role: "window",
-          label: node.name || node.app_id || "unknown",
-          bbox: [
-            Number(rect.x ?? 0),
-            Number(rect.y ?? 0),
-            Number(rect.width ?? 0),
-            Number(rect.height ?? 0),
-          ],
-          actions: ["focus", "close"],
-          displayId,
-        });
-      }
+    const nodes = Array.isArray(node.nodes) ? node.nodes : [];
+    const floatingNodes = Array.isArray(node.floating_nodes)
+      ? node.floating_nodes
+      : [];
+    let candidate: unknown;
+    if (frame.nodeIndex < nodes.length) {
+      candidate = nodes[frame.nodeIndex];
+      frame.nodeIndex += 1;
+    } else if (frame.floatingIndex < floatingNodes.length) {
+      candidate = floatingNodes[frame.floatingIndex];
+      frame.floatingIndex += 1;
+    } else {
+      stack.pop();
+      continue;
     }
 
-    if (depth >= MAX_SWAY_TREE_DEPTH) continue;
-    const children: SwayNode[] = [];
-    if (Array.isArray(node.nodes)) {
-      for (const child of node.nodes) {
-        if (isSwayNode(child)) children.push(child);
-      }
-    }
-    if (Array.isArray(node.floating_nodes)) {
-      for (const child of node.floating_nodes) {
-        if (isSwayNode(child)) children.push(child);
-      }
-    }
-    for (let index = children.length - 1; index >= 0; index -= 1) {
-      stack.push({
-        node: children[index],
-        currentOutput,
-        depth: depth + 1,
-      });
-    }
+    work += 1;
+    if (!isSwayNode(candidate)) continue;
+    stack.push({
+      node: candidate,
+      currentOutput: frame.currentOutput,
+      depth: depth + 1,
+      entered: false,
+      nodeIndex: 0,
+      floatingIndex: 0,
+    });
   }
   return out;
 }

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -26,6 +26,10 @@
  * The Android `AccessibilityService` impl is owned by WS8 and registers via
  * `setAccessibilityProvider()` at runtime — this module exposes the seam
  * but does not ship a JS-side implementation.
+ *
+ * `swaymsg -t get_tree` JSON is untrusted compositor output. `parseSwayTree`
+ * walks it iteratively with a depth and visit budget so a 40k-deep nest cannot
+ * stack-overflow the scene scan after `JSON.parse` succeeds.
  */
 
 import { execFileSync } from "node:child_process";
@@ -346,21 +350,43 @@ interface SwayNode {
   focused?: boolean;
 }
 
+/** Honest Sway trees are ~10 containers deep (root → output → workspace → con). */
+export const MAX_SWAY_TREE_DEPTH = 64;
+/** Bound untrusted `swaymsg -t get_tree` walks before they pin the scene scan. */
+export const MAX_SWAY_TREE_VISIT = 4096;
+
+function isSwayNode(value: unknown): value is SwayNode {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 export function parseSwayTree(text: string): SceneAxNode[] {
-  let raw: SwayNode | null;
+  let raw: unknown;
   try {
-    raw = JSON.parse(text) as SwayNode;
+    raw = JSON.parse(text);
   } catch {
     // error-policy:J3 untrusted `swaymsg` output; unparseable JSON yields the
     // explicit empty node list rather than a fabricated window.
     return [];
   }
-  if (!raw) return [];
+  if (!isSwayNode(raw)) return [];
   const out: SceneAxNode[] = [];
   let seq = 0;
   const outputToDisplay = new Map<string, number>();
-  // First pass — assign display ids by output name encounter order.
-  const visit = (node: SwayNode, currentOutput: string): void => {
+  const stack: Array<{
+    node: SwayNode;
+    currentOutput: string;
+    depth: number;
+  }> = [{ node: raw, currentOutput: "", depth: 0 }];
+  let visited = 0;
+
+  while (stack.length > 0) {
+    if (visited >= MAX_SWAY_TREE_VISIT) break;
+    const frame = stack.pop();
+    if (!frame) break;
+    const { node, depth } = frame;
+    let currentOutput = frame.currentOutput;
+    visited += 1;
+
     if (node.type === "output" && typeof node.name === "string") {
       if (!outputToDisplay.has(node.name)) {
         outputToDisplay.set(node.name, outputToDisplay.size);
@@ -387,10 +413,27 @@ export function parseSwayTree(text: string): SceneAxNode[] {
         });
       }
     }
-    for (const child of node.nodes ?? []) visit(child, currentOutput);
-    for (const child of node.floating_nodes ?? []) visit(child, currentOutput);
-  };
-  visit(raw, "");
+
+    if (depth >= MAX_SWAY_TREE_DEPTH) continue;
+    const children: SwayNode[] = [];
+    if (Array.isArray(node.nodes)) {
+      for (const child of node.nodes) {
+        if (isSwayNode(child)) children.push(child);
+      }
+    }
+    if (Array.isArray(node.floating_nodes)) {
+      for (const child of node.floating_nodes) {
+        if (isSwayNode(child)) children.push(child);
+      }
+    }
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push({
+        node: children[index],
+        currentOutput,
+        depth: depth + 1,
+      });
+    }
+  }
   return out;
 }
 


### PR DESCRIPTION

## Problem

`parseSwayTree` walked untrusted `swaymsg -t get_tree` JSON with a recursive visitor. `JSON.parse` accepts a 40k-deep nest; the visitor then threw `RangeError: Maximum call stack size exceeded` and took down the Linux computer-use scene scan.

Measured on origin `41a407be09d3`:

| input | `JSON.parse` | `parseSwayTree` |
| --- | --- | --- |
| honest dual-output fixture | ok | 3 windows |
| 20k-deep nest | ok (~3ms) | ok |
| 40k-deep nest | **ok (~14ms)** | **RangeError ~10ms** |
| 60k-deep nest | ok | RangeError |

Complete stack overflow, not leftover-tax, not fetch timeout, not GGUF/XML/shader. Occupancy-FREE `a11y-provider.ts`.

## Change

- Walk the tree iteratively.
- `MAX_SWAY_TREE_DEPTH = 64` (honest Sway trees are ~10 deep).
- `MAX_SWAY_TREE_VISIT = 4096`.
- Skip non-object children. Hostile depth returns `[]` in ~5ms instead of throwing.

## Proof

```
ORIGIN_RED: JSON.parse 40000 ok; parseSwayTree RangeError
GREEN: 40k-deep nodes=0; wide child arrays stop inside the 4096 work budget
NEGATIVE MUTATION: weakened budget read 4596 siblings and failed the regression test
bun test a11y-provider.parsers.test.ts  11/11
bun run verify  358/358 tasks; 8997 anti-LARP test files clean
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22539.

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused parser tests pass 11/11 at `14f6cf2d42a0`; `bun run verify` passes 358/358 tasks and scans 8997 anti-LARP test files clean.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Maintainer repair provenance: OpenAI/gpt-5.6-sol via Codex desktop added lazy wide-tree budget enforcement and the two wide-tree regression tests at `14f6cf2d42a0`; contribution guidance revision `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. The change is confined to Linux Sway accessibility-tree parsing. Honest trees retain depth-first ordering; hostile deep or wide trees return only the prefix admitted by explicit budgets.

# Background

## What does this PR do?

Replaces recursive and eager Sway-tree traversal with a depth-bounded, lazily inspected DFS so compositor JSON cannot overflow the stack or force unbounded sibling processing.

## What kind of change is this?

Bug fix and input-hardening improvement.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

No documentation change is needed; this preserves the existing internal parser contract while hardening hostile input behavior.

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/scene/a11y-provider.ts`, then the hostile deep/wide fixtures in `a11y-provider.parsers.test.ts`.

## Detailed testing steps

1. Run `bun test plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts` and confirm 11/11 pass.
2. Run `bun run --cwd plugins/plugin-computeruse typecheck`.
3. Run `bun run verify`; the reviewed head passes 358/358 tasks.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:14f6cf2d42a0aa83b5d1bc21c8d447ea254f8d70 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - parser-only; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - parser-only; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - parser-only; no user-visible flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic parser proof: 40k-deep input stays stack-safe and wide arrays stay inside the 4096 work budget
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, or action change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Sway JSON parser contract only; no persisted artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

No command failures remain. UI, frontend, model, and persisted-domain evidence is N/A because this is a deterministic Linux compositor JSON parser change. The exact-head focused tests, negative mutation, package typecheck, and full repository verify cover the changed contract.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

