### PR TITLE
fix(plugin-native-canvas): balance drawImage save/restore on image load failure

### DIFF
--- a/plugins/plugin-native-canvas/src/web-drawimage.test.ts
+++ b/plugins/plugin-native-canvas/src/web-drawimage.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for `CanvasWeb.drawImage` save/restore balance. Exercises
+ * the real `CanvasWeb` against a stubbed 2D context (jsdom has no canvas
+ * renderer) with a fake `Image` whose `src` setter fires `onload`/`onerror`
+ * asynchronously. Guards the contract that a failed image load must not leak
+ * the `ctx.save()` frame or the mutated draw-option state (globalAlpha,
+ * blendMode, shadow, transform) onto later unrelated draws, and that the
+ * success path still restores exactly once while drawing at the requested
+ * opacity.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasWeb } from "./web";
+
+interface CountingContext extends CanvasRenderingContext2D {
+  saveCount: number;
+  restoreCount: number;
+  fillAlphas: number[];
+  drawImageAlphas: number[];
+}
+
+/**
+ * A 2D context stub that tracks save/restore balance and records
+ * `globalAlpha` at the moment `fill()` and `drawImage()` are invoked, so a
+ * leaked alpha from a prior draw is observable on a later one.
+ */
+function createCountingContext(): CountingContext {
+  const ctx = {
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over",
+    shadowColor: "",
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    saveCount: 0,
+    restoreCount: 0,
+    fillAlphas: [] as number[],
+    drawImageAlphas: [] as number[],
+    save(this: CountingContext) {
+      this.saveCount += 1;
+    },
+    restore(this: CountingContext) {
+      this.restoreCount += 1;
+      this.globalAlpha = 1;
+    },
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    rect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    scale: vi.fn(),
+    transform: vi.fn(),
+    setTransform: vi.fn(),
+    setLineDash: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    getImageData: vi.fn(() => ({
+      data: new Uint8ClampedArray(4),
+      width: 1,
+      height: 1,
+    })),
+    putImageData: vi.fn(),
+  } as unknown as CountingContext;
+
+  ctx.fill = vi.fn(function fill(this: CountingContext) {
+    this.fillAlphas.push(this.globalAlpha);
+  }) as unknown as CanvasRenderingContext2D["fill"];
+  ctx.drawImage = vi.fn(function drawImage(this: CountingContext) {
+    this.drawImageAlphas.push(this.globalAlpha);
+  }) as unknown as CanvasRenderingContext2D["drawImage"];
+
+  return ctx;
+}
+
+/**
+ * Replaces the global `Image` with a fake whose `src` setter schedules
+ * `onerror` (load failure) or `onload` (success) on a microtask, matching how
+ * a real browser resolves image loads asynchronously.
+ */
+function installFakeImage(outcome: "error" | "load"): void {
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    private _src = "";
+    set src(value: string) {
+      this._src = value;
+      queueMicrotask(() => {
+        if (outcome === "error") {
+          this.onerror?.();
+        } else {
+          this.onload?.();
+        }
+      });
+    }
+    get src(): string {
+      return this._src;
+    }
+  }
+  vi.stubGlobal("Image", FakeImage);
+}
+
+describe("CanvasWeb.drawImage save/restore balance", () => {
+  let ctx: CountingContext;
+
+  beforeEach(() => {
+    ctx = createCountingContext();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("balances save/restore when the image fails to load", async () => {
+    installFakeImage("error");
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    ctx.saveCount = 0;
+    ctx.restoreCount = 0;
+
+    await expect(
+      canvas.drawImage({
+        canvasId,
+        image: "https://example.invalid/missing.png",
+        destRect: { x: 0, y: 0, width: 10, height: 10 },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow("Failed to load image");
+
+    // The save() frame must be fully unwound even though drawImage rejected.
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("does not leak the failed draw opacity onto a later drawRect", async () => {
+    installFakeImage("error");
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+
+    await expect(
+      canvas.drawImage({
+        canvasId,
+        image: "https://example.invalid/missing.png",
+        destRect: { x: 0, y: 0, width: 10, height: 10 },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow("Failed to load image");
+
+    // A subsequent fully-opaque rectangle must fill at alpha 1, not the 0.5
+    // requested by the failed image draw.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 255, g: 0, b: 0 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
+  });
+
+  it("restores exactly once and draws at the requested opacity on success", async () => {
+    installFakeImage("load");
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    ctx.saveCount = 0;
+    ctx.restoreCount = 0;
+
+    await canvas.drawImage({
+      canvasId,
+      image: "https://example.test/ok.png",
+      destRect: { x: 0, y: 0, width: 10, height: 10 },
+      drawOptions: { opacity: 0.5 },
+    });
+
+    // Success path: one save, one restore, and the image drawn at 0.5 alpha.
+    expect(ctx.saveCount).toBe(1);
+    expect(ctx.restoreCount).toBe(1);
+    expect(ctx.drawImageAlphas).toEqual([0.5]);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("does not leak opacity through a failed drawBatch image command", async () => {
+    installFakeImage("error");
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+
+    // drawImage is also reachable via drawBatch({type:"image"}).
+    await expect(
+      canvas.drawBatch({
+        canvasId,
+        commands: [
+          {
+            type: "image",
+            args: {
+              image: "https://example.invalid/missing.png",
+              destRect: { x: 0, y: 0, width: 10, height: 10 },
+              drawOptions: { opacity: 0.5 },
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("Failed to load image");
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+});

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -661,8 +661,6 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
-
     const img = new Image();
 
     if (typeof options.image === "string") {
@@ -671,10 +669,19 @@ export class CanvasWeb extends WebPlugin {
       img.src = `data:image/${options.image.format};base64,${options.image.base64}`;
     }
 
+    // Resolve the image load BEFORE pushing any save()/draw-option state.
+    // applyDrawOptions() runs ctx.save() and mutates ctx (globalAlpha,
+    // blendMode, shadow, transform); holding that frame across the await
+    // would leak the mutated state onto every subsequent draw whenever the
+    // load rejects (bad URL/base64, network, CORS — all normal runtime
+    // conditions). Applying draw options only after a successful load keeps
+    // save()/restore() balanced on both the success and failure paths.
     await new Promise<void>((resolve, reject) => {
       img.onload = () => resolve();
       img.onerror = () => reject(new Error("Failed to load image"));
     });
+
+    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
 
     if (options.srcRect) {
       ctx.drawImage(


### PR DESCRIPTION
# Relates to

Closes #22567

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and package checks were run after sync; see **Known gaps / failures** for the one unrelated `bun run verify` blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f99e882c249fe24c6170254a4e0815c307060225:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package gates (test, typecheck, lint) pass post-sync. The full `bun run verify` is blocked only by an unrelated workspace install policy documented in **Known gaps / failures**.

# Risks

Low. The change is a few lines confined to `CanvasWeb.drawImage()` in
`plugins/plugin-native-canvas/src/web.ts`. It reorders when draw options are
applied relative to the image-load `await`; it does not change any method
signature, public type, or the success-path rendering result. No native
(iOS/Android) code is touched.

# Background

## What does this PR do?

`CanvasWeb.drawImage()` called `applyDrawOptions(ctx, ...)` — which
unconditionally runs `ctx.save()` and then mutates the context state
(`globalAlpha`, `globalCompositeOperation`/blend mode, shadow, transform) — and
only called `ctx.restore()` **after** a successful `ctx.drawImage()`. It
`await`ed the `Image` load in between. When the image failed to load the awaited
promise rejected (`"Failed to load image"`) and the method returned before
reaching `ctx.restore()`. The `save()` stack frame and the mutated draw state
were never unwound, so **every subsequent draw on that canvas inherited the
leaked opacity / blend / shadow / transform.**

`drawImage` is a public API and is also reachable through
`drawBatch({ type: "image" })`. Image loads fail routinely on bad URLs/base64,
network errors, or CORS — all normal runtime conditions, not adversarial input —
so a single failed image draw silently corrupts the reference web/Electrobun
bridge that the iOS/Android native bridges must match.

**Fix:** resolve the `Image` load **before** calling `applyDrawOptions()`. The
context is fetched, the image is awaited, and only then are draw options applied
→ `drawImage` → `restore`. This keeps `save()`/`restore()` balanced on both the
success and failure paths and never holds a `save()` frame across the `await`
window. No signature or contract change.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behaviour is
restored to the documented contract (draw options are scoped to a single draw);
no user-facing API changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-canvas/src/web-drawimage.test.ts` (new) and the ~8-line
diff in `plugins/plugin-native-canvas/src/web.ts` `drawImage()`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-native-canvas test        # 26 passed (3 files)
bun run --cwd plugins/plugin-native-canvas typecheck   # tsc --noEmit, clean
bun run --cwd plugins/plugin-native-canvas lint:check   # biome, no fixes
```

The new tests run the real `CanvasWeb` against a stubbed 2D context (jsdom has
no canvas renderer, matching the existing `web.test.ts` harness) with a fake
`Image` whose `src` setter fires `onerror`/`onload` on a microtask:

1. **save/restore balance on load failure** — after a failed
   `drawImage({ drawOptions: { opacity: 0.5 } })`, `saveCount === restoreCount`
   and `globalAlpha === 1`.
2. **no opacity leak onto a later `drawRect`** — a fully-opaque `drawRect` after
   the failed image fills at alpha `1`, not the leaked `0.5`.
3. **same guarantee through `drawBatch({ type: "image" })`** — the batch entry
   point is covered too.
4. **success path** — `drawImage` still restores exactly once and draws the
   image at the requested `0.5` opacity.

Verified failing-before / passing-after by reverting only `web.ts` to its
pre-fix state (see **Domain artifacts** below).

# Evidence Gate

<!-- evidence-head:d2e0161f1a36a1aabc4e2954c2691ff2d33cdc7d -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this is a Capacitor canvas drawing-library fix (src/web.ts), no app view or component changes.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing UI flow; behaviour is verified by deterministic vitest against the real CanvasWeb (see Domain artifacts).`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - library-only change with no server/runtime process; the real code path (CanvasWeb.drawImage) is exercised end to end by the vitest run captured under Domain artifacts.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend request/response or state change; the browser Canvas 2D path is exercised via jsdom + a stubbed 2D context in the test run below.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts (inline, deterministic): failing-before and passing-after vitest output showing the exact save/restore counts and the `globalAlpha [0.5] → [1]` assertion.

<details><summary>BEFORE — bug present (reverted only <code>web.ts</code> to <code>HEAD~1</code>, kept the new test): vitest 3 failed / 1 passed</summary>

```
 ❯ src/web-drawimage.test.ts (4 tests | 3 failed)
     × balances save/restore when the image fails to load
     × does not leak the failed draw opacity onto a later drawRect
     × does not leak opacity through a failed drawBatch image command

 FAIL  ... > balances save/restore when the image fails to load
 AssertionError: expected 1 to be +0 // Object.is equality
   - Expected  - 0
   + Received  + 1
   ❯ src/web-drawimage.test.ts:142:27   expect(ctx.saveCount).toBe(ctx.restoreCount);

 FAIL  ... > does not leak the failed draw opacity onto a later drawRect
 AssertionError: expected [ 0.5 ] to deeply equal [ 1 ]
   [ -   1,  +   0.5, ]
   ❯ src/web-drawimage.test.ts:170:28   expect(ctx.fillAlphas).toEqual([1]);

 FAIL  ... > does not leak opacity through a failed drawBatch image command
 AssertionError: expected 1 to be +0 // Object.is equality  (- 0 / + 1)

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

The `save()` frame is never unwound (`restoreCount = 0` while `saveCount = 1`) and the leaked `0.5` opacity from the failed image bleeds onto a later intended-opaque `drawRect` (`[0.5]` observed, `[1]` expected).

</details>

<details><summary>AFTER — fix applied: full package suite vitest 26 passed (3 files), typecheck + lint green</summary>

```
 RUN  v4.1.5  plugins/plugin-native-canvas
 Test Files  3 passed (3)
      Tests  26 passed (26)

$ tsc --noEmit -p tsconfig.json      # no output, exit 0
$ bunx @biomejs/biome check .        # Checked 9 files. No fixes applied. exit 0
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - library-only change; see Domain artifacts for the real CanvasWeb code path exercised end to end.`

## Domain artifacts (failing-before / passing-after)

See the inline `BEFORE` / `AFTER` `<details>` transcripts attached to the
**Domain artifacts** row in the Evidence Gate above.

Environment note: the fork-only attachment uploader could not mint
`user-attachments` URLs in this session (GitHub login hit a 2FA/verification
interstitial), and the `pr-evidence` release upload needs `elizaOS/eliza` push
access a fork contributor lacks. The proof is short deterministic text, embedded
inline in the row block above.

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - not a voice/transcript/TTS/STT change.`

## Known gaps / failures

- **`bun run verify` (full repo gate):** not run to completion here. `bun install`
  in this environment is blocked by a global bun supply-chain policy
  (`minimumReleaseAge = 604800`) rejecting a **recently-published, unrelated**
  transitive dependency (`viem@2.55.17`, `smthrs@0.34.0`) pulled by other
  workspaces — not by `plugin-native-canvas`, which has no such deps. The
  owning-package gates (test, typecheck, lint) all pass. Not a blocker for this
  library-only fix.
- **Attachment URLs:** the fork attachment uploader hit a GitHub 2FA/verification
  interstitial and the `pr-evidence` release needs upstream push access; the
  short deterministic evidence is embedded inline above instead.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@f99e882c249fe24c6170254a4e0815c307060225:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@f99e882c249fe24c6170254a4e0815c307060225:packages/skills/skills/contribute-to-eliza"} -->
