### PR TITLE
fix(coding-tools): fire destructive gate on long-form rm flags (--recursive/--force)

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -3160,6 +3160,30 @@ describe("destructive-bulk confirm gate", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "blocks GNU long-form recursive delete before shell execution",
+    async () => {
+      const { command, target } = await createRecursiveDeleteCommand();
+      const { runtime } = await makeRuntime();
+      try {
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(undefined, "clean up the old projects"),
+          undefined,
+          { command: command.replace("rm -rf", "rm --recursive --force") },
+        );
+        expect(result.success).toBe(false);
+        expect(result.text).toContain("needs_confirmation");
+        expect(result.data).toMatchObject({
+          destructive_reason: "recursive delete",
+        });
+        expect(await pathExists(target)).toBe(true);
+      } finally {
+        await fs.rm(target, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("runs the same command when confirm=true", async () => {
     const { command, target } = await createRecursiveDeleteCommand();
     const { runtime } = await makeRuntime();

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -38,6 +38,27 @@ describe("classifyDestructiveCommand — fires", () => {
     expect(v.reason).toBe("forced glob delete");
     expect(v.targets).toContain("/var/log/*.log");
   });
+  it("recognizes GNU's unambiguous long-option abbreviations", () => {
+    expect(classifyDestructiveCommand("rm --rec build")).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["build"],
+    });
+    expect(classifyDestructiveCommand("rm --f *.log")).toMatchObject({
+      destructive: true,
+      reason: "forced glob delete",
+      targets: ["*.log"],
+    });
+  });
+  it("reports a dash-prefixed target after the option terminator", () => {
+    expect(
+      classifyDestructiveCommand("rm --recursive -- -old-cache"),
+    ).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["-old-cache"],
+    });
+  });
   it.each([
     ["Remove-Item -LiteralPath C:\\temp\\old -Recurse -Force"],
     ["remove-item C:\\temp\\old -Rec -Force"],
@@ -90,6 +111,8 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["rm single-file.txt"],
     ["rm -f one-exact-file.log"],
     ["rm --force one-exact-file.log"],
+    ["rm -- --recursive"],
+    ["rm -- --force"],
     ["git rm --recursive old-module"],
     ["Remove-Item one-exact-file.log"],
     ["git rm old.ts"],

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -16,6 +16,28 @@ describe("classifyDestructiveCommand — fires", () => {
     expect(classifyDestructiveCommand("rm -fr build").destructive).toBe(true);
     expect(classifyDestructiveCommand("rm -R cache").destructive).toBe(true);
   });
+  it("GNU long-form --recursive/--force fire like their short flags", () => {
+    const recursive = classifyDestructiveCommand("rm --recursive build");
+    expect(recursive.destructive).toBe(true);
+    expect(recursive.reason).toBe("recursive delete");
+    expect(recursive.targets).toContain("build");
+
+    const mixed = classifyDestructiveCommand("rm -R --force cache");
+    expect(mixed.destructive).toBe(true);
+    expect(mixed.reason).toBe("recursive delete");
+    expect(mixed.targets).toContain("cache");
+
+    const both = classifyDestructiveCommand("rm --recursive --force ./data");
+    expect(both.destructive).toBe(true);
+    expect(both.reason).toBe("recursive delete");
+    expect(both.targets).toContain("./data");
+  });
+  it("forced glob delete via long-form --force", () => {
+    const v = classifyDestructiveCommand("rm --force /var/log/*.log");
+    expect(v.destructive).toBe(true);
+    expect(v.reason).toBe("forced glob delete");
+    expect(v.targets).toContain("/var/log/*.log");
+  });
   it.each([
     ["Remove-Item -LiteralPath C:\\temp\\old -Recurse -Force"],
     ["remove-item C:\\temp\\old -Rec -Force"],
@@ -67,6 +89,8 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["ls -la /tmp"],
     ["rm single-file.txt"],
     ["rm -f one-exact-file.log"],
+    ["rm --force one-exact-file.log"],
+    ["git rm --recursive old-module"],
     ["Remove-Item one-exact-file.log"],
     ["git rm old.ts"],
     ["df -h / && du -sh /home"],

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -18,6 +18,19 @@ export interface DestructiveVerdict {
 
 const RECURSIVE_RM_FLAG = /^-[a-z]*[rR][a-z]*$/;
 const FORCE_ONLY_FLAG = /^-[a-z]*f[a-z]*$/;
+
+// GNU coreutils accepts long options as equivalents of the bundled short
+// flags. `rm --recursive` is the same delete as `rm -r`, and `rm --force` is
+// the same as `rm -f`; the short-flag regexes above cannot match them because
+// the second leading dash breaks `^-[a-z]*`. A recursive rm fires the gate
+// unconditionally; a force-only rm fires only against a glob, mirroring the
+// short-flag semantics so a single-file `rm --force x` still does not fire.
+function isRecursiveRmFlag(arg: string): boolean {
+  return arg === "--recursive" || RECURSIVE_RM_FLAG.test(arg);
+}
+function isForceRmFlag(arg: string): boolean {
+  return arg === "--force" || FORCE_ONLY_FLAG.test(arg);
+}
 const POWERSHELL_RECURSE_FLAG = /^-(?:r|re|rec|recu|recur|recurs|recurse)$/i;
 const POWERSHELL_REMOVE_ITEM_BINS = new Set([
   "remove-item",
@@ -88,13 +101,13 @@ export function classifyDestructiveCommand(
     const rest = argv.slice(i + 1);
 
     if (bin === "rm") {
-      const recursive = rest.some((a) => RECURSIVE_RM_FLAG.test(a));
+      const recursive = rest.some((a) => isRecursiveRmFlag(a));
       if (recursive) {
         const targets = rest.filter((a) => !a.startsWith("-"));
         return { destructive: true, reason: "recursive delete", targets };
       }
       // rm -f on a glob is bulk too; single explicit path is not.
-      const force = rest.some((a) => FORCE_ONLY_FLAG.test(a));
+      const force = rest.some((a) => isForceRmFlag(a));
       const paths = rest.filter((a) => !a.startsWith("-"));
       if (force && paths.some((p) => p.includes("*"))) {
         return {

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -19,17 +19,42 @@ export interface DestructiveVerdict {
 const RECURSIVE_RM_FLAG = /^-[a-z]*[rR][a-z]*$/;
 const FORCE_ONLY_FLAG = /^-[a-z]*f[a-z]*$/;
 
-// GNU coreutils accepts long options as equivalents of the bundled short
-// flags. `rm --recursive` is the same delete as `rm -r`, and `rm --force` is
-// the same as `rm -f`; the short-flag regexes above cannot match them because
-// the second leading dash breaks `^-[a-z]*`. A recursive rm fires the gate
-// unconditionally; a force-only rm fires only against a glob, mirroring the
-// short-flag semantics so a single-file `rm --force x` still does not fire.
+// GNU getopt accepts an unambiguous long-option prefix, so `--rec` and `--f`
+// have the same effect as their complete spellings.
+function isLongOption(arg: string, option: string): boolean {
+  return arg.length > 2 && option.startsWith(arg);
+}
+
 function isRecursiveRmFlag(arg: string): boolean {
-  return arg === "--recursive" || RECURSIVE_RM_FLAG.test(arg);
+  return isLongOption(arg, "--recursive") || RECURSIVE_RM_FLAG.test(arg);
 }
 function isForceRmFlag(arg: string): boolean {
-  return arg === "--force" || FORCE_ONLY_FLAG.test(arg);
+  return isLongOption(arg, "--force") || FORCE_ONLY_FLAG.test(arg);
+}
+
+function parseRmArguments(rest: readonly string[]): {
+  force: boolean;
+  paths: string[];
+  recursive: boolean;
+} {
+  let force = false;
+  let parsingOptions = true;
+  let recursive = false;
+  const paths: string[] = [];
+
+  for (const arg of rest) {
+    if (parsingOptions && arg === "--") {
+      parsingOptions = false;
+    } else if (parsingOptions && isRecursiveRmFlag(arg)) {
+      recursive = true;
+    } else if (parsingOptions && isForceRmFlag(arg)) {
+      force = true;
+    } else if (!parsingOptions || !arg.startsWith("-")) {
+      paths.push(arg);
+    }
+  }
+
+  return { force, paths, recursive };
 }
 const POWERSHELL_RECURSE_FLAG = /^-(?:r|re|rec|recu|recur|recurs|recurse)$/i;
 const POWERSHELL_REMOVE_ITEM_BINS = new Set([
@@ -101,14 +126,15 @@ export function classifyDestructiveCommand(
     const rest = argv.slice(i + 1);
 
     if (bin === "rm") {
-      const recursive = rest.some((a) => isRecursiveRmFlag(a));
+      const { force, paths, recursive } = parseRmArguments(rest);
       if (recursive) {
-        const targets = rest.filter((a) => !a.startsWith("-"));
-        return { destructive: true, reason: "recursive delete", targets };
+        return {
+          destructive: true,
+          reason: "recursive delete",
+          targets: paths,
+        };
       }
       // rm -f on a glob is bulk too; single explicit path is not.
-      const force = rest.some((a) => isForceRmFlag(a));
-      const paths = rest.filter((a) => !a.startsWith("-"));
       if (force && paths.some((p) => p.includes("*"))) {
         return {
           destructive: true,


### PR DESCRIPTION
# Relates to

Closes #22490

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install`/checks were run; the unrelated offline blocker is recorded under **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the before/after evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6787e147b86efc3e91f2081603b48f36bb5a9cf6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (HEAD was 0 commits behind at push time).
- [ ] `bun run verify` passes post-sync — blocked offline; see **Known gaps**. The changed contract's package tests are green.

# Risks

Low. The confirmation gate now follows GNU `rm` option parsing for recursive/force flags: complete long options and unique abbreviations are recognized, while `--` terminates option parsing. Recursive deletion remains gated; force-only deletion remains gated only for glob targets. Commands such as `rm -- --recursive`, single-file `rm --force x`, and `git rm --recursive x` remain outside this classifier. No public API or schema changes.

# Background

## What does this PR do?

`classifyDestructiveCommand()` in `plugins/plugin-coding-tools/src/lib/destructive-gate.ts` only recognized recursive/forced `rm` through **short** flags:

```
RECURSIVE_RM_FLAG = /^-[a-z]*[rR][a-z]*$/
FORCE_ONLY_FLAG   = /^-[a-z]*f[a-z]*$/
```

Both patterns anchor on a single leading dash (`^-[a-z]*`), so the GNU coreutils long options `--recursive` and `--force` never match — the second leading dash breaks the pattern. As a result these standard, documented commands classified `{destructive:false, targets:[]}`:

- `rm --recursive <path>`
- `rm --recursive --force <path>`
- `rm --force <glob>`

On the chat SHELL path (`src/actions/bash.ts:1647`, `classifyDestructiveCommand(command)` → `reason: "needs_confirmation"` when `verdict.destructive && !confirmed`) that means an irreversible bulk delete emitted by an LLM planner runs immediately, bypassing the two-phase confirmation gate.

The fix treats the long options as equivalents of their short forms:

- `--recursive` is recognized as recursive (fires the gate unconditionally, like `-r`).
- `--force` is recognized as force (fires **only** against a glob, mirroring `-f` semantics, so single-file `rm --force x` still does not fire).

## Mapping back to PR #16572 (the gate's intended coverage)

PR #16572 added this two-phase confirmation gate specifically to require a user "yes" before **recursive rm / forced glob deletes**; its description lists "recursive rm, forced glob deletes" as intended coverage. `rm --recursive` / `rm --force` are the standard long-form spellings of exactly those operations, so failing to catch them is an unintended bypass, not a design exclusion. This PR closes that bypass while keeping the gate's non-firing cases intact.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation — behavior is corrected to match the gate's already-documented intent; no user-facing config or API changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts` — the new cases assert the three long-flag commands now classify `destructive:true` with the correct `reason`, and the must-NOT-fire set (`rm --force one-exact-file.log`, `git rm --recursive old-module`) stays `false`.

## Detailed testing steps

```
cd plugins/plugin-coding-tools
vitest run src/lib/destructive-gate.test.ts
```

# Evidence Gate

<!-- evidence-head:031cf41da61420094661517acf2ff2c296b7f5e6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this is a pure string classifier on the server-side chat SHELL gate.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; the change is a deterministic classifier. Failing→passing reproduction attached below instead.
<!-- evidence-row:backend-logs -->
- [ ] N/A - classifier verdict before/after logs are inline in Evidence Details below; upstream pr-evidence release-asset upload is not writable by fork contributors (HTTP 404) and no other attachment host is reachable from this sandbox.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this is a lexical command classifier with no model call.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the classifier verdict transition (destructive:false to destructive:true), shown inline in Evidence Details; release-asset upload unavailable to fork contributors.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic classifier, no model call on this path.

## Backend + frontend logs

**BEFORE (origin/develop `destructive-gate.ts`, probe asserting `destructive===true`): all 3 long-form commands FAIL — the gate returns `false` and the delete would run unconfirmed.**

```
 × rm --recursive <path> -> destructive true (EXPECTED true)
 × rm --recursive --force <path> -> destructive true (EXPECTED true)
 × rm --force <glob> -> destructive true (EXPECTED true)
 Test Files  1 failed (1)
      Tests  3 failed (3)
```

**AFTER (this PR) — `destructive-gate.test.ts` including the new long-form regression cases and the preserved must-NOT-fire set:**

```
 Test Files  1 passed (1)
      Tests  28 passed (28)
```

**Full package suite (`vitest run`) — every executed test passes (104):**

```
 Tests  104 passed (104)
```

<details><summary>Why 29 of 36 test files could not execute here (unrelated offline blocker)</summary>

```
Error: Cannot find package '@noble/hashes/sha2.js' imported from packages/core/src/contracts/computer-use.ts
 Test Files  29 failed | 7 passed (36)
 Tests  104 passed (104)
```

Every one of the 29 "failed" files is the same module-resolution error (`@noble/hashes/sha2.js`, `drizzle-orm`, `uuid`) originating in `packages/core`/`packages/shared`, not in this plugin. It is caused by an offline `bun install` blocker (see Known gaps), not by this change: the `destructive-gate` suite — the exact contract changed — is fully green, and no error references a file under `plugins/plugin-coding-tools/src`.
</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio path.

## Known gaps / failures

Exact-head focused validation at `031cf41da61420094661517acf2ff2c296b7f5e6` passes: classifier plus real SHELL confirmation-boundary tests 33 passed (121 unrelated tests skipped), package typecheck clean, package build clean, changed-file Biome clean. A full plugin attempt loaded all 36 files and completed 502 passing tests, but 99 shell-execution tests failed because this review process booted without a boot-authorized shell (`No boot-authorized shell was detected`); the failures span unchanged shell execution paths and do not involve classification. The pure classifier and the pre-execution production confirmation path both pass.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@6787e147b86efc3e91f2081603b48f36bb5a9cf6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@6787e147b86efc3e91f2081603b48f36bb5a9cf6:packages/skills/skills/contribute-to-eliza"} -->

