### PR TITLE
fix(agent): bound raw audio-redaction transcript size

### DIFF
--- a/packages/agent/src/services/audio-redaction-word-budget.test.ts
+++ b/packages/agent/src/services/audio-redaction-word-budget.test.ts
@@ -8,11 +8,13 @@ import { describe, expect, it } from "bun:test";
 import {
   AudioRedactionWordBudgetError,
   assertAudioRedactionInputBudget,
+  assertAudioRedactionWordBudget,
   MAX_AUDIO_REDACTION_MATCH_CANDIDATES,
   MAX_AUDIO_REDACTION_NORMALIZED_CHARS,
   MAX_AUDIO_REDACTION_PII_NORMALIZED_CHARS,
   MAX_AUDIO_REDACTION_PII_SPAN_CHARS,
   MAX_AUDIO_REDACTION_PII_SPANS,
+  MAX_AUDIO_REDACTION_RAW_CHARS,
   MAX_AUDIO_REDACTION_WORD_CHARS,
   MAX_AUDIO_REDACTION_WORDS,
   selectAudioRedactionSentinels,
@@ -145,6 +147,39 @@ describe("selectAudioRedactionSentinels", () => {
     );
     expect(() => selectAudioRedactionSentinels(words, [])).toThrow(
       /normalized timed-word stream exceeds/,
+    );
+  });
+
+  it("fails closed on aggregate raw punctuation before normalization", () => {
+    const words = Array.from(
+      {
+        length:
+          Math.floor(
+            MAX_AUDIO_REDACTION_RAW_CHARS / MAX_AUDIO_REDACTION_WORD_CHARS,
+          ) + 1,
+      },
+      (_, index) => ({
+        text: "!".repeat(MAX_AUDIO_REDACTION_WORD_CHARS),
+        startMs: index,
+        endMs: index + 1,
+      }),
+    );
+    try {
+      assertAudioRedactionWordBudget(words);
+      throw new Error("expected AUDIO_REDACTION_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AudioRedactionWordBudgetError);
+      expect((error as AudioRedactionWordBudgetError).code).toBe(
+        "AUDIO_REDACTION_UNBOUNDED",
+      );
+      expect((error as Error).message).toMatch(/raw timed-word stream exceeds/);
+      expect((error as AudioRedactionWordBudgetError).context).toEqual({
+        rawChars: words.length * MAX_AUDIO_REDACTION_WORD_CHARS,
+        maxRawChars: MAX_AUDIO_REDACTION_RAW_CHARS,
+      });
+    }
+    expect(() => assertAudioRedactionInputBudget(words, [])).toThrow(
+      /raw timed-word stream exceeds/,
     );
   });
 

--- a/packages/agent/src/services/audio-redaction-word-budget.ts
+++ b/packages/agent/src/services/audio-redaction-word-budget.ts
@@ -9,6 +9,7 @@
 
 export const MAX_AUDIO_REDACTION_WORDS = 100_000;
 export const MAX_AUDIO_REDACTION_WORD_CHARS = 4_096;
+export const MAX_AUDIO_REDACTION_RAW_CHARS = 4_194_304;
 export const MAX_AUDIO_REDACTION_NORMALIZED_CHARS = 1_000_000;
 export const MAX_AUDIO_REDACTION_PII_SPANS = 1_024;
 export const MAX_AUDIO_REDACTION_PII_SPAN_CHARS = 4_096;
@@ -69,6 +70,7 @@ function normalizedWordCharsWithinBudget(
       },
     );
   }
+  let rawChars = 0;
   let normalizedChars = 0;
   for (const word of words) {
     if (word.text.length > MAX_AUDIO_REDACTION_WORD_CHARS) {
@@ -78,6 +80,17 @@ function normalizedWordCharsWithinBudget(
         {
           wordChars: word.text.length,
           maxWordChars: MAX_AUDIO_REDACTION_WORD_CHARS,
+        },
+      );
+    }
+    rawChars += word.text.length;
+    if (rawChars > MAX_AUDIO_REDACTION_RAW_CHARS) {
+      throw new AudioRedactionWordBudgetError(
+        `audio redaction raw timed-word stream exceeds ${MAX_AUDIO_REDACTION_RAW_CHARS} characters`,
+        "AUDIO_REDACTION_UNBOUNDED",
+        {
+          rawChars,
+          maxRawChars: MAX_AUDIO_REDACTION_RAW_CHARS,
         },
       );
     }


### PR DESCRIPTION
Closes #22569.

The normalized-character budget did not bound punctuation-only or other characters removed during normalization, allowing up to roughly 409 million raw characters to be traversed first. This adds a 4 Mi-character aggregate raw timed-word cap before normalization while preserving the existing word-count, per-word, normalized-text, PII, and occurrence budgets.

## Validation

- pinned Bun 1.3.14
- focused adversarial suite: 11/11 passed, 100% helper coverage
- standalone strict TypeScript compile passed
- Biome: two changed files clean
- `git diff --check` clean
- package typecheck was attempted; the isolated sparse checkout lacked private/workspace dependency artifacts, with no changed-file diagnostic

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@fb5818d5406e9bd2fe9d2cbb8311df00ec1e60ae:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- {"ai_provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@fb5818d5406e9bd2fe9d2cbb8311df00ec1e60ae:packages/skills/skills/contribute-to-eliza","attribution":"self-reported"} -->
