### PR TITLE
fix(canvas): enforce bidirectional web-view origins

### DIFF
--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -185,7 +185,7 @@ describe("CanvasWeb eval message source", () => {
     window.dispatchEvent(
       new MessageEvent("message", {
         data: { type: "eliza:evalResult", result: "2" },
-        origin: "null",
+        origin: window.location.origin,
         source: webView,
       }),
     );
@@ -242,9 +242,71 @@ describe("CanvasWeb eval message source", () => {
     await expect(evalPromise).resolves.toEqual({ result: "Canvas App" });
   });
 
+  it("rejects an eval result from the right WindowProxy at the wrong origin", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "https://canvas.eliza.how/view" });
+    const webView = document.querySelector("iframe")?.contentWindow;
+    expect(webView).toBeTruthy();
+
+    const evalPromise = canvas.eval({ script: "document.title" });
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "eliza:evalResult", result: "spoofed" },
+        origin: "https://attacker.example",
+        source: webView,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "eliza:evalResult", result: "Canvas App" },
+        origin: "https://canvas.eliza.how",
+        source: webView,
+      }),
+    );
+
+    await expect(evalPromise).resolves.toEqual({ result: "Canvas App" });
+  });
+
+  it("rejects shared web view events from the right WindowProxy at the wrong origin", async () => {
+    const canvas = new CanvasWeb();
+    const onAction = vi.fn();
+    await canvas.addListener("a2uiAction", onAction);
+    await canvas.navigate({ url: "https://canvas.eliza.how/view" });
+    const webView = document.querySelector("iframe")?.contentWindow;
+    expect(webView).toBeTruthy();
+
+    const message = {
+      type: "eliza:a2uiAction",
+      action: "confirm",
+      data: { accepted: true },
+    };
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: message,
+        origin: "https://attacker.example",
+        source: webView,
+      }),
+    );
+    expect(onAction).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: message,
+        origin: "https://canvas.eliza.how",
+        source: webView,
+      }),
+    );
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(onAction).toHaveBeenCalledWith({
+      action: "confirm",
+      data: { accepted: true },
+      messageId: undefined,
+    });
+  });
+
   it("fails closed when navigating to an invalid or opaque URL and attempting postMessage", async () => {
     const canvas = new CanvasWeb();
-    await canvas.navigate({ url: "javascript:alert(1)" });
+    await canvas.navigate({ url: "data:text/html,opaque" });
 
     await expect(canvas.a2uiPush({ messages: [] })).rejects.toThrow(
       "Cannot determine web view target origin",

--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -192,4 +192,68 @@ describe("CanvasWeb eval message source", () => {
 
     await expect(evalPromise).resolves.toEqual({ result: "2" });
   });
+
+  it("pins postMessage targetOrigin to the navigation origin, not wildcard *", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "https://canvas.eliza.how/view" });
+    const iframe = document.querySelector("iframe");
+    const webView = iframe?.contentWindow;
+    expect(webView).toBeTruthy();
+    if (!webView) throw new Error("Missing webView contentWindow");
+
+    const postMessageSpy = vi.spyOn(webView, "postMessage");
+
+    // 1. a2uiPush
+    await canvas.a2uiPush({
+      messages: [{ role: "assistant", type: "text", content: "hi" }],
+    });
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "eliza:a2uiPush" }),
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // 2. a2uiReset
+    postMessageSpy.mockClear();
+    await canvas.a2uiReset();
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: "eliza:a2uiReset" },
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // 3. eval
+    postMessageSpy.mockClear();
+    const evalPromise = canvas.eval({ script: "document.title" });
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: "eliza:eval", script: "document.title" },
+      "https://canvas.eliza.how",
+    );
+    expect(postMessageSpy).not.toHaveBeenCalledWith(expect.anything(), "*");
+
+    // Complete eval
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "eliza:evalResult", result: "Canvas App" },
+        origin: "https://canvas.eliza.how",
+        source: webView,
+      }),
+    );
+    await expect(evalPromise).resolves.toEqual({ result: "Canvas App" });
+  });
+
+  it("fails closed when navigating to an invalid or opaque URL and attempting postMessage", async () => {
+    const canvas = new CanvasWeb();
+    await canvas.navigate({ url: "javascript:alert(1)" });
+
+    await expect(canvas.a2uiPush({ messages: [] })).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+    await expect(canvas.a2uiReset()).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+    await expect(canvas.eval({ script: "1+1" })).rejects.toThrow(
+      "Cannot determine web view target origin",
+    );
+  });
 });

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -1209,10 +1209,10 @@ export class CanvasWeb extends WebPlugin {
       }, timeoutMs);
 
       const handler = (event: MessageEvent) => {
-        // The request is posted with targetOrigin pinned to the web view.
-        // Any same-page window can emit `eliza:evalResult`; only the web view
-        // that received the script is allowed to complete this eval.
-        if (event.source !== target) return;
+        // A WindowProxy keeps its identity when its document navigates. Check
+        // both source and origin so a later cross-origin document cannot
+        // complete an eval intended for the original navigation origin.
+        if (event.source !== target || event.origin !== targetOrigin) return;
         const data = event.data;
         if (!data || typeof data !== "object") return;
         const msg = data as WebViewIncomingMessage;
@@ -1237,6 +1237,7 @@ export class CanvasWeb extends WebPlugin {
       const iframeSrc = this.webViewIframe?.contentWindow;
       const popupSrc = this.webViewPopup;
       if (event.source !== iframeSrc && event.source !== popupSrc) return;
+      if (!this.webViewOrigin || event.origin !== this.webViewOrigin) return;
 
       const msg = event.data as WebViewIncomingMessage;
       if (!msg || typeof msg.type !== "string") return;

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -178,6 +178,7 @@ export class CanvasWeb extends WebPlugin {
   }> = [];
   private webViewIframe: HTMLIFrameElement | null = null;
   private webViewPopup: Window | null = null;
+  private webViewOrigin: string | null = null;
   private messageListenerBound = false;
 
   async create(options: {
@@ -874,6 +875,26 @@ export class CanvasWeb extends WebPlugin {
     const placement = options.placement || "inline";
 
     this.destroyWebView();
+    try {
+      const base =
+        typeof window !== "undefined" && window.location?.href
+          ? window.location.href
+          : undefined;
+      const parsed = new URL(options.url, base);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        this.webViewOrigin = parsed.origin;
+      } else if (options.url === "about:blank") {
+        this.webViewOrigin =
+          typeof window !== "undefined" && window.location?.origin
+            ? window.location.origin
+            : null;
+      } else {
+        this.webViewOrigin = null;
+      }
+    } catch {
+      // error-policy:J3 invalid navigation URL fails closed
+      this.webViewOrigin = null;
+    }
 
     // Intercept eliza:// deep links immediately
     if (options.url.startsWith("eliza://")) {
@@ -1114,7 +1135,7 @@ export class CanvasWeb extends WebPlugin {
           jsonl: options.jsonl || "",
           payload: options.payload || null,
         },
-        "*",
+        this.getWebViewTargetOrigin(),
       );
       return;
     }
@@ -1139,7 +1160,10 @@ export class CanvasWeb extends WebPlugin {
         : null);
 
     if (target) {
-      target.postMessage({ type: "eliza:a2uiReset" }, "*");
+      target.postMessage(
+        { type: "eliza:a2uiReset" },
+        this.getWebViewTargetOrigin(),
+      );
       return;
     }
 
@@ -1157,6 +1181,19 @@ export class CanvasWeb extends WebPlugin {
       this.webViewPopup.close();
     }
     this.webViewPopup = null;
+    this.webViewOrigin = null;
+  }
+
+  private getWebViewTargetOrigin(): string {
+    const origin = this.webViewOrigin;
+    if (
+      origin &&
+      (origin.startsWith("http://") || origin.startsWith("https://"))
+    ) {
+      return origin;
+    }
+    // error-policy:J3 fail closed when origin cannot be proven; never fall back to wildcard "*"
+    throw new Error("Cannot determine web view target origin");
   }
 
   private evalViaPostMessage(
@@ -1164,6 +1201,7 @@ export class CanvasWeb extends WebPlugin {
     script: string,
   ): Promise<EvalResult> {
     return new Promise<EvalResult>((resolve, reject) => {
+      const targetOrigin = this.getWebViewTargetOrigin();
       const timeoutMs = 5000;
       const timeout = setTimeout(() => {
         window.removeEventListener("message", handler);
@@ -1171,9 +1209,9 @@ export class CanvasWeb extends WebPlugin {
       }, timeoutMs);
 
       const handler = (event: MessageEvent) => {
-        // The request is posted with targetOrigin "*". Any same-page window
-        // can therefore emit `eliza:evalResult`; only the web view that
-        // received the script is allowed to complete this eval.
+        // The request is posted with targetOrigin pinned to the web view.
+        // Any same-page window can emit `eliza:evalResult`; only the web view
+        // that received the script is allowed to complete this eval.
         if (event.source !== target) return;
         const data = event.data;
         if (!data || typeof data !== "object") return;
@@ -1186,7 +1224,7 @@ export class CanvasWeb extends WebPlugin {
       };
 
       window.addEventListener("message", handler);
-      target.postMessage({ type: "eliza:eval", script }, "*");
+      target.postMessage({ type: "eliza:eval", script }, targetOrigin);
     });
   }
 


### PR DESCRIPTION
# Relates to

Fixes #22650. Supersedes #22640 with complete bidirectional origin validation and current evidence.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is rebased onto `origin/develop@3a16d2654db32e89f6a9be371fcd6a42b281926b` with zero conflicts.
- [ ] `bun install` and full `bun run verify` were not run in the sparse isolated review checkout; focused owning-package gates are recorded below.
- [x] A reviewer can confirm the changed browser boundary from exact-head behavioral tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3a16d2654db32e89f6a9be371fcd6a42b281926b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The first commit preserves the scoped byt61 outbound-origin patch from #22640. The second repair commit was authored and committed by OpenAI Codex and requires independent exact-head review before merge.

# Sync with develop

- [x] Rebased onto live `develop@3a16d2654db32e89f6a9be371fcd6a42b281926b`.
- [x] Exact head: `b4b627d66e44b62ef19e56bfeef5223a67e412b2`.

# Risks

Medium security boundary change. Outbound A2UI and eval messages now target only the canonical navigation origin. Inbound eval results, deep links, and A2UI actions require both the active WindowProxy and expected origin. Invalid and opaque origins fail closed. No native Canvas implementation or public type changes.

# Background

## What does this PR do?

- Canonicalizes HTTP(S), relative, and inherited `about:blank` origins during Canvas web-view navigation.
- Removes wildcard outbound `postMessage` targets for A2UI push/reset and eval.
- Rejects inbound messages when the WindowProxy source is correct but the sender origin differs from the navigation origin.
- Clears the trusted origin when the web view is destroyed.

## What kind of change is this?

Security bug fix with no public API change.

# Documentation changes needed?

No documentation change is needed; the documented web-view API and timeout behavior are unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-canvas/src/web.test.ts`, especially the same-source/wrong-origin eval and shared-event cases.

## Detailed testing steps

Exact head after final rebase:

```text
vitest run plugins/plugin-native-canvas --configLoader runner
3 files passed; 30 tests passed

tsc --noEmit -p plugins/plugin-native-canvas/tsconfig.json
pass

bun run --cwd plugins/plugin-native-canvas build:unlocked
pass

biome check web.ts web.test.ts
2 files passed

git diff --check origin/develop...HEAD
pass
```

Tests ran in an isolated, network-denied process using read-only audited dependencies. The real `CanvasWeb` instance and jsdom iframe WindowProxy are the system under test; only the unavailable 2D canvas renderer remains stubbed by the existing harness.

# Evidence Gate

<!-- evidence-head:b4b627d66e44b62ef19e56bfeef5223a67e412b2 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered visual output changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered visual output changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a browser-only Canvas boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - deterministic exact-head browser-boundary test output is recorded above; no deployed network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent data or domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

The sparse isolated checkout did not run full repository `bun run verify`. The owning package test, typecheck, build, formatting, diff, source-origin, and adversarial origin gates pass on the exact head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3a16d2654db32e89f6a9be371fcd6a42b281926b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61-new-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3a16d2654db32e89f6a9be371fcd6a42b281926b:packages/skills/skills/contribute-to-eliza"} -->
