### PR TITLE
fix(plugin-google-workspace): bound Gmail search/subscription-scan pagination against empty-page loops

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `searchGmailMessages`/`getGmailSubscriptionHeaders` loop `while (results.length
+ * < limit)`, but that count only advances on a page with at least one mapped
+ * message — a page with an empty `messages` array and a distinct
+ * `nextPageToken` never grows it. Both must still terminate against a
+ * repeated or a never-repeating-but-never-stopping page token. Mirrors the
+ * equivalent Calendar pagination coverage in `calendar.pagination.test.ts`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import { GoogleGmailClient } from "./gmail.js";
+
+function clientFor(list: ReturnType<typeof vi.fn>): GoogleGmailClient {
+  const factory = {
+    gmail: vi.fn(async () => ({ users: { messages: { list } } })),
+  } as unknown as GoogleApiClientFactory;
+  return new GoogleGmailClient(factory);
+}
+
+describe("searchGmailMessages pagination", () => {
+  it("stops once the API stops returning a next cursor, even on empty pages", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "c1" } })
+      .mockResolvedValueOnce({ data: { messages: [] } });
+    const client = clientFor(list);
+
+    const result = await client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" });
+
+    expect(result).toEqual([]);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a cursor cycle instead of looping forever on empty pages", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "A" } })
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "B" } })
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "A" } });
+    const client = clientFor(list);
+
+    await expect(
+      client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" })
+    ).rejects.toMatchObject({ code: "GOOGLE_GMAIL_PAGINATION_LOOP" });
+    // Exactly 3 calls: the cycle back to "A" is caught on the page that
+    // returns it, not after further oscillation.
+    expect(list).toHaveBeenCalledTimes(3);
+  });
+
+  it("bounds pagination against a provider that mints a novel token on every empty page", async () => {
+    let page = 0;
+    const list = vi.fn(async () => {
+      page += 1;
+      return { data: { messages: [], nextPageToken: `token-${page}` } };
+    });
+    const client = clientFor(list);
+
+    await expect(
+      client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" })
+    ).rejects.toMatchObject({ code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" });
+    expect(list).toHaveBeenCalledTimes(1_000);
+  });
+});
+
+describe("getGmailSubscriptionHeaders pagination", () => {
+  it("stops once the API stops returning a next cursor, even on empty pages", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "c1" } })
+      .mockResolvedValueOnce({ data: { messages: [] } });
+    const client = clientFor(list);
+
+    const result = await client.getGmailSubscriptionHeaders({ accountId: "acct-1" });
+
+    expect(result).toEqual([]);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds pagination against a provider that mints a novel token on every empty page", async () => {
+    let page = 0;
+    const list = vi.fn(async () => {
+      page += 1;
+      return { data: { messages: [], nextPageToken: `token-${page}` } };
+    });
+    const client = clientFor(list);
+
+    await expect(client.getGmailSubscriptionHeaders({ accountId: "acct-1" })).rejects.toMatchObject(
+      { code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" }
+    );
+    expect(list).toHaveBeenCalledTimes(1_000);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
@@ -10,11 +10,25 @@ import { describe, expect, it, vi } from "vitest";
 import type { GoogleApiClientFactory } from "./client-factory.js";
 import { GoogleGmailClient } from "./gmail.js";
 
-function clientFor(list: ReturnType<typeof vi.fn>): GoogleGmailClient {
+function clientFor(
+  list: ReturnType<typeof vi.fn>,
+  get: ReturnType<typeof vi.fn> = vi.fn()
+): GoogleGmailClient {
   const factory = {
-    gmail: vi.fn(async () => ({ users: { messages: { list } } })),
+    gmail: vi.fn(async () => ({ users: { messages: { get, list } } })),
   } as unknown as GoogleApiClientFactory;
   return new GoogleGmailClient(factory);
+}
+
+function mappedMessage(id: string): { data: object } {
+  return {
+    data: {
+      id,
+      threadId: `thread-${id}`,
+      internalDate: "0",
+      payload: { headers: [] },
+    },
+  };
 }
 
 describe("searchGmailMessages pagination", () => {
@@ -47,6 +61,19 @@ describe("searchGmailMessages pagination", () => {
     expect(list).toHaveBeenCalledTimes(3);
   });
 
+  it("replays an opaque page token without rewriting it", async () => {
+    const opaqueToken = "  opaque-token  ";
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: opaqueToken } })
+      .mockResolvedValueOnce({ data: { messages: [] } });
+    const client = clientFor(list);
+
+    await client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" });
+
+    expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageToken: opaqueToken }));
+  });
+
   it("bounds pagination against a provider that mints a novel token on every empty page", async () => {
     let page = 0;
     const list = vi.fn(async () => {
@@ -58,6 +85,28 @@ describe("searchGmailMessages pagination", () => {
     await expect(
       client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" })
     ).rejects.toMatchObject({ code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" });
+    expect(list).toHaveBeenCalledTimes(1_000);
+  });
+
+  it("returns a satisfied result limit on the final allowed page", async () => {
+    let page = 0;
+    const list = vi.fn(async () => {
+      page += 1;
+      return {
+        data: {
+          messages: page === 1_000 ? [{ id: "last" }] : [],
+          nextPageToken: `token-${page}`,
+        },
+      };
+    });
+    const client = clientFor(
+      list,
+      vi.fn(async () => mappedMessage("last"))
+    );
+
+    await expect(
+      client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox", maxResults: 1 })
+    ).resolves.toMatchObject([{ externalId: "last" }]);
     expect(list).toHaveBeenCalledTimes(1_000);
   });
 });
@@ -87,6 +136,42 @@ describe("getGmailSubscriptionHeaders pagination", () => {
     await expect(client.getGmailSubscriptionHeaders({ accountId: "acct-1" })).rejects.toMatchObject(
       { code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" }
     );
+    expect(list).toHaveBeenCalledTimes(1_000);
+  });
+
+  it("rejects a cursor cycle instead of looping forever on empty pages", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "A" } })
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "B" } })
+      .mockResolvedValueOnce({ data: { messages: [], nextPageToken: "A" } });
+    const client = clientFor(list);
+
+    await expect(client.getGmailSubscriptionHeaders({ accountId: "acct-1" })).rejects.toMatchObject(
+      { code: "GOOGLE_GMAIL_PAGINATION_LOOP" }
+    );
+    expect(list).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns a satisfied result limit on the final allowed page", async () => {
+    let page = 0;
+    const list = vi.fn(async () => {
+      page += 1;
+      return {
+        data: {
+          messages: page === 1_000 ? [{ id: "last" }] : [],
+          nextPageToken: `token-${page}`,
+        },
+      };
+    });
+    const client = clientFor(
+      list,
+      vi.fn(async () => mappedMessage("last"))
+    );
+
+    await expect(
+      client.getGmailSubscriptionHeaders({ accountId: "acct-1", maxMessages: 1 })
+    ).resolves.toMatchObject([{ messageId: "last" }]);
     expect(list).toHaveBeenCalledTimes(1_000);
   });
 });

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -67,10 +67,12 @@ function nextGmailPageToken(
   resource: string
 ): string | undefined {
   state.pageCount += 1;
-  const token = value?.trim();
-  if (!token) {
+  if (!value?.trim()) {
     return undefined;
   }
+  // Google page tokens are opaque. Whitespace-only values are terminal, but
+  // a non-empty token must be replayed byte-for-byte rather than normalized.
+  const token = value;
   if (state.seenPageTokens.has(token)) {
     throw new ElizaError(`Gmail repeated a ${resource} page token.`, {
       code: "GOOGLE_GMAIL_PAGINATION_LOOP",
@@ -196,6 +198,9 @@ export class GoogleGmailClient {
         if (message) {
           messages.push(message);
         }
+      }
+      if (messages.length >= maxResults) {
+        break;
       }
       pageToken = nextGmailPageToken(response.data.nextPageToken, pagination, "message search");
       if (!pageToken) {
@@ -459,6 +464,9 @@ export class GoogleGmailClient {
         if (headers) {
           results.push(headers);
         }
+      }
+      if (results.length >= maxMessages) {
+        break;
       }
       pageToken = nextGmailPageToken(
         response.data.nextPageToken,

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -6,6 +6,7 @@
  * helpers. Maps Gmail API payloads into the plugin's `GoogleGmail*` DTOs. Each
  * method acquires a scoped googleapis client from `GoogleApiClientFactory`.
  */
+import { ElizaError } from "@elizaos/core";
 import type { gmail_v1 } from "googleapis";
 import type { GoogleApiClientFactory } from "./client-factory.js";
 import type {
@@ -44,6 +45,49 @@ const SUBSCRIPTION_SCAN_QUERY_DEFAULT =
 const GMAIL_LIST_PAGE_SIZE = 500;
 const GMAIL_METADATA_CONCURRENCY = 25;
 const MAX_GMAIL_RESULTS = 1000;
+const MAX_GMAIL_PAGES = 1_000;
+
+interface GmailPaginationState {
+  pageCount: number;
+  seenPageTokens: Set<string>;
+}
+
+function createGmailPaginationState(): GmailPaginationState {
+  return { pageCount: 0, seenPageTokens: new Set<string>() };
+}
+
+// Both searchGmailMessages and getGmailSubscriptionHeaders loop `while
+// (results.length < limit)`, but a page with zero mapped messages (e.g. every
+// message.id was blank, or the API returned an empty page with a distinct
+// nextPageToken) never grows that count. Without this guard, an API or proxy
+// that keeps minting novel page tokens on empty pages loops forever.
+function nextGmailPageToken(
+  value: string | null | undefined,
+  state: GmailPaginationState,
+  resource: string
+): string | undefined {
+  state.pageCount += 1;
+  const token = value?.trim();
+  if (!token) {
+    return undefined;
+  }
+  if (state.seenPageTokens.has(token)) {
+    throw new ElizaError(`Gmail repeated a ${resource} page token.`, {
+      code: "GOOGLE_GMAIL_PAGINATION_LOOP",
+      context: { resource },
+      severity: "fatal",
+    });
+  }
+  if (state.pageCount >= MAX_GMAIL_PAGES) {
+    throw new ElizaError(`Gmail ${resource} pagination exceeded ${MAX_GMAIL_PAGES} pages.`, {
+      code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED",
+      context: { maxPages: MAX_GMAIL_PAGES, resource },
+      severity: "fatal",
+    });
+  }
+  state.seenPageTokens.add(token);
+  return token;
+}
 
 export class GoogleGmailClient {
   constructor(private readonly clientFactory: GoogleApiClientFactory) {}
@@ -122,6 +166,7 @@ export class GoogleGmailClient {
     );
     const maxResults = normalizedLimit(params.maxResults, 20, MAX_GMAIL_RESULTS);
     const messages: GoogleGmailMessageSummary[] = [];
+    const pagination = createGmailPaginationState();
     let pageToken: string | undefined;
 
     while (messages.length < maxResults) {
@@ -152,11 +197,10 @@ export class GoogleGmailClient {
           messages.push(message);
         }
       }
-      const nextPageToken = response.data.nextPageToken?.trim();
-      if (!nextPageToken || nextPageToken === pageToken) {
+      pageToken = nextGmailPageToken(response.data.nextPageToken, pagination, "message search");
+      if (!pageToken) {
         break;
       }
-      pageToken = nextPageToken;
     }
 
     return sortGmailMessages(messages).slice(0, maxResults);
@@ -385,6 +429,7 @@ export class GoogleGmailClient {
     const query = params.query?.trim() || SUBSCRIPTION_SCAN_QUERY_DEFAULT;
     const maxMessages = normalizedLimit(params.maxMessages, 200, MAX_GMAIL_RESULTS);
     const results: GoogleGmailSubscriptionMessageHeaders[] = [];
+    const pagination = createGmailPaginationState();
     let pageToken: string | undefined;
 
     while (results.length < maxMessages) {
@@ -415,11 +460,14 @@ export class GoogleGmailClient {
           results.push(headers);
         }
       }
-      const nextPageToken = response.data.nextPageToken?.trim();
-      if (!nextPageToken || nextPageToken === pageToken) {
+      pageToken = nextGmailPageToken(
+        response.data.nextPageToken,
+        pagination,
+        "subscription header scan"
+      );
+      if (!pageToken) {
         break;
       }
-      pageToken = nextPageToken;
     }
 
     return results;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No existing issue — found directly in the code (checked GitHub issues/PRs for "gmail pagination", "searchGmailMessages", "getGmailSubscriptionHeaders" before starting; no collision, only unrelated hits). Third instance of the same bug class this session: #21445/#22612 (plugin-x retweeters) and #22631 (Calendar list pagination, same package) — the `meet.ts` precedent (`MAX_GOOGLE_MEET_PAGES`/`nextMeetPageToken`) that #22631 mirrored is reused again here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package-scoped verify commands run after sync (see Testing below); full-repo `bun run verify` not run — documented in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f53ee8e7a6f56302929f919cbd8cec91131caac5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Package-scoped verify passes post-sync — see Testing below. Full-repo `bun run verify` not run; documented in **Known gaps / failures**.

# Risks

Low. Single-package (`plugin-google-workspace`), one new private helper plus its two call sites, no public API/signature change (`GoogleGmailClient.searchGmailMessages`/`getGmailSubscriptionHeaders` keep their existing signatures and return types). Adds a page cap identical in shape and value to the `meet.ts`/`calendar.ts` precedent already in this package.

# Background

## What does this PR do?

`GoogleGmailClient.searchGmailMessages` and `getGmailSubscriptionHeaders` (`plugins/plugin-google-workspace/src/gmail.ts`) both loop `while (results.length < limit)`, fetching a page and appending any successfully-mapped messages. That count-based bound only advances when a page yields at least one non-null mapped message. A page that returns zero messages (every `message.id` was blank, or the Gmail API/a proxy in front of it returns an empty `messages` array) with a distinct `nextPageToken` never grows the count — and the only remaining termination check was `!nextPageToken || nextPageToken === pageToken`, immediate-previous-token equality only. A provider that keeps minting novel tokens on empty pages, or cycles through more than one token before repeating (A → B → A), loops forever: unbounded API calls, no termination.

Both methods are reachable from a public surface: `GoogleWorkspaceService` (`service.ts`) delegates directly to both, and `searchGmailMessages` is also called by the public `listGmailTriageMessages`.

This is the third instance of the same bug class fixed this session in this package. `meet.ts` already has the correct shape (`MAX_GOOGLE_MEET_PAGES`/`nextMeetPageToken`, merged precedent), and #22631 applied the identical fix to `calendar.ts`'s single shared `nextPageToken()` helper. Here the defect is duplicated across **two** call sites with no shared helper at all — the root-cause fix is one new `nextGmailPageToken()`/`GmailPaginationState` helper (`MAX_GMAIL_PAGES = 1_000`, full seen-token cycle detection via a `Set`, not just immediate-previous) that both `searchGmailMessages` and `getGmailSubscriptionHeaders` now call, rather than patching each loop's termination check separately. Throws `GOOGLE_GMAIL_PAGINATION_LOOP` on a repeated token and `GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED` once the cap is hit.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/gmail.pagination.test.ts` (new file) — five tests: normal termination on empty pages for both `searchGmailMessages` and `getGmailSubscriptionHeaders`, an A→B→A cycle throw for `searchGmailMessages` (the case an immediate-previous-only check misses), and a page-cap-exceeded throw for both methods against a provider that mints a unique token on every empty page. Mirrors the equivalent Calendar coverage in `calendar.pagination.test.ts` and the mocking convention already used in `gmail-header-injection.test.ts` (stub `GoogleApiClientFactory`, real `GoogleGmailClient`).

Before the fix, the two "bounds pagination ... on every empty page" tests reproduce the bug directly: run against the pre-fix loops (count-only bound, immediate-previous-token check), they hang. A throwaway repro test against `searchGmailMessages` on pre-fix code confirmed this independently (vitest's fork worker force-killed after ~14s, `[vitest-pool]: Timeout terminating forks worker`, identical failure signature to the `calendar.ts` repro from #22631). Against this PR's fix, both terminate cleanly at exactly 1,000 calls with the new typed error.

## Detailed testing steps

None: automated tests are acceptable.

```
$ bun run --cwd plugins/plugin-google-workspace test -- gmail.pagination
 RUN  v4.1.5 plugins/plugin-google-workspace
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ bunx @biomejs/biome check plugins/plugin-google-workspace/src/gmail.ts plugins/plugin-google-workspace/src/gmail.pagination.test.ts
Checked 2 files in 40ms. No fixes applied.

$ bun run --cwd plugins/plugin-google-workspace typecheck
$ tsc --noEmit
(clean, exit 0)

$ bun run --cwd plugins/plugin-google-workspace test
 Test Files  20 passed (20)
      Tests  194 passed (194)
```

All re-run and confirmed clean after a final rebase onto `origin/develop` at `f53ee8e7a6f56302929f919cbd8cec91131caac5`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:43beb8084e662b0287875e4fe5638ef9dde22b8e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/library-only change (Node googleapis client pagination logic), no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/library-only change, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is exercised by the automated test transcript above.
<!-- evidence-row:backend-logs -->
- [x] N/A - covered by the mocked-API test transcript above (exact call counts and thrown/returned values asserted per scenario), the deterministic equivalent of backend log evidence for a pure pagination-logic fix; no live Gmail OAuth credentials available in this environment to produce real request/response logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; this is a pagination-loop fix in the Gmail API client, unreachable from any LLM-facing action or evaluator.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, or generated files are produced by this code path; it returns an in-memory array of message/header records to its caller.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - see Testing section above; mocked-API test transcript is the applicable evidence for this pagination-logic fix.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- Full-repo `bun run verify` was not run (large monorepo-wide command); instead ran the package-scoped equivalents directly relevant to this diff: `plugin-google-workspace`'s full test suite (194/194 passing, no pre-existing failures), Biome check on both changed files, and its typecheck (after building `@elizaos/core`, a known local prerequisite for this package's typecheck/tests to resolve the workspace dependency). All passed clean, both before and after a final rebase onto latest `origin/develop`.
- No live Gmail OAuth credentials available in this environment; pagination behavior is verified against a mocked `googleapis` Gmail client, matching the existing test file conventions in this package (`gmail-header-injection.test.ts`, `calendar.pagination.test.ts`).

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@f53ee8e7a6f56302929f919cbd8cec91131caac5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mode-a]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@f53ee8e7a6f56302929f919cbd8cec91131caac5:packages/skills/skills/contribute-to-eliza"} -->


## Maintainer exact-head addendum

Current reviewed head: `43beb8084e662b0287875e4fe5638ef9dde22b8e`, rebased through `develop` `663176f21a9d`.

The original five-test implementation was expanded during review to nine focused cases. Exact-head coverage now includes both public Gmail scans for normal empty-page termination, A-B-A cycle rejection, unique-token ceiling rejection, opaque-token byte preservation, and successful result-bound completion on the final allowed page. Exact-head focused result: 9 passed, 0 failed, 17 assertions; Biome on both changed files and `git diff --check` passed. See the maintainer evidence comment for the official Gmail contract review and repair rationale.

Maintainer repair attribution: OpenAI / gpt-5.6-sol; Codex desktop / multi-agent; self-reported.