### PR TITLE
fix(plugin-whatsapp): remove TypeScript import suffix

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -6,7 +6,7 @@
  */
 
 import { truncateWellFormed } from "@elizaos/core";
-import { stripWhatsAppTargetPrefixes } from "./whatsapp-target-prefix.ts";
+import { stripWhatsAppTargetPrefixes } from "./whatsapp-target-prefix";
 
 /**
  * WhatsApp text chunk limit


### PR DESCRIPTION
Closes #22605.

## Summary

Removes the `.ts` suffix from the relative `whatsapp-target-prefix` import introduced by #22558. The package does not enable `allowImportingTsExtensions`, so the suffix made the required typecheck fail with TS5097.

## Verification

Exact head: `bf4e2d4ddca7142b7c61988082f3390948ce4b28`

- `bun run --cwd plugins/plugin-whatsapp typecheck` — pass
- `bun run --cwd plugins/plugin-whatsapp lint:check` — pass, 37 files
- `bun run --cwd plugins/plugin-whatsapp test` — pass, 13 files / 100 tests
- `bun run --cwd plugins/plugin-whatsapp build` — pass
- Root `bun run verify` previously reached 248 successful Turbo tasks and identified this exact WhatsApp typecheck as its only reported blocker; a clean post-merge root rerun is required before dependent PR acceptance.

## Evidence Gate

<!-- evidence-head:bf4e2d4ddca7142b7c61988082f3390948ce4b28 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — exact compiler, test, lint, and build results are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no persistent domain artifact changed; exact package gates are recorded above.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual surface changed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->

