### PR TITLE
fix(cloud): guard social media SSRF with safeFetch

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -15,8 +15,11 @@ import type {
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
+import { safeFetch } from "../../../security/safe-fetch";
 
 const BLUESKY_SERVICE = "https://bsky.social";
+
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 interface BskySession {
   did: string;
@@ -237,8 +240,13 @@ export const blueskyProvider: SocialMediaProvider = {
           } else if (media.base64) {
             imageData = Buffer.from(media.base64, "base64");
           } else if (media.url) {
-            const response = await fetch(media.url);
-            imageData = Buffer.from(await response.arrayBuffer());
+            const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
+            if (!response.ok) throw new Error(`Media fetch failed: ${response.status}`);
+            const hdrLen = response.headers.get("content-length");
+            if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+            const ab = await response.arrayBuffer();
+            if (ab.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab.byteLength} > ${MAX_MEDIA_BYTES}`);
+            imageData = Buffer.from(ab);
           } else {
             continue;
           }
@@ -414,8 +422,13 @@ export const blueskyProvider: SocialMediaProvider = {
     } else if (media.base64) {
       imageData = Buffer.from(media.base64, "base64");
     } else if (media.url) {
-      const response = await fetch(media.url);
-      imageData = Buffer.from(await response.arrayBuffer());
+      const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
+      if (!response.ok) throw new Error(`Media fetch failed: ${response.status}`);
+      const hdrLen = response.headers.get("content-length");
+      if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+      const ab = await response.arrayBuffer();
+      if (ab.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab.byteLength} > ${MAX_MEDIA_BYTES}`);
+      imageData = Buffer.from(ab);
     } else {
       throw new Error("No media data provided");
     }

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
@@ -15,8 +15,11 @@ import type {
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
+import { safeFetch } from "../../../security/safe-fetch";
 
 const LINKEDIN_API_BASE = "https://api.linkedin.com/v2";
+
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 interface LinkedInProfile {
   id: string;
@@ -216,13 +219,17 @@ export const linkedinProvider: SocialMediaProvider = {
             // Download and upload the image. A non-OK download or upload must
             // surface: otherwise the asset below is marked READY and attached to
             // a published post that references bytes LinkedIn never received.
-            const imageResponse = await fetch(media.url);
+            const imageResponse = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
             if (!imageResponse.ok) {
               throw new Error(
                 `LinkedIn image download failed for ${media.url}: ${imageResponse.status}`,
               );
             }
-            const imageData = await imageResponse.arrayBuffer();
+            const hdrLen = imageResponse.headers.get("content-length");
+            if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+            const ab0 = await imageResponse.arrayBuffer();
+            if (ab0.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab0.byteLength} > ${MAX_MEDIA_BYTES}`);
+            const imageData = ab0;
 
             const uploadResponse = await fetch(uploadUrl, {
               method: "PUT",
@@ -394,11 +401,15 @@ export const linkedinProvider: SocialMediaProvider = {
     } else if (media.base64) {
       imageData = Uint8Array.from(Buffer.from(media.base64, "base64"));
     } else if (media.url) {
-      const response = await fetch(media.url);
+      const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
       if (!response.ok) {
         throw new Error(`LinkedIn image download failed for ${media.url}: ${response.status}`);
       }
-      imageData = new Uint8Array(await response.arrayBuffer());
+      const hdrLen2 = response.headers.get("content-length");
+      if (hdrLen2 && Number(hdrLen2) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen2} > ${MAX_MEDIA_BYTES}`);
+      const ab2 = await response.arrayBuffer();
+      if (ab2.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab2.byteLength} > ${MAX_MEDIA_BYTES}`);
+      imageData = new Uint8Array(ab2);
     } else {
       throw new Error("No media data provided");
     }

--- a/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
@@ -11,6 +11,8 @@ import type {
 } from "../../../types/social-media";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
+import { safeFetch } from "../../../security/safe-fetch";
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 interface MastodonStatus {
   id: string;
@@ -101,8 +103,13 @@ async function uploadMedia(
   } else if (media.base64) {
     fileData = Buffer.from(media.base64, "base64");
   } else if (media.url) {
-    const response = await fetch(media.url);
-    fileData = Buffer.from(await response.arrayBuffer());
+    const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
+    if (!response.ok) throw new Error(`Media fetch failed: ${response.status}`);
+    const hdrLen = response.headers.get("content-length");
+    if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+    const ab = await response.arrayBuffer();
+    if (ab.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab.byteLength} > ${MAX_MEDIA_BYTES}`);
+    fileData = Buffer.from(ab);
   } else {
     throw new Error("No media data provided");
   }

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -10,8 +10,11 @@ import type {
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
+import { safeFetch } from "../../../security/safe-fetch";
 
 const SLACK_API_BASE = "https://slack.com/api";
+
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 interface SlackResponse<_T = unknown> {
   ok: boolean;
@@ -343,11 +346,15 @@ export const slackProvider: SocialMediaProvider = {
     } else if (media.base64) {
       fileData = Buffer.from(media.base64, "base64");
     } else if (media.url) {
-      const response = await fetch(media.url);
+      const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
       if (!response.ok) {
         throw new Error(`Failed to download media from ${media.url}: ${response.status}`);
       }
-      fileData = Buffer.from(await response.arrayBuffer());
+      const hdrLen = response.headers.get("content-length");
+      if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+      const ab = await response.arrayBuffer();
+      if (ab.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab.byteLength} > ${MAX_MEDIA_BYTES}`);
+      fileData = Buffer.from(ab);
       const urlParts = media.url.split("/");
       filename = urlParts[urlParts.length - 1].split("?")[0] || filename;
     } else {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
@@ -13,6 +13,8 @@ import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { TWITTER_API_BASE, TWITTER_UPLOAD_BASE } from "../../../utils/twitter-api";
 import { withRetry } from "../rate-limit";
+import { safeFetch } from "../../../security/safe-fetch";
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 // Wrapped with retry logic for social media provider
 async function twitterApiRequest<T>(
@@ -44,8 +46,13 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
   } else if (media.base64) {
     mediaData = Buffer.from(media.base64, "base64");
   } else if (media.url) {
-    const response = await fetch(media.url);
-    mediaData = Buffer.from(await response.arrayBuffer());
+    const response = await safeFetch(media.url, { signal: AbortSignal.timeout(10_000) });
+    if (!response.ok) throw new Error(`Media fetch failed: ${response.status}`);
+    const hdrLen = response.headers.get("content-length");
+    if (hdrLen && Number(hdrLen) > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${hdrLen} > ${MAX_MEDIA_BYTES}`);
+    const ab = await response.arrayBuffer();
+    if (ab.byteLength > MAX_MEDIA_BYTES) throw new Error(`Media exceeds size limit: ${ab.byteLength} > ${MAX_MEDIA_BYTES}`);
+    mediaData = Buffer.from(ab);
   } else {
     throw new Error("No media data provided");
   }


### PR DESCRIPTION
## Relates to

- [x] Targets `develop` at current `origin/develop` with zero conflicts.
- [x] `bun install` and proportional exact-head verification were run; the unrelated local root-verify resolution blocker is recorded below.
- [x] A reviewer can confirm the repair from the exact typecheck evidence below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low. Single-class outbound-fetch hardening — no API change, no helper refactor, no behavior change on valid inputs under 10 MiB. All 7 sites fail closed on non-OK status, declared `content-length` >10 MiB, or materialized `arrayBuffer.byteLength` >10 MiB, with `AbortSignal.timeout(10_000)`. Uses the existing `safeFetch` guard (`packages/cloud/shared/src/lib/security/safe-fetch.ts:256`, already used in `blob.ts:312` and `basic-capabilities/index.ts:262`) which pins DNS and blocks private/link-local/metadata IPs. Valid media under the cap is unchanged.

## What does this PR do?

Bounds 7 unbounded `fetch(media.url)` sites in cloud social-media providers that fetch attacker-controlled `media.url` with no SSRF guard, no timeout, and no size bound (tiny URL → SSRF to `169.254.169.254`/`127.0.0.1`/`::ffff:127.0.0.1` or DNS rebinding, plus OOM via `Buffer.from(await response.arrayBuffer())`):

- `packages/cloud/shared/src/lib/services/social-media/providers/slack.ts:349` `fetch(media.url)` → `safeFetch(media.url, { signal: AbortSignal.timeout(10_000) })` + `response.ok` check + `content-length` header pre-check + `ab.byteLength` post-check against `MAX_MEDIA_BYTES = 10 * 1024 * 1024` → `Buffer.from(ab)`.
- `packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts:243` `createPost` image fetch (up to 4 images) — same `safeFetch` + ok + header + byteLength caps.
- `packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts:425` `uploadMedia` single image — same guard.
- `packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts:222` `createPost` image download before `PUT uploadUrl` — now `safeFetch` + header + byteLength caps (preserves existing `!ok` throw).
- `packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts:404` `uploadMedia` image download — same guard (header `hdrLen2` + `ab2` caps, `new Uint8Array(ab2)`).
- `packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts:49` `uploadMedia` (covers simple + chunked upload paths) — same guard.
- `packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts:106` `uploadMedia` — same guard (`fileData = Buffer.from(ab)`).

Adds `import { safeFetch } from "../../../security/safe-fetch"` and `const MAX_MEDIA_BYTES = 10 * 1024 * 1024` to each of the 5 provider files. All sites keep `media.data` / `media.base64` fast paths unchanged.

## Testing

- `bun run --cwd packages/cloud/shared typecheck` — pass
- `git diff --check` — pass
- `git diff --stat` — 5 files, 59 insertions, 14 deletions

## Known gaps / failures

`bun run verify` reaches Turbo tasks then the local sparse setup resolves some Wrangler/drizzle peer deps through the global cache; unrelated to this diff. Package typecheck lane above is green on the exact head. Hosted PR CI remains authoritative.

## Evidence Gate

<!-- evidence-head:PENDING -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed beyond bounded/SSRF-guarded media fetches
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend product behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A
Attribution status: self-reported
— [cloud-social-ssrf]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A"} -->
