### PR TITLE
test(cloud): install Stripe authority in auto-top-up fixture

### DIFF
--- a/packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts
@@ -45,21 +45,63 @@ async function insertOrganization(input: {
   customerId?: string | null;
   paymentMethodId?: string | null;
 }): Promise<void> {
+  const customerId =
+    input.customerId === undefined ? `cus_${input.id.slice(-1)}` : input.customerId;
   await dbWrite.execute(sql`
     INSERT INTO organizations (
-      id, name, slug, credit_balance, settings, stripe_customer_id,
+      id, name, slug, credit_balance, settings,
       stripe_default_payment_method, auto_top_up_enabled,
       auto_top_up_threshold, auto_top_up_amount, is_active, updated_at
     ) VALUES (
       ${input.id}, ${`Org ${input.id.slice(-1)}`}, ${`org-${input.id.slice(-1)}`},
       ${input.balance ?? "1.000000"}::numeric, '{}'::jsonb,
-      ${input.customerId === undefined ? `cus_${input.id.slice(-1)}` : input.customerId},
       ${input.paymentMethodId === undefined ? `pm_${input.id.slice(-1)}` : input.paymentMethodId},
       ${input.enabled ?? true},
       ${input.threshold === undefined ? "5.00" : input.threshold}::numeric,
       ${input.amount === undefined ? "10.00" : input.amount}::numeric,
       ${input.active ?? true}, ${at(0)}
     )
+  `);
+  if (customerId === null) return;
+
+  const authorityAttemptId = randomUUID();
+  const requestDigest = "a".repeat(64);
+  await dbWrite.execute(sql`
+    INSERT INTO stripe_customer_attempts (
+      id, organization_id, generation, request_digest, caller_intent, idempotency_key
+    ) VALUES (
+      ${authorityAttemptId}, ${input.id}, 1, ${requestDigest}, 'auto_top_up',
+      ${`eliza-customer-attempt:${authorityAttemptId}`}
+    )
+  `);
+  await dbWrite.execute(sql`
+    UPDATE stripe_customer_attempts
+    SET status = 'provider_started', provider_started_at = ${at(0)}
+    WHERE id = ${authorityAttemptId}
+  `);
+  const receipt = {
+    binding_kind: "attempt_created",
+    created: 1_700_000_000,
+    customer_id: customerId,
+    livemode: false,
+    metadata: {
+      organization_id: input.id,
+      eliza_organization_id: input.id,
+      eliza_customer_attempt_id: authorityAttemptId,
+      eliza_customer_generation: "1",
+      eliza_customer_request_digest: requestDigest,
+      eliza_customer_provider: "stripe",
+    },
+  };
+  await dbWrite.execute(sql`
+    UPDATE stripe_customer_attempts
+    SET status = 'bound', provider_customer_id = ${customerId},
+        provider_receipt = ${JSON.stringify(receipt)}::jsonb,
+        provider_livemode = false, bound_at = ${at(0)}
+    WHERE id = ${authorityAttemptId}
+  `);
+  await dbWrite.execute(sql`
+    UPDATE organizations SET stripe_customer_id = ${customerId} WHERE id = ${input.id}
   `);
 }
 
@@ -185,6 +227,8 @@ beforeAll(async () => {
       id uuid PRIMARY KEY,
       organization_id uuid REFERENCES organizations(id) ON DELETE CASCADE
     );
+    CREATE UNIQUE INDEX organizations_stripe_customer_authority_unique
+      ON organizations(stripe_customer_id) WHERE stripe_customer_id IS NOT NULL;
   `);
   const migrations = await Promise.all([
     readFile(
@@ -206,6 +250,13 @@ beforeAll(async () => {
     ),
   ]);
   await getPgliteClientForTests().exec(migrations.join("\n"));
+  const customerAuthorityMigration = await readFile(
+    new URL("../migrations/0267_stripe_customer_attempts.sql", import.meta.url),
+    "utf8",
+  );
+  for (const statement of customerAuthorityMigration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await getPgliteClientForTests().exec(statement);
+  }
 }, TIMEOUT);
 
 beforeEach(async () => {
@@ -213,10 +264,20 @@ beforeEach(async () => {
     UPDATE auto_top_up_control
     SET mode = 'durable', legacy_reconciled_through = paused_at
     WHERE singleton = true;
+    ALTER TABLE stripe_customer_attempts
+      DISABLE TRIGGER stripe_customer_attempt_delete_guard;
+    ALTER TABLE stripe_customer_legacy_quarantines
+      DISABLE TRIGGER stripe_customer_legacy_quarantine_delete_guard;
     DELETE FROM auto_top_up_attempts;
     DELETE FROM auto_top_up_legacy_payment_quarantine;
+    DELETE FROM stripe_customer_legacy_quarantines;
+    DELETE FROM stripe_customer_attempts;
     DELETE FROM credit_transactions;
     DELETE FROM organizations;
+    ALTER TABLE stripe_customer_attempts
+      ENABLE TRIGGER stripe_customer_attempt_delete_guard;
+    ALTER TABLE stripe_customer_legacy_quarantines
+      ENABLE TRIGGER stripe_customer_legacy_quarantine_delete_guard;
     UPDATE auto_top_up_control
     SET mode = 'paused', paused_at = '${at(0).toISOString()}',
         legacy_reconciled_through = NULL, updated_at = '${at(0).toISOString()}'
@@ -278,6 +339,38 @@ describe("AutoTopUpAttemptsRepository", () => {
     expect(lockedQuarantine).toBeLessThan(lockedCredit);
     expect(resolve.slice(resolveOrganization, lockedQuarantine)).toContain('.for("update")');
     expect(resolve.slice(lockedQuarantine, lockedCredit)).toContain('.for("update")');
+  });
+
+  test("uses 0267 receipt authority instead of trusting the organization customer alone", async () => {
+    await insertOrganization({ id: ORG_A });
+    expect(
+      await scalar<{ authoritative: boolean }>(sql`
+        SELECT stripe_customer_binding_is_authoritative(${ORG_A}, 'cus_1') AS authoritative
+      `),
+    ).toEqual({ authoritative: true });
+
+    // Corrupt only the test fixture through a privileged bypass, then restore
+    // the immutable-authority guard before exercising the production function.
+    await getPgliteClientForTests().exec(
+      "ALTER TABLE stripe_customer_attempts DISABLE TRIGGER stripe_customer_attempt_authority_guard",
+    );
+    await dbWrite.execute(sql`
+      UPDATE stripe_customer_attempts
+      SET provider_receipt = jsonb_set(
+        provider_receipt,
+        '{metadata,organization_id}',
+        to_jsonb(${ORG_B}::text)
+      )
+      WHERE organization_id = ${ORG_A}
+    `);
+    await getPgliteClientForTests().exec(
+      "ALTER TABLE stripe_customer_attempts ENABLE TRIGGER stripe_customer_attempt_authority_guard",
+    );
+    expect(
+      await scalar<{ authoritative: boolean }>(sql`
+        SELECT stripe_customer_binding_is_authoritative(${ORG_A}, 'cus_1') AS authoritative
+      `),
+    ).toEqual({ authoritative: false });
   });
 
   test("starts from an explicit control state and paused mode blocks only new claims", async () => {
@@ -950,11 +1043,20 @@ describe("AutoTopUpAttemptsRepository", () => {
     );
     expect(count.count).toBe("1");
 
+    // Model out-of-band publication drift without weakening the real 0267
+    // guard for the rest of the suite. The replay must retain its persisted
+    // provider snapshot even if a privileged repair changes the organization.
+    await getPgliteClientForTests().exec(
+      "ALTER TABLE organizations DISABLE TRIGGER organization_stripe_customer_publication_guard",
+    );
     await dbWrite.execute(sql`
       UPDATE organizations
       SET auto_top_up_amount = 20, stripe_customer_id = 'cus_changed'
       WHERE id = ${ORG_A}
     `);
+    await getPgliteClientForTests().exec(
+      "ALTER TABLE organizations ENABLE TRIGGER organization_stripe_customer_publication_guard",
+    );
     const replay = await repository.claimEligibleAttempt({
       organizationId: ORG_A,
       triggerSource: "manual",


### PR DESCRIPTION
# Relates to

Closes #22559.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run; the exact local dependency/disk blocker is recorded below.
- [x] A reviewer can confirm the changed fixture behavior from the exact-head PGlite output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@68e82f702d44c97ec6f661035646de30b34b6efb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `e7910664110a2c2559988490933ae6314a6849d1`; zero conflicts.
- [ ] `bun run verify` was not run; see **Known gaps / failures**.

# Risks

Low. The production repository and migration are unchanged. This only aligns one isolated PGlite fixture with the existing 0267 Stripe customer authority contract. The main risk is future fixture drift, covered by an assertion that the real authority function rejects a receipt whose organization binding was corrupted.

# Background

## What does this PR do?

The auto-top-up repository fixture previously applied migrations 0213-0217 even though the repository now invokes `stripe_customer_binding_is_authoritative(uuid,text)`, introduced by migration 0267. That schema drift made all 18 relevant CI cases fail with PostgreSQL `42883` before their intended assertions.

This PR applies the exact 0267 migration SQL using its canonical statement breakpoints, creates organizations through the real 0267 attempt/receipt/publication authority path, and cleans the immutable attempt tables in a trigger-bounded per-test reset. It does not introduce a fake function or loosen production behavior.

## What kind of change is this?

Bug fix to a deterministic test fixture.

# Documentation changes needed?

No. The product and public contracts are unchanged.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts`

## Detailed testing steps

At exact head `812531e55e667b420193195905b6f6b055b294d4`:

```text
bun test ../../packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts --timeout 120000 --isolate
26 pass
0 fail
252 expect() calls

Cloud unit batch 2/18 (80 files, same runner partition as failed CI job 96182541649)
521 pass
0 fail
Ran 522 tests across 80 files (one skipped)

bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts
Checked 1 file. No fixes applied.

git diff --check origin/develop...HEAD
clean
```

# Evidence Gate

<!-- evidence-head:812531e55e667b420193195905b6f6b055b294d4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic backend-only PGlite fixture; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic backend-only PGlite fixture; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic backend-only PGlite fixture; no interactive flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic PGlite test fixture only; exact-head repository and owning Cloud batch output is inline under Testing.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no production data artifact is mutated; the exact 0267-backed PGlite assertions and results are inline under Testing.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

The exact-head deterministic backend results are inline under **Testing**. Frontend logs are N/A because no frontend code or route is affected.

## Screenshots (before / after) + video walkthrough

N/A - backend-only test fixture.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- `bun run --cwd packages/cloud/shared typecheck` was attempted and reported 128 errors across 54 unrelated files because this disk-constrained isolated worktree intentionally reused the existing Bun cache instead of installing. Errors were missing ambient declarations/dependencies (`pg`, `gray-matter`, MCP SDK, `ajv`, `exceljs`, provider packages) plus existing AI SDK version incompatibilities; it reported no error in the touched test file.
- `bun install` and root `bun run verify` were not run because the host was under critical disk pressure and the task explicitly prohibited installation/broad tests. The exact repository suite, original failing Cloud batch, Biome, and diff check all pass on the PR head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@68e82f702d44c97ec6f661035646de30b34b6efb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-auto-top-up-authority-fixture]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@68e82f702d44c97ec6f661035646de30b34b6efb:packages/skills/skills/contribute-to-eliza"} -->