### PR TITLE
fix(plugin-native-swabble): free mic and level meter on fatal web recognition error

### DIFF
--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -25,6 +25,41 @@ class FakeRecognition extends EventTarget {
   }
 }
 
+class FakeAnalyser {
+  fftSize = 256;
+  frequencyBinCount = 128;
+  getByteFrequencyData(array: Uint8Array): void {
+    array.fill(0);
+  }
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  sampleRate = 48000;
+  close = vi.fn(async () => undefined);
+  constructor() {
+    FakeAudioContext.instances.push(this);
+  }
+  createAnalyser(): FakeAnalyser {
+    return new FakeAnalyser();
+  }
+  createMediaStreamSource(): { connect: (target: unknown) => void } {
+    return { connect: vi.fn() };
+  }
+}
+
+function makeMicStream(): {
+  stream: MediaStream;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  const stop = vi.fn();
+  const track = { stop, kind: "audio" };
+  const stream = {
+    getTracks: () => [track],
+  } as unknown as MediaStream;
+  return { stream, stop };
+}
+
 function setWindow(overrides: Record<string, unknown> = {}): void {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
@@ -274,5 +309,118 @@ describe("SwabbleWeb fallback", () => {
         message: expect.stringContaining("Permission denied"),
       }),
     );
+  });
+
+  it("tears down the level meter and mic stream on a non-recoverable recognition error", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const { stream, stop } = makeMicStream();
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: {
+          getUserMedia: vi.fn(async () => stream),
+        } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      const audioLevels = vi.fn();
+      await plugin.addListener("audioLevel", audioLevels);
+      await plugin.start({ config: { triggers: ["eliza"] } });
+
+      // The level-meter interval is live before the fatal error.
+      vi.advanceTimersByTime(100);
+      expect(audioLevels.mock.calls.length).toBeGreaterThan(0);
+
+      // A non-recoverable recognizer error, followed by the browser's onend.
+      FakeRecognition.latest?.onerror?.({ error: "audio-capture" });
+      FakeRecognition.latest?.onend?.();
+
+      // The plugin now reports it is not listening.
+      await expect(plugin.isListening()).resolves.toEqual({
+        listening: false,
+      });
+
+      // The microphone track was released exactly once (no privacy leak) ...
+      expect(stop).toHaveBeenCalledTimes(1);
+
+      // ... and no further audioLevel events fire after entering idle/error.
+      audioLevels.mockClear();
+      vi.advanceTimersByTime(300);
+      expect(audioLevels).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the level meter and mic stream alive on a recoverable no-speech error", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const { stream, stop } = makeMicStream();
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: {
+          getUserMedia: vi.fn(async () => stream),
+        } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      const audioLevels = vi.fn();
+      await plugin.addListener("audioLevel", audioLevels);
+      await plugin.start({ config: { triggers: ["eliza"] } });
+
+      const recognition = FakeRecognition.latest;
+      recognition?.start.mockClear();
+
+      // no-speech is recoverable: state stays listening and the mic is retained.
+      recognition?.onerror?.({ error: "no-speech" });
+      await expect(plugin.isListening()).resolves.toEqual({ listening: true });
+      expect(stop).not.toHaveBeenCalled();
+
+      // onend restarts recognition while active (the untouched restart path).
+      recognition?.onend?.();
+      expect(recognition?.start).toHaveBeenCalled();
+
+      // The level meter continues to emit and the mic stays open.
+      audioLevels.mockClear();
+      vi.advanceTimersByTime(200);
+      expect(audioLevels).toHaveBeenCalled();
+      expect(stop).not.toHaveBeenCalled();
+
+      await plugin.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not double-close or throw when stop() follows a fatal recognition error", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const { stream, stop } = makeMicStream();
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: {
+          getUserMedia: vi.fn(async () => stream),
+        } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      await plugin.start({ config: { triggers: ["eliza"] } });
+
+      FakeRecognition.latest?.onerror?.({ error: "not-allowed" });
+      FakeRecognition.latest?.onend?.();
+      expect(stop).toHaveBeenCalledTimes(1);
+
+      // A redundant stop() after teardown must be a safe no-op.
+      await expect(plugin.stop()).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises the real SwabbleWeb state machine with deterministic browser API
+ * doubles, including recognition-session ownership and microphone teardown.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SwabbleWeb } from "./web";
@@ -326,7 +330,9 @@ describe("SwabbleWeb fallback", () => {
 
       const plugin = new SwabbleWeb();
       const audioLevels = vi.fn();
+      const states = vi.fn();
       await plugin.addListener("audioLevel", audioLevels);
+      await plugin.addListener("stateChange", states);
       await plugin.start({ config: { triggers: ["eliza"] } });
 
       // The level-meter interval is live before the fatal error.
@@ -335,7 +341,12 @@ describe("SwabbleWeb fallback", () => {
 
       // A non-recoverable recognizer error, followed by the browser's onend.
       FakeRecognition.latest?.onerror?.({ error: "audio-capture" });
+      expect(states).toHaveBeenLastCalledWith({
+        state: "error",
+        reason: "audio-capture",
+      });
       FakeRecognition.latest?.onend?.();
+      expect(states).toHaveBeenLastCalledWith({ state: "idle" });
 
       // The plugin now reports it is not listening.
       await expect(plugin.isListening()).resolves.toEqual({
@@ -419,6 +430,55 @@ describe("SwabbleWeb fallback", () => {
       // A redundant stop() after teardown must be a safe no-op.
       await expect(plugin.stop()).resolves.toBeUndefined();
       expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores callbacks from a retired recognizer after a replacement starts", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const firstMic = makeMicStream();
+      const secondMic = makeMicStream();
+      const getUserMedia = vi
+        .fn<() => Promise<MediaStream>>()
+        .mockResolvedValueOnce(firstMic.stream)
+        .mockResolvedValueOnce(secondMic.stream);
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: { getUserMedia } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      const errors = vi.fn();
+      const audioLevels = vi.fn();
+      await plugin.addListener("error", errors);
+      await plugin.addListener("audioLevel", audioLevels);
+
+      await plugin.start({ config: { triggers: ["eliza"] } });
+      const firstRecognition = FakeRecognition.latest;
+      await plugin.stop();
+      expect(firstMic.stop).toHaveBeenCalledTimes(1);
+
+      await plugin.start({ config: { triggers: ["eliza"] } });
+      const secondRecognition = FakeRecognition.latest;
+      expect(secondRecognition).not.toBe(firstRecognition);
+
+      firstRecognition?.onerror?.({ error: "not-allowed" });
+      firstRecognition?.onend?.();
+      await expect(plugin.isListening()).resolves.toEqual({ listening: true });
+      expect(errors).not.toHaveBeenCalled();
+      expect(secondRecognition?.abort).not.toHaveBeenCalled();
+      expect(secondMic.stop).not.toHaveBeenCalled();
+
+      audioLevels.mockClear();
+      vi.advanceTimersByTime(100);
+      expect(audioLevels).toHaveBeenCalled();
+
+      await plugin.stop();
+      expect(secondMic.stop).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -1,3 +1,7 @@
+/**
+ * Implements browser speech recognition and Electrobun audio capture for the
+ * Swabble Capacitor surface, with session-owned callback and resource cleanup.
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   SpeechRecognitionCtor,
@@ -389,22 +393,28 @@ export class SwabbleWeb extends WebPlugin {
     recognition.lang = config.locale || "en-US";
 
     recognition.onstart = () => {
+      if (this.recognition !== recognition) return;
       this.isActive = true;
       this.notifyListeners("stateChange", { state: "listening" });
     };
 
     recognition.onend = () => {
+      if (this.recognition !== recognition) return;
       if (this.isActive) {
-        this.recognition?.start();
+        recognition.start();
       } else {
         // Terminal end (stop() or a fatal error already cleared isActive):
         // release the level-meter mic so no capture outlives the idle state.
+        this.recognition = null;
         this.stopAudioLevelMonitoring();
         this.notifyListeners("stateChange", { state: "idle" });
       }
     };
 
     recognition.onerror = (event: { error: string }) => {
+      // Browser callbacks can arrive after stop() and a subsequent start().
+      // A retired recognizer must never tear down or restart its replacement.
+      if (this.recognition !== recognition) return;
       const recoverable =
         event.error === "no-speech" || event.error === "aborted";
       this.notifyListeners("error", {
@@ -414,11 +424,11 @@ export class SwabbleWeb extends WebPlugin {
       });
       if (!recoverable) {
         // A non-recoverable error ends capture without a consumer stop():
-        // tear the recognizer and level meter down here so the microphone
-        // track and the 100 ms interval do not outlive the error state.
+        // tear the level meter down here so its microphone track and 100 ms
+        // interval do not outlive the error state. Keep this recognizer owned
+        // until its required end event arrives, unless start() replaces it.
         this.isActive = false;
         this.stopAudioLevelMonitoring();
-        this.recognition = null;
         this.notifyListeners("stateChange", {
           state: "error",
           reason: event.error,
@@ -426,8 +436,10 @@ export class SwabbleWeb extends WebPlugin {
       }
     };
 
-    recognition.onresult = (event: SpeechRecognitionResultEvent) =>
+    recognition.onresult = (event: SpeechRecognitionResultEvent) => {
+      if (this.recognition !== recognition) return;
       this.handleSpeechResult(event);
+    };
 
     this.recognition = recognition;
     await this.startAudioLevelMonitoring();
@@ -533,9 +545,10 @@ export class SwabbleWeb extends WebPlugin {
       return;
     }
 
-    if (this.recognition) {
-      this.recognition.stop();
-      this.recognition = null;
+    const recognition = this.recognition;
+    this.recognition = null;
+    if (recognition) {
+      recognition.stop();
     }
     this.stopAudioLevelMonitoring();
     this.notifyListeners("stateChange", { state: "idle" });

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -397,6 +397,9 @@ export class SwabbleWeb extends WebPlugin {
       if (this.isActive) {
         this.recognition?.start();
       } else {
+        // Terminal end (stop() or a fatal error already cleared isActive):
+        // release the level-meter mic so no capture outlives the idle state.
+        this.stopAudioLevelMonitoring();
         this.notifyListeners("stateChange", { state: "idle" });
       }
     };
@@ -410,7 +413,12 @@ export class SwabbleWeb extends WebPlugin {
         recoverable,
       });
       if (!recoverable) {
+        // A non-recoverable error ends capture without a consumer stop():
+        // tear the recognizer and level meter down here so the microphone
+        // track and the 100 ms interval do not outlive the error state.
         this.isActive = false;
+        this.stopAudioLevelMonitoring();
+        this.recognition = null;
         this.notifyListeners("stateChange", {
           state: "error",
           reason: event.error,


### PR DESCRIPTION
# Relates to

Closes #22659

## What changed

The browser Web Speech fallback opens a second `getUserMedia` stream for its
audio-level meter. A fatal recognition error previously reported inactive/error
state without releasing that stream or its 100 ms interval, so microphone capture
and `audioLevel` events could outlive the session.

This change now:

- releases the level-meter track and interval immediately on a fatal error;
- preserves the required fatal `error` then `end` lifecycle and recoverable
  `no-speech` / `aborted` restart behavior;
- binds every recognition callback to its owning recognizer instance, preventing
  a late callback from a stopped recognizer from restarting or tearing down a
  newer replacement session;
- retires the current recognizer before `stop()` can synchronously emit `onend`,
  keeping teardown and idle notification idempotent.

The session-identity repair was added during review. The submitted head cleaned
up the original leak but still allowed stale callbacks to make a replacement
session inactive and stop its microphone stream.

## Exact-head validation

<!-- evidence-head:e65d722b24cf8cab9c2128b5c6aede7832d02083 -->

Reviewed head: `e65d722b24cf8cab9c2128b5c6aede7832d02083`

Develop base: `578256176c813edb1440984edcf3cba7281fac6a`

- Package tests: 15/15 passed.
- Package typecheck passed.
- Production IIFE/CJS/ESM build passed.
- Package Biome (7 files) and `git diff --check` passed.
- Mutation: restoring submitted shared callback semantics makes the replacement
  test fail (`listening: false` instead of `true`).
- Real Chromium loaded the exact production IIFE with real AudioContext-backed
  MediaStream tracks: fatal cleanup changed the first track to `ended`, stopped
  level events, preserved `error → idle`; stale callbacks left the replacement
  track `live` and listening; explicit stop ended it. Browser console was clean.

Full exact-head report: [pr-evidence-5 artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22656-pr-22656-validation.txt).

The implementation follows the current [Web Speech API report](https://webaudio.github.io/web-speech-api/): an `end` event terminates every session and restarting an already-started recognizer is invalid, so restart/teardown must remain recognizer-local.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - this plugin module has no rendered product view; the before state is a live MediaStreamTrack and continuing level events, covered by the attached mutation/test evidence.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no rendered product view; exact-built Chromium reports the track state and event lifecycle in the attached artifact.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive rendered surface; the exact production bundle is exercised directly in Chromium.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - browser-side Capacitor WebPlugin only; no backend path changes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: [exact Chromium built-bundle report, including zero console warnings/errors](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22656-pr-22656-chromium.json).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, action, provider, or planner behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [mutation, tests, build, and standards report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22656-pr-22656-domain.txt).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered text or visual surface.`

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@578256176c813edb1440984edcf3cba7281fac6a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop-multi-agent","skill_revision":"elizaOS/eliza@578256176c813edb1440984edcf3cba7281fac6a:packages/skills/skills/contribute-to-eliza"} -->
