### PR TITLE
fix(plugin-native-settings): preserve concurrent unsaved volume edits when applying one stream or brightness

### DIFF
--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
@@ -5,6 +5,7 @@ import type {
   SystemStatus,
 } from "@elizaos/capacitor-system";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -584,6 +585,165 @@ describe("DeviceSettingsAppView — interactions", () => {
     const status = await screen.findByRole("status");
     expect(status.textContent).toContain("System settings opened.");
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("DeviceSettingsAppView — concurrent unsaved volume edits", () => {
+  // Regression for #22648: applying one stream (or brightness) must NOT discard
+  // the in-progress slider edits the user made to OTHER streams. Previously a
+  // deviceSettings-change effect rebuilt the whole `volumes` map on every
+  // setDeviceSettings, silently snapping every other slider back to the last
+  // saved server value.
+  it("preserves an unsaved edit on stream A while applying stream B", async () => {
+    mockBridgeFull();
+    // Applying ring returns a merged server value of 8/10.
+    systemBridge.setVolume.mockResolvedValue({
+      stream: "ring",
+      current: 8,
+      max: 10,
+    });
+    renderView();
+
+    const music = (await screen.findByTestId(
+      "device-settings-volume-music",
+    )) as HTMLInputElement;
+    const ring = screen.getByTestId(
+      "device-settings-volume-ring",
+    ) as HTMLInputElement;
+
+    // Nudge Media (music) to 12 WITHOUT applying it — pending edit only.
+    fireEvent.change(music, { target: { value: "12" } });
+    await waitFor(() => expect(music.value).toBe("12"));
+
+    // Nudge Ring to 7 and apply ONLY Ring.
+    fireEvent.change(ring, { target: { value: "7" } });
+    await waitFor(() => expect(ring.value).toBe("7"));
+    fireEvent.click(screen.getByTestId("device-settings-apply-volume-ring"));
+
+    await waitFor(() =>
+      expect(systemBridge.setVolume).toHaveBeenCalledWith({
+        stream: "ring",
+        volume: 7,
+      }),
+    );
+
+    // Applied stream snaps to the merged server value (8), as before.
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("device-settings-volume-ring") as HTMLInputElement)
+          .value,
+      ).toBe("8"),
+    );
+
+    // The unrelated unsaved Media edit of 12 must SURVIVE the ring apply.
+    expect(
+      (screen.getByTestId("device-settings-volume-music") as HTMLInputElement)
+        .value,
+    ).toBe("12");
+  });
+
+  it("preserves an unsaved volume edit while applying brightness", async () => {
+    mockBridgeFull();
+    // setScreenBrightness returns a full DeviceSettingsStatus INCLUDING volumes
+    // at their last-saved values — the object identity change must not clobber
+    // the pending slider edit.
+    systemBridge.setScreenBrightness.mockResolvedValue({
+      brightness: 0.4,
+      brightnessMode: "automatic",
+      canWriteSettings: true,
+      volumes: fullDeviceSettings().volumes,
+    });
+    // The bridge returns Media at its last-saved 9 when Media is later applied,
+    // so the value written back proves whether the pending edit survived.
+    systemBridge.setVolume.mockResolvedValue({
+      stream: "music",
+      current: 13,
+      max: 15,
+    });
+    renderView();
+
+    const music = (await screen.findByTestId(
+      "device-settings-volume-music",
+    )) as HTMLInputElement;
+    // Pending edit: Media 9 -> 13, never applied.
+    fireEvent.change(music, { target: { value: "13" } });
+    await waitFor(() => expect(music.value).toBe("13"));
+
+    // Apply brightness (unrelated stream family). Its returned
+    // DeviceSettingsStatus carries the full volumes array at server values.
+    fireEvent.click(screen.getByTestId("device-settings-apply-brightness"));
+    await waitFor(() =>
+      expect(systemBridge.setScreenBrightness).toHaveBeenCalledTimes(1),
+    );
+    // Brightness readout reflects the merged 0.4 -> 40%, proving the
+    // deviceSettings object was actually replaced by the brightness apply.
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("device-settings-brightness") as HTMLInputElement)
+          .value,
+      ).toBe("40"),
+    );
+    // Flush any pending passive effect deterministically. In the buggy version
+    // a deviceSettings-change effect reseeds the whole volumes map here; act()
+    // guarantees it has run before we assert, removing the scheduler race.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The pending Media slider must still read 13, not the server's 9.
+    expect(
+      (screen.getByTestId("device-settings-volume-music") as HTMLInputElement)
+        .value,
+    ).toBe("13");
+
+    // Deterministic proof (race-free): applying Media now must send the
+    // PENDING 13 to the bridge, not the clobbered server value 9. React flushes
+    // any pending passive effect before this click handler runs, so a
+    // deviceSettings-driven reseed (the old bug) would already have reset the
+    // slider to 9 by this point.
+    fireEvent.click(screen.getByTestId("device-settings-apply-volume-music"));
+    await waitFor(() =>
+      expect(systemBridge.setVolume).toHaveBeenCalledWith({
+        stream: "music",
+        volume: 13,
+      }),
+    );
+  });
+
+  it("explicit Refresh reloads every slider from the server, discarding pending edits", async () => {
+    // Initial load, then Refresh returns music raised to 11/15 server-side.
+    systemBridge.getDeviceSettings
+      .mockResolvedValueOnce(fullDeviceSettings())
+      .mockResolvedValueOnce({
+        ...fullDeviceSettings(),
+        volumes: fullDeviceSettings().volumes.map((v) =>
+          v.stream === "music" ? { ...v, current: 11 } : v,
+        ),
+      });
+    systemBridge.getStatus.mockResolvedValue(fullSystemStatus());
+    renderView();
+
+    const music = (await screen.findByTestId(
+      "device-settings-volume-music",
+    )) as HTMLInputElement;
+    expect(music.value).toBe("9");
+
+    // Pending edit that Refresh is EXPECTED to discard.
+    fireEvent.change(music, { target: { value: "2" } });
+    await waitFor(() => expect(music.value).toBe("2"));
+
+    fireEvent.click(screen.getByTestId("device-settings-refresh"));
+    await waitFor(() =>
+      expect(systemBridge.getDeviceSettings).toHaveBeenCalledTimes(2),
+    );
+
+    // Refresh is an explicit reseed: the slider reflects the new server value.
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("device-settings-volume-music") as HTMLInputElement)
+          .value,
+      ).toBe("11"),
+    );
   });
 });
 

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
@@ -710,6 +710,44 @@ describe("DeviceSettingsAppView — concurrent unsaved volume edits", () => {
     );
   });
 
+  it("clamps a preserved edit when brightness returns a lower native stream maximum", async () => {
+    mockBridgeFull();
+    systemBridge.setScreenBrightness.mockResolvedValue({
+      brightness: 0.4,
+      brightnessMode: "automatic",
+      canWriteSettings: true,
+      volumes: fullDeviceSettings().volumes.map((volume) =>
+        volume.stream === "music" ? { ...volume, current: 9, max: 10 } : volume,
+      ),
+    });
+    systemBridge.setVolume.mockResolvedValue({
+      stream: "music",
+      current: 10,
+      max: 10,
+    });
+    renderView();
+
+    const music = (await screen.findByTestId(
+      "device-settings-volume-music",
+    )) as HTMLInputElement;
+    fireEvent.change(music, { target: { value: "13" } });
+    await waitFor(() => expect(music.value).toBe("13"));
+
+    fireEvent.click(screen.getByTestId("device-settings-apply-brightness"));
+
+    await waitFor(() => expect(music.max).toBe("10"));
+    await waitFor(() => expect(music.value).toBe("10"));
+    expect(within(volumeCard("music")).getByText("100%")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("device-settings-apply-volume-music"));
+    await waitFor(() =>
+      expect(systemBridge.setVolume).toHaveBeenCalledWith({
+        stream: "music",
+        volume: 10,
+      }),
+    );
+  });
+
   it("explicit Refresh reloads every slider from the server, discarding pending edits", async () => {
     // Initial load, then Refresh returns music raised to 11/15 server-side.
     systemBridge.getDeviceSettings

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
@@ -145,6 +145,17 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       });
       setDeviceSettings(next);
       setBrightness(clampUnit(next.brightness));
+      setVolumes((current) =>
+        Object.fromEntries(
+          next.volumes.map((volume) => [
+            volume.stream,
+            clampVolumeValue(
+              current[volume.stream] ?? volume.current,
+              volume.max,
+            ),
+          ]),
+        ),
+      );
       setNotice("Brightness updated.");
     } catch (err) {
       // error-policy:J4 surface the brightness-save failure into the view's error state

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
@@ -99,6 +99,18 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       setDeviceSettings(settingsResult);
       setSystemStatus(statusResult);
       setBrightness(clampUnit(settingsResult.brightness));
+      // Seed slider positions from the freshly loaded/refreshed server state.
+      // This is the ONLY place the whole map is rebuilt: doing it on every
+      // deviceSettings change would clobber unsaved edits to other streams
+      // whenever a single stream (or brightness) apply replaces the object.
+      setVolumes(
+        Object.fromEntries(
+          settingsResult.volumes.map((volume) => [
+            volume.stream,
+            clampVolumeValue(volume.current, volume.max),
+          ]),
+        ),
+      );
     } catch (err) {
       // error-policy:J4 surface the load failure into the view's error state (three-state UI)
       setError(err instanceof Error ? err.message : String(err));
@@ -110,18 +122,6 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
   useEffect(() => {
     void refresh();
   }, [refresh]);
-
-  useEffect(() => {
-    if (!deviceSettings) return;
-    setVolumes(
-      Object.fromEntries(
-        deviceSettings.volumes.map((volume) => [
-          volume.stream,
-          clampVolumeValue(volume.current, volume.max),
-        ]),
-      ),
-    );
-  }, [deviceSettings]);
 
   const roles = useMemo(() => systemStatus?.roles ?? [], [systemStatus]);
   const orderedVolumes = useMemo(
@@ -168,6 +168,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
           stream: volume.stream,
           volume: nextValue,
         });
+        const mergedCurrent = clampVolumeValue(next.current, next.max);
         setDeviceSettings((current) => {
           if (!current) return current;
           return {
@@ -176,12 +177,18 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               entry.stream === next.stream
                 ? {
                     ...next,
-                    current: clampVolumeValue(next.current, next.max),
+                    current: mergedCurrent,
                   }
                 : entry,
             ),
           };
         });
+        // Only the applied stream's slider snaps to the merged server value;
+        // other streams retain their in-progress unsaved edits.
+        setVolumes((current) => ({
+          ...current,
+          [next.stream]: mergedCurrent,
+        }));
         setNotice(
           `${VOLUME_LABELS[volume.stream] ?? volume.stream} volume updated.`,
         );


### PR DESCRIPTION
# Relates to

Closes #22648

## What changed

The Android-only Device Settings overlay previously rebuilt every local volume
slider whenever any native settings response replaced `deviceSettings`. Applying
one stream or brightness therefore discarded unrelated in-progress slider edits.

The reviewed implementation now:

- seeds the complete slider map only during initial load or explicit Refresh;
- updates only the applied stream after a volume response;
- preserves pending edits after a brightness response while re-clamping them to
  each stream's newly reported native maximum.

The last point is a reviewer repair. The submitted head preserved a stale local
value even when the brightness response lowered that stream's maximum, which
could display and later submit an out-of-range value.

## Exact-head validation

<!-- evidence-head:bafeb33b2a0479851d5e96a707d66f21a1d34154 -->

Reviewed head: `bafeb33b2a0479851d5e96a707d66f21a1d34154`

Develop base at final device review: `e3136ad177dbd9c7059434b6365d1dc3b6ac27b8`

- Real component suite: 19/19 passed.
- Full package suite, serialized to avoid the package's global bridge-mock race:
  3 files, 24/24 passed.
- Package typecheck passed.
- Package production ESM/declaration build passed.
- Biome on both changed files and `git diff --check` passed.
- Mutation proof: removing the brightness reconciliation leaves a pending value
  at 13 after the native maximum falls to 10, and the regression fails.
- Clean Android sideload build passed: 9,903-module Vite bundle, mobile-agent
  bundle load smoke, 35 Capacitor plugins including `@elizaos/capacitor-system`,
  and Gradle `assembleDebug` (766 tasks).
- APK SHA-256 matched locally and after installation on `emulator-5554`:
  `b81a5fc08e12f6e60a0830d9a846afc9176c275f91697b27be38d53558111c64`.
- Real WebView/Capacitor/Kotlin concurrent-edit scenario: 1/1 passed. It confirmed
  Android native mode, six streams including `voiceCall`, one stream applied
  without losing the second draft, brightness applied without losing a pending
  volume draft, native values changed, and explicit Refresh reseeded the UI.
- Existing real Kotlin bridge smoke: 1/1 passed.

Code/mutation log: [validation artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22654-pr-22654-validation.txt).

Device result: [structured JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-device-result.json).

Full device bundle: [logs, console, screenshots, and result](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-android-evidence.zip).

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - the defect is a transient state overwrite after an async native response; the exact regression/mutation proof records the failing before behavior more accurately than a static frame.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [exact-head installed Android Device Settings overlay](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-device-settings.png).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [exact-head real Android native-plugin bridge walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-native-bridge.mp4).
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - this is local overlay state and native bridge interaction; no backend path changes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: [exact-head WebView console and Android logcat bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-android-evidence.zip).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, action, provider, or planner behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [structured real-bridge result](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-device-result.json) and [full exact-head device bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/pr-22654-bafeb33-android-evidence.zip).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `Reviewed the unobscured exact-head capture: Device Settings renders six native volume streams, per-stream Apply controls, Refresh, and native role/app rows. The QA-only shell exposes the untranslated deviceSettings.title key; this is pre-existing localization loading in the test route and not part of the changed component state contract.`

## Device-scope note

The real supported Android bridge proves the reachable concurrent edit, apply,
brightness, and refresh behavior. Stock Android exposes stream maxima as
platform-owned read-only values; there is no supported emulator control that
lowers a stream maximum at runtime. The lowered-maximum reconciliation is
therefore covered by the exact component mutation regression rather than a
fabricated or privileged device condition.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`, `Codex Desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6bd45306a74a19b4f6b71af64421a67985c9af6b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop-multi-agent","skill_revision":"elizaOS/eliza@e3136ad177dbd9c7059434b6365d1dc3b6ac27b8:packages/skills/skills/contribute-to-eliza"} -->
