### PR TITLE
fix(cloud): type reservation lock backend pids

### DIFF
--- a/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
+++ b/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
@@ -10,6 +10,7 @@ const migrationSql = await Bun.file(
   new URL("./0268_app_reservation_settlement_authority.sql", import.meta.url),
 ).text();
 let admin: Client;
+const backendPidByClient = new WeakMap<Client, number>();
 
 describeRealPg("0268 app reservation settlement real PostgreSQL concurrency", () => {
   beforeAll(async () => {
@@ -143,22 +144,32 @@ describeRealPg("0268 app reservation settlement real PostgreSQL concurrency", ()
     const client = new Client({ connectionString: dsn });
     await client.connect();
     await client.query(`SET search_path TO ${schemaName}`);
+    const pidResult = await client.query<{ pid: number }>("SELECT pg_backend_pid()::int AS pid");
+    const pid = pidResult.rows[0]?.pid;
+    if (pid === undefined || !Number.isInteger(pid))
+      throw new Error("PostgreSQL connection did not report a backend PID");
+    backendPidByClient.set(client, pid);
     return client;
   }
 
   async function expectBackendBlocked(blocked: Client, blocker: Client): Promise<void> {
+    const blockedPid = backendPidByClient.get(blocked);
+    const blockerPid = backendPidByClient.get(blocker);
+    if (blockedPid === undefined || blockerPid === undefined) {
+      throw new Error("PostgreSQL blocking assertion requires captured backend PIDs");
+    }
     for (let attempt = 0; attempt < 100; attempt++) {
       const result = await admin.query<{ blockers: number[] }>(
         "SELECT pg_blocking_pids($1)::int[] AS blockers",
-        [blocked.processID],
+        [blockedPid],
       );
-      if (result.rows[0]?.blockers.includes(blocker.processID)) {
-        expect(result.rows[0].blockers).toContain(blocker.processID);
+      if (result.rows[0]?.blockers.includes(blockerPid)) {
+        expect(result.rows[0].blockers).toContain(blockerPid);
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    throw new Error(`backend ${blocked.processID} did not block on ${blocker.processID}`);
+    throw new Error(`backend ${blockedPid} did not block on ${blockerPid}`);
   }
 
   test("provider-first and sweep-first differing actuals each commit one exact receipt", async () => {


### PR DESCRIPTION
Follow-up to #22478.

## Outcome

Repairs the Cloud type failure in the real PostgreSQL reservation-settlement concurrency test. The test no longer reads `Client.processID`, which is absent from the repository's `pg` client type.

Each connected test client now captures its authoritative backend PID through `SELECT pg_backend_pid()::int AS pid`. The existing `pg_blocking_pids` assertions still prove both lock orders and exactly one terminal receipt/quarantine authority.

## Exact-head evidence

- Head: `396b70bef6312c7cdf0b99031b22916e06ac4ac5`
- Base: `6158e0abd87649c5b5ffa18591928eefbd6d323d`
- Exact-file TypeScript check using the pinned `@types/pg`: passed.
- Real PostgreSQL concurrency suite: 2 passed, 18 assertions.
- Biome: passed.
- `git diff --check origin/develop...HEAD`: passed.
- Shared package typecheck is blocked by the checkout's broader missing dependency graph; it reports no diagnostic for the changed test file.

## Scope

Test-only type correction. No migration, service, runtime, UI, deployment, or data changes.

Draft for exact-head review. Do not merge or deploy without approval.
