### PR TITLE
fix(core): bound exec-command regex so external content cannot ReDoS

### DIFF
--- a/packages/core/src/features/trust/injection-primitives.ts
+++ b/packages/core/src/features/trust/injection-primitives.ts
@@ -5,7 +5,9 @@
  * obfuscation-aware matching helpers. Both the rich `SecurityModule` advisory
  * detector and the fast deterministic should-respond risk gate
  * (`should-respond-risk-gate.ts`) consume these — there is intentionally NO
- * second pattern set (see issue #9949).
+ * second pattern set (see issue #9949). The external-content `exec` indicator
+ * uses a bounded window: an unbounded `.*` hung the monitor for ~33s on a
+ * 100k-token "exec " flood (origin).
  */
 
 /** Regexes for direct prompt-injection phrasing (multi-language + obfuscation). */
@@ -67,7 +69,7 @@ export const INJECTION_KEYWORDS: readonly string[] = [
  * merely mentions e.g. `rm -rf`. Consumed by the external-content monitor.
  */
 export const EXTERNAL_CONTENT_RISK_PATTERNS: readonly RegExp[] = [
-	/\bexec\b.*command\s*=/i,
+	/\bexec\b.{0,200}command\s*=/i,
 	/elevated\s*=\s*true/i,
 	/rm\s+-rf/i,
 	/delete\s+all\s+(emails?|files?|data)/i,

--- a/packages/core/src/features/trust/injection-primitives.ts
+++ b/packages/core/src/features/trust/injection-primitives.ts
@@ -6,8 +6,8 @@
  * detector and the fast deterministic should-respond risk gate
  * (`should-respond-risk-gate.ts`) consume these — there is intentionally NO
  * second pattern set (see issue #9949). The external-content `exec` indicator
- * uses a bounded window: an unbounded `.*` hung the monitor for ~33s on a
- * 100k-token "exec " flood (origin).
+ * stops each `exec` search at the next `exec`: the legacy `.*` retried the
+ * remaining line from every occurrence and hung on a 100k-character flood.
  */
 
 /** Regexes for direct prompt-injection phrasing (multi-language + obfuscation). */
@@ -69,7 +69,7 @@ export const INJECTION_KEYWORDS: readonly string[] = [
  * merely mentions e.g. `rm -rf`. Consumed by the external-content monitor.
  */
 export const EXTERNAL_CONTENT_RISK_PATTERNS: readonly RegExp[] = [
-	/\bexec\b.{0,200}command\s*=/i,
+	/\bexec\b(?:(?!\bexec\b).)*command\s*=/i,
 	/elevated\s*=\s*true/i,
 	/rm\s+-rf/i,
 	/delete\s+all\s+(emails?|files?|data)/i,

--- a/packages/core/src/security/external-content.test.ts
+++ b/packages/core/src/security/external-content.test.ts
@@ -37,6 +37,22 @@ describe("detectSuspiciousPatterns", () => {
 			detectSuspiciousPatterns("Hi, can we reschedule our meeting?"),
 		).toEqual([]);
 	});
+
+	it("still flags an honest exec command= indicator", () => {
+		expect(
+			detectSuspiciousPatterns("please exec the shell command=ls"),
+		).not.toHaveLength(0);
+	});
+
+	it("does not hang on a 100k-char exec flood", () => {
+		const flood = "exec ".repeat(20_000);
+		const t0 = performance.now();
+		const matches = detectSuspiciousPatterns(flood);
+		const ms = performance.now() - t0;
+		expect(matches).toEqual([]);
+		// Origin `.*` took ~1.3s on this same 100k-char flood.
+		expect(ms).toBeLessThan(200);
+	});
 });
 
 /**

--- a/packages/core/src/security/external-content.test.ts
+++ b/packages/core/src/security/external-content.test.ts
@@ -44,6 +44,14 @@ describe("detectSuspiciousPatterns", () => {
 		).not.toHaveLength(0);
 	});
 
+	it("preserves legacy detection when exec and command are far apart", () => {
+		expect(
+			detectSuspiciousPatterns(
+				`exec ${"untrusted payload ".repeat(1_000)} command=ls`,
+			),
+		).not.toHaveLength(0);
+	});
+
 	it("does not hang on a 100k-char exec flood", () => {
 		const flood = "exec ".repeat(20_000);
 		const t0 = performance.now();


### PR DESCRIPTION
## Problem

`EXTERNAL_CONTENT_RISK_PATTERNS` used `/\bexec\b.*command\s*=/i` on
untrusted email / webhook / web content. `detectSuspiciousPatterns`
already slices to 100k chars, but that is still enough for the unbounded
`.*` to backtrack.

Measured on origin `0717f457296e`:

| flood | time | result |
| --- | --- | --- |
| `"exec ".repeat(20_000)` (100k chars) | **1,265 ms** | no match |
| `"exec ".repeat(50_000)` | **8,120 ms** | no match |
| `"exec ".repeat(100_000)` | **32,972 ms** | no match |

Complete hang on the external-content monitor, not leftover-tax, not
`#22505` recursion, not `#22506` stdio. Occupancy-FREE.

## Change

Linearize the same-line search: `/\bexec\b(?:(?!\bexec\b).)*command\s*=/i`. Each attempt stops at the next `exec`, so repeated tokens cannot rescan the remaining input; arbitrary-distance legacy matches are preserved.

## Proof

```
ORIGIN_RED: 100k-char exec flood 1265ms; 500k-char 32972ms
GREEN: 100k flood 1.69ms; 500k flood 3.16ms, no hang; honest sample still flagged
bun test packages/core/src/security/external-content.test.ts  54/54
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Occupancy-FREE complete hang on
`packages/core/src/features/trust/injection-primitives.ts`
(`EXTERNAL_CONTENT_RISK_PATTERNS`). Disjoint from `#22505` / `#22506`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bun test packages/core/src/security/external-content.test.ts` 54/54 at this head. Full `bun run verify` not re-run this cycle; change is isolated to the exec-command indicator.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused external-content tests pass. Full `bun run verify` not re-run this cycle; the diff is isolated to the exec-command indicator.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. The same-line `exec … command=` semantics are preserved at arbitrary distance. A 100k-char flood no longer hangs the monitor. Detection samples
from the #9949 legacy bank still match.

# Background

## What does this PR do?

Bounds the external-content `exec … command=` regex so a hostile flood
cannot ReDoS the untrusted-content monitor.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/trust/injection-primitives.ts` and
`packages/core/src/security/external-content.test.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```
bun test packages/core/src/security/external-content.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:90cd6cc499b177a93e0e29d1c2e21fbb4831255b -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - regex hang on untrusted content scan; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - regex hang on untrusted content scan; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; hang is a ReDoS scan
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic bun proof: origin 1265ms / 32972ms vs patched 65ms
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - pattern bound; no stored domain artifact
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

```
origin SHA 0717f457296ec031e42f540b2229de166dbc64ae
ORIGIN_RED exec flood n=20000 1265ms
ORIGIN_RED exec flood n=50000 8120ms
ORIGIN_RED exec flood n=100000 32972ms
GREEN: 100k flood 1.69ms; 500k flood 3.16ms; honest "please exec the shell command=ls" still flagged
bun test packages/core/src/security/external-content.test.ts  53 pass 0 fail
```

## Screenshots (before / after) + video walkthrough

N/A - Node regex; no UI.

### Before

### After

### Walkthrough video

N/A - Node regex; no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Focused `bun test packages/core/src/security/external-content.test.ts`
54/54 at `90cd6cc499b1`. Full `bun run verify` not re-run this cycle; the
diff is isolated to the exec-command indicator.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


## Maintainer validation addendum

The final exact head is `90cd6cc499b177a93e0e29d1c2e21fbb4831255b`. The submitted 200-character window was replaced because it introduced a detection false negative. The final regex stops an attempt at the next `exec`, preserving arbitrary-distance same-line matches while preventing repeated suffix rescans. Independent measurements: 100,000-character flood 1.69 ms; 500,000-character flood 3.16 ms; a valid indicator separated by 500,000 characters matched in 74.92 ms. Three consecutive focused runs passed 54/54; core typecheck, 1,318-file Biome scan, and all four core build targets passed.
