### PR TITLE
fix(cloud): decouple router health from DB warmup

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -777,15 +777,18 @@ jobs:
                   fi
                   ROUTER_PORT=$(systemctl show eliza-agent-router.service --property=Environment --value | tr ' ' '\n' | awk -F= '$1=="AGENT_ROUTER_PORT" {print $2}')
                   : "${ROUTER_PORT:=3458}"
-                  if curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/healthz" >/dev/null 2>&1; then
+                  if curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/healthz" >/dev/null 2>&1 && \
+                     curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/readyz" >/dev/null 2>&1; then
                     PUBLIC_HEALTH=""
+                    PUBLIC_READINESS=""
                     public_route_ok=false
                     for public_attempt in 1 2 3; do
-                      if PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz"); then
+                      if PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz") && \
+                         PUBLIC_READINESS=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/readyz"); then
                         public_route_ok=true
                         break
                       fi
-                      echo "Canonical /healthz attempt ${public_attempt}/3 failed for ${AGENT_ROUTER_PUBLIC_HOST}; retrying in 2s."
+                      echo "Canonical health/readiness attempt ${public_attempt}/3 failed for ${AGENT_ROUTER_PUBLIC_HOST}; retrying in 2s."
                       sleep 2
                     done
                     if [ "$public_route_ok" != "true" ]; then
@@ -798,10 +801,15 @@ jobs:
                       report_public_route_failure
                       exit 1
                     fi
-                    echo "Both daemons active and stable (worker ${AGE}s, router ${ROUTER_AGE}s, local and canonical /healthz OK) on attempt $attempt."
+                    if ! printf '%s' "$PUBLIC_READINESS" | validate_public_health_payload; then
+                      echo "::error::Canonical agent-router host returned an unexpected readiness payload: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      report_public_route_failure
+                      exit 1
+                    fi
+                    echo "Both daemons active and stable (worker ${AGE}s, router ${ROUTER_AGE}s, local and canonical health/readiness OK) on attempt $attempt."
                     exit 0
                   fi
-                  echo "Health check attempt $attempt/18: worker stable (${AGE}s), router ${ROUTER_AGE}s but /healthz not ready on port ${ROUTER_PORT}."
+                  echo "Health check attempt $attempt/18: worker stable (${AGE}s), router ${ROUTER_AGE}s but health/readiness not ready on port ${ROUTER_PORT}."
                   sleep 5
                   continue
                 fi

--- a/packages/cloud/scripts/admin/daemons/agent-router.test.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.test.ts
@@ -4,7 +4,8 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import { PassThrough } from "node:stream";
 import {
   buildProxyHeaders,
@@ -17,6 +18,7 @@ import {
   resolveSandboxRouting,
   selectAgentProxyTarget,
   sendResponse,
+  startAgentRouter,
 } from "./agent-router";
 
 function makeRequest(
@@ -50,6 +52,118 @@ function makeResponseStub() {
   output.statusCode = 0;
   return { output, headers, headersFlushed: () => headersFlushed };
 }
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("agent-router startup readiness", () => {
+  it("binds liveness while a routing dependency warmup is stalled", async () => {
+    const reported: Error[] = [];
+    const started = await startAgentRouter({
+      config: { port: 0, bindHost: "127.0.0.1" },
+      warmRoutingDependencies: () => new Promise(() => undefined),
+      warmupTimeoutMs: 100,
+      onWarmupError: (error) => reported.push(error),
+    });
+    const { port } = started.server.address() as AddressInfo;
+
+    try {
+      const health = await fetch(`http://127.0.0.1:${port}/healthz`);
+      const readiness = await fetch(`http://127.0.0.1:${port}/readyz`);
+      const route = await fetch(
+        `http://127.0.0.1:${port}/agents/e06bb509-6c52-4c33-a9f7-66addc43e8c8/routing`,
+      );
+
+      expect(health.status).toBe(200);
+      expect(await health.json()).toEqual({ ok: true });
+      expect(readiness.status).toBe(503);
+      expect(await readiness.json()).toEqual({
+        ok: false,
+        code: "router_warming",
+      });
+      expect(route.status).toBe(503);
+      expect(await route.json()).toEqual({
+        error: "agent router is not ready",
+        code: "router_warming",
+      });
+
+      await started.warmupSettled;
+      const failedReadiness = await fetch(`http://127.0.0.1:${port}/readyz`);
+      expect(failedReadiness.status).toBe(503);
+      expect(await failedReadiness.json()).toEqual({
+        ok: false,
+        code: "router_dependencies_unavailable",
+      });
+      expect(reported[0]?.message).toBe(
+        "routing dependency warmup timed out after 100ms",
+      );
+    } finally {
+      await closeServer(started.server);
+    }
+  });
+
+  it("transitions to ready only after dependency warmup succeeds", async () => {
+    let resolveWarmup: (() => void) | undefined;
+    const started = await startAgentRouter({
+      config: { port: 0, bindHost: "127.0.0.1" },
+      warmRoutingDependencies: () =>
+        new Promise<void>((resolve) => {
+          resolveWarmup = resolve;
+        }),
+    });
+    const { port } = started.server.address() as AddressInfo;
+
+    try {
+      expect((await fetch(`http://127.0.0.1:${port}/readyz`)).status).toBe(503);
+      resolveWarmup?.();
+      await started.warmupSettled;
+      const readiness = await fetch(`http://127.0.0.1:${port}/readyz`);
+      expect(readiness.status).toBe(200);
+      expect(await readiness.json()).toEqual({ ok: true });
+    } finally {
+      await closeServer(started.server);
+    }
+  });
+
+  it("reports rejected warmup without an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const reported: Error[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    const started = await startAgentRouter({
+      config: { port: 0, bindHost: "127.0.0.1" },
+      warmRoutingDependencies: async () => {
+        throw new Error("database unavailable");
+      },
+      onWarmupError: (error) => reported.push(error),
+    });
+    const { port } = started.server.address() as AddressInfo;
+
+    try {
+      await started.warmupSettled;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const readiness = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(started.readiness.status).toBe("failed");
+      expect(readiness.status).toBe(503);
+      expect(await readiness.json()).toEqual({
+        ok: false,
+        code: "router_dependencies_unavailable",
+      });
+      expect(reported.map((error) => error.message)).toEqual([
+        "database unavailable",
+      ]);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      await closeServer(started.server);
+    }
+  });
+});
 
 describe("sendResponse", () => {
   it("relays streaming response chunks before the upstream body closes", async () => {

--- a/packages/cloud/scripts/admin/daemons/agent-router.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.ts
@@ -19,7 +19,7 @@
  *   DATABASE_URL            Postgres connection (loaded from .env.local).
  */
 
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import * as path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -36,13 +36,33 @@ interface RouterDeps {
   findAgentSandboxRoutingById: FindAgentSandboxRoutingById;
 }
 
-interface AgentRouterConfig {
+export interface AgentRouterConfig {
   port: number;
   bindHost: string;
 }
 
+export type RouterReadinessStatus = "warming" | "ready" | "failed";
+
+export interface RouterReadinessState {
+  status: RouterReadinessStatus;
+}
+
+export interface StartAgentRouterOptions {
+  config?: AgentRouterConfig;
+  warmRoutingDependencies?: () => Promise<void>;
+  warmupTimeoutMs?: number;
+  onWarmupError?: (error: Error) => void;
+}
+
+export interface StartedAgentRouter {
+  server: Server;
+  readiness: RouterReadinessState;
+  warmupSettled: Promise<void>;
+}
+
 const DEFAULT_PORT = 3458;
 const DEFAULT_BIND_HOST = "127.0.0.1";
+const DEFAULT_WARMUP_TIMEOUT_MS = 15_000;
 const DEFAULT_AGENT_BASE_DOMAIN = "cloud.eliza.app";
 const AGENT_ID_RE =
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
@@ -463,9 +483,25 @@ async function proxyAgentRequest(
 export async function handleRequest(
   url: URL,
   req?: IncomingMessage,
+  readiness: RouterReadinessState = { status: "ready" },
 ): Promise<Response> {
   if (url.pathname === "/healthz") {
     return Response.json({ ok: true }, { status: 200 });
+  }
+  if (url.pathname === "/readyz") {
+    if (readiness.status === "ready") {
+      return Response.json({ ok: true }, { status: 200 });
+    }
+    return Response.json(
+      {
+        ok: false,
+        code:
+          readiness.status === "warming"
+            ? "router_warming"
+            : "router_dependencies_unavailable",
+      },
+      { status: 503, headers: { "retry-after": "5" } },
+    );
   }
   // /headscale-ip is the path nginx Lua already calls; /routing is the alias
   // for new callers.
@@ -484,6 +520,13 @@ export async function handleRequest(
           headers: corsHeaders(headerValue(req.headers.origin)),
         });
       }
+      if (readiness.status !== "ready") {
+        return buildRouterUnavailableResponse(
+          readiness,
+          headerValue(req.headers.origin),
+          true,
+        );
+      }
       return proxyAgentRequest(agentId, url, req);
     }
     return Response.json({ error: "not found" }, { status: 404 });
@@ -491,6 +534,9 @@ export async function handleRequest(
   const agentId = match[1];
   if (!AGENT_ID_RE.test(agentId)) {
     return Response.json({ error: "invalid agent id" }, { status: 400 });
+  }
+  if (readiness.status !== "ready") {
+    return buildRouterUnavailableResponse(readiness);
   }
   const routing = await resolveAgentRouting(agentId);
   if (!routing) {
@@ -500,6 +546,29 @@ export async function handleRequest(
     );
   }
   return Response.json(routing, { status: 200 });
+}
+
+function buildRouterUnavailableResponse(
+  readiness: RouterReadinessState,
+  origin?: string,
+  includeCors = false,
+): Response {
+  return Response.json(
+    {
+      error: "agent router is not ready",
+      code:
+        readiness.status === "warming"
+          ? "router_warming"
+          : "router_dependencies_unavailable",
+    },
+    {
+      status: 503,
+      headers: {
+        ...(includeCors ? corsHeaders(origin) : {}),
+        "retry-after": "5",
+      },
+    },
+  );
 }
 
 export async function sendResponse(
@@ -522,33 +591,63 @@ export async function sendResponse(
   await pipeline(Readable.from(response.body), res);
 }
 
-let server: import("node:http").Server | null = null;
+let server: Server | null = null;
 let shuttingDown = false;
 
-async function main(): Promise<void> {
-  loadLocalEnv(import.meta.url);
-  const config = readRouterConfig();
-  await resolveAgentRouting("00000000-0000-4000-8000-000000000000");
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+async function reportRouterError(label: string, error: Error): Promise<void> {
+  try {
+    const { logger } = await loadDeps();
+    logger.error(`[agent-router] ${label}`, { error: error.message });
+  } catch {
+    // error-policy:J7 Diagnostics must retain a dependency-free fallback.
+    process.stderr.write(`[agent-router] ${label}: ${error.message}\n`);
+  }
+}
+
+function withTimeout(task: Promise<void>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(`routing dependency warmup timed out after ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([task, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+export async function startAgentRouter(
+  options: StartAgentRouterOptions = {},
+): Promise<StartedAgentRouter> {
+  const config = options.config ?? readRouterConfig();
+  const readiness: RouterReadinessState = { status: "warming" };
+  const warmRoutingDependencies =
+    options.warmRoutingDependencies ??
+    (async () => {
+      await resolveAgentRouting("00000000-0000-4000-8000-000000000000");
+    });
+  const warmupTimeoutMs = options.warmupTimeoutMs ?? DEFAULT_WARMUP_TIMEOUT_MS;
 
   const { createServer } = await import("node:http");
-  server = createServer((req, res) => {
+  const startedServer = createServer((req, res) => {
     const url = new URL(
       req.url ?? "/",
       `http://${req.headers.host || "localhost"}`,
     );
-    handleRequest(url, req)
+    handleRequest(url, req, readiness)
       .then((response) => sendResponse(res, response))
       .catch((err) => {
-        const error = err instanceof Error ? err.message : String(err);
-        void loadDeps()
-          .then(({ logger }) => {
-            logger.error("[agent-router] handler error", { error });
-          })
-          .catch(() => {
-            console.error(`[agent-router] handler error: ${error}`);
-          });
+        const error = toError(err);
+        void reportRouterError("handler error", error);
         if (res.headersSent) {
-          res.destroy(err instanceof Error ? err : new Error(error));
+          res.destroy(error);
           return;
         }
         res.statusCode = 500;
@@ -557,24 +656,57 @@ async function main(): Promise<void> {
       });
   });
 
-  server.listen(config.port, config.bindHost, () => {
-    console.log("[agent-router] starting", {
-      port: config.port,
-      bindHost: config.bindHost,
+  await new Promise<void>((resolve, reject) => {
+    startedServer.once("error", reject);
+    startedServer.listen(config.port, config.bindHost, () => {
+      startedServer.off("error", reject);
+      resolve();
     });
   });
 
-  server.on("error", (err) => {
-    const error = err instanceof Error ? err.message : String(err);
-    void loadDeps()
-      .then(({ logger }) => {
-        logger.error("[agent-router] server error", { error });
-      })
-      .catch(() => {
-        console.error(`[agent-router] server error: ${error}`);
-      });
+  console.log("[agent-router] starting", {
+    port: config.port,
+    bindHost: config.bindHost,
+  });
+
+  startedServer.on("error", (error) => {
+    void reportRouterError("server error", toError(error));
     process.exitCode = 1;
   });
+
+  const warmupSettled = withTimeout(
+    Promise.resolve().then(warmRoutingDependencies),
+    warmupTimeoutMs,
+  ).then(
+    () => {
+      readiness.status = "ready";
+    },
+    async (cause) => {
+      readiness.status = "failed";
+      const error = toError(cause);
+      if (options.onWarmupError) {
+        try {
+          options.onWarmupError(error);
+        } catch (reportingError) {
+          // error-policy:J7 A diagnostic callback must not reject warmup observation.
+          await reportRouterError(
+            "warmup error reporter failed",
+            toError(reportingError),
+          );
+        }
+        return;
+      }
+      await reportRouterError("dependency warmup failed", error);
+    },
+  );
+
+  return { server: startedServer, readiness, warmupSettled };
+}
+
+async function main(): Promise<void> {
+  loadLocalEnv(import.meta.url);
+  const started = await startAgentRouter();
+  server = started.server;
 }
 
 function shutdown(signal: NodeJS.Signals): void {
@@ -585,12 +717,7 @@ function shutdown(signal: NodeJS.Signals): void {
   }
   server.close((err) => {
     if (err) {
-      void loadDeps().then(({ logger }) => {
-        logger.error("[agent-router] close error", {
-          signal,
-          error: err.message,
-        });
-      });
+      void reportRouterError(`${signal} close error`, err);
       process.exitCode = 1;
     }
     process.exit(process.exitCode ?? 0);
@@ -601,11 +728,7 @@ process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 
 process.on("unhandledRejection", (reason) => {
-  void loadDeps().then(({ logger }) => {
-    logger.error("[agent-router] unhandled rejection", {
-      error: reason instanceof Error ? reason.message : String(reason),
-    });
-  });
+  void reportRouterError("unhandled rejection", toError(reason));
 });
 
 function isMainModule(): boolean {

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -315,13 +315,21 @@ describe("provisioning worker deployment contract", () => {
     const localHealth = workflow.indexOf(
       `curl -sf -m 3 "http://127.0.0.1:${routerPort}/healthz"`,
     );
+    const localReadiness = workflow.indexOf(
+      `curl -sf -m 3 "http://127.0.0.1:${routerPort}/readyz"`,
+    );
     const canonicalHealth = workflow.indexOf(
       `curl -fsS -m 5 "https://${publicHost}/healthz"`,
+    );
+    const canonicalReadiness = workflow.indexOf(
+      `curl -fsS -m 5 "https://${publicHost}/readyz"`,
     );
 
     expect(healthStep).toBeGreaterThan(-1);
     expect(localHealth).toBeGreaterThan(healthStep);
-    expect(canonicalHealth).toBeGreaterThan(localHealth);
+    expect(localReadiness).toBeGreaterThan(localHealth);
+    expect(canonicalHealth).toBeGreaterThan(localReadiness);
+    expect(canonicalReadiness).toBeGreaterThan(canonicalHealth);
     expect(workflow.slice(0, healthStep)).not.toContain(
       `"https://${publicHost}/healthz"`,
     );
@@ -330,6 +338,9 @@ describe("provisioning worker deployment contract", () => {
     );
     expect(workflow).toContain(
       "Canonical agent-router host returned an unexpected health payload",
+    );
+    expect(workflow).toContain(
+      "Canonical agent-router host returned an unexpected readiness payload",
     );
     expect(workflow).toContain(
       "sudo systemctl status eliza-agent-router.service --no-pager || true",
@@ -343,7 +354,7 @@ describe("provisioning worker deployment contract", () => {
     const failFast = [
       ...workflow.matchAll(/report_public_route_failure\n\s*exit 1\b/g),
     ];
-    expect(failFast).toHaveLength(2);
+    expect(failFast).toHaveLength(3);
     // The transport probe is bounded: a short retry absorbs one-off blips
     // without reintroducing the blind 30-attempt loop this PR removed.
     expect(workflow).toContain("for public_attempt in 1 2 3; do");


### PR DESCRIPTION
# Relates to

Closes #22544.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e508136064fa2db28d276614ffd042833b6a533f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `2bca2475c434e3b57d1b84753087fc73309094ab`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low-to-medium. The change is isolated to agent-router startup and the provisioning deploy health gate. Routing now fails closed with retryable 503s until dependencies are ready; `/healthz` remains a pure liveness probe.

# Background

## What does this PR do?

- Starts the HTTP listener before any routing database lookup.
- Adds `/readyz`: 503 while warming or after a bounded warmup failure, 200 only after the dependency/DB probe succeeds.
- Returns retryable 503 responses for agent routing while the router is not ready, while preserving DB-free CORS preflight behavior.
- Observes warmup and diagnostic failures so they cannot become unhandled rejections.
- Requires local and canonical liveness plus readiness in the provisioning deployment gate.

## What kind of change is this?

Bug fix (non-breaking operational startup hardening).

# Documentation changes needed?

No public documentation change is needed. The daemon and deployment workflow encode the internal health/readiness contract.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/admin/daemons/agent-router.test.ts`, especially `agent-router startup readiness`.

## Detailed testing steps

```bash
bun test packages/cloud/scripts/admin/daemons/agent-router.test.ts packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
bunx @biomejs/biome check packages/cloud/scripts/admin/daemons/agent-router.ts packages/cloud/scripts/admin/daemons/agent-router.test.ts packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
git diff --check origin/develop...HEAD
```

The first command passes 48 tests / 263 expectations at exact head. The startup tests use a real ephemeral HTTP listener and prove that a never-settling dependency does not block `/healthz`, readiness remains closed, the warmup times out, successful warmup opens readiness, and rejected warmup emits no `unhandledRejection`.

# Evidence Gate

<!-- evidence-head:42e7aefe38100f95121091d5e5d2cfdd03033353 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - daemon and workflow only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - daemon and workflow only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered UI flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - production deploy intentionally not run; exact-head real-listener test summary is inline in Evidence Details
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent behavior, action, provider, prompt, or model changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database migration or persisted domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

<details>
<summary>Exact-head focused test result</summary>

```text
48 pass
0 fail
263 expect() calls
Ran 48 tests across 2 files.
```

</details>

Frontend: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - daemon and deployment workflow only.

## Audio / voice walkthrough

N/A - no audio or voice path changed.

## Known gaps / failures

- `bun install` was not rerun because the host was under critical disk pressure; the pinned Bun 1.3.14 workspace dependencies already present in the shared checkout were used read-only.
- Full `bun run verify` was not run because the requested scope explicitly prohibited broad tests under that disk constraint.
- A focused ad hoc `tsc` invocation is not an owning repository gate for `packages/**/scripts/**` (the root tsconfig excludes scripts) and surfaced existing workspace-generation/dependency errors, including missing `generated/validation-keyword-data.ts`, `file-type`, `dedent`, `pg` declarations, and the pre-existing `Uint8Array<ArrayBufferLike>` fetch-body diagnostic in `agent-router.ts`. The executable focused tests and Biome check pass at exact head.
- Biome reports the pre-existing advisory that `ELIZA_CLOUD_AGENT_BASE_DOMAIN` is not declared in Turbo environment configuration; it reports no formatting or lint errors in the touched TypeScript files.
- No deploy was run. This draft is intentionally for independent review and must not be merged or deployed from this work item.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e508136064fa2db28d276614ffd042833b6a533f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-router-startup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e508136064fa2db28d276614ffd042833b6a533f:packages/skills/skills/contribute-to-eliza"} -->



