### PR TITLE
feat(core): restore bound provider integration contracts

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,6 +61,29 @@ envelope and invariant checks, not proof that a real adapter induced each OS or
 browser behavior. Every adapter package still needs stateful fault-injection
 tests plus real browser or OS E2E evidence.
 
+## Provider integration authorization contract
+
+`types/provider-integrations.ts` is the provider-neutral boundary for opaque
+connected-account projections and capability dispatch. Adapters keep provider
+arguments and credentials private, expose only a provider-owned SHA-256 input
+digest, and bind that digest to the selected account snapshot, capability,
+operation, contextual risk, and binding time before policy evaluation.
+
+`CapabilityAuthorizationConsumer.consume` is a trusted host boundary. It must
+atomically consume one current policy decision and its exact confirmation grant
+when confirmation is required. Allowed decisions are one-shot too: a successful
+dispatch authorization can never be replayed merely because it did not require
+interactive confirmation. Distributed implementations use one durable
+compare-and-delete transaction and verify that the account/capability snapshot
+is still current; a separate read, verify, and delete sequence is unsafe.
+
+The returned `AuthorizedCapabilityRequest` is an in-process immutable value,
+not a wire credential. `normalizeCapabilityActionReceipt` accepts effect proof
+only against that exact authority and binds the complete policy and confirmation
+digests, request digest, opaque account, capability, operation, input digest,
+and post-authorization chronology. Provider payloads and secrets never belong
+in requests, decisions, confirmations, errors, or receipts.
+
 ### Bounded pairing operator reads
 
 `PairingService` keeps its existing complete-array methods (`listPendingRequests`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -76,6 +76,10 @@ dispatch authorization can never be replayed merely because it did not require
 interactive confirmation. Distributed implementations use one durable
 compare-and-delete transaction and verify that the account/capability snapshot
 is still current; a separate read, verify, and delete sequence is unsafe.
+The in-memory `CapabilityAuthorizationCoordinator` therefore requires a
+synchronous `isSnapshotCurrent` reader. A false result burns the registered
+authority before returning a stale-authorization error, so reconnecting the
+account cannot resurrect consent issued before revocation.
 
 The returned `AuthorizedCapabilityRequest` is an in-process immutable value,
 not a wire credential. `normalizeCapabilityActionReceipt` accepts effect proof

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,6 +65,7 @@ export * from "./prompt-optimization-hooks";
 export * from "./prompt-optimization-score-card";
 export * from "./prompt-optimization-trace";
 export * from "./prompts";
+export * from "./provider-integrations";
 export * from "./runtime";
 export * from "./schema";
 export * from "./schema-builder";

--- a/packages/core/src/types/provider-integrations.test.ts
+++ b/packages/core/src/types/provider-integrations.test.ts
@@ -1,0 +1,680 @@
+/**
+ * Adversarial contract tests for provider-neutral account projection,
+ * account-selected policy binding, consume-once confirmation, and receipts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	type AuthorizedCapabilityRequest,
+	authorizeCapabilityDispatch,
+	type BoundCapabilityRequest,
+	bindCapabilityRequest,
+	CapabilityAuthorizationCoordinator,
+	computeBoundCapabilityRequestDigest,
+	normalizeBoundCapabilityRequest,
+	normalizeCapabilityActionReceipt,
+	normalizeCapabilityConfirmationGrant,
+	normalizeCapabilityExecutionOutcome,
+	normalizeCapabilityPolicyDecision,
+	normalizeCapabilityRequest,
+	normalizeConnectedAccount,
+	PROVIDER_INTEGRATION_CONTRACT_VERSION,
+} from "./provider-integrations";
+
+const VERSION = PROVIDER_INTEGRATION_CONTRACT_VERSION;
+const INPUT_DIGEST = "a".repeat(64);
+const OTHER_DIGEST = "b".repeat(64);
+const BOUND_AT = "2026-08-18T12:00:00.000Z";
+const ISSUED_AT = "2026-08-18T12:00:10.000Z";
+const CONFIRMED_AT = "2026-08-18T12:00:20.000Z";
+const AUTHORIZED_NOW = Date.parse("2026-08-18T12:00:30.000Z");
+const EXPIRES_AT = "2026-08-18T12:05:00.000Z";
+
+function account(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		contractVersion: VERSION,
+		accountId: "conn_opaque_work",
+		providerId: "calendar",
+		mode: "cloud",
+		status: "connected",
+		displayName: "Work calendar",
+		capabilities: [
+			{
+				capabilityId: "calendar.events.write",
+				riskLevel: "R2",
+				status: "available",
+			},
+		],
+		lastUsedAt: "2026-08-18T05:00:00-07:00",
+		...overrides,
+	};
+}
+
+function request(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		contractVersion: VERSION,
+		requestId: "req_create_event_1",
+		capabilityId: "calendar.events.write",
+		operation: "calendar.event.create",
+		riskLevel: "R2",
+		accountId: null,
+		inputDigest: INPUT_DIGEST,
+		...overrides,
+	};
+}
+
+function bound(
+	requestOverrides: Record<string, unknown> = {},
+	accountOverrides: Record<string, unknown> = {},
+): BoundCapabilityRequest {
+	return bindCapabilityRequest(
+		request(requestOverrides),
+		account(accountOverrides),
+		BOUND_AT,
+	);
+}
+
+function decision(
+	requestValue: BoundCapabilityRequest,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		contractVersion: VERSION,
+		decisionId: "policy_decision_1",
+		requestDigest: requestValue.requestDigest,
+		riskLevel: requestValue.riskLevel,
+		issuedAt: ISSUED_AT,
+		expiresAt: EXPIRES_AT,
+		outcome: "allowed",
+		confirmation: "not_required",
+		...overrides,
+	};
+}
+
+async function allowedAuthorization(
+	requestValue: BoundCapabilityRequest = bound(),
+): Promise<AuthorizedCapabilityRequest> {
+	const coordinator = new CapabilityAuthorizationCoordinator();
+	const policy = coordinator.register(
+		decision(requestValue),
+		requestValue,
+		AUTHORIZED_NOW,
+	);
+	return authorizeCapabilityDispatch(requestValue, policy, {
+		authorizationConsumer: coordinator,
+		now: AUTHORIZED_NOW,
+	});
+}
+
+function appliedReceipt(
+	authorization: AuthorizedCapabilityRequest,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		contractVersion: VERSION,
+		authorizationId: authorization.authorizationId,
+		policyDecisionId: authorization.policyDecisionId,
+		policyDecisionDigest: authorization.policyDecisionDigest,
+		confirmationId: authorization.confirmationId,
+		confirmationGrantDigest: authorization.confirmationGrantDigest,
+		requestDigest: authorization.requestDigest,
+		accountId: authorization.account.accountId,
+		capabilityId: authorization.capabilityId,
+		operation: authorization.operation,
+		inputDigest: authorization.inputDigest,
+		effect: {
+			receiptId: "provider_receipt_1",
+			operation: authorization.operation,
+			resource: { kind: "calendar.event", id: "event_opaque_1" },
+			artifacts: [],
+			idempotency: {
+				key: authorization.requestDigest,
+				replayed: false,
+			},
+			observedAt: "2026-08-18T12:00:40.000Z",
+			outcome: "applied",
+			commit: {
+				kind: "provider_accepted",
+				id: "provider_commit_1",
+				committedAt: "2026-08-18T12:00:39.000Z",
+			},
+		},
+		...overrides,
+	};
+}
+
+describe("provider integration contracts", () => {
+	it("round-trips a versioned opaque account and freezes nested state", () => {
+		const normalized = normalizeConnectedAccount(account());
+		const wire = JSON.stringify(normalized);
+
+		expect(wire).not.toMatch(/token|secret|credential|@/i);
+		expect(normalized.lastUsedAt).toBe("2026-08-18T12:00:00.000Z");
+		expect(Object.isFrozen(normalized)).toBe(true);
+		expect(Object.isFrozen(normalized.capabilities)).toBe(true);
+		expect(Object.isFrozen(normalized.capabilities[0])).toBe(true);
+		expect(normalizeConnectedAccount(JSON.parse(wire))).toEqual(normalized);
+	});
+
+	it("rejects secret-shaped additions, duplicate capabilities, and invalid versions", () => {
+		expect(() =>
+			normalizeConnectedAccount({
+				...account(),
+				accessToken: "must-not-cross",
+			}),
+		).toThrow(/unsupported fields/);
+		expect(() =>
+			normalizeConnectedAccount(
+				account({
+					capabilities: [
+						{
+							capabilityId: "calendar.events.write",
+							riskLevel: "R2",
+							status: "available",
+						},
+						{
+							capabilityId: "calendar.events.write",
+							riskLevel: "R3",
+							status: "needs_scope",
+						},
+					],
+				}),
+			),
+		).toThrow(/unique/);
+		expect(() =>
+			normalizeConnectedAccount(account({ contractVersion: 1 })),
+		).toThrow(/contract version/);
+	});
+
+	it("normalizes provider-owned input digests without accepting raw input", () => {
+		expect(normalizeCapabilityRequest(request())).toEqual(request());
+		expect(() =>
+			normalizeCapabilityRequest({
+				...request(),
+				input: { title: "private meeting" },
+			}),
+		).toThrow(/unsupported fields/);
+		expect(() =>
+			normalizeCapabilityRequest(request({ inputDigest: "not-a-digest" })),
+		).toThrow(/SHA-256/);
+	});
+
+	it("binds account, capability, operation, risk, and exact input", () => {
+		const original = bound();
+		const variants = [
+			bound(
+				{ accountId: "conn_opaque_other" },
+				{ accountId: "conn_opaque_other" },
+			),
+			bound(
+				{
+					capabilityId: "calendar.events.delete",
+					operation: "calendar.event.delete",
+					riskLevel: "R3",
+				},
+				{
+					capabilities: [
+						{
+							capabilityId: "calendar.events.delete",
+							riskLevel: "R3",
+							status: "available",
+						},
+					],
+				},
+			),
+			bound({ operation: "calendar.event.update" }),
+			bound({ riskLevel: "R3" }),
+			bound({ inputDigest: OTHER_DIGEST }),
+			bindCapabilityRequest(request(), account(), "2026-08-18T12:00:01.000Z"),
+		];
+
+		for (const variant of variants) {
+			expect(variant.requestDigest).not.toBe(original.requestDigest);
+		}
+		expect(
+			computeBoundCapabilityRequestDigest({
+				contractVersion: original.contractVersion,
+				requestId: original.requestId,
+				account: original.account,
+				capabilityId: original.capabilityId,
+				operation: original.operation,
+				riskLevel: original.riskLevel,
+				inputDigest: original.inputDigest,
+				boundAt: original.boundAt,
+			}),
+		).toBe(original.requestDigest);
+		const elevatedFromR2 = bound({ riskLevel: "R3" });
+		const catalogR3 = bound(
+			{ riskLevel: "R3" },
+			{
+				capabilities: [
+					{
+						capabilityId: "calendar.events.write",
+						riskLevel: "R3",
+						status: "available",
+					},
+				],
+			},
+		);
+		expect(catalogR3.requestDigest).not.toBe(elevatedFromR2.requestDigest);
+	});
+
+	it("allows contextual risk elevation but rejects downgrade and unavailable accounts", () => {
+		expect(bound({ riskLevel: "R3" }).riskLevel).toBe("R3");
+		expect(() => bound({ riskLevel: "R1" })).toThrow(/downgrade/);
+		expect(() => bound({}, { status: "revoked" })).toThrow(/not connected/);
+		expect(() =>
+			bound(
+				{},
+				{
+					capabilities: [
+						{
+							capabilityId: "calendar.events.write",
+							riskLevel: "R2",
+							status: "needs_scope",
+						},
+					],
+				},
+			),
+		).toThrow(/unavailable/);
+	});
+
+	it("copies an immutable authorization snapshot and rejects digest tampering", () => {
+		const mutable = account();
+		const selected = bindCapabilityRequest(request(), mutable, BOUND_AT);
+		mutable.status = "revoked";
+		const mutableCapability = (
+			mutable.capabilities as Array<Record<string, unknown>>
+		)[0];
+		if (!mutableCapability) throw new Error("fixture capability is missing");
+		mutableCapability.riskLevel = "R3";
+
+		expect(selected.account.status).toBe("connected");
+		expect(selected.account.capability.riskLevel).toBe("R2");
+		expect(Object.isFrozen(selected.account)).toBe(true);
+		expect(Object.isFrozen(selected.account.capability)).toBe(true);
+		expect(
+			normalizeBoundCapabilityRequest(JSON.parse(JSON.stringify(selected))),
+		).toEqual(selected);
+		expect(() =>
+			normalizeBoundCapabilityRequest({
+				...selected,
+				operation: "calendar.event.delete",
+			}),
+		).toThrow(/digest/);
+		expect(() =>
+			normalizeBoundCapabilityRequest({
+				...selected,
+				account: {
+					...selected.account,
+					capability: {
+						...selected.account.capability,
+						riskLevel: "R1",
+					},
+				},
+			}),
+		).toThrow(/digest/);
+	});
+
+	it("keeps invalid wire values out of fatal error context", () => {
+		const sentinel = "secret-token-sentinel";
+		const serializedErrors: string[] = [];
+		try {
+			normalizeCapabilityPolicyDecision({
+				...decision(bound()),
+				outcome: sentinel,
+			});
+		} catch (error) {
+			serializedErrors.push(JSON.stringify(error));
+		}
+		try {
+			normalizeConnectedAccount({
+				...account(),
+				[sentinel]: "also-private",
+			});
+		} catch (error) {
+			serializedErrors.push(JSON.stringify(error));
+		}
+		expect(serializedErrors).toHaveLength(2);
+		expect(serializedErrors.join("\n")).not.toContain(sentinel);
+	});
+
+	it("requires a registered, current policy decision for dispatch", async () => {
+		const selected = bound();
+		const rawPolicy = normalizeCapabilityPolicyDecision(decision(selected));
+		const unregistered = new CapabilityAuthorizationCoordinator();
+		await expect(
+			authorizeCapabilityDispatch(selected, rawPolicy, {
+				authorizationConsumer: unregistered,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+
+		const coordinator = new CapabilityAuthorizationCoordinator();
+		const policy = coordinator.register(rawPolicy, selected, AUTHORIZED_NOW);
+		const authorization = await authorizeCapabilityDispatch(selected, policy, {
+			authorizationConsumer: coordinator,
+			now: AUTHORIZED_NOW,
+		});
+		expect(authorization.policyDecisionId).toBe(policy.decisionId);
+		expect(authorization.confirmationId).toBeNull();
+		expect(Object.isFrozen(authorization)).toBe(true);
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				authorizationConsumer: coordinator,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+	});
+
+	it("refuses stale policy and altered request reuse", async () => {
+		const selected = bound();
+		const coordinator = new CapabilityAuthorizationCoordinator();
+		expect(() =>
+			coordinator.register(
+				decision(selected, { expiresAt: "2026-08-18T12:00:29.000Z" }),
+				selected,
+				AUTHORIZED_NOW,
+			),
+		).toThrow(/stale or misbound/);
+
+		const policy = coordinator.register(
+			decision(selected),
+			selected,
+			AUTHORIZED_NOW,
+		);
+		const altered = bound({ inputDigest: OTHER_DIGEST });
+		await expect(
+			authorizeCapabilityDispatch(altered, policy, {
+				authorizationConsumer: coordinator,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "UNTRUSTED_CAPABILITY_POLICY_DECISION" });
+	});
+
+	it("atomically consumes one exact expiring confirmation under concurrency", async () => {
+		const selected = bound();
+		const coordinator = new CapabilityAuthorizationCoordinator();
+		const rawDecision = decision(selected, {
+			outcome: "confirmation_required",
+			confirmation: undefined,
+			confirmationId: "confirm_create_event_1",
+		});
+		delete rawDecision.confirmation;
+		const policy = coordinator.register(rawDecision, selected, AUTHORIZED_NOW);
+		const grant = coordinator.issue(
+			"confirm_create_event_1",
+			policy,
+			selected,
+			CONFIRMED_AT,
+			AUTHORIZED_NOW,
+		);
+		expect(
+			normalizeCapabilityConfirmationGrant(JSON.parse(JSON.stringify(grant))),
+		).toEqual(grant);
+		const options = {
+			authorizationConsumer: coordinator,
+			confirmationGrant: grant,
+			now: AUTHORIZED_NOW,
+		};
+		const results = await Promise.allSettled([
+			authorizeCapabilityDispatch(selected, policy, options),
+			authorizeCapabilityDispatch(selected, policy, options),
+		]);
+
+		expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(
+			1,
+		);
+		expect(results.filter(({ status }) => status === "rejected")).toHaveLength(
+			1,
+		);
+		const fulfilled = results.find(
+			(result): result is PromiseFulfilledResult<AuthorizedCapabilityRequest> =>
+				result.status === "fulfilled",
+		);
+		expect(fulfilled?.value.confirmationId).toBe("confirm_create_event_1");
+		expect(fulfilled?.value.policyDecisionDigest).toMatch(/^[0-9a-f]{64}$/);
+		expect(fulfilled?.value.confirmationGrantDigest).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("burns confirmation but refuses dispatch when policy expires during consume", async () => {
+		const selected = bound();
+		const coordinator = new CapabilityAuthorizationCoordinator();
+		const rawDecision = decision(selected, {
+			outcome: "confirmation_required",
+			confirmationId: "confirm_expiring",
+			expiresAt: "2026-08-18T12:00:31.000Z",
+		});
+		delete rawDecision.confirmation;
+		const policy = coordinator.register(rawDecision, selected, AUTHORIZED_NOW);
+		const grant = {
+			contractVersion: VERSION,
+			confirmationId: "confirm_expiring",
+			decisionId: policy.decisionId,
+			requestDigest: selected.requestDigest,
+			confirmedAt: CONFIRMED_AT,
+			expiresAt: "2026-08-18T12:00:31.000Z",
+		};
+		const clockValues = [
+			AUTHORIZED_NOW,
+			Date.parse("2026-08-18T12:00:32.000Z"),
+		];
+		let consumed = 0;
+
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				confirmationGrant: grant,
+				authorizationConsumer: {
+					async consume() {
+						consumed += 1;
+					},
+				},
+				clock: () => clockValues.shift() ?? Number.NaN,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+		expect(consumed).toBe(1);
+	});
+
+	it("burns consumed authority when the trusted clock moves backward", async () => {
+		const selected = bound();
+		const policy = normalizeCapabilityPolicyDecision(decision(selected));
+		const clockValues = [
+			AUTHORIZED_NOW,
+			Date.parse("2026-08-18T12:00:29.000Z"),
+		];
+		let consumed = 0;
+
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				authorizationConsumer: {
+					async consume() {
+						consumed += 1;
+					},
+				},
+				clock: () => clockValues.shift() ?? Number.NaN,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+		expect(consumed).toBe(1);
+	});
+
+	it("rejects confirmation substitution by account, operation, input, or decision", async () => {
+		const selected = bound();
+		const coordinator = new CapabilityAuthorizationCoordinator();
+		const rawDecision = decision(selected, {
+			outcome: "confirmation_required",
+			confirmationId: "confirm_create_event_2",
+		});
+		delete rawDecision.confirmation;
+		const policy = coordinator.register(rawDecision, selected, AUTHORIZED_NOW);
+		const grant = coordinator.issue(
+			"confirm_create_event_2",
+			policy,
+			selected,
+			CONFIRMED_AT,
+			AUTHORIZED_NOW,
+		);
+
+		for (const altered of [
+			bound({ accountId: "conn_other" }, { accountId: "conn_other" }),
+			bound({ operation: "calendar.event.delete" }),
+			bound({ inputDigest: OTHER_DIGEST }),
+		]) {
+			await expect(
+				authorizeCapabilityDispatch(altered, policy, {
+					authorizationConsumer: coordinator,
+					confirmationGrant: grant,
+					now: AUTHORIZED_NOW,
+				}),
+			).rejects.toMatchObject({ code: "UNTRUSTED_CAPABILITY_POLICY_DECISION" });
+		}
+	});
+
+	it("binds effect proof to immutable authority and excludes private input", async () => {
+		const authorization = await allowedAuthorization();
+		const receipt = normalizeCapabilityActionReceipt(
+			appliedReceipt(authorization),
+			{
+				authorization,
+				now: Date.parse("2026-08-18T12:01:00.000Z"),
+			},
+		);
+		const wire = JSON.stringify(receipt);
+
+		expect(receipt.effect.outcome).toBe("applied");
+		expect(receipt.effect.idempotency.key).toBe(authorization.requestDigest);
+		expect(wire).not.toMatch(/private meeting|token|secret|credential/i);
+	});
+
+	it("rejects old receipt relabeling and every authority substitution", async () => {
+		const authorization = await allowedAuthorization();
+		const base = appliedReceipt(authorization);
+		const mutations: Record<string, unknown>[] = [
+			{ authorizationId: "old_authorization" },
+			{ policyDecisionId: "other_decision" },
+			{ policyDecisionDigest: OTHER_DIGEST },
+			{ confirmationId: "other_confirmation" },
+			{ confirmationGrantDigest: OTHER_DIGEST },
+			{ requestDigest: OTHER_DIGEST },
+			{ accountId: "conn_other" },
+			{ capabilityId: "calendar.events.delete" },
+			{ operation: "calendar.event.delete" },
+			{ inputDigest: OTHER_DIGEST },
+			{
+				effect: {
+					...(base.effect as Record<string, unknown>),
+					operation: "calendar.event.delete",
+				},
+			},
+			{
+				effect: {
+					...(base.effect as Record<string, unknown>),
+					idempotency: { key: OTHER_DIGEST, replayed: false },
+				},
+			},
+		];
+
+		for (const mutation of mutations) {
+			expect(() =>
+				normalizeCapabilityActionReceipt(
+					{ ...base, ...mutation },
+					{
+						authorization,
+						now: Date.parse("2026-08-18T12:01:00.000Z"),
+					},
+				),
+			).toThrow(/does not match/);
+		}
+	});
+
+	it("rejects pre-authorization proof and fabricated authorization objects", async () => {
+		const authorization = await allowedAuthorization();
+		const base = appliedReceipt(authorization);
+		expect(() =>
+			normalizeCapabilityActionReceipt(
+				{
+					...base,
+					effect: {
+						...(base.effect as Record<string, unknown>),
+						observedAt: "2026-08-18T12:00:29.000Z",
+					},
+				},
+				{
+					authorization,
+					now: Date.parse("2026-08-18T12:01:00.000Z"),
+				},
+			),
+		).toThrow(/chronology/);
+		expect(() =>
+			normalizeCapabilityActionReceipt(
+				{
+					...base,
+					effect: {
+						...(base.effect as Record<string, unknown>),
+						commit: {
+							kind: "provider_accepted",
+							id: "old_provider_commit",
+							committedAt: "2026-08-18T12:00:29.000Z",
+						},
+					},
+				},
+				{
+					authorization,
+					now: Date.parse("2026-08-18T12:01:00.000Z"),
+				},
+			),
+		).toThrow(/commit chronology/);
+		expect(() =>
+			normalizeCapabilityActionReceipt(base, {
+				authorization: {
+					...authorization,
+				} as AuthorizedCapabilityRequest,
+				now: Date.parse("2026-08-18T12:01:00.000Z"),
+			}),
+		).toThrow(/trusted dispatch authority/);
+	});
+
+	it("keeps designed-empty, unavailable, and error outcomes distinct", () => {
+		const normalizeString = (value: unknown): string => {
+			if (typeof value !== "string") throw new TypeError("expected string");
+			return value;
+		};
+		expect(
+			normalizeCapabilityExecutionOutcome(
+				{ contractVersion: VERSION, status: "success", value: "result" },
+				normalizeString,
+			),
+		).toMatchObject({ status: "success", value: "result" });
+		expect(
+			normalizeCapabilityExecutionOutcome(
+				{ contractVersion: VERSION, status: "empty" },
+				normalizeString,
+			),
+		).toMatchObject({ status: "empty" });
+		expect(
+			normalizeCapabilityExecutionOutcome(
+				{
+					contractVersion: VERSION,
+					status: "unavailable",
+					code: "needs_scope",
+					retryable: true,
+				},
+				normalizeString,
+			),
+		).toMatchObject({ status: "unavailable", code: "needs_scope" });
+		expect(
+			normalizeCapabilityExecutionOutcome(
+				{
+					contractVersion: VERSION,
+					status: "error",
+					code: "UPSTREAM_SCHEMA_DRIFT",
+					retryable: false,
+				},
+				normalizeString,
+			),
+		).toMatchObject({ status: "error", code: "UPSTREAM_SCHEMA_DRIFT" });
+	});
+});

--- a/packages/core/src/types/provider-integrations.test.ts
+++ b/packages/core/src/types/provider-integrations.test.ts
@@ -95,10 +95,19 @@ function decision(
 	};
 }
 
+function authorizationCoordinator(
+	isSnapshotCurrent: (
+		request: BoundCapabilityRequest,
+		now: number,
+	) => boolean = () => true,
+): CapabilityAuthorizationCoordinator {
+	return new CapabilityAuthorizationCoordinator({ isSnapshotCurrent });
+}
+
 async function allowedAuthorization(
 	requestValue: BoundCapabilityRequest = bound(),
 ): Promise<AuthorizedCapabilityRequest> {
-	const coordinator = new CapabilityAuthorizationCoordinator();
+	const coordinator = authorizationCoordinator();
 	const policy = coordinator.register(
 		decision(requestValue),
 		requestValue,
@@ -343,10 +352,39 @@ describe("provider integration contracts", () => {
 		expect(serializedErrors.join("\n")).not.toContain(sentinel);
 	});
 
+	it("sanitizes malformed nested effect proof errors", async () => {
+		const authorization = await allowedAuthorization();
+		const sentinel = "secret-token-sentinel";
+		let serializedError = "";
+		try {
+			normalizeCapabilityActionReceipt(
+				{
+					...appliedReceipt(authorization),
+					effect: {
+						...(appliedReceipt(authorization).effect as Record<
+							string,
+							unknown
+						>),
+						receiptId: sentinel,
+						outcome: sentinel,
+					},
+				},
+				{
+					authorization,
+					now: Date.parse("2026-08-18T12:01:00.000Z"),
+				},
+			);
+		} catch (error) {
+			serializedError = JSON.stringify(error);
+		}
+		expect(serializedError).not.toBe("");
+		expect(serializedError).not.toContain(sentinel);
+	});
+
 	it("requires a registered, current policy decision for dispatch", async () => {
 		const selected = bound();
 		const rawPolicy = normalizeCapabilityPolicyDecision(decision(selected));
-		const unregistered = new CapabilityAuthorizationCoordinator();
+		const unregistered = authorizationCoordinator();
 		await expect(
 			authorizeCapabilityDispatch(selected, rawPolicy, {
 				authorizationConsumer: unregistered,
@@ -354,7 +392,7 @@ describe("provider integration contracts", () => {
 			}),
 		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
 
-		const coordinator = new CapabilityAuthorizationCoordinator();
+		const coordinator = authorizationCoordinator();
 		const policy = coordinator.register(rawPolicy, selected, AUTHORIZED_NOW);
 		const authorization = await authorizeCapabilityDispatch(selected, policy, {
 			authorizationConsumer: coordinator,
@@ -371,9 +409,57 @@ describe("provider integration contracts", () => {
 		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
 	});
 
+	it("burns registered authority when the selected account is revoked", async () => {
+		const selected = bound();
+		let accountCurrent = true;
+		const coordinator = authorizationCoordinator(() => accountCurrent);
+		const policy = coordinator.register(
+			decision(selected),
+			selected,
+			AUTHORIZED_NOW,
+		);
+		accountCurrent = false;
+
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				authorizationConsumer: coordinator,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+
+		accountCurrent = true;
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				authorizationConsumer: coordinator,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+	});
+
+	it("fails closed when a snapshot validator is accidentally asynchronous", async () => {
+		const selected = bound();
+		const asynchronousValidator = (() => Promise.resolve(true)) as unknown as (
+			request: BoundCapabilityRequest,
+			now: number,
+		) => boolean;
+		const coordinator = authorizationCoordinator(asynchronousValidator);
+		const policy = coordinator.register(
+			decision(selected),
+			selected,
+			AUTHORIZED_NOW,
+		);
+
+		await expect(
+			authorizeCapabilityDispatch(selected, policy, {
+				authorizationConsumer: coordinator,
+				now: AUTHORIZED_NOW,
+			}),
+		).rejects.toMatchObject({ code: "STALE_CAPABILITY_AUTHORIZATION" });
+	});
+
 	it("refuses stale policy and altered request reuse", async () => {
 		const selected = bound();
-		const coordinator = new CapabilityAuthorizationCoordinator();
+		const coordinator = authorizationCoordinator();
 		expect(() =>
 			coordinator.register(
 				decision(selected, { expiresAt: "2026-08-18T12:00:29.000Z" }),
@@ -398,7 +484,7 @@ describe("provider integration contracts", () => {
 
 	it("atomically consumes one exact expiring confirmation under concurrency", async () => {
 		const selected = bound();
-		const coordinator = new CapabilityAuthorizationCoordinator();
+		const coordinator = authorizationCoordinator();
 		const rawDecision = decision(selected, {
 			outcome: "confirmation_required",
 			confirmation: undefined,
@@ -443,7 +529,7 @@ describe("provider integration contracts", () => {
 
 	it("burns confirmation but refuses dispatch when policy expires during consume", async () => {
 		const selected = bound();
-		const coordinator = new CapabilityAuthorizationCoordinator();
+		const coordinator = authorizationCoordinator();
 		const rawDecision = decision(selected, {
 			outcome: "confirmation_required",
 			confirmationId: "confirm_expiring",
@@ -503,7 +589,7 @@ describe("provider integration contracts", () => {
 
 	it("rejects confirmation substitution by account, operation, input, or decision", async () => {
 		const selected = bound();
-		const coordinator = new CapabilityAuthorizationCoordinator();
+		const coordinator = authorizationCoordinator();
 		const rawDecision = decision(selected, {
 			outcome: "confirmation_required",
 			confirmationId: "confirm_create_event_2",
@@ -634,6 +720,32 @@ describe("provider integration contracts", () => {
 				} as AuthorizedCapabilityRequest,
 				now: Date.parse("2026-08-18T12:01:00.000Z"),
 			}),
+		).toThrow(/trusted dispatch authority/);
+
+		const relabeledAccount = {
+			...authorization.account,
+			accountId: "conn_other",
+		};
+		const symbolBrandedForgery = {
+			...authorization,
+			account: relabeledAccount,
+		} as AuthorizedCapabilityRequest;
+		for (const symbol of Object.getOwnPropertySymbols(authorization)) {
+			Object.defineProperty(symbolBrandedForgery, symbol, {
+				value: authorization[symbol as keyof typeof authorization],
+			});
+		}
+		expect(() =>
+			normalizeCapabilityActionReceipt(
+				{
+					...base,
+					accountId: "conn_other",
+				},
+				{
+					authorization: symbolBrandedForgery,
+					now: Date.parse("2026-08-18T12:01:00.000Z"),
+				},
+			),
 		).toThrow(/trusted dispatch authority/);
 	});
 

--- a/packages/core/src/types/provider-integrations.ts
+++ b/packages/core/src/types/provider-integrations.ts
@@ -1,0 +1,1360 @@
+/**
+ * Provider-neutral contracts for connected accounts, capability policy, and
+ * effect proof. Provider adapters expose opaque metadata through this module;
+ * credentials and provider-specific request payloads never cross the boundary.
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ElizaError } from "../errors";
+import { type EffectReceipt, normalizeEffectReceipt } from "./effects";
+
+export const PROVIDER_INTEGRATION_CONTRACT_VERSION = 2 as const;
+
+export const CAPABILITY_RISK_LEVELS = ["R0", "R1", "R2", "R3"] as const;
+export type CapabilityRiskLevel = (typeof CAPABILITY_RISK_LEVELS)[number];
+
+export const CONNECTED_ACCOUNT_MODES = [
+	"cloud",
+	"connector",
+	"local",
+	"native",
+] as const;
+export type ConnectedAccountMode = (typeof CONNECTED_ACCOUNT_MODES)[number];
+
+export const CONNECTED_ACCOUNT_STATUSES = [
+	"connected",
+	"disabled",
+	"error",
+	"reauth_required",
+	"revoked",
+	"unavailable",
+] as const;
+export type ConnectedAccountStatus =
+	(typeof CONNECTED_ACCOUNT_STATUSES)[number];
+
+export const CAPABILITY_UNAVAILABLE_CODES = [
+	"account_disabled",
+	"account_error",
+	"account_revoked",
+	"cost_blocked",
+	"needs_admin",
+	"needs_review",
+	"needs_scope",
+	"not_configured",
+	"provider_unavailable",
+	"unsupported",
+] as const;
+export type CapabilityUnavailableCode =
+	(typeof CAPABILITY_UNAVAILABLE_CODES)[number];
+
+export interface ConnectedAccountCapability {
+	capabilityId: string;
+	riskLevel: CapabilityRiskLevel;
+	status: "available" | CapabilityUnavailableCode;
+}
+
+/**
+ * Public account projection. `accountId` is an opaque capability handle, not
+ * a provider account ID, credential row ID, email address, or token.
+ */
+export interface ConnectedAccount {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	accountId: string;
+	providerId: string;
+	mode: ConnectedAccountMode;
+	status: ConnectedAccountStatus;
+	displayName: string | null;
+	capabilities: readonly ConnectedAccountCapability[];
+	lastUsedAt: string | null;
+}
+
+/** Untrusted provider-neutral intent before deterministic account selection. */
+export interface CapabilityRequest {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	requestId: string;
+	capabilityId: string;
+	operation: string;
+	riskLevel: CapabilityRiskLevel;
+	accountId: string | null;
+	/** Provider-owned digest of canonical inputs; raw arguments stay private. */
+	inputDigest: string;
+}
+
+export interface ConnectedAccountAuthorizationSnapshot {
+	accountId: string;
+	providerId: string;
+	mode: ConnectedAccountMode;
+	status: "connected";
+	capability: ConnectedAccountCapability & { status: "available" };
+}
+
+/** Immutable account-selected request evaluated by policy before dispatch. */
+export interface BoundCapabilityRequest {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	requestId: string;
+	account: ConnectedAccountAuthorizationSnapshot;
+	capabilityId: string;
+	operation: string;
+	riskLevel: CapabilityRiskLevel;
+	inputDigest: string;
+	requestDigest: string;
+	boundAt: string;
+}
+
+interface CapabilityPolicyDecisionBase {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	decisionId: string;
+	requestDigest: string;
+	riskLevel: CapabilityRiskLevel;
+	issuedAt: string;
+	expiresAt: string;
+}
+
+/** Explicit policy result bound to one exact immutable request digest. */
+export type CapabilityPolicyDecision =
+	| (CapabilityPolicyDecisionBase & {
+			outcome: "allowed";
+			confirmation: "not_required";
+	  })
+	| (CapabilityPolicyDecisionBase & {
+			outcome: "confirmation_required";
+			confirmationId: string;
+	  })
+	| (CapabilityPolicyDecisionBase & {
+			outcome: "denied";
+			reasonCode: string;
+	  })
+	| (CapabilityPolicyDecisionBase & {
+			outcome: "unavailable";
+			code: CapabilityUnavailableCode;
+			retryable: boolean;
+	  });
+
+export interface CapabilityConfirmationGrant {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	confirmationId: string;
+	decisionId: string;
+	requestDigest: string;
+	confirmedAt: string;
+	expiresAt: string;
+}
+
+export interface CapabilityAuthorizationConsumer {
+	/**
+	 * Atomically consumes one current policy decision and, when required, its
+	 * exact confirmation grant while verifying the account/capability snapshot
+	 * remains current. Durable implementations must perform the compare-and-
+	 * delete in one transaction; verify-then-delete is replayable.
+	 */
+	consume(
+		request: BoundCapabilityRequest,
+		decision: CapabilityPolicyDecision,
+		confirmationGrant: CapabilityConfirmationGrant | null,
+		now: number,
+	): Promise<void>;
+}
+
+const authorizedCapabilityRequest: unique symbol = Symbol(
+	"elizaos.authorizedCapabilityRequest",
+);
+
+/** Host-verified, consume-once dispatch authority. This value is not a wire DTO. */
+export interface AuthorizedCapabilityRequest extends BoundCapabilityRequest {
+	authorizationId: string;
+	policyDecisionId: string;
+	policyDecisionDigest: string;
+	confirmationId: string | null;
+	confirmationGrantDigest: string | null;
+	authorizedAt: string;
+	readonly [authorizedCapabilityRequest]: true;
+}
+
+/** Mutation proof bound to the exact immutable pre-dispatch authority. */
+export interface CapabilityActionReceipt {
+	contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+	authorizationId: string;
+	policyDecisionId: string;
+	policyDecisionDigest: string;
+	confirmationId: string | null;
+	confirmationGrantDigest: string | null;
+	requestDigest: string;
+	accountId: string;
+	capabilityId: string;
+	operation: string;
+	inputDigest: string;
+	effect: EffectReceipt;
+}
+
+/** Explicit execution result that keeps designed-empty distinct from failure. */
+export type CapabilityExecutionOutcome<T> =
+	| {
+			contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+			status: "success";
+			value: T;
+	  }
+	| {
+			contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+			status: "empty";
+	  }
+	| {
+			contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+			status: "unavailable";
+			code: CapabilityUnavailableCode;
+			retryable: boolean;
+	  }
+	| {
+			contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
+			status: "error";
+			code: string;
+			retryable: boolean;
+	  };
+
+const RISK_RANK: Readonly<Record<CapabilityRiskLevel, number>> = Object.freeze({
+	R0: 0,
+	R1: 1,
+	R2: 2,
+	R3: 3,
+});
+
+function invalid(
+	message: string,
+	context: Record<string, unknown> = {},
+	code = "INVALID_PROVIDER_INTEGRATION_CONTRACT",
+): never {
+	throw new ElizaError(message, {
+		code,
+		context,
+		severity: "fatal",
+	});
+}
+
+function record(value: unknown, contract: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return invalid(`${contract} must be an object.`, { contract });
+	}
+	return value as Record<string, unknown>;
+}
+
+function exactKeys(
+	raw: Record<string, unknown>,
+	allowed: readonly string[],
+	contract: string,
+): void {
+	const unexpectedFields = Object.keys(raw).filter(
+		(key) => !allowed.includes(key),
+	);
+	if (unexpectedFields.length > 0) {
+		invalid(`${contract} contains unsupported fields.`, {
+			contract,
+			unexpectedFieldCount: unexpectedFields.length,
+		});
+	}
+}
+
+function version(raw: Record<string, unknown>, contract: string): void {
+	if (raw.contractVersion !== PROVIDER_INTEGRATION_CONTRACT_VERSION) {
+		invalid(`${contract} has an unsupported contract version.`, { contract });
+	}
+}
+
+function nonEmptyString(
+	value: unknown,
+	field: string,
+	maxLength = 256,
+): string {
+	if (
+		typeof value !== "string" ||
+		value.trim().length === 0 ||
+		value.length > maxLength
+	) {
+		return invalid(`${field} must be a bounded non-empty string.`, { field });
+	}
+	return value.trim();
+}
+
+function nullableString(value: unknown, field: string): string | null {
+	return value === null ? null : nonEmptyString(value, field);
+}
+
+function booleanValue(value: unknown, field: string): boolean {
+	if (typeof value !== "boolean") {
+		return invalid(`${field} must be a boolean.`, { field });
+	}
+	return value;
+}
+
+function enumValue<T extends string>(
+	value: unknown,
+	values: readonly T[],
+	field: string,
+): T {
+	if (typeof value !== "string" || !values.includes(value as T)) {
+		return invalid(`${field} has an unsupported value.`, { field });
+	}
+	return value as T;
+}
+
+function digest(value: unknown, field: string): string {
+	const normalized = nonEmptyString(value, field, 64).toLowerCase();
+	if (!/^[0-9a-f]{64}$/.test(normalized)) {
+		return invalid(`${field} must be a SHA-256 digest.`, { field });
+	}
+	return normalized;
+}
+
+function isoTimestamp(value: unknown, field: string): string {
+	const normalized = nonEmptyString(value, field);
+	const match =
+		/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-](\d{2}):(\d{2}))$/.exec(
+			normalized,
+		);
+	if (!match) {
+		return invalid(`${field} must be an ISO-8601 timestamp with a timezone.`, {
+			field,
+		});
+	}
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const hour = Number(match[4]);
+	const minute = Number(match[5]);
+	const second = Number(match[6]);
+	const offsetHour = match[9] === undefined ? 0 : Number(match[9]);
+	const offsetMinute = match[10] === undefined ? 0 : Number(match[10]);
+	const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+	const daysInMonth = [
+		31,
+		leapYear ? 29 : 28,
+		31,
+		30,
+		31,
+		30,
+		31,
+		31,
+		30,
+		31,
+		30,
+		31,
+	][month - 1];
+	const parsed = Date.parse(normalized);
+	if (
+		month < 1 ||
+		month > 12 ||
+		daysInMonth === undefined ||
+		day < 1 ||
+		day > daysInMonth ||
+		hour > 23 ||
+		minute > 59 ||
+		second > 59 ||
+		offsetHour > 23 ||
+		offsetMinute > 59 ||
+		!Number.isFinite(parsed)
+	) {
+		return invalid(`${field} must be a valid ISO-8601 timestamp.`, { field });
+	}
+	return new Date(parsed).toISOString();
+}
+
+function nullableTimestamp(value: unknown, field: string): string | null {
+	return value === null ? null : isoTimestamp(value, field);
+}
+
+function trustedClock(value: number, field = "now"): number {
+	if (!Number.isFinite(value) || Number.isNaN(new Date(value).getTime())) {
+		return invalid(`${field} must be a valid timestamp.`, { field });
+	}
+	return value;
+}
+
+function stableJson(value: unknown): string {
+	if (
+		value === null ||
+		typeof value === "string" ||
+		typeof value === "boolean"
+	) {
+		return JSON.stringify(value);
+	}
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+	}
+	const raw = record(value, "digest input");
+	return `{${Object.keys(raw)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${stableJson(raw[key])}`)
+		.join(",")}}`;
+}
+
+function sha256Hex(domain: string, value: unknown): string {
+	const canonical = stableJson(value);
+	return Array.from(
+		sha256(new TextEncoder().encode(`${domain}\n${canonical}`)),
+		(byte) => byte.toString(16).padStart(2, "0"),
+	).join("");
+}
+
+/** Validates and canonicalizes an account projection at a trust boundary. */
+export function normalizeConnectedAccount(value: unknown): ConnectedAccount {
+	const raw = record(value, "ConnectedAccount");
+	exactKeys(
+		raw,
+		[
+			"contractVersion",
+			"accountId",
+			"providerId",
+			"mode",
+			"status",
+			"displayName",
+			"capabilities",
+			"lastUsedAt",
+		],
+		"ConnectedAccount",
+	);
+	version(raw, "ConnectedAccount");
+	if (!Array.isArray(raw.capabilities)) {
+		return invalid("ConnectedAccount.capabilities must be an array.");
+	}
+	const capabilities = raw.capabilities.map((entry, index) => {
+		const capability = record(entry, "ConnectedAccountCapability");
+		exactKeys(
+			capability,
+			["capabilityId", "riskLevel", "status"],
+			"ConnectedAccountCapability",
+		);
+		return Object.freeze({
+			capabilityId: nonEmptyString(
+				capability.capabilityId,
+				`capabilities[${index}].capabilityId`,
+			),
+			riskLevel: enumValue(
+				capability.riskLevel,
+				CAPABILITY_RISK_LEVELS,
+				`capabilities[${index}].riskLevel`,
+			),
+			status:
+				capability.status === "available"
+					? "available"
+					: enumValue(
+							capability.status,
+							CAPABILITY_UNAVAILABLE_CODES,
+							`capabilities[${index}].status`,
+						),
+		} satisfies ConnectedAccountCapability);
+	});
+	if (
+		new Set(capabilities.map(({ capabilityId }) => capabilityId)).size !==
+		capabilities.length
+	) {
+		return invalid("ConnectedAccount capability IDs must be unique.");
+	}
+	return Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		accountId: nonEmptyString(raw.accountId, "accountId"),
+		providerId: nonEmptyString(raw.providerId, "providerId"),
+		mode: enumValue(raw.mode, CONNECTED_ACCOUNT_MODES, "mode"),
+		status: enumValue(raw.status, CONNECTED_ACCOUNT_STATUSES, "status"),
+		displayName: nullableString(raw.displayName, "displayName"),
+		capabilities: Object.freeze(capabilities),
+		lastUsedAt: nullableTimestamp(raw.lastUsedAt, "lastUsedAt"),
+	});
+}
+
+/** Validates and canonicalizes an untrusted capability request. */
+export function normalizeCapabilityRequest(value: unknown): CapabilityRequest {
+	const raw = record(value, "CapabilityRequest");
+	exactKeys(
+		raw,
+		[
+			"contractVersion",
+			"requestId",
+			"capabilityId",
+			"operation",
+			"riskLevel",
+			"accountId",
+			"inputDigest",
+		],
+		"CapabilityRequest",
+	);
+	version(raw, "CapabilityRequest");
+	return Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		requestId: nonEmptyString(raw.requestId, "requestId"),
+		capabilityId: nonEmptyString(raw.capabilityId, "capabilityId"),
+		operation: nonEmptyString(raw.operation, "operation"),
+		riskLevel: enumValue(raw.riskLevel, CAPABILITY_RISK_LEVELS, "riskLevel"),
+		accountId: nullableString(raw.accountId, "accountId"),
+		inputDigest: digest(raw.inputDigest, "inputDigest"),
+	});
+}
+
+function requestDigestFields(
+	request: Omit<BoundCapabilityRequest, "requestDigest">,
+): Record<string, unknown> {
+	return {
+		contractVersion: request.contractVersion,
+		requestId: request.requestId,
+		accountId: request.account.accountId,
+		providerId: request.account.providerId,
+		mode: request.account.mode,
+		accountCapabilityRiskLevel: request.account.capability.riskLevel,
+		capabilityId: request.capabilityId,
+		operation: request.operation,
+		riskLevel: request.riskLevel,
+		inputDigest: request.inputDigest,
+		boundAt: request.boundAt,
+	};
+}
+
+/** Computes the domain-separated digest policy and confirmation must bind. */
+export function computeBoundCapabilityRequestDigest(
+	request: Omit<BoundCapabilityRequest, "requestDigest">,
+): string {
+	return sha256Hex(
+		"elizaos:provider-capability-request:v2",
+		requestDigestFields(request),
+	);
+}
+
+/**
+ * Selects one account and freezes the exact authorization snapshot. Contextual
+ * risk may be elevated, but never lowered below the catalog risk.
+ */
+export function bindCapabilityRequest(
+	requestValue: unknown,
+	accountValue: unknown,
+	boundAt: string,
+): BoundCapabilityRequest {
+	const request = normalizeCapabilityRequest(requestValue);
+	const account = normalizeConnectedAccount(accountValue);
+	const normalizedBoundAt = isoTimestamp(boundAt, "boundAt");
+	if (request.accountId && request.accountId !== account.accountId) {
+		return invalid("Capability request selected a different account.", {
+			requestId: request.requestId,
+		});
+	}
+	if (account.status !== "connected") {
+		return invalid("Capability request account is not connected.", {
+			requestId: request.requestId,
+			accountId: account.accountId,
+		});
+	}
+	const capability = account.capabilities.find(
+		(entry) => entry.capabilityId === request.capabilityId,
+	);
+	if (capability?.status !== "available") {
+		return invalid(
+			"Capability request is unavailable for the selected account.",
+			{
+				requestId: request.requestId,
+				accountId: account.accountId,
+				capabilityId: request.capabilityId,
+			},
+		);
+	}
+	if (RISK_RANK[request.riskLevel] < RISK_RANK[capability.riskLevel]) {
+		return invalid("Capability request cannot downgrade catalog risk.", {
+			requestId: request.requestId,
+			capabilityId: request.capabilityId,
+		});
+	}
+	const accountSnapshot = Object.freeze({
+		accountId: account.accountId,
+		providerId: account.providerId,
+		mode: account.mode,
+		status: "connected" as const,
+		capability: Object.freeze({
+			...capability,
+			status: "available" as const,
+		}),
+	});
+	const digestable = Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		requestId: request.requestId,
+		account: accountSnapshot,
+		capabilityId: request.capabilityId,
+		operation: request.operation,
+		riskLevel: request.riskLevel,
+		inputDigest: request.inputDigest,
+		boundAt: normalizedBoundAt,
+	});
+	return Object.freeze({
+		...digestable,
+		requestDigest: computeBoundCapabilityRequestDigest(digestable),
+	});
+}
+
+/** Revalidates a transported bound request and recomputes its exact digest. */
+export function normalizeBoundCapabilityRequest(
+	value: unknown,
+): BoundCapabilityRequest {
+	const raw = record(value, "BoundCapabilityRequest");
+	exactKeys(
+		raw,
+		[
+			"contractVersion",
+			"requestId",
+			"account",
+			"capabilityId",
+			"operation",
+			"riskLevel",
+			"inputDigest",
+			"requestDigest",
+			"boundAt",
+		],
+		"BoundCapabilityRequest",
+	);
+	version(raw, "BoundCapabilityRequest");
+	const accountRaw = record(
+		raw.account,
+		"ConnectedAccountAuthorizationSnapshot",
+	);
+	exactKeys(
+		accountRaw,
+		["accountId", "providerId", "mode", "status", "capability"],
+		"ConnectedAccountAuthorizationSnapshot",
+	);
+	if (accountRaw.status !== "connected") {
+		return invalid("Bound capability account snapshot must be connected.");
+	}
+	const capabilityRaw = record(
+		accountRaw.capability,
+		"ConnectedAccountCapability",
+	);
+	exactKeys(
+		capabilityRaw,
+		["capabilityId", "riskLevel", "status"],
+		"ConnectedAccountCapability",
+	);
+	if (capabilityRaw.status !== "available") {
+		return invalid("Bound capability snapshot must be available.");
+	}
+	const account = Object.freeze({
+		accountId: nonEmptyString(accountRaw.accountId, "account.accountId"),
+		providerId: nonEmptyString(accountRaw.providerId, "account.providerId"),
+		mode: enumValue(accountRaw.mode, CONNECTED_ACCOUNT_MODES, "account.mode"),
+		status: "connected" as const,
+		capability: Object.freeze({
+			capabilityId: nonEmptyString(
+				capabilityRaw.capabilityId,
+				"account.capability.capabilityId",
+			),
+			riskLevel: enumValue(
+				capabilityRaw.riskLevel,
+				CAPABILITY_RISK_LEVELS,
+				"account.capability.riskLevel",
+			),
+			status: "available" as const,
+		}),
+	});
+	const capabilityId = nonEmptyString(raw.capabilityId, "capabilityId");
+	const riskLevel = enumValue(
+		raw.riskLevel,
+		CAPABILITY_RISK_LEVELS,
+		"riskLevel",
+	);
+	if (account.capability.capabilityId !== capabilityId) {
+		return invalid(
+			"Bound request capability does not match its account snapshot.",
+		);
+	}
+	if (RISK_RANK[riskLevel] < RISK_RANK[account.capability.riskLevel]) {
+		return invalid("Bound capability request downgraded catalog risk.");
+	}
+	const digestable = Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		requestId: nonEmptyString(raw.requestId, "requestId"),
+		account,
+		capabilityId,
+		operation: nonEmptyString(raw.operation, "operation"),
+		riskLevel,
+		inputDigest: digest(raw.inputDigest, "inputDigest"),
+		boundAt: isoTimestamp(raw.boundAt, "boundAt"),
+	});
+	const requestDigest = digest(raw.requestDigest, "requestDigest");
+	if (computeBoundCapabilityRequestDigest(digestable) !== requestDigest) {
+		return invalid("Bound capability request digest is stale or invalid.");
+	}
+	return Object.freeze({
+		...digestable,
+		requestDigest,
+	});
+}
+
+/** Validates a versioned policy decision without treating it as trusted. */
+export function normalizeCapabilityPolicyDecision(
+	value: unknown,
+): CapabilityPolicyDecision {
+	const raw = record(value, "CapabilityPolicyDecision");
+	version(raw, "CapabilityPolicyDecision");
+	const base = {
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		decisionId: nonEmptyString(raw.decisionId, "decisionId"),
+		requestDigest: digest(raw.requestDigest, "requestDigest"),
+		riskLevel: enumValue(raw.riskLevel, CAPABILITY_RISK_LEVELS, "riskLevel"),
+		issuedAt: isoTimestamp(raw.issuedAt, "issuedAt"),
+		expiresAt: isoTimestamp(raw.expiresAt, "expiresAt"),
+	};
+	if (Date.parse(base.expiresAt) <= Date.parse(base.issuedAt)) {
+		return invalid("Capability policy decision must expire after issuance.");
+	}
+	switch (raw.outcome) {
+		case "allowed":
+			exactKeys(
+				raw,
+				[
+					"contractVersion",
+					"decisionId",
+					"requestDigest",
+					"riskLevel",
+					"issuedAt",
+					"expiresAt",
+					"outcome",
+					"confirmation",
+				],
+				"CapabilityPolicyDecision",
+			);
+			if (raw.confirmation !== "not_required") {
+				return invalid(
+					"Allowed policy decisions cannot carry reusable grants.",
+				);
+			}
+			return Object.freeze({
+				...base,
+				outcome: "allowed",
+				confirmation: "not_required",
+			});
+		case "confirmation_required":
+			exactKeys(
+				raw,
+				[
+					"contractVersion",
+					"decisionId",
+					"requestDigest",
+					"riskLevel",
+					"issuedAt",
+					"expiresAt",
+					"outcome",
+					"confirmationId",
+				],
+				"CapabilityPolicyDecision",
+			);
+			return Object.freeze({
+				...base,
+				outcome: "confirmation_required",
+				confirmationId: nonEmptyString(raw.confirmationId, "confirmationId"),
+			});
+		case "denied":
+			exactKeys(
+				raw,
+				[
+					"contractVersion",
+					"decisionId",
+					"requestDigest",
+					"riskLevel",
+					"issuedAt",
+					"expiresAt",
+					"outcome",
+					"reasonCode",
+				],
+				"CapabilityPolicyDecision",
+			);
+			return Object.freeze({
+				...base,
+				outcome: "denied",
+				reasonCode: nonEmptyString(raw.reasonCode, "reasonCode", 128),
+			});
+		case "unavailable":
+			exactKeys(
+				raw,
+				[
+					"contractVersion",
+					"decisionId",
+					"requestDigest",
+					"riskLevel",
+					"issuedAt",
+					"expiresAt",
+					"outcome",
+					"code",
+					"retryable",
+				],
+				"CapabilityPolicyDecision",
+			);
+			return Object.freeze({
+				...base,
+				outcome: "unavailable",
+				code: enumValue(raw.code, CAPABILITY_UNAVAILABLE_CODES, "code"),
+				retryable: booleanValue(raw.retryable, "retryable"),
+			});
+		default:
+			return invalid("CapabilityPolicyDecision outcome is unsupported.", {
+				contract: "CapabilityPolicyDecision",
+			});
+	}
+}
+
+/** Computes the domain-separated identity of the complete policy snapshot. */
+export function computeCapabilityPolicyDecisionDigest(
+	decision: CapabilityPolicyDecision,
+): string {
+	return sha256Hex("elizaos:provider-policy-decision:v2", decision);
+}
+
+/** Validates and freezes a transported confirmation grant without trusting it. */
+export function normalizeCapabilityConfirmationGrant(
+	value: unknown,
+): CapabilityConfirmationGrant {
+	const raw = record(value, "CapabilityConfirmationGrant");
+	exactKeys(
+		raw,
+		[
+			"contractVersion",
+			"confirmationId",
+			"decisionId",
+			"requestDigest",
+			"confirmedAt",
+			"expiresAt",
+		],
+		"CapabilityConfirmationGrant",
+	);
+	version(raw, "CapabilityConfirmationGrant");
+	const grant = Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		confirmationId: nonEmptyString(raw.confirmationId, "confirmationId"),
+		decisionId: nonEmptyString(raw.decisionId, "decisionId"),
+		requestDigest: digest(raw.requestDigest, "requestDigest"),
+		confirmedAt: isoTimestamp(raw.confirmedAt, "confirmedAt"),
+		expiresAt: isoTimestamp(raw.expiresAt, "expiresAt"),
+	});
+	if (Date.parse(grant.expiresAt) <= Date.parse(grant.confirmedAt)) {
+		return invalid("Capability confirmation must expire after approval.");
+	}
+	return grant;
+}
+
+/** Computes the domain-separated identity of the complete confirmation grant. */
+export function computeCapabilityConfirmationGrantDigest(
+	grant: CapabilityConfirmationGrant,
+): string {
+	return sha256Hex("elizaos:provider-confirmation-grant:v2", grant);
+}
+
+interface RegisteredCapabilityAuthorization {
+	decisionDigest: string;
+	requestDigest: string;
+	requestBoundAt: string;
+	expiresAt: string;
+	confirmationId: string | null;
+	confirmationGrant: CapabilityConfirmationGrant | null;
+}
+
+/**
+ * In-memory policy/confirmation authority with atomic consume-once dispatch.
+ * Durable hosts implement the consumer with one transactional
+ * compare-and-delete over the decision and optional confirmation grant.
+ */
+export class CapabilityAuthorizationCoordinator
+	implements CapabilityAuthorizationConsumer
+{
+	private readonly registered = new Map<
+		string,
+		RegisteredCapabilityAuthorization
+	>();
+	private readonly reservedDecisionIds = new Set<string>();
+	private readonly reservedConfirmationIds = new Set<string>();
+
+	register(
+		decisionValue: unknown,
+		requestValue: unknown,
+		now: number = Date.now(),
+	): CapabilityPolicyDecision &
+		({ outcome: "allowed" } | { outcome: "confirmation_required" }) {
+		const decision = normalizeCapabilityPolicyDecision(decisionValue);
+		const request = normalizeBoundCapabilityRequest(requestValue);
+		const trustedNow = trustedClock(now);
+		if (
+			decision.outcome !== "allowed" &&
+			decision.outcome !== "confirmation_required"
+		) {
+			return invalid("Only dispatchable policy decisions can be registered.");
+		}
+		if (
+			decision.requestDigest !== request.requestDigest ||
+			decision.riskLevel !== request.riskLevel ||
+			Date.parse(decision.issuedAt) > trustedNow ||
+			Date.parse(decision.issuedAt) < Date.parse(request.boundAt) ||
+			Date.parse(decision.expiresAt) <= trustedNow
+		) {
+			return invalid("Capability policy decision is stale or misbound.");
+		}
+		if (this.reservedDecisionIds.has(decision.decisionId)) {
+			return invalid("Capability policy decision ID is already registered.");
+		}
+		const confirmationId =
+			decision.outcome === "confirmation_required"
+				? decision.confirmationId
+				: null;
+		if (
+			confirmationId !== null &&
+			this.reservedConfirmationIds.has(confirmationId)
+		) {
+			return invalid("Capability confirmation ID is already registered.");
+		}
+		this.reservedDecisionIds.add(decision.decisionId);
+		if (confirmationId !== null) {
+			this.reservedConfirmationIds.add(confirmationId);
+		}
+		this.registered.set(decision.decisionId, {
+			decisionDigest: computeCapabilityPolicyDecisionDigest(decision),
+			requestDigest: request.requestDigest,
+			requestBoundAt: request.boundAt,
+			expiresAt: decision.expiresAt,
+			confirmationId,
+			confirmationGrant: null,
+		});
+		return decision as CapabilityPolicyDecision &
+			({ outcome: "allowed" } | { outcome: "confirmation_required" });
+	}
+
+	issue(
+		confirmationId: string,
+		decisionValue: unknown,
+		requestValue: unknown,
+		confirmedAt: string,
+		now: number = Date.now(),
+	): CapabilityConfirmationGrant {
+		const id = nonEmptyString(confirmationId, "confirmationId");
+		const decision = normalizeCapabilityPolicyDecision(decisionValue);
+		const request = normalizeBoundCapabilityRequest(requestValue);
+		const trustedNow = trustedClock(now);
+		const registered = this.registered.get(decision.decisionId);
+		if (
+			!registered ||
+			decision.outcome !== "confirmation_required" ||
+			decision.confirmationId !== id ||
+			registered.confirmationId !== id ||
+			registered.confirmationGrant !== null ||
+			registered.decisionDigest !==
+				computeCapabilityPolicyDecisionDigest(decision) ||
+			registered.requestDigest !== request.requestDigest ||
+			registered.requestBoundAt !== request.boundAt ||
+			decision.requestDigest !== request.requestDigest ||
+			decision.riskLevel !== request.riskLevel
+		) {
+			return invalid(
+				"Capability confirmation is not pending for this request.",
+			);
+		}
+		const normalizedConfirmedAt = isoTimestamp(confirmedAt, "confirmedAt");
+		if (
+			Date.parse(normalizedConfirmedAt) < Date.parse(decision.issuedAt) ||
+			Date.parse(normalizedConfirmedAt) > trustedNow ||
+			Date.parse(registered.expiresAt) <= trustedNow
+		) {
+			return invalid("Capability confirmation approval time is invalid.");
+		}
+		const grant = Object.freeze({
+			contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+			confirmationId: id,
+			decisionId: decision.decisionId,
+			requestDigest: request.requestDigest,
+			confirmedAt: normalizedConfirmedAt,
+			expiresAt: registered.expiresAt,
+		});
+		this.registered.set(decision.decisionId, {
+			...registered,
+			confirmationGrant: grant,
+		});
+		return grant;
+	}
+
+	async consume(
+		requestValue: BoundCapabilityRequest,
+		decisionValue: CapabilityPolicyDecision,
+		grantValue: CapabilityConfirmationGrant | null,
+		now: number = Date.now(),
+	): Promise<void> {
+		const request = normalizeBoundCapabilityRequest(requestValue);
+		const decision = normalizeCapabilityPolicyDecision(decisionValue);
+		const grant =
+			grantValue === null
+				? null
+				: normalizeCapabilityConfirmationGrant(grantValue);
+		const trustedNow = trustedClock(now);
+		const registered = this.registered.get(decision.decisionId);
+		const confirmationMatches =
+			decision.outcome === "allowed"
+				? grant === null &&
+					registered?.confirmationId === null &&
+					registered.confirmationGrant === null
+				: decision.outcome === "confirmation_required" &&
+					grant !== null &&
+					registered?.confirmationId === grant.confirmationId &&
+					registered.confirmationGrant !== null &&
+					decision.confirmationId === grant.confirmationId &&
+					grant.decisionId === decision.decisionId &&
+					grant.requestDigest === request.requestDigest &&
+					computeCapabilityConfirmationGrantDigest(
+						registered.confirmationGrant,
+					) === computeCapabilityConfirmationGrantDigest(grant) &&
+					Date.parse(grant.confirmedAt) >= Date.parse(decision.issuedAt) &&
+					Date.parse(grant.expiresAt) > trustedNow;
+		if (
+			!registered ||
+			registered.decisionDigest !==
+				computeCapabilityPolicyDecisionDigest(decision) ||
+			registered.requestDigest !== request.requestDigest ||
+			registered.requestBoundAt !== request.boundAt ||
+			decision.requestDigest !== request.requestDigest ||
+			decision.riskLevel !== request.riskLevel ||
+			Date.parse(decision.issuedAt) < Date.parse(request.boundAt) ||
+			Date.parse(decision.issuedAt) > trustedNow ||
+			Date.parse(registered.expiresAt) <= trustedNow ||
+			!confirmationMatches
+		) {
+			throw new ElizaError(
+				"Capability authorization is missing, stale, or already consumed.",
+				{
+					code: "STALE_CAPABILITY_AUTHORIZATION",
+					context: {
+						decisionId: decision.decisionId,
+						requestId: request.requestId,
+					},
+					severity: "ephemeral",
+				},
+			);
+		}
+		// No await occurs before deletion: one concurrent caller owns dispatch.
+		this.registered.delete(decision.decisionId);
+	}
+}
+
+function authorizationId(
+	request: BoundCapabilityRequest,
+	policyDecisionDigest: string,
+	confirmationGrantDigest: string | null,
+): string {
+	return sha256Hex("elizaos:provider-capability-authorization:v2", {
+		requestDigest: request.requestDigest,
+		policyDecisionDigest,
+		confirmationGrantDigest,
+	});
+}
+
+export interface AuthorizeCapabilityDispatchOptions {
+	authorizationConsumer: CapabilityAuthorizationConsumer;
+	confirmationGrant?: CapabilityConfirmationGrant;
+	now?: number;
+	clock?: () => number;
+}
+
+/** Atomically consumes the exact policy/confirmation authority before dispatch. */
+export async function authorizeCapabilityDispatch(
+	requestValue: unknown,
+	decisionValue: unknown,
+	options: AuthorizeCapabilityDispatchOptions,
+): Promise<AuthorizedCapabilityRequest> {
+	if (options.now !== undefined && options.clock) {
+		return invalid(
+			"Capability dispatch accepts either now or clock, not both.",
+		);
+	}
+	const clock = options.clock ?? (() => options.now ?? Date.now());
+	const trustedNow = trustedClock(clock());
+	const request = normalizeBoundCapabilityRequest(requestValue);
+	const decision = normalizeCapabilityPolicyDecision(decisionValue);
+	if (
+		decision.requestDigest !== request.requestDigest ||
+		decision.riskLevel !== request.riskLevel ||
+		Date.parse(decision.issuedAt) < Date.parse(request.boundAt) ||
+		Date.parse(decision.issuedAt) > trustedNow ||
+		Date.parse(decision.expiresAt) <= trustedNow
+	) {
+		return invalid(
+			"Capability policy decision is untrusted or misbound.",
+			{
+				requestId: request.requestId,
+			},
+			"UNTRUSTED_CAPABILITY_POLICY_DECISION",
+		);
+	}
+	if (decision.outcome === "denied") {
+		return invalid(
+			"Capability policy denied dispatch.",
+			{
+				requestId: request.requestId,
+				reasonCode: decision.reasonCode,
+			},
+			"CAPABILITY_POLICY_DENIED",
+		);
+	}
+	if (decision.outcome === "unavailable") {
+		return invalid(
+			"Capability is unavailable for dispatch.",
+			{
+				requestId: request.requestId,
+				code: decision.code,
+				retryable: decision.retryable,
+			},
+			"CAPABILITY_UNAVAILABLE",
+		);
+	}
+	let confirmationGrant: CapabilityConfirmationGrant | null = null;
+	if (decision.outcome === "confirmation_required") {
+		if (!options.confirmationGrant) {
+			return invalid(
+				"Capability dispatch requires consume-once confirmation.",
+				{
+					requestId: request.requestId,
+				},
+				"CAPABILITY_CONFIRMATION_REQUIRED",
+			);
+		}
+		confirmationGrant = normalizeCapabilityConfirmationGrant(
+			options.confirmationGrant,
+		);
+		if (
+			confirmationGrant.confirmationId !== decision.confirmationId ||
+			confirmationGrant.decisionId !== decision.decisionId ||
+			confirmationGrant.requestDigest !== request.requestDigest ||
+			Date.parse(confirmationGrant.confirmedAt) <
+				Date.parse(decision.issuedAt) ||
+			Date.parse(confirmationGrant.expiresAt) <= trustedNow
+		) {
+			return invalid(
+				"Capability confirmation is stale or misbound.",
+				{ requestId: request.requestId },
+				"STALE_CAPABILITY_CONFIRMATION",
+			);
+		}
+	} else if (options.confirmationGrant) {
+		return invalid("Unconfirmed capability dispatch cannot carry a grant.");
+	}
+	await options.authorizationConsumer.consume(
+		request,
+		decision,
+		confirmationGrant,
+		trustedNow,
+	);
+	const authorizedNow = trustedClock(clock());
+	if (
+		authorizedNow < trustedNow ||
+		Date.parse(decision.expiresAt) <= authorizedNow ||
+		(confirmationGrant !== null &&
+			Date.parse(confirmationGrant.expiresAt) <= authorizedNow)
+	) {
+		return invalid(
+			"Capability policy expired while dispatch authorization was pending.",
+			{ requestId: request.requestId },
+			"STALE_CAPABILITY_AUTHORIZATION",
+		);
+	}
+	const authorizedAt = isoTimestamp(
+		new Date(authorizedNow).toISOString(),
+		"authorizedAt",
+	);
+	const policyDecisionDigest = computeCapabilityPolicyDecisionDigest(decision);
+	const confirmationGrantDigest =
+		confirmationGrant === null
+			? null
+			: computeCapabilityConfirmationGrantDigest(confirmationGrant);
+	const authorized = {
+		...request,
+		authorizationId: authorizationId(
+			request,
+			policyDecisionDigest,
+			confirmationGrantDigest,
+		),
+		policyDecisionId: decision.decisionId,
+		policyDecisionDigest,
+		confirmationId: confirmationGrant?.confirmationId ?? null,
+		confirmationGrantDigest,
+		authorizedAt,
+	} as BoundCapabilityRequest & {
+		authorizationId: string;
+		policyDecisionId: string;
+		policyDecisionDigest: string;
+		confirmationId: string | null;
+		confirmationGrantDigest: string | null;
+		authorizedAt: string;
+		[authorizedCapabilityRequest]: true;
+	};
+	Object.defineProperty(authorized, authorizedCapabilityRequest, {
+		value: true,
+		enumerable: false,
+		configurable: false,
+		writable: false,
+	});
+	return Object.freeze(authorized);
+}
+
+export interface NormalizeCapabilityActionReceiptOptions {
+	authorization: AuthorizedCapabilityRequest;
+	now?: number;
+}
+
+/** Validates receipt identity and chronology against trusted dispatch authority. */
+export function normalizeCapabilityActionReceipt(
+	value: unknown,
+	options: NormalizeCapabilityActionReceiptOptions,
+): CapabilityActionReceipt {
+	const authorization = options.authorization;
+	if (authorization[authorizedCapabilityRequest] !== true) {
+		return invalid("Capability receipt requires trusted dispatch authority.");
+	}
+	const raw = record(value, "CapabilityActionReceipt");
+	exactKeys(
+		raw,
+		[
+			"contractVersion",
+			"authorizationId",
+			"policyDecisionId",
+			"policyDecisionDigest",
+			"confirmationId",
+			"confirmationGrantDigest",
+			"requestDigest",
+			"accountId",
+			"capabilityId",
+			"operation",
+			"inputDigest",
+			"effect",
+		],
+		"CapabilityActionReceipt",
+	);
+	version(raw, "CapabilityActionReceipt");
+	const receipt = Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		authorizationId: nonEmptyString(raw.authorizationId, "authorizationId"),
+		policyDecisionId: nonEmptyString(raw.policyDecisionId, "policyDecisionId"),
+		policyDecisionDigest: digest(
+			raw.policyDecisionDigest,
+			"policyDecisionDigest",
+		),
+		confirmationId: nullableString(raw.confirmationId, "confirmationId"),
+		confirmationGrantDigest:
+			raw.confirmationGrantDigest === null
+				? null
+				: digest(raw.confirmationGrantDigest, "confirmationGrantDigest"),
+		requestDigest: digest(raw.requestDigest, "requestDigest"),
+		accountId: nonEmptyString(raw.accountId, "accountId"),
+		capabilityId: nonEmptyString(raw.capabilityId, "capabilityId"),
+		operation: nonEmptyString(raw.operation, "operation"),
+		inputDigest: digest(raw.inputDigest, "inputDigest"),
+		effect: normalizeEffectReceipt(raw.effect),
+	});
+	if (
+		receipt.authorizationId !== authorization.authorizationId ||
+		receipt.policyDecisionId !== authorization.policyDecisionId ||
+		receipt.policyDecisionDigest !== authorization.policyDecisionDigest ||
+		receipt.confirmationId !== authorization.confirmationId ||
+		receipt.confirmationGrantDigest !== authorization.confirmationGrantDigest ||
+		receipt.requestDigest !== authorization.requestDigest ||
+		receipt.accountId !== authorization.account.accountId ||
+		receipt.capabilityId !== authorization.capabilityId ||
+		receipt.operation !== authorization.operation ||
+		receipt.inputDigest !== authorization.inputDigest ||
+		receipt.effect.operation !== authorization.operation ||
+		receipt.effect.idempotency.key !== authorization.requestDigest
+	) {
+		return invalid("Capability receipt does not match dispatch authority.", {
+			requestId: authorization.requestId,
+		});
+	}
+	const trustedNow = trustedClock(options.now ?? Date.now());
+	if (
+		Date.parse(receipt.effect.observedAt) <
+			Date.parse(authorization.authorizedAt) ||
+		Date.parse(receipt.effect.observedAt) > trustedNow
+	) {
+		return invalid("Capability receipt chronology is invalid.", {
+			requestId: authorization.requestId,
+		});
+	}
+	if (
+		receipt.effect.outcome === "applied" &&
+		(Date.parse(receipt.effect.commit.committedAt) <
+			Date.parse(authorization.authorizedAt) ||
+			Date.parse(receipt.effect.commit.committedAt) >
+				Date.parse(receipt.effect.observedAt))
+	) {
+		return invalid("Capability receipt commit chronology is invalid.", {
+			requestId: authorization.requestId,
+		});
+	}
+	if (
+		receipt.effect.outcome === "rolled_back" &&
+		(Date.parse(receipt.effect.rollback.rolledBackAt) <
+			Date.parse(authorization.authorizedAt) ||
+			Date.parse(receipt.effect.rollback.rolledBackAt) >
+				Date.parse(receipt.effect.observedAt))
+	) {
+		return invalid("Capability rollback chronology is invalid.", {
+			requestId: authorization.requestId,
+		});
+	}
+	return receipt;
+}
+
+/**
+ * Validates an execution envelope while leaving successful domain payload
+ * validation to the owning capability adapter.
+ */
+export function normalizeCapabilityExecutionOutcome<T>(
+	value: unknown,
+	normalizeValue: (value: unknown) => T,
+): CapabilityExecutionOutcome<T> {
+	const raw = record(value, "CapabilityExecutionOutcome");
+	version(raw, "CapabilityExecutionOutcome");
+	switch (raw.status) {
+		case "success":
+			exactKeys(
+				raw,
+				["contractVersion", "status", "value"],
+				"CapabilityExecutionOutcome",
+			);
+			return Object.freeze({
+				contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+				status: "success",
+				value: normalizeValue(raw.value),
+			});
+		case "empty":
+			exactKeys(
+				raw,
+				["contractVersion", "status"],
+				"CapabilityExecutionOutcome",
+			);
+			return Object.freeze({
+				contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+				status: "empty",
+			});
+		case "unavailable":
+			exactKeys(
+				raw,
+				["contractVersion", "status", "code", "retryable"],
+				"CapabilityExecutionOutcome",
+			);
+			return Object.freeze({
+				contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+				status: "unavailable",
+				code: enumValue(raw.code, CAPABILITY_UNAVAILABLE_CODES, "code"),
+				retryable: booleanValue(raw.retryable, "retryable"),
+			});
+		case "error":
+			exactKeys(
+				raw,
+				["contractVersion", "status", "code", "retryable"],
+				"CapabilityExecutionOutcome",
+			);
+			return Object.freeze({
+				contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+				status: "error",
+				code: nonEmptyString(raw.code, "code", 128),
+				retryable: booleanValue(raw.retryable, "retryable"),
+			});
+		default:
+			return invalid("CapabilityExecutionOutcome status is unsupported.", {
+				contract: "CapabilityExecutionOutcome",
+			});
+	}
+}

--- a/packages/core/src/types/provider-integrations.ts
+++ b/packages/core/src/types/provider-integrations.ts
@@ -157,6 +157,7 @@ export interface CapabilityAuthorizationConsumer {
 const authorizedCapabilityRequest: unique symbol = Symbol(
 	"elizaos.authorizedCapabilityRequest",
 );
+const authorizedCapabilityRequests = new WeakSet<object>();
 
 /** Host-verified, consume-once dispatch authority. This value is not a wire DTO. */
 export interface AuthorizedCapabilityRequest extends BoundCapabilityRequest {
@@ -393,6 +394,15 @@ function sha256Hex(domain: string, value: unknown): string {
 		sha256(new TextEncoder().encode(`${domain}\n${canonical}`)),
 		(byte) => byte.toString(16).padStart(2, "0"),
 	).join("");
+}
+
+function normalizePrivateEffectReceipt(value: unknown): EffectReceipt {
+	try {
+		return normalizeEffectReceipt(value);
+	} catch {
+		// error-policy:J3 Nested provider receipt values must not enter error context.
+		return invalid("Capability receipt effect proof is invalid.");
+	}
 }
 
 /** Validates and canonicalizes an account projection at a trust boundary. */
@@ -849,6 +859,15 @@ interface RegisteredCapabilityAuthorization {
 	confirmationGrant: CapabilityConfirmationGrant | null;
 }
 
+export interface CapabilityAuthorizationCoordinatorOptions {
+	/**
+	 * Reads the authoritative in-memory account state immediately before
+	 * consumption. It must not perform asynchronous I/O: validation and deletion
+	 * share one event-loop turn so revocation cannot interleave with dispatch.
+	 */
+	isSnapshotCurrent(request: BoundCapabilityRequest, now: number): boolean;
+}
+
 /**
  * In-memory policy/confirmation authority with atomic consume-once dispatch.
  * Durable hosts implement the consumer with one transactional
@@ -857,12 +876,20 @@ interface RegisteredCapabilityAuthorization {
 export class CapabilityAuthorizationCoordinator
 	implements CapabilityAuthorizationConsumer
 {
+	private readonly isSnapshotCurrent: (
+		request: BoundCapabilityRequest,
+		now: number,
+	) => boolean;
 	private readonly registered = new Map<
 		string,
 		RegisteredCapabilityAuthorization
 	>();
 	private readonly reservedDecisionIds = new Set<string>();
 	private readonly reservedConfirmationIds = new Set<string>();
+
+	constructor(options: CapabilityAuthorizationCoordinatorOptions) {
+		this.isSnapshotCurrent = options.isSnapshotCurrent;
+	}
 
 	register(
 		decisionValue: unknown,
@@ -1015,6 +1042,20 @@ export class CapabilityAuthorizationCoordinator
 		) {
 			throw new ElizaError(
 				"Capability authorization is missing, stale, or already consumed.",
+				{
+					code: "STALE_CAPABILITY_AUTHORIZATION",
+					context: {
+						decisionId: decision.decisionId,
+						requestId: request.requestId,
+					},
+					severity: "ephemeral",
+				},
+			);
+		}
+		if (this.isSnapshotCurrent(request, trustedNow) !== true) {
+			this.registered.delete(decision.decisionId);
+			throw new ElizaError(
+				"Capability authorization account snapshot is no longer current.",
 				{
 					code: "STALE_CAPABILITY_AUTHORIZATION",
 					context: {
@@ -1186,7 +1227,9 @@ export async function authorizeCapabilityDispatch(
 		configurable: false,
 		writable: false,
 	});
-	return Object.freeze(authorized);
+	Object.freeze(authorized);
+	authorizedCapabilityRequests.add(authorized);
+	return authorized;
 }
 
 export interface NormalizeCapabilityActionReceiptOptions {
@@ -1200,7 +1243,10 @@ export function normalizeCapabilityActionReceipt(
 	options: NormalizeCapabilityActionReceiptOptions,
 ): CapabilityActionReceipt {
 	const authorization = options.authorization;
-	if (authorization[authorizedCapabilityRequest] !== true) {
+	if (
+		!authorizedCapabilityRequests.has(authorization) ||
+		authorization[authorizedCapabilityRequest] !== true
+	) {
 		return invalid("Capability receipt requires trusted dispatch authority.");
 	}
 	const raw = record(value, "CapabilityActionReceipt");
@@ -1241,7 +1287,7 @@ export function normalizeCapabilityActionReceipt(
 		capabilityId: nonEmptyString(raw.capabilityId, "capabilityId"),
 		operation: nonEmptyString(raw.operation, "operation"),
 		inputDigest: digest(raw.inputDigest, "inputDigest"),
-		effect: normalizeEffectReceipt(raw.effect),
+		effect: normalizePrivateEffectReceipt(raw.effect),
 	});
 	if (
 		receipt.authorizationId !== authorization.authorizationId ||


### PR DESCRIPTION
Closes #19878.

## Summary

- add the versioned provider-neutral connected-account and capability DTOs removed by #21696, without restoring the unsafe v1 authorization model
- bind policy to an immutable selected-account snapshot, capability, operation, contextual risk, provider-owned exact-input digest, and binding time
- make both allowed and confirmation-required decisions consume-once through one trusted atomic authorization boundary
- bind the complete policy and confirmation grant digests into the in-process dispatch authority and canonical effect receipt
- keep successful, designed-empty, unavailable, and error outcomes structurally distinct without exposing provider payloads or credentials

## Security contract

- Public account IDs are opaque handles; provider credentials, request payloads, and secret material are rejected from the wire contracts.
- Contextual risk may be elevated but never downgraded below the selected account capability catalog.
- The request digest includes the selected account/provider/mode, catalog risk, requested capability/risk, operation, exact-input digest, request identity, and binding time.
- `CapabilityAuthorizationConsumer.consume` is the single trusted host boundary. Durable hosts must atomically compare-and-delete the current account/capability policy decision and its exact confirmation grant; a separate verify/delete sequence is replayable.
- Allowed decisions are one-shot too. Lack of interactive confirmation does not create reusable dispatch authority.
- The returned authority is branded, recursively immutable, and intentionally not a wire credential.
- Receipts bind the exact authorization, complete policy digest, optional confirmation digest, request/account/capability/operation/input identities, canonical `EffectReceipt`, and post-authorization chronology.

## Verification

Exact head `7e11c22ae3811df533fa508ccd659c03b3cc0392`, rebased on `develop@463779cf070cfd7e217b73d3e92b9b924cb627ec`, with Bun 1.3.14 and Node 24.15.0:

- `bun install --frozen-lockfile` — pass, no lockfile change
- `bun test packages/core/src/types/provider-integrations.test.ts` — pass, 20 tests / 81 assertions
- `bun run --cwd packages/core typecheck` — pass
- `bun run --cwd packages/core lint:check` — pass with seven pre-existing warnings in `truncation-suffix-reserve-2.test.ts`; changed files are clean
- `bun run --cwd packages/core build` — pass: Node, browser, edge, testing, declarations, and packed edge runtime/declaration import
- `git diff --check` — pass

`bun run verify` was rerun after `bun install --frozen-lockfile` and completed 339 tasks before an unchanged `plugin-personal-assistant` typecheck failure at `definitions-service.ts:539-540`; that file is byte-identical to the rebased `origin/develop`. The bounded core suite, core typecheck, scoped Biome, and full multi-target core build all pass on the final reviewed head.

## Independent security review\n\nThe second-wave review fixed three dispatch-boundary defects before approval: copied symbols could forge the authority brand, a registered decision did not recheck the live account/capability snapshot immediately before consumption, and malformed nested effect proof could leak provider values through error context. The reviewed implementation now uses module-private WeakSet membership, requires a synchronous fail-closed snapshot reader that burns revoked authority, and sanitizes nested receipt validation errors. Adversarial tests cover all three paths.\n\n## Evidence

<!-- evidence-head:7e11c22ae3811df533fa508ccd659c03b3cc0392 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - additive TypeScript contracts have no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - additive TypeScript contracts have no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - this PR adds no interactive surface or production adapter flow.

<!-- evidence-row:backend-logs -->
- [x] Exact-head contract and build transcript:

<details><summary>Core boundary validation</summary>

~~~text
$ bun test packages/core/src/types/provider-integrations.test.ts
20 pass, 0 fail, 81 assertions; provider-integrations.ts reached 100% line coverage.
$ bun run --cwd packages/core typecheck
passed with Node 24.15.0 and Bun 1.3.14.
$ bun run --cwd packages/core build
Node, browser, edge, testing, declarations, and packed edge import all passed.
~~~

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser behavior changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, model, or agent execution path changes.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - this additive contract has no production adapter or external domain artifact; serialized projections, consume-once authorities, and bound receipts are inspected by the adversarial test transcript above.

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact exists.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7e11c22ae3811df533fa508ccd659c03b3cc0392:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7e11c22ae3811df533fa508ccd659c03b3cc0392:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-provider-contract-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7e11c22ae3811df533fa508ccd659c03b3cc0392:packages/skills/skills/contribute-to-eliza"} -->


