### PR TITLE
fix(core): stream attachment bodies under a hard byte cap

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -108,7 +108,10 @@ export * from "./actions/index.ts";
 export * from "./evaluators/index.ts";
 export * from "./providers/index.ts";
 
-import { describeImageCached } from "../../media/index.ts";
+import {
+	describeImageCached,
+	readResponseWithLimit,
+} from "../../media/index.ts";
 import { recentErrorsProvider } from "../../providers/recent-errors.ts";
 import { generateMediaAction } from "../advanced-capabilities/actions/generateMedia.ts";
 // Import advanced capabilities
@@ -206,6 +209,26 @@ interface PostCreationJson {
 
 const MAX_POST_GENERATION_ATTEMPTS = 3;
 
+/** Hard cap for any single media fetch — attacker-supplied URLs can lie about size. */
+export const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+
+async function readBoundedMediaResponse(
+	response: Response,
+	label: string,
+	url: string,
+): Promise<Buffer> {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength !== null) {
+		const declared = Number(contentLength);
+		if (Number.isFinite(declared) && declared > MAX_MEDIA_BYTES) {
+			throw new Error(
+				`${label} exceeds size limit ${declared} > ${MAX_MEDIA_BYTES}: ${url}`,
+			);
+		}
+	}
+	return await readResponseWithLimit(response, MAX_MEDIA_BYTES);
+}
+
 function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -267,7 +290,11 @@ export async function fetchMediaData(
 					if (!response.ok) {
 						throw new Error(`Failed to fetch file: ${attachment.url}`);
 					}
-					const mediaBuffer = Buffer.from(await response.arrayBuffer());
+					const mediaBuffer = await readBoundedMediaResponse(
+						response,
+						"Media",
+						attachment.url,
+					);
 					const mediaType = attachment.contentType || "image/png";
 					return { data: mediaBuffer, mediaType };
 				} finally {
@@ -333,8 +360,7 @@ export async function processAttachments(
 					throw new Error(`Failed to fetch image: ${res.statusText}`);
 				}
 
-				const arrayBuffer = await res.arrayBuffer();
-				const buffer = Buffer.from(arrayBuffer);
+				const buffer = await readBoundedMediaResponse(res, "Image", url);
 				const contentType =
 					res.headers.get("content-type") || "application/octet-stream";
 				imageUrl = `data:${contentType};base64,${buffer.toString("base64")}`;
@@ -400,7 +426,9 @@ export async function processAttachments(
 					"Processing text document",
 				);
 
-				const textContent = await res.text();
+				const textContent = (
+					await readBoundedMediaResponse(res, "Text document", url)
+				).toString("utf8");
 				processedAttachment.text = textContent;
 				processedAttachment.title = processedAttachment.title || "Text File";
 
@@ -421,7 +449,7 @@ export async function processAttachments(
 				const { convertPdfToTextFromBuffer } = await import(
 					"../documents/utils"
 				);
-				const pdfBuffer = Buffer.from(await res.arrayBuffer());
+				const pdfBuffer = await readBoundedMediaResponse(res, "PDF", url);
 				const textContent = await convertPdfToTextFromBuffer(
 					pdfBuffer,
 					processedAttachment.title ?? undefined,

--- a/packages/core/src/features/basic-capabilities/media-response-limits.test.ts
+++ b/packages/core/src/features/basic-capabilities/media-response-limits.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Exercises attachment body limits through the real basic-capabilities document
+ * path, including declared oversize rejection before reading and cancellation of
+ * a chunked response as soon as its running byte total crosses the cap.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ContentType,
+	type IAgentRuntime,
+	type Media,
+	type UUID,
+} from "../../types/index.ts";
+import { MAX_MEDIA_BYTES, processAttachments } from "./index.ts";
+
+const agentId = "00000000-0000-0000-0000-0000000000ab" as UUID;
+
+function makeRuntime(): IAgentRuntime {
+	return {
+		agentId,
+		logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+	} as unknown as IAgentRuntime;
+}
+
+function textDocument(url: string): Media {
+	return { id: url, url, contentType: ContentType.DOCUMENT } as Media;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("basic-capabilities attachment body limits", () => {
+	it("rejects an oversized Content-Length without reading the body", async () => {
+		let readerRequests = 0;
+		const response = {
+			ok: true,
+			statusText: "OK",
+			headers: new Headers({
+				"content-length": String(MAX_MEDIA_BYTES + 1),
+				"content-type": "text/plain",
+			}),
+			body: {
+				getReader() {
+					readerRequests += 1;
+					throw new Error("body must not be read");
+				},
+			},
+		} as unknown as Response;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => response),
+		);
+
+		await expect(
+			processAttachments(
+				[textDocument("https://media.test/declared-too-large.txt")],
+				makeRuntime(),
+			),
+		).rejects.toThrow(/exceeds size limit/);
+		expect(readerRequests).toBe(0);
+	});
+
+	it("cancels a chunked body when the running byte total exceeds the cap", async () => {
+		let reads = 0;
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>(
+			{
+				pull(controller) {
+					reads += 1;
+					if (reads === 1) {
+						controller.enqueue(new Uint8Array(MAX_MEDIA_BYTES));
+					} else if (reads === 2) {
+						controller.enqueue(new Uint8Array([1]));
+					} else {
+						controller.close();
+					}
+				},
+				cancel() {
+					cancelled = true;
+				},
+			},
+			{ highWaterMark: 0 },
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(body, { headers: { "content-type": "text/plain" } }),
+			),
+		);
+
+		await expect(
+			processAttachments(
+				[textDocument("https://media.test/chunked-too-large.txt")],
+				makeRuntime(),
+			),
+		).rejects.toThrow(/maxBytes/);
+		expect(reads).toBeLessThanOrEqual(3);
+		expect(cancelled).toBe(true);
+	});
+});


### PR DESCRIPTION
## Relates to

Closes #22560.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`, `gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## What does this PR do?

Bounds four attachment response-body materialization paths at 10 MiB:

- guarded remote media reads in `fetchMediaData`
- trusted local image reads before base64 conversion
- text and JSON document reads
- PDF document reads

The original contribution checked size only after `arrayBuffer()` or `text()`, which still allowed chunked or dishonest servers to force an unbounded allocation. The review repair now:

- rejects an oversized `Content-Length` before acquiring a reader
- delegates to the canonical streaming `readResponseWithLimit`
- cancels the response stream as soon as its running byte total crosses the cap
- decodes bounded text bytes only after the cap has been enforced
- removes the PNG decompression changes that are already merged through #22415

## Risks

Low and fail-closed. Valid attachments at or below 10 MiB retain their existing behavior. Oversized declared or streamed payloads now fail explicitly.

## Exact-head testing

Verified at `9a2bea7364f8cd324a4f97a7a4be5db328c951f5`:

```text
node packages/scripts/run-vitest.mjs run   packages/core/src/features/basic-capabilities/media-response-limits.test.ts   packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts
2 files passed, 7 tests passed

bun run --cwd packages/core typecheck
pass

bunx biome check   packages/core/src/features/basic-capabilities/index.ts   packages/core/src/features/basic-capabilities/media-response-limits.test.ts
Checked 2 files. No fixes applied.

git diff --check
pass
```

Negative mutation proof: replacing the streaming reader with `arrayBuffer()` makes the chunked `10 MiB + 1 byte` regression resolve successfully instead of rejecting. Restoring the implementation returns the suite to 2/2 green.

`bun run verify` reaches the workspace lint lane but current `develop` fails on three pre-existing formatting errors introduced by merged PR #22517 in `action-retrieval.ts`, `action-wildcard-glob.ts`, and its test. None differ in this PR. That base blocker is being repaired separately.

## Evidence Gate

<!-- evidence-head:9a2bea7364f8cd324a4f97a7a4be5db328c951f5 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — deterministic core attachment boundary; exact test and mutation evidence is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual content changed.

Original contribution: Anthropic / claude-fable-5 via Claude Code. Review repair and exact-head validation:

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->