### PR TITLE
fix(agent): preserve JsonValue contract in delayed rewards

### DIFF
--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -906,6 +906,51 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
     ).toBe(true);
   });
 
+  it("rejects malformed persisted delayed-reward components", async () => {
+    const { runtime, execute } = makeRuntime();
+    const persistedAt = Date.now();
+    execute.mockImplementation(async (query: unknown) => {
+      const text = sqlText(query);
+      if (
+        text.includes("SELECT * FROM trajectories") &&
+        text.includes("agent-reward-corrupt")
+      ) {
+        return [
+          {
+            id: "agent-reward-corrupt",
+            agent_id: runtime.agentId,
+            source: "morning-brief",
+            status: "completed",
+            start_time: persistedAt,
+            end_time: persistedAt + 1,
+            duration_ms: 1,
+            steps_json: "[]",
+            metadata_json: "{}",
+            metrics_json: '{"episodeLength":0,"finalStatus":"completed"}',
+            reward_components_json:
+              '{"environmentReward":0,"components":"corrupt"}',
+            total_reward: 0,
+            created_at: new Date(persistedAt).toISOString(),
+            updated_at: new Date(persistedAt + 1).toISOString(),
+          },
+        ];
+      }
+      return [];
+    });
+    const standalone = new DatabaseTrajectoryLogger(runtime);
+    standalone.setEnabled(true);
+
+    await expect(
+      standalone.applyReward({
+        trajectoryId: "agent-reward-corrupt",
+        idempotencyKey: "brief-engagement:event-corrupt",
+        reward: 0.75,
+        component: "briefEngagementReward",
+      }),
+    ).rejects.toMatchObject({ code: "TRAJECTORY_CAPTURE_INVALID" });
+    expect(trajectoryParentWriteSql(execute)).toEqual([]);
+  });
+
   it("keeps canonical metrics valid across provider/LLM appends and completion", async () => {
     const { runtime, logger, execute } = makeRuntime();
     await installDatabaseTrajectoryLogger(runtime);

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -2618,8 +2618,11 @@ export class DatabaseTrajectoryLogger extends Service {
           params.idempotencyKey,
         ];
         trajectory.totalReward += params.reward;
+        const componentValues = trajectory.rewardComponents.components;
         const components =
-          asRecord(trajectory.rewardComponents.components) ?? {};
+          componentValues === undefined
+            ? {}
+            : normalizeJsonRecord(componentValues, "rewardComponents");
         const current = components[params.component];
         trajectory.rewardComponents = {
           ...trajectory.rewardComponents,


### PR DESCRIPTION
## Relates to

Closes #22566.

## What does this PR do?

Repairs the cross-package JSON contract broken by merged PR #22530. Delayed reward settlement previously widened persisted `components` through `asRecord(...)` to `Record<string, unknown>`, which could not be assigned to the JSON-typed reward record and blocked `packages/app-core` typecheck.

The repair validates the nested persisted value through the existing trajectory JSON boundary before rebuilding reward components. Missing components remain an empty map; malformed present data now fails fast with the existing typed `TRAJECTORY_CAPTURE_INVALID` error instead of being silently replaced.

## Exact-head testing

Verified at `599e53f02b4884fa9d2186101a929366cb332253`:

- trajectory bridge Vitest: 29\/29 passed; rebased production\/test blobs are identical
- `bun run --cwd packages/agent typecheck`: passed
- `bun run --cwd packages/app-core typecheck`: passed
- Biome on both changed files: passed
- `git diff --check`: passed
- regression proves malformed persisted components reject without issuing an UPDATE

The root gate’s prior `trajectory-storage.ts:2626` failure is eliminated. The independent formatting-only root blocker from #22517 is handled by #22564.

## Evidence Gate

<!-- evidence-head:599e53f02b4884fa9d2186101a929366cb332253 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — exact trajectory test and cross-package typecheck evidence is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — deterministic persistence SQL assertions verify that corrupted input emits no update.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface changed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->