### PR TITLE
fix(plugin-native-gateway): reject connect() when the socket fails before 'open'

### DIFF
--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -13,6 +13,7 @@ type Listener = (event: unknown) => void;
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
   static deferClose = false;
+  static constructorError: Error | null = null;
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
   static readonly CLOSED = 3;
@@ -23,6 +24,9 @@ class FakeWebSocket {
   private deferredClose: { code: number; reason: string } | null = null;
 
   constructor(readonly url: string) {
+    if (FakeWebSocket.constructorError) {
+      throw FakeWebSocket.constructorError;
+    }
     FakeWebSocket.instances.push(this);
   }
 
@@ -86,6 +90,7 @@ describe("GatewayWeb", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
     FakeWebSocket.deferClose = false;
+    FakeWebSocket.constructorError = null;
     Object.assign(FakeWebSocket, {
       CONNECTING: 0,
       OPEN: 1,
@@ -464,6 +469,32 @@ describe("GatewayWeb", () => {
     expect(await gateway.isConnected()).toEqual({ connected: false });
   });
 
+  it("cancels a superseded connect timeout without tearing down its replacement", async () => {
+    vi.useFakeTimers();
+    const gateway = new GatewayWeb();
+    const first = gateway.connect({ url: "ws://localhost:1234/first" });
+    const firstRejected = expect(first).rejects.toThrow("Connection replaced");
+
+    const second = gateway.connect({ url: "ws://localhost:1234/second" });
+    await firstRejected;
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    secondSocket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(secondSocket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await second;
+
+    // The first connect's deadline must not fire against the now-active socket.
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(await gateway.isConnected()).toEqual({ connected: true });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
   // Regression for #22594: a socket that errors/closes before it ever reaches
   // `open` (the normal browser behavior for a refused/unreachable gateway) must
   // reject connect() and must NOT spin an unbounded background reconnect loop
@@ -512,9 +543,35 @@ describe("GatewayWeb", () => {
     warn.mockRestore();
   });
 
+  it("rejects and cleans up when WebSocket construction throws", async () => {
+    vi.useFakeTimers();
+    FakeWebSocket.constructorError = new Error("blocked by browser policy");
+    const gateway = new GatewayWeb();
+    const states: unknown[] = [];
+    await gateway.addListener("stateChange", (event) => {
+      states.push(event);
+    });
+
+    await expect(
+      gateway.connect({ url: "wss://gateway.example/socket" }),
+    ).rejects.toThrow("blocked by browser policy");
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(await gateway.isConnected()).toEqual({ connected: false });
+    expect(states).toEqual([
+      { state: "connecting" },
+      { state: "disconnected", reason: "blocked by browser policy" },
+    ]);
+  });
+
   it("rejects connect() after the handshake timeout when the socket never opens", async () => {
     vi.useFakeTimers();
     const gateway = new GatewayWeb();
+    const states: unknown[] = [];
+    await gateway.addListener("stateChange", (event) => {
+      states.push(event);
+    });
     const connected = gateway.connect({ url: "ws://localhost:9/socket" });
     let settled = "pending";
     connected.then(
@@ -534,6 +591,10 @@ describe("GatewayWeb", () => {
     await expect(connected).rejects.toThrow(/Connection timeout/);
     expect(settled).toBe("rejected");
     expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(states).toEqual([
+      { state: "connecting" },
+      { state: "disconnected", reason: "Connection timeout" },
+    ]);
   });
 
   it("does not spawn an unbounded reconnect loop after an initial-connect failure", async () => {
@@ -594,5 +655,58 @@ describe("GatewayWeb", () => {
     socket2.open();
     expect(parseSent(socket2, 0)).toMatchObject({ method: "connect" });
     warn.mockRestore();
+  });
+
+  it("retries when a post-connect replacement socket stalls during handshake", async () => {
+    vi.useFakeTimers();
+    const gateway = new GatewayWeb();
+    const connected = gateway.connect({ url: "wss://gateway.example/socket" });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    socket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(socket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await connected;
+
+    socket.close(1006, "network blip");
+    await vi.advanceTimersByTimeAsync(800);
+    const stalledSocket = FakeWebSocket.instances[1];
+    stalledSocket.open();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(1_360);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(await gateway.isConnected()).toEqual({ connected: false });
+  });
+
+  it("retries when WebSocket construction throws during reconnect", async () => {
+    vi.useFakeTimers();
+    const gateway = new GatewayWeb();
+    const connected = gateway.connect({ url: "wss://gateway.example/socket" });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    socket.message(
+      JSON.stringify({
+        type: "res",
+        id: parseSent(socket, 0).id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await connected;
+
+    FakeWebSocket.constructorError = new Error("temporarily blocked");
+    socket.close(1006, "network blip");
+    await vi.advanceTimersByTimeAsync(800);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    FakeWebSocket.constructorError = null;
+    await vi.advanceTimersByTimeAsync(1_360);
+    expect(FakeWebSocket.instances).toHaveLength(2);
   });
 });

--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -463,4 +463,136 @@ describe("GatewayWeb", () => {
     await rejected;
     expect(await gateway.isConnected()).toEqual({ connected: false });
   });
+
+  // Regression for #22594: a socket that errors/closes before it ever reaches
+  // `open` (the normal browser behavior for a refused/unreachable gateway) must
+  // reject connect() and must NOT spin an unbounded background reconnect loop
+  // behind a promise the caller can never observe. Before the fix, connect()
+  // stayed pending forever while fresh sockets were opened indefinitely.
+  it("rejects connect() when the socket closes before it opens", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = new GatewayWeb();
+    const states: unknown[] = [];
+    await gateway.addListener("stateChange", (event) => {
+      states.push(event);
+    });
+
+    const connected = gateway.connect({ url: "ws://localhost:9/socket" });
+    let settled = "pending";
+    connected.then(
+      () => {
+        settled = "resolved";
+      },
+      () => {
+        settled = "rejected";
+      },
+    );
+    const socket = FakeWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    // Refused/unreachable gateway: 'error' then 'close', never 'open'.
+    socket.error(new Error("connection refused"));
+    socket.close(1006, "connection refused");
+
+    await expect(connected).rejects.toThrow(
+      /Connection failed: connection refused/,
+    );
+    expect(settled).toBe("rejected");
+    // No background reconnect socket must be created, even long after backoff.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(states).toEqual([
+      { state: "connecting" },
+      {
+        state: "disconnected",
+        reason: "Connection failed: connection refused",
+      },
+    ]);
+    warn.mockRestore();
+  });
+
+  it("rejects connect() after the handshake timeout when the socket never opens", async () => {
+    vi.useFakeTimers();
+    const gateway = new GatewayWeb();
+    const connected = gateway.connect({ url: "ws://localhost:9/socket" });
+    let settled = "pending";
+    connected.then(
+      () => {
+        settled = "resolved";
+      },
+      () => {
+        settled = "rejected";
+      },
+    );
+
+    // The socket neither opens nor closes; only the bounded connect timeout
+    // can settle the promise.
+    await vi.advanceTimersByTimeAsync(29_000);
+    expect(settled).toBe("pending");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(connected).rejects.toThrow(/Connection timeout/);
+    expect(settled).toBe("rejected");
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not spawn an unbounded reconnect loop after an initial-connect failure", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = new GatewayWeb();
+    const connected = gateway.connect({ url: "ws://localhost:9/socket" });
+    connected.catch(() => {
+      // observed below; prevents an unhandled rejection
+    });
+
+    FakeWebSocket.instances[0].close(1006, "connection refused");
+
+    // Advance far past many exponential-backoff windows (800ms → 15s cap).
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await expect(connected).rejects.toThrow(/Connection failed/);
+    await expect(gateway.isConnected()).resolves.toEqual({ connected: false });
+    warn.mockRestore();
+  });
+
+  it("resolves a normal handshake and still reconnects after a post-connect drop", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = new GatewayWeb();
+    const states: unknown[] = [];
+    await gateway.addListener("stateChange", (event) => {
+      states.push(event);
+    });
+
+    const connected = gateway.connect({ url: "wss://gateway.example/socket" });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    const connectFrame = parseSent(socket, 0);
+    socket.message(
+      JSON.stringify({
+        type: "res",
+        id: connectFrame.id,
+        ok: true,
+        payload: { protocol: 3 },
+      }),
+    );
+    await expect(connected).resolves.toMatchObject({
+      connected: true,
+      protocol: 3,
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // A drop AFTER a successful handshake must still reconnect (unchanged).
+    socket.close(1006, "network blip");
+    expect(states[states.length - 1]).toEqual({
+      state: "reconnecting",
+      reason: "network blip",
+    });
+    await vi.advanceTimersByTimeAsync(1_000); // first backoff is 800ms
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    const socket2 = FakeWebSocket.instances[1];
+    socket2.open();
+    expect(parseSent(socket2, 0)).toMatchObject({ method: "connect" });
+    warn.mockRestore();
+  });
 });

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -247,7 +247,23 @@ export class GatewayWeb extends WebPlugin {
 
     this.notifyStateChange("connecting");
 
-    const ws = new WebSocket(this.options.url);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.options.url);
+    } catch (cause) {
+      // error-policy:J1 WebSocket construction is a browser boundary. Initial
+      // callers receive the failure; reconnects retain the retry contract.
+      const error =
+        cause instanceof Error
+          ? cause
+          : new Error("Failed to create WebSocket connection");
+      if (this.connectReject) {
+        this.failConnect(error);
+      } else {
+        this.handleClose(0, error.message);
+      }
+      return;
+    }
     this.ws = ws;
 
     ws.addEventListener("open", () => {
@@ -339,9 +355,7 @@ export class GatewayWeb extends WebPlugin {
         } else {
           // A gateway that answers the handshake with an error is as fatal to
           // the initial connect as a dropped socket: reject and stop retrying.
-          const error = new Error(
-            result.error?.message || "Connection failed",
-          );
+          const error = new Error(result.error?.message || "Connection failed");
           if (this.connectReject) {
             this.failConnect(error);
           } else {

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -27,6 +27,12 @@ interface PendingRequest {
   timeout: ReturnType<typeof setTimeout>;
 }
 
+// Upper bound on the initial handshake. Covers the pre-open phase (socket never
+// reaches `open`) as well as the post-open wait for the gateway `hello`, so a
+// refused, unreachable, or silently stalled gateway rejects `connect()` instead
+// of leaving the caller's promise pending forever.
+const CONNECT_TIMEOUT_MS = 30000;
+
 function generateUUID(): string {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
     return crypto.randomUUID();
@@ -121,8 +127,10 @@ export class GatewayWeb extends WebPlugin {
   private events: string[] = [];
   private lastSeq: number | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
   private backoffMs = 800;
   private closed = false;
+  private handshakeComplete = false;
   private connectResolve: ((result: GatewayConnectResult) => void) | null =
     null;
   private connectReject: ((error: Error) => void) | null = null;
@@ -160,6 +168,10 @@ export class GatewayWeb extends WebPlugin {
 
   async connect(options: GatewayConnectOptions): Promise<GatewayConnectResult> {
     const url = assertGatewayUrl(options.url);
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -176,14 +188,56 @@ export class GatewayWeb extends WebPlugin {
 
     this.options = { ...options, url };
     this.closed = false;
+    this.handshakeComplete = false;
     this.backoffMs = 800;
     this.resetSessionState();
 
     return new Promise<GatewayConnectResult>((resolve, reject) => {
       this.connectResolve = resolve;
       this.connectReject = reject;
+      // Arm the handshake timeout here — not only in sendConnectFrame — so a
+      // socket that errors/closes before `open` (or never opens at all) still
+      // settles connect() rather than hanging behind an unresolved promise.
+      this.connectTimer = setTimeout(() => {
+        this.connectTimer = null;
+        this.failConnect(new Error("Connection timeout"));
+      }, CONNECT_TIMEOUT_MS);
       this.establishConnection();
     });
+  }
+
+  /**
+   * Settle a failed initial handshake: reject the pending connect() promise,
+   * tear down the socket, and stop the reconnect loop. A gateway that never
+   * completes its first handshake must not spawn sockets forever behind a
+   * promise the caller can neither observe nor cancel except via disconnect().
+   * Post-connect drops keep the normal reconnect behavior and never reach here.
+   */
+  private failConnect(error: Error): void {
+    const reject = this.connectReject;
+    this.connectResolve = null;
+    this.connectReject = null;
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.closed = true;
+    const socket = this.ws;
+    this.ws = null;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+    }
+    this.pending.clear();
+    this.resetSessionState();
+    // Detach before close: browser and test WebSockets may emit `close`
+    // synchronously, and that stale event must not re-enter this failure path.
+    socket?.close(1000, error.message);
+    this.notifyStateChange("disconnected", error.message);
+    reject?.(error);
   }
 
   private establishConnection(): void {
@@ -260,37 +314,48 @@ export class GatewayWeb extends WebPlugin {
 
     this.ws.send(JSON.stringify(frame));
 
+    // Backstop for a socket that opens but whose `hello` response never arrives.
+    // The connect() timer already covers this window; this keeps the pending
+    // RPC entry from leaking and routes any timeout through the same fail path.
     const timeout = setTimeout(() => {
       this.pending.delete(frame.id);
+      const error = new Error("Connection timeout");
       if (this.connectReject) {
-        this.connectReject(new Error("Connection timeout"));
-        this.connectReject = null;
-        this.connectResolve = null;
+        this.failConnect(error);
+      } else {
+        // A reconnect handshake has no connect() promise to reject. Closing
+        // the owned socket routes it through the established retry policy.
+        this.ws?.close(1011, error.message);
       }
-    }, 30000);
+    }, CONNECT_TIMEOUT_MS);
 
     this.pending.set(frame.id, {
       resolve: (result) => {
         clearTimeout(timeout);
         if (result.ok && result.payload && isJsonObject(result.payload)) {
           this.handleHelloOk(result.payload);
+          this.connectReject = null;
+          this.connectResolve = null;
         } else {
+          // A gateway that answers the handshake with an error is as fatal to
+          // the initial connect as a dropped socket: reject and stop retrying.
+          const error = new Error(
+            result.error?.message || "Connection failed",
+          );
           if (this.connectReject) {
-            this.connectReject(
-              new Error(result.error?.message || "Connection failed"),
-            );
+            this.failConnect(error);
+          } else {
+            this.ws?.close(1011, error.message);
           }
         }
-        this.connectReject = null;
-        this.connectResolve = null;
       },
       reject: (error) => {
         clearTimeout(timeout);
+        // Socket-close handling owns post-connect retry. During the initial
+        // handshake there is still a caller promise that must be rejected.
         if (this.connectReject) {
-          this.connectReject(error);
+          this.failConnect(error);
         }
-        this.connectReject = null;
-        this.connectResolve = null;
       },
       timeout,
     });
@@ -309,6 +374,11 @@ export class GatewayWeb extends WebPlugin {
     this.events = toStringArray(features?.events);
     this.backoffMs = 800;
 
+    this.handshakeComplete = true;
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
     this.notifyStateChange("connected");
 
     if (this.connectResolve) {
@@ -417,6 +487,16 @@ export class GatewayWeb extends WebPlugin {
 
   private handleClose(code: number, reason: string): void {
     this.ws = null;
+
+    // The initial handshake never completed: the socket closed/errored before or
+    // during the connect handshake. Reject connect() with the close reason and
+    // stop retrying so a permanently-unreachable gateway cannot leak an unbounded
+    // reconnect loop. failConnect() rejects the pending connect() promise and
+    // clears any in-flight pending entry, so do not double-reject them here.
+    if (!this.handshakeComplete) {
+      this.failConnect(new Error(`Connection failed: ${reason}`));
+      return;
+    }
     this.rejectPending(new Error(`Connection closed: ${reason}`));
     this.resetSessionState();
 
@@ -492,6 +572,10 @@ export class GatewayWeb extends WebPlugin {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
     }
     const socket = this.ws;
     this.ws = null;


### PR DESCRIPTION
# Relates to

Closes #22594

## What changed

`GatewayWeb.connect()` now has a bounded deadline covering the period before a browser WebSocket emits `open`. A close during the initial handshake rejects the caller and stops the otherwise-unobservable reconnect loop, while drops after a completed handshake retain automatic reconnect behavior.

The maintainer repair on top of the submitted fix also:

- clears the prior handshake deadline before an explicit replacement connection, so a stale timer cannot tear down the new socket;
- detaches the owned socket before closing it, preventing synchronous `close` delivery from re-entering teardown and emitting duplicate state;
- translates synchronous WebSocket-constructor failures into the same rejected `connect()` lifecycle;
- retries a stalled/error response on a post-connect reconnect handshake instead of leaving an open but unusable transport;
- retains all lifecycle/identity-fencing coverage merged in #22554.

The change is limited to the browser implementation and its deterministic test harness. Public types and native implementations are unchanged.

## Sync and exact revision

- [x] Target: `develop`
- [x] Rebased without conflicts onto `origin/develop` `7a5464bc27848cfca8e0d19839d85f5d19ffa30c`
- [x] Evidence head: `2294626cb6251cff0de01c6ccfb9df393f255d1b`

<!-- evidence-head:2294626cb6251cff0de01c6ccfb9df393f255d1b -->

## Verification

Run with repository-pinned Bun 1.3.14 and Node 24:

```text
bun run --cwd plugins/plugin-native-gateway test -- --maxWorkers=2
Test Files  1 passed (1)
Tests       29 passed (29)

bun run --cwd plugins/plugin-native-gateway typecheck
$ tsc --noEmit -p tsconfig.json

bun run --cwd plugins/plugin-native-gateway build
created dist/plugin.js, dist/plugin.cjs.js

bunx @biomejs/biome check \
  plugins/plugin-native-gateway/src/web.ts \
  plugins/plugin-native-gateway/src/web.test.ts
Checked 2 files. No fixes applied.
```

Adversarial mutation validation deliberately restored three defects: the stale replacement timer, close-before-detach reentrancy, and unhandled synchronous constructor failure. The three targeted regression tests all failed (`0/3`) for the expected reasons: the healthy replacement became disconnected, the constructor error degraded into a later timeout, and timeout teardown emitted two disconnected states. The exact reviewed head is `3/3` green for those regressions and `29/29` across the package. A separate reconnect-constructor regression proves a synchronous browser-policy failure during an automatic reconnect schedules the next bounded retry rather than escaping the timer callback.

### Real browser proof

The built browser bundle was loaded in headless Chromium with the browser's real `WebSocket`. A connection to an unused loopback port rejected in **12 ms** with `Connection failed: Connection closed`; no timeout or reconnect loop was observed. Reusing the same plugin instance against a real local WebSocket server then completed protocol 3 handshake successfully. The observed state sequence was:

```json
[
  { "state": "connecting" },
  { "state": "disconnected", "reason": "Connection failed: Connection closed" },
  { "state": "connecting" },
  { "state": "connected" },
  { "state": "disconnected", "reason": "Client disconnect" }
]
```

The server accepted exactly one socket: the subsequent healthy connection. Chromium logged the expected `ERR_CONNECTION_REFUSED` for the first URL.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A — transport-only browser plugin; no rendered UI changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A — transport-only browser plugin; no rendered UI changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A — no visual user flow. The observable promise/state contract is captured above with a real Chromium WebSocket.`
<!-- evidence-row:backend-logs -->
- [x] Package verification transcript:

```text
RUN v4.1.5 plugins/plugin-native-gateway
Test Files 1 passed (1); Tests 29 passed (29)
Typecheck: tsc --noEmit -p tsconfig.json completed successfully
Build: created dist/plugin.js and dist/plugin.cjs.js; Biome checked 2 files with no fixes
```
<!-- evidence-row:frontend-logs -->
- [x] Real Chromium console/network transcript:

```text
WebSocket connection to ws://127.0.0.1:<unused>/unreachable failed: net::ERR_CONNECTION_REFUSED
[Gateway] WebSocket error: Event
connect() rejected after 12 ms; recovery server accepted exactly one healthy socket and completed protocol 3
```
<!-- evidence-row:llm-trajectory -->
- [x] `N/A — no model, prompt, action, provider, or agent behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Real browser rejection/recovery artifact:

```json
{"initialFailure":{"outcome":"rejected","message":"Connection failed: Connection closed"},"elapsedMs":12}
{"recovered":{"connected":true,"protocol":3},"isConnected":{"connected":true}}
{"states":["connecting","disconnected","connecting","connected","disconnected"]}
{"acceptedSockets":1,"unexpectedReconnectSockets":0}
```
<!-- evidence-row:ocr-review -->
- [x] `N/A — no rendered visual surface.`

## Known gaps

- The full monorepo `bun run verify` aggregate was not rerun for this isolated browser transport change. The owning package's complete tests, typecheck, production build, formatter/linter, mutation checks, and a real Chromium execution were run at the exact reviewed revision.
- Native iOS/Android hardware evidence is not applicable because only `GatewayWeb` changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8` (original submission), `openai/gpt-5.6-sol` (maintainer review and repair)
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent` (original submission), `Codex desktop` (maintainer review and repair)
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7a5464bc27848cfca8e0d19839d85f5d19ffa30c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@7a5464bc27848cfca8e0d19839d85f5d19ffa30c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@7a5464bc27848cfca8e0d19839d85f5d19ffa30c:packages/skills/skills/contribute-to-eliza"} -->
