### PR TITLE
fix(plugin-x): retweeter pagination false-positives repeat guard on terminal previous_token

### DIFF
--- a/plugins/plugin-x/src/client/retweeters.test.ts
+++ b/plugins/plugin-x/src/client/retweeters.test.ts
@@ -159,6 +159,11 @@ describe("getAllRetweeters", () => {
 
     expect(result.map((r) => r.rest_id)).toEqual(["user-1", "user-2"]);
     expect(tweetRetweetedBy).toHaveBeenCalledTimes(2);
+    expect(tweetRetweetedBy).toHaveBeenNthCalledWith(
+      2,
+      "tweet-1",
+      expect.objectContaining({ pagination_token: "c1" }),
+    );
   });
 
   it("completes on a terminal page whose previous_token is a novel value", async () => {
@@ -174,6 +179,11 @@ describe("getAllRetweeters", () => {
 
     expect(result.map((r) => r.rest_id)).toEqual(["user-1", "user-2"]);
     expect(tweetRetweetedBy).toHaveBeenCalledTimes(2);
+    expect(tweetRetweetedBy).toHaveBeenNthCalledWith(
+      2,
+      "tweet-1",
+      expect.objectContaining({ pagination_token: "c1" }),
+    );
   });
 
   it("caps total pages so a provider that never repeats but never stops still terminates", async () => {

--- a/plugins/plugin-x/src/client/retweeters.test.ts
+++ b/plugins/plugin-x/src/client/retweeters.test.ts
@@ -80,6 +80,13 @@ function retweeterPage(id: string, nextToken?: string) {
   };
 }
 
+function terminalPage(id: string, previousToken?: string) {
+  return {
+    data: [{ id, username: id, name: id, description: "" }],
+    meta: previousToken ? { previous_token: previousToken } : {},
+  };
+}
+
 describe("getAllRetweeters", () => {
   it("concatenates pages until the API stops returning a next cursor", async () => {
     const tweetRetweetedBy = vi
@@ -137,6 +144,36 @@ describe("getAllRetweeters", () => {
     // Exactly 3 calls: the cycle back to "A" is caught on the page that
     // returns it, not after further oscillation.
     expect(tweetRetweetedBy).toHaveBeenCalledTimes(3);
+  });
+
+  it("completes on a terminal page whose previous_token echoes the just-sent cursor", async () => {
+    const tweetRetweetedBy = vi
+      .fn()
+      .mockResolvedValueOnce(retweeterPage("user-1", "c1"))
+      .mockResolvedValueOnce(terminalPage("user-2", "c1"));
+    const auth = {
+      getV2Client: async () => ({ v2: { tweetRetweetedBy } }),
+    };
+
+    const result = await getAllRetweeters("tweet-1", auth as never);
+
+    expect(result.map((r) => r.rest_id)).toEqual(["user-1", "user-2"]);
+    expect(tweetRetweetedBy).toHaveBeenCalledTimes(2);
+  });
+
+  it("completes on a terminal page whose previous_token is a novel value", async () => {
+    const tweetRetweetedBy = vi
+      .fn()
+      .mockResolvedValueOnce(retweeterPage("user-1", "c1"))
+      .mockResolvedValueOnce(terminalPage("user-2", "novel-value"));
+    const auth = {
+      getV2Client: async () => ({ v2: { tweetRetweetedBy } }),
+    };
+
+    const result = await getAllRetweeters("tweet-1", auth as never);
+
+    expect(result.map((r) => r.rest_id)).toEqual(["user-1", "user-2"]);
+    expect(tweetRetweetedBy).toHaveBeenCalledTimes(2);
   });
 
   it("caps total pages so a provider that never repeats but never stops still terminates", async () => {

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -1299,8 +1299,7 @@ export async function getAllRetweeters(
       );
     }
 
-    // Destructure bottomCursor / topCursor
-    const { retweeters, bottomCursor, topCursor } = await fetchRetweetersPage(
+    const { retweeters, bottomCursor } = await fetchRetweetersPage(
       tweetId,
       auth,
       cursor,
@@ -1308,17 +1307,19 @@ export async function getAllRetweeters(
     );
     allRetweeters = allRetweeters.concat(retweeters);
 
-    const newCursor = bottomCursor || topCursor;
-
-    // Stop if there is no new cursor
-    if (!newCursor) {
+    // Pagination continuation is driven by `bottomCursor` (next_token)
+    // alone. `topCursor` (previous_token) is deliberately ignored here: a
+    // well-behaved terminal page has no next_token but can still echo a
+    // non-empty previous_token, which would otherwise re-trigger pagination
+    // backwards and false-positive the repeat/cycle guard below.
+    if (!bottomCursor) {
       break;
     }
 
     // A cursor the API already returned means it stopped advancing (an
     // immediate repeat or a longer cycle) — treat it as a fault rather than
     // looping forever on it.
-    if (seenCursors.has(newCursor)) {
+    if (seenCursors.has(bottomCursor)) {
       throw new ElizaError(
         `Retweeter pagination for tweet ${tweetId} repeated a page cursor`,
         {
@@ -1327,8 +1328,8 @@ export async function getAllRetweeters(
         },
       );
     }
-    seenCursors.add(newCursor);
-    cursor = newCursor;
+    seenCursors.add(bottomCursor);
+    cursor = bottomCursor;
   }
 
   return allRetweeters;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Follow-up to #21445. That PR's own reviewer, [@HomunculusLabs](https://github.com/HomunculusLabs), filed a `CHANGES_REQUESTED` review with a reproducible blocking finding (see the review thread on #21445) that was not addressed before #21445 was rebased and merged. This PR applies that reviewer's own verified fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package-scoped verify commands were run after sync (see Testing below for exact commands/output; full-repo `bun run verify` not run — see Known gaps).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fa0f17f88e7b5339f1487143ba62af5bb6c06a5d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Package-scoped verify passes post-sync — see Testing below. Full-repo `bun run verify` not run; documented in **Known gaps / failures**.

# Risks

Low. Single-package (`plugin-x`), single-function change, no public API/signature change. Narrows an over-eager termination condition back to the documented Twitter API v2 pagination contract (`next_token` drives continuation); does not change the page-cap or repeat-detection guards from #21445, only the cursor they key off of.

# Background

## What does this PR do?

Fixes a regression introduced by #21445 (merged with an outstanding, verified `CHANGES_REQUESTED` review from [@HomunculusLabs](https://github.com/HomunculusLabs)):

`getAllRetweeters` computed `newCursor = bottomCursor || topCursor` to decide both (a) whether to keep paginating and (b) what to add to the seen-cursor cycle-detection set. `bottomCursor` maps to the API's `next_token`; `topCursor` maps to `previous_token`. A well-behaved **terminal** page (no more results) has no `next_token`, but per the Twitter API v2 contract can still echo a non-empty `previous_token` — so the `|| topCursor` fallback kept the loop going backwards on a page that should have ended it, and then threw `X_RETWEETERS_PAGINATION_CURSOR_REPEATED` on what was actually a normal, complete fetch (either immediately, if `previous_token` echoed the just-sent cursor, or a page later, if it was a novel value that then repeated on the way back).

Fix: pagination continuation and the seen-cursor set are now keyed on `bottomCursor` (`next_token`) alone. `topCursor` is still returned by `fetchRetweetersPage` (used elsewhere/available to callers) but no longer influences loop termination. This is exactly the fix [@HomunculusLabs](https://github.com/HomunculusLabs) verified by patching a copy of the PR head and probing all six cursor shapes (see their review on #21445).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/client/retweeters.test.ts` — `describe("getAllRetweeters", ...)`. Two new cases added:
- `"completes on a terminal page whose previous_token echoes the just-sent cursor"`
- `"completes on a terminal page whose previous_token is a novel value"`

Both were the exact reproduction shapes [@HomunculusLabs](https://github.com/HomunculusLabs) used to demonstrate the regression against PR #21445's merged head; both fail against the pre-fix code (throw `X_RETWEETERS_PAGINATION_CURSOR_REPEATED` instead of returning the complete list) and pass against this PR's fix.

## Detailed testing steps

None: automated tests are acceptable.

```
$ bun run --cwd plugins/plugin-x test -- retweeters
 RUN  v4.1.5 plugins/plugin-x
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ bunx @biomejs/biome check plugins/plugin-x/src/client/tweets.ts plugins/plugin-x/src/client/retweeters.test.ts
Checked 2 files in 21ms. No fixes applied.

$ bun run --cwd plugins/plugin-x typecheck
$ tsc --noEmit -p tsconfig.json
(clean, exit 0)

$ bun run --cwd plugins/plugin-x test
 Test Files  1 failed | 32 passed | 1 skipped (34)
      Tests  237 passed | 13 skipped (250)
```

The one failing file (`src/lifeops-message-adapter.encoding.test.ts`, `Cannot find package 'bun:test'`) is pre-existing and untouched by this diff — confirmed via `git diff --stat origin/develop..HEAD -- plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts` (empty) and `git log` showing it was introduced by an unrelated prior PR (#21682). Not caused or touched by this change.

# Maintainer validation addendum\n\nReviewed at exact head `8b93df4eef414e871a0590687f0d490e0695c887`. The [official X API pagination contract](https://docs.x.com/x-api/fundamentals/pagination) says to continue with `meta.next_token` and stop when it is absent; `previous_token` navigates backward, and the documented terminal response retains `previous_token` while omitting `next_token`. The production fix therefore restores the correct forward-only contract. Tests were strengthened to assert that the second SDK request actually sends `pagination_token: c1`, preventing sequential mocks from passing if cursor propagation is broken.\n\nExact-head validation: official plugin-x Vitest configuration 8/8; a narrow built-package lane 8/8 three consecutive runs; package typecheck clean; package Biome 92 files clean; package ESM, source map, and declaration build clean. No live X credentials were used; the deterministic mocked SDK seam checks exact request arguments, terminal responses, repeated-token cycles, and the 1,000-page bound.\n\n# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:8b93df4eef414e871a0590687f0d490e0695c887 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/library-only change (Node/Bun HTTP client pagination logic), no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/library-only change, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is exercised by the automated test transcript above.
<!-- evidence-row:backend-logs -->
- [x] N/A - covered by the mocked-API test transcript above (exact call counts and thrown/returned values asserted per scenario), which is the deterministic equivalent of backend log evidence for a pure pagination-logic fix; no live Twitter API credentials available in this environment to produce real request/response logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, or generated files produced by this change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - see Testing section above; mocked-API test transcript is the applicable evidence for this pagination-logic fix.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- Full-repo `bun run verify` was not run (large monorepo-wide command); instead ran the package-scoped equivalents directly relevant to this diff: `plugins/plugin-x` test suite (targeted + full), Biome check on both changed files, and `plugins/plugin-x` typecheck (after building `@elizaos/core`, a known local prerequisite for this package's typecheck/tests to resolve the workspace dependency). All passed clean.
- `plugins/plugin-x`'s full test suite has one pre-existing unrelated failure (`src/lifeops-message-adapter.encoding.test.ts` imports `bun:test` in a vitest-run package) — confirmed pre-existing and untouched by this diff (see Testing section). Not fixed here; out of scope for this PR.
- No live Twitter/X API credentials available in this environment; all pagination behavior is verified against a mocked `twitter-api-v2` v2 client, matching the existing test file's established pattern and the reviewing pattern HomunculusLabs used to find and verify this regression on #21445.

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@fa0f17f88e7b5339f1487143ba62af5bb6c06a5d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mode-a]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@fa0f17f88e7b5339f1487143ba62af5bb6c06a5d:packages/skills/skills/contribute-to-eliza"} -->
