### PR TITLE
fix(cloud/gateways): bound Kubernetes EndpointSlice resolution with timeout

### DIFF
--- a/packages/cloud/services/gateway-discord/src/hash-router.ts
+++ b/packages/cloud/services/gateway-discord/src/hash-router.ts
@@ -7,6 +7,7 @@ import HashRing from "hashring";
 import { logger } from "./logger";
 
 const REFRESH_MS = 5_000;
+const ENDPOINT_SLICE_FETCH_TIMEOUT_MS = 10_000;
 
 interface RingState {
   ring: HashRing;
@@ -64,6 +65,7 @@ async function resolvePodIPs(
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
+      signal: AbortSignal.timeout(ENDPOINT_SLICE_FETCH_TIMEOUT_MS),
     } as RequestInit);
 
     if (!res.ok) return [];

--- a/packages/cloud/services/gateway-discord/src/hash-router.ts
+++ b/packages/cloud/services/gateway-discord/src/hash-router.ts
@@ -8,14 +8,17 @@ import { logger } from "./logger";
 
 const REFRESH_MS = 5_000;
 const ENDPOINT_SLICE_FETCH_TIMEOUT_MS = 10_000;
+const MAX_STALE_RING_MS = 30_000;
 
 interface RingState {
   ring: HashRing;
   podIPs: string[];
   lastRefresh: number;
+  lastAttempt: number;
 }
 
 const rings = new Map<string, RingState>();
+const refreshes = new Map<string, Promise<RingState | undefined>>();
 
 function parseServerUrl(serverUrl: string): {
   serviceName: string;
@@ -52,23 +55,24 @@ interface EndpointSliceList {
   }>;
 }
 
+type PodIPResolution = { ok: true; podIPs: string[] } | { ok: false };
+
 async function resolvePodIPs(
   serviceName: string,
   namespace: string,
-): Promise<string[]> {
+): Promise<PodIPResolution> {
   const apiUrl = `https://kubernetes.default.svc/apis/discovery.k8s.io/v1/namespaces/${namespace}/endpointslices?labelSelector=kubernetes.io/service-name=${serviceName}`;
 
-  const token = readServiceAccountToken();
-  if (!token) return [];
-
   try {
+    const token = readServiceAccountToken();
+    if (!token) return { ok: false };
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
       signal: AbortSignal.timeout(ENDPOINT_SLICE_FETCH_TIMEOUT_MS),
     } as RequestInit);
 
-    if (!res.ok) return [];
+    if (!res.ok) return { ok: false };
 
     const data = (await res.json()) as EndpointSliceList;
     const ips: string[] = [];
@@ -80,13 +84,15 @@ async function resolvePodIPs(
         }
       }
     }
-    return ips;
+    return { ok: true, podIPs: ips };
   } catch (err) {
+    // error-policy:J3 Kubernetes discovery failures remain distinct from an
+    // authoritative empty EndpointSlice response so callers can retain cache.
     logger.error("[hash-router] EndpointSlice resolution failed", {
       serviceName,
       error: err instanceof Error ? err.message : String(err),
     });
-    return [];
+    return { ok: false };
   }
 }
 
@@ -113,7 +119,9 @@ function updateRing(
   }
 
   if (existing && sameIPs(existing.podIPs, podIPs)) {
-    existing.lastRefresh = Date.now();
+    const now = Date.now();
+    existing.lastRefresh = now;
+    existing.lastAttempt = now;
     return existing;
   }
 
@@ -128,13 +136,73 @@ function updateRing(
     });
   }
 
+  const now = Date.now();
   const state: RingState = {
     ring: new HashRing(podIPs, "md5", { "max cache size": 1000 }),
     podIPs,
-    lastRefresh: Date.now(),
+    lastRefresh: now,
+    lastAttempt: now,
   };
   rings.set(serviceName, state);
   return state;
+}
+
+function retainUsableStaleRing(
+  serviceName: string,
+  existing: RingState | undefined,
+): RingState | undefined {
+  if (!existing) return undefined;
+  const staleForMs = Date.now() - existing.lastRefresh;
+  if (staleForMs <= MAX_STALE_RING_MS) {
+    return existing;
+  }
+  logger.warn("[hash-router] Discovery failed, dropping stale ring", {
+    serviceName,
+    staleForMs,
+  });
+  rings.delete(serviceName);
+  return undefined;
+}
+
+function refreshRing(
+  serviceName: string,
+  namespace: string,
+): Promise<RingState | undefined> {
+  const refreshKey = `${namespace}/${serviceName}`;
+  const inFlight = refreshes.get(refreshKey);
+  if (inFlight) return inFlight;
+
+  const current = rings.get(serviceName);
+  if (current) current.lastAttempt = Date.now();
+
+  let refresh!: Promise<RingState | undefined>;
+  refresh = (async () => {
+    try {
+      const resolution = await resolvePodIPs(serviceName, namespace);
+      return resolution.ok
+        ? updateRing(serviceName, resolution.podIPs, rings.get(serviceName))
+        : retainUsableStaleRing(serviceName, rings.get(serviceName));
+    } finally {
+      if (refreshes.get(refreshKey) === refresh) {
+        refreshes.delete(refreshKey);
+      }
+    }
+  })();
+  refreshes.set(refreshKey, refresh);
+  return refresh;
+}
+
+function observeRefresh(
+  promise: Promise<RingState | undefined>,
+  serviceName: string,
+): void {
+  // error-policy:J5 The background stale-ring refresh is observed here.
+  void promise.catch((err) => {
+    logger.error("[hash-router] Background refresh failed", {
+      serviceName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 export async function getHashTargets(
@@ -152,9 +220,10 @@ export async function getHashTargets(
   let entry = rings.get(serviceName);
   const now = Date.now();
 
-  if (!entry || now - entry.lastRefresh > REFRESH_MS) {
-    const podIPs = await resolvePodIPs(serviceName, namespace);
-    entry = updateRing(serviceName, podIPs, entry);
+  if (!entry || now - entry.lastRefresh > MAX_STALE_RING_MS) {
+    entry = await refreshRing(serviceName, namespace);
+  } else if (now - entry.lastAttempt > REFRESH_MS) {
+    observeRefresh(refreshRing(serviceName, namespace), serviceName);
   }
 
   if (!entry) return [];
@@ -169,6 +238,5 @@ export async function refreshHashRing(serverUrl: string): Promise<void> {
   }
 
   const { serviceName, namespace } = parseServerUrl(serverUrl);
-  const podIPs = await resolvePodIPs(serviceName, namespace);
-  updateRing(serviceName, podIPs, rings.get(serviceName));
+  await refreshRing(serviceName, namespace);
 }

--- a/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
@@ -1,8 +1,13 @@
 // Exercises the gateway-discord hash router path with deterministic cloud service fixtures.
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as common from "@elizaos/cloud-services-common";
 import { getHashTargets, refreshHashRing } from "../src/hash-router";
 
 describe("hash-router direct targets", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
   test("uses non-Kubernetes service URLs directly", async () => {
     await expect(
       getHashTargets("http://agent-server.railway.internal:3000", "user-1", 2),
@@ -19,5 +24,58 @@ describe("hash-router direct targets", () => {
     await expect(
       refreshHashRing("https://agent-server.up.railway.app"),
     ).resolves.toBeUndefined();
+  });
+
+  test("resolves Kubernetes EndpointSlice with timeout signal", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedInit = init;
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                endpoints: [
+                  {
+                    addresses: ["10.0.0.1", "10.0.0.2"],
+                    conditions: { ready: true },
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      },
+    ) as unknown as typeof fetch;
+
+    const targets = await getHashTargets(
+      "http://agent-server.eliza-agents.svc.cluster.local:3000",
+      "user-1",
+      2,
+    );
+
+    expect(targets.length).toBe(2);
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("handles EndpointSlice fetch timeout or failure safely without throwing", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+
+    globalThis.fetch = mock(async () => {
+      throw new Error("EndpointSlice fetch timed out");
+    }) as unknown as typeof fetch;
+
+    const targets = await getHashTargets(
+      "http://failed-server.eliza-agents.svc.cluster.local:3000",
+      "user-1",
+      2,
+    );
+
+    expect(targets).toEqual([]);
   });
 });

--- a/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
@@ -1,9 +1,27 @@
-// Exercises the gateway-discord hash router path with deterministic cloud service fixtures.
+/** Exercises direct and Kubernetes-backed Discord gateway hash routing with deterministic fetch boundaries. */
+
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as common from "@elizaos/cloud-services-common";
 import { getHashTargets, refreshHashRing } from "../src/hash-router";
 
-describe("hash-router direct targets", () => {
+function endpointSliceResponse(addresses: string[]): Response {
+  return Response.json({
+    items: addresses.length
+      ? [
+          {
+            endpoints: [
+              {
+                addresses,
+                conditions: { ready: true },
+              },
+            ],
+          },
+        ]
+      : [],
+  });
+}
+
+describe("hash router", () => {
   afterEach(() => {
     mock.restore();
   });
@@ -26,56 +44,166 @@ describe("hash-router direct targets", () => {
     ).resolves.toBeUndefined();
   });
 
-  test("resolves Kubernetes EndpointSlice with timeout signal", async () => {
+  test("uses the exact EndpointSlice timeout signal", async () => {
     spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
     spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
-
+    const timeoutSignal = new AbortController().signal;
+    const timeoutSpy = spyOn(AbortSignal, "timeout").mockReturnValue(
+      timeoutSignal,
+    );
     let capturedInit: RequestInit | undefined;
-    globalThis.fetch = mock(
+    spyOn(globalThis, "fetch").mockImplementation(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
         capturedInit = init;
-        return new Response(
-          JSON.stringify({
-            items: [
-              {
-                endpoints: [
-                  {
-                    addresses: ["10.0.0.1", "10.0.0.2"],
-                    conditions: { ready: true },
-                  },
-                ],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
+        return endpointSliceResponse(["10.0.0.1", "10.0.0.2"]);
       },
-    ) as unknown as typeof fetch;
+    );
 
     const targets = await getHashTargets(
-      "http://agent-server.eliza-agents.svc.cluster.local:3000",
+      "http://timeout-signal.eliza-agents.svc.cluster.local:3000",
       "user-1",
       2,
     );
 
     expect(targets.length).toBe(2);
-    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(capturedInit?.signal).toBe(timeoutSignal);
   });
 
-  test("handles EndpointSlice fetch timeout or failure safely without throwing", async () => {
+  test("handles an aborted EndpointSlice fetch without throwing", async () => {
     spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
     spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    spyOn(AbortSignal, "timeout").mockReturnValue(
+      AbortSignal.abort(new DOMException("timed out", "TimeoutError")),
+    );
+    spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return endpointSliceResponse(["10.0.0.1"]);
+    });
 
-    globalThis.fetch = mock(async () => {
-      throw new Error("EndpointSlice fetch timed out");
-    }) as unknown as typeof fetch;
+    await expect(
+      getHashTargets(
+        "http://aborted-server.eliza-agents.svc.cluster.local:3000",
+        "user-1",
+        2,
+      ),
+    ).resolves.toEqual([]);
+  });
 
-    const targets = await getHashTargets(
-      "http://failed-server.eliza-agents.svc.cluster.local:3000",
-      "user-1",
-      2,
+  test("retains the last known-good ring on discovery failure", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1", "10.0.0.2"]),
+    );
+    const serverUrl =
+      "http://retained-server.eliza-agents.svc.cluster.local:3000";
+
+    const before = await getHashTargets(serverUrl, "user-1", 2);
+    fetchSpy.mockRejectedValue(new Error("control plane unavailable"));
+    await refreshHashRing(serverUrl);
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual(
+      before,
+    );
+  });
+
+  test("coalesces concurrent stale-ring refreshes without delaying callers", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(2_000_000);
+    let releaseRefresh: (() => void) | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let fetchCalls = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCalls++;
+      if (fetchCalls > 1) await refreshGate;
+      return endpointSliceResponse(["10.0.0.1"]);
+    });
+    const serverUrl =
+      "http://concurrent-stale.eliza-agents.svc.cluster.local:3000";
+    await getHashTargets(serverUrl, "seed", 1);
+    nowSpy.mockReturnValue(2_006_000);
+
+    const results = await Promise.all(
+      Array.from({ length: 25 }, (_, index) =>
+        getHashTargets(serverUrl, `user-${index}`, 1),
+      ),
     );
 
-    expect(targets).toEqual([]);
+    expect(results.every((targets) => targets.length === 1)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    releaseRefresh?.();
+    await refreshHashRing(serverUrl);
+  });
+
+  test("coalesces expired-ring refreshes and fails closed", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(3_000_000);
+    let releaseRefresh: (() => void) | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let fetchCalls = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) return endpointSliceResponse(["10.0.0.1"]);
+      await refreshGate;
+      throw new Error("control plane unavailable");
+    });
+    const serverUrl =
+      "http://concurrent-expired.eliza-agents.svc.cluster.local:3000";
+    await getHashTargets(serverUrl, "seed", 1);
+    nowSpy.mockReturnValue(3_030_001);
+
+    const pending = Promise.all(
+      Array.from({ length: 25 }, (_, index) =>
+        getHashTargets(serverUrl, `user-${index}`, 1),
+      ),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    releaseRefresh?.();
+
+    const results = await pending;
+    expect(results.every((targets) => targets.length === 0)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("drops a stale ring after prolonged discovery failure", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(1_000_000);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1"]),
+    );
+    const serverUrl = "http://stale-server.eliza-agents.svc.cluster.local:3000";
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toHaveLength(
+      1,
+    );
+    nowSpy.mockReturnValue(1_030_001);
+    fetchSpy.mockRejectedValue(new Error("control plane unavailable"));
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual([]);
+  });
+
+  test("clears the ring after an authoritative empty response", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1"]),
+    );
+    const serverUrl = "http://empty-server.eliza-agents.svc.cluster.local:3000";
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toHaveLength(
+      1,
+    );
+    fetchSpy.mockImplementation(async () => endpointSliceResponse([]));
+    await refreshHashRing(serverUrl);
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual([]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/__tests__/hash-router.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/hash-router.test.ts
@@ -1,8 +1,13 @@
 // Exercises the gateway-webhook hash router path with deterministic cloud service fixtures.
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as common from "@elizaos/cloud-services-common";
 import { getHashTargets, refreshHashRing } from "../src/hash-router";
 
 describe("hash-router direct targets", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
   test("uses non-Kubernetes service URLs directly", async () => {
     await expect(
       getHashTargets("http://agent-server.railway.internal:3000", "user-1", 2),
@@ -19,5 +24,58 @@ describe("hash-router direct targets", () => {
     await expect(
       refreshHashRing("https://agent-server.up.railway.app"),
     ).resolves.toBeUndefined();
+  });
+
+  test("resolves Kubernetes EndpointSlice with timeout signal", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedInit = init;
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                endpoints: [
+                  {
+                    addresses: ["10.0.0.1", "10.0.0.2"],
+                    conditions: { ready: true },
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      },
+    ) as unknown as typeof fetch;
+
+    const targets = await getHashTargets(
+      "http://agent-server.eliza-agents.svc.cluster.local:3000",
+      "user-1",
+      2,
+    );
+
+    expect(targets.length).toBe(2);
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("handles EndpointSlice fetch timeout or failure safely without throwing", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+
+    globalThis.fetch = mock(async () => {
+      throw new Error("EndpointSlice fetch timed out");
+    }) as unknown as typeof fetch;
+
+    const targets = await getHashTargets(
+      "http://failed-server.eliza-agents.svc.cluster.local:3000",
+      "user-1",
+      2,
+    );
+
+    expect(targets).toEqual([]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/__tests__/hash-router.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/hash-router.test.ts
@@ -1,9 +1,27 @@
-// Exercises the gateway-webhook hash router path with deterministic cloud service fixtures.
+/** Exercises direct and Kubernetes-backed webhook gateway hash routing with deterministic fetch boundaries. */
+
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as common from "@elizaos/cloud-services-common";
 import { getHashTargets, refreshHashRing } from "../src/hash-router";
 
-describe("hash-router direct targets", () => {
+function endpointSliceResponse(addresses: string[]): Response {
+  return Response.json({
+    items: addresses.length
+      ? [
+          {
+            endpoints: [
+              {
+                addresses,
+                conditions: { ready: true },
+              },
+            ],
+          },
+        ]
+      : [],
+  });
+}
+
+describe("hash router", () => {
   afterEach(() => {
     mock.restore();
   });
@@ -26,56 +44,166 @@ describe("hash-router direct targets", () => {
     ).resolves.toBeUndefined();
   });
 
-  test("resolves Kubernetes EndpointSlice with timeout signal", async () => {
+  test("uses the exact EndpointSlice timeout signal", async () => {
     spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
     spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
-
+    const timeoutSignal = new AbortController().signal;
+    const timeoutSpy = spyOn(AbortSignal, "timeout").mockReturnValue(
+      timeoutSignal,
+    );
     let capturedInit: RequestInit | undefined;
-    globalThis.fetch = mock(
+    spyOn(globalThis, "fetch").mockImplementation(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
         capturedInit = init;
-        return new Response(
-          JSON.stringify({
-            items: [
-              {
-                endpoints: [
-                  {
-                    addresses: ["10.0.0.1", "10.0.0.2"],
-                    conditions: { ready: true },
-                  },
-                ],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
+        return endpointSliceResponse(["10.0.0.1", "10.0.0.2"]);
       },
-    ) as unknown as typeof fetch;
+    );
 
     const targets = await getHashTargets(
-      "http://agent-server.eliza-agents.svc.cluster.local:3000",
+      "http://timeout-signal.eliza-agents.svc.cluster.local:3000",
       "user-1",
       2,
     );
 
     expect(targets.length).toBe(2);
-    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(capturedInit?.signal).toBe(timeoutSignal);
   });
 
-  test("handles EndpointSlice fetch timeout or failure safely without throwing", async () => {
+  test("handles an aborted EndpointSlice fetch without throwing", async () => {
     spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
     spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    spyOn(AbortSignal, "timeout").mockReturnValue(
+      AbortSignal.abort(new DOMException("timed out", "TimeoutError")),
+    );
+    spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return endpointSliceResponse(["10.0.0.1"]);
+    });
 
-    globalThis.fetch = mock(async () => {
-      throw new Error("EndpointSlice fetch timed out");
-    }) as unknown as typeof fetch;
+    await expect(
+      getHashTargets(
+        "http://aborted-server.eliza-agents.svc.cluster.local:3000",
+        "user-1",
+        2,
+      ),
+    ).resolves.toEqual([]);
+  });
 
-    const targets = await getHashTargets(
-      "http://failed-server.eliza-agents.svc.cluster.local:3000",
-      "user-1",
-      2,
+  test("retains the last known-good ring on discovery failure", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1", "10.0.0.2"]),
+    );
+    const serverUrl =
+      "http://retained-server.eliza-agents.svc.cluster.local:3000";
+
+    const before = await getHashTargets(serverUrl, "user-1", 2);
+    fetchSpy.mockRejectedValue(new Error("control plane unavailable"));
+    await refreshHashRing(serverUrl);
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual(
+      before,
+    );
+  });
+
+  test("coalesces concurrent stale-ring refreshes without delaying callers", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(2_000_000);
+    let releaseRefresh: (() => void) | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let fetchCalls = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCalls++;
+      if (fetchCalls > 1) await refreshGate;
+      return endpointSliceResponse(["10.0.0.1"]);
+    });
+    const serverUrl =
+      "http://concurrent-stale.eliza-agents.svc.cluster.local:3000";
+    await getHashTargets(serverUrl, "seed", 1);
+    nowSpy.mockReturnValue(2_006_000);
+
+    const results = await Promise.all(
+      Array.from({ length: 25 }, (_, index) =>
+        getHashTargets(serverUrl, `user-${index}`, 1),
+      ),
     );
 
-    expect(targets).toEqual([]);
+    expect(results.every((targets) => targets.length === 1)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    releaseRefresh?.();
+    await refreshHashRing(serverUrl);
+  });
+
+  test("coalesces expired-ring refreshes and fails closed", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(3_000_000);
+    let releaseRefresh: (() => void) | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let fetchCalls = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) return endpointSliceResponse(["10.0.0.1"]);
+      await refreshGate;
+      throw new Error("control plane unavailable");
+    });
+    const serverUrl =
+      "http://concurrent-expired.eliza-agents.svc.cluster.local:3000";
+    await getHashTargets(serverUrl, "seed", 1);
+    nowSpy.mockReturnValue(3_030_001);
+
+    const pending = Promise.all(
+      Array.from({ length: 25 }, (_, index) =>
+        getHashTargets(serverUrl, `user-${index}`, 1),
+      ),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    releaseRefresh?.();
+
+    const results = await pending;
+    expect(results.every((targets) => targets.length === 0)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("drops a stale ring after prolonged discovery failure", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const nowSpy = spyOn(Date, "now").mockReturnValue(1_000_000);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1"]),
+    );
+    const serverUrl = "http://stale-server.eliza-agents.svc.cluster.local:3000";
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toHaveLength(
+      1,
+    );
+    nowSpy.mockReturnValue(1_030_001);
+    fetchSpy.mockRejectedValue(new Error("control plane unavailable"));
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual([]);
+  });
+
+  test("clears the ring after an authoritative empty response", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      endpointSliceResponse(["10.0.0.1"]),
+    );
+    const serverUrl = "http://empty-server.eliza-agents.svc.cluster.local:3000";
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toHaveLength(
+      1,
+    );
+    fetchSpy.mockImplementation(async () => endpointSliceResponse([]));
+    await refreshHashRing(serverUrl);
+
+    await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual([]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/hash-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/hash-router.ts
@@ -7,6 +7,7 @@ import HashRing from "hashring";
 import { logger } from "./logger";
 
 const REFRESH_MS = 5_000;
+const ENDPOINT_SLICE_FETCH_TIMEOUT_MS = 10_000;
 
 interface RingState {
   ring: HashRing;
@@ -64,6 +65,7 @@ async function resolvePodIPs(
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
+      signal: AbortSignal.timeout(ENDPOINT_SLICE_FETCH_TIMEOUT_MS),
     } as RequestInit);
 
     if (!res.ok) return [];

--- a/packages/cloud/services/gateway-webhook/src/hash-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/hash-router.ts
@@ -8,14 +8,17 @@ import { logger } from "./logger";
 
 const REFRESH_MS = 5_000;
 const ENDPOINT_SLICE_FETCH_TIMEOUT_MS = 10_000;
+const MAX_STALE_RING_MS = 30_000;
 
 interface RingState {
   ring: HashRing;
   podIPs: string[];
   lastRefresh: number;
+  lastAttempt: number;
 }
 
 const rings = new Map<string, RingState>();
+const refreshes = new Map<string, Promise<RingState | undefined>>();
 
 function parseServerUrl(serverUrl: string): {
   serviceName: string;
@@ -52,23 +55,24 @@ interface EndpointSliceList {
   }>;
 }
 
+type PodIPResolution = { ok: true; podIPs: string[] } | { ok: false };
+
 async function resolvePodIPs(
   serviceName: string,
   namespace: string,
-): Promise<string[]> {
+): Promise<PodIPResolution> {
   const apiUrl = `https://kubernetes.default.svc/apis/discovery.k8s.io/v1/namespaces/${namespace}/endpointslices?labelSelector=kubernetes.io/service-name=${serviceName}`;
 
-  const token = readServiceAccountToken();
-  if (!token) return [];
-
   try {
+    const token = readServiceAccountToken();
+    if (!token) return { ok: false };
     const res = await fetch(apiUrl, {
       headers: { Authorization: `Bearer ${token}` },
       tls: { ca: readServiceAccountCaCert() ?? undefined },
       signal: AbortSignal.timeout(ENDPOINT_SLICE_FETCH_TIMEOUT_MS),
     } as RequestInit);
 
-    if (!res.ok) return [];
+    if (!res.ok) return { ok: false };
 
     const data = (await res.json()) as EndpointSliceList;
     const ips: string[] = [];
@@ -80,14 +84,16 @@ async function resolvePodIPs(
         }
       }
     }
-    return ips;
+    return { ok: true, podIPs: ips };
   } catch (err) {
+    // error-policy:J3 Kubernetes discovery failures remain distinct from an
+    // authoritative empty EndpointSlice response so callers can retain cache.
     logger.debug("EndpointSlice resolution failed", {
       serviceName,
       namespace,
       error: err instanceof Error ? err.message : String(err),
     });
-    return [];
+    return { ok: false };
   }
 }
 
@@ -112,7 +118,9 @@ function updateRing(
   }
 
   if (existing && sameIPs(existing.podIPs, podIPs)) {
-    existing.lastRefresh = Date.now();
+    const now = Date.now();
+    existing.lastRefresh = now;
+    existing.lastAttempt = now;
     return existing;
   }
 
@@ -127,13 +135,73 @@ function updateRing(
     });
   }
 
+  const now = Date.now();
   const state: RingState = {
     ring: new HashRing(podIPs, "md5", { "max cache size": 1000 }),
     podIPs,
-    lastRefresh: Date.now(),
+    lastRefresh: now,
+    lastAttempt: now,
   };
   rings.set(serviceName, state);
   return state;
+}
+
+function retainUsableStaleRing(
+  serviceName: string,
+  existing: RingState | undefined,
+): RingState | undefined {
+  if (!existing) return undefined;
+  const staleForMs = Date.now() - existing.lastRefresh;
+  if (staleForMs <= MAX_STALE_RING_MS) {
+    return existing;
+  }
+  logger.warn("Discovery failed, dropping stale hash ring", {
+    serviceName,
+    staleForMs,
+  });
+  rings.delete(serviceName);
+  return undefined;
+}
+
+function refreshRing(
+  serviceName: string,
+  namespace: string,
+): Promise<RingState | undefined> {
+  const refreshKey = `${namespace}/${serviceName}`;
+  const inFlight = refreshes.get(refreshKey);
+  if (inFlight) return inFlight;
+
+  const current = rings.get(serviceName);
+  if (current) current.lastAttempt = Date.now();
+
+  let refresh!: Promise<RingState | undefined>;
+  refresh = (async () => {
+    try {
+      const resolution = await resolvePodIPs(serviceName, namespace);
+      return resolution.ok
+        ? updateRing(serviceName, resolution.podIPs, rings.get(serviceName))
+        : retainUsableStaleRing(serviceName, rings.get(serviceName));
+    } finally {
+      if (refreshes.get(refreshKey) === refresh) {
+        refreshes.delete(refreshKey);
+      }
+    }
+  })();
+  refreshes.set(refreshKey, refresh);
+  return refresh;
+}
+
+function observeRefresh(
+  promise: Promise<RingState | undefined>,
+  serviceName: string,
+): void {
+  // error-policy:J5 The background stale-ring refresh is observed here.
+  void promise.catch((err) => {
+    logger.error("Background hash-ring refresh failed", {
+      serviceName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 export async function getHashTargets(
@@ -151,9 +219,10 @@ export async function getHashTargets(
   let entry = rings.get(serviceName);
   const now = Date.now();
 
-  if (!entry || now - entry.lastRefresh > REFRESH_MS) {
-    const podIPs = await resolvePodIPs(serviceName, namespace);
-    entry = updateRing(serviceName, podIPs, entry);
+  if (!entry || now - entry.lastRefresh > MAX_STALE_RING_MS) {
+    entry = await refreshRing(serviceName, namespace);
+  } else if (now - entry.lastAttempt > REFRESH_MS) {
+    observeRefresh(refreshRing(serviceName, namespace), serviceName);
   }
 
   if (!entry) return [];
@@ -168,6 +237,5 @@ export async function refreshHashRing(serverUrl: string): Promise<void> {
   }
 
   const { serviceName, namespace } = parseServerUrl(serverUrl);
-  const podIPs = await resolvePodIPs(serviceName, namespace);
-  updateRing(serviceName, podIPs, rings.get(serviceName));
+  await refreshRing(serviceName, namespace);
 }


### PR DESCRIPTION
## Summary

Bounds and coalesces Kubernetes EndpointSlice discovery in both cloud gateway hash routers so a stalled control plane cannot wedge or amplify message routing.

- Applies a 10-second `AbortSignal.timeout` to EndpointSlice fetches in `gateway-discord` and `gateway-webhook`.
- Coalesces each namespace/service refresh into one in-flight request and throttles repeated attempts.
- Serves a recent ring immediately while one background refresh runs, so concurrent messages do not wait on the Kubernetes API.
- Distinguishes discovery failure from a successful empty EndpointSlice list.
- After a bounded 30-second grace, callers await the same coalesced refresh and fail closed; expired pod IPs cannot route to recycled addresses.
- A successful empty response clears the ring immediately.

## Review research

- Bun documents `AbortSignal.timeout(...)` as its supported fetch timeout mechanism: https://bun.sh/docs/runtime/networking/fetch
- Kubernetes documents that EndpointSlices are namespaced and selected by the `kubernetes.io/service-name` label, and that absent `ready` / `terminating` conditions mean ready / not terminating: https://kubernetes.io/docs/reference/kubernetes-api/discovery/endpoint-slice-v1/

## Verification

Evidence head: `ff6dfb41bb9be423ee291d862ff638a1e6c048e2`

- `bun run --cwd packages/cloud/services/gateway-discord test`: 142 passed, 0 failed
- `bun run --cwd packages/cloud/services/gateway-discord typecheck`: passed
- `bun run --cwd packages/cloud/services/gateway-discord build`: passed; 747 modules bundled
- `bun run --cwd packages/cloud/services/gateway-discord lint:check`: 41 files clean
- `bun run --cwd packages/cloud/services/gateway-webhook test`: 179 passed, 0 failed
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck`: passed
- `bun run --cwd packages/cloud/services/gateway-webhook build`: passed; 197 modules bundled
- `bun run --cwd packages/cloud/services/gateway-webhook lint:check`: 46 files clean
- `git diff --check origin/develop...HEAD`: passed
- Both focused suites prove 25 concurrent stale-ring callers return immediately behind one background fetch, and 25 expired-ring callers await one fetch then fail closed.
- Bun 1.3.14 real-runtime receipt: a local HTTP handler delayed for 1 second; `fetch` with `AbortSignal.timeout(50)` rejected with `DOMException: TimeoutError` after 54 ms.

## Evidence matrix

- Desktop/mobile screenshots and video: N/A — backend-only Kubernetes discovery code; no UI or rendered surface changes.
- Native/device evidence: N/A — no native or device path is touched.
- Live Kubernetes capture: N/A — the review environment has no production cluster service-account capability and deployment is outside this PR's authorization. The production boundary is exercised with real `AbortSignal` objects and deterministic concurrency gates, and both complete gateway suites pass.
- Security: the service-account bearer token remains request-header-only and is never logged; failure logs contain service identity, stale duration, and sanitized error text only.