### PR TITLE
fix(cloud-shared): bound managed Google Calendar feed pagination and accumulation

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
@@ -1,12 +1,7 @@
-// fetchManagedGoogleCalendarFeed drains pages with `do { ... } while
-// (pageToken)`. Before this fix that loop had no termination guard beyond the
-// token going empty -- a Google response (or misbehaving proxy) that repeats
-// or never stops minting a nextPageToken looped forever. Pins: normal
-// termination is unaffected, a repeated token throws instead of looping, and
-// a provider that never repeats but never stops still terminates at the page
-// cap. Deterministic: the real exported function runs through the real
-// googleFetch fail-closed wrapper, with the OAuth token layer stubbed and
-// global fetch mocked, mirroring calendar.error-policy.test.ts.
+/**
+ * Exercises the real managed Calendar feed through its authenticated fetch
+ * boundary, including token cycles and independent request/event ceilings.
+ */
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { logger } from "../../utils/logger";
 import { fetchManagedGoogleCalendarFeed } from "./calendar";
@@ -26,13 +21,23 @@ const savedFetch = globalThis.fetch;
 const savedGetToken =
   managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId;
 
-function installFetchSequence(handler: (callIndex: number) => Response | Promise<Response>) {
+function installFetchSequence(
+  handler: (callIndex: number, input: Parameters<typeof fetch>[0]) => Response | Promise<Response>,
+) {
   let callIndex = 0;
-  globalThis.fetch = mock(async () => handler(callIndex++)) as typeof fetch;
+  globalThis.fetch = mock(async (input) => handler(callIndex++, input)) as typeof fetch;
 }
 
-function page(nextPageToken?: string): Response {
-  return new Response(JSON.stringify({ items: [], ...(nextPageToken ? { nextPageToken } : {}) }), {
+function calendarEvent(index: number) {
+  return {
+    id: `event-${index}`,
+    start: { dateTime: "2026-01-01T10:00:00.000Z" },
+    end: { dateTime: "2026-01-01T11:00:00.000Z" },
+  };
+}
+
+function page(nextPageToken?: string, items: unknown[] = []): Response {
+  return new Response(JSON.stringify({ items, ...(nextPageToken ? { nextPageToken } : {}) }), {
     status: 200,
   });
 }
@@ -54,10 +59,16 @@ afterEach(() => {
 
 describe("fetchManagedGoogleCalendarFeed pagination", () => {
   test("drains pages until the API stops returning a next cursor", async () => {
-    installFetchSequence((i) => (i === 0 ? page("c1") : page()));
+    const requestedUrls: string[] = [];
+    installFetchSequence((i, input) => {
+      requestedUrls.push(String(input));
+      return i === 0 ? page("c1") : page();
+    });
     const result = await fetchManagedGoogleCalendarFeed(FEED_ARGS);
     expect(result.events).toEqual([]);
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(new URL(requestedUrls[0]).searchParams.has("pageToken")).toBe(false);
+    expect(new URL(requestedUrls[1]).searchParams.get("pageToken")).toBe("c1");
   });
 
   test("rejects a repeated page token instead of looping forever", async () => {
@@ -79,5 +90,30 @@ describe("fetchManagedGoogleCalendarFeed pagination", () => {
       AgentGoogleConnectorError,
     );
     expect(globalThis.fetch).toHaveBeenCalledTimes(1_000);
+  });
+
+  test("allows the exact terminal page ceiling", async () => {
+    installFetchSequence((i) => (i === 999 ? page() : page(`token-${i + 1}`)));
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).resolves.toMatchObject({
+      events: [],
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1_000);
+  });
+
+  test("allows exactly 10,000 normalized events", async () => {
+    const items = Array.from({ length: 2_500 }, (_, index) => calendarEvent(index));
+    installFetchSequence((i) => page(i === 3 ? undefined : `token-${i + 1}`, items));
+    const result = await fetchManagedGoogleCalendarFeed(FEED_ARGS);
+    expect(result.events).toHaveLength(10_000);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  test("rejects an event page before appending beyond the Worker response ceiling", async () => {
+    const items = Array.from({ length: 10_001 }, (_, index) => calendarEvent(index));
+    installFetchSequence(() => page(undefined, items));
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toThrow(
+      "Google Calendar feed exceeded 10000 events",
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
@@ -1,0 +1,83 @@
+// fetchManagedGoogleCalendarFeed drains pages with `do { ... } while
+// (pageToken)`. Before this fix that loop had no termination guard beyond the
+// token going empty -- a Google response (or misbehaving proxy) that repeats
+// or never stops minting a nextPageToken looped forever. Pins: normal
+// termination is unaffected, a repeated token throws instead of looping, and
+// a provider that never repeats but never stops still terminates at the page
+// cap. Deterministic: the real exported function runs through the real
+// googleFetch fail-closed wrapper, with the OAuth token layer stubbed and
+// global fetch mocked, mirroring calendar.error-policy.test.ts.
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "../../utils/logger";
+import { fetchManagedGoogleCalendarFeed } from "./calendar";
+import { AgentGoogleConnectorError, managedGoogleConnectorDeps } from "./shared";
+
+const FEED_ARGS = {
+  organizationId: "org-1",
+  userId: "user-1",
+  side: "owner" as const,
+  calendarId: "primary",
+  timeMin: "2026-01-01T00:00:00.000Z",
+  timeMax: "2026-02-01T00:00:00.000Z",
+  timeZone: "UTC",
+};
+
+const savedFetch = globalThis.fetch;
+const savedGetToken =
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId;
+
+function installFetchSequence(handler: (callIndex: number) => Response | Promise<Response>) {
+  let callIndex = 0;
+  globalThis.fetch = mock(async () => handler(callIndex++)) as typeof fetch;
+}
+
+function page(nextPageToken?: string): Response {
+  return new Response(JSON.stringify({ items: [], ...(nextPageToken ? { nextPageToken } : {}) }), {
+    status: 200,
+  });
+}
+
+beforeEach(() => {
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId = (async () => ({
+    token: { accessToken: "test-token" },
+    connectionId: "conn-1",
+  })) as typeof savedGetToken;
+  spyOn(logger, "error").mockImplementation(() => {});
+  spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId = savedGetToken;
+  mock.restore();
+});
+
+describe("fetchManagedGoogleCalendarFeed pagination", () => {
+  test("drains pages until the API stops returning a next cursor", async () => {
+    installFetchSequence((i) => (i === 0 ? page("c1") : page()));
+    const result = await fetchManagedGoogleCalendarFeed(FEED_ARGS);
+    expect(result.events).toEqual([]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects a repeated page token instead of looping forever", async () => {
+    installFetchSequence(() => page("stuck"));
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toBeInstanceOf(
+      AgentGoogleConnectorError,
+    );
+    // Stopped after the repeat was detected on the second page, not a third.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("bounds pagination against a provider that never repeats but never stops", async () => {
+    let callCount = 0;
+    installFetchSequence(() => {
+      callCount += 1;
+      return page(`token-${callCount}`);
+    });
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toBeInstanceOf(
+      AgentGoogleConnectorError,
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1_000);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -15,6 +15,10 @@ import {
 const GOOGLE_CALENDAR_EVENTS_ENDPOINT = "https://www.googleapis.com/calendar/v3/calendars";
 const GOOGLE_CALENDAR_LIST_ENDPOINT =
   "https://www.googleapis.com/calendar/v3/users/me/calendarList";
+// Bounds the feed loop against a provider (or misbehaving proxy) that repeats
+// or never stops minting a nextPageToken -- 1,000 pages * 2,500/page covers
+// even a very dense calendar while keeping worst-case requests/memory finite.
+const MAX_GOOGLE_CALENDAR_FEED_PAGES = 1_000;
 
 type GoogleCalendarEventDate = {
   date?: string;
@@ -323,7 +327,16 @@ export async function fetchManagedGoogleCalendarFeed(args: {
 
   const events: ManagedGoogleCalendarEvent[] = [];
   let pageToken: string | undefined;
+  let pageCount = 0;
+  const seenPageTokens = new Set<string>();
   do {
+    pageCount += 1;
+    if (pageCount > MAX_GOOGLE_CALENDAR_FEED_PAGES) {
+      fail(
+        502,
+        `Google Calendar feed pagination exceeded ${MAX_GOOGLE_CALENDAR_FEED_PAGES} pages.`,
+      );
+    }
     const params = new URLSearchParams(baseParams);
     if (pageToken) {
       params.set("pageToken", pageToken);
@@ -344,7 +357,14 @@ export async function fetchManagedGoogleCalendarFeed(args: {
         .map((event) => normalizeGoogleCalendarEvent(args.calendarId, event, args.timeZone))
         .filter((event): event is ManagedGoogleCalendarEvent => event !== null),
     );
-    pageToken = parsed.nextPageToken?.trim() || undefined;
+    const nextPageToken = parsed.nextPageToken?.trim() || undefined;
+    if (nextPageToken && seenPageTokens.has(nextPageToken)) {
+      fail(502, "Google Calendar feed pagination repeated a page token.");
+    }
+    if (nextPageToken) {
+      seenPageTokens.add(nextPageToken);
+    }
+    pageToken = nextPageToken;
   } while (pageToken);
 
   return {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -15,10 +15,9 @@ import {
 const GOOGLE_CALENDAR_EVENTS_ENDPOINT = "https://www.googleapis.com/calendar/v3/calendars";
 const GOOGLE_CALENDAR_LIST_ENDPOINT =
   "https://www.googleapis.com/calendar/v3/users/me/calendarList";
-// Bounds the feed loop against a provider (or misbehaving proxy) that repeats
-// or never stops minting a nextPageToken -- 1,000 pages * 2,500/page covers
-// even a very dense calendar while keeping worst-case requests/memory finite.
+// Bounds provider calls independently from the accumulated Worker response.
 const MAX_GOOGLE_CALENDAR_FEED_PAGES = 1_000;
+const MAX_GOOGLE_CALENDAR_FEED_EVENTS = 10_000;
 
 type GoogleCalendarEventDate = {
   date?: string;
@@ -352,11 +351,16 @@ export async function fetchManagedGoogleCalendarFeed(args: {
       items?: GoogleCalendarApiEvent[];
       nextPageToken?: string;
     };
-    events.push(
-      ...(parsed.items ?? [])
-        .map((event) => normalizeGoogleCalendarEvent(args.calendarId, event, args.timeZone))
-        .filter((event): event is ManagedGoogleCalendarEvent => event !== null),
-    );
+    const normalizedPage = (parsed.items ?? [])
+      .map((event) => normalizeGoogleCalendarEvent(args.calendarId, event, args.timeZone))
+      .filter((event): event is ManagedGoogleCalendarEvent => event !== null);
+    if (events.length + normalizedPage.length > MAX_GOOGLE_CALENDAR_FEED_EVENTS) {
+      fail(
+        502,
+        `Google Calendar feed exceeded ${MAX_GOOGLE_CALENDAR_FEED_EVENTS} events; narrow the requested time range.`,
+      );
+    }
+    events.push(...normalizedPage);
     const nextPageToken = parsed.nextPageToken?.trim() || undefined;
     if (nextPageToken && seenPageTokens.has(nextPageToken)) {
       fail(502, "Google Calendar feed pagination repeated a page token.");


### PR DESCRIPTION
# Relates to

Closes #22661.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@578256176c813edb1440984edcf3cba7281fac6a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

`fetchManagedGoogleCalendarFeed` could follow repeated or perpetually novel `nextPageToken` values forever. The submitted repair added token-cycle detection and a 1,000-request ceiling.

Deep review found that request bound was not a sufficient Worker resource bound: Google documents up to 2,500 events per page, so 1,000 successful pages could accumulate roughly 2.5 million normalized objects before returning. The reviewed head therefore also caps the accumulated result at 10,000 normalized events and returns the existing typed 502 boundary with an actionable instruction to narrow the requested time range.

The two guards are intentionally independent: the page ceiling limits provider/subrequest work, while the event ceiling limits the in-memory response. Public signatures and normal token forwarding are unchanged.

Contract references:

- [Google Calendar events.list](https://developers.google.com/workspace/calendar/api/v3/reference/events/list) documents `maxResults` up to 2,500 and `nextPageToken` continuation.
- [Cloudflare Workers limits](https://developers.cloudflare.com/workers/platform/limits/) documents the 128 MB Worker memory limit and recommends avoiding large in-memory objects.

# Sync with develop

- [x] Rebased onto `e86b210916ce7dae0d0c72710f3ae94863191e09` with zero conflicts.
- [x] Exact reviewed head: `64e217626c357a2d0de4ed430fdad475691c029c`.

# Testing

Pinned Bun 1.3.14, exact reviewed head:

```text
bun test calendar.pagination.test.ts calendar.error-policy.test.ts calendar.local-time.test.ts
21 pass, 0 fail, 35 assertions, exit 0

biome check <two changed files>
2 files clean

git diff --check upstream/develop...HEAD
clean
```

The real exported production function proves:

- normal page-token forwarding and terminal behavior;
- repeated-token rejection;
- a perpetually novel-token provider stops after exactly 1,000 requests;
- a terminal 1,000th page succeeds;
- exactly 10,000 normalized events succeed;
- event 10,001 is rejected before append.

Mutation proof: removing only the new accumulated-event guard makes the 10,001-event production-boundary test resolve instead of reject. Restoring it returns all 21 tests to green.

# Evidence Gate

<!-- evidence-head:64e217626c357a2d0de4ed430fdad475691c029c -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Calendar connector logic; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Calendar connector logic; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interaction or UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head backend validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22660-pr22660-final-backend-validation.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, planner, or reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Verified pagination and accumulation boundary artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22660-pr22660-final-domain-boundaries.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

The owning-package typecheck was attempted after the focused gates. The isolated review checkout resolved duplicate Drizzle installations and lacked unrelated plugin dependencies, producing only dependency/baseline diagnostics; neither changed file appeared in the diagnostics. The exact production-boundary suites, changed-file Biome, diff check, and prior exact package typecheck evidence cover the changed surface.

No live Google OAuth credential or deployed Worker was used. The behavior is deterministic at the connector's real authenticated fetch boundary, with OAuth token lookup and remote HTTP responses controlled in the same established harness as the existing error-policy suite.

AI provider/model: Anthropic / claude-sonnet-5; OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code; Codex Desktop multi-agent review
Contribution skill revision: original `elizaOS/eliza@578256176c813edb1440984edcf3cba7281fac6a:packages/skills/skills/contribute-to-eliza`; reviewer repair used no contribution skill
Attribution status: self-reported
— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
