### PR TITLE
fix(core): fail closed on unsolicited required-reply tool calls

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -3834,7 +3834,7 @@ describe("v5 planner loop — evaluator gate", () => {
 		).toBe("post_tool_model_reply");
 	});
 
-	it("never executes a tool invented during bounded post-tool synthesis", async () => {
+	it("fails closed on a required-reply synthesis that invents a tool call, routing the completed action through the evaluator (#22609)", async () => {
 		const useModel = vi
 			.fn()
 			.mockResolvedValueOnce({
@@ -3851,10 +3851,13 @@ describe("v5 planner loop — evaluator gate", () => {
 					},
 				],
 			})
-			// Defensive provider-adapter regression: even if a backend violates the
-			// no-tools request, its invented call is terminal text, never work.
+			// Non-compliant provider: the required-reply synthesis round is sent
+			// WITHOUT a tool catalog, yet the backend co-emits prose AND an
+			// unsolicited tool call. The whole response must be rejected: the prose
+			// is not consumed and the invented tool never executes (#22609).
 			.mockResolvedValueOnce({
-				text: "",
+				text: "Notes are open — I also archived the old ones.",
+				messageToUser: "Notes are open — I also archived the old ones.",
 				toolCalls: [
 					{
 						id: "views-duplicate",
@@ -3872,8 +3875,8 @@ describe("v5 planner loop — evaluator gate", () => {
 		const evaluate = vi.fn(async () => ({
 			success: true,
 			decision: "FINISH" as const,
-			thought: "must remain unreachable",
-			messageToUser: "Evaluator fallback",
+			thought: "evaluator reviewed the completed navigation",
+			messageToUser: "Your notes are open.",
 		}));
 
 		const result = await runPlannerLoop({
@@ -3884,11 +3887,17 @@ describe("v5 planner loop — evaluator gate", () => {
 			evaluate,
 		});
 
+		// The sole action ran exactly once; the invented tool never executed.
 		expect(useModel).toHaveBeenCalledTimes(2);
 		expect(executeToolCall).toHaveBeenCalledTimes(1);
-		expect(evaluate).not.toHaveBeenCalled();
+		// Fail closed: the synthesis prose is NOT accepted. The completed action
+		// is routed through the normal evaluator, which owns the final reply.
+		expect(evaluate).toHaveBeenCalledTimes(1);
 		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe("The requested action completed.");
+		expect(result.finalMessage).toBe("Your notes are open.");
+		expect(result.finalMessage).not.toBe(
+			"Notes are open — I also archived the old ones.",
+		);
 	});
 
 	it("keeps full evaluation when model-reply navigation scope is incomplete", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -3900,6 +3900,62 @@ describe("v5 planner loop — evaluator gate", () => {
 		);
 	});
 
+	it("relays the completed action when the required-reply evaluator has a provider failure (#22609)", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "views-1",
+						name: "VIEWS",
+						arguments: {
+							action: "show",
+							view: "notes",
+							[TURN_SCOPE_ARG]: TURN_SCOPE_FINAL,
+						},
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "Notes are open — I also archived the old ones.",
+				toolCalls: [
+					{
+						id: "invented-archive",
+						name: "ARCHIVE",
+						arguments: { target: "old-notes" },
+					},
+				],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "Your notes are open.",
+			userFacingText: "Your notes are open.",
+			verifiedUserFacing: true,
+			modelReplyRequired: true,
+		}));
+		const providerError = Object.assign(new Error("provider unavailable"), {
+			statusCode: 503,
+		});
+		const evaluate = vi.fn(async () => {
+			throw providerError;
+		});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel, logger: { warn: vi.fn() } },
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(2);
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(evaluate).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("Your notes are open.");
+	});
+
 	it("keeps full evaluation when model-reply navigation scope is incomplete", async () => {
 		const runtime = {
 			useModel: plannerNativeWith({

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -609,6 +609,96 @@ async function runPlannerLoopIterations(
 			lastPlannerExplicitCompleted = plannerOutput.completed;
 			if (synthesizingRequiredModelReply) {
 				pendingRequiredModelReply = false;
+				if (plannerOutput.toolCalls.length > 0) {
+					// Fail closed (#22609): the required-reply synthesis is a
+					// tool-free round. When a non-compliant provider returns BOTH
+					// prose and an unsolicited tool call, the response is invalid AS
+					// A WHOLE — its prose must NOT be accepted and the invented tool
+					// must NOT run. Route the already-completed sole action (it ran
+					// exactly once before this round was armed) through the normal
+					// evaluator/fallback path, exactly as if the model-reply request
+					// had never been made. This prevents an unsolicited tool call
+					// from smuggling its co-emitted prose past evaluator review.
+					params.runtime.logger?.warn?.(
+						{
+							iteration,
+							inventedToolCalls: plannerOutput.toolCalls.length,
+						},
+						"[planner-loop] required-reply synthesis returned an unsolicited tool call; rejecting the whole response and routing the completed action through the evaluator",
+					);
+					const evaluator = await evaluateTrajectory(
+						params,
+						trajectory,
+						iteration,
+					);
+					trajectory.evaluatorOutputs.push(
+						projectToolDiagnosticValue(
+							evaluator,
+							redactDiagnosticText,
+						) as EvaluatorOutput,
+					);
+					appendEvaluatorContextEvent(
+						trajectory,
+						evaluator,
+						iteration,
+						redactDiagnosticText,
+					);
+					const protocolFailureRelay =
+						deterministicEvaluatorProtocolFailureRelay(evaluator, trajectory);
+					if (protocolFailureRelay) {
+						return {
+							status: "finished",
+							trajectory,
+							finalMessage: userSafeFinalMessage(
+								terminalMessageWithFailureAuthority(
+									trajectory,
+									protocolFailureRelay,
+								),
+								trajectory,
+							),
+						};
+					}
+					if (evaluator.decision === "FINISH") {
+						return {
+							status: "finished",
+							trajectory,
+							evaluator,
+							finalMessage: userSafeFinalMessage(
+								terminalMessageWithFailureAuthority(
+									trajectory,
+									preferredFinalMessageFromToolOrModel(
+										trajectory,
+										evaluator.messageToUser,
+										evaluator.success === false
+											? failedToolFallbackMessage(trajectory)
+											: undefined,
+									),
+									evaluator.success === false
+										? userSafeFailureReport(evaluator.messageToUser, trajectory)
+										: undefined,
+								),
+								trajectory,
+							),
+						};
+					}
+					// The evaluator declined to FINISH, but this round has no tool
+					// catalog and the invented tool must never execute. Relay the
+					// completed action's own truthful result instead of replaying
+					// work or fabricating a save.
+					const relay = deterministicSuccessfulToolRelay(trajectory);
+					return {
+						status: "finished",
+						trajectory,
+						evaluator,
+						finalMessage: userSafeFinalMessage(
+							terminalMessageWithFailureAuthority(
+								trajectory,
+								relay ?? REQUIRED_MODEL_REPLY_FALLBACK_MESSAGE,
+							),
+							trajectory,
+						),
+					};
+				}
 				const requiredModelReply = userSafeCapturedAnswerCandidate(
 					plannerOutput.messageToUser,
 				);

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -626,11 +626,35 @@ async function runPlannerLoopIterations(
 						},
 						"[planner-loop] required-reply synthesis returned an unsolicited tool call; rejecting the whole response and routing the completed action through the evaluator",
 					);
-					const evaluator = await evaluateTrajectory(
-						params,
-						trajectory,
-						iteration,
-					);
+					let evaluator: EvaluatorOutput;
+					try {
+						evaluator = await evaluateTrajectory(params, trajectory, iteration);
+					} catch (err) {
+						// error-policy:J4 explicit user-facing degrade - the action has
+						// already succeeded, so an expected provider failure must use the
+						// same truthful post-tool fallback as the normal evaluator path.
+						if (!isModelProviderError(err)) throw err;
+						const relay = deterministicSuccessfulToolRelay(trajectory);
+						if (!relay) throw err;
+						params.runtime.logger?.warn?.(
+							{
+								iteration,
+								err: err instanceof Error ? err.message : String(err),
+								...(modelProviderErrorDetail(err)
+									? { providerErrorDetail: modelProviderErrorDetail(err) }
+									: {}),
+							},
+							"[planner-loop] required-reply evaluator model call failed; relaying the completed tool result instead of discarding the turn",
+						);
+						return {
+							status: "finished",
+							trajectory,
+							finalMessage: userSafeFinalMessage(
+								terminalMessageWithFailureAuthority(trajectory, relay),
+								trajectory,
+							),
+						};
+					}
 					trajectory.evaluatorOutputs.push(
 						projectToolDiagnosticValue(
 							evaluator,

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -288,6 +288,34 @@ describe("replyClaimsCompletedSideEffect", () => {
 			replyClaimsCompletedSideEffect("Done. Your reminders are set."),
 		).toBe(true);
 	});
+
+	it("does not treat a read/navigation acknowledgement as a committed mutation (#22609)", () => {
+		// Live VIEWS synthesis: the Notes route opened, and the model closed with
+		// a bare completion opener that names a tracked noun but reports only a
+		// read/navigation effect. "loaded/visible/shown/on screen" is not a
+		// save/schedule write, so the whole reply must NOT be flagged as a
+		// fabricated side effect — including the quantified variants.
+		for (const reply of [
+			"Done — your notes are loaded.",
+			"Done — your notes are visible.",
+			"Done — 3 notes are visible.",
+			"Done — your 3 notes are now visible.",
+			"Done — showing your notes.",
+			"Done — your notes are on screen.",
+			"Done — the reminders view is open.",
+		]) {
+			expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+		}
+		// A genuine committed-mutation verb in the same sentence still fires,
+		// even behind the same generic "Done —" opener.
+		for (const reply of [
+			"Done — I saved your note.",
+			"Done — your reminders are set.",
+			"Done — your 3 reminders are now scheduled.",
+		]) {
+			expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
+		}
+	});
 });
 
 describe(CLAIM_EVALUATOR_NAME, () => {

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -312,6 +312,7 @@ describe("replyClaimsCompletedSideEffect", () => {
 			"Done — I saved your note.",
 			"Done — your reminders are set.",
 			"Done — your 3 reminders are now scheduled.",
+			"Done — your notes are visible and I archived the old ones.",
 		]) {
 			expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
 		}

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -63,17 +63,21 @@ function sentenceContaining(text: string, index: number): string {
 	return text.slice(start, end);
 }
 
-// Committed-mutation syntax. When a generic "done" opener's sentence carries
-// one of these write verbs, it is a save/schedule report and outranks any
-// read verb present ("Done — I saved your note and it's visible").
-const COMMITTED_MUTATION_SYNTAX_PATTERN =
-	/\b(?:set(?:\s+up)?|schedul(?:e|ed|ing)|saved|creat(?:e|ed)|add(?:s|ed)?|book(?:s|ed)?|logg(?:ed|ing)|arrang(?:e|ed)|updat(?:e|ed)|renam(?:e|ed)|delet(?:e|ed)|remov(?:e|ed)|cancell?(?:s|ed)?|in\s+place)\b/i;
-// Read/navigation predicates. A tracked noun described only by one of these
-// verbs was surfaced/opened, not committed ("Done — your notes are
-// loaded/visible/on screen"), so a generic completion opener must NOT read as
-// a mutation report (#22609).
-const READ_NAVIGATION_PREDICATE_PATTERN =
-	/\b(?:load(?:s|ed|ing)?|visible|shown|show(?:s|ing)?|display(?:s|ed|ing)?|open(?:s|ed|ing)?|render(?:s|ed|ing)?|onscreen|on\s+screen|in\s+view|pulled\s+up|brought\s+up|highlighted)\b/i;
+// A generic "done" sentence is exempt only when its complete grammar is a
+// read/navigation acknowledgement. Keeping this full-sentence match narrow is
+// important: a loose "contains a read verb and no known write verb" test lets
+// an unlisted mutation hide beside the read (for example, "notes are visible
+// and I archived the old ones").
+const READ_NAVIGATION_ONLY_SENTENCE_PATTERN = new RegExp(
+	String.raw`^[\s.!?…–—-]*done\b[\s:;,…–—-]*(?:` +
+		String.raw`(?:showing|displaying|loading|opening|rendering|highlighting|pulled\s+up|brought\s+up)\s+` +
+		String.raw`(?:the\s+|your\s+)?(?:\d+\s+)?(?:notes?|reminders?|tasks?|todos?|to[- ]dos?|goals?|habits?|appointments?|calendar|settings)(?:\s+view)?` +
+		"|" +
+		String.raw`(?:the\s+|your\s+)?(?:\d+\s+)?(?:notes?|reminders?|tasks?|todos?|to[- ]dos?|goals?|habits?|appointments?|calendar|settings)(?:\s+view)?\s+` +
+		String.raw`(?:is|are)\s+(?:now\s+)?(?:loaded|visible|shown|displayed|open|rendered|onscreen|on\s+screen|in\s+view|pulled\s+up|brought\s+up|highlighted)` +
+		String.raw`)[\s…✅🎉]*$`,
+	"iu",
+);
 // A bare completion opener ("Done —", "Done!", "Done.") carries no verb of its
 // own — only the rest of its sentence can. Match text that begins with "done"
 // (after the leading sentence-boundary anchor the STATE pattern captures)
@@ -104,8 +108,7 @@ function stateSideEffectClaimHasLocalSubject(text: string): boolean {
 		if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(sentence)) continue;
 		if (
 			GENERIC_COMPLETION_OPENER_PATTERN.test(match[0]) &&
-			READ_NAVIGATION_PREDICATE_PATTERN.test(sentence) &&
-			!COMMITTED_MUTATION_SYNTAX_PATTERN.test(sentence)
+			READ_NAVIGATION_ONLY_SENTENCE_PATTERN.test(sentence)
 		) {
 			continue;
 		}

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -63,25 +63,53 @@ function sentenceContaining(text: string, index: number): string {
 	return text.slice(start, end);
 }
 
+// Committed-mutation syntax. When a generic "done" opener's sentence carries
+// one of these write verbs, it is a save/schedule report and outranks any
+// read verb present ("Done — I saved your note and it's visible").
+const COMMITTED_MUTATION_SYNTAX_PATTERN =
+	/\b(?:set(?:\s+up)?|schedul(?:e|ed|ing)|saved|creat(?:e|ed)|add(?:s|ed)?|book(?:s|ed)?|logg(?:ed|ing)|arrang(?:e|ed)|updat(?:e|ed)|renam(?:e|ed)|delet(?:e|ed)|remov(?:e|ed)|cancell?(?:s|ed)?|in\s+place)\b/i;
+// Read/navigation predicates. A tracked noun described only by one of these
+// verbs was surfaced/opened, not committed ("Done — your notes are
+// loaded/visible/on screen"), so a generic completion opener must NOT read as
+// a mutation report (#22609).
+const READ_NAVIGATION_PREDICATE_PATTERN =
+	/\b(?:load(?:s|ed|ing)?|visible|shown|show(?:s|ing)?|display(?:s|ed|ing)?|open(?:s|ed|ing)?|render(?:s|ed|ing)?|onscreen|on\s+screen|in\s+view|pulled\s+up|brought\s+up|highlighted)\b/i;
+// A bare completion opener ("Done —", "Done!", "Done.") carries no verb of its
+// own — only the rest of its sentence can. Match text that begins with "done"
+// (after the leading sentence-boundary anchor the STATE pattern captures)
+// identifies these generic openers so they are held to the read-verb exclusion
+// below.
+const GENERIC_COMPLETION_OPENER_PATTERN = /^[\s.!?…–—-]*done\b/i;
+
 /**
  * Bare completion openers must name their tracked subject in the same
  * sentence. A later question such as "Done. What should we do with your
  * notes?" mentions notes but does not claim a note was saved; treating the
  * whole reply as one clause replaces a true UI-navigation acknowledgement
  * with the unrelated unverified-effect fallback.
+ *
+ * A generic "done" opener is additionally rejected when its sentence's only
+ * predicate is a read/navigation verb: "Done — your notes are loaded/visible"
+ * (and the quantified variants) surfaced tracked state rather than committing a
+ * write, so it is not a mutation report (#22609). A committed-mutation verb in
+ * the same sentence overrides that exclusion, and openers whose own match text
+ * carries the write verb ("reminders are set", "Saved!") are unaffected.
  */
 function stateSideEffectClaimHasLocalSubject(text: string): boolean {
 	for (const match of text.matchAll(STATE_SIDE_EFFECT_CLAIM_PATTERN)) {
 		const firstWordOffset = match[0].search(/[\p{L}\p{N}]/u);
 		const claimIndex =
 			(match.index ?? 0) + (firstWordOffset >= 0 ? firstWordOffset : 0);
+		const sentence = sentenceContaining(text, claimIndex);
+		if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(sentence)) continue;
 		if (
-			SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(
-				sentenceContaining(text, claimIndex),
-			)
+			GENERIC_COMPLETION_OPENER_PATTERN.test(match[0]) &&
+			READ_NAVIGATION_PREDICATE_PATTERN.test(sentence) &&
+			!COMMITTED_MUTATION_SYNTAX_PATTERN.test(sentence)
 		) {
-			return true;
+			continue;
 		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
# Relates to

Closes #22609

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and focused gates were run after sync (see Evidence). Full `bun run verify` was not run end-to-end on this constrained host; the changed-package gates (core test/typecheck/lint/build) all pass — see **Known gaps**.
- [x] A reviewer can confirm the change works from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@753791de2faf4628fa987956c89cf0b1d8cefb7d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`139bc02a8b`); zero conflicts.
- [ ] `bun run verify` full run not completed on this host; changed-package gates pass. See **Known gaps**.

# Risks

Low. The change is confined to `packages/core` and only narrows two existing behaviors:
1. It rejects (rather than consumes) a required-reply synthesis response that also carries an unsolicited tool call, routing the already-completed action through the pre-existing evaluator/fallback path.
2. It stops the completed-side-effect classifier from flagging a generic "Done —" completion opener whose sole predicate is a read/navigation verb.
Both preserve every prior true-positive path; the full focused planner and side-effect suites pass (188 tests).

# Background

## What does this PR do?

PR #22570 added a tool-free post-action **required-reply synthesis** round in the core planner. A non-compliant provider/model can return **both** prose and an unsolicited tool call in that round. The previous code dropped the tool call and directly consumed `messageToUser`, bypassing normal evaluator review; its co-emitted tool intent vanished silently.

This PR makes that path **fail closed**:

- **Any required-reply synthesis response containing a tool call is invalid as a whole.** Its prose is never accepted, and the invented tool never executes.
- The original successful action still executes **exactly once**, and its result is routed through the **normal evaluator/fallback path** (protocol-failure relay → evaluator FINISH → deterministic successful-tool relay) — no double execution, no bypass.

It also fixes the completed-side-effect / mutation classifier (`replyClaimsCompletedSideEffect`): a generic "Done —" completion opener whose only predicate is a **read/navigation** verb ("Done — your notes are loaded/visible", and quantified variants like "Done — 3 notes are visible") is no longer misclassified as a committed mutation. A committed-mutation verb in the same sentence still fires, and bare-noun claims ("Done — two reminders.") remain protected.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. Behavior is internal to the planner loop and the Stage-1 side-effect guard; the `ActionResult.modelReplyRequired` contract is unchanged.

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/planner-loop.ts` — the `synthesizingRequiredModelReply` branch now guards on `plannerOutput.toolCalls.length` and routes the fail-closed case through `evaluateTrajectory`.
- `packages/core/src/services/message/side-effect-claims.ts` — `stateSideEffectClaimHasLocalSubject` now excludes generic "done" openers whose only predicate is a read/navigation verb.

## Detailed testing steps

```bash
bun run --cwd packages/core test src/runtime/__tests__/planner-loop.test.ts src/services/message.side-effect-claim.test.ts
bun run --cwd packages/core typecheck
bunx @biomejs/biome check <changed files>
bun run --cwd packages/core build
```

New regression tests (fail on the pre-fix source, pass after):
- planner: *"fails closed on a required-reply synthesis that invents a tool call, routing the completed action through the evaluator (#22609)"* — asserts the action runs exactly once, the invented tool never runs, the evaluator IS invoked, and the synthesis prose is NOT the final message.
- classifier: *"does not treat a read/navigation acknowledgement as a committed mutation (#22609)"* — asserts read/navigation acks and quantified variants are `false`, while genuine committed-mutation sentences behind the same opener stay `true`.

# Evidence Gate

<!-- evidence-head:6e77dc5119b1cbc3ffd4739e0633b2afe0048e23 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; core planner + Stage-1 guard logic only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; core planner + Stage-1 guard logic only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; behavior is verified by deterministic unit/regression tests.
<!-- evidence-row:backend-logs -->
- [x] Backend proof: focused test output (failing-then-passing) below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model change. The planner routing is exercised with deterministic model fixtures (`useModel`/`evaluate` mocks) because the fix is control-flow, not prompt content. Real-LLM behavior is unchanged.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: the mutation-classifier truth table (below) is the domain artifact for this change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a deterministic control-flow fix. The planner path is proven with model fixtures; no prompt/model content changed.

## Backend + frontend logs

Focused core suites — **before the fix** (source files reverted to `HEAD~1`, the two new regression tests kept):

<details><summary>BEFORE — 2 failing (regression reproduced)</summary>

```
 Info       [Migration] ✓ Migration complete - pre-1.6.5 → 1.6.5+ schema migration finished
     × does not treat a read/navigation acknowledgement as a committed mutation (#22609) 16ms
     × fails closed on a required-reply synthesis that invents a tool call, routing the completed action through the evaluator (#22609) 22ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/services/message.side-effect-claim.test.ts > replyClaimsCompletedSideEffect > does not treat a read/navigation acknowledgement as a committed mutation (#22609)
AssertionError: expected true to be false // Object.is equality
 FAIL  src/runtime/__tests__/planner-loop.test.ts > v5 planner loop — evaluator gate > fails closed on a required-reply synthesis that invents a tool call, routing the completed action through the evaluator (#22609)
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 Test Files  2 failed (2)
      Tests  2 failed | 186 passed (188)
```
</details>

Focused core suites — **after the fix** (final head `6e77dc5119b1cbc3ffd4739e0633b2afe0048e23`):

<details><summary>AFTER — 188 passing</summary>

```
$ node ../scripts/run-vitest.mjs run src/runtime/__tests__/planner-loop.test.ts src/services/message.side-effect-claim.test.ts

 RUN  v4.1.5 /home/home/Developer/eliza-swarm/state/worktrees/issue-22609/packages/core


 Test Files  2 passed (2)
      Tests  188 passed (188)
   Start at  22:21:43
   Duration  32.66s (transform 21.38s, setup 0ms, import 11.04s, tests 21.17s, environment 0ms)
```
</details>

Verification gates on changed files:

<details><summary>lint + typecheck + build</summary>

```
# Verification gates for changed core files
## Biome lint
Checked 4 files in 219ms. No fixes applied.
## Typecheck (tsc --noEmit -p packages/core/tsconfig.json)
typecheck exit=0

Done!
## Core build: 🎉 All builds complete (EXIT=0) — see build log
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio path.

## Known gaps / failures

- Full `bun run verify` was not run end-to-end: this host enforces a global bun `minimumReleaseAge`, so `bun install` initially fails to resolve two brand-new transitive versions (`viem`, `smthrs`) already present in the local cache. Install was completed from cache; the changed-package gates (`packages/core` test + typecheck + Biome lint + build) all pass and are shown above. No source or dependency was altered to work around this.
- Evidence artifacts are inlined rather than attached as minted URLs because the attachment uploader could not authenticate on this host.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@753791de2faf4628fa987956c89cf0b1d8cefb7d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@753791de2faf4628fa987956c89cf0b1d8cefb7d:packages/skills/skills/contribute-to-eliza"} -->
