### PR TITLE
fix(cloud): let the production control plane reach agents over the tailnet

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1152,7 +1152,11 @@ else
     --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
   [ -n "$PREAUTH_KEY" ] || { echo "failed to mint preauth key for cp-router"; exit 1; }
 
+  # This branch already proved the expected router is absent and minted a
+  # fresh, single-use key. Force reauthentication so a daemon still signed in
+  # to the legacy login server can move to the canonical Headscale origin.
   sudo tailscale up \\
+    --force-reauth \\
     --login-server="$LOGIN_SERVER" \\
     --authkey="$PREAUTH_KEY" \\
     --hostname="$CP_ROUTER_HOST" \\

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Locks the protected Headscale self-enrollment, ACL policy, and workflow
+ * boundaries without connecting to a host or using live credentials.
+ *
+ * A malformed or over-broad `acl.hujson` fails here instead of taking the
+ * control plane's tailnet down after the next converge run. The policy is read
+ * with json5, a superset of HuJSON: it accepts a few forms headscale rejects
+ * (unquoted keys, single quotes, leading `+`), so a green parse is necessary
+ * but not sufficient. It catches the failure that actually matters — a
+ * malformed edit shipping base64-encoded and taking headscale down on restart
+ * — without hand-rolling a parser to chase parity.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import JSON5 from "json5";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface HeadscaleAclRule {
+  action: string;
+  src: string[];
+  dst: string[];
+}
+
+interface HeadscalePolicy {
+  tagOwners: Record<string, string[]>;
+  acls: HeadscaleAclRule[];
+}
+
+interface HeadscaleWorkflow {
+  jobs: {
+    arm: {
+      environment: string;
+      steps: WorkflowStep[];
+    };
+  };
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        environment: { options: string[] };
+        operation: { options: string[] };
+      };
+    };
+  };
+}
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const scriptPath = resolve(
+  repoRoot,
+  "packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+);
+const workflowPath = resolve(
+  repoRoot,
+  ".github/workflows/arm-headscale-control-plane.yml",
+);
+const aclPath = resolve(
+  repoRoot,
+  "packages/cloud/services/headscale/acl.hujson",
+);
+// Must equal the port in acl.hujson; that file explains why the coupling is manual.
+const AGENT_CONTAINER_PORT = "2138";
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function renderRemoteScript(extraArgs: string[] = []): string {
+  const root = mkdtempSync(join(tmpdir(), "headscale-arm-test-"));
+  tempRoots.push(root);
+  const keyPath = join(root, "deploy-key");
+  const knownHostsPath = join(root, "known-hosts");
+  writeFileSync(keyPath, "test-only-key\n", { mode: 0o600 });
+  writeFileSync(knownHostsPath, "test-only-known-host\n", { mode: 0o600 });
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--host",
+      "control-plane.test.invalid",
+      "--ssh-key",
+      keyPath,
+      "--ssh-known-hosts",
+      knownHostsPath,
+      "--headscale-public-url",
+      "https://headscale.eliza.app",
+      "--headscale-legacy-public-url",
+      "https://headscale.elizacloud.ai",
+      "--headscale-api-key",
+      "test-only-api-key",
+      "--skip-nginx-cert",
+      "--dry-run",
+      ...extraArgs,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe("");
+  return result.stdout;
+}
+
+/** Re-read per call so a malformed ACL fails the test that reads it, rather
+ * than aborting collection for the whole file. */
+function committedPolicy(): HeadscalePolicy {
+  return JSON5.parse(readFileSync(aclPath, "utf8")) as HeadscalePolicy;
+}
+
+function rulesFrom(
+  policy: HeadscalePolicy,
+  src: string,
+  dstTag: string,
+): HeadscaleAclRule[] {
+  return policy.acls.filter(
+    (rule) =>
+      rule.src.includes(src) &&
+      rule.dst.some((dst) => dst.startsWith(`${dstTag}:`)),
+  );
+}
+
+function namedStep(workflow: HeadscaleWorkflow, name: string): WorkflowStep {
+  const step = workflow.jobs.arm.steps.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!step) throw new Error(`Missing Headscale workflow step: ${name}`);
+  return step;
+}
+
+describe("Headscale control-plane self-enrollment", () => {
+  test("forces reauthentication only after minting a fresh single-use key", () => {
+    const remote = renderRemoteScript();
+    const forceReauth = remote.indexOf("    --force-reauth \\");
+    const mintKey = remote.indexOf(
+      "PREAUTH_KEY=$(sudo headscale preauthkeys create",
+    );
+    const tailscaleUp = remote.indexOf("sudo tailscale up \\");
+    const loginServer = remote.indexOf('    --login-server="$LOGIN_SERVER" \\');
+
+    expect(forceReauth).toBeGreaterThan(mintKey);
+    expect(forceReauth).toBeGreaterThan(tailscaleUp);
+    expect(forceReauth).toBeLessThan(loginServer);
+    expect(remote.match(/--force-reauth/g)).toHaveLength(1);
+    expect(remote).toContain(
+      "already enrolled in headscale; skipping tailscale up",
+    );
+  });
+
+  test("does not emit forced reauthentication when router enrollment is skipped", () => {
+    const remote = renderRemoteScript(["--skip-cp-router"]);
+
+    expect(remote).toContain(
+      "skip-cp-router set: leaving CP tailscale enrollment untouched",
+    );
+    expect(remote).not.toContain("--force-reauth");
+    expect(remote).not.toContain("headscale preauthkeys create");
+  });
+});
+
+describe("Headscale ACL policy", () => {
+  test("parses as HuJSON with every rule fully specified", () => {
+    const policy = committedPolicy();
+
+    expect(policy.acls.length).toBeGreaterThan(0);
+    for (const rule of policy.acls) {
+      expect(rule.action).toBe("accept");
+      expect(rule.src.length).toBeGreaterThan(0);
+      expect(rule.dst.length).toBeGreaterThan(0);
+    }
+    for (const tag of Object.keys(policy.tagOwners)) {
+      expect(tag).toMatch(/^tag:/);
+    }
+    for (const rule of policy.acls) {
+      for (const tag of [...rule.src, ...rule.dst]) {
+        expect(
+          policy.tagOwners[tag.split(":").slice(0, 2).join(":")],
+        ).toBeDefined();
+      }
+    }
+  });
+
+  test("grants tag:eliza-proxy (control plane AND public tunnel proxy) the agent container port only", () => {
+    const proxyToAgent = rulesFrom(
+      committedPolicy(),
+      "tag:eliza-proxy",
+      "tag:agent",
+    );
+
+    expect(proxyToAgent).toHaveLength(1);
+    expect(proxyToAgent[0]?.dst).toEqual([`tag:agent:${AGENT_CONTAINER_PORT}`]);
+  });
+
+  test("keeps customer tunnels and iMessage gateways off the agent fleet", () => {
+    const policy = committedPolicy();
+
+    for (const src of ["tag:eliza-tunnel", "tag:imessage-gateway"]) {
+      expect(rulesFrom(policy, src, "tag:agent")).toEqual([]);
+    }
+  });
+
+  test("ships the committed policy to the control plane", () => {
+    const remote = renderRemoteScript();
+    const encoded = remote.match(
+      /printf '%s' '([A-Za-z0-9+/=]+)' \| base64 -d \| sudo tee \/etc\/headscale\/acl\.hujson/,
+    )?.[1];
+    if (!encoded) throw new Error("remote script does not install an ACL file");
+
+    const shipped = JSON5.parse(
+      Buffer.from(encoded, "base64").toString("utf8"),
+    ) as HeadscalePolicy;
+
+    const shippedProxyToAgent = rulesFrom(
+      shipped,
+      "tag:eliza-proxy",
+      "tag:agent",
+    );
+    expect(shippedProxyToAgent).toHaveLength(1);
+    expect(shippedProxyToAgent[0]?.dst).toEqual([
+      `tag:agent:${AGENT_CONTAINER_PORT}`,
+    ]);
+    expect(shipped).toEqual(committedPolicy());
+  });
+});
+
+describe("Headscale protected workflow contract", () => {
+  const workflow = parse(
+    readFileSync(workflowPath, "utf8"),
+  ) as HeadscaleWorkflow;
+
+  test("keeps production convergence behind the protected environment and main ref", () => {
+    expect(workflow.on.workflow_dispatch.inputs.environment.options).toEqual([
+      "staging",
+      "production",
+    ]);
+    expect(workflow.on.workflow_dispatch.inputs.operation.options).toContain(
+      "converge",
+    );
+    expect(workflow.jobs.arm.environment).toBe(
+      ["$", "{{ inputs.environment }}"].join(""),
+    );
+
+    const sourceGuard = namedStep(
+      workflow,
+      "Validate protected deploy source",
+    ).run;
+    expect(sourceGuard).toContain('production) expected_ref="refs/heads/main"');
+    expect(sourceGuard).toContain('if [ "$GITHUB_REF" != "$expected_ref" ]');
+  });
+
+  test("invokes the reviewed script without exposing a force-reauth input", () => {
+    const converge = namedStep(
+      workflow,
+      "Inspect or converge Headscale control plane",
+    ).run;
+
+    expect(converge).toContain(
+      "node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+    );
+    expect(converge).not.toContain("force-reauth");
+  });
+});

--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -18,7 +18,7 @@ deploys to `/etc/headscale/acl.hujson`.
 |---|---|---|
 | `tag:agent` | Internal agent containers (set in [`headscale-integration.ts`](../../shared/src/lib/services/headscale-integration.ts:57)) | Internal services only — must NOT reach customer tunnels. |
 | `tag:eliza-tunnel` | Customer tunnel sessions minted by [`auth-key/route.ts`](../../api/v1/apis/tunnels/tailscale/auth-key/route.ts) | The reverse proxy and the customer's own node. Cross-customer routing is enforced by the proxy lookup layer. |
-| `tag:eliza-proxy` | The public reverse proxy node | Customer tunnel HTTPS endpoints only. |
+| `tag:eliza-proxy` | The public reverse proxy node and the control plane's own `cp-<env>-router` | Customer tunnel HTTPS endpoints, plus the agent fleet on the container port only (`tag:agent:2138`) for bridge and health traffic. |
 
 The exact ACL policy lives in `acl.hujson` next to this README. **Edit there, not in the headscale admin UI** — the file is committed and deployed.
 

--- a/packages/cloud/services/headscale/acl.hujson
+++ b/packages/cloud/services/headscale/acl.hujson
@@ -29,6 +29,22 @@
       "src": ["tag:eliza-proxy"],
       "dst": ["tag:eliza-tunnel:443"]
     },
+    // The control plane reaches dedicated agents on the container port only:
+    // health probes and bridge traffic go to http://100.64.x.y:2138. The port
+    // is resolved per sandbox — environmentVars.PORT, then HTTP_PORT, then
+    // container.port, then ELIZA_AGENT_PORT (whose own fallback is 3000) — and
+    // this file is static, so changing the resolved port anywhere requires
+    // widening this rule to match. Otherwise default-deny drops the probe with
+    // no symptom but a timeout.
+    //
+    // Scope: tag:eliza-proxy is carried by BOTH the control plane router and
+    // the internet-facing tunnel proxy, so this also grants the public proxy
+    // reach to agents on 2138. A dedicated tag:eliza-cp would narrow it.
+    {
+      "action": "accept",
+      "src": ["tag:eliza-proxy"],
+      "dst": ["tag:agent:2138"]
+    },
     // Agents can reach each other on internal ports (existing behavior).
     {
       "action": "accept",


### PR DESCRIPTION
## Why this targets `main` and not `develop`

`develop` is staging, `main` is production. The Headscale converge job encodes it:

```bash
# .github/workflows/arm-headscale-control-plane.yml
staging)    expected_ref="refs/heads/develop" ;;
production) expected_ref="refs/heads/main" ;;
```

The same ACL rule is already up as #22617 against `develop`. That PR is correct and should still land, but **it cannot restore production** — nothing on `develop` reaches the production control plane. This is the production-side copy.

## What is broken

`main`'s `acl.hujson` has no rule granting `tag:eliza-proxy` reach to `tag:agent`. Headscale is default-deny, so once `acl_policy_path` was set on the box every control-plane → agent probe started being dropped with no symptom but a timeout. Dedicated agents have been unreachable since 2026-08-18 01:39 UTC.

The rule added here:

```jsonc
{
  "action": "accept",
  "src": ["tag:eliza-proxy"],
  "dst": ["tag:agent:2138"]
}
```

**On the port.** The rule is written for `:2138` because that is what production resolves, not because 2138 is the fallback. The chain is `environmentVars.PORT → HTTP_PORT → container.port → DEFAULT_AGENT_PORT`, and `DEFAULT_AGENT_PORT` is `containersEnv.agentPort()` = `ELIZA_AGENT_PORT ?? AGENT_AGENT_PORT ?? "3000"`. Production sets `ELIZA_AGENT_PORT=2138`, and all 33 tailnet-routed sandboxes carry a `bridge_url` on `:2138`. The `3000` at the end of that chain is the unconfigured-environment default; it is not what production resolves. The ACL file is static, so the coupling is manual — the comment in `acl.hujson` says so, and the tests below fail if the two drift apart.

**Scope caveat, stated in the file:** `tag:eliza-proxy` is carried by both the control-plane router and the internet-facing tunnel proxy, so this also grants the public proxy reach to agents on 2138. A dedicated `tag:eliza-cp` would narrow it. That is a follow-up, not a reason to leave production dark.

## The `--force-reauth` carry-over

`main`'s `arm-headscale-control-plane.mjs` did not have the `--force-reauth` flag that `develop` carries — so production has been converging with a different script from the reviewed one. It is included here, unchanged from `develop`, because the tests assert on it and because a control-plane router still signed in to the legacy login server cannot otherwise move to the canonical Headscale origin. It only runs in the branch that has already established the expected router is absent and minted a fresh single-use key.

## Tests

`arm-headscale-control-plane.test.ts` does not exist on `main`; it is added whole. It parses the committed policy and asserts the proxy → agent rule resolves to exactly `tag:agent:2138`, both as committed and as base64-encoded into the remote script that lands on the box. Changing the port in `acl.hujson` turns two assertions red, including the one that decodes the shipped payload.

## Merging this does not deploy it

These workflows have no push trigger. After merge, someone with production environment access must run `Arm Headscale Control Plane` via `workflow_dispatch` from `main` with `environment: production`, `operation: converge`. Until that dispatch runs, production is unchanged.

Part of #22508 · production-side counterpart of #22617
