### PR TITLE
fix(agent): validate consumer paths before host lookup

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -446,10 +446,10 @@ describe("connector account routes", () => {
   it("preserves valid encoded provider, account, and action segments", async () => {
     const { ctx, captured, storage } = createConnectorAccountHarness({
       method: "POST",
-      pathname: "/api/connectors/%73lack/accounts/acct%5Fencoded/t%65st",
+      pathname: "/api/connectors/%73lack/accounts/acct%2Fencoded/t%65st",
     });
     await storage.upsertAccount({
-      id: "acct_encoded",
+      id: "acct/encoded",
       provider: "slack",
       role: "OWNER",
       purpose: ["messaging"],
@@ -465,7 +465,7 @@ describe("connector account routes", () => {
     expect(captured.body).toMatchObject({
       ok: true,
       provider: "slack",
-      account: { id: "acct_encoded" },
+      account: { id: "acct/encoded" },
     });
   });
 

--- a/packages/agent/src/api/connector-routes.test.ts
+++ b/packages/agent/src/api/connector-routes.test.ts
@@ -133,10 +133,14 @@ describe("connector routes", () => {
   });
 
   it("DELETE /api/connectors/:name returns 400 on malformed percent-encoded name", async () => {
+    const saveElizaConfig = vi.fn();
+    const onConnectorDisconnect = vi.fn();
     for (const badName of ["%", "%2", "%ZZ", "%E0%A4"]) {
       const { ctx, captured } = createHarness({
         method: "DELETE",
         pathname: `/api/connectors/${badName}`,
+        saveElizaConfig,
+        onConnectorDisconnect,
       });
       await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
       expect(captured.status).toBe(400);
@@ -144,6 +148,60 @@ describe("connector routes", () => {
         error: "Invalid connector name encoding",
       });
     }
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect(onConnectorDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("preserves encoded connector-name separators without crossing route boundaries", async () => {
+    const saveElizaConfig = vi.fn();
+    const onConnectorDisconnect = vi.fn();
+    const config: ConnectorRouteContext["state"]["config"] = {
+      connectors: {
+        "slack/accounts": { enabled: true },
+        "slack\\accounts": { enabled: true },
+      },
+    };
+
+    for (const encodedName of ["slack%2Faccounts", "slack%5Caccounts"]) {
+      const { ctx, captured } = createHarness({
+        method: "DELETE",
+        pathname: `/api/connectors/${encodedName}`,
+        state: { config },
+        saveElizaConfig,
+        onConnectorDisconnect,
+      });
+      await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+      expect(captured.status).toBe(200);
+    }
+
+    expect(config.connectors).toEqual({});
+    expect(saveElizaConfig).toHaveBeenCalledTimes(2);
+    expect(onConnectorDisconnect).toHaveBeenNthCalledWith(1, "slack/accounts");
+    expect(onConnectorDisconnect).toHaveBeenNthCalledWith(2, "slack\\accounts");
+  });
+
+  it("rejects encoded blocked object keys before deletion side effects", async () => {
+    const saveElizaConfig = vi.fn();
+    const onConnectorDisconnect = vi.fn();
+    for (const badName of [
+      "%5F%5Fproto%5F%5F",
+      "%63onstructor",
+      "%70rototype",
+    ]) {
+      const { ctx, captured } = createHarness({
+        method: "DELETE",
+        pathname: `/api/connectors/${badName}`,
+        saveElizaConfig,
+        onConnectorDisconnect,
+      });
+      await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+      expect(captured.status).toBe(400);
+      expect(captured.body).toEqual({
+        error: "Missing or invalid connector name",
+      });
+    }
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect(onConnectorDisconnect).not.toHaveBeenCalled();
   });
 
   it("DELETE /api/connectors/:name decodes valid percent-encoded connector name", async () => {

--- a/packages/agent/src/api/consumer-key-routes.test.ts
+++ b/packages/agent/src/api/consumer-key-routes.test.ts
@@ -4,7 +4,7 @@
  * injected through the agent host bridge; no vi.mock and no network.
  */
 import type http from "node:http";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AccountPoolConsumerKeyAdmin,
   type AccountPoolConsumerKeySummary,
@@ -269,20 +269,51 @@ describe("consumer-key routes CRUD", () => {
   });
 
   it("rejects malformed percent-encoded consumer key id with 400", async () => {
-    installAdmin();
+    const getAdmin = vi.fn(() => {
+      throw new Error("invalid paths must not resolve the admin service");
+    });
+    setAgentHostBridge({
+      ...defaultAgentHostBridge,
+      getAccountPoolConsumerKeyAdmin: getAdmin,
+    });
     for (const badId of ["%", "%2", "%ZZ", "%E0%A4"]) {
-      const badReq = makeRequest({
-        method: "PATCH",
-        pathname: `/api/accounts/consumer-keys/${badId}`,
-        authorized: true,
-        body: { enabled: true },
-      });
-      await handleConsumerKeyRoutes(badReq.ctx);
-      expect(badReq.reply.status).toBe(400);
-      expect(badReq.reply.body).toEqual({
-        error: "Invalid consumer-key id encoding",
-      });
+      for (const [method, suffix, body] of [
+        ["PATCH", "", { enabled: true }],
+        ["POST", "/rotate", undefined],
+      ] as const) {
+        const badReq = makeRequest({
+          method,
+          pathname: `/api/accounts/consumer-keys/${badId}${suffix}`,
+          authorized: true,
+          body,
+        });
+        await handleConsumerKeyRoutes(badReq.ctx);
+        expect(badReq.reply.status).toBe(400);
+        expect(badReq.reply.body).toEqual({
+          error: "Invalid consumer-key id encoding",
+        });
+      }
     }
+    expect(getAdmin).not.toHaveBeenCalled();
+  });
+
+  it("authenticates before reporting malformed consumer-key paths", async () => {
+    const getAdmin = vi.fn();
+    setAgentHostBridge({
+      ...defaultAgentHostBridge,
+      getAccountPoolConsumerKeyAdmin: getAdmin,
+    });
+    const request = makeRequest({
+      method: "PATCH",
+      pathname: "/api/accounts/consumer-keys/%",
+      authorized: false,
+      body: { enabled: true },
+    });
+
+    await handleConsumerKeyRoutes(request.ctx);
+
+    expect(request.reply.status).toBe(403);
+    expect(getAdmin).not.toHaveBeenCalled();
   });
 
   it("decodes valid percent-encoded consumer key id", async () => {
@@ -290,7 +321,8 @@ describe("consumer-key routes CRUD", () => {
     const created = admin.create({ label: "encoded" });
     expect(created).not.toBeNull();
     if (!created) throw new Error("expected created consumer key");
-    const id = created.consumer.id; // e.g. "ck_1"
+    const id = "ck/legacy\\id";
+    created.consumer.id = id;
     const encodedId = encodeURIComponent(id);
 
     const patchReq = makeRequest({

--- a/packages/agent/src/api/consumer-key-routes.ts
+++ b/packages/agent/src/api/consumer-key-routes.ts
@@ -46,16 +46,33 @@ export async function handleConsumerKeyRoutes(
     return true;
   }
 
+  const remainder = pathname.slice(CONSUMER_KEYS_PREFIX.length);
+  const segments = remainder.split("/").filter((s) => s.length > 0);
+
+  let id: string | null = null;
+  if (segments.length > 0) {
+    try {
+      id = decodeURIComponent(segments[0] ?? "");
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid consumer-key id encoding", 400);
+      return true;
+    }
+    if (!id) {
+      error(res, "Missing consumer-key id", 400);
+      return true;
+    }
+  }
+
+  // Resolve the host service only after the authenticated path is known-valid,
+  // so rejected paths cannot observe host capability or invoke bridge code.
   const admin = getAgentHostBridge().getAccountPoolConsumerKeyAdmin?.() ?? null;
   if (!admin) {
     error(res, "Consumer-key administration is unavailable on this host", 501);
     return true;
   }
 
-  const remainder = pathname.slice(CONSUMER_KEYS_PREFIX.length);
-  const segments = remainder.split("/").filter((s) => s.length > 0);
-
-  if (segments.length === 0) {
+  if (id === null) {
     if (method === "GET") {
       json(res, { keys: admin.list() });
       return true;
@@ -72,19 +89,6 @@ export async function handleConsumerKeyRoutes(
       return true;
     }
     error(res, "Method not allowed", 405);
-    return true;
-  }
-
-  let id: string;
-  try {
-    id = decodeURIComponent(segments[0] ?? "");
-  } catch {
-    // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-    error(res, "Invalid consumer-key id encoding", 400);
-    return true;
-  }
-  if (!id) {
-    error(res, "Missing consumer-key id", 400);
     return true;
   }
 


### PR DESCRIPTION
# Relates to

Follow-up hardening for #20941 and merged PR #20944. The original malformed-decode fix was correct; independent review found the consumer-key handler still resolved the host capability before validating an authenticated malformed path.

- [x] Targets `develop` and is rebased onto `43718d969bb554a254b54fe63e2f397c21f0cdfa`.
- [x] Preserves opaque encoded separator compatibility.
- [x] Focused route tests passed before rebase; current-head Biome and diff checks pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/applied cleanly onto current `origin/develop`; zero conflicts.
- [ ] Full root verify was not run; exact environment blockers are below.

# Risks

Low. The production change only moves authenticated path decoding ahead of host-service resolution. OWNER authorization remains first, and opaque IDs containing encoded `/` or `\` remain valid.

# Background

## What does this PR do?

For consumer-key routes, OWNER authorization now precedes path decoding, while decoding precedes `getAccountPoolConsumerKeyAdmin()`. An authenticated malformed path therefore returns stable 400 without revealing whether the host capability exists or invoking bridge code. Connector tests also pin no persistence/disconnect side effects on malformed or blocked names.

The review explicitly rejected an earlier over-hardening idea that banned decoded separators: connector/account/key identifiers are opaque contracts, so `%2F` and `%5C` compatibility is retained and tested.

## What kind of change is this?

Boundary ordering and side-effect hardening.

# Documentation changes needed?

No public API changes.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/consumer-key-routes.test.ts`

## Detailed testing steps

```text
Focused route suites before current-head rebase: 3 files, 37/37 passed
Current-head Biome: 4 changed files clean
Current-head git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:d9c68d547e117b16719ac00e43d45c791c843724 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - HTTP boundary change with no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - HTTP boundary change with no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic handler tests prove response ordering and zero bridge/storage callbacks.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM or agent-planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Route tests cover malformed PATCH/rotate, unauthorized malformed requests, capability isolation, no side effects, and legacy encoded-separator identifiers.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

- The current-head sparse checkout could not collect the focused suites because its borrowed dependency tree lacks `dedent` and other full-core dependencies. The same final patch passed all 37 focused tests before rebase, applied without conflict, and current-head Biome/diff checks pass.
- Full package/root verify was not run.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@43718d969bb554a254b54fe63e2f397c21f0cdfa:packages/skills/skills/contribute-to-eliza"} -->