### PR TITLE
fix(cloud): make app reservation settlement authoritative

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0268_app_reservation_settlement_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0268_app_reservation_settlement_authority.sql
@@ -1,0 +1,527 @@
+-- Durable first-terminal authority for app-inference reservation settlement.
+-- Provisional: journal only after queued 0266 and 0267 land.
+
+CREATE TABLE app_reservation_settlements (
+  reservation_transaction_id uuid PRIMARY KEY,
+  organization_id uuid NOT NULL,
+  app_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  creator_user_id uuid,
+  terminal_source text NOT NULL,
+  outcome text NOT NULL,
+  reserved_base_cost numeric(16,6) NOT NULL,
+  actual_base_cost numeric(16,6) NOT NULL,
+  markup_percentage numeric(12,6) NOT NULL,
+  reserved_total_cost numeric(16,6) NOT NULL,
+  actual_total_cost numeric(16,6) NOT NULL,
+  organization_adjustment numeric(16,6) NOT NULL,
+  creator_adjustment numeric(16,6) NOT NULL,
+  platform_adjustment numeric(16,6) NOT NULL,
+  credit_transaction_id uuid,
+  redeemable_ledger_entry_id uuid,
+  app_earnings_transaction_id uuid,
+  settled_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT app_reservation_settlements_organization_fk
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE RESTRICT,
+  CONSTRAINT app_reservation_settlements_reservation_tenant_fk
+    FOREIGN KEY (reservation_transaction_id, organization_id)
+    REFERENCES credit_transactions(id, organization_id) ON DELETE RESTRICT,
+  CONSTRAINT app_reservation_settlements_adjustment_tenant_fk
+    FOREIGN KEY (credit_transaction_id, organization_id)
+    REFERENCES credit_transactions(id, organization_id) ON DELETE RESTRICT,
+  CONSTRAINT app_reservation_settlements_source_check
+    CHECK (terminal_source IN ('provider','stale_sweep')),
+  CONSTRAINT app_reservation_settlements_outcome_check
+    CHECK (outcome IN ('refund','overage','uncollected_overage','none')),
+  CONSTRAINT app_reservation_settlements_economics_check
+    CHECK (reserved_base_cost >= 0 AND actual_base_cost >= 0
+      AND markup_percentage >= 0 AND reserved_total_cost >= 0 AND actual_total_cost >= 0)
+);
+
+CREATE INDEX app_reservation_settlements_org_time_idx
+  ON app_reservation_settlements (organization_id, settled_at);
+
+CREATE TABLE app_reservation_settlement_quarantines (
+  reservation_transaction_id uuid PRIMARY KEY,
+  organization_id uuid NOT NULL,
+  app_id text NOT NULL,
+  user_id text NOT NULL,
+  creator_user_id text,
+  reason text NOT NULL,
+  quarantined_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT app_reservation_settlement_quarantines_organization_fk
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE RESTRICT,
+  CONSTRAINT app_reservation_settlement_quarantines_reservation_tenant_fk
+    FOREIGN KEY (reservation_transaction_id, organization_id)
+    REFERENCES credit_transactions(id, organization_id) ON DELETE RESTRICT,
+  CONSTRAINT app_reservation_settlement_quarantines_reason_check
+    CHECK (reason = 'pre_authority_economics_unreconstructable')
+);
+
+CREATE FUNCTION app_reservation_quarantine_uuid(value text) RETURNS text AS $$
+  SELECT CASE
+    WHEN value ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+      THEN lower(value)
+    ELSE 'invalid-or-missing'
+  END
+$$ LANGUAGE sql IMMUTABLE;
+
+CREATE FUNCTION validate_app_reservation_settlement_quarantine() RETURNS trigger AS $$
+DECLARE
+  reservation_row credit_transactions%ROWTYPE;
+  expected_creator text;
+BEGIN
+  SELECT * INTO reservation_row
+  FROM credit_transactions
+  WHERE id = NEW.reservation_transaction_id
+    AND organization_id = NEW.organization_id
+  FOR UPDATE;
+  expected_creator := CASE
+    WHEN NULLIF(reservation_row.metadata->>'creatorUserId', '') IS NULL THEN NULL
+    ELSE app_reservation_quarantine_uuid(reservation_row.metadata->>'creatorUserId')
+  END;
+  IF NOT FOUND
+     OR reservation_row.settled_at IS NULL
+     OR reservation_row.type <> 'debit'
+     OR reservation_row.metadata->>'type' <> 'app_chat_reservation'
+     OR reservation_row.metadata->>'settlement_marker' <> 'app_chat_reservation_v1'
+     OR NEW.app_id IS DISTINCT FROM
+          app_reservation_quarantine_uuid(reservation_row.metadata->>'appId')
+     OR NEW.user_id IS DISTINCT FROM
+          app_reservation_quarantine_uuid(reservation_row.metadata->>'userId')
+     OR NEW.creator_user_id IS DISTINCT FROM expected_creator
+     OR NEW.reason <> 'pre_authority_economics_unreconstructable'
+     OR NEW.quarantined_at IS DISTINCT FROM reservation_row.settled_at
+     OR EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE reservation_transaction_id = NEW.reservation_transaction_id
+     ) THEN
+    RAISE EXCEPTION 'app reservation quarantine does not match a legacy terminal hold'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'app_reservation_settlement_quarantines_authority_match';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_reservation_settlement_quarantines_validate_guard
+  BEFORE INSERT ON app_reservation_settlement_quarantines
+  FOR EACH ROW EXECUTE FUNCTION validate_app_reservation_settlement_quarantine();
+
+CREATE FUNCTION guard_app_reservation_facts() RETURNS trigger AS $$
+BEGIN
+  IF OLD.type = 'debit'
+     AND OLD.metadata->>'type' = 'app_chat_reservation'
+     AND OLD.metadata->>'settlement_marker' = 'app_chat_reservation_v1'
+     AND (NEW.organization_id IS DISTINCT FROM OLD.organization_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.type IS DISTINCT FROM OLD.type
+       OR NEW.metadata IS DISTINCT FROM OLD.metadata) THEN
+    RAISE EXCEPTION 'app reservation identity and economic facts are immutable'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'credit_transactions_app_reservation_facts_immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER credit_transactions_app_reservation_facts_immutable_guard
+  BEFORE UPDATE ON credit_transactions
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_facts();
+
+CREATE FUNCTION validate_app_reservation_settlement_receipt() RETURNS trigger AS $$
+DECLARE
+  reservation_row credit_transactions%ROWTYPE;
+  adjustment_row credit_transactions%ROWTYPE;
+  creator_ledger_amount numeric;
+  creator_ledger_user uuid;
+  creator_ledger_source text;
+  app_projection_app uuid;
+  app_projection_user uuid;
+  app_projection_amount numeric;
+  app_projection_ledger text;
+BEGIN
+  SELECT * INTO reservation_row
+  FROM credit_transactions
+  WHERE id = NEW.reservation_transaction_id
+    AND organization_id = NEW.organization_id
+  FOR UPDATE;
+  IF NOT FOUND
+     OR reservation_row.type <> 'debit'
+     OR reservation_row.metadata->>'type' <> 'app_chat_reservation'
+     OR reservation_row.metadata->>'settlement_marker' <> 'app_chat_reservation_v1'
+     OR lower(reservation_row.metadata->>'appId') IS DISTINCT FROM NEW.app_id::text
+     OR lower(reservation_row.metadata->>'userId') IS DISTINCT FROM NEW.user_id::text
+     OR lower(NULLIF(reservation_row.metadata->>'creatorUserId', ''))::uuid
+          IS DISTINCT FROM NEW.creator_user_id
+     OR abs(reservation_row.amount) IS DISTINCT FROM NEW.reserved_total_cost
+     OR COALESCE(reservation_row.metadata->>'reserved_amount',
+                 reservation_row.metadata->>'baseCost')::numeric
+          IS DISTINCT FROM NEW.reserved_base_cost
+     OR EXISTS (
+       SELECT 1 FROM app_reservation_settlement_quarantines
+       WHERE reservation_transaction_id = NEW.reservation_transaction_id
+     ) THEN
+    RAISE EXCEPTION 'app reservation receipt does not match immutable reservation facts'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'app_reservation_settlements_reservation_match';
+  END IF;
+
+  IF round(NEW.reserved_base_cost * (1 + NEW.markup_percentage / 100), 6)
+       IS DISTINCT FROM NEW.reserved_total_cost
+     OR round(NEW.actual_base_cost * (1 + NEW.markup_percentage / 100), 6)
+       IS DISTINCT FROM NEW.actual_total_cost
+     OR NEW.actual_total_cost - NEW.reserved_total_cost
+       IS DISTINCT FROM NEW.organization_adjustment
+     OR round((NEW.actual_base_cost - NEW.reserved_base_cost)
+       * NEW.markup_percentage / 100, 6) IS DISTINCT FROM NEW.creator_adjustment
+     OR NEW.actual_base_cost - NEW.reserved_base_cost
+       IS DISTINCT FROM NEW.platform_adjustment THEN
+    RAISE EXCEPTION 'app reservation receipt economics are inconsistent'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'app_reservation_settlements_economic_match';
+  END IF;
+
+  IF NEW.credit_transaction_id IS NOT NULL THEN
+    SELECT * INTO adjustment_row
+    FROM credit_transactions
+    WHERE id = NEW.credit_transaction_id
+      AND organization_id = NEW.organization_id;
+  END IF;
+  IF (NEW.outcome = 'refund' AND (
+        NEW.credit_transaction_id IS NULL OR adjustment_row.type <> 'refund'
+        OR adjustment_row.amount IS DISTINCT FROM -NEW.organization_adjustment
+        OR adjustment_row.stripe_payment_intent_id
+          IS DISTINCT FROM 'reconcile-refund:' || NEW.reservation_transaction_id::text
+      ))
+     OR (NEW.outcome = 'overage' AND (
+        NEW.credit_transaction_id IS NULL OR adjustment_row.type <> 'debit'
+        OR adjustment_row.amount IS DISTINCT FROM -NEW.organization_adjustment
+        OR adjustment_row.stripe_payment_intent_id
+          IS DISTINCT FROM 'reconcile-charge:' || NEW.reservation_transaction_id::text
+      ))
+     OR (NEW.outcome IN ('none', 'uncollected_overage')
+       AND NEW.credit_transaction_id IS NOT NULL) THEN
+    RAISE EXCEPTION 'app reservation receipt adjustment ledger does not match outcome'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'app_reservation_settlements_adjustment_match';
+  END IF;
+
+  IF NEW.redeemable_ledger_entry_id IS NOT NULL THEN
+    SELECT amount, user_id, earnings_source
+      INTO creator_ledger_amount, creator_ledger_user, creator_ledger_source
+    FROM redeemable_earnings_ledger
+    WHERE id = NEW.redeemable_ledger_entry_id;
+  END IF;
+  IF NEW.outcome IN ('refund', 'overage') AND trunc(NEW.creator_adjustment, 4) <> 0 THEN
+    IF NEW.redeemable_ledger_entry_id IS NULL
+       OR creator_ledger_user IS DISTINCT FROM NEW.creator_user_id
+       OR creator_ledger_source <> 'miniapp'
+       OR creator_ledger_amount IS DISTINCT FROM trunc(NEW.creator_adjustment, 4) THEN
+      RAISE EXCEPTION 'app reservation creator ledger does not match receipt'
+        USING ERRCODE = '23514',
+              CONSTRAINT = 'app_reservation_settlements_creator_match';
+    END IF;
+  ELSIF NEW.redeemable_ledger_entry_id IS NOT NULL THEN
+    RAISE EXCEPTION 'app reservation receipt has an unexpected creator ledger'
+      USING ERRCODE = '23514',
+            CONSTRAINT = 'app_reservation_settlements_creator_match';
+  END IF;
+
+  IF NEW.app_earnings_transaction_id IS NOT NULL THEN
+    SELECT app_id, user_id, amount, metadata->>'redeemableLedgerEntryId'
+      INTO app_projection_app, app_projection_user, app_projection_amount, app_projection_ledger
+    FROM app_earnings_transactions
+    WHERE id = NEW.app_earnings_transaction_id;
+    IF app_projection_app IS DISTINCT FROM NEW.app_id
+       OR app_projection_user IS DISTINCT FROM NEW.user_id
+       OR app_projection_amount IS DISTINCT FROM trunc(NEW.creator_adjustment, 4)
+       OR app_projection_ledger IS DISTINCT FROM NEW.redeemable_ledger_entry_id::text THEN
+      RAISE EXCEPTION 'app reservation app projection does not match receipt'
+        USING ERRCODE = '23514',
+              CONSTRAINT = 'app_reservation_settlements_app_projection_match';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_reservation_settlements_validate_guard
+  BEFORE INSERT ON app_reservation_settlements
+  FOR EACH ROW EXECUTE FUNCTION validate_app_reservation_settlement_receipt();
+
+CREATE FUNCTION guard_app_reservation_settlement_receipt() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'app reservation settlement receipts are immutable'
+    USING ERRCODE = '23514',
+          CONSTRAINT = 'app_reservation_settlements_immutable';
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_reservation_settlements_immutable_guard
+  BEFORE UPDATE OR DELETE ON app_reservation_settlements
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_settlement_receipt();
+
+CREATE TRIGGER app_reservation_settlements_truncate_guard
+  BEFORE TRUNCATE ON app_reservation_settlements
+  FOR EACH STATEMENT EXECUTE FUNCTION guard_app_reservation_settlement_receipt();
+
+CREATE FUNCTION guard_app_reservation_settlement_quarantine() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'app reservation settlement quarantines are immutable'
+    USING ERRCODE = '23514',
+          CONSTRAINT = 'app_reservation_settlement_quarantines_immutable';
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_reservation_settlement_quarantines_immutable_guard
+  BEFORE UPDATE OR DELETE ON app_reservation_settlement_quarantines
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_settlement_quarantine();
+
+CREATE TRIGGER app_reservation_settlement_quarantines_truncate_guard
+  BEFORE TRUNCATE ON app_reservation_settlement_quarantines
+  FOR EACH STATEMENT EXECUTE FUNCTION guard_app_reservation_settlement_quarantine();
+
+CREATE FUNCTION quarantine_legacy_app_reservation_settlement() RETURNS trigger AS $$
+BEGIN
+  IF OLD.settled_at IS NULL
+     AND NEW.settled_at IS NOT NULL
+     AND NEW.type = 'debit'
+     AND NEW.metadata->>'type' = 'app_chat_reservation'
+     AND NEW.metadata->>'settlement_marker' = 'app_chat_reservation_v1'
+     AND NOT EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE reservation_transaction_id = NEW.id
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM app_reservation_settlement_quarantines
+       WHERE reservation_transaction_id = NEW.id
+     ) THEN
+    INSERT INTO app_reservation_settlement_quarantines (
+      reservation_transaction_id, organization_id, app_id, user_id,
+      creator_user_id, reason, quarantined_at
+    ) VALUES (
+      NEW.id, NEW.organization_id,
+      app_reservation_quarantine_uuid(NEW.metadata->>'appId'),
+      app_reservation_quarantine_uuid(NEW.metadata->>'userId'),
+      CASE WHEN NULLIF(NEW.metadata->>'creatorUserId', '') IS NULL THEN NULL
+        ELSE app_reservation_quarantine_uuid(NEW.metadata->>'creatorUserId') END,
+      'pre_authority_economics_unreconstructable', NEW.settled_at
+    );
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER credit_transactions_legacy_app_settlement_quarantine_guard
+  AFTER UPDATE OF settled_at ON credit_transactions
+  FOR EACH ROW EXECUTE FUNCTION quarantine_legacy_app_reservation_settlement();
+
+CREATE FUNCTION guard_app_reservation_credit_projection() RETURNS trigger AS $$
+BEGIN
+  IF EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE credit_transaction_id = OLD.id
+     )
+     AND (NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.organization_id IS DISTINCT FROM OLD.organization_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.type IS DISTINCT FROM OLD.type
+       OR NEW.stripe_payment_intent_id IS DISTINCT FROM OLD.stripe_payment_intent_id
+       OR NEW.metadata IS DISTINCT FROM OLD.metadata
+       OR NEW.settled_at IS DISTINCT FROM OLD.settled_at) THEN
+    RAISE EXCEPTION 'referenced app reservation credit projection is immutable'
+      USING ERRCODE = '23514', CONSTRAINT = 'credit_transactions_app_settlement_projection_immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE FUNCTION guard_app_reservation_creator_projection() RETURNS trigger AS $$
+BEGIN
+  IF EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE redeemable_ledger_entry_id = OLD.id
+     )
+     AND (NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.user_id IS DISTINCT FROM OLD.user_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.earnings_source IS DISTINCT FROM OLD.earnings_source
+       OR NEW.source_id IS DISTINCT FROM OLD.source_id
+       OR NEW.entry_type IS DISTINCT FROM OLD.entry_type
+       OR NEW.metadata IS DISTINCT FROM OLD.metadata) THEN
+    RAISE EXCEPTION 'referenced app reservation creator projection is immutable'
+      USING ERRCODE = '23514', CONSTRAINT = 'redeemable_earnings_app_settlement_projection_immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE FUNCTION guard_app_reservation_app_projection() RETURNS trigger AS $$
+BEGIN
+  IF EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE app_earnings_transaction_id = OLD.id
+     )
+     AND (NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.app_id IS DISTINCT FROM OLD.app_id
+       OR NEW.user_id IS DISTINCT FROM OLD.user_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.type IS DISTINCT FROM OLD.type
+       OR NEW.metadata IS DISTINCT FROM OLD.metadata) THEN
+    RAISE EXCEPTION 'referenced app reservation app projection is immutable'
+      USING ERRCODE = '23514', CONSTRAINT = 'app_earnings_transactions_app_settlement_projection_immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER credit_transactions_app_settlement_projection_immutable_guard
+  BEFORE UPDATE ON credit_transactions
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_credit_projection();
+
+CREATE TRIGGER redeemable_earnings_app_settlement_projection_immutable_guard
+  BEFORE UPDATE ON redeemable_earnings_ledger
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_creator_projection();
+
+CREATE TRIGGER app_earnings_transactions_app_settlement_projection_immutable_guard
+  BEFORE UPDATE ON app_earnings_transactions
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_app_projection();
+
+CREATE FUNCTION guard_app_reservation_creator_projection_delete() RETURNS trigger AS $$
+BEGIN
+  IF pg_trigger_depth() <= 1
+     AND EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE redeemable_ledger_entry_id = OLD.id
+     ) THEN
+    RAISE EXCEPTION 'referenced app reservation creator projection cannot be deleted directly'
+      USING ERRCODE = '23514', CONSTRAINT = 'redeemable_earnings_app_settlement_projection_delete';
+  END IF;
+  RETURN OLD;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER redeemable_earnings_app_settlement_projection_delete_guard
+  BEFORE DELETE ON redeemable_earnings_ledger
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_creator_projection_delete();
+
+CREATE FUNCTION guard_app_reservation_app_projection_delete() RETURNS trigger AS $$
+BEGIN
+  IF pg_trigger_depth() <= 1
+     AND EXISTS (
+       SELECT 1 FROM app_reservation_settlements
+       WHERE app_earnings_transaction_id = OLD.id
+     ) THEN
+    RAISE EXCEPTION 'referenced app reservation app projection cannot be deleted directly'
+      USING ERRCODE = '23514', CONSTRAINT = 'app_earnings_transactions_app_settlement_projection_delete';
+  END IF;
+  RETURN OLD;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_earnings_transactions_app_settlement_projection_delete_guard
+  BEFORE DELETE ON app_earnings_transactions
+  FOR EACH ROW EXECUTE FUNCTION guard_app_reservation_app_projection_delete();
+
+CREATE FUNCTION guard_app_reservation_creator_projection_truncate() RETURNS trigger AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM app_reservation_settlements WHERE redeemable_ledger_entry_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'referenced app reservation creator projections cannot be truncated'
+      USING ERRCODE = '23514', CONSTRAINT = 'redeemable_earnings_app_settlement_projection_truncate';
+  END IF;
+  RETURN NULL;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER redeemable_earnings_app_settlement_projection_truncate_guard
+  BEFORE TRUNCATE ON redeemable_earnings_ledger
+  FOR EACH STATEMENT EXECUTE FUNCTION guard_app_reservation_creator_projection_truncate();
+
+CREATE FUNCTION guard_app_reservation_app_projection_truncate() RETURNS trigger AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM app_reservation_settlements WHERE app_earnings_transaction_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'referenced app reservation app projections cannot be truncated'
+      USING ERRCODE = '23514', CONSTRAINT = 'app_earnings_transactions_app_settlement_projection_truncate';
+  END IF;
+  RETURN NULL;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER app_earnings_transactions_app_settlement_projection_truncate_guard
+  BEFORE TRUNCATE ON app_earnings_transactions
+  FOR EACH STATEMENT EXECUTE FUNCTION guard_app_reservation_app_projection_truncate();
+
+-- A historical settlement is exact only when its server-keyed org adjustment
+-- contains the complete zero-markup contract. Creator-bearing historical rows
+-- are quarantined below because their multi-ledger commit cannot be proven from
+-- the pre-authority schema without inventing a projection identity.
+WITH historical AS (
+  SELECT
+    r.*,
+    CASE WHEN r.metadata->>'reserved_amount' ~ '^[0-9]+([.][0-9]+)?$'
+      THEN (r.metadata->>'reserved_amount')::numeric END AS reserved_base,
+    CASE WHEN a.metadata->>'actualBaseCost' ~ '^[0-9]+([.][0-9]+)?$'
+      THEN (a.metadata->>'actualBaseCost')::numeric END AS actual_base,
+    CASE WHEN a.metadata->>'estimatedBaseCost' ~ '^[0-9]+([.][0-9]+)?$'
+      THEN (a.metadata->>'estimatedBaseCost')::numeric END AS adjustment_estimate,
+    CASE WHEN a.metadata->>'markupPercentage' ~ '^[0-9]+([.][0-9]+)?$'
+      THEN (a.metadata->>'markupPercentage')::numeric END AS adjustment_markup,
+    a.id AS adjustment_id,
+    a.amount AS adjustment_amount,
+    a.type AS adjustment_type,
+    a.metadata AS adjustment_metadata
+  FROM credit_transactions r
+  JOIN credit_transactions a
+    ON a.organization_id = r.organization_id
+   AND a.stripe_payment_intent_id IN (
+     'reconcile-refund:' || r.id::text,
+     'reconcile-charge:' || r.id::text
+   )
+  WHERE r.settled_at IS NOT NULL
+    AND r.type = 'debit'
+    AND r.metadata->>'type' = 'app_chat_reservation'
+    AND r.metadata->>'settlement_marker' = 'app_chat_reservation_v1'
+), exact AS (
+  SELECT * FROM historical
+  WHERE reserved_base IS NOT NULL
+    AND actual_base IS NOT NULL
+    AND abs(amount) = round(reserved_base, 6)
+    AND adjustment_estimate = reserved_base
+    AND adjustment_markup = 0
+    AND adjustment_metadata->>'reservation_transaction_id' = id::text
+    AND ((adjustment_type = 'refund' AND actual_base < reserved_base
+          AND adjustment_amount = reserved_base - actual_base)
+      OR (adjustment_type = 'debit' AND actual_base > reserved_base
+          AND adjustment_amount = -(actual_base - reserved_base)))
+)
+INSERT INTO app_reservation_settlements (
+  reservation_transaction_id, organization_id, app_id, user_id, creator_user_id,
+  terminal_source, outcome, reserved_base_cost, actual_base_cost, markup_percentage,
+  reserved_total_cost, actual_total_cost, organization_adjustment,
+  creator_adjustment, platform_adjustment, credit_transaction_id, settled_at
+)
+SELECT
+  id, organization_id, (metadata->>'appId')::uuid, (metadata->>'userId')::uuid,
+  NULLIF(metadata->>'creatorUserId', '')::uuid,
+  CASE WHEN adjustment_metadata->>'settlement_source' = 'stale_reservation_sweep'
+    THEN 'stale_sweep' ELSE 'provider' END,
+  CASE WHEN adjustment_type = 'refund' THEN 'refund' ELSE 'overage' END,
+  round(reserved_base, 6), round(actual_base, 6), 0,
+  abs(amount), round(actual_base, 6), round(actual_base - reserved_base, 6),
+  0, round(actual_base - reserved_base, 6), adjustment_id, settled_at
+FROM exact
+WHERE metadata->>'appId' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+  AND metadata->>'userId' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+  AND (NULLIF(metadata->>'creatorUserId', '') IS NULL
+    OR metadata->>'creatorUserId' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+
+INSERT INTO app_reservation_settlement_quarantines (
+  reservation_transaction_id, organization_id, app_id, user_id, creator_user_id, reason,
+  quarantined_at
+)
+SELECT
+  r.id, r.organization_id,
+  app_reservation_quarantine_uuid(r.metadata->>'appId'),
+  app_reservation_quarantine_uuid(r.metadata->>'userId'),
+  CASE WHEN NULLIF(r.metadata->>'creatorUserId', '') IS NULL THEN NULL
+    ELSE app_reservation_quarantine_uuid(r.metadata->>'creatorUserId') END,
+  'pre_authority_economics_unreconstructable', r.settled_at
+FROM credit_transactions r
+LEFT JOIN app_reservation_settlements s ON s.reservation_transaction_id = r.id
+WHERE r.settled_at IS NOT NULL
+  AND r.type = 'debit'
+  AND r.metadata->>'type' = 'app_chat_reservation'
+  AND r.metadata->>'settlement_marker' = 'app_chat_reservation_v1'
+  AND s.reservation_transaction_id IS NULL;

--- a/packages/cloud/shared/src/db/migrations/app-reservation-settlement-authority.test.ts
+++ b/packages/cloud/shared/src/db/migrations/app-reservation-settlement-authority.test.ts
@@ -1,0 +1,382 @@
+/** Verifies the provisional 0268 receipt migration against real PostgreSQL semantics in PGlite. */
+
+import { describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const migrationUrl = new URL("./0268_app_reservation_settlement_authority.sql", import.meta.url);
+const migrationSql = await Bun.file(migrationUrl).text();
+
+const organizationId = "00000000-0000-4000-8000-000000000001";
+const otherOrganizationId = "00000000-0000-4000-8000-000000000002";
+const reservationId = "00000000-0000-4000-8000-000000000010";
+const adjustmentId = "00000000-0000-4000-8000-000000000011";
+const appId = "00000000-0000-4000-8000-000000000020";
+const userId = "00000000-0000-4000-8000-000000000021";
+const creatorId = "00000000-0000-4000-8000-000000000022";
+const creatorLedgerId = "00000000-0000-4000-8000-000000000030";
+const appProjectionId = "00000000-0000-4000-8000-000000000031";
+const monetizedReservationId = "00000000-0000-4000-8000-000000000032";
+const monetizedAdjustmentId = "00000000-0000-4000-8000-000000000033";
+const historicalExactId = "00000000-0000-4000-8000-000000000040";
+const historicalExactAdjustmentId = "00000000-0000-4000-8000-000000000041";
+const historicalQuarantineId = "00000000-0000-4000-8000-000000000042";
+const rollingCutoverId = "00000000-0000-4000-8000-000000000043";
+
+async function prerequisiteDb(): Promise<PGlite> {
+  const db = new PGlite();
+  await db.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE apps (id uuid PRIMARY KEY);
+    CREATE TABLE credit_transactions (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL REFERENCES organizations(id),
+      amount numeric(16,6) NOT NULL,
+      type text NOT NULL,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      stripe_payment_intent_id text,
+      settled_at timestamptz,
+      CONSTRAINT credit_transactions_id_organization_unique UNIQUE (id, organization_id)
+    );
+    CREATE TABLE redeemable_earnings_ledger (
+      id uuid PRIMARY KEY, user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+      amount numeric(16,4), earnings_source text,
+      source_id uuid, entry_type text, metadata jsonb NOT NULL DEFAULT '{}'
+    );
+    CREATE TABLE app_earnings_transactions (
+      id uuid PRIMARY KEY, app_id uuid REFERENCES apps(id) ON DELETE CASCADE,
+      user_id uuid, type text,
+      amount numeric(16,6), metadata jsonb NOT NULL DEFAULT '{}'
+    );
+    INSERT INTO organizations(id) VALUES ('${organizationId}'), ('${otherOrganizationId}');
+    INSERT INTO users(id) VALUES ('${creatorId}');
+    INSERT INTO apps(id) VALUES ('${appId}');
+    INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+      VALUES (
+        '${reservationId}', '${organizationId}', -0.03, 'debit',
+        '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","reserved_amount":0.03}'
+      );
+    INSERT INTO credit_transactions(
+      id, organization_id, amount, type, stripe_payment_intent_id
+    ) VALUES (
+      '${adjustmentId}', '${organizationId}', 0.02, 'refund',
+      'reconcile-refund:${reservationId}'
+    );
+    INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+      VALUES (
+        '${historicalExactId}', '${organizationId}', -0.03, 'debit',
+        '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","reserved_amount":0.03,"markupPercentage":0}'
+      ), (
+        '${historicalQuarantineId}', '${organizationId}', -0.06, 'debit',
+        '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","creatorUserId":"${creatorId}","reserved_amount":0.03,"markupPercentage":100}'
+      );
+    UPDATE credit_transactions SET settled_at = now()
+      WHERE id IN ('${historicalExactId}', '${historicalQuarantineId}');
+    INSERT INTO credit_transactions(
+      id, organization_id, amount, type, stripe_payment_intent_id, metadata
+    ) VALUES (
+      '${historicalExactAdjustmentId}', '${organizationId}', 0.02, 'refund',
+      'reconcile-refund:${historicalExactId}',
+      '{"reservation_transaction_id":"${historicalExactId}","estimatedBaseCost":0.03,"actualBaseCost":0.01,"markupPercentage":0}'
+    );
+  `);
+  return db;
+}
+
+describe("0268 app reservation settlement authority", () => {
+  test("creates exact tenant fences and immutable receipts", async () => {
+    const db = await prerequisiteDb();
+    try {
+      await db.exec(migrationSql);
+      await db.exec(`
+        INSERT INTO app_reservation_settlements (
+          reservation_transaction_id, organization_id, app_id, user_id,
+          terminal_source, outcome, reserved_base_cost, actual_base_cost,
+          markup_percentage, reserved_total_cost, actual_total_cost,
+          organization_adjustment, creator_adjustment, platform_adjustment,
+          credit_transaction_id
+        ) VALUES (
+          '${reservationId}', '${organizationId}', '${appId}', '${userId}',
+          'provider', 'refund', 0.03, 0.01, 0, 0.03, 0.01, -0.02, 0, -0.02,
+          '${adjustmentId}'
+        );
+      `);
+      await expect(
+        db.exec(
+          "UPDATE app_reservation_settlements SET actual_base_cost = 0.02 WHERE reservation_transaction_id = '" +
+            reservationId +
+            "'",
+        ),
+      ).rejects.toThrow("immutable");
+      await expect(db.exec("TRUNCATE app_reservation_settlements")).rejects.toThrow("immutable");
+      await expect(
+        db.exec(`UPDATE credit_transactions SET amount = -0.04 WHERE id = '${reservationId}'`),
+      ).rejects.toThrow("facts are immutable");
+      await expect(
+        db.exec(
+          `UPDATE credit_transactions SET metadata = metadata || '{"appId":"${userId}"}' WHERE id = '${reservationId}'`,
+        ),
+      ).rejects.toThrow("facts are immutable");
+      await db.exec(
+        `UPDATE credit_transactions SET settled_at = now() WHERE id = '${reservationId}'`,
+      );
+      await db.exec(`
+        INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+        VALUES (
+          '${rollingCutoverId}', '${organizationId}', -0.06, 'debit',
+          '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","creatorUserId":"${creatorId}","reserved_amount":0.03}'
+        );
+        UPDATE credit_transactions SET settled_at = now() WHERE id = '${rollingCutoverId}';
+      `);
+
+      const exactBackfill = await db.query<{ actual_base_cost: string; outcome: string }>(`
+        SELECT actual_base_cost, outcome FROM app_reservation_settlements
+        WHERE reservation_transaction_id = '${historicalExactId}'
+      `);
+      expect(exactBackfill.rows).toEqual([{ actual_base_cost: "0.010000", outcome: "refund" }]);
+      const quarantine = await db.query<{ reason: string }>(`
+        SELECT reason FROM app_reservation_settlement_quarantines
+        WHERE reservation_transaction_id = '${historicalQuarantineId}'
+      `);
+      expect(quarantine.rows).toEqual([{ reason: "pre_authority_economics_unreconstructable" }]);
+      await expect(
+        db.exec(`
+          INSERT INTO app_reservation_settlements (
+            reservation_transaction_id, organization_id, app_id, user_id, creator_user_id,
+            terminal_source, outcome, reserved_base_cost, actual_base_cost,
+            markup_percentage, reserved_total_cost, actual_total_cost,
+            organization_adjustment, creator_adjustment, platform_adjustment
+          ) VALUES (
+            '${historicalQuarantineId}', '${organizationId}', '${appId}', '${userId}',
+            '${creatorId}', 'provider', 'none', 0.03, 0.03, 100, 0.06, 0.06, 0, 0, 0
+          )
+        `),
+      ).rejects.toThrow("does not match immutable reservation facts");
+      const quarantineAuthority = await db.query<{ quarantines: number; receipts: number }>(`
+        SELECT
+          (SELECT count(*)::int FROM app_reservation_settlement_quarantines
+            WHERE reservation_transaction_id = '${historicalQuarantineId}') AS quarantines,
+          (SELECT count(*)::int FROM app_reservation_settlements
+            WHERE reservation_transaction_id = '${historicalQuarantineId}') AS receipts
+      `);
+      expect(quarantineAuthority.rows).toEqual([{ quarantines: 1, receipts: 0 }]);
+      const rollingQuarantine = await db.query<{ reservation_transaction_id: string }>(`
+        SELECT reservation_transaction_id FROM app_reservation_settlement_quarantines
+        WHERE reservation_transaction_id = '${rollingCutoverId}'
+      `);
+      expect(rollingQuarantine.rows).toEqual([{ reservation_transaction_id: rollingCutoverId }]);
+      await expect(
+        db.exec(
+          `DELETE FROM app_reservation_settlement_quarantines WHERE reservation_transaction_id = '${historicalQuarantineId}'`,
+        ),
+      ).rejects.toThrow("immutable");
+
+      const constraints = await db.query<{ conname: string }>(`
+        SELECT conname FROM pg_constraint
+        WHERE conrelid = 'app_reservation_settlements'::regclass
+        ORDER BY conname
+      `);
+      expect(constraints.rows.map((row) => row.conname)).toEqual(
+        expect.arrayContaining([
+          "app_reservation_settlements_adjustment_tenant_fk",
+          "app_reservation_settlements_economics_check",
+          "app_reservation_settlements_organization_fk",
+          "app_reservation_settlements_outcome_check",
+          "app_reservation_settlements_pkey",
+          "app_reservation_settlements_reservation_tenant_fk",
+          "app_reservation_settlements_source_check",
+        ]),
+      );
+    } finally {
+      await db.close();
+    }
+  });
+
+  test("freezes every referenced ledger projection but leaves unrelated rows mutable", async () => {
+    const db = await prerequisiteDb();
+    try {
+      await db.exec(migrationSql);
+      await db.exec(`
+        INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+        VALUES (
+          '${monetizedReservationId}', '${organizationId}', -0.06, 'debit',
+          '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","creatorUserId":"${creatorId}","reserved_amount":0.03}'
+        );
+        INSERT INTO credit_transactions(
+          id, organization_id, amount, type, stripe_payment_intent_id, metadata
+        ) VALUES (
+          '${monetizedAdjustmentId}', '${organizationId}', 0.04, 'refund',
+          'reconcile-refund:${monetizedReservationId}', '{"authority":"settlement"}'
+        );
+        INSERT INTO redeemable_earnings_ledger(
+          id, user_id, amount, earnings_source, entry_type, metadata
+        ) VALUES (
+          '${creatorLedgerId}', '${creatorId}', -0.02, 'miniapp',
+          'reconciliation_reduction', '{"authority":"settlement"}'
+        );
+        INSERT INTO app_earnings_transactions(id, app_id, user_id, type, amount, metadata)
+        VALUES (
+          '${appProjectionId}', '${appId}', '${userId}', 'inference_markup', -0.02,
+          '{"redeemableLedgerEntryId":"${creatorLedgerId}","authority":"settlement"}'
+        );
+        INSERT INTO app_reservation_settlements (
+          reservation_transaction_id, organization_id, app_id, user_id, creator_user_id,
+          terminal_source, outcome, reserved_base_cost, actual_base_cost,
+          markup_percentage, reserved_total_cost, actual_total_cost,
+          organization_adjustment, creator_adjustment, platform_adjustment,
+          credit_transaction_id, redeemable_ledger_entry_id, app_earnings_transaction_id
+        ) VALUES (
+          '${monetizedReservationId}', '${organizationId}', '${appId}', '${userId}', '${creatorId}',
+          'provider', 'refund', 0.03, 0.01, 100, 0.06, 0.02, -0.04, -0.02, -0.02,
+          '${monetizedAdjustmentId}', '${creatorLedgerId}', '${appProjectionId}'
+        );
+      `);
+
+      await expect(
+        db.exec(
+          `UPDATE credit_transactions SET metadata = '{}' WHERE id = '${monetizedAdjustmentId}'`,
+        ),
+      ).rejects.toThrow("immutable");
+      await expect(
+        db.exec(
+          `UPDATE redeemable_earnings_ledger SET amount = -0.01 WHERE id = '${creatorLedgerId}'`,
+        ),
+      ).rejects.toThrow("immutable");
+      await expect(
+        db.exec(
+          `UPDATE app_earnings_transactions SET amount = -0.01 WHERE id = '${appProjectionId}'`,
+        ),
+      ).rejects.toThrow("immutable");
+      await expect(
+        db.exec(`DELETE FROM credit_transactions WHERE id = '${monetizedAdjustmentId}'`),
+      ).rejects.toThrow();
+      await expect(
+        db.exec(`DELETE FROM redeemable_earnings_ledger WHERE id = '${creatorLedgerId}'`),
+      ).rejects.toThrow();
+      await expect(
+        db.exec(`DELETE FROM app_earnings_transactions WHERE id = '${appProjectionId}'`),
+      ).rejects.toThrow();
+      await expect(db.exec("TRUNCATE credit_transactions")).rejects.toThrow();
+      await expect(db.exec("TRUNCATE redeemable_earnings_ledger")).rejects.toThrow();
+      await expect(db.exec("TRUNCATE app_earnings_transactions")).rejects.toThrow();
+
+      await db.exec(`
+        INSERT INTO redeemable_earnings_ledger(id, user_id, amount, earnings_source, entry_type)
+        VALUES ('00000000-0000-4000-8000-000000000099', '${creatorId}', 1, 'miniapp', 'earning');
+        UPDATE redeemable_earnings_ledger SET amount = 2
+        WHERE id = '00000000-0000-4000-8000-000000000099';
+      `);
+
+      await db.exec(`DELETE FROM apps WHERE id = '${appId}'`);
+      await db.exec(`DELETE FROM users WHERE id = '${creatorId}'`);
+      const retainedReceipt = await db.query<{ app_earnings_transaction_id: string }>(`
+        SELECT app_earnings_transaction_id, redeemable_ledger_entry_id
+        FROM app_reservation_settlements
+        WHERE reservation_transaction_id = '${monetizedReservationId}'
+      `);
+      expect(retainedReceipt.rows).toHaveLength(1);
+      expect(
+        await db.query(`SELECT id FROM app_earnings_transactions WHERE id = '${appProjectionId}'`),
+      ).toMatchObject({ rows: [] });
+      expect(
+        await db.query(`SELECT id FROM redeemable_earnings_ledger WHERE id = '${creatorLedgerId}'`),
+      ).toMatchObject({ rows: [] });
+    } finally {
+      await db.close();
+    }
+  });
+
+  test("rejects forged quarantine authority for active or mismatched reservations", async () => {
+    const db = await prerequisiteDb();
+    const activeId = "00000000-0000-4000-8000-000000000050";
+    const mismatchId = "00000000-0000-4000-8000-000000000051";
+    const wrongTypeId = "00000000-0000-4000-8000-000000000052";
+    const wrongMarkerId = "00000000-0000-4000-8000-000000000053";
+    try {
+      await db.exec(migrationSql);
+      await db.exec(`
+        INSERT INTO credit_transactions(id, organization_id, amount, type, metadata, settled_at)
+        VALUES
+          ('${activeId}', '${organizationId}', -0.03, 'debit',
+           '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","reserved_amount":0.03}', NULL),
+          ('${mismatchId}', '${organizationId}', -0.03, 'debit',
+           '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","reserved_amount":0.03}', '2026-08-19T12:00:00Z'),
+          ('${wrongTypeId}', '${organizationId}', -0.03, 'refund',
+           '{"type":"app_chat_reservation","settlement_marker":"app_chat_reservation_v1","appId":"${appId}","userId":"${userId}","reserved_amount":0.03}', '2026-08-19T12:00:00Z'),
+          ('${wrongMarkerId}', '${organizationId}', -0.03, 'debit',
+           '{"type":"app_chat_reservation","settlement_marker":"wrong","appId":"${appId}","userId":"${userId}","reserved_amount":0.03}', '2026-08-19T12:00:00Z');
+      `);
+      const quarantineInsert = (reservation: string, app: string, time: string) =>
+        db.exec(`
+          INSERT INTO app_reservation_settlement_quarantines(
+            reservation_transaction_id, organization_id, app_id, user_id, reason, quarantined_at
+          ) VALUES (
+            '${reservation}', '${organizationId}', '${app}', '${userId}',
+            'pre_authority_economics_unreconstructable', '${time}'
+          )
+        `);
+      await expect(quarantineInsert(activeId, appId, "2026-08-19T12:00:00Z")).rejects.toThrow(
+        "does not match",
+      );
+      await expect(quarantineInsert(mismatchId, userId, "2026-08-19T12:00:00Z")).rejects.toThrow(
+        "does not match",
+      );
+      await expect(quarantineInsert(mismatchId, appId, "2026-08-19T12:00:01Z")).rejects.toThrow(
+        "does not match",
+      );
+      await expect(quarantineInsert(wrongTypeId, appId, "2026-08-19T12:00:00Z")).rejects.toThrow(
+        "does not match",
+      );
+      await expect(quarantineInsert(wrongMarkerId, appId, "2026-08-19T12:00:00Z")).rejects.toThrow(
+        "does not match",
+      );
+    } finally {
+      await db.close();
+    }
+  });
+
+  test("rejects cross-tenant receipts", async () => {
+    const db = await prerequisiteDb();
+    try {
+      await db.exec(migrationSql);
+      await expect(
+        db.exec(`
+          INSERT INTO app_reservation_settlements (
+            reservation_transaction_id, organization_id, app_id, user_id,
+            terminal_source, outcome, reserved_base_cost, actual_base_cost,
+            markup_percentage, reserved_total_cost, actual_total_cost,
+            organization_adjustment, creator_adjustment, platform_adjustment
+          ) VALUES (
+            '${reservationId}', '${otherOrganizationId}', '${appId}', '${userId}',
+            'provider', 'none', 0.03, 0.03, 0, 0.03, 0.03, 0, 0, 0
+          );
+        `),
+      ).rejects.toThrow();
+    } finally {
+      await db.close();
+    }
+  });
+
+  test("fails loudly on replay and partial collision", async () => {
+    const replayDb = await prerequisiteDb();
+    try {
+      await replayDb.exec(migrationSql);
+      await expect(replayDb.exec(migrationSql)).rejects.toThrow();
+    } finally {
+      await replayDb.close();
+    }
+
+    const partialDb = await prerequisiteDb();
+    try {
+      await partialDb.exec("CREATE TABLE app_reservation_settlements (wrong text)");
+      await expect(partialDb.exec(migrationSql)).rejects.toThrow();
+      const columns = await partialDb.query<{ column_name: string }>(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'app_reservation_settlements'
+      `);
+      expect(columns.rows.map((row) => row.column_name)).toEqual(["wrong"]);
+    } finally {
+      await partialDb.close();
+    }
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
+++ b/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
@@ -1,0 +1,422 @@
+/** Exercises the 0268 first-terminal reservation lock with two real PostgreSQL connections. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Client } from "pg";
+
+const dsn = process.env.APP_RESERVATION_SETTLEMENT_TEST_DSN;
+const describeRealPg = dsn ? describe : describe.skip;
+const schemaName = `app_settlement_${process.pid}_${Date.now()}`;
+const migrationSql = await Bun.file(
+  new URL("./0268_app_reservation_settlement_authority.sql", import.meta.url),
+).text();
+let admin: Client;
+
+describeRealPg("0268 app reservation settlement real PostgreSQL concurrency", () => {
+  beforeAll(async () => {
+    admin = new Client({ connectionString: dsn });
+    await admin.connect();
+    await admin.query(`CREATE SCHEMA ${schemaName}`);
+    await admin.query(`SET search_path TO ${schemaName}`);
+    await admin.query(`
+      CREATE TABLE organizations (id uuid PRIMARY KEY);
+      CREATE TABLE users (id uuid PRIMARY KEY);
+      CREATE TABLE apps (id uuid PRIMARY KEY);
+      CREATE TABLE credit_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL REFERENCES organizations(id),
+        amount numeric(16,6) NOT NULL,
+        type text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        stripe_payment_intent_id text UNIQUE,
+        settled_at timestamptz,
+        CONSTRAINT credit_transactions_id_organization_unique UNIQUE (id, organization_id)
+      );
+      CREATE TABLE redeemable_earnings_ledger (
+        id uuid PRIMARY KEY, user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+        amount numeric(16,4), earnings_source text,
+        source_id uuid, entry_type text, metadata jsonb NOT NULL DEFAULT '{}'
+      );
+      CREATE TABLE app_earnings_transactions (
+        id uuid PRIMARY KEY, app_id uuid REFERENCES apps(id) ON DELETE CASCADE,
+        user_id uuid, type text,
+        amount numeric(16,6), metadata jsonb NOT NULL DEFAULT '{}'
+      );
+    `);
+    await admin.query(migrationSql);
+  });
+
+  afterAll(async () => {
+    if (!admin) return;
+    await admin.query("SET search_path TO public");
+    await admin.query(`DROP SCHEMA ${schemaName} CASCADE`);
+    await admin.end();
+  });
+
+  async function settle(
+    reservationId: string,
+    source: "provider" | "stale_sweep",
+    actual: string,
+    holdMs: number,
+    onReservationLocked?: () => void,
+  ) {
+    const client = new Client({ connectionString: dsn });
+    await client.connect();
+    try {
+      await client.query(`SET search_path TO ${schemaName}`);
+      await client.query("BEGIN");
+      const reservation = await client.query(
+        "SELECT * FROM credit_transactions WHERE id = $1 FOR UPDATE",
+        [reservationId],
+      );
+      onReservationLocked?.();
+      const existing = await client.query(
+        "SELECT * FROM app_reservation_settlements WHERE reservation_transaction_id = $1",
+        [reservationId],
+      );
+      if (existing.rowCount) {
+        await client.query("COMMIT");
+        return existing.rows[0];
+      }
+      if (holdMs > 0) await client.query("SELECT pg_sleep($1)", [holdMs / 1000]);
+      const org = reservation.rows[0].organization_id as string;
+      const adjustment = actual === "0.01" ? "-0.02" : "-0.01";
+      const adjustmentRow = await client.query(
+        `INSERT INTO credit_transactions(
+          organization_id, amount, type, stripe_payment_intent_id
+        ) VALUES ($1, $2, 'refund', $3) RETURNING id`,
+        [org, adjustment === "-0.02" ? "0.02" : "0.01", `reconcile-refund:${reservationId}`],
+      );
+      const inserted = await client.query(
+        `INSERT INTO app_reservation_settlements(
+          reservation_transaction_id, organization_id, app_id, user_id,
+          terminal_source, outcome, reserved_base_cost, actual_base_cost,
+          markup_percentage, reserved_total_cost, actual_total_cost,
+          organization_adjustment, creator_adjustment, platform_adjustment,
+          credit_transaction_id
+        ) VALUES ($1,$2,$3,$4,$5,'refund',0.03,$6,0,0.03,$6,$7,0,$7,$8)
+        RETURNING *`,
+        [
+          reservationId,
+          org,
+          reservation.rows[0].metadata.appId,
+          reservation.rows[0].metadata.userId,
+          source,
+          actual,
+          adjustment,
+          adjustmentRow.rows[0].id,
+        ],
+      );
+      await client.query("COMMIT");
+      return inserted.rows[0];
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      await client.end();
+    }
+  }
+
+  async function seed(reservationId: string) {
+    const org = crypto.randomUUID();
+    const app = crypto.randomUUID();
+    const user = crypto.randomUUID();
+    await admin.query("INSERT INTO organizations(id) VALUES ($1)", [org]);
+    await admin.query(
+      `INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+       VALUES ($1,$2,-0.03,'debit',$3)`,
+      [
+        reservationId,
+        org,
+        {
+          type: "app_chat_reservation",
+          settlement_marker: "app_chat_reservation_v1",
+          appId: app,
+          userId: user,
+          reserved_amount: 0.03,
+        },
+      ],
+    );
+    return { org, app, user };
+  }
+
+  async function connectedClient(): Promise<Client> {
+    const client = new Client({ connectionString: dsn });
+    await client.connect();
+    await client.query(`SET search_path TO ${schemaName}`);
+    return client;
+  }
+
+  async function expectBackendBlocked(blocked: Client, blocker: Client): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const result = await admin.query<{ blockers: number[] }>(
+        "SELECT pg_blocking_pids($1)::int[] AS blockers",
+        [blocked.processID],
+      );
+      if (result.rows[0]?.blockers.includes(blocker.processID)) {
+        expect(result.rows[0].blockers).toContain(blocker.processID);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`backend ${blocked.processID} did not block on ${blocker.processID}`);
+  }
+
+  test("provider-first and sweep-first differing actuals each commit one exact receipt", async () => {
+    const providerFirst = crypto.randomUUID();
+    await seed(providerFirst);
+    let signalProviderLocked!: () => void;
+    const providerLocked = new Promise<void>((resolve) => {
+      signalProviderLocked = resolve;
+    });
+    const provider = settle(providerFirst, "provider", "0.01", 100, signalProviderLocked);
+    await providerLocked;
+    const lateSweep = settle(providerFirst, "stale_sweep", "0.02", 0);
+    const providerResults = await Promise.all([provider, lateSweep]);
+    expect(providerResults[0].actual_base_cost).toBe("0.010000");
+    expect(providerResults[1].actual_base_cost).toBe("0.010000");
+
+    const sweepFirst = crypto.randomUUID();
+    await seed(sweepFirst);
+    let signalSweepLocked!: () => void;
+    const sweepLocked = new Promise<void>((resolve) => {
+      signalSweepLocked = resolve;
+    });
+    const sweep = settle(sweepFirst, "stale_sweep", "0.02", 100, signalSweepLocked);
+    await sweepLocked;
+    const lateProvider = settle(sweepFirst, "provider", "0.01", 0);
+    const sweepResults = await Promise.all([sweep, lateProvider]);
+    expect(sweepResults[0].actual_base_cost).toBe("0.020000");
+    expect(sweepResults[1].actual_base_cost).toBe("0.020000");
+
+    const counts = await admin.query(
+      `SELECT reservation_transaction_id, count(*)::int AS receipts
+       FROM app_reservation_settlements GROUP BY reservation_transaction_id`,
+    );
+    expect(counts.rows).toHaveLength(2);
+    expect(counts.rows.every((row) => row.receipts === 1)).toBe(true);
+
+    const cascadeOrg = crypto.randomUUID();
+    const cascadeCreator = crypto.randomUUID();
+    const cascadeApp = crypto.randomUUID();
+    const cascadeUser = crypto.randomUUID();
+    const cascadeReservation = crypto.randomUUID();
+    const cascadeAdjustment = crypto.randomUUID();
+    const cascadeLedger = crypto.randomUUID();
+    const cascadeProjection = crypto.randomUUID();
+    await admin.query("INSERT INTO organizations(id) VALUES ($1)", [cascadeOrg]);
+    await admin.query("INSERT INTO users(id) VALUES ($1)", [cascadeCreator]);
+    await admin.query("INSERT INTO apps(id) VALUES ($1)", [cascadeApp]);
+    await admin.query(
+      `INSERT INTO credit_transactions(id, organization_id, amount, type, metadata)
+       VALUES ($1,$2,-0.06,'debit',$3)`,
+      [
+        cascadeReservation,
+        cascadeOrg,
+        {
+          type: "app_chat_reservation",
+          settlement_marker: "app_chat_reservation_v1",
+          appId: cascadeApp,
+          userId: cascadeUser,
+          creatorUserId: cascadeCreator,
+          reserved_amount: 0.03,
+        },
+      ],
+    );
+    await admin.query(
+      `INSERT INTO credit_transactions(
+         id, organization_id, amount, type, stripe_payment_intent_id, metadata
+       ) VALUES ($1,$2,0.04,'refund',$3,'{}')`,
+      [cascadeAdjustment, cascadeOrg, `reconcile-refund:${cascadeReservation}`],
+    );
+    await admin.query(
+      `INSERT INTO redeemable_earnings_ledger(
+         id, user_id, amount, earnings_source, entry_type
+       ) VALUES ($1,$2,-0.02,'miniapp','reconciliation_reduction')`,
+      [cascadeLedger, cascadeCreator],
+    );
+    await admin.query(
+      `INSERT INTO app_earnings_transactions(id, app_id, user_id, type, amount, metadata)
+       VALUES ($1,$2,$3,'inference_markup',-0.02,$4)`,
+      [cascadeProjection, cascadeApp, cascadeUser, { redeemableLedgerEntryId: cascadeLedger }],
+    );
+    await admin.query(
+      `INSERT INTO app_reservation_settlements(
+         reservation_transaction_id, organization_id, app_id, user_id, creator_user_id,
+         terminal_source, outcome, reserved_base_cost, actual_base_cost,
+         markup_percentage, reserved_total_cost, actual_total_cost,
+         organization_adjustment, creator_adjustment, platform_adjustment,
+         credit_transaction_id, redeemable_ledger_entry_id, app_earnings_transaction_id
+       ) VALUES ($1,$2,$3,$4,$5,'provider','refund',0.03,0.01,100,0.06,0.02,
+         -0.04,-0.02,-0.02,$6,$7,$8)`,
+      [
+        cascadeReservation,
+        cascadeOrg,
+        cascadeApp,
+        cascadeUser,
+        cascadeCreator,
+        cascadeAdjustment,
+        cascadeLedger,
+        cascadeProjection,
+      ],
+    );
+    await expect(
+      admin.query("DELETE FROM redeemable_earnings_ledger WHERE id = $1", [cascadeLedger]),
+    ).rejects.toThrow("cannot be deleted directly");
+    await expect(
+      admin.query("DELETE FROM app_earnings_transactions WHERE id = $1", [cascadeProjection]),
+    ).rejects.toThrow("cannot be deleted directly");
+    await admin.query("DELETE FROM apps WHERE id = $1", [cascadeApp]);
+    await admin.query("DELETE FROM users WHERE id = $1", [cascadeCreator]);
+    const cascadeProof = await admin.query(
+      `SELECT
+         (SELECT count(*)::int FROM app_reservation_settlements
+           WHERE reservation_transaction_id = $1) AS receipts,
+         (SELECT count(*)::int FROM app_earnings_transactions WHERE id = $2) AS app_rows,
+         (SELECT count(*)::int FROM redeemable_earnings_ledger WHERE id = $3) AS creator_rows`,
+      [cascadeReservation, cascadeProjection, cascadeLedger],
+    );
+    expect(cascadeProof.rows[0]).toEqual({ receipts: 1, app_rows: 0, creator_rows: 0 });
+
+    const quarantineReservation = crypto.randomUUID();
+    await seed(quarantineReservation);
+    await admin.query("UPDATE credit_transactions SET settled_at = now() WHERE id = $1", [
+      quarantineReservation,
+    ]);
+    const quarantineFacts = await admin.query(
+      "SELECT organization_id, metadata FROM credit_transactions WHERE id = $1",
+      [quarantineReservation],
+    );
+    await expect(
+      admin.query(
+        `INSERT INTO app_reservation_settlements(
+           reservation_transaction_id, organization_id, app_id, user_id,
+           terminal_source, outcome, reserved_base_cost, actual_base_cost,
+           markup_percentage, reserved_total_cost, actual_total_cost,
+           organization_adjustment, creator_adjustment, platform_adjustment
+         ) VALUES ($1,$2,$3,$4,'provider','none',0.03,0.03,0,0.03,0.03,0,0,0)`,
+        [
+          quarantineReservation,
+          quarantineFacts.rows[0].organization_id,
+          quarantineFacts.rows[0].metadata.appId,
+          quarantineFacts.rows[0].metadata.userId,
+        ],
+      ),
+    ).rejects.toThrow("does not match immutable reservation facts");
+    const quarantineProof = await admin.query(
+      `SELECT
+         (SELECT count(*)::int FROM app_reservation_settlement_quarantines
+           WHERE reservation_transaction_id = $1) AS quarantines,
+         (SELECT count(*)::int FROM app_reservation_settlements
+           WHERE reservation_transaction_id = $1) AS receipts`,
+      [quarantineReservation],
+    );
+    expect(quarantineProof.rows[0]).toEqual({ quarantines: 1, receipts: 0 });
+  });
+
+  test("serializes receipt and quarantine contenders in both reservation-lock orders", async () => {
+    const receiptFirstReservation = crypto.randomUUID();
+    const receiptFirstFacts = await seed(receiptFirstReservation);
+    const receiptWinner = await connectedClient();
+    const legacyWaiter = await connectedClient();
+    try {
+      await receiptWinner.query("BEGIN");
+      await receiptWinner.query(
+        `INSERT INTO app_reservation_settlements(
+           reservation_transaction_id, organization_id, app_id, user_id,
+           terminal_source, outcome, reserved_base_cost, actual_base_cost,
+           markup_percentage, reserved_total_cost, actual_total_cost,
+           organization_adjustment, creator_adjustment, platform_adjustment
+         ) VALUES ($1,$2,$3,$4,'provider','none',0.03,0.03,0,0.03,0.03,0,0,0)`,
+        [
+          receiptFirstReservation,
+          receiptFirstFacts.org,
+          receiptFirstFacts.app,
+          receiptFirstFacts.user,
+        ],
+      );
+
+      await legacyWaiter.query("BEGIN");
+      const legacyAttempt = legacyWaiter
+        .query("UPDATE credit_transactions SET settled_at = now() WHERE id = $1", [
+          receiptFirstReservation,
+        ])
+        .then(
+          () => ({ ok: true as const }),
+          (error: Error) => ({ ok: false as const, error }),
+        );
+      await expectBackendBlocked(legacyWaiter, receiptWinner);
+      await receiptWinner.query("COMMIT");
+      expect(await legacyAttempt).toEqual({ ok: true });
+      await legacyWaiter.query("COMMIT");
+
+      const receiptFirstProof = await admin.query(
+        `SELECT
+           (SELECT count(*)::int FROM app_reservation_settlements
+             WHERE reservation_transaction_id = $1) AS receipts,
+           (SELECT count(*)::int FROM app_reservation_settlement_quarantines
+             WHERE reservation_transaction_id = $1) AS quarantines`,
+        [receiptFirstReservation],
+      );
+      expect(receiptFirstProof.rows[0]).toEqual({ receipts: 1, quarantines: 0 });
+    } finally {
+      await receiptWinner.query("ROLLBACK");
+      await legacyWaiter.query("ROLLBACK");
+      await receiptWinner.end();
+      await legacyWaiter.end();
+    }
+
+    const quarantineFirstReservation = crypto.randomUUID();
+    const quarantineFirstFacts = await seed(quarantineFirstReservation);
+    const legacyWinner = await connectedClient();
+    const receiptWaiter = await connectedClient();
+    try {
+      await legacyWinner.query("BEGIN");
+      await legacyWinner.query("UPDATE credit_transactions SET settled_at = now() WHERE id = $1", [
+        quarantineFirstReservation,
+      ]);
+
+      await receiptWaiter.query("BEGIN");
+      const receiptAttempt = receiptWaiter
+        .query(
+          `INSERT INTO app_reservation_settlements(
+             reservation_transaction_id, organization_id, app_id, user_id,
+             terminal_source, outcome, reserved_base_cost, actual_base_cost,
+             markup_percentage, reserved_total_cost, actual_total_cost,
+             organization_adjustment, creator_adjustment, platform_adjustment
+           ) VALUES ($1,$2,$3,$4,'provider','none',0.03,0.03,0,0.03,0.03,0,0,0)`,
+          [
+            quarantineFirstReservation,
+            quarantineFirstFacts.org,
+            quarantineFirstFacts.app,
+            quarantineFirstFacts.user,
+          ],
+        )
+        .then(
+          () => ({ ok: true as const }),
+          (error: Error) => ({ ok: false as const, error }),
+        );
+      await expectBackendBlocked(receiptWaiter, legacyWinner);
+      await legacyWinner.query("COMMIT");
+      const rejectedReceipt = await receiptAttempt;
+      expect(rejectedReceipt.ok).toBe(false);
+      if (rejectedReceipt.ok) throw new Error("quarantine-first receipt unexpectedly committed");
+      expect(rejectedReceipt.error.message).toContain("does not match immutable reservation facts");
+      await receiptWaiter.query("ROLLBACK");
+
+      const quarantineFirstProof = await admin.query(
+        `SELECT
+           (SELECT count(*)::int FROM app_reservation_settlements
+             WHERE reservation_transaction_id = $1) AS receipts,
+           (SELECT count(*)::int FROM app_reservation_settlement_quarantines
+             WHERE reservation_transaction_id = $1) AS quarantines`,
+        [quarantineFirstReservation],
+      );
+      expect(quarantineFirstProof.rows[0]).toEqual({ receipts: 0, quarantines: 1 });
+    } finally {
+      await legacyWinner.query("ROLLBACK");
+      await receiptWaiter.query("ROLLBACK");
+      await legacyWinner.end();
+      await receiptWaiter.end();
+    }
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1870,6 +1870,13 @@
       "when": 1792526400000,
       "tag": "0267_stripe_customer_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 267,
+      "version": "7",
+      "when": 1792612800000,
+      "tag": "0268_app_reservation_settlement_authority",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/app-reservation-settlements.ts
+++ b/packages/cloud/shared/src/db/schemas/app-reservation-settlements.ts
@@ -1,0 +1,113 @@
+/** Defines immutable terminal receipts for app-inference reservation settlement. */
+
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { creditTransactions } from "./credit-transactions";
+import { organizations } from "./organizations";
+
+/**
+ * First-committed-wins authority for an app-chat hold. Identity and economics
+ * are copied from immutable reservation facts so later delivery replays them.
+ */
+export const appReservationSettlements = pgTable(
+  "app_reservation_settlements",
+  {
+    reservation_transaction_id: uuid("reservation_transaction_id").primaryKey(),
+    organization_id: uuid("organization_id").notNull(),
+    app_id: uuid("app_id").notNull(),
+    user_id: uuid("user_id").notNull(),
+    creator_user_id: uuid("creator_user_id"),
+    terminal_source: text("terminal_source").notNull(),
+    outcome: text("outcome").notNull(),
+    reserved_base_cost: numeric("reserved_base_cost", { precision: 16, scale: 6 }).notNull(),
+    actual_base_cost: numeric("actual_base_cost", { precision: 16, scale: 6 }).notNull(),
+    markup_percentage: numeric("markup_percentage", { precision: 12, scale: 6 }).notNull(),
+    reserved_total_cost: numeric("reserved_total_cost", { precision: 16, scale: 6 }).notNull(),
+    actual_total_cost: numeric("actual_total_cost", { precision: 16, scale: 6 }).notNull(),
+    organization_adjustment: numeric("organization_adjustment", {
+      precision: 16,
+      scale: 6,
+    }).notNull(),
+    creator_adjustment: numeric("creator_adjustment", { precision: 16, scale: 6 }).notNull(),
+    platform_adjustment: numeric("platform_adjustment", { precision: 16, scale: 6 }).notNull(),
+    credit_transaction_id: uuid("credit_transaction_id"),
+    redeemable_ledger_entry_id: uuid("redeemable_ledger_entry_id"),
+    app_earnings_transaction_id: uuid("app_earnings_transaction_id"),
+    settled_at: timestamp("settled_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    organization_fk: foreignKey({
+      name: "app_reservation_settlements_organization_fk",
+      columns: [table.organization_id],
+      foreignColumns: [organizations.id],
+    }).onDelete("restrict"),
+    reservation_tenant_fk: foreignKey({
+      name: "app_reservation_settlements_reservation_tenant_fk",
+      columns: [table.reservation_transaction_id, table.organization_id],
+      foreignColumns: [creditTransactions.id, creditTransactions.organization_id],
+    }).onDelete("restrict"),
+    adjustment_tenant_fk: foreignKey({
+      name: "app_reservation_settlements_adjustment_tenant_fk",
+      columns: [table.credit_transaction_id, table.organization_id],
+      foreignColumns: [creditTransactions.id, creditTransactions.organization_id],
+    }).onDelete("restrict"),
+    source_check: check(
+      "app_reservation_settlements_source_check",
+      sql`${table.terminal_source} IN ('provider','stale_sweep')`,
+    ),
+    outcome_check: check(
+      "app_reservation_settlements_outcome_check",
+      sql`${table.outcome} IN ('refund','overage','uncollected_overage','none')`,
+    ),
+    economics_check: check(
+      "app_reservation_settlements_economics_check",
+      sql`${table.reserved_base_cost} >= 0 AND ${table.actual_base_cost} >= 0 AND ${table.markup_percentage} >= 0 AND ${table.reserved_total_cost} >= 0 AND ${table.actual_total_cost} >= 0`,
+    ),
+    org_time_idx: index("app_reservation_settlements_org_time_idx").on(
+      table.organization_id,
+      table.settled_at,
+    ),
+  }),
+);
+
+export type AppReservationSettlement = InferSelectModel<typeof appReservationSettlements>;
+export type NewAppReservationSettlement = InferInsertModel<typeof appReservationSettlements>;
+
+/** Fail-closed terminal markers for pre-authority rows whose economics cannot be reconstructed. */
+export const appReservationSettlementQuarantines = pgTable(
+  "app_reservation_settlement_quarantines",
+  {
+    reservation_transaction_id: uuid("reservation_transaction_id").primaryKey(),
+    organization_id: uuid("organization_id").notNull(),
+    app_id: text("app_id").notNull(),
+    user_id: text("user_id").notNull(),
+    creator_user_id: text("creator_user_id"),
+    reason: text("reason").notNull(),
+    quarantined_at: timestamp("quarantined_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    organization_fk: foreignKey({
+      name: "app_reservation_settlement_quarantines_organization_fk",
+      columns: [table.organization_id],
+      foreignColumns: [organizations.id],
+    }).onDelete("restrict"),
+    reservation_tenant_fk: foreignKey({
+      name: "app_reservation_settlement_quarantines_reservation_tenant_fk",
+      columns: [table.reservation_transaction_id, table.organization_id],
+      foreignColumns: [creditTransactions.id, creditTransactions.organization_id],
+    }).onDelete("restrict"),
+    reason_check: check(
+      "app_reservation_settlement_quarantines_reason_check",
+      sql`${table.reason} = 'pre_authority_economics_unreconstructable'`,
+    ),
+  }),
+);

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -40,6 +40,7 @@ export * from "./app-domains";
 export * from "./app-earnings";
 export * from "./app-frontend-deployments";
 export * from "./app-image-generation-idempotency";
+export * from "./app-reservation-settlements";
 export * from "./app-reviews";
 export * from "./app-usage-projections";
 export * from "./apps";

--- a/packages/cloud/shared/src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts
@@ -48,9 +48,13 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
 import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import {
+  appReservationSettlementQuarantines,
+  appReservationSettlements,
+} from "../../../db/schemas/app-reservation-settlements";
 import {
   appDeploymentStatusEnum,
   appReviewStatusEnum,
@@ -58,6 +62,7 @@ import {
   appUsers,
   userDatabaseStatusEnum,
 } from "../../../db/schemas/apps";
+import { autoTopUpAttempts } from "../../../db/schemas/auto-top-up-attempts";
 import { creditTransactions } from "../../../db/schemas/credit-transactions";
 import { organizations } from "../../../db/schemas/organizations";
 import {
@@ -204,6 +209,12 @@ async function holdSettledAt(holdId: string): Promise<Date | null> {
   return row?.settled_at ?? null;
 }
 
+async function settlementReceipt(holdId: string) {
+  return dbWrite.query.appReservationSettlements.findFirst({
+    where: eq(appReservationSettlements.reservation_transaction_id, holdId),
+  });
+}
+
 beforeAll(async () => {
   try {
     ({ appCreditsService } = await import("../app-credits"));
@@ -215,6 +226,9 @@ beforeAll(async () => {
       appUsers,
       appEarnings,
       appEarningsTransactions,
+      appReservationSettlements,
+      appReservationSettlementQuarantines,
+      autoTopUpAttempts,
       redeemableEarnings,
       redeemableEarningsLedger,
       redeemedEarningsTracking,
@@ -344,6 +358,15 @@ describe("stale-reservation sweep vs app-chat settle lane (#11683)", () => {
     expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.02, 6);
     expect(await appCreatorEarningsCounter(appId)).toBeCloseTo(0.02, 6);
     expect(await refundRows(payerOrgId)).toHaveLength(1);
+    expect(await settlementReceipt(holdId)).toMatchObject({
+      terminal_source: "stale_sweep",
+      outcome: "refund",
+      actual_base_cost: "0.020000",
+      organization_id: payerOrgId,
+      app_id: appId,
+      user_id: payerUserId,
+      creator_user_id: creatorUserId,
+    });
   });
 
   test("stale sweep refunds the original payer org even if the user moved orgs", async () => {
@@ -450,6 +473,232 @@ describe("stale-reservation sweep vs app-chat settle lane (#11683)", () => {
 
     // The sweep must not touch the settled hold — no second refund.
     await creditsService.sweepStaleReservations();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+    expect(await refundRows(payerOrgId)).toHaveLength(1);
+    expect(await settlementReceipt(holdId)).toMatchObject({
+      terminal_source: "provider",
+      outcome: "refund",
+      actual_base_cost: "0.010000",
+    });
+  });
+
+  test("pre-authority quarantined settlement makes provider-late delivery a durable no-op", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+    const historicalHold = await dbWrite.query.creditTransactions.findFirst({
+      where: eq(creditTransactions.id, holdId),
+    });
+    expect(historicalHold).toBeTruthy();
+    await dbWrite
+      .update(creditTransactions)
+      .set({
+        metadata: {
+          ...(historicalHold?.metadata ?? {}),
+          appId: appId.toUpperCase(),
+          userId: payerUserId.toUpperCase(),
+          creatorUserId: creatorUserId.toUpperCase(),
+        },
+        settled_at: new Date(),
+      })
+      .where(eq(creditTransactions.id, holdId));
+    await dbWrite.insert(appReservationSettlementQuarantines).values({
+      reservation_transaction_id: holdId,
+      organization_id: payerOrgId,
+      app_id: appId,
+      user_id: payerUserId,
+      creator_user_id: creatorUserId,
+      reason: "pre_authority_economics_unreconstructable",
+    });
+
+    const beforeOrg = await orgBalance(payerOrgId);
+    const beforeCreator = await creatorBalance(creatorUserId);
+    const result = await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      organizationId: payerOrgId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.005,
+      description: "provider-late after authority cutover",
+      reservationTransactionId: holdId,
+    });
+
+    expect(result).toMatchObject({
+      reconciled: false,
+      difference: 0,
+      action: "none",
+      adjustedAmount: 0,
+    });
+    expect(await orgBalance(payerOrgId)).toBe(beforeOrg);
+    expect(await creatorBalance(creatorUserId)).toBe(beforeCreator);
+    expect(await refundRows(payerOrgId)).toHaveLength(0);
+    expect(await settlementReceipt(holdId)).toBeUndefined();
+    await creditsService.sweepStaleReservations();
+    expect(await orgBalance(payerOrgId)).toBe(beforeOrg);
+  });
+
+  test("concurrent sweep/provider settlement has one durable winner and duplicate delivery replays it", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+
+    await Promise.all([
+      creditsService.sweepStaleReservations(),
+      appCreditsService.reconcileCredits({
+        appId,
+        userId: payerUserId,
+        estimatedBaseCost: 0.03,
+        actualBaseCost: 0.01,
+        description: "concurrent provider settle",
+        reservationTransactionId: holdId,
+      }),
+    ]);
+    const receipt = await settlementReceipt(holdId);
+    expect(receipt).toBeTruthy();
+    expect(await refundRows(payerOrgId)).toHaveLength(1);
+
+    await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.005,
+      description: "duplicate with a third amount",
+      reservationTransactionId: holdId,
+    });
+    expect(await settlementReceipt(holdId)).toEqual(receipt);
+    expect(await refundRows(payerOrgId)).toHaveLength(1);
+    const expectedCreator = receipt?.actual_base_cost === "0.010000" ? 0.01 : 0.02;
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(expectedCreator, 6);
+  });
+
+  test("provider-first overage and insufficient overage each become terminal receipts", async () => {
+    if (!pgliteReady) return;
+    const first = await seed();
+    const firstHold = await openRouteShapedHold({
+      appId: first.appId,
+      userId: first.payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+    await appCreditsService.reconcileCredits({
+      appId: first.appId,
+      userId: first.payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.04,
+      description: "provider overage",
+      reservationTransactionId: firstHold,
+    });
+    expect(await settlementReceipt(firstHold)).toMatchObject({
+      terminal_source: "provider",
+      outcome: "overage",
+      actual_base_cost: "0.040000",
+      organization_adjustment: "0.020000",
+    });
+    expect(await orgBalance(first.payerOrgId)).toBeCloseTo(99.92, 6);
+    expect(await creatorBalance(first.creatorUserId)).toBeCloseTo(0.04, 6);
+    await appCreditsService.reconcileCredits({
+      appId: first.appId,
+      userId: first.payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.1,
+      description: "different duplicate overage",
+      reservationTransactionId: firstHold,
+    });
+    await creditsService.sweepStaleReservations();
+    expect(await orgBalance(first.payerOrgId)).toBeCloseTo(99.92, 6);
+    expect(await creatorBalance(first.creatorUserId)).toBeCloseTo(0.04, 6);
+
+    const second = await seed();
+    const secondHold = await openRouteShapedHold({
+      appId: second.appId,
+      userId: second.payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+    await dbWrite
+      .update(organizations)
+      .set({ credit_balance: "0.000000" })
+      .where(eq(organizations.id, second.payerOrgId));
+    await appCreditsService.reconcileCredits({
+      appId: second.appId,
+      userId: second.payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.04,
+      description: "uncollected provider overage",
+      reservationTransactionId: secondHold,
+    });
+    expect(await settlementReceipt(secondHold)).toMatchObject({
+      outcome: "uncollected_overage",
+      credit_transaction_id: null,
+      redeemable_ledger_entry_id: null,
+      app_earnings_transaction_id: null,
+    });
+    expect(await orgBalance(second.payerOrgId)).toBe(0);
+    expect(await creatorBalance(second.creatorUserId)).toBeCloseTo(0.03, 6);
+  });
+
+  test("receipt failure rolls every ledger projection back and a retry settles once", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+    await dbWrite.execute(sql`
+      CREATE FUNCTION fail_app_reservation_receipt() RETURNS trigger AS $$
+      BEGIN RAISE EXCEPTION 'injected receipt failure'; END $$ LANGUAGE plpgsql;
+    `);
+    await dbWrite.execute(sql`
+      CREATE TRIGGER fail_app_reservation_receipt
+      BEFORE INSERT ON app_reservation_settlements
+      FOR EACH ROW EXECUTE FUNCTION fail_app_reservation_receipt();
+    `);
+    await expect(
+      appCreditsService.reconcileCredits({
+        appId,
+        userId: payerUserId,
+        estimatedBaseCost: 0.03,
+        actualBaseCost: 0.01,
+        description: "fault-injected settle",
+        reservationTransactionId: holdId,
+      }),
+    ).rejects.toThrow("app_reservation_settlements");
+    expect(await settlementReceipt(holdId)).toBeUndefined();
+    expect(await holdSettledAt(holdId)).toBeNull();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.94, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.03, 6);
+    expect(await refundRows(payerOrgId)).toHaveLength(0);
+
+    await dbWrite.execute(
+      sql`DROP TRIGGER fail_app_reservation_receipt ON app_reservation_settlements`,
+    );
+    await dbWrite.execute(sql`DROP FUNCTION fail_app_reservation_receipt()`);
+    await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.01,
+      description: "retry after rollback",
+      reservationTransactionId: holdId,
+    });
     expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
     expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
     expect(await refundRows(payerOrgId)).toHaveLength(1);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
@@ -70,6 +70,10 @@ import { and, eq } from "drizzle-orm";
 import type { App } from "../../../db/repositories/apps";
 import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
 import {
+  appReservationSettlementQuarantines,
+  appReservationSettlements,
+} from "../../../db/schemas/app-reservation-settlements";
+import {
   appDeploymentStatusEnum,
   appReviewStatusEnum,
   apps,
@@ -200,6 +204,8 @@ beforeAll(async () => {
       appEarnings,
       appEarningsTransactions,
       creditTransactions,
+      appReservationSettlements,
+      appReservationSettlementQuarantines,
       redeemableEarnings,
       redeemableEarningsLedger,
       redeemedEarningsTracking,

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
@@ -30,6 +30,10 @@ import { and, eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
 import { appEarningsRepository } from "../../../db/repositories/app-earnings";
 import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import {
+  appReservationSettlementQuarantines,
+  appReservationSettlements,
+} from "../../../db/schemas/app-reservation-settlements";
 import { appUsageProjections } from "../../../db/schemas/app-usage-projections";
 import {
   appDeploymentStatusEnum,
@@ -278,6 +282,8 @@ beforeAll(async () => {
       redeemableEarningsLedger,
       redeemedEarningsTracking,
       creditTransactions,
+      appReservationSettlements,
+      appReservationSettlementQuarantines,
       appUsageProjections,
       appDeploymentStatusEnum,
       appReviewStatusEnum,
@@ -674,8 +680,8 @@ describe("creator movement retry healing", () => {
       appEarningsRepository.applyCreatorMovement.bind(appEarningsRepository);
     let loseAcknowledgement = true;
     const projectionSpy = spyOn(appEarningsRepository, "applyCreatorMovement").mockImplementation(
-      async (params) => {
-        const result = await originalProjection(params);
+      async (params, transaction) => {
+        const result = await originalProjection(params, transaction);
         if (loseAcknowledgement) {
           loseAcknowledgement = false;
           throw new Error("simulated reservation projection acknowledgement loss");
@@ -843,8 +849,8 @@ describe("creator movement retry healing", () => {
       appEarningsRepository.applyCreatorMovement.bind(appEarningsRepository);
     let loseAcknowledgement = true;
     const projectionSpy = spyOn(appEarningsRepository, "applyCreatorMovement").mockImplementation(
-      async (params) => {
-        const result = await originalProjection(params);
+      async (params, transaction) => {
+        const result = await originalProjection(params, transaction);
         if (loseAcknowledgement) {
           loseAcknowledgement = false;
           throw new Error("simulated projection commit acknowledgement loss");

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
@@ -49,6 +49,10 @@ import { and, eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
 import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
 import {
+  appReservationSettlementQuarantines,
+  appReservationSettlements,
+} from "../../../db/schemas/app-reservation-settlements";
+import {
   appDeploymentStatusEnum,
   appReviewStatusEnum,
   apps,
@@ -183,6 +187,8 @@ beforeAll(async () => {
       redeemableEarningsLedger,
       redeemedEarningsTracking,
       creditTransactions,
+      appReservationSettlements,
+      appReservationSettlementQuarantines,
       appDeploymentStatusEnum,
       appReviewStatusEnum,
       userDatabaseStatusEnum,

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -5,13 +5,20 @@
 import Decimal from "decimal.js";
 import { and, eq, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
+import { dbWrite, writeTransaction } from "../../db/helpers";
 import { appEarningsRepository } from "../../db/repositories/app-earnings";
 import * as appsRepositoryModule from "../../db/repositories/apps";
 import { type App, appsRepository } from "../../db/repositories/apps";
 import { organizationsRepository } from "../../db/repositories/organizations";
 import { usersRepository } from "../../db/repositories/users";
+import {
+  appReservationSettlementQuarantines,
+  appReservationSettlements,
+} from "../../db/schemas/app-reservation-settlements";
 import { apps, appUsers } from "../../db/schemas/apps";
+import { creditTransactions } from "../../db/schemas/credit-transactions";
 import { organizations } from "../../db/schemas/organizations";
+import { redeemableEarnings } from "../../db/schemas/redeemable-earnings";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { getRequestIdempotencyKey } from "../runtime/request-context";
@@ -206,6 +213,16 @@ function creatorEarningsIdentity(
     sourceId: chargeKey ? `${chargeKey}:${type}:${leg}` : appId,
     dedupeBySourceId: chargeKey !== null,
   };
+}
+
+function normalizeUuidIdentity(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+  ) {
+    return null;
+  }
+  return value.toLowerCase();
 }
 
 /**
@@ -1179,6 +1196,31 @@ export class AppCreditsService {
 
     // Validate metadata size and depth
     const metadata = validateMetadata(rawMetadata, "reconcileCredits");
+    if (reservationTransactionId) {
+      const [candidate] = await dbWrite
+        .select({ metadata: creditTransactions.metadata })
+        .from(creditTransactions)
+        .where(eq(creditTransactions.id, reservationTransactionId))
+        .limit(1);
+      if (!candidate) {
+        throw new Error("App reconciliation reservation does not exist");
+      }
+      if (
+        candidate.metadata.type === "app_chat_reservation" &&
+        candidate.metadata.settlement_marker === APP_CHAT_RESERVATION_SETTLEMENT_MARKER
+      ) {
+        return this.settleAppReservation({
+          appId,
+          userId,
+          organizationId: providedOrganizationId,
+          estimatedBaseCost,
+          actualBaseCost,
+          description,
+          metadata,
+          reservationTransactionId,
+        });
+      }
+    }
     const settlementMetadata = reservationTransactionId
       ? { ...metadata, reservation_transaction_id: reservationTransactionId }
       : metadata;
@@ -1489,6 +1531,330 @@ export class AppCreditsService {
   }
 
   /**
+   * Commits the first terminal app-chat settlement as one database unit. The
+   * reservation lock serializes sweep/provider contenders; a committed receipt
+   * is replayed verbatim even when the loser reports a different actual cost.
+   */
+  private async settleAppReservation(params: {
+    appId: string;
+    userId: string;
+    organizationId?: string;
+    estimatedBaseCost: number;
+    actualBaseCost: number;
+    description: string;
+    metadata?: Record<string, unknown>;
+    reservationTransactionId: string;
+  }): Promise<AppCreditReconciliationResult> {
+    if (!Number.isFinite(params.actualBaseCost) || params.actualBaseCost < 0) {
+      throw new Error("App reservation actual cost must be finite and non-negative");
+    }
+    const terminalSource =
+      params.metadata?.settlement_source === "stale_reservation_sweep"
+        ? ("stale_sweep" as const)
+        : ("provider" as const);
+
+    const outcome = await writeTransaction(async (tx) => {
+      const [reservation] = await tx
+        .select()
+        .from(creditTransactions)
+        .where(eq(creditTransactions.id, params.reservationTransactionId))
+        .for("update")
+        .limit(1);
+      const facts =
+        reservation?.metadata && typeof reservation.metadata === "object"
+          ? reservation.metadata
+          : {};
+      const organizationId = reservation?.organization_id;
+      const reservedBaseValue = facts.reserved_amount ?? facts.baseCost;
+      const reservedBase = new Decimal(String(reservedBaseValue));
+      const markupPercentage = new Decimal(String(facts.markupPercentage ?? 0));
+      const reservedTotal = new Decimal(reservation?.amount ?? Number.NaN).abs();
+      const factAppId = normalizeUuidIdentity(facts.appId);
+      const factUserId = normalizeUuidIdentity(facts.userId);
+      const creatorUserId = normalizeUuidIdentity(facts.creatorUserId);
+      if (
+        !reservation ||
+        reservation.type !== "debit" ||
+        facts.type !== "app_chat_reservation" ||
+        facts.settlement_marker !== APP_CHAT_RESERVATION_SETTLEMENT_MARKER ||
+        !organizationId ||
+        !factAppId ||
+        !factUserId ||
+        factAppId !== normalizeUuidIdentity(params.appId) ||
+        factUserId !== normalizeUuidIdentity(params.userId) ||
+        (params.organizationId !== undefined && params.organizationId !== organizationId) ||
+        !reservedBase.isFinite() ||
+        reservedBase.isNegative() ||
+        !markupPercentage.isFinite() ||
+        markupPercentage.isNegative() ||
+        !reservedTotal.isFinite()
+      ) {
+        throw new Error("App reservation identity or economic facts do not match settlement");
+      }
+
+      const [existing] = await tx
+        .select()
+        .from(appReservationSettlements)
+        .where(
+          eq(appReservationSettlements.reservation_transaction_id, params.reservationTransactionId),
+        )
+        .limit(1);
+      const [legacyQuarantine] = await tx
+        .select()
+        .from(appReservationSettlementQuarantines)
+        .where(
+          eq(
+            appReservationSettlementQuarantines.reservation_transaction_id,
+            params.reservationTransactionId,
+          ),
+        )
+        .limit(1);
+      const [lockedOrg] = await tx
+        .select({ balance: organizations.credit_balance })
+        .from(organizations)
+        .where(eq(organizations.id, organizationId))
+        .for("update")
+        .limit(1);
+      if (!lockedOrg) throw new Error("Reservation organization no longer exists");
+      if (existing) {
+        return {
+          receipt: existing,
+          legacyQuarantine: undefined,
+          newBalance: parseOrgCreditBalance(lockedOrg.balance),
+          claimed: false,
+        };
+      }
+      if (legacyQuarantine) {
+        if (
+          legacyQuarantine.organization_id !== organizationId ||
+          legacyQuarantine.app_id !== factAppId ||
+          legacyQuarantine.user_id !== factUserId ||
+          legacyQuarantine.creator_user_id !== creatorUserId
+        ) {
+          throw new Error("Legacy app reservation quarantine identity does not match hold facts");
+        }
+        return {
+          receipt: undefined,
+          legacyQuarantine,
+          newBalance: parseOrgCreditBalance(lockedOrg.balance),
+          claimed: false,
+        };
+      }
+      if (reservation.settled_at) {
+        throw new Error("Settled app reservation is missing its terminal receipt");
+      }
+      if (!new Decimal(params.estimatedBaseCost).toDecimalPlaces(6).equals(reservedBase)) {
+        throw new Error("App reservation estimated cost differs from immutable hold facts");
+      }
+
+      const expectedReservedTotal = reservedBase
+        .mul(new Decimal(1).plus(markupPercentage.div(100)))
+        .toDecimalPlaces(6);
+      if (!expectedReservedTotal.equals(reservedTotal)) {
+        throw new Error("App reservation total does not match its immutable markup contract");
+      }
+      const actualBase = new Decimal(params.actualBaseCost).toDecimalPlaces(6);
+      const actualTotal = actualBase
+        .mul(new Decimal(1).plus(markupPercentage.div(100)))
+        .toDecimalPlaces(6);
+      const organizationAdjustment = actualTotal.minus(reservedTotal).toDecimalPlaces(6);
+      const creatorAdjustment = actualBase
+        .minus(reservedBase)
+        .mul(markupPercentage)
+        .div(100)
+        .toDecimalPlaces(6);
+      const platformAdjustment = actualBase.minus(reservedBase).toDecimalPlaces(6);
+
+      if (creatorUserId) {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${`redeemable_earnings:${creatorUserId}`}))`,
+        );
+        await tx
+          .select({ userId: redeemableEarnings.user_id })
+          .from(redeemableEarnings)
+          .where(eq(redeemableEarnings.user_id, creatorUserId))
+          .for("update")
+          .limit(1);
+      } else if (!creatorAdjustment.isZero()) {
+        throw new Error("Monetized app reservation is missing its charge-time creator");
+      }
+      const [currentApp] = await tx
+        .select()
+        .from(apps)
+        .where(eq(apps.id, params.appId))
+        .for("update")
+        .limit(1);
+      const accountingApp: AppCreditAccountingApp = {
+        ...(currentApp ?? {}),
+        name: typeof facts.appName === "string" ? facts.appName : params.appId,
+        created_by_user_id: creatorUserId,
+        monetization_enabled: markupPercentage.gt(0),
+        review_status: markupPercentage.gt(0) ? "approved" : "rejected",
+        platform_offset_amount: 0,
+        purchase_share_percentage: 0,
+        inference_markup_percentage: markupPercentage.toNumber(),
+        persistAppEarnings: Boolean(currentApp),
+      };
+      const identityMetadata = {
+        ...params.metadata,
+        reservation_transaction_id: params.reservationTransactionId,
+        idempotencyKey: `app-reservation-settlement:${params.reservationTransactionId}`,
+        terminal_source: terminalSource,
+      };
+
+      let resultOutcome: "refund" | "overage" | "uncollected_overage" | "none" = "none";
+      let creditTransactionId: string | undefined;
+      let redeemableLedgerEntryId: string | undefined;
+      let appEarningsTransactionId: string | undefined;
+      let newBalance = parseOrgCreditBalance(lockedOrg.balance);
+
+      if (organizationAdjustment.lt(0)) {
+        resultOutcome = "refund";
+        if (creatorAdjustment.lt(0) && creatorUserId) {
+          const reversal = await this.reverseCreatorEarnings(
+            params.appId,
+            params.userId,
+            creatorAdjustment.abs().toNumber(),
+            platformAdjustment.abs().toNumber(),
+            "reconcile_refund",
+            identityMetadata,
+            accountingApp,
+            tx,
+          );
+          redeemableLedgerEntryId = reversal.redeemableLedgerEntryId;
+          appEarningsTransactionId = reversal.appEarningsTransactionId;
+        }
+        const refund = await creditsService.refundCredits({
+          organizationId,
+          amount: organizationAdjustment.abs().toFixed(6),
+          description: `App reconciliation refund (${accountingApp.name ?? params.appId})`,
+          stripePaymentIntentId: `reconcile-refund:${params.reservationTransactionId}`,
+          metadata: identityMetadata,
+          db: tx,
+          deferCacheInvalidation: true,
+        });
+        creditTransactionId = refund.transaction.id;
+        newBalance = refund.newBalance;
+      } else if (organizationAdjustment.gt(0)) {
+        if (new Decimal(lockedOrg.balance).gte(organizationAdjustment)) {
+          const debit = await creditsService.reserveAndDeductCredits({
+            organizationId,
+            amount: organizationAdjustment.toNumber(),
+            description: `App reconciliation charge (${accountingApp.name ?? params.appId})`,
+            stripePaymentIntentId: `reconcile-charge:${params.reservationTransactionId}`,
+            metadata: identityMetadata,
+            db: tx,
+            deferPostCommitEffects: true,
+          });
+          if (!debit.success || !debit.transaction) {
+            throw new Error("Locked reservation organization lost its overage debit eligibility");
+          }
+          newBalance = debit.newBalance;
+          resultOutcome = "overage";
+          creditTransactionId = debit.transaction.id;
+          if (creatorAdjustment.gt(0) && creatorUserId) {
+            const earning = await this.recordCreatorEarnings(
+              params.appId,
+              params.userId,
+              "inference_markup",
+              creatorAdjustment.toNumber(),
+              platformAdjustment.toNumber(),
+              "reconcile_charge",
+              identityMetadata,
+              accountingApp,
+              tx,
+            );
+            redeemableLedgerEntryId = earning.redeemableLedgerEntryId;
+            appEarningsTransactionId = earning.appEarningsTransactionId;
+          }
+        } else {
+          resultOutcome = "uncollected_overage";
+        }
+      }
+
+      const [receipt] = await tx
+        .insert(appReservationSettlements)
+        .values({
+          reservation_transaction_id: params.reservationTransactionId,
+          organization_id: organizationId,
+          app_id: params.appId,
+          user_id: params.userId,
+          creator_user_id: creatorUserId,
+          terminal_source: terminalSource,
+          outcome: resultOutcome,
+          reserved_base_cost: reservedBase.toFixed(6),
+          actual_base_cost: actualBase.toFixed(6),
+          markup_percentage: markupPercentage.toFixed(6),
+          reserved_total_cost: reservedTotal.toFixed(6),
+          actual_total_cost: actualTotal.toFixed(6),
+          organization_adjustment: organizationAdjustment.toFixed(6),
+          creator_adjustment: creatorAdjustment.toFixed(6),
+          platform_adjustment: platformAdjustment.toFixed(6),
+          credit_transaction_id: creditTransactionId,
+          redeemable_ledger_entry_id: redeemableLedgerEntryId,
+          app_earnings_transaction_id: appEarningsTransactionId,
+        })
+        .returning();
+      if (!receipt) throw new Error("App reservation settlement receipt was not created");
+      const [settled] = await tx
+        .update(creditTransactions)
+        .set({ settled_at: new Date() })
+        .where(
+          and(
+            eq(creditTransactions.id, params.reservationTransactionId),
+            eq(creditTransactions.organization_id, organizationId),
+            sql`${creditTransactions.settled_at} IS NULL`,
+          ),
+        )
+        .returning({ id: creditTransactions.id });
+      if (!settled) throw new Error("App reservation settlement fence was lost");
+      return { receipt, legacyQuarantine: undefined, newBalance, claimed: true };
+    });
+
+    if (outcome.legacyQuarantine) {
+      return {
+        reconciled: false,
+        difference: 0,
+        action: "none",
+        adjustedAmount: 0,
+        newBalance: outcome.newBalance,
+      };
+    }
+    if (!outcome.receipt) {
+      throw new Error("App reservation settlement completed without terminal authority");
+    }
+    if (outcome.claimed) {
+      await creditsService.invalidateCreditCaches(outcome.receipt.organization_id);
+      if (outcome.receipt.outcome === "overage") {
+        await creditsService.notifyBalanceDecrease(
+          outcome.receipt.organization_id,
+          outcome.newBalance,
+          params.metadata,
+        );
+      }
+    }
+    const organizationAdjustment = new Decimal(outcome.receipt.organization_adjustment);
+    const action =
+      outcome.receipt.outcome === "refund"
+        ? "refund"
+        : outcome.receipt.outcome === "overage" || outcome.receipt.outcome === "uncollected_overage"
+          ? "charge"
+          : "none";
+    return {
+      reconciled: outcome.receipt.outcome === "refund" || outcome.receipt.outcome === "overage",
+      difference: new Decimal(outcome.receipt.actual_base_cost)
+        .minus(outcome.receipt.reserved_base_cost)
+        .toNumber(),
+      action,
+      adjustedAmount:
+        outcome.receipt.outcome === "uncollected_overage"
+          ? 0
+          : organizationAdjustment.abs().toNumber(),
+      newBalance: outcome.newBalance,
+    };
+  }
+
+  /**
    * Read the cached markup config for an app, or fetch + cache it.
    *
    * Caches only the monetization fields (not the per-call computed cost — that
@@ -1605,7 +1971,12 @@ export class AppCreditsService {
     metadata: Record<string, unknown>,
     providedApp?: AppCreditAccountingApp,
     transaction?: DbTransaction,
-  ): Promise<{ deduplicated: boolean; commitState: CreatorEarningsCommitState }> {
+  ): Promise<{
+    deduplicated: boolean;
+    commitState: CreatorEarningsCommitState;
+    redeemableLedgerEntryId?: string;
+    appEarningsTransactionId?: string;
+  }> {
     const app: AppCreditAccountingApp | undefined =
       providedApp ?? (await appsRepository.findById(appId));
     const identity = creatorEarningsIdentity(appId, type, leg, metadata);
@@ -1642,6 +2013,8 @@ export class AppCreditsService {
       return {
         deduplicated: false,
         commitState: { ...commitState, redeemable: "below_ledger_unit" },
+        redeemableLedgerEntryId: undefined,
+        appEarningsTransactionId: undefined,
       };
     }
 
@@ -1736,7 +2109,12 @@ export class AppCreditsService {
     // Synthetic stale-sweep facts can outlive the app FK target. Their
     // redeemable entry remains the authoritative payout record.
     if (app.persistAppEarnings === false) {
-      return { deduplicated: redeemableDeduplicated, commitState };
+      return {
+        deduplicated: redeemableDeduplicated,
+        commitState,
+        redeemableLedgerEntryId: result.ledgerEntryId,
+        appEarningsTransactionId: undefined,
+      };
     }
 
     try {
@@ -1757,7 +2135,12 @@ export class AppCreditsService {
         : await appEarningsRepository.applyCreatorMovement(movement);
       commitState.shadowBalanceRecorded = true;
       commitState.shadowTransactionRecorded = true;
-      return { deduplicated: projection.deduplicated, commitState };
+      return {
+        deduplicated: projection.deduplicated,
+        commitState,
+        redeemableLedgerEntryId: result.ledgerEntryId,
+        appEarningsTransactionId: projection.transaction?.id,
+      };
     } catch (cause) {
       // error-policy:J2 projection acknowledgement ambiguity must retain the
       // redeemable ledger identity and backing charge for keyed retry.
@@ -1782,7 +2165,12 @@ export class AppCreditsService {
     leg: CreatorEarningsReversalLeg,
     metadata: Record<string, unknown>,
     providedApp?: AppCreditAccountingApp,
-  ): Promise<{ deduplicated: boolean }> {
+    transaction?: DbTransaction,
+  ): Promise<{
+    deduplicated: boolean;
+    redeemableLedgerEntryId?: string;
+    appEarningsTransactionId?: string;
+  }> {
     const app: AppCreditAccountingApp | undefined =
       providedApp ?? (await appsRepository.findById(appId));
     const chargeKey =
@@ -1831,6 +2219,7 @@ export class AppCreditsService {
         appCreatorShadowVersion: 1,
         appPlatformRevenueDelta: new Decimal(-platformRevenueAmount).toFixed(6),
       },
+      transaction,
     });
     const redeemableDeduplicated = result.deduplicated === true;
     if (!result.success) {
@@ -1855,24 +2244,34 @@ export class AppCreditsService {
     );
 
     if (app.persistAppEarnings === false) {
-      return { deduplicated: redeemableDeduplicated };
+      return {
+        deduplicated: redeemableDeduplicated,
+        redeemableLedgerEntryId: result.ledgerEntryId,
+      };
     }
 
-    const projection = await appEarningsRepository.applyCreatorMovement({
-      appId,
-      userId,
-      type: "inference_markup",
-      creatorAmount: -amount,
-      platformRevenueAmount: -platformRevenueAmount,
-      description: "Reconciliation adjustment (refund)",
-      metadata: {
-        ...metadata,
-        type: "reconciliation_refund",
+    const projection = await appEarningsRepository.applyCreatorMovement(
+      {
+        appId,
+        userId,
+        type: "inference_markup",
+        creatorAmount: -amount,
+        platformRevenueAmount: -platformRevenueAmount,
+        description: "Reconciliation adjustment (refund)",
+        metadata: {
+          ...metadata,
+          type: "reconciliation_refund",
+        },
+        redeemableLedgerEntryId: result.ledgerEntryId,
+        redeemableDeduplicated,
       },
+      transaction,
+    );
+    return {
+      deduplicated: projection.deduplicated,
       redeemableLedgerEntryId: result.ledgerEntryId,
-      redeemableDeduplicated,
-    });
-    return { deduplicated: projection.deduplicated };
+      appEarningsTransactionId: projection.transaction?.id,
+    };
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -334,6 +334,10 @@ export interface DeductCreditsParams {
 export interface ReserveAndDeductParams extends DeductCreditsParams {
   /** Minimum balance required before deduction (prevents race conditions) */
   minimumBalanceRequired?: number;
+  /** Internal: execute this ledger mutation inside an owning transaction. */
+  db?: SqlExecutor;
+  /** Internal: the owner performs post-commit cache and notification work. */
+  deferPostCommitEffects?: boolean;
 }
 
 interface CreditMutationRow {
@@ -737,6 +741,8 @@ export class CreditsService {
       tokens_consumed,
       minimumBalanceRequired = 0,
       stripePaymentIntentId,
+      db,
+      deferPostCommitEffects = false,
     } = params;
 
     // Authoritative money-write guard: `<= 0` alone lets NaN through (the
@@ -775,7 +781,7 @@ export class CreditsService {
     const stripeId = stripePaymentIntentId ?? null;
 
     const metadataJson = JSON.stringify(metadata ?? {});
-    const rows = await writeTransaction(async (tx) => {
+    const applyMutation = async (tx: SqlExecutor) => {
       const mutationRows = await sqlRows<CreditMutationRow>(
         tx,
         sql`
@@ -857,7 +863,8 @@ export class CreditsService {
         throw new Error("[CreditsService] Deduction claim committed without a balance mutation");
       }
       return mutationRows;
-    });
+    };
+    const rows = db ? await applyMutation(db) : await writeTransaction(applyMutation);
 
     const row = rows[0];
     if (!row?.id && stripePaymentIntentId) {
@@ -908,7 +915,7 @@ export class CreditsService {
 
     return await Promise.resolve(result).then(async (result) => {
       // Invalidate organization cache if balance changed
-      if (result.success) {
+      if (result.success && !deferPostCommitEffects) {
         invalidateOrganizationCache(organizationId).catch((error) => {
           logger.error("[CreditsService] Failed to invalidate org cache:", error);
         });
@@ -1054,7 +1061,15 @@ export class CreditsService {
     transaction: CreditTransaction;
     newBalance: number;
   }> {
-    const { organizationId, amount, description, metadata, stripePaymentIntentId } = params;
+    const {
+      organizationId,
+      amount,
+      description,
+      metadata,
+      stripePaymentIntentId,
+      db,
+      deferCacheInvalidation = false,
+    } = params;
 
     const refundAmount = new Decimal(String(amount));
     if (!refundAmount.isFinite() || !refundAmount.gt(0)) {
@@ -1070,11 +1085,13 @@ export class CreditsService {
       // (applyCreditIncrease dedupes on stripe_payment_intent_id via ON
       // CONFLICT DO NOTHING). (#10846)
       stripePaymentIntentId,
+      db,
+      deferCacheInvalidation: true,
       transactionType: "refund",
     }).then(async (result) => {
-      invalidateOrganizationCache(organizationId).catch((error) => {
-        logger.error("[CreditsService] Failed to invalidate org cache:", error);
-      });
+      if (!deferCacheInvalidation) {
+        await this.invalidateCreditCaches(organizationId);
+      }
       return result;
     });
   }

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -526,6 +526,8 @@ class RedeemableEarningsService {
      * once. Default false preserves the additive reconciliation behavior.
      */
     dedupeBySourceId?: boolean;
+    /** Reuse an owning settlement transaction so every money leg commits together. */
+    transaction?: DbTransaction;
   }): Promise<{
     success: boolean;
     newBalance: number;
@@ -542,6 +544,7 @@ class RedeemableEarningsService {
       metadata = {},
       requireSufficientBalance = false,
       dedupeBySourceId = false,
+      transaction,
     } = params;
 
     if (amount <= 0) {
@@ -561,7 +564,7 @@ class RedeemableEarningsService {
       type: "reconciliation_reduction",
     });
 
-    const result = await dbWrite.transaction(async (tx) => {
+    const apply = async (tx: DbTransaction) => {
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${`redeemable_earnings:${userId}`}))`,
       );
@@ -687,7 +690,8 @@ class RedeemableEarningsService {
         deduplicated: false,
         currentBalance: 0,
       };
-    });
+    };
+    const result = transaction ? await apply(transaction) : await dbWrite.transaction(apply);
 
     if (result.deduplicated) {
       logger.info("[RedeemableEarnings] reduceEarnings deduplicated by sourceId (retry)", {


### PR DESCRIPTION
Fixes #22478.

## Outcome

Makes the first terminal app-chat reservation settlement a durable database authority. A stale sweep that wins before a late provider result, or a provider result that wins before the sweep, now replays the same terminal receipt exactly once instead of retrying a mismatched generic credit idempotency key.

## Design

- Adds migration `0268_app_reservation_settlement_authority` and the immutable `app_reservation_settlements` receipt, snapshotting tenant, app, user, creator, exact six-decimal economics, outcome, source, and committed projection IDs.
- Claims the winner and applies organization refund/overage, creator earnings, app counters, receipt, and `settled_at` in one transaction under reservation -> organization -> creator -> app lock order.
- Replays the stored receipt for duplicate or opposite-order delivery; generic credit idempotency remains strict and mismatched amounts are never accepted.
- Backfills only uniquely reconstructable pre-cutover settlements. Irreconstructable historical terminal rows receive a validated, non-sensitive quarantine authority and replay as a fail-closed terminal no-op without fabricated economics.
- Freezes receipt-backed projection fields. Direct projection deletion/truncation is rejected while existing user/app owner cascades remain valid and retain the immutable receipt evidence.
- Validates tenant and normalized UUID identity at the database and runtime boundaries.

## Exact-head evidence

Head: `9d6bd01593c6238baa8118b3ce12cce494edc90d`

- PGlite migration/cutover/adversarial guard suite: 5 passed, 32 assertions, including receipt-after-quarantine rejection with the single quarantine unchanged.
- App reservation authority/sweep suite: 12 passed, 95 assertions.
- Credit idempotency suite: 19 passed, 96 assertions.
- Hold concurrency suite: 11 passed, 102 assertions.
- Legacy reconciliation suite: 8 passed, 52 assertions.
- Real PostgreSQL migration/trigger/cascade suite: 2 passed, 18 assertions. Both lock orders inspect `pg_blocking_pids` before releasing the winner and prove exactly one terminal authority: receipt-first leaves receipt 1/quarantine 0; quarantine-first rejects the waiting receipt and leaves receipt 0/quarantine 1.
- `drizzle-kit check`: passed.
- Biome on all changed maintained files: passed (12 files).
- `git diff --check origin/develop...HEAD`: passed.
- Scoped shared typecheck reached only existing workspace dependency failures in `plugin-elizacloud` (`@clack/prompts`, `viem/accounts`, `js-tiktoken`, `jose`, `undici`, and `ai`); no changed settlement file emitted a diagnostic.

## Evidence scope

Backend/database-only change: UI screenshots, video, browser console/network logs, and live-model trajectories are N/A. The real artifact inspected is the committed PostgreSQL receipt/projection state and its mutation/cascade behavior.

## Merge gate

Draft for independent exact-head review. Do not merge until the protected staging acceptance for migration 0267 is green.
