### PR TITLE
fix(agent): bound aggregate raw audio-redaction transcript bytes

### DIFF
--- a/packages/agent/src/services/audio-redaction-word-budget.test.ts
+++ b/packages/agent/src/services/audio-redaction-word-budget.test.ts
@@ -8,11 +8,13 @@ import { describe, expect, it } from "bun:test";
 import {
   AudioRedactionWordBudgetError,
   assertAudioRedactionInputBudget,
+  assertAudioRedactionWordBudget,
   MAX_AUDIO_REDACTION_MATCH_CANDIDATES,
   MAX_AUDIO_REDACTION_NORMALIZED_CHARS,
   MAX_AUDIO_REDACTION_PII_NORMALIZED_CHARS,
   MAX_AUDIO_REDACTION_PII_SPAN_CHARS,
   MAX_AUDIO_REDACTION_PII_SPANS,
+  MAX_AUDIO_REDACTION_RAW_CHARS,
   MAX_AUDIO_REDACTION_WORD_CHARS,
   MAX_AUDIO_REDACTION_WORDS,
   selectAudioRedactionSentinels,
@@ -188,6 +190,57 @@ describe("selectAudioRedactionSentinels", () => {
     expect(() =>
       assertAudioRedactionInputBudget(words, [{ text: "a" }, { text: "a" }]),
     ).toThrow(/matcher exceeds/);
+  });
+
+  it("fails closed on a punctuation-only raw byte flood that normalizes to zero", () => {
+    // Each token is pure punctuation: it normalizes to zero characters, so it
+    // slips past the per-word (<= MAX_AUDIO_REDACTION_WORD_CHARS) and the
+    // aggregate normalized (stays at 0) budgets, yet its raw length still
+    // forces Unicode normalization over the whole stream.
+    const punctuationToken = "!".repeat(MAX_AUDIO_REDACTION_WORD_CHARS);
+    const wordCount =
+      Math.floor(
+        MAX_AUDIO_REDACTION_RAW_CHARS / MAX_AUDIO_REDACTION_WORD_CHARS,
+      ) + 1;
+    expect(wordCount).toBeLessThanOrEqual(MAX_AUDIO_REDACTION_WORDS);
+    const words = Array.from({ length: wordCount }, (_, index) => ({
+      text: punctuationToken,
+      startMs: index,
+      endMs: index + 1,
+    }));
+    let thrown: unknown;
+    try {
+      assertAudioRedactionWordBudget(words);
+      throw new Error("expected AUDIO_REDACTION_UNBOUNDED");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(AudioRedactionWordBudgetError);
+    expect((thrown as AudioRedactionWordBudgetError).code).toBe(
+      "AUDIO_REDACTION_UNBOUNDED",
+    );
+    expect((thrown as Error).message).toMatch(/raw timed-word stream exceeds/);
+    expect((thrown as AudioRedactionWordBudgetError).context?.maxRawChars).toBe(
+      MAX_AUDIO_REDACTION_RAW_CHARS,
+    );
+    // The shared final head guards assertAudioRedactionInputBudget too.
+    expect(() => assertAudioRedactionInputBudget(words, [])).toThrow(
+      /raw timed-word stream exceeds/,
+    );
+  });
+
+  it("admits a large in-budget transcript below the raw byte ceiling", () => {
+    // A transcript that already passes the normalized budget must not be newly
+    // rejected by the raw ceiling, which sits well above it.
+    const words = Array.from({ length: 20_000 }, (_, index) => ({
+      text: `token${index}`,
+      startMs: index * 10,
+      endMs: index * 10 + 5,
+    }));
+    const rawChars = words.reduce((sum, word) => sum + word.text.length, 0);
+    expect(rawChars).toBeLessThan(MAX_AUDIO_REDACTION_RAW_CHARS);
+    expect(() => assertAudioRedactionWordBudget(words)).not.toThrow();
+    expect(() => assertAudioRedactionInputBudget(words, [])).not.toThrow();
   });
 
   it("fails closed on an oversized sentinel span plan", () => {

--- a/packages/agent/src/services/audio-redaction-word-budget.ts
+++ b/packages/agent/src/services/audio-redaction-word-budget.ts
@@ -10,6 +10,13 @@
 export const MAX_AUDIO_REDACTION_WORDS = 100_000;
 export const MAX_AUDIO_REDACTION_WORD_CHARS = 4_096;
 export const MAX_AUDIO_REDACTION_NORMALIZED_CHARS = 1_000_000;
+// Caps the aggregate *raw* timed-word bytes normalization must scan. The
+// per-word and normalized-aggregate budgets both miss a punctuation-only flood
+// (each word <= 4,096 raw chars, all normalizing to zero) that still forces
+// normalizeSpokenText over the entire raw stream. 4 MiB sits far above the
+// 1,000,000 normalized-char budget legitimate transcripts must already clear,
+// yet far below the ~409.6M-char adversarial ceiling (100,000 x 4,096).
+export const MAX_AUDIO_REDACTION_RAW_CHARS = 4_194_304;
 export const MAX_AUDIO_REDACTION_PII_SPANS = 1_024;
 export const MAX_AUDIO_REDACTION_PII_SPAN_CHARS = 4_096;
 export const MAX_AUDIO_REDACTION_PII_NORMALIZED_CHARS = 262_144;
@@ -70,6 +77,7 @@ function normalizedWordCharsWithinBudget(
     );
   }
   let normalizedChars = 0;
+  let rawChars = 0;
   for (const word of words) {
     if (word.text.length > MAX_AUDIO_REDACTION_WORD_CHARS) {
       throw new AudioRedactionWordBudgetError(
@@ -78,6 +86,17 @@ function normalizedWordCharsWithinBudget(
         {
           wordChars: word.text.length,
           maxWordChars: MAX_AUDIO_REDACTION_WORD_CHARS,
+        },
+      );
+    }
+    rawChars += word.text.length;
+    if (rawChars > MAX_AUDIO_REDACTION_RAW_CHARS) {
+      throw new AudioRedactionWordBudgetError(
+        `audio redaction raw timed-word stream exceeds ${MAX_AUDIO_REDACTION_RAW_CHARS} characters`,
+        "AUDIO_REDACTION_UNBOUNDED",
+        {
+          rawChars,
+          maxRawChars: MAX_AUDIO_REDACTION_RAW_CHARS,
         },
       );
     }


### PR DESCRIPTION
# Relates to

Closes #22569

Mandatory post-merge correction to #22563 (bounded audio-redaction word-budget helper), part of the audio-redaction hardening series (#22560/#22561/#22565/#22566/#22567).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package tests, typecheck, and lint were run (see **Known gaps / failures** for the `bun run verify` blocker).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fb790575cdb844182a860777b04b4d3d57c92197:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch is 0 commits behind `origin/develop`).
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures**; the full repo verify cannot complete on this machine because two unrelated dependencies (`viem`, `smthrs`) are blocked by a local `minimumReleaseAge` install policy and several generated/unbuilt-workspace modules are absent. The two changed files typecheck and lint clean.

# Risks

Low. The change adds a single new upper-bound guard (`MAX_AUDIO_REDACTION_RAW_CHARS = 4 MiB`) inside the existing shared validation head. It only rejects inputs that were previously unbounded; it does not alter any existing thrown code/message or the normalized/per-word budgets. The raw ceiling (4,194,304) sits far above the pre-existing 1,000,000 normalized-char budget legitimate transcripts must already clear, so realistic transcripts cannot be newly rejected (proven by a positive in-budget test).

# Background

## What does this PR do?

The bounded audio-redaction matcher caps word count (`MAX_AUDIO_REDACTION_WORDS`), per-word characters (`MAX_AUDIO_REDACTION_WORD_CHARS`), and aggregate **normalized** characters (`MAX_AUDIO_REDACTION_NORMALIZED_CHARS`), but never bounded aggregate **raw** characters. A punctuation-only transcript can supply 100,000 words × 4,096 chars each (~409.6M raw characters) that all normalize to zero. This evades the normalized-aggregate budget (stays at 0) and the per-word budget (each word ≤ 4,096), yet still forces repeated Unicode normalization (`normalizeSpokenText`, a `\p{L}\p{N}` regex replace) over the entire ~410 MB raw input — a DoS vector.

This PR:

1. Adds `export const MAX_AUDIO_REDACTION_RAW_CHARS = 4_194_304;` (4 MiB) with a rationale comment. It is strictly ≥ the 1,000,000 normalized budget (no new rejection of realistic text) and far below the ~409.6M adversarial ceiling.
2. Accumulates a `rawChars` counter inside the single shared final head `normalizedWordCharsWithinBudget`, checked **before** `normalizeSpokenText(word.text)` runs for that word. It fails closed with `AudioRedactionWordBudgetError`, code `"AUDIO_REDACTION_UNBOUNDED"`, and context `{ rawChars, maxRawChars }`.
3. Because the check lives in the shared head, every public entry point — `assertAudioRedactionWordBudget`, `assertAudioRedactionInputBudget`, and (transitively) `selectAudioRedactionSentinels` — inherits it. This satisfies "validate at the exact final head" so the guard cannot be bypassed.

Existing normalized-character and per-word budgets, and all existing thrown codes/messages, are unchanged. `audio-redaction-service.ts` needs no change (it funnels through the same shared head).

## What kind of change is this?

Bug fix (non-breaking; hardens an unbounded DoS path).

# Documentation changes needed?

No. Behavior is internal input validation; the rationale is documented in a source comment beside the new constant.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/audio-redaction-word-budget.test.ts` — the new adversarial `punctuation-only raw byte flood` test and the positive `admits a large in-budget transcript` test, then the guard in `normalizedWordCharsWithinBudget` in `audio-redaction-word-budget.ts`.

## Detailed testing steps

```bash
bun test packages/agent/src/services/audio-redaction-word-budget.test.ts
cd packages/agent && bunx @biomejs/biome check ./src/services/audio-redaction-word-budget.ts ./src/services/audio-redaction-word-budget.test.ts
```

Reproduce the vulnerability: remove the new `rawChars` guard block and rerun the focused test — the punctuation-only flood test fails (no throw), proving the regression test exercises the real contract (red→green output below).

# Evidence Gate

<!-- evidence-head:c7feae15ddcadfe0845672dd55db3da6b3c1836b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - server/runtime input-validation change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - server/runtime input-validation change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user-facing flow; the change is an internal DoS guard, proven by the red→green test output below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the real code path firing end to end is shown by the focused test output (the guard throws `AudioRedactionWordBudgetError`/`AUDIO_REDACTION_UNBOUNDED`) in **Backend + frontend logs** below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — `N/A - no frontend surface is exercised by this change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - deterministic input-validation helper; no agent/action/provider/prompt/model path is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the adversarial reproduction (failing-then-passing punctuation-only case) is the domain artifact; captured inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic input-validation helper; no live-model path changed.`

## Backend + frontend logs

Focused test — RED (new `rawChars` guard removed, constant kept): the punctuation-only flood evades every existing budget and the regression test fails.

<details><summary>RED — raw guard removed → punctuation-only flood test fails</summary>

```

Expected constructor: [class AudioRedactionWordBudgetError extends Error]
Received value: 209 |       endMs: index + 1,
210 |     }));
211 |     let thrown: unknown;
212 |     try {
213 |       assertAudioRedactionWordBudget(words);
214 |       throw new Error("expected AUDIO_REDACTION_UNBOUNDED");
                      ^
error: expected AUDIO_REDACTION_UNBOUNDED
      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-22569/packages/agent/src/services/audio-redaction-word-budget.test.ts:214:17)


      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-22569/packages/agent/src/services/audio-redaction-word-budget.test.ts:218:20)
(fail) selectAudioRedactionSentinels > fails closed on a punctuation-only raw byte flood that normalizes to zero [18.48ms]
...
(fail) selectAudioRedactionSentinels > fails closed on a punctuation-only raw byte flood that normalizes to zero [18.48ms]
(pass) selectAudioRedactionSentinels > admits a large in-budget transcript below the raw byte ceiling [10.14ms]
(pass) selectAudioRedactionSentinels > fails closed on an oversized sentinel span plan [3.46ms]

 11 pass
 1 fail
 23 expect() calls
Ran 12 tests across 1 file. [165.00ms]
```

</details>

Focused test — GREEN (guard in place): all 12 tests pass, 100% line/function coverage of the helper.

<details><summary>GREEN — full fix → 12 pass, 100% coverage</summary>

```
(pass) selectAudioRedactionSentinels > keeps first-occurrence uniqueness on a hostile unique-token stream [40.90ms]
(pass) selectAudioRedactionSentinels > sweeps a hostile word-by-span product without a quadratic scan [21.10ms]
(pass) selectAudioRedactionSentinels > preserves midpoint ordering with unsorted words and spans [0.27ms]
(pass) selectAudioRedactionSentinels > fails closed on an oversized timed-word stream [4.93ms]
(pass) selectAudioRedactionSentinels > fails closed on an oversized timed-word token [0.29ms]
(pass) selectAudioRedactionSentinels > fails closed before allocating an oversized normalized word stream [4.68ms]
(pass) selectAudioRedactionSentinels > fails closed on excessive PII count and aggregate PII text [2.05ms]
(pass) selectAudioRedactionSentinels > fails closed before repeated needles can allocate unbounded matches [11.11ms]
(pass) selectAudioRedactionSentinels > fails closed on a punctuation-only raw byte flood that normalizes to zero [35.96ms]
(pass) selectAudioRedactionSentinels > admits a large in-budget transcript below the raw byte ceiling [10.74ms]
(pass) selectAudioRedactionSentinels > fails closed on an oversized sentinel span plan [4.09ms]
------------------------------------------------------------|---------|---------|-------------------
File                                                        | % Funcs | % Lines | Uncovered Line #s
------------------------------------------------------------|---------|---------|-------------------
All files                                                   |  100.00 |  100.00 |
 packages/agent/src/services/audio-redaction-word-budget.ts |  100.00 |  100.00 | 
------------------------------------------------------------|---------|---------|-------------------

 12 pass
 0 fail
 27 expect() calls
Ran 12 tests across 1 file. [321.00ms]
```

</details>

Lint (Biome) on both changed files:

<details><summary>Biome check — clean</summary>

```
Checked 2 files in 29ms. No fixes applied.
```

</details>

Typecheck: the two changed files produce no `tsc` errors. The remaining repo baseline errors are unrelated missing generated files / unbuilt workspace packages (`@elizaos/cloud-routing`, `plugin-capacitor-bridge`, generated `validation-keyword-data`, etc.) that predate this branch and are absent because a full `bun run build` did not run on this machine.

<details><summary>tsc — no audio-redaction errors</summary>

```
No audio-redaction type errors (pre-existing baseline errors are unrelated generated/unbuilt-workspace modules)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - server/runtime input-validation change; no rendered UI surface.`

## Audio / voice walkthrough

`N/A - this change bounds the raw byte count of the timed-word validation head; it does not alter transcript/TTS/STT round-trip behavior, only rejects an adversarial unbounded input before normalization.`

## Known gaps / failures

- `bun run verify` (full repo gate) could not complete on this machine: `bun install` is blocked by a local `minimumReleaseAge` policy on two unrelated fresh dependencies (`viem@2.55.17`, `smthrs@0.34.0`), and a full workspace build (generating i18n keyword data, cloud-routing, capacitor-bridge shims, etc.) was not run, so a repo-wide `tsc` reports pre-existing errors in those unrelated modules. The **changed files** typecheck and lint clean, and the focused package test passes with 100% coverage. This is an environment limitation, not a defect in the change.
- Evidence artifacts are inlined as `<details>` log blocks rather than minted attachment URLs because the fork attachment/login flow hit a 2FA verification interstitial in this environment.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@fb790575cdb844182a860777b04b4d3d57c92197:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@fb790575cdb844182a860777b04b4d3d57c92197:packages/skills/skills/contribute-to-eliza"} -->
