### PR TITLE
fix(discord): bound avatar download with streaming limits and timeout

### DIFF
--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -20,6 +20,82 @@ describe("fetchRemoteMedia", () => {
 		await expect(request).rejects.toMatchObject({ code: "max_bytes" });
 	});
 
+	it("cancels a declared-oversize body before clearing the request deadline", async () => {
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.enqueue(new Uint8Array([1]));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		await expect(
+			fetchRemoteMedia({
+				url: "https://example.com/declared-bomb.png",
+				maxBytes: 1,
+				lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+				pinnedFetchImpl: async () =>
+					new Response(body, {
+						headers: { "content-length": "2" },
+					}),
+			}),
+		).rejects.toMatchObject({ code: "max_bytes" });
+		expect(cancelled).toBe(true);
+	});
+
+	it("bounds and cancels diagnostic bodies on HTTP errors", async () => {
+		let cancelled = false;
+		let pulls = 0;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				pulls += 1;
+				controller.enqueue(new Uint8Array(128));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		await expect(
+			fetchRemoteMedia({
+				url: "https://example.com/error",
+				maxBytes: 1,
+				lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+				pinnedFetchImpl: async () => new Response(body, { status: 500 }),
+			}),
+		).rejects.toMatchObject({ code: "http_error" });
+		expect(cancelled).toBe(true);
+		expect(pulls).toBeLessThanOrEqual(3);
+	});
+
+	it("rejects response metadata before consuming the body", async () => {
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		await expect(
+			fetchRemoteMedia({
+				url: "https://example.com/avatar.png",
+				requiredContentTypePrefix: "image/",
+				rejectContentEncoding: true,
+				lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+				pinnedFetchImpl: async () =>
+					new Response(body, {
+						headers: {
+							"content-encoding": "gzip",
+							"content-type": "image/png",
+						},
+					}),
+			}),
+		).rejects.toMatchObject({ code: "invalid_response" });
+		expect(cancelled).toBe(true);
+	});
+
 	it("applies timeout signals to guarded fetches", async () => {
 		let sawAbortSignal = false;
 		const result = await fetchRemoteMedia({

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -17,7 +17,11 @@ export type FetchMediaResult = {
 	fileName?: string;
 };
 
-export type MediaFetchErrorCode = "max_bytes" | "http_error" | "fetch_failed";
+export type MediaFetchErrorCode =
+	| "max_bytes"
+	| "http_error"
+	| "fetch_failed"
+	| "invalid_response";
 
 export class MediaFetchError extends Error {
 	readonly code: MediaFetchErrorCode;
@@ -41,6 +45,10 @@ export type FetchMediaOptions = {
 	maxBytes?: number;
 	maxRedirects?: number;
 	timeoutMs?: number;
+	/** Require the declared response MIME type to start with this prefix. */
+	requiredContentTypePrefix?: string;
+	/** Reject Content-Encoding other than identity when callers need raw media bytes. */
+	rejectContentEncoding?: boolean;
 	ssrfPolicy?: SsrfPolicy;
 	lookupFn?: LookupFn;
 	pinnedFetchImpl?: PinnedLookupFetchLike;
@@ -96,7 +104,9 @@ async function readErrorBodySnippet(
 	maxChars = 200,
 ): Promise<string | undefined> {
 	try {
-		const text = await res.text();
+		// Bound diagnostics too: an error response is still an untrusted body and
+		// must not bypass the caller's successful-response byte limit.
+		const text = (await readResponseWithLimit(res, maxChars)).toString("utf8");
 		if (!text) {
 			return undefined;
 		}
@@ -112,6 +122,35 @@ async function readErrorBodySnippet(
 		// error-policy:J7 The HTTP status remains authoritative when its optional
 		// diagnostic body snippet cannot be read.
 		return undefined;
+	}
+}
+
+function enforceResponsePolicy(
+	res: Response,
+	url: string,
+	options: FetchMediaOptions,
+): void {
+	const requiredPrefix = options.requiredContentTypePrefix
+		?.trim()
+		.toLowerCase();
+	if (requiredPrefix) {
+		const declared = res.headers.get("content-type")?.trim().toLowerCase();
+		if (!declared?.startsWith(requiredPrefix)) {
+			throw new MediaFetchError(
+				"invalid_response",
+				`Failed to fetch media from ${url}: expected Content-Type starting with ${requiredPrefix}`,
+			);
+		}
+	}
+
+	if (options.rejectContentEncoding) {
+		const encoding = res.headers.get("content-encoding")?.trim().toLowerCase();
+		if (encoding && encoding !== "identity") {
+			throw new MediaFetchError(
+				"invalid_response",
+				`Failed to fetch media from ${url}: encoded response bodies are not accepted`,
+			);
+		}
 	}
 }
 
@@ -248,6 +287,7 @@ export async function fetchRemoteMedia(
 
 	try {
 		await throwIfHttpError(res, options.url, finalUrl);
+		enforceResponsePolicy(res, options.url, options);
 		enforceContentLengthLimit(res, options.url, options.maxBytes);
 
 		const buffer =
@@ -266,6 +306,12 @@ export async function fetchRemoteMedia(
 			...metadata,
 		};
 	} finally {
+		try {
+			await res.body?.cancel();
+		} catch {
+			// error-policy:J6 The result or primary fetch failure is authoritative;
+			// cancelling a rejected or already-consumed body is best-effort teardown.
+		}
 		await release();
 	}
 }

--- a/packages/core/src/network/pinned-fetch.integration.test.ts
+++ b/packages/core/src/network/pinned-fetch.integration.test.ts
@@ -21,6 +21,12 @@ describe("pinned fetch through a real local HTTP server", () => {
 	beforeAll(async () => {
 		server = createServer((req, res) => {
 			seenRequests.push({ host: req.headers.host, url: req.url ?? "" });
+			if (req.url === "/stall-body") {
+				res.statusCode = 200;
+				res.setHeader("content-type", "image/png");
+				res.write(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+				return;
+			}
 			if (req.url === "/redirect-to-rebound") {
 				res.statusCode = 302;
 				res.setHeader("location", `http://rebound.example.test:${port}/steal`);
@@ -138,5 +144,21 @@ describe("pinned fetch through a real local HTTP server", () => {
 		);
 		expect(firstHop.length).toBe(1);
 		expect(seenRequests.some((entry) => entry.url === "/steal")).toBe(false);
+	});
+
+	it("aborts a real response body that stalls after headers", async () => {
+		const guarded = await fetchWithSsrfGuard({
+			url: `http://pinned.example.test:${port}/stall-body`,
+			lookupFn: async () => [{ address: "127.0.0.1", family: 4 }],
+			pinnedFetchImpl: nodePinnedFetch,
+			policy: { allowedHostnames: ["pinned.example.test"] },
+			timeoutMs: 100,
+		});
+
+		try {
+			await expect(guarded.response.arrayBuffer()).rejects.toThrow();
+		} finally {
+			await guarded.release();
+		}
 	});
 });

--- a/plugins/plugin-discord/__tests__/discord-avatar-cache.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-avatar-cache.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for Discord avatar caching: validates URL filtering, bounded
+ * streaming downloads, Content-Length guards, timeout deadlines, and cache
+ * hit/miss semantics.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import {
+	cacheDiscordAvatarUrl,
+	isDiscordAvatarUrl,
+} from "../discord-avatar-cache";
+
+const tempDirs: string[] = [];
+
+describe("discord-avatar-cache", () => {
+	let testCacheDir: string;
+
+	beforeEach(async () => {
+		testCacheDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "discord-avatar-test-"),
+		);
+		tempDirs.push(testCacheDir);
+		vi.stubEnv("ELIZA_STATE_DIR", testCacheDir);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	afterAll(async () => {
+		await Promise.all(
+			tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })),
+		);
+	});
+
+	describe("isDiscordAvatarUrl", () => {
+		it("accepts valid Discord CDN and media hosts", () => {
+			expect(
+				isDiscordAvatarUrl(
+					"https://cdn.discordapp.com/avatars/12345/abcdef.png",
+				),
+			).toBe(true);
+			expect(
+				isDiscordAvatarUrl(
+					"https://media.discordapp.net/avatars/12345/abcdef.jpg",
+				),
+			).toBe(true);
+			expect(
+				isDiscordAvatarUrl(
+					"https://images-ext-1.discordapp.net/external/xyz/avatar.png",
+				),
+			).toBe(true);
+		});
+
+		it("rejects non-Discord hosts and non-https protocols", () => {
+			expect(isDiscordAvatarUrl("http://cdn.discordapp.com/avatar.png")).toBe(
+				false,
+			);
+			expect(isDiscordAvatarUrl("https://evil.com/avatar.png")).toBe(false);
+			expect(isDiscordAvatarUrl("not-a-url")).toBe(false);
+		});
+	});
+
+	describe("cacheDiscordAvatarUrl", () => {
+		it("skips non-Discord URLs and returns the input unchanged", async () => {
+			const nonDiscordUrl = "https://example.com/avatar.png";
+			const result = await cacheDiscordAvatarUrl(nonDiscordUrl);
+			expect(result).toBe(nonDiscordUrl);
+		});
+
+		it("rejects responses with non-image Content-Type", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/1/test.png";
+			const fakeFetch = vi.fn(async () => {
+				return new Response("<html>Not Found</html>", {
+					status: 200,
+					headers: { "Content-Type": "text/html" },
+				});
+			});
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+			});
+			expect(result).toBe(avatarUrl);
+		});
+
+		it("rejects responses exceeding MAX_DISCORD_AVATAR_BYTES via Content-Length", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/1/huge.png";
+			const fakeFetch = vi.fn(async () => {
+				return new Response(new Uint8Array(10), {
+					status: 200,
+					headers: {
+						"Content-Type": "image/png",
+						"Content-Length": String(10 * 1024 * 1024), // 10MB > 2MB cap
+					},
+				});
+			});
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+			});
+			expect(result).toBe(avatarUrl);
+		});
+
+		it("aborts stream if chunked payload exceeds MAX_DISCORD_AVATAR_BYTES", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/1/stream-bomb.png";
+			const chunkSize = 1024 * 1024; // 1MB
+			let chunkCount = 0;
+			const stream = new ReadableStream({
+				pull(controller) {
+					chunkCount++;
+					controller.enqueue(new Uint8Array(chunkSize));
+					if (chunkCount > 5) {
+						controller.close();
+					}
+				},
+			});
+
+			const fakeFetch = vi.fn(async () => {
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "image/png" },
+				});
+			});
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+			});
+			expect(result).toBe(avatarUrl);
+		});
+
+		it("caches valid Discord avatar and returns the local public route", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/123/valid.png";
+			const fakeImageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header
+			const fakeFetch = vi.fn(async () => {
+				return new Response(fakeImageBytes, {
+					status: 200,
+					headers: {
+						"Content-Type": "image/png",
+						"Content-Length": String(fakeImageBytes.byteLength),
+					},
+				});
+			});
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+				userId: "user-123",
+			});
+
+			expect(result).toMatch(/^\/api\/avatar\/discord\/user-123-/);
+			expect(fakeFetch).toHaveBeenCalledTimes(1);
+
+			// Subsequent call should hit cache without invoking fetch again
+			const secondResult = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+				userId: "user-123",
+			});
+			expect(secondResult).toBe(result);
+			expect(fakeFetch).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/plugins/plugin-discord/__tests__/discord-avatar-cache.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-avatar-cache.test.ts
@@ -96,6 +96,43 @@ describe("discord-avatar-cache", () => {
 			expect(result).toBe(avatarUrl);
 		});
 
+		it("does not follow redirects away from the validated Discord URL", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/1/redirect.png";
+			const fakeFetch = vi.fn(
+				async () =>
+					new Response(null, {
+						status: 302,
+						headers: { Location: "http://127.0.0.1/internal" },
+					}),
+			);
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+			});
+
+			expect(result).toBe(avatarUrl);
+			expect(fakeFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("rejects encoded image bodies instead of caching transport bytes", async () => {
+			const avatarUrl = "https://cdn.discordapp.com/avatars/1/encoded.png";
+			const fakeFetch = vi.fn(
+				async () =>
+					new Response(new Uint8Array([0x1f, 0x8b]), {
+						status: 200,
+						headers: {
+							"Content-Encoding": "gzip",
+							"Content-Type": "image/png",
+						},
+					}),
+			);
+
+			const result = await cacheDiscordAvatarUrl(avatarUrl, {
+				fetchImpl: fakeFetch as unknown as typeof fetch,
+			});
+			expect(result).toBe(avatarUrl);
+		});
+
 		it("rejects responses exceeding MAX_DISCORD_AVATAR_BYTES via Content-Length", async () => {
 			const avatarUrl = "https://cdn.discordapp.com/avatars/1/huge.png";
 			const fakeFetch = vi.fn(async () => {

--- a/plugins/plugin-discord/__tests__/profile-sync-avatar-diagnostics.test.ts
+++ b/plugins/plugin-discord/__tests__/profile-sync-avatar-diagnostics.test.ts
@@ -153,4 +153,69 @@ describe("Discord profile avatar resolution diagnostics", () => {
 		);
 		expect(setAvatar).not.toHaveBeenCalled();
 	});
+
+	it("rejects remote avatar exceeding MAX_PROFILE_AVATAR_BYTES via Content-Length", async () => {
+		const remoteUrl = "https://example.com/huge-avatar.png";
+		const runtime = {
+			...fakeRuntime(remoteUrl),
+			fetch: vi.fn(async () => {
+				return new Response(new Uint8Array(10), {
+					status: 200,
+					headers: {
+						"Content-Type": "image/png",
+						"Content-Length": String(10 * 1024 * 1024), // 10MB > 8MB cap
+					},
+				});
+			}),
+		} as unknown as IAgentRuntime;
+
+		const error = await syncDiscordClientProfile(runtime, clientUser, {
+			syncProfile: true,
+		} as DiscordSettings).then(
+			() => null,
+			(value: unknown) => value,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
+			"Discord profile avatar exceeds 8388608 bytes",
+		);
+	});
+
+	it("aborts remote avatar stream exceeding MAX_PROFILE_AVATAR_BYTES", async () => {
+		const remoteUrl = "https://example.com/stream-bomb-avatar.png";
+		const chunkSize = 2 * 1024 * 1024; // 2MB
+		let chunkCount = 0;
+		const stream = new ReadableStream({
+			pull(controller) {
+				chunkCount++;
+				controller.enqueue(new Uint8Array(chunkSize));
+				if (chunkCount > 5) {
+					controller.close();
+				}
+			},
+		});
+
+		const runtime = {
+			...fakeRuntime(remoteUrl),
+			fetch: vi.fn(async () => {
+				return new Response(stream, {
+					status: 200,
+					headers: { "Content-Type": "image/png" },
+				});
+			}),
+		} as unknown as IAgentRuntime;
+
+		const error = await syncDiscordClientProfile(runtime, clientUser, {
+			syncProfile: true,
+		} as DiscordSettings).then(
+			() => null,
+			(value: unknown) => value,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
+			"Discord profile avatar exceeds 8388608 bytes",
+		);
+	});
 });

--- a/plugins/plugin-discord/__tests__/profile-sync-avatar-diagnostics.test.ts
+++ b/plugins/plugin-discord/__tests__/profile-sync-avatar-diagnostics.test.ts
@@ -156,30 +156,33 @@ describe("Discord profile avatar resolution diagnostics", () => {
 
 	it("rejects remote avatar exceeding MAX_PROFILE_AVATAR_BYTES via Content-Length", async () => {
 		const remoteUrl = "https://example.com/huge-avatar.png";
-		const runtime = {
-			...fakeRuntime(remoteUrl),
-			fetch: vi.fn(async () => {
-				return new Response(new Uint8Array(10), {
-					status: 200,
-					headers: {
-						"Content-Type": "image/png",
-						"Content-Length": String(10 * 1024 * 1024), // 10MB > 8MB cap
-					},
-				});
-			}),
-		} as unknown as IAgentRuntime;
+		const fetchImpl = vi.fn(async () => {
+			return new Response(new Uint8Array(10), {
+				status: 200,
+				headers: {
+					"Content-Type": "image/png",
+					"Content-Length": String(10 * 1024 * 1024), // 10MB > 8MB cap
+				},
+			});
+		});
+		const runtime = fakeRuntime(remoteUrl);
 
-		const error = await syncDiscordClientProfile(runtime, clientUser, {
-			syncProfile: true,
-		} as DiscordSettings).then(
+		const error = await syncDiscordClientProfile(
+			runtime,
+			clientUser,
+			{
+				syncProfile: true,
+			} as DiscordSettings,
+			{
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+			},
+		).then(
 			() => null,
 			(value: unknown) => value,
 		);
 
 		expect(error).toBeInstanceOf(Error);
-		expect((error as Error).message).toContain(
-			"Discord profile avatar exceeds 8388608 bytes",
-		);
+		expect(error).toMatchObject({ code: "max_bytes" });
 	});
 
 	it("aborts remote avatar stream exceeding MAX_PROFILE_AVATAR_BYTES", async () => {
@@ -196,26 +199,76 @@ describe("Discord profile avatar resolution diagnostics", () => {
 			},
 		});
 
-		const runtime = {
-			...fakeRuntime(remoteUrl),
-			fetch: vi.fn(async () => {
-				return new Response(stream, {
-					status: 200,
-					headers: { "Content-Type": "image/png" },
-				});
-			}),
-		} as unknown as IAgentRuntime;
+		const fetchImpl = vi.fn(async () => {
+			return new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "image/png" },
+			});
+		});
+		const runtime = fakeRuntime(remoteUrl);
 
-		const error = await syncDiscordClientProfile(runtime, clientUser, {
-			syncProfile: true,
-		} as DiscordSettings).then(
+		const error = await syncDiscordClientProfile(
+			runtime,
+			clientUser,
+			{
+				syncProfile: true,
+			} as DiscordSettings,
+			{
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+			},
+		).then(
 			() => null,
 			(value: unknown) => value,
 		);
 
 		expect(error).toBeInstanceOf(Error);
-		expect((error as Error).message).toContain(
-			"Discord profile avatar exceeds 8388608 bytes",
+		expect(error).toMatchObject({ code: "max_bytes" });
+	});
+
+	it("blocks private remote avatars before transport", async () => {
+		const remoteUrl = "http://127.0.0.1/private-avatar.png";
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+					headers: { "Content-Type": "image/png" },
+				}),
 		);
+
+		const error = await syncDiscordClientProfile(
+			fakeRuntime(remoteUrl),
+			clientUser,
+			{ syncProfile: true } as DiscordSettings,
+			{ fetchImpl: fetchImpl as unknown as typeof fetch },
+		).then(
+			() => null,
+			(value: unknown) => value,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("revalidates redirect targets and blocks a private second hop", async () => {
+		const remoteUrl = "https://example.com/avatar.png";
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 302,
+					headers: { Location: "http://127.0.0.1/private-avatar.png" },
+				}),
+		);
+
+		const error = await syncDiscordClientProfile(
+			fakeRuntime(remoteUrl),
+			clientUser,
+			{ syncProfile: true } as DiscordSettings,
+			{ fetchImpl: fetchImpl as unknown as typeof fetch },
+		).then(
+			() => null,
+			(value: unknown) => value,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 });

--- a/plugins/plugin-discord/discord-avatar-cache.ts
+++ b/plugins/plugin-discord/discord-avatar-cache.ts
@@ -10,6 +10,7 @@ import { resolveStateDir } from "@elizaos/core";
 
 const DISCORD_AVATAR_ROUTE_PREFIX = "/api/avatar/discord";
 const MAX_DISCORD_AVATAR_BYTES = 2 * 1024 * 1024;
+const DISCORD_AVATAR_FETCH_TIMEOUT_MS = 15_000;
 const ALLOWED_DISCORD_AVATAR_HOSTS = new Set([
 	"cdn.discordapp.com",
 	"media.discordapp.net",
@@ -135,60 +136,114 @@ export async function cacheDiscordAvatarUrl(
 	}
 
 	const downloadPromise = (async () => {
-		await fs.mkdir(getDiscordAvatarCacheDir(), { recursive: true });
-
-		const response = await fetchImpl(url, {
-			headers: { Accept: "image/*" },
-		});
-		if (!response.ok) {
-			return url;
-		}
-
-		const contentType = response.headers.get("content-type");
-		if (!contentType?.toLowerCase().startsWith("image/")) {
-			return url;
-		}
-
-		const bytes = Buffer.from(await response.arrayBuffer());
-		if (bytes.length === 0 || bytes.length > MAX_DISCORD_AVATAR_BYTES) {
-			return url;
-		}
-
-		const preferredExtension = extensionFromContentType(contentType);
-		const finalFileName = requestedFileName.endsWith(`.${preferredExtension}`)
-			? requestedFileName
-			: requestedFileName.replace(/\.[^.]+$/, `.${preferredExtension}`);
-		const finalFilePath = getDiscordAvatarCachePath(finalFileName);
-
 		try {
-			const stat = await fs.stat(finalFilePath);
-			if (stat.isFile()) {
-				return getDiscordAvatarPublicPath(finalFileName);
+			await fs.mkdir(getDiscordAvatarCacheDir(), { recursive: true });
+
+			const response = await fetchImpl(url, {
+				headers: { Accept: "image/*" },
+				signal: AbortSignal.timeout(DISCORD_AVATAR_FETCH_TIMEOUT_MS),
+			});
+			if (!response.ok) {
+				return url;
 			}
+
+			const contentType = response.headers.get("content-type");
+			if (!contentType?.toLowerCase().startsWith("image/")) {
+				return url;
+			}
+
+			const rawLength = response.headers.get("content-length");
+			const declaredLength = rawLength === null ? null : Number(rawLength);
+			if (
+				declaredLength !== null &&
+				Number.isFinite(declaredLength) &&
+				declaredLength > MAX_DISCORD_AVATAR_BYTES
+			) {
+				return url;
+			}
+
+			let bytes: Buffer;
+			if (!response.body) {
+				const ab = await response.arrayBuffer();
+				if (ab.byteLength === 0 || ab.byteLength > MAX_DISCORD_AVATAR_BYTES) {
+					return url;
+				}
+				bytes = Buffer.from(ab);
+			} else {
+				const reader = response.body.getReader();
+				const chunks: Uint8Array[] = [];
+				let total = 0;
+				try {
+					for (;;) {
+						const { done, value } = await reader.read();
+						if (done) break;
+						if (!value?.byteLength) continue;
+						total += value.byteLength;
+						if (total > MAX_DISCORD_AVATAR_BYTES) {
+							try {
+								await reader.cancel();
+							} catch {
+								// error-policy:J6 best-effort stream cancellation
+							}
+							return url;
+						}
+						chunks.push(value);
+					}
+				} finally {
+					try {
+						reader.releaseLock();
+					} catch {
+						// error-policy:J6 stream lock release is best-effort teardown
+					}
+				}
+				if (total === 0) {
+					return url;
+				}
+				bytes = Buffer.concat(
+					chunks.map((chunk) => Buffer.from(chunk)),
+					total,
+				);
+			}
+
+			const preferredExtension = extensionFromContentType(contentType);
+			const finalFileName = requestedFileName.endsWith(`.${preferredExtension}`)
+				? requestedFileName
+				: requestedFileName.replace(/\.[^.]+$/, `.${preferredExtension}`);
+			const finalFilePath = getDiscordAvatarCachePath(finalFileName);
+
+			try {
+				const stat = await fs.stat(finalFilePath);
+				if (stat.isFile()) {
+					return getDiscordAvatarPublicPath(finalFileName);
+				}
+			} catch {
+				// error-policy:J3 stat probe for a concurrently-materialized cache entry; a
+				// miss is expected and falls through to the atomic write below.
+			}
+
+			const tempFilePath = `${finalFilePath}.${process.pid}.${Date.now()}.tmp`;
+			await fs.writeFile(tempFilePath, bytes, { mode: 0o600 });
+			try {
+				await fs.rename(tempFilePath, finalFilePath);
+			} catch (error) {
+				await fs.unlink(tempFilePath).catch(() => {});
+				const code =
+					typeof error === "object" &&
+					error !== null &&
+					"code" in error &&
+					typeof (error as { code?: unknown }).code === "string"
+						? (error as { code: string }).code
+						: "";
+				if (code !== "EEXIST") {
+					throw error;
+				}
+			}
+
+			return getDiscordAvatarPublicPath(finalFileName);
 		} catch {
-			// error-policy:J3 stat probe for a concurrently-materialized cache entry; a
-			// miss is expected and falls through to the atomic write below.
+			// error-policy:J4 avatar caching failure gracefully degrades to the original volatile URL
+			return url;
 		}
-
-		const tempFilePath = `${finalFilePath}.${process.pid}.${Date.now()}.tmp`;
-		await fs.writeFile(tempFilePath, bytes, { mode: 0o600 });
-		try {
-			await fs.rename(tempFilePath, finalFilePath);
-		} catch (error) {
-			await fs.unlink(tempFilePath).catch(() => {});
-			const code =
-				typeof error === "object" &&
-				error !== null &&
-				"code" in error &&
-				typeof (error as { code?: unknown }).code === "string"
-					? (error as { code: string }).code
-					: "";
-			if (code !== "EEXIST") {
-				throw error;
-			}
-		}
-
-		return getDiscordAvatarPublicPath(finalFileName);
 	})().finally(() => {
 		inflightDiscordAvatarDownloads.delete(requestedFileName);
 	});

--- a/plugins/plugin-discord/discord-avatar-cache.ts
+++ b/plugins/plugin-discord/discord-avatar-cache.ts
@@ -6,7 +6,11 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveStateDir } from "@elizaos/core";
+import {
+	type FetchMediaOptions,
+	fetchRemoteMedia,
+	resolveStateDir,
+} from "@elizaos/core";
 
 const DISCORD_AVATAR_ROUTE_PREFIX = "/api/avatar/discord";
 const MAX_DISCORD_AVATAR_BYTES = 2 * 1024 * 1024;
@@ -102,16 +106,13 @@ export function buildDiscordAvatarCacheFileName(
 export async function cacheDiscordAvatarUrl(
 	url: string | undefined,
 	options: {
-		fetchImpl?: typeof fetch;
+		fetchImpl?: FetchMediaOptions["fetchImpl"];
+		lookupFn?: FetchMediaOptions["lookupFn"];
+		pinnedFetchImpl?: FetchMediaOptions["pinnedFetchImpl"];
 		userId?: string;
 	} = {},
 ): Promise<string | undefined> {
 	if (!url || !isDiscordAvatarUrl(url)) {
-		return url;
-	}
-
-	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-	if (typeof fetchImpl !== "function") {
 		return url;
 	}
 
@@ -139,73 +140,25 @@ export async function cacheDiscordAvatarUrl(
 		try {
 			await fs.mkdir(getDiscordAvatarCacheDir(), { recursive: true });
 
-			const response = await fetchImpl(url, {
-				headers: { Accept: "image/*" },
-				signal: AbortSignal.timeout(DISCORD_AVATAR_FETCH_TIMEOUT_MS),
+			const fetched = await fetchRemoteMedia({
+				url,
+				maxBytes: MAX_DISCORD_AVATAR_BYTES,
+				maxRedirects: 0,
+				timeoutMs: DISCORD_AVATAR_FETCH_TIMEOUT_MS,
+				requiredContentTypePrefix: "image/",
+				rejectContentEncoding: true,
+				fetchImpl: options.fetchImpl,
+				lookupFn: options.lookupFn,
+				pinnedFetchImpl: options.pinnedFetchImpl,
 			});
-			if (!response.ok) {
+			const bytes = fetched.buffer;
+			if (bytes.length === 0) {
 				return url;
 			}
 
-			const contentType = response.headers.get("content-type");
-			if (!contentType?.toLowerCase().startsWith("image/")) {
-				return url;
-			}
-
-			const rawLength = response.headers.get("content-length");
-			const declaredLength = rawLength === null ? null : Number(rawLength);
-			if (
-				declaredLength !== null &&
-				Number.isFinite(declaredLength) &&
-				declaredLength > MAX_DISCORD_AVATAR_BYTES
-			) {
-				return url;
-			}
-
-			let bytes: Buffer;
-			if (!response.body) {
-				const ab = await response.arrayBuffer();
-				if (ab.byteLength === 0 || ab.byteLength > MAX_DISCORD_AVATAR_BYTES) {
-					return url;
-				}
-				bytes = Buffer.from(ab);
-			} else {
-				const reader = response.body.getReader();
-				const chunks: Uint8Array[] = [];
-				let total = 0;
-				try {
-					for (;;) {
-						const { done, value } = await reader.read();
-						if (done) break;
-						if (!value?.byteLength) continue;
-						total += value.byteLength;
-						if (total > MAX_DISCORD_AVATAR_BYTES) {
-							try {
-								await reader.cancel();
-							} catch {
-								// error-policy:J6 best-effort stream cancellation
-							}
-							return url;
-						}
-						chunks.push(value);
-					}
-				} finally {
-					try {
-						reader.releaseLock();
-					} catch {
-						// error-policy:J6 stream lock release is best-effort teardown
-					}
-				}
-				if (total === 0) {
-					return url;
-				}
-				bytes = Buffer.concat(
-					chunks.map((chunk) => Buffer.from(chunk)),
-					total,
-				);
-			}
-
-			const preferredExtension = extensionFromContentType(contentType);
+			const preferredExtension = extensionFromContentType(
+				fetched.contentType ?? null,
+			);
 			const finalFileName = requestedFileName.endsWith(`.${preferredExtension}`)
 				? requestedFileName
 				: requestedFileName.replace(/\.[^.]+$/, `.${preferredExtension}`);

--- a/plugins/plugin-discord/discord-profiles.ts
+++ b/plugins/plugin-discord/discord-profiles.ts
@@ -206,12 +206,11 @@ export function isCanonicalDiscordSource(
 }
 
 export async function cacheDiscordAvatarForRuntime(
-	runtime: AgentRuntime,
+	_runtime: AgentRuntime,
 	avatarUrl: string | undefined,
 	userId?: string,
 ): Promise<string | undefined> {
 	return cacheDiscordAvatarUrl(avatarUrl, {
-		fetchImpl: runtime.fetch ?? globalThis.fetch,
 		userId,
 	});
 }

--- a/plugins/plugin-discord/profileSync.ts
+++ b/plugins/plugin-discord/profileSync.ts
@@ -6,8 +6,13 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { IAgentRuntime } from "@elizaos/core";
-import { ElizaError, resolveStateDir, resolveUserPath } from "@elizaos/core";
+import type { FetchMediaOptions, IAgentRuntime } from "@elizaos/core";
+import {
+	ElizaError,
+	fetchRemoteMedia,
+	resolveStateDir,
+	resolveUserPath,
+} from "@elizaos/core";
 import type { ClientUser } from "discord.js";
 import type { DiscordSettings } from "./types";
 
@@ -20,6 +25,12 @@ type PersistedDiscordProfileSyncState = {
 	avatarHash?: string;
 	username?: string;
 };
+
+/** Deterministic transport seam for profile-sync tests. Production callers omit it. */
+export type DiscordProfileSyncOptions = Pick<
+	FetchMediaOptions,
+	"fetchImpl" | "lookupFn" | "pinnedFetchImpl"
+>;
 
 function resolveProfileSyncStatePath(
 	env: NodeJS.ProcessEnv = process.env,
@@ -219,7 +230,7 @@ async function readAvatarBytesFromLocalCandidates(
 
 async function loadDiscordProfileAvatarBytes(
 	source: string,
-	runtime: IAgentRuntime,
+	fetchOptions: DiscordProfileSyncOptions,
 ): Promise<{ bytes: Buffer; hash: string } | null> {
 	const trimmed = source.trim();
 	if (!trimmed) {
@@ -241,78 +252,15 @@ async function loadDiscordProfileAvatarBytes(
 		}
 
 		if (remoteUrl) {
-			const fetchImpl = runtime.fetch ?? globalThis.fetch;
-			if (typeof fetchImpl !== "function") {
-				return null;
-			}
-			const response = await fetchImpl(trimmed, {
-				headers: { Accept: "image/*" },
-				signal: AbortSignal.timeout(PROFILE_AVATAR_FETCH_TIMEOUT_MS),
+			const fetched = await fetchRemoteMedia({
+				url: trimmed,
+				maxBytes: MAX_PROFILE_AVATAR_BYTES,
+				timeoutMs: PROFILE_AVATAR_FETCH_TIMEOUT_MS,
+				requiredContentTypePrefix: "image/",
+				rejectContentEncoding: true,
+				...fetchOptions,
 			});
-			if (!response.ok) {
-				throw new Error(`HTTP ${response.status}`);
-			}
-			const contentType = response.headers.get("content-type");
-			if (!contentType?.toLowerCase().startsWith("image/")) {
-				throw new Error(
-					`Expected image content-type, got ${contentType ?? "unknown"}`,
-				);
-			}
-
-			const rawLength = response.headers.get("content-length");
-			const declaredLength = rawLength === null ? null : Number(rawLength);
-			if (
-				declaredLength !== null &&
-				Number.isFinite(declaredLength) &&
-				declaredLength > MAX_PROFILE_AVATAR_BYTES
-			) {
-				throw new Error(
-					`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
-				);
-			}
-
-			if (!response.body) {
-				const ab = await response.arrayBuffer();
-				if (ab.byteLength > MAX_PROFILE_AVATAR_BYTES) {
-					throw new Error(
-						`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
-					);
-				}
-				bytes = Buffer.from(ab);
-			} else {
-				const reader = response.body.getReader();
-				const chunks: Uint8Array[] = [];
-				let total = 0;
-				try {
-					for (;;) {
-						const { done, value } = await reader.read();
-						if (done) break;
-						if (!value?.byteLength) continue;
-						total += value.byteLength;
-						if (total > MAX_PROFILE_AVATAR_BYTES) {
-							try {
-								await reader.cancel();
-							} catch {
-								// error-policy:J6 best-effort stream cancellation
-							}
-							throw new Error(
-								`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
-							);
-						}
-						chunks.push(value);
-					}
-				} finally {
-					try {
-						reader.releaseLock();
-					} catch {
-						// error-policy:J6 stream lock release is best-effort teardown
-					}
-				}
-				bytes = Buffer.concat(
-					chunks.map((chunk) => Buffer.from(chunk)),
-					total,
-				);
-			}
+			bytes = fetched.buffer;
 		} else {
 			bytes = await readAvatarBytesFromLocalCandidates(trimmed);
 		}
@@ -340,6 +288,7 @@ export async function syncDiscordClientProfile(
 		setUsername?: (username: string) => Promise<unknown>;
 	},
 	settings: DiscordSettings,
+	options: DiscordProfileSyncOptions = {},
 ): Promise<void> {
 	if (settings.syncProfile === false) {
 		return;
@@ -381,7 +330,7 @@ export async function syncDiscordClientProfile(
 	if (desiredAvatarSource) {
 		const avatar = await loadDiscordProfileAvatarBytes(
 			desiredAvatarSource,
-			runtime,
+			options,
 		);
 		if (avatar && persisted.avatarHash !== avatar.hash) {
 			if (typeof clientUser.setAvatar === "function") {

--- a/plugins/plugin-discord/profileSync.ts
+++ b/plugins/plugin-discord/profileSync.ts
@@ -12,6 +12,7 @@ import type { ClientUser } from "discord.js";
 import type { DiscordSettings } from "./types";
 
 const MAX_PROFILE_AVATAR_BYTES = 8 * 1024 * 1024;
+const PROFILE_AVATAR_FETCH_TIMEOUT_MS = 15_000;
 const PROFILE_SYNC_STATE_FILE = "discord-profile-sync.v1.json";
 const DEFAULT_DISCORD_PROFILE_AVATAR = "/avatars/eliza.png";
 
@@ -246,6 +247,7 @@ async function loadDiscordProfileAvatarBytes(
 			}
 			const response = await fetchImpl(trimmed, {
 				headers: { Accept: "image/*" },
+				signal: AbortSignal.timeout(PROFILE_AVATAR_FETCH_TIMEOUT_MS),
 			});
 			if (!response.ok) {
 				throw new Error(`HTTP ${response.status}`);
@@ -256,7 +258,61 @@ async function loadDiscordProfileAvatarBytes(
 					`Expected image content-type, got ${contentType ?? "unknown"}`,
 				);
 			}
-			bytes = Buffer.from(await response.arrayBuffer());
+
+			const rawLength = response.headers.get("content-length");
+			const declaredLength = rawLength === null ? null : Number(rawLength);
+			if (
+				declaredLength !== null &&
+				Number.isFinite(declaredLength) &&
+				declaredLength > MAX_PROFILE_AVATAR_BYTES
+			) {
+				throw new Error(
+					`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
+				);
+			}
+
+			if (!response.body) {
+				const ab = await response.arrayBuffer();
+				if (ab.byteLength > MAX_PROFILE_AVATAR_BYTES) {
+					throw new Error(
+						`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
+					);
+				}
+				bytes = Buffer.from(ab);
+			} else {
+				const reader = response.body.getReader();
+				const chunks: Uint8Array[] = [];
+				let total = 0;
+				try {
+					for (;;) {
+						const { done, value } = await reader.read();
+						if (done) break;
+						if (!value?.byteLength) continue;
+						total += value.byteLength;
+						if (total > MAX_PROFILE_AVATAR_BYTES) {
+							try {
+								await reader.cancel();
+							} catch {
+								// error-policy:J6 best-effort stream cancellation
+							}
+							throw new Error(
+								`Discord profile avatar exceeds ${MAX_PROFILE_AVATAR_BYTES} bytes`,
+							);
+						}
+						chunks.push(value);
+					}
+				} finally {
+					try {
+						reader.releaseLock();
+					} catch {
+						// error-policy:J6 stream lock release is best-effort teardown
+					}
+				}
+				bytes = Buffer.concat(
+					chunks.map((chunk) => Buffer.from(chunk)),
+					total,
+				);
+			}
 		} else {
 			bytes = await readAvatarBytesFromLocalCandidates(trimmed);
 		}


### PR DESCRIPTION
# Relates to

Bounded Discord avatar fetch hardening for `plugins/plugin-discord`.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is rebased onto `origin/develop@663176f21a9da5a539728278fe4d992ff1e8afd3` with zero conflicts.
- [x] The final implementation uses core's DNS-pinned SSRF/media boundary rather than connector-local raw fetches.
- [x] Exact-head focused tests, package typechecks, Biome, builds, and real Node socket evidence passed (see Testing).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`; maintainer repair/review: `GPT-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`; maintainer repair/review: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0bf4826f0026b81e8edfb9d23f470f644254f298:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported contributor provenance; maintainer repair disclosed`

# Sync with develop

- [x] Rebased onto live `develop@663176f21a9da5a539728278fe4d992ff1e8afd3`.
- [x] Exact head: `0b25dfc62585e6ec8768f6f042ca74aff83a1bcc`.
- [x] Two commits atop develop: contributor implementation plus maintainer security/boundary repair.

# What changed

- Keeps the contributor's 2 MiB cached-avatar and 8 MiB profile-avatar limits and 15 second deadline.
- Routes both remote-avatar paths through core `fetchRemoteMedia`, which performs DNS pinning, blocks private/literal targets, revalidates redirect hops, enforces declared and streamed byte limits, and keeps the deadline active while reading the body.
- Refuses redirects for allowlisted Discord CDN cache URLs, so validation of the first hostname cannot be bypassed by a redirect.
- Requires declared `image/*` content and rejects encoded transport bodies rather than storing/uploading compressed bytes under an image MIME type.
- Bounds HTTP-error diagnostics and cancels response bodies on all early policy/declared-size exits before clearing the timeout.
- Removes duplicated stream readers from the Discord plugin and uses an explicit deterministic transport seam only in tests.

# Risks

Low after repair. Invalid, redirected, encoded, oversized, stalled, or SSRF-blocked cache downloads degrade to the original Discord URL. Profile-sync failures remain best-effort startup diagnostics. Discord CDN images are already compressed media and are normally served without HTTP content encoding; rejecting an encoded body is fail-closed and avoids treating raw transport bytes as an avatar.

# Testing

Exact head `0b25dfc62585e6ec8768f6f042ca74aff83a1bcc`:

```text
bunx vitest run plugins/plugin-discord/__tests__/discord-avatar-cache.test.ts plugins/plugin-discord/__tests__/profile-sync-avatar-diagnostics.test.ts
2 files passed; 21 tests passed

bun test packages/core/src/media/fetch.test.ts packages/core/src/network/pinned-fetch.integration.test.ts
12 tests passed

bun run --cwd packages/core typecheck
pass

bun run --cwd plugins/plugin-discord typecheck
pass

bun run --cwd plugins/plugin-discord build
pass

bunx @biomejs/biome check <8 touched files>
pass

git diff --check origin/develop...HEAD
pass
```

The real Node integration opens a local HTTP socket, sends headers plus initial image bytes, then stalls indefinitely. The 100 ms guard deadline aborts the response body and the assertion passes. Additional deterministic adversarial proofs cover private literal URLs, redirect-to-loopback, Discord redirect refusal, declared-length overflow, chunked overflow, encoded bodies, early-body cancellation, non-image content, cache hits, and valid writes.

The complete Discord package suite also passed on the identical repair tree immediately before the conflict-free base-only rebase: 82 files, 661 tests. Exact-head focused tests and both exact-head typechecks were rerun after rebase.

# Evidence Gate

<!-- evidence-head:0b25dfc62585e6ec8768f6f042ca74aff83a1bcc -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered visual output changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered visual output changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head test output above includes the real Node socket deadline proof and deterministic connector results.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head cache tests inspect the real filesystem artifact and cache-hit behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

No behavior blocker found. A repeated full-suite run after the base-only rebase was abandoned under severe shared-runner CPU contention; the identical repair tree's full 661-test result, plus exact-head focused tests, typechecks, Biome, and package build, are recorded above.

Original AI provider/model: Anthropic / claude-fable-5
Original client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@0bf4826f0026b81e8edfb9d23f470f644254f298:packages/skills/skills/contribute-to-eliza
Original attribution status: self-reported
Maintainer repair/review: OpenAI GPT-5 via Codex
— [byt61], repaired and validated by maintainer
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@0bf4826f0026b81e8edfb9d23f470f644254f298:packages/skills/skills/contribute-to-eliza"} -->
