### PR TITLE
feat(cloud): unify Shared Agent on AgentRuntime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -830,9 +830,13 @@
     "packages/corpus-tools": {
       "name": "@elizaos/corpus-tools",
       "version": "0.0.0",
+      "bin": {
+        "corpus": "./src/cli.ts",
+      },
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "fflate": "^0.8.3",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
+++ b/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
@@ -11,7 +11,7 @@ async function render(configuredOrigin?: string): Promise<string> {
   const response = await app.request(
     "/connection-success?source=eliza-app&platform=github",
     {},
-    { AGENT_APP_ORIGIN: configuredOrigin } as AppEnv["Bindings"],
+    { AGENT_APP_ORIGIN: configuredOrigin } as unknown as AppEnv["Bindings"],
   );
   expect(response.status).toBe(200);
   return response.text();

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1064,7 +1064,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(productionRoutes).toContain("*.cloud.eliza.app/*");
   });
 
-  test("publishes the genuine Shared runtime in staging and production", async () => {
+  test("has no rollback flag to bypass the canonical Shared AgentRuntime", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -1075,11 +1075,13 @@ describe("cloud-api worker entrypoint", () => {
       };
     };
 
-    expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("false");
-    expect(config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("true");
-    expect(config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe(
-      "true",
-    );
+    expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME,
+    ).toBeUndefined();
   });
 
   test("keeps the legacy edge guard false and reserves the replacement names for the cutover secrets", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -392,6 +392,31 @@ async function pushOperation(
   );
 }
 
+test("rejects malformed channel metadata before runtime dispatch", async () => {
+  const object = new SharedRuntimeConversation(
+    makeState(new Map<string, unknown>(), []) as never,
+    {} as never,
+  );
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/bridge", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "bridge",
+        agent: AGENT_FIXTURE,
+        channel: { type: "NOT_A_CHANNEL", source: "forged source" },
+        rpc: {
+          jsonrpc: "2.0",
+          id: "invalid-channel",
+          method: "message.send",
+          params: { text: "hi", roomId: "room-1" },
+        },
+      }),
+    }),
+  );
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({ code: "invalid_channel" });
+});
+
 test("mobile push registration is durable, idempotent, iOS-only, and removable", async () => {
   const data = new Map<string, unknown>();
   const object = new SharedRuntimeConversation(

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -65,6 +65,10 @@ mock.module("@/db/client", () => ({
   runWithDbCacheAsync: async <T>(fn: () => Promise<T>) => await fn(),
 }));
 mock.module("@/lib/runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => process.env,
+  getCloudBinding: () => undefined,
+  hasCloudBindingsContext: () => false,
+  runWithCloudBindings: <T>(_env: unknown, fn: () => T) => fn(),
   runWithCloudBindingsAsync: async <T>(_env: unknown, fn: () => Promise<T>) =>
     await fn(),
 }));
@@ -255,7 +259,12 @@ mock.module("@/lib/mobile-push/apns-provider", () => ({
   },
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { warn: loggerWarn },
+  logger: {
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: loggerWarn,
+  },
 }));
 
 const { SharedRuntimeConversation } = await import(

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -18,8 +18,12 @@ import {
 } from "@/lib/mobile-push/types";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import type { CachedAgentSandbox } from "@/lib/services/shared-runtime/cached-agent-dates";
-import type { SharedTurnMessage } from "@/lib/services/shared-runtime/run-shared-agent-turn";
+import type {
+  SharedRuntimeChannel,
+  SharedTurnMessage,
+} from "@/lib/services/shared-runtime/run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
+import { parseSharedRuntimeChannel } from "@/lib/services/shared-runtime/shared-runtime-channel";
 import type {
   SharedRuntimeHistoryStore,
   SharedTurnClaimStore,
@@ -42,6 +46,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      channel?: SharedRuntimeChannel;
     }
   | {
       operation: "personal-bridge";
@@ -49,6 +54,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      channel?: SharedRuntimeChannel;
     }
   | {
       operation: "stream";
@@ -56,6 +62,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      channel?: SharedRuntimeChannel;
     }
   | {
       operation: "personal-stream";
@@ -63,6 +70,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      channel?: SharedRuntimeChannel;
     }
   | {
       operation: "prewarm";
@@ -444,13 +452,11 @@ export class SharedRuntimeConversation {
         import("@/lib/services/shared-runtime/shared-runtime-chat"),
         import("@/lib/services/shared-runtime/cached-agent-dates"),
       ];
-      if (this.env.SHARED_ELIZA_AGENT_RUNTIME === "true") {
-        imports.push(
-          import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
-            ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
-          ),
-        );
-      }
+      imports.push(
+        import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
+          ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
+        ),
+      );
       await Promise.all(imports);
     });
   }
@@ -1038,6 +1044,22 @@ export class SharedRuntimeConversation {
 
   private async handle(request: Request): Promise<Response> {
     const payload = (await request.json()) as ConversationRequest;
+    const suppliedChannel = "channel" in payload ? payload.channel : undefined;
+    const channel =
+      suppliedChannel === undefined
+        ? undefined
+        : parseSharedRuntimeChannel(suppliedChannel);
+    if (suppliedChannel !== undefined && channel === null) {
+      return Response.json(
+        {
+          success: false,
+          error: "Invalid Shared runtime channel",
+          code: "invalid_channel",
+        },
+        { status: 400 },
+      );
+    }
+    const validatedChannel = channel ?? undefined;
     // Deletion fence: once the agent behind this room is purged, every later
     // operation (save, hydration, history read, forwarded turn) fails closed
     // instead of re-creating state for a deleted agent. The `delete` op stays
@@ -1623,10 +1645,6 @@ export class SharedRuntimeConversation {
       const executionCtx = {
         waitUntil: (promise: Promise<unknown>) => this.state.waitUntil(promise),
       };
-      const executionEngine =
-        this.env.SHARED_ELIZA_AGENT_RUNTIME === "true"
-          ? ("eliza-runtime" as const)
-          : ("direct-model" as const);
       if (
         payload.operation === "stream" ||
         payload.operation === "personal-stream"
@@ -1639,7 +1657,7 @@ export class SharedRuntimeConversation {
           funding: personal ? "platform" : "organization-credits",
           trustedMessageRole: payload.trustedMessageRole,
           trustedUserUtterance: payload.trustedUserUtterance,
-          executionEngine,
+          channel: validatedChannel,
           mobilePushDispatch: personal
             ? async (message: MobilePushMessage) => {
                 this.enqueueMobilePush(message);
@@ -1654,7 +1672,7 @@ export class SharedRuntimeConversation {
         funding: personal ? "platform" : "organization-credits",
         trustedMessageRole: payload.trustedMessageRole,
         trustedUserUtterance: payload.trustedUserUtterance,
-        executionEngine,
+        channel: validatedChannel,
         mobilePushDispatch: personal
           ? async (message: MobilePushMessage) => {
               this.enqueueMobilePush(message);

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -44,6 +44,7 @@ type ConversationRequest =
       operation: "bridge";
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
+      traceId?: string;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
       channel?: SharedRuntimeChannel;
@@ -52,6 +53,7 @@ type ConversationRequest =
       operation: "personal-bridge";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
+      traceId?: string;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
       channel?: SharedRuntimeChannel;
@@ -60,6 +62,7 @@ type ConversationRequest =
       operation: "stream";
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
+      traceId?: string;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
       channel?: SharedRuntimeChannel;
@@ -68,6 +71,7 @@ type ConversationRequest =
       operation: "personal-stream";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
+      traceId?: string;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
       channel?: SharedRuntimeChannel;
@@ -1651,6 +1655,7 @@ export class SharedRuntimeConversation {
       ) {
         return await sharedRuntimeChatService.stream(agent, payload.rpc, {
           abortSignal: request.signal,
+          traceId: payload.traceId,
           executionCtx,
           historyStore,
           turnClaims,
@@ -1666,6 +1671,7 @@ export class SharedRuntimeConversation {
         });
       }
       const result = await sharedRuntimeChatService.bridge(agent, payload.rpc, {
+        traceId: payload.traceId,
         executionCtx,
         historyStore,
         turnClaims,

--- a/packages/cloud/api/test/fixtures/shared-eliza-runtime-worker.ts
+++ b/packages/cloud/api/test/fixtures/shared-eliza-runtime-worker.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  ChannelType,
   type MediaGenerationRequest,
   searchKeylessWeb,
   type UUID,
@@ -140,7 +141,7 @@ function createCoordinatorProbe(agent: SharedRuntimeAgent) {
               assistant: "70000000-0000-5000-8000-000000000084",
             },
             execution: {
-              engine: "eliza-runtime",
+              channel: { type: ChannelType.DM, source: "shared-runtime" },
               agentKey: agent.id,
               ...(serverAttestedPersonalSharedUser
                 ? { authenticatedPersonalSharedUser: true as const }
@@ -390,7 +391,7 @@ export default {
             assistant: "70000000-0000-5000-8000-000000000004",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:70000000-0000-5000-8000-000000000005",
             todos: {
               scope,
@@ -415,7 +416,7 @@ export default {
             assistant: "70000000-0000-5000-8000-000000000014",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:70000000-0000-5000-8000-000000000015",
             reminders: {
               delivery: {
@@ -444,7 +445,7 @@ export default {
             assistant: "70000000-0000-5000-8000-000000000024",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:70000000-0000-5000-8000-000000000025",
             authenticatedPersonalSharedUser: true,
             media: {
@@ -505,7 +506,7 @@ export default {
             assistant: "70000000-0000-5000-8000-000000000054",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:70000000-0000-5000-8000-000000000055",
             authenticatedPersonalSharedUser: true,
           },
@@ -529,7 +530,7 @@ export default {
             assistant: "70000000-0000-5000-8000-000000000044",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:70000000-0000-5000-8000-000000000045",
             authenticatedPersonalSharedUser: true,
             media: {
@@ -559,7 +560,7 @@ export default {
             assistant: "059e33bc-8215-49f4-841f-7642e7505bc7",
           },
           execution: {
-            engine: "eliza-runtime",
+            channel: { type: ChannelType.DM, source: "shared-runtime" },
             agentKey: "personal:b55d99d0-ae38-4c7c-8791-7443e5de8ebc",
           },
         });
@@ -584,7 +585,7 @@ export default {
           assistant: "f492130b-2fc6-4b2b-bdca-51f441b0483d",
         },
         execution: {
-          engine: "eliza-runtime",
+          channel: { type: ChannelType.DM, source: "shared-runtime" },
           agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
         },
       });

--- a/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.test.ts
+++ b/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.test.ts
@@ -33,7 +33,7 @@ const { default: app } = await import("./route");
 const PERSONAL_AGENT_ID = "personal:9610511b-dff2-5ca3-989a-8e1004ff44b1";
 const SANDBOX_AGENT_ID = "9610511b-dff2-4ca3-889a-8e1004ff44b2";
 
-function hitCron(sharedRuntimeEnabled = true) {
+function hitCron() {
   return app.fetch(
     new Request("https://api.example.test/", {
       method: "POST",
@@ -41,7 +41,6 @@ function hitCron(sharedRuntimeEnabled = true) {
     }),
     {
       CRON_SECRET: "cron-secret",
-      SHARED_ELIZA_AGENT_RUNTIME: sharedRuntimeEnabled ? "true" : "false",
       SHARED_RUNTIME_CONVERSATIONS: {},
     },
   );
@@ -121,16 +120,6 @@ describe("shared-agent keepwarm cron", () => {
     });
     expect(prewarmSharedAgentTurnCaches).not.toHaveBeenCalled();
     expect(prewarmSharedElizaRuntime).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not prewarm the process-wide runtime when the feature is disabled", async () => {
-    listRecentlyActiveAgentIds.mockResolvedValueOnce([PERSONAL_AGENT_ID]);
-
-    const response = await hitCron(false);
-
-    expect(response.status).toBe(200);
-    expect(prewarmSharedElizaRuntime).not.toHaveBeenCalled();
-    expect(findById).not.toHaveBeenCalled();
   });
 
   test("rejects an invalid cron secret before querying history", async () => {

--- a/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.ts
+++ b/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.ts
@@ -63,9 +63,7 @@ async function runKeepwarm(c: AppContext) {
       warmed++;
     }
 
-    if (c.env.SHARED_ELIZA_AGENT_RUNTIME === "true") {
-      await prewarmSharedElizaRuntime();
-    }
+    await prewarmSharedElizaRuntime();
 
     logger.info("[SharedKeepwarm Cron] swept recently active shared agents", {
       candidates: agentIds.length,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -258,6 +258,7 @@ app.post("/", async (c) => {
 
   const conversationId = c.req.param("conversationId") ?? r.agentId;
   return handleCanonicalScopedAgentStream({
+    traceId: c.get("traceId"),
     abortSignal: c.req.raw.signal,
     agent: r.agent,
     agentId: r.agentId,

--- a/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
+++ b/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
@@ -10,7 +10,7 @@ const app = new Hono<AppEnv>().route("/callback", route);
 async function render(configuredOrigin?: string): Promise<string> {
   const response = await app.request("/callback?code=secret&state=state", {}, {
     AGENT_APP_ORIGIN: configuredOrigin,
-  } as AppEnv["Bindings"]);
+  } as unknown as AppEnv["Bindings"]);
   expect(response.status).toBe(200);
   return response.text();
 }

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterEach, expect, test } from "bun:test";
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import type { Bindings } from "@/types/cloud-worker-env";
 
 process.env.MOCK_REDIS = "1";
@@ -132,6 +133,10 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
   expect(JSON.parse(String(coordinatorCalls[1]?.init?.body))).toMatchObject({
     operation: "stream",
     agent: cachedAgent,
+    channel: {
+      type: ChannelType.VOICE_DM,
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+    },
     rpc: {
       method: "message.send",
       params: {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -590,6 +590,16 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBeGreaterThan(0);
     expect(client.controlTypes()).toContain("speaking_start");
     expect(responseRequests).toBe(0);
+    const greetingLatencyLog = fakeLogger.logger.info.mock.calls.findLast(
+      ([message]) => message === "[voice-session] opening greeting latency",
+    );
+    expect(greetingLatencyLog?.[1]).toMatchObject({
+      greetingChars: "hello? who's this?".length,
+      prewarmStatus: "not_configured",
+      firstAudioMs: expect.any(Number),
+      ttsTransportReadyMs: expect.any(Number),
+      ttsSynthesisAfterReadyMs: expect.any(Number),
+    });
 
     cartesia.emitDone();
     await flush();
@@ -882,6 +892,14 @@ describe("voice-session WS lifecycle", () => {
     });
     expect(client.controlTypes()).toContain("ready");
     expect(prewarmCalls).toBe(1);
+    const prewarmLog = fakeLogger.logger.info.mock.calls.findLast(
+      ([message]) =>
+        message === "[voice-session] Eliza context prewarm completed",
+    );
+    expect(prewarmLog?.[1]).toMatchObject({
+      sessionId: CLAIMS.sessionId,
+      prewarmDurationMs: expect.any(Number),
+    });
   });
 
   test("first response does not wait for latency-only prewarm", async () => {
@@ -1555,6 +1573,9 @@ describe("voice-session WS lifecycle", () => {
     );
     expect(latencyLog?.[1]).toMatchObject({
       upstreamAttemptCount: 3,
+      prewarmStatus: "not_configured",
+      ttsTransportReadyMs: expect.any(Number),
+      ttsSynthesisAfterReadyMs: expect.any(Number),
       upstreamAttempts: [
         { attempt: 1, status: 503 },
         { attempt: 2, status: 503 },
@@ -1570,6 +1591,46 @@ describe("voice-session WS lifecycle", () => {
     cartesia.emitDone();
     await flush();
     expect(client.controlTypes()).toContain("speaking_end");
+  });
+
+  test("prewarm completion wakes a cold-turn retry before its backoff expires", async () => {
+    const prewarm = Promise.withResolvers<void>();
+    const client = new FakeClientSocket();
+    const successFetch = makeSseFetch(["Warm now."]);
+    let calls = 0;
+    await connectSession({
+      client,
+      prewarmElizaContext: () => prewarm.promise,
+      cacheWarmingRetryDelaysMs: [5_000],
+      fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls += 1;
+        if (calls === 1) {
+          prewarm.resolve();
+          return Response.json(
+            {
+              success: false,
+              error: "Shared runtime cache is warming. Retry shortly.",
+              code: "shared_runtime_cache_warming",
+              retryable: true,
+            },
+            { status: 503 },
+          );
+        }
+        return successFetch(input, init);
+      }) as typeof fetch,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "answer after prewarm");
+    await flush();
+    await flush();
+
+    expect(calls).toBe(2);
+    expect(client.controlTypes()).toContain("llm_first_text");
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    cartesia.emitDone();
+    client.clientSend(JSON.stringify({ t: "bye" }));
+    await flush();
   });
 
   test("canonical 402 becomes a non-retryable insufficient-credits turn error", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1550,6 +1550,23 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("llm_first_text");
     const cartesia = FakeCartesiaSocket.instances.at(-1)!;
     expect(cartesia.sentText()).toBe("Cache warmed.Here is your answer.");
+    const latencyLog = fakeLogger.logger.info.mock.calls.findLast(
+      ([message]) => message === "[voice-session] first-turn latency",
+    );
+    expect(latencyLog?.[1]).toMatchObject({
+      upstreamAttemptCount: 3,
+      upstreamAttempts: [
+        { attempt: 1, status: 503 },
+        { attempt: 2, status: 503 },
+        { attempt: 3, status: 200 },
+      ],
+    });
+    const timingFields = latencyLog?.[1] as
+      | { upstreamSuccessfulHeadersOffsetMs?: number }
+      | undefined;
+    expect(
+      timingFields?.upstreamSuccessfulHeadersOffsetMs,
+    ).toBeGreaterThanOrEqual(0);
     cartesia.emitDone();
     await flush();
     expect(client.controlTypes()).toContain("speaking_end");

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -12,6 +12,7 @@ import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
+import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
 import {
   hasCloudBindingsContext,
   runWithCloudBindingsAsync,
@@ -332,6 +333,7 @@ async function dispatchInternalElizaConversationFetch(
   }
 
   return handleCanonicalScopedAgentStream({
+    traceId: resolveElizaTraceId(headers),
     abortSignal: request.signal,
     agent,
     agentId: claims.agentId,

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -8,6 +8,7 @@
  * contract cannot select the legacy database-backed bridge.
  */
 
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
@@ -344,6 +345,10 @@ async function dispatchInternalElizaConversationFetch(
       (body as { messageRole?: unknown }).messageRole === "system"
         ? "system"
         : undefined,
+    channel: {
+      type: ChannelType.VOICE_DM,
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+    },
     body,
     origin: headers.get("origin"),
     namespace: runtime.namespace,

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -231,6 +231,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private started = false;
   private closed = false;
   private startedAtMs: number | null = null;
+  private prewarmStartedAtMs: number | null = null;
+  private prewarmCompletedAtMs: number | null = null;
+  private prewarmStatus: "not_configured" | "pending" | "success" | "error" =
+    "not_configured";
+  private prewarmPromise: Promise<void> | null = null;
+  private prewarmRetryWakeConsumed = false;
 
   /** Monotonic turn counter; the current turn's trace id derives from it. */
   private turnCounter = 0;
@@ -363,14 +369,40 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     // is a latency hint only: the response path has its own typed cache-warming
     // retries and must never wait indefinitely for optional background fills.
     if (this.config.prewarmElizaContext) {
-      void this.config.prewarmElizaContext().catch((error) => {
-        // error-policy:J7 prewarm is latency-only; the response path retains
-        // its typed cache-warming retry fallback and reports the failed hint.
-        logger.warn("[voice-session] Eliza context prewarm failed", {
-          sessionId: this.sessionId,
-          error: error instanceof Error ? error.message : String(error),
+      this.prewarmStartedAtMs = this.now();
+      this.prewarmStatus = "pending";
+      const prewarmPromise: Promise<void> = Promise.resolve()
+        .then(() => this.config.prewarmElizaContext?.())
+        .then(() => {
+          this.prewarmCompletedAtMs = this.now();
+          this.prewarmStatus = "success";
+          logger.info("[voice-session] Eliza context prewarm completed", {
+            sessionId: this.sessionId,
+            prewarmDurationMs:
+              this.prewarmCompletedAtMs -
+              (this.prewarmStartedAtMs ?? this.prewarmCompletedAtMs),
+          });
+        })
+        .catch((error) => {
+          this.prewarmCompletedAtMs = this.now();
+          this.prewarmStatus = "error";
+          // error-policy:J7 prewarm is latency-only; the response path retains
+          // its typed cache-warming retry fallback and reports the failed hint.
+          logger.warn("[voice-session] Eliza context prewarm failed", {
+            sessionId: this.sessionId,
+            prewarmDurationMs:
+              this.prewarmCompletedAtMs -
+              (this.prewarmStartedAtMs ?? this.prewarmCompletedAtMs),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .finally(() => {
+          if (this.prewarmPromise === prewarmPromise) {
+            this.prewarmPromise = null;
+          }
         });
-      });
+      this.prewarmPromise = prewarmPromise;
+      void prewarmPromise;
     }
     // The session-level trace span id is stable until the first turn mints its own.
     const sessionTrace = this.mintTraceId("session");
@@ -820,10 +852,23 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     this.currentVoiceTurnId = traceId;
     this.turnTtsChars = text.length;
     this.firstLlmTextEmitted = false;
+    const greetingStartedAt = this.now();
+    let ttsOpenedAt: number | null = null;
 
     const stream = this.createTtsStream(traceId, {
       onFirstAudio: () => {
         if (this.currentVoiceTurnId !== traceId) return;
+        const firstAudioAt = this.now();
+        logger.info("[voice-session] opening greeting latency", {
+          traceId,
+          greetingChars: text.length,
+          firstAudioMs: firstAudioAt - greetingStartedAt,
+          ttsTransportReadyMs:
+            ttsOpenedAt === null ? null : ttsOpenedAt - greetingStartedAt,
+          ttsSynthesisAfterReadyMs:
+            ttsOpenedAt === null ? null : firstAudioAt - ttsOpenedAt,
+          ...this.prewarmTimingFields(firstAudioAt),
+        });
         this.state = "speaking";
         this.send({ t: "speaking_start", traceId });
       },
@@ -847,8 +892,67 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       },
     });
     this.ttsStream = stream;
-    void stream.opened.catch(() => undefined);
+    void stream.opened
+      .then(() => {
+        ttsOpenedAt = this.now();
+      })
+      .catch(() => undefined);
     stream.sendPhrase({ text, continueContext: false });
+  }
+
+  private prewarmTimingFields(atMs: number): {
+    prewarmStatus: "not_configured" | "pending" | "success" | "error";
+    prewarmStartedOffsetMs: number | null;
+    prewarmDurationMs: number | null;
+    prewarmCompletedBeforeEventMs: number | null;
+  } {
+    return {
+      prewarmStatus: this.prewarmStatus,
+      prewarmStartedOffsetMs:
+        this.startedAtMs === null || this.prewarmStartedAtMs === null
+          ? null
+          : this.prewarmStartedAtMs - this.startedAtMs,
+      prewarmDurationMs:
+        this.prewarmStartedAtMs === null || this.prewarmCompletedAtMs === null
+          ? null
+          : this.prewarmCompletedAtMs - this.prewarmStartedAtMs,
+      prewarmCompletedBeforeEventMs:
+        this.prewarmCompletedAtMs === null
+          ? null
+          : atMs - this.prewarmCompletedAtMs,
+    };
+  }
+
+  /**
+   * A cold-turn 503 normally sleeps before retrying. If the session prewarm
+   * lands sooner, retry immediately; the normal hot request never waits for
+   * this latency-only hint, and the delay remains the upper bound.
+   */
+  private waitForRetryDelayOrPrewarm(
+    delayMs: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const pendingPrewarm = this.prewarmPromise;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        signal.removeEventListener("abort", settle);
+        resolve();
+      };
+      const timeout = setTimeout(settle, delayMs);
+      signal.addEventListener("abort", settle, { once: true });
+      if (
+        !this.prewarmRetryWakeConsumed &&
+        (pendingPrewarm || this.prewarmCompletedAtMs !== null)
+      ) {
+        this.prewarmRetryWakeConsumed = true;
+        if (pendingPrewarm) void pendingPrewarm.then(settle);
+        else queueMicrotask(settle);
+      }
+    });
   }
 
   private createTtsStream(
@@ -889,6 +993,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     let activeUpstreamAttempt = 0;
     let upstreamSuccessfulHeadersOffsetMs: number | null = null;
     let upstreamServerTiming: string | null = null;
+    let ttsTransportReadyAt: number | null = null;
     const abort = new AbortController();
     this.llmAbort = abort;
     const phrase = new PhraseAggregator({
@@ -921,10 +1026,19 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
               firstModelTextAt === null
                 ? null
                 : firstAudioAt - firstModelTextAt,
+            ttsTransportReadyMs:
+              ttsTransportReadyAt === null
+                ? null
+                : ttsTransportReadyAt - responseStartedAt,
+            ttsSynthesisAfterReadyMs:
+              ttsTransportReadyAt === null
+                ? null
+                : firstAudioAt - ttsTransportReadyAt,
             upstreamAttemptCount,
             upstreamAttempts,
             upstreamSuccessfulHeadersOffsetMs,
             upstreamServerTiming,
+            ...this.prewarmTimingFields(firstAudioAt),
           });
           this.state = "speaking";
           this.send({ t: "speaking_start", traceId });
@@ -970,7 +1084,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // Cancellation before the provider's open event rejects `opened`. This
       // turn does not await readiness because outbound phrases queue in the
       // adapter, so consume that designed rejection on fast teardown.
-      void prewarmedTts.opened.catch(() => undefined);
+      void prewarmedTts.opened
+        .then(() => {
+          ttsTransportReadyAt = this.now();
+        })
+        .catch(() => undefined);
 
       const request = {
         endpoint: this.config.elizaEndpoint,
@@ -1072,17 +1190,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
             upstreamCode: bridgeError.upstreamCode,
             elapsedMs: this.now() - responseStartedAt,
           });
-          await new Promise<void>((resolve) => {
-            const timeout = setTimeout(resolve, retryDelay);
-            abort.signal.addEventListener(
-              "abort",
-              () => {
-                clearTimeout(timeout);
-                resolve();
-              },
-              { once: true },
-            );
-          });
+          await this.waitForRetryDelayOrPrewarm(retryDelay, abort.signal);
           if (abort.signal.aborted || this.currentVoiceTurnId !== traceId) {
             return;
           }

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -101,6 +101,7 @@ const STT_PARTIAL_EMIT_INTERVAL_MS = 40;
  * land, while keeping the total first-turn penalty bounded below eight seconds.
  */
 const CACHE_WARMING_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+const MAX_RECORDED_UPSTREAM_ATTEMPTS = 8;
 /** Replace a failed realtime recognizer without dropping the live phone call. */
 const STT_RECONNECT_DELAYS_MS = [0, 250, 1_000, 2_000, 5_000] as const;
 /** Consecutive revoke-store failures tolerated before the session fails closed. */
@@ -878,7 +879,15 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   ): Promise<void> {
     const responseStartedAt = this.now();
     let firstModelTextAt: number | null = null;
-    let upstreamHeadersMs: number | null = null;
+    const upstreamAttempts: Array<{
+      attempt: number;
+      status: number;
+      attemptHeadersMs: number;
+      turnHeadersOffsetMs: number;
+    }> = [];
+    let upstreamAttemptCount = 0;
+    let activeUpstreamAttempt = 0;
+    let upstreamSuccessfulHeadersOffsetMs: number | null = null;
     let upstreamServerTiming: string | null = null;
     const abort = new AbortController();
     this.llmAbort = abort;
@@ -912,7 +921,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
               firstModelTextAt === null
                 ? null
                 : firstAudioAt - firstModelTextAt,
-            upstreamHeadersMs,
+            upstreamAttemptCount,
+            upstreamAttempts,
+            upstreamSuccessfulHeadersOffsetMs,
             upstreamServerTiming,
           });
           this.state = "speaking";
@@ -978,11 +989,26 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         signal: abort.signal,
         fetchImpl: this.config.fetchImpl,
         onResponseHeaders: (headers: ElizaSseBridgeResponseHeaders) => {
-          upstreamHeadersMs = headers.elapsedMs;
-          upstreamServerTiming = headers.serverTiming;
+          const turnHeadersOffsetMs = this.now() - responseStartedAt;
+          upstreamAttemptCount += 1;
+          if (upstreamAttempts.length < MAX_RECORDED_UPSTREAM_ATTEMPTS) {
+            upstreamAttempts.push({
+              attempt: activeUpstreamAttempt,
+              status: headers.status,
+              attemptHeadersMs: headers.elapsedMs,
+              turnHeadersOffsetMs,
+            });
+          }
+          if (headers.status >= 200 && headers.status < 300) {
+            upstreamSuccessfulHeadersOffsetMs = turnHeadersOffsetMs;
+            upstreamServerTiming = headers.serverTiming;
+          }
           logger.info("[voice-session] Eliza response headers", {
             traceId,
-            elapsedMs: headers.elapsedMs,
+            attempt: activeUpstreamAttempt,
+            status: headers.status,
+            attemptHeadersMs: headers.elapsedMs,
+            turnHeadersOffsetMs,
             serverTiming: headers.serverTiming,
           });
         },
@@ -1020,6 +1046,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         this.config.cacheWarmingRetryDelaysMs ?? CACHE_WARMING_RETRY_DELAYS_MS;
       let result: Awaited<ReturnType<typeof streamElizaConversation>>;
       for (let attempt = 0; ; attempt += 1) {
+        activeUpstreamAttempt = attempt + 1;
         try {
           result = await streamElizaConversation(request, onDelta);
           break;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -204,9 +204,7 @@ new_sqlite_classes = ["InferenceRateLimitV2RollbackFloor"]
 # transition the database control durable -> paused, then remove/false this
 # secondary switch; keep the durable binary deployed so recovery can converge.
 [vars]
-# Local/default deployments retain the direct-model control unless explicitly opted in.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED and
@@ -488,9 +486,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.staging.vars]
-# Protected staging proves the genuine Workerd AgentRuntime before production promotion.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
@@ -774,9 +770,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.production.vars]
-# Production uses the genuine Shared Workerd runtime for personal voice.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "true"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 # The protected production cutover owns

--- a/packages/cloud/shared/src/lib/services/default-agent-character.test.ts
+++ b/packages/cloud/shared/src/lib/services/default-agent-character.test.ts
@@ -4,10 +4,8 @@
  * it rather than only at the seed itself.
  *
  * Deterministic and self-contained: the seed and the shared-turn projection are
- * pure, and the one turn that reaches a provider drives the real exported
- * `runSharedAgentTurn` with the `ai` SDK and the model router stubbed via
- * `mock.module`, capturing the system prompt the model would have received. No
- * network, no database, no live model.
+ * pure, and the turn boundary captures the character passed to AgentRuntime.
+ * No network, database, or live model is involved.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -25,17 +23,20 @@ import { buildWarmClaimCharacterPayload } from "./warm-claim-character-push";
 let capturedSystem: string | undefined;
 
 mock.module("../providers/language-model", () => ({
-  getLanguageModel: () => ({ __sentinel: "model" }),
-  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
   hasLanguageModelProviderConfigured: () => true,
 }));
 
-mock.module("ai", () => ({
-  generateText: async (options?: { system?: string }) => {
-    capturedSystem = options?.system;
-    return { text: "ok reply" };
+mock.module("./shared-runtime/shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: Record<string, unknown>) => {
+    capturedSystem = (input.character as { system: string }).system;
+    return {
+      reply: "ok reply",
+      history: [],
+      model: String(input.model),
+      degraded: false,
+    };
   },
-  streamText: () => {
+  runSharedElizaRuntimeTurnStream: () => {
     throw new Error("streaming is not exercised by this suite");
   },
 }));
@@ -70,6 +71,7 @@ describe("default agent character seed", () => {
     expect(seed.topics).toEqual(preset.topics);
     expect(seed.style).toEqual(preset.style);
     expect(seed.postExamples).toEqual(preset.postExamples);
+    expect(seed.templates).toEqual(preset.templates);
     // Flat keys only: the container env loader, the warm-claim push, and the
     // first-boot bootstrap agent all read agent_config at the top level.
     expect(Object.keys(seed).sort()).toEqual([
@@ -79,6 +81,7 @@ describe("default agent character seed", () => {
       "postExamples",
       "style",
       "system",
+      "templates",
       "topics",
     ]);
   });
@@ -169,6 +172,11 @@ describe("a newly created cloud agent's character", () => {
     expect(character.name).toBe("Nyx");
     expect(character.system).toBe(buildCloudElizaPersona().system);
     expect(character.bio?.length).toBeGreaterThan(0);
+    expect(character.adjectives).toEqual(buildCloudElizaPersona().adjectives);
+    expect(character.topics).toEqual(buildCloudElizaPersona().topics);
+    expect(character.style).toEqual(buildCloudElizaPersona().style);
+    expect(character.messageExamples?.length).toBeGreaterThan(0);
+    expect(character.templates).toEqual(buildCloudElizaPersona().templates);
     expect(character.system).not.toBe("You are Nyx, a helpful assistant.");
 
     const result = await runSharedAgentTurn({

--- a/packages/cloud/shared/src/lib/services/default-agent-character.ts
+++ b/packages/cloud/shared/src/lib/services/default-agent-character.ts
@@ -73,6 +73,7 @@ export function buildDefaultAgentCharacterConfig(): Record<string, unknown> {
     messageExamples: preset.messageExamples.map((group) => ({
       examples: group.map((turn) => ({ name: turn.user, content: { ...turn.content } })),
     })),
+    ...(preset.templates ? { templates: { ...preset.templates } } : {}),
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,6 +6,7 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
+import { ChannelType } from "@elizaos/core/edge";
 import {
   MAX_RESTORABLE_AGENT_BACKUP_BYTES,
   resolveRetainableAgentBackupBytes,
@@ -4294,6 +4295,10 @@ export class ElizaSandboxService {
         character,
         history,
         message: text,
+        execution: {
+          agentKey: rec.id,
+          channel: { type: ChannelType.DM, source: "shared-runtime" },
+        },
       });
       if (turn.degraded) {
         // A failed/degraded turn isn't persisted or billed — just refund the hold.
@@ -4456,6 +4461,10 @@ export class ElizaSandboxService {
         character,
         history,
         message: text,
+        execution: {
+          agentKey: rec.id,
+          channel: { type: ChannelType.DM, source: "shared-runtime" },
+        },
       });
       if (turn.degraded) {
         await settleReservation(0);

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.test.ts
@@ -71,6 +71,7 @@ describe("managed Discord Shared connector boundary", () => {
     expect(call?.[2]).toContain("[Public Discord guild channel; speaker: Alice.");
     expect(call?.[2]).toContain(message);
     expect(call?.[9]).toBe(message);
+    expect(call?.[10]).toEqual({ type: "GROUP", source: "discord" });
   });
 
   test("keeps the voice privacy wrapper for the model and sends raw transcript separately", async () => {
@@ -93,6 +94,7 @@ describe("managed Discord Shared connector boundary", () => {
     expect(call?.[2]).toContain("[Public Discord guild voice; speaker: Alice.");
     expect(call?.[2]).toContain(transcript);
     expect(call?.[9]).toBe(transcript);
+    expect(call?.[10]).toEqual({ type: "VOICE_GROUP", source: "discord" });
     expect(textToSpeech).toHaveBeenCalledWith({
       text: "Shared reply",
       outputFormat: "mp3_44100_128",

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -2,6 +2,7 @@
  * Authorizes and executes managed Discord guild text and voice turns against
  * personal Shared Eliza while isolating public guild history from private transports.
  */
+import { ChannelType } from "@elizaos/core/edge";
 import { ElevenLabsService } from "./elevenlabs";
 import { elizaAppUserService } from "./eliza-app";
 import {
@@ -85,6 +86,7 @@ export async function runManagedDiscordGuildTextTurn(
     "platform",
     undefined,
     input.message,
+    { type: ChannelType.GROUP, source: "discord" },
   );
   return {
     replyText: reply.text.trim(),
@@ -193,6 +195,7 @@ export async function runManagedDiscordGuildVoiceTurn(
     "platform",
     undefined,
     transcript,
+    { type: ChannelType.VOICE_GROUP, source: "discord" },
   );
   const replyText = reply.text.trim();
   if (!replyText) throw new Error("Shared Eliza returned no guild voice reply");

--- a/packages/cloud/shared/src/lib/services/personal-message-delivery.test.ts
+++ b/packages/cloud/shared/src/lib/services/personal-message-delivery.test.ts
@@ -3,6 +3,7 @@
  * proving Shared fallback and active Dedicated selection.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
 
 let dedicatedTarget: { id: string; status: "running"; bridge_url: string } | null = null;
 const findActivePersonalDedicatedTarget = mock(async () => dedicatedTarget);
@@ -61,6 +62,10 @@ describe("deliverPersonalTextMessage", () => {
       reply: "Shared reply",
     });
     expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend.mock.calls[0]?.[10]).toEqual({
+      type: ChannelType.DM,
+      source: "x",
+    });
     expect(bridge).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
+++ b/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
@@ -2,6 +2,8 @@
  * Routes a normalized personal connector turn to the user's active Dedicated
  * runtime when present, otherwise to their rowless personal Shared runtime.
  */
+
+import { ChannelType } from "@elizaos/core/edge";
 import type { Organization } from "../../db/schemas/organizations";
 import type { User } from "../../db/schemas/users";
 import type { AppEnv, RuntimeDurableObjectNamespace } from "../../types/cloud-worker-env";
@@ -188,6 +190,8 @@ export async function deliverPersonalTextMessage(params: {
     params.messageId,
     "platform",
     undefined,
+    undefined,
+    { type: ChannelType.DM, source: params.platform },
   );
   return {
     success: true,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { RateLimitError } from "../../api/errors";
 import * as coordinatorActual from "./conversation-coordinator";
 
@@ -76,7 +77,21 @@ describe("handleCanonicalScopedAgentStream", () => {
       executionCtx: EXECUTION_CTX,
       agentKind: undefined,
       trustedMessageRole: undefined,
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
     });
+  });
+
+  test("preserves an authenticated voice channel outside untrusted RPC params", async () => {
+    const channel = { type: ChannelType.VOICE_DM, source: MESSAGE_SOURCE_CLIENT_CHAT };
+    await handleCanonicalScopedAgentStream({ ...BASE, channel });
+
+    const [, rpc, options] = coordinateSharedStream.mock.calls[0] as unknown as [
+      unknown,
+      { params: Record<string, unknown> },
+      Record<string, unknown>,
+    ];
+    expect(rpc.params).not.toHaveProperty("channel");
+    expect(options.channel).toEqual(channel);
   });
 
   test("preserves coordinator phase timings beside route timings", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -44,6 +44,7 @@ const EXECUTION_CTX = {
 };
 const ABORT_SIGNAL = new AbortController().signal;
 const BASE = {
+  traceId: "trace-canonical-stream",
   abortSignal: ABORT_SIGNAL,
   agent: AGENT,
   agentId: AGENT.id,
@@ -78,6 +79,7 @@ describe("handleCanonicalScopedAgentStream", () => {
       agentKind: undefined,
       trustedMessageRole: undefined,
       channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
+      traceId: "trace-canonical-stream",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -5,6 +5,7 @@
  * SSE/CORS response shape used by HTTP routes and in-process voice turns.
  */
 
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
 import { logger } from "../../utils/logger";
@@ -12,6 +13,7 @@ import { chatSseFrame } from "../chat-sse-frames";
 import type { BridgeRequest } from "../eliza-sandbox-bridge";
 import { applyCorsHeaders } from "../proxy/cors";
 import { coordinateSharedStream } from "./conversation-coordinator";
+import type { SharedRuntimeChannel } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
 import { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
@@ -38,6 +40,8 @@ export interface CanonicalScopedStreamRequest {
   agentKind?: "sandbox" | "personal";
   /** Set only by the authenticated in-process voice adapter for lifecycle turns. */
   trustedMessageRole?: "system";
+  /** Authenticated transport semantics supplied by the route adapter. */
+  channel?: SharedRuntimeChannel;
   namespace: RuntimeDurableObjectNamespace;
   executionCtx: BridgeExecutionContext;
   abortSignal?: AbortSignal;
@@ -116,6 +120,10 @@ export async function handleCanonicalScopedAgentStream(
       executionCtx: request.executionCtx,
       agentKind: request.agentKind,
       trustedMessageRole: request.trustedMessageRole,
+      channel: request.channel ?? {
+        type: ChannelType.DM,
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      },
     });
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -27,6 +27,8 @@ const STREAM_HEADERS = {
 } as const;
 
 export interface CanonicalScopedStreamRequest {
+  /** Standard request correlation identity resolved by the HTTP boundary. */
+  traceId?: string;
   /**
    * Tenancy-resolved agent supplied by the caller. Requiring this at the type
    * boundary prevents Worker callers from falling through to the legacy
@@ -124,6 +126,7 @@ export async function handleCanonicalScopedAgentStream(
         type: ChannelType.DM,
         source: MESSAGE_SOURCE_CLIENT_CHAT,
       },
+      traceId: request.traceId,
     });
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
 
 const directBridge = mock(() => {
   throw new Error("direct bridge must not run");
@@ -151,6 +152,7 @@ describe("shared conversation coordinator", () => {
       agentKind: "personal",
       trustedMessageRole: "system",
       trustedUserUtterance: "email Bob now",
+      channel: { type: ChannelType.VOICE_DM, source: "client_chat" },
     });
     await coordinateSharedLifecycleEvent(
       agent.id,
@@ -166,6 +168,7 @@ describe("shared conversation coordinator", () => {
         rpc,
         trustedMessageRole: "system",
         trustedUserUtterance: "email Bob now",
+        channel: { type: ChannelType.VOICE_DM, source: "client_chat" },
       },
       {
         operation: "lifecycle",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -96,6 +96,7 @@ describe("shared conversation coordinator", () => {
       await (
         await coordinateSharedStream(agent, rpc, {
           abortSignal: abortController.signal,
+          traceId: "trace-coordinator-stream",
           namespace,
           executionCtx,
         })
@@ -114,6 +115,7 @@ describe("shared conversation coordinator", () => {
       "history",
     ]);
     expect(signals).toEqual([undefined, abortController.signal, undefined, undefined]);
+    expect(envelopes[1]).toMatchObject({ traceId: "trace-coordinator-stream" });
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
     expect(directHistory).not.toHaveBeenCalled();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -21,6 +21,8 @@ import type { BridgeExecutionContext } from "./shared-runtime-chat";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
 
 export interface SharedConversationCoordinatorOptions {
+  /** Standard request correlation identity; never accepted from RPC params. */
+  traceId?: string;
   namespace: RuntimeDurableObjectNamespace;
   executionCtx: BridgeExecutionContext;
   abortSignal?: AbortSignal;
@@ -294,6 +296,7 @@ export async function coordinateSharedBridge(
         operation: options.agentKind === "personal" ? "personal-bridge" : "bridge",
         agent,
         rpc,
+        ...(options.traceId ? { traceId: options.traceId } : {}),
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }
@@ -320,6 +323,7 @@ export async function coordinateSharedStream(
         operation: options.agentKind === "personal" ? "personal-stream" : "stream",
         agent,
         rpc,
+        ...(options.traceId ? { traceId: options.traceId } : {}),
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -15,7 +15,7 @@ import type {
 } from "../../mobile-push/types";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
-import type { SharedTurnMessage } from "./run-shared-agent-turn";
+import type { SharedRuntimeChannel, SharedTurnMessage } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
@@ -30,6 +30,8 @@ export interface SharedConversationCoordinatorOptions {
   trustedMessageRole?: "system";
   /** Authenticated raw utterance when RPC text also contains server-composed context. */
   trustedUserUtterance?: string;
+  /** Authenticated transport semantics; never accepted from bridge RPC params. */
+  channel?: SharedRuntimeChannel;
 }
 
 export interface SharedConversationHistoryCoordinatorOptions {
@@ -296,6 +298,7 @@ export async function coordinateSharedBridge(
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }
           : {}),
+        ...(options.channel ? { channel: options.channel } : {}),
       }),
     });
   await requireCoordinatorResponse(response, "conversation");
@@ -321,6 +324,7 @@ export async function coordinateSharedStream(
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }
           : {}),
+        ...(options.channel ? { channel: options.channel } : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -1,664 +1,193 @@
 /**
- * Error-policy pin (#13415): in runSharedAgentTurn an INTERNAL inference/provider
- * failure must PROPAGATE (throw with `cause`) so the caller refunds the credit
- * hold and the failure surfaces, while the DESIGNED no-model-configured
- * "unavailable" state stays a distinguishable `degraded` result — the two must
- * never collapse into the same signal. Drives the real exported function with the
- * `ai` SDK's `generateText` and the language-model router stubbed via mock.module
- * (deterministic, no live model); global fetch is trapped and restored to prove
- * no accidental network.
+ * Pins the Shared turn boundary after AgentRuntime became its sole inference
+ * engine. The deterministic harness verifies capability gating, runtime
+ * delegation, memory commit ordering, and cause-preserving failures; provider
+ * streaming mechanics are covered by shared-eliza-runtime.test.ts.
  */
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Per-test controls for the collaborators used by both turn entry points.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
+
 let providerConfigured = true;
-let generateTextImpl: (options?: {
-  abortSignal?: AbortSignal;
-  messages?: Array<{ role: string; content: string }>;
-  system?: string;
-}) => Promise<{ text: string; usage?: unknown }> = async () => ({
-  text: "ok reply",
-});
-type StreamTextOptions = {
-  abortSignal?: AbortSignal;
-  messages?: Array<{ role: string; content: string }>;
-};
-
-function aiFullStream(iterable: AsyncIterable<unknown>): ReadableStream<unknown> {
-  const iterator = iterable[Symbol.asyncIterator]();
-  return new ReadableStream({
-    async pull(controller) {
-      try {
-        const next = await iterator.next();
-        if (next.done) controller.close();
-        else controller.enqueue(next.value);
-      } catch (error) {
-        controller.error(error);
-      }
-    },
-    async cancel(reason) {
-      await iterator.return?.(reason);
-    },
-  });
-}
-
-let lastStreamTextOptions: StreamTextOptions | undefined;
-let streamTextImpl: (options?: StreamTextOptions) => {
-  fullStream: ReadableStream<unknown>;
-  text: Promise<string>;
-  totalUsage: Promise<unknown>;
-} = () => ({
-  fullStream: aiFullStream(
-    (async function* () {
-      yield { type: "text-delta", text: "ok " };
-      yield { type: "text-delta", text: "reply" };
-      yield { type: "finish", totalUsage: { totalTokens: 3 } };
-    })(),
-  ),
-  text: Promise.resolve("ok reply"),
-  totalUsage: Promise.resolve({ totalTokens: 3 }),
-});
+let runtimeFailure: Error | null = null;
+let streamFailure: Error | null = null;
+const runtimeInputs: Array<Record<string, unknown>> = [];
+const streamInputs: Array<Record<string, unknown>> = [];
 
 mock.module("../../providers/language-model", () => ({
-  // The returned handle is opaque here — generateText is stubbed, so it is never
-  // actually invoked against a provider.
-  getLanguageModel: () => ({ __sentinel: "model" }),
-  // COLDPATH-FIX-2026-07-21: the shared turn now resolves its model through the
-  // interactive-Cerebras failover wrapper; stub it the same opaque way.
-  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
   hasLanguageModelProviderConfigured: () => providerConfigured,
 }));
 
-mock.module("ai", () => ({
-  generateText: async (options?: {
-    messages?: Array<{ role: string; content: string }>;
-    system?: string;
-  }) => generateTextImpl(options),
-  streamText: (options?: StreamTextOptions) => {
-    lastStreamTextOptions = options;
-    return streamTextImpl(options);
-  },
-}));
-
 mock.module("./shared-eliza-runtime", () => ({
-  runSharedElizaRuntimeTurn: async (input: {
-    history: Array<{ role: "system" | "user" | "assistant"; content: string }>;
-    message: string;
-  }) => ({
-    reply: "Todo saved.",
-    history: [...input.history, { role: "user", content: input.message }],
-    model: "runtime-model",
-    degraded: false,
-    actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
-  }),
-  runSharedElizaRuntimeTurnStream: async () => ({
-    model: "runtime-model",
-    degraded: false,
-    parts: (async function* () {
-      yield { type: "text-delta" as const, text: "Todo saved." };
-      yield {
-        type: "finish" as const,
-        text: "Todo saved.",
-        actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
-      };
-    })(),
-  }),
+  runSharedElizaRuntimeTurn: async (input: Record<string, unknown>) => {
+    runtimeInputs.push(input);
+    if (runtimeFailure) throw runtimeFailure;
+    const history = input.history as Array<{ role: string; content: string }>;
+    return {
+      reply: "runtime reply",
+      history: [
+        ...history,
+        { role: "user", content: String(input.message) },
+        { role: "assistant", content: "runtime reply" },
+      ],
+      model: String(input.model),
+      degraded: false,
+    };
+  },
+  runSharedElizaRuntimeTurnStream: async (input: Record<string, unknown>) => {
+    streamInputs.push(input);
+    if (streamFailure) throw streamFailure;
+    return {
+      model: String(input.model),
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta" as const, text: "runtime " };
+        yield { type: "finish" as const, text: "runtime reply" };
+      })(),
+    };
+  },
 }));
 
 const { runSharedAgentTurn, runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
 
-const originalFetch = globalThis.fetch;
-
 beforeEach(() => {
   providerConfigured = true;
-  lastStreamTextOptions = undefined;
-  generateTextImpl = async () => ({ text: "ok reply" });
-  streamTextImpl = () => ({
-    fullStream: aiFullStream(
-      (async function* () {
-        yield { type: "text-delta", text: "ok " };
-        yield { type: "text-delta", text: "reply" };
-        yield { type: "finish", totalUsage: { totalTokens: 3 } };
-      })(),
-    ),
-    text: Promise.resolve("ok reply"),
-    totalUsage: Promise.resolve({ totalTokens: 3 }),
-  });
-  globalThis.fetch = mock(async () => {
-    throw new Error("no network expected in this unit test");
-  }) as unknown as typeof fetch;
+  runtimeFailure = null;
+  streamFailure = null;
+  runtimeInputs.length = 0;
+  streamInputs.length = 0;
 });
 
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
-describe("runSharedAgentTurn — internal failure propagates vs designed-empty degrades", () => {
-  test("marks dispatch only at the final model handoff", async () => {
-    let dispatches = 0;
-    generateTextImpl = async () => {
-      expect(dispatches).toBeGreaterThan(0);
-      return { text: "provider reply" };
-    };
-    const onProviderDispatch = async () => {
-      dispatches += 1;
-    };
-
-    const providerTurn = await runSharedAgentTurn({
-      character: {
-        name: "Nova",
-        system: "You are Nova.",
-        model: "gpt-oss-120b",
-      },
-      history: [],
-      message: "hello",
-      onProviderDispatch,
-    });
-    expect(providerTurn.reply).toBe("provider reply");
-    expect(dispatches).toBe(1);
-
-    const navigationLanguageTurn = await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova." },
-      history: [],
-      message: "go to settings",
-      onProviderDispatch,
-    });
-    expect(navigationLanguageTurn.reply).toBe("provider reply");
-    expect(navigationLanguageTurn.actionResults).toBeUndefined();
-    expect(dispatches).toBe(2);
-
-    providerConfigured = false;
-    const degradedTurn = await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova." },
-      history: [],
-      message: "hello again",
-      onProviderDispatch,
-    });
-    expect(degradedTurn.degraded).toBe(true);
-    expect(dispatches).toBe(2);
-  });
-
-  test.each([
-    "What is one small way to reset my focus?",
-    "How can I reset my focus?",
-    "What is one way to improve my focus?",
-  ])("ordinary focus language reaches the model: %s", async (message) => {
-    generateTextImpl = async () => ({ text: "Take one slow breath and choose one task." });
-
-    const turn = await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova." },
-      history: [],
-      message,
-    });
-
-    expect(turn.actionResults).toBeUndefined();
-    expect(turn.reply).toBe("Take one slow breath and choose one task.");
-  });
-
-  test("blocks unsupported Shared actions before provider dispatch", async () => {
-    let dispatches = 0;
-    generateTextImpl = async () => {
-      throw new Error("capability-gated requests must not reach a model");
-    };
-
-    const turn = await runSharedAgentTurn({
-      character: {
-        name: "Eliza",
-        system: "You are Eliza.",
-        model: "gpt-oss-120b",
-      },
-      history: [],
-      message: "book me dinner for four tomorrow",
-      onProviderDispatch: async () => {
-        dispatches++;
-      },
-    });
-
-    expect(turn.model).toBe("capability-wall");
-    expect(turn.capabilityWall?.capability).toBe("bookings");
-    expect(turn.reply).toContain("need Dedicated");
-    expect(dispatches).toBe(0);
-  });
-
-  test.each(["add milk to my todo list", "メール担当者"])(
-    "uses the authenticated raw utterance instead of connector speaker metadata: %s",
-    async (speaker) => {
-      let dispatches = 0;
-      const message = [
-        `[Public Discord guild channel; speaker: ${speaker}.`,
-        "Use only this public guild channel's context.]",
-        "email Bob now",
-      ].join("\n");
-      const turn = await runSharedAgentTurn({
-        character: { name: "Eliza", system: "You are Eliza." },
-        history: [],
-        message,
-        capabilityText: "email Bob now",
-        execution: {
-          engine: "eliza-runtime",
-          agentKey: "personal:agent",
-          todos: {} as never,
-        },
-        onProviderDispatch: async () => {
-          dispatches++;
-        },
-      });
-
-      expect(turn.capabilityWall?.capability).toBe("communications");
-      expect(dispatches).toBe(0);
-    },
-  );
-
-  test("executes an enabled primary and carries a blocked secondary clause truthfully", async () => {
-    const recordedReplies: string[] = [];
-    const input = {
-      character: { name: "Eliza", system: "You are Eliza." },
-      history: [],
-      message: "add call Mom to my todo list. Then email Bob now",
-      memory: {
-        recordTurnPair: async ({ assistantReply }: { assistantReply: string }) => {
-          recordedReplies.push(assistantReply);
-        },
-      } as never,
-      execution: {
-        engine: "eliza-runtime" as const,
-        agentKey: "personal:agent",
-        todos: {} as never,
-      },
-    };
-    const turn = await runSharedAgentTurn(input);
-    expect(turn.reply).toContain("Todo saved.");
-    expect(turn.reply).toContain("can't initiate a separate call, email, text, or DM");
-    expect(turn.actionResults?.[0]).toMatchObject({ actionName: "TODO", success: true });
-    expect(turn.blockedSecondaryCapabilities).toEqual([
-      expect.objectContaining({ capability: "communications" }),
-    ]);
-    expect(recordedReplies).toEqual([turn.reply]);
-
-    const streamed = await runSharedAgentTurnStream(input);
-    const parts = [];
-    for await (const part of streamed.parts ?? []) parts.push(part);
-    expect(parts).toContainEqual(
-      expect.objectContaining({
-        type: "finish",
-        text: expect.stringContaining("can't initiate a separate call, email, text, or DM"),
-      }),
-    );
-    expect(streamed.blockedSecondaryCapabilities?.[0]?.capability).toBe("communications");
-    // Streaming persistence is owned by SharedRuntimeChatService so cancellation
-    // and retries converge on the transport's stable message ids.
-    expect(recordedReplies).toEqual([turn.reply]);
-  });
-
-  test("tells the model the same capability truth for ambiguous follow-ups", async () => {
-    let system = "";
-    generateTextImpl = async (options) => {
-      system = options?.system ?? "";
-      return { text: "I can help draft that here." };
-    };
-
-    await runSharedAgentTurn({
-      character: {
-        name: "Eliza",
-        system: "Be helpful.",
-        model: "gpt-oss-120b",
-      },
-      history: [
-        { role: "user", content: "draft a message to Sam" },
-        { role: "assistant", content: "Here is a draft." },
-      ],
-      message: "yes, do it",
-    });
-
-    expect(system).toContain("Shared runtime boundaries");
-    expect(system).toContain("no connected accounts");
-    expect(system).toContain("Never claim that you performed");
-    expect(system).toContain("needs Dedicated");
-  });
-
-  test("an internal inference/provider failure throws (propagates) instead of degrading", async () => {
-    providerConfigured = true;
-    generateTextImpl = async () => {
-      throw new Error("provider 503 during shared-runtime turn");
-    };
-
-    const error = await runSharedAgentTurn({
+describe("Shared turn AgentRuntime boundary", () => {
+  test("delegates every ordinary turn to AgentRuntime with a fail-closed guest execution", async () => {
+    const result = await runSharedAgentTurn({
       character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
       history: [],
       message: "hello",
-    }).then(
-      () => {
-        throw new Error("expected runSharedAgentTurn to throw on inference failure");
-      },
-      (e: unknown) => e,
-    );
+    });
 
-    expect(error).toBeInstanceOf(Error);
-    // Context is added (agent + model) and the original error is preserved as cause,
-    // so the failure is diagnosable rather than swallowed into a canned reply.
-    expect((error as Error).message).toContain("Nova");
-    expect((error as Error).message).toContain("gpt-oss-120b");
-    const cause = (error as { cause?: unknown }).cause;
-    expect(cause).toBeInstanceOf(Error);
-    expect((cause as Error).message).toContain("provider 503");
+    expect(result.reply).toBe("runtime reply");
+    expect(runtimeInputs).toHaveLength(1);
+    expect(runtimeInputs[0]).toMatchObject({
+      agentKey: "shared:Nova",
+      execution: {
+        agentKey: "shared:Nova",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
+      },
+    });
+    expect(JSON.stringify(runtimeInputs[0])).toContain("Shared runtime boundaries");
   });
 
-  test("the designed no-model-configured state stays a distinguishable degraded result (no throw)", async () => {
-    // No provider configured for any model → resolveSharedAgentTurnModel() is null,
-    // so this is the intentional unavailable state, NOT an internal failure. It must
-    // return degraded without ever calling generateText.
-    providerConfigured = false;
-    generateTextImpl = async () => {
-      throw new Error("generateText must not be reached when no model is configured");
-    };
+  test("preserves server-owned voice execution semantics", async () => {
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "hello",
+      execution: {
+        agentKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.VOICE_DM, source: "client_chat" },
+      },
+    });
 
+    expect(runtimeInputs[0]?.execution).toMatchObject({
+      agentKey: "personal:user-1",
+      authenticatedPersonalSharedUser: true,
+      channel: { type: ChannelType.VOICE_DM, source: "client_chat" },
+    });
+  });
+
+  test("blocks unsupported capabilities before runtime or provider dispatch", async () => {
+    let dispatches = 0;
+    const result = await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "email Bob now",
+      onProviderDispatch: async () => {
+        dispatches += 1;
+      },
+    });
+
+    expect(result.capabilityWall?.capability).toBe("communications");
+    expect(runtimeInputs).toHaveLength(0);
+    expect(dispatches).toBe(0);
+  });
+
+  test("commits durable memory only after a runtime reply lands", async () => {
+    const replies: string[] = [];
+    await runSharedAgentTurn({
+      character: { name: "Nova", system: "You are Nova." },
+      history: [],
+      message: "hello",
+      memory: {
+        recordTurnPair: async ({ assistantReply }: { assistantReply: string }) => {
+          replies.push(assistantReply);
+        },
+      } as never,
+    });
+    expect(replies).toEqual(["runtime reply"]);
+
+    runtimeFailure = new Error("provider failed");
+    await expect(
+      runSharedAgentTurn({
+        character: { name: "Nova", system: "You are Nova." },
+        history: [],
+        message: "again",
+        memory: {
+          recordTurnPair: async () => {
+            replies.push("must not commit");
+          },
+        } as never,
+      }),
+    ).rejects.toThrow("AgentRuntime turn failed");
+    expect(replies).toEqual(["runtime reply"]);
+  });
+
+  test("preserves the AgentRuntime failure as the turn error cause", async () => {
+    runtimeFailure = new Error("provider failed");
+    const error = await runSharedAgentTurn({
+      character: { name: "Nova", system: "You are Nova." },
+      history: [],
+      message: "hello",
+    }).catch((caught) => caught as Error);
+
+    expect(error.message).toContain("AgentRuntime turn failed");
+    expect(error.message).toContain("Nova");
+    expect(error.cause).toBe(runtimeFailure);
+  });
+
+  test("keeps no-model configuration as the sole degraded result", async () => {
+    providerConfigured = false;
     const result = await runSharedAgentTurn({
       character: { name: "Nova", system: "You are Nova." },
       history: [],
-      message: "  hello there  ",
+      message: "hello",
     });
 
     expect(result.degraded).toBe(true);
     expect(result.model).toBe("none");
-    expect(result.reply).toContain("no shared model configured");
-    expect(result.history).toHaveLength(2);
-    expect(result.history[0]).toMatchObject({
-      role: "user",
-      content: "hello there",
-    });
-    expect(typeof result.history[0]?.createdAt).toBe("number");
-    expect(result.history[1]?.role).toBe("assistant");
-    expect(typeof result.history[1]?.createdAt).toBe("number");
+    expect(runtimeInputs).toHaveLength(0);
   });
 
-  test("a successful turn returns the reply with degraded:false (not a tautology — real SUT runs)", async () => {
-    providerConfigured = true;
-    generateTextImpl = async () => ({ text: "  hi from Nova  ", usage: { totalTokens: 7 } });
-
-    const result = await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
-      history: [
-        { role: "user", content: "prev-q" },
-        { role: "assistant", content: "prev-a" },
-      ],
-      message: "hi",
-    });
-
-    expect(result.degraded).toBe(false);
-    expect(result.reply).toBe("hi from Nova");
-    expect(result.model).toBe("gpt-oss-120b");
-    expect(result.usage).toEqual({ totalTokens: 7 });
-    // history + new user message + assistant reply.
-    expect(result.history).toHaveLength(4);
-    expect(result.history[2]).toMatchObject({ role: "user", content: "hi" });
-    expect(typeof result.history[2]?.createdAt).toBe("number");
-    expect(result.history[3]).toMatchObject({
-      role: "assistant",
-      content: "hi from Nova",
-    });
-    expect(typeof result.history[3]?.createdAt).toBe("number");
-  });
-
-  test("annotates interrupted assistant history before provider input", async () => {
-    let providerMessages: Array<{ role: string; content: string }> = [];
-    generateTextImpl = async (options) => {
-      providerMessages = options?.messages ?? [];
-      return { text: "continued" };
-    };
-
-    await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
-      history: [
-        { role: "user", content: "first" },
-        { role: "assistant", content: "partial answer", interrupted: true },
-      ],
-      message: "continue",
-    });
-
-    expect(providerMessages[1]).toEqual({
-      role: "assistant",
-      content: "[interrupted assistant partial]\npartial answer",
-    });
-  });
-});
-
-describe("runSharedAgentTurnStream — incremental provider policy", () => {
-  test.each(["open settings", "What is one small way to reset my focus?"])(
-    "routes navigation-like language through the provider without view actions: %s",
-    async (message) => {
-      let providerStreams = 0;
-      streamTextImpl = () => {
-        providerStreams++;
-        return {
-          fullStream: aiFullStream(
-            (async function* () {
-              yield { type: "text-delta", text: "normal reply" };
-              yield { type: "finish", totalUsage: { totalTokens: 2 } };
-            })(),
-          ),
-          text: Promise.resolve("normal reply"),
-          totalUsage: Promise.resolve({ totalTokens: 2 }),
-        };
-      };
-
-      const turn = await runSharedAgentTurnStream({
-        character: { name: "Nova", system: "You are Nova." },
-        history: [],
-        message,
-      });
-      expect(turn.actionResults).toBeUndefined();
-      expect(providerStreams).toBe(1);
-      if (!turn.parts) throw new Error("expected provider stream");
-      const parts = [];
-      for await (const part of turn.parts) parts.push(part);
-      expect(parts.at(-1)).toMatchObject({ type: "finish", text: "normal reply" });
-    },
-  );
-
-  test("streams text deltas and a final usage-bearing finish part", async () => {
+  test("delegates streaming setup to AgentRuntime and wraps setup failures", async () => {
     const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
+      character: { name: "Nova", system: "You are Nova." },
       history: [],
-      message: " hello ",
+      message: "hello",
     });
-
-    expect(result.degraded).toBe(false);
-    expect(result.model).toBe("gpt-oss-120b");
-    if (!("parts" in result)) throw new Error("expected streaming result");
+    expect(streamInputs).toHaveLength(1);
     const parts = [];
+    if (!result.parts) throw new Error("Expected runtime stream parts");
     for await (const part of result.parts) parts.push(part);
-    expect(parts).toEqual([
-      { type: "text-delta", text: "ok " },
-      { type: "text-delta", text: "reply" },
-      { type: "finish", text: "ok reply", usage: { totalTokens: 3 } },
-    ]);
-  });
+    expect(parts.at(-1)).toEqual({ type: "finish", text: "runtime reply" });
 
-  test("synthesizes finish from the SDK result when a provider closes cleanly after text", async () => {
-    streamTextImpl = () => ({
-      fullStream: aiFullStream(
-        (async function* () {
-          yield { type: "text-delta", text: "clean " };
-          yield { type: "text-delta", text: "eof" };
-        })(),
-      ),
-      text: Promise.resolve("clean eof"),
-      totalUsage: Promise.resolve({ totalTokens: 2 }),
-    });
-
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
+    streamFailure = new Error("stream setup failed");
+    const error = await runSharedAgentTurnStream({
+      character: { name: "Nova", system: "You are Nova." },
       history: [],
-      message: "hello",
-    });
-    if (!("parts" in result)) throw new Error("expected streaming result");
-
-    const parts = [];
-    for await (const part of result.parts) parts.push(part);
-    expect(parts).toEqual([
-      { type: "text-delta", text: "clean " },
-      { type: "text-delta", text: "eof" },
-      { type: "finish", text: "clean eof", usage: { totalTokens: 2 } },
-    ]);
-  });
-
-  test("keeps no-model turns degraded without starting a provider stream", async () => {
-    providerConfigured = false;
-    streamTextImpl = () => {
-      throw new Error("streamText must not be reached when no model is configured");
-    };
-
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova" },
-      history: [],
-      message: " hello ",
-    });
-
-    expect(result).toMatchObject({
-      degraded: true,
-      model: "none",
-      reply: "Nova is temporarily unavailable (no shared model configured).",
-    });
-    if (!("history" in result)) throw new Error("expected degraded history result");
-    expect(result.history.map((entry) => entry.content)).toEqual([
-      "hello",
-      "Nova is temporarily unavailable (no shared model configured).",
-    ]);
-  });
-
-  test("wraps failures raised while consuming the provider stream", async () => {
-    streamTextImpl = () => ({
-      fullStream: aiFullStream(
-        (async function* () {
-          yield { type: "text-delta", text: "partial" };
-          throw new Error("provider stream reset");
-        })(),
-      ),
-      text: Promise.resolve("partial"),
-      totalUsage: Promise.resolve({ totalTokens: 0 }),
-    });
-
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    if (!("parts" in result)) throw new Error("expected streaming result");
-
-    const error = await (async () => {
-      try {
-        for await (const _part of result.parts) {
-          // Consume the stream so the late provider failure is observable.
-        }
-        throw new Error("expected stream consumption to fail");
-      } catch (caught) {
-        return caught;
-      }
-    })();
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("streaming agent turn failed");
-    expect(((error as Error).cause as Error).message).toContain("provider stream reset");
-  });
-
-  test("propagates explicit provider error parts instead of treating them as clean EOF", async () => {
-    streamTextImpl = () => ({
-      fullStream: aiFullStream(
-        (async function* () {
-          yield { type: "text-delta", text: "partial" };
-          yield { type: "error", error: new Error("provider rejected stream") };
-        })(),
-      ),
-      text: Promise.resolve("partial"),
-      totalUsage: Promise.resolve({ totalTokens: 0 }),
-    });
-
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    if (!("parts" in result)) throw new Error("expected streaming result");
-
-    const error = await (async () => {
-      try {
-        for await (const _part of result.parts) {
-          // Consume through the explicit provider error part.
-        }
-        throw new Error("expected stream consumption to fail");
-      } catch (caught) {
-        return caught;
-      }
-    })();
-    expect(error).toBeInstanceOf(Error);
-    expect(((error as Error).cause as Error).message).toBe("provider rejected stream");
-  });
-
-  test("propagates a clean EOF whose authoritative SDK result rejects", async () => {
-    streamTextImpl = () => {
-      const text = Promise.reject(new Error("provider completion failed"));
-      void text.catch(() => {
-        // The SUT observes the original rejecting promise after consuming fullStream.
-      });
-      return {
-        fullStream: aiFullStream(
-          (async function* () {
-            yield { type: "text-delta", text: "partial" };
-          })(),
-        ),
-        text,
-        totalUsage: Promise.resolve({ totalTokens: 0 }),
-      };
-    };
-
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    if (!("parts" in result)) throw new Error("expected streaming result");
-
-    await expect(async () => {
-      for await (const _part of result.parts) {
-        // Consume through clean EOF so the SDK completion promise is checked.
-      }
-    }).toThrow("streaming agent turn failed");
-  });
-
-  test("passes cancellation to the AI SDK and cancels its response reader", async () => {
-    const abortController = new AbortController();
-    let providerCancelReason: unknown;
-    streamTextImpl = () => ({
-      fullStream: new ReadableStream({
-        start(controller) {
-          controller.enqueue({ type: "text-delta", text: "partial" });
-        },
-        cancel(reason) {
-          providerCancelReason = reason;
-        },
-      }),
-      text: new Promise(() => {}),
-      totalUsage: new Promise(() => {}),
-    });
-
-    const result = await runSharedAgentTurnStream({
-      abortSignal: abortController.signal,
-      character: { name: "Nova", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    if (!result.parts || !result.cancel) {
-      throw new Error("expected cancellable streaming result");
-    }
-    const iterator = result.parts[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: { type: "text-delta", text: "partial" },
-    });
-
-    await result.cancel("barge-in");
-
-    expect(lastStreamTextOptions?.abortSignal).toBe(abortController.signal);
-    expect(providerCancelReason).toBe("barge-in");
-    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+      message: "again",
+    }).catch((caught) => caught as Error);
+    expect(error.message).toContain("AgentRuntime stream setup failed");
+    expect(error.cause).toBe(streamFailure);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
@@ -1,57 +1,44 @@
 /**
- * Pins the P2 edge-memory commit point in runSharedAgentTurn(Stream): a landed
- * user/assistant pair is durably recorded through the attached SharedMemoryStore
- * exactly once after a non-streamed reply lands. Streaming ownership stays at
- * the transport finalization boundary, which alone knows whether the consumer
- * accepted a complete reply or cancelled on an interrupted prefix. Failed
- * provider turns never write; store failures surface as storage faults, not
- * provider outcomes. The language-model router and `ai` SDK are stubbed
- * deterministically; the memory store is a scripted double.
+ * Pins Shared memory commits around the sole AgentRuntime turn boundary. A
+ * landed non-stream reply commits once; failed or degraded turns never write.
  */
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SharedMemoryStore, SharedMemoryTurnPair } from "./shared-memory-store";
 
 let providerConfigured = true;
-let generateTextImpl: () => Promise<{ text: string; usage?: unknown }> = async () => ({
-  text: "landed reply",
-});
-
-function aiFullStream(iterable: AsyncIterable<unknown>): ReadableStream<unknown> {
-  const iterator = iterable[Symbol.asyncIterator]();
-  return new ReadableStream({
-    async pull(controller) {
-      try {
-        const next = await iterator.next();
-        if (next.done) controller.close();
-        else controller.enqueue(next.value);
-      } catch (error) {
-        controller.error(error);
-      }
-    },
-    async cancel(reason) {
-      await iterator.return?.(reason);
-    },
-  });
-}
+let runtimeFailure: Error | null = null;
 
 mock.module("../../providers/language-model", () => ({
-  getLanguageModel: () => ({ __sentinel: "model" }),
-  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
   hasLanguageModelProviderConfigured: () => providerConfigured,
 }));
 
-mock.module("ai", () => ({
-  generateText: async () => generateTextImpl(),
-  streamText: () => ({
-    fullStream: aiFullStream(
-      (async function* () {
-        yield { type: "text-delta", text: "landed " };
-        yield { type: "text-delta", text: "reply" };
-        yield { type: "finish", totalUsage: { totalTokens: 3 } };
-      })(),
-    ),
-    text: Promise.resolve("landed reply"),
-    totalUsage: Promise.resolve({ totalTokens: 3 }),
+mock.module("./shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: Record<string, unknown>) => {
+    if (runtimeFailure) throw runtimeFailure;
+    const history = input.history as Array<{
+      role: "system" | "user" | "assistant";
+      content: string;
+    }>;
+    return {
+      reply: "landed reply",
+      history: [
+        ...history,
+        { role: "user" as const, content: String(input.message) },
+        { role: "assistant" as const, content: "landed reply" },
+      ],
+      model: String(input.model),
+      degraded: false,
+    };
+  },
+  runSharedElizaRuntimeTurnStream: async (input: Record<string, unknown>) => ({
+    model: String(input.model),
+    degraded: false,
+    parts: (async function* () {
+      yield { type: "text-delta" as const, text: "landed " };
+      yield { type: "text-delta" as const, text: "reply" };
+      yield { type: "finish" as const, text: "landed reply" };
+    })(),
   }),
 }));
 
@@ -79,11 +66,11 @@ const messageIds = {
 
 beforeEach(() => {
   providerConfigured = true;
-  generateTextImpl = async () => ({ text: "landed reply" });
+  runtimeFailure = null;
 });
 
 describe("runSharedAgentTurn memory commit", () => {
-  test("records the landed pair exactly once with the transport ids", async () => {
+  test("records the landed pair exactly once with transport ids", async () => {
     const memory = scriptedMemory();
     const result = await runSharedAgentTurn({
       character,
@@ -94,31 +81,25 @@ describe("runSharedAgentTurn memory commit", () => {
     });
     expect(result.reply).toBe("landed reply");
     expect(memory.pairs).toEqual([
-      {
-        userMessage: "remember this",
-        assistantReply: "landed reply",
-        messageIds,
-      },
+      { userMessage: "remember this", assistantReply: "landed reply", messageIds },
     ]);
   });
 
-  test("does not write when the provider turn fails, and the provider cause survives", async () => {
+  test("does not write when AgentRuntime fails and preserves its cause", async () => {
     const memory = scriptedMemory();
-    generateTextImpl = async () => {
-      throw new Error("provider exploded");
-    };
-    await expect(
-      runSharedAgentTurn({
-        character,
-        history: [],
-        message: "will fail",
-        memory: memory.store,
-      }),
-    ).rejects.toThrow("agent turn failed");
+    runtimeFailure = new Error("provider exploded");
+    const error = await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "will fail",
+      memory: memory.store,
+    }).catch((caught) => caught as Error);
+    expect(error.message).toContain("AgentRuntime turn failed");
+    expect(error.cause).toBe(runtimeFailure);
     expect(memory.pairs).toEqual([]);
   });
 
-  test("a memory-store failure surfaces as a storage fault, not a provider outcome", async () => {
+  test("surfaces memory storage failures", async () => {
     const failing = scriptedMemory({ fail: true });
     await expect(
       runSharedAgentTurn({
@@ -130,7 +111,7 @@ describe("runSharedAgentTurn memory commit", () => {
     ).rejects.toThrow("scripted memory failure");
   });
 
-  test("the designed degraded (no model) state never writes memory", async () => {
+  test("does not write the designed no-model degraded state", async () => {
     const memory = scriptedMemory();
     providerConfigured = false;
     const result = await runSharedAgentTurn({
@@ -145,7 +126,7 @@ describe("runSharedAgentTurn memory commit", () => {
 });
 
 describe("runSharedAgentTurnStream memory boundary", () => {
-  test("leaves streaming memory commits to the consumer-aware transport boundary", async () => {
+  test("leaves streaming commits to the consumer-aware transport finalizer", async () => {
     const turn = await runSharedAgentTurnStream({
       character,
       history: [],
@@ -154,21 +135,7 @@ describe("runSharedAgentTurnStream memory boundary", () => {
     });
     if (!turn.parts) throw new Error("stream turn returned no parts");
     const seen: string[] = [];
-    for await (const part of turn.parts) {
-      seen.push(part.type);
-    }
+    for await (const part of turn.parts) seen.push(part.type);
     expect(seen).toEqual(["text-delta", "text-delta", "finish"]);
-  });
-
-  test("without a memory store the stream shape is unchanged and nothing writes", async () => {
-    const turn = await runSharedAgentTurnStream({
-      character,
-      history: [],
-      message: "no store attached",
-    });
-    if (!turn.parts) throw new Error("stream turn returned no parts");
-    const types: string[] = [];
-    for await (const part of turn.parts) types.push(part.type);
-    expect(types).toEqual(["text-delta", "text-delta", "finish"]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.recall-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.recall-context.test.ts
@@ -1,36 +1,40 @@
 /**
- * Pins the P3 recall-context contract on the shared turn: a caller-provided
- * `recallContext` is appended to the system prompt the model receives, and an
- * absent one leaves the prompt untouched. The `ai` SDK and language-model
- * router are stubbed; the capture is the real `system` argument.
+ * Pins recall projection before the Shared turn enters AgentRuntime. Recall is
+ * appended to the character system prompt without changing the base persona.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let capturedSystem: string | undefined;
 
 mock.module("../../providers/language-model", () => ({
-  getInteractiveCerebrasLanguageModel: () => ({ modelId: "stub" }),
   hasLanguageModelProviderConfigured: () => true,
 }));
 
-mock.module("ai", () => ({
-  generateText: async (options: { system?: string }) => {
-    capturedSystem = options.system;
-    return { text: "reply", usage: { totalTokens: 2 } };
+mock.module("./shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: Record<string, unknown>) => {
+    capturedSystem = (input.character as { system: string }).system;
+    return {
+      reply: "reply",
+      history: [],
+      model: String(input.model),
+      degraded: false,
+    };
   },
-  streamText: () => {
+  runSharedElizaRuntimeTurnStream: () => {
     throw new Error("stream path not under test");
   },
 }));
 
 const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
-
 const character = { name: "Recall Probe", system: "Base persona." };
 
+beforeEach(() => {
+  capturedSystem = undefined;
+});
+
 describe("shared turn recall context", () => {
-  test("appends the recall block to the system prompt", async () => {
-    capturedSystem = undefined;
+  test("appends the recall block to the runtime character prompt", async () => {
     const block = "Recalled from earlier in this conversation:\n- [user] pick blue";
     await runSharedAgentTurn({
       character,
@@ -43,14 +47,9 @@ describe("shared turn recall context", () => {
     expect(capturedSystem?.startsWith("Base persona.")).toBe(true);
   });
 
-  test("leaves the system prompt untouched without recall", async () => {
-    capturedSystem = undefined;
-    await runSharedAgentTurn({
-      character,
-      history: [],
-      message: "hello",
-    });
-    expect(capturedSystem).toBeDefined();
+  test("does not add recall when none was provided", async () => {
+    await runSharedAgentTurn({ character, history: [], message: "hello" });
+    expect(capturedSystem?.startsWith("Base persona.")).toBe(true);
     expect(capturedSystem).not.toContain("Recalled from earlier");
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.retry-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.retry-budget.test.ts
@@ -1,127 +1,20 @@
 /**
- * Latency pin: the shared-runtime (Tier 0) chat turn must bound its provider
- * retry backoff. The AI SDK default is `maxRetries: 2` with 2s->4s exponential
- * backoff, so a single transient Cerebras 5xx/network blip on the no-fallback
- * default route turns an interactive turn into a 2-6s stall — the measured
- * bimodal 5-10s warm-stall promotion blocker (LATENCY-STALL-2026-07-20).
- *
- * COLD-PATH stall-B fix (COLDPATH-FIX-2026-07-21): the default budget is now
- * ZERO, not one. #16713's single-retry cap still cost a ~2s `initialDelayInMs`
- * sleep that retried the SAME dead Cerebras upstream. The interactive turn now
- * routes through `getInteractiveCerebrasLanguageModel`, whose middleware fails
- * over to OpenRouter INSTANTLY (no backoff) on a transient 5xx — so the SDK's
- * sleeping retry is redundant and additive, and the healthy default is 0.
- *
- * These tests drive the REAL exported functions with `ai`'s generateText /
- * streamText stubbed to CAPTURE the options object, proving the bounded
- * `maxRetries` is actually passed through on both the non-stream and stream
- * entry points, and pin the env-driven `resolveSharedTurnMaxRetries` clamp.
+ * Pins the bounded AI SDK retry budget used by the Shared AgentRuntime model
+ * adapter so interactive turns never inherit multi-second SDK backoff.
  */
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-let providerConfigured = true;
-let lastGenerateOptions: Record<string, unknown> | null = null;
-let lastStreamOptions: Record<string, unknown> | null = null;
+import { describe, expect, test } from "bun:test";
+import { resolveSharedTurnMaxRetries, SHARED_TURN_MAX_RETRIES } from "./shared-turn-retry-budget";
 
-mock.module("../../providers/language-model", () => ({
-  getLanguageModel: () => ({ __sentinel: "model" }),
-  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
-  hasLanguageModelProviderConfigured: () => providerConfigured,
-}));
-
-mock.module("ai", () => ({
-  generateText: async (options: Record<string, unknown>) => {
-    lastGenerateOptions = options;
-    return { text: "ok reply", usage: { totalTokens: 3 } };
-  },
-  streamText: (options: Record<string, unknown>) => {
-    lastStreamOptions = options;
-    return {
-      // Match the AI SDK's AsyncIterableStream cancellation surface. The
-      // production path takes a reader so an interrupted voice turn can cancel
-      // provider generation instead of only abandoning local iteration.
-      fullStream: new ReadableStream({
-        start(controller) {
-          controller.enqueue({ type: "text-delta", text: "ok" });
-          controller.enqueue({ type: "finish", totalUsage: { totalTokens: 3 } });
-          controller.close();
-        },
-      }),
-    };
-  },
-}));
-
-const { runSharedAgentTurn, runSharedAgentTurnStream, SHARED_TURN_MAX_RETRIES } = await import(
-  "./run-shared-agent-turn"
-);
-// resolveSharedTurnMaxRetries is not exported (module-load-time constant); we
-// re-derive the same clamp here to pin its contract without widening the API.
-function clampExpectation(raw: string | undefined): number {
-  if (raw === undefined || raw.trim() === "") return 0;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return 0;
-  return Math.min(parsed, 2);
-}
-
-const originalFetch = globalThis.fetch;
-
-beforeEach(() => {
-  providerConfigured = true;
-  lastGenerateOptions = null;
-  lastStreamOptions = null;
-  globalThis.fetch = mock(async () => {
-    throw new Error("no network expected in this unit test");
-  }) as unknown as typeof fetch;
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
-describe("shared-runtime turn retry budget", () => {
-  test("default budget is ZERO SDK backoff (the instant-failover wrapper owns resilience)", () => {
-    // With no SHARED_TURN_MAX_RETRIES env set in the test process, the resolved
-    // constant is 0: the interactive model wrapper fails over to a healthy
-    // provider instantly on a 5xx, so the SDK's ~2s sleeping retry is redundant.
-    expect(SHARED_TURN_MAX_RETRIES).toBe(clampExpectation(process.env.SHARED_TURN_MAX_RETRIES));
-    expect(SHARED_TURN_MAX_RETRIES).toBeLessThanOrEqual(2);
+describe("shared AgentRuntime turn retry budget", () => {
+  test("uses the bounded environment-derived budget", () => {
+    expect(SHARED_TURN_MAX_RETRIES).toBe(
+      resolveSharedTurnMaxRetries(process.env.SHARED_TURN_MAX_RETRIES),
+    );
     expect(SHARED_TURN_MAX_RETRIES).toBeGreaterThanOrEqual(0);
+    expect(SHARED_TURN_MAX_RETRIES).toBeLessThanOrEqual(2);
   });
 
-  test("runSharedAgentTurn passes the bounded maxRetries to generateText", async () => {
-    await runSharedAgentTurn({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    expect(lastGenerateOptions).not.toBeNull();
-    expect(lastGenerateOptions?.maxRetries).toBe(SHARED_TURN_MAX_RETRIES);
-    // The bound must never silently regress to the SDK default that caused the stall.
-    expect(lastGenerateOptions?.maxRetries).toBeLessThanOrEqual(1);
-    // Healthy default is zero SDK backoff on the interactive path.
-    expect(lastGenerateOptions?.maxRetries).toBe(0);
-  });
-
-  test("runSharedAgentTurnStream passes the bounded maxRetries to streamText", async () => {
-    const result = await runSharedAgentTurnStream({
-      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
-      history: [],
-      message: "hello",
-    });
-    // Drain so the stream generator runs, matching real caller behavior.
-    if ("parts" in result && result.parts) {
-      for await (const _part of result.parts) {
-        // consume
-      }
-    }
-    expect(lastStreamOptions).not.toBeNull();
-    expect(lastStreamOptions?.maxRetries).toBe(SHARED_TURN_MAX_RETRIES);
-    expect(lastStreamOptions?.maxRetries).toBeLessThanOrEqual(1);
-    expect(lastStreamOptions?.maxRetries).toBe(0);
-  });
-});
-
-describe("resolveSharedTurnMaxRetries clamp contract (re-derived)", () => {
   test.each([
     [undefined, 0],
     ["", 0],
@@ -129,10 +22,10 @@ describe("resolveSharedTurnMaxRetries clamp contract (re-derived)", () => {
     ["0", 0],
     ["1", 1],
     ["2", 2],
-    ["5", 2], // clamped down: can never exceed the SDK default it bounds
-    ["-1", 0], // negative -> fall back to safe (zero-backoff) default
-    ["abc", 0], // unparseable -> safe (zero-backoff) default
+    ["5", 2],
+    ["-1", 0],
+    ["abc", 0],
   ])("SHARED_TURN_MAX_RETRIES=%p resolves to %p", (raw, expected) => {
-    expect(clampExpectation(raw as string | undefined)).toBe(expected);
+    expect(resolveSharedTurnMaxRetries(raw)).toBe(expected);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -40,6 +40,7 @@ import {
 } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
+import type { SharedRuntimeTimingReceipt } from "./shared-runtime-timing";
 
 export type { SharedRuntimeChannel } from "./shared-runtime-channel";
 export {
@@ -107,6 +108,10 @@ export interface RunSharedAgentTurnInput {
   originClientMessageId?: string;
   /** Durable accounting transition invoked at the final provider handoff. */
   onProviderDispatch?: () => Promise<void>;
+  /** Non-authoritative diagnostics observer; runtime failures never depend on it. */
+  onRuntimeTiming?: (receipt: SharedRuntimeTimingReceipt) => void;
+  /** Request correlation identity propagated from the HTTP ingress. */
+  traceId?: string;
   /** Cancels provider generation when the response consumer disconnects. */
   abortSignal?: AbortSignal;
   /**

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -24,24 +24,28 @@ import {
   type ActionResult,
   type MediaGenerationRequest,
   type MediaGenerationResponse,
+  type MessageExampleGroup,
   replaceNameTokens,
   type UUID,
 } from "@elizaos/core/edge";
 import type { ScheduledTaskRunner, SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { TodoStore } from "@elizaos/plugin-todos/edge";
-import { generateText, streamText } from "ai";
 import type { MobilePushMessage } from "../../mobile-push/types";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
-import {
-  getInteractiveCerebrasLanguageModel,
-  hasLanguageModelProviderConfigured,
-} from "../../providers/language-model";
+import { hasLanguageModelProviderConfigured } from "../../providers/language-model";
 import {
   resolveSharedCapabilityIntent,
   type SharedCapabilityResolution,
   type SharedCapabilityWall,
 } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
+import type { SharedRuntimeChannel } from "./shared-runtime-channel";
+
+export type { SharedRuntimeChannel } from "./shared-runtime-channel";
+export {
+  resolveSharedTurnMaxRetries,
+  SHARED_TURN_MAX_RETRIES,
+} from "./shared-turn-retry-budget";
 
 export interface SharedTurnMessage {
   /** Stable message id used by SSE, REST history, and storage merge paths. */
@@ -64,6 +68,14 @@ export interface SharedAgentCharacter {
   system: string;
   /** Optional bio/lore bullets folded into the system prompt. */
   bio?: string[];
+  /** Canonical behavioral persona fields projected into AgentRuntime providers. */
+  messageExamples?: MessageExampleGroup[];
+  postExamples?: string[];
+  topics?: string[];
+  adjectives?: string[];
+  style?: { all?: string[]; chat?: string[]; post?: string[] };
+  /** Character-owned response templates; server code still owns plugins and authority. */
+  templates?: Record<string, string>;
   /** Optional model id override; otherwise the shared default is used. */
   model?: string;
 }
@@ -101,24 +113,21 @@ export interface RunSharedAgentTurnInput {
    * Flag-gated durable mirror of the landed user/assistant pair into the
    * tenant-scoped `shared_agent_memories` table (P2 edge memory store).
    * Attached by the caller only while `SHARED_MEMORY_TABLES_ENABLED === "true"`;
-   * both the direct-model and eliza-runtime engines commit through it.
+   * the AgentRuntime boundary commits through it.
    */
   memory?: SharedMemoryStore;
   /**
    * Pre-rendered semantic-recall block (P3, `buildSharedRecallContext`) the
    * caller computed from the tenant memory store when the recall flag is on
    * and the recent window missed. Appended verbatim to the system prompt on
-   * every engine path; absent means recall contributed nothing this turn.
+   * every runtime path; absent means recall contributed nothing this turn.
    */
   recallContext?: string;
-  /**
-   * Transition-only selector for the genuine Workerd AgentRuntime path. The
-   * direct model path remains the control until the runtime path has passed
-   * live model and connector proof.
-   */
+  /** Server-owned execution authority for the canonical edge AgentRuntime. */
   execution?: {
-    engine: "eliza-runtime";
     agentKey: string;
+    /** Trusted transport semantics projected into the runtime connection and memories. */
+    channel: SharedRuntimeChannel;
     /**
      * Server-only attestation that the hosting boundary resolved this turn to an
      * authenticated Personal Shared tenant/account. Transport payload fields
@@ -141,11 +150,24 @@ export interface RunSharedAgentTurnInput {
   };
 }
 
+type SharedRuntimeExecution = NonNullable<RunSharedAgentTurnInput["execution"]>;
+
+function resolveRuntimeExecution(input: RunSharedAgentTurnInput): SharedRuntimeExecution {
+  return (
+    input.execution ?? {
+      agentKey: `shared:${input.character.name}`,
+      channel: { type: "DM", source: "shared-runtime" },
+    }
+  );
+}
+
 /** Streaming persistence belongs to the consumer-aware transport finalizer. */
 export type RunSharedAgentTurnStreamInput = Omit<RunSharedAgentTurnInput, "memory">;
 
 export interface RunSharedAgentTurnResult {
   reply: string;
+  /** False when the canonical runtime deliberately chose IGNORE/STOP. */
+  responded?: boolean;
   /** history + the new user message + the assistant reply (persist this). */
   history: SharedTurnMessage[];
   model: string;
@@ -170,6 +192,7 @@ export type SharedAgentTurnStreamPart =
   | {
       type: "finish";
       text: string;
+      responded?: boolean;
       usage?: SharedAgentTurnUsage;
       /** Applied plugin effects that must land with the terminal turn. */
       actionResults?: ActionResult[];
@@ -224,17 +247,6 @@ const DEFAULT_SHARED_MODEL = CEREBRAS_DEFAULT_TEXT_SMALL_MODEL;
  * Ops can raise it, but the healthy default keeps zero SDK backoff on the
  * interactive path since the failover wrapper owns resilience now.
  */
-function resolveSharedTurnMaxRetries(
-  raw: string | undefined = process.env.SHARED_TURN_MAX_RETRIES,
-): number {
-  if (raw === undefined || raw.trim() === "") return 0;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return 0;
-  return Math.min(parsed, 2);
-}
-
-export const SHARED_TURN_MAX_RETRIES = resolveSharedTurnMaxRetries();
-
 /** Token counts the shared-runtime billing path consumes (input/output/total). */
 export interface SharedAgentTurnUsage {
   promptTokens?: number;
@@ -266,10 +278,10 @@ export function resolveSharedAgentTurnModel(preferred?: string): string | null {
  * reach this path still carrying them: the shipped presets ship tokenized
  * `system` / `bio` so a later rename keeps propagating, and the cloud create
  * path seeds one verbatim. A container-backed agent gets the same substitution
- * from `@elizaos/core`'s prompt builder; the shared turn talks to the provider
- * directly, so it is the only renderer on this side.
+ * from `@elizaos/core`'s prompt builder; the Shared runtime receives the
+ * already-projected edge character, so this is the renderer on this side.
  */
-function buildSystemPrompt(
+function buildSharedRuntimeSystem(
   character: SharedAgentCharacter,
   capabilities: { webSearch: boolean; reminders: boolean; todos: boolean; media: boolean },
   recallContext?: string,
@@ -277,14 +289,6 @@ function buildSystemPrompt(
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
   if (system) parts.push(system);
-  if (character.bio?.length) {
-    parts.push(
-      `About you:\n- ${character.bio
-        .map((b) => replaceNameTokens(b, character.name).trim())
-        .filter(Boolean)
-        .join("\n- ")}`,
-    );
-  }
   parts.push(
     "Shared runtime boundaries:\n" +
       (capabilities.webSearch
@@ -323,6 +327,24 @@ export function appendSharedTurn(
   ];
 }
 
+/** Persist an observed turn without inventing an assistant message for IGNORE. */
+export function appendSharedInput(
+  history: SharedTurnMessage[],
+  userMessage: string,
+  messageIds?: RunSharedAgentTurnInput["messageIds"],
+  messageRole: "system" | "user" = "user",
+): SharedTurnMessage[] {
+  return [
+    ...history,
+    {
+      id: messageIds?.user,
+      role: messageRole,
+      content: userMessage,
+      createdAt: Date.now(),
+    },
+  ];
+}
+
 /**
  * Durable commit of the landed user/assistant pair into the tenant-scoped
  * memory table. Runs only when the caller attached a flag-gated
@@ -348,14 +370,8 @@ async function commitSharedTurnMemory(
     assistantReply: reply,
     ...(input.messageIds ? { messageIds: input.messageIds } : {}),
     ...(input.messageRole ? { messageRole: input.messageRole } : {}),
+    ...(input.execution?.channel ? { channel: input.execution.channel } : {}),
   });
-}
-
-function modelHistoryContent(message: SharedTurnMessage): string {
-  if (message.role === "assistant" && message.interrupted) {
-    return `[interrupted assistant partial]\n${message.content}`;
-  }
-  return message.content;
 }
 
 function capabilityResolution(
@@ -385,6 +401,7 @@ function withBlockedSecondaryCapabilities(
   return {
     ...result,
     reply,
+    responded: true,
     history: appendSharedTurn(
       input.history,
       input.message.trim(),
@@ -467,87 +484,38 @@ export async function runSharedAgentTurn(
     };
   }
 
-  if (input.execution?.engine === "eliza-runtime") {
-    const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
-    const result = await runSharedElizaRuntimeTurn({
-      ...input,
-      character: {
-        ...input.character,
-        system: buildSystemPrompt(
-          input.character,
-          {
-            webSearch: actionsEnabled,
-            reminders: remindersEnabled,
-            todos: todosEnabled,
-            media: actionsEnabled && Boolean(input.execution.media),
-          },
-          input.recallContext,
-        ),
-      },
-      agentKey: input.execution.agentKey,
-      model: modelId,
-    });
-    const turn = withBlockedSecondaryCapabilities(result, input, blockedSecondary);
-    await commitSharedTurnMemory(input, turn.reply);
-    return turn;
-  }
-
   let turn: RunSharedAgentTurnResult;
   try {
-    const model = getInteractiveCerebrasLanguageModel(modelId);
-    const system = buildSystemPrompt(
-      input.character,
-      {
-        webSearch: actionsEnabled,
-        reminders: remindersEnabled,
-        todos: todosEnabled,
-        media: false,
-      },
-      input.recallContext,
-    );
-    const messages = [
-      ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
-      { role: input.messageRole ?? ("user" as const), content: message },
-    ];
-    await input.onProviderDispatch?.();
-    const { text, usage } = await generateText({
-      model,
-      // Zero SDK backoff on the interactive turn (see SHARED_TURN_MAX_RETRIES):
-      // the model wrapper fails over to a healthy provider INSTANTLY on a 5xx,
-      // so the SDK's 2-6s sleeping retry is redundant and only adds latency.
-      maxRetries: SHARED_TURN_MAX_RETRIES,
-      system,
-      messages,
-      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
-    });
-    const reply = text.trim() || "…";
+    const execution = resolveRuntimeExecution(input);
+    const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
     turn = withBlockedSecondaryCapabilities(
-      {
-        reply,
-        history: appendSharedTurn(
-          input.history,
-          message,
-          reply,
-          input.messageIds,
-          input.messageRole,
-        ),
+      await runSharedElizaRuntimeTurn({
+        ...input,
+        character: {
+          ...input.character,
+          system: buildSharedRuntimeSystem(
+            input.character,
+            {
+              webSearch: actionsEnabled,
+              reminders: remindersEnabled,
+              todos: todosEnabled,
+              media: actionsEnabled && Boolean(execution.media),
+            },
+            input.recallContext,
+          ),
+        },
+        execution,
+        agentKey: execution.agentKey,
         model: modelId,
-        degraded: false,
-        usage,
-      },
+      }),
       input,
       blockedSecondary,
     );
   } catch (error) {
-    // error-policy:J2 context-adding rethrow. An inference/provider failure is an
-    // INTERNAL failure, not a designed-empty result: swallowing it into a
-    // `degraded: true` reply made a broken turn indistinguishable from the
-    // no-model-configured unavailable state above and let it read as a delivered
-    // (if apologetic) chat message. Rethrow with `cause` so it surfaces and the
-    // caller can distinguish explicit rejection from an ambiguous provider
-    // outcome before choosing zero-cost versus estimate settlement.
+    // error-policy:J2 the runtime is the sole inference engine; preserve its
+    // cause while adding the agent/model identity used by billing boundaries.
     throw new Error(
-      `[shared-runtime] agent turn failed (agent=${input.character.name}, model=${modelId})`,
+      `[shared-runtime] AgentRuntime turn failed (agent=${input.character.name}, model=${modelId})`,
       { cause: error },
     );
   }
@@ -608,181 +576,36 @@ export async function runSharedAgentTurnStream(
     };
   }
 
-  if (input.execution?.engine === "eliza-runtime") {
+  try {
+    const execution = resolveRuntimeExecution(input);
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
     return withBlockedSecondaryStream(
       await runSharedElizaRuntimeTurnStream({
         ...input,
         character: {
           ...input.character,
-          system: buildSystemPrompt(
+          system: buildSharedRuntimeSystem(
             input.character,
             {
               webSearch: actionsEnabled,
               reminders: remindersEnabled,
               todos: todosEnabled,
-              media: actionsEnabled && Boolean(input.execution.media),
+              media: actionsEnabled && Boolean(execution.media),
             },
             input.recallContext,
           ),
         },
-        agentKey: input.execution.agentKey,
+        execution,
+        agentKey: execution.agentKey,
         model: modelId,
       }),
       blockedSecondary,
     );
-  }
-
-  try {
-    const model = getInteractiveCerebrasLanguageModel(modelId);
-    const system = buildSystemPrompt(
-      input.character,
-      {
-        webSearch: actionsEnabled,
-        reminders: remindersEnabled,
-        todos: todosEnabled,
-        media: false,
-      },
-      input.recallContext,
-    );
-    const messages = [
-      ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
-      { role: input.messageRole ?? ("user" as const), content: message },
-    ];
-    await input.onProviderDispatch?.();
-    const result = streamText({
-      model,
-      // Zero SDK backoff on the interactive turn (see SHARED_TURN_MAX_RETRIES):
-      // the model wrapper fails over to a healthy provider INSTANTLY on a 5xx,
-      // so the SDK's 2-6s sleeping retry is redundant and only adds latency.
-      maxRetries: SHARED_TURN_MAX_RETRIES,
-      system,
-      messages,
-      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
-    });
-
-    const providerReader = result.fullStream.getReader();
-    // error-policy:J5 cancel(reason) rejects the SDK's pending result
-    // promises; the parts iterator below is the observed failure channel, so
-    // mark every promise-typed result property handled here to keep a
-    // barge-in from surfacing its cancellation reason as unhandled
-    // rejections on the event loop. Stream-typed getters (fullStream,
-    // textStream, ...) are deliberately NOT touched — accessing them tees or
-    // locks the provider stream.
-    const settledResultProps = [
-      "content",
-      "text",
-      "reasoning",
-      "reasoningText",
-      "files",
-      "sources",
-      "toolCalls",
-      "staticToolCalls",
-      "dynamicToolCalls",
-      "staticToolResults",
-      "dynamicToolResults",
-      "toolResults",
-      "finishReason",
-      "rawFinishReason",
-      "usage",
-      "totalUsage",
-      "warnings",
-      "steps",
-      "request",
-      "response",
-      "providerMetadata",
-    ] as const;
-    for (const prop of settledResultProps) {
-      const pending = (result as unknown as Record<string, unknown>)[prop];
-      if (pending && typeof (pending as PromiseLike<unknown>).then === "function") {
-        void Promise.resolve(pending as PromiseLike<unknown>).catch(() => {});
-      }
-    }
-    let providerStreamDone = false;
-    let providerStreamCancelled = false;
-    let providerCancelPromise: Promise<void> | null = null;
-    const cancel = async (reason?: unknown): Promise<void> => {
-      if (providerStreamDone) return;
-      providerStreamCancelled = true;
-      providerCancelPromise ??= providerReader.cancel(reason).finally(() => {
-        providerStreamDone = true;
-      });
-      await providerCancelPromise;
-    };
-    const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
-      let reply = "";
-      let finishSeen = false;
-      try {
-        for (;;) {
-          const next = await providerReader.read();
-          if (next.done) {
-            providerStreamDone = true;
-            if (!finishSeen && !providerStreamCancelled) {
-              // Some AI SDK provider streams close cleanly after their text deltas
-              // without forwarding a finish part. The SDK result promises are the
-              // authoritative completion signal: they reject for a failed stream.
-              const finalText = (await result.text).trim();
-              if (!finalText) {
-                throw new Error("provider stream ended without text or a finish part");
-              }
-              yield {
-                type: "finish",
-                text: finalText,
-                usage: await result.totalUsage,
-              };
-            }
-            break;
-          }
-          const part = next.value;
-          if (part.type === "text-delta") {
-            reply += part.text;
-            yield { type: "text-delta", text: part.text };
-          }
-          if (part.type === "error") {
-            throw part.error instanceof Error
-              ? part.error
-              : new Error("provider stream reported an unknown error");
-          }
-          if (part.type === "finish") {
-            finishSeen = true;
-            yield {
-              type: "finish",
-              text: reply.trim() || "…",
-              usage: part.totalUsage,
-            };
-          }
-        }
-      } catch (error) {
-        providerStreamDone = true;
-        // error-policy:J2 context-adding rethrow. Stream failures happen after
-        // the HTTP response may have started, so callers need this failure to
-        // classify the preserved provider outcome before settling the reservation.
-        throw new Error(
-          `[shared-runtime] streaming agent turn failed (agent=${input.character.name}, model=${modelId})`,
-          { cause: error },
-        );
-      } finally {
-        if (!providerStreamDone) {
-          await cancel("shared runtime stream consumer stopped");
-        }
-        providerReader.releaseLock();
-      }
-    })();
-
-    return withBlockedSecondaryStream(
-      {
-        model: modelId,
-        degraded: false,
-        parts,
-        cancel,
-      },
-      blockedSecondary,
-    );
   } catch (error) {
-    // error-policy:J2 context-adding rethrow. Preserve the setup/provider cause
-    // so the caller refunds only a provably unaccepted invocation.
+    // error-policy:J2 no SSE bytes exist during setup, so retain the exact
+    // runtime cause and add stable billing/diagnostic context for the caller.
     throw new Error(
-      `[shared-runtime] streaming agent turn failed (agent=${input.character.name}, model=${modelId})`,
+      `[shared-runtime] AgentRuntime stream setup failed (agent=${input.character.name}, model=${modelId})`,
       { cause: error },
     );
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins full behavioral persona projection into the Shared AgentRuntime while
+ * excluding character-controlled plugins, secrets, settings, and knowledge.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { UserCharacter } from "../../../db/repositories/characters";
+import { projectSharedAgentCharacter } from "./shared-agent-character";
+import type { SharedRuntimeAgent } from "./shared-runtime-agent";
+
+function agent(agentConfig: Record<string, unknown>): SharedRuntimeAgent {
+  return {
+    id: "agent-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    character_id: null,
+    agent_name: "Eliza",
+    agent_config: agentConfig,
+    execution_tier: "shared",
+  };
+}
+
+describe("projectSharedAgentCharacter", () => {
+  test("projects behavioral fields but not capability authority", () => {
+    const projected = projectSharedAgentCharacter(
+      agent({
+        character: {
+          name: "Nyx",
+          system: "You are {{name}}.",
+          bio: ["Useful."],
+          adjectives: ["dry", "capable"],
+          topics: ["planning"],
+          style: { all: ["answer first"], chat: ["be direct"], post: ["one idea"] },
+          postExamples: ["A useful post."],
+          messageExamples: [
+            {
+              examples: [
+                { name: "{{user1}}", content: { text: "help" } },
+                { name: "{{agentName}}", content: { text: "What is stuck?" } },
+              ],
+            },
+          ],
+          character_data: { templates: { transientFailureReply: "Try that again." } },
+          plugins: ["untrusted-plugin"],
+          settings: { ENABLE_AUTONOMY: true },
+          secrets: { TOKEN: "must-not-project" },
+          knowledge: ["must-not-project"],
+        },
+      }),
+    );
+
+    expect(projected).toEqual({
+      name: "Nyx",
+      system: "You are {{name}}.",
+      bio: ["Useful."],
+      messageExamples: [
+        {
+          examples: [
+            { name: "{{user1}}", content: { text: "help" } },
+            { name: "{{agentName}}", content: { text: "What is stuck?" } },
+          ],
+        },
+      ],
+      postExamples: ["A useful post."],
+      topics: ["planning"],
+      adjectives: ["dry", "capable"],
+      style: { all: ["answer first"], chat: ["be direct"], post: ["one idea"] },
+      templates: { transientFailureReply: "Try that again." },
+    });
+    expect(JSON.stringify(projected)).not.toContain("must-not-project");
+    expect(JSON.stringify(projected)).not.toContain("untrusted-plugin");
+  });
+
+  test("linked character wins without merging fallback persona arrays", () => {
+    const linked = {
+      organization_id: "org-1",
+      name: "Linked",
+      system: "Linked system",
+      bio: ["Linked bio"],
+      message_examples: [
+        [
+          { name: "person", content: { text: "hello" } },
+          { name: "Linked", content: { text: "hi" } },
+        ],
+      ],
+      topics: ["linked topic"],
+      adjectives: ["linked adjective"],
+      style: { chat: ["linked style"] },
+      character_data: { templates: { rateLimitedReply: "Wait a moment." } },
+      settings: { model: "linked-model" },
+    } as unknown as UserCharacter;
+
+    const projected = projectSharedAgentCharacter(
+      agent({ system: "fallback", bio: ["fallback bio"], topics: ["fallback topic"] }),
+      linked,
+    );
+    expect(projected.bio).toEqual(["Linked bio"]);
+    expect(projected.topics).toEqual(["linked topic"]);
+    expect(projected.messageExamples?.[0]?.examples[1]?.content.text).toBe("hi");
+    expect(projected.templates).toEqual({ rateLimitedReply: "Wait a moment." });
+    expect(projected.model).toBe("linked-model");
+  });
+
+  test("rejects linked characters from another organization", () => {
+    expect(() =>
+      projectSharedAgentCharacter(agent({}), {
+        organization_id: "other-org",
+      } as unknown as UserCharacter),
+    ).toThrow("linked character organization mismatch");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.ts
@@ -18,8 +18,71 @@ function stringList(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
 }
 
+function firstStringList(...values: unknown[]): string[] {
+  for (const value of values) {
+    const list = stringList(value);
+    if (list.length > 0) return list;
+  }
+  return [];
+}
+
 function record(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function styleValue(...values: unknown[]): SharedAgentCharacter["style"] | undefined {
+  for (const value of values) {
+    const candidate = record(value);
+    if (!candidate) continue;
+    const style = {
+      all: stringList(candidate.all),
+      chat: stringList(candidate.chat),
+      post: stringList(candidate.post),
+    };
+    if (style.all.length || style.chat.length || style.post.length) return style;
+  }
+  return undefined;
+}
+
+function templatesValue(...values: unknown[]): Record<string, string> | undefined {
+  for (const value of values) {
+    const candidate = record(value);
+    if (!candidate) continue;
+    const templates = Object.fromEntries(
+      Object.entries(candidate).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === "string" && entry[1].trim().length > 0,
+      ),
+    );
+    if (Object.keys(templates).length > 0) return templates;
+  }
+  return undefined;
+}
+
+function messageExamplesValue(
+  ...values: unknown[]
+): NonNullable<SharedAgentCharacter["messageExamples"]> {
+  for (const value of values) {
+    if (!Array.isArray(value)) continue;
+    const groups = value.flatMap((group) => {
+      const rawMessages = Array.isArray(group) ? group : record(group)?.examples;
+      if (!Array.isArray(rawMessages)) return [];
+      const examples = rawMessages.flatMap((message) => {
+        const candidate = record(message);
+        const content = record(candidate?.content);
+        const name = stringValue(candidate?.name ?? candidate?.user);
+        const text = stringValue(content?.text);
+        if (!name || !text) return [];
+        const actions = stringList(content?.actions);
+        return [{ name, content: { text, ...(actions.length ? { actions } : {}) } }];
+      });
+      return examples.length ? [{ examples }] : [];
+    });
+    if (groups.length > 0) return groups;
+  }
+  return [];
 }
 
 /** Build the shared-turn character with linked, nested, then top-level precedence. */
@@ -46,11 +109,38 @@ export function projectSharedAgentCharacter(
     stringValue(configuredCharacter.prompt) ??
     stringValue(config.prompt) ??
     `You are ${name}, a helpful assistant.`;
-  const bio = [
-    ...stringList(linked?.bio),
-    ...stringList(configuredCharacter.bio),
-    ...stringList(config.bio),
-  ];
+  const bio = firstStringList(linked?.bio, configuredCharacter.bio, config.bio);
+  const messageExamples = messageExamplesValue(
+    linked?.message_examples,
+    configuredCharacter.messageExamples,
+    configuredCharacter.message_examples,
+    config.messageExamples,
+    config.message_examples,
+  );
+  const postExamples = firstStringList(
+    linked?.post_examples,
+    configuredCharacter.postExamples,
+    configuredCharacter.post_examples,
+    config.postExamples,
+    config.post_examples,
+  );
+  const topics = firstStringList(linked?.topics, configuredCharacter.topics, config.topics);
+  const adjectives = firstStringList(
+    linked?.adjectives,
+    configuredCharacter.adjectives,
+    config.adjectives,
+  );
+  const style = styleValue(linked?.style, configuredCharacter.style, config.style);
+  const characterData = record(linked?.character_data);
+  const configuredCharacterData = record(configuredCharacter.character_data);
+  const configCharacterData = record(config.character_data);
+  const templates = templatesValue(
+    characterData?.templates,
+    configuredCharacterData?.templates,
+    configCharacterData?.templates,
+    configuredCharacter.templates,
+    config.templates,
+  );
   const model =
     stringValue(settings?.model) ??
     stringValue(configuredCharacter.model) ??
@@ -59,6 +149,12 @@ export function projectSharedAgentCharacter(
     name,
     system,
     ...(bio.length ? { bio } : {}),
+    ...(messageExamples.length ? { messageExamples } : {}),
+    ...(postExamples.length ? { postExamples } : {}),
+    ...(topics.length ? { topics } : {}),
+    ...(adjectives.length ? { adjectives } : {}),
+    ...(style ? { style } : {}),
+    ...(templates ? { templates } : {}),
     ...(model ? { model } : {}),
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -8,6 +8,7 @@ import { AgentRuntime, ChannelType } from "@elizaos/core/edge";
 import { NotificationService } from "@elizaos/core/services/notification";
 import type { ScheduledTask, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 import type { CreateTodoInput, TodoMutationRecord, TodoStore } from "@elizaos/plugin-todos/edge";
+import type { SharedRuntimeTimingReceipt } from "./shared-runtime-timing";
 
 const scheduledInputs: Array<Record<string, unknown>> = [];
 type StoredTodo = Awaited<ReturnType<TodoStore["create"]>>;
@@ -488,6 +489,7 @@ describe("Shared Eliza Workerd runtime", () => {
   });
 
   test("persists an ambiguous group message when AgentRuntime chooses IGNORE", async () => {
+    let timingReceipt: SharedRuntimeTimingReceipt | null = null;
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
@@ -540,6 +542,10 @@ describe("Shared Eliza Workerd runtime", () => {
         user: "ba919f47-c00d-4dfa-a4da-09d1078c1462",
         assistant: "be654e90-f3e7-44ef-b9ba-e215212c430e",
       },
+      traceId: "trace-shared-ignore",
+      onRuntimeTiming: (receipt) => {
+        timingReceipt = receipt;
+      },
       execution: {
         channel: { type: ChannelType.GROUP, source: "discord" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
@@ -551,6 +557,16 @@ describe("Shared Eliza Workerd runtime", () => {
     expect(result.history[0]).toMatchObject({
       role: "user",
       content: "Alice and Bob should continue without me.",
+    });
+    expect(timingReceipt).toMatchObject({
+      traceId: "trace-shared-ignore",
+      outcome: "success",
+      routing: { decision: "silent", contextIds: ["general"] },
+      inference: {
+        composeStateDurationMs: expect.any(Number),
+        shouldRespondAndContextDurationMs: expect.any(Number),
+        providerTotalDurationMs: expect.any(Number),
+      },
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -307,6 +307,10 @@ describe("Shared Eliza Workerd runtime", () => {
       onProviderDispatch: async () => {
         dispatches += 1;
       },
+      traceId: "trace-observer-nonfatal",
+      onRuntimeTiming: () => {
+        throw new Error("diagnostics sink unavailable");
+      },
       execution: {
         channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
@@ -335,6 +339,7 @@ describe("Shared Eliza Workerd runtime", () => {
 
   test("aborts the genuine runtime provider stream before barge-in can emit text", async () => {
     const providerStarted = Promise.withResolvers<AbortSignal>();
+    const timingOutcomes: string[] = [];
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
       const signal = init?.signal;
       if (!signal) throw new Error("Expected the runtime provider abort signal");
@@ -362,6 +367,8 @@ describe("Shared Eliza Workerd runtime", () => {
       },
       history: [],
       message: "do not finish this turn",
+      traceId: "trace-aborted-runtime",
+      onRuntimeTiming: (receipt) => timingOutcomes.push(`${receipt.traceId}:${receipt.outcome}`),
       execution: {
         channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
@@ -380,6 +387,7 @@ describe("Shared Eliza Workerd runtime", () => {
 
     expect(providerSignal.aborted).toBe(true);
     await expect(nextPart).rejects.toThrow();
+    expect(timingOutcomes).toContain("trace-aborted-runtime:aborted");
   });
 
   test("runs HANDLE_RESPONSE through AgentRuntime and preserves native usage", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { AgentRuntime } from "@elizaos/core/edge";
+import { AgentRuntime, ChannelType } from "@elizaos/core/edge";
 import { NotificationService } from "@elizaos/core/services/notification";
 import type { ScheduledTask, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 import type { CreateTodoInput, TodoMutationRecord, TodoStore } from "@elizaos/plugin-todos/edge";
@@ -308,7 +308,7 @@ describe("Shared Eliza Workerd runtime", () => {
         dispatches += 1;
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
       },
     });
@@ -363,7 +363,7 @@ describe("Shared Eliza Workerd runtime", () => {
       history: [],
       message: "do not finish this turn",
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
       },
     });
@@ -451,7 +451,7 @@ describe("Shared Eliza Workerd runtime", () => {
         dispatches += 1;
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
       },
     });
@@ -477,6 +477,73 @@ describe("Shared Eliza Workerd runtime", () => {
         (tool) => tool.function?.name === "HANDLE_RESPONSE",
       ),
     ).toBe(true);
+  });
+
+  test("persists an ambiguous group message when AgentRuntime chooses IGNORE", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-shared-runtime-ignore",
+          object: "chat.completion",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "shared-handle-response-ignore",
+                    type: "function",
+                    function: {
+                      name: "HANDLE_RESPONSE",
+                      arguments: JSON.stringify({
+                        shouldRespond: "IGNORE",
+                        thought: "The guild message is ambient and not addressed to Eliza.",
+                        contexts: ["general"],
+                        intents: [],
+                        candidateActionNames: [],
+                        replyText: "",
+                        replyEffectStatus: "none",
+                        facts: [],
+                        relationships: [],
+                        addressedTo: [],
+                      }),
+                    },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 21, completion_tokens: 7, total_tokens: 28 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+    const result = await runSharedAgentTurn({
+      character: { name: "Shared Eliza", system: "You are Eliza.", model: "gemma-4-31b" },
+      history: [],
+      message: "Alice and Bob should continue without me.",
+      messageIds: {
+        user: "ba919f47-c00d-4dfa-a4da-09d1078c1462",
+        assistant: "be654e90-f3e7-44ef-b9ba-e215212c430e",
+      },
+      execution: {
+        channel: { type: ChannelType.GROUP, source: "discord" },
+        agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+      },
+    });
+
+    expect(result).toMatchObject({ reply: "", responded: false, degraded: false });
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0]).toMatchObject({
+      role: "user",
+      content: "Alice and Bob should continue without me.",
+    });
   });
 
   test("awaits notification hydration before inference and dispatches through the genuine runtime", async () => {
@@ -559,7 +626,7 @@ describe("Shared Eliza Workerd runtime", () => {
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
         model: "gemma-4-31b",
         execution: {
-          engine: "eliza-runtime",
+          channel: { type: ChannelType.DM, source: "shared-runtime" },
           agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
           mobilePush: {
             dispatch: async (message) => {
@@ -662,7 +729,7 @@ describe("Shared Eliza Workerd runtime", () => {
       ],
       message: "summarize the previous three messages",
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:d6b81293-6440-4ec1-ae46-8fed715c1570",
       },
     });
@@ -815,7 +882,7 @@ describe("Shared Eliza Workerd runtime", () => {
         assistant: "059e33bc-8215-49f4-841f-7642e7505bc7",
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:b55d99d0-ae38-4c7c-8791-7443e5de8ebc",
       },
     });
@@ -933,7 +1000,7 @@ describe("Shared Eliza Workerd runtime", () => {
         assistant: "d042cc9e-c7d4-485b-a49f-ff6eb231bc27",
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:2d88dfa1-7687-4285-a423-f51883f2aa66",
         authenticatedPersonalSharedUser: true,
         media: {
@@ -1078,7 +1145,7 @@ describe("Shared Eliza Workerd runtime", () => {
         message: "A phone call connected. Greet the caller without taking any action.",
         messageRole: "system",
         execution: {
-          engine: "eliza-runtime",
+          channel: { type: ChannelType.VOICE_DM, source: "shared-runtime" },
           agentKey: "personal:4fa13137-cb01-43a9-948c-76d162be13af",
           authenticatedPersonalSharedUser: true,
           media: {
@@ -1121,6 +1188,7 @@ describe("Shared Eliza Workerd runtime", () => {
       expect(lifecycleConnection).toMatchObject({
         userName: "Shared lifecycle",
         source: "shared-runtime-system",
+        type: ChannelType.VOICE_DM,
       });
       expect(lifecycleConnection?.metadata).toBeUndefined();
     } finally {
@@ -1243,7 +1311,7 @@ describe("Shared Eliza Workerd runtime", () => {
       history: [],
       message: "Generate an image of a tiny orange lighthouse at dusk",
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:f5f2c7dd-cec2-432f-8882-9b43c84ecbcf",
         authenticatedPersonalSharedUser: true,
         media: {
@@ -1351,7 +1419,7 @@ describe("Shared Eliza Workerd runtime", () => {
       history: [],
       message: "Generate an image of a tiny orange lighthouse at dusk",
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:dd283829-b3d2-4ae1-a788-15ca74a9aa04",
       },
     });
@@ -1480,7 +1548,7 @@ describe("Shared Eliza Workerd runtime", () => {
         assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
         reminders: {
           runner: reminderRunner,
@@ -1762,7 +1830,7 @@ describe("Shared Eliza Workerd runtime", () => {
           assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
         },
         execution: {
-          engine: "eliza-runtime",
+          channel: { type: ChannelType.DM, source: "shared-runtime" },
           agentKey: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
           reminders: {
             runner: lifecycleRunner,
@@ -1950,7 +2018,7 @@ describe("Shared Eliza Workerd runtime", () => {
         assistant: "70000000-0000-5000-8000-000000000004",
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:70000000-0000-5000-8000-000000000005",
         todos: { scope, store: todoStore },
       },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -12,14 +12,13 @@ import {
   AgentRuntime,
   basicProviders,
   basicServices,
-  ChannelType,
   createMessageMemory,
   type GenerateTextParams,
   generateMediaAction,
   type IAgentRuntime,
   IMediaGenerationService,
+  type InferenceTurnSummary,
   InMemoryDatabaseAdapter,
-  MESSAGE_SOURCE_CLIENT_CHAT,
   type MediaGenerationRequest,
   ModelType,
   NOTIFICATION_STREAM,
@@ -57,11 +56,17 @@ import type {
   SharedMediaGenerationPort,
   SharedTurnMessage,
 } from "./run-shared-agent-turn";
-import { appendSharedTurn } from "./run-shared-agent-turn";
+import { appendSharedInput, appendSharedTurn } from "./run-shared-agent-turn";
+import {
+  createSharedRuntimeCapabilitiesPlugin,
+  REQUEST_DEDICATED_UPGRADE_ACTION,
+  SHARED_RUNTIME_CAPABILITIES_PROVIDER,
+} from "./shared-runtime-capabilities";
 import {
   sharedRuntimeConversationRoomId,
   sharedRuntimeWorldId,
 } from "./shared-runtime-storage-identity";
+import { SHARED_TURN_MAX_RETRIES } from "./shared-turn-retry-budget";
 
 type NativeTextModelResult = string & {
   text: string;
@@ -69,6 +74,12 @@ type NativeTextModelResult = string & {
   finishReason: string;
   usage: SharedAgentTurnUsage;
   providerMetadata: { modelName: string };
+};
+
+type SharedElizaRuntimeTurnInput = Omit<RunSharedAgentTurnInput, "execution"> & {
+  execution: NonNullable<RunSharedAgentTurnInput["execution"]>;
+  agentKey: string;
+  model: string;
 };
 
 interface SharedNotificationEventBus {
@@ -219,12 +230,25 @@ function createRuntime(options: {
   reminderPlugin?: Plugin;
   todoPlugin?: Plugin;
 }): AgentRuntime {
+  const capabilityPlugin = createSharedRuntimeCapabilitiesPlugin({
+    agentId: options.agentKey,
+    webSearch: options.actionsEnabled,
+    reminders: options.actionsEnabled && Boolean(options.reminderPlugin),
+    todos: options.actionsEnabled && Boolean(options.todoPlugin),
+    media: options.actionsEnabled && Boolean(options.mediaPlugin),
+  });
   return new AgentRuntime({
     agentId: options.agentId ?? stringToUuid(options.agentKey),
     character: {
       name: options.character.name,
       system: options.character.system,
       bio: options.character.bio ?? [],
+      messageExamples: options.character.messageExamples ?? [],
+      postExamples: options.character.postExamples ?? [],
+      topics: options.character.topics ?? [],
+      adjectives: options.character.adjectives ?? [],
+      style: options.character.style,
+      templates: options.character.templates,
       plugins: [],
       settings: {
         ELIZA_CANONICAL_LLM_TEXT_ENABLED: true,
@@ -235,6 +259,7 @@ function createRuntime(options: {
     plugins: [
       options.modelPlugin,
       ...(!options.actionsEnabled ? [sharedSystemLifecyclePlugin] : []),
+      ...(options.actionsEnabled ? [capabilityPlugin] : []),
       ...(options.actionsEnabled ? [webSearchEdgePlugin] : []),
       ...(options.actionsEnabled && options.mediaPlugin ? [options.mediaPlugin] : []),
       ...(options.actionsEnabled && options.reminderPlugin ? [options.reminderPlugin] : []),
@@ -243,7 +268,7 @@ function createRuntime(options: {
     logLevel: "error",
     disableBasicCapabilities: !options.actionsEnabled,
     actionPlanning: options.actionsEnabled,
-    checkShouldRespond: false,
+    checkShouldRespond: true,
     enableAutonomy: false,
     enableDocuments: false,
     enableRelationships: false,
@@ -416,7 +441,7 @@ function projectedHistoryTimestamps(history: SharedTurnMessage[]): number[] {
 }
 
 async function executeSharedElizaRuntimeTurn(
-  input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+  input: SharedElizaRuntimeTurnInput,
   onStreamChunk?: (chunk: string) => void | Promise<void>,
 ): Promise<RunSharedAgentTurnResult> {
   const turnStartedAt = performance.now();
@@ -426,6 +451,7 @@ async function executeSharedElizaRuntimeTurn(
   let providerDispatched = false;
   let providerDispatchedAt: number | null = null;
   let providerFirstTextAt: number | null = null;
+  const inferenceTelemetry: { summary?: InferenceTurnSummary } = {};
   let usage: SharedAgentTurnUsage | undefined;
   const model = getInteractiveCerebrasLanguageModel(input.model);
 
@@ -440,7 +466,7 @@ async function executeSharedElizaRuntimeTurn(
     }
     const generation = {
       model,
-      maxRetries: 0,
+      maxRetries: SHARED_TURN_MAX_RETRIES,
       allowSystemInMessages: true,
       ...(params.messages
         ? { messages: params.messages as ModelMessage[] }
@@ -608,6 +634,16 @@ async function executeSharedElizaRuntimeTurn(
       if (!runtime.actions.some((action) => action.name === webSearchEdgeAction.name)) {
         throw new Error("Eliza Shared runtime initialized without its WEB_SEARCH action");
       }
+      if (!runtime.actions.some((action) => action.name === REQUEST_DEDICATED_UPGRADE_ACTION)) {
+        throw new Error("Eliza Shared runtime initialized without its Dedicated review action");
+      }
+      if (
+        !runtime.providers.some(
+          (provider) => provider.name === SHARED_RUNTIME_CAPABILITIES_PROVIDER,
+        )
+      ) {
+        throw new Error("Eliza Shared runtime initialized without its capability provider");
+      }
       if (
         input.execution?.reminders &&
         !runtime.actions.some((action) => action.name === "REMINDERS")
@@ -631,8 +667,8 @@ async function executeSharedElizaRuntimeTurn(
       roomId,
       worldId: sharedRuntimeWorldId(input.agentKey),
       userName: actionsEnabled ? "Shared user" : "Shared lifecycle",
-      source: actionsEnabled ? "shared-runtime" : "shared-runtime-system",
-      type: ChannelType.DM,
+      source: actionsEnabled ? input.execution.channel.source : "shared-runtime-system",
+      type: input.execution.channel.type,
       ...(authenticatedPersonalSharedUser
         ? {
             metadata: {
@@ -661,8 +697,11 @@ async function executeSharedElizaRuntimeTurn(
             roomId,
             content: {
               text: message.content,
-              source: message.role === "system" ? "shared-runtime-system" : "shared-runtime",
-              channelType: ChannelType.DM,
+              source:
+                message.role === "system"
+                  ? "shared-runtime-system"
+                  : input.execution.channel.source,
+              channelType: input.execution.channel.type,
             },
           });
           memory.createdAt = createdAt;
@@ -696,12 +735,8 @@ async function executeSharedElizaRuntimeTurn(
           // Only the server-owned execution attestation may translate a Shared
           // turn to authenticated client-chat provenance. Connector payloads and
           // direct runtime callers remain on the fail-closed Shared source.
-          source: !actionsEnabled
-            ? "shared-runtime-system"
-            : authenticatedPersonalSharedUser
-              ? MESSAGE_SOURCE_CLIENT_CHAT
-              : "shared-runtime",
-          channelType: ChannelType.DM,
+          source: actionsEnabled ? input.execution.channel.source : "shared-runtime-system",
+          channelType: input.execution.channel.type,
           ...(input.originClientMessageId
             ? {
                 chatIdempotency: {
@@ -727,8 +762,15 @@ async function executeSharedElizaRuntimeTurn(
         ? {
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
             ...(onStreamChunk ? { onStreamChunk } : {}),
+            onInferenceTimingSummary: (summary) => {
+              inferenceTelemetry.summary = summary;
+            },
           }
-        : undefined,
+        : {
+            onInferenceTimingSummary: (summary) => {
+              inferenceTelemetry.summary = summary;
+            },
+          },
     );
     unsubscribePush?.();
     const pushResults = await Promise.allSettled(pushDispatches);
@@ -746,10 +788,46 @@ async function executeSharedElizaRuntimeTurn(
     // A verified action may own the response and deliver it through the
     // callback with `agentVoiced`; core then correctly reports no second model
     // response. The callback receipt is still an actual user-visible delivery.
-    if ((!result?.didRespond && delivered.length === 0) || !reply) {
+    if (!result?.didRespond && delivered.length === 0) {
+      const completedAt = performance.now();
+      const providerSpans = (inferenceTelemetry.summary?.spans ?? [])
+        .filter((span) => span.name === "composeState" || span.name.startsWith("provider:"))
+        .map((span) => ({ name: span.name, durationMs: span.durationMs }));
+      logger.info("[shared-eliza-runtime] turn intentionally suppressed", {
+        turnId: input.messageIds?.assistant ?? null,
+        channelType: input.execution.channel.type,
+        source: input.execution.channel.source,
+        providerSpans,
+        providerBudgetTargetMs: 300,
+        providerBudgetCeilingMs: 500,
+        providerDispatchMs:
+          providerDispatchedAt === null
+            ? null
+            : Math.round((providerDispatchedAt - turnStartedAt) * 10) / 10,
+        totalMs: Math.round((completedAt - turnStartedAt) * 10) / 10,
+      });
+      return {
+        reply: "",
+        responded: false,
+        history: appendSharedInput(
+          input.history,
+          input.message.trim(),
+          input.messageIds,
+          input.messageRole,
+        ),
+        model: input.model,
+        degraded: false,
+        usage,
+      };
+    }
+    if (!reply) {
       throw new Error("Eliza Shared runtime completed without a user-visible reply");
     }
     const completedAt = performance.now();
+    const providerSpans = (inferenceTelemetry.summary?.spans ?? [])
+      .filter((span) => span.name === "composeState" || span.name.startsWith("provider:"))
+      .map((span) => ({ name: span.name, durationMs: span.durationMs }));
+    const slowProviderSpans = providerSpans.filter((span) => span.durationMs > 500);
     logger.info("[shared-eliza-runtime] turn latency", {
       turnId: input.messageIds?.assistant ?? null,
       historyMessages: input.history.length,
@@ -757,6 +835,9 @@ async function executeSharedElizaRuntimeTurn(
       runtimeInitializeMs: Math.round((runtimeReadyAt - initializeStartedAt) * 10) / 10,
       connectionMs: Math.round((connectionReadyAt - connectionStartedAt) * 10) / 10,
       historyProjectionMs: Math.round((historyReadyAt - historyStartedAt) * 10) / 10,
+      providerSpans,
+      providerBudgetTargetMs: 300,
+      providerBudgetCeilingMs: 500,
       providerDispatchMs:
         providerDispatchedAt === null
           ? null
@@ -767,8 +848,16 @@ async function executeSharedElizaRuntimeTurn(
           : Math.round((providerFirstTextAt - turnStartedAt) * 10) / 10,
       totalMs: Math.round((completedAt - turnStartedAt) * 10) / 10,
     });
+    if (slowProviderSpans.length > 0) {
+      logger.warn("[shared-eliza-runtime] provider latency exceeded ceiling", {
+        turnId: input.messageIds?.assistant ?? null,
+        slowProviderSpans,
+        providerBudgetCeilingMs: 500,
+      });
+    }
     return {
       reply,
+      responded: true,
       history: appendSharedTurn(
         input.history,
         input.message.trim(),
@@ -788,7 +877,7 @@ async function executeSharedElizaRuntimeTurn(
 }
 
 export async function runSharedElizaRuntimeTurn(
-  input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+  input: SharedElizaRuntimeTurnInput,
 ): Promise<RunSharedAgentTurnResult> {
   return await executeSharedElizaRuntimeTurn(input);
 }
@@ -810,7 +899,7 @@ function isRuntimeControlChunk(chunk: string): boolean {
 }
 
 export async function runSharedElizaRuntimeTurnStream(
-  input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+  input: SharedElizaRuntimeTurnInput,
 ): Promise<RunSharedAgentTurnStreamResult> {
   const controller = new AbortController();
   const abortFromCaller = () => controller.abort(input.abortSignal?.reason);
@@ -852,6 +941,7 @@ export async function runSharedElizaRuntimeTurnStream(
       push({
         type: "finish",
         text: result.reply,
+        ...(result.responded === false ? { responded: false } : {}),
         usage: result.usage,
         ...(result.actionResults?.length ? { actionResults: result.actionResults } : {}),
       });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -66,6 +66,10 @@ import {
   sharedRuntimeConversationRoomId,
   sharedRuntimeWorldId,
 } from "./shared-runtime-storage-identity";
+import {
+  SharedRuntimeTimingCollector,
+  type SharedRuntimeTimingOutcome,
+} from "./shared-runtime-timing";
 import { SHARED_TURN_MAX_RETRIES } from "./shared-turn-retry-budget";
 
 type NativeTextModelResult = string & {
@@ -440,17 +444,72 @@ function projectedHistoryTimestamps(history: SharedTurnMessage[]): number[] {
   return timestamps;
 }
 
+function logSharedProviderSpans(
+  input: SharedElizaRuntimeTurnInput,
+  summary: InferenceTurnSummary | undefined,
+  responded: boolean,
+): void {
+  const providerSpans = (summary?.spans ?? [])
+    .filter((span) => span.name === "composeState" || span.name.startsWith("provider:"))
+    .map((span) => ({ name: span.name, durationMs: span.durationMs }));
+  const slowProviderSpans = providerSpans.filter((span) => span.durationMs > 500);
+  logger.info("[shared-eliza-runtime] provider latency", {
+    traceId: input.traceId ?? input.messageIds?.assistant ?? null,
+    channelType: input.execution.channel.type,
+    source: input.execution.channel.source,
+    responded,
+    providerSpans,
+    providerBudgetTargetMs: 300,
+    providerBudgetCeilingMs: 500,
+  });
+  if (slowProviderSpans.length > 0) {
+    logger.warn("[shared-eliza-runtime] provider latency exceeded ceiling", {
+      traceId: input.traceId ?? input.messageIds?.assistant ?? null,
+      slowProviderSpans,
+      providerBudgetCeilingMs: 500,
+    });
+  }
+}
+
 async function executeSharedElizaRuntimeTurn(
   input: SharedElizaRuntimeTurnInput,
   onStreamChunk?: (chunk: string) => void | Promise<void>,
 ): Promise<RunSharedAgentTurnResult> {
-  const turnStartedAt = performance.now();
+  const timing = new SharedRuntimeTimingCollector(
+    input.traceId ?? input.messageIds?.assistant ?? "unattributed",
+    input.history.length,
+  );
+  const emitTiming = (outcome: SharedRuntimeTimingOutcome): void => {
+    try {
+      input.onRuntimeTiming?.(timing.receipt(outcome));
+    } catch (error) {
+      // error-policy:J7 diagnostics must not kill the loop — the observer is
+      // outside the authoritative response and persistence path.
+      logger.warn("[shared-eliza-runtime] timing observer failed", {
+        traceId: input.traceId ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+  try {
+    const result = await executeMeasuredSharedElizaRuntimeTurn(input, onStreamChunk, timing);
+    emitTiming("success");
+    return result;
+  } catch (error) {
+    emitTiming(input.abortSignal?.aborted ? "aborted" : "error");
+    throw error;
+  }
+}
+
+async function executeMeasuredSharedElizaRuntimeTurn(
+  input: SharedElizaRuntimeTurnInput,
+  onStreamChunk: ((chunk: string) => void | Promise<void>) | undefined,
+  timing: SharedRuntimeTimingCollector,
+): Promise<RunSharedAgentTurnResult> {
   await ensureEdgeStreamingContext();
-  const edgeContextReadyAt = performance.now();
+  timing.markEdgeContextReady();
   const adapter = new InMemoryDatabaseAdapter();
   let providerDispatched = false;
-  let providerDispatchedAt: number | null = null;
-  let providerFirstTextAt: number | null = null;
   const inferenceTelemetry: { summary?: InferenceTurnSummary } = {};
   let usage: SharedAgentTurnUsage | undefined;
   const model = getInteractiveCerebrasLanguageModel(input.model);
@@ -461,8 +520,8 @@ async function executeSharedElizaRuntimeTurn(
   ): Promise<string | NativeTextModelResult | TextStreamResult> => {
     if (!providerDispatched) {
       providerDispatched = true;
-      providerDispatchedAt = performance.now();
       await input.onProviderDispatch?.();
+      timing.markProviderDispatched();
     }
     const generation = {
       model,
@@ -505,14 +564,13 @@ async function executeSharedElizaRuntimeTurn(
                 ? (record.inputTextDelta ?? record.delta)
                 : undefined;
             if (chunk) {
-              providerFirstTextAt ??= performance.now();
               yield chunk;
             }
           }
           return;
         }
         for await (const chunk of result.textStream) {
-          providerFirstTextAt ??= performance.now();
+          if (chunk) timing.markProviderFirstText();
           yield chunk;
         }
       })();
@@ -544,7 +602,7 @@ async function executeSharedElizaRuntimeTurn(
     const result = await generateText({
       ...generation,
     });
-    providerFirstTextAt ??= performance.now();
+    if (result.text.trim()) timing.markProviderFirstText();
     usage = addUsage(usage, normalizeUsage(result.usage));
     if (result.toolCalls.length === 0) {
       return result.text;
@@ -596,9 +654,8 @@ async function executeSharedElizaRuntimeTurn(
     reminderPlugin,
     todoPlugin,
   });
-
   try {
-    const initializeStartedAt = performance.now();
+    timing.markRuntimeInitializeStarted();
     await runtime.initialize({ skipMigrations: true });
     if (mediaPlugin) {
       await runtime.getServiceLoadPromise(ServiceType.MEDIA_GENERATION);
@@ -620,7 +677,7 @@ async function executeSharedElizaRuntimeTurn(
       mobilePushDispatch && isSharedNotificationEventBus(eventBus)
         ? subscribeSharedMobilePush(eventBus, mobilePushDispatch, pushDispatches)
         : undefined;
-    const runtimeReadyAt = performance.now();
+    timing.markRuntimeReady();
     if (runtime.actions.some((action) => action.name === "VIEWS")) {
       throw new Error("Eliza Shared runtime must not register client view-navigation actions");
     }
@@ -661,7 +718,7 @@ async function executeSharedElizaRuntimeTurn(
       }
     }
     const roomId = sharedRuntimeConversationRoomId(input.agentKey);
-    const connectionStartedAt = performance.now();
+    timing.markConnectionStarted();
     await runtime.ensureConnection({
       entityId: incomingEntityId,
       roomId,
@@ -678,8 +735,8 @@ async function executeSharedElizaRuntimeTurn(
           }
         : {}),
     });
-    const connectionReadyAt = performance.now();
-    const historyStartedAt = performance.now();
+    timing.markConnectionReady();
+    timing.markHistoryStarted();
     if (input.history.length > 0) {
       const historyTimestamps = projectedHistoryTimestamps(input.history);
       await adapter.createMemories(
@@ -716,7 +773,7 @@ async function executeSharedElizaRuntimeTurn(
         }),
       );
     }
-    const historyReadyAt = performance.now();
+    timing.markHistoryReady();
 
     const delivered: string[] = [];
     const messageService = runtime.messageService;
@@ -789,23 +846,7 @@ async function executeSharedElizaRuntimeTurn(
     // callback with `agentVoiced`; core then correctly reports no second model
     // response. The callback receipt is still an actual user-visible delivery.
     if (!result?.didRespond && delivered.length === 0) {
-      const completedAt = performance.now();
-      const providerSpans = (inferenceTelemetry.summary?.spans ?? [])
-        .filter((span) => span.name === "composeState" || span.name.startsWith("provider:"))
-        .map((span) => ({ name: span.name, durationMs: span.durationMs }));
-      logger.info("[shared-eliza-runtime] turn intentionally suppressed", {
-        turnId: input.messageIds?.assistant ?? null,
-        channelType: input.execution.channel.type,
-        source: input.execution.channel.source,
-        providerSpans,
-        providerBudgetTargetMs: 300,
-        providerBudgetCeilingMs: 500,
-        providerDispatchMs:
-          providerDispatchedAt === null
-            ? null
-            : Math.round((providerDispatchedAt - turnStartedAt) * 10) / 10,
-        totalMs: Math.round((completedAt - turnStartedAt) * 10) / 10,
-      });
+      logSharedProviderSpans(input, inferenceTelemetry.summary, false);
       return {
         reply: "",
         responded: false,
@@ -823,38 +864,7 @@ async function executeSharedElizaRuntimeTurn(
     if (!reply) {
       throw new Error("Eliza Shared runtime completed without a user-visible reply");
     }
-    const completedAt = performance.now();
-    const providerSpans = (inferenceTelemetry.summary?.spans ?? [])
-      .filter((span) => span.name === "composeState" || span.name.startsWith("provider:"))
-      .map((span) => ({ name: span.name, durationMs: span.durationMs }));
-    const slowProviderSpans = providerSpans.filter((span) => span.durationMs > 500);
-    logger.info("[shared-eliza-runtime] turn latency", {
-      turnId: input.messageIds?.assistant ?? null,
-      historyMessages: input.history.length,
-      edgeContextMs: Math.round((edgeContextReadyAt - turnStartedAt) * 10) / 10,
-      runtimeInitializeMs: Math.round((runtimeReadyAt - initializeStartedAt) * 10) / 10,
-      connectionMs: Math.round((connectionReadyAt - connectionStartedAt) * 10) / 10,
-      historyProjectionMs: Math.round((historyReadyAt - historyStartedAt) * 10) / 10,
-      providerSpans,
-      providerBudgetTargetMs: 300,
-      providerBudgetCeilingMs: 500,
-      providerDispatchMs:
-        providerDispatchedAt === null
-          ? null
-          : Math.round((providerDispatchedAt - turnStartedAt) * 10) / 10,
-      providerFirstTextMs:
-        providerFirstTextAt === null
-          ? null
-          : Math.round((providerFirstTextAt - turnStartedAt) * 10) / 10,
-      totalMs: Math.round((completedAt - turnStartedAt) * 10) / 10,
-    });
-    if (slowProviderSpans.length > 0) {
-      logger.warn("[shared-eliza-runtime] provider latency exceeded ceiling", {
-        turnId: input.messageIds?.assistant ?? null,
-        slowProviderSpans,
-        providerBudgetCeilingMs: 500,
-      });
-    }
+    logSharedProviderSpans(input, inferenceTelemetry.summary, true);
     return {
       reply,
       responded: true,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -12,6 +12,7 @@ import {
   AgentRuntime,
   basicProviders,
   basicServices,
+  CONTEXT_ROUTING_METADATA_KEY,
   createMessageMemory,
   type GenerateTextParams,
   generateMediaAction,
@@ -20,6 +21,7 @@ import {
   type InferenceTurnSummary,
   InMemoryDatabaseAdapter,
   type MediaGenerationRequest,
+  type Memory,
   ModelType,
   NOTIFICATION_STREAM,
   NotificationService,
@@ -471,6 +473,19 @@ function logSharedProviderSpans(
   }
 }
 
+function routedContextIds(message: Memory): string[] {
+  const metadata = message.content?.metadata;
+  if (!metadata || typeof metadata !== "object") return [];
+  const routing = (metadata as Record<string, unknown>)[CONTEXT_ROUTING_METADATA_KEY];
+  if (!routing || typeof routing !== "object" || Array.isArray(routing)) return [];
+  const record = routing as Record<string, unknown>;
+  const primary = typeof record.primaryContext === "string" ? [record.primaryContext] : [];
+  const secondary = Array.isArray(record.secondaryContexts)
+    ? record.secondaryContexts.filter((value): value is string => typeof value === "string")
+    : [];
+  return [...primary, ...secondary];
+}
+
 async function executeSharedElizaRuntimeTurn(
   input: SharedElizaRuntimeTurnInput,
   onStreamChunk?: (chunk: string) => void | Promise<void>,
@@ -780,30 +795,31 @@ async function executeMeasuredSharedElizaRuntimeTurn(
     if (!messageService) {
       throw new Error("Eliza Shared runtime initialized without a message service");
     }
+    const incomingMessage = createMessageMemory({
+      id: stringToUuid(input.messageIds?.user ?? `${input.agentKey}:${input.message}`),
+      entityId: incomingEntityId,
+      agentId: runtime.agentId,
+      roomId,
+      content: {
+        text: input.message.trim(),
+        // Only the server-owned execution attestation may translate a Shared
+        // turn to authenticated client-chat provenance. Connector payloads and
+        // direct runtime callers remain on the fail-closed Shared source.
+        source: actionsEnabled ? input.execution.channel.source : "shared-runtime-system",
+        channelType: input.execution.channel.type,
+        ...(input.originClientMessageId
+          ? {
+              chatIdempotency: {
+                version: 1,
+                clientMessageId: input.originClientMessageId,
+              },
+            }
+          : {}),
+      },
+    });
     const result = await messageService.handleMessage(
       runtime,
-      createMessageMemory({
-        id: stringToUuid(input.messageIds?.user ?? `${input.agentKey}:${input.message}`),
-        entityId: incomingEntityId,
-        agentId: runtime.agentId,
-        roomId,
-        content: {
-          text: input.message.trim(),
-          // Only the server-owned execution attestation may translate a Shared
-          // turn to authenticated client-chat provenance. Connector payloads and
-          // direct runtime callers remain on the fail-closed Shared source.
-          source: actionsEnabled ? input.execution.channel.source : "shared-runtime-system",
-          channelType: input.execution.channel.type,
-          ...(input.originClientMessageId
-            ? {
-                chatIdempotency: {
-                  version: 1,
-                  clientMessageId: input.originClientMessageId,
-                },
-              }
-            : {}),
-        },
-      }),
+      incomingMessage,
       async (content) => {
         const text = content.text?.trim();
         const attachmentUrls = (content.attachments ?? []).flatMap((attachment) =>
@@ -828,6 +844,11 @@ async function executeMeasuredSharedElizaRuntimeTurn(
               inferenceTelemetry.summary = summary;
             },
           },
+    );
+    timing.markInferenceSpans(inferenceTelemetry.summary?.spans ?? []);
+    timing.markRoutingDecision(
+      result?.didRespond || delivered.length > 0 ? "respond" : "silent",
+      routedContextIds(incomingMessage),
     );
     unsubscribePush?.();
     const pushResults = await Promise.allSettled(pushDispatches);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -18,6 +18,7 @@ import {
   sharedAgentMemoriesWriter,
 } from "../../../db/repositories/shared-agent-memories";
 import { logger } from "../../utils/logger";
+import type { SharedRuntimeChannel } from "./shared-runtime-channel";
 import {
   type SharedTodoStorageScope,
   sharedRuntimeConversationRoomId,
@@ -51,6 +52,8 @@ export interface SharedMemoryTurnPair {
   messageRole?: "system" | "user";
   /** Mirrors the canonical history marker for a client-cancelled partial reply. */
   interrupted?: boolean;
+  /** Trusted transport semantics projected onto durable runtime memories. */
+  channel?: SharedRuntimeChannel;
 }
 
 /** Row id from a transport message id: pass through uuids, hash anything else. */
@@ -146,8 +149,8 @@ export class SharedMemoryStore {
       type: SHARED_MEMORY_TYPE,
       content: {
         text: pair.userMessage,
-        source: "shared-runtime",
-        channelType: "DM",
+        source: pair.channel?.source ?? "shared-runtime",
+        channelType: pair.channel?.type ?? "DM",
         ...(pair.messageRole === "system" ? { role: "system" } : {}),
       },
       ...embeddingFields(0),
@@ -165,8 +168,8 @@ export class SharedMemoryStore {
       type: SHARED_MEMORY_TYPE,
       content: {
         text: assistantReply,
-        source: "shared-runtime",
-        channelType: "DM",
+        source: pair.channel?.source ?? "shared-runtime",
+        channelType: pair.channel?.type ?? "DM",
       },
       createdAt: new Date(landedAt + 1),
     };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -1,6 +1,7 @@
 /** Drives the genuine Shared AgentRuntime reminder action with a fixed clock and deterministic model boundary. */
 
 import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
 import type { ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 
 const NOW = "2026-08-16T04:48:56.509Z";
@@ -209,7 +210,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
         assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
       },
       execution: {
-        engine: "eliza-runtime",
+        channel: { type: ChannelType.DM, source: "shared-runtime" },
         agentKey: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
         reminders: {
           runner: reminderRunner,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 
 class InsufficientCreditsError extends Error {}
 
@@ -302,6 +303,7 @@ describe("shared-rest-adapter — messages", () => {
     expect(call[2]).toEqual({
       executionCtx: EXECUTION_CTX,
       namespace: NAMESPACE,
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
     });
   });
 
@@ -351,6 +353,59 @@ describe("shared-rest-adapter — messages", () => {
       namespace: NAMESPACE,
       agentKind: "personal",
       trustedUserUtterance: "hello",
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
+    });
+  });
+
+  test("projects a trusted managed connector into runtime channel provenance", async () => {
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "discord:update-1",
+      result: { text: "hello" },
+    });
+
+    await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "hello",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+      "discord:update-1",
+      "platform",
+      { platform: "discord", discordUserId: "123456789012345678" },
+    );
+
+    expect(coordinateSharedBridge.mock.calls[0][2].channel).toEqual({
+      type: ChannelType.DM,
+      source: "discord",
+    });
+  });
+
+  test("projects a trusted group transport into runtime should-respond semantics", async () => {
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "discord:guild-message-1",
+      result: { text: "hello" },
+    });
+
+    await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "hello",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+      "discord:guild-message-1",
+      "platform",
+      undefined,
+      "hello",
+      { type: ChannelType.GROUP, source: "discord" },
+    );
+
+    expect(coordinateSharedBridge.mock.calls[0][2].channel).toEqual({
+      type: ChannelType.GROUP,
+      source: "discord",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -16,6 +16,7 @@
  * item, so no conversation index is needed.
  */
 
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import type { SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError } from "../../api/errors";
@@ -23,6 +24,7 @@ import type { BridgeRequest } from "../eliza-sandbox-bridge";
 import { coordinateSharedBridge, coordinateSharedHistory } from "./conversation-coordinator";
 import type { SharedAgentCharacter } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
+import type { SharedRuntimeChannel } from "./shared-runtime-channel";
 import { type BridgeExecutionContext, sharedRuntimeChatService } from "./shared-runtime-chat";
 
 const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
@@ -541,6 +543,7 @@ export async function sharedRestMessageSend(
   funding: "organization-credits" | "platform" = "organization-credits",
   trustedDelivery?: SharedReminderDelivery,
   trustedUserUtterance?: string,
+  trustedChannel?: SharedRuntimeChannel,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -562,6 +565,10 @@ export async function sharedRestMessageSend(
     namespace,
     ...(funding === "platform" ? { agentKind: "personal" as const } : {}),
     ...(trustedUserUtterance ? { trustedUserUtterance } : {}),
+    channel: trustedChannel ?? {
+      type: ChannelType.DM,
+      source: trustedDelivery?.platform ?? MESSAGE_SOURCE_CLIENT_CHAT,
+    },
   });
   if (response.error) {
     // A credit-reserve rejection is a permanent add-credits condition, not a

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Verifies the Shared capability provider is synchronous-edge-safe in effect
+ * and that its upgrade action never mutates or activates Dedicated compute.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createRequestDedicatedUpgradeAction,
+  createSharedRuntimeCapabilitiesProvider,
+  REQUEST_DEDICATED_UPGRADE_ACTION,
+  SHARED_RUNTIME_PLUGIN_COMPATIBILITY,
+} from "./shared-runtime-capabilities";
+
+describe("Shared runtime capability components", () => {
+  test("audits every first-party plugin with an explicit edge entrypoint", () => {
+    expect(SHARED_RUNTIME_PLUGIN_COMPATIBILITY.map(({ plugin }) => plugin)).toEqual(
+      expect.arrayContaining([
+        "@elizaos/core/edge",
+        "@elizaos/plugin-web-search/edge",
+        "@elizaos/plugin-scheduling/edge",
+        "@elizaos/plugin-todos/edge",
+      ]),
+    );
+  });
+
+  test("provides complete capability context well below the provider budget", async () => {
+    const provider = createSharedRuntimeCapabilitiesProvider({
+      agentId: "personal:user-1",
+      webSearch: true,
+      reminders: true,
+      todos: false,
+      media: false,
+    });
+    const startedAt = performance.now();
+    const result = await provider.get({} as never, {} as never);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(25);
+    expect(result.data).toMatchObject({
+      runtimeMode: "shared",
+      available: [
+        "conversation and reasoning",
+        "conversation memory",
+        "public web search",
+        "private reminders",
+      ],
+      canActivateDedicatedWithoutConfirmation: false,
+    });
+    expect(result.text).toContain(REQUEST_DEDICATED_UPGRADE_ACTION);
+  });
+
+  test("returns a review handoff without provisioning or charging", async () => {
+    const action = createRequestDedicatedUpgradeAction("personal:user/1");
+    const delivered: string[] = [];
+    const result = await action.handler(
+      {} as never,
+      {} as never,
+      undefined,
+      { parameters: { capability: "coding" } },
+      async (content) => {
+        delivered.push(content.text ?? "");
+        return [];
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      upgradePath: "/cloud/agents/personal%3Auser%2F1",
+      mutationPerformed: false,
+      requiresUserConfirmation: true,
+    });
+    expect(delivered[0]).toContain("Nothing has been activated or charged");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
@@ -1,0 +1,195 @@
+/**
+ * Registers the Shared runtime's self-description and safe Dedicated-upgrade
+ * handoff action without provisioning compute or accepting billing consent.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  Plugin,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core/edge";
+
+export const SHARED_RUNTIME_CAPABILITIES_PROVIDER = "SHARED_RUNTIME_CAPABILITIES";
+export const REQUEST_DEDICATED_UPGRADE_ACTION = "REQUEST_DEDICATED_UPGRADE";
+
+export const SHARED_RUNTIME_EDGE_COMPATIBILITY = {
+  target: "edge",
+  state: "conversation-durable-object",
+  effects: ["upgrade-review-link"],
+  requiredBindings: ["SHARED_RUNTIME_CONVERSATIONS"],
+  requiredSecrets: [],
+} as const;
+
+/**
+ * Audited plugin boundary for Workerd. Every first-party plugin that publishes
+ * an explicit `./edge` entrypoint is registered; Node-only plugins stay behind
+ * the Dedicated handoff instead of being bundled speculatively.
+ */
+export const SHARED_RUNTIME_PLUGIN_COMPATIBILITY = [
+  {
+    plugin: "@elizaos/core/edge",
+    status: "enabled",
+    provides: ["AgentRuntime", "basic actions", "character and dynamic providers"],
+  },
+  {
+    plugin: "@elizaos/plugin-web-search/edge",
+    status: "enabled",
+    provides: ["public web search"],
+  },
+  {
+    plugin: "@elizaos/plugin-scheduling/edge",
+    status: "enabled-when-bound",
+    provides: ["private reminders"],
+  },
+  {
+    plugin: "@elizaos/plugin-todos/edge",
+    status: "enabled-when-bound",
+    provides: ["persistent todos"],
+  },
+  {
+    plugin: "shared-cloud-media",
+    status: "enabled-when-bound",
+    provides: ["image generation"],
+  },
+  {
+    plugin: "node-or-container-only plugins",
+    status: "dedicated-required",
+    provides: ["coding", "shell", "filesystem", "browser", "private account connectors"],
+  },
+] as const;
+
+export interface SharedRuntimeCapabilityOptions {
+  agentId: string;
+  webSearch: boolean;
+  reminders: boolean;
+  todos: boolean;
+  media: boolean;
+}
+
+function availableCapabilities(options: SharedRuntimeCapabilityOptions): string[] {
+  return [
+    "conversation and reasoning",
+    "conversation memory",
+    ...(options.webSearch ? ["public web search"] : []),
+    ...(options.reminders ? ["private reminders"] : []),
+    ...(options.todos ? ["persistent todos"] : []),
+    ...(options.media ? ["image generation"] : []),
+  ];
+}
+
+const DEDICATED_CAPABILITIES = [
+  "coding and sub-agents",
+  "shell and filesystem",
+  "browser or computer control",
+  "connected private accounts",
+  "arbitrary outbound communications",
+] as const;
+
+export function createSharedRuntimeCapabilitiesProvider(
+  options: SharedRuntimeCapabilityOptions,
+): Provider {
+  return {
+    name: SHARED_RUNTIME_CAPABILITIES_PROVIDER,
+    description: "The current Shared runtime's available and Dedicated-only capabilities.",
+    position: -100,
+    cacheStable: true,
+    cacheScope: "turn",
+    roleGate: { minRole: "GUEST" },
+    get: async (): Promise<ProviderResult> => {
+      const available = availableCapabilities(options);
+      return {
+        text: [
+          "# Runtime capabilities",
+          "",
+          "This agent is running on Shared, stateless edge compute.",
+          `Available now: ${available.join(", ")}.`,
+          `Dedicated required: ${DEDICATED_CAPABILITIES.join(", ")}.`,
+          `Use ${REQUEST_DEDICATED_UPGRADE_ACTION} only when the user asks to review upgrading for a capability Shared cannot perform. It opens a review flow and never starts paid compute by itself.`,
+        ].join("\n"),
+        data: {
+          runtimeMode: "shared",
+          agentId: options.agentId,
+          available,
+          dedicatedRequired: [...DEDICATED_CAPABILITIES],
+          canRequestDedicatedReview: true,
+          canActivateDedicatedWithoutConfirmation: false,
+        },
+      };
+    },
+  };
+}
+
+function readParameters(options: unknown): Record<string, unknown> {
+  if (!options || typeof options !== "object") return {};
+  const record = options as Record<string, unknown>;
+  return record.parameters && typeof record.parameters === "object"
+    ? (record.parameters as Record<string, unknown>)
+    : record;
+}
+
+export function createRequestDedicatedUpgradeAction(agentId: string): Action {
+  return {
+    name: REQUEST_DEDICATED_UPGRADE_ACTION,
+    similes: ["UPGRADE_AGENT", "ENABLE_ADVANCED_CAPABILITIES", "GET_DEDICATED"],
+    tags: ["resource:cloud", "capability:read"],
+    contexts: ["general"],
+    roleGate: { minRole: "GUEST" },
+    suppressEarlyReply: true,
+    suppressPostActionContinuation: true,
+    description:
+      "Give the user the explicit review link for moving this Shared agent to Dedicated when they ask for coding, shell, browser control, connected accounts, or another unavailable advanced capability. This action does not purchase, provision, or activate anything.",
+    parameters: [
+      {
+        name: "capability",
+        description: "The unavailable capability that motivated the user's upgrade request.",
+        required: false,
+        schema: { type: "string", maxLength: 160 },
+      },
+    ],
+    validate: async () => true,
+    handler: async (
+      _runtime: IAgentRuntime,
+      _message: Memory,
+      _state?: State,
+      handlerOptions?: unknown,
+      callback?: HandlerCallback,
+    ): Promise<ActionResult> => {
+      const parameters = readParameters(handlerOptions);
+      const capability =
+        typeof parameters.capability === "string" && parameters.capability.trim()
+          ? parameters.capability.trim().slice(0, 160)
+          : "advanced capabilities";
+      const upgradePath = `/cloud/agents/${encodeURIComponent(agentId)}`;
+      const text = `Shared can't perform ${capability}. You can review Dedicated capabilities, price, and confirmation here: ${upgradePath}. Nothing has been activated or charged.`;
+      await callback?.({ text });
+      return {
+        success: true,
+        text,
+        data: {
+          actionName: REQUEST_DEDICATED_UPGRADE_ACTION,
+          capability,
+          upgradePath,
+          mutationPerformed: false,
+          requiresUserConfirmation: true,
+        },
+      };
+    },
+  };
+}
+
+export function createSharedRuntimeCapabilitiesPlugin(
+  options: SharedRuntimeCapabilityOptions,
+): Plugin {
+  return {
+    name: "shared-runtime-capabilities",
+    description: "Shared runtime capability context and safe Dedicated review handoff.",
+    providers: [createSharedRuntimeCapabilitiesProvider(options)],
+    actions: [createRequestDedicatedUpgradeAction(options.agentId)],
+  };
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-channel.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-channel.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Verifies channel metadata accepts canonical runtime values and rejects
+ * malformed or unbounded coordinator payloads.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
+import { parseSharedRuntimeChannel } from "./shared-runtime-channel";
+
+describe("parseSharedRuntimeChannel", () => {
+  test("accepts canonical voice and connector metadata", () => {
+    expect(
+      parseSharedRuntimeChannel({ type: ChannelType.VOICE_DM, source: "client_chat" }),
+    ).toEqual({ type: ChannelType.VOICE_DM, source: "client_chat" });
+    expect(parseSharedRuntimeChannel({ type: ChannelType.DM, source: "telegram" })).toEqual({
+      type: ChannelType.DM,
+      source: "telegram",
+    });
+  });
+
+  test.each([
+    [null],
+    [{}],
+    [{ type: "NOT_A_CHANNEL", source: "client_chat" }],
+    [{ type: ChannelType.DM, source: "" }],
+    [{ type: ChannelType.DM, source: "bad source" }],
+    [{ type: ChannelType.DM, source: "x".repeat(65) }],
+  ])("rejects malformed channel metadata %#", (value) => {
+    expect(parseSharedRuntimeChannel(value)).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-channel.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-channel.ts
@@ -1,0 +1,31 @@
+/**
+ * Defines and validates trusted transport semantics crossing the Shared
+ * coordinator boundary before they are projected into runtime memories.
+ */
+
+import { ChannelType } from "@elizaos/core/edge";
+
+export interface SharedRuntimeChannel {
+  type: ChannelType;
+  source: string;
+}
+
+const CHANNEL_TYPES = new Set<string>(Object.values(ChannelType));
+const CHANNEL_SOURCE = /^[a-z0-9][a-z0-9_-]*$/i;
+const MAX_CHANNEL_SOURCE_LENGTH = 64;
+
+/** Reject malformed boundary data instead of allowing arbitrary metadata. */
+export function parseSharedRuntimeChannel(value: unknown): SharedRuntimeChannel | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as { type?: unknown; source?: unknown };
+  if (typeof candidate.type !== "string" || !CHANNEL_TYPES.has(candidate.type)) return null;
+  if (
+    typeof candidate.source !== "string" ||
+    candidate.source.length === 0 ||
+    candidate.source.length > MAX_CHANNEL_SOURCE_LENGTH ||
+    !CHANNEL_SOURCE.test(candidate.source)
+  ) {
+    return null;
+  }
+  return { type: candidate.type as ChannelType, source: candidate.source };
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -8,6 +8,7 @@
 process.env.MOCK_REDIS = "1";
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 
 let turn: Record<string, unknown>;
 let streamTurn: Record<string, unknown>;
@@ -172,11 +173,13 @@ mock.module("./run-shared-agent-turn", () => ({
     if (turnError) throw turnError;
     const history = Array.isArray(turn.history)
       ? turn.history.map((message, index) =>
-          index === turn.history.length - 2
+          turn.responded === false && index === turn.history.length - 1
             ? { ...message, id: input.messageIds?.user }
-            : index === turn.history.length - 1
-              ? { ...message, id: input.messageIds?.assistant }
-              : message,
+            : index === turn.history.length - 2
+              ? { ...message, id: input.messageIds?.user }
+              : index === turn.history.length - 1
+                ? { ...message, id: input.messageIds?.assistant }
+                : message,
         )
       : turn.history;
     return { ...turn, history };
@@ -545,7 +548,41 @@ describe("SharedRuntimeChatService", () => {
     expect(h.history()).toHaveLength(3);
   });
 
-  test("passes the explicit AgentRuntime transition gate without changing identity", async () => {
+  test("lands a deliberate silent group turn without fabricating an assistant message", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    turn = {
+      degraded: false,
+      responded: false,
+      reply: "",
+      history: [
+        { role: "assistant", content: "prior" },
+        { role: "user", content: "ambient guild chatter" },
+      ],
+      model: "openai/gpt-oss-120b",
+    };
+
+    const response = await service.bridge(
+      agent,
+      { ...rpc, params: { text: "ambient guild chatter", roomId: "guild-room" } },
+      {
+        ...h,
+        funding: "platform",
+        channel: { type: ChannelType.GROUP, source: "discord" },
+      },
+    );
+
+    expect(response.result).toMatchObject({ text: "", responded: false });
+    expect(h.history()).toEqual([
+      { role: "assistant", content: "prior" },
+      expect.objectContaining({ role: "user", content: "ambient guild chatter" }),
+    ]);
+    expect(lastTurnInput?.execution).toMatchObject({
+      channel: { type: ChannelType.GROUP, source: "discord" },
+    });
+  });
+
+  test("always uses AgentRuntime execution without changing identity", async () => {
     const service = new SharedRuntimeChatService();
     const h = harness();
     turn.actionResults = [expectedTodoActionResult];
@@ -553,12 +590,11 @@ describe("SharedRuntimeChatService", () => {
     const response = await service.bridge(agent, rpc, {
       ...h,
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     expect(lastTurnInput?.execution).toEqual({
-      engine: "eliza-runtime",
       agentKey: agent.id,
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
       authenticatedPersonalSharedUser: true,
       todos: expectedTodoExecution,
     });
@@ -588,12 +624,11 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(forgedAgent, forgedRpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     expect(lastTurnInput?.execution).toEqual({
-      engine: "eliza-runtime",
       agentKey: forgedAgent.id,
+      channel: { type: ChannelType.DM, source: "shared-runtime" },
       todos: expectedTodoExecution,
     });
   });
@@ -613,7 +648,6 @@ describe("SharedRuntimeChatService", () => {
     const response = await new SharedRuntimeChatService().stream(agent, rpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     expect(response.status).toBe(200);
@@ -621,8 +655,8 @@ describe("SharedRuntimeChatService", () => {
       JSON.stringify({ actionResults: [expectedTodoActionResult] }).slice(1, -1),
     );
     expect(lastStreamTurnInput?.execution).toEqual({
-      engine: "eliza-runtime",
       agentKey: agent.id,
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
       authenticatedPersonalSharedUser: true,
       todos: expectedTodoExecution,
     });
@@ -654,7 +688,6 @@ describe("SharedRuntimeChatService", () => {
     const response = await new SharedRuntimeChatService().stream(agent, rpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     const body = await response.text();
@@ -686,11 +719,10 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(agent, trustedRpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
     expect(lastTurnInput?.execution).toEqual({
-      engine: "eliza-runtime",
       agentKey: agent.id,
+      channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
       authenticatedPersonalSharedUser: true,
       todos: expectedTodoExecution,
       reminders: {
@@ -706,11 +738,10 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(agent, trustedRpc, {
       ...harness(),
       funding: "organization-credits",
-      executionEngine: "eliza-runtime",
     });
     expect(lastTurnInput?.execution).toEqual({
-      engine: "eliza-runtime",
       agentKey: agent.id,
+      channel: { type: ChannelType.DM, source: "shared-runtime" },
       todos: expectedTodoExecution,
     });
 
@@ -734,7 +765,6 @@ describe("SharedRuntimeChatService", () => {
         {
           ...harness(),
           funding: "platform",
-          executionEngine: "eliza-runtime",
         },
       );
       expect(lastTurnInput?.execution).toMatchObject({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -80,12 +80,15 @@ import {
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
 import { MAX_HISTORY_MESSAGES } from "./shared-runtime-history-policy";
+import type { SharedRuntimeTimingReceipt } from "./shared-runtime-timing";
 import { createSharedScheduledTaskRunner } from "./shared-scheduling";
 import { createSharedTodoStore, sharedTodoStorageScope } from "./shared-todos";
 import { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
 import {
   buildTurnSummary,
+  isSharedTurnTraceSampled,
   recordSharedTurnTrace,
+  resolveSharedTurnTraceSampleRate,
   type SharedTurnSummaryResult,
 } from "./shared-turn-trace-recorder";
 
@@ -158,6 +161,19 @@ function recordTurnTraceOffPath(
   });
 }
 
+/** Keep detailed latency diagnostics on the same bounded sampled off-path as traces. */
+function recordRuntimeTimingOffPath(
+  executionCtx: BridgeExecutionContext | undefined,
+  receipt: SharedRuntimeTimingReceipt,
+): void {
+  if (process.env.SHARED_TURN_TRACES_ENABLED !== "true") return;
+  const sampleRate = resolveSharedTurnTraceSampleRate(process.env.SHARED_TURN_TRACES_SAMPLE);
+  if (!isSharedTurnTraceSampled(receipt.traceId, sampleRate)) return;
+  void settleOffResponsePath(executionCtx, async () => {
+    logger.info("[shared-eliza-runtime] sampled turn latency", receipt);
+  });
+}
+
 function turnActionResults(
   turn: Pick<
     RunSharedAgentTurnResult,
@@ -217,6 +233,8 @@ export interface SharedTurnClaimStore {
 }
 
 export interface SharedRuntimeChatOptions {
+  /** Standard request trace propagated through the conversation coordinator. */
+  traceId?: string;
   abortSignal?: AbortSignal;
   executionCtx?: BridgeExecutionContext;
   historyStore?: SharedRuntimeHistoryStore;
@@ -1145,6 +1163,8 @@ export class SharedRuntimeChatService {
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
+        traceId: options.traceId ?? messageIds.assistant,
+        onRuntimeTiming: (receipt) => recordRuntimeTimingOffPath(options.executionCtx, receipt),
         ...(memoryStore ? { memory: memoryStore } : {}),
         execution: sharedElizaRuntimeExecution(
           agent,
@@ -1172,7 +1192,7 @@ export class SharedRuntimeChatService {
       options.executionCtx,
       agent,
       roomId,
-      messageIds.assistant,
+      options.traceId ?? messageIds.assistant,
       turnStartedAtEpochMs,
       turn,
     );
@@ -1346,6 +1366,8 @@ export class SharedRuntimeChatService {
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
+        traceId: options.traceId ?? messageIds.assistant,
+        onRuntimeTiming: (receipt) => recordRuntimeTimingOffPath(options.executionCtx, receipt),
         execution: sharedElizaRuntimeExecution(
           agent,
           roomId,
@@ -1471,7 +1493,7 @@ export class SharedRuntimeChatService {
           options.executionCtx,
           agent,
           roomId,
-          messageIds.assistant,
+          options.traceId ?? messageIds.assistant,
           streamTurnStartedAtEpochMs,
           {
             model: turn.model,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -7,6 +7,7 @@
  */
 
 import crypto from "node:crypto";
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { parseSharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { UserCharacter } from "../../../db/repositories/characters";
 import { sharedTurnTracesRepository } from "../../../db/repositories/shared-turn-traces";
@@ -178,6 +179,7 @@ function isProviderFreeTurn(turn: Pick<RunSharedAgentTurnResult, "capabilityWall
 /** Terminal result of a landed shared turn, durably replayable by claim key. */
 export interface SharedTurnTerminalResult {
   text: string;
+  responded?: boolean;
   messageId: string;
   userMessageId: string;
   agentName: string;
@@ -225,8 +227,8 @@ export interface SharedRuntimeChatOptions {
   trustedMessageRole?: "system";
   /** Server-authenticated raw utterance when the model message includes connector context. */
   trustedUserUtterance?: string;
-  /** Local/transition gate for proving the genuine Workerd AgentRuntime path. */
-  executionEngine?: "direct-model" | "eliza-runtime";
+  /** Server-resolved transport semantics; untrusted RPC params never populate this. */
+  channel?: NonNullable<RunSharedAgentTurnInput["execution"]>["channel"];
   mobilePushDispatch?: NonNullable<
     NonNullable<RunSharedAgentTurnInput["execution"]>["mobilePush"]
   >["dispatch"];
@@ -399,15 +401,20 @@ function sharedElizaRuntimeExecution(
   funding: SharedRuntimeChatOptions["funding"],
   executionCtx: BridgeExecutionContext | undefined,
   mobilePushDispatch?: SharedRuntimeChatOptions["mobilePushDispatch"],
+  channel?: NonNullable<RunSharedAgentTurnInput["execution"]>["channel"],
 ): NonNullable<RunSharedAgentTurnInput["execution"]> {
   const personalShared = funding === "platform" && isCanonicalPersonalSharedAgent(agent);
+  const runtimeChannel = channel ?? {
+    type: ChannelType.DM,
+    source: personalShared ? MESSAGE_SOURCE_CLIENT_CHAT : "shared-runtime",
+  };
   const reminderDelivery = personalShared ? trustedReminderDelivery(params) : undefined;
   const media = personalShared
     ? personalSharedImagePort(agent, roomId, turnKey, executionCtx)
     : undefined;
   return {
-    engine: "eliza-runtime",
     agentKey: agent.id,
+    channel: runtimeChannel,
     // Personal funding is selected by the server-owned coordinator only after
     // account/tenant resolution; RPC params cannot grant this attestation.
     ...(personalShared ? { authenticatedPersonalSharedUser: true as const } : {}),
@@ -1139,19 +1146,16 @@ export class SharedRuntimeChatService {
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
         ...(memoryStore ? { memory: memoryStore } : {}),
-        ...(options.executionEngine === "eliza-runtime"
-          ? {
-              execution: sharedElizaRuntimeExecution(
-                agent,
-                roomId,
-                claimKey,
-                params,
-                options.funding,
-                options.executionCtx,
-                options.mobilePushDispatch,
-              ),
-            }
-          : {}),
+        execution: sharedElizaRuntimeExecution(
+          agent,
+          roomId,
+          claimKey,
+          params,
+          options.funding,
+          options.executionCtx,
+          options.mobilePushDispatch,
+          options.channel,
+        ),
       });
     } catch (error) {
       await settleFailedProviderWorkOffPath(
@@ -1179,6 +1183,7 @@ export class SharedRuntimeChatService {
       const actionResults = turnActionResults(turn);
       const result: SharedTurnTerminalResult = {
         text: turn.reply,
+        ...(turn.responded === false ? { responded: false } : {}),
         messageId: messageIds.assistant,
         userMessageId: messageIds.user,
         agentName: character.name,
@@ -1341,19 +1346,16 @@ export class SharedRuntimeChatService {
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
-        ...(options.executionEngine === "eliza-runtime"
-          ? {
-              execution: sharedElizaRuntimeExecution(
-                agent,
-                roomId,
-                claimKey,
-                params,
-                options.funding,
-                options.executionCtx,
-                options.mobilePushDispatch,
-              ),
-            }
-          : {}),
+        execution: sharedElizaRuntimeExecution(
+          agent,
+          roomId,
+          claimKey,
+          params,
+          options.funding,
+          options.executionCtx,
+          options.mobilePushDispatch,
+          options.channel,
+        ),
       });
     } catch (error) {
       detachRequestAbort();
@@ -1459,6 +1461,7 @@ export class SharedRuntimeChatService {
             messageIds,
             messageRole,
             interrupted,
+            channel: options.channel,
           });
         }
         await afterWrite?.();
@@ -1509,6 +1512,43 @@ export class SharedRuntimeChatService {
             if (consumerCanceled) continue;
             finished = true;
             const finalReply = part.text.trim() || streamedReply.trim();
+            if (part.responded === false) {
+              await finalizeMessages("", false, async () => {
+                if (claimKey && options.turnClaims) {
+                  await options.turnClaims.complete(claimKey, {
+                    text: "",
+                    responded: false,
+                    messageId: messageIds.assistant,
+                    userMessageId: messageIds.user,
+                    agentName: character.name,
+                    channelId: roomId,
+                    model: turn.model,
+                    degraded: false,
+                    runtime: "shared",
+                    transport: "shared-runtime",
+                  });
+                }
+                terminalSettlementStarted = true;
+                if (isProviderFreeTurn(turn)) await billing?.settle(0);
+                else if (billing) {
+                  await settleOffResponsePath(options.executionCtx, () =>
+                    finishBilling(agent, billing, "", text, part.usage),
+                  );
+                }
+              });
+              controller.enqueue(
+                encoder.encode(
+                  chatSseFrame("done", {
+                    messageId: messageIds.assistant,
+                    userMessageId: messageIds.user,
+                    text: "",
+                    fullText: "",
+                    responded: false,
+                  }),
+                ),
+              );
+              continue;
+            }
             if (!finalReply) {
               // An empty completion is a failed turn: never fabricate, persist,
               // or bill a placeholder reply (repo policy: throw, never fabricate).

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Deterministically exercises bounded per-turn runtime timing receipts,
+ * including concurrent isolation and incomplete failure paths.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { SharedRuntimeTimingCollector } from "./shared-runtime-timing";
+
+function clock(values: number[]): () => number {
+  let index = 0;
+  return () => values[index++] ?? values.at(-1) ?? 0;
+}
+
+describe("SharedRuntimeTimingCollector", () => {
+  test("keeps phase durations distinct from turn-relative offsets", () => {
+    const timing = new SharedRuntimeTimingCollector(
+      "trace-a",
+      3,
+      clock([100, 110, 115, 125, 130, 145, 150, 170, 190, 220, 250]),
+    );
+    timing.markEdgeContextReady();
+    timing.markRuntimeInitializeStarted();
+    timing.markRuntimeReady();
+    timing.markConnectionStarted();
+    timing.markConnectionReady();
+    timing.markHistoryStarted();
+    timing.markHistoryReady();
+    timing.markProviderDispatched();
+    timing.markProviderFirstText();
+
+    expect(timing.receipt("success")).toEqual({
+      traceId: "trace-a",
+      outcome: "success",
+      historyMessageCount: 3,
+      phases: {
+        edgeContextDurationMs: 10,
+        runtimeInitializeDurationMs: 10,
+        connectionDurationMs: 15,
+        historyProjectionDurationMs: 20,
+      },
+      offsets: {
+        providerDispatchOffsetMs: 90,
+        providerFirstTextOffsetMs: 120,
+        completedOffsetMs: 150,
+      },
+    });
+  });
+
+  test("isolates concurrent turns and emits partial aborted receipts", () => {
+    const first = new SharedRuntimeTimingCollector("first", 0, clock([0, 10, 20]));
+    const second = new SharedRuntimeTimingCollector("second", 7, clock([100, 130, 160]));
+    first.markEdgeContextReady();
+    second.markProviderDispatched();
+
+    expect(first.receipt("aborted")).toMatchObject({
+      traceId: "first",
+      outcome: "aborted",
+      phases: { edgeContextDurationMs: 10 },
+      offsets: { providerDispatchOffsetMs: null, completedOffsetMs: 20 },
+    });
+    expect(second.receipt("error")).toMatchObject({
+      traceId: "second",
+      outcome: "error",
+      historyMessageCount: 7,
+      phases: { edgeContextDurationMs: null },
+      offsets: { providerDispatchOffsetMs: 30, completedOffsetMs: 60 },
+    });
+  });
+
+  test("rejects invalid durations and caps pathological values", () => {
+    const timing = new SharedRuntimeTimingCollector("bounded", 0, clock([50, 40, 700_100]));
+    timing.markProviderDispatched();
+    const receipt = timing.receipt("error");
+    expect(receipt.offsets.providerDispatchOffsetMs).toBeNull();
+    expect(receipt.offsets.completedOffsetMs).toBe(600_000);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
@@ -43,6 +43,43 @@ describe("SharedRuntimeTimingCollector", () => {
         providerFirstTextOffsetMs: 120,
         completedOffsetMs: 150,
       },
+      inference: {
+        composeStateDurationMs: null,
+        shouldRespondAndContextDurationMs: null,
+        responseHandlerFieldsDurationMs: null,
+        providerTotalDurationMs: 0,
+        slowestProviderDurationMs: null,
+      },
+      routing: {
+        decision: "unknown",
+        contextIds: [],
+      },
+    });
+  });
+
+  test("records content-free inference phases, provider totals, and routing", () => {
+    const timing = new SharedRuntimeTimingCollector("trace-routing", 2, clock([0, 100]));
+    timing.markInferenceSpans([
+      { name: "composeState", durationMs: 42.25 },
+      { name: "provider:CHARACTER", durationMs: 10.04 },
+      { name: "provider:RECENT_MESSAGES", durationMs: 31.16 },
+      { name: "message:planner", durationMs: 188.88 },
+      { name: "evaluators:response-handler-fields", durationMs: 3.33 },
+    ]);
+    timing.markRoutingDecision("silent", ["Simple", "memory", "simple", "not private"]);
+
+    expect(timing.receipt("success")).toMatchObject({
+      inference: {
+        composeStateDurationMs: 42.3,
+        shouldRespondAndContextDurationMs: 188.9,
+        responseHandlerFieldsDurationMs: 3.3,
+        providerTotalDurationMs: 41.2,
+        slowestProviderDurationMs: 31.2,
+      },
+      routing: {
+        decision: "silent",
+        contextIds: ["simple", "memory"],
+      },
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -1,0 +1,110 @@
+/**
+ * Collects bounded, per-turn Shared runtime latency without retaining content.
+ * Phase durations and turn-relative offsets are separate fields so consumers
+ * cannot accidentally compare unlike measurements.
+ */
+
+const MAX_RUNTIME_TIMING_MS = 10 * 60 * 1_000;
+
+export type SharedRuntimeTimingOutcome = "success" | "aborted" | "error";
+
+export interface SharedRuntimeTimingReceipt {
+  traceId: string;
+  outcome: SharedRuntimeTimingOutcome;
+  historyMessageCount: number;
+  phases: {
+    edgeContextDurationMs: number | null;
+    runtimeInitializeDurationMs: number | null;
+    connectionDurationMs: number | null;
+    historyProjectionDurationMs: number | null;
+  };
+  offsets: {
+    providerDispatchOffsetMs: number | null;
+    providerFirstTextOffsetMs: number | null;
+    completedOffsetMs: number;
+  };
+}
+
+type Clock = () => number;
+
+function boundedDuration(startedAt: number | null, completedAt: number | null): number | null {
+  if (startedAt === null || completedAt === null) return null;
+  const value = completedAt - startedAt;
+  if (!Number.isFinite(value) || value < 0) return null;
+  return Math.round(Math.min(value, MAX_RUNTIME_TIMING_MS) * 10) / 10;
+}
+
+/** Mutable timestamps are private to one invocation and produce an immutable receipt. */
+export class SharedRuntimeTimingCollector {
+  readonly #startedAt: number;
+  readonly #now: Clock;
+  #edgeContextReadyAt: number | null = null;
+  #runtimeInitializeStartedAt: number | null = null;
+  #runtimeReadyAt: number | null = null;
+  #connectionStartedAt: number | null = null;
+  #connectionReadyAt: number | null = null;
+  #historyStartedAt: number | null = null;
+  #historyReadyAt: number | null = null;
+  #providerDispatchedAt: number | null = null;
+  #providerFirstTextAt: number | null = null;
+
+  constructor(
+    readonly traceId: string,
+    readonly historyMessageCount: number,
+    now: Clock = performance.now.bind(performance),
+  ) {
+    this.#now = now;
+    this.#startedAt = now();
+  }
+
+  markEdgeContextReady(): void {
+    this.#edgeContextReadyAt ??= this.#now();
+  }
+  markRuntimeInitializeStarted(): void {
+    this.#runtimeInitializeStartedAt ??= this.#now();
+  }
+  markRuntimeReady(): void {
+    this.#runtimeReadyAt ??= this.#now();
+  }
+  markConnectionStarted(): void {
+    this.#connectionStartedAt ??= this.#now();
+  }
+  markConnectionReady(): void {
+    this.#connectionReadyAt ??= this.#now();
+  }
+  markHistoryStarted(): void {
+    this.#historyStartedAt ??= this.#now();
+  }
+  markHistoryReady(): void {
+    this.#historyReadyAt ??= this.#now();
+  }
+  markProviderDispatched(): void {
+    this.#providerDispatchedAt ??= this.#now();
+  }
+  markProviderFirstText(): void {
+    this.#providerFirstTextAt ??= this.#now();
+  }
+
+  receipt(outcome: SharedRuntimeTimingOutcome): SharedRuntimeTimingReceipt {
+    const completedAt = this.#now();
+    return {
+      traceId: this.traceId,
+      outcome,
+      historyMessageCount: this.historyMessageCount,
+      phases: {
+        edgeContextDurationMs: boundedDuration(this.#startedAt, this.#edgeContextReadyAt),
+        runtimeInitializeDurationMs: boundedDuration(
+          this.#runtimeInitializeStartedAt,
+          this.#runtimeReadyAt,
+        ),
+        connectionDurationMs: boundedDuration(this.#connectionStartedAt, this.#connectionReadyAt),
+        historyProjectionDurationMs: boundedDuration(this.#historyStartedAt, this.#historyReadyAt),
+      },
+      offsets: {
+        providerDispatchOffsetMs: boundedDuration(this.#startedAt, this.#providerDispatchedAt),
+        providerFirstTextOffsetMs: boundedDuration(this.#startedAt, this.#providerFirstTextAt),
+        completedOffsetMs: boundedDuration(this.#startedAt, completedAt) ?? 0,
+      },
+    };
+  }
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -7,6 +7,12 @@
 const MAX_RUNTIME_TIMING_MS = 10 * 60 * 1_000;
 
 export type SharedRuntimeTimingOutcome = "success" | "aborted" | "error";
+export type SharedRuntimeRoutingDecision = "respond" | "silent" | "unknown";
+
+export interface SharedRuntimeInferenceSpan {
+  name: string;
+  durationMs: number;
+}
 
 export interface SharedRuntimeTimingReceipt {
   traceId: string;
@@ -23,6 +29,17 @@ export interface SharedRuntimeTimingReceipt {
     providerFirstTextOffsetMs: number | null;
     completedOffsetMs: number;
   };
+  inference: {
+    composeStateDurationMs: number | null;
+    shouldRespondAndContextDurationMs: number | null;
+    responseHandlerFieldsDurationMs: number | null;
+    providerTotalDurationMs: number;
+    slowestProviderDurationMs: number | null;
+  };
+  routing: {
+    decision: SharedRuntimeRoutingDecision;
+    contextIds: string[];
+  };
 }
 
 type Clock = () => number;
@@ -30,6 +47,11 @@ type Clock = () => number;
 function boundedDuration(startedAt: number | null, completedAt: number | null): number | null {
   if (startedAt === null || completedAt === null) return null;
   const value = completedAt - startedAt;
+  if (!Number.isFinite(value) || value < 0) return null;
+  return Math.round(Math.min(value, MAX_RUNTIME_TIMING_MS) * 10) / 10;
+}
+
+function boundedMeasuredDuration(value: number): number | null {
   if (!Number.isFinite(value) || value < 0) return null;
   return Math.round(Math.min(value, MAX_RUNTIME_TIMING_MS) * 10) / 10;
 }
@@ -47,6 +69,13 @@ export class SharedRuntimeTimingCollector {
   #historyReadyAt: number | null = null;
   #providerDispatchedAt: number | null = null;
   #providerFirstTextAt: number | null = null;
+  #composeStateDurationMs: number | null = null;
+  #shouldRespondAndContextDurationMs: number | null = null;
+  #responseHandlerFieldsDurationMs: number | null = null;
+  #providerTotalDurationMs = 0;
+  #slowestProviderDurationMs: number | null = null;
+  #routingDecision: SharedRuntimeRoutingDecision = "unknown";
+  #contextIds: string[] = [];
 
   constructor(
     readonly traceId: string,
@@ -85,6 +114,42 @@ export class SharedRuntimeTimingCollector {
     this.#providerFirstTextAt ??= this.#now();
   }
 
+  markInferenceSpans(spans: readonly SharedRuntimeInferenceSpan[]): void {
+    const providerDurations: number[] = [];
+    for (const span of spans) {
+      const durationMs = boundedMeasuredDuration(span.durationMs);
+      if (durationMs === null) continue;
+      if (span.name === "composeState") {
+        this.#composeStateDurationMs = durationMs;
+      } else if (span.name === "message:planner") {
+        this.#shouldRespondAndContextDurationMs = durationMs;
+      } else if (span.name === "evaluators:response-handler-fields") {
+        this.#responseHandlerFieldsDurationMs = durationMs;
+      }
+      if (span.name.startsWith("provider:")) providerDurations.push(durationMs);
+    }
+    this.#providerTotalDurationMs =
+      Math.round(
+        Math.min(
+          providerDurations.reduce((total, durationMs) => total + durationMs, 0),
+          MAX_RUNTIME_TIMING_MS,
+        ) * 10,
+      ) / 10;
+    this.#slowestProviderDurationMs =
+      providerDurations.length > 0 ? Math.max(...providerDurations) : null;
+  }
+
+  markRoutingDecision(decision: SharedRuntimeRoutingDecision, contextIds: readonly string[]): void {
+    this.#routingDecision = decision;
+    this.#contextIds = Array.from(
+      new Set(
+        contextIds
+          .map((contextId) => contextId.trim().toLowerCase())
+          .filter((contextId) => /^[a-z0-9_-]{1,64}$/.test(contextId)),
+      ),
+    ).slice(0, 16);
+  }
+
   receipt(outcome: SharedRuntimeTimingOutcome): SharedRuntimeTimingReceipt {
     const completedAt = this.#now();
     return {
@@ -104,6 +169,17 @@ export class SharedRuntimeTimingCollector {
         providerDispatchOffsetMs: boundedDuration(this.#startedAt, this.#providerDispatchedAt),
         providerFirstTextOffsetMs: boundedDuration(this.#startedAt, this.#providerFirstTextAt),
         completedOffsetMs: boundedDuration(this.#startedAt, completedAt) ?? 0,
+      },
+      inference: {
+        composeStateDurationMs: this.#composeStateDurationMs,
+        shouldRespondAndContextDurationMs: this.#shouldRespondAndContextDurationMs,
+        responseHandlerFieldsDurationMs: this.#responseHandlerFieldsDurationMs,
+        providerTotalDurationMs: this.#providerTotalDurationMs,
+        slowestProviderDurationMs: this.#slowestProviderDurationMs,
+      },
+      routing: {
+        decision: this.#routingDecision,
+        contextIds: [...this.#contextIds],
       },
     };
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-retry-budget.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-retry-budget.ts
@@ -1,0 +1,15 @@
+/**
+ * Defines the bounded AI SDK retry budget for latency-sensitive Shared turns.
+ */
+
+/** Resolve the operator override while preventing multi-retry backoff stalls. */
+export function resolveSharedTurnMaxRetries(
+  raw: string | undefined = process.env.SHARED_TURN_MAX_RETRIES,
+): number {
+  if (raw === undefined || raw.trim() === "") return 0;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.min(parsed, 2);
+}
+
+export const SHARED_TURN_MAX_RETRIES = resolveSharedTurnMaxRetries();

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -79,6 +79,7 @@ describe("eliza sse bridge", () => {
     );
 
     expect(observed).toHaveLength(1);
+    expect(observed[0]).toMatchObject({ status: 200 });
     expect(observed[0]?.elapsedMs).toBeGreaterThanOrEqual(0);
     expect(observed[0]?.serverTiming).toBe("turn_hydrate;dur=12.3, turn_admission;dur=4.5");
   });
@@ -548,10 +549,13 @@ describe("eliza sse bridge", () => {
     expect(deltas).toEqual([]);
   });
 
-  test("propagates the voice trace header", async () => {
-    let seenHeader: string | null = null;
+  test("propagates both voice and standard trace headers", async () => {
+    let seenVoiceHeader: string | null = null;
+    let seenStandardHeader: string | null = null;
     const fetchImpl = (async (_url: string, init: RequestInit) => {
-      seenHeader = new Headers(init.headers).get(VOICE_TRACE_HEADER);
+      const headers = new Headers(init.headers);
+      seenVoiceHeader = headers.get(VOICE_TRACE_HEADER);
+      seenStandardHeader = headers.get("X-Eliza-Trace-Id");
       return sseResponse(["data: [DONE]\n\n"]);
     }) as unknown as typeof fetch;
     await streamElizaConversation(
@@ -568,7 +572,29 @@ describe("eliza sse bridge", () => {
       },
       () => {},
     );
-    expect(seenHeader).toBe("trace-XYZ");
+    expect(seenVoiceHeader).toBe("trace-XYZ");
+    expect(seenStandardHeader).toBe("trace-XYZ");
+  });
+
+  test("does not let a timing observer failure break a healthy stream", async () => {
+    const result = await streamElizaConversation(
+      {
+        endpoint: "http://x",
+        authorization: "Bearer s",
+        model: "m",
+        transcript: "hi",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        traceId: "trace-observer",
+        signal: new AbortController().signal,
+        fetchImpl: (async () => sseResponse(["data: [DONE]\n\n"])) as unknown as typeof fetch,
+        onResponseHeaders: () => {
+          throw new Error("diagnostics unavailable");
+        },
+      },
+      () => undefined,
+    );
+    expect(result).toEqual({ completed: true, aborted: false });
   });
 
   test("uses the canonical persisted message route with minted agent + conversation identity", async () => {

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -21,6 +21,8 @@
  */
 
 import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
+import { ELIZA_TRACE_ID_HEADER } from "../observability/http-telemetry";
+import { logger } from "../utils/logger";
 
 export const VOICE_TRACE_HEADER = "X-Eliza-Voice-Trace-Id";
 /** Scope headers so the configured endpoint routes the turn to the right agent. */
@@ -63,6 +65,8 @@ export interface ElizaSseBridgeRequest {
 }
 
 export interface ElizaSseBridgeResponseHeaders {
+  /** HTTP result for this attempt, including retryable non-2xx responses. */
+  status: number;
   /** Time from dispatch until the canonical route returned streaming headers. */
   elapsedMs: number;
   /** Sanitized phase timings emitted by the canonical Shared route. */
@@ -131,6 +135,7 @@ export async function streamElizaConversation(
         "X-Service-Key": request.authorization,
         Accept: "text/event-stream",
         [VOICE_TRACE_HEADER]: request.traceId,
+        [ELIZA_TRACE_ID_HEADER]: request.traceId,
         [VOICE_AGENT_HEADER]: request.agentId,
         [VOICE_CONVERSATION_HEADER]: request.conversationId,
         ...(request.organizationId ? { [VOICE_ORGANIZATION_HEADER]: request.organizationId } : {}),
@@ -165,10 +170,20 @@ export async function streamElizaConversation(
     );
   }
 
-  request.onResponseHeaders?.({
-    elapsedMs: Math.round((performance.now() - fetchStartedAt) * 10) / 10,
-    serverTiming: response.headers.get("Server-Timing"),
-  });
+  try {
+    request.onResponseHeaders?.({
+      status: response.status,
+      elapsedMs: Math.round((performance.now() - fetchStartedAt) * 10) / 10,
+      serverTiming: response.headers.get("Server-Timing"),
+    });
+  } catch (error) {
+    // error-policy:J7 diagnostics must not kill the loop — response decoding is
+    // authoritative and an optional header observer cannot reject healthy SSE.
+    logger.warn("[eliza-sse-bridge] response header observer failed", {
+      traceId: request.traceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   if (!response.ok) {
     const upstreamError = await readUpstreamError(response);

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -525,8 +525,6 @@ export interface Bindings {
   INFERENCE_PASSTHROUGH_STREAMING?: string;
   RATE_LIMIT_DISABLED?: string;
   RATE_LIMIT_MULTIPLIER?: string;
-  /** Transition gate for the genuine AgentRuntime-backed Shared turn. */
-  SHARED_ELIZA_AGENT_RUNTIME?: string;
   PLAYWRIGHT_TEST_AUTH?: string;
   PLAYWRIGHT_TEST_AUTH_SECRET?: string;
   TWILIO_SMS_COST_PER_SEGMENT_USD?: string;

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1714,6 +1714,58 @@ describe("runV5MessageRuntimeStage1", () => {
 		);
 	});
 
+	it("keeps shouldRespond in the compact live-voice Stage-1 call", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				shouldRespond: "IGNORE",
+				contexts: ["simple"],
+				replyText: "",
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				channelType: ChannelType.VOICE_DM,
+				text: "uh huh",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("terminal");
+		if (result.kind === "terminal") {
+			expect(result.action).toBe("IGNORE");
+		}
+		const firstCall = useModelCalls(runtime)[0];
+		expect(firstCall).toBeDefined();
+		if (!firstCall) {
+			throw new Error("Expected the voice Stage-1 model call to be captured");
+		}
+		const params = firstCall[1] as {
+			tools?: Array<{ parameters?: { required?: string[] } }>;
+			responseSkeleton?: { spans?: Array<{ key?: string }> };
+			messages?: Array<{ content?: unknown }>;
+		};
+		const required = params.tools?.[0]?.parameters?.required ?? [];
+		expect(required).toContain("shouldRespond");
+		expect(required).toContain("contexts");
+		expect(required).not.toContain("facts");
+		expect(
+			params.responseSkeleton?.spans?.some(
+				(span) => span.key === "shouldRespond",
+			),
+		).toBe(true);
+		const systemContent = String(params.messages?.[0]?.content ?? "");
+		expect(systemContent).toContain(
+			"task: Decide whether to respond, then plan this live voice turn.",
+		);
+		expect(systemContent).toContain(
+			"shouldRespond=IGNORE for content-free acknowledgements",
+		);
+		expect(systemContent.length).toBeLessThan(5_000);
+	});
+
 	it("keeps generic programming questions on the simple path even when stale attachments linger in state", async () => {
 		// Regression for the false-positive routing where a verb like "read"
 		// in a normal dev question ("read a large file line by line in node")

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -45,6 +45,7 @@ export { generateMediaAction } from "./features/advanced-capabilities/actions/ge
 export * from "./features/basic-capabilities/index.edge";
 export * from "./generated/action-docs";
 export * from "./generated/spec-helpers";
+export type { InferenceTurnSummary } from "./inference-timing";
 export * from "./logger";
 export * from "./markdown";
 export * from "./memory";

--- a/packages/core/src/runtime/__tests__/response-grammar.test.ts
+++ b/packages/core/src/runtime/__tests__/response-grammar.test.ts
@@ -140,16 +140,20 @@ describe("buildResponseGrammar — Stage-1 envelope", () => {
 		);
 	});
 
-	it("treats one-to-one voice as a direct channel", () => {
+	it("keeps turn-taking on one-to-one voice while omitting sidecar fields", () => {
 		clearResponseGrammarCache();
 		const { responseSkeleton, grammar } = buildResponseGrammar(
 			{ actions: [] },
 			{ contexts: ["general"], channelType: "VOICE_DM" },
 		);
 		expect(responseSkeleton.spans.some((s) => s.key === "shouldRespond")).toBe(
+			true,
+		);
+		expect(responseSkeleton.spans.some((s) => s.key === "facts")).toBe(false);
+		expect(responseSkeleton.spans.some((s) => s.key === "relationships")).toBe(
 			false,
 		);
-		expect(grammar).not.toContain(
+		expect(grammar).toContain(
 			'"\\"RESPOND\\"" | "\\"IGNORE\\"" | "\\"STOP\\""',
 		);
 	});
@@ -263,7 +267,7 @@ describe("buildResponseGrammar — Stage-1 envelope", () => {
 		expect(c).not.toBe(a);
 	});
 
-	it("shares direct-channel semantics with one-to-one voice", () => {
+	it("separates text-direct and one-to-one voice grammar profiles", () => {
 		clearResponseGrammarCache();
 		const direct = buildResponseGrammar(
 			{ actions: [] },
@@ -273,14 +277,14 @@ describe("buildResponseGrammar — Stage-1 envelope", () => {
 			{ actions: [] },
 			{ contexts: ["general"], channelType: "VOICE_DM" },
 		);
-		expect(direct).toBe(voice);
-		expect(direct.responseSkeleton.id).toBe(voice.responseSkeleton.id);
+		expect(direct).not.toBe(voice);
+		expect(direct.responseSkeleton.id).not.toBe(voice.responseSkeleton.id);
 		expect(
 			direct.responseSkeleton.spans.some((s) => s.key === "shouldRespond"),
 		).toBe(false);
 		expect(
 			voice.responseSkeleton.spans.some((s) => s.key === "shouldRespond"),
-		).toBe(false);
+		).toBe(true);
 	});
 });
 

--- a/packages/core/src/runtime/response-grammar.ts
+++ b/packages/core/src/runtime/response-grammar.ts
@@ -827,7 +827,9 @@ function selectResponseFieldsForChannel(
 ): ResponseHandlerFieldShape[] {
 	if (!isDirectResponseChannel(channelType)) return fields;
 	return fields.filter(
-		(field) => !DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS.has(field.name),
+		(field) =>
+			!DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS.has(field.name) ||
+			(channelType === "VOICE_DM" && field.name === "shouldRespond"),
 	);
 }
 
@@ -999,9 +1001,12 @@ export function buildResponseGrammar(
 		fields.length === baseFields.length
 			? suppliedFieldSignature
 			: `${suppliedFieldSignature}|selected:${deriveFieldSignature(fields)}`;
-	const channelProfile = isDirectResponseChannel(options.channelType)
-		? "direct"
-		: "default";
+	const channelProfile =
+		options.channelType === "VOICE_DM"
+			? "voice-direct"
+			: isDirectResponseChannel(options.channelType)
+				? "direct"
+				: "default";
 
 	const cacheKey = [
 		"stage1",

--- a/packages/core/src/services/message.deliver-then-persist.test.ts
+++ b/packages/core/src/services/message.deliver-then-persist.test.ts
@@ -449,14 +449,25 @@ describe("simple-path deliver-then-persist ordering", () => {
 
 	it("overlaps reply delivery with persistence and records reply time independently", async () => {
 		const h = await createHarness({ persistDelayMs: 150 });
+		let observedTurnId: string | undefined;
 
-		await h.service.handleMessage(h.runtime, h.makeMessage(), async () => {
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			return [];
-		});
+		await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage(),
+			async () => {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return [];
+			},
+			{
+				onInferenceTimingSummary: (summary) => {
+					observedTurnId = summary.turnId;
+				},
+			},
+		);
 
 		const turn = inferenceTimingRegistry.recentTurns(1)[0];
 		expect(turn).toBeDefined();
+		expect(observedTurnId).toBe(turn.turnId);
 		const callbackSpan = turn.spans.find(
 			(s) => s.name === "message:delivery:callback",
 		);
@@ -472,7 +483,7 @@ describe("simple-path deliver-then-persist ordering", () => {
 		expect(persistSpan.startMs).toBeLessThanOrEqual(callbackSpan.endMs);
 		expect(persistSpan.durationMs).toBeGreaterThanOrEqual(140);
 		expect(turn.timeToReplyMs).not.toBeNull();
-		expect(turn.timeToReplyMs as number).toBeLessThan(persistSpan.endMs);
+		expect(turn.timeToReplyMs as number).toBeLessThanOrEqual(persistSpan.endMs);
 	});
 
 	it("bars a same-room follow-up fired from the delivery callback from composing until the reply persist completes", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -435,10 +435,14 @@ const DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS = new Set([
 
 function buildDirectChannelResponseFieldSelection(
 	fields: ReadonlyArray<Pick<ResponseHandlerFieldEvaluator, "name">>,
+	options?: { includeShouldRespond?: boolean },
 ): ResponseHandlerFieldSelectionOptions {
 	const includeFieldNames = new Set<string>();
 	for (const field of fields) {
-		if (!DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS.has(field.name)) {
+		if (
+			!DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS.has(field.name) ||
+			(options?.includeShouldRespond === true && field.name === "shouldRespond")
+		) {
 			includeFieldNames.add(field.name);
 		}
 	}
@@ -4504,6 +4508,22 @@ direct/private rules:
 Return one {{handleResponseToolName}} JSON object; no prose, markdown, or thinking.
 `;
 
+// Live voice keeps the compact direct-message prompt and its single model call,
+// but must retain the runtime's engagement decision. This pays no additional
+// inference round trip while allowing natural acknowledgements and ambient
+// speech to end in deliberate silence.
+const VOICE_DIRECT_MESSAGE_HANDLER_TEMPLATE =
+	DIRECT_MESSAGE_HANDLER_TEMPLATE.replace(
+		"task: Plan this direct message.",
+		"task: Decide whether to respond, then plan this live voice turn.",
+	).replace("- Never invent omitted shouldRespond.\n", "");
+const VOICE_ENGAGEMENT_RULES = [
+	"- shouldRespond=RESPOND for a completed caller question, request, substantive statement, or conversational continuation.",
+	"- shouldRespond=IGNORE for content-free acknowledgements, non-speech/noise, or ambient speech clearly not addressed to the agent.",
+	"- shouldRespond=STOP only when the caller explicitly asks the agent to disengage or end the conversation.",
+	"- Do not use IGNORE merely because the answer is brief, uncertain, or requires a tool.",
+].join("\n");
+
 /**
  * Answer-free refusal stubs, matched against the WHOLE normalized reply after
  * an optional leading apology ("I'm sorry, but …") is stripped. A refusal that
@@ -4795,21 +4815,27 @@ function renderMessageHandlerInstructions(
 	availableContexts: readonly ContextDefinition[],
 	options?: {
 		directMessage?: boolean;
+		voiceDirectMessage?: boolean;
 		groupTriage?: boolean;
 		responseHandlerFields?: string;
 	},
 ): string {
-	// Three tiers: DM/private (compact, no shouldRespond), unaddressed
+	// Four tiers: DM/private (compact, no shouldRespond), live voice DM
+	// (compact + shouldRespond), unaddressed
 	// group-triage (compact + shouldRespond — most such turns end in IGNORE,
 	// so they must not pay the full ~16KB rule block), and the full template
 	// for addressed/respond-likely turns.
 	const compactTier =
-		options?.directMessage === true || options?.groupTriage === true;
-	const baselineTemplate = options?.directMessage
-		? DIRECT_MESSAGE_HANDLER_TEMPLATE
-		: options?.groupTriage
-			? GROUP_TRIAGE_MESSAGE_HANDLER_TEMPLATE
-			: messageHandlerTemplate;
+		options?.directMessage === true ||
+		options?.voiceDirectMessage === true ||
+		options?.groupTriage === true;
+	const baselineTemplate = options?.voiceDirectMessage
+		? VOICE_DIRECT_MESSAGE_HANDLER_TEMPLATE
+		: options?.directMessage
+			? DIRECT_MESSAGE_HANDLER_TEMPLATE
+			: options?.groupTriage
+				? GROUP_TRIAGE_MESSAGE_HANDLER_TEMPLATE
+				: messageHandlerTemplate;
 	const baseline = resolveOptimizedPromptForRuntime(
 		runtime,
 		selectMessageHandlerTask(availableContexts),
@@ -4825,12 +4851,19 @@ function renderMessageHandlerInstructions(
 		},
 		template: baseline,
 	}).trim();
-	const renderedWithSharedRules = compactTier
-		? [rendered, "", `- ${COMPACT_CODE_SNIPPET_VALIDITY_INSTRUCTION}`].join(
+	const renderedWithVoiceRules = options?.voiceDirectMessage
+		? [rendered, "", "voice engagement rules:", VOICE_ENGAGEMENT_RULES].join(
 				"\n",
 			)
+		: rendered;
+	const renderedWithSharedRules = compactTier
+		? [
+				renderedWithVoiceRules,
+				"",
+				`- ${COMPACT_CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
+			].join("\n")
 		: [
-				rendered,
+				renderedWithVoiceRules,
 				"",
 				"## Shared Response Quality Rules",
 				`- ${CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
@@ -4853,6 +4886,7 @@ function renderMessageHandlerModelInput(
 	availableContexts: readonly ContextDefinition[] = [],
 	options?: {
 		directMessage?: boolean;
+		voiceDirectMessage?: boolean;
 		groupTriage?: boolean;
 		responseHandlerFields?: string;
 	},
@@ -7725,6 +7759,8 @@ export async function runV5MessageRuntimeStage1(args: {
 			args.message.content?.channelType === ChannelType.VOICE_DM ||
 			args.message.content?.channelType === ChannelType.API ||
 			args.message.content?.channelType === ChannelType.SELF;
+		const voiceDirectMessageChannel =
+			args.message.content?.channelType === ChannelType.VOICE_DM;
 		// Ambient turn = a positively-identified unaddressed text-group turn
 		// (structural classifier only — channel type + addressing + source
 		// metadata, never message text; anything uncertain fails open to
@@ -7760,7 +7796,9 @@ export async function runV5MessageRuntimeStage1(args: {
 		// point) but render the compressed prompt slices; the schema is
 		// unaffected by `compact` so the HANDLE_RESPONSE contract is identical.
 		const responseHandlerFieldSelection = directMessageChannel
-			? buildDirectChannelResponseFieldSelection(responseHandlerFields)
+			? buildDirectChannelResponseFieldSelection(responseHandlerFields, {
+					includeShouldRespond: voiceDirectMessageChannel,
+				})
 			: groupTriageTurn
 				? { compact: true }
 				: undefined;
@@ -7782,7 +7820,8 @@ export async function runV5MessageRuntimeStage1(args: {
 			context,
 			availableContexts,
 			{
-				directMessage: directMessageChannel,
+				directMessage: directMessageChannel && !voiceDirectMessageChannel,
+				voiceDirectMessage: voiceDirectMessageChannel,
 				groupTriage: groupTriageTurn,
 				responseHandlerFields: responseHandlerFieldPrompt.rendered,
 			},

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1515,6 +1515,7 @@ type ResolvedMessageOptions = {
 	roomHandlerLease?: RoomHandlerLease;
 	onSettledActionResult?: (result: ActionResult) => void;
 	onTrajectoryTerminalOwner?: (owner: "run") => void;
+	onInferenceTimingSummary?: (summary: InferenceTurnSummary) => void;
 	runTerminalOwner?: MessageRunTerminalOwner;
 };
 
@@ -12341,6 +12342,11 @@ export class DefaultMessageService implements IMessageService {
 								onTrajectoryTerminalOwner: options.onTrajectoryTerminalOwner,
 							}
 						: {}),
+					...(options?.onInferenceTimingSummary
+						? {
+								onInferenceTimingSummary: options.onInferenceTimingSummary,
+							}
+						: {}),
 				};
 
 				const deliveredVisibleTexts = new Set<string>();
@@ -12625,6 +12631,21 @@ export class DefaultMessageService implements IMessageService {
 						? emitInferenceTiming(inferenceTimer)
 						: null;
 					if (inferenceSummary) {
+						try {
+							opts.onInferenceTimingSummary?.(inferenceSummary);
+						} catch (error) {
+							// error-policy:J7 host timing export must not replace the
+							// user-visible result whose summary it observes.
+							runtime.logger.warn(
+								{ error, turnId: inferenceSummary.turnId },
+								"Inference timing summary callback failed",
+							);
+							runtime.reportError(
+								"MessageService.inferenceTimingSummary",
+								error,
+								{ turnId: inferenceSummary.turnId },
+							);
+						}
 						detachPostDeliverySideEffect(
 							runtime,
 							"persist_inference_timing",

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -4,6 +4,7 @@
  * shapes the message service returns. Consumed by the runtime message handler.
  */
 
+import type { InferenceTurnSummary } from "../inference-timing";
 import type { RoomHandlerLease } from "../runtime/room-handler-queue";
 import type {
 	ActionResult,
@@ -52,6 +53,12 @@ export interface MessageProcessingOptions {
 	 * mistaken for a delivery-only trajectory terminal.
 	 */
 	onTrajectoryTerminalOwner?: (owner: "run") => void;
+	/**
+	 * Receives the exact closed turn timing summary synchronously after response
+	 * delivery. Hosting boundaries can export edge telemetry before disposing an
+	 * ephemeral runtime; callback failures are diagnostic-only.
+	 */
+	onInferenceTimingSummary?: (summary: InferenceTurnSummary) => void;
 	/**
 	 * When true, do not discard responses when a newer message is being processed (same as BASIC_CAPABILITIES_KEEP_RESP).
 	 * @default resolved from runtime.getSetting("BASIC_CAPABILITIES_KEEP_RESP") if not set

--- a/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
@@ -80,6 +80,7 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
       stop,
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -134,6 +135,7 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
       stop: vi.fn(),
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -164,6 +166,7 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
       stop,
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -208,6 +211,7 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
       stop,
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -249,6 +253,7 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
       stop,
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 

--- a/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
@@ -64,6 +64,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop,
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -124,6 +125,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([9, 9])),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -185,6 +187,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop,
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -253,6 +256,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([1, 2])),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -357,6 +361,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const { result } = renderHook(() =>
       useVoiceChat({
@@ -382,6 +387,7 @@ describe("useVoiceChat cloud ASR", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     fetchWithCsrfMock.mockImplementation(async (input) => {
       const url = typeof input === "string" ? input : String(input);

--- a/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
@@ -54,6 +54,7 @@ describe("useVoiceChat local ASR", () => {
       stop,
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
     const onTranscriptPreview = vi.fn();

--- a/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
@@ -71,6 +71,7 @@ describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
       stop,
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
 
@@ -127,6 +128,7 @@ describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
       stop: vi.fn(),
       cancel,
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
 
     const { result } = renderHook(() =>

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -101,6 +101,7 @@ describe("createVoiceCapture", () => {
           stop,
           cancel: vi.fn(),
           analyser: null,
+          inputDevice: { deviceId: "test-mic", label: "Test microphone" },
         };
       },
     );
@@ -138,6 +139,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
       cancel: vi.fn(),
       analyser,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const capture = createVoiceCapture({
       asrProvider: "local-inference",
@@ -187,6 +189,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(wav),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
     const capture = createVoiceCapture({
@@ -216,6 +219,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(wav),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
     const capture = createVoiceCapture({
@@ -381,6 +385,7 @@ describe("createVoiceCapture", () => {
       stop,
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
     const onStateChange = vi.fn();
@@ -418,6 +423,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(wav),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     const onTranscript = vi.fn();
     const capture = createVoiceCapture({
@@ -444,6 +450,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(wav),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     isSilentWavMock.mockReturnValue(true);
     const onTranscript = vi.fn();
@@ -479,6 +486,7 @@ describe("createVoiceCapture", () => {
       stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
       cancel: vi.fn(),
       analyser: null,
+      inputDevice: { deviceId: "test-mic", label: "Test microphone" },
     });
     transcribeCloudWavMock.mockRejectedValue(new Error("Cloud ASR 502: down"));
     const onTranscript = vi.fn();


### PR DESCRIPTION
# Relates to

Closes #21794.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; the implementation was repeatedly rebased without conflicts. One unrelated coding-tools commit landed after the final validation rebase and is left to GitHub's merge gate.
- [x] `bun install` completed. `bun run verify` reached 237/356 workspace tasks and failed only on the then-current `plugin-whatsapp` `.ts` import suffix; upstream #22607 fixed that exact failure, and the rebased package typecheck now passes.
- [x] Deterministic runtime, voice lifecycle, and connector evidence is recorded below. Live staging/PSTN evidence remains an explicit pre-merge deployment gate.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f92f84628085f6fa079e106afc655de1e41c5aca:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` repeatedly with zero conflicts; latest validated base was `139bc02a8b640f0fa0c4bf4c3cf0a3738ffc46c5`.
- [x] The only full-gate failure was the upstream WhatsApp suffix regression fixed by #22607; exact-head `plugin-whatsapp`, UI, core, Cloud Shared, and Cloud API checks pass.

# Risks

Large runtime-path change. It affects Personal Shared text, voice, Discord, Telegram, and BlueBubbles/iMessage routing. Main risks are workerd compatibility, first-turn cold hydration, provider latency, conversation idempotency, and transport cancellation. The implementation fails closed on unsupported tools and preserves Durable Object serialization.

# Background

## What does this PR do?

- Replaces the alternate Shared-agent inference engine with the canonical elizaOS `AgentRuntime` for every ordinary Shared turn.
- Projects the full behavioral character while excluding secrets, settings, knowledge, and plugin authority.
- Adds the `SHARED_RUNTIME_CAPABILITIES` provider and `REQUEST_DEDICATED_UPGRADE` action. The action creates a review handoff only; it cannot provision or charge.
- Loads the edge-compatible web search, reminders, todos, and injected-media capabilities through genuine runtime plugins; Node/container-only capabilities remain explicit Dedicated upgrades.
- Preserves trusted channel provenance (`DM`, `GROUP`, `VOICE_DM`, `VOICE_GROUP`) so the runtime owns should-respond behavior and silent turns.
- Adds content-free timing receipts for runtime initialization, history hydration, compose state, provider totals/slowest provider, routing, first model text/audio, TTS transport, and upstream retries.
- Reuses the Cartesia transport across the opening greeting and first response, makes barge-in cancel only active synthesis, and wakes cold-turn retries as soon as prewarm completes.
- Integrates the canonical workerd schema-convergence fix from #22582 via the now-merged upstream commit.
- Repairs integration-base test fixtures exposed by the full repository gate.

## What kind of change is this?

Feature, performance improvement, and regression fix; no intended public API break.

# Documentation changes needed?

No end-user documentation change is required. The capability provider is the runtime-visible documentation of Shared versus Dedicated support.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts`
2. `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts`
3. `packages/cloud/api/v1/voice/session/lib/session.ts`
4. `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts`

## Detailed testing steps

- Core runtime grammar/Stage 1/delivery: 238 passed.
- Shared Runtime, character, tools, memory, timing, REST, channel and coordinator contracts: 180 passed.
- Durable Object prewarm/history/cutover: 32 passed.
- Voice WebSocket lifecycle: 61 passed, including greeting socket reuse, prewarm wake, cache-warming retries, Cartesia terminal frames, barge-in with zero post-cancel audio, transcript-confirmed interruption, reconnect, and teardown.
- Discord managed text/voice/DM policy: 32 passed.
- Telegram edge and voice-note contracts: 23 passed.
- BlueBubbles/iMessage auth, inbound policy, connector, webhook and dedupe: 43 passed.
- Cloud Worker production dry bundle: 24.4 MiB upload / 5.8 MiB gzip with `SHARED_RUNTIME_CONVERSATIONS` bound.
- Exact-head typechecks: core, cloud-shared, cloud-api, UI, plugin-whatsapp.

# Evidence Gate

<!-- evidence-head:01a2a8f81b55693df0d16e2af5335a70005bb424 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI behavior changed; UI edits only repair typed test fixtures.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI behavior changed; UI edits only repair typed test fixtures.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI surface changed. Live audio acceptance is tracked below.
<!-- evidence-row:backend-logs -->
- [ ] Pending staging deployment - attach content-free timing receipts and exact deployed SHA before merge.
<!-- evidence-row:frontend-logs -->
- [x] N/A - this change is Worker/runtime/telephony and connector routing, not frontend state.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending staging deployment - attach a real Shared AgentRuntime trajectory before merge.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending staging deployment - attach voice audio/timing trace plus connector receipts before merge.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

Pending the staging deployment from this PR head. Deterministic genuine-runtime tests prove the execution boundary but are not represented as live-model evidence.

## Backend + frontend logs

Pending staging content-free timing receipt. No sensitive transcript content is logged by the new instrumentation.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI change.

## Audio / voice walkthrough

Pending staging deploy and action-time phone confirmation. The automated voice lifecycle suite passes 61/61 and proves zero post-barge-in audio frames.

## Known gaps / failures

- `bun run verify` on the prior base failed only at `plugin-whatsapp/src/normalize.ts` because that upstream source imported `./whatsapp-target-prefix.ts`. Upstream #22607 removed the suffix; the branch was rebased and `bun run --cwd plugins/plugin-whatsapp typecheck` passes.
- Live PSTN, real-model, Discord, Telegram, and iMessage delivery evidence must be captured from the deployed staging SHA. No handset call was initiated without action-time confirmation.
- Production promotion remains gated on exact-head CI, staging acceptance, and a `develop` to `main` PR.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f92f84628085f6fa079e106afc655de1e41c5aca:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-shared-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@f92f84628085f6fa079e106afc655de1e41c5aca:packages/skills/skills/contribute-to-eliza"} -->
