### PR TITLE
fix(core): keep attachment limit failures typed and internal

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -110,6 +110,7 @@ export * from "./providers/index.ts";
 
 import {
 	describeImageCached,
+	MediaFetchError,
 	readResponseWithLimit,
 } from "../../media/index.ts";
 import { recentErrorsProvider } from "../../providers/recent-errors.ts";
@@ -210,7 +211,7 @@ interface PostCreationJson {
 const MAX_POST_GENERATION_ATTEMPTS = 3;
 
 /** Hard cap for any single media fetch — attacker-supplied URLs can lie about size. */
-export const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 async function readBoundedMediaResponse(
 	response: Response,
@@ -221,7 +222,8 @@ async function readBoundedMediaResponse(
 	if (contentLength !== null) {
 		const declared = Number(contentLength);
 		if (Number.isFinite(declared) && declared > MAX_MEDIA_BYTES) {
-			throw new Error(
+			throw new MediaFetchError(
+				"max_bytes",
 				`${label} exceeds size limit ${declared} > ${MAX_MEDIA_BYTES}: ${url}`,
 			);
 		}

--- a/packages/core/src/features/basic-capabilities/media-response-limits.test.ts
+++ b/packages/core/src/features/basic-capabilities/media-response-limits.test.ts
@@ -4,15 +4,17 @@
  * a chunked response as soon as its running byte total crosses the cap.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MediaFetchError } from "../../media/index.ts";
 import {
 	ContentType,
 	type IAgentRuntime,
 	type Media,
 	type UUID,
 } from "../../types/index.ts";
-import { MAX_MEDIA_BYTES, processAttachments } from "./index.ts";
+import { processAttachments } from "./index.ts";
 
 const agentId = "00000000-0000-0000-0000-0000000000ab" as UUID;
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 function makeRuntime(): IAgentRuntime {
 	return {
@@ -51,12 +53,13 @@ describe("basic-capabilities attachment body limits", () => {
 			vi.fn(async () => response),
 		);
 
-		await expect(
-			processAttachments(
-				[textDocument("https://media.test/declared-too-large.txt")],
-				makeRuntime(),
-			),
-		).rejects.toThrow(/exceeds size limit/);
+		const error = await processAttachments(
+			[textDocument("https://media.test/declared-too-large.txt")],
+			makeRuntime(),
+		).catch((cause: unknown) => cause);
+		expect(error).toBeInstanceOf(MediaFetchError);
+		expect(error).toMatchObject({ code: "max_bytes" });
+		expect((error as Error).message).toMatch(/exceeds size limit/);
 		expect(readerRequests).toBe(0);
 	});
 
@@ -89,12 +92,13 @@ describe("basic-capabilities attachment body limits", () => {
 			),
 		);
 
-		await expect(
-			processAttachments(
-				[textDocument("https://media.test/chunked-too-large.txt")],
-				makeRuntime(),
-			),
-		).rejects.toThrow(/maxBytes/);
+		const error = await processAttachments(
+			[textDocument("https://media.test/chunked-too-large.txt")],
+			makeRuntime(),
+		).catch((cause: unknown) => cause);
+		expect(error).toBeInstanceOf(MediaFetchError);
+		expect(error).toMatchObject({ code: "max_bytes" });
+		expect((error as Error).message).toMatch(/maxBytes/);
 		expect(reads).toBeLessThanOrEqual(3);
 		expect(cancelled).toBe(true);
 	});


### PR DESCRIPTION
# Relates to

Fixes #22574. Follow-up to #22528.

- [x] Targets `develop` and is rebased onto `949fe07774525685db2f2e2e0813313deaffb26f` with zero conflicts.
- [x] Focused package tests and core typecheck passed; the rebased head retains byte-identical production and test files.
- [x] A reviewer can verify both overflow paths through public `processAttachments` tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@949fe07774525685db2f2e2e0813313deaffb26f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `origin/develop@949fe07774525685db2f2e2e0813313deaffb26f`; zero conflicts.
- [ ] Root `bun run verify` was not rerun in the isolated sparse checkout; exact core gates are recorded below.

# Risks

Low. This narrows an accidental public export and makes an existing early rejection use the same typed error already used by streamed overflow. Streaming cancellation, byte limits, attachment success paths, and SSRF ownership are unchanged.

# Background

## What does this PR do?

- Makes the 10 MiB `MAX_MEDIA_BYTES` implementation constant private instead of exporting it through the basic-capabilities barrel for a test.
- Throws `MediaFetchError` with code `max_bytes` when declared `Content-Length` exceeds the cap, matching chunked-body overflow.
- Extends the public `processAttachments` tests to assert typed parity for both declared and streamed overflow.

## What kind of change is this?

Bug fix (non-breaking internal contract correction).

# Documentation changes needed?

N/A - no supported configuration or public API is added.

# Testing

## Where should a reviewer start?

Review the two branches of `readBoundedMediaResponse` and the two tests in `media-response-limits.test.ts`.

## Detailed testing steps

Exact head: `316b2d4a41d0bbdd29933ec467907cbec6a0205c`

```text
bun run --cwd packages/core test -- media-response-limits.test.ts process-attachments-documents.test.ts media/fetch.test.ts network/fetch-guard.test.ts --no-file-parallelism --pool=threads --maxWorkers=1 --no-cache
4 files passed, 32 tests passed

bun run --cwd packages/core typecheck
PASS

biome check <2 changed files>
PASS

git diff --check origin/develop...HEAD
PASS
```

# Evidence Gate

<!-- evidence-head:316b2d4a41d0bbdd29933ec467907cbec6a0205c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic core boundary; exact public-path test output is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or planner behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

The focused test output proves declared-size rejection happens before body access, streamed overflow cancels the body, and both reject through public `processAttachments` as `MediaFetchError { code: "max_bytes" }`.

## Screenshots (before / after) + video walkthrough

N/A - backend-only contract.

## Audio / voice walkthrough

N/A - no audio/voice change.

## Known gaps / failures

- Root `bun run verify` was not run in the sparse isolated checkout. Core typecheck and 32 focused attachment/media/SSRF tests pass on the exact head.
- Test execution used isolated temporary/cache directories and explicit single-worker threads because the shared host's default Vitest cache was contended by concurrent lanes.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@949fe07774525685db2f2e2e0813313deaffb26f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61-new-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@949fe07774525685db2f2e2e0813313deaffb26f:packages/skills/skills/contribute-to-eliza"} -->