### PR TITLE
fix(cloud): type settlement backend pids

### DIFF
--- a/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
+++ b/packages/cloud/shared/src/db/migrations/app-reservation-settlement-real-pg.integration.test.ts
@@ -10,6 +10,7 @@ const migrationSql = await Bun.file(
   new URL("./0268_app_reservation_settlement_authority.sql", import.meta.url),
 ).text();
 let admin: Client;
+const backendPids = new WeakMap<Client, number>();
 
 describeRealPg("0268 app reservation settlement real PostgreSQL concurrency", () => {
   beforeAll(async () => {
@@ -143,22 +144,36 @@ describeRealPg("0268 app reservation settlement real PostgreSQL concurrency", ()
     const client = new Client({ connectionString: dsn });
     await client.connect();
     await client.query(`SET search_path TO ${schemaName}`);
+    const result = await client.query<{ backend_pid: number }>(
+      "SELECT pg_backend_pid()::int AS backend_pid",
+    );
+    const backendPid = result.rows[0]?.backend_pid;
+    if (!Number.isInteger(backendPid)) {
+      await client.end();
+      throw new Error("PostgreSQL connection did not return a backend PID");
+    }
+    backendPids.set(client, backendPid);
     return client;
   }
 
   async function expectBackendBlocked(blocked: Client, blocker: Client): Promise<void> {
+    const blockedPid = backendPids.get(blocked);
+    const blockerPid = backendPids.get(blocker);
+    if (blockedPid === undefined || blockerPid === undefined) {
+      throw new Error("PostgreSQL connection is missing its backend PID");
+    }
     for (let attempt = 0; attempt < 100; attempt++) {
       const result = await admin.query<{ blockers: number[] }>(
         "SELECT pg_blocking_pids($1)::int[] AS blockers",
-        [blocked.processID],
+        [blockedPid],
       );
-      if (result.rows[0]?.blockers.includes(blocker.processID)) {
-        expect(result.rows[0].blockers).toContain(blocker.processID);
+      if (result.rows[0]?.blockers.includes(blockerPid)) {
+        expect(result.rows[0].blockers).toContain(blockerPid);
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    throw new Error(`backend ${blocked.processID} did not block on ${blocker.processID}`);
+    throw new Error(`backend ${blockedPid} did not block on ${blockerPid}`);
   }
 
   test("provider-first and sweep-first differing actuals each commit one exact receipt", async () => {


### PR DESCRIPTION
## Summary

- capture each real PostgreSQL test connection's backend PID with `pg_backend_pid()`
- retain the typed PID in a test-only `WeakMap<Client, number>`
- use the captured values for `pg_blocking_pids()` assertions instead of the untyped driver property `Client.processID`
- fail fast if a connection cannot provide or retain its backend PID

Closes #22523.

## Verification

- focused test collection: 4 expected skips without `APP_RESERVATION_SETTLEMENT_TEST_DSN`, 0 failures
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `bunx tsc --noEmit` from `packages/cloud/api` — passed
- `bun run --cwd packages/cloud/api typecheck` — passed, including Wrangler production dry-run bundle
- negative mutation: temporarily restored `void blocked.processID`; cloud-api TypeScript failed at that line with TS2339; mutation removed and exact check reran green
- Biome and `git diff --check` — passed
- `bun run verify` — 358/358 Turbo tasks; anti-LARP scanned 8,996 test files clean

The real concurrency cases remain gated by `APP_RESERVATION_SETTLEMENT_TEST_DSN`; this PR does not fabricate a database-backed run when that credential is absent.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->
