### PR TITLE
fix(core): restore wildcard matcher formatting gate

### DIFF
--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1049,7 +1049,9 @@ type CandidatePattern = {
 	score: number;
 };
 
-function buildCandidatePatterns(candidateActions: string[]): CandidatePattern[] {
+function buildCandidatePatterns(
+	candidateActions: string[],
+): CandidatePattern[] {
 	const patterns: CandidatePattern[] = [];
 
 	for (const candidateAction of candidateActions) {

--- a/packages/core/src/runtime/action-wildcard-glob.test.ts
+++ b/packages/core/src/runtime/action-wildcard-glob.test.ts
@@ -6,32 +6,32 @@ import { describe, expect, it } from "vitest";
 import { matchActionWildcardParts } from "./action-wildcard-glob.ts";
 
 describe("matchActionWildcardParts", () => {
-  it("preserves GMAIL_* / GMAIL_SEND* / *_DRAFT shapes", () => {
-    expect(matchActionWildcardParts(["GMAIL_", ""], "GMAIL_SEND")).toBe(true);
-    expect(matchActionWildcardParts(["GMAIL_", ""], "GMAILSYNC")).toBe(false);
-    expect(matchActionWildcardParts(["GMAIL_SEND", ""], "GMAIL_SEND")).toBe(
-      true,
-    );
-    expect(
-      matchActionWildcardParts(["GMAIL_SEND", ""], "GMAIL_SEND_LATER"),
-    ).toBe(true);
-    expect(matchActionWildcardParts(["GMAIL_SEND", ""], "GMAILSYNC")).toBe(
-      false,
-    );
-    expect(matchActionWildcardParts(["", "SYNC"], "GMAILSYNC")).toBe(true);
-    expect(
-      matchActionWildcardParts(["GMAIL", "_", "DRAFT"], "GMAIL_CREATE_DRAFT"),
-    ).toBe(true);
-    expect(
-      matchActionWildcardParts(["GMAIL", "_", "DRAFT"], "GMAILCREATEDRAFT"),
-    ).toBe(false);
-  });
+	it("preserves GMAIL_* / GMAIL_SEND* / *_DRAFT shapes", () => {
+		expect(matchActionWildcardParts(["GMAIL_", ""], "GMAIL_SEND")).toBe(true);
+		expect(matchActionWildcardParts(["GMAIL_", ""], "GMAILSYNC")).toBe(false);
+		expect(matchActionWildcardParts(["GMAIL_SEND", ""], "GMAIL_SEND")).toBe(
+			true,
+		);
+		expect(
+			matchActionWildcardParts(["GMAIL_SEND", ""], "GMAIL_SEND_LATER"),
+		).toBe(true);
+		expect(matchActionWildcardParts(["GMAIL_SEND", ""], "GMAILSYNC")).toBe(
+			false,
+		);
+		expect(matchActionWildcardParts(["", "SYNC"], "GMAILSYNC")).toBe(true);
+		expect(
+			matchActionWildcardParts(["GMAIL", "_", "DRAFT"], "GMAIL_CREATE_DRAFT"),
+		).toBe(true);
+		expect(
+			matchActionWildcardParts(["GMAIL", "_", "DRAFT"], "GMAILCREATEDRAFT"),
+		).toBe(false);
+	});
 
-  it("rejects a 14-star fail-closed hint in well under the origin regex hang", () => {
-    const parts = [...Array.from({ length: 14 }, () => "A"), "Z"];
-    const name = "A".repeat(40);
-    const t0 = performance.now();
-    expect(matchActionWildcardParts(parts, name)).toBe(false);
-    expect(performance.now() - t0).toBeLessThan(20);
-  });
+	it("rejects a 14-star fail-closed hint in well under the origin regex hang", () => {
+		const parts = [...Array.from({ length: 14 }, () => "A"), "Z"];
+		const name = "A".repeat(40);
+		const t0 = performance.now();
+		expect(matchActionWildcardParts(parts, name)).toBe(false);
+		expect(performance.now() - t0).toBeLessThan(20);
+	});
 });

--- a/packages/core/src/runtime/action-wildcard-glob.ts
+++ b/packages/core/src/runtime/action-wildcard-glob.ts
@@ -8,32 +8,32 @@
 
 /** True when `name` matches `^parts[0].*parts[1].*…parts[n]$`. */
 export function matchActionWildcardParts(
-  parts: readonly string[],
-  name: string,
+	parts: readonly string[],
+	name: string,
 ): boolean {
-  if (parts.length === 0) return false;
+	if (parts.length === 0) return false;
 
-  const first = parts[0] ?? "";
-  const last = parts[parts.length - 1] ?? "";
-  let pos = 0;
+	const first = parts[0] ?? "";
+	const last = parts[parts.length - 1] ?? "";
+	let pos = 0;
 
-  if (first) {
-    if (!name.startsWith(first)) return false;
-    pos = first.length;
-  }
+	if (first) {
+		if (!name.startsWith(first)) return false;
+		pos = first.length;
+	}
 
-  for (let index = 1; index < parts.length - 1; index += 1) {
-    const literal = parts[index] ?? "";
-    if (!literal) continue;
-    const found = name.indexOf(literal, pos);
-    if (found === -1) return false;
-    pos = found + literal.length;
-  }
+	for (let index = 1; index < parts.length - 1; index += 1) {
+		const literal = parts[index] ?? "";
+		if (!literal) continue;
+		const found = name.indexOf(literal, pos);
+		if (found === -1) return false;
+		pos = found + literal.length;
+	}
 
-  if (last) {
-    if (!name.endsWith(last)) return false;
-    if (pos > name.length - last.length) return false;
-  }
+	if (last) {
+		if (!name.endsWith(last)) return false;
+		if (pos > name.length - last.length) return false;
+	}
 
-  return true;
+	return true;
 }


### PR DESCRIPTION
## Relates to

Closes #22561.

## What does this PR do?

Restores the root Biome gate after merged PR #22517 by applying the repository formatter to exactly its three failing wildcard-matcher files. There is no intended behavior change.

## Testing

Exact head `ef13e42ce6fc83ba5091417377b99ec28c2dfd2e`:

- wildcard matcher Vitest: 2/2 passed
- `bun run --cwd packages/core lint:check`: passed with only pre-existing warnings
- `bun run --cwd packages/core typecheck`: passed
- `git diff --check`: passed
- `bun run verify`: the repaired core lint lane passed and the gate advanced to a separate pre-existing `packages/app-core` type failure at `packages/agent/src/runtime/trajectory-storage.ts:2626` from merged PR #22530. That blocker is being repaired separately.

## Evidence Gate

<!-- evidence-head:ef13e42ce6fc83ba5091417377b99ec28c2dfd2e -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — formatter-only core source change.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — exact lint, typecheck, focused test, and root-gate progression are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no persistent artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual surface changed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->