### PR TITLE
fix(voice): fail closed on hostile resample sample rates

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
@@ -368,6 +368,15 @@ describe("transcriber helpers", () => {
 		const down = resampleLinear(pcm, 48000, 16000);
 		expect(down.length).toBe(Math.round((pcm.length * 16000) / 48000));
 	});
+
+	it("resampleLinear fails closed on a 1 Hz header instead of allocating millions of frames", () => {
+		const pcm = new Float32Array(8_000);
+		const started = performance.now();
+		expect(() => resampleLinear(pcm, 1, 16_000)).toThrow(
+			/rejected source rate/,
+		);
+		expect(performance.now() - started).toBeLessThan(50);
+	});
 });
 
 /* ---- fake ElizaInferenceFfi -------------------------------------- */

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
@@ -369,13 +369,34 @@ describe("transcriber helpers", () => {
 		expect(down.length).toBe(Math.round((pcm.length * 16000) / 48000));
 	});
 
-	it("resampleLinear fails closed on a 1 Hz header instead of allocating millions of frames", () => {
-		const pcm = new Float32Array(8_000);
-		const started = performance.now();
-		expect(() => resampleLinear(pcm, 1, 16_000)).toThrow(
-			/rejected source rate/,
+	it.each([0, 1, 999, 192_001, 16_000.5, Number.NaN, Number.POSITIVE_INFINITY])(
+		"resampleLinear rejects unsafe source rate %s before allocating output",
+		(fromRate) => {
+			expect(() =>
+				resampleLinear(new Float32Array([0.25]), fromRate, 16_000),
+			).toThrow(/rejected source rate/);
+		},
+	);
+
+	it.each([0, 999, 192_001, 16_000.5, Number.NaN, Number.NEGATIVE_INFINITY])(
+		"resampleLinear rejects unsafe target rate %s",
+		(toRate) => {
+			expect(() =>
+				resampleLinear(new Float32Array([0.25]), 16_000, toRate),
+			).toThrow(/rejected target rate/);
+		},
+	);
+
+	it("resampleLinear accepts boundary rates and rejects oversized output", () => {
+		expect(resampleLinear(new Float32Array([0.25]), 1_000, 1_000)).toHaveLength(
+			1,
 		);
-		expect(performance.now() - started).toBeLessThan(50);
+		expect(
+			resampleLinear(new Float32Array([0.25]), 192_000, 192_000),
+		).toHaveLength(1);
+		expect(() =>
+			resampleLinear(new Float32Array(120_001), 1_000, 16_000),
+		).toThrow(/resample output .* exceeds/);
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.ts
@@ -110,15 +110,40 @@ function extractWords(text: string): string[] {
  * frames (commonly 16 / 24 / 48 kHz) to the ASR rate. Not a polyphase
  * filter — adequate for speech ASR; the fused build does its own
  * resampling so this is interim-batch only.
+ *
+ * `fromRate` is often a WAV/container header. A 1 Hz header on a few
+ * thousand samples would allocate tens of millions of output frames.
  */
+export const MIN_RESAMPLE_RATE_HZ = 1_000;
+export const MAX_RESAMPLE_RATE_HZ = 192_000;
+/** Two minutes at 16 kHz — hostile 1 Hz headers cannot allocate past this. */
+export const MAX_RESAMPLE_OUTPUT_SAMPLES = 16_000 * 120;
+
+function requireResampleRate(rate: number, label: string): void {
+	if (
+		!Number.isFinite(rate) ||
+		rate < MIN_RESAMPLE_RATE_HZ ||
+		rate > MAX_RESAMPLE_RATE_HZ
+	) {
+		throw new Error(`[transcriber] resample rejected ${label} rate ${rate}`);
+	}
+}
+
 export function resampleLinear(
 	pcm: Float32Array,
 	fromRate: number,
 	toRate: number,
 ): Float32Array {
+	requireResampleRate(fromRate, "source");
+	requireResampleRate(toRate, "target");
 	if (fromRate === toRate || pcm.length === 0) return pcm;
 	const ratio = toRate / fromRate;
 	const outLen = Math.max(1, Math.round(pcm.length * ratio));
+	if (outLen > MAX_RESAMPLE_OUTPUT_SAMPLES) {
+		throw new Error(
+			`[transcriber] resample output ${outLen} exceeds ${MAX_RESAMPLE_OUTPUT_SAMPLES}`,
+		);
+	}
 	const out = new Float32Array(outLen);
 	for (let i = 0; i < outLen; i++) {
 		const srcPos = i / ratio;

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.ts
@@ -121,7 +121,7 @@ export const MAX_RESAMPLE_OUTPUT_SAMPLES = 16_000 * 120;
 
 function requireResampleRate(rate: number, label: string): void {
 	if (
-		!Number.isFinite(rate) ||
+		!Number.isSafeInteger(rate) ||
 		rate < MIN_RESAMPLE_RATE_HZ ||
 		rate > MAX_RESAMPLE_RATE_HZ
 	) {

--- a/plugins/plugin-native-inference/__tests__/aosp-audio-resample.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-audio-resample.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Exercises the real AOSP batch-ASR resampler against hostile rate metadata
+ * and bounded-output invariants without loading the native FFI library.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES,
+  resampleAospLinear,
+} from "../src/aosp-audio-resample";
+
+describe("AOSP audio resampling bounds", () => {
+  it.each([0, 1, 999, 192_001, 16_000.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects unsafe source rate %s",
+    (fromRate) => {
+      expect(() =>
+        resampleAospLinear(new Float32Array([0.25]), fromRate, 16_000),
+      ).toThrow(/rejected source rate/);
+    },
+  );
+
+  it.each([0, 999, 192_001, 16_000.5, Number.NaN, Number.NEGATIVE_INFINITY])(
+    "rejects unsafe target rate %s",
+    (toRate) => {
+      expect(() =>
+        resampleAospLinear(new Float32Array([0.25]), 16_000, toRate),
+      ).toThrow(/rejected target rate/);
+    },
+  );
+
+  it("preserves valid no-op and downsample behavior", () => {
+    const pcm = new Float32Array(48_000);
+    expect(resampleAospLinear(pcm, 16_000, 16_000)).toBe(pcm);
+    expect(resampleAospLinear(pcm, 48_000, 16_000)).toHaveLength(16_000);
+  });
+
+  it("rejects output above the fixed allocation budget", () => {
+    const inputLength = Math.floor(MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES / 16) + 1;
+    expect(() =>
+      resampleAospLinear(new Float32Array(inputLength), 1_000, 16_000),
+    ).toThrow(/resample output .* exceeds/);
+  });
+});

--- a/plugins/plugin-native-inference/src/aosp-audio-resample.ts
+++ b/plugins/plugin-native-inference/src/aosp-audio-resample.ts
@@ -1,0 +1,49 @@
+/**
+ * Bounds the AOSP batch-ASR linear resampler before it allocates output from
+ * untrusted WAV sample-rate metadata.
+ */
+
+export const MIN_AOSP_RESAMPLE_RATE_HZ = 1_000;
+export const MAX_AOSP_RESAMPLE_RATE_HZ = 192_000;
+export const MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES = 16_000 * 120;
+
+function requireAospResampleRate(rate: number, label: string): void {
+  if (
+    !Number.isSafeInteger(rate) ||
+    rate < MIN_AOSP_RESAMPLE_RATE_HZ ||
+    rate > MAX_AOSP_RESAMPLE_RATE_HZ
+  ) {
+    throw new Error(
+      `[aosp-local-inference] resample rejected ${label} rate ${rate}`,
+    );
+  }
+}
+
+export function resampleAospLinear(
+  samples: Float32Array,
+  fromHz: number,
+  toHz: number,
+): Float32Array {
+  requireAospResampleRate(fromHz, "source");
+  requireAospResampleRate(toHz, "target");
+  if (fromHz === toHz || samples.length === 0) return samples;
+
+  const ratio = toHz / fromHz;
+  const outLen = Math.max(1, Math.round(samples.length * ratio));
+  if (outLen > MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES) {
+    throw new Error(
+      `[aosp-local-inference] resample output ${outLen} exceeds ${MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES}`,
+    );
+  }
+
+  const out = new Float32Array(outLen);
+  for (let i = 0; i < out.length; i++) {
+    const src = i / ratio;
+    const i0 = Math.floor(src);
+    const i1 = Math.min(samples.length - 1, i0 + 1);
+    const fraction = src - i0;
+    out[i] =
+      (samples[i0] ?? 0) * (1 - fraction) + (samples[i1] ?? 0) * fraction;
+  }
+  return out;
+}

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -63,6 +63,7 @@ import {
   type TextToSpeechParams,
   type TranscriptionParams,
 } from "@elizaos/core";
+import { resampleAospLinear } from "./aosp-audio-resample.js";
 // @elizaos/shared/local-inference is intentionally not imported here: every
 // AOSP TTS path flows through `makeAospFusedKokoroTextToSpeechHandler` below,
 // which dlopens `libelizainference.so` via bun:ffi and synthesizes Kokoro
@@ -2745,52 +2746,6 @@ function decodeMonoPcm16WavBytes(bytes: Uint8Array): {
   return { samples, sampleRate };
 }
 
-const MIN_AOSP_RESAMPLE_RATE_HZ = 1_000;
-const MAX_AOSP_RESAMPLE_RATE_HZ = 192_000;
-const MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES = 16_000 * 120;
-
-function resampleLinear(
-  samples: Float32Array,
-  fromHz: number,
-  toHz: number,
-): Float32Array {
-  if (
-    !Number.isFinite(fromHz) ||
-    fromHz < MIN_AOSP_RESAMPLE_RATE_HZ ||
-    fromHz > MAX_AOSP_RESAMPLE_RATE_HZ
-  ) {
-    throw new Error(
-      `[aosp-local-inference] resample rejected source rate ${fromHz}`,
-    );
-  }
-  if (
-    !Number.isFinite(toHz) ||
-    toHz < MIN_AOSP_RESAMPLE_RATE_HZ ||
-    toHz > MAX_AOSP_RESAMPLE_RATE_HZ
-  ) {
-    throw new Error(
-      `[aosp-local-inference] resample rejected target rate ${toHz}`,
-    );
-  }
-  if (fromHz === toHz) return samples;
-  const ratio = toHz / fromHz;
-  const outLen = Math.max(1, Math.round(samples.length * ratio));
-  if (outLen > MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES) {
-    throw new Error(
-      `[aosp-local-inference] resample output ${outLen} exceeds ${MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES}`,
-    );
-  }
-  const out = new Float32Array(outLen);
-  for (let i = 0; i < out.length; i++) {
-    const src = i / ratio;
-    const i0 = Math.floor(src);
-    const i1 = Math.min(samples.length - 1, i0 + 1);
-    const f = src - i0;
-    out[i] = (samples[i0] ?? 0) * (1 - f) + (samples[i1] ?? 0) * f;
-  }
-  return out;
-}
-
 function bytesFromTranscriptionInput(
   value: Uint8Array | ArrayBuffer | Buffer,
 ): Uint8Array {
@@ -2937,7 +2892,7 @@ async function transcribeWithAospElizaInference(
       );
     }
     assertNotAborted(signal);
-    const pcm16k = resampleLinear(audio.samples, audio.sampleRate, 16000);
+    const pcm16k = resampleAospLinear(audio.samples, audio.sampleRate, 16000);
     const pcmBytes = Buffer.from(
       pcm16k.buffer,
       pcm16k.byteOffset,

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -2745,14 +2745,42 @@ function decodeMonoPcm16WavBytes(bytes: Uint8Array): {
   return { samples, sampleRate };
 }
 
+const MIN_AOSP_RESAMPLE_RATE_HZ = 1_000;
+const MAX_AOSP_RESAMPLE_RATE_HZ = 192_000;
+const MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES = 16_000 * 120;
+
 function resampleLinear(
   samples: Float32Array,
   fromHz: number,
   toHz: number,
 ): Float32Array {
+  if (
+    !Number.isFinite(fromHz) ||
+    fromHz < MIN_AOSP_RESAMPLE_RATE_HZ ||
+    fromHz > MAX_AOSP_RESAMPLE_RATE_HZ
+  ) {
+    throw new Error(
+      `[aosp-local-inference] resample rejected source rate ${fromHz}`,
+    );
+  }
+  if (
+    !Number.isFinite(toHz) ||
+    toHz < MIN_AOSP_RESAMPLE_RATE_HZ ||
+    toHz > MAX_AOSP_RESAMPLE_RATE_HZ
+  ) {
+    throw new Error(
+      `[aosp-local-inference] resample rejected target rate ${toHz}`,
+    );
+  }
   if (fromHz === toHz) return samples;
   const ratio = toHz / fromHz;
-  const out = new Float32Array(Math.max(1, Math.round(samples.length * ratio)));
+  const outLen = Math.max(1, Math.round(samples.length * ratio));
+  if (outLen > MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES) {
+    throw new Error(
+      `[aosp-local-inference] resample output ${outLen} exceeds ${MAX_AOSP_RESAMPLE_OUTPUT_SAMPLES}`,
+    );
+  }
+  const out = new Float32Array(outLen);
   for (let i = 0; i < out.length; i++) {
     const src = i / ratio;
     const i0 = Math.floor(src);


### PR DESCRIPTION

## Problem

`resampleLinear` treated a WAV/mic `sampleRate` header as a trusted scale for `new Float32Array(samples * 16000 / rate)`.

Measured on origin `41a407be09d3`:

| input | result |
| --- | --- |
| honest 1 s 48 kHz → 16 kHz | 16k samples, 2.6 ms |
| 4k samples @ **1 Hz** → 16 kHz | **64,000,000** samples, 141 ms, 256 MiB |
| 8k samples @ **1 Hz** → 16 kHz | **128,000,000** samples, 263 ms, 512 MiB |

A 1-second 16 kHz clip labeled 1 Hz is 1 GiB. Complete overflow, not leftover-tax, not fetch/GGUF/XML. Occupancy-FREE.

## Change

- Reject rates outside 1–192 kHz.
- Cap output at two minutes of 16 kHz (`1_920_000` samples).
- Same guard on the AOSP transcription copy.

## Proof

```
ORIGIN_RED: 8k @ 1 Hz → 128e6 frames / 263ms
GREEN: throw 0.18ms; honest 48k→16k 0.95ms
bun test transcriber.test.ts  15/15
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bun test` 15/15 on `transcriber.test.ts` at this head. Full `bun run verify` not re-run this cycle; change is isolated to resampleLinear.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6, OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:851472037be1e20e91c2491656d2acbf90402b16 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - resample helper; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - resample helper; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - parser/DSP helper; no user-visible flow
<!-- evidence-row:backend-logs -->
- [x] Exact-head tests and type/lint gates: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22488-pr22488-validation.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] Verified resample-bound matrix: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22488-pr22488-domain.json
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->



## Maintainer repair validation

Rebased onto current develop. The repair removes the allocation-heavy timing assertion, validates safe-integer source and target rates, covers every invalid/boundary family, and moves the AOSP resampler into an independently executable production module. Exact head 851472037be1e20e91c2491656d2acbf90402b16: focused 43/43, both owning-package typechecks, touched-file Biome, and diff-check pass. The complete native package test assertions passed before its coverage reporter hit a host write failure; no test assertion failed.

Repair contribution: OpenAI / gpt-5.6-sol via Codex desktop / multi-agent.
