### PR TITLE
fix(cloud): add required top-level resource to topup x402 v2 PaymentRequired

### DIFF
--- a/packages/cloud/shared/src/lib/services/topup-handler.test.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.test.ts
@@ -149,6 +149,113 @@ test("exact_permit quote fails closed when facilitator setup fails despite a con
   expect(getSignerAddress).not.toHaveBeenCalled();
 });
 
+test("402 quote carries the required x402 v2 top-level resource object (exact scheme)", async () => {
+  // A configured recipient skips facilitator init for an `exact` EVM network,
+  // so this drives a real HTTP 402 PaymentRequired with no X-PAYMENT header.
+  const url = "https://api.example.test/api/v1/topup/10";
+  const handler = createTopupHandler({
+    amount: 10,
+    getSourceId: (walletAddress, paymentId) => `${walletAddress}:${paymentId}`,
+  });
+
+  const response = await handler(
+    new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        walletAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    }),
+    { X402_RECIPIENT_ADDRESS: "0x2222222222222222222222222222222222222222" },
+  );
+
+  expect(response.status).toBe(402);
+  const body = (await response.json()) as {
+    x402Version: number;
+    resource: { url: string; description: string; mimeType: string };
+    accepts: Array<{ resource: string; description: string; mimeType: string; scheme: string }>;
+  };
+
+  // The defect under test: the top-level `resource` object was missing even
+  // though `x402Version: 2` was declared. A strict facilitator validates the
+  // top-level object, not accepts[0].
+  expect(body.x402Version).toBe(2);
+  expect(typeof body.resource).toBe("object");
+  expect(body.resource).not.toBeNull();
+  expect(body.resource.url).toBe(url);
+  expect(body.resource.url.length).toBeGreaterThan(0);
+  expect(body.resource.description).toBe("Top up $10");
+  expect(body.resource.mimeType).toBe("application/json");
+
+  // The same object must appear in the base64 PAYMENT-REQUIRED header. Both
+  // header spellings collapse into one case-insensitive header value, so the
+  // Fetch API returns them comma-joined; decode the first encoded segment.
+  const header = response.headers.get("PAYMENT-REQUIRED");
+  expect(header).toBeTruthy();
+  const encodedSegment = (header as string).split(", ")[0];
+  const decoded = JSON.parse(Buffer.from(encodedSegment, "base64").toString("utf-8")) as {
+    resource: { url: string; description: string; mimeType: string };
+  };
+  expect(decoded.resource).toEqual(body.resource);
+  expect(response.headers.get("Payment-Required")).toBe(header);
+
+  // Regression guard: the additive v1 fields on accepts[0] are still present.
+  const entry = body.accepts[0];
+  expect(entry.scheme).toBe("exact");
+  expect(entry.resource).toBe(url);
+  expect(entry.description).toBe("Top up $10");
+  expect(entry.mimeType).toBe("application/json");
+});
+
+test("402 quote carries the top-level resource and extensions on the exact_permit path", async () => {
+  initialize.mockClear();
+  getSignerAddress.mockClear();
+  // exact_permit (bsc) reaches the signer-init call; let it succeed so the
+  // full PaymentRequired with extensions is emitted.
+  initialize.mockResolvedValueOnce(undefined as never);
+  getSignerAddress.mockReturnValueOnce("0x2222222222222222222222222222222222222222");
+
+  const url = "https://api.example.test/api/v1/topup/10";
+  const handler = createTopupHandler({
+    amount: 10,
+    getSourceId: (walletAddress, paymentId) => `${walletAddress}:${paymentId}`,
+  });
+
+  const response = await handler(
+    new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        walletAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    }),
+    {
+      X402_RECIPIENT_ADDRESS: "0x2222222222222222222222222222222222222222",
+      X402_NETWORK: "bsc",
+    },
+  );
+
+  expect(response.status).toBe(402);
+  const body = (await response.json()) as {
+    resource: { url: string; description: string; mimeType: string };
+    accepts: Array<{ scheme: string; resource: string }>;
+    extensions?: { paymentPermitContext?: { meta?: { kind?: string } } };
+  };
+  expect(body.resource.url).toBe(url);
+  expect(body.resource.description).toBe("Top up $10");
+  expect(body.resource.mimeType).toBe("application/json");
+  expect(body.accepts[0].scheme).toBe("exact_permit");
+  expect(body.accepts[0].resource).toBe(url);
+  expect(body.extensions?.paymentPermitContext?.meta?.kind).toBe("PAYMENT_ONLY");
+
+  const header = response.headers.get("PAYMENT-REQUIRED");
+  const encodedSegment = (header as string).split(", ")[0];
+  const decoded = JSON.parse(Buffer.from(encodedSegment, "base64").toString("utf-8")) as {
+    resource: { url: string };
+  };
+  expect(decoded.resource.url).toBe(url);
+});
+
 test("a settled top-up creates a zero-balance wallet account then credits only the paid amount", async () => {
   settle.mockResolvedValueOnce({
     success: true,

--- a/packages/cloud/shared/src/lib/services/topup-handler.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.ts
@@ -317,9 +317,19 @@ function paymentRequiredResponse(
   requirements: PaymentRequirements,
   extensions?: PaymentRequiredExtensions,
 ): Response {
+  // x402 v2 (section 5.1.2) requires a top-level `resource` object on
+  // PaymentRequired. It is derived from the single-source v1 fields already on
+  // `requirements`; those fields are retained additively on accepts[0] for
+  // dual-version clients. A strict v2 facilitator validates the top-level
+  // object below, not the accepts entry.
   const paymentRequired = {
     x402Version: 2,
     error: "payment_required",
+    resource: {
+      url: requirements.resource,
+      description: requirements.description,
+      mimeType: requirements.mimeType,
+    },
     accepts: [requirements],
     ...(extensions && { extensions }),
   };


### PR DESCRIPTION
# Relates to

Closes #22630

Twin of #22625 / #22615: the same x402 v2 `PaymentRequired` top-level-`resource`
defect in a **second, independent emitter**. It was deliberately kept out of
#22625 to keep that PR scoped to its single emitter (`x402-payment-requests.ts`),
so this PR is scoped strictly to `topup-handler.ts` and its test.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync. Full-repo `bun run verify` was **not** run — see **Known gaps / failures**; the owning package's focused test, typecheck, and lint were run instead.
- [x] A reviewer can confirm the change works without reading the code, from the before/after evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`a6b612298d`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run; see **Known gaps / failures** for the exact blocker.

# Risks

Low. The change is additive: it adds the required x402 v2 top-level `resource`
object to the `PaymentRequired` payload and its base64 `PAYMENT-REQUIRED` /
`Payment-Required` headers. No existing field is removed or renamed — the v1
compatibility fields on `accepts[0]` (`maxAmountRequired`, `resource`,
`description`, `mimeType`) are preserved. A tolerant facilitator that ignored
the missing field is unaffected; a strict v2 facilitator that previously
rejected the payload now receives a spec-conformant object.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/services/topup-handler.ts` builds an x402 v2
`PaymentRequired` response in `paymentRequiredResponse()`, declares
`x402Version: 2`, and returns it as both the HTTP 402 JSON body and the base64
`PAYMENT-REQUIRED` / `Payment-Required` headers, directly to clients. But the
object had **no top-level `resource` field**, which the x402 v2 schema
(section 5.1.2) marks as **required**. `resource` only existed as a string
inside the `accepts[0]` entry. A strict facilitator validates the top-level
`ResourceInfo` object (`{ url (required), description?, mimeType? }`), not
`accepts[0]`, so the emitted 402 was non-conformant and externally exposed.

The fix derives the top-level `resource` object from the single-source fields
already present on `requirements` (`requirements.resource` → `url`,
`requirements.description`, `requirements.mimeType`), which are computed in
`createPaymentRequirements()`. `resource.url` is always the request URL
(`req.url`), so it is always a non-empty string. Because the JSON body and both
header spellings are built from one `paymentRequired` object, adding the field
once covers all three.

Scope boundary (deliberately minimal, per the issue):
- Only `paymentRequiredResponse()` was touched (10 added lines).
- The additive v1 compatibility fields on `accepts[0]` are **kept**.
- `x402-payment-requests.ts` (the sibling emitter fixed in #22625) is **not**
  touched here — that PR is open and owns that file.

## What kind of change is this?

Bug fix (non-breaking change which fixes a spec-conformance defect).

# Documentation changes needed?

My changes do not require a change to the project documentation. The fix aligns
the emitted payload with the already-referenced x402 v2 schema.

# Testing

## Where should a reviewer start?

Extended regression test:
`packages/cloud/shared/src/lib/services/topup-handler.test.ts`. Two new tests
drive the public `createTopupHandler(...)` surface to produce a real HTTP 402
`Response` (hermetic facilitator/credits/wallet mocks, same pattern as the
existing tests in the file), covering both the `exact` scheme and the
`exact_permit` (bsc) extensions path.

## Detailed testing steps

```bash
cd packages/cloud/shared
bun test --conditions=eliza-source src/lib/services/topup-handler.test.ts
```

The new tests assert:
1. The parsed 402 JSON body has a top-level `resource` **object** with a
   non-empty `url` equal to the request URL, plus the expected
   `description`/`mimeType`.
2. The base64 `PAYMENT-REQUIRED` header, decoded and JSON-parsed, carries the
   same top-level `resource` object (both header spellings collapse into one
   case-insensitive comma-joined value; the first segment is decoded).
3. `accepts[0]` still retains its additive v1 fields (regression guard that the
   change is additive).
4. The `exact_permit` path emits the `resource` object **and** its
   `paymentPermitContext` extensions.

# Evidence Gate

<!-- evidence-head:ec0843efe70e9e8894929a753c51a81fc73ff24d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only change to a cloud service payload builder; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only change; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - backend-only change; the user-facing behavior is the JSON/header payload, shown as before/after test output and decoded payload below.`
<!-- evidence-row:backend-logs -->
- [x] Failing-then-passing focused test transcript (pre-fix: the 2 new tests fail; post-fix: all 5 pass):

<details><summary>backend test output / logs (before → after)</summary>

```
# BEFORE (pre-fix source, top-level `resource` missing)
(pass) topup quote returns x402_not_configured when facilitator setup fails
(pass) exact_permit quote fails closed when facilitator setup fails despite a configured recipient
(fail) 402 quote carries the required x402 v2 top-level resource object (exact scheme)
(fail) 402 quote carries the top-level resource and extensions on the exact_permit path
(pass) a settled top-up creates a zero-balance wallet account then credits only the paid amount
 3 pass
 2 fail

# AFTER (with fix)
(pass) topup quote returns x402_not_configured when facilitator setup fails
(pass) exact_permit quote fails closed when facilitator setup fails despite a configured recipient
(pass) 402 quote carries the required x402 v2 top-level resource object (exact scheme)
(pass) 402 quote carries the top-level resource and extensions on the exact_permit path
(pass) a settled top-up creates a zero-balance wallet account then credits only the paid amount
 5 pass
 0 fail
 36 expect() calls
Ran 5 tests across 1 file.
```

</details>

Mirror copies also uploaded to the fork release: [before](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-22638/22638-topup-handler-tests-before.txt) · [after](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-22638/22638-topup-handler-tests-after.txt).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the emitted 402 `PaymentRequired` body + decoded base64 `PAYMENT-REQUIRED` header, now carrying the top-level `resource` object:

<details><summary>emitted PaymentRequired payload (response body + decoded header)</summary>

```json
{
  "x402Version": 2,
  "error": "payment_required",
  "resource": {
    "url": "https://api.example.test/api/v1/topup/10",
    "description": "Top up $10",
    "mimeType": "application/json"
  },
  "accepts": [
    {
      "scheme": "exact",
      "network": "eip155:8453",
      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
      "amount": "10000000",
      "maxAmountRequired": "10000000",
      "resource": "https://api.example.test/api/v1/topup/10",
      "description": "Top up $10",
      "mimeType": "application/json",
      "payTo": "0x2222222222222222222222222222222222222222",
      "maxTimeoutSeconds": 300
    }
  ]
}
```
Decoded base64 `PAYMENT-REQUIRED` header `resource`:
`{"url":"https://api.example.test/api/v1/topup/10","description":"Top up $10","mimeType":"application/json"}`

</details>

Mirror copy uploaded to the fork release: [payload](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-22638/22638-topup-payment-required-payload.txt).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Frontend: `N/A - no frontend involved.`

Backend / domain artifact — the two new regression tests fail against the
pre-fix code (top-level `resource` missing) and pass after the fix:

<details>
<summary>BEFORE (pre-fix source, top-level <code>resource</code> missing) — 2 fail</summary>

```
(pass) topup quote returns x402_not_configured when facilitator setup fails
(pass) exact_permit quote fails closed when facilitator setup fails despite a configured recipient
(fail) 402 quote carries the required x402 v2 top-level resource object (exact scheme)
(fail) 402 quote carries the top-level resource and extensions on the exact_permit path
(pass) a settled top-up creates a zero-balance wallet account then credits only the paid amount

 3 pass
 2 fail
```
</details>

<details>
<summary>AFTER (with fix) — 5 pass</summary>

```
(pass) topup quote returns x402_not_configured when facilitator setup fails
(pass) exact_permit quote fails closed when facilitator setup fails despite a configured recipient
(pass) 402 quote carries the required x402 v2 top-level resource object (exact scheme)
(pass) 402 quote carries the top-level resource and extensions on the exact_permit path
(pass) a settled top-up creates a zero-balance wallet account then credits only the paid amount

 5 pass
 0 fail
 36 expect() calls
Ran 5 tests across 1 file.
```
</details>

<details>
<summary>AFTER — real emitted 402 payload (domain artifact), top-level <code>resource</code> now present</summary>

```json
{
  "x402Version": 2,
  "error": "payment_required",
  "resource": {
    "url": "https://api.example.test/api/v1/topup/10",
    "description": "Top up $10",
    "mimeType": "application/json"
  },
  "accepts": [
    {
      "scheme": "exact",
      "network": "eip155:8453",
      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
      "amount": "10000000",
      "maxAmountRequired": "10000000",
      "resource": "https://api.example.test/api/v1/topup/10",
      "description": "Top up $10",
      "mimeType": "application/json",
      "payTo": "0x2222222222222222222222222222222222222222",
      "maxTimeoutSeconds": 300,
      "extra": { "name": "Eliza credits", "version": "1", "amountUsd": 10, "endpoint": "/api/v1/topup/10" }
    }
  ]
}
```
Decoded base64 `PAYMENT-REQUIRED` header `resource`:
`{"url":"https://api.example.test/api/v1/topup/10","description":"Top up $10","mimeType":"application/json"}`
</details>

<details>
<summary>Typecheck (tsc --noEmit) + lint (biome) — clean</summary>

```
# bun run --cwd packages/cloud/shared typecheck  → no TypeScript errors referencing topup-handler
# bunx @biomejs/biome check topup-handler.ts topup-handler.test.ts
Checked 2 files in 31ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change; no rendered UI. The user-facing artifact is the payload, evidenced by the before/after test output and decoded payload above.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT change.`

## Known gaps / failures

- Full-repo `bun run verify` was **not** run: it is a heavy workspace-wide gate
  (parity/dependency/type/lint/audit across all packages) disproportionate for a
  10-line service fix, and unrelated failures elsewhere are outside this PR's
  scope. Instead I ran the owning package's focused checks: the extended
  `topup-handler.test.ts` suite under the package's Bun harness
  (`--conditions=eliza-source`), `tsc --noEmit` for `@elizaos/cloud-shared` (no
  errors in the touched files), and Biome on the touched files (clean). CI runs
  the full gate on this PR.
- Tests run with `--conditions=eliza-source` locally because workspace packages
  (`@elizaos/core`) are not pre-built in this worktree; this mirrors how the
  package resolves source in development.
- `bun install` was run with `--minimum-release-age=0` to satisfy the local
  registry-age guard for a lockfile-pinned `viem`; this affects only local
  dependency resolution, not the change or its tests.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0879608ea5ff701285af710fe0d945a263515604:packages/skills/skills/contribute-to-eliza"} -->
