### PR TITLE
fix(agent-skills): bound registry, search, and package download fetches with timeout

### DIFF
--- a/plugins/plugin-agent-skills/README.md
+++ b/plugins/plugin-agent-skills/README.md
@@ -54,6 +54,9 @@ import { AgentSkillsService, MemorySkillStore } from '@elizaos/plugin-agent-skil
 // Create with explicit memory storage
 const service = await AgentSkillsService.start(runtime, {
   storageType: 'memory',
+  // Registry metadata and package bodies share this per-request deadline.
+  // The default is 30 seconds; null explicitly accepts unbounded remote I/O.
+  fetchTimeoutMs: 30_000,
 });
 
 // Or use the store directly

--- a/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
@@ -1,9 +1,11 @@
 /**
- * Unit tests for `AgentSkillsService` fetch timeout deadlines: asserts that
- * all 7 remote registry, search, detail, and download fetch call sites
- * supply an AbortSignal timeout.
+ * Registry and install fetch deadline tests for `AgentSkillsService`. The
+ * harness checks every call site and uses real Node HTTP sockets to prove the
+ * deadline covers both stalled response headers and stalled body streams.
  */
 
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemorySkillStore } from "../storage";
@@ -21,6 +23,29 @@ function createRuntime(
 			warn: vi.fn(),
 		},
 	} as unknown as IAgentRuntime;
+}
+
+async function listenLocally(
+	onRequest: Parameters<typeof createServer>[0],
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+	const server = createServer(onRequest);
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		close: async () => {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		},
+	};
 }
 
 describe("AgentSkillsService fetch timeouts", () => {
@@ -156,7 +181,7 @@ describe("AgentSkillsService fetch timeouts", () => {
 		expect(readmeCall).toBeDefined();
 		const readmeOptions = readmeCall?.[1] as RequestInit;
 		expect(readmeOptions.signal).toBeInstanceOf(AbortSignal);
-	});
+	}, 15_000);
 
 	it("7. installFromUrl supplies an AbortSignal timeout to fetch", async () => {
 		const skillMd = "---\nname: URL Skill\ndescription: A url test skill\n---\n# Docs";
@@ -173,5 +198,122 @@ describe("AgentSkillsService fetch timeouts", () => {
 		expect(fetchMock).toHaveBeenCalledOnce();
 		const options = fetchMock.mock.calls[0][1] as RequestInit;
 		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("supports an explicit service deadline override", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ items: [] }), { status: 200 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const timeoutSignal = new AbortController().signal;
+		const timeoutSpy = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockReturnValue(timeoutSignal);
+		const localService = (await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			fetchTimeoutMs: 1_234,
+			storage: new MemorySkillStore(),
+		})) as AgentSkillsService;
+
+		await localService.getCatalog({ forceRefresh: true });
+
+		expect(timeoutSpy).toHaveBeenCalledWith(1_234);
+		expect(fetchMock.mock.calls[0][1]).toMatchObject({ signal: timeoutSignal });
+	});
+
+	it("allows the service deadline to be explicitly disabled", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ items: [] }), { status: 200 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+		const localService = (await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			fetchTimeoutMs: null,
+			storage: new MemorySkillStore(),
+		})) as AgentSkillsService;
+
+		await localService.getCatalog({ forceRefresh: true });
+
+		expect(timeoutSpy).not.toHaveBeenCalled();
+		expect(fetchMock.mock.calls[0][1]).toMatchObject({ signal: undefined });
+	});
+
+	it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+		"rejects invalid service deadline %s",
+		async (fetchTimeoutMs) => {
+			await expect(
+				AgentSkillsService.start(createRuntime(), {
+					autoLoad: false,
+					fetchTimeoutMs,
+					storage: new MemorySkillStore(),
+				}),
+			).rejects.toThrow(
+				"fetchTimeoutMs must be a positive finite number or null",
+			);
+		},
+	);
+
+	it("aborts a real Node fetch that stalls before response headers", async () => {
+		let requestCount = 0;
+		const endpoint = await listenLocally(() => {
+			requestCount += 1;
+			// Deliberately never send response headers.
+		});
+		const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+		vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(40));
+		const localService = (await AgentSkillsService.start(
+			createRuntime(),
+			{
+				autoLoad: false,
+				registryUrl: endpoint.baseUrl,
+				storage: new MemorySkillStore(),
+			},
+		)) as AgentSkillsService;
+
+		try {
+			const startedAt = performance.now();
+			await expect(
+				localService.getCatalog({ forceRefresh: true }),
+			).resolves.toEqual([]);
+			expect(performance.now() - startedAt).toBeLessThan(2_000);
+
+			// A timed-out catalog fetch enters the existing cooldown even when a
+			// caller forces refresh, so retries cannot hammer an unhealthy registry.
+			await expect(
+				localService.getCatalog({ forceRefresh: true }),
+			).resolves.toEqual([]);
+			expect(requestCount).toBe(1);
+		} finally {
+			await endpoint.close();
+		}
+	});
+
+	it("aborts a real Node response while its package body is stalled", async () => {
+		const endpoint = await listenLocally((_request, response) => {
+			response.writeHead(200, { "content-type": "text/markdown" });
+			response.write("---\nname: stalled\ndescription: partial");
+			// Deliberately never finish the response body.
+		});
+		const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+		vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(40));
+		const storage = new MemorySkillStore();
+		const localService = (await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		})) as AgentSkillsService;
+
+		try {
+			const startedAt = performance.now();
+			await expect(
+				localService.installFromUrl(`${endpoint.baseUrl}/SKILL.md`, {
+					slug: "stalled",
+				}),
+			).resolves.toBe(false);
+			expect(performance.now() - startedAt).toBeLessThan(2_000);
+			expect(storage.getPackage("stalled")).toBeUndefined();
+		} finally {
+			await endpoint.close();
+		}
 	});
 });

--- a/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for `AgentSkillsService` fetch timeout deadlines: asserts that
+ * all 7 remote registry, search, detail, and download fetch call sites
+ * supply an AbortSignal timeout.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemorySkillStore } from "../storage";
+import { AgentSkillsService } from "./skills";
+
+function createRuntime(
+	settings: Record<string, unknown> = {},
+): IAgentRuntime {
+	return {
+		getSetting: vi.fn((key: string) => settings[key]),
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+}
+
+describe("AgentSkillsService fetch timeouts", () => {
+	let service: AgentSkillsService;
+
+	beforeEach(async () => {
+		service = (await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage: new MemorySkillStore(),
+		})) as AgentSkillsService;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("1. getCatalog supplies an AbortSignal timeout to fetch", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ items: [] }), {
+				headers: { "content-type": "application/json" },
+				status: 200,
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.getCatalog({ forceRefresh: true });
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const options = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("2. search supplies an AbortSignal timeout to fetch", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ results: [] }), {
+				headers: { "content-type": "application/json" },
+				status: 200,
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.search("weather", 10, { forceRefresh: true });
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const options = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("3. getSkillDetails supplies an AbortSignal timeout to fetch", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					slug: "test-skill",
+					latestVersion: { version: "1.0.0" },
+				}),
+				{
+					headers: { "content-type": "application/json" },
+					status: 200,
+				},
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.getSkillDetails("test-skill", { forceRefresh: true });
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const options = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("4. install (package download) supplies an AbortSignal timeout to fetch", async () => {
+		const detailsResponse = new Response(
+			JSON.stringify({
+				slug: "test-skill",
+				latestVersion: { version: "1.0.0" },
+			}),
+			{
+				headers: { "content-type": "application/json" },
+				status: 200,
+			},
+		);
+
+		const downloadResponse = new Response(new Uint8Array([0x50, 0x4b, 0x05, 0x06]), {
+			headers: { "content-type": "application/zip" },
+			status: 200,
+		});
+
+		const fetchMock = vi.fn(async (url: string) => {
+			if (String(url).includes("/api/v1/skills/")) return detailsResponse;
+			if (String(url).includes("/api/v1/download")) return downloadResponse;
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.install("test-skill", "1.0.0");
+
+		const downloadCall = fetchMock.mock.calls.find((call) =>
+			String(call[0]).includes("/api/v1/download"),
+		);
+		expect(downloadCall).toBeDefined();
+		const options = downloadCall?.[1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("5 & 6. installFromGitHub supplies AbortSignal timeouts for SKILL.md and README.md", async () => {
+		const skillMd = "---\nname: GitHub Skill\ndescription: A test skill\n---\n# Docs";
+		const readmeMd = "# Readme Docs";
+
+		const fetchMock = vi.fn(async (url: string) => {
+			if (String(url).endsWith("SKILL.md")) {
+				return new Response(skillMd, { status: 200 });
+			}
+			if (String(url).endsWith("README.md")) {
+				return new Response(readmeMd, { status: 200 });
+			}
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.installFromGitHub("owner/repo", { force: true });
+
+		const skillMdCall = fetchMock.mock.calls.find((call) =>
+			String(call[0]).endsWith("SKILL.md"),
+		);
+		expect(skillMdCall).toBeDefined();
+		const skillMdOptions = skillMdCall?.[1] as RequestInit;
+		expect(skillMdOptions.signal).toBeInstanceOf(AbortSignal);
+
+		const readmeCall = fetchMock.mock.calls.find((call) =>
+			String(call[0]).endsWith("README.md"),
+		);
+		expect(readmeCall).toBeDefined();
+		const readmeOptions = readmeCall?.[1] as RequestInit;
+		expect(readmeOptions.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("7. installFromUrl supplies an AbortSignal timeout to fetch", async () => {
+		const skillMd = "---\nname: URL Skill\ndescription: A url test skill\n---\n# Docs";
+		const fetchMock = vi.fn(async () =>
+			new Response(skillMd, {
+				headers: { "content-type": "text/markdown" },
+				status: 200,
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await service.installFromUrl("https://example.com/SKILL.md");
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const options = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
+});

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -82,6 +82,7 @@ const CACHE_TTL = {
  */
 const FETCH_ERROR_COOLDOWN = 1000 * 60 * 5;
 const MAX_CATALOG_PAGES = 100;
+const REGISTRY_FETCH_TIMEOUT_MS = 15_000;
 
 class CatalogPaginationError extends Error {
 	constructor(message: string) {
@@ -1863,6 +1864,7 @@ export class AgentSkillsService extends Service {
 				const url = `${this.apiBase}/api/v1/skills?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`;
 				const response = await fetch(url, {
 					headers: { Accept: "application/json" },
+					signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 				});
 
 				if (!response.ok) {
@@ -1955,6 +1957,7 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/search?q=${encodeURIComponent(query)}&limit=${limit}`;
 			const response = await fetch(url, {
 				headers: { Accept: "application/json" },
+				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 			});
 
 			if (!response.ok) {
@@ -1995,6 +1998,7 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/skills/${safeSlug}`;
 			const response = await fetch(url, {
 				headers: { Accept: "application/json" },
+				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 			});
 
 			if (!response.ok) {
@@ -2207,7 +2211,9 @@ export class AgentSkillsService extends Service {
 
 			// Download
 			const downloadUrl = `${this.apiBase}/api/v1/download?slug=${safeSlug}&version=${resolvedVersion}`;
-			const response = await fetch(downloadUrl);
+			const response = await fetch(downloadUrl, {
+				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+			});
 
 			if (!response.ok) {
 				throw new Error(`Download failed: ${response.status}`);
@@ -2326,7 +2332,9 @@ export class AgentSkillsService extends Service {
 
 			// Download SKILL.md
 			const skillMdUrl = `${rawBase}SKILL.md`;
-			const response = await fetch(skillMdUrl);
+			const response = await fetch(skillMdUrl, {
+				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+			});
 
 			if (!response.ok) {
 				throw new Error(
@@ -2344,7 +2352,9 @@ export class AgentSkillsService extends Service {
 			// Try to fetch README.md if it exists (optional)
 			try {
 				const readmeUrl = `${rawBase}README.md`;
-				const readmeResponse = await fetch(readmeUrl);
+				const readmeResponse = await fetch(readmeUrl, {
+					signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+				});
 				if (readmeResponse.ok) {
 					const readmeContent = await readCappedSkillText(readmeResponse);
 					files.push({ name: "README.md", content: readmeContent });
@@ -2400,7 +2410,9 @@ export class AgentSkillsService extends Service {
 		options: InstallSkillOptions & { slug?: string } = {},
 	): Promise<boolean> {
 		try {
-			const response = await fetch(url);
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+			});
 
 			if (!response.ok) {
 				throw new Error(`Failed to fetch: ${response.status}`);

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -82,7 +82,7 @@ const CACHE_TTL = {
  */
 const FETCH_ERROR_COOLDOWN = 1000 * 60 * 5;
 const MAX_CATALOG_PAGES = 100;
-const REGISTRY_FETCH_TIMEOUT_MS = 15_000;
+const DEFAULT_REGISTRY_FETCH_TIMEOUT_MS = 30_000;
 
 class CatalogPaginationError extends Error {
 	constructor(message: string) {
@@ -132,6 +132,8 @@ export interface AgentSkillsServiceConfig {
 	skillsDir?: string;
 	/** Registry API URL */
 	registryUrl?: string;
+	/** Remote request deadline in milliseconds. Set to null to disable. */
+	fetchTimeoutMs?: number | null;
 	/** Sync the remote skill catalog during service initialization */
 	syncCatalogOnStart?: boolean;
 	/** Auto-load installed skills on init */
@@ -242,6 +244,7 @@ export class AgentSkillsService extends Service {
 	private lastFetchErrorAt: number = 0;
 	// Duration of the current cooldown (may be overridden by Retry-After header on 429).
 	private fetchCooldownMs: number = FETCH_ERROR_COOLDOWN;
+	private readonly fetchTimeoutMs: number | null;
 
 	constructor(
 		protected runtime: IAgentRuntime,
@@ -273,6 +276,19 @@ export class AgentSkillsService extends Service {
 			config?.registryUrl ||
 			(typeof registrySetting === "string" ? registrySetting : null) ||
 			CLAWHUB_API;
+
+		const configuredFetchTimeout = config?.fetchTimeoutMs;
+		if (
+			configuredFetchTimeout !== undefined &&
+			configuredFetchTimeout !== null &&
+			(!Number.isFinite(configuredFetchTimeout) || configuredFetchTimeout <= 0)
+		) {
+			throw new Error("fetchTimeoutMs must be a positive finite number or null");
+		}
+		this.fetchTimeoutMs =
+			configuredFetchTimeout === undefined
+				? DEFAULT_REGISTRY_FETCH_TIMEOUT_MS
+				: configuredFetchTimeout;
 
 		// Registry I/O is opt-in during startup. getSetting() may preserve the
 		// string or coerce it to a boolean, so accept both explicit true forms.
@@ -1814,6 +1830,22 @@ export class AgentSkillsService extends Service {
 		return [...this.bundledSkillsDirs];
 	}
 
+	/** Apply the configured deadline across fetch and response-body consumption. */
+	private fetchSkillResource(
+		input: string | URL,
+		init: RequestInit = {},
+	): Promise<Response> {
+		const timeoutSignal =
+			this.fetchTimeoutMs === null
+				? undefined
+				: AbortSignal.timeout(this.fetchTimeoutMs);
+		const signal =
+			timeoutSignal && init.signal
+				? AbortSignal.any([init.signal, timeoutSignal])
+				: (timeoutSignal ?? init.signal);
+		return fetch(input, { ...init, signal });
+	}
+
 	// ============================================================
 	// REGISTRY OPERATIONS (ClawHub Integration)
 	// ============================================================
@@ -1862,9 +1894,8 @@ export class AgentSkillsService extends Service {
 					requestedCursors.add(cursor);
 				}
 				const url = `${this.apiBase}/api/v1/skills?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`;
-				const response = await fetch(url, {
+				const response = await this.fetchSkillResource(url, {
 					headers: { Accept: "application/json" },
-					signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 				});
 
 				if (!response.ok) {
@@ -1955,9 +1986,8 @@ export class AgentSkillsService extends Service {
 
 		try {
 			const url = `${this.apiBase}/api/v1/search?q=${encodeURIComponent(query)}&limit=${limit}`;
-			const response = await fetch(url, {
+			const response = await this.fetchSkillResource(url, {
 				headers: { Accept: "application/json" },
-				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 			});
 
 			if (!response.ok) {
@@ -1996,9 +2026,8 @@ export class AgentSkillsService extends Service {
 
 		try {
 			const url = `${this.apiBase}/api/v1/skills/${safeSlug}`;
-			const response = await fetch(url, {
+			const response = await this.fetchSkillResource(url, {
 				headers: { Accept: "application/json" },
-				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
 			});
 
 			if (!response.ok) {
@@ -2211,9 +2240,7 @@ export class AgentSkillsService extends Service {
 
 			// Download
 			const downloadUrl = `${this.apiBase}/api/v1/download?slug=${safeSlug}&version=${resolvedVersion}`;
-			const response = await fetch(downloadUrl, {
-				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-			});
+			const response = await this.fetchSkillResource(downloadUrl);
 
 			if (!response.ok) {
 				throw new Error(`Download failed: ${response.status}`);
@@ -2332,9 +2359,7 @@ export class AgentSkillsService extends Service {
 
 			// Download SKILL.md
 			const skillMdUrl = `${rawBase}SKILL.md`;
-			const response = await fetch(skillMdUrl, {
-				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-			});
+			const response = await this.fetchSkillResource(skillMdUrl);
 
 			if (!response.ok) {
 				throw new Error(
@@ -2352,15 +2377,14 @@ export class AgentSkillsService extends Service {
 			// Try to fetch README.md if it exists (optional)
 			try {
 				const readmeUrl = `${rawBase}README.md`;
-				const readmeResponse = await fetch(readmeUrl, {
-					signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-				});
+				const readmeResponse = await this.fetchSkillResource(readmeUrl);
 				if (readmeResponse.ok) {
 					const readmeContent = await readCappedSkillText(readmeResponse);
 					files.push({ name: "README.md", content: readmeContent });
 				}
 			} catch {
-				// README is optional, ignore errors
+				// error-policy:J4 README enrichment is optional; a timeout or missing
+				// file leaves the installed skill visibly without that extra file.
 			}
 
 			// Save to storage
@@ -2410,9 +2434,7 @@ export class AgentSkillsService extends Service {
 		options: InstallSkillOptions & { slug?: string } = {},
 	): Promise<boolean> {
 		try {
-			const response = await fetch(url, {
-				signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-			});
+			const response = await this.fetchSkillResource(url);
 
 			if (!response.ok) {
 				throw new Error(`Failed to fetch: ${response.status}`);

--- a/plugins/plugin-agent-skills/src/types.ts
+++ b/plugins/plugin-agent-skills/src/types.ts
@@ -473,6 +473,9 @@ export interface SkillsServiceConfig {
 	/** Registry API URL */
 	registryUrl?: string;
 
+	/** Remote request deadline in milliseconds. Set to null to disable. */
+	fetchTimeoutMs?: number | null;
+
 	/** Sync the remote skill catalog during service initialization */
 	syncCatalogOnStart?: boolean;
 


### PR DESCRIPTION
# Relates to

Partial progress on #22300. This PR bounds every current `AgentSkillsService` registry/package fetch and proves the Node fetch/body deadline. It deliberately does not close #22300: per-call caller cancellation and a typed public install failure remain residual work because the existing public install contract returns `boolean`.

# Summary

- Routes all seven catalog, search, details, registry-package, GitHub, and direct-URL fetch sites through one deadline helper.
- Uses the package's established marketplace default of 30 seconds instead of an arbitrary shorter deadline.
- Adds `fetchTimeoutMs` to service configuration: a positive finite millisecond override, or explicit `null` opt-out that accepts unbounded remote I/O.
- Keeps one `AbortSignal` alive through response-body consumption, so a server that sends headers/partial bytes and then stalls cannot hang installation.
- Documents the default/override/opt-out contract and marks the optional README degradation under the repository error policy.

The platform contract supports this approach: Node exposes `AbortSignal.timeout()` and the Fetch Standard abort algorithm errors the response stream, so the same signal bounds both header wait and body reads.

- [Node global `AbortSignal.timeout`](https://nodejs.org/docs/latest/api/globals.html)
- [Fetch Standard abort steps](https://fetch.spec.whatwg.org/)
- [MDN `AbortSignal` fetch body behavior](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository review workflow; no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebases the contributor fix and repair directly onto current `origin/develop@f53ee8e7a6f56302929f919cbd8cec91131caac5`.
- [x] Exact head: `89ad93a5e475b55fe7f9dcb123f6257fb4be21d5`.

# Risks

This is a remote-I/O lifecycle change. The default is aligned with the existing agent-skills marketplace client. Hosts that intentionally allow longer requests can override the positive finite deadline or disable it with `null`; invalid zero, negative, infinite, and NaN values fail fast. Timeout failures retain the existing public method result semantics and never save the partial package.

# Testing

Exact-head package validation:

```text
bun run --cwd plugins/plugin-agent-skills test
26 files passed; 272 tests passed

bun run --cwd plugins/plugin-agent-skills typecheck
pass

bun run --cwd plugins/plugin-agent-skills lint:check
65 files passed

bun run --cwd plugins/plugin-agent-skills format:check
pass

bun run --cwd plugins/plugin-agent-skills build
ESM output and declarations built

git diff --check origin/develop...HEAD
pass
```

The new integration-backed test file covers all seven production fetch callers. Real Node HTTP servers additionally prove:

- a request that never sends headers returns on the deadline;
- the existing catalog cooldown suppresses an immediate forced retry after timeout;
- a response that sends valid headers and partial SKILL.md bytes but never ends is aborted during body consumption;
- no partial skill package is persisted;
- the configured override is forwarded and explicit `null` creates no timeout signal.

# Evidence Gate

<!-- evidence-head:89ad93a5e475b55fe7f9dcb123f6257fb4be21d5 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no product pixels or layout changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no product pixels or layout changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible product flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head loopback Node HTTP tests passed.

<details><summary>Backend lifecycle transcript</summary>

```text
stalled headers: deadline returned [] before 2,000ms; requestCount=1
forced retry during cooldown: returned []; requestCount remained 1
stalled partial SKILL.md body: install returned false before 2,000ms
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The real stalled-body test inspects `MemorySkillStore`.

```json
{
  "attemptedSlug": "stalled",
  "installResult": false,
  "persistedPackage": null,
  "assertion": "storage.getPackage('stalled') is undefined after body timeout"
}
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text/layout changed.

# Known gaps / failures

Full repository `bun run verify` was not run in the isolated sparse checkout. The owning package's complete test, typecheck, Biome, and production build gates passed. #22300 remains open for a separately reviewed public typed-failure and per-call caller-cancellation design.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - repository review workflow; no contribution skill used
Attribution status: self-reported
— [quality-bounds-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
