### PR TITLE
fix(cloud): bind local voice gateway identity before network access

### DIFF
--- a/packages/cloud/api/scripts/local-voice-gateway.ts
+++ b/packages/cloud/api/scripts/local-voice-gateway.ts
@@ -4,6 +4,8 @@
  * the already-running local elizaOS API rather than a second model runtime.
  */
 
+import { resolveLocalVoiceRuntimeIdentity } from "./local-voice-runtime-identity";
+
 const DEFAULT_RUNTIME_ORIGIN = "http://127.0.0.1:31337";
 const DEFAULT_GATEWAY_PORT = 31_338;
 const DEFAULT_CARTESIA_VOICE_ID = "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4";
@@ -53,80 +55,10 @@ function assertUuid(label: string, value: string): string {
   return value;
 }
 
-async function readLocalIdentity(runtimeOrigin: string): Promise<{
-  agentId: string;
-  conversationId: string;
-}> {
-  const healthResponse = await fetch(new URL("/api/health", runtimeOrigin));
-  if (!healthResponse.ok) {
-    throw new Error(
-      `local runtime health returned HTTP ${healthResponse.status}`,
-    );
-  }
-  const health = (await healthResponse.json()) as {
-    ready?: unknown;
-    canRespond?: unknown;
-  };
-  if (health.ready !== true || health.canRespond !== true) {
-    throw new Error("local runtime is not ready to respond");
-  }
-
-  const configuredAgentId = process.env.ELIZA_LOCAL_VOICE_AGENT_ID?.trim();
-  let discoveredAgentId: string | undefined;
-  if (!configuredAgentId) {
-    const agentResponse = await fetch(new URL("/api/agents", runtimeOrigin));
-    if (!agentResponse.ok) {
-      throw new Error(
-        `local agents route returned HTTP ${agentResponse.status}`,
-      );
-    }
-    const agentsBody = (await agentResponse.json()) as {
-      agents?: Array<{ id?: unknown; status?: unknown }>;
-    };
-    discoveredAgentId = agentsBody.agents?.find(
-      (agent) => agent.status === "running" && typeof agent.id === "string",
-    )?.id as string | undefined;
-  }
-  const agentId = assertUuid(
-    "local agent id",
-    configuredAgentId || discoveredAgentId || "",
-  );
-
-  const configuredConversationId =
-    process.env.ELIZA_LOCAL_VOICE_CONVERSATION_ID?.trim();
-  let discoveredConversationId: string | undefined;
-  if (!configuredConversationId) {
-    const conversationResponse = await fetch(
-      new URL("/api/conversations", runtimeOrigin),
-    );
-    if (!conversationResponse.ok) {
-      throw new Error(
-        `local conversations route returned HTTP ${conversationResponse.status}`,
-      );
-    }
-    const conversationsBody = (await conversationResponse.json()) as {
-      conversations?: Array<{ id?: unknown; updatedAt?: unknown }>;
-    };
-    discoveredConversationId = conversationsBody.conversations
-      ?.filter((conversation) => typeof conversation.id === "string")
-      .sort((left, right) =>
-        String(right.updatedAt ?? "").localeCompare(
-          String(left.updatedAt ?? ""),
-        ),
-      )[0]?.id as string | undefined;
-  }
-  const conversationId = assertUuid(
-    "local conversation id",
-    configuredConversationId || discoveredConversationId || "",
-  );
-
-  return { agentId, conversationId };
-}
-
 async function main(): Promise<void> {
   const cartesiaApiKey = requiredSecret("CARTESIA_API_KEY");
-  const runtimeOrigin =
-    process.env.ELIZA_LOCAL_API_ORIGIN?.trim() || DEFAULT_RUNTIME_ORIGIN;
+  const configuredRuntimeOrigin =
+    process.env.ELIZA_LOCAL_API_ORIGIN || DEFAULT_RUNTIME_ORIGIN;
   const gatewayPort = readPort(
     "ELIZA_LOCAL_VOICE_GATEWAY_PORT",
     DEFAULT_GATEWAY_PORT,
@@ -136,7 +68,12 @@ async function main(): Promise<void> {
     process.env.VOICE_REALTIME_CARTESIA_VOICE_ID?.trim() ||
       DEFAULT_CARTESIA_VOICE_ID,
   );
-  const { agentId, conversationId } = await readLocalIdentity(runtimeOrigin);
+  const { runtimeOrigin, agentId, conversationId } =
+    await resolveLocalVoiceRuntimeIdentity({
+      runtimeOrigin: configuredRuntimeOrigin,
+      configuredAgentId: process.env.ELIZA_LOCAL_VOICE_AGENT_ID,
+      configuredConversationId: process.env.ELIZA_LOCAL_VOICE_CONVERSATION_ID,
+    });
   const [{ createLocalRuntimeConversationFetch }, harness] = await Promise.all([
     import("../v1/voice/session/lib/local-runtime-conversation-fetch"),
     import("../v1/voice/session/lib/harness-real-server"),

--- a/packages/cloud/api/scripts/local-voice-gateway.ts
+++ b/packages/cloud/api/scripts/local-voice-gateway.ts
@@ -89,7 +89,10 @@ async function main(): Promise<void> {
     userId: LOCAL_USER_ID,
     agentId,
     conversationId,
-    fetchImpl: createLocalRuntimeConversationFetch(runtimeOrigin),
+    fetchImpl: createLocalRuntimeConversationFetch(runtimeOrigin, {
+      agentId,
+      conversationId,
+    }),
     listenPort: gatewayPort,
     hooks: { log: writeLog },
   });

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -62,7 +62,6 @@ describe("local voice runtime identity", () => {
         {
           id: CONVERSATION_ID,
           updatedAt: "2026-08-19T20:00:00.000Z",
-          agentId: AGENT_ID,
         },
       ],
     });
@@ -87,12 +86,14 @@ describe("local voice runtime identity", () => {
     expect(redirects).toEqual(["error", "error", "error"]);
   });
 
-  test("discovers the newest conversation belonging to the singleton running agent", async () => {
+  test("discovers the newest conversation under the singleton running agent", async () => {
     const { fetchImpl } = runtimeFetch({
       conversations: [
         {
           id: NEWER_CONVERSATION_ID,
           updatedAt: "2026-08-19T22:00:00.000Z",
+          // The production ConversationMeta DTO has no agentId. Unknown fields
+          // cannot override the singleton /api/agents authority.
           agentId: OTHER_AGENT_ID,
         },
         {
@@ -108,7 +109,7 @@ describe("local voice runtime identity", () => {
       fetchImpl,
     });
     expect(identity.agentId).toBe(AGENT_ID);
-    expect(identity.conversationId).toBe(CONVERSATION_ID);
+    expect(identity.conversationId).toBe(NEWER_CONVERSATION_ID);
   });
 
   test.each([
@@ -177,19 +178,6 @@ describe("local voice runtime identity", () => {
       configuredAgentId: AGENT_ID,
       agents: [{ id: AGENT_ID, status: "running" }],
       conversations: [],
-      configuredConversationId: CONVERSATION_ID,
-    },
-    {
-      name: "conversation owned by another agent",
-      configuredAgentId: AGENT_ID,
-      agents: [{ id: AGENT_ID, status: "running" }],
-      conversations: [
-        {
-          id: CONVERSATION_ID,
-          updatedAt: "2026-08-19T20:00:00.000Z",
-          agentId: OTHER_AGENT_ID,
-        },
-      ],
       configuredConversationId: CONVERSATION_ID,
     },
     {

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -273,10 +273,12 @@ describe("local voice runtime identity", () => {
         runtimeOrigin: "http://127.0.0.1:31337",
         fetchImpl: tooManyAgents.fetchImpl,
       }),
-    ).rejects.toThrow("agents response exceeds the record limit");
+      // Two agents is not a "record limit" condition — selectAgentId owns the
+      // exactly-one rule and says so in words an operator can act on.
+    ).rejects.toThrow("local runtime must expose exactly one agent");
 
     const tooManyConversations = runtimeFetch({
-      conversations: Array.from({ length: 501 }, (_, index) => ({
+      conversations: Array.from({ length: 2001 }, (_, index) => ({
         id: `${index.toString(16).padStart(8, "0")}-c333-4333-8333-c33333333333`,
         updatedAt: "2026-08-19T20:00:00.000Z",
       })),
@@ -318,4 +320,42 @@ describe("local voice runtime identity", () => {
       target.stop(true);
     }
   });
+});
+
+// restoreConversationsFromDb derives a conversation id by stripping the
+// "web-conv-" prefix off a channel id, and the create path accepts one from a
+// client payload — so a non-UUID id is ordinary, not corruption. Rejecting the
+// whole listing over one such record refused startup on healthy hosts.
+test("selects a conversation whose id is not a UUID", async () => {
+  const runtime = runtimeFetch({
+    conversations: [
+      {
+        id: "web-conv-legacy-channel",
+        updatedAt: "2026-08-19T20:00:00.000Z",
+      },
+    ],
+  });
+
+  const identity = await resolveLocalVoiceRuntimeIdentity({
+    runtimeOrigin: "http://127.0.0.1:31337",
+    fetchImpl: runtime.fetchImpl,
+  });
+
+  expect(identity.conversationId).toBe("web-conv-legacy-channel");
+});
+
+test("skips an unreadable conversation record instead of refusing startup", async () => {
+  const runtime = runtimeFetch({
+    conversations: [
+      "not-an-object",
+      { id: "usable-conversation", updatedAt: "2026-08-19T20:00:00.000Z" },
+    ],
+  });
+
+  const identity = await resolveLocalVoiceRuntimeIdentity({
+    runtimeOrigin: "http://127.0.0.1:31337",
+    fetchImpl: runtime.fetchImpl,
+  });
+
+  expect(identity.conversationId).toBe("usable-conversation");
 });

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -342,14 +342,13 @@ describe("local voice runtime identity", () => {
 });
 
 // restoreConversationsFromDb derives a conversation id by stripping the
-// "web-conv-" prefix off a channel id, and the create path accepts one from a
-// client payload — so a non-UUID id is ordinary, not corruption. Rejecting the
-// whole listing over one such record refused startup on healthy hosts.
+// "web-conv-" prefix off a persisted channel id, so legacy non-UUID ids are
+// ordinary runtime data rather than corruption.
 test("selects a conversation whose id is not a UUID", async () => {
   const runtime = runtimeFetch({
     conversations: [
       {
-        id: "web-conv-legacy-channel",
+        id: "legacy-channel",
         updatedAt: "2026-08-19T20:00:00.000Z",
       },
     ],
@@ -357,10 +356,11 @@ test("selects a conversation whose id is not a UUID", async () => {
 
   const identity = await resolveLocalVoiceRuntimeIdentity({
     runtimeOrigin: "http://127.0.0.1:31337",
+    configuredConversationId: "legacy-channel",
     fetchImpl: runtime.fetchImpl,
   });
 
-  expect(identity.conversationId).toBe("web-conv-legacy-channel");
+  expect(identity.conversationId).toBe("legacy-channel");
 });
 
 test("skips an unreadable conversation record instead of refusing startup", async () => {

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -92,22 +92,19 @@ describe("local voice runtime identity", () => {
         {
           id: NEWER_CONVERSATION_ID,
           updatedAt: "2026-08-19T22:00:00.000Z",
-          // The production ConversationMeta DTO has no agentId. Unknown fields
-          // cannot override the singleton /api/agents authority.
-          agentId: OTHER_AGENT_ID,
         },
         {
           id: CONVERSATION_ID,
           updatedAt: "2026-08-19T20:00:00.000Z",
-          agentId: AGENT_ID,
         },
       ],
     });
 
     const identity = await resolveLocalVoiceRuntimeIdentity({
-      runtimeOrigin: "http://localhost:31337/",
+      runtimeOrigin: "http://[::1]:31337/",
       fetchImpl,
     });
+    expect(identity.runtimeOrigin).toBe("http://[::1]:31337");
     expect(identity.agentId).toBe(AGENT_ID);
     expect(identity.conversationId).toBe(NEWER_CONVERSATION_ID);
   });
@@ -117,6 +114,7 @@ describe("local voice runtime identity", () => {
     "http://127.0.0.1.evil:31337",
     "http://127.0.0.1:31337/path",
     "http://user@127.0.0.1:31337",
+    "http://localhost:31337",
     " http://127.0.0.1:31337",
   ])(
     "rejects a noncanonical or hostile origin before fetching: %s",
@@ -247,6 +245,39 @@ describe("local voice runtime identity", () => {
         fetchImpl,
       }),
     ).rejects.toThrow("response size limit");
+  });
+
+  test("rejects a declared oversized runtime response before reading it", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return new Response('{"ready":true,"canRespond":true}', {
+        headers: { "Content-Length": String(1024 * 1024 + 1) },
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("response size limit");
+    expect(calls).toBe(1);
+  });
+
+  test.each([
+    { ready: false, canRespond: true },
+    { ready: true, canRespond: false },
+    {},
+  ])("rejects a runtime that is not ready to respond", async (health) => {
+    const { fetchImpl, calls } = runtimeFetch({ health });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("local runtime is not ready to respond");
+    expect(calls).toEqual(["http://127.0.0.1:31337/api/health"]);
   });
 
   test("rejects runtime record sets above their bounded ceilings", async () => {

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -1,7 +1,7 @@
 /**
- * Deterministic boundary tests for local voice runtime identity resolution.
- * Injected fetch responses exercise the production resolver without starting
- * Cartesia or a realtime gateway server.
+ * Deterministic and integration-backed boundary tests for local voice runtime
+ * identity resolution. Injected responses cover malformed runtime state while
+ * real loopback servers prove redirects cannot escape the validated origin.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -24,11 +24,14 @@ interface RuntimeFixtureOptions {
 function runtimeFetch(options: RuntimeFixtureOptions = {}): {
   fetchImpl: typeof fetch;
   calls: string[];
+  redirects: Array<RequestRedirect | undefined>;
 } {
   const calls: string[] = [];
-  const fetchImpl = (async (input: RequestInfo | URL) => {
+  const redirects: Array<RequestRedirect | undefined> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = new URL(String(input));
     calls.push(url.href);
+    redirects.push(init?.redirect);
     if (url.pathname === "/api/health") {
       return Response.json(options.health ?? { ready: true, canRespond: true });
     }
@@ -49,12 +52,12 @@ function runtimeFetch(options: RuntimeFixtureOptions = {}): {
     }
     return new Response(null, { status: 404 });
   }) as typeof fetch;
-  return { fetchImpl, calls };
+  return { fetchImpl, calls, redirects };
 }
 
 describe("local voice runtime identity", () => {
   test("binds configured canonical IDs to live running runtime records", async () => {
-    const { fetchImpl, calls } = runtimeFetch({
+    const { fetchImpl, calls, redirects } = runtimeFetch({
       conversations: [
         {
           id: CONVERSATION_ID,
@@ -81,6 +84,7 @@ describe("local voice runtime identity", () => {
       "http://127.0.0.1:31337/api/agents",
       "http://127.0.0.1:31337/api/conversations",
     ]);
+    expect(redirects).toEqual(["error", "error", "error"]);
   });
 
   test("discovers the newest conversation belonging to the singleton running agent", async () => {
@@ -226,5 +230,35 @@ describe("local voice runtime identity", () => {
         fetchImpl,
       }),
     ).rejects.toThrow("canonical lowercase UUID");
+  });
+
+  test("refuses a loopback redirect without contacting its target", async () => {
+    let targetRequests = 0;
+    const target = Bun.serve({
+      port: 0,
+      fetch: () => {
+        targetRequests += 1;
+        return Response.json({ ready: true, canRespond: true });
+      },
+    });
+    const source = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: `http://127.0.0.1:${target.port}/captured` },
+        }),
+    });
+    try {
+      await expect(
+        resolveLocalVoiceRuntimeIdentity({
+          runtimeOrigin: `http://127.0.0.1:${source.port}`,
+        }),
+      ).rejects.toBeInstanceOf(LocalVoiceRuntimeIdentityError);
+      expect(targetRequests).toBe(0);
+    } finally {
+      source.stop(true);
+      target.stop(true);
+    }
   });
 });

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic boundary tests for local voice runtime identity resolution.
+ * Injected fetch responses exercise the production resolver without starting
+ * Cartesia or a realtime gateway server.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  LocalVoiceRuntimeIdentityError,
+  resolveLocalVoiceRuntimeIdentity,
+} from "./local-voice-runtime-identity";
+
+const AGENT_ID = "a1111111-a111-4111-8111-a11111111111";
+const OTHER_AGENT_ID = "b2222222-b222-4222-8222-b22222222222";
+const CONVERSATION_ID = "c3333333-c333-4333-8333-c33333333333";
+const NEWER_CONVERSATION_ID = "d4444444-d444-4444-8444-d44444444444";
+
+interface RuntimeFixtureOptions {
+  agents?: readonly unknown[];
+  conversations?: readonly unknown[];
+  health?: unknown;
+}
+
+function runtimeFetch(options: RuntimeFixtureOptions = {}): {
+  fetchImpl: typeof fetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    calls.push(url.href);
+    if (url.pathname === "/api/health") {
+      return Response.json(options.health ?? { ready: true, canRespond: true });
+    }
+    if (url.pathname === "/api/agents") {
+      return Response.json({
+        agents: options.agents ?? [{ id: AGENT_ID, status: "running" }],
+      });
+    }
+    if (url.pathname === "/api/conversations") {
+      return Response.json({
+        conversations: options.conversations ?? [
+          {
+            id: CONVERSATION_ID,
+            updatedAt: "2026-08-19T20:00:00.000Z",
+          },
+        ],
+      });
+    }
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("local voice runtime identity", () => {
+  test("binds configured canonical IDs to live running runtime records", async () => {
+    const { fetchImpl, calls } = runtimeFetch({
+      conversations: [
+        {
+          id: CONVERSATION_ID,
+          updatedAt: "2026-08-19T20:00:00.000Z",
+          agentId: AGENT_ID,
+        },
+      ],
+    });
+
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        configuredAgentId: AGENT_ID,
+        configuredConversationId: CONVERSATION_ID,
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      runtimeOrigin: "http://127.0.0.1:31337",
+      agentId: AGENT_ID,
+      conversationId: CONVERSATION_ID,
+    });
+    expect(calls).toEqual([
+      "http://127.0.0.1:31337/api/health",
+      "http://127.0.0.1:31337/api/agents",
+      "http://127.0.0.1:31337/api/conversations",
+    ]);
+  });
+
+  test("discovers the newest conversation belonging to the singleton running agent", async () => {
+    const { fetchImpl } = runtimeFetch({
+      conversations: [
+        {
+          id: NEWER_CONVERSATION_ID,
+          updatedAt: "2026-08-19T22:00:00.000Z",
+          agentId: OTHER_AGENT_ID,
+        },
+        {
+          id: CONVERSATION_ID,
+          updatedAt: "2026-08-19T20:00:00.000Z",
+          agentId: AGENT_ID,
+        },
+      ],
+    });
+
+    const identity = await resolveLocalVoiceRuntimeIdentity({
+      runtimeOrigin: "http://localhost:31337/",
+      fetchImpl,
+    });
+    expect(identity.agentId).toBe(AGENT_ID);
+    expect(identity.conversationId).toBe(CONVERSATION_ID);
+  });
+
+  test.each([
+    "https://127.0.0.1:31337",
+    "http://127.0.0.1.evil:31337",
+    "http://127.0.0.1:31337/path",
+    "http://user@127.0.0.1:31337",
+    " http://127.0.0.1:31337",
+  ])(
+    "rejects a noncanonical or hostile origin before fetching: %s",
+    async (runtimeOrigin) => {
+      const { fetchImpl, calls } = runtimeFetch();
+      await expect(
+        resolveLocalVoiceRuntimeIdentity({ runtimeOrigin, fetchImpl }),
+      ).rejects.toBeInstanceOf(LocalVoiceRuntimeIdentityError);
+      expect(calls).toEqual([]);
+    },
+  );
+
+  test.each([
+    { configuredAgentId: AGENT_ID.toUpperCase() },
+    { configuredAgentId: ` ${AGENT_ID}` },
+    { configuredConversationId: CONVERSATION_ID.toUpperCase() },
+  ])(
+    "rejects noncanonical configured identity before fetching",
+    async (configured) => {
+      const { fetchImpl, calls } = runtimeFetch();
+      await expect(
+        resolveLocalVoiceRuntimeIdentity({
+          runtimeOrigin: "http://127.0.0.1:31337",
+          ...configured,
+          fetchImpl,
+        }),
+      ).rejects.toBeInstanceOf(LocalVoiceRuntimeIdentityError);
+      expect(calls).toEqual([]);
+    },
+  );
+
+  test.each([
+    {
+      name: "missing agent",
+      configuredAgentId: OTHER_AGENT_ID,
+      agents: [{ id: AGENT_ID, status: "running" }],
+      conversations: undefined,
+      configuredConversationId: undefined,
+    },
+    {
+      name: "stopped agent",
+      configuredAgentId: AGENT_ID,
+      agents: [{ id: AGENT_ID, status: "stopped" }],
+      conversations: undefined,
+      configuredConversationId: undefined,
+    },
+    {
+      name: "ambiguous multi-agent runtime",
+      configuredAgentId: AGENT_ID,
+      agents: [
+        { id: AGENT_ID, status: "running" },
+        { id: OTHER_AGENT_ID, status: "stopped" },
+      ],
+      conversations: undefined,
+      configuredConversationId: undefined,
+    },
+    {
+      name: "missing conversation",
+      configuredAgentId: AGENT_ID,
+      agents: [{ id: AGENT_ID, status: "running" }],
+      conversations: [],
+      configuredConversationId: CONVERSATION_ID,
+    },
+    {
+      name: "conversation owned by another agent",
+      configuredAgentId: AGENT_ID,
+      agents: [{ id: AGENT_ID, status: "running" }],
+      conversations: [
+        {
+          id: CONVERSATION_ID,
+          updatedAt: "2026-08-19T20:00:00.000Z",
+          agentId: OTHER_AGENT_ID,
+        },
+      ],
+      configuredConversationId: CONVERSATION_ID,
+    },
+    {
+      name: "conversation with an invalid timestamp",
+      configuredAgentId: AGENT_ID,
+      agents: [{ id: AGENT_ID, status: "running" }],
+      conversations: [
+        {
+          id: CONVERSATION_ID,
+          updatedAt: "not-a-timestamp",
+          agentId: AGENT_ID,
+        },
+      ],
+      configuredConversationId: CONVERSATION_ID,
+    },
+  ])("fails closed for $name", async (fixture) => {
+    const { fetchImpl } = runtimeFetch({
+      agents: fixture.agents,
+      conversations: fixture.conversations,
+    });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        configuredAgentId: fixture.configuredAgentId,
+        configuredConversationId: fixture.configuredConversationId,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(LocalVoiceRuntimeIdentityError);
+  });
+
+  test("rejects noncanonical live identity responses", async () => {
+    const { fetchImpl } = runtimeFetch({
+      agents: [{ id: AGENT_ID.toUpperCase(), status: "running" }],
+    });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("canonical lowercase UUID");
+  });
+});

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.test.ts
@@ -232,6 +232,63 @@ describe("local voice runtime identity", () => {
     ).rejects.toThrow("canonical lowercase UUID");
   });
 
+  test.each([
+    "2026-08-19T20:00:00Z",
+    "2026-08-19T13:00:00.000-07:00",
+    "Wed, 19 Aug 2026 20:00:00 GMT",
+  ])("rejects a noncanonical live timestamp: %s", async (updatedAt) => {
+    const { fetchImpl } = runtimeFetch({
+      conversations: [{ id: CONVERSATION_ID, updatedAt }],
+    });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("canonical ISO timestamp");
+  });
+
+  test("rejects an oversized runtime response while reading its stream", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        `{"padding":"${"x".repeat(1024 * 1024)}"}`,
+      )) as unknown as typeof fetch;
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("response size limit");
+  });
+
+  test("rejects runtime record sets above their bounded ceilings", async () => {
+    const tooManyAgents = runtimeFetch({
+      agents: [
+        { id: AGENT_ID, status: "running" },
+        { id: OTHER_AGENT_ID, status: "running" },
+      ],
+    });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl: tooManyAgents.fetchImpl,
+      }),
+    ).rejects.toThrow("agents response exceeds the record limit");
+
+    const tooManyConversations = runtimeFetch({
+      conversations: Array.from({ length: 501 }, (_, index) => ({
+        id: `${index.toString(16).padStart(8, "0")}-c333-4333-8333-c33333333333`,
+        updatedAt: "2026-08-19T20:00:00.000Z",
+      })),
+    });
+    await expect(
+      resolveLocalVoiceRuntimeIdentity({
+        runtimeOrigin: "http://127.0.0.1:31337",
+        fetchImpl: tooManyConversations.fetchImpl,
+      }),
+    ).rejects.toThrow("conversations response exceeds the record limit");
+  });
+
   test("refuses a loopback redirect without contacting its target", async () => {
     let targetRequests = 0;
     const target = Bun.serve({

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -1,0 +1,309 @@
+/**
+ * Binds the local voice gateway to one live loopback runtime, running agent,
+ * and conversation before the gateway can create a realtime session. Runtime
+ * responses and operator-provided identifiers are validated as untrusted
+ * boundary data; a conversation without an explicit agent field is scoped by
+ * the standalone runtime's singleton `/api/agents` authority.
+ */
+
+const CANONICAL_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface RuntimeAgent {
+  id: string;
+  status: string;
+}
+
+interface RuntimeConversation {
+  id: string;
+  updatedAt: string;
+  agentId?: string;
+}
+
+export interface LocalVoiceRuntimeIdentity {
+  runtimeOrigin: string;
+  agentId: string;
+  conversationId: string;
+}
+
+export interface ResolveLocalVoiceRuntimeIdentityOptions {
+  runtimeOrigin: string;
+  configuredAgentId?: string;
+  configuredConversationId?: string;
+  fetchImpl?: FetchLike;
+}
+
+export class LocalVoiceRuntimeIdentityError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LocalVoiceRuntimeIdentityError";
+  }
+}
+
+export function resolveCanonicalLoopbackRuntimeOrigin(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch (error) {
+    // error-policy:J2 Startup retains the URL parser cause while failing before
+    // any request can escape the local voice process.
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime origin is not a valid URL",
+      { cause: error },
+    );
+  }
+
+  if (
+    parsed.protocol !== "http:" ||
+    !LOOPBACK_HOSTNAMES.has(parsed.hostname) ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime origin must be a canonical HTTP loopback origin",
+    );
+  }
+
+  if (raw !== parsed.origin && raw !== `${parsed.origin}/`) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime origin must use its canonical serialized form",
+    );
+  }
+  return parsed.origin;
+}
+
+export async function resolveLocalVoiceRuntimeIdentity(
+  options: ResolveLocalVoiceRuntimeIdentityOptions,
+): Promise<LocalVoiceRuntimeIdentity> {
+  const runtimeOrigin = resolveCanonicalLoopbackRuntimeOrigin(
+    options.runtimeOrigin,
+  );
+  const configuredAgentId = readOptionalCanonicalUuid(
+    "configured local agent id",
+    options.configuredAgentId,
+  );
+  const configuredConversationId = readOptionalCanonicalUuid(
+    "configured local conversation id",
+    options.configuredConversationId,
+  );
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const health = readRecord(
+    "local runtime health",
+    await fetchJson(
+      "local runtime health",
+      new URL("/api/health", runtimeOrigin),
+      fetchImpl,
+    ),
+  );
+  if (health.ready !== true || health.canRespond !== true) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime is not ready to respond",
+    );
+  }
+
+  const agents = readAgents(
+    await fetchJson(
+      "local agents route",
+      new URL("/api/agents", runtimeOrigin),
+      fetchImpl,
+    ),
+  );
+  const agentId = selectAgentId(agents, configuredAgentId);
+
+  const conversations = readConversations(
+    await fetchJson(
+      "local conversations route",
+      new URL("/api/conversations", runtimeOrigin),
+      fetchImpl,
+    ),
+  );
+  const conversationId = selectConversationId(
+    conversations,
+    agentId,
+    configuredConversationId,
+  );
+
+  return { runtimeOrigin, agentId, conversationId };
+}
+
+async function fetchJson(
+  label: string,
+  url: URL,
+  fetchImpl: FetchLike,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url);
+  } catch (error) {
+    // error-policy:J2 The process boundary needs the failed route and original
+    // transport cause to diagnose an unavailable local runtime.
+    throw new LocalVoiceRuntimeIdentityError(`${label} request failed`, {
+      cause: error,
+    });
+  }
+  if (!response.ok) {
+    throw new LocalVoiceRuntimeIdentityError(
+      `${label} returned HTTP ${response.status}`,
+    );
+  }
+  try {
+    return await response.json();
+  } catch (error) {
+    // error-policy:J3 Runtime JSON is untrusted input and malformed responses
+    // fail explicitly instead of becoming an empty healthy identity list.
+    throw new LocalVoiceRuntimeIdentityError(`${label} returned invalid JSON`, {
+      cause: error,
+    });
+  }
+}
+
+function readRecord(label: string, value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new LocalVoiceRuntimeIdentityError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function readAgents(value: unknown): RuntimeAgent[] {
+  const body = readRecord("local agents response", value);
+  if (!Array.isArray(body.agents)) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local agents response must include an agents array",
+    );
+  }
+  return body.agents.map((value, index) => {
+    const record = readRecord(`local agent ${index}`, value);
+    return {
+      id: readCanonicalUuid(`local agent ${index} id`, record.id),
+      status: readRequiredString(`local agent ${index} status`, record.status),
+    };
+  });
+}
+
+function readConversations(value: unknown): RuntimeConversation[] {
+  const body = readRecord("local conversations response", value);
+  if (!Array.isArray(body.conversations)) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local conversations response must include a conversations array",
+    );
+  }
+  return body.conversations.map((value, index) => {
+    const record = readRecord(`local conversation ${index}`, value);
+    const agentId =
+      record.agentId === undefined
+        ? undefined
+        : readCanonicalUuid(
+            `local conversation ${index} agent id`,
+            record.agentId,
+          );
+    return {
+      id: readCanonicalUuid(`local conversation ${index} id`, record.id),
+      updatedAt: readTimestamp(
+        `local conversation ${index} updatedAt`,
+        record.updatedAt,
+      ),
+      ...(agentId === undefined ? {} : { agentId }),
+    };
+  });
+}
+
+function selectAgentId(
+  agents: RuntimeAgent[],
+  configuredAgentId: string | undefined,
+): string {
+  if (agents.length !== 1) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime must expose exactly one agent",
+    );
+  }
+  const agent = agents[0]!;
+  if (configuredAgentId !== undefined && agent.id !== configuredAgentId) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "configured local agent does not exist in the runtime",
+    );
+  }
+  if (agent.status !== "running") {
+    throw new LocalVoiceRuntimeIdentityError("local agent is not running");
+  }
+  return agent.id;
+}
+
+function selectConversationId(
+  conversations: RuntimeConversation[],
+  agentId: string,
+  configuredConversationId: string | undefined,
+): string {
+  if (configuredConversationId !== undefined) {
+    const configured = conversations.find(
+      (conversation) => conversation.id === configuredConversationId,
+    );
+    if (!configured) {
+      throw new LocalVoiceRuntimeIdentityError(
+        "configured local conversation does not exist in the runtime",
+      );
+    }
+    if (configured.agentId !== undefined && configured.agentId !== agentId) {
+      throw new LocalVoiceRuntimeIdentityError(
+        "configured local conversation belongs to a different agent",
+      );
+    }
+    return configured.id;
+  }
+
+  const candidates = conversations
+    .filter(
+      (conversation) =>
+        conversation.agentId === undefined || conversation.agentId === agentId,
+    )
+    .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  if (candidates.length === 0) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local runtime has no conversation for the running agent",
+    );
+  }
+  return candidates[0]!.id;
+}
+
+function readOptionalCanonicalUuid(
+  label: string,
+  value: string | undefined,
+): string | undefined {
+  if (value === undefined || value === "") return undefined;
+  return readCanonicalUuid(label, value);
+}
+
+function readCanonicalUuid(label: string, value: unknown): string {
+  if (typeof value !== "string" || !CANONICAL_UUID_PATTERN.test(value)) {
+    throw new LocalVoiceRuntimeIdentityError(
+      `${label} must be a canonical lowercase UUID`,
+    );
+  }
+  return value;
+}
+
+function readRequiredString(label: string, value: unknown): string {
+  if (typeof value !== "string" || value === "") {
+    throw new LocalVoiceRuntimeIdentityError(`${label} must be a string`);
+  }
+  return value;
+}
+
+function readTimestamp(label: string, value: unknown): string {
+  const timestamp = readRequiredString(label, value);
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    throw new LocalVoiceRuntimeIdentityError(
+      `${label} must be an ISO-compatible timestamp`,
+    );
+  }
+  return timestamp;
+}

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -9,6 +9,9 @@
 const CANONICAL_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const MAX_RUNTIME_RESPONSE_BYTES = 1024 * 1024;
+const MAX_RUNTIME_AGENT_RECORDS = 1;
+const MAX_RUNTIME_CONVERSATION_RECORDS = 500;
 
 type FetchLike = (
   input: RequestInfo | URL,
@@ -22,7 +25,7 @@ interface RuntimeAgent {
 
 interface RuntimeConversation {
   id: string;
-  updatedAt: string;
+  updatedAtEpochMs: number;
   agentId?: string;
 }
 
@@ -156,8 +159,20 @@ async function fetchJson(
       `${label} returned HTTP ${response.status}`,
     );
   }
+  let rawBody: string;
   try {
-    return await response.json();
+    rawBody = await readBoundedResponseBody(label, response);
+  } catch (error) {
+    if (error instanceof LocalVoiceRuntimeIdentityError) throw error;
+    // error-policy:J2 Response stream failures retain their transport cause
+    // and cannot become a partially parsed runtime identity document.
+    throw new LocalVoiceRuntimeIdentityError(
+      `${label} response body could not be read`,
+      { cause: error },
+    );
+  }
+  try {
+    return JSON.parse(rawBody) as unknown;
   } catch (error) {
     // error-policy:J3 Runtime JSON is untrusted input and malformed responses
     // fail explicitly instead of becoming an empty healthy identity list.
@@ -165,6 +180,43 @@ async function fetchJson(
       cause: error,
     });
   }
+}
+
+async function readBoundedResponseBody(
+  label: string,
+  response: Response,
+): Promise<string> {
+  const declaredLength = response.headers.get("Content-Length");
+  if (declaredLength !== null) {
+    const parsedLength = Number(declaredLength);
+    if (
+      Number.isFinite(parsedLength) &&
+      parsedLength > MAX_RUNTIME_RESPONSE_BYTES
+    ) {
+      throw new LocalVoiceRuntimeIdentityError(
+        `${label} exceeded the response size limit`,
+      );
+    }
+  }
+
+  if (response.body === null) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let receivedBytes = 0;
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    receivedBytes += value.byteLength;
+    if (receivedBytes > MAX_RUNTIME_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new LocalVoiceRuntimeIdentityError(
+        `${label} exceeded the response size limit`,
+      );
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
 }
 
 function readRecord(label: string, value: unknown): Record<string, unknown> {
@@ -179,6 +231,11 @@ function readAgents(value: unknown): RuntimeAgent[] {
   if (!Array.isArray(body.agents)) {
     throw new LocalVoiceRuntimeIdentityError(
       "local agents response must include an agents array",
+    );
+  }
+  if (body.agents.length > MAX_RUNTIME_AGENT_RECORDS) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local agents response exceeds the record limit",
     );
   }
   return body.agents.map((value, index) => {
@@ -197,6 +254,11 @@ function readConversations(value: unknown): RuntimeConversation[] {
       "local conversations response must include a conversations array",
     );
   }
+  if (body.conversations.length > MAX_RUNTIME_CONVERSATION_RECORDS) {
+    throw new LocalVoiceRuntimeIdentityError(
+      "local conversations response exceeds the record limit",
+    );
+  }
   return body.conversations.map((value, index) => {
     const record = readRecord(`local conversation ${index}`, value);
     const agentId =
@@ -208,7 +270,7 @@ function readConversations(value: unknown): RuntimeConversation[] {
           );
     return {
       id: readCanonicalUuid(`local conversation ${index} id`, record.id),
-      updatedAt: readTimestamp(
+      updatedAtEpochMs: readCanonicalTimestamp(
         `local conversation ${index} updatedAt`,
         record.updatedAt,
       ),
@@ -265,7 +327,7 @@ function selectConversationId(
       (conversation) =>
         conversation.agentId === undefined || conversation.agentId === agentId,
     )
-    .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    .toSorted((left, right) => right.updatedAtEpochMs - left.updatedAtEpochMs);
   if (candidates.length === 0) {
     throw new LocalVoiceRuntimeIdentityError(
       "local runtime has no conversation for the running agent",
@@ -298,12 +360,16 @@ function readRequiredString(label: string, value: unknown): string {
   return value;
 }
 
-function readTimestamp(label: string, value: unknown): string {
+function readCanonicalTimestamp(label: string, value: unknown): number {
   const timestamp = readRequiredString(label, value);
-  if (!Number.isFinite(Date.parse(timestamp))) {
+  const epochMs = Date.parse(timestamp);
+  if (
+    !Number.isFinite(epochMs) ||
+    new Date(epochMs).toISOString() !== timestamp
+  ) {
     throw new LocalVoiceRuntimeIdentityError(
-      `${label} must be an ISO-compatible timestamp`,
+      `${label} must be a canonical ISO timestamp`,
     );
   }
-  return timestamp;
+  return epochMs;
 }

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -143,7 +143,7 @@ async function fetchJson(
 ): Promise<unknown> {
   let response: Response;
   try {
-    response = await fetchImpl(url);
+    response = await fetchImpl(url, { redirect: "error" });
   } catch (error) {
     // error-policy:J2 The process boundary needs the failed route and original
     // transport cause to diagnose an unavailable local runtime.

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -9,7 +9,7 @@
 
 const CANONICAL_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const LOOPBACK_IP_LITERALS = new Set(["127.0.0.1", "[::1]"]);
 const MAX_RUNTIME_RESPONSE_BYTES = 1024 * 1024;
 // restoreConversationsFromDb bypasses the runtime's own
 // evictOldestConversation(..., 500), so a legitimate list can exceed 500 and a
@@ -67,7 +67,7 @@ export function resolveCanonicalLoopbackRuntimeOrigin(raw: string): string {
 
   if (
     parsed.protocol !== "http:" ||
-    !LOOPBACK_HOSTNAMES.has(parsed.hostname) ||
+    !LOOPBACK_IP_LITERALS.has(parsed.hostname) ||
     parsed.username !== "" ||
     parsed.password !== "" ||
     parsed.pathname !== "/" ||

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -2,8 +2,9 @@
  * Binds the local voice gateway to one live loopback runtime, running agent,
  * and conversation before the gateway can create a realtime session. Runtime
  * responses and operator-provided identifiers are validated as untrusted
- * boundary data; a conversation without an explicit agent field is scoped by
- * the standalone runtime's singleton `/api/agents` authority.
+ * boundary data; conversations are scoped by the standalone runtime's
+ * singleton `/api/agents` authority because the runtime conversation DTO does
+ * not carry an agent identifier.
  */
 
 const CANONICAL_UUID_PATTERN =
@@ -29,7 +30,6 @@ interface RuntimeAgent {
 interface RuntimeConversation {
   id: string;
   updatedAtEpochMs: number;
-  agentId?: string;
 }
 
 export interface LocalVoiceRuntimeIdentity {
@@ -135,7 +135,6 @@ export async function resolveLocalVoiceRuntimeIdentity(
   );
   const conversationId = selectConversationId(
     conversations,
-    agentId,
     configuredConversationId,
   );
 
@@ -274,20 +273,12 @@ function readConversations(value: unknown): RuntimeConversation[] {
       // nothing usable survives.
       return;
     }
-    const agentId =
-      record.agentId === undefined
-        ? undefined
-        : readCanonicalUuid(
-            `local conversation ${index} agent id`,
-            record.agentId,
-          );
     parsed.push({
       id: readRequiredString(`local conversation ${index} id`, record.id),
       updatedAtEpochMs: readCanonicalTimestamp(
         `local conversation ${index} updatedAt`,
         record.updatedAt,
       ),
-      ...(agentId === undefined ? {} : { agentId }),
     });
   });
   return parsed;
@@ -316,7 +307,6 @@ function selectAgentId(
 
 function selectConversationId(
   conversations: RuntimeConversation[],
-  agentId: string,
   configuredConversationId: string | undefined,
 ): string {
   if (configuredConversationId !== undefined) {
@@ -328,20 +318,12 @@ function selectConversationId(
         "configured local conversation does not exist in the runtime",
       );
     }
-    if (configured.agentId !== undefined && configured.agentId !== agentId) {
-      throw new LocalVoiceRuntimeIdentityError(
-        "configured local conversation belongs to a different agent",
-      );
-    }
     return configured.id;
   }
 
-  const candidates = conversations
-    .filter(
-      (conversation) =>
-        conversation.agentId === undefined || conversation.agentId === agentId,
-    )
-    .toSorted((left, right) => right.updatedAtEpochMs - left.updatedAtEpochMs);
+  const candidates = conversations.toSorted(
+    (left, right) => right.updatedAtEpochMs - left.updatedAtEpochMs,
+  );
   if (candidates.length === 0) {
     throw new LocalVoiceRuntimeIdentityError(
       "local runtime has no conversation for the running agent",

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -9,8 +9,11 @@
 
 const CANONICAL_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const UUID_SHAPE_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const LOOPBACK_IP_LITERALS = new Set(["127.0.0.1", "[::1]"]);
 const MAX_RUNTIME_RESPONSE_BYTES = 1024 * 1024;
+const MAX_RUNTIME_CONVERSATION_ID_LENGTH = 128;
 // restoreConversationsFromDb bypasses the runtime's own
 // evictOldestConversation(..., 500), so a legitimate list can exceed 500 and a
 // cap at that number would refuse startup on a healthy host. This bound exists
@@ -97,7 +100,7 @@ export async function resolveLocalVoiceRuntimeIdentity(
     "configured local agent id",
     options.configuredAgentId,
   );
-  const configuredConversationId = readOptionalCanonicalUuid(
+  const configuredConversationId = readOptionalConversationId(
     "configured local conversation id",
     options.configuredConversationId,
   );
@@ -257,11 +260,10 @@ function readConversations(value: unknown): RuntimeConversation[] {
     );
   }
   // Conversation ids are not UUIDs in general: restoreConversationsFromDb
-  // derives one by stripping the "web-conv-" prefix off a channel id, and the
-  // create path accepts one from a client payload. Rejecting the whole listing
-  // because a single record has an unexpected id would refuse startup on an
-  // ordinary host, so unreadable records are skipped and the selected one is
-  // still validated strictly below.
+  // derives one by stripping the "web-conv-" prefix off a persisted channel
+  // id. Rejecting the whole listing because a single record has an unexpected
+  // id would refuse startup on an ordinary host, so unreadable records are
+  // skipped and the selected one is still validated strictly below.
   const parsed: RuntimeConversation[] = [];
   body.conversations.forEach((value, index) => {
     let record: Record<string, unknown>;
@@ -274,7 +276,10 @@ function readConversations(value: unknown): RuntimeConversation[] {
       return;
     }
     parsed.push({
-      id: readRequiredString(`local conversation ${index} id`, record.id),
+      id: readCanonicalConversationId(
+        `local conversation ${index} id`,
+        record.id,
+      ),
       updatedAtEpochMs: readCanonicalTimestamp(
         `local conversation ${index} updatedAt`,
         record.updatedAt,
@@ -338,6 +343,28 @@ function readOptionalCanonicalUuid(
 ): string | undefined {
   if (value === undefined || value === "") return undefined;
   return readCanonicalUuid(label, value);
+}
+
+function readOptionalConversationId(
+  label: string,
+  value: string | undefined,
+): string | undefined {
+  if (value === undefined || value === "") return undefined;
+  return readCanonicalConversationId(label, value);
+}
+
+function readCanonicalConversationId(label: string, value: unknown): string {
+  const id = readRequiredString(label, value);
+  if (
+    id.length > MAX_RUNTIME_CONVERSATION_ID_LENGTH ||
+    id.trim() !== id ||
+    (UUID_SHAPE_PATTERN.test(id) && !CANONICAL_UUID_PATTERN.test(id))
+  ) {
+    throw new LocalVoiceRuntimeIdentityError(
+      `${label} must be canonical and at most 128 characters`,
+    );
+  }
+  return id;
 }
 
 function readCanonicalUuid(label: string, value: unknown): string {

--- a/packages/cloud/api/scripts/local-voice-runtime-identity.ts
+++ b/packages/cloud/api/scripts/local-voice-runtime-identity.ts
@@ -10,8 +10,11 @@ const CANONICAL_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
 const MAX_RUNTIME_RESPONSE_BYTES = 1024 * 1024;
-const MAX_RUNTIME_AGENT_RECORDS = 1;
-const MAX_RUNTIME_CONVERSATION_RECORDS = 500;
+// restoreConversationsFromDb bypasses the runtime's own
+// evictOldestConversation(..., 500), so a legitimate list can exceed 500 and a
+// cap at that number would refuse startup on a healthy host. This bound exists
+// only to stop an unbounded response, not to express a product limit.
+const MAX_RUNTIME_CONVERSATION_RECORDS = 2000;
 
 type FetchLike = (
   input: RequestInfo | URL,
@@ -233,11 +236,6 @@ function readAgents(value: unknown): RuntimeAgent[] {
       "local agents response must include an agents array",
     );
   }
-  if (body.agents.length > MAX_RUNTIME_AGENT_RECORDS) {
-    throw new LocalVoiceRuntimeIdentityError(
-      "local agents response exceeds the record limit",
-    );
-  }
   return body.agents.map((value, index) => {
     const record = readRecord(`local agent ${index}`, value);
     return {
@@ -259,8 +257,23 @@ function readConversations(value: unknown): RuntimeConversation[] {
       "local conversations response exceeds the record limit",
     );
   }
-  return body.conversations.map((value, index) => {
-    const record = readRecord(`local conversation ${index}`, value);
+  // Conversation ids are not UUIDs in general: restoreConversationsFromDb
+  // derives one by stripping the "web-conv-" prefix off a channel id, and the
+  // create path accepts one from a client payload. Rejecting the whole listing
+  // because a single record has an unexpected id would refuse startup on an
+  // ordinary host, so unreadable records are skipped and the selected one is
+  // still validated strictly below.
+  const parsed: RuntimeConversation[] = [];
+  body.conversations.forEach((value, index) => {
+    let record: Record<string, unknown>;
+    try {
+      record = readRecord(`local conversation ${index}`, value);
+    } catch {
+      // error-policy:J3 an unreadable record yields an explicit skip rather
+      // than a fabricated conversation; the selection below fails closed if
+      // nothing usable survives.
+      return;
+    }
     const agentId =
       record.agentId === undefined
         ? undefined
@@ -268,15 +281,16 @@ function readConversations(value: unknown): RuntimeConversation[] {
             `local conversation ${index} agent id`,
             record.agentId,
           );
-    return {
-      id: readCanonicalUuid(`local conversation ${index} id`, record.id),
+    parsed.push({
+      id: readRequiredString(`local conversation ${index} id`, record.id),
       updatedAtEpochMs: readCanonicalTimestamp(
         `local conversation ${index} updatedAt`,
         record.updatedAt,
       ),
       ...(agentId === undefined ? {} : { agentId }),
-    };
+    });
   });
+  return parsed;
 }
 
 function selectAgentId(

--- a/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
@@ -1,9 +1,16 @@
+/**
+ * Integration-backed tests for the loopback real-voice harness transport,
+ * session mint scope, provider seams, and shutdown behavior. Provider sockets
+ * are deterministic mocks while the HTTP and WebSocket servers are real.
+ */
+
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { connect } from "node:net";
 import { fileURLToPath } from "node:url";
 
 const calls: string[] = [];
+const CONVERSATION_ID = "11111111-1111-4111-8111-111111111111";
 
 class FakeSocket {
   addEventListener() {}
@@ -157,7 +164,7 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
         organizationId: "org",
         userId: "user",
         agentId: "agent",
-        conversationId: "conversation",
+        conversationId: CONVERSATION_ID,
         fetchImpl: fetch,
         hooks: { log: (_level, message) => logs.push(message) },
       });
@@ -180,6 +187,24 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
       const consentBody = (await consent.json()) as { consentNonce: string };
       expect(consentBody.consentNonce).toBe("consent");
 
+      const mismatchedMint = await fetch(
+        `${server.httpUrl}/api/v1/voice/session`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            conversationId: "22222222-2222-4222-8222-222222222222",
+            consentNonce: consentBody.consentNonce,
+            transport: "websocket",
+          }),
+        },
+      );
+      expect(mismatchedMint.status).toBe(403);
+      expect((await mismatchedMint.json()) as unknown).toEqual({
+        code: "conversation_scope_mismatch",
+      });
+      expect(calls).not.toContain("recorded");
+
       const browserMint = await fetch(
         `${server.httpUrl}/api/v1/voice/session`,
         {
@@ -191,7 +216,7 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
           },
           body: JSON.stringify({
             agentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
-            conversationId: "11111111-1111-4111-8111-111111111111",
+            conversationId: CONVERSATION_ID,
             consentNonce: consentBody.consentNonce,
             transport: "websocket",
           }),
@@ -270,5 +295,5 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
         `isolated harness failed:\n${result.stdout ?? ""}${result.stderr ?? ""}`,
       );
     }
-  });
+  }, 120_000);
 }

--- a/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
@@ -10,7 +10,7 @@ import { connect } from "node:net";
 import { fileURLToPath } from "node:url";
 
 const calls: string[] = [];
-const CONVERSATION_ID = "11111111-1111-4111-8111-111111111111";
+const CONVERSATION_ID = "legacy-channel";
 
 class FakeSocket {
   addEventListener() {}
@@ -97,7 +97,7 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
           organizationId: "org",
           userId: "user",
           agentId: "agent",
-          conversationId: "conversation",
+          conversationId: CONVERSATION_ID,
         },
         jti: "jti",
         tokenExpSeconds: 123,
@@ -193,7 +193,7 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            conversationId: "22222222-2222-4222-8222-222222222222",
+            conversationId: "other-legacy-channel",
             consentNonce: consentBody.consentNonce,
             transport: "websocket",
           }),

--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts
@@ -17,6 +17,7 @@ const VALID_BODY = JSON.stringify({
   },
   streamProtocol: "delta-v2",
 });
+const SCOPE = { agentId: "agent-a", conversationId: "conv-id" };
 
 function unusedDownstream(): typeof fetch {
   return (async () => {
@@ -38,6 +39,7 @@ describe("local runtime conversation fetch encoding", () => {
   test("unsupported path is untouched", async () => {
     const bridge = createLocalRuntimeConversationFetch(
       "http://127.0.0.1:31337",
+      SCOPE,
       unusedDownstream(),
     );
     await expect(
@@ -59,6 +61,7 @@ describe("local runtime conversation fetch encoding", () => {
     }) as typeof fetch;
     const bridge = createLocalRuntimeConversationFetch(
       "http://127.0.0.1:31337",
+      SCOPE,
       downstream,
     );
     const response = await bridge(
@@ -80,6 +83,7 @@ describe("local runtime conversation fetch encoding", () => {
     async (token) => {
       const bridge = createLocalRuntimeConversationFetch(
         "http://127.0.0.1:31337",
+        SCOPE,
         unusedDownstream(),
       );
       try {

--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
@@ -159,13 +159,18 @@ describe("local runtime conversation fetch", () => {
     ]);
   });
 
-  test("rejects non-loopback origins and unsupported upstream paths", async () => {
-    expect(() =>
-      createLocalRuntimeConversationFetch("https://api.example.com", SCOPE),
-    ).toThrow(LocalRuntimeConversationFetchError);
+  test.each(["https://api.example.com", "http://localhost:31337"])(
+    "rejects a non-literal loopback origin before downstream fetch: %s",
+    (origin) => {
+      expect(() => createLocalRuntimeConversationFetch(origin, SCOPE)).toThrow(
+        LocalRuntimeConversationFetchError,
+      );
+    },
+  );
 
+  test("rejects unsupported upstream paths", async () => {
     const bridge = createLocalRuntimeConversationFetch(
-      "http://localhost:31337",
+      "http://127.0.0.1:31337",
       SCOPE,
     );
     await expect(
@@ -180,6 +185,72 @@ describe("local runtime conversation fetch", () => {
       }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
   });
+
+  test("rejects non-POST requests before downstream fetch", async () => {
+    let calls = 0;
+    const bridge = createLocalRuntimeConversationFetch(
+      "http://127.0.0.1:31337",
+      SCOPE,
+      (async () => {
+        calls += 1;
+        return new Response();
+      }) as unknown as typeof fetch,
+    );
+    const url =
+      "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream";
+
+    await expect(
+      bridge(url, {
+        method: "GET",
+        body: JSON.stringify({
+          text: "hello",
+          metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+          streamProtocol: "delta-v2",
+        }),
+      }),
+    ).rejects.toThrow("requires POST");
+    expect(calls).toBe(0);
+  });
+
+  test.each([
+    {
+      text: "",
+      metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+    },
+    {
+      text: "   ",
+      metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+    },
+    {
+      text: 42,
+      metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+    },
+    { text: "hello" },
+    { text: "hello", metadata: { clientTransport: "browser-chat" } },
+  ])(
+    "rejects invalid text or transport metadata before downstream fetch",
+    async (fields) => {
+      let calls = 0;
+      const bridge = createLocalRuntimeConversationFetch(
+        "http://127.0.0.1:31337",
+        SCOPE,
+        (async () => {
+          calls += 1;
+          return new Response();
+        }) as unknown as typeof fetch,
+      );
+      const url =
+        "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream";
+
+      await expect(
+        bridge(url, {
+          method: "POST",
+          body: JSON.stringify({ ...fields, streamProtocol: "delta-v2" }),
+        }),
+      ).rejects.toBeInstanceOf(LocalRuntimeConversationFetchError);
+      expect(calls).toBe(0);
+    },
+  );
 
   test("rejects malformed or empty conversation bodies", async () => {
     const bridge = createLocalRuntimeConversationFetch(

--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
@@ -11,6 +11,11 @@ import {
   LocalRuntimeConversationFetchError,
 } from "../lib/local-runtime-conversation-fetch";
 
+const SCOPE = {
+  agentId: "agent-a",
+  conversationId: "11111111-1111-4111-8111-111111111111",
+};
+
 describe("local runtime conversation fetch", () => {
   test("rewrites the cloud route to canonical local SSE without cloud credentials", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
@@ -23,10 +28,11 @@ describe("local runtime conversation fetch", () => {
         status: 200,
         headers: { "Content-Type": "text/event-stream" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const signal = new AbortController().signal;
     const bridge = createLocalRuntimeConversationFetch(
-      "http://127.0.0.1:31337/path?ignored=1",
+      "http://127.0.0.1:31337",
+      SCOPE,
       downstream,
     );
 
@@ -34,6 +40,7 @@ describe("local runtime conversation fetch", () => {
       "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream",
       {
         method: "POST",
+        redirect: "follow",
         signal,
         headers: {
           Authorization: "Bearer cloud-secret",
@@ -58,6 +65,7 @@ describe("local runtime conversation fetch", () => {
       "http://127.0.0.1:31337/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream",
     );
     expect(calls[0]?.init?.signal).toBe(signal);
+    expect(calls[0]?.init?.redirect).toBe("error");
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
       text: "hello locally",
       metadata: {
@@ -105,7 +113,7 @@ describe("local runtime conversation fetch", () => {
         ].join(""),
         { headers: { "Content-Type": "text/event-stream" } },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const deltas: string[] = [];
 
     const result = await streamElizaConversation(
@@ -120,6 +128,7 @@ describe("local runtime conversation fetch", () => {
         signal: new AbortController().signal,
         fetchImpl: createLocalRuntimeConversationFetch(
           "http://127.0.0.1:31337",
+          SCOPE,
           downstream,
         ),
       },
@@ -142,11 +151,12 @@ describe("local runtime conversation fetch", () => {
 
   test("rejects non-loopback origins and unsupported upstream paths", async () => {
     expect(() =>
-      createLocalRuntimeConversationFetch("https://api.example.com"),
+      createLocalRuntimeConversationFetch("https://api.example.com", SCOPE),
     ).toThrow(LocalRuntimeConversationFetchError);
 
     const bridge = createLocalRuntimeConversationFetch(
       "http://localhost:31337",
+      SCOPE,
     );
     await expect(
       bridge("https://cloud.example/not-a-conversation", {
@@ -164,6 +174,7 @@ describe("local runtime conversation fetch", () => {
   test("rejects malformed or empty conversation bodies", async () => {
     const bridge = createLocalRuntimeConversationFetch(
       "http://127.0.0.1:31337",
+      SCOPE,
     );
     const url =
       "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream";
@@ -201,4 +212,54 @@ describe("local runtime conversation fetch", () => {
       }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
   });
+
+  test.each([
+    "https://127.0.0.1:31337",
+    "http://127.0.0.1:31337/path",
+    "http://user@127.0.0.1:31337",
+    "http://127.0.0.1.evil:31337",
+    " http://127.0.0.1:31337",
+  ])(
+    "rejects noncanonical target origin before downstream fetch: %s",
+    (origin) => {
+      let calls = 0;
+      const downstream = (async () => {
+        calls += 1;
+        return new Response();
+      }) as unknown as typeof fetch;
+      expect(() =>
+        createLocalRuntimeConversationFetch(origin, SCOPE, downstream),
+      ).toThrow(LocalRuntimeConversationFetchError);
+      expect(calls).toBe(0);
+    },
+  );
+
+  test.each([
+    "https://cloud.example/api/v1/eliza/agents/other-agent/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream",
+    "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/22222222-2222-4222-8222-222222222222/messages/stream",
+  ])(
+    "rejects an upstream identity outside the startup scope: %s",
+    async (url) => {
+      let calls = 0;
+      const bridge = createLocalRuntimeConversationFetch(
+        "http://127.0.0.1:31337",
+        SCOPE,
+        (async () => {
+          calls += 1;
+          return new Response();
+        }) as unknown as typeof fetch,
+      );
+      await expect(
+        bridge(url, {
+          method: "POST",
+          body: JSON.stringify({
+            text: "hello",
+            metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+            streamProtocol: "delta-v2",
+          }),
+        }),
+      ).rejects.toThrow("bound runtime identity");
+      expect(calls).toBe(0);
+    },
+  );
 });

--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
@@ -48,9 +48,14 @@ describe("local runtime conversation fetch", () => {
           "X-Eliza-Organization-Id": "org-a",
           "X-Eliza-User-Id": "user-a",
           "X-Eliza-Voice-Trace-Id": "trace-a",
+          "X-Eliza-Trace-Id": "trace-a",
+          Cookie: "session=cloud-secret",
+          "X-Future-Cloud-Secret": "must-not-cross-loopback",
         },
         body: JSON.stringify({
           text: "hello locally",
+          messageRole: "system",
+          clientMessageId: "twilio-call:CA123:started",
           metadata: {
             clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
           },
@@ -68,6 +73,8 @@ describe("local runtime conversation fetch", () => {
     expect(calls[0]?.init?.redirect).toBe("error");
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
       text: "hello locally",
+      messageRole: "system",
+      clientMessageId: "twilio-call:CA123:started",
       metadata: {
         clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
       },
@@ -78,7 +85,10 @@ describe("local runtime conversation fetch", () => {
     expect(headers.has("X-Service-Key")).toBe(false);
     expect(headers.has("X-Eliza-Organization-Id")).toBe(false);
     expect(headers.has("X-Eliza-User-Id")).toBe(false);
+    expect(headers.has("Cookie")).toBe(false);
+    expect(headers.has("X-Future-Cloud-Secret")).toBe(false);
     expect(headers.get("X-Eliza-Voice-Trace-Id")).toBe("trace-a");
+    expect(headers.get("X-Eliza-Trace-Id")).toBe("trace-a");
     expect(headers.get("Accept")).toBe("text/event-stream");
   });
 
@@ -212,6 +222,43 @@ describe("local runtime conversation fetch", () => {
       }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
   });
+
+  test.each([
+    { messageRole: "user" },
+    { messageRole: null },
+    { clientMessageId: "" },
+    { clientMessageId: " leading-space" },
+    { clientMessageId: "trailing-space " },
+    { clientMessageId: "x".repeat(129) },
+    { clientMessageId: 42 },
+  ])(
+    "rejects noncanonical lifecycle fields before downstream fetch",
+    async (field) => {
+      let calls = 0;
+      const bridge = createLocalRuntimeConversationFetch(
+        "http://127.0.0.1:31337",
+        SCOPE,
+        (async () => {
+          calls += 1;
+          return new Response();
+        }) as unknown as typeof fetch,
+      );
+      const url =
+        "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/11111111-1111-4111-8111-111111111111/messages/stream";
+      await expect(
+        bridge(url, {
+          method: "POST",
+          body: JSON.stringify({
+            text: "opening lifecycle event",
+            ...field,
+            metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+            streamProtocol: "delta-v2",
+          }),
+        }),
+      ).rejects.toBeInstanceOf(LocalRuntimeConversationFetchError);
+      expect(calls).toBe(0);
+    },
+  );
 
   test.each([
     "https://127.0.0.1:31337",

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -479,6 +479,10 @@ export async function startRealVoiceServer(
       // local agent in its config and scopes only the active conversation here.
       const conversationId = readRequiredUuid(body, "conversationId");
       const consentNonce = readRequiredString(body, "consentNonce");
+      if (conversationId !== config.conversationId) {
+        writeJson(res, 403, { code: "conversation_scope_mismatch" });
+        return;
+      }
       if (body.transport !== "websocket") {
         writeJson(res, 400, { code: "invalid_transport" });
         return;

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -477,7 +477,7 @@ export async function startRealVoiceServer(
       // The force-armed browser sends a recognizable sentinel. Identity never
       // comes from that debug affordance: this loopback server binds the real
       // local agent in its config and scopes only the active conversation here.
-      const conversationId = readRequiredUuid(body, "conversationId");
+      const conversationId = readCanonicalConversationId(body);
       const consentNonce = readRequiredString(body, "consentNonce");
       if (conversationId !== config.conversationId) {
         writeJson(res, 403, { code: "conversation_scope_mismatch" });
@@ -644,8 +644,7 @@ export async function startRealVoiceServer(
 }
 
 const MAX_LOCAL_HTTP_BODY_BYTES = 16 * 1024;
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_LOCAL_CONVERSATION_ID_LENGTH = 128;
 
 class LocalVoiceRequestError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -701,10 +700,17 @@ function readRequiredString(
   return value.trim();
 }
 
-function readRequiredUuid(body: Record<string, unknown>, key: string): string {
-  const value = readRequiredString(body, key);
-  if (!UUID_PATTERN.test(value)) {
-    throw new LocalVoiceRequestError(`${key} must be a UUID`);
+function readCanonicalConversationId(body: Record<string, unknown>): string {
+  const value = body.conversationId;
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_LOCAL_CONVERSATION_ID_LENGTH ||
+    value.trim() !== value
+  ) {
+    throw new LocalVoiceRequestError(
+      "conversationId must be canonical and at most 128 characters",
+    );
   }
   return value;
 }

--- a/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
@@ -9,7 +9,13 @@ import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { VOICE_STREAM_PROTOCOL } from "@/lib/voice-session/eliza-sse-bridge";
 
 const CLOUD_CONVERSATION_STREAM_PATH =
-  /^\/api\/v1\/eliza\/agents\/[^/]+\/api\/conversations\/([^/]+)\/messages\/stream$/;
+  /^\/api\/v1\/eliza\/agents\/([^/]+)\/api\/conversations\/([^/]+)\/messages\/stream$/;
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+export interface LocalRuntimeConversationScope {
+  agentId: string;
+  conversationId: string;
+}
 
 export class LocalRuntimeConversationFetchError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -18,15 +24,15 @@ export class LocalRuntimeConversationFetchError extends Error {
   }
 }
 
-/** Decode an untrusted conversation-id path segment into a typed boundary error. */
-function decodeConversationId(raw: string): string {
+/** Decode an untrusted identity path segment into a typed boundary error. */
+function decodeIdentity(label: string, raw: string): string {
   try {
     return decodeURIComponent(raw);
   } catch (error) {
     // error-policy:J3 untrusted conversation path segments are client input;
     // malformed percent-encoding is a typed fetch error, not an uncaught URIError.
     throw new LocalRuntimeConversationFetchError(
-      "conversation id is not valid percent-encoding",
+      `${label} is not valid percent-encoding`,
       { cause: error },
     );
   }
@@ -34,6 +40,7 @@ function decodeConversationId(raw: string): string {
 
 export function createLocalRuntimeConversationFetch(
   localRuntimeOrigin: string,
+  scope: LocalRuntimeConversationScope,
   fetchImpl: typeof fetch = fetch,
 ): typeof fetch {
   const origin = resolveLoopbackOrigin(localRuntimeOrigin);
@@ -44,7 +51,7 @@ export function createLocalRuntimeConversationFetch(
   ): Promise<Response> => {
     const sourceUrl = resolveRequestUrl(input);
     const match = CLOUD_CONVERSATION_STREAM_PATH.exec(sourceUrl.pathname);
-    if (!match?.[1]) {
+    if (!match?.[1] || !match[2]) {
       throw new LocalRuntimeConversationFetchError(
         `unsupported local voice upstream path: ${sourceUrl.pathname}`,
       );
@@ -55,7 +62,13 @@ export function createLocalRuntimeConversationFetch(
       );
     }
 
-    const conversationId = decodeConversationId(match[1]);
+    const agentId = decodeIdentity("agent id", match[1]);
+    const conversationId = decodeIdentity("conversation id", match[2]);
+    if (agentId !== scope.agentId || conversationId !== scope.conversationId) {
+      throw new LocalRuntimeConversationFetchError(
+        "local voice request does not match the bound runtime identity",
+      );
+    }
     const target = new URL(
       `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
       origin,
@@ -73,6 +86,7 @@ export function createLocalRuntimeConversationFetch(
       ...init,
       headers,
       body: JSON.stringify(body),
+      redirect: "error",
     });
   }) as typeof fetch;
 }
@@ -90,19 +104,24 @@ function resolveLoopbackOrigin(raw: string): URL {
     );
   }
   if (
-    (url.protocol !== "http:" && url.protocol !== "https:") ||
-    (url.hostname !== "127.0.0.1" &&
-      url.hostname !== "localhost" &&
-      url.hostname !== "::1")
+    url.protocol !== "http:" ||
+    !LOOPBACK_HOSTNAMES.has(url.hostname) ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.pathname !== "/" ||
+    url.search !== "" ||
+    url.hash !== ""
   ) {
     throw new LocalRuntimeConversationFetchError(
-      "local runtime origin must be an HTTP loopback URL",
+      "local runtime origin must be a canonical HTTP loopback origin",
     );
   }
-  url.pathname = "/";
-  url.search = "";
-  url.hash = "";
-  return url;
+  if (raw !== url.origin && raw !== `${url.origin}/`) {
+    throw new LocalRuntimeConversationFetchError(
+      "local runtime origin must use its canonical serialized form",
+    );
+  }
+  return new URL(`${url.origin}/`);
 }
 
 function resolveRequestUrl(input: RequestInfo | URL): URL {

--- a/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
@@ -10,7 +10,7 @@ import { VOICE_STREAM_PROTOCOL } from "@/lib/voice-session/eliza-sse-bridge";
 
 const CLOUD_CONVERSATION_STREAM_PATH =
   /^\/api\/v1\/eliza\/agents\/([^/]+)\/api\/conversations\/([^/]+)\/messages\/stream$/;
-const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const LOOPBACK_IP_LITERALS = new Set(["127.0.0.1", "[::1]"]);
 const MAX_CLIENT_MESSAGE_ID_LENGTH = 128;
 const FORWARDED_HEADER_NAMES = [
   "X-Eliza-Voice-Trace-Id",
@@ -111,7 +111,7 @@ function resolveLoopbackOrigin(raw: string): URL {
   }
   if (
     url.protocol !== "http:" ||
-    !LOOPBACK_HOSTNAMES.has(url.hostname) ||
+    !LOOPBACK_IP_LITERALS.has(url.hostname) ||
     url.username !== "" ||
     url.password !== "" ||
     url.pathname !== "/" ||

--- a/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
@@ -11,6 +11,11 @@ import { VOICE_STREAM_PROTOCOL } from "@/lib/voice-session/eliza-sse-bridge";
 const CLOUD_CONVERSATION_STREAM_PATH =
   /^\/api\/v1\/eliza\/agents\/([^/]+)\/api\/conversations\/([^/]+)\/messages\/stream$/;
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const MAX_CLIENT_MESSAGE_ID_LENGTH = 128;
+const FORWARDED_HEADER_NAMES = [
+  "X-Eliza-Voice-Trace-Id",
+  "X-Eliza-Trace-Id",
+] as const;
 
 export interface LocalRuntimeConversationScope {
   agentId: string;
@@ -74,11 +79,12 @@ export function createLocalRuntimeConversationFetch(
       origin,
     );
     const body = parseRequestBody(init?.body);
-    const headers = new Headers(init?.headers);
-    headers.delete("Authorization");
-    headers.delete("X-Service-Key");
-    headers.delete("X-Eliza-Organization-Id");
-    headers.delete("X-Eliza-User-Id");
+    const sourceHeaders = new Headers(init?.headers);
+    const headers = new Headers();
+    for (const name of FORWARDED_HEADER_NAMES) {
+      const value = sourceHeaders.get(name);
+      if (value !== null) headers.set(name, value);
+    }
     headers.set("Content-Type", "application/json");
     headers.set("Accept", "text/event-stream");
 
@@ -132,6 +138,8 @@ function resolveRequestUrl(input: RequestInfo | URL): URL {
 
 function parseRequestBody(body: BodyInit | null | undefined): {
   text: string;
+  messageRole?: "system";
+  clientMessageId?: string;
   metadata: { clientTransport: typeof REALTIME_VOICE_CLIENT_TRANSPORT };
   streamProtocol: typeof VOICE_STREAM_PROTOCOL;
 } {
@@ -143,6 +151,8 @@ function parseRequestBody(body: BodyInit | null | undefined): {
   try {
     const parsed = JSON.parse(body) as {
       text?: unknown;
+      messageRole?: unknown;
+      clientMessageId?: unknown;
       metadata?: unknown;
       streamProtocol?: unknown;
     };
@@ -167,8 +177,31 @@ function parseRequestBody(body: BodyInit | null | undefined): {
         "local voice conversation delta stream protocol is required",
       );
     }
+    if (parsed.messageRole !== undefined && parsed.messageRole !== "system") {
+      throw new LocalRuntimeConversationFetchError(
+        "local voice conversation message role must be system",
+      );
+    }
+    if (parsed.clientMessageId !== undefined) {
+      if (
+        typeof parsed.clientMessageId !== "string" ||
+        parsed.clientMessageId.length === 0 ||
+        parsed.clientMessageId.length > MAX_CLIENT_MESSAGE_ID_LENGTH ||
+        parsed.clientMessageId.trim() !== parsed.clientMessageId
+      ) {
+        throw new LocalRuntimeConversationFetchError(
+          "local voice client message id must be canonical and at most 128 characters",
+        );
+      }
+    }
     return {
       text: parsed.text,
+      ...(parsed.messageRole === undefined
+        ? {}
+        : { messageRole: parsed.messageRole }),
+      ...(parsed.clientMessageId === undefined
+        ? {}
+        : { clientMessageId: parsed.clientMessageId }),
       metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
       streamProtocol: parsed.streamProtocol,
     };


### PR DESCRIPTION
## Relates to

Refs #22610.

This PR is source-complete and ready for review. Merge remains held on the protected real-runtime/Cartesia microphone acceptance described below; that external hold is not a draft hold.

## Summary

- Validate `ELIZA_LOCAL_API_ORIGIN` before the first fetch and admit only canonical HTTP loopback IP literals (`127.0.0.1` or `[::1]`).
- Reject `localhost` name-resolution ambiguity, credentials, path/query/fragment suffixes, TLS/non-loopback hosts, noncanonical serialization, lookalike hosts, and redirects before an untrusted fetch.
- Validate configured agent and conversation IDs against bounded live `/api/agents` and `/api/conversations` responses.
- Require exactly one running standalone agent; the runtime's real `ConversationMeta` DTO has no `agentId`, so conversation ownership derives from that singleton runtime authority rather than a fabricated response field.
- Preserve bounded canonical UUID and legacy non-UUID conversation IDs through identity discovery, browser mint, JWT scope, and loopback streaming.
- Bind every stream and mint request to the resolved agent/conversation scope.
- Preserve trusted opening lifecycle fields: optional `messageRole: "system"` and a canonical non-empty `clientMessageId` of at most 128 characters.
- Reconstruct loopback headers from an explicit trace-header allowlist plus fixed content negotiation so cloud authorization, tenancy, cookies, and unknown future headers cannot cross the boundary.
- Stream runtime JSON under a 1 MiB byte ceiling, cap conversation records at 2,000, require canonical timestamps, and choose the newest live conversation by numeric epoch time.

## Review remediation

Independent review waves found and repaired:

1. runtime identity fetches followed redirects after origin validation;
2. the stream adapter and session mint path accepted request-time scope drift;
3. opening lifecycle identity was silently dropped;
4. runtime responses, records, timestamps, and forwarded headers were insufficiently bounded;
5. strict UUID parsing and a 500-record ceiling could reject ordinary restored runtime conversations;
6. conversation ownership tests relied on an `agentId` field that the real runtime never emits; and
7. `localhost` was treated as proof of loopback even though local name resolution can remap it away from a loopback address; and
8. legacy non-UUID conversations could pass startup discovery but were then rejected by the local browser-mint handler's stale UUID-only guard.

The final regression suite exercises real `ConversationMeta`-shaped records, literal IPv4/IPv6 admission, zero-fetch hostile-origin rejection, redirect refusal with two real loopback servers, readiness, response-size preflight and streaming ceilings, newest selection, request scope, header stripping, methods, text/metadata, and lifecycle validation.

## Sync with develop

- [x] Rebased all seven PR commits onto exact `develop` parent `d9ba0dc482d6c81d2551defe528455e73027619b`.
- [x] Lease-checked both the public PR ref and `develop` immediately before the exact-head push.
- [x] Zero rebase conflicts; isolated worktree clean after the push.

## Testing

Exact head: `9a10ea6d104c4d596c293e8740a4d7cbf9758a1f`

```text
bun test packages/cloud/api/scripts/local-voice-runtime-identity.test.ts \
  packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts \
  packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts \
  packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
PASS - 62 tests, 0 failures, 129 assertions

bunx @biomejs/biome check <6 repaired source/test files>
PASS - 6 files checked, no fixes

git diff --check origin/develop...HEAD
PASS

bun run --cwd packages/cloud/api build
NOT REPRESENTED AS GREEN - the source-light checkout's linked install lacks unrelated cloud-shared dependencies; no diagnostic names either changed production file. Hosted Quality is the clean-install authority.
```

## Evidence Gate

<!-- evidence-head:9a10ea6d104c4d596c293e8740a4d7cbf9758a1f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend startup and loopback transport boundary; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend startup and loopback transport boundary; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [x] N/A - unavailable in this source-only environment; the required real local-runtime plus Cartesia microphone-to-audio walkthrough remains a protected merge hold
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic and real-loopback harness log: https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22642-focused-9a10ea6d.txt (`sha256:96aa82cc5247a52656df7cfac8ecbb3909c361021502cc6dbbf99e0a674b0f1b`)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unavailable without the protected Cartesia/runtime path; the exact local SSE model trajectory remains a merge hold
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head deterministic domain receipt and explicit protected hold: https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22642-local-voice-domain-9a10ea6d.txt (`sha256:e5502dda751dba05dddd83281e33c9580f2841d37966dc6a4bd6fecd6f3fe421`)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed

## Required protected acceptance before merge

On this exact head, attach one redacted real run proving:

- a supported local runtime reports ready/can-respond and the gateway selects the exact running agent and conversation IDs;
- a real microphone utterance reaches Cartesia Ink STT, becomes the local canonical SSE model turn, and reaches Cartesia Sonic TTS as audible output;
- consent is issued and consumed once, the minted JWT is scoped to the selected IDs, and the turn persists in that exact conversation;
- the opening lifecycle turn lands with `messageRole: "system"` and its stable `clientMessageId` intact;
- barge-in produces no late audio, metering/JTI behavior is recorded, teardown is clean, and logs disclose no secret.

No Cartesia credential or supported running local runtime was available in this isolated review environment. Hosted Quality must also be green for this exact head. Do not merge until both conditions are satisfied.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol; anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop; Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@a6b612298d68bfd42f47a1ab7f8c957ee18eaf62:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol; Anthropic / claude-fable-5
Client / agent tooling: Codex Desktop; Claude Code
Contribution skill revision: elizaOS/eliza@a6b612298d68bfd42f47a1ab7f8c957ee18eaf62:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-22610]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a6b612298d68bfd42f47a1ab7f8c957ee18eaf62:packages/skills/skills/contribute-to-eliza"} -->
