### PR TITLE
fix(computeruse): preserve native input settling

### DIFF
--- a/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
@@ -354,7 +354,7 @@ async function runCheck(checks, details, id, fn, options = {}) {
 
 async function runTextEditInputCheck(service, displays) {
   let previousWindow = null;
-  let createdDocument = false;
+  let createdDocumentName = null;
   const token = `macos-cua-${Date.now()}`;
 
   try {
@@ -365,7 +365,7 @@ async function runTextEditInputCheck(service, displays) {
       previousWindow = activeBefore.window;
     }
 
-    runText(
+    createdDocumentName = runText(
       "osascript",
       [
         "-e",
@@ -373,50 +373,51 @@ async function runTextEditInputCheck(service, displays) {
         "-e",
         "activate",
         "-e",
-        'make new document with properties {text:""}',
+        'set evidenceDocument to make new document with properties {text:""}',
+        "-e",
+        "return name of evidenceDocument",
         "-e",
         "end tell",
       ],
       { timeout: 30_000 },
     );
-    createdDocument = true;
-    let active = null;
-    let boundsResult = null;
+    let bounds = null;
     for (let attempt = 0; attempt < 20; attempt += 1) {
-      active = await service.executeWindowAction({
-        action: "get_current_window_id",
-      });
-      if (active.success && active.window?.app === "TextEdit") {
-        boundsResult = await service.executeWindowAction({
-          action: "get_window_position",
-          windowId: active.window.id,
-        });
-        if (boundsResult.success && boundsResult.bounds) break;
+      try {
+        const rawBounds = runText(
+          "osascript",
+          [
+            "-e",
+            `tell application "System Events" to tell process "TextEdit" to tell window ${JSON.stringify(createdDocumentName)}`,
+            "-e",
+            "set windowPosition to position",
+            "-e",
+            "set windowSize to size",
+            "-e",
+            'return ((item 1 of windowPosition) as text) & "," & ((item 2 of windowPosition) as text) & "," & ((item 1 of windowSize) as text) & "," & ((item 2 of windowSize) as text)',
+            "-e",
+            "end tell",
+          ],
+          { timeout: 15_000 },
+        );
+        const [x, y, width, height] = rawBounds
+          .split(",")
+          .map((value) => Number(value));
+        if ([x, y, width, height].every(Number.isFinite)) {
+          bounds = { x, y, width, height };
+          break;
+        }
+      } catch {
+        // TextEdit can create the document before its accessibility window exists.
       }
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    if (
-      !active?.success ||
-      !active.window ||
-      active.window.app !== "TextEdit"
-    ) {
+    if (!bounds) {
       throw new Error(
-        `could not identify active TextEdit window: ${active?.error ?? "unknown"}`,
+        `could not read TextEdit bounds for ${createdDocumentName ?? "unknown"}; grant Accessibility permission in System Settings > Privacy & Security > Accessibility, then retry`,
       );
     }
 
-    if (!boundsResult) {
-      throw new Error("could not query TextEdit window bounds");
-    }
-    if (!boundsResult.success || !boundsResult.bounds) {
-      const rawReason = boundsResult.error ?? "unknown";
-      const reason = String(rawReason).includes("Window not found")
-        ? `${rawReason}; listWindows could not resolve the TextEdit window. Grant Accessibility permission in System Settings > Privacy & Security > Accessibility, then retry.`
-        : rawReason;
-      throw new Error(`could not read TextEdit bounds: ${reason}`);
-    }
-
-    const bounds = boundsResult.bounds;
     const globalX = Math.round(bounds.x + bounds.width / 2);
     const globalY = Math.round(bounds.y + Math.max(90, bounds.height / 2));
     const display = displayForPoint(displays, globalX, globalY);
@@ -500,7 +501,7 @@ async function runTextEditInputCheck(service, displays) {
         "post-action screenshots were requested by service configuration",
       ],
       details: {
-        activeWindow: active.window,
+        activeWindow: { app: "TextEdit", title: createdDocumentName },
         bounds,
         coordinate,
         displayId: display.id,
@@ -508,7 +509,7 @@ async function runTextEditInputCheck(service, displays) {
       },
     };
   } finally {
-    if (createdDocument) {
+    if (createdDocumentName) {
       // The close Apple Event is blocked by the same transient post-input state
       // as the read above; retry with a short delay so the document still closes
       // and runs don't accumulate stale windows (which slow TextEdit further).
@@ -518,7 +519,7 @@ async function runTextEditInputCheck(service, displays) {
             "osascript",
             [
               "-e",
-              'tell application "TextEdit" to close front document saving no',
+              `tell application "TextEdit" to close document ${JSON.stringify(createdDocumentName)} saving no`,
             ],
             { timeout: 20_000 },
           );

--- a/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
@@ -14,9 +14,29 @@
 import { describe, expect, it } from "vitest";
 import {
   clampScrollNotches,
+  configureNutInput,
   densifyDragPath,
   interpolateDragSteps,
+  NUT_INPUT_SETTLE_DELAY_MS,
 } from "../platform/nut-driver.js";
+
+describe("configureNutInput", () => {
+  it("retains nonzero settling for both native input channels", () => {
+    const target = {
+      mouse: { config: { mouseSpeed: 1, autoDelayMs: 0 } },
+      keyboard: { config: { autoDelayMs: 0 } },
+    };
+
+    configureNutInput(target);
+
+    expect(NUT_INPUT_SETTLE_DELAY_MS).toBeGreaterThan(0);
+    expect(target.mouse.config).toEqual({
+      mouseSpeed: 1000,
+      autoDelayMs: NUT_INPUT_SETTLE_DELAY_MS,
+    });
+    expect(target.keyboard.config.autoDelayMs).toBe(NUT_INPUT_SETTLE_DELAY_MS);
+  });
+});
 
 describe("clampScrollNotches", () => {
   it("clamps to the 1..20 notch range and rounds", () => {

--- a/plugins/plugin-computeruse/src/platform/nut-driver.ts
+++ b/plugins/plugin-computeruse/src/platform/nut-driver.ts
@@ -68,14 +68,28 @@ interface NutModule {
 let cachedModule: NutModule | null = null;
 let loadError: Error | null = null;
 
+export const NUT_INPUT_SETTLE_DELAY_MS = 20;
+
+interface NutInputConfigTarget {
+  mouse: { config: { mouseSpeed: number; autoDelayMs: number } };
+  keyboard: { config: { autoDelayMs: number } };
+}
+
+/** Applies the input pacing required for native event delivery. nut.js waits
+ * before each affected action; zero-delay dispatch can acknowledge commands
+ * before macOS has delivered the preceding focus or input event. */
+export function configureNutInput(target: NutInputConfigTarget): void {
+  target.mouse.config.mouseSpeed = 1000;
+  target.mouse.config.autoDelayMs = NUT_INPUT_SETTLE_DELAY_MS;
+  target.keyboard.config.autoDelayMs = NUT_INPUT_SETTLE_DELAY_MS;
+}
+
 function loadNut(): NutModule | null {
   if (cachedModule !== null) return cachedModule;
   if (loadError !== null) return null;
   try {
     const mod = requireFromHere("@nut-tree-fork/nut-js") as NutModule;
-    mod.mouse.config.mouseSpeed = 1000;
-    mod.mouse.config.autoDelayMs = 0;
-    mod.keyboard.config.autoDelayMs = 0;
+    configureNutInput(mod);
     cachedModule = mod;
     return mod;
   } catch (err) {


### PR DESCRIPTION
## Summary

- retain a 20 ms nut.js settle delay for both mouse and keyboard native input channels
- keep the existing 1000 px/s mouse speed while centralizing input configuration in a testable boundary
- add a contract test that rejects zero-delay dispatch and verifies both channels are configured
- bind the macOS evidence input check to the exact TextEdit document it creates and close that exact document during teardown

Closes #22519.

## Why

The real macOS evidence loop was intermittently acknowledging native commands before the preceding focus/input event had been delivered. Empirical default-driver runs isolated the failure to zero-delay mouse and keyboard dispatch; 20 ms on both channels produced three consecutive complete 9-check runs before this patch. The evidence harness also selected whichever window became active after creating its controlled document, which could target and close an unrelated TextEdit document under focus contention; it now keeps the created document identity throughout the check and teardown.

## Exact-head verification

Head: `a77c96e8ec5ca52b8428193eb6d0a12e6bc31aa8`

- `bun test plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts` — 8 passed, 0 failed
- pinned Biome over `nut-driver.ts`, its focused test, and the macOS capture harness — passed
- `git diff --check origin/develop...HEAD` — passed
- negative mutation from the original review: setting the settle delay to zero makes the new contract fail; restored to 20 ms

## Remaining device acceptance

The final exact-head macOS run was attempted locally, but the Mac is currently at the locked login screen. The runner correctly rejected the resulting one-color capture and classified Accessibility-gated input as requiring device evidence. No password or credential was used or requested. Rerun `bun run --cwd plugins/plugin-computeruse capture:macos-desktop-evidence` at this exact head in an unlocked macOS session before merge; the authoritative acceptance is 9/9 checks and a manifest bound to the full head SHA.

## Evidence Gate

<!-- evidence-head:a77c96e8ec5ca52b8428193eb6d0a12e6bc31aa8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered product UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered product UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - native input timing and evidence-harness behavior, not a product walkthrough.
<!-- evidence-row:backend-logs -->
- [x] Focused 8/8 unit output and strict local formatting/diff checks are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Exact-head 9/9 macOS desktop validation is pending an unlocked macOS session; the locked-screen attempt was rejected rather than represented as success.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered product surface changed.

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@a77c96e8ec5ca52b8428193eb6d0a12e6bc31aa8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@a77c96e8ec5ca52b8428193eb6d0a12e6bc31aa8:packages/skills/skills/contribute-to-eliza"} -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a77c96e8ec5ca52b8428193eb6d0a12e6bc31aa8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
