### PR TITLE
fix(plugin-mcp): give each tool-generated image a unique attachment id

### DIFF
--- a/plugins/plugin-mcp/src/utils/__tests__/processing.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/processing.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression coverage for `processToolResult`'s attachment ID integrity.
+ * Exercises the real exported helper with a lightweight runtime stub (only
+ * `agentId` is read by `createUniqueUuid`). Guards the contract that every
+ * image `Media` a tool call emits gets a genuinely unique `id`: the UI treats
+ * `Media.id` as a unique handle for React keys and download filenames
+ * (packages/ui/src/components/chat/MessageAttachments.tsx), so colliding ids
+ * produced duplicate keys and identical download names for distinct images
+ * (#22511).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { processToolResult } from "../processing";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const runtime = {
+  agentId: "11111111-1111-1111-1111-111111111111",
+} as unknown as IAgentRuntime;
+
+const messageEntityId = "22222222-2222-2222-2222-222222222222";
+
+function imageContent(data: string) {
+  return { type: "image", mimeType: "image/png", data } as const;
+}
+
+describe("processToolResult attachment ids", () => {
+  it("assigns a distinct id to each image in a multi-image tool result", () => {
+    const { attachments, hasAttachments } = processToolResult(
+      { content: [imageContent("AAAA"), imageContent("BBBB"), imageContent("CCCC")] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+
+    expect(hasAttachments).toBe(true);
+    expect(attachments).toHaveLength(3);
+    const ids = attachments.map((a) => a.id);
+    for (const id of ids) {
+      expect(id).toMatch(UUID_RE);
+    }
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("still yields a single well-formed id for a single-image tool result", () => {
+    const { attachments } = processToolResult(
+      { content: [imageContent("ZZZZ")] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.id).toMatch(UUID_RE);
+    expect(attachments[0]?.url).toBe("data:image/png;base64,ZZZZ");
+  });
+
+  it("does not reuse an id across separate tool calls with different image bytes", () => {
+    const first = processToolResult(
+      { content: [imageContent("AAAA")] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+    const second = processToolResult(
+      { content: [imageContent("DDDD")] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+
+    expect(first.attachments[0]?.id).not.toBe(second.attachments[0]?.id);
+  });
+
+  it("distinguishes two images that share identical bytes within one call", () => {
+    const { attachments } = processToolResult(
+      { content: [imageContent("SAME"), imageContent("SAME")] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0]?.id).not.toBe(attachments[1]?.id);
+  });
+
+  it("emits no attachments and no id churn for a text-only result", () => {
+    const { attachments, hasAttachments, toolOutput } = processToolResult(
+      { content: [{ type: "text", text: "hello" }] },
+      "img-server",
+      "generate_image",
+      runtime,
+      messageEntityId
+    );
+
+    expect(hasAttachments).toBe(false);
+    expect(attachments).toHaveLength(0);
+    expect(toolOutput).toBe("hello");
+  });
+});

--- a/plugins/plugin-mcp/src/utils/processing.ts
+++ b/plugins/plugin-mcp/src/utils/processing.ts
@@ -86,16 +86,27 @@ export function processToolResult(
   let toolOutput = "";
   let hasAttachments = false;
   const attachments: Media[] = [];
+  // Distinguishes each image within one tool result so its `Media.id` is
+  // unique even when several attachments share identical bytes.
+  let imageIndex = 0;
 
   for (const content of result.content) {
     if (content.type === "text" && content.text) {
       toolOutput += content.text;
     } else if (content.type === "image" && content.data && content.mimeType) {
       hasAttachments = true;
+      // Seed the deterministic UUID with values that vary per attachment (the
+      // base64 bytes plus a positional index) rather than the constant
+      // `messageEntityId`. A constant seed gave every image in a batch — and
+      // every tool call by the same user — the same `Media.id`, which the UI
+      // treats as a unique handle for React keys and download filenames
+      // (packages/ui/src/components/chat/MessageAttachments.tsx).
+      const attachmentSeed = `${messageEntityId}:${serverName}/${toolName}:${imageIndex}:${content.data}`;
+      imageIndex += 1;
       attachments.push({
         contentType: getMimeTypeToContentType(content.mimeType),
         url: `data:${content.mimeType};base64,${content.data}`,
-        id: createUniqueUuid(runtime, messageEntityId),
+        id: createUniqueUuid(runtime, attachmentSeed),
         title: "Generated image",
         source: `${serverName}/${toolName}`,
         description: "Tool-generated image",


### PR DESCRIPTION
# Relates to

Closes #22511

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates pass (see Evidence). `bun run verify` was not run whole — see Known gaps.
- [x] A reviewer can confirm the change works without reading the code, from the failing-then-passing reproduction below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0717f457296ec031e42f540b2229de166dbc64ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (0 commits behind at push); zero conflicts.
- [ ] `bun run verify` full run not completed on this machine — see **Known gaps / failures**. Owning-package test, typecheck, and lint all pass.

# Risks

Low. The change is bounded to the single `attachments.push({...})` block in `plugins/plugin-mcp/src/utils/processing.ts`. It only alters the *seed* passed to `createUniqueUuid` for tool-generated image `Media.id`s. `Media.id` is a client-side display/handle field (React key + download filename); it is not a persistence key, so changing its value has no storage or migration impact. Attachment `url`, `contentType`, `title`, `source`, `description`, and `text` are unchanged.

# Background

## What does this PR do?

`processToolResult` built every image `Media` attachment with `id: createUniqueUuid(runtime, messageEntityId)`. `createUniqueUuid` (packages/core/src/entities.ts) is **deterministic** — it returns `stringToUuid(\`${baseUserId}:${agentId}\`)`. Because the seed here was the constant `messageEntityId`:

- when one MCP tool call returns multiple images, **all** of them received the **same** `Media.id`; and
- the id was **identical across every tool call** the same user ever makes.

The UI treats `Media.id` as a unique handle: `packages/ui/src/components/chat/MessageAttachments.tsx` uses `key={att.id}` for every attachment tile and derives the download filename as `${att.id || "attachment"}.${ext}`. Colliding ids therefore produced **duplicate React keys** (unstable/mis-rendered tiles) and **identical download filenames** for distinct images — e.g. an MCP image-generation tool returning a batch. Every other connector (plugin-telegram, plugin-discord) assigns a genuinely unique per-attachment id; MCP was the outlier fabricating a non-unique one.

The fix seeds `createUniqueUuid` with values that vary per attachment — the positional index within the result plus the base64 `content.data` (and server/tool name) — so each image gets a genuinely unique, still-deterministic id. Identical bytes within one batch stay distinct via the index.

## What kind of change is this?

Bug fix (non-breaking change which fixes an ID-integrity defect on the real image-tool path).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior of the public plugin surface is unchanged except that colliding ids are now unique; no documented contract described the old collision.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/src/utils/__tests__/processing.test.ts` — a new regression suite that calls the exported `processToolResult` and asserts attachment-id uniqueness. Run from `plugins/plugin-mcp`:

```bash
npx vitest run src/utils/__tests__/processing.test.ts
```

## Detailed testing steps

The suite covers: (1) three distinct image contents → three distinct well-formed UUID ids; (2) a single-image call still yields one well-formed id and the expected data URL; (3) two separate calls with different image bytes do not reuse an id; (4) two images sharing identical bytes within one call are still distinguished by index; (5) a text-only result emits no attachments. On the pre-fix code, tests (1), (3), and (4) fail because all ids collapse to one constant UUID; after the fix all five pass.

# Evidence Gate

<!-- evidence-head:b58005fced131e44f215d339df373ea128181ff4 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - no rendered UI surface changed in this PR. The defect is server-side ID generation in plugin-mcp; the UI consumer (MessageAttachments.tsx) is unchanged and only referenced to explain user-visible impact.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no rendered UI surface changed (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI flow changed; the contract is exercised by the deterministic failing-then-passing unit reproduction below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — failing-then-passing vitest run of the real `processToolResult` code path:

<details>
<summary>Backend output: before/after reproduction + owning-package test / typecheck / lint logs</summary>

```
BEFORE  (buggy: id = createUniqueUuid(runtime, messageEntityId)) — feeding image bytes AAAA / BBBB / CCCC
 x assigns a distinct id to each image in a multi-image tool result
 x does not reuse an id across separate tool calls with different image bytes
 x distinguishes two images that share identical bytes within one call
   AssertionError: expected 1 to be 3            (new Set(ids).size === 1: all three ids identical)
   AssertionError: expected '343760e3-6ba8-096c-a3b6-a54050685be7'
                not to be '343760e3-6ba8-096c-a3b6-a54050685be7'
 Tests  3 failed | 2 passed (5)

AFTER  (fixed: seed = messageEntityId:server/tool:index:base64bytes) — same AAAA / BBBB / CCCC inputs
 + assigns a distinct id to each image in a multi-image tool result
 + still yields a single well-formed id for a single-image tool result
 + does not reuse an id across separate tool calls with different image bytes
 + distinguishes two images that share identical bytes within one call
 + emits no attachments and no id churn for a text-only result
 Test Files  1 passed (1)
 Tests  5 passed (5)

Owning-package gates (from plugins/plugin-mcp):
$ npx vitest run --no-file-parallelism
 Test Files  15 passed (15)
 Tests  97 passed | 3 skipped (100)
$ bun run typecheck   ->  tsc --noEmit   (clean, no errors)
$ bun run lint        ->  biome check    Checked 54 files. No fixes applied.
```
</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend request/response path changed; the fix is in server-side attachment construction.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the changed code path (attachment id construction) is a pure, deterministic function with no model call; no prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete attachment ids produced for image bytes AAAA / BBBB / CCCC:

<details>
<summary>Generated attachment id output (before = colliding, after = distinct)</summary>

```
BEFORE (buggy constant seed) — all three images collide on ONE id:
  AAAA -> 343760e3-6ba8-096c-a3b6-a54050685be7
  BBBB -> 343760e3-6ba8-096c-a3b6-a54050685be7
  CCCC -> 343760e3-6ba8-096c-a3b6-a54050685be7
  => new Set(ids).size === 1  (duplicate React keys + identical download filenames)

AFTER (per-attachment seed) — three genuinely distinct ids:
  AAAA -> 773172de-14f0-090f-b907-e0b0d052c231
  BBBB -> 7e8dd5ac-04b5-0685-9c40-3d4cb7ef83d8
  CCCC -> 4d5a3015-4f1a-0e05-9954-d14e40d841c7
  => new Set(ids).size === 3  (stable keys + unique download filenames)
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

N/A - the modified path is a deterministic, non-model function.

## Backend + frontend logs

See the Backend logs evidence row above (inline `<details>`). Frontend: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed. See Evidence Gate rows above for the specific reasons.

### Before

N/A - server-side ID-generation fix; no rendered surface in this diff.

### After

N/A - server-side ID-generation fix; no rendered surface in this diff.

### Walkthrough video

N/A - deterministic unit reproduction stands in for a UI flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path touched.

## Known gaps / failures

- **`bun run verify` (full repo gate):** not completed on this machine. `bun install` required a one-off `--minimum-release-age=0` because a machine-global bun supply-chain guard blocked repo-pinned, already-cached deps (`viem@2.55.17`, `smthrs@0.34.0`) published <7 days ago; and two workspace codegen/build steps (`@elizaos/cloud-routing` dist, core i18n `generate-keywords.mjs`) had to be run before vitest could resolve `@elizaos/core`. These are environment/setup constraints, not defects in this change. The **owning package's** test (97 passed / 3 skipped, single-threaded), typecheck (`tsc --noEmit`, clean), and lint (biome, no fixes) all pass — see inline logs.
- **Full plugin-mcp suite under parallel workers is pre-existing-flaky:** on unmodified `develop` the parallel run already fails ~5 tests (validation/service suites) due to cross-file test pollution; those same suites pass in isolation and the whole suite passes single-threaded (15 files / 97 tests). My change touches only `processing.ts` and adds `processing.test.ts`; it does not introduce or affect that flakiness.
- **Evidence attachment URLs:** the immutable-attachment uploader and `scripts/pr-evidence.mjs attach` both require maintainer write access to the upstream repo's releases, which a fork contributor does not have (HTTP 404). Per CONTRIBUTING.md § Evidence, the textual logs are pasted inline in `<details>` blocks instead.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@0717f457296ec031e42f540b2229de166dbc64ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0717f457296ec031e42f540b2229de166dbc64ae:packages/skills/skills/contribute-to-eliza"} -->
