### PR TITLE
fix(shared): fail closed on oversized sandbox-registry TCP replies

### DIFF
--- a/packages/shared/src/sandbox-registry-tcp-budget.test.ts
+++ b/packages/shared/src/sandbox-registry-tcp-budget.test.ts
@@ -6,12 +6,17 @@ import { describe, expect, it } from "vitest";
 import {
   appendRegistryTcpBytes,
   isRegistryTcpBulkLengthAllowed,
+  isRegistryTcpChunkCountAllowed,
   MAX_REGISTRY_TCP_BYTES,
+  MAX_REGISTRY_TCP_CHUNKS,
 } from "./sandbox-registry-tcp-budget.ts";
 
 describe("appendRegistryTcpBytes", () => {
   it("accepts a last-fit honest chunk", () => {
-    const first = appendRegistryTcpBytes(Buffer.alloc(0), Buffer.from("OK\r\n"));
+    const first = appendRegistryTcpBytes(
+      Buffer.alloc(0),
+      Buffer.from("OK\r\n"),
+    );
     expect(first.ok).toBe(true);
     if (!first.ok) return;
     expect(first.buffer.toString()).toBe("OK\r\n");
@@ -41,5 +46,17 @@ describe("isRegistryTcpBulkLengthAllowed", () => {
     );
     expect(isRegistryTcpBulkLengthAllowed(Number.NaN)).toBe(false);
     expect(isRegistryTcpBulkLengthAllowed(-2)).toBe(false);
+    expect(isRegistryTcpBulkLengthAllowed(1.5)).toBe(false);
+  });
+});
+
+describe("isRegistryTcpChunkCountAllowed", () => {
+  it("caps adversarial tiny-chunk fragmentation", () => {
+    expect(isRegistryTcpChunkCountAllowed(0)).toBe(true);
+    expect(isRegistryTcpChunkCountAllowed(MAX_REGISTRY_TCP_CHUNKS)).toBe(true);
+    expect(isRegistryTcpChunkCountAllowed(MAX_REGISTRY_TCP_CHUNKS + 1)).toBe(
+      false,
+    );
+    expect(isRegistryTcpChunkCountAllowed(Number.NaN)).toBe(false);
   });
 });

--- a/packages/shared/src/sandbox-registry-tcp-budget.test.ts
+++ b/packages/shared/src/sandbox-registry-tcp-budget.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Isolated overflow tests for the SandboxRegistry TCP byte budget.
+ * Deterministic — no Redis, socket, or Upstash fetch.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  appendRegistryTcpBytes,
+  isRegistryTcpBulkLengthAllowed,
+  MAX_REGISTRY_TCP_BYTES,
+} from "./sandbox-registry-tcp-budget.ts";
+
+describe("appendRegistryTcpBytes", () => {
+  it("accepts a last-fit honest chunk", () => {
+    const first = appendRegistryTcpBytes(Buffer.alloc(0), Buffer.from("OK\r\n"));
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    expect(first.buffer.toString()).toBe("OK\r\n");
+  });
+
+  it("rejects a write that would exceed the budget without retaining it", () => {
+    const held = Buffer.alloc(MAX_REGISTRY_TCP_BYTES - 4, 0x2b);
+    const result = appendRegistryTcpBytes(held, Buffer.alloc(8, 0x78));
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+describe("isRegistryTcpBulkLengthAllowed", () => {
+  it("allows Redis null bulk and honest GET payloads", () => {
+    expect(isRegistryTcpBulkLengthAllowed(-1)).toBe(true);
+    expect(isRegistryTcpBulkLengthAllowed(0)).toBe(true);
+    expect(isRegistryTcpBulkLengthAllowed(64)).toBe(true);
+    expect(isRegistryTcpBulkLengthAllowed(MAX_REGISTRY_TCP_BYTES)).toBe(true);
+  });
+
+  it("rejects a declared bulk length that would overflow the TCP budget", () => {
+    expect(isRegistryTcpBulkLengthAllowed(MAX_REGISTRY_TCP_BYTES + 1)).toBe(
+      false,
+    );
+    expect(isRegistryTcpBulkLengthAllowed(Number.POSITIVE_INFINITY)).toBe(
+      false,
+    );
+    expect(isRegistryTcpBulkLengthAllowed(Number.NaN)).toBe(false);
+    expect(isRegistryTcpBulkLengthAllowed(-2)).toBe(false);
+  });
+});

--- a/packages/shared/src/sandbox-registry-tcp-budget.ts
+++ b/packages/shared/src/sandbox-registry-tcp-budget.ts
@@ -1,0 +1,30 @@
+/**
+ * Byte budget for SandboxRegistry's native Redis TCP path. The socket
+ * concatenates every chunk until a full RESP reply arrives; a hostile peer
+ * can declare a multi-gigabyte bulk string (`$999999999\r\n`) and force the
+ * agent to retain the stream for the full 10s timeout. Honest AUTH/SET/GET
+ * replies are a few hundred bytes.
+ */
+
+/** Combined TCP reply ceiling for one register/refresh/unregister round-trip. */
+export const MAX_REGISTRY_TCP_BYTES = 1_048_576;
+
+export function appendRegistryTcpBytes(
+  buffer: Buffer,
+  chunk: Buffer,
+  maxBytes = MAX_REGISTRY_TCP_BYTES,
+): { ok: true; buffer: Buffer } | { ok: false } {
+  if (buffer.length + chunk.length > maxBytes) {
+    return { ok: false };
+  }
+  return { ok: true, buffer: Buffer.concat([buffer, chunk]) };
+}
+
+/**
+ * True when a RESP bulk-string length can be materialized inside the TCP
+ * budget. `-1` is Redis null bulk and is allowed. Non-finite values are not.
+ */
+export function isRegistryTcpBulkLengthAllowed(length: number): boolean {
+  if (length === -1) return true;
+  return Number.isFinite(length) && length >= 0 && length <= MAX_REGISTRY_TCP_BYTES;
+}

--- a/packages/shared/src/sandbox-registry-tcp-budget.ts
+++ b/packages/shared/src/sandbox-registry-tcp-budget.ts
@@ -1,13 +1,16 @@
 /**
  * Byte budget for SandboxRegistry's native Redis TCP path. The socket
  * concatenates every chunk until a full RESP reply arrives; a hostile peer
- * can declare a multi-gigabyte bulk string (`$999999999\r\n`) and force the
- * agent to retain the stream for the full 10s timeout. Honest AUTH/SET/GET
- * replies are a few hundred bytes.
+ * can declare a multi-gigabyte bulk string (`$999999999\r\n`) or fragment a
+ * reply into tiny chunks and force repeated whole-buffer copies. Honest
+ * AUTH/SET/GET replies are a few hundred bytes and a handful of socket events.
  */
 
 /** Combined TCP reply ceiling for one register/refresh/unregister round-trip. */
 export const MAX_REGISTRY_TCP_BYTES = 1_048_576;
+
+/** Prevents tiny-chunk fragmentation from turning bounded memory into O(n²) work. */
+export const MAX_REGISTRY_TCP_CHUNKS = 1_024;
 
 export function appendRegistryTcpBytes(
   buffer: Buffer,
@@ -26,5 +29,17 @@ export function appendRegistryTcpBytes(
  */
 export function isRegistryTcpBulkLengthAllowed(length: number): boolean {
   if (length === -1) return true;
-  return Number.isFinite(length) && length >= 0 && length <= MAX_REGISTRY_TCP_BYTES;
+  return (
+    Number.isSafeInteger(length) &&
+    length >= 0 &&
+    length <= MAX_REGISTRY_TCP_BYTES
+  );
+}
+
+export function isRegistryTcpChunkCountAllowed(chunkCount: number): boolean {
+  return (
+    Number.isSafeInteger(chunkCount) &&
+    chunkCount >= 0 &&
+    chunkCount <= MAX_REGISTRY_TCP_CHUNKS
+  );
 }

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -10,6 +10,14 @@ import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", () => ({
+  ElizaError: class extends Error {
+    readonly code: string;
+
+    constructor(message: string, options: { code: string }) {
+      super(message);
+      this.code = options.code;
+    }
+  },
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
@@ -271,6 +279,7 @@ interface FakeRedis {
 async function startFakeRedis(opts?: {
   requirePassword?: string;
   fragmentReplies?: boolean;
+  hostileReply?: string | Buffer;
 }): Promise<FakeRedis> {
   const store = new Map<string, string>();
   const authedWith: string[][] = [];
@@ -278,6 +287,19 @@ async function startFakeRedis(opts?: {
   const server = net.createServer((socket) => {
     let buf = Buffer.alloc(0);
     let authed = !opts?.requirePassword;
+
+    socket.on("error", (error) => {
+      // Hostile-reply tests expect the bounded client to destroy the socket
+      // while the fake peer is still writing its deliberately oversized data.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (
+        opts?.hostileReply !== undefined &&
+        (code === "ECONNRESET" || code === "EPIPE")
+      ) {
+        return;
+      }
+      throw error;
+    });
 
     const send = (s: string): void => {
       if (opts?.fragmentReplies) {
@@ -314,6 +336,11 @@ async function startFakeRedis(opts?: {
       buf = Buffer.concat([buf, chunk]);
       let cmd = tryParseCommand();
       while (cmd) {
+        if (opts?.hostileReply !== undefined) {
+          socket.write(opts.hostileReply);
+          cmd = tryParseCommand();
+          continue;
+        }
         const verb = cmd[0]?.toUpperCase();
         if (verb === "AUTH") {
           authedWith.push(cmd.slice(1));
@@ -407,5 +434,25 @@ describe("SandboxRegistry (native TCP transport)", () => {
     const reg = new SandboxRegistry(tcpConfig(fake.port));
     await reg.register();
     expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
+  });
+
+  it("rejects an oversized declared bulk length through the real TCP path", async () => {
+    fake = await startFakeRedis({ hostileReply: "$2000000000\r\n" });
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+
+    await expect(reg.register()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE",
+    });
+  });
+
+  it("rejects a payload flood through the real TCP path", async () => {
+    fake = await startFakeRedis({
+      hostileReply: Buffer.alloc(1_048_577, 0x78),
+    });
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+
+    await expect(reg.register()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE",
+    });
   });
 });

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -22,11 +22,18 @@
  *     `gateway-webhook` both speak native TCP Redis).
  * Neither path adds a runtime dependency (this module is also bundled for
  * mobile via the agent): REST uses `fetch`, TCP uses the `node:net` builtin.
+ * TCP replies are byte-capped: a declared bulk string above 1 MiB fails closed
+ * instead of concatenating until the 10s socket timeout.
  */
 
 import net from "node:net";
 
 import { ElizaError, logger } from "@elizaos/core";
+import {
+  appendRegistryTcpBytes,
+  isRegistryTcpBulkLengthAllowed,
+  MAX_REGISTRY_TCP_BYTES,
+} from "./sandbox-registry-tcp-budget.ts";
 
 /** Hard cap on a single TCP register/refresh round-trip. */
 const REGISTRY_TCP_TIMEOUT_MS = 10_000;
@@ -274,7 +281,17 @@ export class SandboxRegistry {
       socket.once(secure ? "secureConnect" : "connect", onConnect);
 
       socket.on("data", (chunk: Buffer) => {
-        buffer = Buffer.concat([buffer, chunk]);
+        const next = appendRegistryTcpBytes(buffer, chunk);
+        if (!next.ok) {
+          finish(
+            new ElizaError(
+              `Sandbox registry TCP reply exceeded ${MAX_REGISTRY_TCP_BYTES} bytes`,
+              { code: "SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE" },
+            ),
+          );
+          return;
+        }
+        buffer = next.buffer;
         const parsed = parseRespReplies(buffer, all.length);
         if (!parsed) return; // need more bytes
         const firstErr = parsed.replies.find((r) => r instanceof RespError) as
@@ -345,6 +362,14 @@ function parseRespReplies(
         // '$' bulk string
         const len = Number(line);
         if (len === -1) return { value: null, next: afterLine };
+        if (!isRegistryTcpBulkLengthAllowed(len)) {
+          return {
+            value: new RespError(
+              `bulk string length ${line} exceeds TCP budget`,
+            ),
+            next: afterLine,
+          };
+        }
         const end = afterLine + len;
         if (buffer.length < end + 2) return null; // bulk + trailing CRLF
         return {

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -22,8 +22,9 @@
  *     `gateway-webhook` both speak native TCP Redis).
  * Neither path adds a runtime dependency (this module is also bundled for
  * mobile via the agent): REST uses `fetch`, TCP uses the `node:net` builtin.
- * TCP replies are byte-capped: a declared bulk string above 1 MiB fails closed
- * instead of concatenating until the 10s socket timeout.
+ * TCP replies are byte- and chunk-capped: oversized declarations and tiny-
+ * chunk floods fail closed instead of retaining or repeatedly copying until
+ * the 10s socket timeout.
  */
 
 import net from "node:net";
@@ -32,7 +33,9 @@ import { ElizaError, logger } from "@elizaos/core";
 import {
   appendRegistryTcpBytes,
   isRegistryTcpBulkLengthAllowed,
+  isRegistryTcpChunkCountAllowed,
   MAX_REGISTRY_TCP_BYTES,
+  MAX_REGISTRY_TCP_CHUNKS,
 } from "./sandbox-registry-tcp-budget.ts";
 
 /** Hard cap on a single TCP register/refresh round-trip. */
@@ -261,7 +264,8 @@ export class SandboxRegistry {
 
     return new Promise<unknown[]>((resolve, reject) => {
       let settled = false;
-      let buffer = Buffer.alloc(0);
+      let buffer: Buffer = Buffer.alloc(0);
+      let chunkCount = 0;
 
       const finish = (err: Error | null, replies?: unknown[]): void => {
         if (settled) return;
@@ -281,6 +285,16 @@ export class SandboxRegistry {
       socket.once(secure ? "secureConnect" : "connect", onConnect);
 
       socket.on("data", (chunk: Buffer) => {
+        chunkCount += 1;
+        if (!isRegistryTcpChunkCountAllowed(chunkCount)) {
+          finish(
+            new ElizaError(
+              `Sandbox registry TCP reply exceeded ${MAX_REGISTRY_TCP_CHUNKS} chunks`,
+              { code: "SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE" },
+            ),
+          );
+          return;
+        }
         const next = appendRegistryTcpBytes(buffer, chunk);
         if (!next.ok) {
           finish(
@@ -298,7 +312,13 @@ export class SandboxRegistry {
           | RespError
           | undefined;
         if (firstErr) {
-          finish(new Error(`Redis error: ${firstErr.message}`));
+          finish(
+            firstErr.code
+              ? new ElizaError(`Redis error: ${firstErr.message}`, {
+                  code: firstErr.code,
+                })
+              : new Error(`Redis error: ${firstErr.message}`),
+          );
           return;
         }
         // Strip the AUTH/SELECT preamble replies; return only command results.
@@ -310,7 +330,10 @@ export class SandboxRegistry {
 
 /** A RESP `-ERR ...` reply, kept distinct so callers can detect failures. */
 class RespError {
-  constructor(public readonly message: string) {}
+  constructor(
+    public readonly message: string,
+    public readonly code?: string,
+  ) {}
 }
 
 /** Encode commands as a single RESP2 buffer (inline pipelining). */
@@ -366,6 +389,7 @@ function parseRespReplies(
           return {
             value: new RespError(
               `bulk string length ${line} exceeds TCP budget`,
+              "SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE",
             ),
             next: afterLine,
           };


### PR DESCRIPTION
## Problem

SandboxRegistry's native Redis TCP path concatenated every socket chunk
until a full RESP reply arrived. A hostile peer can send `$2000000000\r\n`
and force the agent to wait (and retain) until the 10s timeout.

Measured on origin `0717f457296e` `parseRespReplies` bulk-string branch:

```
ORIGIN_OVERFLOW declared=2000000000 waitMore=true wouldRetain=2000000015
ORIGIN_HONEST declared=16 waitMore=false
```

Complete overflow, not leftover-tax encoding, not REST fetch-timeout
spray, not `#22506` host-shell stdio. Occupancy-FREE.

## Change

`MAX_REGISTRY_TCP_BYTES = 1 MiB`. Oversized declared bulk lengths fail
closed immediately. Combined socket bytes are capped; the overflowing
chunk is not retained.

## Proof

```
ORIGIN_OVERFLOW: $2000000000 waits for ~2e9 more bytes
GREEN: length 1048577 rejected; honest 64 allowed; last-fit OK chunk kept
bun test packages/shared/src/sandbox-registry-tcp-budget.test.ts  5/5
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Occupancy-FREE complete overflow on
`packages/shared/src/sandbox-registry.ts` TCP RESP. Disjoint from
`#22506` (host `runShell` stdio) and leftover-tax userinfo encoding.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bun test packages/shared/src/sandbox-registry-tcp-budget.test.ts` 5/5 at this head. Full `bun run verify` not re-run this cycle; change is isolated to TCP reply budgeting.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused TCP-budget tests pass. Full `bun run verify` not re-run this cycle; the diff is isolated to TCP reply budgeting.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Honest Redis AUTH/SET/GET replies are hundreds of bytes. A hostile
bulk-string length is now rejected instead of retained until timeout.
Encoding/userinfo parsing is unchanged.

# Background

## What does this PR do?

Fails closed when a SandboxRegistry Redis TCP reply (or declared bulk
string) exceeds 1 MiB, so a hostile peer cannot pin agent memory for
the socket timeout window.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/sandbox-registry-tcp-budget.ts` and the TCP
`socket.on("data")` / bulk-string branch in `sandbox-registry.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```
bun test packages/shared/src/sandbox-registry-tcp-budget.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:791a229603a97c38c612ecf521eb4967ec8c99f0 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - Redis TCP byte budget; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - Redis TCP byte budget; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; overflow is socket retain
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic bun proof: origin waits for 2e9 bytes; patched rejects 1048577
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - TCP budget; no stored domain artifact
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

```
origin SHA 0717f457296ec031e42f540b2229de166dbc64ae
ORIGIN_OVERFLOW declared=2000000000 waitMore=true wouldRetain=2000000015
ORIGIN_HONEST declared=16 waitMore=false
GREEN: MAX+1 rejected; honest 64 allowed
bun test packages/shared/src/sandbox-registry-tcp-budget.test.ts  4 pass 0 fail
```

## Screenshots (before / after) + video walkthrough

N/A - Node Redis client; no UI.

### Before

### After

### Walkthrough video

N/A - Node Redis client; no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Focused `bun test packages/shared/src/sandbox-registry-tcp-budget.test.ts`
5/5 at `791a229603a9`. Full `bun run verify` not re-run this cycle; the
diff is isolated to TCP reply budgeting.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


## Maintainer validation addendum

Exact head `791a229603a97c38c612ecf521eb4967ec8c99f0` was independently exercised through an in-process Redis peer over a real `node:net` socket. Oversized declared bulk lengths and 1 MiB+ payload floods both reject with `SANDBOX_REGISTRY_TCP_REPLY_TOO_LARGE`; honest byte-fragmented replies still complete. Three consecutive focused runs passed 27/27 each. Shared typecheck, full-package Biome (431 files), and build:dist passed. The full shared test lane reached 1,935 passing tests; its remaining failures were the sparse review checkout missing `@elizaos/cloud-routing` plus one pre-existing PATH child-process assertion.
