### PR TITLE
fix(cloud-api): make the target-origin tests compile and actually run

### DIFF
--- a/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
+++ b/packages/cloud/api/eliza-app/auth/connection-success/route.target-origin.test.ts
@@ -11,7 +11,7 @@ async function render(configuredOrigin?: string): Promise<string> {
   const response = await app.request(
     "/connection-success?source=eliza-app&platform=github",
     {},
-    { AGENT_APP_ORIGIN: configuredOrigin } as AppEnv["Bindings"],
+    { AGENT_APP_ORIGIN: configuredOrigin } as unknown as AppEnv["Bindings"],
   );
   expect(response.status).toBe(200);
   return response.text();

--- a/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
+++ b/packages/cloud/api/v1/eliza/paypal/popup-callback/route.target-origin.test.ts
@@ -10,7 +10,7 @@ const app = new Hono<AppEnv>().route("/callback", route);
 async function render(configuredOrigin?: string): Promise<string> {
   const response = await app.request("/callback?code=secret&state=state", {}, {
     AGENT_APP_ORIGIN: configuredOrigin,
-  } as AppEnv["Bindings"]);
+  } as unknown as AppEnv["Bindings"]);
   expect(response.status).toBe(200);
   return response.text();
 }


### PR DESCRIPTION
# Relates to

Fallout of the CI outage fixed by #22634: #22410 merged while every CI run was `startup_failure`, so no lane ever typechecked its two `route.target-origin.test.ts` files. The moment #22634 restores CI, `@elizaos/cloud-api#typecheck` is red for **every** PR on this. Found running root `bun run verify` on #22634's head.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop@9b93d46c894`; zero conflicts.
- [x] Focused verification is green (see Testing); the root-verify blocker this PR removes is exactly the defect it fixes.

# Risks

Low. Two one-line type casts in test files; no runtime code changes, no behavior change — on the pinned bun both suites already pass as written once they compile.

# Background

## What does this PR do?

Makes the two #22410 target-origin suites compile. `{ AGENT_APP_ORIGIN } as AppEnv["Bindings"]` is a TS2352 — insufficient overlap, `Bindings` requires `DATABASE_URL`, `BLOB`, … — in both files. Both casts now go through the `as unknown as AppEnv["Bindings"]` idiom every sibling suite already uses (`route.auto-provision.test.ts:18`, `route.post-message.test.ts:44`, …).

Behavior is untouched: on the pinned `bun@1.3.14` both suites pass exactly as #22410 wrote them, 12/12 across the two files.

One trap documented for the next person: on older buns (verified on 1.3.8) these two tests fail with `Cannot find module '@/lib/services/agent-github-return'` — they are the only cloud-api suites importing a route with an unmocked `@/lib/*` dependency, and older buns do not resolve those tsconfig-path escapes into `../shared`. The pinned toolchain resolves them fine, so this is a local-env symptom, not a repo defect — nothing to fix beyond using the pinned bun.

## What kind of change is this?

Bug fix (unblocks the typecheck gate for all PRs once CI restarts; non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api`: revert either hunk → `run-turbo run typecheck --filter=@elizaos/cloud-api` reproduces the TS2352 at the exact line.

## Detailed testing steps

- Before (clean `origin/develop@9b93d46c894`): `run-turbo run typecheck --filter=@elizaos/cloud-api` → **exit 1**, TS2352 in `route.target-origin.test.ts(11,79)` (paypal) and `(14,5)` (connection-success).
- After:
  - same command → **exit 0** (11/11 tasks);
  - `bun@1.3.14 test` on both files → **12 pass / 0 fail** (36 assertions);
  - Biome clean on both files (exit 0).

# Evidence Gate

<!-- evidence-head:0d19bda9bc46f479cf05e5e23634c6cc29dfa7ac -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only type-cast change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only type-cast change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow; observable behavior is the typecheck gate going green
<!-- evidence-row:backend-logs -->
- [x] Exact before/after transcripts inline in **Testing** above
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or runtime path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, storage, or generated-artifact surface
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact

# Known gaps / failures

None in scope. Root `bun run verify` on the sibling #22634 head reached 205/207 with this exact typecheck failure as the only red — this PR removes it.
