### PR TITLE
fix(cloud): finish Steward binding retries from primary state

### DIFF
--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -563,6 +563,16 @@ export class UsersRepository {
   }
 
   /**
+   * Finds a user by ID from primary storage.
+   *
+   * Lifecycle mutations use this reader when the current organization and
+   * identity binding determine which durable authorization fences must move.
+   */
+  async findByIdForWrite(id: string): Promise<User | undefined> {
+    return await this.findUserByPredicate(dbWrite, eq(users.id, id));
+  }
+
+  /**
    * Finds a user by email address.
    */
   async findByEmail(email: string): Promise<User | undefined> {

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -26,6 +26,9 @@ const lifecycleEvents: string[] = [];
 let userApiKeys: Array<{ key_hash: string }> = [];
 let orgApiKeys: Array<{ key_hash: string }> = [];
 let userRecord: Record<string, unknown> | undefined;
+let readUserRecordOverride: Record<string, unknown> | undefined;
+let useReadUserRecordOverride = false;
+let failNextBindingActivation = false;
 let listByOrganizationUsers: unknown[] = [];
 let listByUserError: Error | null = null;
 
@@ -46,6 +49,10 @@ mock.module("./inference-credential-revocation", () => ({
     active: boolean,
   ) => {
     lifecycleEvents.push(`session-binding:${orgId}:${userId}:${stewardUserId}:${active}`);
+    if (active && failNextBindingActivation) {
+      failNextBindingActivation = false;
+      throw new Error("binding activation unavailable");
+    }
   },
   revokeInferenceSessionsThrough: async (orgId: string, userId: string) => {
     lifecycleEvents.push(`session:${orgId}:${userId}`);
@@ -70,22 +77,30 @@ mock.module("../../db/repositories", () => ({
       return userApiKeys;
     },
     listByOrganization: async (_orgId: string) => orgApiKeys,
+    deactivateByUserAndOrganization: async (userId: string, orgId: string) => {
+      lifecycleEvents.push(`api-keys-deactivate:${userId}:${orgId}`);
+    },
   },
   usersRepository: {
-    findById: async (_id: string) => userRecord,
+    findById: async (_id: string) =>
+      useReadUserRecordOverride ? readUserRecordOverride : userRecord,
+    findByIdForWrite: async (_id: string) => userRecord,
     findIdentityByUserIdForWrite: async () =>
       userRecord?.steward_user_id ? { steward_user_id: userRecord.steward_user_id } : undefined,
     upsertStewardIdentity: async (id: string, stewardUserId: string) => {
       lifecycleEvents.push(`identity-upsert:${id}:${stewardUserId}`);
+      if (userRecord) userRecord.steward_user_id = stewardUserId;
       return { user_id: id, steward_user_id: stewardUserId };
     },
     linkStewardId: async (id: string, stewardUserId: string) => {
       lifecycleEvents.push(`identity-link:${id}:${stewardUserId}`);
-      return { ...userRecord, id, steward_user_id: stewardUserId };
+      userRecord = { ...userRecord, id, steward_user_id: stewardUserId };
+      return userRecord;
     },
     update: async (id: string, data: Record<string, unknown>) => {
       lifecycleEvents.push(`user-update:${id}`);
-      return { ...userRecord, ...data, id };
+      userRecord = { ...userRecord, ...data, id };
+      return userRecord;
     },
     delete: async (id: string) => {
       userDeleteCalls.push(id);
@@ -96,6 +111,8 @@ mock.module("../../db/repositories", () => ({
     listByOrganization: async (_orgId: string) => listByOrganizationUsers,
   },
   organizationsRepository: {
+    findBySlug: async () => undefined,
+    create: async (data: Record<string, unknown>) => ({ id: "o2", ...data }),
     update: async (id: string, data: Record<string, unknown>) => ({ id, ...data }),
     findWithUsers: async () => ({
       users: listByOrganizationUsers,
@@ -127,6 +144,9 @@ beforeEach(() => {
   userApiKeys = [];
   orgApiKeys = [];
   userRecord = undefined;
+  readUserRecordOverride = undefined;
+  useReadUserRecordOverride = false;
+  failNextBindingActivation = false;
   listByOrganizationUsers = [];
   listByUserError = null;
   lifecycleEvents.length = 0;
@@ -227,6 +247,27 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     ]);
   });
 
+  test("direct Steward identity update fences the primary binding when the read replica lags", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+    useReadUserRecordOverride = true;
+    readUserRecordOverride = undefined;
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { steward_user_id: "steward-new" });
+
+    expect(lifecycleEvents).toEqual([
+      "session-binding:o1:u1:steward-old:false",
+      "session:o1:u1",
+      "user-update:u1",
+      "session-binding:o1:u1:steward-new:true",
+    ]);
+  });
+
   test("retrying a committed Steward identity update repairs its active binding", async () => {
     userRecord = {
       id: "u1",
@@ -256,6 +297,46 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     await usersService.upsertStewardIdentity("u1", "steward-new");
 
     expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-new:true"]);
+    expect(invalidatedSessionBatches).toEqual([["steward-new"]]);
+  });
+
+  test("Steward identity upsert retry uses the primary user when the read replica lags", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-new",
+    };
+    useReadUserRecordOverride = true;
+    readUserRecordOverride = undefined;
+
+    const { usersService } = await import("./users");
+    await usersService.upsertStewardIdentity("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-new:true"]);
+  });
+
+  test("Steward identity upsert retries cache invalidation after a post-write fence failure", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+    failNextBindingActivation = true;
+
+    const { usersService } = await import("./users");
+    await expect(usersService.upsertStewardIdentity("u1", "steward-new")).rejects.toThrow(
+      "binding activation unavailable",
+    );
+    expect(userRecord?.steward_user_id).toBe("steward-new");
+    expect(invalidatedSessionBatches).toEqual([]);
+
+    lifecycleEvents.length = 0;
+    await usersService.upsertStewardIdentity("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-new:true"]);
+    expect(invalidatedSessionBatches).toEqual([["steward-new"]]);
   });
 
   test("Steward identity link fences the prior session generation before relinking", async () => {
@@ -265,6 +346,27 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
       email: null,
       steward_user_id: "steward-old",
     };
+
+    const { usersService } = await import("./users");
+    await usersService.linkStewardId("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual([
+      "session-binding:o1:u1:steward-old:false",
+      "session:o1:u1",
+      "identity-link:u1:steward-new",
+      "session-binding:o1:u1:steward-new:true",
+    ]);
+  });
+
+  test("Steward identity link fences the primary binding when the read replica lags", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+    useReadUserRecordOverride = true;
+    readUserRecordOverride = undefined;
 
     const { usersService } = await import("./users");
     await usersService.linkStewardId("u1", "steward-new");
@@ -294,6 +396,49 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     // The row is wiped on delete; a non-empty batch proves resolution happened first.
     expect(invalidatedHashBatches).toEqual([["uh1"]]);
     expect(invalidatedSessionBatches).toContainEqual(["steward-u1"]);
+  });
+
+  test("delete fences the primary organization when the read replica lags", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-u1",
+    };
+    useReadUserRecordOverride = true;
+    readUserRecordOverride = undefined;
+    listByOrganizationUsers = [{ id: "u2" }];
+
+    const { usersService } = await import("./users");
+    await usersService.delete("u1");
+
+    expect(lifecycleEvents).toContain("subject:o1:u1:false:account");
+    expect(userDeleteCalls).toEqual(["u1"]);
+  });
+
+  test("detach fences the primary organization when the read replica lags", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: "member@example.com",
+      name: "Member",
+      role: "member",
+      steward_user_id: "steward-u1",
+      is_active: true,
+    };
+    useReadUserRecordOverride = true;
+    readUserRecordOverride = undefined;
+
+    const { usersService } = await import("./users");
+    const detached = await usersService.detachFromOrganization("u1");
+
+    expect(detached.organization_id).toBe("o2");
+    expect(detached.role).toBe("owner");
+    expect(lifecycleEvents).toEqual([
+      "subject:o1:u1:false:membership",
+      "user-update:u1",
+      "api-keys-deactivate:u1:o1",
+    ]);
   });
 
   test("delete invalidation is best-effort: a cache/db failure does not throw", async () => {

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -289,7 +289,7 @@ export class UsersService {
   }
 
   async update(id: string, data: Partial<NewUser>): Promise<User | undefined> {
-    const existing = await usersRepository.findById(id);
+    const existing = await usersRepository.findByIdForWrite(id);
     const movingOrganizations =
       typeof data.organization_id === "string" &&
       data.organization_id !== existing?.organization_id;
@@ -366,7 +366,7 @@ export class UsersService {
     const existingIdentity = await usersRepository.findIdentityByUserIdForWrite(userId);
 
     if (existingIdentity?.steward_user_id === stewardUserId) {
-      const user = await usersRepository.findById(userId);
+      const user = await usersRepository.findByIdForWrite(userId);
       if (user?.organization_id) {
         // The identity row may have committed before a prior attempt failed to
         // clear the durable binding fence. Make the idempotent retry complete
@@ -376,11 +376,12 @@ export class UsersService {
       await Promise.all([
         cache.del(CacheKeys.user.byStewardId(stewardUserId)),
         cache.del(CacheKeys.user.byStewardIdWithOrg(stewardUserId)),
+        invalidateInferenceSessionAuthContexts([stewardUserId]),
       ]);
       return;
     }
 
-    const user = await usersRepository.findById(userId);
+    const user = await usersRepository.findByIdForWrite(userId);
     if (user?.organization_id) {
       if (existingIdentity?.steward_user_id) {
         await setInferenceSessionBindingActive(
@@ -420,7 +421,7 @@ export class UsersService {
   }
 
   async linkStewardId(userId: string, stewardUserId: string): Promise<void> {
-    const existing = await usersRepository.findById(userId);
+    const existing = await usersRepository.findByIdForWrite(userId);
     if (existing?.organization_id && existing.steward_user_id !== stewardUserId) {
       if (existing.steward_user_id) {
         await setInferenceSessionBindingActive(
@@ -465,7 +466,7 @@ export class UsersService {
    * invite→remove cycle must not mint free credit.
    */
   async detachFromOrganization(id: string): Promise<User> {
-    const user = await usersRepository.findById(id);
+    const user = await usersRepository.findByIdForWrite(id);
     if (!user) {
       throw new Error(`User ${id} not found`);
     }
@@ -528,7 +529,7 @@ export class UsersService {
   }
 
   async delete(id: string): Promise<void> {
-    const user = await this.getById(id);
+    const user = await usersRepository.findByIdForWrite(id);
 
     if (!user) {
       throw new Error(`User ${id} not found`);


### PR DESCRIPTION
# Relates to

Closes #20913.

- [x] Targets `develop` and is rebased onto `43718d969bb554a254b54fe63e2f397c21f0cdfa` with zero conflicts.
- [ ] `bun install` and full `bun run verify` were not rerun in the sparse integration checkout; exact scoped evidence and environmental gaps are recorded below.
- [x] The lifecycle behavior is covered by deterministic failure/retry and replica-lag tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Full repository verify was not run; see Known gaps / failures.

# Risks

Medium. This changes which database reader supplies authority preimages for user lifecycle mutations and repeats cache invalidation on idempotent retries. The scope is limited to primary-authoritative lifecycle fencing.

# Background

## What does this PR do?

It finishes recovery after a Steward binding row commits but activation subsequently fails:

- adds a primary/write-authority `findByIdForWrite` repository read;
- uses primary preimages for update, upsert, link, detach, and delete fencing;
- repeats session-auth-context invalidation when an idempotent binding retry repairs activation;
- covers post-write activation failure and lagging-replica retries for every affected lifecycle path.

## What kind of change is this?

Bug fix and retry-consistency hardening.

# Documentation changes needed?

No public API or operator workflow changes.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts`

## Detailed testing steps

```text
Bun 1.3.14 / Node 24.15.0 focused lifecycle suite:
19 pass, 0 fail, 34 assertions

Biome: 3 changed files clean
git diff --check origin/develop...HEAD: clean
```

# Evidence Gate

<!-- evidence-head:80158a83bf66586afff1ab734c7897c10c8868f3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend repository/service change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend repository/service change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic lifecycle tests directly exercise the service/repository seams; no deploy is required for this retry contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The 19-test lifecycle transcript covers committed-row retry repair, primary preimages, cache invalidation, detach, and delete.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

- The exact-head sparse checkout borrowed an existing dependency tree. A secondary `users.error-policy.test.ts` attempt was blocked before collection by that tree missing `markdown-it`; no changed-file diagnostic was emitted.
- Full `bun install`, package typecheck, and root `bun run verify` were not practical in the sparse integration checkout. The focused lifecycle suite, Biome check, and diff check are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza"} -->