### PR TITLE
fix(plugin-elizacloud): fence the full bridge replacement lifecycle

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
@@ -1,19 +1,9 @@
 /**
- * Regression coverage for a stale-close race in CloudBridgeService: a socket
- * replaced by a newer establishConnection() call can still deliver its
- * "close" event after the replacement is already connected. Without a
- * same-instance guard, that late close mutates the CURRENT connection entry
- * (looked up fresh by containerId in scheduleReconnect()), moving an active
- * replacement out of "connected" and scheduling an unwanted reconnect on top
- * of it.
+ * Deterministic lifecycle tests for replacement Cloud bridge sockets and their timers.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime } from "@elizaos/core";
 
-// The real @elizaos/core pulls in a generated-codegen dependency
-// (i18n/validation-keywords.ts -> ./generated/validation-keyword-data.ts)
-// that isn't present in a plain checkout and is unrelated to this race --
-// stub the two exports cloud-bridge.ts actually uses.
 vi.mock("@elizaos/core", () => ({
   Service: class {
     protected runtime: unknown;
@@ -29,7 +19,13 @@ vi.mock("@elizaos/core", () => ({
   },
 }));
 
-type Listener = (event: any) => void;
+interface FakeSocketEvent {
+  code?: number;
+  data?: unknown;
+  reason?: string;
+}
+
+type Listener = (event: FakeSocketEvent) => void;
 
 class FakeWebSocket {
   static readonly CONNECTING = 0;
@@ -51,13 +47,13 @@ class FakeWebSocket {
     this.listeners.set(type, set);
   }
 
-  send(_data: string): void {}
+  readonly send = vi.fn((_data: string): void => {});
 
   close(): void {
     this.readyState = FakeWebSocket.CLOSED;
   }
 
-  emit(type: string, event: any = {}): void {
+  emit(type: string, event: FakeSocketEvent = {}): void {
     for (const listener of this.listeners.get(type) ?? []) listener(event);
   }
 }
@@ -70,30 +66,30 @@ describe("CloudBridgeService stale close race", () => {
     vi.useFakeTimers();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it("ignores a stale close event from a socket replaced by a newer establishConnection()", async () => {
     const { CloudBridgeService } = await import("./cloud-bridge");
     const runtime = {} as IAgentRuntime;
     const service = new CloudBridgeService(runtime);
-    // Bypass initialize()'s CLOUD_AUTH dependency -- not relevant to the
-    // connection-replacement race under test.
-    (service as any).authService = {
+    Reflect.set(service, "authService", {
       getApiKey: () => undefined,
       getClient: () => ({ buildWsUrl: (path: string) => `ws://test${path}` }),
-    };
+    });
 
     await service.connect("container-1");
     const firstSocket = FakeWebSocket.instances[0];
     firstSocket.emit("open");
     expect(service.getConnectionState("container-1")).toBe("connected");
 
-    // Simulate the first socket disconnecting uncleanly and a replacement
-    // being established, but the first socket's own "close" event is
-    // delivered late -- after the replacement has already opened.
-    const disconnect = (service as any).establishConnection(
-      "container-1",
-      0,
-    ) as Promise<void>;
-    await disconnect;
+    const establishConnection = Reflect.get(service, "establishConnection") as (
+      containerId: string,
+      attempts: number,
+    ) => Promise<void>;
+    await establishConnection.call(service, "container-1", 0);
     const secondSocket = FakeWebSocket.instances[1];
     secondSocket.emit("open");
     expect(service.getConnectionState("container-1")).toBe("connected");
@@ -101,7 +97,32 @@ describe("CloudBridgeService stale close race", () => {
     firstSocket.emit("close", { code: 1006, reason: "late stale event" });
 
     expect(service.getConnectionState("container-1")).toBe("connected");
-    // No spurious third connection attempt scheduled off the stale close.
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    vi.advanceTimersByTime(30_000);
+    expect(secondSocket.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a reconnect timer after a manual connection replaces its socket", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { CloudBridgeService } = await import("./cloud-bridge");
+    const service = new CloudBridgeService({} as IAgentRuntime);
+    Reflect.set(service, "authService", {
+      getApiKey: () => undefined,
+      getClient: () => ({ buildWsUrl: (path: string) => `ws://test${path}` }),
+    });
+
+    await service.connect("container-1");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.emit("open");
+    firstSocket.emit("close", { code: 1006, reason: "network loss" });
+    expect(service.getConnectionState("container-1")).toBe("reconnecting");
+
+    await service.connect("container-1");
+    const replacementSocket = FakeWebSocket.instances[1];
+    replacementSocket.emit("open");
+    vi.advanceTimersByTime(6_000);
+
+    expect(service.getConnectionState("container-1")).toBe("connected");
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
 });

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression coverage for a stale-close race in CloudBridgeService: a socket
+ * replaced by a newer establishConnection() call can still deliver its
+ * "close" event after the replacement is already connected. Without a
+ * same-instance guard, that late close mutates the CURRENT connection entry
+ * (looked up fresh by containerId in scheduleReconnect()), moving an active
+ * replacement out of "connected" and scheduling an unwanted reconnect on top
+ * of it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime } from "@elizaos/core";
+
+// The real @elizaos/core pulls in a generated-codegen dependency
+// (i18n/validation-keywords.ts -> ./generated/validation-keyword-data.ts)
+// that isn't present in a plain checkout and is unrelated to this race --
+// stub the two exports cloud-bridge.ts actually uses.
+vi.mock("@elizaos/core", () => ({
+  Service: class {
+    protected runtime: unknown;
+    constructor(runtime?: unknown) {
+      this.runtime = runtime;
+    }
+  },
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+type Listener = (event: any) => void;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  emit(type: string, event: any = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+vi.mock("undici", () => ({ WebSocket: FakeWebSocket }));
+
+describe("CloudBridgeService stale close race", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.useFakeTimers();
+  });
+
+  it("ignores a stale close event from a socket replaced by a newer establishConnection()", async () => {
+    const { CloudBridgeService } = await import("./cloud-bridge");
+    const runtime = {} as IAgentRuntime;
+    const service = new CloudBridgeService(runtime);
+    // Bypass initialize()'s CLOUD_AUTH dependency -- not relevant to the
+    // connection-replacement race under test.
+    (service as any).authService = {
+      getApiKey: () => undefined,
+      getClient: () => ({ buildWsUrl: (path: string) => `ws://test${path}` }),
+    };
+
+    await service.connect("container-1");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.emit("open");
+    expect(service.getConnectionState("container-1")).toBe("connected");
+
+    // Simulate the first socket disconnecting uncleanly and a replacement
+    // being established, but the first socket's own "close" event is
+    // delivered late -- after the replacement has already opened.
+    const disconnect = (service as any).establishConnection(
+      "container-1",
+      0,
+    ) as Promise<void>;
+    await disconnect;
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.emit("open");
+    expect(service.getConnectionState("container-1")).toBe("connected");
+
+    firstSocket.emit("close", { code: 1006, reason: "late stale event" });
+
+    expect(service.getConnectionState("container-1")).toBe("connected");
+    // No spurious third connection attempt scheduled off the stale close.
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -138,6 +138,7 @@ export class CloudBridgeService extends Service {
     this.connections.set(containerId, conn);
 
     ws.addEventListener("open", () => {
+      if (this.connections.get(containerId) !== conn) return;
       conn.state = "connected";
       conn.connectedAt = Date.now();
       conn.reconnectAttempts = 0;
@@ -150,6 +151,7 @@ export class CloudBridgeService extends Service {
     });
 
     ws.addEventListener("message", (event) => {
+      if (this.connections.get(containerId) !== conn) return;
       const raw = event.data;
       const data =
         typeof raw === "string" ? raw : raw instanceof Buffer ? raw.toString("utf-8") : String(raw);
@@ -183,14 +185,11 @@ export class CloudBridgeService extends Service {
     });
 
     ws.addEventListener("close", (event) => {
-      // A socket replaced by a newer establishConnection() (see disconnect()'s
-      // ws.close() and the reconnect timer's own establishConnection() call)
-      // can still deliver its "close" event after `this.connections.get(containerId)`
-      // has moved on to the replacement's `conn`. scheduleReconnect() below looks
-      // up that CURRENT entry by containerId, so an unguarded stale close would
-      // mark an already-connected replacement "reconnecting" and schedule an
-      // unnecessary reconnect on top of it.
-      if (this.connections.get(containerId) !== conn) return;
+      // A late close must clean up its own timer without mutating the replacement.
+      if (this.connections.get(containerId) !== conn) {
+        if (conn.heartbeatTimer) clearInterval(conn.heartbeatTimer);
+        return;
+      }
 
       conn.state = "disconnected";
       if (conn.heartbeatTimer) clearInterval(conn.heartbeatTimer);
@@ -208,6 +207,7 @@ export class CloudBridgeService extends Service {
     });
 
     ws.addEventListener("error", () => {
+      if (this.connections.get(containerId) !== conn) return;
       logger.error(`[CloudBridge] WebSocket error for ${containerId}`);
     });
   }
@@ -234,6 +234,7 @@ export class CloudBridgeService extends Service {
     if (conn) {
       conn.state = "reconnecting";
       conn.reconnectTimer = setTimeout(() => {
+        if (this.connections.get(containerId) !== conn) return;
         this.establishConnection(containerId, attempt);
       }, delay + jitter);
     }

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -183,6 +183,15 @@ export class CloudBridgeService extends Service {
     });
 
     ws.addEventListener("close", (event) => {
+      // A socket replaced by a newer establishConnection() (see disconnect()'s
+      // ws.close() and the reconnect timer's own establishConnection() call)
+      // can still deliver its "close" event after `this.connections.get(containerId)`
+      // has moved on to the replacement's `conn`. scheduleReconnect() below looks
+      // up that CURRENT entry by containerId, so an unguarded stale close would
+      // mark an already-connected replacement "reconnecting" and schedule an
+      // unnecessary reconnect on top of it.
+      if (this.connections.get(containerId) !== conn) return;
+
       conn.state = "disconnected";
       if (conn.heartbeatTimer) clearInterval(conn.heartbeatTimer);
 


### PR DESCRIPTION
## Problem

PR #22562 correctly guards a late `close` event from a replaced Cloud bridge socket, but the same replacement can still deliver stale `open`, `message`, and `error` events. Its heartbeat interval also survives the stale-close early return, and a reconnect timer already scheduled by the old connection can replace a manually restored live socket.

## Fix

- Preserve the original contributor's stale-close guard.
- Ignore every event whose connection object is no longer authoritative.
- Clear the stale connection's own heartbeat during late close cleanup.
- Fence the delayed reconnect callback against the exact connection that scheduled it.
- Add deterministic fake-timer coverage proving a manual replacement remains connected, no third socket appears, and only the live heartbeat runs.

This supersedes #22562 while retaining its original commit and author.

## Validation

- `bun test src/services/cloud-bridge.test.ts`: 2 passed, 0 failed.
- Pinned Bun 1.3.14 and Node 24.15.0.
- `git diff --check`: clean.
- Package typecheck was attempted, but this isolated checkout lacks unrelated workspace/generated dependencies (`uuid`, `drizzle-orm`, generated validation keywords, Capacitor packages, and others). No diagnostic was attributable to the changed files beyond those missing imports.

## Evidence

The deterministic harness exercises real `CloudBridgeService` connection state and timers with a transport-only fake WebSocket. It does not claim a live Cloud bridge session; the change is a local event-ordering contract with no UI surface.

## Attribution

- Original stale-close diagnosis and commit: @Svector-anu in #22562.
- Deep lifecycle review and correction: Codex.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@b258b8315f61:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex-pr-review]

<!-- codex-attribution: {"ai_provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skills":[{"path":"packages/skills/skills/contribute-to-eliza","revision":"b258b8315f61"}],"status":"self-reported"} -->
