### PR TITLE
fix(canvas): pin web view postMessage targetOrigin, fail closed

### DIFF
--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -192,4 +192,68 @@ describe("CanvasWeb eval message source", () => {
 
     await expect(evalPromise).resolves.toEqual({ result: "2" });
   });
+
+  it("pins postMessage targetOrigin to the navigation origin, not wildcard *", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "https://canvas.eliza.how/view" });
+    const iframe = document.querySelector("iframe");
+    const webView = iframe?.contentWindow;
+    expect(webView).toBeTruthy();
+    if (!webView) throw new Error("Missing webView contentWindow");
+
+    const postMessageSpy = vi.spyOn(webView, "postMessage");
+
+    // 1. a2uiPush
+    await canvas.a2uiPush({
+      messages: [{ role: "assistant", type: "text", content: "hi" }],
+    });
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "eliza:a2uiPush" }),
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // 2. a2uiReset
+    postMessageSpy.mockClear();
+    await canvas.a2uiReset();
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: "eliza:a2uiReset" },
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // 3. eval
+    postMessageSpy.mockClear();
+    const evalPromise = canvas.eval({ script: "document.title" });
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: "eliza:eval", script: "document.title" },
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // Complete eval
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "eliza:evalResult", result: "Canvas App" },
+        origin: "https://canvas.eliza.how",
+        source: webView,
+      }),
+    );
+    await expect(evalPromise).resolves.toEqual({ result: "Canvas App" });
+  });
+
+  it("fails closed when navigating to an invalid or opaque URL and attempting postMessage", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "javascript:alert(1)" });
+
+    await expect(canvas.a2uiPush({ messages: [] })).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+    await expect(canvas.a2uiReset()).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+    await expect(canvas.eval({ script: "1+1" })).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+  });
 });

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -178,6 +178,7 @@ export class CanvasWeb extends WebPlugin {
   }> = [];
   private webViewIframe: HTMLIFrameElement | null = null;
   private webViewPopup: Window | null = null;
+  private webViewOrigin: string | null = null;
   private messageListenerBound = false;
 
   async create(options: {
@@ -874,6 +875,26 @@ export class CanvasWeb extends WebPlugin {
     const placement = options.placement || "inline";
 
     this.destroyWebView();
+    try {
+      const base =
+        typeof window !== "undefined" && window.location?.href
+          ? window.location.href
+          : undefined;
+      const parsed = new URL(options.url, base);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        this.webViewOrigin = parsed.origin;
+      } else if (options.url === "about:blank") {
+        this.webViewOrigin =
+          typeof window !== "undefined" && window.location?.origin
+            ? window.location.origin
+            : null;
+      } else {
+        this.webViewOrigin = null;
+      }
+    } catch {
+      // error-policy:J3 invalid navigation URL fails closed
+      this.webViewOrigin = null;
+    }
 
     // Intercept eliza:// deep links immediately
     if (options.url.startsWith("eliza://")) {
@@ -1114,7 +1135,7 @@ export class CanvasWeb extends WebPlugin {
           jsonl: options.jsonl || "",
           payload: options.payload || null,
         },
-        "*",
+        this.getWebViewTargetOrigin(),
       );
       return;
     }
@@ -1139,7 +1160,10 @@ export class CanvasWeb extends WebPlugin {
         : null);
 
     if (target) {
-      target.postMessage({ type: "eliza:a2uiReset" }, "*");
+      target.postMessage(
+        { type: "eliza:a2uiReset" },
+        this.getWebViewTargetOrigin(),
+      );
       return;
     }
 
@@ -1157,6 +1181,19 @@ export class CanvasWeb extends WebPlugin {
       this.webViewPopup.close();
     }
     this.webViewPopup = null;
+    this.webViewOrigin = null;
+  }
+
+  private getWebViewTargetOrigin(): string {
+    const origin = this.webViewOrigin;
+    if (
+      origin &&
+      (origin.startsWith("http://") || origin.startsWith("https://"))
+    ) {
+      return origin;
+    }
+    // error-policy:J3 fail closed when origin cannot be proven; never fall back to wildcard "*"
+    throw new Error("Cannot determine web view target origin");
   }
 
   private evalViaPostMessage(
@@ -1164,6 +1201,7 @@ export class CanvasWeb extends WebPlugin {
     script: string,
   ): Promise<EvalResult> {
     return new Promise<EvalResult>((resolve, reject) => {
+      const targetOrigin = this.getWebViewTargetOrigin();
       const timeoutMs = 5000;
       const timeout = setTimeout(() => {
         window.removeEventListener("message", handler);
@@ -1171,9 +1209,9 @@ export class CanvasWeb extends WebPlugin {
       }, timeoutMs);
 
       const handler = (event: MessageEvent) => {
-        // The request is posted with targetOrigin "*". Any same-page window
-        // can therefore emit `eliza:evalResult`; only the web view that
-        // received the script is allowed to complete this eval.
+        // The request is posted with targetOrigin pinned to the web view.
+        // Any same-page window can emit `eliza:evalResult`; only the web view
+        // that received the script is allowed to complete this eval.
         if (event.source !== target) return;
         const data = event.data;
         if (!data || typeof data !== "object") return;
@@ -1186,7 +1224,7 @@ export class CanvasWeb extends WebPlugin {
       };
 
       window.addEventListener("message", handler);
-      target.postMessage({ type: "eliza:eval", script }, "*");
+      target.postMessage({ type: "eliza:eval", script }, targetOrigin);
     });
   }
 


### PR DESCRIPTION
## Summary

Pins `postMessage` target origin in `CanvasWeb` (`plugins/plugin-native-canvas`) to the web view's navigation origin, removing insecure wildcard `*` broadcasts and enforcing fail-closed behavior when the target origin cannot be determined.

- Resolves web view origin on `navigate()` (`options.url`) and clears it on `destroyWebView()`.
- Replaces wildcard `"*"` with `getWebViewTargetOrigin()` across `a2uiPush`, `a2uiReset`, and `evalViaPostMessage`.
- Fails closed if the web view origin cannot be resolved (invalid URL, opaque origin), throwing an explicit error rather than broadcasting sensitive eval scripts or A2UI state to unintended origins.
- Adds comprehensive unit tests in `src/web.test.ts` covering `a2uiPush`, `a2uiReset`, `eval`, and fail-closed error paths.

## Verification

- `bun run --cwd plugins/plugin-native-canvas test`: 28/28 passed (3 test files)
- `bun run --cwd plugins/plugin-native-canvas typecheck`: clean
- `bun run --cwd plugins/plugin-native-canvas lint`: clean
- `bun run --cwd plugins/plugin-native-canvas build`: clean