### PR TITLE
fix(core): fail closed on unbounded well-formed Unicode walks

### DIFF
--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -482,16 +482,13 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 	});
 
 	it("throws WELL_FORMED_UNBOUNDED before a 20k-deep array can blow the stack", () => {
-		const t0 = performance.now();
 		try {
 			deepToWellFormedUnicode(nestArray(20_000));
 			expect.unreachable("20k-deep array must fail closed");
 		} catch (error) {
-			const ms = performance.now() - t0;
 			expect(error).toBeInstanceOf(ElizaError);
 			expect((error as ElizaError).code).toBe("WELL_FORMED_UNBOUNDED");
 			expect((error as ElizaError).context?.reason).toBe("depth");
-			expect(ms).toBeLessThan(50);
 		}
 	});
 

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -4,12 +4,16 @@
  * slice produced a lone leading surrogate that Cerebras's strict JSON parser
  * rejected with `wrong_api_format`), and the sanitizers must turn any lone
  * surrogate into U+FFFD so a serialized request body never carries a bare
- * \uD8xx escape.
+ * \uD8xx escape. Also covers fail-closed depth / cycle / visit bounds on
+ * `deepToWellFormedUnicode` (origin hung the model-call path with RangeError).
  */
 
 import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.ts";
 import {
 	deepToWellFormedUnicode,
+	MAX_WELL_FORMED_DEPTH,
+	MAX_WELL_FORMED_VISITS,
 	tailWellFormed,
 	toWellFormedUnicode,
 	truncateWellFormed,
@@ -420,5 +424,96 @@ describe("#18025 wire regression: the captured Cerebras failure shape", () => {
 			messages: [{ role: "tool", content: safe }],
 		});
 		expect(LONE_SURROGATE_ESCAPE.test(body)).toBe(false);
+	});
+});
+
+describe("deepToWellFormedUnicode unbounded input", () => {
+	function nestArray(depth: number): unknown {
+		let value: unknown = ["ok"];
+		for (let i = 0; i < depth; i++) {
+			value = [value];
+		}
+		return value;
+	}
+
+	function nestObject(depth: number): unknown {
+		let value: unknown = { s: "ok" };
+		for (let i = 0; i < depth; i++) {
+			value = { child: value };
+		}
+		return value;
+	}
+
+	it("sanitizes an honest nested provider body under the depth cap", () => {
+		const input = nestObject(8);
+		expect(deepToWellFormedUnicode(input)).toBe(input);
+	});
+
+	it("accepts a diamond DAG (shared child is not a cycle)", () => {
+		const shared = { s: "ok" };
+		const input = { a: shared, b: shared };
+		expect(deepToWellFormedUnicode(input)).toBe(input);
+	});
+
+	it("throws WELL_FORMED_UNBOUNDED on a cyclic object", () => {
+		const input: Record<string, unknown> = { a: "ok" };
+		input.self = input;
+		try {
+			deepToWellFormedUnicode(input);
+			expect.unreachable("cyclic object must fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("WELL_FORMED_UNBOUNDED");
+			expect((error as ElizaError).context?.reason).toBe("cycle");
+		}
+	});
+
+	it("throws WELL_FORMED_UNBOUNDED on a cyclic array", () => {
+		const input: unknown[] = ["ok"];
+		input.push(input);
+		try {
+			deepToWellFormedUnicode(input);
+			expect.unreachable("cyclic array must fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("WELL_FORMED_UNBOUNDED");
+			expect((error as ElizaError).context?.reason).toBe("cycle");
+		}
+	});
+
+	it("throws WELL_FORMED_UNBOUNDED before a 20k-deep array can blow the stack", () => {
+		const t0 = performance.now();
+		try {
+			deepToWellFormedUnicode(nestArray(20_000));
+			expect.unreachable("20k-deep array must fail closed");
+		} catch (error) {
+			const ms = performance.now() - t0;
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("WELL_FORMED_UNBOUNDED");
+			expect((error as ElizaError).context?.reason).toBe("depth");
+			expect(ms).toBeLessThan(50);
+		}
+	});
+
+	it(`throws WELL_FORMED_UNBOUNDED at depth ${MAX_WELL_FORMED_DEPTH}`, () => {
+		try {
+			deepToWellFormedUnicode(nestArray(MAX_WELL_FORMED_DEPTH));
+			expect.unreachable("depth cap must fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).context?.reason).toBe("depth");
+		}
+	});
+
+	it("throws WELL_FORMED_UNBOUNDED on a visit-budget array of strings", () => {
+		const input = new Array<string>(MAX_WELL_FORMED_VISITS).fill("ok");
+		try {
+			deepToWellFormedUnicode(input);
+			expect.unreachable("visit budget must fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("WELL_FORMED_UNBOUNDED");
+			expect((error as ElizaError).context?.reason).toBe("visits");
+		}
 	});
 });

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -495,7 +495,13 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 		}
 	});
 
-	it(`throws WELL_FORMED_UNBOUNDED at depth ${MAX_WELL_FORMED_DEPTH}`, () => {
+	it("accepts nesting exactly at the depth cap", () => {
+		// nestArray(n) wraps n times around ["ok"], so n=63 is 64 containers.
+		const input = nestArray(MAX_WELL_FORMED_DEPTH - 1);
+		expect(deepToWellFormedUnicode(input)).toBe(input);
+	});
+
+	it(`throws WELL_FORMED_UNBOUNDED one past depth ${MAX_WELL_FORMED_DEPTH}`, () => {
 		try {
 			deepToWellFormedUnicode(nestArray(MAX_WELL_FORMED_DEPTH));
 			expect.unreachable("depth cap must fail closed");
@@ -503,6 +509,12 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 			expect(error).toBeInstanceOf(ElizaError);
 			expect((error as ElizaError).context?.reason).toBe("depth");
 		}
+	});
+
+	it("accepts a visit count exactly at the budget", () => {
+		// Array node + (MAX-1) strings = MAX visits.
+		const input = new Array<string>(MAX_WELL_FORMED_VISITS - 1).fill("ok");
+		expect(deepToWellFormedUnicode(input)).toBe(input);
 	});
 
 	it("throws WELL_FORMED_UNBOUNDED on a visit-budget array of strings", () => {

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -517,6 +517,39 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 		expect(deepToWellFormedUnicode(input)).toBe(input);
 	});
 
+	it("charges sparse array holes before provider serialization", () => {
+		const exact = new Array(MAX_WELL_FORMED_VISITS - 1);
+		expect(deepToWellFormedUnicode(exact)).toBe(exact);
+
+		const oversized = new Array(MAX_WELL_FORMED_VISITS);
+		expect(() => deepToWellFormedUnicode(oversized)).toThrowError(
+			expect.objectContaining({
+				code: "WELL_FORMED_UNBOUNDED",
+				context: expect.objectContaining({ reason: "visits" }),
+			}),
+		);
+	});
+
+	it("rejects an over-budget object before invoking an enumerable getter", () => {
+		const input: Record<string, unknown> = {};
+		for (let i = 0; i < MAX_WELL_FORMED_VISITS - 1; i++) {
+			input[`key-${i}`] = "ok";
+		}
+		let getterCalls = 0;
+		Object.defineProperty(input, "hostile", {
+			enumerable: true,
+			get() {
+				getterCalls += 1;
+				return "should not run";
+			},
+		});
+
+		expect(() => deepToWellFormedUnicode(input)).toThrow(
+			/WELL_FORMED|visit budget/i,
+		);
+		expect(getterCalls).toBe(0);
+	});
+
 	it("throws WELL_FORMED_UNBOUNDED on a visit-budget array of strings", () => {
 		const input = new Array<string>(MAX_WELL_FORMED_VISITS).fill("ok");
 		try {

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -7,7 +7,19 @@
  * Truncation helpers here never create a lone surrogate, and the sanitizers
  * replace any pre-existing lone surrogate with U+FFFD so a wire request is
  * always well-formed regardless of upstream text handling.
+ *
+ * `deepToWellFormedUnicode` is depth-, visit-, and cycle-bounded. OpenAI and
+ * Anthropic text handlers call it on every request body; on origin a cyclic
+ * object and a 20k-deep array both threw `RangeError: Maximum call stack`
+ * and hung the turn. Over-budget input throws `ElizaError` `WELL_FORMED_UNBOUNDED`.
  */
+
+import { ElizaError } from "../errors.ts";
+
+/** Nesting ceiling. Honest provider bodies are a handful of objects deep. */
+export const MAX_WELL_FORMED_DEPTH = 64;
+/** Node visit ceiling so a wide hostile tree cannot pin a model call. */
+export const MAX_WELL_FORMED_VISITS = 65_536;
 
 const HIGH_SURROGATE_START = 0xd800;
 const HIGH_SURROGATE_END = 0xdbff;
@@ -109,17 +121,49 @@ export function tailWellFormed(text: string, maxLength: number): string {
 	return text.slice(start);
 }
 
+type WalkCtx = {
+	visits: number;
+	visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+	reason: "depth" | "cycle" | "visits",
+	context: Record<string, unknown>,
+): never {
+	const message =
+		reason === "cycle"
+			? "deepToWellFormedUnicode: cyclic object"
+			: reason === "depth"
+				? "deepToWellFormedUnicode: nesting exceeds cap"
+				: "deepToWellFormedUnicode: visit budget exceeded";
+	throw new ElizaError(message, {
+		code: "WELL_FORMED_UNBOUNDED",
+		context: { reason, ...context },
+		severity: "fatal",
+	});
+}
+
+function enterContainer(value: object, depth: number, ctx: WalkCtx): void {
+	if (depth >= MAX_WELL_FORMED_DEPTH) {
+		failUnbounded("depth", { depth, max: MAX_WELL_FORMED_DEPTH });
+	}
+	if (ctx.visiting.has(value)) {
+		failUnbounded("cycle", { depth });
+	}
+	ctx.visiting.add(value);
+}
+
 /**
  * Copy-on-write sanitizer for objects that carry SDK-identifying symbols or
  * function-valued or accessor properties (AI SDK tool schemas and execute
  * callbacks).
  *
- * Unlike the plain-object path in {@link deepToWellFormedUnicode}, this builds
- * a NEW object so the caller's input is never mutated — even if frozen. String
- * enumerable string keys AND values are sanitized; non-enumerable and symbol
- * properties retain their original descriptors; nested enumerable values are
- * routed through {@link deepToWellFormedUnicode} for the same recursive
- * treatment. Returns the same reference when nothing needed sanitizing.
+ * Unlike the plain-object path in {@link walkDeep}, this builds a NEW object so
+ * the caller's input is never mutated — even if frozen. String enumerable
+ * string keys AND values are sanitized; non-enumerable and symbol properties
+ * retain their original descriptors; nested enumerable values are routed
+ * through {@link walkDeep}. Returns the same reference when nothing needed
+ * sanitizing.
  *
  * Key-safety policy mirrors the plain-object branch: the clone is built on a
  * null-prototype staging object with `Object.defineProperty` so an own
@@ -127,14 +171,18 @@ export function tailWellFormed(text: string, maxLength: number): string {
  * after all keys are defined, and a first-write-wins collision policy prevents
  * distinct keys from collapsing onto the same sanitized form.
  */
-function sanitizeObjectPreservingDescriptors<T>(value: T): T {
+function sanitizeObjectPreservingDescriptors<T>(
+	value: T,
+	depth: number,
+	ctx: WalkCtx,
+): T {
 	if (value === null || typeof value !== "object") {
 		return value;
 	}
 	if (Array.isArray(value)) {
 		let changed = false;
 		const next = value.map((item) => {
-			const sanitized = deepToWellFormedUnicode(item);
+			const sanitized = walkDeep(item, depth + 1, ctx);
 			if (sanitized !== item) {
 				changed = true;
 			}
@@ -161,7 +209,7 @@ function sanitizeObjectPreservingDescriptors<T>(value: T): T {
 
 		const sanitizedKey = toWellFormedUnicode(key);
 		const entry = "value" in descriptor ? descriptor.value : source[key];
-		const sanitizedValue = deepToWellFormedUnicode(entry);
+		const sanitizedValue = walkDeep(entry, depth + 1, ctx);
 		if (sanitizedKey !== key || sanitizedValue !== entry) {
 			changed = true;
 		}
@@ -186,36 +234,32 @@ function sanitizeObjectPreservingDescriptors<T>(value: T): T {
 	return (changed ? clone : value) as T;
 }
 
-/**
- * Recursively applies {@link toWellFormedUnicode} to every string in a
- * JSON-shaped value — including **object keys**, which `Object.entries`
- * skips by default. A key containing a lone surrogate (e.g.
- * `{"bad\uD83D": "ok"}`) serializes to the same `\\uD8xx` escape that strict
- * provider JSON parsers reject.
- *
- * The clone is built on a null-prototype object with `Object.defineProperty`
- * so an own `__proto__` key from a JSON-parsed input is preserved as a data
- * member instead of mutating the clone's prototype chain. A collision policy
- * (first-write-wins) prevents two distinct keys from collapsing onto the same
- * sanitized form. Non-plain objects (typed arrays, URLs, class instances such
- * as AI SDK model handles) pass through untouched, and untouched subtrees keep
- * their original references so a clean input returns the same instance.
- * Intended for provider request bodies right before serialization.
- */
-export function deepToWellFormedUnicode<T>(value: T): T {
+function walkDeep<T>(value: T, depth: number, ctx: WalkCtx): T {
+	ctx.visits += 1;
+	if (ctx.visits > MAX_WELL_FORMED_VISITS) {
+		failUnbounded("visits", {
+			visits: ctx.visits,
+			max: MAX_WELL_FORMED_VISITS,
+		});
+	}
 	if (typeof value === "string") {
 		return toWellFormedUnicode(value) as unknown as T;
 	}
 	if (Array.isArray(value)) {
-		let changed = false;
-		const next = value.map((item) => {
-			const sanitized = deepToWellFormedUnicode(item);
-			if (sanitized !== item) {
-				changed = true;
-			}
-			return sanitized;
-		});
-		return (changed ? next : value) as T;
+		enterContainer(value, depth, ctx);
+		try {
+			let changed = false;
+			const next = value.map((item) => {
+				const sanitized = walkDeep(item, depth + 1, ctx);
+				if (sanitized !== item) {
+					changed = true;
+				}
+				return sanitized;
+			});
+			return (changed ? next : value) as T;
+		} finally {
+			ctx.visiting.delete(value);
+		}
 	}
 	if (value !== null && typeof value === "object") {
 		const proto = Object.getPrototypeOf(value);
@@ -239,31 +283,59 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 				);
 			},
 		);
-		if (needsDescriptorPreservingClone) {
-			return sanitizeObjectPreservingDescriptors(value);
-		}
-		let changed = false;
-		const next = Object.create(null) as Record<string, unknown>;
-		for (const [key, entry] of Object.entries(value)) {
-			const sanitizedKey = toWellFormedUnicode(key);
-			const sanitized = deepToWellFormedUnicode(entry);
-			if (sanitizedKey !== key || sanitized !== entry) {
-				changed = true;
+		enterContainer(value, depth, ctx);
+		try {
+			if (needsDescriptorPreservingClone) {
+				return sanitizeObjectPreservingDescriptors(value, depth, ctx);
 			}
-			if (!(sanitizedKey in next)) {
-				Object.defineProperty(next, sanitizedKey, {
-					value: sanitized,
-					writable: true,
-					enumerable: true,
-					configurable: true,
-				});
+			let changed = false;
+			const next = Object.create(null) as Record<string, unknown>;
+			for (const [key, entry] of Object.entries(value)) {
+				const sanitizedKey = toWellFormedUnicode(key);
+				const sanitized = walkDeep(entry, depth + 1, ctx);
+				if (sanitizedKey !== key || sanitized !== entry) {
+					changed = true;
+				}
+				if (!(sanitizedKey in next)) {
+					Object.defineProperty(next, sanitizedKey, {
+						value: sanitized,
+						writable: true,
+						enumerable: true,
+						configurable: true,
+					});
+				}
 			}
+			// Restore the source prototype after defining every own key. Staging on
+			// a null prototype makes `__proto__` safe; restoring afterward preserves
+			// the caller's Object.prototype/null-prototype contract.
+			Object.setPrototypeOf(next, proto);
+			return (changed ? next : value) as T;
+		} finally {
+			ctx.visiting.delete(value);
 		}
-		// Restore the source prototype after defining every own key. Staging on
-		// a null prototype makes `__proto__` safe; restoring afterward preserves
-		// the caller's Object.prototype/null-prototype contract.
-		Object.setPrototypeOf(next, proto);
-		return (changed ? next : value) as T;
 	}
 	return value;
+}
+
+/**
+ * Recursively applies {@link toWellFormedUnicode} to every string in a
+ * JSON-shaped value — including **object keys**, which `Object.entries`
+ * skips by default. A key containing a lone surrogate (e.g.
+ * `{"bad\uD83D": "ok"}`) serializes to the same `\\uD8xx` escape that strict
+ * provider JSON parsers reject.
+ *
+ * The clone is built on a null-prototype object with `Object.defineProperty`
+ * so an own `__proto__` key from a JSON-parsed input is preserved as a data
+ * member instead of mutating the clone's prototype chain. A collision policy
+ * (first-write-wins) prevents two distinct keys from collapsing onto the same
+ * sanitized form. Non-plain objects (typed arrays, URLs, class instances such
+ * as AI SDK model handles) pass through untouched, and untouched subtrees keep
+ * their original references so a clean input returns the same instance.
+ * Intended for provider request bodies right before serialization.
+ *
+ * Depth, visit count, and cycles fail closed with {@link ElizaError}
+ * `WELL_FORMED_UNBOUNDED` so a hostile nest cannot hang the model call.
+ */
+export function deepToWellFormedUnicode<T>(value: T): T {
+	return walkDeep(value, 0, { visits: 0, visiting: new WeakSet<object>() });
 }

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -19,12 +19,11 @@ import { ElizaError } from "../errors.ts";
 /** Nesting ceiling. Honest provider bodies are a handful of objects deep. */
 export const MAX_WELL_FORMED_DEPTH = 64;
 /**
- * Node visit ceiling. Must sit well above an honest OpenAI/Anthropic body
- * (transcript objects plus tool JSON schemas) so the sanitizer does not
- * `fatal` a working turn. Origin completed a 200k-key object in ~123ms;
- * 65,536 was below that. A hostile wide tree still fail-closes.
+ * Node/slot ceiling. Text length does not consume visits, so this still permits
+ * very large transcripts while rejecting pathological object graphs and sparse
+ * arrays before provider serialization must walk them.
  */
-export const MAX_WELL_FORMED_VISITS = 1_048_576;
+export const MAX_WELL_FORMED_VISITS = 65_536;
 
 const HIGH_SURROGATE_START = 0xd800;
 const HIGH_SURROGATE_END = 0xdbff;
@@ -131,6 +130,16 @@ type WalkCtx = {
 	visiting: WeakSet<object>;
 };
 
+function reserveVisits(ctx: WalkCtx, count: number): void {
+	if (count > MAX_WELL_FORMED_VISITS - ctx.visits) {
+		failUnbounded("visits", {
+			visits: ctx.visits + count,
+			max: MAX_WELL_FORMED_VISITS,
+		});
+	}
+	ctx.visits += count;
+}
+
 function failUnbounded(
 	reason: "depth" | "cycle" | "visits",
 	context: Record<string, unknown>,
@@ -180,6 +189,7 @@ function sanitizeObjectPreservingDescriptors<T>(
 	value: T,
 	depth: number,
 	ctx: WalkCtx,
+	ownKeys: readonly (string | symbol)[],
 ): T {
 	if (value === null || typeof value !== "object") {
 		return value;
@@ -187,7 +197,7 @@ function sanitizeObjectPreservingDescriptors<T>(
 	if (Array.isArray(value)) {
 		let changed = false;
 		const next = value.map((item) => {
-			const sanitized = walkDeep(item, depth + 1, ctx);
+			const sanitized = walkDeep(item, depth + 1, ctx, true);
 			if (sanitized !== item) {
 				changed = true;
 			}
@@ -198,7 +208,7 @@ function sanitizeObjectPreservingDescriptors<T>(
 	const source = value as Record<PropertyKey, unknown>;
 	const clone = Object.create(null) as Record<PropertyKey, unknown>;
 	let changed = false;
-	for (const key of Reflect.ownKeys(source)) {
+	for (const key of ownKeys) {
 		const descriptor = Object.getOwnPropertyDescriptor(source, key);
 		if (!descriptor) {
 			continue;
@@ -214,7 +224,7 @@ function sanitizeObjectPreservingDescriptors<T>(
 
 		const sanitizedKey = toWellFormedUnicode(key);
 		const entry = "value" in descriptor ? descriptor.value : source[key];
-		const sanitizedValue = walkDeep(entry, depth + 1, ctx);
+		const sanitizedValue = walkDeep(entry, depth + 1, ctx, true);
 		if (sanitizedKey !== key || sanitizedValue !== entry) {
 			changed = true;
 		}
@@ -239,23 +249,26 @@ function sanitizeObjectPreservingDescriptors<T>(
 	return (changed ? clone : value) as T;
 }
 
-function walkDeep<T>(value: T, depth: number, ctx: WalkCtx): T {
-	ctx.visits += 1;
-	if (ctx.visits > MAX_WELL_FORMED_VISITS) {
-		failUnbounded("visits", {
-			visits: ctx.visits,
-			max: MAX_WELL_FORMED_VISITS,
-		});
-	}
+function walkDeep<T>(
+	value: T,
+	depth: number,
+	ctx: WalkCtx,
+	visitAlreadyReserved = false,
+): T {
+	if (!visitAlreadyReserved) reserveVisits(ctx, 1);
 	if (typeof value === "string") {
 		return toWellFormedUnicode(value) as unknown as T;
 	}
 	if (Array.isArray(value)) {
 		enterContainer(value, depth, ctx);
 		try {
+			// JSON serialization visits every array index, including holes. Reserve
+			// the whole logical length before mapping so a huge sparse array cannot
+			// bypass the budget or reach the provider serializer.
+			reserveVisits(ctx, value.length);
 			let changed = false;
 			const next = value.map((item) => {
-				const sanitized = walkDeep(item, depth + 1, ctx);
+				const sanitized = walkDeep(item, depth + 1, ctx, true);
 				if (sanitized !== item) {
 					changed = true;
 				}
@@ -278,26 +291,32 @@ function walkDeep<T>(value: T, depth: number, ctx: WalkCtx): T {
 		// non-enumerable symbol properties and breaks SDK contract checks
 		// (asSchema throws "schema is not a function"). Sanitize their
 		// string-valued own properties in-place instead (#18081).
-		const needsDescriptorPreservingClone = Reflect.ownKeys(value).some(
-			(key) => {
+		enterContainer(value, depth, ctx);
+		try {
+			const ownKeys = Reflect.ownKeys(value);
+			// Reserve before reading getters or walking children. Descriptor-bearing
+			// objects also copy symbols/non-enumerables, so every own key counts.
+			reserveVisits(ctx, ownKeys.length);
+			const needsDescriptorPreservingClone = ownKeys.some((key) => {
 				const descriptor = Object.getOwnPropertyDescriptor(value, key);
 				return (
 					typeof key === "symbol" ||
 					Boolean(descriptor && !("value" in descriptor)) ||
 					typeof descriptor?.value === "function"
 				);
-			},
-		);
-		enterContainer(value, depth, ctx);
-		try {
+			});
 			if (needsDescriptorPreservingClone) {
-				return sanitizeObjectPreservingDescriptors(value, depth, ctx);
+				return sanitizeObjectPreservingDescriptors(value, depth, ctx, ownKeys);
 			}
 			let changed = false;
 			const next = Object.create(null) as Record<string, unknown>;
-			for (const [key, entry] of Object.entries(value)) {
+			for (const key of ownKeys) {
+				if (typeof key !== "string") continue;
+				const descriptor = Object.getOwnPropertyDescriptor(value, key);
+				if (!descriptor?.enumerable || !("value" in descriptor)) continue;
+				const entry = descriptor.value;
 				const sanitizedKey = toWellFormedUnicode(key);
-				const sanitized = walkDeep(entry, depth + 1, ctx);
+				const sanitized = walkDeep(entry, depth + 1, ctx, true);
 				if (sanitizedKey !== key || sanitized !== entry) {
 					changed = true;
 				}

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -18,8 +18,13 @@ import { ElizaError } from "../errors.ts";
 
 /** Nesting ceiling. Honest provider bodies are a handful of objects deep. */
 export const MAX_WELL_FORMED_DEPTH = 64;
-/** Node visit ceiling so a wide hostile tree cannot pin a model call. */
-export const MAX_WELL_FORMED_VISITS = 65_536;
+/**
+ * Node visit ceiling. Must sit well above an honest OpenAI/Anthropic body
+ * (transcript objects plus tool JSON schemas) so the sanitizer does not
+ * `fatal` a working turn. Origin completed a 200k-key object in ~123ms;
+ * 65,536 was below that. A hostile wide tree still fail-closes.
+ */
+export const MAX_WELL_FORMED_VISITS = 1_048_576;
 
 const HIGH_SURROGATE_START = 0xd800;
 const HIGH_SURROGATE_END = 0xdbff;

--- a/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
@@ -7,7 +7,7 @@
  * client against a loopback Messages API server capturing raw request bytes.
  */
 import { createServer, type Server } from "node:http";
-import type { IAgentRuntime } from "@elizaos/core";
+import { type ElizaError, type IAgentRuntime, MAX_WELL_FORMED_VISITS } from "@elizaos/core";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTextSmall } from "../models";
 
@@ -89,6 +89,21 @@ beforeEach(() => {
 });
 
 describe("#18025: Anthropic request bodies are well-formed strict JSON", () => {
+  it("rejects an oversized sparse response schema before opening a provider request", async () => {
+    const sparseSchema = new Array(MAX_WELL_FORMED_VISITS);
+
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "hello",
+        responseSchema: sparseSchema,
+      } as never)
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNBOUNDED",
+      context: { reason: "visits" },
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
   it("sanitizes a prompt truncated mid-emoji (lone leading surrogate)", async () => {
     const brokenPrompt = "summarize this page 🤖 please".slice(0, 21); // splits 🤖
     expect(LONE_SURROGATE_ESCAPE.test(JSON.stringify(brokenPrompt))).toBe(true);

--- a/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
@@ -9,7 +9,7 @@
  * raw request bytes; the assertions replay a strict parser's view of the body.
  */
 import { createServer, type Server } from "node:http";
-import type { IAgentRuntime } from "@elizaos/core";
+import { type ElizaError, type IAgentRuntime, MAX_WELL_FORMED_VISITS } from "@elizaos/core";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTextSmall } from "../models";
 
@@ -108,6 +108,21 @@ beforeEach(() => {
 });
 
 describe("#18025: request bodies are well-formed strict JSON", () => {
+  it("rejects an oversized sparse response schema before opening a provider request", async () => {
+    const sparseSchema = new Array(MAX_WELL_FORMED_VISITS);
+
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "return structured data",
+        responseSchema: sparseSchema,
+      } as never)
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNBOUNDED",
+      context: { reason: "visits" },
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
   it("sanitizes a prompt truncated mid-emoji (lone leading surrogate)", async () => {
     const brokenPrompt = "summarize this page 🤖 please".slice(0, 21); // splits 🤖
     expect(LONE_SURROGATE_ESCAPE.test(JSON.stringify(brokenPrompt))).toBe(true);


### PR DESCRIPTION
## Problem

`deepToWellFormedUnicode` walked every array/object in a provider request
body with unbounded recursion. No cycle set, no depth cap, no visit budget.
OpenAI and Anthropic text handlers call this on every model request
(`plugins/plugin-openai/models/text.ts`, `plugins/plugin-anthropic/models/text.ts`).

Measured on origin `0717f457296e` (`packages/core/src/utils/well-formed.ts`):

| payload | time | result |
| --- | --- | --- |
| honest nest 8 | 0.30 ms | same reference |
| nestObj 200 / 2000 / 8000 | 1.96 / 1.19 / 4.63 ms | ok |
| nestArr 10000 | 2.40 ms | ok |
| **nestArr 20000** | **1.89 ms** | **RangeError Maximum call stack** |
| **nestObj 40000** | **5.66 ms** | **RangeError** |
| **cyclic object** (`self = self`) | **12.32 ms** | **RangeError** |
| wide 200k keys | 123 ms | ok (CPU pin, not stack) |

Complete hang / stack overflow on the model-call sanitizer, not leftover-tax,
not `#22500` scenario redaction (different host). Occupancy-FREE.

## Change

`MAX_WELL_FORMED_DEPTH = 64`, `MAX_WELL_FORMED_VISITS = 65536`, visiting
`WeakSet` so diamonds are not treated as cycles. Over-budget / cyclic input
throws `ElizaError` `WELL_FORMED_UNBOUNDED` instead of blowing the stack.

## Proof

```
ORIGIN_RED: nestArr 20000 → RangeError 1.89ms
ORIGIN_RED: nestObj 40000 → RangeError 5.66ms
ORIGIN_RED: cyclic object → RangeError 12.32ms
GREEN: honest nest 8 0.30ms; cycle 0.18ms ElizaError; 20k-deep 0.72ms; 40k-deep 0.58ms
bun test packages/core/src/utils/well-formed.test.ts  44/44
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Occupancy-FREE complete hang on `packages/core/src/utils/well-formed.ts`.
Disjoint from `#22500` (scenario report redaction) and `#22486` (Sway a11y tree).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bun test packages/core/src/utils/well-formed.test.ts` 44/44 at this head. Full `bun run verify` not re-run this cycle; change is isolated to the well-formed walk.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused well-formed tests pass post-sync. Full `bun run verify` not re-run this cycle; the diff is isolated to `well-formed.ts` + its test.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Honest provider bodies are a handful of objects deep and far under\n65,536 nodes/slots. A pathologically deep or cyclic payload now fails closed
instead of hanging the model turn. Lone-surrogate sanitizing is unchanged.

# Background

## What does this PR do?

Fails closed when well-formed Unicode sanitizing would recurse without bound,
so a cyclic or 20k-deep provider body cannot RangeError the model-call path.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/well-formed.ts` and `well-formed.test.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```
bun test packages/core/src/utils/well-formed.test.ts
```

# Maintainer validation addendum\n\nAt exact head `df2981e04cd7f44c5a7c3433ee3d21ca1b458b8a`, review found that ordinary `.map()` accounting skipped sparse array holes even though downstream JSON serialization visits every logical slot. The repair now reserves the full logical array length, reserves object keys before reading accessors, and retains the 65,536 node/slot cap. An adversarial 65,536-slot sparse schema now throws `WELL_FORMED_UNBOUNDED` before any SDK request; the exact boundary remains accepted. A 65,536-key object is also rejected before an enumerable getter can execute.\n\nValidation: core focused suite passed 44/44 three consecutive times; OpenAI loopback wire suite 6/6; Anthropic loopback wire suite 5/5; core/OpenAI/Anthropic typechecks passed; all three package lint checks passed (core reports seven pre-existing warnings in `truncation-suffix-reserve-2.test.ts`); the complete core Node/browser/edge/testing build and declaration generation passed. The scheduler-sensitive `<50 ms` assertion was removed after reproducing a 55.6 ms failure under parallel package load; the test continues to require the typed depth error rather than `RangeError`.\n\n# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:df2981e04cd7f44c5a7c3433ee3d21ca1b458b8a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - request-body Unicode sanitizer; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - request-body Unicode sanitizer; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; hang is a recursive walk
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic bun proof: origin cyclic 12.32ms RangeError vs patched 0.18ms ElizaError
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - sanitizer bound only; no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - walk bound; no stored domain artifact
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; the walk is the existing
pre-serialize sanitizer.

## Backend + frontend logs

```
origin SHA 0717f457296ec031e42f540b2229de166dbc64ae
honest nest 8 OK 0.30ms
nestArr 20000 THROW 1.89ms RangeError: Maximum call stack size exceeded.
nestObj 40000 THROW 5.66ms RangeError
cyclic object THROW 12.32ms RangeError
FIXED honest 0.30ms; cycle 0.18ms ElizaError WELL_FORMED_UNBOUNDED; 20k-deep 0.72ms; 40k-deep 0.58ms
bun test packages/core/src/utils/well-formed.test.ts  44 pass 0 fail
```

## Screenshots (before / after) + video walkthrough

N/A - Node sanitizer; no UI.

### Before

### After

### Walkthrough video

N/A - Node sanitizer; no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Focused `bun test packages/core/src/utils/well-formed.test.ts` 44/44 at
`df2981e04cd7`. Full `bun run verify` not re-run this cycle; the diff is
isolated to `well-formed.ts` + its test. Exact-head package build, typechecks, lint checks, and loopback provider tests passed with the pinned Bun 1.3.14 and Node 24.15.0 toolchain.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
