### PR TITLE
fix(cloud): restore compute checkpoint dependencies

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -118,8 +118,13 @@ async function expectedPendingBanner(): Promise<string> {
 async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
   await client.query(`
     CREATE TABLE jobs (
-      id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      type text NOT NULL DEFAULT 'checkpoint_fixture',
       status text NOT NULL DEFAULT 'pending',
+      data jsonb NOT NULL DEFAULT '{}'::jsonb,
+      data_storage text NOT NULL DEFAULT 'inline',
+      agent_id text,
+      organization_id uuid,
       execution_quiesced_at timestamp with time zone,
       started_at timestamp with time zone,
       completed_at timestamp with time zone,
@@ -140,6 +145,7 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
       bridge_url text,
       health_url text,
       headscale_ip text,
+      last_backup_at timestamp with time zone,
       billing_status text NOT NULL DEFAULT 'active',
       last_billed_at timestamp with time zone,
       hourly_rate numeric(10, 4) DEFAULT '0.0200',
@@ -221,6 +227,38 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
       metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
       stripe_payment_intent_id text,
       created_at timestamp with time zone NOT NULL DEFAULT now()
+    );
+    CREATE TABLE containers (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+      status text NOT NULL DEFAULT 'pending',
+      image_tag text,
+      environment_vars jsonb NOT NULL DEFAULT '{}'::jsonb,
+      desired_count integer NOT NULL DEFAULT 1,
+      cpu integer NOT NULL DEFAULT 1792,
+      memory integer NOT NULL DEFAULT 1792,
+      node_id text,
+      volume_path text,
+      last_billed_at timestamp without time zone,
+      total_billed numeric(10, 2) NOT NULL DEFAULT '0.00'
+    );
+    CREATE TABLE container_billing_records (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      container_id uuid NOT NULL,
+      organization_id uuid NOT NULL,
+      amount numeric(10, 2) NOT NULL,
+      billing_period_start timestamp without time zone NOT NULL,
+      billing_period_end timestamp without time zone NOT NULL,
+      status text NOT NULL DEFAULT 'success',
+      credit_transaction_id uuid,
+      error_message text,
+      created_at timestamp without time zone NOT NULL DEFAULT now(),
+      CONSTRAINT container_billing_records_container_id_containers_id_fk
+        FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE,
+      CONSTRAINT container_billing_records_organization_id_organizations_id_fk
+        FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+      CONSTRAINT container_billing_records_credit_transaction_id_credit_transactions_id_fk
+        FOREIGN KEY (credit_transaction_id) REFERENCES credit_transactions(id) ON DELETE SET NULL
     );
     CREATE TABLE credit_packs (
       id uuid PRIMARY KEY
@@ -609,6 +647,96 @@ async function expectPreCheckpointOrganizationBillingAuthority(
   });
 }
 
+async function expectPreCheckpointComputeBillingAuthority(
+  client: pg.Client,
+): Promise<void> {
+  const authority = await client.query<{
+    container_columns: string[];
+    receipt_columns: string[];
+    jobs_id_type: string;
+    last_backup_type: string;
+    container_lifecycle_revision: string | null;
+    receipt_rate_segments: string | null;
+    container_tenant_index: string | null;
+    agent_receipts: string | null;
+    container_stop_intents: string | null;
+    agent_stop_intents: string | null;
+    rate_segments: string | null;
+  }>(`
+    SELECT
+      (SELECT array_agg(format('%s:%s:%s:%s', a.attname,
+          format_type(a.atttypid, a.atttypmod),
+          CASE WHEN a.attnotnull THEN 'required' ELSE 'nullable' END,
+          COALESCE(pg_get_expr(d.adbin, d.adrelid), 'none')) ORDER BY a.attnum)
+        FROM pg_attribute a
+        LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = 'containers'::regclass
+          AND a.attnum > 0 AND NOT a.attisdropped) AS container_columns,
+      (SELECT array_agg(format('%s:%s:%s:%s', a.attname,
+          format_type(a.atttypid, a.atttypmod),
+          CASE WHEN a.attnotnull THEN 'required' ELSE 'nullable' END,
+          COALESCE(pg_get_expr(d.adbin, d.adrelid), 'none')) ORDER BY a.attnum)
+        FROM pg_attribute a
+        LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = 'container_billing_records'::regclass
+          AND a.attnum > 0 AND NOT a.attisdropped) AS receipt_columns,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'jobs' AND column_name = 'id')
+        AS jobs_id_type,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'agent_sandboxes'
+          AND column_name = 'last_backup_at') AS last_backup_type,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'containers'
+          AND column_name = 'lifecycle_revision') AS container_lifecycle_revision,
+      (SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'container_billing_records'
+          AND column_name = 'rate_segments') AS receipt_rate_segments,
+      to_regclass('public.containers_id_organization_unique')::text AS container_tenant_index,
+      to_regclass('public.agent_billing_records')::text AS agent_receipts,
+      to_regclass('public.container_compute_stop_intents')::text AS container_stop_intents,
+      to_regclass('public.agent_compute_stop_intents')::text AS agent_stop_intents,
+      to_regclass('public.compute_billing_rate_segments')::text AS rate_segments
+  `);
+  expect(authority.rows[0]).toEqual({
+    container_columns: [
+      "id:uuid:required:gen_random_uuid()",
+      "organization_id:uuid:required:none",
+      "status:text:required:'pending'::text",
+      "image_tag:text:nullable:none",
+      "environment_vars:jsonb:required:'{}'::jsonb",
+      "desired_count:integer:required:1",
+      "cpu:integer:required:1792",
+      "memory:integer:required:1792",
+      "node_id:text:nullable:none",
+      "volume_path:text:nullable:none",
+      "last_billed_at:timestamp without time zone:nullable:none",
+      "total_billed:numeric(10,2):required:0.00",
+    ],
+    receipt_columns: [
+      "id:uuid:required:gen_random_uuid()",
+      "container_id:uuid:required:none",
+      "organization_id:uuid:required:none",
+      "amount:numeric(10,2):required:none",
+      "billing_period_start:timestamp without time zone:required:none",
+      "billing_period_end:timestamp without time zone:required:none",
+      "status:text:required:'success'::text",
+      "credit_transaction_id:uuid:nullable:none",
+      "error_message:text:nullable:none",
+      "created_at:timestamp without time zone:required:now()",
+    ],
+    jobs_id_type: "uuid",
+    last_backup_type: "timestamp with time zone",
+    container_lifecycle_revision: null,
+    receipt_rate_segments: null,
+    container_tenant_index: null,
+    agent_receipts: null,
+    container_stop_intents: null,
+    agent_stop_intents: null,
+    rate_segments: null,
+  });
+}
+
 describe.skipIf(!ENABLED)(
   "migrate-with-diagnostics real PostgreSQL safety",
   () => {
@@ -631,6 +759,7 @@ describe.skipIf(!ENABLED)(
       await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       await expectPreCheckpointPaymentRequestAuthority(database.client);
       await expectPreCheckpointOrganizationBillingAuthority(database.client);
+      await expectPreCheckpointComputeBillingAuthority(database.client);
       await database.client.query(`
         INSERT INTO jobs (
           status,


### PR DESCRIPTION
Closes #22497

## Summary

- restore the dependency-minimal pre-0265 `containers` and `container_billing_records` catalog in the production migrator checkpoint fixture
- correct the fixture's historical `jobs.id` type to UUID and add only the job/agent columns consumed by 0265
- assert exact pre-migration column types, nullability, defaults, and precision for both container tables
- prove every 0265-owned column, index, receipt table, stop-intent table, and rate-segment table is absent before the pending migration runs
- preserve the checkpoint at 184 applied ledger entries; no production migration, schema, or runtime source changed

## Exact failure reproduced

On base `6787e147b86efc3e91f2081603b48f36bb5a9cf6`, migration 0265 was the first causal failure after migrations 0185 through 0264 applied successfully:

```text
[db:migrate] failed 0265_compute_billing_recovery statement 1/1
error: relation "containers" does not exist
code=42P01
```

This matches Cloud E2E run `32267012991`, job `96116635101`.

## Exact-head verification

Head: `24b995acd402c16994e8321a171274291f34e043`
Base: `2760f77ac92253d63dcc0b41eae5f47c02860d25`

- rebase from `6787e147` to `2760f77`: conflict-free
- `git range-diff`: patch-equivalent (`b6686236a3f57 = 24b995acd402c`)
- exact rebased-head focused real PostgreSQL checkpoint: 1/1 pass, 11 assertions
- pre-rebase full real PostgreSQL matrix: all 10 behavioral cases passed, 50 assertions
  - journal and timestamp inversion modes
  - production-hybrid and missing-ledger-history modes
  - catalog/hash drift rejection
  - concurrent migrator serialization and bounded terminal retry
- Cloud Shared typecheck: pass
- Drizzle migration check: pass
- focused Biome: pass with the file's three pre-existing undeclared-test-environment warnings
- `git diff --check`: pass

## PostgreSQL cleanup note

After the ten full-matrix cases passed, the suite's 300-second cleanup hook timed out while the nearly-full local volume was physically dropping disposable `migration_*` databases. The remaining five test databases were explicitly removed, PostgreSQL reported zero `migration_*` databases afterward, and the exact rebased-head focused test completed with a clean exit and no leftover database.

`bun install` and root `bun run verify` were not run because this is a one-file real-PostgreSQL fixture repair on a shared host that reached critical disk pressure during validation. Existing pinned Bun 1.3.14 dependencies were reused; draft CI and independent exact-head review remain required.

## Reviewer start

```bash
RUN_REAL_POSTGRES_MIGRATION_TESTS=1 \
MIGRATION_TEST_DATABASE_URL=<disposable-postgres-admin-url> \
bun test ./packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
```

Confirm the pre-checkpoint assertion runs before migration, migration 0265 applies, all checkpoint modes remain green, and the disposable databases are removed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:24b995acd402c16994e8321a171274291f34e043 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - PostgreSQL test-fixture-only change; no rendered UI
<!-- evidence-row:after-screenshots -->
- [ ] N/A - PostgreSQL test-fixture-only change; no rendered UI
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - PostgreSQL test-fixture-only change; no interactive surface
<!-- evidence-row:backend-logs -->
- [x] Exact 42P01 failure and real-PostgreSQL pass results are recorded above
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real PostgreSQL catalogs assert the dependency-minimal pre-0265 shape and absence of 0265-owned authority
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or rendered surface changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2760f77ac92253d63dcc0b41eae5f47c02860d25:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-0265-checkpoint]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@2760f77ac92253d63dcc0b41eae5f47c02860d25:packages/skills/skills/contribute-to-eliza"} -->
