### PR TITLE
fix(agent): fail closed on oversized $include config files

### DIFF
--- a/packages/agent/src/config/include-file-budget.test.ts
+++ b/packages/agent/src/config/include-file-budget.test.ts
@@ -1,12 +1,17 @@
 /**
- * Isolated overflow tests for the `$include` file byte budget. Deterministic —
- * no filesystem, JSON5, or character-config loader.
+ * Exercises the `$include` byte budget through both the real filesystem-backed
+ * config loader and an injected deterministic resolver.
  */
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
 import {
   isIncludeFileTooLarge,
   MAX_INCLUDE_BYTES,
+  readIncludeFileWithinBudget,
 } from "./include-file-budget.ts";
+import { ConfigIncludeError, resolveConfigIncludes } from "./includes.ts";
 
 describe("isIncludeFileTooLarge", () => {
   it("accepts an honest small include", () => {
@@ -16,5 +21,67 @@ describe("isIncludeFileTooLarge", () => {
 
   it("rejects a file one byte over the budget", () => {
     expect(isIncludeFileTooLarge("x".repeat(MAX_INCLUDE_BYTES + 1))).toBe(true);
+  });
+
+  it("counts UTF-8 bytes instead of JavaScript code units", () => {
+    const multibyte = "é".repeat(MAX_INCLUDE_BYTES / 2);
+    expect(isIncludeFileTooLarge(multibyte)).toBe(false);
+    expect(isIncludeFileTooLarge(`${multibyte}x`)).toBe(true);
+  });
+
+  it("rejects an oversized real include before reading it into a string", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-include-"));
+    const readSpy = vi.spyOn(fs, "readSync");
+    try {
+      const includePath = path.join(directory, "oversized.json5");
+      fs.writeFileSync(includePath, Buffer.alloc(MAX_INCLUDE_BYTES + 1, 0x20));
+
+      expect(() =>
+        resolveConfigIncludes(
+          { $include: "./oversized.json5" },
+          path.join(directory, "character.json5"),
+        ),
+      ).toThrowError(ConfigIncludeError);
+      expect(() => readIncludeFileWithinBudget(includePath)).toThrow(
+        `Include file exceeds ${MAX_INCLUDE_BYTES} bytes`,
+      );
+      expect(readSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("loads and parses a real include exactly at the byte limit", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-include-"));
+    try {
+      const includePath = path.join(directory, "exact.json5");
+      const prefix = '{ "name": "exact" }';
+      fs.writeFileSync(
+        includePath,
+        prefix + " ".repeat(MAX_INCLUDE_BYTES - Buffer.byteLength(prefix)),
+      );
+
+      expect(
+        resolveConfigIncludes(
+          { $include: "./exact.json5" },
+          path.join(directory, "character.json5"),
+        ),
+      ).toEqual({ name: "exact" });
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("never parses an oversized value returned by an injected resolver", () => {
+    const parseJson = vi.fn();
+
+    expect(() =>
+      resolveConfigIncludes({ $include: "large.json5" }, "/config/root.json5", {
+        readFile: () => "x".repeat(MAX_INCLUDE_BYTES + 1),
+        parseJson,
+      }),
+    ).toThrow(`Include file exceeds ${MAX_INCLUDE_BYTES} bytes`);
+    expect(parseJson).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/config/include-file-budget.test.ts
+++ b/packages/agent/src/config/include-file-budget.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Isolated overflow tests for the `$include` file byte budget. Deterministic —
+ * no filesystem, JSON5, or character-config loader.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isIncludeFileTooLarge,
+  MAX_INCLUDE_BYTES,
+} from "./include-file-budget.ts";
+
+describe("isIncludeFileTooLarge", () => {
+  it("accepts an honest small include", () => {
+    expect(isIncludeFileTooLarge('{ "name": "ok" }\n')).toBe(false);
+    expect(isIncludeFileTooLarge("x".repeat(MAX_INCLUDE_BYTES))).toBe(false);
+  });
+
+  it("rejects a file one byte over the budget", () => {
+    expect(isIncludeFileTooLarge("x".repeat(MAX_INCLUDE_BYTES + 1))).toBe(true);
+  });
+});

--- a/packages/agent/src/config/include-file-budget.ts
+++ b/packages/agent/src/config/include-file-budget.ts
@@ -1,12 +1,64 @@
 /**
- * Byte budget for `$include` files. `IncludeProcessor.loadFile` reads the
- * whole file then `JSON5.parse`s it; a hostile include can be gigabytes and
- * hang agent boot. Honest character/config fragments are a few kilobytes.
+ * Enforces the byte budget for `$include` files before their contents reach
+ * the config parser. The production reader checks the opened descriptor and
+ * also stops bounded reads, covering ordinary files, growing files, and
+ * streams whose stat size is not useful.
  */
+
+import fs from "node:fs";
 
 /** UTF-8 ceiling for one `$include` file. */
 export const MAX_INCLUDE_BYTES = 1_048_576;
 
+const INCLUDE_READ_CHUNK_BYTES = 64 * 1024;
+
+export class IncludeFileTooLargeError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly maxBytes: number,
+  ) {
+    super(`Include file exceeds ${maxBytes} bytes: ${filePath}`);
+    this.name = "IncludeFileTooLargeError";
+  }
+}
+
 export function isIncludeFileTooLarge(raw: string): boolean {
   return Buffer.byteLength(raw, "utf8") > MAX_INCLUDE_BYTES;
+}
+
+/** Reads at most one byte beyond the limit so an oversized source is never retained. */
+export function readIncludeFileWithinBudget(filePath: string): string {
+  const descriptor = fs.openSync(filePath, "r");
+  try {
+    if (fs.fstatSync(descriptor).size > MAX_INCLUDE_BYTES) {
+      throw new IncludeFileTooLargeError(filePath, MAX_INCLUDE_BYTES);
+    }
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    while (true) {
+      const remainingProbeBytes = MAX_INCLUDE_BYTES + 1 - totalBytes;
+      const buffer = Buffer.allocUnsafe(
+        Math.min(INCLUDE_READ_CHUNK_BYTES, remainingProbeBytes),
+      );
+      const bytesRead = fs.readSync(
+        descriptor,
+        buffer,
+        0,
+        buffer.byteLength,
+        null,
+      );
+      if (bytesRead === 0) break;
+
+      totalBytes += bytesRead;
+      if (totalBytes > MAX_INCLUDE_BYTES) {
+        throw new IncludeFileTooLargeError(filePath, MAX_INCLUDE_BYTES);
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+
+    return Buffer.concat(chunks, totalBytes).toString("utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }

--- a/packages/agent/src/config/include-file-budget.ts
+++ b/packages/agent/src/config/include-file-budget.ts
@@ -1,0 +1,12 @@
+/**
+ * Byte budget for `$include` files. `IncludeProcessor.loadFile` reads the
+ * whole file then `JSON5.parse`s it; a hostile include can be gigabytes and
+ * hang agent boot. Honest character/config fragments are a few kilobytes.
+ */
+
+/** UTF-8 ceiling for one `$include` file. */
+export const MAX_INCLUDE_BYTES = 1_048_576;
+
+export function isIncludeFileTooLarge(raw: string): boolean {
+  return Buffer.byteLength(raw, "utf8") > MAX_INCLUDE_BYTES;
+}

--- a/packages/agent/src/config/includes.ts
+++ b/packages/agent/src/config/includes.ts
@@ -5,11 +5,19 @@
  * { "$include": "./base.json5" }
  * { "$include": ["./a.json5", "./b.json5"] }
  * ```
+ *
+ * Included files are byte-capped before parse. Origin read the whole file
+ * then JSON5.parse'd it with no size budget, so a hostile include could hang
+ * agent boot.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
+import {
+  isIncludeFileTooLarge,
+  MAX_INCLUDE_BYTES,
+} from "./include-file-budget.ts";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -165,6 +173,13 @@ class IncludeProcessor {
         `Failed to read include file: ${includePath} (resolved: ${normalized})`,
         includePath,
         err instanceof Error ? err : undefined,
+      );
+    }
+
+    if (isIncludeFileTooLarge(raw)) {
+      throw new ConfigIncludeError(
+        `Include file exceeds ${MAX_INCLUDE_BYTES} bytes at: ${includePath}`,
+        includePath,
       );
     }
 

--- a/packages/agent/src/config/includes.ts
+++ b/packages/agent/src/config/includes.ts
@@ -6,17 +6,18 @@
  * { "$include": ["./a.json5", "./b.json5"] }
  * ```
  *
- * Included files are byte-capped before parse. Origin read the whole file
- * then JSON5.parse'd it with no size budget, so a hostile include could hang
- * agent boot.
+ * Included files are byte-capped while they are read and checked again before
+ * parse for custom resolvers. This keeps hostile inputs from being retained or
+ * handed to JSON5 during agent boot.
  */
 
-import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import {
+  IncludeFileTooLargeError,
   isIncludeFileTooLarge,
   MAX_INCLUDE_BYTES,
+  readIncludeFileWithinBudget,
 } from "./include-file-budget.ts";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -169,6 +170,13 @@ class IncludeProcessor {
     try {
       raw = this.resolver.readFile(normalized);
     } catch (err) {
+      if (err instanceof IncludeFileTooLargeError) {
+        throw new ConfigIncludeError(
+          `Include file exceeds ${MAX_INCLUDE_BYTES} bytes at: ${includePath}`,
+          includePath,
+          err,
+        );
+      }
       throw new ConfigIncludeError(
         `Failed to read include file: ${includePath} (resolved: ${normalized})`,
         includePath,
@@ -202,7 +210,7 @@ class IncludeProcessor {
 }
 
 const defaultResolver: IncludeResolver = {
-  readFile: (p) => fs.readFileSync(p, "utf-8"),
+  readFile: readIncludeFileWithinBudget,
   parseJson: (raw) => JSON5.parse(raw),
 };
 


### PR DESCRIPTION
## Problem

`IncludeProcessor.loadFile` read the entire `$include` file then
`JSON5.parse`d it with no byte budget. File-include depth is capped at 10;
payload size is not. A hostile include can hang agent boot.

Origin `0717f457296e` `packages/agent/src/config/includes.ts` `loadFile`:

```
raw = this.resolver.readFile(normalized);
parsed = this.resolver.parseJson(raw); // no size check
```

Complete overflow, not leftover-tax, not object-walk recursion (`#22505`),
not TCP reply cap (`#22509`). Occupancy-FREE.

## Change

`MAX_INCLUDE_BYTES = 1 MiB`. Oversized includes throw `ConfigIncludeError`
before parse.

## Proof

```
ORIGIN: readFile + JSON5.parse with no byte check
GREEN: "x".repeat(1048576) allowed; 1048577 rejected
bun test packages/agent/src/config/include-file-budget.test.ts  6/6
```

Did not please-merge.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Occupancy-FREE complete overflow on `$include` file reads.
Disjoint from `#22505` (Unicode walk) and `#22509` (Redis TCP).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused `bun test packages/agent/src/config/include-file-budget.test.ts` 6/6 at this head. Full `bun run verify` not re-run this cycle; change is isolated to include-file budgeting.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused include-budget tests pass. Full `bun run verify` not re-run this cycle; the diff is isolated to include-file budgeting.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Honest character/config fragments are a few kilobytes. A 1 MiB
include is already pathological. Depth/cycle include checks are
unchanged.

# Background

## What does this PR do?

Fails closed when a `$include` file exceeds 1 MiB, so a hostile include
cannot hang agent boot at JSON5.parse.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/config/include-file-budget.ts` and `loadFile` in
`includes.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```
bun test packages/agent/src/config/include-file-budget.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:476d5102b21d654f2f443a797f4f436acc60d213 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - config include byte budget; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - config include byte budget; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; overflow is include-file retain
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic bun proof: origin has no size check; patched rejects 1048577
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - include budget; no stored domain artifact
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

```
origin SHA 0717f457296ec031e42f540b2229de166dbc64ae
ORIGIN: loadFile reads whole include then JSON5.parse with no byte check
GREEN: MAX_INCLUDE_BYTES accepted; MAX+1 rejected
bun test packages/agent/src/config/include-file-budget.test.ts  2 pass 0 fail
```

## Screenshots (before / after) + video walkthrough

N/A - Node config loader; no UI.

### Before

### After

### Walkthrough video

N/A - Node config loader; no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Focused `bun test packages/agent/src/config/include-file-budget.test.ts`
6/6 at `476d5102b21d`. Full `bun run verify` not re-run this cycle; the
diff is isolated to include-file budgeting.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
