### PR TITLE
fix(cloud): align storage quota PGlite fixture

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts
@@ -1,8 +1,8 @@
 /**
  * Exercises organization storage reservations through the real repository,
- * schema, and quota migration on isolated in-process PGlite. The harness
- * installs only the prerequisite organization shape and quota DDL, so bigint
- * arithmetic and concurrent admission run without repository mocks.
+ * schema, and quota migrations on isolated in-process PGlite. The harness
+ * installs only the prerequisite organization shape and quota-table DDL, so
+ * bigint arithmetic and concurrent admission run without repository mocks.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
@@ -19,6 +19,10 @@ const PGLITE_TIMEOUT_MS = 60_000;
 const QUOTA_MIGRATION_PATH = join(
   import.meta.dir,
   "../../migrations/0102_add_org_storage_quota.sql",
+);
+const NATIVE_CATALOG_MIGRATION_PATH = join(
+  import.meta.dir,
+  "../../migrations/0256_org_storage_native_objects.sql",
 );
 
 let closeDatabaseConnectionsForTests:
@@ -58,6 +62,20 @@ beforeAll(async () => {
     }
   }
 
+  const nativeCatalogMigration = readFileSync(NATIVE_CATALOG_MIGRATION_PATH, "utf8");
+  const reconciliationDdl = nativeCatalogMigration
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .find(
+      (statement) =>
+        statement.startsWith('ALTER TABLE "org_storage_quota"') &&
+        statement.includes('ADD COLUMN "native_catalog_reconciled_at"'),
+    );
+  if (reconciliationDdl === undefined) {
+    throw new Error("Native-catalog migration is missing the quota reconciliation column DDL");
+  }
+  await dbWrite.execute(sql.raw(reconciliationDdl));
+
   ({ orgStorageQuotaRepository: repository } = await import("../org-storage-quota"));
 }, PGLITE_TIMEOUT_MS);
 
@@ -74,6 +92,28 @@ afterAll(async () => {
 });
 
 describe("OrgStorageQuotaRepository", () => {
+  test("matches the nullable native-catalog reconciliation column without installing its catalog", async () => {
+    const column = await dbWrite.execute(sql`
+      SELECT data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'org_storage_quota'
+        AND column_name = 'native_catalog_reconciled_at'
+    `);
+    expect(column.rows).toEqual([
+      {
+        data_type: "timestamp with time zone",
+        is_nullable: "YES",
+        column_default: null,
+      },
+    ]);
+
+    const unrelatedCatalog = await dbWrite.execute(sql`
+      SELECT to_regclass('public.org_storage_objects')::text AS relation
+    `);
+    expect(unrelatedCatalog.rows).toEqual([{ relation: null }]);
+  });
+
   test("reserves and releases bigint byte counts exactly, clamping releases at zero", async () => {
     const exactBytes = 9_007_199_254_740_993n;
     await repository.setBytesLimit(ORGANIZATION_ID, exactBytes + 10n);


### PR DESCRIPTION
Closes #22477

## Summary

- apply only the `org_storage_quota.native_catalog_reconciled_at` statement from migration 0256 after the dependency-minimal 0102 quota fixture
- assert the live column contract exactly: `timestamp with time zone`, nullable, and no default
- prove the focused fixture does not pre-install the unrelated `org_storage_objects` catalog authority
- preserve real PGlite coverage for bigint exactness, quota rejection, release clamping, and concurrent admission

## Exact-head verification

Head: `26a39a99252aa9e722d600134d8a2d62f2144a5c`
Base: `6787e147b86efc3e91f2081603b48f36bb5a9cf6`

Before the repair, the exact base failed all three repository cases with PostgreSQL/PGlite `42703` because Drizzle inserted `native_catalog_reconciled_at` into the synthetic 0102 table where the column did not exist.

After the repair:

- focused OrgStorageQuotaRepository PGlite suite: 4/4 pass, 13 assertions
- `bun run --cwd packages/cloud/shared typecheck`: pass
- `bun run --cwd packages/cloud/shared db:check-migrations`: pass
- focused Biome check: pass
- `git diff --check`: pass

`bun install` and root `bun run verify` were not run because the shared host is at 100% disk utilization with less than 1 GiB free. Validation reused the repository's pinned Bun 1.3.14 dependency tree without downloading or installing packages. This draft changes one test fixture and is awaiting independent exact-head review.

## Reviewer start

Run:

```bash
bun test ./packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts
```

Confirm four passes, including the information-schema assertion and the `to_regclass` proof that `org_storage_objects` remains absent.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:26a39a99252aa9e722d600134d8a2d62f2144a5c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-fixture-only change; no rendered UI
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-fixture-only change; no rendered UI
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-fixture-only change; no interactive surface
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend path changed; exact PGlite failure and pass evidence is recorded above
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] PGlite catalog assertion proves `{ data_type: "timestamp with time zone", is_nullable: "YES", column_default: null }` and `{ relation: null }` for `org_storage_objects`
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or rendered surface changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6787e147b86efc3e91f2081603b48f36bb5a9cf6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-storage-quota-fixture]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@6787e147b86efc3e91f2081603b48f36bb5a9cf6:packages/skills/skills/contribute-to-eliza"} -->
