### PR TITLE
fix(computeruse): restore real macOS browser evidence

### DIFF
--- a/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
@@ -531,8 +531,47 @@ async function runTextEditInputCheck(service, displays) {
   }
 }
 
-async function runBrowserCheck(service, outDir, artifacts) {
-  const fixture = await startMacosBrowserEvidenceServer();
+function combineBrowserCleanupErrors(errors) {
+  if (errors.length === 0) return null;
+  if (errors.length === 1) return errors[0];
+  return new AggregateError(errors, "macOS browser evidence cleanup failed");
+}
+
+/** Attempts every browser-evidence teardown and returns the combined failure. */
+export async function cleanupMacosBrowserEvidence(
+  service,
+  fixture,
+  browserOpened,
+) {
+  const errors = [];
+  if (browserOpened) {
+    try {
+      const close = await service.executeCommand("browser_close");
+      if (!close.success) {
+        errors.push(
+          new Error(`browser_close failed: ${close.error ?? "unknown"}`),
+        );
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  try {
+    await fixture.close();
+  } catch (error) {
+    errors.push(error);
+  }
+  return combineBrowserCleanupErrors(errors);
+}
+
+/** Runs the browser evidence check with an injectable fixture for failure tests. */
+export async function runBrowserCheck(
+  service,
+  outDir,
+  artifacts,
+  startFixture = startMacosBrowserEvidenceServer,
+) {
+  const fixture = await startFixture();
   let browserOpened = false;
   let primaryError = null;
   let result = null;
@@ -593,19 +632,11 @@ async function runBrowserCheck(service, outDir, artifacts) {
   } catch (error) {
     primaryError = error;
   } finally {
-    if (browserOpened) {
-      const close = await service.executeCommand("browser_close");
-      if (!close.success) {
-        cleanupError = new Error(
-          `browser_close failed: ${close.error ?? "unknown"}`,
-        );
-      }
-    }
-    try {
-      await fixture.close();
-    } catch (error) {
-      cleanupError ??= error;
-    }
+    cleanupError = await cleanupMacosBrowserEvidence(
+      service,
+      fixture,
+      browserOpened,
+    );
   }
   if (primaryError) {
     if (cleanupError) {

--- a/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
@@ -167,6 +167,15 @@ function commandText(command, args, fallback = "unknown") {
   }
 }
 
+/** Resolves the full immutable revision bound into every evidence artifact. */
+export function resolveMacosEvidenceGitHead(runCommand = commandText) {
+  const gitHead = runCommand("git", ["rev-parse", "HEAD"]);
+  if (!/^[0-9a-f]{40,64}$/i.test(gitHead)) {
+    throw new Error("macOS desktop evidence requires a full Git commit SHA");
+  }
+  return gitHead;
+}
+
 function createRuntime(settings = {}) {
   return {
     character: {},
@@ -753,7 +762,7 @@ async function main() {
   const machineModel = commandText("sysctl", ["-n", "hw.model"]);
   const macosVersion = commandText("sw_vers", ["-productVersion"]);
   const buildId = commandText("sw_vers", ["-buildVersion"]);
-  const gitHead = commandText("git", ["rev-parse", "--short", "HEAD"]);
+  const gitHead = resolveMacosEvidenceGitHead();
   const artifacts = [];
   const details = {};
   const checks = new Map(CHECK_ORDER.map((id) => [id, newCheck(id)]));

--- a/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
@@ -9,6 +9,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -60,6 +61,50 @@ const approvalConfigPath = path.join(
   ".eliza",
   "computer-use-approval.json",
 );
+
+const BROWSER_EVIDENCE_HTML =
+  "<!doctype html><html><head><title>macOS CUA Evidence</title></head><body><main><h1>macOS CUA Evidence</h1><button id='go'>Ready</button><input id='field' value=''></main></body></html>";
+
+export async function startMacosBrowserEvidenceServer() {
+  const server = createServer((request, response) => {
+    if (request.method !== "GET" || request.url !== "/") {
+      response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      response.end("Not found");
+      return;
+    }
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": "text/html; charset=utf-8",
+    });
+    response.end(BROWSER_EVIDENCE_HTML);
+  });
+
+  await new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await new Promise((resolve) => server.close(resolve));
+    throw new Error("macOS browser evidence server did not bind a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/`,
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
 
 function usage() {
   return [
@@ -326,21 +371,34 @@ async function runTextEditInputCheck(service, displays) {
       { timeout: 30_000 },
     );
     createdDocument = true;
-    await new Promise((resolve) => setTimeout(resolve, 700));
-
-    const active = await service.executeWindowAction({
-      action: "get_current_window_id",
-    });
-    if (!active.success || !active.window) {
+    let active = null;
+    let boundsResult = null;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      active = await service.executeWindowAction({
+        action: "get_current_window_id",
+      });
+      if (active.success && active.window?.app === "TextEdit") {
+        boundsResult = await service.executeWindowAction({
+          action: "get_window_position",
+          windowId: active.window.id,
+        });
+        if (boundsResult.success && boundsResult.bounds) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    if (
+      !active?.success ||
+      !active.window ||
+      active.window.app !== "TextEdit"
+    ) {
       throw new Error(
-        `could not identify active TextEdit window: ${active.error ?? "unknown"}`,
+        `could not identify active TextEdit window: ${active?.error ?? "unknown"}`,
       );
     }
 
-    const boundsResult = await service.executeWindowAction({
-      action: "get_window_position",
-      windowId: active.window.id,
-    });
+    if (!boundsResult) {
+      throw new Error("could not query TextEdit window bounds");
+    }
     if (!boundsResult.success || !boundsResult.bounds) {
       const rawReason = boundsResult.error ?? "unknown";
       const reason = String(rawReason).includes("Window not found")
@@ -374,6 +432,7 @@ async function runTextEditInputCheck(service, displays) {
     if (!click.success) {
       throw new Error(`click failed: ${click.error ?? "unknown"}`);
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     const selectAll = await service.executeCommand("key_combo", {
       key: "cmd+a",
@@ -381,6 +440,7 @@ async function runTextEditInputCheck(service, displays) {
     if (!selectAll.success) {
       throw new Error(`key_combo failed: ${selectAll.error ?? "unknown"}`);
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     const typed = await service.executeCommand("type", {
       text: token,
@@ -472,63 +532,93 @@ async function runTextEditInputCheck(service, displays) {
 }
 
 async function runBrowserCheck(service, outDir, artifacts) {
-  const pageUrl =
-    "data:text/html,<html><head><title>macOS CUA Evidence</title></head><body><main><h1>macOS CUA Evidence</h1><button id='go'>Ready</button><input id='field' value=''></main></body></html>";
+  const fixture = await startMacosBrowserEvidenceServer();
+  let browserOpened = false;
+  let primaryError = null;
+  let result = null;
+  let cleanupError = null;
+  try {
+    const open = await service.executeCommand("browser_open", {
+      url: fixture.url,
+    });
+    if (!open.success) {
+      throw new Error(`browser_open failed: ${open.error ?? "unknown"}`);
+    }
+    browserOpened = true;
+    const dom = await service.executeCommand("browser_get_dom");
+    if (
+      !dom.success ||
+      !String(dom.content ?? "").includes("macOS CUA Evidence")
+    ) {
+      throw new Error(
+        `browser_get_dom did not return the evidence page: ${dom.error ?? "unknown"}`,
+      );
+    }
+    const clickables = await service.executeCommand("browser_get_clickables");
+    if (!clickables.success) {
+      throw new Error(
+        `browser_get_clickables failed: ${clickables.error ?? "unknown"}`,
+      );
+    }
+    const screenshot = await service.executeCommand("browser_screenshot");
+    if (!screenshot.success) {
+      throw new Error(
+        `browser_screenshot failed: ${screenshot.error ?? "unknown"}`,
+      );
+    }
 
-  const open = await service.executeCommand("browser_open", { url: pageUrl });
-  if (!open.success) {
-    throw new Error(`browser_open failed: ${open.error ?? "unknown"}`);
-  }
-  const dom = await service.executeCommand("browser_get_dom");
-  if (
-    !dom.success ||
-    !String(dom.content ?? "").includes("macOS CUA Evidence")
-  ) {
-    throw new Error(
-      `browser_get_dom did not return the evidence page: ${dom.error ?? "unknown"}`,
-    );
-  }
-  const clickables = await service.executeCommand("browser_get_clickables");
-  if (!clickables.success) {
-    throw new Error(
-      `browser_get_clickables failed: ${clickables.error ?? "unknown"}`,
-    );
-  }
-  const screenshot = await service.executeCommand("browser_screenshot");
-  if (!screenshot.success) {
-    throw new Error(
-      `browser_screenshot failed: ${screenshot.error ?? "unknown"}`,
-    );
-  }
+    const browserPng = pngBufferFromBase64(screenshot.screenshot);
+    const browserQuality = describePng(browserPng, "browser screenshot");
+    const browserArtifact = path.join(outDir, "browser-evidence.png");
+    await writeFile(browserArtifact, browserPng);
+    artifacts.push(relativeToRepo(browserArtifact));
 
-  const browserPng = pngBufferFromBase64(screenshot.screenshot);
-  const browserQuality = describePng(browserPng, "browser screenshot");
-  const browserArtifact = path.join(outDir, "browser-evidence.png");
-  await writeFile(browserArtifact, browserPng);
-  artifacts.push(relativeToRepo(browserArtifact));
-
-  const close = await service.executeCommand("browser_close");
-  if (!close.success) {
-    throw new Error(`browser_close failed: ${close.error ?? "unknown"}`);
-  }
-
-  return {
-    status: "passed",
-    requiredEvidence: [
-      `browser target opened ${open.url ?? "data URL"}`,
-      "browser_get_dom returned the local evidence page",
-      `browser_get_clickables returned ${clickables.count ?? clickables.elements?.length ?? "some"} element(s)`,
-      `browser screenshot artifact ${relativeToRepo(browserArtifact)} (${browserQuality.width}x${browserQuality.height})`,
-      "browser cleanup closed the test browser",
-    ],
-    details: {
-      open: {
-        url: open.url,
-        title: open.title,
+    result = {
+      status: "passed",
+      requiredEvidence: [
+        `browser target opened ${open.url ?? fixture.url}`,
+        "browser_get_dom returned the local evidence page",
+        `browser_get_clickables returned ${clickables.count ?? clickables.elements?.length ?? "some"} element(s)`,
+        `browser screenshot artifact ${relativeToRepo(browserArtifact)} (${browserQuality.width}x${browserQuality.height})`,
+        "browser and loopback fixture cleanup completed",
+      ],
+      details: {
+        open: {
+          url: open.url,
+          title: open.title,
+        },
+        browserQuality,
       },
-      browserQuality,
-    },
-  };
+    };
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    if (browserOpened) {
+      const close = await service.executeCommand("browser_close");
+      if (!close.success) {
+        cleanupError = new Error(
+          `browser_close failed: ${close.error ?? "unknown"}`,
+        );
+      }
+    }
+    try {
+      await fixture.close();
+    } catch (error) {
+      cleanupError ??= error;
+    }
+  }
+  if (primaryError) {
+    if (cleanupError) {
+      // error-policy:J6 Preserve the owning browser failure while reporting a
+      // secondary cleanup problem from the disposable evidence fixture.
+      console.warn(
+        `macOS browser evidence cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+      );
+    }
+    throw primaryError;
+  }
+  if (cleanupError) throw cleanupError;
+  return result;
 }
 
 async function runApprovalCheck(outDir, artifacts) {

--- a/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
@@ -1,14 +1,21 @@
 /**
- * Classifier that maps macOS Accessibility/TCC blocker messages to
- * requires-device-evidence in the capture harness. Deterministic unit test.
+ * Deterministic coverage for the macOS evidence classifier, loopback fixture,
+ * and browser-cleanup failure precedence. Failure paths use an injected fixture
+ * and command-service fake; the listener lifecycle test uses real loopback I/O.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  cleanupMacosBrowserEvidence,
   isMacosAccessibilityEvidenceBlocker,
+  runBrowserCheck,
   startMacosBrowserEvidenceServer,
 } from "../../scripts/capture-macos-desktop-evidence.mjs";
 
 describe("macOS desktop evidence capture", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("classifies known Accessibility/TCC blockers as missing device evidence", () => {
     expect(
       isMacosAccessibilityEvidenceBlocker(
@@ -50,5 +57,63 @@ describe("macOS desktop evidence capture", () => {
     await expect(
       fetch(fixture.url, { signal: AbortSignal.timeout(1_000) }),
     ).rejects.toThrow();
+  });
+
+  it("always closes the fixture when browser_close rejects and preserves the primary failure", async () => {
+    const cleanupWarning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const fixtureClose = vi.fn(async () => {});
+    const service = {
+      async executeCommand(command: string, params?: { url?: string }) {
+        if (command === "browser_open") {
+          return { success: true, url: params?.url };
+        }
+        if (command === "browser_get_dom") {
+          return { success: false, error: "primary DOM failure" };
+        }
+        if (command === "browser_close") {
+          throw new Error("browser shutdown rejected");
+        }
+        throw new Error(`unexpected command: ${command}`);
+      },
+    };
+
+    await expect(
+      runBrowserCheck(service, "/unused", [], async () => ({
+        url: "http://127.0.0.1:12345/",
+        close: fixtureClose,
+      })),
+    ).rejects.toThrow("primary DOM failure");
+    expect(cleanupWarning).toHaveBeenCalledWith(
+      expect.stringContaining("browser shutdown rejected"),
+    );
+    expect(fixtureClose).toHaveBeenCalledOnce();
+  });
+
+  it("aggregates browser and fixture cleanup failures without skipping either", async () => {
+    const browserError = new Error("browser shutdown rejected");
+    const fixtureError = new Error("fixture shutdown rejected");
+    const fixtureClose = vi.fn(async () => {
+      throw fixtureError;
+    });
+
+    const cleanupError = await cleanupMacosBrowserEvidence(
+      {
+        async executeCommand(command: string) {
+          expect(command).toBe("browser_close");
+          throw browserError;
+        },
+      },
+      { close: fixtureClose },
+      true,
+    );
+
+    expect(fixtureClose).toHaveBeenCalledOnce();
+    expect(cleanupError).toBeInstanceOf(AggregateError);
+    expect((cleanupError as AggregateError).errors).toEqual([
+      browserError,
+      fixtureError,
+    ]);
   });
 });

--- a/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
@@ -3,7 +3,10 @@
  * requires-device-evidence in the capture harness. Deterministic unit test.
  */
 import { describe, expect, it } from "vitest";
-import { isMacosAccessibilityEvidenceBlocker } from "../../scripts/capture-macos-desktop-evidence.mjs";
+import {
+  isMacosAccessibilityEvidenceBlocker,
+  startMacosBrowserEvidenceServer,
+} from "../../scripts/capture-macos-desktop-evidence.mjs";
 
 describe("macOS desktop evidence capture", () => {
   it("classifies known Accessibility/TCC blockers as missing device evidence", () => {
@@ -33,5 +36,19 @@ describe("macOS desktop evidence capture", () => {
         "primary display screenshot: screenshot quality failed",
       ),
     ).toBe(false);
+  });
+
+  it("serves the browser fixture only on ephemeral loopback and closes it", async () => {
+    const fixture = await startMacosBrowserEvidenceServer();
+    expect(fixture.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+
+    const response = await fetch(fixture.url);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("macOS CUA Evidence");
+
+    await fixture.close();
+    await expect(
+      fetch(fixture.url, { signal: AbortSignal.timeout(1_000) }),
+    ).rejects.toThrow();
   });
 });

--- a/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupMacosBrowserEvidence,
   isMacosAccessibilityEvidenceBlocker,
+  resolveMacosEvidenceGitHead,
   runBrowserCheck,
   startMacosBrowserEvidenceServer,
 } from "../../scripts/capture-macos-desktop-evidence.mjs";
@@ -14,6 +15,17 @@ import {
 describe("macOS desktop evidence capture", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("binds evidence to the full immutable Git revision", () => {
+    const fullSha = "a".repeat(40);
+    const command = vi.fn(() => fullSha);
+
+    expect(resolveMacosEvidenceGitHead(command)).toBe(fullSha);
+    expect(command).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"]);
+    expect(() => resolveMacosEvidenceGitHead(() => "abc1234")).toThrow(
+      "requires a full Git commit SHA",
+    );
   });
 
   it("classifies known Accessibility/TCC blockers as missing device evidence", () => {


### PR DESCRIPTION
## Summary

- replace the rejected `data:` browser target with an ephemeral fixture bound only to `127.0.0.1`
- close both the controlled browser and loopback fixture on every success/failure path while preserving primary failure precedence
- wait for the controlled TextEdit window and native input settling points instead of racing focus delivery
- bind every generated evidence artifact to the full immutable Git commit SHA and fail closed on abbreviated/invalid revisions

Closes #22512.

## Exact verification

Exact head: `34a0db5b604cc2c3ec252910d047d72fc82a4ac6`

- Focused Vitest: 6 passed, including full-SHA binding, loopback-only listener lifecycle, and cleanup failure precedence.
- Repository-pinned Biome and `git diff --check`: passed.
- Real macOS capture on `Mac16,5`, macOS `26.2 (25C56)`: all 9 required checks passed (capabilities, Screen Recording, screenshot, Accessibility, mouse/keyboard input, window focus, browser automation, clipboard, approval modes).
- Strict platform evidence validator: 9 checks validated, status passed.
- Generated report and manifest both bind validator/output to full revision `34a0db5b604cc2c3ec252910d047d72fc82a4ac6`.

## Evidence Gate

<!-- evidence-head:34a0db5b604cc2c3ec252910d047d72fc82a4ac6 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - the previous harness aborted before browser capture because hardened navigation rejects `data:` URLs.
<!-- evidence-row:after-screenshots -->
- [x] [Exact-head browser screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22518-browser-evidence.png)
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this changes a CLI evidence harness, not an interactive product view.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head capture report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22518-report.json) and [strict validation manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22518-macos-desktop-validation.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend application code or browser console contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head full-display screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22518-screenshot-primary.png) and [evidence README](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22518-README.md)
<!-- evidence-row:ocr-review -->
- [x] N/A - no application UI or OCR surface changed.

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@34a0db5b604cc2c3ec252910d047d72fc82a4ac6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@34a0db5b604cc2c3ec252910d047d72fc82a4ac6:packages/skills/skills/contribute-to-eliza"} -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@34a0db5b604cc2c3ec252910d047d72fc82a4ac6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
