### PR TITLE
test(cloud): repair migration checkpoint columns

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -199,11 +199,18 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
     );
     CREATE TABLE users (
       id uuid PRIMARY KEY,
-      organization_id uuid
+      name text NOT NULL,
+      organization_id uuid,
+      role text NOT NULL,
+      wallet_verified boolean NOT NULL DEFAULT false,
+      is_active boolean NOT NULL DEFAULT true
     );
     CREATE TABLE organizations (
       id uuid PRIMARY KEY,
+      name text NOT NULL,
+      slug text NOT NULL UNIQUE,
       credit_balance numeric(16, 6) NOT NULL DEFAULT '0.000000',
+      is_active boolean NOT NULL DEFAULT true,
       stripe_customer_id text,
       billing_email text,
       stripe_payment_method_id text,


### PR DESCRIPTION
## Summary

- add the historical `users` columns required by post-migration sandbox convergence
- add the historical `organizations` identity and active-state columns required by the same convergence batch
- keep the change limited to the real-PostgreSQL checkpoint fixture

Closes #22632

## Why

The checkpoint fixture records the migration ledger through the immutable prefix and then runs the pending migrations plus the deploy-time convergence batch. The convergence SQL reads these historical required columns, so omitting them makes the fixture fail before it can verify the intended migration contract.

## Evidence

Validated commit: `0bb6543c7aee6252316d24a17976b028ea6be33b`

- Representative real-PostgreSQL fix-forward test: 1 passed, 10 filtered, 12 assertions.
- Full isolated PostgreSQL 16 suite: 11 passed, 0 failed, 54 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: passed.
- `bun run --cwd packages/cloud/shared db:check-migrations`: passed (`Everything's fine`).
- Biome on the changed test: 0 errors; the existing three undeclared test-environment-variable warnings remain.
- `git diff --check`: passed.

The first full-suite attempt overlapped typecheck and Drizzle validation and two tests narrowly crossed their hard-coded 30-second limits. The uncontended complete rerun passed all 11 tests. The temporary PostgreSQL cluster was stopped and moved to Trash after validation.

## Scope

No production migration, runtime implementation, deployment, or database was changed.

<!-- evidence-head:0bb6543c7aee6252316d24a17976b028ea6be33b -->
