### PR TITLE
fix(app): recover desktop from failed cloud agents

### DIFF
--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -647,6 +647,23 @@ describe("dedicated-agent-proxy — unified auth", () => {
     );
   });
 
+  test("owner of a terminal-error agent receives a machine-readable 503 without a resume", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, status: "error" };
+    const r = makeRequest("cloud-token", "https://app-staging.elizacloud.ai");
+
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      success: false,
+      code: "agent_error_state",
+      data: { status: "error" },
+    });
+    expect(enqueueCalls).toBe(0);
+    expect(captured).toBeNull();
+  });
+
   test("owner of a NON-RUNNING agent WITH sufficient credits → 202 and enqueues the resume (#11583)", async () => {
     authResult = { user: { id: "u1", organization_id: "org1" } };
     sandboxResult = { ...runningDedicated, status: "stopped" };

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -425,6 +425,7 @@ async function resumeAndRespond(
     return Response.json(
       {
         success: false,
+        code: "agent_error_state",
         error:
           "Agent is in an error state. Resolve the failure before connecting.",
         data: { status: sandbox.status },

--- a/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
+++ b/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
@@ -290,10 +290,11 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
     async ({ baseUrl, native }) => {
       platform.native = native;
       setPageLocation("localhost");
-      localStorage.setItem(STEWARD_TOKEN_KEY, "preserved-token");
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+      const fetchSpy = mockTrustedShellResponse(
+        { error: "unauthorized" },
+        401,
+        () => localStorage.setItem(STEWARD_TOKEN_KEY, "preserved-token"),
+      );
       const client = new ElizaClient(baseUrl, "client-token");
 
       await client.getCloudStatus().catch(() => undefined);

--- a/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
+++ b/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
@@ -251,7 +251,7 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
       label: "direct account request switched to dedicated",
       initialBase: STAGING_CONTROL_PLANE,
       switchedBase: DEDICATED_STAGING_BASE,
-      expectedToken: "rejected-token",
+      expectedToken: null,
     },
   ])(
     "uses the request-time client scope for a $label 401",
@@ -286,7 +286,7 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
       native: true,
     },
   ])(
-    "keeps Steward storage outside the dedicated-client cleanup scope for an $label 401",
+    "preserves a different Steward token after an $label 401",
     async ({ baseUrl, native }) => {
       platform.native = native;
       setPageLocation("localhost");

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -943,7 +943,6 @@ async function directCloudRequest<T>(
   const apiBase = resolveDirectCloudClientApiBase(client);
   if (!apiBase) return null;
 
-  const isDedicatedRequest = isDedicatedCloudAgentClient(client);
   const token = readDirectCloudToken(client);
   if (!token) return null;
 
@@ -972,7 +971,7 @@ async function directCloudRequest<T>(
       }),
       { method, url },
     );
-    if (res.status === 401 && isDedicatedRequest) {
+    if (res.status === 401) {
       clearStoredStewardTokenIfCurrent(token);
     }
     const parsed = parseDirectCloudJson(res.data) as T;
@@ -996,7 +995,7 @@ async function directCloudRequest<T>(
     { ...init, method, headers },
     { method, url },
   );
-  if (res.status === 401 && isDedicatedRequest) {
+  if (res.status === 401) {
     clearStoredStewardTokenIfCurrent(token);
   }
   const data = await res.json().catch(async () => ({

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -34,6 +34,10 @@ const clientMock = vi.hoisted(() => ({
   selectOrProvisionCloudAgent: vi.fn(),
 }));
 
+const targetClientMock = vi.hoisted(() => ({
+  listConversations: vi.fn(),
+}));
+
 const cloudAuthMock = vi.hoisted(() => ({
   token: "tok" as string | null,
 }));
@@ -76,6 +80,7 @@ vi.mock("../../state", () => ({
 
 vi.mock("../../api", () => ({
   client: clientMock,
+  ElizaClient: vi.fn(() => targetClientMock),
 }));
 
 vi.mock("../../api/client-cloud", () => ({
@@ -306,6 +311,8 @@ function resetClientMocks() {
   clientMock.resumeCloudCompatAgent.mockReset();
   clientMock.getCloudCompatJobStatus.mockReset();
   clientMock.getCloudCompatAgentStatus.mockReset();
+  targetClientMock.listConversations.mockReset();
+  targetClientMock.listConversations.mockResolvedValue({ conversations: [] });
   persistenceMock.loadPersistedActiveServer.mockReset();
   persistenceMock.savePersistedActiveServer.mockReset();
   // deleteAgent now guards on window.confirm; default it to accept so the
@@ -551,6 +558,7 @@ describe("CloudAgentsSection waking on switch", () => {
     await waitFor(() => expect(reloadSpy).toHaveBeenCalled());
     expect(clientMock.resumeCloudCompatAgent).not.toHaveBeenCalled();
     expect(clientMock.getCloudCompatAgentStatus).not.toHaveBeenCalled();
+    expect(targetClientMock.listConversations).toHaveBeenCalledTimes(1);
     const bound = loadAgentProfileRegistry().profiles.find(
       (profile) => profile.cloudAgentId === agentId,
     );
@@ -562,6 +570,42 @@ describe("CloudAgentsSection waking on switch", () => {
         accessToken: "tok",
       }),
     );
+  });
+
+  it("keeps the current agent active when a running target does not answer", async () => {
+    targetClientMock.listConversations.mockRejectedValue(
+      Object.assign(new Error("unreachable"), { status: 503 }),
+    );
+    await renderWithAgents([agent({ status: "running" })]);
+
+    fireEvent.click(screen.getByText("Use"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "Could not connect to Old Name. Your current agent is still active.",
+        "error",
+        5000,
+      ),
+    );
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses a failed target without probing or changing persistence", async () => {
+    await renderWithAgents([
+      agent({ status: "error", error_message: "container failed" }),
+    ]);
+
+    fireEvent.click(screen.getByText("Use"));
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      "container failed",
+      "error",
+      5000,
+    );
+    expect(targetClientMock.listConversations).not.toHaveBeenCalled();
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   it("surfaces an error and does not bind when the resume call is rejected", async () => {

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -80,7 +80,9 @@ vi.mock("../../state", () => ({
 
 vi.mock("../../api", () => ({
   client: clientMock,
-  ElizaClient: vi.fn(() => targetClientMock),
+  ElizaClient: vi.fn(function MockElizaClient() {
+    return targetClientMock;
+  }),
 }));
 
 vi.mock("../../api/client-cloud", () => ({

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -17,7 +17,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { client } from "../../api";
+import { client, ElizaClient } from "../../api";
 import {
   getCloudAuthToken,
   resolveCloudAgentApiBase,
@@ -241,6 +241,15 @@ export function CloudAgentsSection() {
       });
       const label = agent.agent_name || "Eliza Cloud";
       const status = (agent.status || "").toLowerCase();
+      if (ERROR_STATES.has(status)) {
+        setActionNotice(
+          agent.error_message ||
+            `${label} failed to start. Resolve the failure before connecting.`,
+          "error",
+          5000,
+        );
+        return;
+      }
       // A non-running agent has no live container to talk to — wake it and
       // wait for readiness before binding, so chat doesn't land on a 404.
       if (NON_RUNNING_STATES.has(status)) {
@@ -251,6 +260,7 @@ export function CloudAgentsSection() {
           const outcome = await wakeUntilRunning(agent);
           if (!outcome.ok) {
             setActionNotice(outcome.error, "error", 4000);
+            setBusyId(null);
             return;
           }
         } catch (err) {
@@ -261,15 +271,30 @@ export function CloudAgentsSection() {
             "error",
             4000,
           );
+          setBusyId(null);
           return;
         } finally {
-          setBusyId(null);
           setWakingId(null);
         }
       } else {
         setBusyId(agent.agent_id);
       }
-      bindAndReload(agent.agent_id, apiBase, label);
+      try {
+        // Probe with an isolated client. Mutating the shared singleton or the
+        // persisted target before this succeeds would strand the whole shell
+        // on a failed/unreachable agent after reload.
+        const targetClient = new ElizaClient(apiBase, currentCloudToken());
+        await targetClient.listConversations();
+        bindAndReload(agent.agent_id, apiBase, label);
+      } catch {
+        setActionNotice(
+          `Could not connect to ${label}. Your current agent is still active.`,
+          "error",
+          5000,
+        );
+      } finally {
+        setBusyId(null);
+      }
     },
     [activeId, cloudApiBase, bindAndReload, setActionNotice, wakeUntilRunning],
   );

--- a/packages/ui/src/state/dedicated-cloud-agent-error.ts
+++ b/packages/ui/src/state/dedicated-cloud-agent-error.ts
@@ -1,0 +1,20 @@
+/** Classifies the terminal dedicated-agent proxy failure that requires choosing another Cloud agent. */
+
+import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
+
+const LEGACY_ERROR_STATE_FRAGMENT = "Agent is in an error state";
+
+export function isTerminalDedicatedCloudAgentErrorState(args: {
+  status: number | undefined;
+  code?: string;
+  message: string | null | undefined;
+  clientBaseUrl: string;
+}): boolean {
+  return (
+    args.status === 503 &&
+    isDedicatedCloudAgentBase(args.clientBaseUrl) &&
+    (args.code === "agent_error_state" ||
+      (typeof args.message === "string" &&
+        args.message.includes(LEGACY_ERROR_STATE_FRAGMENT)))
+  );
+}

--- a/packages/ui/src/state/parsers.ts
+++ b/packages/ui/src/state/parsers.ts
@@ -423,6 +423,7 @@ export function formatSearchBullet(label: string, items: string[]): string {
 export function asApiLikeError(err: unknown): ApiLikeError | null {
   if (!isRecord(err)) return null;
   const kind = err.kind;
+  const code = err.code;
   const status = err.status;
   const path = err.path;
   const message = err.message;
@@ -433,6 +434,7 @@ export function asApiLikeError(err: unknown): ApiLikeError | null {
   if (!hasApiShape) return null;
   return {
     kind: typeof kind === "string" ? kind : undefined,
+    code: typeof code === "string" ? code : undefined,
     status: typeof status === "number" ? status : undefined,
     path: typeof path === "string" ? path : undefined,
     message: typeof message === "string" ? message : undefined,

--- a/packages/ui/src/state/startup-coordinator.test.ts
+++ b/packages/ui/src/state/startup-coordinator.test.ts
@@ -130,6 +130,19 @@ describe("startup coordinator", () => {
     });
   });
 
+  it("returns a terminal managed agent to the reachable Cloud selection flow", () => {
+    expect(
+      startupReducer(
+        { phase: "starting-runtime", attempts: 0, target: "cloud-managed" },
+        { type: "CLOUD_AGENT_SELECTION_REQUIRED" },
+      ),
+    ).toEqual({
+      phase: "first-run-required",
+      serverReachable: false,
+      target: "cloud-managed",
+    });
+  });
+
   it("resets back to session restoration", () => {
     expect(
       startupReducer(

--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -138,6 +138,7 @@ export type StartupEvent =
   | { type: "AGENT_ERROR"; message: string }
   | { type: "AGENT_TIMEOUT" }
   | { type: "AGENT_POLL_RETRY" }
+  | { type: "CLOUD_AGENT_SELECTION_REQUIRED" }
 
   // Hydration
   | { type: "HYDRATION_COMPLETE" }
@@ -287,6 +288,12 @@ export function startupReducer(
 
     case "starting-runtime":
       switch (event.type) {
+        case "CLOUD_AGENT_SELECTION_REQUIRED":
+          return {
+            phase: "first-run-required",
+            serverReachable: false,
+            target: "cloud-managed",
+          };
         case "AGENT_RUNNING":
           return { phase: "hydrating" };
         case "AGENT_STARTING":

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -46,6 +46,7 @@ import {
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
 } from "../utils/cloud-agent-base";
+import { isTerminalDedicatedCloudAgentErrorState as classifyTerminalDedicatedCloudAgentErrorState } from "./dedicated-cloud-agent-error";
 import {
   asApiLikeError,
   deriveFirstRunResumeFieldsFromConfig,
@@ -119,23 +120,17 @@ class ApiHangTimeoutError extends Error {
  * `cloud` runtime mode pinned every launch (icon tap, devicectl, XCUITest) to
  * a dead dedicated agent, 503ing /api/auth/status until the 90s budget fired.
  */
-const DEDICATED_CLOUD_AGENT_ERROR_STATE_FRAGMENT = "Agent is in an error state";
-
 /**
  * True when the failure is the dedicated-agent proxy's terminal
  * sandbox-error 503 for the currently pinned dedicated cloud agent base.
  */
 export function isTerminalDedicatedCloudAgentErrorState(args: {
   status: number | undefined;
+  code?: string;
   message: string | null | undefined;
   clientBaseUrl: string;
 }): boolean {
-  return (
-    args.status === 503 &&
-    typeof args.message === "string" &&
-    args.message.includes(DEDICATED_CLOUD_AGENT_ERROR_STATE_FRAGMENT) &&
-    isDedicatedCloudAgentBase(args.clientBaseUrl)
-  );
+  return classifyTerminalDedicatedCloudAgentErrorState(args);
 }
 
 /**
@@ -1070,6 +1065,7 @@ export async function runPollingBackend(
       if (
         isTerminalDedicatedCloudAgentErrorState({
           status: ae?.status,
+          code: ae?.code,
           message: terminalMessage,
           clientBaseUrl: client.getBaseUrl(),
         })

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -31,10 +31,14 @@ const clientMock = vi.hoisted(() => ({
   startAgent: vi.fn(),
   listConversations: vi.fn(),
   fetch: vi.fn(),
+  getBaseUrl: vi.fn(),
+  setBaseUrl: vi.fn(),
+  setToken: vi.fn(),
 }));
 
 const persistenceMock = vi.hoisted(() => ({
   loadPersistedActiveServer: vi.fn(),
+  clearPersistedActiveServer: vi.fn(),
 }));
 
 vi.mock("../api", () => ({
@@ -43,6 +47,7 @@ vi.mock("../api", () => ({
 
 vi.mock("./persistence", () => ({
   loadPersistedActiveServer: persistenceMock.loadPersistedActiveServer,
+  clearPersistedActiveServer: persistenceMock.clearPersistedActiveServer,
 }));
 
 function createDeps() {
@@ -51,6 +56,7 @@ function createDeps() {
     setConnected: vi.fn(),
     setStartupError: vi.fn(),
     setFirstRunLoading: vi.fn(),
+    setFirstRunComplete: vi.fn(),
     setAuthRequired: vi.fn(),
     setPairingEnabled: vi.fn(),
     setPairingExpiresAt: vi.fn(),
@@ -74,6 +80,9 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     clientMock.getBootProgress.mockResolvedValue(null);
     clientMock.getStatus.mockResolvedValue(RUNNING_STATUS);
     clientMock.hasToken.mockReturnValue(true);
+    clientMock.getBaseUrl.mockReturnValue(
+      "https://agent-123.cloud.eliza.app/api/v1/eliza/agents/agent-123",
+    );
     clientMock.fetch.mockResolvedValue({
       state: "starting",
       canRespond: false,
@@ -170,6 +179,40 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
       ([e]) => e.type === "AGENT_RUNNING",
     );
     expect(runningDispatches).toHaveLength(1);
+  });
+
+  it("clears a terminal failed agent and returns directly to agent selection", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Failed Cloud Agent",
+    });
+    clientMock.listConversations.mockRejectedValue({
+      status: 503,
+      code: "agent_error_state",
+      message: "machine-readable failure",
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    expect(persistenceMock.clearPersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(clientMock.setBaseUrl).toHaveBeenCalledWith(null);
+    expect(clientMock.setToken).toHaveBeenCalledWith(null);
+    expect(deps.setFirstRunComplete).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "CLOUD_AGENT_SELECTION_REQUIRED",
+    });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
   });
 
   it("advances from the genuine proxy status when conversations are slow or unavailable", async () => {

--- a/packages/ui/src/state/startup-phase-runtime.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.test.ts
@@ -24,6 +24,7 @@ function createDeps() {
     setConnected: vi.fn(),
     setStartupError: vi.fn(),
     setFirstRunLoading: vi.fn(),
+    setFirstRunComplete: vi.fn(),
     setAuthRequired: vi.fn(),
     setPairingEnabled: vi.fn(),
     setPairingExpiresAt: vi.fn(),

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -17,12 +17,16 @@ import {
   computeAgentDeadlineExtensions,
   getAgentReadyTimeoutMs,
 } from "./agent-startup-timing";
+import { isTerminalDedicatedCloudAgentErrorState } from "./dedicated-cloud-agent-error";
 import {
   asApiLikeError,
   formatStartupErrorDetail,
   type StartupErrorState,
 } from "./internal";
-import { loadPersistedActiveServer } from "./persistence";
+import {
+  clearPersistedActiveServer,
+  loadPersistedActiveServer,
+} from "./persistence";
 import type { RuntimeTarget, StartupEvent } from "./startup-coordinator";
 import { runStartupProbe } from "./startup-probe";
 import { STARTUP_TIMING_POLICY } from "./startup-timing-policy";
@@ -43,6 +47,7 @@ export interface StartingRuntimeDeps {
   setConnected: (v: boolean) => void;
   setStartupError: (v: StartupErrorState | null) => void;
   setFirstRunLoading: (v: boolean) => void;
+  setFirstRunComplete: (v: boolean) => void;
   setAuthRequired: (v: boolean) => void;
   setPairingEnabled: (v: boolean) => void;
   setPairingExpiresAt: (v: number | null) => void;
@@ -193,6 +198,7 @@ type PassthroughProbe =
   | { kind: "serving" }
   | { kind: "warming" }
   | { kind: "auth-required"; status: 401 | 429 }
+  | { kind: "terminal-agent-error" }
   | { kind: "errored"; status: number };
 
 async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
@@ -200,7 +206,18 @@ async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
     await client.listConversations();
     return { kind: "serving" };
   } catch (err) {
-    const status = asApiLikeError(err)?.status;
+    const apiError = asApiLikeError(err);
+    const status = apiError?.status;
+    if (
+      isTerminalDedicatedCloudAgentErrorState({
+        status,
+        code: apiError?.code,
+        message: apiError?.message,
+        clientBaseUrl: client.getBaseUrl(),
+      })
+    ) {
+      return { kind: "terminal-agent-error" };
+    }
     if ((status === 401 || status === 429) && client.hasToken()) {
       return { kind: "auth-required", status };
     }
@@ -719,6 +736,20 @@ async function runCloudManagedWarmup(
       deps.setConnected(false);
       deps.setFirstRunLoading(false);
       dispatch({ type: "AGENT_RUNNING" });
+      return;
+    }
+
+    if (probe.kind === "terminal-agent-error") {
+      // The selected sandbox cannot recover through polling or Retry. Remove
+      // the poisoned persisted target and return to the Cloud agent picker,
+      // which keeps the switcher reachable without rebinding to another host.
+      clearPersistedActiveServer();
+      client.setBaseUrl(null);
+      client.setToken(null);
+      deps.setConnected(false);
+      deps.setFirstRunComplete(false);
+      deps.setFirstRunLoading(false);
+      dispatch({ type: "CLOUD_AGENT_SELECTION_REQUIRED" });
       return;
     }
 

--- a/packages/ui/src/state/types.ts
+++ b/packages/ui/src/state/types.ts
@@ -279,6 +279,7 @@ export interface StartupCoordinatorView {
 
 export interface ApiLikeError {
   kind?: string;
+  code?: string;
   status?: number;
   path?: string;
   message?: string;

--- a/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
+++ b/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
@@ -172,9 +172,7 @@ describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
   });
 
   it("selects the restored conversation before its Cloud messages finish loading", async () => {
-    let resolveMessages:
-      | ((value: { messages: ConversationMessage[] }) => void)
-      | null = null;
+    let resolveMessages!: (value: { messages: ConversationMessage[] }) => void;
     const messagesPending = new Promise<{ messages: ConversationMessage[] }>(
       (resolve) => {
         resolveMessages = resolve;
@@ -195,7 +193,7 @@ describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
     );
     expect(setConversationMessages).not.toHaveBeenCalled();
 
-    resolveMessages?.({
+    resolveMessages({
       messages: [{ id: "m1", role: "user", text: "hello", timestamp: 1 }],
     });
     await expect(hydration).resolves.toBeNull();

--- a/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
+++ b/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
@@ -171,6 +171,39 @@ describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
     expect(result).toBeNull(); // already has messages
   });
 
+  it("selects the restored conversation before its Cloud messages finish loading", async () => {
+    let resolveMessages:
+      | ((value: { messages: ConversationMessage[] }) => void)
+      | null = null;
+    const messagesPending = new Promise<{ messages: ConversationMessage[] }>(
+      (resolve) => {
+        resolveMessages = resolve;
+      },
+    );
+    const client = makeFakeClient({
+      listConversations: vi.fn(async () => ({
+        conversations: [{ ...CONVERSATION }],
+      })),
+      getConversationMessages: vi.fn(() => messagesPending),
+    });
+    const { deps, setActiveConversationId, setConversationMessages } =
+      makeDeps(client);
+
+    const hydration = hydrateInitialConversation(deps);
+    await vi.waitFor(() =>
+      expect(setActiveConversationId).toHaveBeenCalledWith("c1"),
+    );
+    expect(setConversationMessages).not.toHaveBeenCalled();
+
+    resolveMessages?.({
+      messages: [{ id: "m1", role: "user", text: "hello", timestamp: 1 }],
+    });
+    await expect(hydration).resolves.toBeNull();
+    expect(setConversationMessages).toHaveBeenCalledWith([
+      { id: "m1", role: "user", text: "hello", timestamp: 1 },
+    ]);
+  });
+
   it("leaves the thread holder UNKNOWN when the restore fetch fails (placeholder [] must never feed draft cleanup)", async () => {
     const client = makeFakeClient({
       listConversations: vi.fn(async () => ({

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -140,6 +140,17 @@ function conversationRecency(conversation: Conversation): number {
   return Number.isNaN(updated) ? 0 : updated;
 }
 
+function selectInitialRestoredConversation(
+  conversations: Conversation[],
+): Conversation {
+  const savedConversationId = loadActiveConversationId();
+  return (
+    conversations.find(
+      (conversation) => conversation.id === savedConversationId,
+    ) ?? conversations[0]
+  );
+}
+
 async function resolveRestoredConversationWithMessages(
   api: HydrateConversationClient,
   conversations: Conversation[],
@@ -150,11 +161,7 @@ async function resolveRestoredConversationWithMessages(
    *  proof the conversation is empty, so it must never feed draft cleanup. */
   messagesLoaded: boolean;
 }> {
-  const savedConversationId = loadActiveConversationId();
-  const restoredConversation =
-    conversations.find(
-      (conversation) => conversation.id === savedConversationId,
-    ) ?? conversations[0];
+  const restoredConversation = selectInitialRestoredConversation(conversations);
   let restoredMessages: ConversationMessage[] = [];
   try {
     restoredMessages = filterRenderableConversationMessages(
@@ -263,6 +270,18 @@ export async function hydrateInitialConversation(
     }
     setConversations(conversations);
     if (conversations.length > 0) {
+      // Select the restored row as soon as the list arrives. Direct Cloud
+      // hydration intentionally does not block shell paint, so waiting for the
+      // messages request here left the sidebar populated while the pane stayed
+      // on "Start a conversation" until a manual click.
+      const initialConversation =
+        selectInitialRestoredConversation(conversations);
+      setActiveConversationId(initialConversation.id);
+      activeConversationIdRef.current = initialConversation.id;
+      api.sendWsMessage({
+        type: "active-conversation",
+        conversationId: initialConversation.id,
+      });
       const {
         conversation: restoredConversation,
         messages: nextMessages,
@@ -271,12 +290,14 @@ export async function hydrateInitialConversation(
       if (!isCurrentHydration()) {
         return null;
       }
-      setActiveConversationId(restoredConversation.id);
-      activeConversationIdRef.current = restoredConversation.id;
-      api.sendWsMessage({
-        type: "active-conversation",
-        conversationId: restoredConversation.id,
-      });
+      if (restoredConversation.id !== initialConversation.id) {
+        setActiveConversationId(restoredConversation.id);
+        activeConversationIdRef.current = restoredConversation.id;
+        api.sendWsMessage({
+          type: "active-conversation",
+          conversationId: restoredConversation.id,
+        });
+      }
       try {
         greetingFiredRef.current =
           hasConversationBootstrapMessage(nextMessages);

--- a/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
@@ -238,6 +238,65 @@ describe("useCloudState — handleCloudLogin with a stale Steward token and no l
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(valid);
   });
 
+  it("reauthenticates on the same click when Cloud rejects a reused opaque token", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "revoked-opaque-token");
+    getCloudStatusSpy
+      .mockImplementationOnce(async () => {
+        localStorage.removeItem(STEWARD_TOKEN_KEY);
+        return {
+          connected: false,
+          enabled: false,
+          reason: "auth-rejected",
+        } as Awaited<ReturnType<typeof client.getCloudStatus>>;
+      })
+      .mockResolvedValueOnce({
+        connected: true,
+        enabled: true,
+      } as Awaited<ReturnType<typeof client.getCloudStatus>>);
+    vi.spyOn(client, "getCloudCredits").mockResolvedValue({
+      balance: 10,
+      low: false,
+      critical: false,
+    } as Awaited<ReturnType<typeof client.getCloudCredits>>);
+    const launcher = vi.fn(async () => ({ token: makeJwt(3600) }));
+    const unregister = registerStewardLoginLauncher(launcher);
+    try {
+      const { result } = renderHook(() => useCloudState(makeParams()));
+      await act(async () => {
+        await result.current.handleCloudLogin();
+      });
+
+      expect(launcher).toHaveBeenCalledTimes(1);
+      expect(getCloudStatusSpy).toHaveBeenCalledTimes(2);
+      expect(result.current.elizaCloudConnected).toBe(true);
+      expect(result.current.elizaCloudLoginError).toBeNull();
+      expect(deviceCodeCalls()).toBe(0);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("falls through to device-code on the same click when no Steward launcher is mounted", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "revoked-opaque-token");
+    getCloudStatusSpy.mockImplementationOnce(async () => {
+      localStorage.removeItem(STEWARD_TOKEN_KEY);
+      return {
+        connected: false,
+        enabled: false,
+        reason: "auth-rejected",
+      } as Awaited<ReturnType<typeof client.getCloudStatus>>;
+    });
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin();
+    });
+
+    expect(deviceCodeCalls()).toBe(1);
+    expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
+    expect(result.current.elizaCloudLoginBusy).toBe(false);
+  });
+
   it("a mounted launcher still owns the stale-token re-auth (no device-code call)", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
     const launcher = vi.fn(async () => ({ token: makeJwt(3600) }));

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -759,8 +759,10 @@ export function useCloudState({
       // reached the working device-code flow. Instead, drain the stale token
       // below and fall through to the device-code flow on the same click.
       if (canUseMountedStewardLoginSurface()) {
-        closePrePoppedWindow();
+        let fallThroughToLegacyLogin = false;
         try {
+          const reusedStoredCredential = hasUsableStoredStewardToken();
+          if (!reusedStoredCredential) closePrePoppedWindow();
           await launchStewardLogin();
           // Gate the connected state + success toast on an ACTUAL authed status
           // call. `launchStewardLogin` short-circuits on a stored token; if that
@@ -768,29 +770,55 @@ export function useCloudState({
           // declaring "connected" + toasting here would be a false success that
           // 401s the agent picker in a loop. Only celebrate a verified session;
           // otherwise surface the re-auth path the login UI already renders.
-          const connected = await pollCloudCredits();
-          // error-policy:J4 wallet config is a secondary panel; a failed load
-          // must not undo a verified login. The wallet section renders its own
-          // unavailable state from the empty config.
-          await loadWalletConfig().catch(() => undefined);
-          if (connected) {
-            setElizaCloudConnected(true);
-            setElizaCloudLoginError(null);
-          } else {
-            setElizaCloudLoginError(
-              "Could not verify your Eliza Cloud session. Please sign in again.",
-            );
+          let connected = await pollCloudCredits();
+          // A direct identity 401 clears only the exact rejected Steward
+          // credential. When launchStewardLogin reused that credential, invoke
+          // the mounted sign-in surface now and verify the replacement on this
+          // same click instead of making the button appear inert.
+          if (
+            !connected &&
+            reusedStoredCredential &&
+            !readStoredStewardToken()?.trim()
+          ) {
+            if (hasStewardLoginLauncher()) {
+              closePrePoppedWindow();
+              await launchStewardLogin();
+              connected = await pollCloudCredits();
+            } else {
+              // The opaque token was the only reason this branch was usable.
+              // With it authoritatively rejected and no in-app provider,
+              // preserve the prepared popup and continue into device-code
+              // login below instead of requiring a second click.
+              fallThroughToLegacyLogin = true;
+            }
+          }
+          if (!fallThroughToLegacyLogin) {
+            closePrePoppedWindow();
+            // error-policy:J4 wallet config is a secondary panel; a failed
+            // load must not undo a verified login. The wallet section renders
+            // its own unavailable state from the empty config.
+            await loadWalletConfig().catch(() => undefined);
+            if (connected) {
+              setElizaCloudConnected(true);
+              setElizaCloudLoginError(null);
+            } else {
+              setElizaCloudLoginError(
+                "Could not verify your Eliza Cloud session. Please sign in again.",
+              );
+            }
           }
         } catch (err) {
           setElizaCloudLoginError(
             err instanceof Error ? err.message : "Eliza Cloud login failed",
           );
         } finally {
-          elizaCloudLoginBusyRef.current = false;
-          setElizaCloudLoginBusy(false);
-          completeLogin();
+          if (!fallThroughToLegacyLogin) {
+            elizaCloudLoginBusyRef.current = false;
+            setElizaCloudLoginBusy(false);
+            completeLogin();
+          }
         }
-        return loginCompletion;
+        if (!fallThroughToLegacyLogin) return loginCompletion;
       }
 
       // A stored-but-stale Steward JWT with no launcher mounted: drain it so it


### PR DESCRIPTION
Closes #22508.

## What changed

- gives the terminal dedicated-agent proxy failure a stable `agent_error_state` code
- clears a poisoned active target at startup and returns directly to the Cloud picker
- refuses failed rows in Settings and probes a candidate with an isolated client before persisting or reloading
- clears only the exact request-time Steward credential after a direct 401, then continues the same click through mounted Steward login or device-code fallback
- restores the selected conversation before its message fetch completes, with an epoch guard that prevents a late response from overwriting a newer choice
- preserves the failed user turn and the existing explicit sign-in/resend notice

## Validation

- pinned Bun 1.3.14 / Node 24.15.0
- seven focused UI files: 134/134 tests passed
- dedicated-agent proxy suite: 40/40 tests, 191 assertions
- UI typecheck passed
- Biome: all 19 changed files clean
- core Node/browser/edge build completed while preparing the full dependency graph
- `git diff --check` passed
- app visual audit exercised 219 cases: 218 passed, broken=0. The sole terminal failure was the existing minimalism ratchet in three untouched views (`builtin-plugins`, `builtin-runtime`, `builtin-background`); none of those paths differ in this PR.

No live Steward account or failed production agent was mutated. The deterministic proxy/client/UI boundary tests cover the recovery and credential-race contracts; production sign-in evidence remains operational.

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@fb790575cdb844182a860777b04b4d3d57c92197:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- {"ai_provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@fb790575cdb844182a860777b04b4d3d57c92197:packages/skills/skills/contribute-to-eliza","attribution":"self-reported"} -->
