### PR TITLE
fix(plugin-vision): fail closed on unbounded screen-tile grids

### DIFF
--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -5,6 +5,7 @@
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 import {
+  MAX_SCREEN_TILES,
   reconstructAbsoluteCoords,
   type ScreenTile,
   tileScreenshot,
@@ -346,6 +347,18 @@ describe("tileScreenshot — overlap math", () => {
         { maxEdge: 16, overlapFraction: 0.1 },
       ),
     ).rejects.toThrow(/maxEdge/);
+  });
+
+  it("fails closed on a hostile width/height that would emit tens of thousands of tiles", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const started = performance.now();
+    await expect(
+      tileScreenshot(
+        { displayId: "x", width: 20_000, height: 20_000, pngBytes: png },
+        { maxEdge: 64, overlapFraction: 0 },
+      ),
+    ).rejects.toThrow(new RegExp(`exceeds ${MAX_SCREEN_TILES}`));
+    expect(performance.now() - started).toBeLessThan(50);
   });
 });
 

--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -360,6 +360,42 @@ describe("tileScreenshot — overlap math", () => {
     ).rejects.toThrow(new RegExp(`exceeds ${MAX_SCREEN_TILES}`));
     expect(performance.now() - started).toBeLessThan(50);
   });
+
+  it("allows exactly the configured tile ceiling to reach image validation", async () => {
+    const invalidPng = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    await expect(
+      tileScreenshot(
+        {
+          displayId: "x",
+          width: 32 * 64,
+          height: 32 * 64,
+          pngBytes: invalidPng,
+        },
+        { maxEdge: 64, overlapFraction: 0 },
+      ),
+    ).rejects.not.toThrow(/exceeds/);
+  });
+
+  it("rejects the first grid above the tile ceiling before image validation", async () => {
+    const invalidPng = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    await expect(
+      tileScreenshot(
+        {
+          displayId: "x",
+          width: 41 * 64,
+          height: 25 * 64,
+          pngBytes: invalidPng,
+        },
+        { maxEdge: 64, overlapFraction: 0 },
+      ),
+    ).rejects.toThrow(
+      new RegExp(`\\(${MAX_SCREEN_TILES + 1}\\) exceeds ${MAX_SCREEN_TILES}`),
+    );
+  });
 });
 
 describe("reconstructAbsoluteCoords", () => {

--- a/plugins/plugin-vision/src/screen-tiler.ts
+++ b/plugins/plugin-vision/src/screen-tiler.ts
@@ -71,6 +71,12 @@ export interface TileScreenshotOptions {
 export const DEFAULT_MAX_EDGE = 1280;
 /** Default seam overlap (12%). */
 export const DEFAULT_OVERLAP_FRACTION = 0.12;
+/**
+ * Grid ceiling. Production `tileSize` defaults to 256px, so honest 8K
+ * (7680×4320) is ~510 tiles. Hostile 20k×20k at the 64px minimum is ~98k
+ * sequential sharp extracts.
+ */
+export const MAX_SCREEN_TILES = 1024;
 
 /**
  * Tile a captured screenshot into local-VLM-sized PNG patches with
@@ -84,6 +90,10 @@ export const DEFAULT_OVERLAP_FRACTION = 0.12;
  * `overlapFraction * tileSize` of overlap between adjacent tiles. The last
  * column/row is anchored to the source's right/bottom edge so we never
  * extend past the screen.
+ *
+ * `width`/`height` are caller-supplied (often PNG IHDR / capture metadata).
+ * A 4k×4k pair with `maxEdge=64` ran 4096 sharp extracts for 105s on
+ * origin. Cap the grid so a hostile size cannot pin the vision pipeline.
  */
 export async function tileScreenshot(
   input: TileScreenshotInput,
@@ -115,6 +125,12 @@ export async function tileScreenshot(
 
   const cols = Math.max(1, Math.ceil(width / maxEdge));
   const rows = Math.max(1, Math.ceil(height / maxEdge));
+  const tileCount = cols * rows;
+  if (tileCount > MAX_SCREEN_TILES) {
+    throw new Error(
+      `[ScreenTiler] tile grid ${cols}x${rows} (${tileCount}) exceeds ${MAX_SCREEN_TILES}`,
+    );
+  }
   const tileWidth = Math.min(
     maxEdge,
     Math.ceil(width / cols + maxEdge * overlapFraction),


### PR DESCRIPTION
## Problem

`tileScreenshot` sized `cols = ceil(width / maxEdge)` × `rows = ceil(height / maxEdge)` from caller-supplied `width`/`height` (PNG IHDR / sharp metadata / dirty-tile input) and then ran that many sequential `sharp.extract` calls. There was no grid ceiling.

Production `tileSize` defaults to 256px. Honest 8K (7680×4320) is ~510 tiles. A hostile or corrupt 4096×4096 pair at the 64px minimum is 4096 extracts.

Measured on origin `6787e147b86e`:

| input | tiles | time |
| --- | --- | --- |
| 20000×20000 claimed, 8-byte buffer, maxEdge=64 | 97,969 (would extract) | origin 85.7ms corrupt-header throw / **fixed 0.29ms** fail-closed |
| **4096×4096 real PNG, maxEdge=64** | **4096 extracts** | **origin 105,807ms / fixed throw 0.15ms** |
| honest 8K @ production 256px | 510 | under cap 1024 |

Complete hang (105s extract loop), not leftover-tax, not PNG-OCR `#22407` (different host: `ocr-service-*` / `ocr-with-coords`). Occupancy-FREE (`screen-tiler.ts` not on any open PR).

## Change

`MAX_SCREEN_TILES = 1024`. After computing `cols`/`rows`, throw if `cols * rows` exceeds the cap — before `getSharp()` or any extract. Honest 8K at the 256px default stays legal. Hostile 20k×20k at 64px (97,969 tiles) and 4k×4k at 64px (4096 tiles) fail closed.

## Proof

```
ORIGIN_RED: 4096×4096 maxEdge=64 real PNG → 4096 tiles in 105807ms
GREEN: throw 0.15ms ([ScreenTiler] tile grid 64x64 (4096) exceeds 1024)
GREEN: 20000×20000 claimed → throw 0.29ms (313x313 / 97969)
honest 8K@256 tileCount=510 allowed
bunx vitest run src/screen-tiler.test.ts  26/26
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Occupancy-FREE complete hang on `plugins/plugin-vision/src/screen-tiler.ts`. Disjoint from the open PNG-dim OCR adapters PR (`ocr-service-linux-tesseract` / `ocr-service-paddleocr` / `ocr-with-coords`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bunx vitest run src/screen-tiler.test.ts` 26/26 at this head. Full `bun run verify` not re-run this cycle; change is isolated to the tile-grid ceiling.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Honest 8K at the production 256px `tileSize` is 510 tiles (under 1024). A
4K capture at the 64px minimum would be ~2040 tiles and now throws — that
config already meant thousands of sequential extracts plus VLM passes, which
is the hang this cap exists to stop. `reconstructAbsoluteCoords` and the
single-tile fast path are unchanged.

# Background

## What does this PR do?

Fails closed when `tileScreenshot` would emit more than 1024 tiles, so a
hostile width/height cannot pin the Gemma vision pipeline in a 105s extract
loop.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-vision/src/screen-tiler.ts` (`MAX_SCREEN_TILES`) and the new
hostile-grid test in `screen-tiler.test.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```
cd plugins/plugin-vision && bunx vitest run src/screen-tiler.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b03d3885dac859347db4d98c41c2d8aa510727d9 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - screen tiler is a Node crop helper; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - screen tiler is a Node crop helper; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; hang is a sequential extract loop
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic bun proof: origin 105807ms vs patched throw 0.15ms
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - tile count ceiling; no stored image artifact in the repo
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

```
origin SHA 6787e147b86efc3e91f2081603b48f36bb5a9cf6
ORIGIN 20000x20000 maxEdge=64 tiny THROW 85.74ms Input buffer has corrupt header:
FIXED  20000x20000 maxEdge=64 tiny THROW 0.29ms [ScreenTiler] tile grid 313x313 (97969) exceeds 1024
ORIGIN 4096x4096 maxEdge=64 real OK 105806.59ms tiles=4096
FIXED  4096x4096 maxEdge=64 real THROW 0.15ms [ScreenTiler] tile grid 64x64 (4096) exceeds 1024
honest 8K@256 tileCount=510 cap=1024 allowed=true
```

## Screenshots (before / after) + video walkthrough

N/A - Node tiler; no UI.

### Before

### After

### Walkthrough video

N/A - Node tiler; no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Exact-head validation at `b03d3885dac859347db4d98c41c2d8aa510727d9`: focused real-Sharp tiler suite 26/26; package typecheck clean; package build clean; changed-file Biome clean. The full plugin run completed 280 passing / 1 skipped and had one unrelated failure in `ocr-service-apple-vision-macos.test.ts`: the external Swift Apple Vision OCR subprocess returned empty text for its fixture after 20 seconds. No diagnostic or failure involved the screen tiler.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
