### PR TITLE
fix(plugin-native-gateway): ignore stale close events from a replaced socket

### DIFF
--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -64,6 +64,10 @@ class FakeWebSocket {
     this.emit("message", { data });
   }
 
+  error(error: unknown): void {
+    this.emit("error", error);
+  }
+
   private emit(eventName: string, event: unknown): void {
     this.listeners.get(eventName)?.forEach((listener) => {
       listener(event);
@@ -94,6 +98,7 @@ describe("GatewayWeb", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -314,12 +319,18 @@ describe("GatewayWeb", () => {
     );
     await first;
 
+    const firstReply = gateway.send({ method: "chat.send" });
+    const firstReplyRejected = expect(firstReply).rejects.toThrow(
+      "Connection replaced",
+    );
+
     // The first socket's close() is called (by the second connect()) but its
     // "close" event doesn't fire until after the replacement is already open
     // and connected -- reproducing the real out-of-order delivery this guards
     // against, not just a same-tick call.
     FakeWebSocket.deferClose = true;
     const second = gateway.connect({ url: "ws://localhost:1234/second" });
+    await firstReplyRejected;
     const secondSocket = FakeWebSocket.instances[1];
     secondSocket.open();
     secondSocket.message(
@@ -356,5 +367,100 @@ describe("GatewayWeb", () => {
     await expect(reply).resolves.toMatchObject({ ok: true });
 
     await gateway.disconnect();
+  });
+
+  it("settles a superseded handshake and ignores every stale socket event", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = new GatewayWeb();
+    const events: unknown[] = [];
+    await gateway.addListener("gatewayEvent", (event) => {
+      events.push(event);
+    });
+
+    FakeWebSocket.deferClose = true;
+    const first = gateway.connect({ url: "ws://localhost:1234/first" });
+    const firstRejected = expect(first).rejects.toThrow("Connection replaced");
+    const firstSocket = FakeWebSocket.instances[0];
+
+    const second = gateway.connect({ url: "ws://localhost:1234/second" });
+    await firstRejected;
+    const secondSocket = FakeWebSocket.instances[1];
+
+    firstSocket.open();
+    firstSocket.message(
+      JSON.stringify({
+        type: "event",
+        event: "chat.delta",
+        payload: { stale: true },
+        seq: 1,
+      }),
+    );
+    firstSocket.error(new Error("stale socket error"));
+
+    expect(firstSocket.sent).toEqual([]);
+    expect(secondSocket.sent).toEqual([]);
+    expect(events).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+
+    secondSocket.open();
+    secondSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(secondSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await expect(second).resolves.toMatchObject({ connected: true });
+
+    await gateway.disconnect();
+  });
+
+  it("cancels a queued automatic reconnect when connect() is called explicitly", async () => {
+    vi.useFakeTimers();
+    const gateway = new GatewayWeb();
+    const first = gateway.connect({ url: "ws://localhost:1234/first" });
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    firstSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(firstSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await first;
+
+    firstSocket.close(1006, "network lost");
+    const second = gateway.connect({ url: "ws://localhost:1234/second" });
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    secondSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(secondSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await second;
+    await vi.advanceTimersByTimeAsync(800);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(await gateway.isConnected()).toEqual({ connected: true });
+
+    await gateway.disconnect();
+  });
+
+  it("rejects an in-progress handshake when disconnected before open", async () => {
+    const gateway = new GatewayWeb();
+    const connecting = gateway.connect({ url: "ws://localhost:1234" });
+    const rejected = expect(connecting).rejects.toThrow("Client disconnect");
+
+    await gateway.disconnect();
+
+    await rejected;
+    expect(await gateway.isConnected()).toEqual({ connected: false });
   });
 });

--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -12,6 +12,7 @@ type Listener = (event: unknown) => void;
 
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
+  static deferClose = false;
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
   static readonly CLOSED = 3;
@@ -19,6 +20,7 @@ class FakeWebSocket {
   readyState = FakeWebSocket.CONNECTING;
   readonly sent: string[] = [];
   private readonly listeners = new Map<string, Listener[]>();
+  private deferredClose: { code: number; reason: string } | null = null;
 
   constructor(readonly url: string) {
     FakeWebSocket.instances.push(this);
@@ -36,7 +38,21 @@ class FakeWebSocket {
 
   close(code = 1000, reason = "closed"): void {
     this.readyState = FakeWebSocket.CLOSED;
+    if (FakeWebSocket.deferClose) {
+      this.deferredClose = { code, reason };
+      return;
+    }
     this.emit("close", { code, reason });
+  }
+
+  // Fires a close() that was deferred above, simulating a stale socket's
+  // "close" event arriving after a replacement connection has already begun.
+  flushClose(): void {
+    if (this.deferredClose) {
+      const close = this.deferredClose;
+      this.deferredClose = null;
+      this.emit("close", close);
+    }
   }
 
   open(): void {
@@ -65,6 +81,7 @@ function parseSent(
 describe("GatewayWeb", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
+    FakeWebSocket.deferClose = false;
     Object.assign(FakeWebSocket, {
       CONNECTING: 0,
       OPEN: 1,
@@ -275,5 +292,69 @@ describe("GatewayWeb", () => {
         message: "Not connected to gateway",
       },
     });
+  });
+
+  it("ignores a stale close event from a socket replaced by a newer connect()", async () => {
+    const gateway = new GatewayWeb();
+    const states: unknown[] = [];
+    await gateway.addListener("stateChange", (event) => {
+      states.push(event);
+    });
+
+    const first = gateway.connect({ url: "ws://localhost:1234/first" });
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    firstSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(firstSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await first;
+
+    // The first socket's close() is called (by the second connect()) but its
+    // "close" event doesn't fire until after the replacement is already open
+    // and connected -- reproducing the real out-of-order delivery this guards
+    // against, not just a same-tick call.
+    FakeWebSocket.deferClose = true;
+    const second = gateway.connect({ url: "ws://localhost:1234/second" });
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    secondSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(secondSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await expect(second).resolves.toMatchObject({ connected: true });
+
+    states.length = 0;
+    firstSocket.flushClose();
+
+    // The stale close must not tear down the active (second) connection: no
+    // "reconnecting"/"disconnected" state change, and no spurious third
+    // socket created by scheduleReconnect().
+    expect(states).toEqual([]);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // The second connection's own pending/reply plumbing must still work --
+    // the stale close must not have nulled out `this.ws` or rejected requests
+    // in flight on it.
+    const reply = gateway.send({ method: "chat.send" });
+    secondSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(secondSocket, 1).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await expect(reply).resolves.toMatchObject({ ok: true });
+
+    await gateway.disconnect();
   });
 });

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -160,15 +160,24 @@ export class GatewayWeb extends WebPlugin {
 
   async connect(options: GatewayConnectOptions): Promise<GatewayConnectResult> {
     const url = assertGatewayUrl(options.url);
-    if (this.ws) {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    const previousSocket = this.ws;
+    if (previousSocket) {
       this.closed = true;
-      this.ws.close();
       this.ws = null;
+      this.rejectPending(new Error("Connection replaced"));
+      previousSocket.close(1000, "Connection replaced");
+    } else if (this.connectReject || this.pending.size > 0) {
+      this.rejectPending(new Error("Connection replaced"));
     }
 
     this.options = { ...options, url };
     this.closed = false;
     this.backoffMs = 800;
+    this.resetSessionState();
 
     return new Promise<GatewayConnectResult>((resolve, reject) => {
       this.connectResolve = resolve;
@@ -188,10 +197,12 @@ export class GatewayWeb extends WebPlugin {
     this.ws = ws;
 
     ws.addEventListener("open", () => {
+      if (this.ws !== ws) return;
       this.sendConnectFrame();
     });
 
     ws.addEventListener("message", (event) => {
+      if (this.ws !== ws) return;
       this.handleMessage(String(event.data));
     });
 
@@ -207,6 +218,7 @@ export class GatewayWeb extends WebPlugin {
     });
 
     ws.addEventListener("error", (event) => {
+      if (this.ws !== ws) return;
       console.warn("[Gateway] WebSocket error:", event);
     });
   }
@@ -249,6 +261,7 @@ export class GatewayWeb extends WebPlugin {
     this.ws.send(JSON.stringify(frame));
 
     const timeout = setTimeout(() => {
+      this.pending.delete(frame.id);
       if (this.connectReject) {
         this.connectReject(new Error("Connection timeout"));
         this.connectReject = null;
@@ -404,12 +417,8 @@ export class GatewayWeb extends WebPlugin {
 
   private handleClose(code: number, reason: string): void {
     this.ws = null;
-
-    for (const [id, pending] of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error(`Connection closed: ${reason}`));
-      this.pending.delete(id);
-    }
+    this.rejectPending(new Error(`Connection closed: ${reason}`));
+    this.resetSessionState();
 
     if (this.closed) {
       this.notifyStateChange("disconnected", reason);
@@ -438,6 +447,29 @@ export class GatewayWeb extends WebPlugin {
     }, this.backoffMs);
   }
 
+  private rejectPending(error: Error): void {
+    const pendingRequests = [...this.pending.values()];
+    this.pending.clear();
+    for (const pending of pendingRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    const rejectConnect = this.connectReject;
+    this.connectReject = null;
+    this.connectResolve = null;
+    rejectConnect?.(error);
+  }
+
+  private resetSessionState(): void {
+    this.sessionId = null;
+    this.protocol = null;
+    this.role = null;
+    this.scopes = [];
+    this.methods = [];
+    this.events = [];
+    this.lastSeq = null;
+  }
+
   private notifyStateChange(
     state: GatewayStateEvent["state"],
     reason?: string,
@@ -461,12 +493,13 @@ export class GatewayWeb extends WebPlugin {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
-    if (this.ws) {
-      this.ws.close(1000, "Client disconnect");
-      this.ws = null;
+    const socket = this.ws;
+    this.ws = null;
+    this.rejectPending(new Error("Client disconnect"));
+    if (socket) {
+      socket.close(1000, "Client disconnect");
     }
-    this.sessionId = null;
-    this.protocol = null;
+    this.resetSessionState();
     this.notifyStateChange("disconnected", "Client disconnect");
   }
 

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -184,22 +184,29 @@ export class GatewayWeb extends WebPlugin {
 
     this.notifyStateChange("connecting");
 
-    this.ws = new WebSocket(this.options.url);
+    const ws = new WebSocket(this.options.url);
+    this.ws = ws;
 
-    this.ws.addEventListener("open", () => {
+    ws.addEventListener("open", () => {
       this.sendConnectFrame();
     });
 
-    this.ws.addEventListener("message", (event) => {
+    ws.addEventListener("message", (event) => {
       this.handleMessage(String(event.data));
     });
 
-    this.ws.addEventListener("close", (event) => {
+    ws.addEventListener("close", (event) => {
+      // A socket replaced by a newer connect() (see connect()'s `this.ws.close()`)
+      // can still deliver its "close" event after `this.ws` has moved on to the
+      // replacement. Without this guard that stale event nulls out the live
+      // socket, rejects requests already pending on it, and schedules a
+      // spurious reconnect on top of the connection that is actually active.
+      if (this.ws !== ws) return;
       const reason = event.reason || "Connection closed";
       this.handleClose(event.code, reason);
     });
 
-    this.ws.addEventListener("error", (event) => {
+    ws.addEventListener("error", (event) => {
       console.warn("[Gateway] WebSocket error:", event);
     });
   }


### PR DESCRIPTION
# Relates to

Fixes an independently reproduced WebSocket replacement race in the web implementation of `@elizaos/capacitor-gateway`.

## What changed

The original PR correctly captured the socket instance and ignored a delayed `close` from a replaced socket. Review found that `close` was only one part of the boundary: stale `open` could send a duplicate handshake through the replacement, stale `message` could resolve current requests or emit old events, a replaced handshake/RPC could remain pending, and an automatic reconnect timer could later replace an explicit connection.

The repaired lifecycle now:

- detaches the previous socket before initiating its close handshake;
- identity-fences `open`, `message`, `close`, and `error` listeners;
- rejects all pending handshake/RPC work on replacement, active close, and disconnect;
- clears explicit-connect versus automatic-reconnect races;
- removes timed-out handshake entries; and
- clears session metadata whenever connection ownership ends.

This follows the WHATWG WebSockets lifecycle: closing a connection eventually queues a socket-specific `close` event, so mutable client state must only be changed by events from the currently owned socket: https://websockets.spec.whatwg.org/

## Verification

- Exact reviewed head: `346201e62e48765c7ae186af74d1a9b03697d6b6`, rebased onto `origin/develop` `734bb035c31d6da52567e3f8192cff81a9168ce7`.
- Focused/full package suite: 21/21 passed.
- Package TypeScript typecheck: passed.
- Production Rollup build: passed.
- Package Biome check: clean; SwiftLint wrapper was unavailable but is not relevant to the unchanged Swift surface.
- `git diff --check`: clean.
- Real Chromium + real local WebSocket server: two sockets were created, the old RPC rejected as `Connection replaced`, the replacement remained connected, and browser console output was empty.
- Mutation proof using the PR's original close-only production guard: 4/21 repaired tests fail; the real-browser old RPC remains pending instead of settling.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol; Anthropic/claude-sonnet-5 (original contributor verification, self-reported)
<!-- attribution-row:client -->
- Agent tooling: Codex desktop; Claude Code (original contributor verification, self-reported)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@734bb035c31d6da52567e3f8192cff81a9168ce7:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:346201e62e48765c7ae186af74d1a9b03697d6b6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - WebSocket transport logic only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - WebSocket transport logic only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; the real browser transport result is recorded below.
<!-- evidence-row:backend-logs -->
- [x] N/A - the proof uses a local protocol server; server socket count and browser result are recorded inline below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the real Chromium console was captured inline below and contained zero messages.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - connection ownership is in-memory and creates no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real browser + WebSocket boundary

```json
{
  "states": ["connecting", "connected", "connecting", "connected", "disconnected"],
  "oldRequestResult": "Connection replaced",
  "connected": { "connected": true },
  "serverSocketCount": 2,
  "consoleMessages": []
}
```

The same Chromium/local-server proof against the PR's original close-only guard reports `"oldRequestResult": "still pending"` after one second.

## Automated proof

```text
GREEN
Test Files  1 passed (1)
Tests       21 passed (21)
TypeScript  passed
Rollup      created dist/plugin.js and dist/plugin.cjs.js
Biome       Checked 7 files. No fixes applied.

MUTATION RED (original close-only production guard)
Test Files  1 failed (1)
Tests       4 failed | 17 passed (21)
- replaced RPC remained pending
- superseded pre-open handshake remained pending
- explicit connect left an automatic reconnect timer alive (3 sockets, expected 2)
- disconnect-before-open left the handshake pending
```

## Known gaps / failures

The diff changes only the web TypeScript implementation. iOS and Android sources are untouched, so native builds and platform screenshots are not applicable. The relevant shipped browser artifact was built and executed in real headless Chromium against a real local WebSocket server.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@734bb035c31d6da52567e3f8192cff81a9168ce7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [security-audio-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@734bb035c31d6da52567e3f8192cff81a9168ce7:packages/skills/skills/contribute-to-eliza"} -->