### PR TITLE
fix(plugin-agent-skills): accept CRLF frontmatter in parseFrontmatter

### DIFF
--- a/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter, validateFrontmatter } from "./parser.ts";
+
+describe("parseFrontmatter", () => {
+  const lf = [
+    "---",
+    "name: my-skill",
+    "description: A clear description here.",
+    "---",
+    "Body text",
+  ].join("\n");
+
+  const crlf = lf.replace(/\n/g, "\r\n");
+
+  it("parses LF frontmatter", () => {
+    const result = parseFrontmatter(lf);
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.name).toBe("my-skill");
+    expect(result.body.trim()).toBe("Body text");
+  });
+
+  it("parses CRLF frontmatter", () => {
+    const result = parseFrontmatter(crlf);
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.name).toBe("my-skill");
+    expect(result.body.trim()).toBe("Body text");
+  });
+
+  it("returns null frontmatter when block is missing", () => {
+    const result = parseFrontmatter("# just a body");
+    expect(result.frontmatter).toBeNull();
+    expect(result.body).toBe("# just a body");
+  });
+
+  it("handles mixed LF/CRLF in one document", () => {
+    const mixed = "---\r\nname: mixed\r\ndescription: desc\r\n---\n\nBody\r\nhere";
+    const result = parseFrontmatter(mixed);
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.name).toBe("mixed");
+    expect(result.body.trim()).toBe("Body\r\nhere");
+  });
+
+  it("validates parsed frontmatter through validateFrontmatter for CRLF content", () => {
+    const result = validateFrontmatter(
+      parseFrontmatter(crlf).frontmatter ?? null,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
@@ -1,5 +1,10 @@
+/**
+ * Verifies line-ending-safe SKILL.md frontmatter parsing directly and through
+ * the deterministic in-memory storage loader used by runtime discovery.
+ */
 import { describe, expect, it } from "vitest";
 import { parseFrontmatter, validateFrontmatter } from "./parser.ts";
+import { loadSkillFromStorage, MemorySkillStore } from "./storage.ts";
 
 describe("parseFrontmatter", () => {
   const lf = [
@@ -24,6 +29,21 @@ describe("parseFrontmatter", () => {
     expect(result.frontmatter).not.toBeNull();
     expect(result.frontmatter?.name).toBe("my-skill");
     expect(result.body.trim()).toBe("Body text");
+  });
+
+  it("loads a CRLF skill through the storage discovery boundary", async () => {
+    const storage = new MemorySkillStore();
+    await storage.initialize();
+    await storage.loadFromContent("my-skill", crlf);
+
+    const skill = await loadSkillFromStorage(storage, "my-skill");
+
+    expect(skill).toMatchObject({
+      slug: "my-skill",
+      name: "my-skill",
+      description: "A clear description here.",
+      content: crlf,
+    });
   });
 
   it("returns null frontmatter when block is missing", () => {

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -38,8 +38,8 @@ export function parseFrontmatter(content: string): {
 	body: string;
 	raw: string;
 } {
-	// Match frontmatter block
-	const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+	// Match frontmatter block regardless of line-ending style.
+	const match = content.match(/^---(?:\r?\n)([\s\S]*?)(?:\r?\n)---(?:\r?\n)?/);
 
 	if (!match) {
 		return { frontmatter: null, body: content, raw: "" };


### PR DESCRIPTION
# Relates to

Closes #22471.

## What changed

`parseFrontmatter` previously required LF delimiters, so a valid Windows-authored `SKILL.md` using CRLF was treated as if it had no frontmatter and runtime discovery returned `null`.

The parser now accepts LF or CRLF independently at the opening and closing delimiters while preserving the original body bytes and line endings. Review retained this narrow regex approach because normalizing the entire document would unnecessarily rewrite the returned skill body.

Tests cover LF, CRLF, mixed delimiters, missing frontmatter, validation, and the real deterministic `MemorySkillStore -> loadSkillFromStorage` discovery boundary.

## Verification

- Exact reviewed head: `d7f29a37bba484690f1665aebc1681c3631ff650`, rebased onto `origin/develop` `6bd45306a74a19b4f6b71af64421a67985c9af6b`.
- Focused parser/storage suite: 6/6 passed.
- Full package suite with bounded worker count: 258/258 passed across 25 files.
- Package production build: passed (`tsup` plus declaration emit).
- Biome on both changed files: clean.
- `git diff --check`: clean.
- Mutation proof restoring the LF-only regex: 4/6 tests fail, including the storage loader returning `null` for the CRLF skill.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol; StepFun/step-3.7-flash (original contributor, self-reported)
<!-- attribution-row:client -->
- Agent tooling: Codex desktop; hermes-stepfun (original contributor, self-reported)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@6bd45306a74a19b4f6b71af64421a67985c9af6b:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:d7f29a37bba484690f1665aebc1681c3631ff650 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - parser/runtime discovery only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - parser/runtime discovery only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Deterministic parser and storage transcript:

```text
Focused: Test Files 1 passed (1); Tests 6 passed (6)
Full package: Test Files 25 passed (25); Tests 258 passed (258)
Build: tsup ESM build success plus declaration emit
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] CRLF storage-load artifact is asserted directly: slug/name/description/content are returned instead of `null`.

```text
Mutation (LF-only parser): 4 failed | 2 passed
The CRLF storage discovery assertion received null instead of the loaded skill.
The fixed exact head returns the complete skill with the original CRLF content.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

No functional gaps. The full suite was deliberately capped at two workers because concurrent repository validation jobs made the default 25-fork run memory-thrash the host; the same 25 test files all completed green under the bounded worker count.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6bd45306a74a19b4f6b71af64421a67985c9af6b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [security-audio-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6bd45306a74a19b4f6b71af64421a67985c9af6b:packages/skills/skills/contribute-to-eliza"} -->
