### PR TITLE
fix(cloud): make warm-pool rollout digest-aware

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -138,12 +138,22 @@ describe("warm-pool image rollout admission", () => {
         configuredImage,
         targetDigest,
       }),
+    ).toBe(false);
+    expect(
+      prePullAllowsPoolImageRollout({
+        attempted: 1,
+        failed: 0,
+        configuredImage,
+        targetDigest,
+      }),
     ).toBe(true);
   });
 
   test("passes one resolved immutable digest into the manager and exposes counts", async () => {
     const rollout = mock(async () => ({
       decision: {
+        toFence: ["old-a", "old-b"],
+        toReplace: ["old-a"],
         counts: {
           target: 1,
           targetReady: 1,
@@ -154,7 +164,12 @@ describe("warm-pool image rollout admission", () => {
       },
       reserved: ["old-a", "old-b"],
       replaced: ["old-a"],
-      deferred: [],
+      deferred: [
+        {
+          id: "old-b",
+          reason: "generation changed before non-selected reservation",
+        },
+      ],
       failed: [],
     }));
     class TestWarmPoolManager {
@@ -331,6 +346,8 @@ describe("real one-shot daemon entrypoint", () => {
       warmPoolPhaseOrder.push("rollout");
       return {
         decision: {
+          toFence: ["warm-agent-old"],
+          toReplace: ["warm-agent-old"],
           counts: {
             target: 1,
             targetReady: 1,

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -10,7 +10,9 @@ import { fileURLToPath } from "node:url";
 import { DEFAULT_WARM_POOL_POLICY } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-forecast";
 import {
   __setDepsForTests,
+  prePullAllowsPoolImageRollout,
   processFleetUpgradeCycle,
+  processPoolImageRolloutCycle,
   readWorkerConfig,
 } from "./provisioning-worker";
 
@@ -110,6 +112,81 @@ describe("processFleetUpgradeCycle shared image-change capacity", () => {
   });
 });
 
+describe("warm-pool image rollout admission", () => {
+  test("only a completed zero-failure pre-pull authorizes rollout", () => {
+    expect(prePullAllowsPoolImageRollout(null)).toBe(false);
+    expect(
+      prePullAllowsPoolImageRollout({
+        attempted: 2,
+        failed: 1,
+        configuredImage,
+        targetDigest,
+      }),
+    ).toBe(false);
+    expect(
+      prePullAllowsPoolImageRollout({
+        attempted: 0,
+        failed: 0,
+        configuredImage,
+        targetDigest: null,
+      }),
+    ).toBe(false);
+    expect(
+      prePullAllowsPoolImageRollout({
+        attempted: 0,
+        failed: 0,
+        configuredImage,
+        targetDigest,
+      }),
+    ).toBe(true);
+  });
+
+  test("passes one resolved immutable digest into the manager and exposes counts", async () => {
+    const rollout = mock(async () => ({
+      decision: {
+        counts: {
+          target: 1,
+          targetReady: 1,
+          stale: 2,
+          selected: 1,
+          deferred: 1,
+        },
+      },
+      reserved: ["old-a", "old-b"],
+      replaced: ["old-a"],
+      deferred: [],
+      failed: [],
+    }));
+    class TestWarmPoolManager {
+      rollout = rollout;
+    }
+    __setDepsForTests({
+      containersEnv: { defaultAgentImage: () => configuredImage },
+      resolveImageDigest: async () => targetDigest,
+      WarmPoolManager: TestWarmPoolManager,
+      getHetznerPoolContainerCreator: () => ({}),
+      envWarmPoolPolicy: () => DEFAULT_WARM_POOL_POLICY,
+    } as unknown as Parameters<typeof __setDepsForTests>[0]);
+
+    const result = await processPoolImageRolloutCycle();
+
+    expect(rollout).toHaveBeenCalledWith(configuredImage, targetDigest);
+    expect(result).toEqual({
+      action: "completed",
+      configuredImage,
+      targetDigest,
+      target: 1,
+      targetReady: 1,
+      stale: 2,
+      selected: 1,
+      reserved: 2,
+      replaced: 1,
+      deferred: 1,
+      failed: 0,
+    });
+  });
+});
+
 const oneShotModuleSpecifiers = [
   "@elizaos/cloud-shared/lib/services/provisioning-jobs",
   "@elizaos/cloud-shared/lib/utils/logger",
@@ -155,6 +232,7 @@ async function withOneShotModuleMocks(
 
 describe("real one-shot daemon entrypoint", () => {
   test("runs one complete canary-aware cycle, closes owned handles, and exits cleanly", async () => {
+    const warmPoolPhaseOrder: string[] = [];
     const logger = {
       info: mock((..._args: unknown[]) => {}),
       warn: mock((..._args: unknown[]) => {}),
@@ -218,10 +296,13 @@ describe("real one-shot daemon entrypoint", () => {
     const syncAllocatedCounts = mock(
       async () => new Map([["node-a", { previous: 0, actual: 1 }]]),
     );
-    const prePullAgentImageOnAvailableNodes = mock(async () => [
-      { nodeId: "node-a", status: "pulled" },
-      { nodeId: "node-b", status: "failed" },
-    ]);
+    const prePullAgentImageOnAvailableNodes = mock(async () => {
+      warmPoolPhaseOrder.push("pre-pull");
+      return [
+        { nodeId: "node-a", status: "pulled" },
+        { nodeId: "node-b", status: "pulled" },
+      ];
+    });
     const evaluateCapacity = mock(async () => ({
       shouldScaleUp: true,
       shouldScaleDownNodeIds: [],
@@ -238,11 +319,32 @@ describe("real one-shot daemon entrypoint", () => {
       reconciliation: {},
       removed: [],
     }));
-    const replenish = mock(async () => ({
-      created: ["warm-agent-next"],
-      failed: [],
-      decision: { reason: "forecast deficit" },
-    }));
+    const replenish = mock(async () => {
+      warmPoolPhaseOrder.push("replenish");
+      return {
+        created: ["warm-agent-next"],
+        failed: [],
+        decision: { reason: "forecast deficit" },
+      };
+    });
+    const rollout = mock(async () => {
+      warmPoolPhaseOrder.push("rollout");
+      return {
+        decision: {
+          counts: {
+            target: 1,
+            targetReady: 1,
+            stale: 1,
+            selected: 1,
+            deferred: 0,
+          },
+        },
+        reserved: ["warm-agent-old"],
+        replaced: ["warm-agent-old"],
+        deferred: [],
+        failed: [],
+      };
+    });
     const countInFlightByTypes = mock(async () => 1);
     const listRunningWithDigestOtherThan = mock(async () => [
       {
@@ -278,11 +380,13 @@ describe("real one-shot daemon entrypoint", () => {
       failedRows: 0,
       invalidRows: 0,
     }));
+    const resolveImageDigest = mock(async () => targetDigest);
 
     class OneShotWarmPoolManager {
       drainIdle = drainIdle;
       healthCheck = healthCheck;
       replenish = replenish;
+      rollout = rollout;
     }
 
     const replacements: Readonly<Record<string, object>> = {
@@ -317,6 +421,8 @@ describe("real one-shot daemon entrypoint", () => {
       "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool": {
         WarmPoolManager: OneShotWarmPoolManager,
         envWarmPoolPolicy: () => DEFAULT_WARM_POOL_POLICY,
+        immutableImageReference: (_image: string, digest: string) =>
+          `ghcr.io/elizaos/eliza@${digest}`,
       },
       "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator": {
         getHetznerPoolContainerCreator: () => ({ kind: "deterministic" }),
@@ -329,7 +435,7 @@ describe("real one-shot daemon entrypoint", () => {
         assertSSHKeyAvailable: () => {},
       },
       "@elizaos/cloud-shared/lib/services/containers/registry-probe": {
-        resolveImageDigest: async () => targetDigest,
+        resolveImageDigest,
       },
       "@elizaos/cloud-shared/db/repositories/agent-sandboxes": {
         agentSandboxesRepository: {
@@ -461,14 +567,21 @@ describe("real one-shot daemon entrypoint", () => {
         expect(healthCheckAll).toHaveBeenCalledTimes(1);
         expect(syncAllocatedCounts).toHaveBeenCalledTimes(1);
         expect(prePullAgentImageOnAvailableNodes).toHaveBeenCalledWith(
-          configuredImage,
+          `ghcr.io/elizaos/eliza@${targetDigest}`,
         );
+        expect(resolveImageDigest).toHaveBeenCalledTimes(2);
         expect(evaluateCapacity).toHaveBeenCalledTimes(1);
         expect(provisionNode).toHaveBeenCalledTimes(1);
         expect(drainNode).not.toHaveBeenCalled();
         expect(drainIdle).toHaveBeenCalledWith(configuredImage);
         expect(healthCheck).toHaveBeenCalledTimes(1);
-        expect(replenish).toHaveBeenCalledWith(configuredImage);
+        expect(rollout).toHaveBeenCalledWith(configuredImage, targetDigest);
+        expect(replenish).toHaveBeenCalledWith(configuredImage, targetDigest);
+        expect(warmPoolPhaseOrder).toEqual([
+          "pre-pull",
+          "rollout",
+          "replenish",
+        ]);
         expect(reconcileOrphanContainersOnNodes).toHaveBeenCalledTimes(1);
         expect(reconcileOrphanAppContainersOnNodes).toHaveBeenCalledTimes(1);
         expect(cleanupExpiredPreDeleteRecoveryBackups).toHaveBeenCalledTimes(1);

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -40,6 +40,8 @@ type WorkerWarmPoolManager =
   typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool").WarmPoolManager;
 type WorkerEnvWarmPoolPolicy =
   typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool").envWarmPoolPolicy;
+type WorkerImmutableImageReference =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool").immutableImageReference;
 type WorkerContainersEnv =
   typeof import("@elizaos/cloud-shared/lib/config/containers-env").containersEnv;
 type WorkerAssertSSHKeyAvailable =
@@ -82,6 +84,7 @@ interface WorkerDeps {
   getNodeAutoscaler: WorkerNodeAutoscaler;
   WarmPoolManager: WorkerWarmPoolManager;
   envWarmPoolPolicy: WorkerEnvWarmPoolPolicy;
+  immutableImageReference: WorkerImmutableImageReference;
   getHetznerPoolContainerCreator: WorkerWarmPoolCreator;
   containersEnv: WorkerContainersEnv;
   assertSSHKeyAvailable: WorkerAssertSSHKeyAvailable;
@@ -338,6 +341,7 @@ async function loadDeps(): Promise<WorkerDeps> {
         getNodeAutoscaler: autoscalerModule.getNodeAutoscaler,
         WarmPoolManager: warmPoolModule.WarmPoolManager,
         envWarmPoolPolicy: warmPoolModule.envWarmPoolPolicy,
+        immutableImageReference: warmPoolModule.immutableImageReference,
         getHetznerPoolContainerCreator:
           warmPoolCreatorModule.getHetznerPoolContainerCreator,
         containersEnv: containersEnvModule.containersEnv,
@@ -807,6 +811,8 @@ interface NodeHealthSummary {
 interface PrePullImagesSummary {
   attempted: number;
   failed: number;
+  configuredImage: string;
+  targetDigest: string | null;
 }
 
 interface NodeAutoscaleSummary {
@@ -828,6 +834,20 @@ interface PoolReplenishSummary {
   created: number;
   failed: number;
   reason: string;
+}
+
+interface PoolImageRolloutSummary {
+  action: "completed" | "skipped_no_digest";
+  configuredImage: string;
+  targetDigest: string | null;
+  target: number;
+  targetReady: number;
+  stale: number;
+  selected: number;
+  reserved: number;
+  replaced: number;
+  deferred: number;
+  failed: number;
 }
 
 interface PoolHealthCheckSummary {
@@ -984,12 +1004,36 @@ async function processSyncAllocatedCountsCycle(): Promise<number> {
  */
 async function processPrePullImagesCycle(): Promise<PrePullImagesSummary | null> {
   if (process.env.ELIZA_AGENT_HOT_POOL_PREPULL === "false") return null;
-  const { dockerNodeManager, containersEnv } = await loadDeps();
-  const image = containersEnv.defaultAgentImage();
+  const {
+    dockerNodeManager,
+    containersEnv,
+    immutableImageReference,
+    resolveImageDigest,
+  } = await loadDeps();
+  const configuredImage = containersEnv.defaultAgentImage();
+  const targetDigest = await resolveImageDigest(configuredImage);
+  if (!targetDigest) {
+    return { attempted: 0, failed: 0, configuredImage, targetDigest: null };
+  }
+  const image = immutableImageReference(configuredImage, targetDigest);
   const result =
     await dockerNodeManager.prePullAgentImageOnAvailableNodes(image);
   const failed = result.filter((n) => n.status === "failed").length;
-  return { attempted: result.length, failed };
+  return {
+    attempted: result.length,
+    failed,
+    configuredImage,
+    targetDigest,
+  };
+}
+
+/** A disabled or failed pre-pull must never authorize destructive rollout. */
+export function prePullAllowsPoolImageRollout(
+  summary: PrePullImagesSummary | null,
+): summary is PrePullImagesSummary {
+  return (
+    summary !== null && summary.failed === 0 && summary.targetDigest !== null
+  );
 }
 
 /**
@@ -1192,6 +1236,54 @@ export async function processPoolHealthCheckCycle(): Promise<PoolHealthCheckSumm
 }
 
 /**
+ * Replace stale warm-pool generations against one immutable registry digest.
+ * The manager generation-fences every selected row before remote teardown and
+ * burst-bounds replacement while preserving the configured ready floor.
+ */
+export async function processPoolImageRolloutCycle(
+  resolvedTarget?: Pick<
+    PrePullImagesSummary,
+    "configuredImage" | "targetDigest"
+  >,
+): Promise<PoolImageRolloutSummary> {
+  const { containersEnv, resolveImageDigest } = await loadDeps();
+  const configuredImage =
+    resolvedTarget?.configuredImage ?? containersEnv.defaultAgentImage();
+  const targetDigest =
+    resolvedTarget?.targetDigest ?? (await resolveImageDigest(configuredImage));
+  if (!targetDigest) {
+    return {
+      action: "skipped_no_digest",
+      configuredImage,
+      targetDigest: null,
+      target: 0,
+      targetReady: 0,
+      stale: 0,
+      selected: 0,
+      reserved: 0,
+      replaced: 0,
+      deferred: 0,
+      failed: 0,
+    };
+  }
+  const pool = await getWarmPoolManager();
+  const result = await pool.rollout(configuredImage, targetDigest);
+  return {
+    action: "completed",
+    configuredImage,
+    targetDigest,
+    target: result.decision.counts.target,
+    targetReady: result.decision.counts.targetReady,
+    stale: result.decision.counts.stale,
+    selected: result.decision.counts.selected,
+    reserved: result.reserved.length,
+    replaced: result.replaced.length,
+    deferred: result.decision.counts.deferred + result.deferred.length,
+    failed: result.failed.length,
+  };
+}
+
+/**
  * Refill the warm pool up to its forecast target. THIS IS THE MISSING CALLER:
  * `WarmPoolManager.replenish()` had no live invocation anywhere in the tree —
  * the only historical caller was the deprecated (undeployed) container-control-
@@ -1207,11 +1299,13 @@ export async function processPoolHealthCheckCycle(): Promise<PoolHealthCheckSumm
  * runs AFTER the node-health / autoscale phases below so it sees fresh node
  * capacity when it decides how many to create.
  */
-export async function processPoolReplenishCycle(): Promise<PoolReplenishSummary> {
+export async function processPoolReplenishCycle(
+  targetDigest?: string,
+): Promise<PoolReplenishSummary> {
   const { containersEnv } = await loadDeps();
   const image = containersEnv.defaultAgentImage();
   const pool = await getWarmPoolManager();
-  const result = await pool.replenish(image);
+  const result = await pool.replenish(image, targetDigest);
   return {
     created: result.created.length,
     failed: result.failed.length,
@@ -1923,11 +2017,13 @@ export async function runInfraMaintenanceCycle(
     },
   );
 
+  let prePullTarget: PrePullImagesSummary | null = null;
   await runBoundedPhase(
     logger,
     "pre-pull images cycle",
     () => processPrePullImagesCycle(),
     (summary) => {
+      prePullTarget = prePullAllowsPoolImageRollout(summary) ? summary : null;
       if (summary) {
         logger.info("[provisioning-worker] pre-pull images cycle complete", {
           attempted: summary.attempted,
@@ -1936,6 +2032,25 @@ export async function runInfraMaintenanceCycle(
       }
     },
   );
+
+  let warmPoolTargetDigest: string | undefined;
+  if (prePullTarget) {
+    await runBoundedPhase(
+      logger,
+      "warm pool image rollout cycle",
+      () => processPoolImageRolloutCycle(prePullTarget),
+      (summary) => {
+        if (summary.targetDigest) warmPoolTargetDigest = summary.targetDigest;
+        logger.info(
+          "[provisioning-worker] warm pool image rollout cycle complete",
+          {
+            event: "warm_pool.image_rollout",
+            ...summary,
+          },
+        );
+      },
+    );
+  }
 
   await runBoundedPhase(
     logger,
@@ -1993,7 +2108,7 @@ export async function runInfraMaintenanceCycle(
   await runBoundedPhase(
     logger,
     "warm pool replenish cycle",
-    () => processPoolReplenishCycle(),
+    () => processPoolReplenishCycle(warmPoolTargetDigest),
     (result) => {
       if (result.created > 0 || result.failed > 0) {
         logger.info(

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -1032,7 +1032,10 @@ export function prePullAllowsPoolImageRollout(
   summary: PrePullImagesSummary | null,
 ): summary is PrePullImagesSummary {
   return (
-    summary !== null && summary.failed === 0 && summary.targetDigest !== null
+    summary !== null &&
+    summary.attempted > 0 &&
+    summary.failed === 0 &&
+    summary.targetDigest !== null
   );
 }
 
@@ -1238,7 +1241,9 @@ export async function processPoolHealthCheckCycle(): Promise<PoolHealthCheckSumm
 /**
  * Replace stale warm-pool generations against one immutable registry digest.
  * The manager generation-fences every selected row before remote teardown and
- * burst-bounds replacement while preserving the configured ready floor.
+ * burst-bounds remote teardown while retaining the configured physical
+ * ready-container floor. Every known-stale row is claim-fenced immediately,
+ * so that retained floor is not advertised as current-digest claim capacity.
  */
 export async function processPoolImageRolloutCycle(
   resolvedTarget?: Pick<
@@ -1268,6 +1273,11 @@ export async function processPoolImageRolloutCycle(
   }
   const pool = await getWarmPoolManager();
   const result = await pool.rollout(configuredImage, targetDigest);
+  const selected = new Set(result.decision.toReplace);
+  const deferredIds = new Set([
+    ...result.decision.toFence.filter((id) => !selected.has(id)),
+    ...result.deferred.map(({ id }) => id),
+  ]);
   return {
     action: "completed",
     configuredImage,
@@ -1278,7 +1288,7 @@ export async function processPoolImageRolloutCycle(
     selected: result.decision.counts.selected,
     reserved: result.reserved.length,
     replaced: result.replaced.length,
-    deferred: result.decision.counts.deferred + result.deferred.length,
+    deferred: deferredIds.size,
     failed: result.failed.length,
   };
 }
@@ -2018,12 +2028,18 @@ export async function runInfraMaintenanceCycle(
   );
 
   let prePullTarget: PrePullImagesSummary | null = null;
+  let warmPoolTargetDigest: string | undefined;
   await runBoundedPhase(
     logger,
     "pre-pull images cycle",
     () => processPrePullImagesCycle(),
     (summary) => {
       prePullTarget = prePullAllowsPoolImageRollout(summary) ? summary : null;
+      // Digest resolution is sufficient to pin newly-created capacity even
+      // when zero/partial pre-pull means destructive stale rollout must stay
+      // closed. Never fall back to a mutable tag once this sweep knows the
+      // immutable target.
+      warmPoolTargetDigest = summary?.targetDigest ?? undefined;
       if (summary) {
         logger.info("[provisioning-worker] pre-pull images cycle complete", {
           attempted: summary.attempted,
@@ -2033,14 +2049,12 @@ export async function runInfraMaintenanceCycle(
     },
   );
 
-  let warmPoolTargetDigest: string | undefined;
   if (prePullTarget) {
     await runBoundedPhase(
       logger,
       "warm pool image rollout cycle",
       () => processPoolImageRolloutCycle(prePullTarget),
       (summary) => {
-        if (summary.targetDigest) warmPoolTargetDigest = summary.targetDigest;
         logger.info(
           "[provisioning-worker] warm pool image rollout cycle complete",
           {

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -33,6 +33,7 @@ import {
   HetznerClientError,
 } from "@elizaos/cloud-shared/lib/services/containers/hetzner-client";
 import { getNodeAutoscaler } from "@elizaos/cloud-shared/lib/services/containers/node-autoscaler";
+import { resolveImageDigest } from "@elizaos/cloud-shared/lib/services/containers/registry-probe";
 import { dockerNodeManager } from "@elizaos/cloud-shared/lib/services/docker-node-manager";
 import { reusesExistingElizaCharacter } from "@elizaos/cloud-shared/lib/services/eliza-agent-config";
 import {
@@ -826,7 +827,11 @@ app.post(
 function poolReplenishResponse(c: Context) {
   return handleInternal(c, async () => {
     const image = containersEnv.defaultAgentImage();
-    const result = await getWarmPoolManager().replenish(image);
+    const targetDigest = await resolveImageDigest(image);
+    const result = await getWarmPoolManager().replenish(
+      image,
+      targetDigest ?? undefined,
+    );
     return c.json({
       success: true,
       data: {
@@ -868,7 +873,23 @@ app.post("/api/v1/cron/pool-health-check", poolHealthCheckResponse);
 function poolImageRolloutResponse(c: Context) {
   return handleInternal(c, async () => {
     const image = containersEnv.defaultAgentImage();
-    const before = await getWarmPoolManager().rolloutStatus(image);
+    const targetDigest = await resolveImageDigest(image);
+    const before = await getWarmPoolManager().rolloutStatus(
+      image,
+      targetDigest ?? undefined,
+    );
+    if (!targetDigest) {
+      return c.json({
+        success: true,
+        data: {
+          image,
+          skipped: true,
+          reason: "Registry probe did not resolve an immutable target digest",
+          rollout: before,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    }
     if (before.safeNextAction === "configure_pinned_desired_image") {
       return c.json({
         success: true,
@@ -881,8 +902,8 @@ function poolImageRolloutResponse(c: Context) {
         },
       });
     }
-    const result = await getWarmPoolManager().rollout(image);
-    const after = await getWarmPoolManager().rolloutStatus(image);
+    const result = await getWarmPoolManager().rollout(image, targetDigest);
+    const after = await getWarmPoolManager().rolloutStatus(image, targetDigest);
     return c.json({
       success: true,
       data: {
@@ -900,7 +921,11 @@ app.post("/api/v1/cron/pool-image-rollout", poolImageRolloutResponse);
 function poolImageRolloutStatusResponse(c: Context) {
   return handleInternal(c, async () => {
     const image = containersEnv.defaultAgentImage();
-    const rollout = await getWarmPoolManager().rolloutStatus(image);
+    const targetDigest = await resolveImageDigest(image);
+    const rollout = await getWarmPoolManager().rolloutStatus(
+      image,
+      targetDigest ?? undefined,
+    );
     return c.json({
       success: true,
       data: {
@@ -946,7 +971,11 @@ function poolImageRollbackResponse(c: Context) {
     }
 
     const image = containersEnv.defaultAgentImage();
-    const rollout = await getWarmPoolManager().rolloutStatus(image);
+    const targetDigest = await resolveImageDigest(image);
+    const rollout = await getWarmPoolManager().rolloutStatus(
+      image,
+      targetDigest ?? undefined,
+    );
     const currentDigest = rollout.desired.digest;
     if (!currentDigest) {
       return c.json({
@@ -1011,8 +1040,15 @@ app.post("/api/v1/admin/warm-pool/rollback", poolImageRollbackResponse);
 function poolStateResponse(c: Context) {
   return handleInternal(c, async () => {
     const image = containersEnv.defaultAgentImage();
-    const state = await getWarmPoolManager().snapshot(image);
-    const rollout = await getWarmPoolManager().rolloutStatus(image);
+    const targetDigest = await resolveImageDigest(image);
+    const state = await getWarmPoolManager().snapshot(
+      image,
+      targetDigest ?? undefined,
+    );
+    const rollout = await getWarmPoolManager().rolloutStatus(
+      image,
+      targetDigest ?? undefined,
+    );
     return c.json({
       success: true,
       data: {

--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -22,6 +22,7 @@ process.env.WARM_POOL_ENABLED = "1";
 const PGLITE_TIMEOUT = 60_000;
 const IMAGE = "ghcr.io/elizaos/eliza:atomic-ready";
 const OTHER_IMAGE = "ghcr.io/elizaos/eliza:stale";
+const TARGET_DIGEST = `sha256:${"a".repeat(64)}`;
 const USER_ORG_ID = "10000000-0000-4000-8000-000000000001";
 const USER_ID = "10000000-0000-4000-8000-000000000002";
 
@@ -92,7 +93,7 @@ async function seedPoolEntry(
     bridge_url: "http://100.64.0.10:3000",
     health_url: healthUrl(),
     docker_image: IMAGE,
-    image_digest: `sha256:${"a".repeat(64)}`,
+    image_digest: TARGET_DIGEST,
     pool_ready_at: new Date("2026-07-30T00:00:00.000Z"),
     ...overrides,
   });
@@ -211,6 +212,40 @@ describe("one claimable-capacity predicate", () => {
   );
 
   test(
+    "digest inventory counts the target generation while provisioning",
+    async () => {
+      await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
+        docker_image: IMAGE,
+        image_digest: TARGET_DIGEST,
+        sandbox_id: null,
+        node_id: null,
+        container_name: null,
+        bridge_url: null,
+        health_url: null,
+      });
+      await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
+        docker_image: IMAGE,
+        image_digest: `sha256:${"b".repeat(64)}`,
+        sandbox_id: null,
+        node_id: null,
+        container_name: null,
+        bridge_url: null,
+        health_url: null,
+      });
+
+      expect(await repository.countAllPoolEntries({ digest: TARGET_DIGEST })).toEqual({
+        ready: 0,
+        provisioning: 1,
+      });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "rollout reservation fences the exact stale generation before a later claim",
     async () => {
       const stale = await seedPoolEntry({
@@ -301,6 +336,92 @@ describe("atomic readiness transition", () => {
       const stored = await repository.findById(provisioning.id);
       expect(stored?.status).toBe("provisioning");
       expect(stored?.pool_ready_at).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a digest-bound in-flight generation becomes claimable under its configured tag",
+    async () => {
+      const provisioning = await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
+        docker_image: IMAGE,
+        image_digest: TARGET_DIGEST,
+      });
+      const ready = await repository.commitPoolEntryReady(provisioning);
+      expect(ready?.docker_image).toBe(IMAGE);
+      expect(ready?.image_digest).toBe(TARGET_DIGEST);
+
+      const userAgentId = await seedUserAgent();
+      const claimed = await repository.claimWarmContainer({
+        userAgentId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "digest-bound-claim",
+      });
+      expect(claimed?.warm_pool_row_id).toBe(provisioning.id);
+      expect(claimed?.image_digest).toBe(TARGET_DIGEST);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "repeated digest-scoped replenish cycles count in-flight rows against the ceiling",
+    async () => {
+      for (let index = 0; index < 2; index++) {
+        await seedPoolEntry({
+          status: "provisioning",
+          pool_ready_at: null,
+          docker_image: IMAGE,
+          image_digest: TARGET_DIGEST,
+          sandbox_id: null,
+          node_id: null,
+          container_name: null,
+          bridge_url: null,
+          health_url: null,
+        });
+      }
+
+      const { WarmPoolManager } = await import("../../../lib/services/containers/agent-warm-pool");
+      const { DEFAULT_WARM_POOL_POLICY } = await import(
+        "../../../lib/services/containers/agent-warm-pool-forecast"
+      );
+      let created = 0;
+      const manager = new WarmPoolManager(
+        {
+          createPoolContainer: async (configuredImage, targetDigest) => {
+            created++;
+            const row = await seedPoolEntry({
+              status: "provisioning",
+              pool_ready_at: null,
+              docker_image: configuredImage,
+              image_digest: targetDigest,
+              sandbox_id: null,
+              node_id: null,
+              container_name: null,
+              bridge_url: null,
+              health_url: null,
+            });
+            return { id: row.id, nodeId: null };
+          },
+          destroyPoolContainer: async () => {},
+          healthProbe: async () => true,
+        },
+        {
+          ...DEFAULT_WARM_POOL_POLICY,
+          minPoolSize: 3,
+          maxPoolSize: 3,
+          replenishBurstLimit: 3,
+        },
+      );
+
+      const first = await manager.replenish(IMAGE, TARGET_DIGEST);
+      const second = await manager.replenish(IMAGE, TARGET_DIGEST);
+      expect(first.created).toHaveLength(1);
+      expect(second.created).toHaveLength(0);
+      expect(second.state.provisioningCount).toBe(3);
+      expect(created).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -190,6 +190,79 @@ describe("one claimable-capacity predicate", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "a null persisted digest is neither counted nor claimable",
+    async () => {
+      await seedPoolEntry({ image_digest: null });
+      expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(0);
+      expect(await repository.listClaimablePool({ image: IMAGE })).toEqual([]);
+
+      const userAgentId = await seedUserAgent();
+      const claimed = await repository.claimWarmContainer({
+        userAgentId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "must-fall-cold",
+      });
+      expect(claimed).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rollout reservation fences the exact stale generation before a later claim",
+    async () => {
+      const stale = await seedPoolEntry({
+        image_digest: `sha256:${"b".repeat(64)}`,
+      });
+      const targetDigest = `sha256:${"a".repeat(64)}`;
+
+      const reserved = await repository.reserveStalePoolEntryForRollout(stale, targetDigest);
+      expect(reserved?.status).toBe("deletion_failed");
+
+      const userAgentId = await seedUserAgent();
+      const claimed = await repository.claimWarmContainer({
+        userAgentId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "cannot-claim-known-stale",
+      });
+      expect(claimed).toBeNull();
+      expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent claim versus stale-generation reservation has exactly one owner",
+    async () => {
+      const stale = await seedPoolEntry({
+        image_digest: `sha256:${"b".repeat(64)}`,
+      });
+      const userAgentId = await seedUserAgent();
+
+      const [reserved, claimed] = await Promise.all([
+        repository.reserveStalePoolEntryForRollout(stale, `sha256:${"a".repeat(64)}`),
+        repository.claimWarmContainer({
+          userAgentId,
+          organizationId: USER_ORG_ID,
+          image: IMAGE,
+          agentName: "claim-race",
+        }),
+      ]);
+
+      expect(Number(Boolean(reserved)) + Number(Boolean(claimed))).toBe(1);
+      if (reserved) {
+        expect(claimed).toBeNull();
+        expect((await repository.findById(stale.id))?.status).toBe("deletion_failed");
+      } else {
+        expect(claimed?.warm_pool_row_id).toBe(stale.id);
+        expect(await repository.findById(stale.id)).toBeUndefined();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
 });
 
 describe("atomic readiness transition", () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -93,6 +93,8 @@ export type {
   NewAgentSandboxBackup,
 };
 
+const CANONICAL_SHA256_IMAGE_DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
 /**
  * Lightweight legacy-list projection. Catalogue-v2 fields are intentionally
  * read through the dedicated catalogue repository so this path never grows
@@ -230,6 +232,7 @@ function warmPoolRuntimeLocatorConditions(): SQL[] {
     sql`${agentSandboxes.bridge_url} IS NOT NULL AND btrim(${agentSandboxes.bridge_url}) <> ''`,
     sql`${agentSandboxes.health_url} IS NOT NULL AND btrim(${agentSandboxes.health_url}) <> ''`,
     sql`${agentSandboxes.docker_image} IS NOT NULL AND btrim(${agentSandboxes.docker_image}) <> ''`,
+    sql`${agentSandboxes.image_digest} ~ '^sha256:[0-9a-f]{64}$'`,
     isNull(agentSandboxes.deleted_at),
     isNull(agentSandboxes.deletion_attempt_id),
     isNull(agentSandboxes.replacement_cleanup_sandbox_id),
@@ -240,7 +243,12 @@ function warmPoolRuntimeReadyConditions(): SQL[] {
   return [isNotNull(agentSandboxes.pool_ready_at), ...warmPoolRuntimeLocatorConditions()];
 }
 
-function claimableWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
+export interface WarmPoolImageFilter {
+  image?: string;
+  digest?: string;
+}
+
+function claimableWarmPoolConditions(filter: WarmPoolImageFilter = {}): SQL[] {
   const conditions: SQL[] = [
     eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
     eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
@@ -251,10 +259,13 @@ function claimableWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
   if (filter.image !== undefined) {
     conditions.push(eq(agentSandboxes.docker_image, filter.image));
   }
+  if (filter.digest !== undefined) {
+    conditions.push(eq(agentSandboxes.image_digest, filter.digest));
+  }
   return conditions;
 }
 
-function inFlightWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
+function inFlightWarmPoolConditions(filter: WarmPoolImageFilter = {}): SQL[] {
   const conditions: SQL[] = [
     eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
     eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
@@ -266,6 +277,9 @@ function inFlightWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
   ];
   if (filter.image !== undefined) {
     conditions.push(eq(agentSandboxes.docker_image, filter.image));
+  }
+  if (filter.digest !== undefined) {
+    conditions.push(eq(agentSandboxes.image_digest, filter.digest));
   }
   return conditions;
 }
@@ -1403,7 +1417,7 @@ export class AgentSandboxesRepository {
   // ── Warm pool ─────────────────────────────────────────────────────────
 
   /** Count entries that the claim transaction can transfer immediately. */
-  async countUnclaimedPool(filter: { image?: string } = {}): Promise<number> {
+  async countUnclaimedPool(filter: WarmPoolImageFilter = {}): Promise<number> {
     await ensureAgentSandboxSchema();
     const [row] = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
@@ -1412,7 +1426,7 @@ export class AgentSandboxesRepository {
     if (!row) {
       throw new ElizaError("Warm-pool capacity query returned no aggregate row", {
         code: "WARM_POOL_CAPACITY_READ_FAILED",
-        context: { image: filter.image },
+        context: { image: filter.image, digest: filter.digest },
       });
     }
     return row.count;
@@ -1424,7 +1438,7 @@ export class AgentSandboxesRepository {
    * replacement capacity.
    */
   async countAllPoolEntries(
-    filter: { image?: string } = {},
+    filter: WarmPoolImageFilter = {},
   ): Promise<{ ready: number; provisioning: number }> {
     await ensureAgentSandboxSchema();
     const claimable = and(...claimableWarmPoolConditions(filter));
@@ -1444,7 +1458,7 @@ export class AgentSandboxesRepository {
     if (!inventory) {
       throw new ElizaError("Warm-pool inventory query returned no aggregate row", {
         code: "WARM_POOL_CAPACITY_READ_FAILED",
-        context: { image: filter.image },
+        context: { image: filter.image, digest: filter.digest },
       });
     }
     return inventory;
@@ -1562,7 +1576,7 @@ export class AgentSandboxesRepository {
   }
 
   /** Claimable rows, ordered by the same FIFO stamp used by the claim path. */
-  async listClaimablePool(filter: { image?: string } = {}): Promise<AgentSandbox[]> {
+  async listClaimablePool(filter: WarmPoolImageFilter = {}): Promise<AgentSandbox[]> {
     await ensureAgentSandboxSchema();
     return dbWrite
       .select()
@@ -1636,6 +1650,29 @@ export class AgentSandboxesRepository {
         ),
       )
       .orderBy(agentSandboxes.pool_ready_at);
+  }
+
+  /**
+   * Every retained warm-pool generation that image rollout may classify.
+   * Unlike the ready-only status reader, this includes provisioning/error
+   * generations and prior failed rollout reservations so a mutable-tag change
+   * cannot leave invisible old-digest capacity behind forever.
+   */
+  async listPoolEntriesForRollout(): Promise<AgentSandbox[]> {
+    await ensureAgentSandboxSchema();
+    return dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
+        ),
+      )
+      .orderBy(agentSandboxes.pool_ready_at, agentSandboxes.created_at);
   }
 
   /**
@@ -2011,6 +2048,50 @@ export class AgentSandboxesRepository {
           isNull(agentSandboxes.deleted_at),
           isNull(agentSandboxes.deletion_attempt_id),
           sql`NOT (${and(...warmPoolRuntimeReadyConditions())})`,
+        ),
+      )
+      .returning();
+    return reserved;
+  }
+
+  /**
+   * Fence one exact stale image generation before rollout tears down its
+   * remote container. The generation CAS closes both races that matter:
+   * a concurrent claim deletes the pool row first and this returns undefined,
+   * while a successful reservation moves the row out of `running` before the
+   * claim query can transfer it. A prior failed teardown may reserve again on
+   * the next sweep because `deletion_failed` remains a retained pool row.
+   */
+  async reserveStalePoolEntryForRollout(
+    expected: WarmPoolRuntimeGeneration,
+    targetDigest: string,
+  ): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    if (!CANONICAL_SHA256_IMAGE_DIGEST_RE.test(targetDigest)) {
+      throw new ElizaError("Warm-pool rollout target digest must be canonical sha256", {
+        code: "WARM_POOL_ROLLOUT_DIGEST_INVALID",
+        context: { targetDigest },
+        severity: "fatal",
+      });
+    }
+    if (expected.organization_id !== WARM_POOL_ORG_ID || expected.image_digest === targetDigest) {
+      return undefined;
+    }
+    const [reserved] = await dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "deletion_failed",
+        error_message: `Warm-pool image rollout reserved stale generation for ${targetDigest}`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          ...warmPoolGenerationConditions(expected),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          sql`${agentSandboxes.image_digest} IS DISTINCT FROM ${targetDigest}`,
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
         ),
       )
       .returning();

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
@@ -177,10 +177,19 @@ describe("createPoolContainer fail-closed", () => {
     });
 
     const creator = getHetznerPoolContainerCreator();
-    await expect(creator.createPoolContainer("img:latest")).resolves.toEqual({
+    const targetDigest = `sha256:${"a".repeat(64)}`;
+    await expect(creator.createPoolContainer("img:latest", targetDigest)).resolves.toEqual({
       id: "row-2",
       nodeId: "node-9",
     });
+    expect(repo.createPoolEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docker_image: "img:latest",
+        image_digest: targetDigest,
+        status: "pending",
+      }),
+    );
+    expect(sandbox.provision).toHaveBeenCalledWith("row-2", WARM_POOL_ORG_ID);
   });
 
   test("a success response without the atomic readiness stamp fails closed", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
@@ -24,10 +24,18 @@ import type { PoolContainerCreator } from "./agent-warm-pool";
 const HEALTH_PROBE_TIMEOUT_MS = 5_000;
 
 export class HetznerPoolContainerCreator implements PoolContainerCreator {
-  async createPoolContainer(image: string): Promise<{ id: string; nodeId: string | null }> {
+  async createPoolContainer(
+    configuredImage: string,
+    targetDigest?: string,
+  ): Promise<{ id: string; nodeId: string | null }> {
     const row = await agentSandboxesRepository.createPoolEntry({
       agent_name: `pool-${randomUUID().slice(0, 8)}`,
-      docker_image: image,
+      // Keep the logical configured reference stable for the claim contract,
+      // while `provision()` binds this warm generation to targetDigest for the
+      // actual Docker pull. Persisting the digest before remote creation also
+      // makes the in-flight row count against exact-digest capacity.
+      docker_image: configuredImage,
+      image_digest: targetDigest,
       status: "pending",
       database_status: "none",
       environment_vars: {},
@@ -43,7 +51,7 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
       });
       throw new ElizaError(`Pool provision failed: ${result.error}`, {
         code: "WARM_POOL_PROVISION_FAILED",
-        context: { poolId: row.id, image },
+        context: { poolId: row.id, image: configuredImage, targetDigest },
         severity: result.retryable ? "ephemeral" : "fatal",
       });
     }

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
@@ -30,6 +30,7 @@ const repo = {
   reserveStuckPoolEntryForReap: mock(async () => undefined),
   listPoolEntriesForRollout: mock(async () => [] as Array<Record<string, unknown>>),
   reserveStalePoolEntryForRollout: mock(async () => undefined),
+  findById: mock(async () => undefined),
   findStuckPoolProvisioning: mock(async () => [] as Array<{ id: string }>),
   countAllPoolEntries: mock(async () => ({ ready: 0, provisioning: 0 })),
   countUserProvisionsByHour: mock(async () => [] as number[]),
@@ -101,6 +102,8 @@ beforeEach(() => {
   repo.listPoolEntriesForRollout.mockResolvedValue([]);
   repo.reserveStalePoolEntryForRollout.mockReset();
   repo.reserveStalePoolEntryForRollout.mockResolvedValue(undefined);
+  repo.findById.mockReset();
+  repo.findById.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -432,5 +435,27 @@ describe("rollout exact-generation claim fencing", () => {
     expect(first.replaced).toEqual([]);
     expect(second.replaced).toEqual(["stale"]);
     expect(destroy).toHaveBeenCalledTimes(2);
+  });
+
+  test("a retained cleanup tombstone is failed, never reported as replaced", async () => {
+    const { WarmPoolManager } = await load();
+    const target = rolloutRow("target", TARGET_DIGEST);
+    const stale = rolloutRow("stale-retained", STALE_DIGEST);
+    repo.listPoolEntriesForRollout.mockResolvedValue([target, stale]);
+    repo.reserveStalePoolEntryForRollout.mockImplementation(async (row) => row);
+    repo.findById.mockResolvedValue(stale);
+    const { creator, destroy } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.rollout("ghcr.io/elizaos/eliza:stable", TARGET_DIGEST);
+
+    expect(destroy).toHaveBeenCalledWith("stale-retained");
+    expect(result.replaced).toEqual([]);
+    expect(result.failed).toEqual([
+      {
+        id: "stale-retained",
+        error: "remote teardown did not remove the fenced pool generation",
+      },
+    ]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
@@ -28,6 +28,8 @@ const repo = {
   promoteStrandedPoolEntryReady: mock(async () => undefined),
   reserveUnclaimablePoolEntryForReap: mock(async () => undefined),
   reserveStuckPoolEntryForReap: mock(async () => undefined),
+  listPoolEntriesForRollout: mock(async () => [] as Array<Record<string, unknown>>),
+  reserveStalePoolEntryForRollout: mock(async () => undefined),
   findStuckPoolProvisioning: mock(async () => [] as Array<{ id: string }>),
   countAllPoolEntries: mock(async () => ({ ready: 0, provisioning: 0 })),
   countUserProvisionsByHour: mock(async () => [] as number[]),
@@ -95,6 +97,10 @@ beforeEach(() => {
   repo.listWarmPoolReconciliationCandidates.mockResolvedValue([]);
   repo.findStuckPoolProvisioning.mockReset();
   repo.findStuckPoolProvisioning.mockResolvedValue([]);
+  repo.listPoolEntriesForRollout.mockReset();
+  repo.listPoolEntriesForRollout.mockResolvedValue([]);
+  repo.reserveStalePoolEntryForRollout.mockReset();
+  repo.reserveStalePoolEntryForRollout.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -335,5 +341,96 @@ describe("healthCheck honors the disabled no-op", () => {
     });
     expect(repo.listClaimablePool).not.toHaveBeenCalled();
     expect(destroy).not.toHaveBeenCalled();
+  });
+});
+
+const TARGET_DIGEST = `sha256:${"a".repeat(64)}`;
+const STALE_DIGEST = `sha256:${"b".repeat(64)}`;
+
+function rolloutRow(
+  id: string,
+  digest: string | null,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id,
+    organization_id: "pool-org",
+    status: "running",
+    environment_revision: 1,
+    sandbox_id: `sandbox-${id}`,
+    node_id: "node-1",
+    container_name: `agent-${id}`,
+    bridge_url: "http://100.64.0.10:3000",
+    health_url: "http://100.64.0.10:3000/health",
+    docker_image: "ghcr.io/elizaos/eliza:stable",
+    image_digest: digest,
+    pool_ready_at: new Date("2026-08-19T00:00:00.000Z"),
+    replacement_cleanup_sandbox_id: null,
+    ...overrides,
+  };
+}
+
+describe("rollout exact-generation claim fencing", () => {
+  test("fences every stale generation even with no target-ready row, but destroys none yet", async () => {
+    const { WarmPoolManager } = await load();
+    const oldA = rolloutRow("old-a", STALE_DIGEST);
+    const oldB = rolloutRow("old-b", STALE_DIGEST);
+    repo.listPoolEntriesForRollout.mockResolvedValue([oldA, oldB]);
+    repo.reserveStalePoolEntryForRollout.mockImplementation(async (row) => row);
+    const { creator, destroy } = fakeCreator();
+    const manager = new WarmPoolManager(creator, {
+      ...DEFAULT_WARM_POOL_POLICY,
+      minPoolSize: 1,
+      replenishBurstLimit: 2,
+    });
+
+    const result = await manager.rollout("ghcr.io/elizaos/eliza:stable", TARGET_DIGEST);
+
+    expect(repo.reserveStalePoolEntryForRollout).toHaveBeenCalledTimes(2);
+    expect(result.reserved).toEqual(["old-a", "old-b"]);
+    expect(result.decision.toReplace).toEqual([]);
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  test("a concurrent claim that wins the generation CAS is never destroyed", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listPoolEntriesForRollout.mockResolvedValue([
+      rolloutRow("claim-winner", STALE_DIGEST, {
+        status: "provisioning",
+        pool_ready_at: null,
+      }),
+    ]);
+    repo.reserveStalePoolEntryForRollout.mockResolvedValue(undefined);
+    const { creator, destroy } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.rollout("ghcr.io/elizaos/eliza:stable", TARGET_DIGEST);
+
+    expect(result.reserved).toEqual([]);
+    expect(result.deferred[0]?.reason).toContain("claimed");
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  test("partial teardown failure stays fenced and succeeds on the next bounded sweep", async () => {
+    const { WarmPoolManager } = await load();
+    const target = rolloutRow("target", TARGET_DIGEST);
+    const stale = rolloutRow("stale", STALE_DIGEST);
+    repo.listPoolEntriesForRollout.mockResolvedValue([target, stale]);
+    repo.reserveStalePoolEntryForRollout.mockImplementation(async (row) => row);
+    let attempts = 0;
+    const destroy = mock(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("ssh timeout");
+    });
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy });
+    const manager = new WarmPoolManager(creator);
+
+    const first = await manager.rollout("ghcr.io/elizaos/eliza:stable", TARGET_DIGEST);
+    const second = await manager.rollout("ghcr.io/elizaos/eliza:stable", TARGET_DIGEST);
+
+    expect(first.failed[0]?.error).toContain("ssh timeout");
+    expect(first.replaced).toEqual([]);
+    expect(second.replaced).toEqual(["stale"]);
+    expect(destroy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
@@ -99,6 +99,20 @@ describe("replenish creates when ENABLED and below target", () => {
     expect(result.decision.toCreate).toBe(1);
   });
 
+  test("binds an exact target digest without changing the configured claim image", async () => {
+    const { WarmPoolManager } = await load();
+    const { creator, create } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+    const targetDigest = `sha256:${"a".repeat(64)}`;
+
+    const result = await manager.replenish("img:stable", targetDigest);
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith("img:stable", targetDigest);
+    expect(repo.countAllPoolEntries).toHaveBeenCalledWith({ digest: targetDigest });
+    expect(result.created).toHaveLength(1);
+  });
+
   test("does NOT over-create when the pool already meets target", async () => {
     const { WarmPoolManager } = await load();
     // ready:1 meets the minPoolSize=1 target => deficit 0 => no creates.

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
@@ -268,6 +268,8 @@ describe("decideRollout", () => {
     expect(d.toFence).toEqual(["old-a", "old-b"]);
     expect(d.toReplace).toEqual([]);
     expect(d.counts).toMatchObject({ stale: 2, selected: 0, deferred: 2 });
+    expect(d.reason).toContain("claim-fencing all 2");
+    expect(d.reason).toContain("physical ready-container floor 1");
   });
 
   test("once target capacity exists, replacement is burst-bounded and preserves the ready floor", () => {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
@@ -15,6 +15,7 @@ import {
   decideReplenish,
   decideRollout,
   envWarmPoolPolicy,
+  immutableImageReference,
   type PoolStateSnapshot,
 } from "./agent-warm-pool";
 import {
@@ -37,6 +38,28 @@ function state(overrides: Partial<PoolStateSnapshot> = {}): PoolStateSnapshot {
     ...overrides,
   };
 }
+
+describe("immutableImageReference", () => {
+  test("replaces a mutable tag while preserving a registry port", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    expect(immutableImageReference("registry.example:5000/team/agent:stable", digest)).toBe(
+      `registry.example:5000/team/agent@${digest}`,
+    );
+  });
+
+  test("rebinds an already pinned reference to the sweep digest", () => {
+    const digest = `sha256:${"b".repeat(64)}`;
+    expect(immutableImageReference(`ghcr.io/elizaos/eliza@sha256:${"a".repeat(64)}`, digest)).toBe(
+      `ghcr.io/elizaos/eliza@${digest}`,
+    );
+  });
+
+  test("rejects a non-canonical registry digest", () => {
+    expect(() => immutableImageReference("ghcr.io/elizaos/eliza:stable", "sha256:short")).toThrow(
+      "canonical sha256",
+    );
+  });
+});
 
 describe("decideReplenish", () => {
   test("creates up to the deficit when under target with headroom + burst room", () => {
@@ -136,6 +159,7 @@ describe("decideDrain", () => {
             id: "fresh",
             pool_ready_at: new Date(now - 100),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -143,6 +167,7 @@ describe("decideDrain", () => {
             id: "fresh2",
             pool_ready_at: new Date(now - 200),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -166,6 +191,7 @@ describe("decideDrain", () => {
             id: "newest",
             pool_ready_at: new Date(now - 2000),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -173,6 +199,7 @@ describe("decideDrain", () => {
             id: "oldest",
             pool_ready_at: new Date(now - 9000),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -180,6 +207,7 @@ describe("decideDrain", () => {
             id: "middle",
             pool_ready_at: new Date(now - 5000),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -199,11 +227,19 @@ describe("decideDrain", () => {
         readyCount: 3,
         targetPoolSize: 1,
         unclaimedRows: [
-          { id: "noTs", pool_ready_at: null, docker_image: null, node_id: null, health_url: null },
+          {
+            id: "noTs",
+            pool_ready_at: null,
+            docker_image: null,
+            image_digest: null,
+            node_id: null,
+            health_url: null,
+          },
           {
             id: "old",
             pool_ready_at: new Date(now - 9000),
             docker_image: null,
+            image_digest: null,
             node_id: null,
             health_url: null,
           },
@@ -217,39 +253,66 @@ describe("decideDrain", () => {
 });
 
 describe("decideRollout", () => {
-  test("replaces rows whose image differs from the current image", () => {
-    const d = decideRollout(
-      [
-        { id: "ok", docker_image: "img:v2" },
-        { id: "stale", docker_image: "img:v1" },
-      ],
-      "img:v2",
-    );
-    expect(d.toReplace).toEqual(["stale"]);
-    expect(d.reason).toContain("replacing 1");
-  });
+  const TARGET = `sha256:${"a".repeat(64)}`;
+  const STALE = `sha256:${"b".repeat(64)}`;
 
-  test("treats every row as current when all images match", () => {
+  test("fences every known-stale row but preserves physical ready rows until target capacity exists", () => {
     const d = decideRollout(
       [
-        { id: "a", docker_image: "img:v2" },
-        { id: "b", docker_image: "img:v2" },
+        { id: "old-a", image_digest: STALE, claimable: true },
+        { id: "old-b", image_digest: STALE, claimable: true },
       ],
-      "img:v2",
+      TARGET,
+      policy({ minPoolSize: 1, replenishBurstLimit: 2 }),
     );
+    expect(d.toFence).toEqual(["old-a", "old-b"]);
     expect(d.toReplace).toEqual([]);
-    expect(d.reason).toMatch(/all rows on current image/);
+    expect(d.counts).toMatchObject({ stale: 2, selected: 0, deferred: 2 });
   });
 
-  test("does NOT replace rows with an unknown (null) image", () => {
+  test("once target capacity exists, replacement is burst-bounded and preserves the ready floor", () => {
     const d = decideRollout(
       [
-        { id: "nullimg", docker_image: null },
-        { id: "stale", docker_image: "img:v1" },
+        { id: "target", image_digest: TARGET, claimable: true },
+        { id: "old-a", image_digest: STALE, claimable: true },
+        { id: "old-b", image_digest: STALE, claimable: true },
+        { id: "old-c", image_digest: STALE, claimable: true },
       ],
-      "img:v2",
+      TARGET,
+      policy({ minPoolSize: 2, replenishBurstLimit: 2 }),
     );
-    expect(d.toReplace).toEqual(["stale"]);
+    expect(d.toFence).toEqual(["old-a", "old-b", "old-c"]);
+    expect(d.toReplace).toEqual(["old-a", "old-b"]);
+    expect(d.counts).toMatchObject({ targetReady: 1, selected: 2, deferred: 1 });
+  });
+
+  test("same persisted digest is a no-op even when the mutable tag moved", () => {
+    const d = decideRollout(
+      [
+        { id: "a", image_digest: TARGET, claimable: true },
+        { id: "b", image_digest: TARGET, claimable: false },
+      ],
+      TARGET,
+      policy(),
+    );
+    expect(d.toFence).toEqual([]);
+    expect(d.toReplace).toEqual([]);
+    expect(d.reason).toMatch(/all 2 generations on target digest/);
+  });
+
+  test("null digest is stale, unclaimable, and consumes the bounded teardown budget", () => {
+    const d = decideRollout(
+      [
+        { id: "unknown", image_digest: null, claimable: false },
+        { id: "old", image_digest: STALE, claimable: false },
+        { id: "old-deferred", image_digest: STALE, claimable: false },
+      ],
+      TARGET,
+      policy({ replenishBurstLimit: 2 }),
+    );
+    expect(d.toFence).toEqual(["unknown", "old", "old-deferred"]);
+    expect(d.toReplace).toEqual(["unknown", "old"]);
+    expect(d.counts).toMatchObject({ unknownDigest: 1, selected: 2, deferred: 1 });
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -160,9 +160,11 @@ export function decideRollout(
   const selectedInFlight = staleInFlightRows.slice(0, replacementBudget);
   const remainingBudget = replacementBudget - selectedInFlight.length;
   const readyFloorHeadroom = Math.max(0, totalReady - policy.minPoolSize);
-  // Do not start draining usable old-digest capacity until at least one
-  // target generation is ready. Replenish counts only the target digest, so
-  // the following daemon phase creates that bridge generation first.
+  // Do not physically tear down ready old-digest containers until at least one
+  // target generation is ready. All stale rows are claim-fenced below, so this
+  // floor preserves only bounded teardown/recovery capacity, never stale
+  // claimable capacity. Replenish counts only the target digest and creates
+  // the bridge generation in the following daemon phase.
   const readyReplacementLimit = targetReady > 0 ? Math.min(remainingBudget, readyFloorHeadroom) : 0;
   const selectedReady = staleReadyRows.slice(0, readyReplacementLimit);
   const selected = [...selectedInFlight, ...selectedReady];
@@ -172,7 +174,7 @@ export function decideRollout(
     toReplace: selected.map((row) => row.id),
     reason:
       stale.length > 0
-        ? `selected ${selected.length}/${stale.length} stale-digest generations; preserving ready floor ${policy.minPoolSize}`
+        ? `claim-fencing all ${stale.length} stale-digest generations; selected ${selected.length} for teardown while retaining physical ready-container floor ${policy.minPoolSize}`
         : `all ${targetRows.length} generations on target digest`,
     counts: {
       target: targetRows.length,
@@ -244,7 +246,10 @@ export interface PoolContainerCreator {
    *      status='running' and `pool_ready_at` together.
    *   4. On failure, leave a non-claimable row for reconciliation.
    */
-  createPoolContainer(image: string): Promise<{ id: string; nodeId: string | null }>;
+  createPoolContainer(
+    configuredImage: string,
+    targetDigest?: string,
+  ): Promise<{ id: string; nodeId: string | null }>;
 
   /**
    * Stop the docker container backing this pool entry and delete the row.
@@ -360,11 +365,13 @@ export class WarmPoolManager {
     const decision = decideReplenish(state, this.policy);
     const created: Array<{ id: string; nodeId: string | null }> = [];
     const failed: Array<{ error: string }> = [];
-    const creationImage = targetDigest ? immutableImageReference(image, targetDigest) : image;
+    if (targetDigest) immutableImageReference(image, targetDigest);
 
     for (let i = 0; i < decision.toCreate; i++) {
       try {
-        const result = await this.creator.createPoolContainer(creationImage);
+        const result = targetDigest
+          ? await this.creator.createPoolContainer(image, targetDigest)
+          : await this.creator.createPoolContainer(image);
         created.push(result);
       } catch (err) {
         // error-policy:J1 batch boundary — a per-container provision failure is
@@ -638,7 +645,18 @@ export class WarmPoolManager {
       if (!reservedSet.has(id)) continue;
       try {
         await this.creator.destroyPoolContainer(id);
-        replaced.push(id);
+        // deleteAgent may deliberately retain a capacity-ownership tombstone
+        // when remote teardown is unresolved. A resolved creator call alone
+        // therefore does not prove replacement; only row absence does.
+        const retained = await agentSandboxesRepository.findById(id);
+        if (retained) {
+          failed.push({
+            id,
+            error: "remote teardown did not remove the fenced pool generation",
+          });
+        } else {
+          replaced.push(id);
+        }
       } catch (err) {
         // error-policy:J1 batch boundary — the exact generation remains
         // claim-fenced and is retried on the next bounded rollout sweep.

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -16,6 +16,7 @@
  * them to repository + Hetzner client I/O.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
 import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
 import { containersEnv } from "../../config/containers-env";
@@ -38,6 +39,7 @@ export interface PoolStateSnapshot {
     id: string;
     pool_ready_at: Date | null;
     docker_image: string | null;
+    image_digest: string | null;
     node_id: string | null;
     health_url: string | null;
   }>;
@@ -106,22 +108,106 @@ export function decideDrain(
 }
 
 export interface RolloutDecision {
+  toFence: string[];
   toReplace: string[];
   reason: string;
+  counts: {
+    target: number;
+    targetReady: number;
+    stale: number;
+    staleReady: number;
+    staleInFlight: number;
+    unknownDigest: number;
+    selected: number;
+    deferred: number;
+  };
+}
+
+export interface RolloutRowSnapshot {
+  id: string;
+  image_digest: string | null;
+  claimable: boolean;
+}
+
+/** Bind a mutable Docker reference to the immutable digest resolved for this sweep. */
+export function immutableImageReference(image: string, digest: string): string {
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new ElizaError("Warm-pool image digest must be canonical sha256", {
+      code: "WARM_POOL_ROLLOUT_DIGEST_INVALID",
+      context: { digest },
+      severity: "fatal",
+    });
+  }
+  const withoutDigest = image.split("@", 1)[0] ?? image;
+  const lastSlash = withoutDigest.lastIndexOf("/");
+  const lastColon = withoutDigest.lastIndexOf(":");
+  const repository = lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+  return `${repository}@${digest}`;
 }
 
 export function decideRollout(
-  unclaimedRows: Array<{ id: string; docker_image: string | null }>,
-  currentImage: string,
+  unclaimedRows: RolloutRowSnapshot[],
+  targetDigest: string,
+  policy: Pick<WarmPoolPolicy, "minPoolSize" | "replenishBurstLimit">,
 ): RolloutDecision {
-  const stale = unclaimedRows.filter(
-    (r) => r.docker_image !== currentImage && r.docker_image !== null,
-  );
+  const stale = unclaimedRows.filter((row) => row.image_digest !== targetDigest);
+  const targetRows = unclaimedRows.filter((row) => row.image_digest === targetDigest);
+  const targetReady = targetRows.filter((row) => row.claimable).length;
+  const staleReadyRows = stale.filter((row) => row.claimable);
+  const staleInFlightRows = stale.filter((row) => !row.claimable);
+  const totalReady = targetReady + staleReadyRows.length;
+  const replacementBudget = Math.max(0, policy.replenishBurstLimit);
+  const selectedInFlight = staleInFlightRows.slice(0, replacementBudget);
+  const remainingBudget = replacementBudget - selectedInFlight.length;
+  const readyFloorHeadroom = Math.max(0, totalReady - policy.minPoolSize);
+  // Do not start draining usable old-digest capacity until at least one
+  // target generation is ready. Replenish counts only the target digest, so
+  // the following daemon phase creates that bridge generation first.
+  const readyReplacementLimit = targetReady > 0 ? Math.min(remainingBudget, readyFloorHeadroom) : 0;
+  const selectedReady = staleReadyRows.slice(0, readyReplacementLimit);
+  const selected = [...selectedInFlight, ...selectedReady];
+  const unknownDigest = stale.filter((row) => row.image_digest === null).length;
   return {
-    toReplace: stale.map((r) => r.id),
+    toFence: stale.map((row) => row.id),
+    toReplace: selected.map((row) => row.id),
     reason:
-      stale.length > 0 ? `replacing ${stale.length} stale-image rows` : "all rows on current image",
+      stale.length > 0
+        ? `selected ${selected.length}/${stale.length} stale-digest generations; preserving ready floor ${policy.minPoolSize}`
+        : `all ${targetRows.length} generations on target digest`,
+    counts: {
+      target: targetRows.length,
+      targetReady,
+      stale: stale.length,
+      staleReady: staleReadyRows.length,
+      staleInFlight: staleInFlightRows.length,
+      unknownDigest,
+      selected: selected.length,
+      deferred: stale.length - selected.length,
+    },
   };
+}
+
+function hasText(value: string | null): value is string {
+  return value !== null && value.trim().length > 0;
+}
+
+function isCanonicalImageDigest(value: string | null): value is string {
+  return value !== null && /^sha256:[0-9a-f]{64}$/.test(value);
+}
+
+function isClaimableRolloutGeneration(row: AgentSandbox): boolean {
+  return (
+    row.status === "running" &&
+    row.pool_ready_at !== null &&
+    hasText(row.sandbox_id) &&
+    hasText(row.node_id) &&
+    hasText(row.container_name) &&
+    hasText(row.bridge_url) &&
+    hasText(row.health_url) &&
+    hasText(row.docker_image) &&
+    isCanonicalImageDigest(row.image_digest) &&
+    row.replacement_cleanup_sandbox_id === null
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -205,7 +291,11 @@ export interface WarmPoolReconciliationResult {
 
 export interface RolloutResult {
   decision: RolloutDecision;
+  configuredImage: string;
+  targetDigest: string;
+  reserved: string[];
   replaced: string[];
+  deferred: Array<{ id: string; reason: string }>;
   failed: Array<{ id: string; error: string }>;
 }
 
@@ -221,9 +311,10 @@ export class WarmPoolManager {
   /**
    * Compute current pool state + forecast. Pure-ish: only reads.
    */
-  async snapshot(image: string): Promise<PoolStateSnapshot> {
-    const counts = await agentSandboxesRepository.countAllPoolEntries({ image });
-    const unclaimedRows = await agentSandboxesRepository.listClaimablePool({ image });
+  async snapshot(image: string, targetDigest?: string): Promise<PoolStateSnapshot> {
+    const filter = targetDigest ? { digest: targetDigest } : { image };
+    const counts = await agentSandboxesRepository.countAllPoolEntries(filter);
+    const unclaimedRows = await agentSandboxesRepository.listClaimablePool(filter);
 
     const buckets = await this.collectHourlyBuckets(this.policy.forecastWindowHours);
     const forecast = computeForecast({
@@ -241,6 +332,7 @@ export class WarmPoolManager {
         id: r.id,
         pool_ready_at: r.pool_ready_at,
         docker_image: r.docker_image,
+        image_digest: r.image_digest,
         node_id: r.node_id,
         health_url: r.health_url,
       })),
@@ -249,7 +341,7 @@ export class WarmPoolManager {
     };
   }
 
-  async replenish(image: string): Promise<ReplenishResult> {
+  async replenish(image: string, targetDigest?: string): Promise<ReplenishResult> {
     if (!containersEnv.warmPoolEnabled()) {
       return {
         decision: { toCreate: 0, reason: "WARM_POOL_ENABLED=false (no-op)" },
@@ -264,14 +356,15 @@ export class WarmPoolManager {
     // manually-invoked health route. A stranded row is repaired or fenced
     // before the capacity snapshot decides whether to create a replacement.
     const reconciliation = await this.reconcileUnclaimable();
-    const state = await this.snapshot(image);
+    const state = await this.snapshot(image, targetDigest);
     const decision = decideReplenish(state, this.policy);
     const created: Array<{ id: string; nodeId: string | null }> = [];
     const failed: Array<{ error: string }> = [];
+    const creationImage = targetDigest ? immutableImageReference(image, targetDigest) : image;
 
     for (let i = 0; i < decision.toCreate; i++) {
       try {
-        const result = await this.creator.createPoolContainer(image);
+        const result = await this.creator.createPoolContainer(creationImage);
         created.push(result);
       } catch (err) {
         // error-policy:J1 batch boundary — a per-container provision failure is
@@ -469,24 +562,70 @@ export class WarmPoolManager {
     );
   }
 
-  async rollout(image: string): Promise<RolloutResult> {
+  async rollout(image: string, targetDigest: string): Promise<RolloutResult> {
     if (!containersEnv.warmPoolEnabled()) {
       return {
-        decision: { toReplace: [], reason: "WARM_POOL_ENABLED=false (no-op)" },
+        decision: {
+          toFence: [],
+          toReplace: [],
+          reason: "WARM_POOL_ENABLED=false (no-op)",
+          counts: {
+            target: 0,
+            targetReady: 0,
+            stale: 0,
+            staleReady: 0,
+            staleInFlight: 0,
+            unknownDigest: 0,
+            selected: 0,
+            deferred: 0,
+          },
+        },
+        configuredImage: image,
+        targetDigest,
+        reserved: [],
         replaced: [],
+        deferred: [],
         failed: [],
       };
     }
 
-    const rows = await agentSandboxesRepository.listAllRunningPoolEntries();
-    const decision = decideRollout(rows, image);
+    const rows = await agentSandboxesRepository.listPoolEntriesForRollout();
+    const decision = decideRollout(
+      rows.map((row) => ({
+        id: row.id,
+        image_digest: row.image_digest,
+        claimable: isClaimableRolloutGeneration(row),
+      })),
+      targetDigest,
+      this.policy,
+    );
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    const reserved: string[] = [];
+    const reservedSet = new Set<string>();
     const replaced: string[] = [];
+    const deferred: Array<{ id: string; reason: string }> = [];
     const failed: Array<{ id: string; error: string }> = [];
 
-    for (const id of decision.toReplace) {
+    for (const id of decision.toFence) {
+      const expected = rowsById.get(id);
+      if (!expected) {
+        deferred.push({ id, reason: "rollout snapshot no longer contains generation" });
+        continue;
+      }
       try {
-        await this.creator.destroyPoolContainer(id);
-        replaced.push(id);
+        const fenced = await agentSandboxesRepository.reserveStalePoolEntryForRollout(
+          expected,
+          targetDigest,
+        );
+        if (!fenced) {
+          deferred.push({
+            id,
+            reason: "generation changed, reached target digest, or was claimed",
+          });
+          continue;
+        }
+        reserved.push(id);
+        reservedSet.add(id);
       } catch (err) {
         // error-policy:J1 batch boundary — a per-row replace failure is recorded
         // in the structured `failed[]` result; the stale row stays and is retried
@@ -495,24 +634,51 @@ export class WarmPoolManager {
       }
     }
 
+    for (const id of decision.toReplace) {
+      if (!reservedSet.has(id)) continue;
+      try {
+        await this.creator.destroyPoolContainer(id);
+        replaced.push(id);
+      } catch (err) {
+        // error-policy:J1 batch boundary — the exact generation remains
+        // claim-fenced and is retried on the next bounded rollout sweep.
+        failed.push({ id, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
     logger.info("[warm-pool] rollout", {
       decision,
+      configuredImage: image,
+      targetDigest,
+      reserved: reserved.length,
       replaced: replaced.length,
+      deferred: deferred.length,
       failed: failed.length,
     });
-    return { decision, replaced, failed };
+    return {
+      decision,
+      configuredImage: image,
+      targetDigest,
+      reserved,
+      replaced,
+      deferred,
+      failed,
+    };
   }
 
-  async rolloutStatus(image: string): Promise<ImageRolloutSummary> {
+  async rolloutStatus(image: string, targetDigest?: string): Promise<ImageRolloutSummary> {
     const rows = containersEnv.warmPoolEnabled()
-      ? await agentSandboxesRepository.listAllRunningPoolEntries()
+      ? await agentSandboxesRepository.listPoolEntriesForRollout()
       : [];
     return summarizeImageRollout({
       desiredImage: image,
+      desiredDigest: targetDigest,
       enabled: containersEnv.warmPoolEnabled(),
       rows: rows.map((r) => ({
         id: r.id,
         docker_image: r.docker_image,
+        image_digest: r.image_digest,
+        claimable: isClaimableRolloutGeneration(r),
         node_id: r.node_id,
         pool_ready_at: r.pool_ready_at,
         health_url: r.health_url,

--- a/packages/cloud/shared/src/lib/services/containers/image-rollout-status.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/image-rollout-status.test.ts
@@ -103,7 +103,15 @@ describe("imageMatchesDesired", () => {
 });
 
 function row(id: string, image: string | null): RolloutPoolRow {
-  return { id, docker_image: image, node_id: null, pool_ready_at: null, health_url: null };
+  return {
+    id,
+    docker_image: image,
+    image_digest: image ? describeImageReference(image).digest : null,
+    claimable: true,
+    node_id: null,
+    pool_ready_at: null,
+    health_url: null,
+  };
 }
 
 const DESIRED = `${REPO}@${DIGEST_A}`;
@@ -163,6 +171,26 @@ describe("summarizeImageRollout — status state machine", () => {
       unknownImage: 0,
     });
     expect(s.staleRows.map((r) => r.id)).toEqual(["old"]);
+  });
+
+  test("a mutable tag is classified by persisted digest, not matching tag text", () => {
+    const tagged = `${REPO}:stable`;
+    const s = summarizeImageRollout({
+      desiredImage: tagged,
+      desiredDigest: DIGEST_A,
+      enabled: true,
+      rows: [
+        { ...row("current", tagged), image_digest: DIGEST_A },
+        { ...row("stale", tagged), image_digest: DIGEST_B },
+      ],
+    });
+    expect(s.desired.digest).toBe(DIGEST_A);
+    expect(s.counts).toMatchObject({ matchingDesired: 1, stale: 1 });
+    expect(s.staleRows[0]).toMatchObject({
+      id: "stale",
+      currentImage: tagged,
+      currentDigest: DIGEST_B,
+    });
   });
 
   test("a null-image row counts as unknown + stale", () => {

--- a/packages/cloud/shared/src/lib/services/containers/image-rollout-status.ts
+++ b/packages/cloud/shared/src/lib/services/containers/image-rollout-status.ts
@@ -16,6 +16,8 @@ export interface ImageReferenceStatus {
 export interface RolloutPoolRow {
   id: string;
   docker_image: string | null;
+  image_digest: string | null;
+  claimable: boolean;
   node_id: string | null;
   pool_ready_at: Date | null;
   health_url: string | null;
@@ -41,8 +43,11 @@ export interface ImageRolloutSummary {
   status: ImageRolloutStatus;
   safeNextAction: ImageRolloutSafeNextAction;
   counts: {
+    totalGenerations: number;
     totalReady: number;
+    inFlightOrUnclaimable: number;
     matchingDesired: number;
+    matchingReady: number;
     stale: number;
     unknownImage: number;
   };
@@ -120,54 +125,66 @@ export function imageMatchesDesired(currentImage: string | null, desiredImage: s
 
 export function summarizeImageRollout(params: {
   desiredImage: string;
+  desiredDigest?: string;
   enabled: boolean;
   rows: RolloutPoolRow[];
 }): ImageRolloutSummary {
-  const desired = describeImageReference(params.desiredImage);
+  const configured = describeImageReference(params.desiredImage);
+  const desired = params.desiredDigest
+    ? {
+        ...configured,
+        reference: `${configured.repository}@${params.desiredDigest}`,
+        digest: params.desiredDigest,
+        pinning: "digest" as const,
+        productionSafe: SHA256_DIGEST_RE.test(params.desiredDigest),
+        warning: SHA256_DIGEST_RE.test(params.desiredDigest)
+          ? null
+          : "Resolved image digest must be a full sha256:<64 hex> reference.",
+      }
+    : configured;
   const currentCounts = new Map<
     string,
     { image: string; tag: string | null; digest: string | null; count: number }
   >();
   const staleRows: ImageRolloutSummary["staleRows"] = [];
   let matchingDesired = 0;
+  let matchingReady = 0;
   let unknownImage = 0;
 
   for (const row of params.rows) {
-    if (!row.docker_image) {
+    if (!row.image_digest) {
       unknownImage++;
-      staleRows.push({
-        id: row.id,
-        currentImage: null,
-        currentTag: null,
-        currentDigest: null,
-        nodeId: row.node_id,
-        poolReadyAt: row.pool_ready_at,
-        healthUrl: row.health_url,
-      });
-      continue;
     }
 
-    const current = describeImageReference(row.docker_image);
-    const existing = currentCounts.get(row.docker_image);
-    if (existing) {
-      existing.count++;
-    } else {
-      currentCounts.set(row.docker_image, {
-        image: row.docker_image,
-        tag: current.tag,
-        digest: current.digest,
-        count: 1,
-      });
+    if (row.docker_image) {
+      const current = describeImageReference(row.docker_image);
+      const currentKey = `${row.docker_image}\u0000${row.image_digest ?? "unknown"}`;
+      const existing = currentCounts.get(currentKey);
+      if (existing) {
+        existing.count++;
+      } else {
+        currentCounts.set(currentKey, {
+          image: row.docker_image,
+          tag: current.tag,
+          digest: row.image_digest,
+          count: 1,
+        });
+      }
     }
 
-    if (imageMatchesDesired(row.docker_image, params.desiredImage)) {
+    const matchesDesired = params.desiredDigest
+      ? row.image_digest === params.desiredDigest
+      : imageMatchesDesired(row.docker_image, params.desiredImage);
+    if (matchesDesired) {
       matchingDesired++;
+      if (row.claimable) matchingReady++;
     } else {
+      const current = row.docker_image ? describeImageReference(row.docker_image) : null;
       staleRows.push({
         id: row.id,
         currentImage: row.docker_image,
-        currentTag: current.tag,
-        currentDigest: current.digest,
+        currentTag: current?.tag ?? null,
+        currentDigest: row.image_digest,
         nodeId: row.node_id,
         poolReadyAt: row.pool_ready_at,
         healthUrl: row.health_url,
@@ -175,7 +192,7 @@ export function summarizeImageRollout(params: {
     }
   }
 
-  const totalReady = params.rows.length;
+  const totalReady = params.rows.filter((row) => row.claimable).length;
   let status: ImageRolloutStatus;
   let safeNextAction: ImageRolloutSafeNextAction;
   if (!params.enabled) {
@@ -184,12 +201,12 @@ export function summarizeImageRollout(params: {
   } else if (!desired.productionSafe) {
     status = "blocked_unpinned_desired_image";
     safeNextAction = "configure_pinned_desired_image";
-  } else if (totalReady === 0) {
-    status = "no_ready_pool";
-    safeNextAction = "replenish_pool";
   } else if (staleRows.length > 0) {
     status = "needs_rollout";
     safeNextAction = "replace_stale_pool_entries";
+  } else if (totalReady === 0) {
+    status = "no_ready_pool";
+    safeNextAction = "replenish_pool";
   } else {
     status = "current";
     safeNextAction = "none";
@@ -201,13 +218,16 @@ export function summarizeImageRollout(params: {
     status,
     safeNextAction,
     counts: {
+      totalGenerations: params.rows.length,
       totalReady,
+      inFlightOrUnclaimable: params.rows.length - totalReady,
       matchingDesired,
+      matchingReady,
       stale: staleRows.length,
       unknownImage,
     },
-    currentImages: Array.from(currentCounts.values()).sort((a, b) =>
-      a.image.localeCompare(b.image),
+    currentImages: Array.from(currentCounts.values()).sort(
+      (a, b) => a.image.localeCompare(b.image) || (a.digest ?? "").localeCompare(b.digest ?? ""),
     ),
     staleRows,
     supportedActions: [

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -6302,13 +6302,24 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
 
   test("a warm-pool provision becomes running only through the final readiness CAS", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const handle = providerHandle();
+    const configuredPoolImage = "ghcr.io/elizaos/eliza:stable";
+    const targetDigest = `sha256:${"a".repeat(64)}`;
+    const handle = {
+      ...providerHandle(),
+      metadata: {
+        ...providerHandle().metadata,
+        dockerImage: `ghcr.io/elizaos/eliza@${targetDigest}`,
+        imageDigest: targetDigest,
+      },
+    };
     const row: AgentSandbox = {
       ...provisioningReadyRow(),
       organization_id: WARM_POOL_ORG_ID,
       user_id: WARM_POOL_USER_ID,
       execution_tier: "dedicated-always",
       pool_status: "unclaimed",
+      docker_image: configuredPoolImage,
+      image_digest: targetDigest,
     };
     const adoptedRow: AgentSandbox = {
       ...row,
@@ -6318,7 +6329,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       container_name: handle.metadata.containerName,
       bridge_url: handle.bridgeUrl,
       health_url: handle.healthUrl,
-      docker_image: handle.metadata.dockerImage,
+      docker_image: configuredPoolImage,
       image_digest: handle.metadata.imageDigest,
     };
     const readyRow: AgentSandbox = {
@@ -6343,8 +6354,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       plainKey: "eliza_test_agent_key",
       prefix: "eliza_test",
     });
+    const create = mock(async () => handle);
     const provider: SandboxProvider = {
-      create: mock(async () => handle),
+      create,
       stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
@@ -6360,6 +6372,19 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
 
       expect(result.success).toBe(true);
       expect(result.sandboxRecord).toBe(readyRow);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dockerImage: `ghcr.io/elizaos/eliza@${targetDigest}`,
+        }),
+      );
+      expect(updateSpy).toHaveBeenCalledWith(
+        AGENT,
+        expect.objectContaining({
+          status: "provisioning",
+          docker_image: configuredPoolImage,
+          image_digest: targetDigest,
+        }),
+      );
       expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
       expect(commitReadySpy).toHaveBeenCalledTimes(1);
       expect(commitReadySpy).toHaveBeenCalledWith(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3123,7 +3123,13 @@ export class ElizaSandboxService {
     // Solution: Retry loop catches unique constraint errors, cleans up ghost container, and retries.
     const MAX_PROVISION_ATTEMPTS = 3;
     let lastError: string = "Unknown error";
-    const provisionDockerImage = resolveManagedProvisionDockerImage(rec.docker_image);
+    const provisionDockerImage =
+      isWarmPoolProvision &&
+      rec.docker_image &&
+      rec.image_digest &&
+      /^sha256:[0-9a-f]{64}$/.test(rec.image_digest)
+        ? digestPinnedImageRef(rec.docker_image, rec.image_digest)
+        : resolveManagedProvisionDockerImage(rec.docker_image);
 
     // Materialize the stored env for the container: BYO secrets are encrypted
     // at rest (#11332); compatibility plaintext values pass through unchanged. A
@@ -3354,7 +3360,13 @@ export class ElizaSandboxService {
           if (dockerMeta.bridgePort) updateData.bridge_port = dockerMeta.bridgePort;
           if (dockerMeta.webUiPort) updateData.web_ui_port = dockerMeta.webUiPort;
           if (dockerMeta.headscaleIp) updateData.headscale_ip = dockerMeta.headscaleIp;
-          if (dockerMeta.dockerImage) updateData.docker_image = dockerMeta.dockerImage;
+          if (dockerMeta.dockerImage) {
+            // Warm-pool rows retain the configured logical image reference so
+            // the API's exact-image claim contract can see them. Their actual
+            // immutable runtime generation is recorded by image_digest.
+            updateData.docker_image =
+              isWarmPoolProvision && rec.docker_image ? rec.docker_image : dockerMeta.dockerImage;
+          }
           // Always overwrite the digest (including null) so a re-provision
           // onto a different image clears any stale value. The reconciler
           // treats null as "unknown, wait until probe succeeds before


### PR DESCRIPTION
# Relates to

Relates to #16961. This closes the bounded source gap only; protected staging/production activation and live timing/claim receipts remain open on the issue.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `2bca2475c434e3b57d1b84753087fc73309094ab` with zero conflicts.
- [ ] `bun run verify` was not run; exact affected suites, package typechecks, Biome, and diff checks are recorded below.
- [x] A reviewer can confirm the concurrency and claim-safety contracts from the deterministic and PGlite evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@2bca2475c434e3b57d1b84753087fc73309094ab`; zero conflicts.
- [ ] Full `bun run verify` was not run; exact scoped gates pass and the omission is documented below.

# Risks

Medium. This changes warm-pool claim/count eligibility and daemon reconciliation ordering. The safety bias is deliberate: an unknown or known-stale digest is fenced from claims immediately, even if that temporarily forces cold provisioning. Physical teardown remains burst/floor bounded. `WARM_POOL_ENABLED` is unchanged and production was not activated.

# Background

## What does this PR do?

- resolves one immutable image digest per daemon sweep, pre-pulls and replenishes the exact `repo@sha256` reference, and passes the same digest into rollout;
- makes persisted canonical `image_digest` part of the shared claim/count predicates, so null/malformed and daemon-known stale generations cannot transfer to a user;
- adds exact-generation CAS fencing over status, environment revision, runtime locators, configured image, persisted digest, and readiness;
- fences every stale generation immediately while selecting only a policy-bounded subset for physical teardown, preserving retained depth until target-ready generations exist;
- reports rollout state from persisted digests rather than mutable tag text;
- wires rollout into the real provisioning daemon after a successful immutable pre-pull and before digest-scoped replenish.

## What kind of change is this?

Bug fix / production safety improvement.

# Documentation changes needed?

N/A - no public contract or operator flag changed; protected rollout remains disabled and tracked by #16961.

# Testing

## Where should a reviewer start?

Start with `agent-sandboxes.ts` for the claim predicate and generation CAS, then `agent-warm-pool.ts` for fence-versus-teardown policy, then the daemon one-shot test for phase/digest binding.

## Detailed testing steps

At exact head `c513b3d4be547d61de780ce8d8a289b2a1089205`:

- Focused warm-pool, creator, rollout-status, real PGlite repository, and daemon one-shot suites — 97 pass, 0 fail, 311 assertions.
- Full `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts` — 225 pass, 0 fail, 1518 assertions.
- `bun run --cwd packages/cloud/services/container-control-plane test` — 19 pass, 0 fail, 88 assertions.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `bun run --cwd packages/cloud/services/container-control-plane typecheck` — pass.
- focused Biome over all changed files — pass with only the daemon files 11 pre-existing undeclared-env warnings.
- `git diff --check` — pass.

The repository bunfig enables monorepo-wide text coverage for every Bun test. On the two broad-import exact suites, its reporter ended with Bun `WriteFailed` after all tests passed; rerunning with `--config=/dev/null` disables only that reporter and produced the authoritative zero exits above.

# Independent exact-head repair review

The first submitted head was not safe to merge. Independent review found and repaired these concrete defects before this final head:

- a zero-node pre-pull (`attempted=0, failed=0`) incorrectly authorized destructive stale-generation fencing;
- exact-digest replenish wrote an immutable runtime ref into `docker_image`, while claims still required the configured tag, making newly-created capacity unclaimable;
- the target digest was absent while a new row was provisioning, so repeated cycles could ignore in-flight capacity and exceed the configured ceiling;
- a retained remote-cleanup tombstone was reported as `replaced`, and daemon deferred arithmetic could count one generation twice;
- floor wording implied claimable capacity even though every known-stale row is deliberately fenced. It now explicitly describes only retained physical teardown capacity.

The repaired contract persists the configured claim image and canonical target digest atomically at pool-row creation, launches Docker from `repo@digest`, preserves the configured image on the ready row, rejects zero-attempt rollout admission, counts in-flight digest generations toward the hard ceiling, verifies row absence before reporting replacement, and keeps all known-stale/null/malformed generations unclaimable.

# Evidence Gate

<!-- evidence-head:c513b3d4be547d61de780ce8d8a289b2a1089205 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only DB/daemon change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only DB/daemon change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - protected providers and production warm-pool rollout were intentionally not mutated; live daemon receipts remain issue acceptance work.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model/prompt/provider/action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - protected production DB/provider rollout was intentionally not activated; deterministic PGlite transaction receipts are listed in Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no protected rollout was executed. The exact-head deterministic daemon and PGlite receipts are listed in Testing.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Audio / voice walkthrough

N/A - no audio/voice surface.

## Known gaps / failures

- Full `bun run verify` was not run; focused affected tests, two owning typechecks, Biome, and diff integrity are green at the exact rebased head.
- `WARM_POOL_ENABLED` remains unchanged. Protected staging/production enablement, real provider pre-pull, live claim receipts, and p95 timing evidence remain open on #16961 and must be completed before the issue itself closes.
- This PR must not merge without independent exact-head review.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-16961-digest-rollout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->




