### PR TITLE
fix(meetings): reserve joins before billing await

### DIFF
--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -161,6 +161,87 @@ describe("MeetingService.requestJoin — validation", () => {
     expect(adapters[0].session).not.toBeNull();
   });
 
+  it("keeps the same-URL reservation atomic while initial billing awaits", async () => {
+    const firstBilling = new FakeMeetingBillingSession();
+    const unusedBilling = new FakeMeetingBillingSession();
+    const { service, adapters } = makeService(undefined, [
+      firstBilling,
+      unusedBilling,
+    ]);
+
+    const results = await Promise.allSettled([
+      service.requestJoin({ platform: "google_meet", meetingUrl: MEET_URL }),
+      service.requestJoin({
+        platform: "google_meet",
+        meetingUrl: "https://meet.google.com/abcdefghij",
+      }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].reason).toMatchObject({ code: "already_joined" });
+    expect(service.listSessions({ active: true })).toHaveLength(1);
+    expect(firstBilling.reserveInitialCalls).toBe(1);
+    expect(unusedBilling.reserveInitialCalls).toBe(0);
+    await adapters[0].started;
+    expect(adapters[0].session).not.toBeNull();
+  });
+
+  it("releases a failed initial billing reservation so the same URL can retry", async () => {
+    const failedBilling = new FakeMeetingBillingSession();
+    failedBilling.initialReserveError = new Error(
+      "billing provider unavailable",
+    );
+    const retryBilling = new FakeMeetingBillingSession();
+    const { service } = makeService(undefined, [failedBilling, retryBilling]);
+
+    await expect(
+      service.requestJoin({ platform: "google_meet", meetingUrl: MEET_URL }),
+    ).rejects.toThrow("billing provider unavailable");
+    expect(service.listSessions({ active: true })).toHaveLength(0);
+    expect(failedBilling.reserveInitialCalls).toBe(1);
+    expect(failedBilling.reconcileCalls).toEqual(["error"]);
+
+    const retried = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: "https://meet.google.com/abcdefghij",
+    });
+    expect(retried.status).toBe("requested");
+    expect(service.listSessions({ active: true })).toHaveLength(1);
+    expect(retryBilling.reserveInitialCalls).toBe(1);
+  });
+
+  it("preserves both setup and billing-release failures", async () => {
+    const adapter = new ScriptedAdapter("google_meet");
+    const billing = new FakeMeetingBillingSession();
+    const reserveFailure = new Error("billing provider unavailable");
+    const releaseFailure = new Error("billing release unavailable");
+    billing.initialReserveError = reserveFailure;
+    billing.reconcileError = releaseFailure;
+    const { service } = makeService([adapter], [billing]);
+
+    const failure = await service
+      .requestJoin({ platform: "google_meet", meetingUrl: MEET_URL })
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      reserveFailure,
+      releaseFailure,
+    ]);
+    expect(service.listSessions()).toHaveLength(0);
+    expect(adapter.session).toBeNull();
+    expect(billing.reconcileCalls).toEqual(["error"]);
+  });
+
   it("releases the reservation when join setup throws, so a retry succeeds (BL-5)", async () => {
     const billing = new FakeMeetingBillingSession();
     const retryBilling = new FakeMeetingBillingSession();
@@ -279,6 +360,7 @@ describe("MeetingService.requestJoin — validation", () => {
     expect(adapter.session).toBeNull();
     expect(service.listSessions()).toHaveLength(0);
     expect(billing.reserveInitialCalls).toBe(1);
+    expect(billing.reconcileCalls).toEqual(["error"]);
   });
 });
 

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -283,21 +283,6 @@ export class MeetingService extends Service {
       maxDurationMs,
     });
 
-    if (billing) {
-      try {
-        await billing.reserveInitial();
-      } catch (err) {
-        if (
-          err instanceof Error &&
-          "code" in err &&
-          err.code === "insufficient_credits"
-        ) {
-          throw new MeetingJoinError("insufficient_credits", err.message);
-        }
-        throw err;
-      }
-    }
-
     const pipeline = this.deps.createPipeline({
       runtime: this.runtime,
       sessionId,
@@ -355,11 +340,12 @@ export class MeetingService extends Service {
     };
     this.sessions.set(sessionId, session);
 
-    // With the reservation held, do the awaited setup. If world/room ensure or
-    // the transcript writer's initial row write throws, release the reservation
-    // so the meeting is joinable again and future joins are not permanently
-    // rejected with `already_joined` by a stranded non-terminal session.
+    // With the reservation held, do every awaited setup step, including the
+    // initial billing hold. If any step throws, release the meeting claim and
+    // reconcile the billing hold so future joins are not permanently rejected
+    // with `already_joined` by a stranded non-terminal session.
     try {
+      if (billing) await billing.reserveInitial();
       const worldId = await this.ensureMeetingsWorld();
       await this.runtime.ensureRoomExists({
         id: roomId,
@@ -382,9 +368,14 @@ export class MeetingService extends Service {
         consentState: "not_required",
       });
     } catch (err) {
+      // error-policy:J2 setup and mandatory billing cleanup failures are
+      // retained together so an uncertain credit hold cannot be reported as a
+      // successfully released reservation.
+      let billingReleaseFailure: unknown;
       try {
         await this.reconcileBillingOnce(session, "error");
       } catch (billingErr) {
+        billingReleaseFailure = billingErr;
         logger.error(
           {
             sessionId,
@@ -406,8 +397,21 @@ export class MeetingService extends Service {
           nativeMeetingId: parsed.nativeMeetingId,
           error: err instanceof Error ? err.message : String(err),
         },
-        "[MeetingService] join setup failed — reservation released",
+        "[MeetingService] join setup failed — meeting reservation released",
       );
+      if (billingReleaseFailure !== undefined) {
+        throw new AggregateError(
+          [err, billingReleaseFailure],
+          "Meeting join setup and billing release both failed",
+        );
+      }
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        err.code === "insufficient_credits"
+      ) {
+        throw new MeetingJoinError("insufficient_credits", err.message);
+      }
       throw err;
     }
 

--- a/plugins/plugin-meetings/src/test-support.ts
+++ b/plugins/plugin-meetings/src/test-support.ts
@@ -184,6 +184,7 @@ export class FakeMeetingBillingSession implements MeetingBillingSession {
     reservationIds: [] as string[],
   };
   initialReserveError: Error | null = null;
+  reconcileError: Error | null = null;
   failAfterConsumedMs: number | null = null;
   reserveInitialCalls = 0;
   reconcileCalls: MeetingEndReason[] = [];
@@ -224,6 +225,7 @@ export class FakeMeetingBillingSession implements MeetingBillingSession {
 
   async reconcile(reason: MeetingEndReason) {
     this.reconcileCalls.push(reason);
+    if (this.reconcileError) throw this.reconcileError;
     this.state.status = "reconciled";
     return this.state;
   }


### PR DESCRIPTION
# Relates to

Closes #22520.

- [x] Targets `develop` and is based on exact current `43718d969bb554a254b54fe63e2f397c21f0cdfa`.
- [x] Focused tests, typecheck, build/declarations, Biome, and diff checks pass.
- [x] The billing-enabled concurrency and rollback contracts have independent review coverage.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop`; zero conflicts.
- [ ] Full root `bun run verify` was not run; package evidence and unrelated broad-suite failures are below.

# Risks

Medium. The ordering of meeting-session insertion moves ahead of the initial billing await. Rollback now explicitly owns both the session claim and billing reconciliation, and preserves dual failures with `AggregateError`.

# Background

## What does this PR do?

It closes the billing-only TOCTOU window in `MeetingService.requestJoin` by constructing and inserting the session claim synchronously before the first `reserveInitial()` await. Concurrent canonical-equivalent URLs can no longer both reserve credits and launch bots.

The initial reservation remains inside the setup rollback boundary. Insufficient-credit errors retain their public mapping, retries succeed after definitive rollback, and a simultaneous setup + billing-release failure is preserved as `AggregateError` instead of being logged as a successful release.

## What kind of change is this?

Concurrency, billing-consistency, and error-preservation bug fix.

# Documentation changes needed?

No public API or configuration changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-meetings/src/service.test.ts`

## Detailed testing steps

```text
Focused service suite: 37/37 passed
Package typecheck: passed
tsup ESM build + declaration emission: passed
Biome: 3 touched files clean
git diff --check: clean
```

The focused suite proves one winner/one `already_joined`, one reserve and one bot, insufficient-credit fail-closed behavior, retry after reserve failure, and preservation of simultaneous setup/reconciliation failures.

# Evidence Gate

<!-- evidence-head:e4371a077a5898d5832c90fbee538f0fe5f96a3b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - service concurrency fix with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - service concurrency fix with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic fake billing/adapter providers directly prove call counts and rollback ownership; no production service was mutated.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent-planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Test artifacts assert exactly one active meeting, one initial billing reserve, one launched bot, zero stranded sessions after failure, and both causes in ambiguous rollback.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

- No real meeting provider or live billing ledger was invoked; deterministic provider seams prove the concurrency and rollback contract.
- The broad package run reached 228/229 tests. One unrelated speaker-attribution expectation failed, and two suites could not load because a borrowed core build interacts with their global `node:fs` mock; none touches this diff.
- Full root verify was not run. Focused package tests, typecheck, build/declarations, Biome, and diff check are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza"} -->