### PR TITLE
fix(plugin-meetings): concurrent same-URL joins launch two bots when billing is enabled (TOCTOU)

### DIFF
--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -161,6 +161,76 @@ describe("MeetingService.requestJoin — validation", () => {
     expect(adapters[0].session).not.toBeNull();
   });
 
+  it("reserves the meeting synchronously on the BILLING-metered path too, so concurrent same-URL joins launch ONE bot and charge ONCE (MJ-4 TOCTOU + billing)", async () => {
+    // Regression for the cloud/organization-managed path: `createBillingSession`
+    // returns a session, so `await billing.reserveInitial()` used to run BETWEEN
+    // the dup-check and the session insert. Two concurrent same-URL joins both
+    // passed the (empty) dup-check, both suspended at reserveInitial, then both
+    // resumed and inserted sessions — launching two notetaker bots into the same
+    // meeting and reserving billing credits twice. The reservation is now taken
+    // synchronously before any await, so the loser rejects at the dup-check.
+    const billingA = new FakeMeetingBillingSession();
+    const billingB = new FakeMeetingBillingSession();
+    const { service, adapters } = makeService(undefined, [billingA, billingB]);
+    const results = await Promise.allSettled([
+      service.requestJoin({ platform: "google_meet", meetingUrl: MEET_URL }),
+      // Same meeting, dashes stripped — canonicalized to the same native id.
+      service.requestJoin({
+        platform: "google_meet",
+        meetingUrl: "https://meet.google.com/abcdefghij",
+      }),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      code: "already_joined",
+    });
+    // Exactly one live session and one bot launched — no double capture.
+    expect(service.listSessions({ active: true })).toHaveLength(1);
+    await adapters[0].started;
+    expect(adapters[0].session).not.toBeNull();
+    // Credits were reserved exactly once across the two billing sessions: the
+    // losing join rejected at the dup-check and never created/charged a billing
+    // session, so no double reservation and no double debit occurred.
+    expect(billingA.reserveInitialCalls + billingB.reserveInitialCalls).toBe(1);
+    expect(billingB.reserveInitialCalls).toBe(0);
+  });
+
+  it("releases the reservation when the initial credit reservation itself throws mid-join, so a retry succeeds (BL-5 + reserveInitial)", async () => {
+    // Moving `reserveInitial` after `sessions.set` means a reservation failure
+    // must also roll back the just-claimed session; otherwise a transient credit
+    // ledger error would permanently strand the meeting behind `already_joined`.
+    const failing = new FakeMeetingBillingSession();
+    failing.initialReserveError = new Error("credit ledger timeout");
+    const retryBilling = new FakeMeetingBillingSession();
+    const { service, adapters } = makeService(undefined, [
+      failing,
+      retryBilling,
+    ]);
+
+    await expect(
+      service.requestJoin({ platform: "google_meet", meetingUrl: MEET_URL }),
+    ).rejects.toThrow("credit ledger timeout");
+    // The failed reservation neither stranded a non-terminal session nor left a
+    // dangling hold: the reservation was released through reconcile("error").
+    expect(service.listSessions()).toHaveLength(0);
+    expect(failing.reconcileCalls).toEqual(["error"]);
+    expect(adapters[0].session).toBeNull();
+
+    // Because the reservation rolled back, a retry for the same meeting URL is
+    // not blocked by `already_joined` and reserves through the second session.
+    const dto = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: MEET_URL,
+    });
+    expect(dto.status).toBe("requested");
+    expect(service.listSessions({ active: true })).toHaveLength(1);
+    expect(retryBilling.reserveInitialCalls).toBe(1);
+    expect(retryBilling.reconcileCalls).toEqual([]);
+  });
+
   it("releases the reservation when join setup throws, so a retry succeeds (BL-5)", async () => {
     const billing = new FakeMeetingBillingSession();
     const retryBilling = new FakeMeetingBillingSession();

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -66,6 +66,7 @@ import type {
   MeetingTranscriptionPipeline,
   ResolvedMeetingBotConfig,
 } from "./types.js";
+import { isMeetingInsufficientCreditsError } from "./types.js";
 
 /** Pipeline instance plus the optional retained-audio accessor. */
 export interface MeetingPipelineInstance extends MeetingTranscriptionPipeline {
@@ -259,11 +260,17 @@ export class MeetingService extends Service {
     }
 
     // Reserve the meeting SYNCHRONOUSLY before the first await. The dup-check
-    // above and this insert run in one uninterrupted turn, so two concurrent
-    // same-URL joins cannot both slip past the check and launch two bots
-    // (TOCTOU). Every construction here (pipeline, writer, room id) is
-    // synchronous; the awaited world/room/writer setup follows with the session
-    // already claimed. Any failure rolls the reservation back (see catch).
+    // above and the `this.sessions.set` below run in one uninterrupted turn, so
+    // two concurrent same-URL joins cannot both slip past the check and launch
+    // two bots (TOCTOU) — even on the billing-metered path. Constructing the
+    // billing session, pipeline, writer, and room id is all synchronous; the
+    // credit reservation (`billing.reserveInitial`) and the world/room/writer
+    // setup are awaited only AFTER the session is claimed, inside the guarded
+    // block below. Deferring `reserveInitial` past `sessions.set` is what closes
+    // the window where two joins used to both suspend at the reservation await
+    // and then both insert; the loser now rejects at the dup-check with
+    // `already_joined` and never creates a billing session. Any failure in the
+    // guarded block rolls the reservation back and frees the meeting (see catch).
     const sessionId = crypto.randomUUID() as UUID;
     const roomId = createUniqueUuid(this.runtime, `meeting:${sessionId}`);
     const botName =
@@ -282,21 +289,6 @@ export class MeetingService extends Service {
       request,
       maxDurationMs,
     });
-
-    if (billing) {
-      try {
-        await billing.reserveInitial();
-      } catch (err) {
-        if (
-          err instanceof Error &&
-          "code" in err &&
-          err.code === "insufficient_credits"
-        ) {
-          throw new MeetingJoinError("insufficient_credits", err.message);
-        }
-        throw err;
-      }
-    }
 
     const pipeline = this.deps.createPipeline({
       runtime: this.runtime,
@@ -355,11 +347,17 @@ export class MeetingService extends Service {
     };
     this.sessions.set(sessionId, session);
 
-    // With the reservation held, do the awaited setup. If world/room ensure or
-    // the transcript writer's initial row write throws, release the reservation
-    // so the meeting is joinable again and future joins are not permanently
-    // rejected with `already_joined` by a stranded non-terminal session.
+    // With the reservation held, do the awaited setup. The credit reservation
+    // (`reserveInitial`) runs here — AFTER `this.sessions.set` — so it can no
+    // longer interleave two same-URL joins past the dup-check. If the reservation,
+    // world/room ensure, or the transcript writer's initial row write throws,
+    // release the reservation so the meeting is joinable again and future joins
+    // are not permanently rejected with `already_joined` by a stranded
+    // non-terminal session.
     try {
+      if (billing) {
+        await billing.reserveInitial();
+      }
       const worldId = await this.ensureMeetingsWorld();
       await this.runtime.ensureRoomExists({
         id: roomId,
@@ -399,6 +397,11 @@ export class MeetingService extends Service {
         );
       }
       this.sessions.delete(sessionId);
+      // Map an insufficient-credits reservation failure to the typed join error
+      // (routes surface it as 402) only after the reservation has been released.
+      if (isMeetingInsufficientCreditsError(err)) {
+        throw new MeetingJoinError("insufficient_credits", err.message);
+      }
       logger.error(
         {
           sessionId,


### PR DESCRIPTION
# Relates to

Closes #22520

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Focused package gates (test/typecheck/lint) run and recorded below; full `bun run verify` not run on this constrained host — see **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below (red→green regression test + backend log lines).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b449259f5854b7501fa071cae93b3a657ba8b4b4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`6158e0abd8`); zero conflicts. `develop` did not touch `plugins/plugin-meetings`.
- [ ] `bun run verify` passes post-sync — not run; focused package gates run instead (see **Known gaps**).

# Risks

Low. The change is confined to `MeetingService.requestJoin` ordering: it moves
`await billing.reserveInitial()` from between the duplicate check and the
session insert to *inside* the already-existing guarded setup block that rolls
the reservation back. No public type, route, or event signature changes. The
billing-free path is byte-for-byte equivalent in behavior; only the metered
(cloud/organization-managed) path changes, and it now matches the invariant the
code already documented.

# Background

## What does this PR do?

`MeetingService.requestJoin` documents and guards "single-bot-per-meeting" by
claiming the reservation **synchronously before the first `await`**. That
invariant held only when no billing session was configured. On the
cloud/organization-managed path `deps.createBillingSession` returns a session,
and `await billing.reserveInitial()` executed **between** the duplicate check
and `this.sessions.set(...)`. Two concurrent same-URL joins both passed the
(empty) dup-check, both suspended at `reserveInitial`, then both resumed and
inserted sessions — launching **two notetaker bots into the same meeting**,
creating **two transcript records**, and **reserving/consuming billing credits
twice**. This is the metered path where duplicate capture and double-charging
matter most, and it silently contradicted the code's own TOCTOU comment and the
existing (billing-free) regression test.

**Fix:** take the meeting reservation truly synchronously. The billing session,
pipeline, writer, and `InternalSession` are now all constructed and
`this.sessions.set(sessionId, session)` runs **before any `await`**. The credit
reservation `await billing.reserveInitial()` moves into the existing `try` block
that already rolls the reservation back (`reconcileBillingOnce(session, "error")`
+ `this.sessions.delete(sessionId)`). The `insufficient_credits` →
`MeetingJoinError` mapping is preserved by mapping it in that catch after the
reservation is released. With no `await` between the dup-check and the insert,
the losing concurrent join rejects at the dup-check with `already_joined` and
never creates a billing session — so no second bot, no second transcript, no
double reservation.

## What kind of change is this?

Bug fix (non-breaking change which fixes a concurrency/billing defect).

# Documentation changes needed?

My changes do not require a documentation change. The in-file TOCTOU comment was
updated to describe the corrected ordering.

# Testing

## Where should a reviewer start?

`plugins/plugin-meetings/src/service.ts` — `requestJoin`, specifically the block
around `this.sessions.set(sessionId, session)` and the guarded `try/catch`.
Then `plugins/plugin-meetings/src/service.test.ts` for the two new regression
tests.

## Detailed testing steps

From `plugins/plugin-meetings`:

```
node_modules/.bin/vitest run src/service.test.ts
```

Two new tests were added (both fail on `develop`, pass here):

1. **`… on the BILLING-metered path too … (MJ-4 TOCTOU + billing)`** — fires two
   concurrent `requestJoin` calls for the same meeting (dashes stripped) with
   two `FakeMeetingBillingSession`s queued. Asserts `fulfilled=1`, `rejected`
   with `code: already_joined`, exactly one active session, one bot launched,
   and `reserveInitial` called exactly **once** across the two billing sessions
   (no double reservation/debit).
2. **`… when the initial credit reservation itself throws mid-join …`** — a
   `reserveInitial` throw must roll the just-claimed session back through
   `reconcile("error")` so a retry for the same URL is not permanently blocked
   by `already_joined`.

The shipped billing-free TOCTOU test and the `insufficient_credits` fail-closed
test remain green.

# Evidence Gate

<!-- evidence-head:1b3143ae6a4bb6fa25a4ff8827fc0aa30bf530ea -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server/runtime orchestration change in plugin-meetings; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server/runtime orchestration change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI flow; behavior is proven by the red→green regression test and backend logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs attached inline below (structured `[MeetingService]` lines).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed; this is session-orchestration ordering.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts attached inline: session/transcript counts and the duplicate `meeting transcript record created` log lines that prove the double-bot before the fix.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed.`

## Backend + frontend logs

**Before the fix (unfixed `service.ts` from `HEAD~1` + the new regression tests):**
the failing billing-path concurrency test emitted **two** transcript-record and
**two** join-requested lines for the **same** `nativeMeetingId=abc-defg-hij` —
two bots launched into one meeting.

<details><summary>BEFORE — vitest run src/service.test.ts (2 failed | 34 passed)</summary>

```
 ✓ MeetingService.requestJoin — validation > reserves the meeting synchronously so concurrent same-URL joins launch ONE bot (MJ-4 TOCTOU)
 × MeetingService.requestJoin — validation > reserves the meeting synchronously on the BILLING-metered path too, so concurrent same-URL joins launch ONE bot and charge ONCE (MJ-4 TOCTOU + billing)
   → expected [ { status: 'fulfilled', …(1) }, …(1) ] to have a length of 1 but got 2
 × MeetingService.requestJoin — validation > releases the reservation when the initial credit reservation itself throws mid-join, so a retry succeeds (BL-5 + reserveInitial)
   → expected [] to deeply equal [ 'error' ]
 ✓ MeetingService.requestJoin — validation > releases the reservation when join setup throws, so a retry succeeds (BL-5)
 ✓ MeetingService.requestJoin — validation > fails closed before bot launch when initial credit reservation is insufficient
 ✓ MeetingService — session state machine > exposes billing state and reconciles it exactly once at normal finish

# From the full log, the failing billing-path test emitted (same nativeMeetingId):
 Info  [MeetingService] meeting transcript record created (recording) (transcriptId=…, sessionId=de380a8c-…)
 Info  [MeetingService] meeting transcript record created (recording) (transcriptId=…, sessionId=a169c0a1-…)
 Info  [MeetingService] meeting join requested (sessionId=de380a8c-…, nativeMeetingId=abc-defg-hij)
 Info  [MeetingService] meeting join requested (sessionId=a169c0a1-…, nativeMeetingId=abc-defg-hij)

 Test Files  1 failed (1)
      Tests  2 failed | 34 passed (36)
```
</details>

<details><summary>AFTER — vitest run src/service.test.ts (36 passed)</summary>

```
 ✓ … reserves the meeting synchronously so concurrent same-URL joins launch ONE bot (MJ-4 TOCTOU)
 ✓ … reserves the meeting synchronously on the BILLING-metered path too, so concurrent same-URL joins launch ONE bot and charge ONCE (MJ-4 TOCTOU + billing)
 ✓ … releases the reservation when the initial credit reservation itself throws mid-join, so a retry succeeds (BL-5 + reserveInitial)
 ✓ … releases the reservation when join setup throws, so a retry succeeds (BL-5)
 ✓ … fails closed before bot launch when initial credit reservation is insufficient
 ✓ … exposes billing state and reconciles it exactly once at normal finish
 Test Files  1 passed (1)
      Tests  36 passed (36)
```
</details>

<details><summary>typecheck + lint (fixed HEAD)</summary>

```
$ bun run --cwd plugins/plugin-meetings typecheck
$ tsc --noEmit
(no errors)

$ bun run --cwd plugins/plugin-meetings lint
$ bunx @biomejs/biome check --write --unsafe .
Checked 100 files in 1164ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - server/runtime orchestration change; no UI surface.`

## Audio / voice walkthrough

`N/A - no audio round-trip changed; this is session-reservation ordering, not capture/TTS/STT.`

## Known gaps / failures

- **Full `bun run verify` not run:** this constrained host cannot run the whole
  workspace verify lane (native/browser deps). The owning package's focused
  gates were run instead: `vitest run src/service.test.ts` (36 passed),
  `typecheck` (clean), `lint` (clean).
- **Pre-existing, unrelated `plugin-meetings` failures** (present on
  `develop` before this change, untouched by it): `pipeline.test.ts` (one
  speaker-attribution assertion), `platform-support.test.ts` and
  `platforms/shared/launch.test.ts` (a `node:fs` mock / `playwright-core`
  environment issue). These do not involve `service.ts`.
- **Evidence attachment URLs:** the minting tool could not authenticate on this
  host, so logs are embedded inline in `<details>` blocks per the rubric.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@b449259f5854b7501fa071cae93b3a657ba8b4b4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@b449259f5854b7501fa071cae93b3a657ba8b4b4:packages/skills/skills/contribute-to-eliza"} -->
