### PR TITLE
fix(cloud): restore Hetzner provider contract fixture

### DIFF
--- a/packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
+++ b/packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
@@ -43,7 +43,10 @@ beforeAll(async () => {
         },
         response: {
           status: 200,
-          body: { servers: [{ id: 7, name: "node-a" }] },
+          body: {
+            servers: [{ id: 7, name: "node-a" }],
+            meta: { pagination: { next_page: null } },
+          },
         },
       },
       {
@@ -110,7 +113,10 @@ describe("HetznerCloudClient provider contract", () => {
         "designed-empty": async () => {
           provider.enqueueFault("GET", "/v1/servers", {
             type: "schema-drift",
-            body: { servers: [] },
+            body: {
+              servers: [],
+              meta: { pagination: { next_page: null } },
+            },
           });
           expect(await client.listServers()).toEqual([]);
           return {


### PR DESCRIPTION
# Relates to

Fixes #22635.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased without conflicts onto fetched `origin/develop` base `a98d9641abfcde00e4d1e15a0317086d1bca0d21` before publication.
- [ ] `bun run verify` remains required after the final pre-merge rebase; focused owning gates are exact-head and green below.
- [x] A reviewer can confirm the deterministic provider contract and promoted-inventory behavior from the exact commands and output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a98d9641abfcde00e4d1e15a0317086d1bca0d21:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto fetched `origin/develop` base `a98d9641abfcde00e4d1e15a0317086d1bca0d21`; zero conflicts.
- [ ] `bun run verify` remains for the final current-`develop` pre-merge revision.

# Risks

Low. The change affects only two deterministic valid-response bodies in the Hetzner managed-provider contract suite. Production client behavior, fail-closed parsing, malformed fixtures, credentials, provider state, and deployment code are unchanged.

# Background

## What does this PR do?

Adds terminal `meta.pagination.next_page: null` metadata to the valid success and designed-empty Hetzner contract responses. This aligns the managed-provider fixture with the production client's authoritative pagination contract introduced by #21837 and restores the Cloud `Managed provider contract inventory` gate.

## What kind of change is this?

Bug fix to deterministic test fixtures.

# Documentation changes needed?

No. The existing package documentation already describes the managed-provider contract harness; no public contract changed.

# Testing

## Where should a reviewer start?

`packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts`, specifically the success fixture and designed-empty scenario.

## Detailed testing steps

At exact head `0f04a61d53d03d157564732f9aee81074a44cf90`:

```text
bun install --frozen-lockfile
PASS (Bun 1.3.14; 6666 packages installed)

bun run --cwd packages/core build
PASS (generated keyword modules and built required core exports)

bun test packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
PASS: 1 pass, 0 fail, 16 expect() calls

node packages/scripts/audit-provider-contracts.mjs
PASS: provider contract inventory: 4 promoted integrations

bun run --cwd packages/cloud/test-mocks typecheck
PASS

bunx @biomejs/biome check packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
PASS: Checked 1 file; no fixes applied

git diff --check
PASS
```

# Evidence Gate

<!-- evidence-head:0f04a61d53d03d157564732f9aee81074a44cf90 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend deterministic fixture only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend deterministic fixture only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or UI behavior changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic test-fixture-only repair; no deployed backend request or runtime logger path changes
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - test-fixture-only change; no model, prompt, agent, action, or production provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [22649-provider-inventory.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22649-provider-inventory.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Evidence Details

## Real LLM-call trajectory

N/A - no model or agent behavior changes.

## Backend + frontend logs

Backend contract result:

```text
(pass) HetznerCloudClient provider contract > exercises success, empty, invalid, rate-limit, malformed, and provider failures over HTTP
1 pass, 0 fail, 16 expect() calls
```

Managed inventory result:

```text
provider contract inventory: 4 promoted integrations (eliza-cloud-api, github-connector-oauth, hetzner-cloud, whatsapp-cloud-webhook)
```

Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - no audio or voice surface.

## Known gaps / failures

- The first focused test/audit/typecheck attempt in the fresh worktree failed before suite execution because generated keyword modules and built `@elizaos/core/edge` exports were absent. Running the repository-owned `bun run --cwd packages/core build` prerequisite generated/built them; every requested gate then passed on the unchanged exact source head.
- The host `node` binary reports v24.5.0 rather than the repository-pinned v24.15.0. CI must reconfirm the Node-driven inventory audit under the pinned toolchain; the audit passed locally.
- `develop` advanced after the bounded rebase. This draft intentionally does not chase rapid unrelated commits; a final current-`develop` rebase and root `bun run verify` remain required immediately before merge.
- No live Hetzner call is applicable: the PR changes only synthetic deterministic fixture metadata and performs no production provider mutation.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a98d9641abfcde00e4d1e15a0317086d1bca0d21:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hetzner-provider-contract-fixture]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a98d9641abfcde00e4d1e15a0317086d1bca0d21:packages/skills/skills/contribute-to-eliza"} -->


