### PR TITLE
fix(plugin-coding-tools): decode production shell streams

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -702,6 +702,37 @@ describeIfPosix("shellAction", () => {
     );
   });
 
+  it("decodes split multibyte background stdout and stderr as UTF-8 streams", async () => {
+    const { runtime } = await makeRuntime();
+    const message = makeMessage();
+    const script = [
+      'const value = Buffer.from("\u4f60");',
+      "process.stdout.write(value.subarray(0, 1));",
+      "process.stderr.write(value.subarray(0, 2));",
+      "setTimeout(() => {",
+      "  process.stdout.write(value.subarray(1));",
+      "  process.stderr.write(value.subarray(2));",
+      "}, 50);",
+    ].join("");
+    const start = await shellAction.handler?.(runtime, message, undefined, {
+      action: "start_background",
+      command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+    });
+    const handle = (requireActionResult(start).data as Record<string, unknown>)
+      .handle as string;
+
+    const poll = await pollUntil(
+      runtime,
+      message,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const data = poll.data as Record<string, unknown>;
+
+    expect((data.stdout as Record<string, unknown>).text).toBe("\u4f60");
+    expect((data.stderr as Record<string, unknown>).text).toBe("\u4f60");
+  });
+
   it("fences every user-facing background/history relay (#16563)", async () => {
     process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = "1";
     const { runtime } = await makeRuntime();

--- a/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
@@ -183,6 +183,29 @@ describe("plugin-coding-tools runShell local-safe sandbox routing", () => {
 });
 
 describe("plugin-coding-tools host execution authority", () => {
+  it("decodes split multibyte stdout and stderr as UTF-8 streams", async () => {
+    process.env.ELIZA_RUNTIME_MODE = "local-yolo";
+    const script = [
+      'const value = Buffer.from("\u4f60");',
+      "process.stdout.write(value.subarray(0, 1));",
+      "process.stderr.write(value.subarray(0, 2));",
+      "setTimeout(() => {",
+      "  process.stdout.write(value.subarray(1));",
+      "  process.stderr.write(value.subarray(2));",
+      "}, 50);",
+    ].join("");
+
+    const result = await runShell({ getService: () => null } as IAgentRuntime, {
+      command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("\u4f60");
+    expect(result.stderr).toBe("\u4f60");
+  });
+
   it("uses the captured PATH without forwarding mutable PATH, HOME, or SHELL", async () => {
     const bootPath = process.env.PATH;
     process.env.ELIZA_RUNTIME_MODE = "local-yolo";

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -562,14 +562,17 @@ function runOnHostWithShell(
     let stderr = "";
     let timedOut = false;
 
-    proc.stdout.on("data", (chunk: Buffer) => {
+    // Preserve code points split across OS pipe chunks before accumulating.
+    proc.stdout.setEncoding("utf8");
+    proc.stderr.setEncoding("utf8");
+    proc.stdout.on("data", (chunk: string) => {
       if (stdout.length < STREAM_CAP_CHARS * 2) {
-        stdout += chunk.toString("utf8");
+        stdout += chunk;
       }
     });
-    proc.stderr.on("data", (chunk: Buffer) => {
+    proc.stderr.on("data", (chunk: string) => {
       if (stderr.length < STREAM_CAP_CHARS * 2) {
-        stderr += chunk.toString("utf8");
+        stderr += chunk;
       }
     });
 

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -164,21 +164,25 @@ export class BackgroundShellService extends Service {
       signalHostProcessGroup(started.process, "SIGKILL");
       throw new Error("background shell process did not expose output streams");
     }
-    started.process.stdout.on("data", (chunk: Buffer) => {
+    // Decode before ring/redaction processing so chunk boundaries cannot
+    // replace valid partial code points with U+FFFD.
+    started.process.stdout.setEncoding("utf8");
+    started.process.stderr.setEncoding("utf8");
+    started.process.stdout.on("data", (chunk: string) => {
       appendSessionOutput(
         this.runtime,
         session,
         "stdout",
-        chunk.toString("utf8"),
+        chunk,
         this.bufferChars,
       );
     });
-    started.process.stderr.on("data", (chunk: Buffer) => {
+    started.process.stderr.on("data", (chunk: string) => {
       appendSessionOutput(
         this.runtime,
         session,
         "stderr",
-        chunk.toString("utf8"),
+        chunk,
         this.bufferChars,
       );
     });

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -89,21 +89,24 @@ describePosixShell("shell plugin real local integration", () => {
     expect(provider.values?.currentWorkingDirectory).toBe(allowedDirectory);
   });
 
-  it("captures multibyte stdout without corruption across pipe chunk boundaries", async () => {
-    // Emit ~150 KB of a 3-byte UTF-8 code point so the subprocess stdout is
-    // delivered as several `data` chunks and code points straddle the
-    // boundaries. Per-chunk `Buffer.toString()` would replace the split bytes
-    // with U+FFFD; a UTF-8 stream decode keeps them intact.
-    const count = 50_000;
+  it("captures deliberately split multibyte stdout and stderr without corruption", async () => {
+    const script = [
+      'const value = Buffer.from("\u4f60");',
+      "process.stdout.write(value.subarray(0, 1));",
+      "process.stderr.write(value.subarray(0, 2));",
+      "setTimeout(() => {",
+      "  process.stdout.write(value.subarray(1));",
+      "  process.stderr.write(value.subarray(2));",
+      "}, 50);",
+    ].join("");
     const result = await service.executeCommand(
-      `node -e 'process.stdout.write("\u4f60".repeat(${count}))' | cat`,
+      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
       "room-utf8",
     );
 
     expect(result.success).toBe(true);
-    expect(result.stdout).not.toContain("\uFFFD");
-    expect(result.stdout.length).toBe(count);
-    expect(result.stdout).toBe("\u4f60".repeat(count));
+    expect(result.stdout).toBe("\u4f60");
+    expect(result.stderr).toBe("\u4f60");
   });
 
   it("stores and provides only redacted configured bare secrets", async () => {


### PR DESCRIPTION
# Relates to

Follow-up to #22493 and #22494. The first fix covered the direct `ShellService`, but the shipped `SHELL` action uses two separate hosts: `runShell()` for foreground commands and `BackgroundShellService` for `start_background`. Both still decoded each raw pipe chunk independently.

## What changed

- Enable Node's UTF-8 stream decoder before foreground `stdout`/`stderr` listeners in `run-shell.ts`.
- Enable the same decoder before background ring/redaction processing.
- Add deterministic regressions that write one UTF-8 code point in two delayed byte fragments for both stdout and stderr through:
  - foreground `runShell()`;
  - the `SHELL action=start_background` boundary;
  - direct `ShellService.executeCommand()` in its real lane.

The delay forces separate pipe events; these tests do not depend on an incidental ~64 KiB OS chunk boundary.

## Validation

Exact reviewed head: `6d0c54fdfe248040f70088e53005c891cd251233`

```text
vitest run src/lib/run-shell.test.ts -t "decodes split multibyte stdout" --pool=threads --maxWorkers=1 --no-file-parallelism
Test Files  1 passed (1)
Tests       1 passed | 4 skipped (5)

vitest run src/actions/bash.test.ts -t "decodes split multibyte background" --pool=threads --maxWorkers=1 --no-file-parallelism
Test Files  1 passed (1)
Tests       1 passed | 122 skipped (123)

biome check <five changed files>
Checked 5 files. No fixes applied.

git diff --check origin/develop...HEAD
PASS
```

Full typecheck/root verify were not rerun in the sparse review worktree: the host was under active disk pressure and the ignored generated i18n inputs required by the package import graph were reused from the installed primary checkout. The focused production-boundary tests and formatting check above ran after the final code rebase.

## Evidence Gate

<!-- evidence-head:6d0c54fdfe248040f70088e53005c891cd251233 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - subprocess stream decoding has no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - subprocess stream decoding has no rendered UI.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - terminal-only behavior; exact test transcript is above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server boundary changed.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend boundary changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no model or prompt behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head foreground/background split-byte test transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22646-eliza-22646-focused-tests.txt)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct Codex remediation; no contribution skill invoked`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: N/A - direct Codex remediation; no contribution skill invoked
Attribution status: self-reported
— [codex]
