### PR TITLE
fix(plugin-coding-tools): decode shell stdout/stderr as a UTF-8 stream

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -89,6 +89,23 @@ describePosixShell("shell plugin real local integration", () => {
     expect(provider.values?.currentWorkingDirectory).toBe(allowedDirectory);
   });
 
+  it("captures multibyte stdout without corruption across pipe chunk boundaries", async () => {
+    // Emit ~150 KB of a 3-byte UTF-8 code point so the subprocess stdout is
+    // delivered as several `data` chunks and code points straddle the
+    // boundaries. Per-chunk `Buffer.toString()` would replace the split bytes
+    // with U+FFFD; a UTF-8 stream decode keeps them intact.
+    const count = 50_000;
+    const result = await service.executeCommand(
+      `node -e 'process.stdout.write("\u4f60".repeat(${count}))'`,
+      "room-utf8",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).not.toContain("\uFFFD");
+    expect(result.stdout.length).toBe(count);
+    expect(result.stdout).toBe("\u4f60".repeat(count));
+  });
+
   it("stores and provides only redacted configured bare secrets", async () => {
     const secret = "marigold9";
     await service.stop();

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -96,7 +96,7 @@ describePosixShell("shell plugin real local integration", () => {
     // with U+FFFD; a UTF-8 stream decode keeps them intact.
     const count = 50_000;
     const result = await service.executeCommand(
-      `node -e 'process.stdout.write("\u4f60".repeat(${count}))'`,
+      `node -e 'process.stdout.write("\u4f60".repeat(${count}))' | cat`,
       "room-utf8",
     );
 

--- a/plugins/plugin-coding-tools/src/shell/services/shellService.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/shellService.ts
@@ -1397,14 +1397,22 @@ export class ShellService extends Service {
       }, this.shellConfig.timeout);
 
       if (child.stdout) {
-        child.stdout.on("data", (data: Buffer) => {
-          stdout += data.toString();
+        // Decode the pipe as a UTF-8 stream, not per-chunk: a multi-byte code
+        // point split across two `data` Buffers would otherwise decode to
+        // U+FFFD on both sides of the boundary, silently corrupting any
+        // non-ASCII command output the agent reads. setEncoding installs
+        // Node's StringDecoder, which holds a partial code point until the
+        // next chunk completes it.
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (data: string) => {
+          stdout += data;
         });
       }
 
       if (child.stderr) {
-        child.stderr.on("data", (data: Buffer) => {
-          stderr += data.toString();
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (data: string) => {
+          stderr += data;
         });
       }
 
@@ -1679,6 +1687,12 @@ export class ShellService extends Service {
         handleStdout(cleaned);
       });
     } else if (child) {
+      // Same UTF-8 stream decode as the foreground path: without setEncoding,
+      // `handleStdout` receives raw Buffers and its `data.toString()` corrupts
+      // any multi-byte code point straddling a chunk boundary before it is
+      // sanitized and chunked. StringDecoder buffers the partial code point.
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
       child.stdout.on("data", handleStdout);
       child.stderr.on("data", handleStderr);
     }


### PR DESCRIPTION
# Relates to

Closes #22493. Shell subprocess output was decoded per pipe chunk with `Buffer.toString()`, silently corrupting multibyte UTF-8 that spans a chunk boundary.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below — **see Known gaps: full verify delegated to PR CI per
      operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from
      the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` (`6787e147b`).
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Low.** Two `setEncoding("utf8")` calls plus the matching handler param-type change (`Buffer` → `string`), in the two subprocess-output paths of one service. `setEncoding` installs Node's StringDecoder, whose output for genuinely-invalid bytes is the same U+FFFD `Buffer.toString()` already produced — so binary/non-UTF-8 handling is byte-for-byte unchanged; the only behavioral difference is that a **valid** multi-byte code point split across two chunks is now decoded correctly instead of becoming U+FFFD. The pty path already receives decoded strings and is untouched.

# Background

## What does this PR do?

`runCommandSimple` did `stdout += data.toString()` / `stderr += data.toString()` per `'data'` event, and the background-shell handlers did `sanitizeBinaryOutput(data.toString())` — decoding each raw pipe chunk independently. A multi-byte UTF-8 code point straddling a chunk boundary splits into fragments that are each invalid UTF-8, so both fragments become U+FFFD. This mangles any non-ASCII command output (CJK file contents, emoji, non-Latin filenames) once output crosses the ~64 KiB pipe chunk size.

The fix calls `child.stdout.setEncoding("utf8")` / `child.stderr.setEncoding("utf8")` before the handlers so Node's StringDecoder holds a partial code point until the next chunk completes it.

**This is the upstream decode fix and is distinct from #22396**, which keeps UTF-16 surrogate pairs intact when `chunkString` cuts the *already-decoded* string for the output ring. The two compose: #22396 chunks the string this change now guarantees is correctly decoded. Same bug class as #22428 (wechat HTTP body), a different surface.

## What kind of change is this?

Bug fix (silent output corruption).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The real-shell integration lane test emits 50k CJK code points from a real subprocess and asserts no corruption:

```bash
bun run --cwd plugins/plugin-coding-tools test -- src/shell/__tests__/shell.real.test.ts -t "multibyte stdout"
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:39bf33c7c9db4082b61fd476171c0508d0fdbfd4 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - subprocess stdout decoding; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - terminal-only; transcripts below are complete.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs; the transcripts below are the artifact.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, prompt, or model behavior changes; this fixes the bytes a tool returns to the agent.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

<details>
<summary>Before/after through the exact code path (setEncoding false vs true)</summary>

```
# real subprocess emits "你".repeat(50000) (~150 KiB); accumulate exactly as runCommandSimple does
BEFORE (child.stdout.on('data', d => stdout += d.toString())):
  stdout length 50003  corrupt: true  contains U+FFFD: true
AFTER  (child.stdout.setEncoding('utf8'); stdout += d):
  stdout length 50000  correct: true  (exact match to input)

$ ./node_modules/.bin/biome check <changed source + test>
Checked 2 files. No fixes applied.
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - the transcript above is the artifact.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Focused real subprocess proof passed on the exact repaired head.** The dedicated real Vitest lane passed for the multibyte stdout test. Mutation proof: removing the four UTF-8 stream decoder calls makes the same test fail with U+FFFD corruption. The submitted command initially bypassed the shell because the simple executor does not parse quotes; piping through cat now exercises the intended real shell/pipe path.
- **Full `bun run verify` was not run locally on this head.** Per the recorded operator hardware constraint it is delegated to this PR's CI.
- **Overlap disclosure:** this file is adjacent to #22396 (surrogate chunking) and the coding-tools area is actively worked; the two changes touch different lines (stream decode vs string chunking) and compose, but if maintainers prefer they land together I'm happy to coordinate.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
