### PR TITLE
fix(core): classify all mixed planner rejections

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -10,6 +10,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { promoteSubactionsToActions } from "../actions/promote-subactions";
+import { CONNECTOR_ACCOUNT_SERVICE_TYPE } from "../connectors/account-manager";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import type { CandidateActionBackstopRule } from "../runtime/candidate-action-backstop";
 import { ContextRegistry } from "../runtime/context-registry";
@@ -636,6 +637,161 @@ describe("runV5MessageRuntimeStage1", () => {
 				/that's private|owner's private info|private information in this conversation/i,
 			);
 		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
+	it("keeps a MIXED disclosure+missing-action set on the planner path (#20869)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user asked for an owner read and an unavailable action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "MISSING_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain that the second capability is unavailable.",
+				toolCalls: [],
+				messageToUser: "That capability is not available here.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000021" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"That capability is not available here.",
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
+	it("keeps a MIXED disclosure+validation-error set on the planner path (#20869)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user asked for an owner read and a failing action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "FAILING_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain that the second capability failed validation.",
+				toolCalls: [],
+				messageToUser: "That capability could not be validated.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+			{
+				...makeMemorySearchAction(),
+				name: "FAILING_TASK",
+				contexts: ["general"],
+				validate: async () => {
+					throw new Error("validation dependency failed");
+				},
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000022" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"That capability could not be validated.",
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(reportErrorCalls(runtime).length).toBeGreaterThan(0);
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
+	it("keeps a MIXED disclosure+account-policy-error set on the planner path (#20869)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user asked for an owner read and a connector action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "CONNECTOR_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain that connector policy could not be evaluated.",
+				toolCalls: [],
+				messageToUser: "That connector capability could not be validated.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+			{
+				...makeMemorySearchAction(),
+				name: "CONNECTOR_TASK",
+				contexts: ["general"],
+				connectorAccountPolicy: { provider: "failing-provider" },
+			} as Action,
+		];
+		const accountPolicyError = new Error("connector policy dependency failed");
+		(runtime.getService as ReturnType<typeof vi.fn>).mockImplementation(
+			(serviceType: string) =>
+				serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE
+					? {
+							registerProvider: vi.fn(),
+							evaluatePolicy: vi.fn(async () => {
+								throw accountPolicyError;
+							}),
+						}
+					: null,
+		);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000023" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"That connector capability could not be validated.",
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(reportErrorCalls(runtime)).toContainEqual([
+			"MessageService.plannerActionValidation",
+			accountPolicyError,
+			{ action: "CONNECTOR_TASK", parentAction: undefined },
+		]);
 		expect(useModelCalls(runtime)).toHaveLength(2);
 	});
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2770,11 +2770,12 @@ async function collectV5PlannerCandidateActions(args: {
 		disclosureRejectedReasons: string[];
 		/** Normalized names of EXPLICIT stage-1 candidates rejected by a
 		 * NON-disclosure gate: role/context/private-action (#20679), plus
-		 * connector-account-policy denials and `validate() === false` (#20869).
-		 * A privacy denial only proves a disclosure boundary; when the same turn
-		 * also has a non-disclosure rejection the request is compound, so the
-		 * privacy short-circuit must stand down and let the planner/recovery
-		 * path answer the non-disclosure limitation honestly. */
+		 * connector-account-policy denials, unavailable explicit capabilities,
+		 * `validate() === false`, and failed policy/validation checks (#20869). A
+		 * privacy denial only proves a disclosure boundary; when the same turn also
+		 * has a non-disclosure rejection the request is compound, so the privacy
+		 * short-circuit must stand down and let the planner/recovery path answer the
+		 * non-disclosure limitation honestly. */
 		nonDisclosureRejectedExplicitCandidates: string[];
 	};
 }): Promise<Action[]> {
@@ -2910,6 +2911,15 @@ async function collectV5PlannerCandidateActions(args: {
 			selectedActions.push(action);
 			return true;
 		} catch (error) {
+			if (explicitCandidateName) {
+				// Provider-policy and validate exceptions are fail-closed capability
+				// rejections, not disclosure decisions. Preserve that distinction so
+				// a sibling disclosure denial cannot mislabel the compound turn as
+				// purely private.
+				args.diagnostics?.nonDisclosureRejectedExplicitCandidates.push(
+					action.name,
+				);
+			}
 			// error-policy:J1 planner exposure fails closed for the affected action
 			// while reporting the validation failure to the agent.
 			args.runtime.reportError(
@@ -2947,6 +2957,15 @@ async function collectV5PlannerCandidateActions(args: {
 					.map((alias) => resolveRuntimeAction(actionLookup, alias))
 					.filter((action): action is Action => action !== undefined);
 		if (resolved.length === 0) {
+			const normalizedCandidate = normalizeActionIdentifier(candidateName);
+			if (normalizedCandidate) {
+				// A missing capability is another non-disclosure limitation. Recording
+				// it keeps a simultaneous disclosure rejection from short-circuiting
+				// the planner with an unrelated privacy-only response.
+				args.diagnostics?.nonDisclosureRejectedExplicitCandidates.push(
+					normalizedCandidate,
+				);
+			}
 			args.runtime.logger.warn(
 				{
 					src: "service:message",


### PR DESCRIPTION
# Relates to

Follow-up hardening for #20869 and merged PR #20892. Independent post-merge review found two rejection classes still absent from the mixed-rejection diagnostic set.

- [x] Targets `develop` and is rebased onto `43718d969bb554a254b54fe63e2f397c21f0cdfa` with zero conflicts.
- [x] Focused Stage-1 suite and Biome pass on the exact head.
- [ ] Full root verify and a live-model trajectory are recorded as gaps below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` was not run; exact blockers are below.

# Risks

Medium-low. This changes only terminal diagnostic classification after explicit planner candidates are rejected. It does not admit an action or bypass disclosure, policy, or validation gates.

# Background

## What does this PR do?

The original fix recorded account-policy-false and validate-false rejections. This follow-up also records:

- explicit action candidates that cannot be resolved after normalization;
- connector policy/validation checks that throw.

Those cases are non-disclosure failures, so a mixed set can no longer be mislabeled as a pure privacy rejection. Tests cover both the unresolved-candidate and thrown-policy boundaries through the real Stage-1 planner/service seams.

## What kind of change is this?

Bug fix and diagnostic-classification hardening.

# Documentation changes needed?

No public API or configuration changes.

# Testing

## Where should a reviewer start?

`packages/core/src/__tests__/message-runtime-stage1.test.ts`

## Detailed testing steps

```text
Bun 1.3.14 / Node 24.15.0 Stage-1 suite: 148/148 passed
Biome: both changed files clean
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:355d86fe92163712f683d7d5cd96c4afdf3992f7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime planner classification with no rendered UI diff.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime planner classification with no rendered UI diff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic Stage-1 tests directly record planner replies and reportError context.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] A live-model compound-turn trajectory remains to be attached; deterministic fake-model coverage proves the branch logic but is not live-model evidence.
<!-- evidence-row:domain-artifacts -->
- [x] Stage-1 test transcripts assert planner reply selection, privacy-template exclusion, exact validation report context, and model-call count.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

- A live-model compound-turn trajectory has not been captured yet.
- Package typecheck reached unrelated missing dependencies in the borrowed checkout (`ai`, `mammoth`, `unpdf`, `dedent`, `markdown-it`, `file-type`, and `dotenv`); no diagnostic referenced either changed file.
- Full root `bun run verify` was not run. The exact-head focused suite, Biome, and diff check are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza"} -->