### PR TITLE
test(cloud): pin migration SQL convergence contract

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.error-precedence.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.error-precedence.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { expect, spyOn, test } from "bun:test";
+import { WARM_POOL_ORG_ID } from "@elizaos/cloud-shared/db/schemas/agent-sandboxes";
 import {
   applyMigration,
   convergeAgentSandboxSchemaOnMigrationClient,
@@ -197,4 +198,8 @@ test("the migration-session adapter executes the complete convergence batch", as
       text.includes('CREATE TABLE IF NOT EXISTS "agent_pairing_tokens"'),
     ),
   ).toBe(true);
+  expect(
+    queries.find(({ text }) => text.includes('INSERT INTO "organizations"'))
+      ?.params,
+  ).toEqual([WARM_POOL_ORG_ID]);
 });

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -199,11 +199,18 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
     );
     CREATE TABLE users (
       id uuid PRIMARY KEY,
-      organization_id uuid
+      name text NOT NULL,
+      organization_id uuid,
+      role text NOT NULL,
+      wallet_verified boolean NOT NULL DEFAULT false,
+      is_active boolean NOT NULL DEFAULT true
     );
     CREATE TABLE organizations (
       id uuid PRIMARY KEY,
+      name text NOT NULL,
+      slug text NOT NULL UNIQUE,
       credit_balance numeric(16, 6) NOT NULL DEFAULT '0.000000',
+      is_active boolean NOT NULL DEFAULT true,
       stripe_customer_id text,
       billing_email text,
       stripe_payment_method_id text,


### PR DESCRIPTION
## Relates to

Refs #22606. The production regression is already repaired on `develop`; this
PR retains the missing migration regression coverage.

## What changed

- Pins the parameterized warm-pool organization insert in the migration-session test.
- Completes the real-PostgreSQL checkpoint fixture with the historical organization/user columns required by the newly added post-migration convergence batch.
- Drops the original production-code patch during rebase because `develop` now owns SQL rendering in the narrower migration-only `migration-sandbox-schema-executor`, avoiding `PgDialect` in the Worker-facing schema guard.

## Correctness boundary

This is test-only after reconciliation. It does not deploy or mutate staging/production data.

## Testing

Final head `a1a6bc2d9d25fcf961f30cdd46d2fd3dbd04f984`, base `9858cdf758a3836b90ed6762e5eefc03865f0576`:

```text
biome check <two changed test files>
pass (three pre-existing undeclared-env warnings in the real-PG test)

git diff --check origin/develop...HEAD
pass
```

An exact-head focused run was attempted, but the shared-checkout dependency
links resolved mismatched generated/core exports before test collection. It is
not claimed as a pass. The retained assertions are unchanged from the prior
real-PostgreSQL run below; hosted Quality is the final exact-head gate.

Real PostgreSQL 16 safety suite on the identical pre-rebase patch (`c703c3a8e9b58`; range-diff `=` through final head):

```text
RUN_REAL_POSTGRES_MIGRATION_TESTS=1 \
MIGRATION_TEST_DATABASE_URL=postgresql://postgres@127.0.0.1:<isolated-port>/postgres \
bun --conditions=eliza-source test \
  packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
11 pass, 0 fail, 54 assertions
```

The canonical `db:migrate` command also applied all 268 migrations to a fresh isolated in-memory PGlite database and released the advisory lock. The temporary 208 MB PostgreSQL cluster was stopped and deleted after the real-PG suite.

## Evidence Gate

<!-- evidence-head:a1a6bc2d9d25fcf961f30cdd46d2fd3dbd04f984 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive surface changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only reconciliation; no runtime backend behavior changes, and the prior identical real-PostgreSQL result is recorded above without being claimed as exact-head proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only reconciliation adds assertions/fixture coverage and produces no deployable domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this test-only reconciliation`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex-open-issues]
