### PR TITLE
fix(agent-orchestrator): guard ACP stdin lifecycle

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.write-after-close.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.write-after-close.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression: write-after-close on the agent stdin pipe must not crash the
+ * host runtime.
+ *
+ * Live failure (sol-dev 2026-08-19, backend-hot.log line 600383): sub-agent
+ * teardown called `closeSession` after the agent subprocess had already gone
+ * away; the JSON-RPC write hit a broken pipe and the resulting EPIPE became an
+ * uncaught exception that killed the entire eliza runtime ("Uncaught
+ * exception: Error: write EPIPE ... acp-native-transport.ts:318 closeSession
+ * <- acp-service.ts stopNativeClient"), 5 crashes in 24h, dropping a live
+ * user turn mid-compose.
+ *
+ * The fix: all writes to the agent stdin go through a guard that checks
+ * destroyed/ended state and swallows synchronous throws, plus a stdin 'error'
+ * listener that absorbs the asynchronous EPIPE emission. These tests fail
+ * against the unguarded transport (bare `proc.stdin.write`, no 'error'
+ * listener) and pass with the guard.
+ */
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NativeAcpClient } from "../../src/services/acp-native-transport.js";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+type MockProc = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: Writable;
+  stdinWrites: string[];
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+  pid?: number;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+};
+
+const spawnMock = vi.mocked(spawn);
+
+function proc(): MockProc {
+  const p = new EventEmitter() as MockProc;
+  p.stdout = new EventEmitter();
+  p.stderr = new EventEmitter();
+  p.stdinWrites = [];
+  p.stdin = new Writable({
+    write(chunk, _enc, cb) {
+      p.stdinWrites.push(chunk.toString());
+      cb();
+    },
+  });
+  p.killed = false;
+  p.kill = vi.fn((signal?: NodeJS.Signals) => {
+    p.killed = true;
+    p.signalCode = signal ?? null;
+    return true;
+  });
+  p.pid = Math.floor(Math.random() * 10_000) + 1_000;
+  p.exitCode = null;
+  p.signalCode = null;
+  return p;
+}
+
+function queueProc(p = proc()): MockProc {
+  spawnMock.mockImplementationOnce(() => p as never);
+  return p;
+}
+
+async function waitForWrites(p: MockProc, count: number): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1_000) {
+    if (p.stdinWrites.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`expected ${count} stdin writes, got ${p.stdinWrites.length}`);
+}
+
+function emitJson(p: MockProc, message: Record<string, unknown>): void {
+  p.stdout.emit("data", Buffer.from(`${JSON.stringify(message)}\n`));
+}
+
+async function startClient(): Promise<{ client: NativeAcpClient; p: MockProc }> {
+  const p = queueProc();
+  const client = new NativeAcpClient({
+    command: "agent-acp",
+    cwd: "/tmp/native-acp",
+    approvalPreset: "autonomous",
+  });
+  const started = client.start();
+  await waitForWrites(p, 1);
+  emitJson(p, { jsonrpc: "2.0", id: 1, result: {} });
+  await started;
+  return { client, p };
+}
+
+/** Replace the mock stdin with one whose write throws EPIPE synchronously. */
+function breakStdinSync(p: MockProc): void {
+  const err = Object.assign(new Error("write EPIPE"), {
+    code: "EPIPE",
+    errno: -32,
+    syscall: "write",
+  });
+  p.stdin.write = (() => {
+    throw err;
+  }) as never;
+}
+
+describe("NativeAcpClient write-after-close (EPIPE crash regression)", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("closeSession after the agent pipe breaks does not throw (teardown race)", async () => {
+    const { client, p } = await startClient();
+    breakStdinSync(p);
+    // Before the guard: proc.stdin.write threw EPIPE synchronously out of
+    // request(), escaping closeSession's .catch on the returned promise and
+    // crashing the caller. Now it must resolve (best-effort teardown).
+    await expect(client.closeSession("s-1")).resolves.toBeUndefined();
+  });
+
+  it("closeSession after stdin is destroyed does not throw and does not write", async () => {
+    const { client, p } = await startClient();
+    p.stdin.destroy();
+    const writesBefore = p.stdinWrites.length;
+    await expect(client.closeSession("s-1")).resolves.toBeUndefined();
+    expect(p.stdinWrites.length).toBe(writesBefore);
+  });
+
+  it("an asynchronous stdin 'error' (EPIPE) is absorbed, not uncaught", async () => {
+    const { p } = await startClient();
+    const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    // Without a listener, EventEmitter turns 'error' into a throw — which is
+    // exactly the uncaught exception that killed the runtime. The transport
+    // must install a listener in start().
+    expect(p.stdin.listenerCount("error")).toBeGreaterThan(0);
+    expect(() => p.stdin.emit("error", err)).not.toThrow();
+  });
+
+  it("request over a broken pipe rejects with a transport-closed error instead of crashing", async () => {
+    const { client, p } = await startClient();
+    breakStdinSync(p);
+    await expect(
+      (
+        client as unknown as {
+          request(method: string, params: unknown): Promise<unknown>;
+        }
+      ).request("session/prompt", { sessionId: "s-1" }),
+    ).rejects.toThrow(/transport closed/i);
+  });
+
+  it("notify over a destroyed pipe resolves silently (cancel during teardown)", async () => {
+    const { client, p } = await startClient();
+    p.stdin.destroy();
+    await expect(client.cancel("s-1")).resolves.toBeUndefined();
+  });
+
+  it("normal request path is unchanged by the guard", async () => {
+    const { client, p } = await startClient();
+    const pending = (
+      client as unknown as {
+        request(method: string, params: unknown): Promise<unknown>;
+      }
+    ).request("session/new", { cwd: "/tmp" });
+    await waitForWrites(p, 2);
+    const written = JSON.parse(p.stdinWrites[1] ?? "{}") as {
+      id: number;
+      method: string;
+    };
+    expect(written.method).toBe("session/new");
+    emitJson(p, { jsonrpc: "2.0", id: written.id, result: { sessionId: "s-9" } });
+    await expect(pending).resolves.toEqual({ sessionId: "s-9" });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.write-after-close.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.write-after-close.test.ts
@@ -1,20 +1,7 @@
 /**
- * Regression: write-after-close on the agent stdin pipe must not crash the
- * host runtime.
- *
- * Live failure (sol-dev 2026-08-19, backend-hot.log line 600383): sub-agent
- * teardown called `closeSession` after the agent subprocess had already gone
- * away; the JSON-RPC write hit a broken pipe and the resulting EPIPE became an
- * uncaught exception that killed the entire eliza runtime ("Uncaught
- * exception: Error: write EPIPE ... acp-native-transport.ts:318 closeSession
- * <- acp-service.ts stopNativeClient"), 5 crashes in 24h, dropping a live
- * user turn mid-compose.
- *
- * The fix: all writes to the agent stdin go through a guard that checks
- * destroyed/ended state and swallows synchronous throws, plus a stdin 'error'
- * listener that absorbs the asynchronous EPIPE emission. These tests fail
- * against the unguarded transport (bare `proc.stdin.write`, no 'error'
- * listener) and pass with the guard.
+ * Deterministic regression coverage for ACP subprocess stdin failures. The
+ * mocked transport exercises write-state guards, synchronous and asynchronous
+ * EPIPE delivery, pending-request settlement, and successful JSON-RPC traffic.
  */
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
@@ -75,19 +62,24 @@ async function waitForWrites(p: MockProc, count: number): Promise<void> {
     if (p.stdinWrites.length >= count) return;
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
-  throw new Error(`expected ${count} stdin writes, got ${p.stdinWrites.length}`);
+  throw new Error(
+    `expected ${count} stdin writes, got ${p.stdinWrites.length}`,
+  );
 }
 
 function emitJson(p: MockProc, message: Record<string, unknown>): void {
   p.stdout.emit("data", Buffer.from(`${JSON.stringify(message)}\n`));
 }
 
-async function startClient(): Promise<{ client: NativeAcpClient; p: MockProc }> {
+async function startClient(opts?: {
+  onEvent?: (event: Record<string, unknown>) => void;
+}): Promise<{ client: NativeAcpClient; p: MockProc }> {
   const p = queueProc();
   const client = new NativeAcpClient({
     command: "agent-acp",
     cwd: "/tmp/native-acp",
     approvalPreset: "autonomous",
+    onEvent: opts?.onEvent,
   });
   const started = client.start();
   await waitForWrites(p, 1);
@@ -133,14 +125,58 @@ describe("NativeAcpClient write-after-close (EPIPE crash regression)", () => {
     expect(p.stdinWrites.length).toBe(writesBefore);
   });
 
-  it("an asynchronous stdin 'error' (EPIPE) is absorbed, not uncaught", async () => {
-    const { p } = await startClient();
+  it.each([
+    ["destroyed", "destroyed"],
+    ["ended", "writableEnded"],
+    ["non-writable", "writable"],
+  ] as const)(
+    "rejects promptly for a %s stream without calling write",
+    async (_label, property) => {
+      const events: Record<string, unknown>[] = [];
+      const { client, p } = await startClient({
+        onEvent: (event) => events.push(event),
+      });
+      events.length = 0;
+      const write = vi.spyOn(p.stdin, "write");
+      Object.defineProperty(p.stdin, property, {
+        configurable: true,
+        value: property !== "writable",
+      });
+
+      const startedAt = Date.now();
+      await expect(
+        (
+          client as unknown as {
+            request(method: string, params: unknown): Promise<unknown>;
+          }
+        ).request("session/prompt", { sessionId: "s-1" }),
+      ).rejects.toThrow(/transport/i);
+
+      expect(Date.now() - startedAt).toBeLessThan(250);
+      expect(write).not.toHaveBeenCalled();
+      expect(events).toEqual([]);
+    },
+  );
+
+  it("an asynchronous stdin EPIPE rejects pending work and closes the transport", async () => {
+    const { client, p } = await startClient();
+    const pending = (
+      client as unknown as {
+        request(method: string, params: unknown): Promise<unknown>;
+      }
+    ).request("session/prompt", { sessionId: "s-1" });
+    await waitForWrites(p, 2);
     const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
-    // Without a listener, EventEmitter turns 'error' into a throw — which is
-    // exactly the uncaught exception that killed the runtime. The transport
-    // must install a listener in start().
     expect(p.stdin.listenerCount("error")).toBeGreaterThan(0);
     expect(() => p.stdin.emit("error", err)).not.toThrow();
+    await expect(pending).rejects.toThrow(/stdin failed.*EPIPE/i);
+    expect(() =>
+      (
+        client as unknown as {
+          request(method: string, params: unknown): Promise<unknown>;
+        }
+      ).request("session/new", { cwd: "/tmp" }),
+    ).toThrow(/client is closed/i);
   });
 
   it("request over a broken pipe rejects with a transport-closed error instead of crashing", async () => {
@@ -152,7 +188,7 @@ describe("NativeAcpClient write-after-close (EPIPE crash regression)", () => {
           request(method: string, params: unknown): Promise<unknown>;
         }
       ).request("session/prompt", { sessionId: "s-1" }),
-    ).rejects.toThrow(/transport closed/i);
+    ).rejects.toThrow(/transport (?:closed|stdin failed)/i);
   });
 
   it("notify over a destroyed pipe resolves silently (cancel during teardown)", async () => {
@@ -174,7 +210,11 @@ describe("NativeAcpClient write-after-close (EPIPE crash regression)", () => {
       method: string;
     };
     expect(written.method).toBe("session/new");
-    emitJson(p, { jsonrpc: "2.0", id: written.id, result: { sessionId: "s-9" } });
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: written.id,
+      result: { sessionId: "s-9" },
+    });
     await expect(pending).resolves.toEqual({ sessionId: "s-9" });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -192,6 +192,19 @@ export class NativeAcpClient {
     this.proc = proc;
 
     proc.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
+    // A write into a pipe whose read end is gone surfaces asynchronously as an
+    // 'error' event on stdin (EPIPE). Without a listener that event becomes an
+    // uncaught exception that kills the whole runtime — observed live as a
+    // crash loop when sub-agent teardown (`closeSession`) raced the agent
+    // process exiting. Teardown-path writes are best-effort; swallow.
+    proc.stdin.on("error", (err: NodeJS.ErrnoException) => {
+      // error-policy:J6 best-effort teardown — a broken agent stdin pipe means
+      // the agent is gone; pending requests are rejected via the process
+      // 'close'/'error' handlers, so nothing is silently lost here.
+      this.emitStderr(
+        `[acp-native-transport] agent stdin error (${err?.code ?? errorMessage(err)}); dropping write\n`,
+      );
+    });
     proc.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
       this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-16_384);
@@ -366,10 +379,14 @@ export class NativeAcpClient {
   ): Promise<unknown> {
     if (this.closed) throw new Error("ACP client is closed");
     const id = this.nextId++;
-    const proc = this.requireProcess();
+    this.requireProcess();
     const payload = { jsonrpc: "2.0", id, method, params };
     this.emitEvent({ ...payload, params: emittedParams } as AcpJsonRpcMessage);
-    proc.stdin.write(`${JSON.stringify(payload)}\n`);
+    if (!this.writeToAgent(payload)) {
+      return Promise.reject(
+        new Error(`ACP transport closed; cannot send ${method}`),
+      );
+    }
     return new Promise((resolve, reject) => {
       const timer =
         timeoutMs > 0
@@ -384,10 +401,46 @@ export class NativeAcpClient {
   }
 
   private async notify(method: string, params: unknown): Promise<void> {
-    const proc = this.requireProcess();
+    this.requireProcess();
     const payload = { jsonrpc: "2.0", method, params };
     this.emitEvent(payload as AcpJsonRpcMessage);
-    proc.stdin.write(`${JSON.stringify(payload)}\n`);
+    this.writeToAgent(payload);
+  }
+
+  /**
+   * Guarded write to the agent subprocess stdin. Returns false (instead of
+   * throwing / crashing the process) when the pipe is already closed,
+   * destroyed, or errors synchronously — the write-after-close case during
+   * sub-agent teardown, where `closeSession` can race the agent exiting.
+   * Async pipe errors (EPIPE) are absorbed by the stdin 'error' listener
+   * installed in `start()`.
+   */
+  private writeToAgent(payload: unknown): boolean {
+    const stdin = this.proc?.stdin;
+    if (!stdin || stdin.destroyed || stdin.writableEnded || !stdin.writable) {
+      return false;
+    }
+    try {
+      stdin.write(`${JSON.stringify(payload)}\n`);
+      return true;
+    } catch (err) {
+      // error-policy:J6 best-effort teardown — a synchronous EPIPE/ERR_STREAM
+      // throw here means the agent already went away; callers treat a false
+      // return as "transport closed" rather than crashing the runtime.
+      this.emitStderr(
+        `[acp-native-transport] agent stdin write failed (${errorMessage(err)}); dropping write\n`,
+      );
+      return false;
+    }
+  }
+
+  /** Route transport diagnostics through the onStderr observer, best-effort. */
+  private emitStderr(text: string): void {
+    try {
+      this.opts.onStderr?.(text);
+    } catch {
+      // error-policy:J7 diagnostics-must-not-kill-the-loop
+    }
   }
 
   /**
@@ -658,9 +711,8 @@ export class NativeAcpClient {
   }
 
   private respond(id: JsonRpcId, result: unknown): void {
-    this.requireProcess().stdin.write(
-      `${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`,
-    );
+    this.requireProcess();
+    this.writeToAgent({ jsonrpc: "2.0", id, result });
   }
 
   private respondError(
@@ -668,13 +720,12 @@ export class NativeAcpClient {
     err: unknown,
     code = JSONRPC_INTERNAL_ERROR,
   ): void {
-    this.requireProcess().stdin.write(
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id,
-        error: { code, message: errorMessage(err) },
-      })}\n`,
-    );
+    this.requireProcess();
+    this.writeToAgent({
+      jsonrpc: "2.0",
+      id,
+      error: { code, message: errorMessage(err) },
+    });
   }
 
   private rejectAll(err: unknown): void {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -192,18 +192,10 @@ export class NativeAcpClient {
     this.proc = proc;
 
     proc.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
-    // A write into a pipe whose read end is gone surfaces asynchronously as an
-    // 'error' event on stdin (EPIPE). Without a listener that event becomes an
-    // uncaught exception that kills the whole runtime — observed live as a
-    // crash loop when sub-agent teardown (`closeSession`) raced the agent
-    // process exiting. Teardown-path writes are best-effort; swallow.
+    // A broken child pipe can report EPIPE asynchronously. Treat stdin failure
+    // as terminal because the client can no longer deliver JSON-RPC requests.
     proc.stdin.on("error", (err: NodeJS.ErrnoException) => {
-      // error-policy:J6 best-effort teardown — a broken agent stdin pipe means
-      // the agent is gone; pending requests are rejected via the process
-      // 'close'/'error' handlers, so nothing is silently lost here.
-      this.emitStderr(
-        `[acp-native-transport] agent stdin error (${err?.code ?? errorMessage(err)}); dropping write\n`,
-      );
+      this.failStdin(err);
     });
     proc.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
@@ -378,15 +370,9 @@ export class NativeAcpClient {
     emittedParams: unknown = params,
   ): Promise<unknown> {
     if (this.closed) throw new Error("ACP client is closed");
-    const id = this.nextId++;
     this.requireProcess();
+    const id = this.nextId++;
     const payload = { jsonrpc: "2.0", id, method, params };
-    this.emitEvent({ ...payload, params: emittedParams } as AcpJsonRpcMessage);
-    if (!this.writeToAgent(payload)) {
-      return Promise.reject(
-        new Error(`ACP transport closed; cannot send ${method}`),
-      );
-    }
     return new Promise((resolve, reject) => {
       const timer =
         timeoutMs > 0
@@ -397,14 +383,32 @@ export class NativeAcpClient {
             }, timeoutMs)
           : undefined;
       this.pending.set(id, { resolve, reject, timer });
+      if (!this.writeToAgent(payload)) {
+        const pending = this.pending.get(id);
+        this.pending.delete(id);
+        if (pending?.timer) clearTimeout(pending.timer);
+        pending?.reject(
+          new Error(`ACP transport closed; cannot send ${method}`),
+        );
+        return;
+      }
+      // Only record outbound traffic once the transport accepted the write.
+      // A synchronous stdin error marks the transport closed in writeToAgent.
+      if (!this.closed) {
+        this.emitEvent({
+          ...payload,
+          params: emittedParams,
+        } as AcpJsonRpcMessage);
+      }
     });
   }
 
   private async notify(method: string, params: unknown): Promise<void> {
     this.requireProcess();
     const payload = { jsonrpc: "2.0", method, params };
-    this.emitEvent(payload as AcpJsonRpcMessage);
-    this.writeToAgent(payload);
+    if (this.writeToAgent(payload)) {
+      this.emitEvent(payload as AcpJsonRpcMessage);
+    }
   }
 
   /**
@@ -412,25 +416,39 @@ export class NativeAcpClient {
    * throwing / crashing the process) when the pipe is already closed,
    * destroyed, or errors synchronously — the write-after-close case during
    * sub-agent teardown, where `closeSession` can race the agent exiting.
-   * Async pipe errors (EPIPE) are absorbed by the stdin 'error' listener
-   * installed in `start()`.
+   * Async pipe errors (EPIPE) are converted into terminal transport failures
+   * by the stdin 'error' listener installed in `start()`.
    */
   private writeToAgent(payload: unknown): boolean {
     const stdin = this.proc?.stdin;
     if (!stdin || stdin.destroyed || stdin.writableEnded || !stdin.writable) {
+      this.failStdin(new Error("agent stdin is not writable"));
       return false;
     }
     try {
       stdin.write(`${JSON.stringify(payload)}\n`);
       return true;
     } catch (err) {
-      // error-policy:J6 best-effort teardown — a synchronous EPIPE/ERR_STREAM
-      // throw here means the agent already went away; callers treat a false
-      // return as "transport closed" rather than crashing the runtime.
-      this.emitStderr(
-        `[acp-native-transport] agent stdin write failed (${errorMessage(err)}); dropping write\n`,
-      );
+      // error-policy:J1 transport boundary — convert a synchronous stream
+      // failure into rejected ACP requests rather than a host exception.
+      this.failStdin(err);
       return false;
+    }
+  }
+
+  /** Mark a failed stdin pipe terminal and settle every outstanding request. */
+  private failStdin(err: unknown): void {
+    const wasClosed = this.closed;
+    this.closed = true;
+    const failure = new Error(
+      `ACP transport stdin failed: ${errorMessage(err)}`,
+      err instanceof Error ? { cause: err } : undefined,
+    );
+    this.rejectAll(failure);
+    if (!wasClosed) {
+      this.emitStderr(
+        `[acp-native-transport] ${failure.message}; closing transport\n`,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #22565 and supersedes #22438 with its exact implementation rebased and independently revalidated on current `develop`.

All four JSON-RPC stdin writes now pass through one fail-closed boundary. Closed or unwritable stdin is rejected before write; synchronous `EPIPE` and the stream `error` event close the transport and reject pending requests; failed requests clear their timers/map entries and emit no outbound audit; notification/response teardown remains bounded best-effort.

## Validation

- five focused files: 42/42 tests passed
- complete package typecheck passed
- Biome passed on both changed files
- rebase onto current develop was conflict-free

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@949fe0777:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- {"ai_provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@949fe0777:packages/skills/skills/contribute-to-eliza","attribution":"self-reported"} -->
