### PR TITLE
ci: automate Chrome, Firefox, and Edge submissions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,14 +91,18 @@ Representative examples:
   reviewer-approved `production-release` environment; a tag protection
   ruleset restricting `v*` creation completes that boundary.
   After finalization, the canonical workflow also calls the reusable,
-  callable-only `snap-publish.yml` and `store-mobile-publish.yml` legs with the
-  exact finalized source SHA, version, channel, and tag. Those legs re-resolve
-  the tag to the supplied commit before using credentials and run behind the
-  `production-release` environment. Snap uploads the registered `eliza` name;
-  Android builds and audits the cloud-only AAB before Google Play upload; iOS
-  embeds the store runtime and uses an App Store Connect API key for signing
-  and delivery. Missing credentials fail the affected store job with the exact
-  secret names instead of silently skipping publication.
+  callable-only `snap-publish.yml`, `store-mobile-publish.yml`, and
+  `store-browser-publish.yml` legs with the exact finalized source SHA,
+  version, channel, and tag. Those legs re-resolve the tag to the supplied
+  commit before using credentials and run behind the `production-release`
+  environment. Snap uploads the registered `eliza` name; Android builds and
+  audits the cloud-only AAB before Google Play upload; iOS embeds the store
+  runtime and uses an App Store Connect API key for signing and delivery; and
+  the browser leg builds reproducible Chrome and Firefox packages, exercises
+  both installed browsers, then submits exact packages to Chrome Web Store,
+  Firefox Add-ons, and stable-only Microsoft Edge Add-ons. Missing credentials
+  fail the affected store job with the exact names instead of silently skipping
+  publication.
 
   Store credentials are environment-owned. Snap needs
   `SNAPCRAFT_STORE_CREDENTIALS`. Google Play needs the four

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -591,3 +591,16 @@ jobs:
       MICROSOFT_STORE_TENANT_ID: ${{ secrets.MICROSOFT_STORE_TENANT_ID }}
       MICROSOFT_STORE_CLIENT_ID: ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
       MICROSOFT_STORE_CLIENT_SECRET: ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}
+
+  publish-browser-stores:
+    name: Publish Chrome, Firefox, and Edge extension releases
+    needs: finalize
+    permissions:
+      contents: read
+    uses: ./.github/workflows/store-browser-publish.yml
+    with:
+      source_sha: ${{ needs.finalize.outputs.source_sha }}
+      version: ${{ needs.finalize.outputs.version }}
+      tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
+      channel: ${{ needs.finalize.outputs.channel }}
+    secrets: inherit

--- a/.github/workflows/store-browser-publish.yml
+++ b/.github/workflows/store-browser-publish.yml
@@ -1,0 +1,338 @@
+name: Publish Browser Stores
+
+# This workflow has no independent trigger. The canonical transactional release
+# calls it only after npm, the exact Git tag, and the GitHub Release finalize.
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact canonical release commit
+        required: true
+        type: string
+      version:
+        description: Canonical release semver
+        required: true
+        type: string
+      channel:
+        description: Canonical release channel (beta or latest)
+        required: true
+        type: string
+      tag:
+        description: Finalized Git tag
+        required: true
+        type: string
+    secrets:
+      CHROME_WEB_STORE_SERVICE_ACCOUNT_JSON:
+        required: false
+      AMO_JWT_ISSUER:
+        required: false
+      AMO_JWT_SECRET:
+        required: false
+      EDGE_ADDONS_CLIENT_ID:
+        required: false
+      EDGE_ADDONS_API_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Build and exercise browser store packages
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    outputs:
+      extension_version: ${{ steps.plan.outputs.extension_version }}
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind packages to finalized release
+        id: plan
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"
+          test "$EXPECTED_TAG" = "v${{ inputs.version }}"
+          test "$(git rev-parse "refs/tags/$EXPECTED_TAG^{commit}")" = "$EXPECTED_SHA"
+          node packages/scripts/store-release-plan.mjs \
+            --version "${{ inputs.version }}" \
+            --channel "${{ inputs.channel }}" \
+            --source-sha "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Typecheck, lint, and unit-test extension
+        run: |
+          bun run --cwd packages/browser-bridge-extension typecheck
+          bun run --cwd packages/browser-bridge-extension lint:check
+          bun run --cwd packages/browser-bridge-extension test:unit
+
+      - name: Build reproducible Chrome and Firefox packages
+        run: |
+          set -euo pipefail
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+          export SOURCE_DATE_EPOCH
+          bun run --cwd packages/browser-bridge-extension package:chrome
+          bun run --cwd packages/browser-bridge-extension package:firefox
+          bun run --cwd packages/browser-bridge-extension package:stores
+          git archive --format=zip \
+            --output packages/browser-bridge-extension/dist/artifacts/browser-bridge-source.zip \
+            "$EXPECTED_SHA" -- \
+            package.json bun.lock \
+            packages/browser-bridge-extension \
+            plugins/plugin-wallet/src/browser-shim/shim.template.js
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          RELEASE_VERSION: ${{ inputs.version }}
+
+      - name: Inspect manifests and Firefox policy
+        env:
+          EXPECTED_EXTENSION_VERSION: ${{ steps.plan.outputs.extension_version }}
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require("node:fs");
+          for (const browser of ["chrome", "firefox"]) {
+            const path = `packages/browser-bridge-extension/dist/${browser}/manifest.json`;
+            const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
+            if (manifest.version !== process.env.EXPECTED_EXTENSION_VERSION) {
+              throw new Error(`${browser} manifest ${manifest.version} != ${process.env.EXPECTED_EXTENSION_VERSION}`);
+            }
+          }
+          NODE
+          bun run --cwd packages/browser-bridge-extension lint:firefox
+          sha256sum packages/browser-bridge-extension/dist/artifacts/* | tee packages/browser-bridge-extension/dist/artifacts/SHA256SUMS
+
+      - name: Exercise installed Chrome and Firefox packages
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          command -v google-chrome
+          command -v firefox
+          bun run --cwd packages/browser-bridge-extension test:smoke
+          bun run --cwd packages/browser-bridge-extension test:smoke:firefox
+
+      - name: Upload exact browser packages and evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-browser-stores-${{ inputs.version }}
+          path: packages/browser-bridge-extension/dist
+          if-no-files-found: error
+          retention-days: 90
+
+  chrome:
+    name: Submit Chrome Web Store package
+    needs: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: production-release
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+
+      - name: Download exact browser packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: eliza-browser-stores-${{ inputs.version }}
+          path: packages/browser-bridge-extension/dist
+
+      - name: Require Chrome Web Store identity and credentials
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.CHROME_WEB_STORE_SERVICE_ACCOUNT_JSON }}
+          PUBLISHER_ID: ${{ vars.CHROME_WEB_STORE_PUBLISHER_ID }}
+          ITEM_ID: ${{ vars.CHROME_WEB_STORE_ITEM_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$SERVICE_ACCOUNT_JSON" ]] && missing+=(CHROME_WEB_STORE_SERVICE_ACCOUNT_JSON)
+          [[ -z "$PUBLISHER_ID" ]] && missing+=(CHROME_WEB_STORE_PUBLISHER_ID)
+          [[ -z "$ITEM_ID" ]] && missing+=(CHROME_WEB_STORE_ITEM_ID)
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required Chrome Web Store release configuration: ${missing[*]}"
+            exit 1
+          fi
+          if [[ "$SERVICE_ACCOUNT_JSON" == \{* ]]; then
+            printf '%s' "$SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/chrome-web-store-service-account.json"
+          else
+            printf '%s' "$SERVICE_ACCOUNT_JSON" | base64 --decode > "$RUNNER_TEMP/chrome-web-store-service-account.json"
+          fi
+          chmod 600 "$RUNNER_TEMP/chrome-web-store-service-account.json"
+
+      - name: Upload and submit Chrome release
+        env:
+          PUBLISHER_ID: ${{ vars.CHROME_WEB_STORE_PUBLISHER_ID }}
+          ITEM_ID: ${{ vars.CHROME_WEB_STORE_ITEM_ID }}
+          PUBLISH_TYPE: ${{ inputs.channel == 'latest' && 'DEFAULT_PUBLISH' || 'STAGED_PUBLISH' }}
+        run: |
+          node packages/scripts/browser-store-submission.mjs chrome \
+            --package packages/browser-bridge-extension/dist/artifacts/browser-bridge-chrome.zip \
+            --service-account "$RUNNER_TEMP/chrome-web-store-service-account.json" \
+            --publisher-id "$PUBLISHER_ID" \
+            --item-id "$ITEM_ID" \
+            --version "${{ needs.package.outputs.extension_version }}" \
+            --publish-type "$PUBLISH_TYPE" \
+            | tee "$RUNNER_TEMP/chrome-submission.json"
+
+      - name: Upload Chrome submission evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-chrome-submission-${{ inputs.version }}
+          path: ${{ runner.temp }}/chrome-submission.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Remove Chrome credential
+        if: always()
+        run: rm -f "$RUNNER_TEMP/chrome-web-store-service-account.json"
+
+  firefox:
+    name: Submit Firefox Add-ons package
+    needs: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment:
+      name: production-release
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Download exact browser packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: eliza-browser-stores-${{ inputs.version }}
+          path: packages/browser-bridge-extension/dist
+
+      - name: Require Firefox Add-ons credentials and metadata
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$AMO_JWT_ISSUER" ]] && missing+=(AMO_JWT_ISSUER)
+          [[ -z "$AMO_JWT_SECRET" ]] && missing+=(AMO_JWT_SECRET)
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required Firefox Add-ons release secrets: ${missing[*]}"
+            exit 1
+          fi
+          cat > "$RUNNER_TEMP/amo-metadata.json" <<'JSON'
+          {
+            "summary": {"en-US": "Owner-approved browser control for Eliza agents."},
+            "categories": ["productivity"],
+            "version": {
+              "license": "MIT",
+              "release_notes": {"en-US": "Automated exact-tag release from the canonical elizaOS release transaction."}
+            }
+          }
+          JSON
+
+      - name: Submit listed or self-hosted Firefox release
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.AMO_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+          AMO_CHANNEL: ${{ inputs.channel == 'latest' && 'listed' || 'unlisted' }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/firefox-signed"
+          bunx web-ext sign \
+            --source-dir packages/browser-bridge-extension/dist/firefox \
+            --artifacts-dir "$RUNNER_TEMP/firefox-signed" \
+            --channel "$AMO_CHANNEL" \
+            --amo-metadata "$RUNNER_TEMP/amo-metadata.json" \
+            --upload-source-code packages/browser-bridge-extension/dist/artifacts/browser-bridge-source.zip \
+            2>&1 | tee "$RUNNER_TEMP/firefox-signed/submission.log"
+          cp "$RUNNER_TEMP/amo-metadata.json" "$RUNNER_TEMP/firefox-signed/amo-metadata.json"
+
+      - name: Upload Firefox submission evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-firefox-submission-${{ inputs.version }}
+          path: ${{ runner.temp }}/firefox-signed
+          if-no-files-found: error
+          retention-days: 90
+
+  edge:
+    name: Submit Microsoft Edge Add-ons package
+    if: inputs.channel == 'latest'
+    needs: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: production-release
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+
+      - name: Download exact browser packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: eliza-browser-stores-${{ inputs.version }}
+          path: packages/browser-bridge-extension/dist
+
+      - name: Require Edge Add-ons product and credentials
+        env:
+          CLIENT_ID: ${{ secrets.EDGE_ADDONS_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_ADDONS_API_KEY }}
+          PRODUCT_ID: ${{ vars.EDGE_ADDONS_PRODUCT_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$CLIENT_ID" ]] && missing+=(EDGE_ADDONS_CLIENT_ID)
+          [[ -z "$API_KEY" ]] && missing+=(EDGE_ADDONS_API_KEY)
+          [[ -z "$PRODUCT_ID" ]] && missing+=(EDGE_ADDONS_PRODUCT_ID)
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required Edge Add-ons release configuration: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Upload and submit Edge release
+        env:
+          CLIENT_ID: ${{ secrets.EDGE_ADDONS_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_ADDONS_API_KEY }}
+          PRODUCT_ID: ${{ vars.EDGE_ADDONS_PRODUCT_ID }}
+        run: |
+          node packages/scripts/browser-store-submission.mjs edge \
+            --package packages/browser-bridge-extension/dist/artifacts/browser-bridge-chrome.zip \
+            --product-id "$PRODUCT_ID" \
+            --client-id "$CLIENT_ID" \
+            --api-key "$API_KEY" \
+            --notes "Canonical elizaOS release ${{ inputs.tag }} (${{ inputs.source_sha }})." \
+            | tee "$RUNNER_TEMP/edge-submission.json"
+
+      - name: Upload Edge submission evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-edge-submission-${{ inputs.version }}
+          path: ${{ runner.temp }}/edge-submission.json
+          if-no-files-found: error
+          retention-days: 90

--- a/packages/scripts/__tests__/browser-store-submission.test.ts
+++ b/packages/scripts/__tests__/browser-store-submission.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Exercises browser-store API boundaries with deterministic HTTP responses,
+ * including exact version checks, async polling, and terminal failures.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  submitChromeExtension,
+  submitEdgeExtension,
+} from "../browser-store-submission.mjs";
+
+const tempDirectories: string[] = [];
+
+function tempFile(name: string, contents: string | Uint8Array) {
+  const directory = mkdtempSync(join(tmpdir(), "eliza-browser-store-"));
+  tempDirectories.push(directory);
+  const path = join(directory, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+function jsonResponse(value: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(value), { status, headers });
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Chrome Web Store submission", () => {
+  test("exchanges service-account auth, uploads the exact version, and publishes", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const serviceAccountPath = tempFile(
+      "service-account.json",
+      JSON.stringify({
+        type: "service_account",
+        client_email: "release@example.iam.gserviceaccount.com",
+        private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+        token_uri: "https://oauth2.googleapis.com/token",
+      }),
+    );
+    const packagePath = tempFile("extension.zip", "extension-bytes");
+    const requests: Array<{ url: string; method: string }> = [];
+    const responses = [
+      jsonResponse({ access_token: "test-token" }),
+      jsonResponse({ uploadState: "UPLOAD_IN_PROGRESS" }),
+      jsonResponse({ lastAsyncUploadState: "UPLOAD_SUCCESS" }),
+      jsonResponse({ state: "SUBMITTED_FOR_REVIEW" }),
+      jsonResponse({
+        submittedItemRevisionStatus: {
+          distributionChannels: [{ crxVersion: "2.0.3.40007" }],
+        },
+      }),
+    ];
+    const fetchImpl = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      requests.push({ url: String(input), method: init?.method ?? "GET" });
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected request");
+      return response;
+    };
+
+    const result = await submitChromeExtension({
+      packagePath,
+      serviceAccountPath,
+      publisherId: "publisher_123456",
+      itemId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedVersion: "2.0.3.40007",
+      publishType: "STAGED_PUBLISH",
+      fetchImpl,
+      poll: { intervalMs: 0, sleep: async () => {} },
+    });
+
+    expect(requests.map((request) => request.method)).toEqual([
+      "POST",
+      "POST",
+      "GET",
+      "POST",
+      "GET",
+    ]);
+    expect(requests[1]?.url).toContain(":upload?uploadType=media");
+    expect(requests[3]?.url).toContain(":publish");
+    expect(result.publish.state).toBe("SUBMITTED_FOR_REVIEW");
+  });
+
+  test("rejects a store-reported version mismatch before publishing", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const serviceAccountPath = tempFile(
+      "service-account.json",
+      JSON.stringify({
+        type: "service_account",
+        client_email: "release@example.iam.gserviceaccount.com",
+        private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+      }),
+    );
+    const packagePath = tempFile("extension.zip", "extension-bytes");
+    const responses = [
+      jsonResponse({ access_token: "test-token" }),
+      jsonResponse({ uploadState: "UPLOAD_SUCCESS", crxVersion: "1.0.0.0" }),
+    ];
+    const fetchImpl = async () => responses.shift() ?? jsonResponse({});
+
+    await expect(
+      submitChromeExtension({
+        packagePath,
+        serviceAccountPath,
+        publisherId: "publisher_123456",
+        itemId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        expectedVersion: "2.0.3.60000",
+        publishType: "DEFAULT_PUBLISH",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("does not match");
+  });
+});
+
+describe("Microsoft Edge Add-ons submission", () => {
+  test("waits for package processing before starting and completing publication", async () => {
+    const packagePath = tempFile("extension.zip", "extension-bytes");
+    const responses = [
+      new Response("", {
+        status: 202,
+        headers: { location: "upload-operation" },
+      }),
+      jsonResponse({ status: "InProgress" }),
+      jsonResponse({ status: "Succeeded" }),
+      new Response("", {
+        status: 202,
+        headers: { location: "publish-operation" },
+      }),
+      jsonResponse({ status: "Succeeded" }),
+    ];
+    const fetchImpl = async () => {
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected request");
+      return response;
+    };
+
+    const result = await submitEdgeExtension({
+      packagePath,
+      productId: "d34f98f5-f9b7-42b1-bebb-98707202b21d",
+      clientId: "client-id",
+      apiKey: "api-key",
+      notes: "Exact canonical release",
+      fetchImpl,
+      poll: { intervalMs: 0, sleep: async () => {} },
+    });
+
+    expect(result.upload.status).toBe("Succeeded");
+    expect(result.publish.status).toBe("Succeeded");
+  });
+
+  test("fails closed when Edge returns a terminal rejection", async () => {
+    const packagePath = tempFile("extension.zip", "extension-bytes");
+    const responses = [
+      new Response("", {
+        status: 202,
+        headers: { location: "upload-operation" },
+      }),
+      jsonResponse({ status: "Failed" }),
+    ];
+    const fetchImpl = async () => {
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected request");
+      return response;
+    };
+
+    await expect(
+      submitEdgeExtension({
+        packagePath,
+        productId: "d34f98f5-f9b7-42b1-bebb-98707202b21d",
+        clientId: "client-id",
+        apiKey: "api-key",
+        notes: "Exact canonical release",
+        fetchImpl,
+        poll: { intervalMs: 0, sleep: async () => {} },
+      }),
+    ).rejects.toThrow("failed in state Failed");
+  });
+});

--- a/packages/scripts/__tests__/store-release-plan.test.ts
+++ b/packages/scripts/__tests__/store-release-plan.test.ts
@@ -5,6 +5,10 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  buildChromeExtensionVersion,
+  parseReleaseVersion,
+} from "../../browser-bridge-extension/scripts/release-version.mjs";
+import {
   createStoreReleasePlan,
   parseStoreSemver,
 } from "../store-release-plan.mjs";
@@ -59,7 +63,7 @@ describe("store release plan", () => {
       windows_package_version: "2.3.4.0",
       windows_publish: false,
       snap_channel: "beta",
-      extension_version: "2.3.4.20000",
+      extension_version: "2.3.4.40000",
       chrome_publish_target: "trustedTesters",
       flathub_branch: "beta",
     });
@@ -87,5 +91,24 @@ describe("store release plan", () => {
         sourceSha: "deadbeef",
       }),
     ).toThrow("40 lowercase hex");
+  });
+
+  test("matches the browser packager's Chrome version for every release lane", () => {
+    for (const version of [
+      "2.3.4-alpha.1",
+      "2.3.4-beta.2",
+      "2.3.4-rc.3",
+      "2.3.4-nightly.4",
+      "2.3.4",
+    ]) {
+      const plan = createStoreReleasePlan({
+        version,
+        channel: version === "2.3.4" ? "latest" : "beta",
+        sourceSha: SOURCE_SHA,
+      });
+      expect(plan.extension_version).toBe(
+        buildChromeExtensionVersion(parseReleaseVersion(version)),
+      );
+    }
   });
 });

--- a/packages/scripts/__tests__/store-release-workflow.test.ts
+++ b/packages/scripts/__tests__/store-release-workflow.test.ts
@@ -27,6 +27,10 @@ const windowsSource = readFileSync(
   new URL(".github/workflows/store-windows-publish.yml", repoRoot),
   "utf8",
 );
+const browserSource = readFileSync(
+  new URL(".github/workflows/store-browser-publish.yml", repoRoot),
+  "utf8",
+);
 
 describe("canonical store release workflow", () => {
   test("calls Snap only after exact release finalization", () => {
@@ -199,5 +203,55 @@ describe("canonical store release workflow", () => {
         "Submit exact package to Partner Center",
       ]);
     }
+  });
+
+  test("calls browser stores only after exact release finalization", () => {
+    const workflow = Bun.YAML.parse(releaseSource) as {
+      jobs?: Record<
+        string,
+        {
+          needs?: string;
+          uses?: string;
+          with?: Record<string, string>;
+          secrets?: string;
+        }
+      >;
+    };
+    const browser = workflow.jobs?.["publish-browser-stores"];
+    expect(browser?.needs).toBe("finalize");
+    expect(browser?.uses).toBe("./.github/workflows/store-browser-publish.yml");
+    expect(browser?.with?.source_sha).toContain(
+      "needs.finalize.outputs.source_sha",
+    );
+    expect(browser?.with?.version).toContain("needs.finalize.outputs.version");
+    expect(browser?.secrets).toBe("inherit");
+  });
+
+  test("keeps browser stores callable-only, exact-tag-bound, protected, and fail-closed", () => {
+    const workflow = Bun.YAML.parse(browserSource) as {
+      on?: Record<string, unknown>;
+      jobs?: Record<string, { environment?: { name?: string } }>;
+    };
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
+    expect(workflow.jobs?.chrome?.environment?.name).toBe("production-release");
+    expect(workflow.jobs?.firefox?.environment?.name).toBe(
+      "production-release",
+    );
+    expect(workflow.jobs?.edge?.environment?.name).toBe("production-release");
+    expect(browserSource).toContain(`ref: \${{ inputs.source_sha }}`);
+    expect(browserSource).toContain("refs/tags/$EXPECTED_TAG^{commit}");
+    expect(browserSource).toContain(
+      "Missing required Chrome Web Store release configuration",
+    );
+    expect(browserSource).toContain(
+      "Missing required Firefox Add-ons release secrets",
+    );
+    expect(browserSource).toContain(
+      "Missing required Edge Add-ons release configuration",
+    );
+    expect(browserSource).toContain("test:smoke:firefox");
+    expect(browserSource).toContain("browser-store-submission.mjs chrome");
+    expect(browserSource).toContain("web-ext sign");
+    expect(browserSource).toContain("browser-store-submission.mjs edge");
   });
 });

--- a/packages/scripts/browser-store-submission.mjs
+++ b/packages/scripts/browser-store-submission.mjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/**
+ * Uploads immutable browser-extension packages to Chrome Web Store and
+ * Microsoft Edge Add-ons, polling each asynchronous operation to completion.
+ */
+
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const CHROME_API_ROOT = "https://chromewebstore.googleapis.com";
+const CHROME_SCOPE = "https://www.googleapis.com/auth/chromewebstore";
+const EDGE_API_ROOT = "https://api.addons.microsoftedge.microsoft.com";
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_POLL_ATTEMPTS = 40;
+
+function requireArgument(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  return args[index + 1];
+}
+
+function requirePattern(value, name, pattern) {
+  if (!pattern.test(value)) throw new Error(`${name} has an invalid format`);
+  return value;
+}
+
+function base64Url(value) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+async function responseError(response, operation) {
+  const body = (await response.text()).slice(0, 2_000);
+  return new Error(`${operation} failed with HTTP ${response.status}: ${body}`);
+}
+
+async function requestJson(url, options, operation, fetchImpl = fetch) {
+  const response = await fetchImpl(url, options);
+  if (!response.ok) throw await responseError(response, operation);
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${operation} returned invalid JSON`, { cause: error });
+  }
+}
+
+async function waitForTerminalState({
+  operation,
+  readState,
+  pending,
+  succeeded,
+  getState = (result) => result?.status ?? result?.uploadState,
+  attempts = DEFAULT_POLL_ATTEMPTS,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await readState();
+    const state = getState(result);
+    if (succeeded.has(state)) return result;
+    if (!pending.has(state)) {
+      throw new Error(`${operation} failed in state ${String(state)}`);
+    }
+    if (attempt < attempts) await sleep(intervalMs);
+  }
+  throw new Error(`${operation} did not finish after ${attempts} attempts`);
+}
+
+async function waitForChromeVersion({
+  readStatus,
+  expectedVersion,
+  attempts = DEFAULT_POLL_ATTEMPTS,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const status = await readStatus();
+    if (status.takenDown || status.warned) {
+      throw new Error(
+        "Chrome Web Store item has an active policy enforcement state",
+      );
+    }
+    const versions = [
+      ...(status.submittedItemRevisionStatus?.distributionChannels ?? []),
+      ...(status.publishedItemRevisionStatus?.distributionChannels ?? []),
+    ].map((channel) => channel.crxVersion);
+    if (versions.includes(expectedVersion)) return status;
+    if (attempt < attempts) await sleep(intervalMs);
+  }
+  throw new Error(
+    `Chrome submission status does not contain exact version ${expectedVersion}`,
+  );
+}
+
+export async function createChromeAccessToken(
+  serviceAccount,
+  fetchImpl = fetch,
+) {
+  if (
+    serviceAccount?.type !== "service_account" ||
+    typeof serviceAccount.client_email !== "string" ||
+    typeof serviceAccount.private_key !== "string"
+  ) {
+    throw new Error("Chrome service account JSON is missing required fields");
+  }
+  const tokenUri =
+    serviceAccount.token_uri ?? "https://oauth2.googleapis.com/token";
+  if (tokenUri !== "https://oauth2.googleapis.com/token") {
+    throw new Error(
+      "Chrome service account token_uri is not the Google OAuth token endpoint",
+    );
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64Url(
+    JSON.stringify({
+      iss: serviceAccount.client_email,
+      scope: CHROME_SCOPE,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${claims}`);
+  signer.end();
+  const assertion = `${header}.${claims}.${base64Url(signer.sign(serviceAccount.private_key))}`;
+  const response = await requestJson(
+    tokenUri,
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      }),
+    },
+    "Chrome OAuth token exchange",
+    fetchImpl,
+  );
+  if (typeof response.access_token !== "string" || !response.access_token) {
+    throw new Error("Chrome OAuth token exchange returned no access token");
+  }
+  return response.access_token;
+}
+
+export async function submitChromeExtension({
+  packagePath,
+  serviceAccountPath,
+  publisherId,
+  itemId,
+  expectedVersion,
+  publishType,
+  fetchImpl = fetch,
+  poll = {},
+}) {
+  requirePattern(publisherId, "Chrome publisher ID", /^[A-Za-z0-9_-]{8,128}$/u);
+  requirePattern(itemId, "Chrome item ID", /^[a-p]{32}$/u);
+  requirePattern(
+    expectedVersion,
+    "Chrome extension version",
+    /^\d+(?:\.\d+){3}$/u,
+  );
+  if (!new Set(["DEFAULT_PUBLISH", "STAGED_PUBLISH"]).has(publishType)) {
+    throw new Error(`Unsupported Chrome publish type: ${publishType}`);
+  }
+  const serviceAccount = JSON.parse(await readFile(serviceAccountPath, "utf8"));
+  const packageBytes = await readFile(packagePath);
+  const token = await createChromeAccessToken(serviceAccount, fetchImpl);
+  const headers = { authorization: `Bearer ${token}` };
+  const itemPath = `publishers/${encodeURIComponent(publisherId)}/items/${encodeURIComponent(itemId)}`;
+  const upload = await requestJson(
+    `${CHROME_API_ROOT}/upload/v2/${itemPath}:upload?uploadType=media`,
+    {
+      method: "POST",
+      headers: { ...headers, "content-type": "application/zip" },
+      body: packageBytes,
+    },
+    "Chrome package upload",
+    fetchImpl,
+  );
+  const readStatus = () =>
+    requestJson(
+      `${CHROME_API_ROOT}/v2/${itemPath}:fetchStatus`,
+      { headers },
+      "Chrome status fetch",
+      fetchImpl,
+    );
+  const uploaded =
+    upload.uploadState === "UPLOAD_SUCCESS"
+      ? upload
+      : await waitForTerminalState({
+          operation: "Chrome package upload",
+          readState: readStatus,
+          pending: new Set(["UPLOAD_IN_PROGRESS"]),
+          succeeded: new Set(["UPLOAD_SUCCESS"]),
+          getState: (result) => result?.lastAsyncUploadState,
+          ...poll,
+        });
+  const uploadedVersion = upload.crxVersion;
+  if (uploadedVersion && uploadedVersion !== expectedVersion) {
+    throw new Error(
+      `Chrome uploaded version ${uploadedVersion} does not match ${expectedVersion}`,
+    );
+  }
+  const published = await requestJson(
+    `${CHROME_API_ROOT}/v2/${itemPath}:publish`,
+    {
+      method: "POST",
+      headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({
+        publishType,
+        skipReview: false,
+        blockOnWarnings: true,
+      }),
+    },
+    "Chrome publish submission",
+    fetchImpl,
+  );
+  if (published.warningInfo?.warnings?.length) {
+    throw new Error("Chrome publish response contained validation warnings");
+  }
+  const status = await waitForChromeVersion({
+    readStatus,
+    expectedVersion,
+    ...poll,
+  });
+  return { upload: uploaded, publish: published, status };
+}
+
+function edgeHeaders(clientId, apiKey, extra = {}) {
+  return {
+    Authorization: `ApiKey ${apiKey}`,
+    "X-ClientID": clientId,
+    ...extra,
+  };
+}
+
+function edgeOperationId(location) {
+  if (!location)
+    throw new Error("Edge operation response omitted the Location header");
+  let value = location;
+  if (/^https?:/u.test(location)) {
+    const parsed = new URL(location);
+    if (parsed.origin !== EDGE_API_ROOT) {
+      throw new Error("Edge operation Location used an unexpected origin");
+    }
+    value = parsed.pathname.split("/").filter(Boolean).at(-1);
+  }
+  return requirePattern(value, "Edge operation ID", /^[A-Za-z0-9-]{8,128}$/u);
+}
+
+async function edgeAccepted(url, options, operation, fetchImpl) {
+  const response = await fetchImpl(url, options);
+  if (response.status !== 202) throw await responseError(response, operation);
+  return edgeOperationId(response.headers.get("location"));
+}
+
+export async function submitEdgeExtension({
+  packagePath,
+  productId,
+  clientId,
+  apiKey,
+  notes,
+  fetchImpl = fetch,
+  poll = {},
+}) {
+  requirePattern(
+    productId,
+    "Edge product ID",
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu,
+  );
+  if (!clientId || !apiKey)
+    throw new Error("Edge Client ID and API key are required");
+  const productPath = `/v1/products/${encodeURIComponent(productId)}`;
+  const packageBytes = await readFile(packagePath);
+  const uploadId = await edgeAccepted(
+    `${EDGE_API_ROOT}${productPath}/submissions/draft/package`,
+    {
+      method: "POST",
+      headers: edgeHeaders(clientId, apiKey, {
+        "content-type": "application/zip",
+      }),
+      body: packageBytes,
+    },
+    "Edge package upload",
+    fetchImpl,
+  );
+  const readOperation = (path, operation) => () =>
+    requestJson(
+      `${EDGE_API_ROOT}${path}`,
+      { headers: edgeHeaders(clientId, apiKey) },
+      operation,
+      fetchImpl,
+    );
+  const upload = await waitForTerminalState({
+    operation: "Edge package upload",
+    readState: readOperation(
+      `${productPath}/submissions/draft/package/operations/${encodeURIComponent(uploadId)}`,
+      "Edge upload status",
+    ),
+    pending: new Set(["InProgress"]),
+    succeeded: new Set(["Succeeded"]),
+    ...poll,
+  });
+  const publishId = await edgeAccepted(
+    `${EDGE_API_ROOT}${productPath}/submissions`,
+    {
+      method: "POST",
+      headers: edgeHeaders(clientId, apiKey, {
+        "content-type": "application/json",
+      }),
+      body: JSON.stringify({ notes }),
+    },
+    "Edge publish submission",
+    fetchImpl,
+  );
+  const publish = await waitForTerminalState({
+    operation: "Edge publish submission",
+    readState: readOperation(
+      `${productPath}/submissions/operations/${encodeURIComponent(publishId)}`,
+      "Edge publishing status",
+    ),
+    pending: new Set(["InProgress"]),
+    succeeded: new Set(["Succeeded"]),
+    ...poll,
+  });
+  return { upload, publish };
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const command = args[0];
+  if (command === "chrome") {
+    const result = await submitChromeExtension({
+      packagePath: requireArgument(args, "--package"),
+      serviceAccountPath: requireArgument(args, "--service-account"),
+      publisherId: requireArgument(args, "--publisher-id"),
+      itemId: requireArgument(args, "--item-id"),
+      expectedVersion: requireArgument(args, "--version"),
+      publishType: requireArgument(args, "--publish-type"),
+    });
+    console.log(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  if (command === "edge") {
+    const result = await submitEdgeExtension({
+      packagePath: requireArgument(args, "--package"),
+      productId: requireArgument(args, "--product-id"),
+      clientId: requireArgument(args, "--client-id"),
+      apiKey: requireArgument(args, "--api-key"),
+      notes: requireArgument(args, "--notes"),
+    });
+    console.log(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  throw new Error("Expected browser store command: chrome or edge");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    // error-policy:J1 command boundary reports store API failures without fabricated success
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/store-release-plan.mjs
+++ b/packages/scripts/store-release-plan.mjs
@@ -18,10 +18,10 @@ const CHANNEL_OFFSETS = Object.freeze({
 });
 
 const EXTENSION_CHANNEL_OFFSETS = Object.freeze({
-  alpha: 10000,
-  beta: 20000,
-  rc: 30000,
-  nightly: 40000,
+  nightly: 10000,
+  alpha: 20000,
+  beta: 40000,
+  rc: 50000,
 });
 
 function requireArgument(args, name) {
@@ -73,6 +73,11 @@ function extensionVersion(parsed) {
   if ([major, minor, patch].some((value) => value > 65535)) {
     throw new Error(
       "Browser extension version components must not exceed 65535",
+    );
+  }
+  if (prerelease && !(prerelease in EXTENSION_CHANNEL_OFFSETS)) {
+    throw new Error(
+      `Unsupported browser extension prerelease lane: ${prerelease}`,
     );
   }
   const fourth = prerelease


### PR DESCRIPTION
## Summary

- add an exact-tag-bound reusable browser-store release workflow called only after canonical release finalization;
- build reproducible Chrome and Firefox packages, upload AMO reviewer source, and run installed Chrome/Firefox smokes;
- automate Chrome Web Store v2 and Microsoft Edge Add-ons v1.1 upload/publish polling with fail-closed identity, credential, warning, terminal-state, and version checks;
- submit stable Firefox builds as listed and prereleases as signed unlisted builds;
- keep the canonical release planner's extension version mapping byte-for-byte aligned with the browser packager across stable, alpha, beta, RC, and nightly lanes.

This PR is intentionally stacked on #21861. It was transplanted onto the current #21861 exact head, so its diff is now only the store-release automation rather than the stale browser-extension implementation history. Retarget it to `develop` only after #21861 lands.

## Exact revision

<!-- evidence-head:6a215e752697284422e12d5b9a0f0b7a262f3ec0 -->

- base: `4b3518a5acef3e078ec971755cdda68544e8f6a3` (#21861 exact head)
- head: `6a215e752697284422e12d5b9a0f0b7a262f3ec0`

## Review and verification

- 18/18 focused workflow, release-plan, Chrome API, and Edge API tests pass at the exact head;
- changed-file Biome and `git diff --check` pass;
- `actionlint` passes for the canonical and reusable release workflows;
- official-contract review confirms the Chrome Web Store v2 media upload, publish, status, service-account scope, Microsoft Edge Add-ons v1.1 API-key headers and operation polling, and `web-ext` v10 listed/unlisted signing flow;
- conflict reconciliation preserved the existing Microsoft Store release leg and its tests;
- no publisher mutation was attempted: the required production identities, credentials, existing listings, and protected-environment approval are not available in this review lane.

## Production prerequisites

- Chrome: create and complete the first item/listing, enable Chrome Web Store API v2, link the publisher service account, then set `CHROME_WEB_STORE_PUBLISHER_ID`, `CHROME_WEB_STORE_ITEM_ID`, and `CHROME_WEB_STORE_SERVICE_ACCOUNT_JSON` in `production-release`;
- Firefox: set the manifest add-on ID and `AMO_JWT_ISSUER` / `AMO_JWT_SECRET` in `production-release`;
- Edge: create and publish the first listing, enable the Partner Center Update API, then set `EDGE_ADDONS_PRODUCT_ID`, `EDGE_ADDONS_CLIENT_ID`, and `EDGE_ADDONS_API_KEY`;
- keep `production-release` reviewer-protected before the canonical workflow is allowed to use publisher credentials.

## Evidence matrix

- UI screenshots/video: N/A - workflow and release tooling only; no rendered UI changed.
- live-model trajectory: N/A - no model or agent behavior changed.
- native/device evidence: N/A - installed Chrome and Firefox smoke commands are encoded in the package job, but no native product path changed in this PR.
- publisher receipts: pending protected production release after #21861 merges and the publisher accounts/listings are configured; unit fixtures are not represented as production proof.

Progresses #20883, #20918, #20919, and #20921.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported
