### PR TITLE
fix(plugin-whatsapp): ignore events from a replaced Baileys socket

### DIFF
--- a/plugins/plugin-whatsapp/src/baileys/connection.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/connection.test.ts
@@ -52,4 +52,75 @@ describe("BaileysConnection socket replacement", () => {
     expect(makeWASocket).toHaveBeenCalledTimes(2);
     expect(connection.getStatus()).toBe("connecting");
   });
+
+  it("lets the active socket reconnect while a replaced socket is backing off", async () => {
+    vi.useFakeTimers();
+    const authManager = {
+      initialize: vi.fn(async () => ({})),
+      save: vi.fn(async () => undefined),
+    };
+    const connection = new BaileysConnection(authManager as never);
+
+    await connection.connect();
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+
+    await connection.connect();
+    sockets[1]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(3);
+    expect(connection.getSocket()).toBe(sockets[2]);
+  });
+
+  it("cancels a queued reconnect when the same socket reopens", async () => {
+    vi.useFakeTimers();
+    const authManager = {
+      initialize: vi.fn(async () => ({})),
+      save: vi.fn(async () => undefined),
+    };
+    const connection = new BaileysConnection(authManager as never);
+
+    await connection.connect();
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+    sockets[0]?.ev.emit("connection.update", { connection: "open" });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+    expect(connection.getStatus()).toBe("open");
+  });
+
+  it("ignores credential and message events from a replaced socket", async () => {
+    const authManager = {
+      initialize: vi.fn(async () => ({})),
+      save: vi.fn(async () => undefined),
+    };
+    const connection = new BaileysConnection(authManager as never);
+    const messages = vi.fn();
+    connection.on("messages", messages);
+
+    await connection.connect();
+    await connection.connect();
+    sockets[0]?.ev.emit("creds.update", {});
+    sockets[0]?.ev.emit("messages.upsert", { messages: ["stale"] });
+    await Promise.resolve();
+
+    expect(authManager.save).not.toHaveBeenCalled();
+    expect(messages).not.toHaveBeenCalled();
+
+    sockets[1]?.ev.emit("creds.update", {});
+    sockets[1]?.ev.emit("messages.upsert", { messages: ["current"] });
+    await Promise.resolve();
+
+    expect(authManager.save).toHaveBeenCalledTimes(1);
+    expect(messages).toHaveBeenCalledWith(["current"]);
+  });
 });

--- a/plugins/plugin-whatsapp/src/baileys/connection.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/connection.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Verifies that replaced Baileys sockets cannot mutate the active connection
+ * lifecycle through delayed connection-update events.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sockets: FakeSocket[] = [];
+
+class FakeSocket {
+  readonly ev = new EventEmitter();
+  readonly ws = { close: vi.fn() };
+}
+
+vi.mock("@whiskeysockets/baileys", () => ({
+  default: vi.fn(() => {
+    const socket = new FakeSocket();
+    sockets.push(socket);
+    return socket;
+  }),
+  DisconnectReason: { loggedOut: 401, badSession: 405 },
+}));
+
+import makeWASocket from "@whiskeysockets/baileys";
+import { BaileysConnection } from "./connection";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  sockets.length = 0;
+});
+
+describe("BaileysConnection socket replacement", () => {
+  it("ignores a delayed close event from a replaced socket", async () => {
+    vi.useFakeTimers();
+    const authManager = {
+      initialize: vi.fn(async () => ({})),
+      save: vi.fn(async () => undefined),
+    };
+    const connection = new BaileysConnection(authManager as never);
+
+    await connection.connect();
+    await connection.connect();
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+    expect(connection.getStatus()).toBe("connecting");
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/connection.ts
+++ b/plugins/plugin-whatsapp/src/baileys/connection.ts
@@ -29,23 +29,21 @@ export class BaileysConnection extends EventEmitter {
     this.emit("connection", "connecting");
 
     const state = await this.authManager.initialize();
-    this.socket = makeWASocket({
+    const socket = makeWASocket({
       auth: state,
       printQRInTerminal: false,
       logger: pino({ level: "silent" }),
       browser: ["Chrome (Linux)", "", ""],
     });
+    this.socket = socket;
 
-    this.setupEventHandlers();
-    return this.socket;
+    this.setupEventHandlers(socket);
+    return socket;
   }
 
-  private setupEventHandlers(): void {
-    if (!this.socket) {
-      return;
-    }
-
-    this.socket.ev.on("connection.update", async (update) => {
+  private setupEventHandlers(socket: WASocket): void {
+    socket.ev.on("connection.update", async (update) => {
+      if (this.socket !== socket) return;
       const { connection, qr, lastDisconnect } = update;
 
       if (qr) {
@@ -93,6 +91,7 @@ export class BaileysConnection extends EventEmitter {
         const baseDelayMs = isQRTimeout ? 1000 : 3000;
         const backoffMs = Math.min(baseDelayMs * 2 ** (this.reconnectAttempts - 1), 30000);
         await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        if (this.socket !== socket) return;
         await this.connect();
       } catch (error) {
         this.emit("error", error);
@@ -101,11 +100,13 @@ export class BaileysConnection extends EventEmitter {
       }
     });
 
-    this.socket.ev.on("creds.update", async () => {
+    socket.ev.on("creds.update", async () => {
+      if (this.socket !== socket) return;
       await this.authManager.save();
     });
 
-    this.socket.ev.on("messages.upsert", ({ messages }) => {
+    socket.ev.on("messages.upsert", ({ messages }) => {
+      if (this.socket !== socket) return;
       this.emit("messages", messages);
     });
   }

--- a/plugins/plugin-whatsapp/src/baileys/connection.ts
+++ b/plugins/plugin-whatsapp/src/baileys/connection.ts
@@ -15,7 +15,6 @@ export class BaileysConnection extends EventEmitter {
   private socket?: WASocket;
   private readonly authManager: BaileysAuthManager;
   private connectionStatus: ConnectionStatus = "close";
-  private reconnecting = false;
   private reconnectAttempts = 0;
   private readonly maxReconnectAttempts = 10;
 
@@ -42,6 +41,9 @@ export class BaileysConnection extends EventEmitter {
   }
 
   private setupEventHandlers(socket: WASocket): void {
+    // Backoff ownership is socket-local so a stale timer cannot suppress a
+    // replacement socket's own reconnect attempt.
+    let reconnecting = false;
     socket.ev.on("connection.update", async (update) => {
       if (this.socket !== socket) return;
       const { connection, qr, lastDisconnect } = update;
@@ -76,7 +78,7 @@ export class BaileysConnection extends EventEmitter {
         return;
       }
 
-      if (this.reconnecting) {
+      if (reconnecting) {
         return;
       }
 
@@ -85,18 +87,18 @@ export class BaileysConnection extends EventEmitter {
         return;
       }
 
-      this.reconnecting = true;
+      reconnecting = true;
       try {
         this.reconnectAttempts += 1;
         const baseDelayMs = isQRTimeout ? 1000 : 3000;
         const backoffMs = Math.min(baseDelayMs * 2 ** (this.reconnectAttempts - 1), 30000);
         await new Promise((resolve) => setTimeout(resolve, backoffMs));
-        if (this.socket !== socket) return;
+        if (this.socket !== socket || this.connectionStatus !== "close") return;
         await this.connect();
       } catch (error) {
         this.emit("error", error);
       } finally {
-        this.reconnecting = false;
+        reconnecting = false;
       }
     });
 


### PR DESCRIPTION
# Relates to

Fixes an independently reproduced stale-socket lifecycle race in the Baileys WhatsApp transport.

## What changed

`BaileysConnection` now binds `connection.update`, `creds.update`, and `messages.upsert` handlers to the exact `WASocket` that registered them. Events from a replaced socket cannot mutate the active connection, persist credentials, or emit messages.

The reviewer repair also makes reconnect ownership socket-local. This matters when socket A is sleeping in backoff, socket B replaces it, and B then closes: B must be allowed to schedule its own reconnect instead of being suppressed by A's stale global flag. A queued reconnect is also cancelled if the same socket reports `open` before the timer expires.

The approach matches the upstream Baileys contract: `connection.update` carries `open`/`close` lifecycle transitions, while `creds.update` and `messages.upsert` are socket event streams. Identity fencing therefore belongs at the listener boundary, before any state mutation or asynchronous backoff.

## Verification

- Exact reviewed head: `78d2ea5b6c43af05088180cfa582f9c1565f2e0e`, rebased onto `origin/develop` `1772d8f787f6e5362d94403a6b16473064af7199`.
- Focused lifecycle suite: 4/4 passed.
- Plugin suite: 14 files, 104/104 tests passed.
- Plugin production build, including declaration generation: passed.
- Biome on both changed files: clean; `git diff --check`: clean.
- Mutation proof: restoring the PR's original global reconnect flag while keeping the repaired tests produces exactly 2 failures: the active replacement never reconnects, and a reopened socket is unnecessarily replaced.
- Plugin `typecheck` is blocked by the same unrelated current-`develop` diagnostic in `src/normalize.ts` (`TS5097` on a `.ts` import). The diagnostic reproduces unchanged at `1772d8f787`; the changed files produce no diagnostic, and the declaration build passes.

The upstream Baileys example documents these same socket event boundaries and reconnect-on-close lifecycle: https://github.com/WhiskeySockets/Baileys/blob/master/Example/example.ts

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol; Anthropic/claude-sonnet-5 (original contributor verification, self-reported)
<!-- attribution-row:client -->
- Agent tooling: Codex desktop; Claude Code (original contributor verification, self-reported)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@1772d8f787f6e5362d94403a6b16473064af7199:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:78d2ea5b6c43af05088180cfa582f9c1565f2e0e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector lifecycle change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector lifecycle change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic socket event ordering; no user-visible flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend server is involved; deterministic connector lifecycle is proven by the inline focused, package, build, and red/green mutation logs below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or browser surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change only controls in-memory socket ownership; it creates no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Backend logs

```text
FOCUSED GREEN
Test Files  1 passed (1)
Tests       4 passed (4)

FULL PLUGIN GREEN
Test Files  14 passed (14)
Tests       104 passed (104)

BUILD GREEN
Node complete
Generating TypeScript declarations
@elizaos/plugin-whatsapp build finished

MUTATION RED (global reconnect flag restored)
Test Files  1 failed (1)
Tests       2 failed | 2 passed (4)
- expected makeWASocket 3 calls, received 2: active replacement close was suppressed
- expected makeWASocket 1 call, received 2: reopened socket's stale timer was not cancelled

BIOME
Checked 2 files. No fixes applied.
```

## Known gaps / failures

Live WhatsApp pairing was not used because it requires an operator-owned WhatsApp account and QR authorization. The changed contract is the deterministic ordering and ownership of Baileys event emissions; the test drives the real production `BaileysConnection` class through the documented event names and verifies socket creation, active identity, credential persistence, message emission, close/open recovery, and delayed backoff.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@1772d8f787f6e5362d94403a6b16473064af7199:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [security-audio-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@1772d8f787f6e5362d94403a6b16473064af7199:packages/skills/skills/contribute-to-eliza"} -->
