### PR TITLE
fix(ci): restore scheduled Android evidence signal

### DIFF
--- a/.github/scripts/device-e2e/arm64-local-preflight.sh
+++ b/.github/scripts/device-e2e/arm64-local-preflight.sh
@@ -14,12 +14,25 @@ set -euo pipefail
   exit 1
 }
 [[ "$(node -p 'process.arch')" == "arm64" ]] || {
-  echo "Android ARM64 lane requires an arm64 host" >&2
+  echo "Android ARM64 lane requires an arm64 Node runtime" >&2
+  exit 1
+}
+
+host_arch=$(uname -m)
+[[ "$host_arch" == "aarch64" || "$host_arch" == "arm64" ]] || {
+  echo "Android ARM64 lane requires an ARM64 kernel host; found ${host_arch:-missing}" >&2
   exit 1
 }
 
 command -v java >/dev/null
 command -v adb >/dev/null
+
+java_major=$(java -XshowSettings:properties -version 2>&1 \
+  | awk -F= '$1 ~ /java.specification.version/ { gsub(/[[:space:]]/, "", $2); print $2; exit }')
+[[ "$java_major" == "21" ]] || {
+  echo "Android ARM64 lane requires Java 21; found ${java_major:-missing}" >&2
+  exit 1
+}
 
 mapfile -t attached_devices < <(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,20 +46,31 @@ Representative examples:
 - `device-e2e.yml` is the exact-head Android-emulator and iOS-simulator
   device-bundle producer (#19640). Canonical `ci.yml` calls it only for PRs
   carrying the `ci:device` label; `workflow_dispatch` is the on-demand route,
-  and a weekly cadence hard-gates the explicit host-safe Android subset.
+  and a weekly cadence hard-gates only the explicit host-safe Android subset;
+  scheduled runs do not allocate the macOS/iOS job. A scheduled Android
+  non-success opens, updates, or reopens one stable failure issue containing
+  exact run-attempt, attempt-scoped artifact, and revision links; the next
+  successful cadence updates and closes it so the issue never remains stale.
+  The notifier has job-scoped read access to Actions and contents plus issue
+  write access; reusable and manually dispatched runs never write issues.
   [![scheduled device e2e](https://github.com/elizaOS/eliza/actions/workflows/device-e2e.yml/badge.svg?branch=develop&event=schedule)](https://github.com/elizaOS/eliza/actions/workflows/device-e2e.yml?query=event%3Aschedule)
-  Both jobs run the bundle-owning runners with `--output` and upload the full
-  bundle (`inline/`, `logs/`, `summary.json`, `junit.xml`) on success and
-  failure, without reading any repository secret.
+  Artifact names include the run ID and attempt so reruns cannot overwrite or
+  link a prior attempt's bundle. Both jobs initialize a revision-bound artifact
+  root after checkout, then run the bundle-owning runners with `--output`. A
+  started runner finalizes the full bundle (`inline/`, `logs/`, `summary.json`,
+  `junit.xml`) on success and failure; an earlier toolchain or device failure
+  retains the bootstrap record plus the Actions log. No job reads a repository
+  secret.
 - `android-arm64-local-e2e.yml` is the separate weekly, schedule-only
   self-hosted physical-device lane for the embedded Bun + GGUF agent. Its
   `[self-hosted, Linux, ARM64, android-device]` labels are an infrastructure
   contract: the job stays queued until such a runner is online, then fails
   closed unless both the host and attached Android target pass ARM64 and pinned
-  toolchain preflight. It runs local chat plus local-runtime/route WebView
-  probes; on-device voice remains separately qualified. Manual arbitrary-ref
-  dispatch is intentionally unavailable because this runner persists and owns
-  a physical device.
+  toolchain preflight. Preflight output is uploaded even when a prerequisite
+  fails before the bundle runner starts. It runs local chat plus
+  local-runtime/route WebView probes; on-device voice remains separately
+  qualified. Manual arbitrary-ref dispatch is intentionally unavailable
+  because this runner persists and owns a physical device.
 
 ## Manual operations
 

--- a/.github/workflows/android-arm64-local-e2e.yml
+++ b/.github/workflows/android-arm64-local-e2e.yml
@@ -45,7 +45,10 @@ jobs:
           submodules: recursive
 
       - name: Fail-closed ARM64 device preflight
-        run: bash .github/scripts/device-e2e/arm64-local-preflight.sh
+        run: |
+          mkdir -p "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local/logs"
+          bash .github/scripts/device-e2e/arm64-local-preflight.sh 2>&1 \
+            | tee "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local/logs/arm64-preflight.log"
 
       - name: Install pinned workspace
         run: bun install --frozen-lockfile
@@ -62,7 +65,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: android-arm64-local-runtime-bundle
+          name: android-arm64-local-runtime-bundle-${{ github.run_id }}-${{ github.run_attempt }}
           path: device-e2e-artifacts/android-arm64-local/**
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -6,17 +6,20 @@ name: Device E2E
 # owns the current hosted-device route without reviving that sprawl. Each job
 # hands the whole lane to the single bundle-owning runner
 # (android-e2e.mjs / ios-e2e.mjs --output) so
-# build, install, boot, and drive failures all land inside one bundle root
-# (inline/, logs/, summary.json, junit.xml), and the artifact is uploaded on
-# success AND failure. No repository secrets are read anywhere, so fork PRs
-# stay credential-free.
+# build, install, and drive failures after the runner starts land inside one
+# finalized bundle root (inline/, logs/, summary.json, junit.xml). Each job
+# initializes its artifact root immediately after checkout, so a later
+# toolchain or emulator/simulator infrastructure failure still leaves a
+# revision-bound bootstrap record alongside the Actions log. No repository
+# secrets are read anywhere, so fork PRs stay credential-free.
 #
 # Reachability: repository policy forbids direct pull-request triggers
 # (audit:workflow-triggers), so canonical ci.yml calls this workflow behind the
 # `ci:device` label gate — the emulator/simulator legs are heavy and a PR runs
 # them only when explicitly opted in. A weekly schedule protects the hosted
-# Android subset between PR opt-ins; its event-filtered status badge is linked
-# from .github/workflows/README.md so failures stay visible outside run history.
+# Android subset between PR opt-ins. The iOS job is deliberately excluded from
+# schedules, and a least-privilege notifier opens a stable issue on failure and
+# closes it after recovery so status stays visible outside run history.
 # Labels are read from the run's event
 # payload, so apply `ci:device` before the head push (or re-open) that should
 # carry the proof. workflow_dispatch remains the on-demand route for arbitrary
@@ -61,6 +64,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Initialize Android artifact root
+        run: |
+          mkdir -p "$ELIZA_DEVICE_BUNDLE_ROOT/android/logs"
+          printf 'revision=%s\nrun=%s/%s\nevent=%s\n' \
+            "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$GITHUB_EVENT_NAME" \
+            > "$ELIZA_DEVICE_BUNDLE_ROOT/android/logs/workflow-bootstrap.txt"
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -101,7 +111,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: android-device-e2e-bundle
+          name: android-device-e2e-bundle-${{ github.run_id }}-${{ github.run_attempt }}
           path: device-e2e-artifacts/android/**
           if-no-files-found: error
           retention-days: 14
@@ -129,6 +139,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: false
+
+      - name: Initialize iOS artifact root
+        run: |
+          mkdir -p "$ELIZA_DEVICE_BUNDLE_ROOT/ios/logs"
+          printf 'revision=%s\nrun=%s/%s\nevent=%s\n' \
+            "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$GITHUB_EVENT_NAME" \
+            > "$ELIZA_DEVICE_BUNDLE_ROOT/ios/logs/workflow-bootstrap.txt"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -158,7 +175,120 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: ios-simulator-e2e-bundle
+          name: ios-simulator-e2e-bundle-${{ github.run_id }}-${{ github.run_attempt }}
           path: device-e2e-artifacts/ios/**
           if-no-files-found: error
           retention-days: 14
+
+  reconcile-scheduled-android-status:
+    name: Reconcile scheduled Android status
+    needs: android-device-bundle
+    if: ${{ always() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    env:
+      ANDROID_JOB_RESULT: ${{ needs.android-device-bundle.result }}
+    steps:
+      - name: Reconcile the scheduled Android status issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const title = "Scheduled Android device E2E is failing (#13580)";
+            const repositoryUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`;
+            const runUrl = `${repositoryUrl}/actions/runs/${context.runId}/attempts/${context.runAttempt}`;
+            const revisionUrl = `${repositoryUrl}/commit/${context.sha}`;
+            const result = process.env.ANDROID_JOB_RESULT || "unknown";
+            const artifactName = `android-device-e2e-bundle-${context.runId}-${context.runAttempt}`;
+            const issues = await github.paginate(
+              github.rest.search.issuesAndPullRequests,
+              {
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:issue in:title "${title}"`,
+                per_page: 100,
+              },
+            );
+            const matchingIssues = issues.filter(
+              (issue) => !issue.pull_request && issue.title === title,
+            );
+            const existing =
+              matchingIssues.find((issue) => issue.state === "open") ??
+              matchingIssues[0];
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                per_page: 100,
+              },
+            );
+            const artifact = artifacts.find(
+              (candidate) =>
+                candidate.name === artifactName && !candidate.expired,
+            );
+            const artifactLine = artifact
+              ? `[${artifactName}](${repositoryUrl}/actions/runs/${context.runId}/artifacts/${artifact.id})`
+              : `Not produced for run attempt ${context.runId}/${context.runAttempt}; inspect the [run artifact list](${repositoryUrl}/actions/runs/${context.runId}#artifacts).`;
+
+            if (result === "success") {
+              if (!existing || existing.state === "closed") {
+                core.info("Scheduled Android run succeeded; no open failure issue to close.");
+                return;
+              }
+              const body = [
+                "The weekly hosted Android device-bundle cadence recovered.",
+                "",
+                `- Result: \`${result}\``,
+                `- Run attempt: [${context.runId}/${context.runAttempt}](${runUrl})`,
+                `- Artifact: ${artifactLine}`,
+                `- Revision: [\`${context.sha}\`](${revisionUrl})`,
+                "",
+                "This stable issue is reconciled only by scheduled runs of `.github/workflows/device-e2e.yml`. Manual dispatches and reusable-workflow calls never write issues.",
+              ].join("\n");
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body,
+                state: "closed",
+                state_reason: "completed",
+              });
+              core.info(`Closed recovered scheduled Android issue #${existing.number}`);
+              return;
+            }
+
+            const body = [
+              "The weekly hosted Android device-bundle cadence is not successful.",
+              "",
+              `- Result: \`${result}\``,
+              `- Run attempt: [${context.runId}/${context.runAttempt}](${runUrl})`,
+              `- Artifact: ${artifactLine}`,
+              `- Revision: [\`${context.sha}\`](${revisionUrl})`,
+              "",
+              "This stable issue is opened, updated, and reopened by `.github/workflows/device-e2e.yml`. Manual dispatches and reusable-workflow calls never write issues.",
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body,
+                state: "open",
+              });
+              core.info(`Updated scheduled Android failure issue #${existing.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+              core.info(`Opened scheduled Android failure issue #${created.number}`);
+            }

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -135,7 +135,9 @@ The scheduled and `ci:device`-label-gated Android job in
    and the native `ElizaSystem` plugin bridge. A newly added Android spec does
    not enter this set implicitly.
 5. Stop the host agent in `android-e2e.mjs` teardown and upload its log inside
-   the device bundle. Missing bundles are upload failures, not warnings.
+   the device bundle. Missing bundles are upload failures, not warnings, and
+   artifact names include the Actions run ID and attempt to keep reruns
+   distinct.
 
 Artifacts are written under
 `packages/app/test-results/android-onboarding-to-home/`:
@@ -152,6 +154,8 @@ that runner, so a queued job is an infrastructure prerequisite rather than
 device proof. Arbitrary-ref manual dispatch is intentionally unavailable on
 this persistent physical-device runner. Do not cite this workflow as ARM64
 evidence until a completed bundle from the current revision has been inspected.
+Preflight output is retained in the artifact root even when a host, toolchain,
+or target check fails before the bundle runner starts.
 
 Local voice, destructive lifecycle, launcher soak, touch, and sleep/wake are
 not smuggled into either set. Run their focused commands explicitly on hardware

--- a/packages/scripts/__tests__/device-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/device-e2e-workflow.test.ts
@@ -8,8 +8,10 @@
  * (android-e2e.mjs / ios-e2e.mjs) with `--output` inside the uploaded artifact
  * root, that the uploads run `if: always()` so an induced failure still ships
  * a bundle, that the bundle producers emit the required inline/, logs/,
- * summary.json, and junit.xml members, and that the workflow stays
- * credential-free for fork PRs with pinned toolchains and SHA-pinned actions.
+ * summary.json, and junit.xml members, and that the Android-only cadence has a
+ * least-privilege stable-issue failure signal without scheduling iOS. The
+ * workflow stays credential-free for fork PRs with pinned toolchains and
+ * SHA-pinned actions.
  * Parses the real workflow YAML; deterministic, no network or devices.
  */
 import { describe, expect, test } from "bun:test";
@@ -25,6 +27,8 @@ function read(path: string): string {
   return readFileSync(new URL(path, repoRoot), "utf8");
 }
 
+const workflowExpression = (body: string): string => `\${{ ${body} }}`;
+
 interface WorkflowStep {
   if?: string;
   name?: string;
@@ -36,6 +40,8 @@ interface WorkflowStep {
 interface WorkflowJob {
   env?: Record<string, string>;
   if?: string;
+  needs?: string | string[];
+  permissions?: Record<string, string>;
   "runs-on"?: string | string[];
   steps?: WorkflowStep[];
   "timeout-minutes"?: number;
@@ -79,6 +85,7 @@ const ci = Bun.YAML.parse(read(".github/workflows/ci.yml")) as {
 
 const androidJob = workflow.jobs?.["android-device-bundle"];
 const iosJob = workflow.jobs?.["ios-simulator-bundle"];
+const notifierJob = workflow.jobs?.["reconcile-scheduled-android-status"];
 
 function requireJob(job: WorkflowJob | undefined, name: string): WorkflowJob {
   if (!job) throw new Error(`Missing device-e2e job: ${name}`);
@@ -129,6 +136,51 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
   });
 
+  test("the weekly schedule spends only Android while calls and dispatches retain iOS", () => {
+    expect(androidJob?.if).toBeUndefined();
+    expect(iosJob?.if).toContain("github.event_name != 'schedule'");
+    expect(workflowReadme).toContain(
+      "scheduled runs do not allocate the macOS/iOS job",
+    );
+  });
+
+  test("scheduled Android results reconcile one actionable issue with least privilege", () => {
+    const notifier = requireJob(
+      notifierJob,
+      "reconcile-scheduled-android-status",
+    );
+    expect(notifier.needs).toBe("android-device-bundle");
+    expect(notifier.if).toContain("always()");
+    expect(notifier.if).toContain("github.event_name == 'schedule'");
+    expect(notifier.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      issues: "write",
+    });
+    const notification = findStep(
+      notifier,
+      (step) => step.uses?.startsWith("actions/github-script@") === true,
+      "scheduled Android status reconciliation",
+    );
+    expect(notification.uses).toBe(
+      "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+    );
+    const script = notification.with?.script ?? "";
+    expect(script).toContain("listWorkflowRunArtifacts");
+    expect(script).toContain("artifact.id");
+    expect(script).toContain("context.runAttempt");
+    expect(script).toContain(
+      "android-device-e2e-bundle-${context.runId}-${context.runAttempt}",
+    );
+    expect(script).toContain("github.rest.search.issuesAndPullRequests");
+    expect(script).toContain("github.rest.issues.update");
+    expect(script).toContain("github.rest.issues.create");
+    expect(script).toContain('if (result === "success")');
+    expect(script).toContain('state: "closed"');
+    expect(script).toContain('state_reason: "completed"');
+    expect(script).not.toContain("createComment");
+  });
+
   test("the Android job invokes the bundle-owning runner with --output inside the artifact root", () => {
     const job = requireJob(androidJob, "android-device-bundle");
     const runner = findStep(
@@ -165,21 +217,41 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
   });
 
   test("both uploads run if: always() and cover the exact --output roots", () => {
+    const androidBootstrap = findStep(
+      requireJob(androidJob, "android-device-bundle"),
+      (step) => step.name === "Initialize Android artifact root",
+      "Android artifact bootstrap",
+    );
+    expect(androidBootstrap.run).toContain("workflow-bootstrap.txt");
+    expect(androidBootstrap.run).toContain('"$GITHUB_SHA"');
     const android = findStep(
       requireJob(androidJob, "android-device-bundle"),
       (step) => step.uses?.startsWith("actions/upload-artifact@") === true,
       "Android upload",
     );
     expect(android.if).toBe("always()");
+    expect(android.with?.name).toBe(
+      `android-device-e2e-bundle-${workflowExpression("github.run_id")}-${workflowExpression("github.run_attempt")}`,
+    );
     expect(android.with?.path).toContain("device-e2e-artifacts/android/**");
     expect(android.with?.["if-no-files-found"]).toBe("error");
 
+    const iosBootstrap = findStep(
+      requireJob(iosJob, "ios-simulator-bundle"),
+      (step) => step.name === "Initialize iOS artifact root",
+      "iOS artifact bootstrap",
+    );
+    expect(iosBootstrap.run).toContain("workflow-bootstrap.txt");
+    expect(iosBootstrap.run).toContain('"$GITHUB_SHA"');
     const ios = findStep(
       requireJob(iosJob, "ios-simulator-bundle"),
       (step) => step.uses?.startsWith("actions/upload-artifact@") === true,
       "iOS upload",
     );
     expect(ios.if).toBe("always()");
+    expect(ios.with?.name).toBe(
+      `ios-simulator-e2e-bundle-${workflowExpression("github.run_id")}-${workflowExpression("github.run_attempt")}`,
+    );
     expect(ios.with?.path).toContain("device-e2e-artifacts/ios/**");
     expect(ios.with?.["if-no-files-found"]).toBe("error");
   });
@@ -296,6 +368,9 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
     expect(arm64PreflightSource).toContain('"v24.15.0"');
     expect(arm64PreflightSource).toContain('"1.3.14"');
     expect(arm64PreflightSource).toContain("process.arch");
+    expect(arm64PreflightSource).toContain("uname -m");
+    expect(arm64PreflightSource).toContain("java.specification.version");
+    expect(arm64PreflightSource).toContain('"21"');
     expect(arm64PreflightSource).toContain('"arm64-v8a"');
     expect(arm64PreflightSource).toContain("sys.boot_completed");
     expect(arm64PreflightSource).toContain("GITHUB_ENV");
@@ -303,6 +378,13 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
 
   test("runs the explicit local probe set and uploads exact artifacts honestly", () => {
     const job = requireJob(armJob, "android-arm64-local-runtime");
+    const preflight = findStep(
+      job,
+      (step) => step.name === "Fail-closed ARM64 device preflight",
+      "ARM64 preflight",
+    );
+    expect(preflight.run).toContain("arm64-local-preflight.sh 2>&1");
+    expect(preflight.run).toContain("arm64-preflight.log");
     const runner = findStep(
       job,
       (step) => step.run?.includes("--arm64-local-probes") === true,
@@ -319,6 +401,9 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
       "ARM64 upload",
     );
     expect(upload.if).toBe("always()");
+    expect(upload.with?.name).toBe(
+      `android-arm64-local-runtime-bundle-${workflowExpression("github.run_id")}-${workflowExpression("github.run_attempt")}`,
+    );
     expect(upload.with?.path).toContain(
       "device-e2e-artifacts/android-arm64-local/**",
     );


### PR DESCRIPTION
## Summary

- preserve the schedule/dispatch/self-hosted security partition merged in #21112
- reconcile the stable scheduled Android failure issue on both failure and recovery
- bind uploaded evidence and issue links to the exact run ID, attempt, revision, and artifact ID
- emit honest bootstrap evidence for hosted setup and ARM64 preflight failures
- fail closed unless the self-hosted lane proves an ARM64 kernel and Java 21

## Verification

- 83 focused device-workflow and bundle tests pass
- `actionlint` passes for both affected workflows
- ARM64 preflight passes `bash -n`
- embedded `github-script` source parses and compiles as async JavaScript
- `git diff --check` passes

## Evidence and residuals

This PR repairs repository-side evidence truth. It does **not** claim that an ARM64 Android device runner exists or that the current revision has completed on physical hardware. #13580 should remain open until a scheduled hosted-emulator bundle is inspected and a real `[self-hosted, Linux, ARM64, android-device]` runner produces the local-runtime bundle.

Refs #13580

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: `elizaOS/eliza@8fc430c996805550c5ed115575c29872e5aa7ebd:packages/skills/skills/contribute-to-eliza`  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@8fc430c996805550c5ed115575c29872e5aa7ebd:packages/skills/skills/contribute-to-eliza"} -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8fc430c996805550c5ed115575c29872e5aa7ebd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`



## Evidence Gate

<!-- evidence-head:979a8df933eb41793623eb037eba61da5b7ca672 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow and preflight code only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow and preflight code only.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pending the scheduled hosted and physical ARM64 device runs described above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime changed; focused workflow and syntax results are recorded in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - current-run hosted and ARM64 bundles remain the issue-level hardware acceptance gate.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.