### PR TITLE
ci: automate Microsoft Store submissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -587,4 +587,7 @@ jobs:
       version: ${{ needs.finalize.outputs.version }}
       tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
       channel: ${{ needs.finalize.outputs.channel }}
-    secrets: inherit
+    secrets:
+      MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
+      MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
+      MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -575,3 +575,16 @@ jobs:
       tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
       channel: ${{ needs.finalize.outputs.channel }}
     secrets: inherit
+
+  publish-microsoft-store:
+    name: Publish Microsoft Store release
+    needs: finalize
+    permissions:
+      contents: read
+    uses: ./.github/workflows/store-windows-publish.yml
+    with:
+      source_sha: ${{ needs.finalize.outputs.source_sha }}
+      version: ${{ needs.finalize.outputs.version }}
+      tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
+      channel: ${{ needs.finalize.outputs.channel }}
+    secrets: inherit

--- a/.github/workflows/store-windows-publish.yml
+++ b/.github/workflows/store-windows-publish.yml
@@ -1,0 +1,236 @@
+name: Publish Microsoft Store
+
+# Callable only: the canonical release transaction invokes this after the exact
+# tag and GitHub Release are finalized. Initial Partner Center product creation
+# remains a one-time portal prerequisite for Microsoft's update API.
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact canonical release commit
+        required: true
+        type: string
+      version:
+        description: Canonical stable release semver
+        required: true
+        type: string
+      channel:
+        description: Canonical release channel
+        required: true
+        type: string
+      tag:
+        description: Finalized Git tag
+        required: true
+        type: string
+    secrets:
+      MICROSOFT_STORE_TENANT_ID:
+        required: false
+      MICROSOFT_STORE_CLIENT_ID:
+        required: false
+      MICROSOFT_STORE_CLIENT_SECRET:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build, validate, and submit AppContainer MSIX
+    if: inputs.channel == 'latest'
+    runs-on: ${{ vars.RUNNER_WINDOWS || 'windows-2025' }}
+    timeout-minutes: 150
+    environment:
+      name: production-release
+    defaults:
+      run:
+        shell: bash -euo pipefail {0}
+    env:
+      CI: "true"
+      ELIZA_BUILD_VARIANT: store
+      ELIZA_RELEASE_AUTHORITY: microsoft-store
+      ELECTROBUN_SKIP_CODESIGN: "1"
+      SKIP_WINDOWS_SIGNING: "1"
+      SKIP_MSIX_SIGN: "1"
+      ELIZA_MSIX_IDENTITY_NAME: ${{ vars.MICROSOFT_STORE_IDENTITY_NAME }}
+      ELIZA_MSIX_PUBLISHER_ID: ${{ vars.MICROSOFT_STORE_PUBLISHER_ID }}
+      ELIZA_MSIX_PUBLISHER_DISPLAY_NAME: ${{ vars.MICROSOFT_STORE_PUBLISHER_DISPLAY_NAME }}
+      MICROSOFT_STORE_APPLICATION_ID: ${{ vars.MICROSOFT_STORE_APPLICATION_ID }}
+      MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
+      MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
+      MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}
+    steps:
+      - name: Enable Git long paths
+        shell: pwsh
+        run: git config --global core.longpaths true
+
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Bind build to finalized stable release
+        id: plan
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"
+          test "$EXPECTED_TAG" = "v${{ inputs.version }}"
+          test "$(git rev-parse "refs/tags/$EXPECTED_TAG^{commit}")" = "$EXPECTED_SHA"
+          node packages/scripts/store-release-plan.mjs \
+            --version "${{ inputs.version }}" \
+            --channel "${{ inputs.channel }}" \
+            --source-sha "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+          test "${{ inputs.channel }}" = "latest"
+
+      - name: Require Partner Center identity and API credentials
+        shell: pwsh
+        run: |
+          $required = @(
+            "ELIZA_MSIX_IDENTITY_NAME",
+            "ELIZA_MSIX_PUBLISHER_ID",
+            "ELIZA_MSIX_PUBLISHER_DISPLAY_NAME",
+            "MICROSOFT_STORE_APPLICATION_ID",
+            "MICROSOFT_STORE_TENANT_ID",
+            "MICROSOFT_STORE_CLIENT_ID",
+            "MICROSOFT_STORE_CLIENT_SECRET"
+          )
+          $missing = @($required | Where-Object { -not (Get-Item "Env:$_" -ErrorAction SilentlyContinue).Value })
+          if ($missing.Count -gt 0) {
+            Write-Error "Missing required Microsoft Store release configuration: $($missing -join ', ')"
+            exit 1
+          }
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          node-version: "24.15.0"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+          install-native-deps: "false"
+          install-protoc: "false"
+
+      - name: Align Electrobun version with release
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          node packages/app-core/scripts/align-electrobun-version.mjs
+          node <<'NODE'
+          const fs = require("node:fs");
+          const version = process.env.RELEASE_VERSION;
+          const packagePath = "packages/app-core/platforms/electrobun/package.json";
+          const configPath = "packages/app-core/platforms/electrobun/electrobun.config.ts";
+          const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2) + "\n");
+          let config = fs.readFileSync(configPath, "utf8");
+          config = config.replace(/version:\s*"[^"]+"/, `version: "${version}"`);
+          fs.writeFileSync(configPath, config);
+          NODE
+
+      - name: Stage desktop bundle inputs
+        run: |
+          node packages/shared/scripts/generate-keywords.mjs
+          node packages/app-core/scripts/desktop-build.mjs stage --variant=base
+          mkdir -p dist/node_modules/@elizaos/shared/src/i18n/generated
+          cp packages/shared/src/i18n/generated/validation-keyword-data.ts dist/node_modules/@elizaos/shared/src/i18n/generated/
+          cp packages/shared/src/i18n/generated/validation-keyword-data.js dist/node_modules/@elizaos/shared/src/i18n/generated/
+          test -f dist/entry.js
+
+      - name: Resolve and build patched Electrobun CLI
+        id: electrobun
+        run: |
+          package_dir="$(node <<'NODE'
+          const { createRequire } = require("node:module");
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const req = createRequire(path.resolve("packages/app-core/platforms/electrobun/package.json"));
+          let packageDir = path.dirname(req.resolve("electrobun"));
+          while (!fs.existsSync(path.join(packageDir, "package.json"))) {
+            const parent = path.dirname(packageDir);
+            if (parent === packageDir) throw new Error("electrobun package.json not found");
+            packageDir = parent;
+          }
+          process.stdout.write(packageDir);
+          NODE
+          )"
+          test -n "$package_dir"
+          node packages/app-core/scripts/build-patched-electrobun-cli.mjs "$package_dir" windows-x64
+
+      - name: Build Store-flavor Electrobun app
+        env:
+          ELIZA_RELEASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/
+        run: node packages/app-core/scripts/desktop-build.mjs package --env=stable
+
+      - name: Inject exact release identity into packaged resources
+        shell: pwsh
+        run: |
+          $buildRoot = "packages/app-core/platforms/electrobun/build"
+          $found = 0
+          Get-ChildItem -Path $buildRoot -Recurse -Directory -Filter "Resources" | ForEach-Object {
+            $versionJson = @{
+              identifier = "ai.elizaos.Eliza"
+              channel = "stable"
+              name = "eliza"
+              version = "${{ inputs.version }}"
+            } | ConvertTo-Json -Compress
+            Set-Content -Path (Join-Path $_.FullName "version.json") -Value $versionJson -Encoding utf8
+            $found++
+          }
+          if ($found -eq 0) { Write-Error "No packaged Resources directory found"; exit 1 }
+
+      - name: Build unsigned Store MSIX for Partner Center re-signing
+        shell: pwsh
+        run: |
+          pwsh -File packages/app-core/packaging/msix/build-msix.ps1 `
+            -BuildDir (Join-Path $PWD "packages/app-core/platforms/electrobun/build") `
+            -OutputDir (Join-Path $PWD "packages/app-core/platforms/electrobun/artifacts") `
+            -Version "${{ inputs.version }}"
+
+      - name: Validate exact Store package and create upload archive
+        id: package
+        shell: pwsh
+        run: |
+          $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Directory |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+            Sort-Object { [version]$_.Name } -Descending |
+            Select-Object -First 1
+          $makeappx = Join-Path $sdkBin.FullName "x64\makeappx.exe"
+          $msix = Get-ChildItem "packages/app-core/platforms/electrobun/artifacts" -File -Filter "*-store.msix" |
+            Select-Object -First 1
+          if (-not $msix) { Write-Error "Store MSIX was not produced"; exit 1 }
+          $unpack = Join-Path $env:RUNNER_TEMP "store-msix-unpacked"
+          & $makeappx unpack /p $msix.FullName /d $unpack /o
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          [xml]$manifest = Get-Content (Join-Path $unpack "AppxManifest.xml") -Raw
+          $identity = $manifest.Package.Identity
+          if ($identity.Name -ne $env:ELIZA_MSIX_IDENTITY_NAME) { throw "MSIX Identity.Name mismatch" }
+          if ($identity.Publisher -ne $env:ELIZA_MSIX_PUBLISHER_ID) { throw "MSIX Identity.Publisher mismatch" }
+          if ($identity.Version -ne "${{ steps.plan.outputs.windows_package_version }}") { throw "MSIX version mismatch: $($identity.Version)" }
+          if ($manifest.OuterXml -match "runFullTrust|windows.fullTrustApplication") { throw "Store MSIX contains a full-trust declaration" }
+          if (-not (Test-Path (Join-Path $unpack "launcher.exe"))) { throw "Store MSIX lacks launcher.exe" }
+          $archive = Join-Path $env:RUNNER_TEMP "eliza-microsoft-store-${{ inputs.version }}.zip"
+          Compress-Archive -LiteralPath $msix.FullName -DestinationPath $archive -Force
+          "msix=$($msix.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "msix_name=$($msix.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "archive=$archive" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Upload Microsoft Store package evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-microsoft-store-${{ inputs.version }}
+          path: ${{ steps.package.outputs.msix }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Submit exact package to Partner Center
+        run: >-
+          node packages/scripts/microsoft-store-submission.mjs
+          --archive "${{ steps.package.outputs.archive }}"
+          --package-file-name "${{ steps.package.outputs.msix_name }}"

--- a/.github/workflows/store-windows-publish.yml
+++ b/.github/workflows/store-windows-publish.yml
@@ -56,9 +56,6 @@ jobs:
       ELIZA_MSIX_PUBLISHER_ID: ${{ vars.MICROSOFT_STORE_PUBLISHER_ID }}
       ELIZA_MSIX_PUBLISHER_DISPLAY_NAME: ${{ vars.MICROSOFT_STORE_PUBLISHER_DISPLAY_NAME }}
       MICROSOFT_STORE_APPLICATION_ID: ${{ vars.MICROSOFT_STORE_APPLICATION_ID }}
-      MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
-      MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
-      MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}
     steps:
       - name: Enable Git long paths
         shell: pwsh
@@ -90,6 +87,10 @@ jobs:
 
       - name: Require Partner Center identity and API credentials
         shell: pwsh
+        env:
+          MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
+          MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
+          MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}
         run: |
           $required = @(
             "ELIZA_MSIX_IDENTITY_NAME",
@@ -230,6 +231,10 @@ jobs:
           retention-days: 90
 
       - name: Submit exact package to Partner Center
+        env:
+          MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
+          MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
+          MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}
         run: >-
           node packages/scripts/microsoft-store-submission.mjs
           --archive "${{ steps.package.outputs.archive }}"

--- a/packages/app-core/packaging/msix/README.md
+++ b/packages/app-core/packaging/msix/README.md
@@ -152,9 +152,26 @@ Output filenames:
 
 ## CI pipeline
 
-`release-electrobun.yml` runs the direct flavor automatically when
-`WINDOWS_SIGN_CERT_BASE64` is configured. The store flavor is opt-in: set
-`ELIZA_BUILD_VARIANT=store` on the CI step that targets Partner Center upload.
+`release-electrobun.yml` builds the direct flavor. The canonical transactional
+release separately calls `store-windows-publish.yml` for stable releases. That
+protected Windows job builds the AppContainer flavor from the finalized commit,
+unpacks and audits the MSIX, uploads evidence, and commits an update through the
+Microsoft Store submission API.
+
+The job fails before building if any required Partner Center configuration is
+missing:
+
+- Repository variables: `MICROSOFT_STORE_IDENTITY_NAME`,
+  `MICROSOFT_STORE_PUBLISHER_ID`,
+  `MICROSOFT_STORE_PUBLISHER_DISPLAY_NAME`, and
+  `MICROSOFT_STORE_APPLICATION_ID`.
+- Environment secrets: `MICROSOFT_STORE_TENANT_ID`,
+  `MICROSOFT_STORE_CLIENT_ID`, and `MICROSOFT_STORE_CLIENT_SECRET`.
+
+Microsoft's submission API can update only an existing Partner Center product
+that already has a completed submission with age ratings. The first product and
+first completed submission are therefore one-time portal prerequisites; after
+that, stable canonical releases use the API lane.
 
 ## Store submission
 
@@ -171,8 +188,8 @@ Output filenames:
    - `ELIZA_MSIX_PUBLISHER_DISPLAY_NAME` — human-readable publisher, e.g.
      `elizaOS Labs`. Defaults to the placeholder `elizaOS` if unset.
    `build-msix.ps1` substitutes these into the staged manifest before
-   `makeappx pack`. When unset, the script prints a `::warning::` and ships
-   the placeholder values (Partner Center will reject the upload).
+   `makeappx pack`. A store build fails closed when any value is unset, so CI
+   cannot silently produce a package that Partner Center will reject.
 4. Replace placeholder assets in `assets/` with final artwork.
 5. Add screenshots to `store/screenshots/`.
 6. Build the store MSIX (`ELIZA_BUILD_VARIANT=store` plus the three Identity

--- a/packages/app-core/packaging/msix/build-msix.ps1
+++ b/packages/app-core/packaging/msix/build-msix.ps1
@@ -52,9 +52,20 @@ if ($buildVariant -eq "store") {
   } else {
     Write-Host "ELIZA_MSIX_STORE_CERT_PATH not set or missing — store MSIX will be built unsigned for Partner Center re-sign."
   }
+
+  $requiredStoreIdentity = @(
+    "ELIZA_MSIX_IDENTITY_NAME",
+    "ELIZA_MSIX_PUBLISHER_ID",
+    "ELIZA_MSIX_PUBLISHER_DISPLAY_NAME"
+  )
+  $missingStoreIdentity = @($requiredStoreIdentity | Where-Object { -not (Get-Item "Env:$_" -ErrorAction SilentlyContinue).Value })
+  if ($missingStoreIdentity.Count -gt 0) {
+    Write-Error "Store MSIX requires Partner Center identity values: $($missingStoreIdentity -join ', ')"
+    exit 1
+  }
 }
 
-if (-not $certBase64 -and -not $azureSigning) {
+if ($buildVariant -ne "store" -and -not $certBase64 -and -not $azureSigning) {
   Write-Host "::warning::WINDOWS_SIGN_CERT_BASE64 not set and no Azure Trusted Signing - skipping MSIX generation"
   exit 0
 }
@@ -147,22 +158,12 @@ if ($buildVariant -eq "store") {
   $identityName = $env:ELIZA_MSIX_IDENTITY_NAME
   $publisherId = $env:ELIZA_MSIX_PUBLISHER_ID
   $publisherDisplayName = $env:ELIZA_MSIX_PUBLISHER_DISPLAY_NAME
-  if ($identityName) {
-    $manifestContent = $manifestContent -replace 'Name="ElizaOS\.App"', "Name=`"$identityName`""
-    Write-Host "Identity.Name set to: $identityName"
-  } else {
-    Write-Host "::warning::ELIZA_MSIX_IDENTITY_NAME not set — store MSIX will use placeholder 'ElizaOS.App' (Partner Center upload will reject)."
-  }
-  if ($publisherId) {
-    $manifestContent = $manifestContent -replace 'Publisher="CN=elizaOS"', "Publisher=`"$publisherId`""
-    Write-Host "Identity.Publisher set to: $publisherId"
-  } else {
-    Write-Host "::warning::ELIZA_MSIX_PUBLISHER_ID not set — store MSIX will use placeholder 'CN=elizaOS' (Partner Center upload will reject)."
-  }
-  if ($publisherDisplayName) {
-    $manifestContent = $manifestContent -replace '<PublisherDisplayName>elizaOS</PublisherDisplayName>', "<PublisherDisplayName>$publisherDisplayName</PublisherDisplayName>"
-    Write-Host "PublisherDisplayName set to: $publisherDisplayName"
-  }
+  $manifestContent = $manifestContent -replace 'Name="ElizaOS\.App"', "Name=`"$identityName`""
+  Write-Host "Identity.Name set to: $identityName"
+  $manifestContent = $manifestContent -replace 'Publisher="CN=elizaOS"', "Publisher=`"$publisherId`""
+  Write-Host "Identity.Publisher set to: $publisherId"
+  $manifestContent = $manifestContent -replace '<PublisherDisplayName>elizaOS</PublisherDisplayName>', "<PublisherDisplayName>$publisherDisplayName</PublisherDisplayName>"
+  Write-Host "PublisherDisplayName set to: $publisherDisplayName"
 }
 
 Set-Content -Path $manifestDest -Value $manifestContent

--- a/packages/scripts/__tests__/microsoft-store-submission.test.ts
+++ b/packages/scripts/__tests__/microsoft-store-submission.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Exercises the Microsoft Store submission boundary with deterministic HTTP
+ * doubles, including token scope, package replacement, commit, and failure.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyCommitStatus,
+  prepareSubmissionPayload,
+  submitMicrosoftStoreUpdate,
+} from "../microsoft-store-submission.mjs";
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Microsoft Store submission", () => {
+  test("replaces copied packages with one exact pending MSIX", () => {
+    const payload = prepareSubmissionPayload(
+      {
+        id: "submission-1",
+        targetPublishMode: "Manual",
+        applicationPackages: [{ fileName: "old.msix", fileStatus: "Uploaded" }],
+        listings: { "en-us": { baseListing: { title: "Eliza" } } },
+      },
+      "nested/Eliza-2.0.0.msix",
+    );
+    expect(payload.targetPublishMode).toBe("Immediate");
+    expect(payload).not.toHaveProperty("id");
+    expect(payload.listings).toEqual({
+      "en-us": { baseListing: { title: "Eliza" } },
+    });
+    expect(payload.applicationPackages).toEqual([
+      {
+        fileName: "Eliza-2.0.0.msix",
+        fileStatus: "PendingUpload",
+        minimumDirectXVersion: "None",
+        minimumSystemRam: "None",
+      },
+    ]);
+  });
+
+  test("classifies Partner Center commit states", () => {
+    expect(classifyCommitStatus("CommitStarted")).toBe("pending");
+    expect(classifyCommitStatus("PreProcessing")).toBe("accepted");
+    expect(classifyCommitStatus("Published")).toBe("accepted");
+    expect(classifyCommitStatus("CommitFailed")).toBe("failed");
+  });
+
+  test("authenticates, uploads, commits, and waits for ingestion", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = async (
+      input: string | URL | Request,
+      init: RequestInit = {},
+    ) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.includes("login.microsoftonline.com")) {
+        return jsonResponse({ access_token: "secret-token" });
+      }
+      if (
+        url.endsWith("/applications/app-1/submissions") &&
+        init.method === "POST"
+      ) {
+        return jsonResponse({
+          id: "submission-1",
+          fileUploadUrl: "https://blob.example.invalid/archive?secret=sas",
+          listings: {},
+          applicationPackages: [],
+        });
+      }
+      if (url.endsWith("/submissions/submission-1") && init.method === "PUT") {
+        return jsonResponse({ status: "PendingCommit" });
+      }
+      if (url.startsWith("https://blob.example.invalid/")) {
+        return new Response("", { status: 201 });
+      }
+      if (url.endsWith("/commit")) return jsonResponse({});
+      if (url.endsWith("/status")) {
+        const statusCalls = calls.filter((call) =>
+          call.url.endsWith("/status"),
+        );
+        return jsonResponse({
+          status: statusCalls.length === 1 ? "CommitStarted" : "PreProcessing",
+        });
+      }
+      return jsonResponse({ message: "unexpected request" }, 500);
+    };
+
+    const result = await submitMicrosoftStoreUpdate({
+      applicationId: "app-1",
+      archivePath: "release.zip",
+      packageFileName: "Eliza-2.0.0.msix",
+      tenantId: "tenant-1",
+      clientId: "client-1",
+      clientSecret: "client-secret",
+      fetchImpl,
+      readFileImpl: async () => Buffer.from("zip bytes"),
+      sleep: async () => {},
+      pollIntervalMs: 0,
+    });
+
+    expect(result).toEqual({
+      submissionId: "submission-1",
+      status: "PreProcessing",
+    });
+    const tokenCall = calls[0];
+    expect(String(tokenCall.init.body)).toContain(
+      "resource=https%3A%2F%2Fmanage.devcenter.microsoft.com",
+    );
+    const updateCall = calls.find(
+      (call) =>
+        call.url.endsWith("/submission-1") && call.init.method === "PUT",
+    );
+    expect(
+      JSON.parse(String(updateCall?.init.body)).applicationPackages,
+    ).toEqual([
+      {
+        fileName: "Eliza-2.0.0.msix",
+        fileStatus: "PendingUpload",
+        minimumDirectXVersion: "None",
+        minimumSystemRam: "None",
+      },
+    ]);
+    const uploadCall = calls.find((call) =>
+      call.url.includes("blob.example.invalid"),
+    );
+    expect(uploadCall).toBeDefined();
+    expect(
+      (uploadCall?.init.headers as Record<string, string> | undefined)?.[
+        "x-ms-blob-type"
+      ],
+    ).toBe("BlockBlob");
+  });
+
+  test("fails closed when Partner Center rejects the commit", async () => {
+    const fetchImpl = async (
+      input: string | URL | Request,
+      init: RequestInit = {},
+    ) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) {
+        return jsonResponse({ access_token: "secret-token" });
+      }
+      if (
+        url.endsWith("/applications/app-1/submissions") &&
+        init.method === "POST"
+      ) {
+        return jsonResponse({
+          id: "submission-1",
+          fileUploadUrl: "https://blob.example.invalid/archive?secret=sas",
+          listings: {},
+        });
+      }
+      if (url.startsWith("https://blob.example.invalid/")) {
+        return new Response("", { status: 201 });
+      }
+      if (url.endsWith("/status")) {
+        return jsonResponse({
+          status: "CommitFailed",
+          statusDetails: { errors: [{ message: "Package identity mismatch" }] },
+        });
+      }
+      return jsonResponse({});
+    };
+
+    await expect(
+      submitMicrosoftStoreUpdate({
+        applicationId: "app-1",
+        archivePath: "release.zip",
+        packageFileName: "Eliza-2.0.0.msix",
+        tenantId: "tenant-1",
+        clientId: "client-1",
+        clientSecret: "client-secret",
+        fetchImpl,
+        readFileImpl: async () => Buffer.from("zip bytes"),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("Package identity mismatch");
+  });
+});

--- a/packages/scripts/__tests__/microsoft-store-submission.test.ts
+++ b/packages/scripts/__tests__/microsoft-store-submission.test.ts
@@ -8,7 +8,11 @@ import {
   classifyCommitStatus,
   prepareSubmissionPayload,
   submitMicrosoftStoreUpdate,
+  validateStoreUploadUrl,
 } from "../microsoft-store-submission.mjs";
+
+const uploadUrl =
+  "https://productingestionbin1.blob.core.windows.net/ingestion/archive.zip?sv=2024-01-01&se=2030-01-01&sp=w&sig=secret";
 
 function jsonResponse(value: unknown, status = 200) {
   return new Response(JSON.stringify(value), {
@@ -67,7 +71,7 @@ describe("Microsoft Store submission", () => {
       ) {
         return jsonResponse({
           id: "submission-1",
-          fileUploadUrl: "https://blob.example.invalid/archive?secret=sas",
+          fileUploadUrl: uploadUrl,
           listings: {},
           applicationPackages: [],
         });
@@ -75,7 +79,9 @@ describe("Microsoft Store submission", () => {
       if (url.endsWith("/submissions/submission-1") && init.method === "PUT") {
         return jsonResponse({ status: "PendingCommit" });
       }
-      if (url.startsWith("https://blob.example.invalid/")) {
+      if (
+        url.startsWith("https://productingestionbin1.blob.core.windows.net/")
+      ) {
         return new Response("", { status: 201 });
       }
       if (url.endsWith("/commit")) return jsonResponse({});
@@ -126,7 +132,7 @@ describe("Microsoft Store submission", () => {
       },
     ]);
     const uploadCall = calls.find((call) =>
-      call.url.includes("blob.example.invalid"),
+      call.url.includes("productingestionbin1.blob.core.windows.net"),
     );
     expect(uploadCall).toBeDefined();
     expect(
@@ -151,11 +157,13 @@ describe("Microsoft Store submission", () => {
       ) {
         return jsonResponse({
           id: "submission-1",
-          fileUploadUrl: "https://blob.example.invalid/archive?secret=sas",
+          fileUploadUrl: uploadUrl,
           listings: {},
         });
       }
-      if (url.startsWith("https://blob.example.invalid/")) {
+      if (
+        url.startsWith("https://productingestionbin1.blob.core.windows.net/")
+      ) {
         return new Response("", { status: 201 });
       }
       if (url.endsWith("/status")) {
@@ -180,5 +188,51 @@ describe("Microsoft Store submission", () => {
         sleep: async () => {},
       }),
     ).rejects.toThrow("Package identity mismatch");
+  });
+
+  test("rejects an untrusted upload URL before reading package bytes", async () => {
+    expect(() =>
+      validateStoreUploadUrl(
+        "http://productingestionbin1.blob.core.windows.net/ingestion/a?sp=w&se=x&sig=x",
+      ),
+    ).toThrow(/writable HTTPS Azure Blob SAS URL/);
+    expect(() =>
+      validateStoreUploadUrl("https://attacker.example/upload?sp=w&se=x&sig=x"),
+    ).toThrow(/writable HTTPS Azure Blob SAS URL/);
+    expect(() =>
+      validateStoreUploadUrl(
+        "https://productingestionbin1.blob.core.windows.net/ingestion/a?sp=r&se=x&sig=x",
+      ),
+    ).toThrow(/writable HTTPS Azure Blob SAS URL/);
+
+    let read = false;
+    await expect(
+      submitMicrosoftStoreUpdate({
+        applicationId: "app-1",
+        archivePath: "release.zip",
+        packageFileName: "Eliza-2.0.0.msix",
+        tenantId: "tenant-1",
+        clientId: "client-1",
+        clientSecret: "client-secret",
+        fetchImpl: async (input, init = {}) => {
+          const url = String(input);
+          if (url.includes("login.microsoftonline.com")) {
+            return jsonResponse({ access_token: "secret-token" });
+          }
+          if (init.method === "POST") {
+            return jsonResponse({
+              id: "submission-1",
+              fileUploadUrl: "https://attacker.example/upload",
+            });
+          }
+          return jsonResponse({});
+        },
+        readFileImpl: async () => {
+          read = true;
+          return Buffer.from("zip bytes");
+        },
+      }),
+    ).rejects.toThrow(/writable HTTPS Azure Blob SAS URL/);
+    expect(read).toBe(false);
   });
 });

--- a/packages/scripts/__tests__/store-release-plan.test.ts
+++ b/packages/scripts/__tests__/store-release-plan.test.ts
@@ -27,6 +27,8 @@ describe("store release plan", () => {
       ios_marketing_version: "2.3.4",
       ios_build_number: "203049000",
       apple_lane: "release",
+      windows_package_version: "2.3.4.0",
+      windows_publish: true,
       snap_channel: "stable",
       extension_version: "2.3.4.60000",
       chrome_publish_target: "default",
@@ -54,6 +56,8 @@ describe("store release plan", () => {
     expect(beta0).toMatchObject({
       android_track: "internal",
       apple_lane: "beta",
+      windows_package_version: "2.3.4.0",
+      windows_publish: false,
       snap_channel: "beta",
       extension_version: "2.3.4.20000",
       chrome_publish_target: "trustedTesters",

--- a/packages/scripts/__tests__/store-release-workflow.test.ts
+++ b/packages/scripts/__tests__/store-release-workflow.test.ts
@@ -23,6 +23,10 @@ const mobileSource = readFileSync(
   new URL(".github/workflows/store-mobile-publish.yml", repoRoot),
   "utf8",
 );
+const windowsSource = readFileSync(
+  new URL(".github/workflows/store-windows-publish.yml", repoRoot),
+  "utf8",
+);
 
 describe("canonical store release workflow", () => {
   test("calls Snap only after exact release finalization", () => {
@@ -40,7 +44,9 @@ describe("canonical store release workflow", () => {
     const snap = workflow.jobs?.["publish-snap"];
     expect(snap?.needs).toBe("finalize");
     expect(snap?.uses).toBe("./.github/workflows/snap-publish.yml");
-    expect(snap?.with?.source_sha).toContain("needs.finalize.outputs.source_sha");
+    expect(snap?.with?.source_sha).toContain(
+      "needs.finalize.outputs.source_sha",
+    );
     expect(snap?.with?.version).toContain("needs.finalize.outputs.version");
     expect(snap?.secrets).toBe("inherit");
   });
@@ -54,30 +60,42 @@ describe("canonical store release workflow", () => {
     expect(workflow.jobs?.["build-and-publish"]?.environment?.name).toBe(
       "production-release",
     );
-    expect(snapSource).toContain('ref: ${{ inputs.source_sha }}');
-    expect(snapSource).toContain('refs/tags/$EXPECTED_TAG^{commit}');
+    expect(snapSource).toContain(`ref: \${{ inputs.source_sha }}`);
+    expect(snapSource).toContain("refs/tags/$EXPECTED_TAG^{commit}");
     expect(snapSource).toContain(
       "SNAPCRAFT_STORE_CREDENTIALS is required for the canonical store release",
     );
     expect(snapSource).toContain("snapcraft whoami");
-    expect(snapSource).toContain('snapcraft upload "$SNAP_FILE" --release "$CHANNEL"');
+    expect(snapSource).toContain(
+      'snapcraft upload "$SNAP_FILE" --release "$CHANNEL"',
+    );
   });
 
   test("publishes the registered stable-grade snap identity", () => {
     expect(snapcraftSource).toMatch(/^name: eliza$/m);
     expect(snapcraftSource).toMatch(/^title: Eliza$/m);
     expect(snapcraftSource).toMatch(/^grade: stable$/m);
-    expect(snapcraftSource).toMatch(/^  eliza:$/m);
+    expect(snapcraftSource).toMatch(/^ {2}eliza:$/m);
   });
 
   test("calls mobile stores only after exact release finalization", () => {
     const workflow = Bun.YAML.parse(releaseSource) as {
-      jobs?: Record<string, { needs?: string; uses?: string; with?: Record<string, string>; secrets?: string }>;
+      jobs?: Record<
+        string,
+        {
+          needs?: string;
+          uses?: string;
+          with?: Record<string, string>;
+          secrets?: string;
+        }
+      >;
     };
     const mobile = workflow.jobs?.["publish-mobile-stores"];
     expect(mobile?.needs).toBe("finalize");
     expect(mobile?.uses).toBe("./.github/workflows/store-mobile-publish.yml");
-    expect(mobile?.with?.source_sha).toContain("needs.finalize.outputs.source_sha");
+    expect(mobile?.with?.source_sha).toContain(
+      "needs.finalize.outputs.source_sha",
+    );
     expect(mobile?.with?.version).toContain("needs.finalize.outputs.version");
     expect(mobile?.secrets).toBe("inherit");
   });
@@ -88,27 +106,72 @@ describe("canonical store release workflow", () => {
       jobs?: Record<string, { environment?: { name?: string } }>;
     };
     expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
-    expect(workflow.jobs?.android?.environment?.name).toBe("production-release");
+    expect(workflow.jobs?.android?.environment?.name).toBe(
+      "production-release",
+    );
     expect(workflow.jobs?.ios?.environment?.name).toBe("production-release");
-    expect(mobileSource).toContain('ref: ${{ inputs.source_sha }}');
-    expect(mobileSource).toContain('refs/tags/$EXPECTED_TAG^{commit}');
-    expect(mobileSource).toContain("Missing required Google Play release secrets");
+    expect(mobileSource).toContain(`ref: \${{ inputs.source_sha }}`);
+    expect(mobileSource).toContain("refs/tags/$EXPECTED_TAG^{commit}");
+    expect(mobileSource).toContain(
+      "Missing required Google Play release secrets",
+    );
     expect(mobileSource).toContain("Missing required Apple release secrets");
     expect(mobileSource).toContain("bun run build:android:cloud");
     expect(mobileSource).toContain('bundle exec fastlane "$APPLE_LANE"');
   });
 
   test("provisions every shipping iOS extension from the generated project", () => {
-    expect(mobileSource).toContain(
-      "PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);",
-    );
-    expect(mobileSource).toContain("index($0, app \".\") == 1");
-    expect(mobileSource).toContain('$0 !~ /\\.AppUITests$/');
+    expect(mobileSource).toContain("PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);");
+    expect(mobileSource).toContain('index($0, app ".") == 1');
+    expect(mobileSource).toContain("$0 !~ /\\.AppUITests$/");
     expect(mobileSource).toContain(
       'echo "APP_IDENTIFIER_EXTRA=$extension_ids" >> "$GITHUB_ENV"',
     );
     expect(mobileSource).not.toContain(
-      'APP_IDENTIFIER_EXTRA=$app_id.WebsiteBlockerContentExtension',
+      "APP_IDENTIFIER_EXTRA=$app_id.WebsiteBlockerContentExtension",
     );
+  });
+
+  test("calls Microsoft Store only after exact release finalization", () => {
+    const workflow = Bun.YAML.parse(releaseSource) as {
+      jobs?: Record<
+        string,
+        {
+          needs?: string;
+          uses?: string;
+          with?: Record<string, string>;
+          secrets?: string;
+        }
+      >;
+    };
+    const windows = workflow.jobs?.["publish-microsoft-store"];
+    expect(windows?.needs).toBe("finalize");
+    expect(windows?.uses).toBe("./.github/workflows/store-windows-publish.yml");
+    expect(windows?.with?.source_sha).toContain(
+      "needs.finalize.outputs.source_sha",
+    );
+    expect(windows?.with?.version).toContain("needs.finalize.outputs.version");
+    expect(windows?.secrets).toBe("inherit");
+  });
+
+  test("keeps Microsoft Store callable-only, protected, stable-only, and fail-closed", () => {
+    const workflow = Bun.YAML.parse(windowsSource) as {
+      on?: Record<string, unknown>;
+      jobs?: Record<string, { environment?: { name?: string }; if?: string }>;
+    };
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
+    const publish = workflow.jobs?.["build-and-publish"];
+    expect(publish?.environment?.name).toBe("production-release");
+    expect(publish?.if).toContain("inputs.channel == 'latest'");
+    expect(windowsSource).toContain(`ref: \${{ inputs.source_sha }}`);
+    expect(windowsSource).toContain("refs/tags/$EXPECTED_TAG^{commit}");
+    expect(windowsSource).toContain(
+      "Missing required Microsoft Store release configuration",
+    );
+    expect(windowsSource).toContain("ELIZA_BUILD_VARIANT: store");
+    expect(windowsSource).toContain(
+      "runFullTrust|windows.fullTrustApplication",
+    );
+    expect(windowsSource).toContain("microsoft-store-submission.mjs");
   });
 });

--- a/packages/scripts/__tests__/store-release-workflow.test.ts
+++ b/packages/scripts/__tests__/store-release-workflow.test.ts
@@ -37,7 +37,7 @@ describe("canonical store release workflow", () => {
           needs?: string | string[];
           uses?: string;
           with?: Record<string, string>;
-          secrets?: string;
+          secrets?: string | Record<string, string>;
         }
       >;
     };
@@ -151,13 +151,25 @@ describe("canonical store release workflow", () => {
       "needs.finalize.outputs.source_sha",
     );
     expect(windows?.with?.version).toContain("needs.finalize.outputs.version");
-    expect(windows?.secrets).toBe("inherit");
+    expect(windows?.secrets).toEqual({
+      MICROSOFT_STORE_TENANT_ID: `\${{ secrets.MICROSOFT_STORE_TENANT_ID }}`,
+      MICROSOFT_STORE_CLIENT_ID: `\${{ secrets.MICROSOFT_STORE_CLIENT_ID }}`,
+      MICROSOFT_STORE_CLIENT_SECRET: `\${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}`,
+    });
   });
 
   test("keeps Microsoft Store callable-only, protected, stable-only, and fail-closed", () => {
     const workflow = Bun.YAML.parse(windowsSource) as {
       on?: Record<string, unknown>;
-      jobs?: Record<string, { environment?: { name?: string }; if?: string }>;
+      jobs?: Record<
+        string,
+        {
+          environment?: { name?: string };
+          if?: string;
+          env?: Record<string, string>;
+          steps?: Array<{ name?: string; env?: Record<string, string> }>;
+        }
+      >;
     };
     expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
     const publish = workflow.jobs?.["build-and-publish"];
@@ -173,5 +185,19 @@ describe("canonical store release workflow", () => {
       "runFullTrust|windows.fullTrustApplication",
     );
     expect(windowsSource).toContain("microsoft-store-submission.mjs");
+    for (const secret of [
+      "MICROSOFT_STORE_TENANT_ID",
+      "MICROSOFT_STORE_CLIENT_ID",
+      "MICROSOFT_STORE_CLIENT_SECRET",
+    ]) {
+      expect(publish?.env).not.toHaveProperty(secret);
+      const exposedSteps = (publish?.steps ?? [])
+        .filter((step) => step.env?.[secret] !== undefined)
+        .map((step) => step.name);
+      expect(exposedSteps).toEqual([
+        "Require Partner Center identity and API credentials",
+        "Submit exact package to Partner Center",
+      ]);
+    }
   });
 });

--- a/packages/scripts/microsoft-store-submission.mjs
+++ b/packages/scripts/microsoft-store-submission.mjs
@@ -110,6 +110,35 @@ export function classifyCommitStatus(status) {
   return "pending";
 }
 
+export function validateStoreUploadUrl(value) {
+  const raw = requiredValue(value, "Microsoft Store submission upload URL");
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("Microsoft Store submission upload URL is invalid");
+  }
+  const trustedAzureBlob = /^[a-z0-9]{3,24}\.blob\.core\.windows\.net$/.test(
+    parsed.hostname,
+  );
+  const permissions = parsed.searchParams.get("sp") ?? "";
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.port !== "" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    !trustedAzureBlob ||
+    !parsed.searchParams.has("sig") ||
+    !parsed.searchParams.has("se") ||
+    !permissions.includes("w")
+  ) {
+    throw new Error(
+      "Microsoft Store submission upload URL must be a writable HTTPS Azure Blob SAS URL",
+    );
+  }
+  return parsed.toString();
+}
+
 export async function obtainStoreToken({
   tenantId,
   clientId,
@@ -182,10 +211,7 @@ export async function submitMicrosoftStoreUpdate({
   const submissionId = encodeURIComponent(
     requiredValue(String(created?.id ?? ""), "Microsoft Store submission ID"),
   );
-  const uploadUrl = requiredValue(
-    created?.fileUploadUrl,
-    "Microsoft Store submission upload URL",
-  );
+  const uploadUrl = validateStoreUploadUrl(created?.fileUploadUrl);
   const submissionUrl = `${submissionsUrl}/${submissionId}`;
   const updated = prepareSubmissionPayload(created, packageName);
 

--- a/packages/scripts/microsoft-store-submission.mjs
+++ b/packages/scripts/microsoft-store-submission.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Publishes one exact MSIX archive into an existing Microsoft Store app
+ * submission and waits until Partner Center accepts the commit for ingestion.
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STORE_API_BASE = "https://manage.devcenter.microsoft.com/v1.0/my";
+const STORE_RESOURCE = "https://manage.devcenter.microsoft.com";
+const ACCEPTED_COMMIT_STATES = new Set([
+  "PreProcessing",
+  "Certification",
+  "Release",
+  "Publishing",
+  "Published",
+]);
+const FAILED_COMMIT_STATES = new Set(["CommitFailed"]);
+const WRITABLE_SUBMISSION_FIELDS = Object.freeze([
+  "applicationCategory",
+  "pricing",
+  "visibility",
+  "targetPublishDate",
+  "listings",
+  "hardwarePreferences",
+  "automaticBackupEnabled",
+  "canInstallOnRemovableMedia",
+  "isGameDvrEnabled",
+  "gamingOptions",
+  "hasExternalInAppProducts",
+  "meetAccessibilityGuidelines",
+  "notesForCertification",
+  "packageDeliveryOptions",
+  "enterpriseLicensing",
+  "allowMicrosoftDecideAppAvailabilityToFutureDeviceFamilies",
+  "allowMicrosftDecideAppAvailabilityToFutureDeviceFamilies",
+  "allowTargetFutureDeviceFamilies",
+  "trailers",
+]);
+
+function requiredValue(value, name) {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${name} is required`);
+  return normalized;
+}
+
+function requireArgument(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  return args[index + 1];
+}
+
+function safeApiError(payload, fallback) {
+  const candidate = payload?.message ?? payload?.code ?? fallback;
+  return String(candidate).replace(/https?:\/\/\S+/g, "[redacted-url]");
+}
+
+async function requestJson(fetchImpl, url, options, operation) {
+  const response = await fetchImpl(url, options);
+  let payload = null;
+  const text = await response.text();
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = null;
+    }
+  }
+  if (!response.ok) {
+    throw new Error(
+      `${operation} failed with HTTP ${response.status}: ${safeApiError(payload, response.statusText)}`,
+    );
+  }
+  return payload;
+}
+
+export function prepareSubmissionPayload(submission, packageFileName) {
+  if (!submission || typeof submission !== "object") {
+    throw new Error("Partner Center returned an invalid submission resource");
+  }
+  const normalizedPackage = basename(
+    requiredValue(packageFileName, "package file name"),
+  );
+  const writable = Object.fromEntries(
+    WRITABLE_SUBMISSION_FIELDS.filter((field) =>
+      Object.hasOwn(submission, field),
+    ).map((field) => [field, submission[field]]),
+  );
+  return {
+    ...writable,
+    targetPublishMode: "Immediate",
+    applicationPackages: [
+      {
+        fileName: normalizedPackage,
+        fileStatus: "PendingUpload",
+        minimumDirectXVersion: "None",
+        minimumSystemRam: "None",
+      },
+    ],
+  };
+}
+
+export function classifyCommitStatus(status) {
+  if (ACCEPTED_COMMIT_STATES.has(status)) return "accepted";
+  if (FAILED_COMMIT_STATES.has(status)) return "failed";
+  return "pending";
+}
+
+export async function obtainStoreToken({
+  tenantId,
+  clientId,
+  clientSecret,
+  fetchImpl = fetch,
+}) {
+  const form = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: requiredValue(clientId, "MICROSOFT_STORE_CLIENT_ID"),
+    client_secret: requiredValue(clientSecret, "MICROSOFT_STORE_CLIENT_SECRET"),
+    resource: STORE_RESOURCE,
+  });
+  const payload = await requestJson(
+    fetchImpl,
+    `https://login.microsoftonline.com/${encodeURIComponent(requiredValue(tenantId, "MICROSOFT_STORE_TENANT_ID"))}/oauth2/token`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+      },
+      body: form,
+    },
+    "Microsoft Store token request",
+  );
+  return requiredValue(payload?.access_token, "Microsoft Store access token");
+}
+
+export async function submitMicrosoftStoreUpdate({
+  applicationId,
+  archivePath,
+  packageFileName,
+  tenantId,
+  clientId,
+  clientSecret,
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  pollIntervalMs = 15_000,
+  maxPolls = 80,
+}) {
+  const appId = encodeURIComponent(
+    requiredValue(applicationId, "MICROSOFT_STORE_APPLICATION_ID"),
+  );
+  const archive = requiredValue(archivePath, "--archive");
+  const packageName = basename(
+    requiredValue(packageFileName, "--package-file-name"),
+  );
+  if (!archive.toLowerCase().endsWith(".zip")) {
+    throw new Error("--archive must be the ZIP uploaded to Partner Center");
+  }
+  if (!packageName.toLowerCase().endsWith(".msix")) {
+    throw new Error("--package-file-name must name the MSIX at the ZIP root");
+  }
+
+  const token = await obtainStoreToken({
+    tenantId,
+    clientId,
+    clientSecret,
+    fetchImpl,
+  });
+  const headers = { authorization: `Bearer ${token}` };
+  const submissionsUrl = `${STORE_API_BASE}/applications/${appId}/submissions`;
+  const created = await requestJson(
+    fetchImpl,
+    submissionsUrl,
+    { method: "POST", headers },
+    "Create Microsoft Store submission",
+  );
+  const submissionId = encodeURIComponent(
+    requiredValue(String(created?.id ?? ""), "Microsoft Store submission ID"),
+  );
+  const uploadUrl = requiredValue(
+    created?.fileUploadUrl,
+    "Microsoft Store submission upload URL",
+  );
+  const submissionUrl = `${submissionsUrl}/${submissionId}`;
+  const updated = prepareSubmissionPayload(created, packageName);
+
+  await requestJson(
+    fetchImpl,
+    submissionUrl,
+    {
+      method: "PUT",
+      headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify(updated),
+    },
+    "Update Microsoft Store submission",
+  );
+
+  const archiveBytes = await readFileImpl(archive);
+  const uploadResponse = await fetchImpl(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/zip",
+      "x-ms-blob-type": "BlockBlob",
+    },
+    body: archiveBytes,
+  });
+  if (!uploadResponse.ok) {
+    throw new Error(
+      `Upload Microsoft Store package archive failed with HTTP ${uploadResponse.status}`,
+    );
+  }
+
+  await requestJson(
+    fetchImpl,
+    `${submissionUrl}/commit`,
+    { method: "POST", headers },
+    "Commit Microsoft Store submission",
+  );
+
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    if (poll > 0) await sleep(pollIntervalMs);
+    const statusPayload = await requestJson(
+      fetchImpl,
+      `${submissionUrl}/status`,
+      { method: "GET", headers },
+      "Read Microsoft Store submission status",
+    );
+    const status = requiredValue(
+      statusPayload?.status,
+      "Microsoft Store submission status",
+    );
+    const classification = classifyCommitStatus(status);
+    if (classification === "accepted") {
+      return { submissionId: decodeURIComponent(submissionId), status };
+    }
+    if (classification === "failed") {
+      const detail = safeApiError(
+        statusPayload?.statusDetails?.errors?.[0],
+        "Partner Center rejected the commit",
+      );
+      throw new Error(`Microsoft Store submission commit failed: ${detail}`);
+    }
+  }
+  throw new Error(
+    `Microsoft Store submission did not reach preprocessing after ${maxPolls} status checks`,
+  );
+}
+
+export async function main(args = process.argv.slice(2), env = process.env) {
+  const result = await submitMicrosoftStoreUpdate({
+    applicationId: env.MICROSOFT_STORE_APPLICATION_ID,
+    archivePath: requireArgument(args, "--archive"),
+    packageFileName: requireArgument(args, "--package-file-name"),
+    tenantId: env.MICROSOFT_STORE_TENANT_ID,
+    clientId: env.MICROSOFT_STORE_CLIENT_ID,
+    clientSecret: env.MICROSOFT_STORE_CLIENT_SECRET,
+  });
+  console.log(
+    `Microsoft Store submission ${result.submissionId} accepted for ingestion (${result.status}).`,
+  );
+  return result;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    // error-policy:J1 command boundary reports a fail-closed store submission
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/store-release-plan.mjs
+++ b/packages/scripts/store-release-plan.mjs
@@ -46,7 +46,9 @@ export function parseStoreSemver(version) {
   const patch = Number(patchRaw);
   const sequence = Number(sequenceRaw);
   if (sequence > 999) {
-    throw new Error(`Store prerelease sequence must not exceed 999: ${version}`);
+    throw new Error(
+      `Store prerelease sequence must not exceed 999: ${version}`,
+    );
   }
   return { major, minor, patch, prerelease, sequence };
 }
@@ -57,9 +59,7 @@ function numericBuild({ major, minor, patch, prerelease, sequence }) {
       "Store release version exceeds the Android versionCode allocation (major <= 20, minor/patch <= 99)",
     );
   }
-  const offset = prerelease
-    ? (CHANNEL_OFFSETS[prerelease] ?? 8000)
-    : 9000;
+  const offset = prerelease ? (CHANNEL_OFFSETS[prerelease] ?? 8000) : 9000;
   const value =
     major * 100000000 + minor * 1000000 + patch * 10000 + offset + sequence;
   if (value > 2100000000) {
@@ -71,20 +71,26 @@ function numericBuild({ major, minor, patch, prerelease, sequence }) {
 function extensionVersion(parsed) {
   const { major, minor, patch, prerelease, sequence } = parsed;
   if ([major, minor, patch].some((value) => value > 65535)) {
-    throw new Error("Browser extension version components must not exceed 65535");
+    throw new Error(
+      "Browser extension version components must not exceed 65535",
+    );
   }
   const fourth = prerelease
     ? (EXTENSION_CHANNEL_OFFSETS[prerelease] ?? 50000) + sequence
     : 60000;
   if (fourth > 65535) {
-    throw new Error(`Browser extension build component ${fourth} exceeds 65535`);
+    throw new Error(
+      `Browser extension build component ${fourth} exceeds 65535`,
+    );
   }
   return `${major}.${minor}.${patch}.${fourth}`;
 }
 
 export function createStoreReleasePlan({ version, channel, sourceSha }) {
   if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
-    throw new Error(`Store release source SHA must be 40 lowercase hex characters: ${sourceSha}`);
+    throw new Error(
+      `Store release source SHA must be 40 lowercase hex characters: ${sourceSha}`,
+    );
   }
   if (channel !== "beta" && channel !== "latest") {
     throw new Error(`Store release channel must be beta or latest: ${channel}`);
@@ -111,6 +117,8 @@ export function createStoreReleasePlan({ version, channel, sourceSha }) {
     ios_marketing_version: `${parsed.major}.${parsed.minor}.${parsed.patch}`,
     ios_build_number: String(buildNumber),
     apple_lane: stable ? "release" : "beta",
+    windows_package_version: `${parsed.major}.${parsed.minor}.${parsed.patch}.0`,
+    windows_publish: stable,
     snap_channel: stable ? "stable" : "beta",
     extension_version: extensionVersion(parsed),
     chrome_publish_target: stable ? "default" : "trustedTesters",
@@ -137,7 +145,8 @@ export function main(args = process.argv.slice(2)) {
   });
   const outputIndex = args.indexOf("--github-output");
   if (outputIndex >= 0) {
-    if (!args[outputIndex + 1]) throw new Error("--github-output requires a path");
+    if (!args[outputIndex + 1])
+      throw new Error("--github-output requires a path");
     writeGitHubOutputs(args[outputIndex + 1], plan);
   }
   console.log(`${JSON.stringify(plan, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- add a callable, stable-only Microsoft Store release workflow after the canonical release finalizes
- build the AppContainer MSIX on Windows from the exact finalized tag, fail closed on missing Partner Center identity, unpack and validate the package, and retain the exact artifact
- add a tested Microsoft Store submission client that authenticates with the documented service-to-service resource, updates an existing product submission, uploads the ZIP, commits it, and waits for ingestion
- isolate Partner Center credentials to the credential check and final submission step; checkout-controlled build and packaging steps cannot read them
- validate the Partner Center upload destination as a writable HTTPS Azure Blob SAS URL before reading or uploading package bytes

Closes the release-automation portion of #20888. Account verification, initial product creation, the first completed submission, certification, and live publication remain external Partner Center prerequisites.

## Validation

- Exact head: `ddded9422b85b5f6e1f3431684c053737629be6d`
- `bun test packages/scripts/__tests__/microsoft-store-submission.test.ts packages/scripts/__tests__/store-release-plan.test.ts packages/scripts/__tests__/store-release-workflow.test.ts` — 16 passed
- `/opt/homebrew/bin/actionlint .github/workflows/store-windows-publish.yml .github/workflows/release.yaml` — passed
- repository-pinned Biome on all changed supported files — passed
- `git diff --check origin/develop...HEAD` — passed

The real Windows build/submission remains intentionally unclaimed until Microsoft finishes verification and the Partner Center-issued product identity and API credentials exist.

## Evidence Gate

<!-- evidence-head:ddded9422b85b5f6e1f3431684c053737629be6d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - release workflow and submission client change, not an interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic workflow and submission-client tests are listed above; live Partner Center submission remains an explicit external prerequisite.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - a real signed MSIX and Partner Center ingestion receipt require the protected Windows release environment and verified store credentials.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@ddded9422b85b5f6e1f3431684c053737629be6d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@ddded9422b85b5f6e1f3431684c053737629be6d:packages/skills/skills/contribute-to-eliza"} -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ddded9422b85b5f6e1f3431684c053737629be6d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
