### PR TITLE
fix(ui): report absent trajectory I/O as zero lines

### DIFF
--- a/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
@@ -1,5 +1,10 @@
+/** Verifies sparse trajectory I/O normalization with deterministic pure helpers. */
+
 import { describe, expect, it } from "vitest";
-import { normalizeTrajectoryCallText } from "./TrajectoryDetailView";
+import {
+  countTrajectoryCallTextLines,
+  normalizeTrajectoryCallText,
+} from "./trajectory-call-text";
 
 describe("normalizeTrajectoryCallText", () => {
   it("keeps sparse trajectory calls renderable", () => {
@@ -20,5 +25,18 @@ describe("normalizeTrajectoryCallText", () => {
         { role: "user", content: "open notes" },
       ]),
     ).toContain('"content": "open notes"');
+  });
+
+  it("reports zero lines when every input or output candidate is absent", () => {
+    expect(countTrajectoryCallTextLines()).toBe(0);
+    expect(countTrajectoryCallTextLines(undefined, null)).toBe(0);
+    expect(countTrajectoryCallTextLines("")).toBe(0);
+  });
+
+  it("counts multiline and structured fallbacks without truthiness coercion", () => {
+    expect(countTrajectoryCallTextLines(undefined, "first\r\nsecond")).toBe(2);
+    expect(countTrajectoryCallTextLines(undefined, { output: false })).toBe(3);
+    expect(countTrajectoryCallTextLines(false)).toBe(1);
+    expect(countTrajectoryCallTextLines(0)).toBe(1);
   });
 });

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -56,6 +56,11 @@ import {
   getToolCallName,
 } from "../tool-events/ToolCallEventLog.helpers";
 import { Button } from "../ui/button";
+import {
+  countTrajectoryCallTextLines,
+  formatTrajectoryCallPayload,
+  normalizeTrajectoryCallText,
+} from "./trajectory-call-text";
 
 // ---------------------------------------------------------------------------
 // Pipeline stage mapping
@@ -126,35 +131,6 @@ function formatTrajectoryStepLabel(
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized) return fallback;
   return normalized.replace(/_/g, " ");
-}
-
-function formatProviderPayload(value: unknown): string {
-  if (value == null) {
-    return "null";
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
-
-/**
- * Trajectory records are intentionally append-only and may omit prompt fields
- * for provider failures, embeddings, or legacy rows. Normalize those sparse
- * records at the rendering boundary so one missing prompt cannot crash the
- * complete trajectory viewer. Structured fallbacks remain inspectable JSON.
- */
-export function normalizeTrajectoryCallText(...candidates: unknown[]): string {
-  for (const candidate of candidates) {
-    if (candidate == null) continue;
-    if (typeof candidate === "string" && candidate.length === 0) continue;
-    return formatProviderPayload(candidate);
-  }
-  return "";
 }
 
 function isNativeToolCallEvent(
@@ -247,7 +223,7 @@ function labelForEvent(event: TrajectoryEvent): string {
 function descriptionForEvent(event: TrajectoryEvent): string | undefined {
   if (isNativeToolCallEvent(event)) {
     const args = event.args ?? event.input;
-    return args ? formatProviderPayload(args) : undefined;
+    return args ? formatTrajectoryCallPayload(args) : undefined;
   }
   if (isEvaluationEvent(event)) {
     return event.thought || event.decision || event.error;
@@ -587,10 +563,10 @@ export function TrajectoryDetailView({
 
       {trajectory.metadata &&
       Object.keys(trajectory.metadata).length > 0 &&
-      formatProviderPayload(trajectory.metadata).trim().length > 0 ? (
+      formatTrajectoryCallPayload(trajectory.metadata).trim().length > 0 ? (
         <PagePanel variant="section" className="p-5">
           <pre className="max-h-[20rem] overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words rounded-sm bg-bg/60 px-4 py-4 text-xs leading-6 text-txt">
-            {formatProviderPayload(trajectory.metadata)}
+            {formatTrajectoryCallPayload(trajectory.metadata)}
           </pre>
         </PagePanel>
       ) : null}
@@ -700,7 +676,7 @@ export function TrajectoryDetailView({
                       })}
                     </div>
                     <pre className="mt-2 max-h-[18rem] overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words rounded-sm border border-border/50 bg-bg/60 px-4 py-4 text-xs leading-6 text-txt">
-                      {formatProviderPayload(access.query)}
+                      {formatTrajectoryCallPayload(access.query)}
                     </pre>
                   </div>
                 ) : null}
@@ -711,7 +687,7 @@ export function TrajectoryDetailView({
                     })}
                   </div>
                   <pre className="mt-2 max-h-[18rem] overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words rounded-sm border border-border/50 bg-bg/60 px-4 py-4 text-xs leading-6 text-txt">
-                    {formatProviderPayload(access.data)}
+                    {formatTrajectoryCallPayload(access.data)}
                   </pre>
                 </div>
               </PagePanel>
@@ -772,18 +748,15 @@ export function TrajectoryDetailView({
                 })}
                 inputLabel={t("trajectorydetailview.InputUser")}
                 outputLabel={t("trajectorydetailview.OutputResponse")}
-                inputLinesLabel={`${
-                  normalizeTrajectoryCallText(
-                    call.userPrompt,
-                    call.prompt,
-                    call.messages,
-                  ).split("\n").length
-                } ${t("trajectorydetailview.lines")}`}
-                outputLinesLabel={`${
-                  normalizeTrajectoryCallText(call.response, call.output).split(
-                    "\n",
-                  ).length
-                } ${t("trajectorydetailview.lines")}`}
+                inputLinesLabel={`${countTrajectoryCallTextLines(
+                  call.userPrompt,
+                  call.prompt,
+                  call.messages,
+                )} ${t("trajectorydetailview.lines")}`}
+                outputLinesLabel={`${countTrajectoryCallTextLines(
+                  call.response,
+                  call.output,
+                )} ${t("trajectorydetailview.lines")}`}
                 tags={(call.tags ?? []).filter((tag) => tag !== "llm")}
                 userPrompt={normalizeTrajectoryCallText(
                   call.userPrompt,

--- a/packages/ui/src/components/pages/trajectory-call-text.ts
+++ b/packages/ui/src/components/pages/trajectory-call-text.ts
@@ -1,0 +1,32 @@
+/**
+ * Normalizes sparse provider call payloads for trajectory rendering and derives
+ * truthful line metadata from the exact rendered text.
+ */
+
+export function formatTrajectoryCallPayload(value: unknown): string {
+  if (value == null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function normalizeTrajectoryCallText(...candidates: unknown[]): string {
+  for (const candidate of candidates) {
+    if (candidate == null) continue;
+    if (typeof candidate === "string" && candidate.length === 0) continue;
+    return formatTrajectoryCallPayload(candidate);
+  }
+  return "";
+}
+
+export function countTrajectoryCallTextLines(...candidates: unknown[]): number {
+  const text = normalizeTrajectoryCallText(...candidates);
+  return text.length === 0 ? 0 : text.split(/\r?\n/).length;
+}


### PR DESCRIPTION
## Summary

- report zero rendered lines when sparse trajectory input or output is absent instead of fabricating `1 lines` from `"".split("\n")`;
- preserve truthful counts for CRLF text, structured fallbacks, `false`, and `0`;
- isolate the production text/line helpers from the full trajectory view so the focused contract test does not transform the application dependency graph;
- add the required deterministic-harness responsibility header to `TrajectoryDetailView.test.ts`.

Fixes #22601. Follow-up to #22570, whose merged tree retains these two defects.

## Exact source

Head `f397bb7ec40106269fe2beddff8bd2110bbc023c` (tree `e8ecbd3994e0f49dea829552a96ca64f1b62cf5d`) is one commit on `develop@28b9f767315c92cb76930eb4cbe2a6539c7c20bc`. The final parent-only rebase was patch-identical by `git range-diff`.

## Testing

- `bun run --cwd packages/ui test -- src/components/pages/TrajectoryDetailView.test.ts`: **4/4 passed** on the exact head;
- repository Biome over all three changed files: passed;
- `git diff --check origin/develop...HEAD`: passed;
- no dependency install, broad packaging, or visual audit was run or claimed.

## Evidence

This is a deterministic text-metadata correction. The exact production helper is exercised for missing, `undefined`, `null`, empty, CRLF, structured, false, and zero values. No package, install, native, model, or external integration behavior changes.

Keep this PR draft until an independent reviewer approves the exact head.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@50edfacddba2beaf4755e8d6c39e9e09dcdfc09e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
