### PR TITLE
fix(cloud): make migration 0267 PostgreSQL catalog-portable

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -22,6 +22,10 @@ const MIGRATIONS_DIR = path.join(
   "packages/cloud/shared/src/db/migrations",
 );
 const JOURNAL_PATH = path.join(MIGRATIONS_DIR, "meta/_journal.json");
+const STRIPE_CUSTOMER_MIGRATION_PATH = path.join(
+  MIGRATIONS_DIR,
+  "0267_stripe_customer_attempts.sql",
+);
 const ADD_COLUMN_CREATED_AT = 1_785_384_000_000;
 const CATALOG_GUARD_CREATED_AT = 1_786_478_400_000;
 const HISTORICAL_DRIFT_CREATED_AT = 1_770_518_468_000;
@@ -753,6 +757,67 @@ describe.skipIf(!ENABLED)(
       }
       await admin.end();
     }, 300_000);
+
+    test("accepts portable Stripe Customer authority catalogs and rejects semantic drift", async () => {
+      const database = await createDatabase();
+      await database.client.query(`
+        CREATE TABLE organizations (
+          id uuid PRIMARY KEY,
+          name text NOT NULL,
+          slug text NOT NULL UNIQUE,
+          stripe_customer_id text,
+          billing_email text,
+          updated_at timestamp with time zone NOT NULL DEFAULT now()
+        );
+        CREATE UNIQUE INDEX organizations_stripe_customer_authority_unique
+          ON organizations(stripe_customer_id) WHERE stripe_customer_id IS NOT NULL;
+        CREATE TABLE auto_top_up_attempts (
+          id uuid PRIMARY KEY,
+          organization_id uuid NOT NULL REFERENCES organizations(id),
+          stripe_customer_id_snapshot text NOT NULL,
+          provider_request_started_at timestamp with time zone
+        );
+      `);
+      const migration = await readFile(STRIPE_CUSTOMER_MIGRATION_PATH, "utf8");
+      const statements = migration
+        .split("--> statement-breakpoint")
+        .filter((statement) => statement.trim());
+      await database.client.query(migration);
+      await database.client.query(migration);
+
+      const catalog = await database.client.query<{
+        attempts: string;
+        quarantines: string;
+      }>(`
+        SELECT
+          count(*) FILTER (
+            WHERE conrelid='stripe_customer_attempts'::regclass AND contype <> 'n'
+          )::text AS attempts,
+          count(*) FILTER (
+            WHERE conrelid='stripe_customer_legacy_quarantines'::regclass AND contype <> 'n'
+          )::text AS quarantines
+        FROM pg_constraint
+      `);
+      expect(catalog.rows[0]).toEqual({ attempts: "10", quarantines: "7" });
+
+      const postcondition = statements.at(-1);
+      if (!postcondition)
+        throw new Error("Migration has no catalog postcondition");
+      await database.client.query(`ALTER TABLE stripe_customer_attempts
+        ADD CONSTRAINT stripe_customer_attempts_unexpected_check CHECK (generation < 1000000)`);
+      await expect(database.client.query(postcondition)).rejects.toThrow(
+        /exact constraint collision/i,
+      );
+      await database.client.query(`ALTER TABLE stripe_customer_attempts
+        DROP CONSTRAINT stripe_customer_attempts_unexpected_check`);
+      await database.client.query(
+        "ALTER TABLE stripe_customer_attempts ALTER COLUMN status DROP NOT NULL",
+      );
+      await expect(database.client.query(postcondition)).rejects.toThrow(
+        /column collision/i,
+      );
+      await database.client.end();
+    }, 120_000);
 
     test("applies the append-only fix-forward once and passes the reusable catalog preflight", async () => {
       const database = await createDatabase();

--- a/packages/cloud/shared/src/db/migrations/0267_stripe_customer_attempts.sql
+++ b/packages/cloud/shared/src/db/migrations/0267_stripe_customer_attempts.sql
@@ -480,10 +480,16 @@ BEGIN
       AND conname = 'stripe_customer_legacy_quarantine_attempt_tenant_fk' AND convalidated
   ) THEN RAISE EXCEPTION 'Stripe Customer authority constraint collision'; END IF;
 
+  -- PostgreSQL 18 represents NOT NULL constraints in pg_constraint as
+  -- contype='n'; PostgreSQL 16 and PGlite do not. Column nullability is
+  -- validated above through pg_attribute, so exclude only that portable
+  -- duplicate representation while still rejecting every other extra
+  -- constraint type.
   IF (SELECT count(*) FROM pg_constraint
-        WHERE conrelid='stripe_customer_attempts'::regclass) <> 10
+        WHERE conrelid='stripe_customer_attempts'::regclass AND contype <> 'n') <> 10
     OR (SELECT count(*) FROM pg_constraint
-        WHERE conrelid='stripe_customer_legacy_quarantines'::regclass) <> 7
+        WHERE conrelid='stripe_customer_legacy_quarantines'::regclass
+          AND contype <> 'n') <> 7
     OR NOT EXISTS (SELECT 1 FROM pg_constraint
       WHERE conrelid='stripe_customer_attempts'::regclass
         AND conname='stripe_customer_attempts_pkey' AND contype='p' AND conkey=ARRAY[1]::smallint[])

--- a/packages/cloud/shared/src/lib/services/__tests__/stripe-customer-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/stripe-customer-authority.pglite.test.ts
@@ -837,6 +837,25 @@ describe("Stripe Customer durable authority", () => {
     }
   });
 
+  test("migration rejects an unexpected non-nullability-independent constraint", async () => {
+    const isolated = new PGlite();
+    try {
+      await isolated.exec(isolatedAuthorityBase);
+      const migration = await Bun.file(
+        new URL("../../../db/migrations/0267_stripe_customer_attempts.sql", import.meta.url),
+      ).text();
+      const statements = migration.split("--> statement-breakpoint").filter((item) => item.trim());
+      for (const statement of statements) await isolated.exec(statement);
+      await isolated.exec(`ALTER TABLE stripe_customer_attempts
+        ADD CONSTRAINT stripe_customer_attempts_unexpected_check CHECK (generation < 1000000)`);
+      const postcondition = statements.at(-1);
+      if (!postcondition) throw new Error("migration has no postcondition");
+      await expect(isolated.exec(postcondition)).rejects.toThrow(/constraint collision/i);
+    } finally {
+      await isolated.close();
+    }
+  });
+
   test("catalog postcondition rejects weakened checks, predicates, FKs, columns, defaults, and triggers", async () => {
     const cases = [
       `ALTER TABLE stripe_customer_attempts DROP CONSTRAINT stripe_customer_attempts_generation_check;


### PR DESCRIPTION
Closes #22501

## Summary

- make migration 0267's exact constraint postcondition portable across PostgreSQL 16/PGlite and PostgreSQL 18 catalogs
- exclude only PostgreSQL 18's duplicate `pg_constraint.contype = 'n'` representation from aggregate constraint counts
- retain exact column nullability validation through `pg_attribute.attnotnull` and retain rejection of every unexpected non-`n` constraint
- add PGlite and real-PostgreSQL replay/adversarial coverage for extra constraints and weakened nullability

## Root cause

PostgreSQL 18 records table `NOT NULL` constraints in `pg_constraint` with `contype = 'n'`. PostgreSQL 16.11 and PGlite do not. The 0267 postcondition expected raw totals of 10 and 7 constraints, but PostgreSQL 18 produced 20 and 11 while every semantic constraint was correct. Protected staging therefore failed at statement 38/38 with `Stripe Customer authority exact constraint collision`.

The repair filters only `contype = 'n'` from the aggregate totals. The existing column loop still checks every expected type, default, and exact nullable/non-nullable state through `pg_attribute`, while named constraint definitions, FKs, indexes, triggers, functions, and all other extra constraint types remain fail-closed.

## Edit-in-place safety evidence

- protected staging run 32270442121, job 96125326394, reported last applied migration 0266, one pending migration, then failed 0267 statement 38/38 and rolled the transaction back
- the exact-SHA Cloud CF Deploy run 32270443547 remains at the staging authorization gate; its production authorization and production certification jobs were skipped
- all other visible exact-SHA workflows were tests/builds, canceled, or skipped and did not execute the canonical database migrator
- therefore no visible official environment successfully applied the old 0267 hash; changing the still-pending migration in place is safe for those official paths

Any separately managed database that applied the old 0267 outside these visible official workflows would hash-fail and must be reconciled explicitly before migration.

## Exact-head verification

Head: `fec15b4e130fd6cb54cdedffe2df2cf5b768d71f`
Base: `521d88db37e97c411e5f871b7fb49a142d4e9019`

- PostgreSQL 16.11 direct 0267 replay plus extra-constraint/nullability drift: 1/1, 3 assertions
- PostgreSQL 18.4 reproduction before repair: exact statement-38 `Stripe Customer authority exact constraint collision`
- PostgreSQL 18.4 repaired direct 0267 replay plus extra-constraint/nullability drift: 1/1, 3 assertions
- PGlite authority, migration replay/collision, catalog drift, legacy retirement, concurrency, and tenant isolation: 23/23, 95 assertions
- migration journal inventory: 5/5, 37 assertions
- total focused: 30/30 tests, 138 assertions
- Cloud shared typecheck: pass
- Drizzle migration check: pass
- focused Biome: pass with the file's three pre-existing undeclared-env warnings and no errors
- `git diff --check`: pass
- rebase range-diff is semantic-identical except Biome formatting of two added assertions

Root `bun run verify` was not started under the disk-aware boundary; focused owning gates and both PostgreSQL versions passed.

## Rollout boundary

No protected migration, deployment, Stripe/provider call, secret mutation, billing mutation, or merge was performed. This draft stops for independent exact-head review before protected staging acceptance.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:fec15b4e130fd6cb54cdedffe2df2cf5b768d71f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend migration catalog guard; no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend migration catalog guard; no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered interactive surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - protected staging rerun is gated on independent review; failing run and local PostgreSQL evidence are documented above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, or inference-provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - protected database catalog artifact requires post-review staging acceptance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@521d88db37e97c411e5f871b7fb49a142d4e9019:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-0267-pg-portability]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@521d88db37e97c411e5f871b7fb49a142d4e9019:packages/skills/skills/contribute-to-eliza"} -->
