### PR TITLE
fix(plugin-whatsapp): linear-strip stacked whatsapp prefixes

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -6,6 +6,7 @@
  */
 
 import { truncateWellFormed } from "@elizaos/core";
+import { stripWhatsAppTargetPrefixes } from "./whatsapp-target-prefix.ts";
 
 /**
  * WhatsApp text chunk limit
@@ -21,20 +22,6 @@ const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
  * Regex for WhatsApp LID (e.g., "123@lid")
  */
 const WHATSAPP_LID_RE = /^(\d+)@lid$/i;
-
-/**
- * Strips WhatsApp target prefixes from a value
- */
-function stripWhatsAppTargetPrefixes(value: string): string {
-  let candidate = value.trim();
-  for (;;) {
-    const before = candidate;
-    candidate = candidate.replace(/^whatsapp:/i, "").trim();
-    if (candidate === before) {
-      return candidate;
-    }
-  }
-}
 
 /**
  * Normalizes a phone number to E.164 format

--- a/plugins/plugin-whatsapp/src/whatsapp-target-prefix.test.ts
+++ b/plugins/plugin-whatsapp/src/whatsapp-target-prefix.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Isolated hang tests for linear `whatsapp:` prefix stripping.
+ * Deterministic — no connector, Baileys, or phone parser.
+ */
+import { describe, expect, it } from "vitest";
+import { stripWhatsAppTargetPrefixes } from "./whatsapp-target-prefix.ts";
+
+describe("stripWhatsAppTargetPrefixes", () => {
+  it("strips zero or one honest prefix", () => {
+    expect(stripWhatsAppTargetPrefixes("41796666864")).toBe("41796666864");
+    expect(stripWhatsAppTargetPrefixes("whatsapp:+41796666864")).toBe("+41796666864");
+    expect(stripWhatsAppTargetPrefixes("WHATSAPP: 41796666864")).toBe("41796666864");
+  });
+
+  it("strips stacked prefixes without quadratic copies", () => {
+    const n = 100_000;
+    const input = `${"whatsapp:".repeat(n)}+4179`;
+    const t0 = performance.now();
+    expect(stripWhatsAppTargetPrefixes(input)).toBe("+4179");
+    expect(performance.now() - t0).toBeLessThan(50);
+  });
+
+  it("preserves String.trim compatibility around every prefix", () => {
+    const whitespace = [
+      "\u0009",
+      "\u000a",
+      "\u000b",
+      "\u000c",
+      "\u000d",
+      "\u0020",
+      "\u00a0",
+      "\u1680",
+      "\u2000",
+      "\u2001",
+      "\u2002",
+      "\u2003",
+      "\u2004",
+      "\u2005",
+      "\u2006",
+      "\u2007",
+      "\u2008",
+      "\u2009",
+      "\u200a",
+      "\u2028",
+      "\u2029",
+      "\u202f",
+      "\u205f",
+      "\u3000",
+      "\ufeff",
+    ];
+
+    for (const space of whitespace) {
+      expect(
+        stripWhatsAppTargetPrefixes(`${space}whatsapp:${space}WHATSAPP:${space}+4179${space}`)
+      ).toBe("+4179");
+    }
+  });
+});

--- a/plugins/plugin-whatsapp/src/whatsapp-target-prefix.ts
+++ b/plugins/plugin-whatsapp/src/whatsapp-target-prefix.ts
@@ -1,0 +1,53 @@
+/**
+ * Linear strip of repeated `whatsapp:` URI prefixes on inbound targets.
+ * The previous loop copied the whole remainder on every peel
+ * (`replace(/^whatsapp:/i) + trim`), so a megabyte of repeated prefixes was
+ * quadratic and hung JID/phone normalization on the ingest path. Honest
+ * handles have zero or one prefix.
+ */
+
+const PREFIX = "whatsapp:";
+
+function isEcmaTrimWhitespace(code: number): boolean {
+  return (
+    (code >= 0x0009 && code <= 0x000d) ||
+    code === 0x0020 ||
+    code === 0x00a0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000 ||
+    code === 0xfeff
+  );
+}
+
+/** Strip every leading `whatsapp:` while preserving `String.trim()` compatibility. */
+export function stripWhatsAppTargetPrefixes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && isEcmaTrimWhitespace(value.charCodeAt(start))) start += 1;
+  while (end > start && isEcmaTrimWhitespace(value.charCodeAt(end - 1))) end -= 1;
+
+  while (start + PREFIX.length <= end) {
+    let matches = true;
+    for (let i = 0; i < PREFIX.length; i += 1) {
+      const code = value.charCodeAt(start + i);
+      const expect = PREFIX.charCodeAt(i);
+      const folded =
+        expect >= 97 && expect <= 122 ? code === expect || code === expect - 32 : code === expect;
+      if (!folded) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) break;
+    start += PREFIX.length;
+    while (start < end && isEcmaTrimWhitespace(value.charCodeAt(start))) start += 1;
+  }
+
+  while (end > start && isEcmaTrimWhitespace(value.charCodeAt(end - 1))) end -= 1;
+  return value.slice(start, end);
+}


### PR DESCRIPTION
Closes the normalization regression in #22521's proposed linear prefix peel while preserving its denial-of-service hardening.

## What changed

- strips arbitrarily stacked case-insensitive `whatsapp:` target prefixes in one forward pass
- preserves the established `String.trim()` boundary contract, including ECMAScript Unicode whitespace such as NBSP, ideographic space, and BOM
- avoids repeated whole-string allocation from the former regex loop
- adds adversarial stacked-prefix and full TrimString whitespace coverage

## Validation

- Bun 1.3.14 focused test: 3 passed, 30 assertions, 100% changed-helper coverage
- Biome: 3 touched files clean
- `git diff --check`: clean
- package typecheck attempted; this isolated checkout lacks built/private workspace dependencies (`@elizaos/core`, Baileys, pino, qrcode), producing dependency-resolution failures before useful scoped diagnostics

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@68e82f702d44c7e50802a8f2ccc9f1425d3a59c0:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- {"ai_provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@68e82f702d44c7e50802a8f2ccc9f1425d3a59c0:packages/skills/skills/contribute-to-eliza","attribution":"self-reported"} -->