### PR TITLE
fix(lifeops): keep creative-draft phrase checks linear

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/creative-draft/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/creative-draft/index.ts
@@ -343,8 +343,35 @@ function normalizedInvariantText(value: string): string {
   );
 }
 
-function isInvariantWordCharacter(value: string | undefined): boolean {
-  return value !== undefined && /[\p{L}\p{M}\p{N}]/u.test(value);
+function isInvariantWordCodePoint(codePoint: number | undefined): boolean {
+  return (
+    codePoint !== undefined &&
+    /[\p{L}\p{M}\p{N}]/u.test(String.fromCodePoint(codePoint))
+  );
+}
+
+/**
+ * Code point immediately before `index`, read without copying the prefix. A
+ * trailing surrogate pair is recombined so an astral character keeps the same
+ * word-boundary classification the old prefix-copy path produced.
+ */
+function codePointBefore(text: string, index: number): number | undefined {
+  if (index <= 0) return undefined;
+  const previous = text.charCodeAt(index - 1);
+  if (previous >= 0xdc00 && previous <= 0xdfff && index - 2 >= 0) {
+    return text.codePointAt(index - 2);
+  }
+  return text.codePointAt(index - 1);
+}
+
+/**
+ * Code point at `index`, read without copying the suffix. `codePointAt`
+ * already combines a surrogate pair that begins at a high surrogate, so an
+ * astral character following the match is classified whole.
+ */
+function codePointStartingAt(text: string, index: number): number | undefined {
+  if (index >= text.length) return undefined;
+  return text.codePointAt(index);
 }
 
 /** Match a normalized phrase without treating a short token as a word fragment. */
@@ -354,21 +381,24 @@ function containsInvariantPhrase(haystack: string, needle: string): boolean {
   if (!normalizedNeedle) return false;
 
   const needleCodePoints = Array.from(normalizedNeedle);
-  const firstNeedle = needleCodePoints[0];
-  const lastNeedle = needleCodePoints.at(-1);
+  const firstNeedle = needleCodePoints[0]?.codePointAt(0);
+  const lastNeedle = needleCodePoints.at(-1)?.codePointAt(0);
   let fromIndex = 0;
   while (fromIndex <= normalizedHaystack.length - normalizedNeedle.length) {
     const index = normalizedHaystack.indexOf(normalizedNeedle, fromIndex);
     if (index < 0) return false;
-    const before = Array.from(normalizedHaystack.slice(0, index)).at(-1);
-    const after = Array.from(
-      normalizedHaystack.slice(index + normalizedNeedle.length),
-    )[0];
+    // Read the neighboring code points by index instead of slicing a growing
+    // prefix/suffix, keeping each search step linear in the haystack length.
+    const before = codePointBefore(normalizedHaystack, index);
+    const after = codePointStartingAt(
+      normalizedHaystack,
+      index + normalizedNeedle.length,
+    );
     const startsAtBoundary =
-      !isInvariantWordCharacter(firstNeedle) ||
-      !isInvariantWordCharacter(before);
+      !isInvariantWordCodePoint(firstNeedle) ||
+      !isInvariantWordCodePoint(before);
     const endsAtBoundary =
-      !isInvariantWordCharacter(lastNeedle) || !isInvariantWordCharacter(after);
+      !isInvariantWordCodePoint(lastNeedle) || !isInvariantWordCodePoint(after);
     if (startsAtBoundary && endsAtBoundary) return true;
     fromIndex = index + 1;
   }

--- a/plugins/plugin-personal-assistant/test/creative-draft.test.ts
+++ b/plugins/plugin-personal-assistant/test/creative-draft.test.ts
@@ -209,6 +209,79 @@ describe("creative draft owner-voice primitives", () => {
     ).toEqual(["vetoed phrase reintroduced: art"]);
   });
 
+  it("scans repeated fragment-only matches in linear time", () => {
+    const initial = createCreativeDraftArtifact({
+      request: {
+        title: "Adversarial fragments",
+        targetForm: "memo",
+        ownerAsk: "Draft this.",
+      },
+      memos: [{ id: "memo-perf", transcript: "Start with the result." }],
+      styleCard: buildOwnerVoiceStyleCard(ownerSources),
+      nowIso: "2026-07-06T10:10:00.000Z",
+    });
+    const revised = applyCreativeDraftRevision(initial, {
+      instruction: "Never use art as a standalone label.",
+      vetoedPhrase: "art",
+      revisedAt: "2026-07-06T10:20:00.000Z",
+    });
+
+    // Each "start " token embeds the needle "art" as a word fragment, so a
+    // naive prefix/suffix-copying boundary check is quadratic in the tens of
+    // thousands of near-miss matches this narrative produces.
+    const adversarialFragments = "start ".repeat(40000);
+    const fragmentStart = performance.now();
+    const fragmentViolations = creativeDraftNarrativeViolations(
+      adversarialFragments,
+      revised,
+    );
+    const fragmentElapsed = performance.now() - fragmentStart;
+    expect(fragmentViolations).toEqual([]);
+    // A quadratic scan of this input runs for many seconds; the linear scan is
+    // a few milliseconds. The generous bound stays green on a slow CI runner
+    // while still failing the quadratic regression.
+    expect(fragmentElapsed).toBeLessThan(1500);
+
+    // A genuinely word-bounded occurrence at the end of the same long prose
+    // must still be caught.
+    expect(
+      creativeDraftNarrativeViolations(
+        `${adversarialFragments}The art speaks.`,
+        revised,
+      ),
+    ).toEqual(["vetoed phrase reintroduced: art"]);
+  });
+
+  it("treats astral neighbors as word-boundary characters via surrogate pairs", () => {
+    const initial = createCreativeDraftArtifact({
+      request: {
+        title: "Astral boundaries",
+        targetForm: "memo",
+        ownerAsk: "Draft this.",
+      },
+      memos: [{ id: "memo-astral", transcript: "Start with the result." }],
+      styleCard: buildOwnerVoiceStyleCard(ownerSources),
+      nowIso: "2026-07-06T10:10:00.000Z",
+    });
+    const revised = applyCreativeDraftRevision(initial, {
+      instruction: "Never use art as a standalone label.",
+      vetoedPhrase: "art",
+      revisedAt: "2026-07-06T10:20:00.000Z",
+    });
+
+    // U+10348 (GOTHIC LETTER HWAIR) is an astral \p{L}. Recombining the
+    // trailing surrogate pair keeps "art" bounded by letters, so it is a
+    // fragment, not a standalone phrase.
+    expect(
+      creativeDraftNarrativeViolations("\u{10348}art\u{10348}", revised),
+    ).toEqual([]);
+    // U+1F600 (GRINNING FACE) is an astral symbol, not a letter, so it forms a
+    // word boundary and the phrase is enforced.
+    expect(
+      creativeDraftNarrativeViolations("\u{1F600}art\u{1F600}", revised),
+    ).toEqual(["vetoed phrase reintroduced: art"]);
+  });
+
   it("replaces a superseded accepted passage instead of requiring both", () => {
     const initial = createCreativeDraftArtifact({
       request: {


### PR DESCRIPTION
# Relates to

Closes #22595

Post-merge follow-up to #22590. A maintainer-authored, unclaimed scoped work item.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused package checks were run after sync; the repo-wide `bun run verify` was not run to completion in this sandbox (unbuilt workspace type declarations) — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1e73b52fd30cfd9132d310b763296a9a6e9ddaf8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to completion; the unrelated blocker (unbuilt `@elizaos/*` workspace type declarations in this sandbox) is documented in **Known gaps / failures**. Focused package tests, Biome, and isolated strict typecheck of the changed code all pass.

# Risks

Low. The change is confined to one private helper (`containsInvariantPhrase`) and two new pure, non-exported helpers in a single file. The observable result of every phrase check is byte-for-byte unchanged (all 21 existing creative-draft tests pass untouched); only the internal neighbor-extraction strategy changed from copying growing slices to indexed code-point reads.

# Background

## What does this PR do?

`containsInvariantPhrase` in the personal-assistant creative-draft module guards generated prose against reintroduced vetoed phrases and dropped accepted passages. For every partial `indexOf` match it inspected the adjacent Unicode code points to enforce an alphanumeric word boundary, using:

```ts
const before = Array.from(normalizedHaystack.slice(0, index)).at(-1);
const after  = Array.from(normalizedHaystack.slice(index + normalizedNeedle.length))[0];
```

Both `slice` + `Array.from` calls copy an **ever-growing** prefix/suffix on **every** iteration. A long generated narrative with many fragment-only matches (the issue's example: repeated `start` while the vetoed phrase is `art`) makes the scan **quadratic** in haystack length. The model-output narrative path (`creativeDraftNarrativeViolations`) has no explicit length cap, so this is reachable from generated prose.

This PR replaces the two growing-slice allocations with **allocation-free, index-based code-point reads**, keeping each search step linear:

- **Before the match** (`codePointBefore`): if `index === 0` there is no neighbor. Otherwise inspect `charCodeAt(index - 1)`; if it is a low surrogate (`0xDC00–0xDFFF`) and `index - 2 >= 0`, recombine via `codePointAt(index - 2)`, else `codePointAt(index - 1)`.
- **After the match** (`codePointStartingAt`): `codePointAt(end)` already combines a surrogate pair that begins at a high surrogate, so astral characters are read whole.

`isInvariantWordCharacter(string)` became `isInvariantWordCodePoint(number)` so the same `/[\p{L}\p{M}\p{N}]/u` boundary test applies without re-allocating single-char strings. The `firstNeedle`/`lastNeedle` short-circuit logic is unchanged. Astral (surrogate-pair) neighbors keep their exact prior word-boundary classification.

## What kind of change is this?

Bug fix (non-breaking): a worst-case algorithmic-complexity regression fix. No public surface change.

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is unchanged; only internal complexity improves.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/lifeops/creative-draft/index.ts` (`containsInvariantPhrase` + new `codePointBefore` / `codePointStartingAt` / `isInvariantWordCodePoint`) and the two new tests in `plugins/plugin-personal-assistant/test/creative-draft.test.ts`.

## Detailed testing steps

From `plugins/plugin-personal-assistant`:

```bash
bunx vitest run --config vitest.config.ts test/creative-draft.test.ts test/creative-draft-action.test.ts
```

Result: **2 files passed, 21 tests passed** (19 pre-existing + 2 new). All pre-existing assertions are unchanged.

New tests:
1. **`scans repeated fragment-only matches in linear time`** — builds an adversarial 240,000-char haystack (`"start ".repeat(40000)`), asserts the fragment case returns no violations, a genuinely word-bounded `art` at the end is still caught, and the scan completes in `< 1500ms` (linear runs in ~50–70ms; the quadratic version does not finish in 120s — see timing artifact).
2. **`treats astral neighbors as word-boundary characters via surrogate pairs`** — locks in surrogate-pair handling: `U+10348` (GOTHIC LETTER HWAIR, a `\p{L}`) makes `art` a fragment (no violation); `U+1F600` (GRINNING FACE, a symbol) forms a word boundary (violation). Without surrogate recombination the astral letter would be misclassified as a lone surrogate and produce a false violation, so this test fails on the naive fix.

# Evidence Gate

<!-- evidence-head:dec9ae2c47d6105bc860ffcf9603f932d51fe1c5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - no UI surface; this is a pure server-side string/complexity fix in @elizaos/plugin-personal-assistant with no rendered output.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user-facing UI flow; behavior is verified by deterministic unit tests and a timing regression pasted below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs / real code path — the focused Vitest run below exercises the real `containsInvariantPhrase` path via `creativeDraftNarrativeViolations` (`bunx vitest run --config vitest.config.ts test/creative-draft.test.ts test/creative-draft-action.test.ts`; from `plugins/plugin-personal-assistant`):
  <details><summary>backend test output / logs</summary>

```
✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > builds a style card from owner-authored examples 23ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > maps memo affect into draft sections and prompt payload 4ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > scores owner-like copy above a generic consultant baseline 1ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > revisions preserve accepted edits and vetoed phrases across turns 4ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > rejects a veto that remains in a structured draft section 2ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > matches vetoes as phrases instead of fragments of other words 1ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > scans repeated fragment-only matches in linear time 49ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > treats astral neighbors as word-boundary characters via surrogate pairs 2ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > replaces a superseded accepted passage instead of requiring both 2ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > revises a non-first section by sectionIndex 1ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > revises a non-first section by sectionId regardless of position 1ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > rejects a revision whose target section does not exist 1ms
 ✓ plugins/plugin-personal-assistant/test/creative-draft.test.ts > creative draft owner-voice primitives > sources instructions through OptimizedPromptService when a runtime is supplied 1ms
 Test Files  1 passed (1)

Test Files  2 passed (2)
Tests  21 passed (21)
```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model behavior changed; this is an internal helper's algorithmic complexity. The function's observable output is byte-for-byte identical (all 21 tests unchanged).`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — failing-then-passing timing reproduction on identical adversarial input (`haystack = "start ".repeat(40000)`, `needle = "art"`): quadratic BEFORE does not finish in a 120s hard timeout (exit 124); linear AFTER returns in ~50ms.
  <details><summary>before/after timing output (domain artifact)</summary>

```
--- default (linear only, quadratic noted) ---
AFTER  (linear):    61.9ms   result=false
BEFORE (quadratic): SKIPPED here; a separate uncapped run did NOT finish in 120s
                    (synchronous quadratic scan blocks the event loop entirely)

--- confirming BEFORE does not finish in 120s (hard timeout) ---
AFTER  (linear):    49.8ms   result=false
exit=124 (124 = timed out at 120s, proving quadratic blowup)
```
  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - internal helper complexity fix with byte-for-byte-identical observable output; no model/agent path changed.`

## Backend + frontend logs

See the **Backend logs / real code path** row in the Evidence Gate above for the full inline Vitest transcript (`Test Files 2 passed`, `Tests 21 passed`).

## Screenshots (before / after) + video walkthrough

### Before
`N/A - no UI change.`
### After
`N/A - no UI change.`
### Walkthrough video
`N/A - no UI flow.`

## Domain artifact — before/after timing reproduction (quadratic → linear)

Same adversarial input for both implementations: `haystack = "start ".repeat(40000)` (240,000 chars), `needle = "art"` (partial-matches inside every `start`, never word-bounded).

See the **Domain artifacts** row in the Evidence Gate above for the full inline before/after timing transcript. The `BEFORE` (quadratic) scan blocks the event loop and does not finish within the 120s `timeout` (exit 124); the `AFTER` (linear) scan returns in ~50ms — exactly the regression the new `scans repeated fragment-only matches in linear time` test guards, with a robust 1500ms budget for slow CI.

## Audio / voice walkthrough

`N/A - no audio/voice surface.`

## Known gaps / failures

- **`bun run verify` (repo-wide) not run to completion.** In this sandbox the `@elizaos/*` workspace packages are not built, so `tsc` reports `TS2307: Cannot find module '@elizaos/core'` for ~822 imports across the whole package (pre-existing, unrelated to this diff — the only error on the changed file is that same baseline import-resolution error). Mitigations run instead: (a) the focused Vitest suite passes (21/21); (b) Biome `check` on both changed files reports "No fixes applied"; (c) the new/changed pure code strict-typechecks in isolation (`tsc --strict --noEmit --target es2022`, "STRICT TYPECHECK OK"). No new type error is introduced — the change uses only standard `String`/`number` APIs.
- **Immutable evidence-attachment URLs not minted.** The fork attachment-upload session could not authenticate in this environment, so evidence is pasted inline as text (real logs) rather than linked as `user-attachments` URLs.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@1e73b52fd30cfd9132d310b763296a9a6e9ddaf8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@1e73b52fd30cfd9132d310b763296a9a6e9ddaf8:packages/skills/skills/contribute-to-eliza"} -->
