### PR TITLE
fix(cloud): bound social media URL downloads

### DIFF
--- a/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
@@ -178,6 +178,28 @@ describe("safeFetch fail-closed", () => {
     );
   });
 
+  test("revalidates a redirect target and refuses a private second hop", async () => {
+    lookupMock
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValueOnce([{ address: "127.0.0.1", family: 4 }]);
+    requestMock.mockImplementation((_options, onResponse) => {
+      const req = createFakeClientRequest(() => {
+        const res = createFakeIncomingMessage({
+          headers: { location: "http://private.example/internal" },
+          statusCode: 302,
+          statusMessage: "Found",
+        });
+        onResponse(res);
+      });
+      return req;
+    });
+
+    await expect(safeFetch("http://public.example/media")).rejects.toThrow(
+      "Endpoint resolves to a private or reserved IP address",
+    );
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
   test("does not connect when DNS resolves after the request is aborted", async () => {
     let finishLookup: ((records: Array<{ address: string; family: number }>) => void) | undefined;
     lookupMock.mockReturnValue(

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Exercises the real social-media download boundary with deterministic
+ * transports, including streaming overflow, cancellation, and abort identity.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, jest, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+
+import * as realSafeFetchModule from "../../security/safe-fetch";
+
+const realSafeFetchExports = { ...realSafeFetchModule };
+const realSafeFetch = realSafeFetchModule.safeFetch;
+const safeFetch = mock(realSafeFetch);
+mock.module("../../security/safe-fetch", () => ({ ...realSafeFetchExports, safeFetch }));
+
+const { downloadSocialMediaBytes } = await import("./media-download");
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+beforeEach(() => {
+  safeFetch.mockClear();
+  safeFetch.mockImplementation(realSafeFetch);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+afterAll(() => {
+  mock.module("../../security/safe-fetch", () => realSafeFetchExports);
+});
+
+describe("downloadSocialMediaBytes", () => {
+  test("uses the real outbound guard and rejects a private initial target", async () => {
+    const error = await downloadSocialMediaBytes("http://127.0.0.1/private").catch(
+      (cause) => cause,
+    );
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SOCIAL_MEDIA_DOWNLOAD_FAILED");
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as Error).message).toMatch(/private|reserved|forbidden/i);
+  });
+
+  test("returns successful response bytes through the shared safe-fetch boundary", async () => {
+    safeFetch.mockResolvedValue(new Response(new Uint8Array([1, 2, 3])));
+    const result = await downloadSocialMediaBytes("https://media.example/image.png");
+
+    expect([...result]).toEqual([1, 2, 3]);
+  });
+
+  test("preserves the provider-specific non-OK message and cancels the body", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { status: 404 },
+    );
+
+    safeFetch.mockResolvedValue(response);
+    const error = await downloadSocialMediaBytes("https://media.example/missing.png", {
+      httpErrorMessage: (status) => `Provider download failed: ${status}`,
+    }).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SOCIAL_MEDIA_DOWNLOAD_HTTP_ERROR");
+    expect(error.message).toBe("Provider download failed: 404");
+    expect(cancelled).toBe(true);
+  });
+
+  test("rejects a declared overflow before reading and cancels the body", async () => {
+    let reads = 0;
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        pull() {
+          reads += 1;
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-length": String(MAX_BYTES + 1) } },
+    );
+
+    safeFetch.mockResolvedValue(response);
+    const error = await downloadSocialMediaBytes("https://media.example/large.bin").catch(
+      (cause) => cause,
+    );
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE");
+    // Web streams may perform one eager pull while constructing the Response;
+    // the downloader itself never acquires a reader for a declared overflow.
+    expect(reads).toBeLessThanOrEqual(1);
+    expect(cancelled).toBe(true);
+  });
+
+  test("stops a chunked response at the cap and cancels without reading the tail", async () => {
+    let cancelled = false;
+    let pulls = 0;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls += 1;
+          if (pulls <= 2) {
+            controller.enqueue(new Uint8Array(6 * 1024 * 1024));
+          } else {
+            controller.enqueue(new Uint8Array([9]));
+          }
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+
+    safeFetch.mockResolvedValue(response);
+    const error = await downloadSocialMediaBytes("https://media.example/chunked.bin").catch(
+      (cause) => cause,
+    );
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE");
+    // The stream implementation may prefetch one tail chunk, but the
+    // downloader retains only the two chunks needed to cross the cap.
+    expect(pulls).toBeLessThanOrEqual(3);
+    expect(cancelled).toBe(true);
+  });
+
+  test("propagates the caller's exact abort reason", async () => {
+    const controller = new AbortController();
+    const reason = new Error("caller stopped");
+    safeFetch.mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+    const pending = downloadSocialMediaBytes("https://media.example/slow.bin", {
+      signal: controller.signal,
+    });
+
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  test("enforces the deadline even when the transport ignores AbortSignal", async () => {
+    jest.useFakeTimers();
+    safeFetch.mockImplementation(() => new Promise(() => undefined));
+    const pending = downloadSocialMediaBytes("https://media.example/stalled.bin");
+
+    jest.advanceTimersByTime(10_000);
+    const error = await pending.catch((cause) => cause);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SOCIAL_MEDIA_DOWNLOAD_TIMEOUT");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.ts
@@ -1,0 +1,169 @@
+/**
+ * Downloads URL-backed social media attachments through the shared outbound
+ * network guard and enforces a hard streaming byte limit before providers
+ * hand the bytes to their authenticated upload APIs.
+ */
+import { ElizaError } from "@elizaos/core";
+
+import { safeFetch } from "../../security/safe-fetch";
+
+const SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES = 10 * 1024 * 1024;
+const SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+interface SocialMediaDownloadOptions {
+  httpErrorMessage?: (status: number) => string;
+  signal?: AbortSignal;
+}
+
+function downloadError(
+  message: string,
+  code: string,
+  context: Record<string, unknown>,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    context,
+    severity: "ephemeral",
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+async function cancelBody(response: Response, reason?: unknown): Promise<void> {
+  try {
+    await response.body?.cancel(reason);
+  } catch {
+    // error-policy:J6 The authoritative download failure is already known;
+    // response cancellation is best-effort connection teardown.
+  }
+}
+
+async function readBodyWithLimit(response: Response, signal: AbortSignal): Promise<Buffer> {
+  const rawLength = response.headers.get("content-length");
+  const declaredLength = rawLength === null ? null : Number(rawLength);
+  if (
+    declaredLength !== null &&
+    Number.isFinite(declaredLength) &&
+    declaredLength > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES
+  ) {
+    await cancelBody(response);
+    throw downloadError(
+      "Remote media exceeds the download byte limit",
+      "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
+      { declaredBytes: declaredLength, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+    );
+  }
+
+  const body = response.body;
+  if (!body) {
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.length > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES) {
+      throw downloadError(
+        "Remote media exceeds the download byte limit",
+        "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
+        { receivedBytes: bytes.length, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+      );
+    }
+    return bytes;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const onAbort = (): void => {
+    void reader.cancel(signal.reason).catch(() => {
+      // error-policy:J6 The abort reason remains authoritative; reader
+      // cancellation is best-effort connection teardown.
+    });
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) onAbort();
+
+  try {
+    for (;;) {
+      signal.throwIfAborted();
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          // error-policy:J6 The byte-limit failure is authoritative; reader
+          // cancellation is best-effort connection teardown.
+        }
+        throw downloadError(
+          "Remote media exceeds the download byte limit",
+          "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
+          { receivedBytes: total, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    try {
+      reader.releaseLock();
+    } catch {
+      // error-policy:J6 Stream lock release is best-effort teardown.
+    }
+  }
+
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    total,
+  );
+}
+
+/** Downloads one untrusted media URL under the social-provider network policy. */
+export async function downloadSocialMediaBytes(
+  sourceUrl: string,
+  options: SocialMediaDownloadOptions = {},
+): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeoutError = downloadError(
+    `Remote media download timed out after ${SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS}ms`,
+    "SOCIAL_MEDIA_DOWNLOAD_TIMEOUT",
+    { timeoutMs: SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS },
+  );
+  let rejectDeadline: (reason: unknown) => void = () => undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  const abort = (reason: unknown): void => {
+    controller.abort(reason);
+    rejectDeadline(reason);
+  };
+  const onCallerAbort = (): void => abort(options.signal?.reason);
+  options.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (options.signal?.aborted) onCallerAbort();
+
+  const timeout = setTimeout(() => abort(timeoutError), SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS);
+  timeout.unref?.();
+
+  try {
+    const response = await Promise.race([
+      safeFetch(sourceUrl, { signal: controller.signal }),
+      deadline,
+    ]);
+    if (!response.ok) {
+      await cancelBody(response);
+      const message =
+        options.httpErrorMessage?.(response.status) ?? `Media fetch failed: ${response.status}`;
+      throw downloadError(message, "SOCIAL_MEDIA_DOWNLOAD_HTTP_ERROR", {
+        status: response.status,
+      });
+    }
+    return await Promise.race([readBodyWithLimit(response, controller.signal), deadline]);
+  } catch (error) {
+    if (error === options.signal?.reason || error === timeoutError || error instanceof ElizaError) {
+      throw error;
+    }
+    // error-policy:J2 Preserve the outbound guard or transport failure as the cause.
+    throw downloadError("Remote media download failed", "SOCIAL_MEDIA_DOWNLOAD_FAILED", {}, error);
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", onCallerAbort);
+  }
+}

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
+import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const BLUESKY_SERVICE = "https://bsky.social";
@@ -237,8 +238,7 @@ export const blueskyProvider: SocialMediaProvider = {
           } else if (media.base64) {
             imageData = Buffer.from(media.base64, "base64");
           } else if (media.url) {
-            const response = await fetch(media.url);
-            imageData = Buffer.from(await response.arrayBuffer());
+            imageData = await downloadSocialMediaBytes(media.url);
           } else {
             continue;
           }
@@ -414,8 +414,7 @@ export const blueskyProvider: SocialMediaProvider = {
     } else if (media.base64) {
       imageData = Buffer.from(media.base64, "base64");
     } else if (media.url) {
-      const response = await fetch(media.url);
-      imageData = Buffer.from(await response.arrayBuffer());
+      imageData = await downloadSocialMediaBytes(media.url);
     } else {
       throw new Error("No media data provided");
     }

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
@@ -10,8 +10,18 @@
 //      social actions) DISTINGUISHABLE from an internal failure, which throws.
 // The rate-limit backoff sleeps are collapsed so a retrying failure rejects
 // promptly instead of waiting out real exponential-backoff delays.
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { MediaAttachment, SocialCredentials } from "../../../types/social-media";
+import * as realMediaDownload from "../media-download";
+
+const realMediaDownloadExports = { ...realMediaDownload };
+const downloadSocialMediaBytes = mock(
+  async (
+    _url: string,
+    _options?: { httpErrorMessage?: (status: number) => string },
+  ): Promise<Buffer> => Buffer.from([1, 2, 3]),
+);
+mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
 
 mock.module("../../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
@@ -55,6 +65,8 @@ const REGISTER_RESPONSE = {
 };
 
 beforeEach(() => {
+  downloadSocialMediaBytes.mockClear();
+  downloadSocialMediaBytes.mockImplementation(async () => Buffer.from([1, 2, 3]));
   (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
     fn();
     return 0 as unknown as ReturnType<typeof setTimeout>;
@@ -64,6 +76,10 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = realFetch;
   globalThis.setTimeout = realSetTimeout;
+});
+
+afterAll(() => {
+  mock.module("../media-download", () => realMediaDownloadExports);
 });
 
 async function rejects(p: Promise<unknown>): Promise<Error> {
@@ -122,6 +138,9 @@ describe("linkedinProvider.uploadMedia — fail closed", () => {
 
   it("PROPAGATES a non-OK image download instead of uploading garbage bytes", async () => {
     mockLinkedInFetch({ uploadStatus: 200, downloadStatus: 404 });
+    downloadSocialMediaBytes.mockImplementation(async (_url, options) => {
+      throw new Error(options?.httpErrorMessage?.(404) ?? "download failed");
+    });
     const media: MediaAttachment = {
       type: "image",
       mimeType: "image/png",
@@ -131,6 +150,7 @@ describe("linkedinProvider.uploadMedia — fail closed", () => {
     const err = await rejects(linkedinProvider.uploadMedia!(CREDS, media));
     expect(err.message).toContain("download failed");
     expect(err.message).toContain("404");
+    expect(downloadSocialMediaBytes).toHaveBeenCalledTimes(1);
   });
 
   it("throws (designed invalid input) without any fetch when the access token is absent", async () => {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
+import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const LINKEDIN_API_BASE = "https://api.linkedin.com/v2";
@@ -216,13 +217,10 @@ export const linkedinProvider: SocialMediaProvider = {
             // Download and upload the image. A non-OK download or upload must
             // surface: otherwise the asset below is marked READY and attached to
             // a published post that references bytes LinkedIn never received.
-            const imageResponse = await fetch(media.url);
-            if (!imageResponse.ok) {
-              throw new Error(
-                `LinkedIn image download failed for ${media.url}: ${imageResponse.status}`,
-              );
-            }
-            const imageData = await imageResponse.arrayBuffer();
+            const imageData = await downloadSocialMediaBytes(media.url, {
+              httpErrorMessage: (status) =>
+                `LinkedIn image download failed for ${media.url}: ${status}`,
+            });
 
             const uploadResponse = await fetch(uploadUrl, {
               method: "PUT",
@@ -230,7 +228,7 @@ export const linkedinProvider: SocialMediaProvider = {
                 Authorization: `Bearer ${credentials.accessToken}`,
                 "Content-Type": media.mimeType,
               },
-              body: imageData,
+              body: new Uint8Array(imageData),
             });
             if (!uploadResponse.ok) {
               throw new Error(`LinkedIn asset upload failed: ${uploadResponse.status}`);
@@ -394,11 +392,12 @@ export const linkedinProvider: SocialMediaProvider = {
     } else if (media.base64) {
       imageData = Uint8Array.from(Buffer.from(media.base64, "base64"));
     } else if (media.url) {
-      const response = await fetch(media.url);
-      if (!response.ok) {
-        throw new Error(`LinkedIn image download failed for ${media.url}: ${response.status}`);
-      }
-      imageData = new Uint8Array(await response.arrayBuffer());
+      imageData = new Uint8Array(
+        await downloadSocialMediaBytes(media.url, {
+          httpErrorMessage: (status) =>
+            `LinkedIn image download failed for ${media.url}: ${status}`,
+        }),
+      );
     } else {
       throw new Error("No media data provided");
     }
@@ -411,7 +410,7 @@ export const linkedinProvider: SocialMediaProvider = {
         Authorization: `Bearer ${credentials.accessToken}`,
         "Content-Type": media.mimeType,
       },
-      body: Buffer.from(imageData),
+      body: new Uint8Array(imageData),
     });
     if (!uploadResponse.ok) {
       throw new Error(`LinkedIn asset upload failed: ${uploadResponse.status}`);

--- a/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service mastodon behavior behind route handlers.
+/** Implements Mastodon publishing, media upload, and analytics for cloud social-media callers. */
 import type {
   AccountAnalytics,
   MediaAttachment,
@@ -10,6 +10,7 @@ import type {
   SocialMediaProvider,
 } from "../../../types/social-media";
 import { logger } from "../../../utils/logger";
+import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 interface MastodonStatus {
@@ -101,8 +102,7 @@ async function uploadMedia(
   } else if (media.base64) {
     fileData = Buffer.from(media.base64, "base64");
   } else if (media.url) {
-    const response = await fetch(media.url);
-    fileData = Buffer.from(await response.arrayBuffer());
+    fileData = await downloadSocialMediaBytes(media.url);
   } else {
     throw new Error("No media data provided");
   }

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -20,6 +20,7 @@
  */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { MediaAttachment, PostContent, SocialCredentials } from "../../../types/social-media";
+import * as realMediaDownload from "../media-download";
 import * as realRateLimit from "../rate-limit";
 
 // bun's `mock.restore()` (afterEach below) restores spies but does NOT undo
@@ -31,6 +32,16 @@ import * as realRateLimit from "../rate-limit";
 // which share the same rate-limit module. Snapshot the real exports now and
 // reinstall them in afterAll so this file's stub is strictly local.
 const realRateLimitExports = { ...realRateLimit };
+const realMediaDownloadExports = { ...realMediaDownload };
+
+const downloadSocialMediaBytes = mock(
+  async (
+    _url: string,
+    _options?: { httpErrorMessage?: (status: number) => string },
+  ): Promise<Buffer> => Buffer.from("PNGBYTES"),
+);
+
+mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
 
 mock.module("../rate-limit", () => ({
   withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => {
@@ -54,9 +65,6 @@ const json = (body: unknown, status = 200): Response =>
     headers: { "content-type": "application/json" },
   });
 
-const raw = (body: string, status = 200): Response =>
-  new Response(body, { status, headers: { "content-type": "text/plain" } });
-
 const BOT_CREDS = { botToken: "xoxb-token", channelId: "C123" } as SocialCredentials;
 
 let fetchQueue: Array<(input: unknown) => Response>;
@@ -64,6 +72,8 @@ const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
   fetchQueue = [];
+  downloadSocialMediaBytes.mockClear();
+  downloadSocialMediaBytes.mockImplementation(async () => Buffer.from("PNGBYTES"));
   globalThis.fetch = mock(async (input: unknown) => {
     const next = fetchQueue.shift();
     if (!next) throw new Error("unexpected fetch call — queue empty");
@@ -78,6 +88,7 @@ afterEach(() => {
 
 afterAll(() => {
   mock.module("../rate-limit", () => realRateLimitExports);
+  mock.module("../media-download", () => realMediaDownloadExports);
 });
 
 async function rejects(p: Promise<unknown>): Promise<Error> {
@@ -97,21 +108,20 @@ describe("slackProvider.uploadMedia — fail closed on a failed source download"
   } as MediaAttachment;
 
   test("PROPAGATES a non-OK media download instead of uploading the error body", async () => {
-    // Only the download is attempted; the files.upload fetch must never run.
-    fetchQueue = [() => raw("not found", 404)];
+    downloadSocialMediaBytes.mockImplementation(async (_url, options) => {
+      throw new Error(options?.httpErrorMessage?.(404) ?? "download failed");
+    });
 
     const err = await rejects(slackProvider.uploadMedia!(BOT_CREDS, urlMedia));
     expect(err.message).toContain("Failed to download media");
     expect(err.message).toContain("404");
     // The upload call was never reached — the download failure short-circuited.
     expect(fetchQueue.length).toBe(0);
+    expect(downloadSocialMediaBytes).toHaveBeenCalledTimes(1);
   });
 
   test("uploads successfully when the download AND files.upload both succeed (drives the real path)", async () => {
-    fetchQueue = [
-      () => raw("PNGBYTES", 200),
-      () => json({ ok: true, file: { id: "F1", permalink: "https://files/x" } }),
-    ];
+    fetchQueue = [() => json({ ok: true, file: { id: "F1", permalink: "https://files/x" } })];
 
     const result = await slackProvider.uploadMedia!(BOT_CREDS, urlMedia);
     expect(result.mediaId).toBe("F1");
@@ -119,7 +129,7 @@ describe("slackProvider.uploadMedia — fail closed on a failed source download"
   });
 
   test("PROPAGATES a files.upload rejection (ok:false) instead of returning a fake mediaId", async () => {
-    fetchQueue = [() => raw("PNGBYTES", 200), () => json({ ok: false, error: "invalid_auth" })];
+    fetchQueue = [() => json({ ok: false, error: "invalid_auth" })];
 
     const err = await rejects(slackProvider.uploadMedia!(BOT_CREDS, urlMedia));
     expect(err.message).toContain("invalid_auth");

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service slack behavior behind route handlers.
+/** Implements Slack publishing, file upload, and reactions for cloud social-media callers. */
 import type {
   MediaAttachment,
   PlatformPostOptions,
@@ -9,6 +9,7 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
+import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const SLACK_API_BASE = "https://slack.com/api";
@@ -343,11 +344,9 @@ export const slackProvider: SocialMediaProvider = {
     } else if (media.base64) {
       fileData = Buffer.from(media.base64, "base64");
     } else if (media.url) {
-      const response = await fetch(media.url);
-      if (!response.ok) {
-        throw new Error(`Failed to download media from ${media.url}: ${response.status}`);
-      }
-      fileData = Buffer.from(await response.arrayBuffer());
+      fileData = await downloadSocialMediaBytes(media.url, {
+        httpErrorMessage: (status) => `Failed to download media from ${media.url}: ${status}`,
+      });
       const urlParts = media.url.split("/");
       filename = urlParts[urlParts.length - 1].split("?")[0] || filename;
     } else {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service twitter behavior behind route handlers.
+/** Implements X publishing, media upload, and analytics for cloud social-media callers. */
 import type {
   AccountAnalytics,
   MediaAttachment,
@@ -12,6 +12,7 @@ import type {
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { TWITTER_API_BASE, TWITTER_UPLOAD_BASE } from "../../../utils/twitter-api";
+import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 // Wrapped with retry logic for social media provider
@@ -44,8 +45,7 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
   } else if (media.base64) {
     mediaData = Buffer.from(media.base64, "base64");
   } else if (media.url) {
-    const response = await fetch(media.url);
-    mediaData = Buffer.from(await response.arrayBuffer());
+    mediaData = await downloadSocialMediaBytes(media.url);
   } else {
     throw new Error("No media data provided");
   }


### PR DESCRIPTION
# Relates to

Fixes #22600.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fa0f17f88e7b5339f1487143ba62af5bb6c06a5d:packages/skills/skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The final repair commit was authored and committed by OpenAI Codex (`codex@openai.com`) using OpenAI gpt-5.6-sol. Independent exact-head review is required before merge.

# Sync with develop

- [x] Rebased onto `origin/develop@fa0f17f88e7b5339f1487143ba62af5bb6c06a5d` with zero conflicts.
- [x] Exact repair head: `a1870c697f644614e139266237971bdbddbb9d4b`.

# What changed

- Added one internal social-media download boundary with no injectable transport bypass, bound unconditionally to the existing per-hop DNS validation and socket-pinning `safeFetch` policy.
- Enforced a private 10 MiB streaming cap with declared-length rejection, chunk-by-chunk accounting, and response cancellation on overflow.
- Added an independent 10-second deadline that rejects even if transport/DNS ignores AbortSignal, while preserving an explicit caller abort reason.
- Routed all seven URL-backed fetches across Bluesky, LinkedIn, Mastodon, Slack, and X through the shared boundary.
- Kept provider-authenticated upload requests and provider-specific HTTP failure messages unchanged.
- Added a real redirect-to-private second-hop test to `safeFetch` and real boundary/provider-path tests.

# Behavioral validation

- `media-download.test.ts`: 7/7 pass (real initial private-target rejection; success; non-OK cancellation; declared overflow; chunked overflow; caller abort identity; non-cooperative timeout).
- `safe-fetch.test.ts`: 19/19 pass, including public first hop redirected to a private second hop with no second socket request.
- Provider error-policy suites: Bluesky 5/5, LinkedIn 9/9, Slack 7/7, X 9/9.
- Total focused tests: 56/56 pass.
- Changed-file Biome: 10 files pass.
- `git diff --check origin/develop...HEAD`: pass.
- Package typecheck was attempted in the sparse isolated checkout. It reports only pre-existing/missing optional workspace dependency diagnostics; filtering the output produced no diagnostics for any changed file.

# Risk and compatibility

The byte and timeout limits intentionally fail closed for oversized or stalled URL-backed media. Inline `data` and `base64` paths are unchanged. Provider authorization headers remain only on provider upload calls and are never forwarded to the untrusted media URL or redirects.

# Evidence Gate

<!-- evidence-head:a1870c697f644614e139266237971bdbddbb9d4b -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only network boundary; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only network boundary; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic exact-head test output above exercises the backend boundary without a deployed provider credential.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent data or external provider artifact was created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact changed.

Author: OpenAI / gpt-5.6-sol (Codex), lane [byt61-new-eliza].

