### PR TITLE
fix(plugin-elizacloud): ignore stale close events from a replaced bridge socket

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression coverage for a stale-close race in CloudBridgeService: a socket
+ * replaced by a newer establishConnection() call can still deliver its
+ * "close" event after the replacement is already connected. Without a
+ * same-instance guard, that late close mutates the CURRENT connection entry
+ * (looked up fresh by containerId in scheduleReconnect()), moving an active
+ * replacement out of "connected" and scheduling an unwanted reconnect on top
+ * of it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime } from "@elizaos/core";
+
+// The real @elizaos/core pulls in a generated-codegen dependency
+// (i18n/validation-keywords.ts -> ./generated/validation-keyword-data.ts)
+// that isn't present in a plain checkout and is unrelated to this race --
+// stub the two exports cloud-bridge.ts actually uses.
+vi.mock("@elizaos/core", () => ({
+  Service: class {
+    protected runtime: unknown;
+    constructor(runtime?: unknown) {
+      this.runtime = runtime;
+    }
+  },
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+type Listener = (event: any) => void;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  emit(type: string, event: any = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+vi.mock("undici", () => ({ WebSocket: FakeWebSocket }));
+
+describe("CloudBridgeService stale close race", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.useFakeTimers();
+  });
+
+  it("ignores a stale close event from a socket replaced by a newer establishConnection()", async () => {
+    const { CloudBridgeService } = await import("./cloud-bridge");
+    const runtime = {} as IAgentRuntime;
+    const service = new CloudBridgeService(runtime);
+    // Bypass initialize()'s CLOUD_AUTH dependency -- not relevant to the
+    // connection-replacement race under test.
+    (service as any).authService = {
+      getApiKey: () => undefined,
+      getClient: () => ({ buildWsUrl: (path: string) => `ws://test${path}` }),
+    };
+
+    await service.connect("container-1");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.emit("open");
+    expect(service.getConnectionState("container-1")).toBe("connected");
+
+    // Simulate the first socket disconnecting uncleanly and a replacement
+    // being established, but the first socket's own "close" event is
+    // delivered late -- after the replacement has already opened.
+    const disconnect = (service as any).establishConnection(
+      "container-1",
+      0,
+    ) as Promise<void>;
+    await disconnect;
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.emit("open");
+    expect(service.getConnectionState("container-1")).toBe("connected");
+
+    firstSocket.emit("close", { code: 1006, reason: "late stale event" });
+
+    expect(service.getConnectionState("container-1")).toBe("connected");
+    // No spurious third connection attempt scheduled off the stale close.
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -183,6 +183,15 @@ export class CloudBridgeService extends Service {
     });
 
     ws.addEventListener("close", (event) => {
+      // A socket replaced by a newer establishConnection() (see disconnect()'s
+      // ws.close() and the reconnect timer's own establishConnection() call)
+      // can still deliver its "close" event after `this.connections.get(containerId)`
+      // has moved on to the replacement's `conn`. scheduleReconnect() below looks
+      // up that CURRENT entry by containerId, so an unguarded stale close would
+      // mark an already-connected replacement "reconnecting" and schedule an
+      // unnecessary reconnect on top of it.
+      if (this.connections.get(containerId) !== conn) return;
+
       conn.state = "disconnected";
       if (conn.heartbeatTimer) clearInterval(conn.heartbeatTimer);
 


### PR DESCRIPTION
## What's wrong

`CloudBridgeService.establishConnection()` creates a fresh `ActiveConnection`
and `WebSocket` per call, registering a `"close"` listener that closes over
the connection object it was created with. When a socket disconnects
uncleanly, its close handler calls `scheduleReconnect()`, which after backoff
calls `establishConnection()` again — but if the **original** socket's
`"close"` event is delivered late (after the replacement has already opened
and connected), the stale handler still fires:

1. it mutates its own closed-over `conn` (harmless on its own, since that
   object is no longer the map entry), but then
2. it calls `scheduleReconnect(containerId, ...)`, which looks up
   `this.connections.get(containerId)` **fresh** — returning the live
   replacement — and sets *its* state to `"reconnecting"`, scheduling an
   unwanted reconnect on top of an already-good connection.

Same bug class as #22554 (`plugin-native-gateway/src/web.ts`), independently
present here.

## Fix

Guard the close handler with a same-instance check
(`this.connections.get(containerId) !== conn`) before acting, so a stale
close from a replaced connection is a no-op.

## Verification

- Added a regression test (`src/services/cloud-bridge.test.ts` — no prior
  coverage existed for this file) using a `FakeWebSocket` harness matching
  this plugin's existing mocking conventions.
- Mutation-resistance: reverted only the source change, confirmed the test
  fails with the exact predicted symptom (`getConnectionState` returns
  `"reconnecting"` instead of `"connected"` after the stale close), restored
  the fix, confirmed it passes again.
- `vitest` passes for the new test, `tsc --noEmit` clean, `biome check`
  clean (62 files, plugin-wide).

## Attribution

Bug found by `gpt-5.6-sol` (via Codex) reading `cloud-bridge.ts` directly
and confirming it with a delayed-close repro — the same pattern that found
#22554. That environment's sandbox could not write to `.git` to create the
branch/commit itself, so the fix, regression test, and verification here
were completed by Claude Code (`claude-sonnet-5`).
