### PR TITLE
fix(cloud): skip the agent-sandbox schema convergence guard on workerd

### DIFF
--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.test.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pins the workerd short-circuit for the agent-sandbox schema convergence
+ * guard (STAGING-FLOW-GREEN-2026-08-19).
+ *
+ * On workerd every pooled connection is maxUses=1 through Hyperdrive, so the
+ * guard's ~40 sequential DDL statements cannot reliably finish inside a
+ * request (or its waitUntil budget). Observed live on staging: every cold
+ * shared-agent scope hydration died with the guard's own
+ * "Failed query: ALTER TABLE agent_sandboxes ..." — keeping the scope cache
+ * permanently cold, so the first-turn warming 503 recurred on every cold
+ * conversation instead of resolving once. The guard must therefore skip on
+ * Workers unless explicitly opted in.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { shouldSkipEnsure } from "./ensure-agent-sandbox-schema";
+
+const globalRecord = globalThis as Record<string, unknown>;
+const hadWebSocketPair = Object.hasOwn(globalRecord, "WebSocketPair");
+const originalWebSocketPair = globalRecord.WebSocketPair;
+
+function enterWorkerRuntime(): void {
+  // isCloudflareWorkerRuntime() detects workerd via the WebSocketPair global.
+  globalRecord.WebSocketPair = class {};
+}
+
+function leaveWorkerRuntime(): void {
+  if (hadWebSocketPair) {
+    globalRecord.WebSocketPair = originalWebSocketPair;
+  } else {
+    delete globalRecord.WebSocketPair;
+  }
+}
+
+afterEach(() => {
+  leaveWorkerRuntime();
+  delete process.env.SKIP_AGENT_SANDBOX_ENSURE;
+  delete process.env.AGENT_SANDBOX_ENSURE_IN_WORKER;
+  delete process.env.ENVIRONMENT;
+});
+
+describe("shouldSkipEnsure", () => {
+  test("skips on workerd by default (the staging cold-scope incident class)", () => {
+    enterWorkerRuntime();
+    expect(shouldSkipEnsure()).toBe(true);
+  });
+
+  test("workerd can opt back in explicitly", () => {
+    enterWorkerRuntime();
+    process.env.AGENT_SANDBOX_ENSURE_IN_WORKER = "1";
+    expect(shouldSkipEnsure()).toBe(false);
+  });
+
+  test("non-Worker runtimes still run the convergence guard", () => {
+    expect(shouldSkipEnsure()).toBe(false);
+  });
+
+  test("explicit escape hatch still wins everywhere", () => {
+    process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+    expect(shouldSkipEnsure()).toBe(true);
+    enterWorkerRuntime();
+    expect(shouldSkipEnsure()).toBe(true);
+  });
+
+  test("local environment still skips", () => {
+    process.env.ENVIRONMENT = "local";
+    expect(shouldSkipEnsure()).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -1,5 +1,6 @@
 // Coordinates cloud DB ensure agent sandbox schema behavior shared by repositories and services.
 import { sql } from "drizzle-orm";
+import { isCloudflareWorkerRuntime } from "../lib/cache/redis-factory";
 import { getCloudAwareEnv } from "../lib/runtime/cloud-bindings";
 import { applyDatabaseUrlFallback } from "./database-url";
 import { dbWrite } from "./helpers";
@@ -558,10 +559,23 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
  *   - ENVIRONMENT === "local" (the dev script sets this), or
  *   - SKIP_AGENT_SANDBOX_ENSURE === "1" (escape hatch for tests/CI).
  */
-function shouldSkipEnsure(): boolean {
+export function shouldSkipEnsure(): boolean {
   const env = getCloudAwareEnv();
   if (env.SKIP_AGENT_SANDBOX_ENSURE === "1") return true;
   if (env.ENVIRONMENT === "local") return true;
+  // workerd: this guard issues ~40 sequential DDL/DO statements, each on a
+  // fresh maxUses=1 connection through Hyperdrive, inside whatever request
+  // (or waitUntil budget) happened to touch an agent-sandboxes repository
+  // first. It cannot reliably finish there: observed live on staging
+  // (2026-08-19) as EVERY cold shared-agent scope hydration failing with the
+  // guard's own "Failed query: ALTER TABLE agent_sandboxes ..." — which kept
+  // the scope cache permanently cold and turned the retryable first-turn
+  // warming 503 into a recurring per-conversation stall. Schema convergence
+  // belongs to environments that can run it to completion (Node daemons,
+  // deploy-time db:migrate); a Worker that needs it can opt in explicitly.
+  if (isCloudflareWorkerRuntime() && env.AGENT_SANDBOX_ENSURE_IN_WORKER !== "1") {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## What

`shouldSkipEnsure()` in `ensure-agent-sandbox-schema.ts` now short-circuits on workerd (same `WebSocketPair` detection the cache client uses), with an explicit `AGENT_SANDBOX_ENSURE_IN_WORKER=1` opt-back-in. Non-Worker runtimes (Node daemons, provisioning worker, deploy-time `db:migrate`) still run the convergence guard unchanged.

## Why (live incident, staging, 2026-08-19)

The guard issues ~40 sequential DDL/DO statements, each on a fresh `maxUses=1` connection through Hyperdrive, inside whatever Worker request (or its `waitUntil` budget) first touches an agent-sandboxes repository. On workerd it cannot reliably finish.

Observed live on `eliza-cloud-api-staging` via `wrangler tail` while probing a fresh signup -> shared agent -> first message:

```
[resolveSharedAgent] background scope hydration failed
{"agentId": "eb4bcc65-...", "error": "Failed query: \n ALTER TABLE \"agent_sandboxes\"\n ADD COLUMN IF NOT EXISTS \"pool_status\" text, ..."}
waitUntil() tasks did not complete within the allowed time after invocation end and have been cancelled.
```

Because the guard fronts `agentSandboxesRepository.findByIdAndOrg` (the scope hydration path), EVERY background scope hydration died mid-DDL:

- `CacheKeys.sharedAgentScope.resolve(...)` never got written (verified empty in the staging `CACHE_KV` namespace across repeated turns),
- so every cold conversation re-paid 1-2 user-visible retryable `shared_runtime_cache_warming` / `agent_cache_warming` 503s instead of warming once,
- and the provision-time prewarm (#18951 / CHAT-CORE-LATENCY item 1) was silently defeated on staging.

The DDL itself is fine when run to completion: the same statement batch completes in ~300ms over one psql connection, and the staging DB already has all 37 columns + both tables + system rows the guard would converge.

The guard's own doc comment already names this failure class for local PGlite ("issues ~15 sequential ALTER/CREATE statements per request, each opening a fresh TCP connection (maxUses: 1)"); this extends the same reasoning to workerd where it was observed breaking a production-shaped path.

## Ops note

Staging is currently healthy because `SKIP_AGENT_SANDBOX_ENSURE=1` was set as a Worker secret during the incident (2026-08-19, reversible). This change makes that behavior the code default for Workers so prod and future environments don't need hand-set secrets.

## Test proof (bidirectional)

`ensure-agent-sandbox-schema.test.ts` pins:
- workerd default => skip (FAILS against the unpatched guard, passes with the gate),
- `AGENT_SANDBOX_ENSURE_IN_WORKER=1` => runs,
- non-Worker => runs (unchanged),
- `SKIP_AGENT_SANDBOX_ENSURE=1` and `ENVIRONMENT=local` => skip (unchanged).

5/5 pass on the patched tree; the workerd-default case verified red against the original source.

Receipt: STAGING-FLOW-GREEN-2026-08-19 (fleet ops log).
