### PR TITLE
fix: package the real Electrobun desktop as Flatpak

### DIFF
--- a/.github/workflows/electrobun-contract.yml
+++ b/.github/workflows/electrobun-contract.yml
@@ -3,6 +3,11 @@ name: Validate Electrobun Release Workflow
 
 on:
   workflow_dispatch:
+    inputs:
+      run_flatpak_e2e:
+        description: Build, install, and exercise the exact-head Flatpak without publishing
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -33,3 +38,91 @@ jobs:
         run: |
           bun run test:regression-matrix:release-contract
           bun run test:release:contract
+
+  flatpak-e2e:
+    name: Flatpak package, install, and liveness
+    if: ${{ inputs.run_flatpak_e2e }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout exact workflow ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Verify exact workflow head
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android
+          docker system prune -af || true
+
+      - name: Install Linux desktop and Flatpak dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            flatpak \
+            libayatana-appindicator3-1 \
+            libgtk-3-0 \
+            libwebkit2gtk-4.1-0 \
+            mesa-utils \
+            xauth \
+            xvfb
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user --noninteractive -y flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Build exact Electrobun desktop tree
+        run: node packages/app-core/scripts/desktop-build.mjs build
+
+      - name: Package exact desktop tree as Flatpak
+        run: |
+          version="$(node -p "require('./packages/app-core/platforms/electrobun/package.json').version")"
+          node packages/app-core/scripts/package-electrobun-flatpak.mjs \
+            --version="$version" \
+            --arch=x86_64
+
+      - name: Install and exercise Flatpak artifact
+        run: |
+          bundle="$(find packages/app-core/platforms/electrobun/artifacts -maxdepth 1 -type f -name '*.flatpak' -print -quit)"
+          test -n "$bundle"
+          flatpak install --user --noninteractive -y --reinstall "$bundle"
+          set +e
+          timeout 45s xvfb-run --auto-servernum \
+            --server-args="-screen 0 1280x900x24 -nolisten tcp" \
+            flatpak run ai.elizaos.app
+          status=$?
+          set -e
+          if [ "$status" -ne 124 ]; then
+            echo "::error::Flatpak app exited before the 45-second liveness window (status $status)."
+            exit 1
+          fi
+          flatpak info --user ai.elizaos.app
+
+      - name: Upload exact Flatpak artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: flatpak-exact-head
+          path: packages/app-core/platforms/electrobun/artifacts/*.flatpak
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/electrobun-contract.yml
+++ b/.github/workflows/electrobun-contract.yml
@@ -74,8 +74,8 @@ jobs:
             xvfb
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user --noninteractive -y flathub \
-            org.freedesktop.Platform//24.08 \
-            org.freedesktop.Sdk//24.08
+            org.gnome.Platform//49 \
+            org.gnome.Sdk//49
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -489,7 +489,12 @@ jobs:
             curl \
             desktop-file-utils \
             file \
+            flatpak \
             rpm
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user --noninteractive -y flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08
 
       - name: Install root dependencies
         # --ignore-scripts skips native dependency install scripts (e.g. @tensorflow/tfjs-node
@@ -900,6 +905,35 @@ jobs:
             --version=${{ needs.prepare.outputs.version }} \
             --channel=${{ needs.prepare.outputs.env }} \
             --arch=x64
+          node packages/app-core/scripts/package-electrobun-flatpak.mjs \
+            --version=${{ needs.prepare.outputs.version }} \
+            --arch=x86_64
+
+      - name: Smoke test packaged Linux desktop
+        if: matrix.platform.os == 'linux' && steps.build-electrobun-app.outputs.fallback != 'true'
+        env:
+          ELIZA_TEST_PACKAGED_AUTO_BUILD: "0"
+          STARTUP_TIMEOUT: "420"
+          LIVENESS_TIMEOUT: "10"
+          SKIP_BUILD: "1"
+          SKIP_SIGNATURE_CHECK: "1"
+        run: bun run test:desktop:packaged
+
+      - name: Install and launch Flatpak artifact
+        if: matrix.platform.os == 'linux' && steps.build-electrobun-app.outputs.fallback != 'true'
+        run: |
+          bundle="$(find packages/app-core/platforms/electrobun/artifacts -maxdepth 1 -type f -name '*.flatpak' -print -quit)"
+          test -n "$bundle"
+          flatpak install --user --noninteractive -y --reinstall "$bundle"
+          set +e
+          timeout 45s flatpak run ai.elizaos.app
+          status=$?
+          set -e
+          if [ "$status" -ne 124 ]; then
+            echo "::error::Flatpak app exited before the 45-second liveness window (status $status)."
+            exit 1
+          fi
+          flatpak info --user ai.elizaos.app
 
       - name: List build output
         run: |
@@ -1646,6 +1680,7 @@ jobs:
             packages/app-core/platforms/electrobun/artifacts/*.AppImage
             packages/app-core/platforms/electrobun/artifacts/*.deb
             packages/app-core/platforms/electrobun/artifacts/*.rpm
+            packages/app-core/platforms/electrobun/artifacts/*.flatpak
             packages/app-core/platforms/electrobun/artifacts/*.tar.zst
             packages/app-core/platforms/electrobun/artifacts/*.exe
             packages/app-core/platforms/electrobun/artifacts/*.exe.zip

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -490,6 +490,7 @@ jobs:
             desktop-file-utils \
             file \
             flatpak \
+            libayatana-appindicator3-1 \
             rpm \
             xauth \
             xvfb

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -490,7 +490,9 @@ jobs:
             desktop-file-utils \
             file \
             flatpak \
-            rpm
+            rpm \
+            xauth \
+            xvfb
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user --noninteractive -y flathub \
             org.freedesktop.Platform//24.08 \
@@ -926,7 +928,9 @@ jobs:
           test -n "$bundle"
           flatpak install --user --noninteractive -y --reinstall "$bundle"
           set +e
-          timeout 45s flatpak run ai.elizaos.app
+          timeout 45s xvfb-run --auto-servernum \
+            --server-args="-screen 0 1280x900x24 -nolisten tcp" \
+            flatpak run ai.elizaos.app
           status=$?
           set -e
           if [ "$status" -ne 124 ]; then

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -495,8 +495,8 @@ jobs:
             xvfb
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user --noninteractive -y flathub \
-            org.freedesktop.Platform//24.08 \
-            org.freedesktop.Sdk//24.08
+            org.gnome.Platform//49 \
+            org.gnome.Sdk//49
 
       - name: Install root dependencies
         # --ignore-scripts skips native dependency install scripts (e.g. @tensorflow/tfjs-node

--- a/packages/app-core/packaging/flatpak/README.md
+++ b/packages/app-core/packaging/flatpak/README.md
@@ -1,160 +1,44 @@
-# Flatpak packaging — store and direct variants
+# Flatpak packaging status
 
-Two manifests live in this directory. They produce the same `ai.elizaos.App`
-app-id, but with very different sandbox postures.
+The canonical desktop release workflow packages the already-built and tested
+Electrobun Linux tree with
+`packages/app-core/scripts/package-electrobun-flatpak.mjs`. The resulting
+side-loadable `.flatpak` contains the same desktop runtime revision as the
+AppImage, Debian, and RPM artifacts. It is installed and held through a
+45-second launch-liveness check before release artifacts are uploaded.
 
-| Variant | Manifest | Wrapper | Posture | Distribution |
-|---------|----------|---------|---------|--------------|
-| **Store** (Flathub) | `ai.elizaos.App.store.yml` | `elizaos-app-wrapper.store.sh` | Locked-down sandbox, no host escape | Flathub |
-| **Direct** (power-user) | `ai.elizaos.App.yml` | `elizaos-app-wrapper.sh` | Full `$HOME` access, host shell reach, EXECUTE_CODE permitted | Self-hosted repo, side-loaded bundles |
-
-Pick the variant that matches the audience. Flathub will reject the direct
-manifest on review. Power users who want host-Ollama, docker reach, and
-EXECUTE_CODE want the direct manifest (or, equivalently, the AppImage /
-.deb / .rpm builds).
-
-The build is selected by the `ELIZA_BUILD_VARIANT` env var at build time —
-see `bun run build:flatpak` (`packages/app-core/scripts/build-flatpak.mjs`).
-
-## Sandbox philosophy (store variant)
-
-The store manifest grants only the capabilities a managed-cloud Eliza
-agent needs:
-
-- `--share=network` — cloud APIs, model providers, plugin registry, the
-  loopback web dashboard.
-- `--share=ipc` — required for localhost loopback the dashboard binds.
-- `--socket=wayland` + `--socket=fallback-x11` — desktop integration.
-- `--filesystem=xdg-documents/Eliza:create` — a single user-granted
-  workspace folder under `~/Documents/Eliza`. The user picks (or
-  confirms) this through the FileChooser portal at first run.
-- `--filesystem=xdg-config/elizaos-app:create` — config and account
-  storage under `~/.config/elizaos-app`.
-- `--persist=.eliza` — `~/.eliza` is rewritten transparently by
-  Flatpak to `~/.var/app/ai.elizaos.App/.eliza`, surviving upgrades.
-- `--talk-name=org.freedesktop.Notifications` — desktop notifications.
-- `--talk-name=org.kde.StatusNotifierWatcher` — system tray.
-
-What it explicitly does NOT grant — and what bubblewrap therefore blocks
-unconditionally:
-
-- **No `--filesystem=home` / `--filesystem=host`.** No reading or writing
-  outside the granted folders.
-- **No `--talk-name=org.freedesktop.Flatpak`.** That D-Bus name is the
-  host-spawn portal; it is the standard way for sandboxed apps to escape
-  the sandbox and run host commands. The store posture forbids host
-  escape, so it is excluded.
-- **No `--device=all`.** No raw device access.
-- **No `--socket=session-bus` / `--socket=system-bus`.** Direct D-Bus
-  exposure would let the runtime talk to anything; we go through the
-  portal stack instead.
-
-The runtime reads `ELIZA_BUILD_VARIANT=store` (set by the store wrapper)
-and gates off:
-
-- PATH-lookup CLI spawning (no `bun`, `python`, `git`, `docker`, etc. on
-  the host PATH — they're not in `$PATH` inside the sandbox anyway, but
-  the runtime reports the disablement explicitly so users see "local
-  agent execution disabled in this build" instead of opaque ENOENT).
-- The `EXECUTE_CODE` action.
-- Host-Ollama discovery (no `127.0.0.1:11434` reach — the sandbox sees
-  its own loopback, not the host's, so Ollama-on-host wouldn't work
-  even if we tried).
-
-Hosting flips to the cloud-only routing: the agent talks to Eliza Cloud
-for inference, plugin registry, app deploys, billing, and any other
-backend that would otherwise have a local fallback.
-
-## Required portals
-
-The store variant relies on these portals (ambient on the
-`org.freedesktop.Platform//24.08` runtime — no extra `--talk-name=`
-needed):
-
-| Portal | Purpose |
-|--------|---------|
-| `org.freedesktop.portal.FileChooser` | Workspace folder picker (first run + "open in workspace") |
-| `org.freedesktop.portal.OpenURI` | Browser launches for OAuth flows (Eliza Cloud sign-in, app domain verification) |
-| `org.freedesktop.portal.Notification` | Notification fallback (the older `org.freedesktop.Notifications` D-Bus name is also granted) |
-
-If a future feature needs camera, microphone, or location, add the
-corresponding portal — do NOT add a raw `--device=` or `--socket=` rule.
-
-## Local testing
+On Linux, run the Electrobun build first and then use:
 
 ```bash
-# Install build tooling.
-sudo apt install flatpak flatpak-builder        # Debian / Ubuntu
-sudo dnf install flatpak flatpak-builder        # Fedora
-
-# Install the runtime + SDK once.
-flatpak install --user flathub org.freedesktop.Platform//24.08
-flatpak install --user flathub org.freedesktop.Sdk//24.08
-
-# Build the store variant.
-ELIZA_BUILD_VARIANT=store bun run build:flatpak
-
-# Or call flatpak-builder directly.
-cd packages/app-core/packaging/flatpak
-flatpak-builder --user --install --force-clean build-dir ai.elizaos.App.store.yml
-
-# Run.
-flatpak run ai.elizaos.App --version
-flatpak run ai.elizaos.App start
-
-# Inspect the granted permissions to confirm the lockdown.
-flatpak info --show-permissions ai.elizaos.App
-# Expect: shared=network;ipc; sockets=wayland;fallback-x11; filesystems
-# limited to xdg-documents/Eliza and xdg-config/elizaos-app; talk-names
-# limited to Notifications + StatusNotifierWatcher.
+bun run --cwd packages/app-core build:flatpak:direct
 ```
 
-## Flathub submission checklist
+The package is written under
+`packages/app-core/platforms/electrobun/artifacts/`.
 
-When you're ready to submit the store variant to Flathub:
+## Flathub is not yet eligible
 
-1. **Vendor the npm tree as offline sources.** Flathub's build
-   infrastructure does not allow network access during `build`. The
-   `test-flatpak.yml` CI workflow regenerates `node-sources.json` on
-   every run via `./generate-sources.sh` and uploads it as the
-   `flatpak-node-sources` artifact. To refresh the committed copy
-   locally (Linux only):
-   ```bash
-   ./generate-sources.sh        # writes node-sources.json next to this README
-   ```
-   Or download the CI artifact from the most recent successful
-   `Test Flatpak Build` workflow run on `develop` and drop it next to
-   this README. Once `node-sources.json` is committed, the manifest can
-   build offline (`npm install -g --offline`) and the
-   `build-options.build-args: --share=network` shim is no longer needed.
-2. **Replace screenshot URLs** in `ai.elizaos.App.metainfo.xml`. Three
-   placeholder `<screenshot>` entries currently point at
-   `https://cloud.eliza.app/screenshots/{dashboard,onboarding,plugins}.png`
-   — host the real 1280×720 PNGs at those paths (or update the URLs to
-   wherever they're served from) before submitting. Flathub fetches the
-   URLs at review time.
-3. **Verify the manifest** with `appstream-util validate` and
-   `flatpak-builder --show-manifest --show-deps`.
-4. **Open a submission issue at https://github.com/flathub/flathub/issues/new**
-   — pick the "App submission" template, link to this manifest in the
-   public elizaos repo, and explicitly call out:
-   - The store variant uses portal-mediated FS access (no
-     `--filesystem=home`).
-   - The runtime hosting mode is forced to Eliza Cloud — no local CLI
-     spawning, no host Ollama.
-   - This Flathub submission is the **store** variant; an unrestricted
-     "direct" build for power users is published separately as a
-     side-loadable bundle and is **not** on Flathub.
-5. **Hand over** to a Flathub maintainer who creates
-   `github.com/flathub/ai.elizaos.App` and applies the manifest +
-   supporting files.
+The YAML manifests in this directory are retained only as evidence of the
+retired CLI-based experiment. They install the `elizaos` command-line package,
+not the Electrobun desktop application. The store manifest also requires
+network access while building. Do not submit either manifest to Flathub or
+treat a successful build as desktop acceptance.
 
-## Direct variant
+`bun run --cwd packages/app-core build:flatpak:store` deliberately fails
+closed. Before enabling it, all of the following must be true:
 
-The direct manifest (`ai.elizaos.App.yml`) keeps the existing
-`--filesystem=home` posture so power users who self-host a Flatpak repo
-or side-load a bundle get the same experience as the AppImage / .deb /
-.rpm builds. It does NOT set `ELIZA_BUILD_VARIANT=store`, so the
-runtime exposes the full coding-agent surface.
+1. A human maintainer has resolved Flathub's generative-AI submission policy
+   for this repository and obtained any required exception.
+2. The manifest builds the real Electrobun application and all dependencies
+   offline from immutable, checksum-pinned sources.
+3. The selected reverse-DNS app ID is controlled and verified by the publisher.
+4. Current AppStream metadata, screenshots, permissions, and portal behavior
+   pass Flathub review and the official linter.
+5. A human authors and submits the Flathub application materials. Automation
+   may test the repository artifact, but it must not generate or submit the
+   application on that person's behalf.
 
-Don't submit this manifest to Flathub. It will fail review.
+The two retired manifests are:
+
+- `ai.elizaos.App.store.yml`: locked-down CLI experiment; not Flathub-ready.
+- `ai.elizaos.App.yml`: host-access CLI experiment; not intended for Flathub.

--- a/packages/app-core/packaging/flatpak/ai.elizaos.App.store.yml
+++ b/packages/app-core/packaging/flatpak/ai.elizaos.App.store.yml
@@ -1,10 +1,9 @@
-# Flatpak manifest — Flathub (store) variant for elizaOS App.
+# RETIRED CLI EXPERIMENT — DO NOT SUBMIT TO FLATHUB.
 #
-# This is the LOCKED-DOWN sandbox build, intended for distribution through
-# Flathub. It is the Flatpak equivalent of an app-store / MAS / MSIX build:
-# the runtime cannot reach the host shell, cannot execute arbitrary CLIs from
-# `$PATH`, and cannot read or write outside its own per-app data directory or
-# user-granted portal-mediated paths.
+# This manifest installs the elizaOS CLI rather than the Electrobun desktop,
+# needs build-time network access, and is retained only to document the former
+# experiment. The canonical release workflow packages the real desktop with
+# package-electrobun-flatpak.mjs; see README.md for the Flathub blockers.
 #
 # When you want the unrestricted, power-user experience that mirrors the
 # AppImage / .deb / .rpm distribution (full $HOME access, host shell, host

--- a/packages/app-core/packaging/flatpak/ai.elizaos.App.yml
+++ b/packages/app-core/packaging/flatpak/ai.elizaos.App.yml
@@ -1,9 +1,8 @@
-# Flatpak manifest — DIRECT (power-user) variant for elizaOS App.
+# RETIRED CLI EXPERIMENT — NOT THE ELECTROBUN DESKTOP.
 #
-# This is the unrestricted build that mirrors the AppImage / .deb / .rpm
-# distribution: full $HOME access, host shell reach via xdg-run, host Ollama
-# and docker discoverable, EXECUTE_CODE permitted. It is intended for
-# self-hosted Flatpak repos and side-loaded bundles, NOT for Flathub.
+# This manifest installs the elizaOS CLI and does not mirror the AppImage,
+# Debian, or RPM desktop artifacts. The canonical release workflow packages
+# the real desktop with package-electrobun-flatpak.mjs; see README.md.
 #
 # For Flathub submission use `ai.elizaos.App.store.yml`, which removes
 # `--filesystem=home` and other host-escape sockets that Flathub reviewers

--- a/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
@@ -16,6 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  FLATPAK_FINISH_ARGS,
   requireLauncher,
   writeMetadata,
 } from "../package-electrobun-flatpak.mjs";
@@ -72,5 +73,17 @@ describe("Electrobun Flatpak packaging", () => {
     expect(desktop).toContain("Exec=eliza");
     expect(metadata).toContain('type="desktop-application"');
     expect(metadata).toContain("https://github.com/elizaOS/eliza/issues");
+  });
+
+  it("keeps the side-load bundle off host escape surfaces", () => {
+    expect(FLATPAK_FINISH_ARGS).toContain("--socket=wayland");
+    expect(FLATPAK_FINISH_ARGS).toContain("--socket=fallback-x11");
+    expect(FLATPAK_FINISH_ARGS).not.toContain("--filesystem=home");
+    expect(FLATPAK_FINISH_ARGS).not.toContain("--filesystem=host");
+    expect(FLATPAK_FINISH_ARGS).not.toContain("--socket=session-bus");
+    expect(FLATPAK_FINISH_ARGS).not.toContain("--socket=system-bus");
+    expect(FLATPAK_FINISH_ARGS).not.toContain(
+      "--talk-name=org.freedesktop.Flatpak",
+    );
   });
 });

--- a/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
@@ -18,6 +18,7 @@ import sharp from "sharp";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   FLATPAK_FINISH_ARGS,
+  FLATPAK_RUNTIME,
   requireLauncher,
   writeMetadata,
 } from "../package-electrobun-flatpak.mjs";
@@ -37,6 +38,14 @@ afterEach(() => {
 });
 
 describe("Electrobun Flatpak packaging", () => {
+  it("uses the GNOME runtime that supplies WebKitGTK", () => {
+    expect(FLATPAK_RUNTIME).toEqual({
+      platform: "org.gnome.Platform",
+      sdk: "org.gnome.Sdk",
+      version: "49",
+    });
+  });
+
   it("requires the packaged Electrobun launcher", () => {
     const buildDir = tempDir();
     mkdirSync(path.join(buildDir, "bin"), { recursive: true });

--- a/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Flatpak packaging tests verify that the release bundle targets the real
+ * Electrobun launcher and emits desktop metadata without host filesystem or
+ * shell escape permissions.
+ */
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  requireLauncher,
+  writeMetadata,
+} from "../package-electrobun-flatpak.mjs";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "flatpak-package-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Electrobun Flatpak packaging", () => {
+  it("requires the packaged Electrobun launcher", () => {
+    const buildDir = tempDir();
+    mkdirSync(path.join(buildDir, "bin"), { recursive: true });
+    const launcher = path.join(buildDir, "bin/launcher");
+    writeFileSync(launcher, "#!/bin/sh\n");
+    chmodSync(launcher, 0o755);
+
+    expect(requireLauncher(buildDir)).toBe("bin/launcher");
+  });
+
+  it("rejects a CLI-only tree", () => {
+    const buildDir = tempDir();
+    mkdirSync(path.join(buildDir, "bin"), { recursive: true });
+    writeFileSync(path.join(buildDir, "bin/elizaos"), "#!/bin/sh\n");
+
+    expect(() => requireLauncher(buildDir)).toThrow(/bin\/launcher/);
+  });
+
+  it("emits a graphical desktop entry and exact launcher wrapper", () => {
+    const filesDir = tempDir();
+    writeMetadata(filesDir, "bin/launcher");
+
+    const wrapper = readFileSync(path.join(filesDir, "bin/eliza"), "utf8");
+    const desktop = readFileSync(
+      path.join(filesDir, "share/applications/ai.elizaos.app.desktop"),
+      "utf8",
+    );
+    const metadata = readFileSync(
+      path.join(filesDir, "share/metainfo/ai.elizaos.app.metainfo.xml"),
+      "utf8",
+    );
+
+    expect(wrapper).toContain("/app/opt/eliza/bin/launcher");
+    expect(desktop).toContain("Terminal=false");
+    expect(desktop).toContain("Exec=eliza");
+    expect(metadata).toContain('type="desktop-application"');
+    expect(metadata).toContain("https://github.com/elizaOS/eliza/issues");
+  });
+});

--- a/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import sharp from "sharp";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  FLATPAK_BUNDLED_LIBRARIES,
   FLATPAK_FINISH_ARGS,
   FLATPAK_RUNTIME,
   requireLauncher,
@@ -44,6 +45,13 @@ describe("Electrobun Flatpak packaging", () => {
       sdk: "org.gnome.Sdk",
       version: "49",
     });
+    expect(FLATPAK_BUNDLED_LIBRARIES.map(({ soname }) => soname)).toEqual([
+      "libayatana-appindicator3.so.1",
+      "libayatana-indicator3.so.7",
+      "libayatana-ido3-0.4.so.0",
+      "libdbusmenu-glib.so.4",
+      "libdbusmenu-gtk3.so.4",
+    ]);
   });
 
   it("requires the packaged Electrobun launcher", () => {

--- a/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import sharp from "sharp";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   FLATPAK_FINISH_ARGS,
@@ -54,9 +55,9 @@ describe("Electrobun Flatpak packaging", () => {
     expect(() => requireLauncher(buildDir)).toThrow(/bin\/launcher/);
   });
 
-  it("emits a graphical desktop entry and exact launcher wrapper", () => {
+  it("emits graphical metadata with an export-safe icon", async () => {
     const filesDir = tempDir();
-    writeMetadata(filesDir, "bin/launcher");
+    await writeMetadata(filesDir, "bin/launcher");
 
     const wrapper = readFileSync(path.join(filesDir, "bin/eliza"), "utf8");
     const desktop = readFileSync(
@@ -67,12 +68,20 @@ describe("Electrobun Flatpak packaging", () => {
       path.join(filesDir, "share/metainfo/ai.elizaos.app.metainfo.xml"),
       "utf8",
     );
+    const icon = await sharp(
+      path.join(
+        filesDir,
+        "share/icons/hicolor/512x512/apps/ai.elizaos.app.png",
+      ),
+    ).metadata();
 
     expect(wrapper).toContain("/app/opt/eliza/bin/launcher");
     expect(desktop).toContain("Terminal=false");
     expect(desktop).toContain("Exec=eliza");
     expect(metadata).toContain('type="desktop-application"');
     expect(metadata).toContain("https://github.com/elizaOS/eliza/issues");
+    expect(icon.width).toBe(512);
+    expect(icon.height).toBe(512);
   });
 
   it("keeps the side-load bundle off host escape surfaces", () => {

--- a/packages/app-core/scripts/build-flatpak.mjs
+++ b/packages/app-core/scripts/build-flatpak.mjs
@@ -1,125 +1,54 @@
 #!/usr/bin/env node
-// ─────────────────────────────────────────────────────────────────────────────
-// build-flatpak.mjs — Flatpak builder driver, store + direct variants.
-//
-// Usage:
-//   ELIZA_BUILD_VARIANT=store bun run build:flatpak
-//   ELIZA_BUILD_VARIANT=direct bun run build:flatpak
-//   bun run build:flatpak --variant store
-//
-// Picks the correct manifest based on ELIZA_BUILD_VARIANT (or --variant),
-// invokes flatpak-builder, and emits a bundle into ./dist-flatpak/.
-//
-// Defaults to `store` when the variant is unspecified. The store variant
-// targets Flathub (locked-down sandbox); the direct variant produces the
-// power-user build with full $HOME access.
-//
-// Requires `flatpak-builder` on $PATH. On macOS dev hosts the script
-// short-circuits with a friendly skip message — Flatpak only builds on
-// Linux.
-// ─────────────────────────────────────────────────────────────────────────────
+/**
+ * Routes local Flatpak packaging to the real Electrobun desktop artifact and
+ * refuses the legacy CLI-based Flathub manifest, which is not an acceptable
+ * store submission or a representation of the shipped desktop application.
+ */
 
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FLATPAK_DIR = resolve(HERE, "../packaging/flatpak");
-const REPO_DIR = resolve(HERE, "../../../dist-flatpak/repo");
-const BUILD_DIR = resolve(HERE, "../../../dist-flatpak/build");
-const BUNDLE_PATH = resolve(HERE, "../../../dist-flatpak/elizaos-app.flatpak");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageScript = path.join(scriptDir, "package-electrobun-flatpak.mjs");
 
-const APP_ID = "ai.elizaos.App";
-
-function parseVariant() {
-  const argIdx = process.argv.indexOf("--variant");
-  const fromArg = argIdx >= 0 ? process.argv[argIdx + 1] : undefined;
-  const raw = fromArg || process.env.ELIZA_BUILD_VARIANT || "store";
-  const variant = raw.toLowerCase();
-  if (variant !== "store" && variant !== "direct") {
-    throw new Error(
-      `ELIZA_BUILD_VARIANT must be 'store' or 'direct' (got '${raw}').`,
-    );
-  }
-  return variant;
+function requestedVariant() {
+  const index = process.argv.indexOf("--variant");
+  return (
+    (index >= 0 ? process.argv[index + 1] : undefined) ??
+    process.env.ELIZA_BUILD_VARIANT ??
+    "direct"
+  ).toLowerCase();
 }
 
-function manifestFor(variant) {
-  const file =
-    variant === "store" ? "ai.elizaos.App.store.yml" : "ai.elizaos.App.yml";
-  const path = resolve(FLATPAK_DIR, file);
-  if (!existsSync(path)) {
-    throw new Error(`Manifest not found: ${path}`);
-  }
-  return path;
-}
-
-function run(cmd, args, opts = {}) {
-  console.log(`\n$ ${cmd} ${args.join(" ")}`);
-  const r = spawnSync(cmd, args, { stdio: "inherit", ...opts });
-  if (r.status !== 0) {
-    throw new Error(`${cmd} exited with status ${r.status}`);
-  }
-}
-
-function which(cmd) {
-  const r = spawnSync("which", [cmd], { stdio: "pipe" });
-  return r.status === 0 ? String(r.stdout).trim() : "";
-}
-
-async function main() {
-  if (process.platform !== "linux") {
-    console.error(
-      "build-flatpak: skipping — Flatpak only builds on Linux. " +
-        "(Detected platform: " +
-        process.platform +
-        ")",
-    );
-    process.exit(0);
-  }
-
-  const variant = parseVariant();
-  const manifest = manifestFor(variant);
-
-  console.log(`build-flatpak: variant=${variant}`);
-  console.log(`build-flatpak: manifest=${manifest}`);
-
-  if (!which("flatpak-builder")) {
-    console.error(
-      "build-flatpak: flatpak-builder not found on $PATH. " +
-        "Install it with `sudo apt install flatpak flatpak-builder` " +
-        "or `sudo dnf install flatpak flatpak-builder`.",
-    );
-    process.exit(1);
-  }
-
-  // Build.
-  run(
-    "flatpak-builder",
+const variant = requestedVariant();
+if (variant === "store") {
+  console.error(
     [
-      `--repo=${REPO_DIR}`,
-      "--force-clean",
-      "--user",
-      "--install-deps-from=flathub",
-      BUILD_DIR,
-      manifest,
-    ],
-    { cwd: FLATPAK_DIR },
+      "build-flatpak: Flathub store packaging is intentionally blocked.",
+      "The retired manifest installed the elizaOS CLI instead of the Electrobun desktop and required build-time network access.",
+      "A human maintainer must first obtain the required Flathub policy exception and provide a fully offline source manifest.",
+      "The canonical release workflow still produces and tests a side-loadable Flatpak of the real Electrobun application.",
+    ].join("\n"),
   );
-
-  // Bundle into a single .flatpak file users can side-load.
-  run("flatpak", ["build-bundle", REPO_DIR, BUNDLE_PATH, APP_ID], {
-    cwd: FLATPAK_DIR,
-  });
-
-  console.log("\nbuild-flatpak: done.");
-  console.log(`  variant: ${variant}`);
-  console.log(`  bundle:  ${BUNDLE_PATH}`);
-  console.log(`  install: flatpak --user install ${BUNDLE_PATH}`);
+  process.exit(1);
+}
+if (variant !== "direct") {
+  console.error(`build-flatpak: unknown variant ${JSON.stringify(variant)}`);
+  process.exit(1);
+}
+if (process.platform !== "linux") {
+  console.error(
+    `build-flatpak: Flatpak packaging requires Linux, got ${process.platform}`,
+  );
+  process.exit(1);
 }
 
-main().catch((err) => {
-  console.error("build-flatpak: failed:", err.message);
-  process.exit(1);
+const forwardedArgs = process.argv
+  .slice(2)
+  .filter(
+    (arg, index, all) => arg !== "--variant" && all[index - 1] !== "--variant",
+  );
+execFileSync(process.execPath, [packageScript, ...forwardedArgs], {
+  stdio: "inherit",
 });

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -8,6 +8,7 @@
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -42,6 +43,22 @@ export const FLATPAK_RUNTIME = {
   sdk: "org.gnome.Sdk",
   version: "49",
 };
+export const FLATPAK_BUNDLED_LIBRARIES = [
+  {
+    package: "libayatana-appindicator3-1",
+    soname: "libayatana-appindicator3.so.1",
+  },
+  {
+    package: "libayatana-indicator3-7",
+    soname: "libayatana-indicator3.so.7",
+  },
+  {
+    package: "libayatana-ido3-0.4-0",
+    soname: "libayatana-ido3-0.4.so.0",
+  },
+  { package: "libdbusmenu-glib4", soname: "libdbusmenu-glib.so.4" },
+  { package: "libdbusmenu-gtk3-4", soname: "libdbusmenu-gtk3.so.4" },
+];
 export const FLATPAK_FINISH_ARGS = [
   "--command=eliza",
   "--share=network",
@@ -163,6 +180,36 @@ export async function writeMetadata(filesDir, relativeLauncher) {
     );
 }
 
+/** Bundle the tray libraries Electrobun links but the GNOME runtime omits. */
+export function copyBundledLibraries(filesDir) {
+  const cache = execFileSync("ldconfig", ["-p"], { encoding: "utf8" });
+  const libraryDir = path.join(filesDir, "lib");
+  const licenseDir = path.join(filesDir, "share/licenses/eliza-bundled");
+  mkdirSync(libraryDir, { recursive: true });
+  mkdirSync(licenseDir, { recursive: true });
+
+  for (const library of FLATPAK_BUNDLED_LIBRARIES) {
+    const line = cache
+      .split("\n")
+      .find((candidate) =>
+        candidate.trimStart().startsWith(`${library.soname} `),
+      );
+    const source = line?.match(/=>\s+(\S+)\s*$/)?.[1];
+    if (!source || !existsSync(source)) {
+      throw new Error(`Missing required Flatpak library ${library.soname}`);
+    }
+    const copyright = path.join("/usr/share/doc", library.package, "copyright");
+    if (!existsSync(copyright)) {
+      throw new Error(`Missing license for bundled package ${library.package}`);
+    }
+    copyFileSync(source, path.join(libraryDir, library.soname));
+    copyFileSync(
+      copyright,
+      path.join(licenseDir, `${library.package}.copyright`),
+    );
+  }
+}
+
 async function main() {
   if (process.platform !== "linux") {
     throw new Error(
@@ -197,6 +244,7 @@ async function main() {
       force: true,
       dereference: true,
     });
+    copyBundledLibraries(path.join(appDir, "files"));
     await writeMetadata(path.join(appDir, "files"), relativeLauncher);
     run("flatpak", ["build-finish", ...FLATPAK_FINISH_ARGS, appDir]);
     run("flatpak", [

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -8,7 +8,6 @@
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
-  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -21,6 +20,7 @@ import { cp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import sharp from "sharp";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..", "..", "..");
@@ -103,7 +103,7 @@ export function requireLauncher(buildDir) {
   return path.relative(buildDir, launcher);
 }
 
-export function writeMetadata(filesDir, relativeLauncher) {
+export async function writeMetadata(filesDir, relativeLauncher) {
   mkdirSync(path.join(filesDir, "bin"), { recursive: true });
   mkdirSync(path.join(filesDir, "share/applications"), { recursive: true });
   mkdirSync(path.join(filesDir, "share/metainfo"), { recursive: true });
@@ -151,10 +151,12 @@ export function writeMetadata(filesDir, relativeLauncher) {
       `  <content_rating type="oars-1.1"/>\n` +
       `</component>\n`,
   );
-  copyFileSync(
-    iconPath,
-    path.join(filesDir, `share/icons/hicolor/512x512/apps/${APP_ID}.png`),
-  );
+  await sharp(iconPath)
+    .resize(512, 512, { fit: "contain" })
+    .png()
+    .toFile(
+      path.join(filesDir, `share/icons/hicolor/512x512/apps/${APP_ID}.png`),
+    );
 }
 
 async function main() {
@@ -191,7 +193,7 @@ async function main() {
       force: true,
       dereference: true,
     });
-    writeMetadata(path.join(appDir, "files"), relativeLauncher);
+    await writeMetadata(path.join(appDir, "files"), relativeLauncher);
     run("flatpak", ["build-finish", ...FLATPAK_FINISH_ARGS, appDir]);
     run("flatpak", [
       "build-export",

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -38,6 +38,15 @@ const cleanupHelper = path.join(
 
 const APP_ID = "ai.elizaos.app";
 const RUNTIME_VERSION = "24.08";
+export const FLATPAK_FINISH_ARGS = [
+  "--command=eliza",
+  "--share=network",
+  "--share=ipc",
+  "--socket=wayland",
+  "--socket=fallback-x11",
+  "--socket=pulseaudio",
+  "--device=dri",
+];
 const args = new Map(
   process.argv.slice(2).map((arg) => {
     const [key, ...rest] = arg.replace(/^--/, "").split("=");
@@ -183,17 +192,7 @@ async function main() {
       dereference: true,
     });
     writeMetadata(path.join(appDir, "files"), relativeLauncher);
-    run("flatpak", [
-      "build-finish",
-      "--command=eliza",
-      "--share=network",
-      "--share=ipc",
-      "--socket=wayland",
-      "--socket=fallback-x11",
-      "--socket=pulseaudio",
-      "--device=dri",
-      appDir,
-    ]);
+    run("flatpak", ["build-finish", ...FLATPAK_FINISH_ARGS, appDir]);
     run("flatpak", [
       "build-export",
       `--arch=${arch}`,

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -37,7 +37,11 @@ const cleanupHelper = path.join(
 );
 
 const APP_ID = "ai.elizaos.app";
-const RUNTIME_VERSION = "24.08";
+export const FLATPAK_RUNTIME = {
+  platform: "org.gnome.Platform",
+  sdk: "org.gnome.Sdk",
+  version: "49",
+};
 export const FLATPAK_FINISH_ARGS = [
   "--command=eliza",
   "--share=network",
@@ -184,9 +188,9 @@ async function main() {
       `--arch=${arch}`,
       appDir,
       APP_ID,
-      "org.freedesktop.Sdk",
-      "org.freedesktop.Platform",
-      RUNTIME_VERSION,
+      FLATPAK_RUNTIME.sdk,
+      FLATPAK_RUNTIME.platform,
+      FLATPAK_RUNTIME.version,
     ]);
     await cp(buildDir, path.join(appDir, "files/opt/eliza"), {
       recursive: true,

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Packages the already-built Linux Electrobun application tree as a
+ * side-loadable Flatpak, preserving the exact desktop runtime tested by the
+ * canonical release lane instead of substituting the command-line package.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { cp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..", "..", "..");
+const electrobunRoot = path.join(
+  repoRoot,
+  "packages/app-core/platforms/electrobun",
+);
+const buildRoot = path.join(electrobunRoot, "build");
+const artifactRoot = path.join(electrobunRoot, "artifacts");
+const iconPath = path.join(electrobunRoot, "assets/appIcon.png");
+const cleanupHelper = path.join(
+  repoRoot,
+  "packages/scripts/rm-path-recursive.mjs",
+);
+
+const APP_ID = "ai.elizaos.app";
+const RUNTIME_VERSION = "24.08";
+const args = new Map(
+  process.argv.slice(2).map((arg) => {
+    const [key, ...rest] = arg.replace(/^--/, "").split("=");
+    return [key, rest.join("=") || "true"];
+  }),
+);
+const version =
+  args.get("version") ??
+  JSON.parse(readFileSync(path.join(electrobunRoot, "package.json"), "utf8"))
+    .version;
+const arch = args.get("arch") ?? "x86_64";
+const releaseDate =
+  args.get("release-date") ??
+  execFileSync("git", ["show", "-s", "--format=%cs", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+
+function run(command, commandArgs, options = {}) {
+  execFileSync(command, commandArgs, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    ...options,
+  });
+}
+
+function latestLinuxBuildDir() {
+  const explicit = args.get("build-dir");
+  if (explicit) return path.resolve(repoRoot, explicit);
+
+  const candidates = readdirSync(buildRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /linux/i.test(entry.name))
+    .map((entry) => path.join(buildRoot, entry.name))
+    .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs);
+  if (!candidates[0]) {
+    throw new Error(`No Linux Electrobun build found under ${buildRoot}`);
+  }
+  return candidates[0];
+}
+
+export function requireLauncher(buildDir) {
+  const candidates = [
+    path.join(buildDir, "bin", "launcher"),
+    ...readdirSync(buildDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(buildDir, entry.name, "bin", "launcher")),
+  ];
+  const launcher = candidates.find((candidate) => existsSync(candidate));
+  if (!launcher || (statSync(launcher).mode & 0o111) === 0) {
+    throw new Error(
+      `The Electrobun build has no executable bin/launcher: ${buildDir}`,
+    );
+  }
+  return path.relative(buildDir, launcher);
+}
+
+export function writeMetadata(filesDir, relativeLauncher) {
+  mkdirSync(path.join(filesDir, "bin"), { recursive: true });
+  mkdirSync(path.join(filesDir, "share/applications"), { recursive: true });
+  mkdirSync(path.join(filesDir, "share/metainfo"), { recursive: true });
+  mkdirSync(path.join(filesDir, "share/icons/hicolor/512x512/apps"), {
+    recursive: true,
+  });
+
+  const wrapper = path.join(filesDir, "bin/eliza");
+  writeFileSync(
+    wrapper,
+    `#!/usr/bin/env sh\nexec /app/opt/eliza/${relativeLauncher} "$@"\n`,
+  );
+  chmodSync(wrapper, 0o755);
+  writeFileSync(
+    path.join(filesDir, `share/applications/${APP_ID}.desktop`),
+    [
+      "[Desktop Entry]",
+      "Type=Application",
+      "Name=Eliza",
+      "Comment=Your AI assistant, everywhere.",
+      "Exec=eliza",
+      `Icon=${APP_ID}`,
+      "Terminal=false",
+      "Categories=Utility;Network;",
+      "StartupNotify=true",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    path.join(filesDir, `share/metainfo/${APP_ID}.metainfo.xml`),
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<component type="desktop-application">\n` +
+      `  <id>${APP_ID}</id>\n` +
+      `  <metadata_license>MIT</metadata_license>\n` +
+      `  <project_license>MIT</project_license>\n` +
+      `  <name>Eliza</name>\n` +
+      `  <summary>Your AI assistant, everywhere</summary>\n` +
+      `  <description><p>Eliza is the elizaOS desktop application for chat, account setup, agents, and connected services.</p></description>\n` +
+      `  <url type="homepage">https://elizaos.ai</url>\n` +
+      `  <url type="bugtracker">https://github.com/elizaOS/eliza/issues</url>\n` +
+      `  <launchable type="desktop-id">${APP_ID}.desktop</launchable>\n` +
+      `  <provides><binary>eliza</binary></provides>\n` +
+      `  <categories><category>Utility</category><category>Network</category></categories>\n` +
+      `  <releases><release version="${version}" date="${releaseDate}"/></releases>\n` +
+      `  <content_rating type="oars-1.1"/>\n` +
+      `</component>\n`,
+  );
+  copyFileSync(
+    iconPath,
+    path.join(filesDir, `share/icons/hicolor/512x512/apps/${APP_ID}.png`),
+  );
+}
+
+async function main() {
+  if (process.platform !== "linux") {
+    throw new Error(
+      `Flatpak packaging requires Linux, got ${process.platform}`,
+    );
+  }
+  if (!existsSync(iconPath)) throw new Error(`Missing app icon: ${iconPath}`);
+
+  const buildDir = latestLinuxBuildDir();
+  const relativeLauncher = requireLauncher(buildDir);
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), "eliza-flatpak-"));
+  const appDir = path.join(tempRoot, "app");
+  const repoDir = path.join(tempRoot, "repo");
+  const output = path.join(
+    artifactRoot,
+    `Eliza-${version}-linux-${arch}.flatpak`,
+  );
+
+  try {
+    run("flatpak", [
+      "build-init",
+      "--type=app",
+      `--arch=${arch}`,
+      appDir,
+      APP_ID,
+      "org.freedesktop.Sdk",
+      "org.freedesktop.Platform",
+      RUNTIME_VERSION,
+    ]);
+    await cp(buildDir, path.join(appDir, "files/opt/eliza"), {
+      recursive: true,
+      force: true,
+      dereference: true,
+    });
+    writeMetadata(path.join(appDir, "files"), relativeLauncher);
+    run("flatpak", [
+      "build-finish",
+      "--command=eliza",
+      "--share=network",
+      "--share=ipc",
+      "--socket=wayland",
+      "--socket=fallback-x11",
+      "--socket=pulseaudio",
+      "--device=dri",
+      appDir,
+    ]);
+    run("flatpak", [
+      "build-export",
+      `--arch=${arch}`,
+      repoDir,
+      appDir,
+      "stable",
+    ]);
+    mkdirSync(artifactRoot, { recursive: true });
+    run("flatpak", [
+      "build-bundle",
+      `--arch=${arch}`,
+      repoDir,
+      output,
+      APP_ID,
+      "stable",
+    ]);
+    console.log(`Wrote ${path.relative(repoRoot, output)}`);
+  } finally {
+    run(process.execPath, [cleanupHelper, tempRoot]);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    console.error(
+      `[package-electrobun-flatpak] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #20916

## Outcome

- packages the exact Linux Electrobun build tree as a side-loadable Flatpak alongside AppImage, DEB, and RPM
- installs the produced bundle and requires a 45-second launch-liveness gate
- makes the existing packaged-desktop Playwright regression lane mandatory on Linux releases
- refuses the retired CLI-based `build:flatpak:store` path instead of presenting it as Flathub-ready
- documents the remaining Flathub offline-source, app-ID verification, metadata, human-submission, and policy-exception blockers

## Why

The previous manifests installed `npm install -g elizaos` and launched a terminal CLI. They did not package the Electrobun desktop that users receive on Linux, and the store manifest requested network access during the build, which Flathub does not permit.

This PR makes the canonical release artifact truthful and testable without claiming the separate Flathub submission is eligible.

<!-- evidence-head:fac3baa492f4b3955af78da052e63734cb336bc1 -->

Exact repaired head: `fac3baa492f4b3955af78da052e63734cb336bc1`.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - packaging and release-validation behavior only; no rendered view changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - packaging and release-validation behavior only; no rendered view changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - acceptance is a non-interactive packaged-app liveness contract
<!-- evidence-row:backend-logs -->
- [x] [22636-pr22636-flatpak-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22636-pr22636-flatpak-backend-logs.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the lane validates process liveness rather than a renderer interaction
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [22636-pr22636-flatpak-acceptance.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22636-pr22636-flatpak-acceptance.txt)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fac3baa492f4b3955af78da052e63734cb336bc1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Verification

- `bun test packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts` (5 passed)
- `bunx @biomejs/biome check packages/app-core/scripts/build-flatpak.mjs packages/app-core/scripts/package-electrobun-flatpak.mjs packages/app-core/scripts/__tests__/package-electrobun-flatpak.test.ts`
- `node --check packages/app-core/scripts/build-flatpak.mjs`
- `node --check packages/app-core/scripts/package-electrobun-flatpak.mjs`
- `actionlint .github/workflows/electrobun-contract.yml .github/workflows/release-electrobun.yml`
- exact-head non-publishing Flatpak acceptance: [run 32340294383](https://github.com/elizaOS/eliza/actions/runs/32340294383) (success)
- prior exact-head Quality: [run 32337415063](https://github.com/elizaOS/eliza/actions/runs/32337415063) (success); fresh exact-head Quality: [run 32340296590](https://github.com/elizaOS/eliza/actions/runs/32340296590) (success)
- initial exact-head run [32333428478](https://github.com/elizaOS/eliza/actions/runs/32333428478) exposed a real 1024px icon mislabeled as 512px; the producer now resizes it and the test asserts exact 512x512 output
- next exact-head run [32334774873](https://github.com/elizaOS/eliza/actions/runs/32334774873) packaged and installed, then exposed missing WebKitGTK in the freedesktop runtime; the canonical package now pins `org.gnome.Platform`/`org.gnome.Sdk` 49 and the test pins that runtime contract
- prior exact-head run [32337413122](https://github.com/elizaOS/eliza/actions/runs/32337413122) then packaged and installed under GNOME 49, exposing missing Ayatana tray libraries; the package now bundles only the five linked libraries plus their license texts without adding host permissions
- `git diff --check origin/develop...HEAD`
- side-load permissions are pinned against host filesystem, session/system bus, and host-spawn escape grants
- Linux launch now runs under an isolated Xvfb display instead of assuming a GUI on the hosted runner
- store variant refusal exercised locally and verified to exit 1 with the fail-closed message

## Remaining live acceptance

The non-publishing exact-head lane completed the real Electrobun build, Flatpak creation, installation, and 45-second Xvfb liveness check successfully in run 32340294383. An actual public desktop release still requires a real protected tag and `production-release` approval; the validation lane has read-only repository permissions and cannot publish. Flathub submission remains intentionally blocked until the documented human and policy requirements are resolved.



