### PR TITLE
fix(ui): harden Cloud login handoff

### DIFF
--- a/packages/cloud/sdk/src/cli-login.ts
+++ b/packages/cloud/sdk/src/cli-login.ts
@@ -1,0 +1,8 @@
+/** Validates server-minted Cloud CLI login session identifiers at trust boundaries. */
+
+const CLI_LOGIN_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isCliLoginSessionId(value: unknown): value is string {
+  return typeof value === "string" && CLI_LOGIN_SESSION_ID_PATTERN.test(value);
+}

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -344,10 +344,13 @@ describe("ElizaCloudClient path parameter encoding", () => {
 describe("ElizaCloudClient CLI login", () => {
   it("uses the API host for session creation but the web host for browser auth", async () => {
     let requestedUrl: string | undefined;
-    const fetchImpl = (async (input) => {
+    let requestedBody: string | undefined;
+    const fetchImpl = (async (input, init) => {
       requestedUrl = String(input);
+      requestedBody = init?.body as string | undefined;
       return new Response(
         JSON.stringify({
+          sessionId: "11111111-2222-4333-8444-555555555555",
           status: "pending",
           expiresAt: "2026-05-14T08:00:00.000Z",
         }),
@@ -368,12 +371,17 @@ describe("ElizaCloudClient CLI login", () => {
     });
 
     expect(requestedUrl).toBe("https://api.eliza.app/api/auth/cli-session");
+    expect(JSON.parse(requestedBody ?? "null")).toEqual({
+      sessionId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+    });
     expect(result.browserUrl).toBe(
-      "https://eliza.app/auth/cli-login?session=cli-test-session",
+      "https://eliza.app/auth/cli-login?session=11111111-2222-4333-8444-555555555555",
     );
   });
 
-  it("honors the server-minted session id over the locally generated one", async () => {
+  it("uses the authoritative server-minted session id", async () => {
     const fetchImpl = (async (_input: unknown) => {
       return new Response(
         JSON.stringify({
@@ -400,6 +408,30 @@ describe("ElizaCloudClient CLI login", () => {
       "https://eliza.app/auth/cli-login?session=11111111-2222-4333-8444-555555555555",
     );
   });
+
+  it.each([
+    undefined,
+    "",
+    "client-chosen",
+    "11111111-2222-6333-8444-555555555555",
+  ])(
+    "rejects a missing or malformed server-minted session id: %s",
+    async (sessionId) => {
+      const fetchImpl = (async () =>
+        new Response(JSON.stringify({ sessionId }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        })) as unknown as typeof fetch;
+      const client = new ElizaCloudClient({
+        baseUrl: "https://api.eliza.app",
+        fetchImpl,
+      });
+
+      await expect(client.startCliLogin()).rejects.toThrow(
+        "invalid login session ID",
+      );
+    },
+  );
 });
 
 describe("ElizaCloudClient web sign-in + app-credits affordances", () => {

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -9,6 +9,7 @@
  * are set. Every method returns a concrete DTO — no `unknown` in public signatures.
  */
 
+import { isCliLoginSessionId } from "./cli-login.js";
 import { CloudApiClient, CloudApiError, ElizaCloudHttpClient } from "./http.js";
 import { ElizaCloudPublicRoutesClient } from "./public-routes.js";
 import {
@@ -264,11 +265,12 @@ function withPathParams(
   });
 }
 
-function getCryptoRandomUuid(): string {
-  if (globalThis.crypto?.randomUUID) {
-    return globalThis.crypto.randomUUID();
+function createCliLoginRequestId(): string {
+  const sessionId = globalThis.crypto?.randomUUID?.();
+  if (!isCliLoginSessionId(sessionId)) {
+    throw new Error("A secure UUID generator is required to start Cloud login");
   }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return sessionId;
 }
 
 export class ElizaCloudClient {
@@ -352,11 +354,10 @@ export class ElizaCloudClient {
   startCliLogin(
     options: CliLoginStartOptions = {},
   ): Promise<CliLoginStartResponse> {
-    // The server mints the session id (client-chosen ids are ignored — they
-    // allowed id squatting and unauthenticated row-spam). A locally generated
-    // id is still sent for backward compatibility with pre-hardening servers,
-    // but the RESPONSE id is authoritative on both old and new servers.
-    const requestedSessionId = options.sessionId ?? getCryptoRandomUuid();
+    // Current servers mint the authoritative id and ignore this proposal. Keep
+    // sending a fresh cryptographic UUID until older deployed servers no longer
+    // require one, but never fall back to it if the response is malformed.
+    const requestSessionId = createCliLoginRequestId();
     const query = options.returnTo
       ? `?returnTo=${encodeURIComponent(options.returnTo)}`
       : "";
@@ -366,10 +367,13 @@ export class ElizaCloudClient {
       status?: string;
       expiresAt?: string;
     }>("POST", "/api/auth/cli-session", {
-      json: { sessionId: requestedSessionId },
+      json: { sessionId: requestSessionId },
       skipAuth: true,
     }).then((response) => {
-      const sessionId = response.sessionId ?? requestedSessionId;
+      if (!isCliLoginSessionId(response.sessionId)) {
+        throw new Error("Eliza Cloud returned an invalid login session ID");
+      }
+      const sessionId = response.sessionId;
       const browserBaseUrl = browserBaseUrlForCliLogin(this.baseUrl);
       const browserUrl = `${browserBaseUrl}/auth/cli-login?session=${encodeURIComponent(
         sessionId,

--- a/packages/cloud/sdk/src/index.ts
+++ b/packages/cloud/sdk/src/index.ts
@@ -5,6 +5,7 @@ export {
   type BuildAppAuthorizeUrlOptions,
   buildAppAuthorizeUrl,
 } from "./app-auth.js";
+export { isCliLoginSessionId } from "./cli-login.js";
 export { createElizaCloudClient, ElizaCloudClient } from "./client.js";
 export {
   CloudApiClient,

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -99,10 +99,9 @@ export interface EndpointCallOptions extends CloudRequestOptions {
 
 export interface CliLoginStartOptions {
   /**
-   * @deprecated The server mints the session id and returns it in the
-   * response (client-chosen ids are ignored there). This value is still sent
-   * for compatibility with pre-hardening servers, but the response id is
-   * always authoritative.
+   * @deprecated The server mints the authoritative session id. This value is
+   * retained for source compatibility but is ignored; the SDK sends its own
+   * fresh compatibility proposal for older deployments.
    */
   sessionId?: string;
   returnTo?: string;

--- a/packages/scripts/test-console/__tests__/oauth-cloud-login.test.mjs
+++ b/packages/scripts/test-console/__tests__/oauth-cloud-login.test.mjs
@@ -1,0 +1,44 @@
+/** Exercises the console's zero-workspace-import Cloud login protocol boundary. */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { startCloudLogin } from "../lib/oauth.mjs";
+
+const originalFetch = globalThis.fetch;
+const SERVER_SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("startCloudLogin", () => {
+  it("uses the server session and derives the paired production browser URL", async () => {
+    let requestBody;
+    globalThis.fetch = mock(async (_input, init) => {
+      requestBody = init?.body;
+      return new Response(JSON.stringify({ sessionId: SERVER_SESSION_ID }), {
+        status: 201,
+      });
+    });
+
+    await expect(startCloudLogin()).resolves.toEqual({
+      sessionId: SERVER_SESSION_ID,
+      browserUrl: `https://eliza.app/auth/cli-login?session=${SERVER_SESSION_ID}`,
+    });
+    expect(JSON.parse(requestBody)).toEqual({
+      sessionId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+    });
+  });
+
+  it.each([{}, { sessionId: "client-chosen" }])(
+    "rejects malformed server session data: %j",
+    async (payload) => {
+      globalThis.fetch = mock(
+        async () => new Response(JSON.stringify(payload), { status: 201 }),
+      );
+
+      await expect(startCloudLogin()).rejects.toThrow("invalid session ID");
+    },
+  );
+});

--- a/packages/scripts/test-console/lib/oauth.mjs
+++ b/packages/scripts/test-console/lib/oauth.mjs
@@ -21,6 +21,9 @@ import crypto from "node:crypto";
 
 export const DEFAULT_CLOUD_BASE_URL = "https://api.eliza.app";
 
+const CLOUD_LOGIN_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_SCOPES = [
@@ -34,15 +37,28 @@ const pendingFlows = new Map();
 export async function startCloudLogin({
   baseUrl = DEFAULT_CLOUD_BASE_URL,
 } = {}) {
+  const requestSessionId = crypto.randomUUID();
   const response = await fetch(`${baseUrl}/api/auth/cli-session`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ client: "eliza-test-console" }),
+    body: JSON.stringify({ sessionId: requestSessionId }),
   });
   if (!response.ok) {
     throw new Error(`cloud cli-session failed: HTTP ${response.status}`);
   }
-  const { sessionId, browserUrl } = await response.json();
+  const { sessionId } = await response.json();
+  if (
+    typeof sessionId !== "string" ||
+    !CLOUD_LOGIN_SESSION_ID_RE.test(sessionId)
+  ) {
+    throw new Error("cloud cli-session returned an invalid session ID");
+  }
+  const apiUrl = new URL(baseUrl);
+  const browserOrigin =
+    apiUrl.hostname === "api.eliza.app"
+      ? `${apiUrl.protocol}//eliza.app`
+      : apiUrl.origin;
+  const browserUrl = `${browserOrigin}/auth/cli-login?session=${encodeURIComponent(sessionId)}`;
   return { sessionId, browserUrl };
 }
 

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -332,7 +332,9 @@ declare module "./client-base" {
       localInference?: LocalInferenceChatMetadata;
       actionResults?: ChatActionResultSummary[];
     }>;
-    listConversations(): Promise<{ conversations: Conversation[] }>;
+    listConversations(options?: {
+      signal?: AbortSignal;
+    }): Promise<{ conversations: Conversation[] }>;
     createConversation(
       title?: string,
       options?: CreateConversationOptions,
@@ -990,7 +992,10 @@ async function invokeLocalDesktopChatRpc<T>(
   return invokeDesktopBridgeRequest<T>(options);
 }
 
-ElizaClient.prototype.listConversations = async function (this: ElizaClient) {
+ElizaClient.prototype.listConversations = async function (
+  this: ElizaClient,
+  options,
+) {
   // Prefer typed Electrobun RPC. The bun-side composer throws
   // AgentNotReadyError if the agent has no port yet; we catch and
   // fall through to HTTP so the sidebar's polling loop sees the same
@@ -1007,7 +1012,9 @@ ElizaClient.prototype.listConversations = async function (this: ElizaClient) {
     /* AgentNotReadyError or any RPC failure → fall through to HTTP */
   }
   return withConversationListDefaults(
-    await this.fetch<{ conversations: Conversation[] }>("/api/conversations"),
+    await this.fetch<{ conversations: Conversation[] }>("/api/conversations", {
+      signal: options?.signal,
+    }),
   );
 };
 

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -40,6 +40,8 @@ import {
   STAGING_DIRECT_CLOUD_BASE_URL,
 } from "./direct-cloud-endpoints";
 
+const SERVER_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -91,7 +93,7 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
   it("creates CLI sessions through the same-origin proxy and opens staging auth", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(jsonResponse({ ok: true }));
+      .mockResolvedValue(jsonResponse({ sessionId: SERVER_SESSION_ID }, 201));
 
     const client = new ElizaClient("http://localhost:31337");
     const result = await client.cloudLoginDirect(
@@ -103,14 +105,14 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: expect.stringContaining("sessionId"),
+        body: "{}",
       }),
     );
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
         apiBase: STAGING_DIRECT_CLOUD_API_BASE_URL,
-        sessionId: expect.any(String),
+        sessionId: SERVER_SESSION_ID,
         browserUrl: expect.stringMatching(
           new RegExp(
             `^${STAGING_DIRECT_CLOUD_BASE_URL}/auth/cli-login\\?session=`,
@@ -119,6 +121,23 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
       }),
     );
   });
+
+  it.each([{}, { sessionId: "not-a-uuid" }])(
+    "rejects a successful web response without a server-issued UUID",
+    async (body) => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(body, 201));
+
+      const client = new ElizaClient("http://localhost:31337");
+      const result = await client.cloudLoginDirect(
+        "https://staging.elizacloud.ai",
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: "Login failed: Eliza Cloud returned an invalid session ID",
+      });
+    },
+  );
 
   it("polls CLI sessions through the same-origin proxy", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -197,7 +216,7 @@ describe("ElizaClient direct Cloud auth served from localhost dev (port-shift)",
   it("creates CLI sessions against the absolute cloud URL, not the local agent", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(jsonResponse({ ok: true }));
+      .mockResolvedValue(jsonResponse({ sessionId: SERVER_SESSION_ID }, 201));
 
     const client = new ElizaClient("http://localhost:31337");
     const result = await client.cloudLoginDirect(
@@ -304,7 +323,7 @@ describe("ElizaClient direct Cloud auth served from Electrobun", () => {
 
   it("keeps the browser callback out of the loopback renderer", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      jsonResponse({ sessionId: "server-issued-electrobun-session" }, 201),
+      jsonResponse({ sessionId: SERVER_SESSION_ID }, 201),
     );
 
     const client = new ElizaClient("http://127.0.0.1:31337");
@@ -315,10 +334,8 @@ describe("ElizaClient direct Cloud auth served from Electrobun", () => {
     const browserUrl = new URL(result.browserUrl ?? "");
     expect(browserUrl.origin).toBe(STAGING_DIRECT_CLOUD_BASE_URL);
     expect(browserUrl.pathname).toBe("/auth/cli-login");
-    expect(result.sessionId).toBe("server-issued-electrobun-session");
-    expect(browserUrl.searchParams.get("session")).toBe(
-      "server-issued-electrobun-session",
-    );
+    expect(result.sessionId).toBe(SERVER_SESSION_ID);
+    expect(browserUrl.searchParams.get("session")).toBe(SERVER_SESSION_ID);
     expect(browserUrl.searchParams.has("returnTo")).toBe(false);
   });
 });

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -41,6 +41,8 @@ import {
 } from "./direct-cloud-endpoints";
 
 const SERVER_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -105,9 +107,13 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: "{}",
+        body: expect.any(String),
       }),
     );
+    const requestBody = JSON.parse(
+      String(fetchSpy.mock.calls[0]?.[1]?.body),
+    ) as { sessionId?: unknown };
+    expect(requestBody.sessionId).toEqual(expect.stringMatching(UUID_V4_RE));
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -25,6 +25,8 @@ import { ElizaClient } from "./client-base";
 import "./client-cloud";
 import { setBootConfig } from "../config/boot-config";
 
+const SERVER_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
+
 function calledNativeUrls(): string[] {
   return [
     ...capacitorMocks.get.mock.calls,
@@ -62,7 +64,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
   it("creates native CLI sessions through the Cloud API host and opens the web auth host", async () => {
     capacitorMocks.post.mockResolvedValue({
       status: 201,
-      data: { sessionId: "server-issued-session" },
+      data: { sessionId: SERVER_SESSION_ID },
     });
 
     const client = new ElizaClient("https://www.elizacloud.ai");
@@ -71,7 +73,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://api.eliza.app/api/auth/cli-session",
-        data: expect.objectContaining({ sessionId: expect.any(String) }),
+        data: {},
       }),
     );
     // The browser URL normalizes the configured www base to the apex host: the
@@ -81,16 +83,18 @@ describe("ElizaClient direct Cloud auth on native", () => {
       expect.objectContaining({
         ok: true,
         apiBase: "https://api.eliza.app",
-        sessionId: "server-issued-session",
-        browserUrl:
-          "https://eliza.app/auth/cli-login?session=server-issued-session",
+        sessionId: SERVER_SESSION_ID,
+        browserUrl: `https://eliza.app/auth/cli-login?session=${SERVER_SESSION_ID}`,
       }),
     );
     expectNoLocalPersistOrStatusProbe();
   });
 
   it("creates staging CLI sessions through the staging API host and opens the staging web auth host", async () => {
-    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+    capacitorMocks.post.mockResolvedValue({
+      status: 201,
+      data: { sessionId: SERVER_SESSION_ID },
+    });
 
     const client = new ElizaClient("https://staging.elizacloud.ai");
     const result = await client.cloudLoginDirect(
@@ -100,7 +104,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://api-staging.eliza.app/api/auth/cli-session",
-        data: expect.objectContaining({ sessionId: expect.any(String) }),
+        data: {},
       }),
     );
     expect(result).toEqual(
@@ -114,8 +118,26 @@ describe("ElizaClient direct Cloud auth on native", () => {
     );
   });
 
+  it.each([{}, { sessionId: "not-a-uuid" }])(
+    "rejects a successful native response without a server-issued UUID",
+    async (data) => {
+      capacitorMocks.post.mockResolvedValue({ status: 201, data });
+
+      const client = new ElizaClient("https://www.elizacloud.ai");
+      const result = await client.cloudLoginDirect("https://www.elizacloud.ai");
+
+      expect(result).toEqual({
+        ok: false,
+        error: "Login failed: Eliza Cloud returned an invalid session ID",
+      });
+    },
+  );
+
   it("maps staging API bases back to the staging web auth host", async () => {
-    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+    capacitorMocks.post.mockResolvedValue({
+      status: 201,
+      data: { sessionId: SERVER_SESSION_ID },
+    });
 
     const client = new ElizaClient("https://api-staging.elizacloud.ai");
     const result = await client.cloudLoginDirect(
@@ -144,7 +166,10 @@ describe("ElizaClient direct Cloud auth on native", () => {
     // Auth for it must ride the staging API/auth hosts — a hop to the
     // production apex would mint a production session that can never see the
     // staging agent.
-    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+    capacitorMocks.post.mockResolvedValue({
+      status: 201,
+      data: { sessionId: SERVER_SESSION_ID },
+    });
 
     const client = new ElizaClient(
       "https://0b5fca39-8d55-4c96-a1a3-000000000000.staging.elizacloud.ai",
@@ -899,7 +924,10 @@ describe("ElizaClient direct Cloud auth on native", () => {
         new Error("native direct Cloud auth must not use fetch"),
       );
 
-    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+    capacitorMocks.post.mockResolvedValue({
+      status: 201,
+      data: { sessionId: SERVER_SESSION_ID },
+    });
     capacitorMocks.get.mockResolvedValue({
       status: 200,
       data: {

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -26,6 +26,8 @@ import "./client-cloud";
 import { setBootConfig } from "../config/boot-config";
 
 const SERVER_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function calledNativeUrls(): string[] {
   return [
@@ -73,7 +75,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://api.eliza.app/api/auth/cli-session",
-        data: {},
+        data: { sessionId: expect.stringMatching(UUID_V4_RE) },
       }),
     );
     // The browser URL normalizes the configured www base to the apex host: the
@@ -104,7 +106,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://api-staging.eliza.app/api/auth/cli-session",
-        data: {},
+        data: { sessionId: expect.stringMatching(UUID_V4_RE) },
       }),
     );
     expect(result).toEqual(

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -429,6 +429,10 @@ function cloudLoginSessionIdOrNull(value: unknown): string | null {
     : null;
 }
 
+function createCloudLoginRequestId(): string | null {
+  return cloudLoginSessionIdOrNull(globalThis.crypto?.randomUUID?.());
+}
+
 function resolveCloudCliLoginReturnUrl(sessionId: string): string | null {
   if (
     shouldUseNativeCloudHttp() ||
@@ -3204,6 +3208,13 @@ ElizaClient.prototype.cloudLoginDirect = async function (
   this: ElizaClient,
   cloudApiBase,
 ) {
+  const requestSessionId = createCloudLoginRequestId();
+  if (!requestSessionId) {
+    return {
+      ok: false,
+      error: "Login failed: a secure UUID generator is unavailable",
+    };
+  }
   const cloudWebBase = resolveDirectCloudWebBase(cloudApiBase);
   const authApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   try {
@@ -3211,7 +3222,7 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       const res = await CapacitorHttp.post({
         url: `${authApiBase}/api/auth/cli-session`,
         headers: { "Content-Type": "application/json" },
-        data: {},
+        data: { sessionId: requestSessionId },
         responseType: "json",
         connectTimeout: 10_000,
         readTimeout: 10_000,
@@ -3240,7 +3251,7 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ sessionId: requestSessionId }),
       },
     );
     if (!res.ok) {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -419,18 +419,14 @@ function parseCloudLoginPollData(data: unknown): {
   };
 }
 
-function generateCloudLoginSessionId(): string {
-  if (typeof globalThis.crypto?.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-  if (typeof globalThis.crypto?.getRandomValues === "function") {
-    const bytes = new Uint8Array(16);
-    globalThis.crypto.getRandomValues(bytes);
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
-      "",
-    );
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+const CLOUD_LOGIN_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function cloudLoginSessionIdOrNull(value: unknown): string | null {
+  const sessionId = stringOrNull(value);
+  return sessionId && CLOUD_LOGIN_SESSION_ID_RE.test(sessionId)
+    ? sessionId
+    : null;
 }
 
 function resolveCloudCliLoginReturnUrl(sessionId: string): string | null {
@@ -3208,7 +3204,6 @@ ElizaClient.prototype.cloudLoginDirect = async function (
   this: ElizaClient,
   cloudApiBase,
 ) {
-  const requestedSessionId = generateCloudLoginSessionId();
   const cloudWebBase = resolveDirectCloudWebBase(cloudApiBase);
   const authApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   try {
@@ -3216,7 +3211,7 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       const res = await CapacitorHttp.post({
         url: `${authApiBase}/api/auth/cli-session`,
         headers: { "Content-Type": "application/json" },
-        data: { sessionId: requestedSessionId },
+        data: {},
         responseType: "json",
         connectTimeout: 10_000,
         readTimeout: 10_000,
@@ -3225,8 +3220,13 @@ ElizaClient.prototype.cloudLoginDirect = async function (
         return { ok: false, error: `Login failed (${res.status})` };
       }
       const responseData = recordOrNull(parseDirectCloudJsonSafe(res.data));
-      const sessionId =
-        stringOrNull(responseData?.sessionId) ?? requestedSessionId;
+      const sessionId = cloudLoginSessionIdOrNull(responseData?.sessionId);
+      if (!sessionId) {
+        return {
+          ok: false,
+          error: "Login failed: Eliza Cloud returned an invalid session ID",
+        };
+      }
       return {
         ok: true,
         apiBase: authApiBase,
@@ -3240,15 +3240,20 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId: requestedSessionId }),
+        body: JSON.stringify({}),
       },
     );
     if (!res.ok) {
       return { ok: false, error: `Login failed (${res.status})` };
     }
     const responseData = recordOrNull(await res.json());
-    const sessionId =
-      stringOrNull(responseData?.sessionId) ?? requestedSessionId;
+    const sessionId = cloudLoginSessionIdOrNull(responseData?.sessionId);
+    if (!sessionId) {
+      return {
+        ok: false,
+        error: "Login failed: Eliza Cloud returned an invalid session ID",
+      };
+    }
     return {
       ok: true,
       apiBase: authApiBase,

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
@@ -130,13 +130,23 @@ describe("SsoBridgeRoute — mint leg (eliza.app auth host)", () => {
     expect(fetchLog).toEqual([]);
   });
 
-  it("a cross-site or absent referrer mints NOTHING — a third-party page cannot use eliza.app as a minting oracle", async () => {
+  it("an absent referrer falls back to app login without minting", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
-    for (const referrer of [
-      "",
-      "https://evil.example/",
-      "https://eliza.app/",
-    ]) {
+    setReferrer("");
+    stubNetwork(() => json(200, { ok: true, code: CODE }));
+    renderBridge("eliza.app", MINT_QS);
+
+    await waitFor(() =>
+      expect(replacedUrls).toEqual([
+        "https://cloud.eliza.app/login?returnTo=%2Fchat",
+      ]),
+    );
+    expect(fetchLog).toEqual([]);
+  });
+
+  it("a cross-site referrer mints NOTHING — a third-party page cannot use eliza.app as a minting oracle", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    for (const referrer of ["https://evil.example/", "https://eliza.app/"]) {
       setReferrer(referrer);
       stubNetwork(() => json(200, { ok: true, code: CODE }));
       renderBridge("eliza.app", MINT_QS);

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
@@ -136,9 +136,18 @@ function MintLeg({
     const appOrigin = pairedAppOrigin(hostname);
     if (!appOrigin) return;
 
-    const appInitiated = referrerIsPairedAppOrigin(appOrigin);
+    const referrer = document.referrer;
+    const appInitiated = referrerIsPairedAppOrigin(appOrigin, referrer);
     const remembered = hasRememberedMintIntent(state);
     if (!appInitiated && !remembered) {
+      if (!referrer) {
+        // Referrer-stripping privacy settings make a legitimate app handoff
+        // indistinguishable from a direct visit. Keep minting fail-closed, but
+        // send the user to the app's ordinary login instead of stranding them
+        // on the public homepage.
+        appModeNavigation.replace(appLoginUrl(appOrigin, returnTo));
+        return;
+      }
       // Not a handshake the app origin initiated (direct visit, or a
       // third-party page forcing a signed-in user here): mint nothing.
       setNotInitiated(true);

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -316,6 +316,49 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     },
   );
 
+  it("advances to the auth gate without waiting for a stalled status probe", async () => {
+    vi.useFakeTimers();
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+    clientMock.hasToken.mockReturnValue(true);
+    clientMock.listConversations.mockRejectedValue({
+      status: 401,
+      message: "Unauthorized",
+    });
+    clientMock.fetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () => resolve({ state: "starting", canRespond: false }),
+            30_000,
+          );
+        }),
+    );
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+    let settled = false;
+    const run = runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    ).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(true);
+    await run;
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+  });
+
   it("keeps a tokenless native 401 in warmup while credential injection is pending", async () => {
     persistenceMock.loadPersistedActiveServer.mockReturnValue({
       id: "cloud:agent-123",

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -239,9 +239,11 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
       "cloud-managed",
     );
 
-    expect(clientMock.fetch).toHaveBeenCalledWith("/api/status", undefined, {
-      timeoutMs: 30_000,
-    });
+    expect(clientMock.fetch).toHaveBeenCalledWith(
+      "/api/status",
+      { signal: expect.any(AbortSignal) },
+      { timeoutMs: 30_000 },
+    );
     expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
     expect(deps.setStartupError).not.toHaveBeenCalled();
   });
@@ -329,11 +331,19 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
       message: "Unauthorized",
     });
     clientMock.fetch.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(
+      (_path, init) =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(
             () => resolve({ state: "starting", canRespond: false }),
             30_000,
+          );
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
           );
         }),
     );
@@ -356,6 +366,9 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(settled).toBe(true);
     await run;
+    const statusRequest = clientMock.fetch.mock.calls[0]?.[1];
+    expect(statusRequest?.signal).toBeInstanceOf(AbortSignal);
+    expect(statusRequest?.signal.aborted).toBe(true);
     expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
   });
 
@@ -424,9 +437,11 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     );
 
     // We fell back to /api/status once the 5xx streak crossed threshold.
-    expect(clientMock.fetch).toHaveBeenCalledWith("/api/status", undefined, {
-      timeoutMs: 30_000,
-    });
+    expect(clientMock.fetch).toHaveBeenCalledWith(
+      "/api/status",
+      { signal: expect.any(AbortSignal) },
+      { timeoutMs: 30_000 },
+    );
     // And advanced to chat exactly once instead of stranding on the boot screen.
     const runningDispatches = dispatch.mock.calls.filter(
       ([e]) => e.type === "AGENT_RUNNING",

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -661,6 +661,12 @@ async function runCloudManagedWarmup(
     dispatch({ type: "AGENT_RUNNING" });
   };
 
+  const advanceAuthGate = (): void => {
+    deps.setConnected(false);
+    deps.setFirstRunLoading(false);
+    dispatch({ type: "AGENT_RUNNING" });
+  };
+
   logger.info(
     "[eliza][startup:init] cloud-managed agent; waiting on proxy passthrough to warm before declaring ready",
   );
@@ -689,22 +695,34 @@ async function runCloudManagedWarmup(
     // runtimes regularly answer just beyond the generic 10s client timeout.
     const conversationProbe = probeCloudProxyPassthrough();
     const statusProbe = isCloudProxyStatusReady();
-    const firstPositive = await Promise.race([
+    const firstDecisive = await Promise.race([
       conversationProbe.then((probe) =>
-        probe.kind === "serving" ? "conversations" : null,
+        probe.kind === "serving"
+          ? "conversations"
+          : probe.kind === "auth-required"
+            ? "auth-required"
+            : null,
       ),
       statusProbe.then((ready) => (ready ? "status" : null)),
     ]);
     if (cancelled.current || effectRunRef.current !== effectRunId) return;
 
-    if (firstPositive === "status") {
+    if (firstDecisive === "status") {
       await advanceReady("status reports running and canRespond");
       return;
     }
 
-    if (firstPositive === "conversations") {
+    if (firstDecisive === "conversations") {
       // The passthrough answers → the warmed runtime is genuinely serving.
       await advanceReady("conversations passthrough serving");
+      return;
+    }
+
+    if (firstDecisive === "auth-required") {
+      // Authentication is a definitive routing result; a concurrent status
+      // probe cannot make the adopted bearer valid. Mount the auth gate now
+      // instead of waiting through the status request's 30-second budget.
+      advanceAuthGate();
       return;
     }
 
@@ -733,9 +751,7 @@ async function runCloudManagedWarmup(
       // the normal auth gate, where managed Cloud recovery can exchange a
       // fresh agent credential; treating this as warmup would hide that gate
       // behind the startup screen until the absolute timeout.
-      deps.setConnected(false);
-      deps.setFirstRunLoading(false);
-      dispatch({ type: "AGENT_RUNNING" });
+      advanceAuthGate();
       return;
     }
 

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -201,9 +201,11 @@ type PassthroughProbe =
   | { kind: "terminal-agent-error" }
   | { kind: "errored"; status: number };
 
-async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
+async function probeCloudProxyPassthrough(
+  signal?: AbortSignal,
+): Promise<PassthroughProbe> {
   try {
-    await client.listConversations();
+    await client.listConversations({ signal });
     return { kind: "serving" };
   } catch (err) {
     const apiError = asApiLikeError(err);
@@ -239,11 +241,13 @@ async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
  * genuinely-serving agent on the boot screen — if status says `canRespond`, the
  * agent is ready and the user should be let into chat (CONVERSATIONS-500).
  */
-async function isCloudProxyStatusReady(): Promise<boolean> {
+async function isCloudProxyStatusReady(signal?: AbortSignal): Promise<boolean> {
   try {
-    const status = await client.fetch<AgentStatus>("/api/status", undefined, {
-      timeoutMs: 30_000,
-    });
+    const status = await client.fetch<AgentStatus>(
+      "/api/status",
+      { signal },
+      { timeoutMs: 30_000 },
+    );
     return status?.state === "running" && status?.canRespond === true;
   } catch {
     return false;
@@ -693,8 +697,12 @@ async function runCloudManagedWarmup(
     // them concurrently so startup pays one proxy wake, not serial 10-second
     // timeouts. The status request has a 30s budget because production shared
     // runtimes regularly answer just beyond the generic 10s client timeout.
-    const conversationProbe = probeCloudProxyPassthrough();
-    const statusProbe = isCloudProxyStatusReady();
+    const conversationAbort = new AbortController();
+    const statusAbort = new AbortController();
+    const conversationProbe = probeCloudProxyPassthrough(
+      conversationAbort.signal,
+    );
+    const statusProbe = isCloudProxyStatusReady(statusAbort.signal);
     const firstDecisive = await Promise.race([
       conversationProbe.then((probe) =>
         probe.kind === "serving"
@@ -708,17 +716,23 @@ async function runCloudManagedWarmup(
     if (cancelled.current || effectRunRef.current !== effectRunId) return;
 
     if (firstDecisive === "status") {
+      conversationAbort.abort();
+      await conversationProbe;
       await advanceReady("status reports running and canRespond");
       return;
     }
 
     if (firstDecisive === "conversations") {
+      statusAbort.abort();
+      await statusProbe;
       // The passthrough answers → the warmed runtime is genuinely serving.
       await advanceReady("conversations passthrough serving");
       return;
     }
 
     if (firstDecisive === "auth-required") {
+      statusAbort.abort();
+      await statusProbe;
       // Authentication is a definitive routing result; a concurrent status
       // probe cannot make the adopted bearer valid. Mount the auth gate now
       // instead of waiting through the status request's 30-second budget.

--- a/plugins/plugin-elizacloud/src/cloud/auth.session-id.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud/auth.session-id.test.ts
@@ -1,5 +1,6 @@
 /** Exercises the real Cloud login create/poll boundary with deterministic fetch responses. */
 
+import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./validate-url.js", () => ({
@@ -12,11 +13,13 @@ const SERVER_SESSION_ID = "11111111-2222-4333-8444-555555555555";
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("cloudLogin server-minted sessions", () => {
-  it("opens and polls the authoritative server session without proposing an id", async () => {
+  it("opens and polls the authoritative session while sending a compatibility proposal", async () => {
     const requests: Array<{ url: string; body?: BodyInit | null }> = [];
+    const logSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -54,6 +57,7 @@ describe("cloudLogin server-minted sessions", () => {
     expect(onBrowserUrl).toHaveBeenCalledWith(
       `https://cloud.example.com/auth/cli-login?session=${SERVER_SESSION_ID}`,
     );
+    expect(logSpy.mock.calls.flat().join(" ")).not.toContain(SERVER_SESSION_ID);
     expect(result.apiKey).toBe("elizakey_test");
   });
 

--- a/plugins/plugin-elizacloud/src/cloud/auth.session-id.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud/auth.session-id.test.ts
@@ -1,0 +1,80 @@
+/** Exercises the real Cloud login create/poll boundary with deterministic fetch responses. */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./validate-url.js", () => ({
+  validateCloudBaseUrl: async () => null,
+}));
+
+import { cloudLogin } from "./auth.js";
+
+const SERVER_SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("cloudLogin server-minted sessions", () => {
+  it("opens and polls the authoritative server session without proposing an id", async () => {
+    const requests: Array<{ url: string; body?: BodyInit | null }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input), body: init?.body });
+        if (requests.length === 1) {
+          return new Response(JSON.stringify({ sessionId: SERVER_SESSION_ID }), {
+            status: 201,
+          });
+        }
+        return new Response(
+          JSON.stringify({ status: "authenticated", apiKey: "elizakey_test" }),
+          { status: 200 },
+        );
+      }),
+    );
+    const onBrowserUrl = vi.fn();
+
+    const result = await cloudLogin({
+      baseUrl: "https://cloud.example.com",
+      pollIntervalMs: 0,
+      onBrowserUrl,
+    });
+
+    expect(requests[0]?.url).toBe(
+      "https://cloud.example.com/api/auth/cli-session",
+    );
+    expect(JSON.parse(String(requests[0]?.body))).toEqual({
+      sessionId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+    });
+    expect(requests[1]?.url).toBe(
+      `https://cloud.example.com/api/auth/cli-session/${SERVER_SESSION_ID}`,
+    );
+    expect(onBrowserUrl).toHaveBeenCalledWith(
+      `https://cloud.example.com/auth/cli-login?session=${SERVER_SESSION_ID}`,
+    );
+    expect(result.apiKey).toBe("elizakey_test");
+  });
+
+  it.each([{}, { sessionId: "client-chosen" }])(
+    "fails closed before opening or polling an invalid create response: %j",
+    async (payload) => {
+      const fetchMock = vi.fn(async () =>
+        new Response(JSON.stringify(payload), { status: 201 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const onBrowserUrl = vi.fn();
+
+      await expect(
+        cloudLogin({
+          baseUrl: "https://cloud.example.com",
+          pollIntervalMs: 0,
+          onBrowserUrl,
+        }),
+      ).rejects.toThrow("invalid login session ID");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onBrowserUrl).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/plugins/plugin-elizacloud/src/cloud/auth.ts
+++ b/plugins/plugin-elizacloud/src/cloud/auth.ts
@@ -114,7 +114,7 @@ export async function cloudLogin(
   }
 
   const browserUrl = `${baseUrl}/auth/cli-login?session=${encodeURIComponent(sessionId)}`;
-  logger.info(`[cloud-auth] Browser URL: ${browserUrl}`);
+  logger.info("[cloud-auth] Browser sign-in URL ready");
   options.onBrowserUrl?.(browserUrl);
 
   const deadline = Date.now() + timeoutMs;

--- a/plugins/plugin-elizacloud/src/cloud/auth.ts
+++ b/plugins/plugin-elizacloud/src/cloud/auth.ts
@@ -4,6 +4,7 @@
  */
 
 import crypto from "node:crypto";
+import { isCliLoginSessionId } from "@elizaos/cloud-sdk";
 import { logger } from "@elizaos/core";
 import { normalizeCloudSiteUrl } from "./base-url.js";
 import { validateCloudBaseUrl } from "./validate-url.js";
@@ -60,8 +61,7 @@ export async function cloudLogin(
   const requestTimeoutMs =
     options.requestTimeoutMs ?? DEFAULT_CLOUD_REQUEST_TIMEOUT_MS;
   const pollIntervalMs = options.pollIntervalMs ?? 2_000;
-  const sessionId = crypto.randomUUID();
-
+  const requestSessionId = crypto.randomUUID();
   logger.info("[cloud-auth] Creating auth session...");
 
   let createResponse: Response;
@@ -71,7 +71,7 @@ export async function cloudLogin(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId }),
+        body: JSON.stringify({ sessionId: requestSessionId }),
       },
       requestTimeoutMs,
     );
@@ -94,6 +94,23 @@ export async function cloudLogin(
     throw new Error(
       `Failed to create auth session (HTTP ${createResponse.status}): ${errorText}`,
     );
+  }
+
+  let createData: unknown;
+  try {
+    createData = await createResponse.json();
+  } catch (err) {
+    // error-policy:J2 preserve the malformed upstream response as the cause.
+    throw new Error("Eliza Cloud returned an invalid login session response", {
+      cause: err,
+    });
+  }
+  const sessionId =
+    typeof createData === "object" && createData !== null
+      ? (createData as { sessionId?: unknown }).sessionId
+      : undefined;
+  if (!isCliLoginSessionId(sessionId)) {
+    throw new Error("Eliza Cloud returned an invalid login session ID");
   }
 
   const browserUrl = `${baseUrl}/auth/cli-login?session=${encodeURIComponent(sessionId)}`;

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.login.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.login.test.ts
@@ -1,0 +1,105 @@
+/** Exercises the local Cloud login proxy against authoritative upstream session responses. */
+
+import type http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../cloud/validate-url.js", () => ({
+  validateCloudBaseUrl: async () => null,
+}));
+
+import {
+  type CloudRouteState,
+  handleCloudRoute,
+} from "./cloud-routes-autonomous.js";
+
+const SERVER_SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+function responseSink(): http.ServerResponse & { jsonBody: () => unknown } {
+  let body = "";
+  const sink = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: () => {},
+    end: (chunk?: unknown) => {
+      body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+      sink.headersSent = true;
+      return sink;
+    },
+    jsonBody: () => JSON.parse(body),
+  };
+  return sink as unknown as http.ServerResponse & { jsonBody: () => unknown };
+}
+
+function state(): CloudRouteState {
+  return {
+    config: { cloud: { baseUrl: "https://cloud.example.com" } },
+    cloudManager: null,
+    runtime: null,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/cloud/login", () => {
+  it("returns the upstream server-minted session and sends no proposed id", async () => {
+    let requestBody: BodyInit | null | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: unknown, init?: RequestInit) => {
+        requestBody = init?.body;
+        return new Response(JSON.stringify({ sessionId: SERVER_SESSION_ID }), {
+          status: 201,
+        });
+      }),
+    );
+    const response = responseSink();
+
+    await handleCloudRoute(
+      {} as http.IncomingMessage,
+      response,
+      "/api/cloud/login",
+      "POST",
+      state(),
+    );
+
+    expect(JSON.parse(String(requestBody))).toEqual({
+      sessionId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.jsonBody()).toEqual({
+      ok: true,
+      sessionId: SERVER_SESSION_ID,
+      browserUrl: `https://cloud.example.com/auth/cli-login?session=${SERVER_SESSION_ID}`,
+    });
+  });
+
+  it.each([{}, { sessionId: "client-chosen" }])(
+    "returns 502 for an invalid upstream session: %j",
+    async (payload) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(JSON.stringify(payload), { status: 201 }),
+        ),
+      );
+      const response = responseSink();
+
+      await handleCloudRoute(
+        {} as http.IncomingMessage,
+        response,
+        "/api/cloud/login",
+        "POST",
+        state(),
+      );
+
+      expect(response.statusCode).toBe(502);
+      expect(response.jsonBody()).toEqual({
+        error: "Eliza Cloud returned an invalid login session",
+      });
+    },
+  );
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.login.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.login.test.ts
@@ -43,7 +43,7 @@ afterEach(() => {
 });
 
 describe("POST /api/cloud/login", () => {
-  it("returns the upstream server-minted session and sends no proposed id", async () => {
+  it("returns the upstream server-minted session and sends a compatibility proposal", async () => {
     let requestBody: BodyInit | null | undefined;
     vi.stubGlobal(
       "fetch",

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.ts
@@ -1,6 +1,8 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import type http from "node:http";
 import path from "node:path";
+import { isCliLoginSessionId } from "@elizaos/cloud-sdk";
 import {
   isCloudInferenceSelectedInConfig,
   migrateLegacyRuntimeConfig,
@@ -319,7 +321,7 @@ export async function handleCloudRoute(
       sendJsonError(res, urlError);
       return true;
     }
-    const sessionId = crypto.randomUUID();
+    const requestSessionId = crypto.randomUUID();
     const loginCreateSpan = getTelemetrySpan(state, {
       boundary: "cloud",
       operation: "login_create_session",
@@ -333,7 +335,7 @@ export async function handleCloudRoute(
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionId }),
+          body: JSON.stringify({ sessionId: requestSessionId }),
         },
         CLOUD_LOGIN_CREATE_TIMEOUT_MS,
       );
@@ -369,6 +371,32 @@ export async function handleCloudRoute(
         errorKind: "http_error",
       });
       sendJsonError(res, "Failed to create auth session with Eliza Cloud", 502);
+      return true;
+    }
+
+    let createData: unknown;
+    try {
+      createData = await createRes.json();
+    } catch (err) {
+      // error-policy:J1 malformed upstream data maps to a gateway failure.
+      loginCreateSpan.failure({
+        error: err,
+        statusCode: 502,
+        errorKind: "invalid_response",
+      });
+      sendJsonError(res, "Eliza Cloud returned an invalid login session", 502);
+      return true;
+    }
+    const sessionId =
+      typeof createData === "object" && createData !== null
+        ? (createData as { sessionId?: unknown }).sessionId
+        : undefined;
+    if (!isCliLoginSessionId(sessionId)) {
+      loginCreateSpan.failure({
+        statusCode: 502,
+        errorKind: "invalid_response",
+      });
+      sendJsonError(res, "Eliza Cloud returned an invalid login session", 502);
       return true;
     }
 


### PR DESCRIPTION
# Relates to

Follow-up to #22082. Relates to #22081.

- [x] This PR targets `develop`.
- [x] Final head `9cf27d5c06d013b94bfbb51bf469b44b48a87068` is conflict-free and GitHub reports `CLEAN` / `MERGEABLE` against current `develop`.
- [x] `bun install --frozen-lockfile` passed with pinned Bun 1.3.14.
- [x] The packaged Cloud-only onboarding surface and current app audit were manually reviewed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (review repair and validation), `openai/gpt-5.6-terra` (original PR context)
<!-- attribution-row:client -->
- Agent tooling: Amp CLI and Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no repository-versioned contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased without conflicts through `e8df86642188`.
- [x] Freshness checked against current `develop` `0bf4826f0026`; the only later commit is documentation-only #22485, has no overlapping paths, and the PR remains cleanly mergeable.
- [ ] Full root `bun run verify` was not rerun; exact-head package tests, typechecks, builds, Biome/diff gates, production protocol probes, and the mandatory app audit are recorded below.

# Risks

Medium, because CLI-login session identifiers are unauthenticated handoff capabilities. Every create caller now sends a fresh cryptographic v4 compatibility proposal for the currently deployed API, then validates and exclusively trusts the server-returned UUID. Missing/malformed responses fail closed before browser navigation or polling, and capability-bearing URLs are not logged.

SSO minting remains fail-closed. Managed-Cloud startup now cancels and drains the losing readiness probe.

# Background

## What does this PR do?

This addresses the three actionable follow-up findings from #22082 and repairs every caller of the shared login-session contract:

1. **Authoritative server session identity:** UI native/web, `@elizaos/cloud-sdk`, plugin setup login, the plugin's autonomous local route, and the zero-import test console validate and use only the response UUID. They send a fresh cryptographic UUID proposal solely for compatibility with the currently deployed endpoint; there is no response fallback.
2. **Referrer-stripped SSO handoff:** an absent referrer still mints nothing, but redirects to the exact paired app origin's normal `/login` with sanitized `returnTo`. Explicit cross-site referrers mint nothing and receive no paired-origin redirect.
3. **Immediate auth gate with cancellation:** a definitive `auth-required` conversations response aborts and drains the concurrent 30-second status probe before mounting the auth gate. A decisive status result likewise aborts and drains the conversations probe.
4. **Capability-safe diagnostics:** the plugin no longer logs the browser handoff URL/session capability; regression coverage asserts the authoritative UUID is absent from logger calls.

The runtime-target Settings behavior noted in #22082 is intentionally unchanged because it is product behavior, not this defect.

## What kind of change is this?

Security-sensitive bug fixes with regression coverage. The deprecated SDK `sessionId` option remains source-compatible but is ignored.

# Documentation changes needed?

No user-facing documentation change. The implementation aligns clients with both the checked-in hardened server contract and the currently deployed compatibility requirement.

# Testing

## Where should a reviewer start?

- `packages/ui/src/api/client-cloud.ts`
- `packages/cloud/sdk/src/client.ts`
- `plugins/plugin-elizacloud/src/cloud/auth.ts`
- `plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.ts`
- `packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx`
- `packages/ui/src/state/startup-phase-runtime.ts`

## Detailed testing steps

1. Create a session with a fresh cryptographic request UUID; return a different valid UUID and confirm only the response UUID is opened/polled.
2. Return a missing, malformed, wrong-version, or wrong-variant response ID and confirm failure before browser navigation/polling.
3. Confirm no logger call contains the response UUID or browser handoff URL.
4. Load the SSO mint leg with absent and explicit cross-site referrers; verify zero mint requests, exact paired-login fallback only for absent referrer, and sanitized `returnTo`.
5. Return `401 auth-required` while status stalls; verify the status request is aborted/drained and the auth gate mounts without advancing the 30-second timer.
6. Inspect packaged-app and audit captures at desktop/mobile sizes.

## Exact-head validation

Head: `9cf27d5c06d013b94bfbb51bf469b44b48a87068`

- UI focused auth/SSO/startup/conversation suite: **77/77 passed**
- Cloud SDK: **83 passed, 19 credential-gated live cases skipped**; typecheck passed
- plugin-elizacloud: focused session tests **6/6**; full package **506 passed, 5 skipped**; dist packaging **4/4**; typecheck and build passed
- test-console Cloud protocol: **3/3 passed**
- checked-in Cloud create route: **2/2 passed**, including server-minted UUID and ignored client proposal
- package UI/plugin/SDK typechecks: passed
- focused Biome and `git diff --check`: passed
- `bun install --frozen-lockfile`: passed with Bun 1.3.14
- live production probes (capability values intentionally never printed): API origin and site proxy both returned HTTP 201 with valid UUID/status/expiry when given a fresh v4 compatibility proposal; production currently returns HTTP 400 for `{}`, proving the proposal is still release-sequencing-critical
- independent exact-head code/security review: **GREEN** after the capability-log repair

# Evidence Gate

<!-- evidence-head:9cf27d5c06d013b94bfbb51bf469b44b48a87068 -->

<!-- evidence-row:before-screenshots -->
- [x] [before baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-before.png)
<!-- evidence-row:after-screenshots -->
- [x] [auth-gate visual reference](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-latest-after.png) — captured at original implementation head `6afc91e...`; subsequent reviewer repairs change request validation, plugin/server logic, cancellation, tests, and log redaction only, with no markup/style changes
<!-- evidence-row:walkthrough-video -->
- [x] [packaged macOS walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-latest-walkthrough-faststart.mp4) — same visual provenance note as above
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic backend/plugin/SDK test receipts are recorded in [review evidence](https://github.com/elizaOS/eliza/pull/22637#issuecomment-5348914726) and [capability-log follow-up](https://github.com/elizaOS/eliza/pull/22637#issuecomment-5348960771); live probe output disclosed only status/schema booleans, never capability values
<!-- evidence-row:frontend-logs -->
- [x] [original renderer log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-green-latest-dev.txt); exact-head focused UI results are inline in the review evidence
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [original packaged-build log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-build-latest-dev.log); exact-head SDK/plugin builds passed after reviewer repair
<!-- evidence-row:ocr-review -->
- [x] [original OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22637-cloud-follow-up-latest-ocr.txt); exact-head repair is non-visual

# Evidence Details

## Real integration evidence

No production credentials were used and no login was completed. The public production create boundary was exercised safely: ephemeral pending sessions auto-expire, the ID was never printed, and both API/site origins returned a valid response contract. Checked-in route tests prove the hardened server ignores the compatibility proposal and generates its own UUID.

## Screenshots + walkthrough

The visual implementation is unchanged from `6afc91e...`; later exact-head repairs do not touch rendered markup or styles. The mandatory `packages/app audit:app` ran on the repaired working tree and completed **222/223** captures with **0 broken**, **0 minimalism-budget failures**, zero console/render-state findings on the affected chat surface, and all four chat desktop/mobile/tablet verdicts `good`. The sole aggregate failure is the existing minimalism ratchet for unrelated `builtin-plugins`, `builtin-runtime`, and `builtin-background`. Desktop/mobile chat captures and the packaged auth-gate screenshot/video were manually inspected.

## Known scoped gaps

- The external browser login was not completed because no production credential was used; request/response, browser handoff selection, polling selection, SSO mint refusal, and auth-gate behavior are covered directly.
- Exact-head screenshot/video recapture is N/A: the post-`6afc91e` reviewer repair has no rendered markup/style/pixel changes. Exact-head app audit captures were generated and manually reviewed locally; the linked visual artifacts preserve the original visible behavior.

— [cloud-onboarding-auth-follow-up]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"N/A - no repository-versioned contribution skill used"} -->

