### PR TITLE
fix(agent): fail closed on unbounded Solana base58 secrets

### DIFF
--- a/packages/agent/src/api/solana-secret-budget.test.ts
+++ b/packages/agent/src/api/solana-secret-budget.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Isolated overflow tests for the Solana secret character budget.
+ * Deterministic — no wallet import, Noble curves, env, or network.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assertSolanaSecretCharBudget,
+  MAX_SOLANA_SECRET_CHARS,
+  SOLANA_SECRET_TOO_LONG,
+} from "./solana-secret-budget.ts";
+
+describe("assertSolanaSecretCharBudget", () => {
+  it("accepts an honest 64-byte base58 length", () => {
+    expect(() => assertSolanaSecretCharBudget("2".repeat(88))).not.toThrow();
+    expect(() =>
+      assertSolanaSecretCharBudget("2".repeat(MAX_SOLANA_SECRET_CHARS)),
+    ).not.toThrow();
+  });
+
+  it("rejects one character past the budget before any BigInt walk", () => {
+    const t0 = performance.now();
+    expect(() =>
+      assertSolanaSecretCharBudget("2".repeat(MAX_SOLANA_SECRET_CHARS + 1)),
+    ).toThrow(SOLANA_SECRET_TOO_LONG);
+    expect(performance.now() - t0).toBeLessThan(20);
+  });
+
+  it("rejects a 160k hostile payload in well under the origin BigInt hang", () => {
+    const t0 = performance.now();
+    expect(() => assertSolanaSecretCharBudget("2".repeat(160_000))).toThrow(
+      SOLANA_SECRET_TOO_LONG,
+    );
+    expect(performance.now() - t0).toBeLessThan(20);
+  });
+});

--- a/packages/agent/src/api/solana-secret-budget.test.ts
+++ b/packages/agent/src/api/solana-secret-budget.test.ts
@@ -1,20 +1,50 @@
 /**
- * Isolated overflow tests for the Solana secret character budget.
- * Deterministic — no wallet import, Noble curves, env, or network.
+ * Exercises Solana input budgets through their deterministic wallet and
+ * environment-sync entry points without network access.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  assertSolanaBase58CharBudget,
   assertSolanaSecretCharBudget,
+  MAX_SOLANA_BASE58_CHARS,
   MAX_SOLANA_SECRET_CHARS,
+  SOLANA_BASE58_TOO_LONG,
   SOLANA_SECRET_TOO_LONG,
 } from "./solana-secret-budget.ts";
+import { importWallet, validateSolanaPrivateKey } from "./wallet.ts";
+import { syncSolanaPublicKeyEnv } from "./wallet-env-sync.ts";
+
+const originalSolanaPrivateKey = process.env.SOLANA_PRIVATE_KEY;
+const originalSolanaPublicKey = process.env.SOLANA_PUBLIC_KEY;
+const originalWalletPublicKey = process.env.WALLET_PUBLIC_KEY;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  restoreEnv("SOLANA_PRIVATE_KEY", originalSolanaPrivateKey);
+  restoreEnv("SOLANA_PUBLIC_KEY", originalSolanaPublicKey);
+  restoreEnv("WALLET_PUBLIC_KEY", originalWalletPublicKey);
+});
 
 describe("assertSolanaSecretCharBudget", () => {
-  it("accepts an honest 64-byte base58 length", () => {
+  it("accepts the supported secret representations", () => {
     expect(() => assertSolanaSecretCharBudget("2".repeat(88))).not.toThrow();
     expect(() =>
       assertSolanaSecretCharBudget("2".repeat(MAX_SOLANA_SECRET_CHARS)),
     ).not.toThrow();
+    expect(() =>
+      assertSolanaBase58CharBudget("2".repeat(MAX_SOLANA_BASE58_CHARS)),
+    ).not.toThrow();
+
+    const jsonSecret = JSON.stringify(Array.from({ length: 64 }, (_, i) => i));
+    expect(validateSolanaPrivateKey(jsonSecret)).toMatchObject({
+      valid: true,
+      chain: "solana",
+      error: null,
+    });
   });
 
   it("rejects one character past the budget before any BigInt walk", () => {
@@ -31,5 +61,39 @@ describe("assertSolanaSecretCharBudget", () => {
       SOLANA_SECRET_TOO_LONG,
     );
     expect(performance.now() - t0).toBeLessThan(20);
+  });
+
+  it("rejects impossible base58 lengths at the real validation boundary", () => {
+    const result = validateSolanaPrivateKey(
+      "2".repeat(MAX_SOLANA_BASE58_CHARS + 1),
+    );
+    expect(result).toMatchObject({
+      valid: false,
+      chain: "solana",
+      address: null,
+    });
+    expect(result.error).toContain(SOLANA_BASE58_TOO_LONG);
+  });
+
+  it("does not mutate wallet env when import rejects an oversized secret", () => {
+    process.env.SOLANA_PRIVATE_KEY = "existing-private";
+    process.env.SOLANA_PUBLIC_KEY = "existing-public";
+    process.env.WALLET_PUBLIC_KEY = "existing-wallet-public";
+
+    const result = importWallet("solana", "2".repeat(160_000));
+
+    expect(result).toMatchObject({ success: false, chain: "solana" });
+    expect(process.env.SOLANA_PRIVATE_KEY).toBe("existing-private");
+    expect(process.env.SOLANA_PUBLIC_KEY).toBe("existing-public");
+    expect(process.env.WALLET_PUBLIC_KEY).toBe("existing-wallet-public");
+  });
+
+  it("does not mutate public-key env when env sync rejects oversized input", () => {
+    process.env.SOLANA_PUBLIC_KEY = "existing-public";
+    process.env.WALLET_PUBLIC_KEY = "existing-wallet-public";
+
+    expect(syncSolanaPublicKeyEnv("2".repeat(160_000))).toBeNull();
+    expect(process.env.SOLANA_PUBLIC_KEY).toBe("existing-public");
+    expect(process.env.WALLET_PUBLIC_KEY).toBe("existing-wallet-public");
   });
 });

--- a/packages/agent/src/api/solana-secret-budget.ts
+++ b/packages/agent/src/api/solana-secret-budget.ts
@@ -1,0 +1,19 @@
+/**
+ * Character budget for Solana secret and address base58. `base58Decode` in
+ * `wallet.ts` / `wallet-env-sync.ts` does one BigInt multiply per input
+ * character; an 88-character 64-byte secret is honest, but a megabyte of
+ * alphabet text is quadratic and hangs first-time setup / import /
+ * `validatePrivateKey` on the request thread.
+ */
+
+/** Ceiling for one Solana secret or address string (base58 or JSON byte array). */
+export const MAX_SOLANA_SECRET_CHARS = 512;
+
+export const SOLANA_SECRET_TOO_LONG = `Solana secret exceeds ${MAX_SOLANA_SECRET_CHARS} characters`;
+
+/** Throw before BigInt-per-character decode when `value` cannot be an honest key. */
+export function assertSolanaSecretCharBudget(value: string): void {
+  if (value.length > MAX_SOLANA_SECRET_CHARS) {
+    throw new Error(SOLANA_SECRET_TOO_LONG);
+  }
+}

--- a/packages/agent/src/api/solana-secret-budget.ts
+++ b/packages/agent/src/api/solana-secret-budget.ts
@@ -1,19 +1,47 @@
 /**
- * Character budget for Solana secret and address base58. `base58Decode` in
+ * Character budgets for Solana secrets and addresses. `base58Decode` in
  * `wallet.ts` / `wallet-env-sync.ts` does one BigInt multiply per input
  * character; an 88-character 64-byte secret is honest, but a megabyte of
  * alphabet text is quadratic and hangs first-time setup / import /
  * `validatePrivateKey` on the request thread.
  */
 
-/** Ceiling for one Solana secret or address string (base58 or JSON byte array). */
+import { ElizaError } from "@elizaos/core";
+
+/** Ceiling for a Solana secret input, including the supported JSON byte-array form. */
 export const MAX_SOLANA_SECRET_CHARS = 512;
 
+/** Maximum base58 length of a 64-byte Solana secret; addresses are shorter. */
+export const MAX_SOLANA_BASE58_CHARS = 88;
+
 export const SOLANA_SECRET_TOO_LONG = `Solana secret exceeds ${MAX_SOLANA_SECRET_CHARS} characters`;
+export const SOLANA_BASE58_TOO_LONG = `Solana base58 value exceeds ${MAX_SOLANA_BASE58_CHARS} characters`;
+
+function throwBudgetError(
+  value: string,
+  maxChars: number,
+  inputKind: "secret" | "base58",
+): never {
+  throw new ElizaError(
+    inputKind === "secret" ? SOLANA_SECRET_TOO_LONG : SOLANA_BASE58_TOO_LONG,
+    {
+      code: "SOLANA_SECRET_INPUT_TOO_LONG",
+      context: { chars: value.length, maxChars, inputKind },
+      severity: "fatal",
+    },
+  );
+}
 
 /** Throw before BigInt-per-character decode when `value` cannot be an honest key. */
 export function assertSolanaSecretCharBudget(value: string): void {
   if (value.length > MAX_SOLANA_SECRET_CHARS) {
-    throw new Error(SOLANA_SECRET_TOO_LONG);
+    throwBudgetError(value, MAX_SOLANA_SECRET_CHARS, "secret");
+  }
+}
+
+/** Throw before base58 decoding when `value` cannot encode a Solana secret. */
+export function assertSolanaBase58CharBudget(value: string): void {
+  if (value.length > MAX_SOLANA_BASE58_CHARS) {
+    throwBudgetError(value, MAX_SOLANA_BASE58_CHARS, "base58");
   }
 }

--- a/packages/agent/src/api/wallet-env-sync.ts
+++ b/packages/agent/src/api/wallet-env-sync.ts
@@ -6,6 +6,7 @@
  * This file must NOT import from ./wallet.ts or ../config/config.ts.
  */
 import crypto from "node:crypto";
+import { assertSolanaSecretCharBudget } from "./solana-secret-budget.ts";
 
 // ── Base58 (Bitcoin alphabet) — duplicated from wallet.ts to stay leaf-level ─
 
@@ -30,6 +31,7 @@ function base58Encode(data: Buffer | Uint8Array): string {
 }
 
 function base58Decode(str: string): Buffer {
+  assertSolanaSecretCharBudget(str);
   if (str.length === 0) return Buffer.alloc(0);
   let num = 0n;
   for (const c of str) {
@@ -54,6 +56,7 @@ const PLACEHOLDER_RE =
   /^\[?\s*(REDACTED|PLACEHOLDER|T(?:O)D(?:O)|CHANGEME|EMPTY)\s*]?$/i;
 
 function decodeSolanaPrivateKey(key: string): Buffer {
+  assertSolanaSecretCharBudget(key);
   if (PLACEHOLDER_RE.test(key)) {
     throw new Error("placeholder value");
   }

--- a/packages/agent/src/api/wallet-env-sync.ts
+++ b/packages/agent/src/api/wallet-env-sync.ts
@@ -6,7 +6,10 @@
  * This file must NOT import from ./wallet.ts or ../config/config.ts.
  */
 import crypto from "node:crypto";
-import { assertSolanaSecretCharBudget } from "./solana-secret-budget.ts";
+import {
+  assertSolanaBase58CharBudget,
+  assertSolanaSecretCharBudget,
+} from "./solana-secret-budget.ts";
 
 // ── Base58 (Bitcoin alphabet) — duplicated from wallet.ts to stay leaf-level ─
 
@@ -31,7 +34,7 @@ function base58Encode(data: Buffer | Uint8Array): string {
 }
 
 function base58Decode(str: string): Buffer {
-  assertSolanaSecretCharBudget(str);
+  assertSolanaBase58CharBudget(str);
   if (str.length === 0) return Buffer.alloc(0);
   let num = 0n;
   for (const c of str) {

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -22,7 +22,10 @@ import type {
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { resolveStewardCredentialsPath } from "../config/paths.ts";
-import { assertSolanaSecretCharBudget } from "./solana-secret-budget.ts";
+import {
+  assertSolanaBase58CharBudget,
+  assertSolanaSecretCharBudget,
+} from "./solana-secret-budget.ts";
 import { computeValueUsd } from "./wallet-dex-prices.ts";
 
 type StewardAgentPayload = {
@@ -334,7 +337,7 @@ function base58Encode(data: Buffer | Uint8Array): string {
 }
 
 function base58Decode(str: string): Buffer {
-  assertSolanaSecretCharBudget(str);
+  assertSolanaBase58CharBudget(str);
   if (str.length === 0) return Buffer.alloc(0);
   let num = 0n;
   for (const c of str) {

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -22,6 +22,7 @@ import type {
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { resolveStewardCredentialsPath } from "../config/paths.ts";
+import { assertSolanaSecretCharBudget } from "./solana-secret-budget.ts";
 import { computeValueUsd } from "./wallet-dex-prices.ts";
 
 type StewardAgentPayload = {
@@ -333,6 +334,7 @@ function base58Encode(data: Buffer | Uint8Array): string {
 }
 
 function base58Decode(str: string): Buffer {
+  assertSolanaSecretCharBudget(str);
   if (str.length === 0) return Buffer.alloc(0);
   let num = 0n;
   for (const c of str) {
@@ -355,6 +357,7 @@ const PLACEHOLDER_RE =
   /^\[?\s*(REDACTED|PLACEHOLDER|T(?:O)D(?:O)|CHANGEME|EMPTY)\s*]?$/i;
 
 function decodeSolanaPrivateKey(key: string): Buffer {
+  assertSolanaSecretCharBudget(key);
   if (PLACEHOLDER_RE.test(key)) {
     throw new Error("placeholder value");
   }


### PR DESCRIPTION
# Relates to

Closes #22472.

## What changed

Solana key validation used a BigInt multiply for every base58 character. A large alphabet-only input could therefore monopolize the synchronous wallet import/validation path before being rejected.

The original PR correctly introduced a constant-time outer character budget. Review strengthened the implementation at the actual contracts:

- preserve a 512-character envelope for the supported JSON byte-array secret representation;
- cap base58 at 88 characters, the mathematical maximum for a 64-byte Solana secret (32-byte addresses and seeds are shorter);
- throw a structured `ElizaError` with length-only context, never secret contents; and
- exercise validation, import, and public-key environment sync, including proof that rejected input cannot mutate wallet environment state.

## Verification

- Exact reviewed head: `e4c824e31a79b347452158fc14d8ee18dd46ef2b`, rebased onto `origin/develop` `0879608ea5ff701285af710fe0d945a263515604`.
- Focused production-boundary suite: 6/6 passed with pinned Bun 1.3.14 and Node 24.
- Agent production build: passed; 199 emitted relative imports rewritten successfully.
- Biome on all four changed files: clean.
- `git diff --check`: clean.
- Mutation proof restoring the original PR's 512-character base58 behavior: 1/6 repaired tests fails because a 89-character impossible value reaches the decoder and reports a decoded byte length instead of being rejected at the budget boundary.
- Package typecheck is currently blocked by unrelated current-develop missing workspace export/module-resolution errors (`plugin-capacitor-bridge`, `plugin-wallet/diagnostic`, `plugin-pty`, `plugin-video`, `plugin-vision`, `plugin-notes/plugin`, `cloud-routing`, and `plugin-todos/edge`); no diagnostic references a changed file.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol; original contributor model self-reported in prior body
<!-- attribution-row:client -->
- Agent tooling: Codex desktop; original contributor tooling self-reported in prior body
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:e4c824e31a79b347452158fc14d8ee18dd46ef2b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend wallet validation only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend wallet validation only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] Deterministic backend validation transcript:

```text
Test Files  1 passed (1); Tests 6 passed (6)
Build passed and rewrote 199 emitted relative imports
Mutation: 1 failed | 5 passed, proving the 88-character boundary is exercised
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejected secrets fail before persistence and create no domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Automated proof

```text
GREEN
Test Files  1 passed (1)
Tests       6 passed (6)
Build       passed; rewrote 199 emitted relative imports
Biome       Checked 4 files. No fixes applied.

MUTATION RED (original PR's 512-character base58 allowance)
Test Files  1 failed (1)
Tests       1 failed | 5 passed (6)
Expected    Solana base58 value exceeds 88 characters
Received    Must be 32 or 64 bytes, got 65
```

## Known gaps / failures

The package-wide typecheck currently reports only unrelated current-develop workspace export/module-resolution failures listed above. The changed modules compile in the focused Vitest transform and the complete production build.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [security-audio-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza"} -->