### PR TITLE
fix(agent-server): preserve well-formed Unicode in bounded metadata

### DIFF
--- a/packages/cloud/services/agent-server/__tests__/unit/metadata-helpers.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/metadata-helpers.test.ts
@@ -110,6 +110,14 @@ describe("resolveUserName", () => {
     expect(result.length).toBe(255);
     expect(result).toBe("A".repeat(255));
   });
+
+  test("does not split a surrogate pair when the 255-cut lands inside one", () => {
+    // 256 UTF-16 units: the emoji's surrogate pair straddles the cut at 255.
+    const longName = `${"A".repeat(254)}\u{1F600}`;
+    const result = resolveUserName("user-001", { senderName: longName });
+    // Backs off before the split pair rather than truncating to a lone surrogate.
+    expect(result).toBe("A".repeat(254));
+  });
 });
 
 describe("buildConnectionMetadata", () => {
@@ -174,6 +182,20 @@ describe("buildConnectionMetadata", () => {
     expect(result).toEqual({
       platformName: "whatsapp",
       chatId: "x".repeat(128),
+    });
+  });
+
+  test("does not split a surrogate pair when the 128-cut lands inside one", () => {
+    // 129 UTF-16 units: the emoji's surrogate pair straddles the cut at 128.
+    const longId = `${"x".repeat(127)}\u{1F600}`;
+    const result = buildConnectionMetadata({
+      platformName: "whatsapp",
+      chatId: longId,
+    });
+    // Backs off before the split pair rather than truncating to a lone surrogate.
+    expect(result).toEqual({
+      platformName: "whatsapp",
+      chatId: "x".repeat(127),
     });
   });
 

--- a/packages/cloud/services/agent-server/__tests__/unit/metadata-helpers.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/metadata-helpers.test.ts
@@ -118,6 +118,12 @@ describe("resolveUserName", () => {
     // Backs off before the split pair rather than truncating to a lone surrogate.
     expect(result).toBe("A".repeat(254));
   });
+
+  test("replaces caller-supplied lone surrogates before persistence", () => {
+    expect(
+      resolveUserName("user-001", { senderName: `Alice\ud800\udc00\udfff` }),
+    ).toBe(`Alice\u{10000}\ufffd`);
+  });
 });
 
 describe("buildConnectionMetadata", () => {
@@ -196,6 +202,41 @@ describe("buildConnectionMetadata", () => {
     expect(result).toEqual({
       platformName: "whatsapp",
       chatId: "x".repeat(127),
+    });
+  });
+
+  test("makes every bounded connection field well-formed", () => {
+    const metadata: MessageMetadata = {
+      platformName: "telegram",
+      chatId: `chat\ud800`,
+      accountId: `account\udc00`,
+      platformRecordId: `record\udfff`,
+      chatType: `private\ud800`,
+      senderName: `Alice\udc00`,
+    };
+    expect(buildConnectionMetadata(metadata)).toEqual({
+      platformName: "telegram",
+      chatId: "chat\ufffd",
+    });
+    expect(
+      buildCanonicalMessageMetadata({
+        source: "telegram",
+        userId: "user-001",
+        entityId: "00000000-0000-0000-0000-000000000001",
+        metadata,
+      }),
+    ).toMatchObject({
+      accountId: "account\ufffd",
+      platformMessageId: "record\ufffd",
+      sourceId: "record\ufffd",
+      chatType: "private\ufffd",
+      sender: { id: "user-001", name: "Alice\ufffd" },
+      entityName: "Alice\ufffd",
+      telegram: {
+        accountId: "account\ufffd",
+        messageId: "record\ufffd",
+        name: "Alice\ufffd",
+      },
     });
   });
 

--- a/packages/cloud/services/agent-server/src/agent-manager.ts
+++ b/packages/cloud/services/agent-server/src/agent-manager.ts
@@ -7,6 +7,7 @@ import {
   mergeCharacterDefaults,
   type Plugin,
   stringToUuid,
+  truncateWellFormed,
 } from "@elizaos/core";
 import sqlPlugin from "@elizaos/plugin-sql";
 import workflowPlugin from "@elizaos/plugin-workflow";
@@ -88,7 +89,7 @@ function bounded(value: string | undefined, max: number): string | undefined {
   if (!value) return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+  return trimmed.length > max ? truncateWellFormed(trimmed, max) : trimmed;
 }
 
 /** Returns the display name for the connection, falling back to the raw userId. Caps length to prevent oversized values from reaching the database. */
@@ -98,7 +99,7 @@ export function resolveUserName(
 ): string {
   const name = metadata?.senderName || userId;
   return name.length > MAX_USER_NAME_LENGTH
-    ? name.slice(0, MAX_USER_NAME_LENGTH)
+    ? truncateWellFormed(name, MAX_USER_NAME_LENGTH)
     : name;
 }
 

--- a/packages/cloud/services/agent-server/src/agent-manager.ts
+++ b/packages/cloud/services/agent-server/src/agent-manager.ts
@@ -7,6 +7,7 @@ import {
   mergeCharacterDefaults,
   type Plugin,
   stringToUuid,
+  toWellFormedUnicode,
   truncateWellFormed,
 } from "@elizaos/core";
 import sqlPlugin from "@elizaos/plugin-sql";
@@ -85,11 +86,18 @@ const MAX_ACCOUNT_ID_LENGTH = 128;
 const MAX_PLATFORM_RECORD_ID_LENGTH = 256;
 const MAX_CHAT_TYPE_LENGTH = 32;
 
+function truncateMetadata(value: string, max: number): string {
+  const wellFormed = toWellFormedUnicode(value);
+  return wellFormed.length > max
+    ? truncateWellFormed(wellFormed, max)
+    : wellFormed;
+}
+
 function bounded(value: string | undefined, max: number): string | undefined {
   if (!value) return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-  return trimmed.length > max ? truncateWellFormed(trimmed, max) : trimmed;
+  return truncateMetadata(trimmed, max);
 }
 
 /** Returns the display name for the connection, falling back to the raw userId. Caps length to prevent oversized values from reaching the database. */
@@ -98,9 +106,7 @@ export function resolveUserName(
   metadata?: MessageMetadata,
 ): string {
   const name = metadata?.senderName || userId;
-  return name.length > MAX_USER_NAME_LENGTH
-    ? truncateWellFormed(name, MAX_USER_NAME_LENGTH)
-    : name;
+  return truncateMetadata(name, MAX_USER_NAME_LENGTH);
 }
 
 /**


### PR DESCRIPTION
# Relates to

Closes #22665.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e8df866421887dbda439c2d72be51b74876162cc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

Inbound `senderName`, user-ID fallback, `chatId`, `accountId`, `platformRecordId`, and `chatType` values are bounded before connection/message persistence. Raw UTF-16 slicing could cut a valid non-BMP character between its surrogate halves.

The submitted repair correctly reused core's `truncateWellFormed`, but deep review found that helper deliberately preserves pre-existing lone surrogates. JSON strings can contain such code units, so the persistence boundary could still emit malformed Unicode despite the PR's database-safety goal.

The exact reviewed head now applies the two core primitives in their intended order through one metadata helper:

1. `toWellFormedUnicode` replaces caller-supplied lone high/low surrogates with U+FFFD.
2. `truncateWellFormed` applies the existing code-unit limits without splitting a valid pair.

Plain ASCII limits, whitespace handling, sender fallback, signatures, and canonical metadata shapes remain unchanged.

# Sync with develop

- [x] Rebased onto `663176f21a9da5a539728278fe4d992ff1e8afd3` with zero conflicts.
- [x] Exact reviewed head: `8cfb31d2152acdce9902ad8ce72be1da69196685`.

# Testing

```text
bun run --cwd packages/cloud/services/agent-server test --timeout=15000
75 pass, 0 fail, 121 assertions

bun test metadata-helpers.test.ts
28 pass, 0 fail, 41 assertions

bun run --cwd packages/cloud/services/agent-server typecheck
pass

biome check <two changed files>
pass

git diff --check
pass
```

The real exported metadata helpers cover the exact 255/128 code-unit cut boundaries and all bounded persistence fields. Mutation proof removes only pre-normalization while retaining the submitted truncation repair: both malformed-input regressions fail. Restoring normalization returns the full package to green.

# Evidence Gate

<!-- evidence-head:8cfb31d2152acdce9902ad8ce72be1da69196685 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend metadata persistence boundary; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend metadata persistence boundary; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible product flow changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head package and mutation validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22662-pr22662-final-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, planner, or reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Verified metadata-field and Unicode outcomes](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22662-pr22662-domain-artifact.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

No live gateway or Postgres instance was used. Validation runs the real exported metadata helpers used by `AgentManager.handleMessage`, checks the exact records they produce for persistence, and includes the owning package's complete suite and typecheck.

AI provider/model: Anthropic / claude-sonnet-5; OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code; Codex Desktop multi-agent review
Contribution skill revision: original `elizaOS/eliza@e8df866421887dbda439c2d72be51b74876162cc:packages/skills/skills/contribute-to-eliza`; reviewer repair used no contribution skill
Attribution status: self-reported
— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
