### PR TITLE
fix(plugin-whatsapp): make pairing stop terminal across lifecycle races

### DIFF
--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
@@ -1,6 +1,7 @@
 /** Exercises WhatsApp authentication-scope validation through the route harness. */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import {
   handleWhatsAppRoute,
@@ -36,6 +37,14 @@ function createHarness(path: string) {
     createWhatsAppPairingSession: vi.fn(),
   };
   return { req, res, state, deps, chunks, whatsappAuthExists };
+}
+
+function createPostHarness(path: string, body: object) {
+  const harness = createHarness(path);
+  const req = Readable.from([JSON.stringify(body)]) as IncomingMessage;
+  req.url = path;
+  req.headers = { host: "localhost" };
+  return { ...harness, req };
 }
 
 function parsed(chunks: string[]): { error?: string; authScope?: string } {
@@ -106,5 +115,113 @@ describe("GET /api/whatsapp/status authScope identity", () => {
     expect(res.statusCode).toBe(400);
     expect(parsed(chunks)).toEqual({ error: "Invalid authScope" });
     expect(whatsappAuthExists).not.toHaveBeenCalled();
+  });
+});
+
+describe("WhatsApp pairing route teardown ordering", () => {
+  it("awaits the replaced session before creating another session for the auth directory", async () => {
+    const { req, res, state, deps } = createPostHarness("/api/whatsapp/pair", {
+      accountId: "default",
+    });
+    let releaseStop: (() => void) | undefined;
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    const oldSession = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => stopGate),
+      getStatus: vi.fn(() => "waiting_for_qr"),
+    };
+    const newSession = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      getStatus: vi.fn(() => "initializing"),
+    };
+    state.whatsappPairingSessions.set("platform:default", oldSession);
+    vi.mocked(deps.createWhatsAppPairingSession).mockReturnValue(newSession);
+
+    const handling = handleWhatsAppRoute(req, res, "/api/whatsapp/pair", "POST", state, deps);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(oldSession.stop).toHaveBeenCalledTimes(1);
+    expect(deps.createWhatsAppPairingSession).not.toHaveBeenCalled();
+
+    releaseStop?.();
+    await expect(handling).resolves.toBe(true);
+    expect(deps.createWhatsAppPairingSession).toHaveBeenCalledTimes(1);
+    expect(newSession.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes concurrent pair requests that begin without an existing session", async () => {
+    const first = createPostHarness("/api/whatsapp/pair", { accountId: "default" });
+    const second = createPostHarness("/api/whatsapp/pair", { accountId: "default" });
+    let releaseFirstStart: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      releaseFirstStart = resolve;
+    });
+    const firstSession = {
+      start: vi.fn(async () => firstStartGate),
+      stop: vi.fn(async () => undefined),
+      getStatus: vi.fn(() => "initializing"),
+    };
+    const secondSession = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      getStatus: vi.fn(() => "initializing"),
+    };
+    vi.mocked(first.deps.createWhatsAppPairingSession)
+      .mockReturnValueOnce(firstSession)
+      .mockReturnValueOnce(secondSession);
+
+    const firstHandling = handleWhatsAppRoute(
+      first.req,
+      first.res,
+      "/api/whatsapp/pair",
+      "POST",
+      first.state,
+      first.deps
+    );
+    await vi.waitFor(() => expect(firstSession.start).toHaveBeenCalledTimes(1));
+    const secondHandling = handleWhatsAppRoute(
+      second.req,
+      second.res,
+      "/api/whatsapp/pair",
+      "POST",
+      first.state,
+      first.deps
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(first.deps.createWhatsAppPairingSession).toHaveBeenCalledTimes(1);
+
+    releaseFirstStart?.();
+    await firstHandling;
+    await secondHandling;
+    expect(firstSession.stop).toHaveBeenCalledTimes(1);
+    expect(first.deps.createWhatsAppPairingSession).toHaveBeenCalledTimes(2);
+    expect(secondSession.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits pairing teardown before deleting or logging out shared auth state", async () => {
+    const { req, res, state, deps } = createPostHarness("/api/whatsapp/disconnect", {
+      accountId: "default",
+    });
+    let releaseStop: (() => void) | undefined;
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    const session = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => stopGate),
+      getStatus: vi.fn(() => "waiting_for_qr"),
+    };
+    state.whatsappPairingSessions.set("platform:default", session);
+
+    const handling = handleWhatsAppRoute(req, res, "/api/whatsapp/disconnect", "POST", state, deps);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(session.stop).toHaveBeenCalledTimes(1);
+    expect(deps.whatsappLogout).not.toHaveBeenCalled();
+
+    releaseStop?.();
+    await expect(handling).resolves.toBe(true);
+    expect(deps.whatsappLogout).toHaveBeenCalledWith(state.workspaceDir, "default");
   });
 });

--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
@@ -15,7 +15,7 @@ export type WhatsAppPairingEventLike = WhatsAppPairingEvent;
 
 export interface WhatsAppPairingSessionLike {
   start(): Promise<void>;
-  stop(): void;
+  stop(): Promise<void>;
   getStatus(): string;
 }
 
@@ -68,6 +68,36 @@ type WhatsAppAuthScope = "platform" | "lifeops";
 
 const MAX_BODY_BYTES = 1_048_576;
 export const MAX_PAIRING_SESSIONS = 10;
+const pairingTransitions = new WeakMap<WhatsAppRouteState, Promise<void>>();
+
+async function acquirePairingTransition(state: WhatsAppRouteState): Promise<() => void> {
+  const previous = pairingTransitions.get(state) ?? Promise.resolve();
+  let releaseTransition: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    releaseTransition = resolve;
+  });
+  pairingTransitions.set(state, current);
+  await previous;
+  return () => {
+    releaseTransition?.();
+    if (pairingTransitions.get(state) === current) pairingTransitions.delete(state);
+  };
+}
+
+async function stopPairingSession(
+  sessions: Map<string, WhatsAppPairingSessionLike>,
+  sessionKey: string
+): Promise<void> {
+  for (;;) {
+    const session = sessions.get(sessionKey);
+    if (!session) return;
+    await session.stop();
+    if (sessions.get(sessionKey) === session) {
+      sessions.delete(sessionKey);
+      return;
+    }
+  }
+}
 
 async function readJsonBody<T = Record<string, unknown>>(
   req: IncomingMessage,
@@ -294,74 +324,80 @@ export async function handleWhatsAppRoute(
       return true;
     }
     const sessionKey = resolveSessionKey(authScope, accountId);
-
-    const isReplacing = state.whatsappPairingSessions.has(sessionKey);
-    if (!isReplacing && state.whatsappPairingSessions.size >= MAX_PAIRING_SESSIONS) {
-      json(
-        res,
-        {
-          error: `Too many concurrent pairing sessions (max ${MAX_PAIRING_SESSIONS})`,
-        },
-        429
-      );
-      return true;
-    }
-
-    const authDir = resolveAuthDir(state.workspaceDir, accountId, authScope);
-    state.whatsappPairingSessions.get(sessionKey)?.stop();
-
-    const session = deps.createWhatsAppPairingSession({
-      authDir,
-      accountId,
-      onEvent: (event) => {
-        state.broadcastWs?.({ ...event, authScope });
-
-        if (event.status === "connected") {
-          let configChanged = false;
-          if (configurePlugin) {
-            if (!state.config.connectors) state.config.connectors = {};
-            state.config.connectors.whatsapp = {
-              ...((state.config.connectors.whatsapp as Record<string, unknown> | undefined) ?? {}),
-              authDir,
-              enabled: true,
-            };
-            configChanged = true;
-          }
-
-          const phoneNumber = event.phoneNumber;
-          configChanged =
-            setOwnerContact(state.config as Parameters<typeof setOwnerContact>[0], {
-              source: "whatsapp",
-              channelId: phoneNumber ?? undefined,
-            }) || configChanged;
-
-          if (!configChanged) {
-            return;
-          }
-
-          try {
-            state.saveConfig();
-          } catch {
-            /* test envs */
-          }
-        }
-      },
-    });
-
-    state.whatsappPairingSessions.set(sessionKey, session);
+    const releaseTransition = await acquirePairingTransition(state);
 
     try {
-      await session.start();
-      json(res, {
-        ok: true,
+      const isReplacing = state.whatsappPairingSessions.has(sessionKey);
+      if (!isReplacing && state.whatsappPairingSessions.size >= MAX_PAIRING_SESSIONS) {
+        json(
+          res,
+          {
+            error: `Too many concurrent pairing sessions (max ${MAX_PAIRING_SESSIONS})`,
+          },
+          429
+        );
+        return true;
+      }
+
+      const authDir = resolveAuthDir(state.workspaceDir, accountId, authScope);
+      await stopPairingSession(state.whatsappPairingSessions, sessionKey);
+
+      const session = deps.createWhatsAppPairingSession({
+        authDir,
         accountId,
-        authScope,
-        status: session.getStatus(),
+        onEvent: (event) => {
+          state.broadcastWs?.({ ...event, authScope });
+
+          if (event.status === "connected") {
+            let configChanged = false;
+            if (configurePlugin) {
+              if (!state.config.connectors) state.config.connectors = {};
+              state.config.connectors.whatsapp = {
+                ...((state.config.connectors.whatsapp as Record<string, unknown> | undefined) ??
+                  {}),
+                authDir,
+                enabled: true,
+              };
+              configChanged = true;
+            }
+
+            const phoneNumber = event.phoneNumber;
+            configChanged =
+              setOwnerContact(state.config as Parameters<typeof setOwnerContact>[0], {
+                source: "whatsapp",
+                channelId: phoneNumber ?? undefined,
+              }) || configChanged;
+
+            if (!configChanged) {
+              return;
+            }
+
+            try {
+              state.saveConfig();
+            } catch {
+              /* test envs */
+            }
+          }
+        },
       });
-    } catch (err) {
-      json(res, { ok: false, error: String(err) }, 500);
+
+      state.whatsappPairingSessions.set(sessionKey, session);
+
+      try {
+        await session.start();
+        json(res, {
+          ok: true,
+          accountId,
+          authScope,
+          status: session.getStatus(),
+        });
+      } catch (err) {
+        json(res, { ok: false, error: String(err) }, 500);
+      }
+      return true;
+    } finally {
+      releaseTransition();
     }
-    return true;
   }
 
   if (method === "GET" && pathname === "/api/whatsapp/status") {
@@ -429,11 +465,11 @@ export async function handleWhatsAppRoute(
       return true;
     }
     const sessionKey = resolveSessionKey(authScope, accountId);
-
-    const session = state.whatsappPairingSessions.get(sessionKey);
-    if (session) {
-      session.stop();
-      state.whatsappPairingSessions.delete(sessionKey);
+    const releaseTransition = await acquirePairingTransition(state);
+    try {
+      await stopPairingSession(state.whatsappPairingSessions, sessionKey);
+    } finally {
+      releaseTransition();
     }
 
     json(res, { ok: true, accountId, authScope, status: "idle" });
@@ -459,42 +495,43 @@ export async function handleWhatsAppRoute(
       return true;
     }
     const sessionKey = resolveSessionKey(authScope, accountId);
+    const releaseTransition = await acquirePairingTransition(state);
 
-    const session = state.whatsappPairingSessions.get(sessionKey);
-    if (session) {
-      session.stop();
-      state.whatsappPairingSessions.delete(sessionKey);
-    }
-
-    const authDir = resolveAuthDir(state.workspaceDir, accountId, authScope);
     try {
-      if (authScope === "platform") {
-        await deps.whatsappLogout(state.workspaceDir, accountId);
-      } else {
-        fs.rmSync(authDir, { recursive: true, force: true });
-      }
-    } catch (logoutErr) {
-      logger.warn(
-        {
-          accountId,
-          error: logoutErr instanceof Error ? logoutErr.message : String(logoutErr),
-        },
-        "[whatsapp] Logout failed, deleting auth files directly"
-      );
-      try {
-        fs.rmSync(authDir, { recursive: true, force: true });
-      } catch {
-        /* may not exist */
-      }
-    }
+      await stopPairingSession(state.whatsappPairingSessions, sessionKey);
 
-    if (configurePlugin && state.config.connectors) {
-      delete state.config.connectors.whatsapp;
+      const authDir = resolveAuthDir(state.workspaceDir, accountId, authScope);
       try {
-        state.saveConfig();
-      } catch {
-        /* test envs */
+        if (authScope === "platform") {
+          await deps.whatsappLogout(state.workspaceDir, accountId);
+        } else {
+          fs.rmSync(authDir, { recursive: true, force: true });
+        }
+      } catch (logoutErr) {
+        logger.warn(
+          {
+            accountId,
+            error: logoutErr instanceof Error ? logoutErr.message : String(logoutErr),
+          },
+          "[whatsapp] Logout failed, deleting auth files directly"
+        );
+        try {
+          fs.rmSync(authDir, { recursive: true, force: true });
+        } catch {
+          /* may not exist */
+        }
       }
+
+      if (configurePlugin && state.config.connectors) {
+        delete state.config.connectors.whatsapp;
+        try {
+          state.saveConfig();
+        } catch {
+          /* test envs */
+        }
+      }
+    } finally {
+      releaseTransition();
     }
 
     json(res, { ok: true, accountId, authScope });

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const sockets: FakeSocket[] = [];
+const credentialSaves: ReturnType<typeof vi.fn>[] = [];
 
 class FakeSocket {
   readonly ev = new EventEmitter();
@@ -19,7 +20,11 @@ vi.mock("@whiskeysockets/baileys", () => ({
     sockets.push(socket);
     return socket;
   }),
-  useMultiFileAuthState: vi.fn(async () => ({ state: {}, saveCreds: vi.fn() })),
+  useMultiFileAuthState: vi.fn(async () => {
+    const saveCreds = vi.fn(async () => undefined);
+    credentialSaves.push(saveCreds);
+    return { state: {}, saveCreds };
+  }),
   fetchLatestBaileysVersion: vi.fn(async () => ({ version: [2, 3000, 0] })),
   DisconnectReason: {
     loggedOut: 401,
@@ -49,12 +54,14 @@ vi.mock("pino", () => ({
 }));
 
 import makeWASocket, { fetchLatestBaileysVersion } from "@whiskeysockets/baileys";
+import QRCode from "qrcode";
 import { WhatsAppPairingSession } from "./whatsapp-pairing";
 
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   sockets.length = 0;
+  credentialSaves.length = 0;
 });
 
 describe("WhatsAppPairingSession stop/restart race", () => {
@@ -199,5 +206,86 @@ describe("WhatsAppPairingSession stop/restart race", () => {
 
     expect(makeWASocket).toHaveBeenCalledTimes(2);
     expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "connected" }));
+  });
+
+  it("does not emit a QR whose generation finishes after stop()", async () => {
+    let releaseQr: (() => void) | undefined;
+    const qrGate = new Promise<void>((resolve) => {
+      releaseQr = resolve;
+    });
+    vi.mocked(QRCode.toDataURL).mockImplementationOnce(async () => {
+      await qrGate;
+      return "data:image/png;base64,late";
+    });
+    const onEvent = vi.fn();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent,
+    });
+    await session.start();
+    sockets[0]?.ev.emit("connection.update", { qr: "sensitive-qr" });
+    await vi.waitFor(() => expect(QRCode.toDataURL).toHaveBeenCalledTimes(1));
+
+    session.stop();
+    releaseQr?.();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: "whatsapp-qr" }));
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "waiting_for_qr" }));
+  });
+
+  it("ignores credential updates from a socket that a restart replaced", async () => {
+    vi.useFakeTimers();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    const firstSocket = sockets[0];
+    firstSocket?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(sockets).toHaveLength(2);
+    expect(credentialSaves).toHaveLength(2);
+
+    firstSocket?.ev.emit("creds.update", { stale: true });
+    sockets[1]?.ev.emit("creds.update", { current: true });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(credentialSaves[0]).not.toHaveBeenCalled();
+    expect(credentialSaves[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes a synchronous close emitted by end() inert", async () => {
+    vi.useFakeTimers();
+    const onEvent = vi.fn();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent,
+    });
+    await session.start();
+    const socket = sockets[0];
+    socket?.end.mockImplementation(() => {
+      socket.ev.emit("connection.update", {
+        connection: "close",
+        lastDisconnect: {
+          error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+        },
+      });
+    });
+
+    session.stop();
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(socket?.end).toHaveBeenCalledTimes(1);
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "disconnected" }));
   });
 });

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
@@ -3,6 +3,10 @@
  * restarted, and replaced Baileys sockets.
  */
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const sockets: FakeSocket[] = [];
@@ -10,7 +14,8 @@ const credentialSaves: ReturnType<typeof vi.fn>[] = [];
 
 class FakeSocket {
   readonly ev = new EventEmitter();
-  end = vi.fn();
+  end = vi.fn(async () => undefined);
+  logout = vi.fn(async () => undefined);
   user = { id: "1234567890:1@s.whatsapp.net" };
 }
 
@@ -55,7 +60,7 @@ vi.mock("pino", () => ({
 
 import makeWASocket, { fetchLatestBaileysVersion } from "@whiskeysockets/baileys";
 import QRCode from "qrcode";
-import { WhatsAppPairingSession } from "./whatsapp-pairing";
+import { WhatsAppPairingSession, whatsappLogout } from "./whatsapp-pairing";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -106,7 +111,7 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     expect(versionCalls).toBe(2);
     expect(makeWASocket).toHaveBeenCalledTimes(1);
 
-    session.stop();
+    await session.stop();
     releaseGate?.();
     await vi.advanceTimersByTimeAsync(0);
 
@@ -166,7 +171,7 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     await vi.advanceTimersByTimeAsync(3000);
     expect(versionCalls).toBe(2);
 
-    session.stop();
+    await session.stop();
     await session.start();
     expect(makeWASocket).toHaveBeenCalledTimes(2);
 
@@ -227,12 +232,52 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     sockets[0]?.ev.emit("connection.update", { qr: "sensitive-qr" });
     await vi.waitFor(() => expect(QRCode.toDataURL).toHaveBeenCalledTimes(1));
 
-    session.stop();
+    await session.stop();
     releaseQr?.();
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: "whatsapp-qr" }));
     expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "waiting_for_qr" }));
+  });
+
+  it("does not let an older QR conversion replace a newer QR from the same socket", async () => {
+    let releaseOlderQr: (() => void) | undefined;
+    const olderQrGate = new Promise<void>((resolve) => {
+      releaseOlderQr = resolve;
+    });
+    vi.mocked(QRCode.toDataURL).mockImplementation(async (qr) => {
+      if (qr === "older-qr") await olderQrGate;
+      return `data:image/png;base64,${qr}`;
+    });
+    const onEvent = vi.fn();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent,
+    });
+    await session.start();
+
+    sockets[0]?.ev.emit("connection.update", { qr: "older-qr" });
+    await vi.waitFor(() => expect(QRCode.toDataURL).toHaveBeenCalledTimes(1));
+    sockets[0]?.ev.emit("connection.update", { qr: "newer-qr" });
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "whatsapp-qr",
+          qrDataUrl: "data:image/png;base64,newer-qr",
+        })
+      )
+    );
+
+    releaseOlderQr?.();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const qrEvents = onEvent.mock.calls
+      .map(([event]) => event as { type: string; qrDataUrl?: string })
+      .filter((event) => event.type === "whatsapp-qr");
+    expect(qrEvents).toEqual([
+      expect.objectContaining({ qrDataUrl: "data:image/png;base64,newer-qr" }),
+    ]);
   });
 
   it("ignores credential updates from a socket that a restart replaced", async () => {
@@ -262,6 +307,95 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     expect(credentialSaves[1]).toHaveBeenCalledTimes(1);
   });
 
+  it("persists an admitted credential update before a same-turn transient restart", async () => {
+    vi.useFakeTimers();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+
+    sockets[0]?.ev.emit("creds.update", { admitted: true });
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(credentialSaves[0]).toHaveBeenCalledTimes(1);
+    expect(credentialSaves).toHaveLength(2);
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+  });
+
+  it("drains every admitted credential save before an explicit replacement", async () => {
+    let releaseFirstSave: (() => void) | undefined;
+    const firstSaveGate = new Promise<void>((resolve) => {
+      releaseFirstSave = resolve;
+    });
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    credentialSaves[0]?.mockImplementationOnce(async () => {
+      await firstSaveGate;
+    });
+
+    sockets[0]?.ev.emit("creds.update", { sequence: 1 });
+    sockets[0]?.ev.emit("creds.update", { sequence: 2 });
+    const replacement = session.start();
+    await vi.waitFor(() => expect(credentialSaves[0]).toHaveBeenCalledTimes(1));
+    expect(credentialSaves).toHaveLength(1);
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+
+    releaseFirstSave?.();
+    await replacement;
+    expect(credentialSaves[0]).toHaveBeenCalledTimes(2);
+    expect(credentialSaves).toHaveLength(2);
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+  });
+
+  it("drains an admitted credential save before loading replacement auth state", async () => {
+    let releaseOldSave: (() => void) | undefined;
+    const oldSaveGate = new Promise<void>((resolve) => {
+      releaseOldSave = resolve;
+    });
+    const saveOrder: string[] = [];
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    credentialSaves[0]?.mockImplementationOnce(async () => {
+      await oldSaveGate;
+      saveOrder.push("old");
+    });
+
+    sockets[0]?.ev.emit("creds.update", { admitted: true });
+    await vi.waitFor(() => expect(credentialSaves[0]).toHaveBeenCalledTimes(1));
+    const replacement = session.start();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+    expect(credentialSaves).toHaveLength(1);
+
+    releaseOldSave?.();
+    await replacement;
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+    expect(credentialSaves).toHaveLength(2);
+
+    credentialSaves[1]?.mockImplementationOnce(async () => {
+      saveOrder.push("new");
+    });
+    sockets[1]?.ev.emit("creds.update", { current: true });
+    await vi.waitFor(() => expect(credentialSaves[1]).toHaveBeenCalledTimes(1));
+    expect(saveOrder).toEqual(["old", "new"]);
+  });
+
   it("makes a synchronous close emitted by end() inert", async () => {
     vi.useFakeTimers();
     const onEvent = vi.fn();
@@ -272,7 +406,7 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     });
     await session.start();
     const socket = sockets[0];
-    socket?.end.mockImplementation(() => {
+    socket?.end.mockImplementation(async () => {
       socket.ev.emit("connection.update", {
         connection: "close",
         lastDisconnect: {
@@ -281,11 +415,88 @@ describe("WhatsAppPairingSession stop/restart race", () => {
       });
     });
 
-    session.stop();
+    await session.stop();
     await vi.advanceTimersByTimeAsync(3000);
 
     expect(socket?.end).toHaveBeenCalledTimes(1);
     expect(makeWASocket).toHaveBeenCalledTimes(1);
     expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "disconnected" }));
+  });
+
+  it("does not finish stop until the asynchronous socket teardown settles", async () => {
+    let releaseEnd: (() => void) | undefined;
+    const endGate = new Promise<void>((resolve) => {
+      releaseEnd = resolve;
+    });
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    sockets[0]?.end.mockImplementationOnce(async () => {
+      await endGate;
+    });
+
+    let stopped = false;
+    const stopping = session.stop().then(() => {
+      stopped = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(stopped).toBe(false);
+
+    releaseEnd?.();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  it("observes an asynchronous socket teardown rejection", async () => {
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    sockets[0]?.end.mockRejectedValueOnce(new Error("teardown failed"));
+
+    await expect(session.stop()).resolves.toBeUndefined();
+    expect(sockets[0]?.end).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("whatsappLogout teardown ordering", () => {
+  it("settles the logout socket before deleting its authentication directory", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "whatsapp-logout-test-"));
+    const authDir = path.join(workspaceDir, "whatsapp-auth", "acct-1");
+    await mkdir(authDir, { recursive: true });
+    await writeFile(path.join(authDir, "creds.json"), "{}");
+    let releaseEnd: (() => void) | undefined;
+    const endGate = new Promise<void>((resolve) => {
+      releaseEnd = resolve;
+    });
+
+    try {
+      let finished = false;
+      const loggingOut = whatsappLogout(workspaceDir, "acct-1").then(() => {
+        finished = true;
+      });
+      await vi.waitFor(() => expect(sockets).toHaveLength(1));
+      sockets[0]?.end.mockImplementationOnce(async () => {
+        await endGate;
+      });
+      sockets[0]?.ev.emit("connection.update", { connection: "open" });
+      await vi.waitFor(() => expect(sockets[0]?.logout).toHaveBeenCalledTimes(1));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(finished).toBe(false);
+      expect(fs.existsSync(authDir)).toBe(true);
+
+      releaseEnd?.();
+      await loggingOut;
+      expect(fs.existsSync(authDir)).toBe(false);
+    } finally {
+      releaseEnd?.();
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
@@ -1,7 +1,6 @@
 /**
- * Verifies stop() prevents an in-flight restart's start() from resurrecting
- * a socket for a session the caller already tore down. Mirrors the mocking
- * style in ../baileys/connection.test.ts.
+ * Deterministically exercises pairing lifecycle ownership across stopped,
+ * restarted, and replaced Baileys sockets.
  */
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -129,5 +128,76 @@ describe("WhatsAppPairingSession stop/restart race", () => {
     await vi.advanceTimersByTimeAsync(3000);
 
     expect(makeWASocket).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an older in-flight restart join a later explicit start", async () => {
+    vi.useFakeTimers();
+
+    let releaseRestart: (() => void) | undefined;
+    const restartGate = new Promise<void>((resolve) => {
+      releaseRestart = resolve;
+    });
+    let versionCalls = 0;
+    vi.mocked(fetchLatestBaileysVersion).mockImplementation(async () => {
+      versionCalls++;
+      if (versionCalls === 2) await restartGate;
+      return { version: [2, 3000, 0] };
+    });
+
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+    await session.start();
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(versionCalls).toBe(2);
+
+    session.stop();
+    await session.start();
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+
+    releaseRestart?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores late close events from the socket a restart replaced", async () => {
+    vi.useFakeTimers();
+
+    const onEvent = vi.fn();
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent,
+    });
+    await session.start();
+    const firstSocket = sockets[0];
+    firstSocket?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+
+    firstSocket?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+    firstSocket?.ev.emit("connection.update", { connection: "open" });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ status: "connected" }));
   });
 });

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Verifies stop() prevents an in-flight restart's start() from resurrecting
+ * a socket for a session the caller already tore down. Mirrors the mocking
+ * style in ../baileys/connection.test.ts.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sockets: FakeSocket[] = [];
+
+class FakeSocket {
+  readonly ev = new EventEmitter();
+  end = vi.fn();
+  user = { id: "1234567890:1@s.whatsapp.net" };
+}
+
+vi.mock("@whiskeysockets/baileys", () => ({
+  default: vi.fn(() => {
+    const socket = new FakeSocket();
+    sockets.push(socket);
+    return socket;
+  }),
+  useMultiFileAuthState: vi.fn(async () => ({ state: {}, saveCreds: vi.fn() })),
+  fetchLatestBaileysVersion: vi.fn(async () => ({ version: [2, 3000, 0] })),
+  DisconnectReason: {
+    loggedOut: 401,
+    restartRequired: 515,
+    timedOut: 408,
+    connectionClosed: 428,
+    connectionReplaced: 440,
+  },
+}));
+
+const DISCONNECT_REASON = {
+  loggedOut: 401,
+  restartRequired: 515,
+  timedOut: 408,
+  connectionClosed: 428,
+  connectionReplaced: 440,
+};
+
+vi.mock("qrcode", () => ({
+  default: { toDataURL: vi.fn(async () => "data:image/png;base64,x") },
+}));
+
+vi.mock("@hapi/boom", () => ({ Boom: class Boom extends Error {} }));
+
+vi.mock("pino", () => ({
+  default: vi.fn(() => ({ level: "silent" })),
+}));
+
+import makeWASocket, { fetchLatestBaileysVersion } from "@whiskeysockets/baileys";
+import { WhatsAppPairingSession } from "./whatsapp-pairing";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  sockets.length = 0;
+});
+
+describe("WhatsAppPairingSession stop/restart race", () => {
+  it("does not resurrect a socket when stop() runs during an in-flight restart", async () => {
+    vi.useFakeTimers();
+
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let versionCalls = 0;
+    vi.mocked(fetchLatestBaileysVersion).mockImplementation(async () => {
+      versionCalls++;
+      if (versionCalls === 2) {
+        // Second call happens inside the restart's start() -- hold it open
+        // so stop() can run while start() is still mid-flight.
+        await gate;
+      }
+      return { version: [2, 3000, 0] };
+    });
+
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+
+    await session.start();
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+
+    // Transient close schedules a restart 3s out.
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(3000);
+    // The restart's start() is now blocked inside the gated version fetch,
+    // before it would otherwise create a second socket.
+    expect(versionCalls).toBe(2);
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+
+    session.stop();
+    releaseGate?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+  });
+
+  it("still restarts normally when stop() is never called", async () => {
+    vi.useFakeTimers();
+
+    const session = new WhatsAppPairingSession({
+      authDir: "/tmp/whatsapp-pairing-test",
+      accountId: "acct-1",
+      onEvent: vi.fn(),
+    });
+
+    await session.start();
+    expect(makeWASocket).toHaveBeenCalledTimes(1);
+
+    sockets[0]?.ev.emit("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DISCONNECT_REASON.restartRequired } },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(makeWASocket).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
@@ -57,6 +57,7 @@ export class WhatsAppPairingSession {
   private readonly MAX_QR_ATTEMPTS = 5;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
+  private lifecycleEpoch = 0;
 
   constructor(options: WhatsAppPairingOptions) {
     this.options = options;
@@ -64,6 +65,11 @@ export class WhatsAppPairingSession {
 
   async start(): Promise<void> {
     this.stopped = false;
+    const epoch = ++this.lifecycleEpoch;
+    await this.startAttempt(epoch);
+  }
+
+  private async startAttempt(epoch: number): Promise<void> {
     this.setStatus("initializing");
 
     const baileys = await import("@whiskeysockets/baileys");
@@ -86,22 +92,26 @@ export class WhatsAppPairingSession {
 
     // stop() may have run while the awaits above were in flight -- don't
     // resurrect a socket for a session the caller already tore down.
-    if (this.stopped) {
+    if (!this.isActiveEpoch(epoch)) {
       return;
     }
 
-    this.socket = makeWASocket({
+    const socket = makeWASocket({
       version,
       auth: state,
       logger: baileysLogger,
       printQRInTerminal: false,
       browser: ["Eliza AI", "Desktop", "1.0.0"],
     });
+    this.socket = socket;
 
-    this.socket.ev.on("creds.update", saveCreds);
+    socket.ev.on("creds.update", async () => {
+      if (!this.isActiveSocket(epoch, socket)) return;
+      await saveCreds();
+    });
 
-    this.socket.ev.on("connection.update", async (update) => {
-      if (this.stopped) return;
+    socket.ev.on("connection.update", async (update) => {
+      if (!this.isActiveSocket(epoch, socket)) return;
       const { connection, lastDisconnect, qr } = update;
 
       if (qr) {
@@ -121,6 +131,7 @@ export class WhatsAppPairingSession {
             margin: 2,
             color: { dark: "#000000", light: "#ffffff" },
           });
+          if (!this.isActiveSocket(epoch, socket)) return;
 
           this.setStatus("waiting_for_qr");
           this.options.onEvent({
@@ -152,7 +163,9 @@ export class WhatsAppPairingSession {
           this.qrAttempts = 0;
           this.restartTimer = setTimeout(() => {
             this.restartTimer = null;
-            this.start().catch((err) => {
+            if (!this.isActiveEpoch(epoch)) return;
+            this.startAttempt(epoch).catch((err) => {
+              if (!this.isActiveEpoch(epoch)) return;
               coreLogger.error(`${LOG_PREFIX} Restart failed: ${String(err)}`);
               this.setStatus("error");
               this.options.onEvent({
@@ -165,7 +178,7 @@ export class WhatsAppPairingSession {
           }, 3000);
         }
       } else if (connection === "open") {
-        const phoneNumber = this.socket?.user?.id?.split(":")[0] ?? "";
+        const phoneNumber = socket.user?.id?.split(":")[0] ?? "";
         this.setStatus("connected");
         this.options.onEvent({
           type: "whatsapp-status",
@@ -179,16 +192,18 @@ export class WhatsAppPairingSession {
 
   stop(): void {
     this.stopped = true;
+    this.lifecycleEpoch++;
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
+    const socket = this.socket;
+    this.socket = null;
     try {
-      this.socket?.end(undefined);
+      socket?.end(undefined);
     } catch {
       // Ignore cleanup errors.
     }
-    this.socket = null;
   }
 
   getStatus(): WhatsAppPairingStatus {
@@ -202,6 +217,17 @@ export class WhatsAppPairingSession {
       accountId: this.options.accountId,
       status,
     });
+  }
+
+  private isActiveEpoch(epoch: number): boolean {
+    return !this.stopped && this.lifecycleEpoch === epoch;
+  }
+
+  private isActiveSocket(
+    epoch: number,
+    socket: ReturnType<typeof import("@whiskeysockets/baileys").default>
+  ): boolean {
+    return this.isActiveEpoch(epoch) && this.socket === socket;
   }
 }
 

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
@@ -56,12 +56,14 @@ export class WhatsAppPairingSession {
   private qrAttempts = 0;
   private readonly MAX_QR_ATTEMPTS = 5;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
 
   constructor(options: WhatsAppPairingOptions) {
     this.options = options;
   }
 
   async start(): Promise<void> {
+    this.stopped = false;
     this.setStatus("initializing");
 
     const baileys = await import("@whiskeysockets/baileys");
@@ -82,6 +84,12 @@ export class WhatsAppPairingSession {
     const pino = (await import("pino")).default;
     const baileysLogger = pino({ level: "silent" });
 
+    // stop() may have run while the awaits above were in flight -- don't
+    // resurrect a socket for a session the caller already tore down.
+    if (this.stopped) {
+      return;
+    }
+
     this.socket = makeWASocket({
       version,
       auth: state,
@@ -93,6 +101,7 @@ export class WhatsAppPairingSession {
     this.socket.ev.on("creds.update", saveCreds);
 
     this.socket.ev.on("connection.update", async (update) => {
+      if (this.stopped) return;
       const { connection, lastDisconnect, qr } = update;
 
       if (qr) {
@@ -169,6 +178,7 @@ export class WhatsAppPairingSession {
   }
 
   stop(): void {
+    this.stopped = true;
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
@@ -58,18 +58,24 @@ export class WhatsAppPairingSession {
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
   private lifecycleEpoch = 0;
+  private qrSequence = 0;
+  private credentialSaveTail: Promise<void> = Promise.resolve();
+  private teardownTail: Promise<void> = Promise.resolve();
 
   constructor(options: WhatsAppPairingOptions) {
     this.options = options;
   }
 
   async start(): Promise<void> {
+    await this.stop();
     this.stopped = false;
     const epoch = ++this.lifecycleEpoch;
     await this.startAttempt(epoch);
   }
 
   private async startAttempt(epoch: number): Promise<void> {
+    await Promise.all([this.credentialSaveTail, this.teardownTail]);
+    if (!this.isActiveEpoch(epoch)) return;
     this.setStatus("initializing");
 
     const baileys = await import("@whiskeysockets/baileys");
@@ -105,9 +111,15 @@ export class WhatsAppPairingSession {
     });
     this.socket = socket;
 
-    socket.ev.on("creds.update", async () => {
+    socket.ev.on("creds.update", () => {
       if (!this.isActiveSocket(epoch, socket)) return;
-      await saveCreds();
+      const save = this.credentialSaveTail.then(async () => {
+        await saveCreds();
+      });
+      this.credentialSaveTail = save.catch((error) => {
+        // error-policy:J1 The Baileys event boundary observes asynchronous credential-save failure.
+        coreLogger.error(`${LOG_PREFIX} Credential save failed: ${String(error)}`);
+      });
     });
 
     socket.ev.on("connection.update", async (update) => {
@@ -115,13 +127,14 @@ export class WhatsAppPairingSession {
       const { connection, lastDisconnect, qr } = update;
 
       if (qr) {
+        const qrSequence = ++this.qrSequence;
         this.qrAttempts++;
         coreLogger.info(
           `${LOG_PREFIX} QR code received (attempt ${this.qrAttempts}/${this.MAX_QR_ATTEMPTS})`
         );
         if (this.qrAttempts > this.MAX_QR_ATTEMPTS) {
           this.setStatus("timeout");
-          this.stop();
+          void this.stop();
           return;
         }
 
@@ -131,7 +144,7 @@ export class WhatsAppPairingSession {
             margin: 2,
             color: { dark: "#000000", light: "#ffffff" },
           });
-          if (!this.isActiveSocket(epoch, socket)) return;
+          if (!this.isActiveSocket(epoch, socket) || this.qrSequence !== qrSequence) return;
 
           this.setStatus("waiting_for_qr");
           this.options.onEvent({
@@ -190,20 +203,34 @@ export class WhatsAppPairingSession {
     });
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stopped = true;
     this.lifecycleEpoch++;
+    this.qrSequence++;
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
     const socket = this.socket;
     this.socket = null;
+    let socketTeardown: Promise<void> = Promise.resolve();
     try {
-      socket?.end(undefined);
-    } catch {
-      // Ignore cleanup errors.
+      socketTeardown = Promise.resolve(socket?.end(undefined)).catch((error) => {
+        // error-policy:J6 Pairing socket teardown is best-effort but must be observed.
+        coreLogger.warn(`${LOG_PREFIX} Socket teardown failed: ${String(error)}`);
+      });
+    } catch (error) {
+      // error-policy:J6 Pairing socket teardown is best-effort but must be observed.
+      coreLogger.warn(`${LOG_PREFIX} Socket teardown failed: ${String(error)}`);
     }
+
+    const previousTeardown = this.teardownTail;
+    this.teardownTail = Promise.all([
+      previousTeardown,
+      this.credentialSaveTail,
+      socketTeardown,
+    ]).then(() => undefined);
+    await this.teardownTail;
   }
 
   getStatus(): WhatsAppPairingStatus {
@@ -260,39 +287,43 @@ export async function whatsappLogout(workspaceDir: string, accountId = "default"
 
       await new Promise<void>((resolve) => {
         let settled = false;
-        const finish = () => {
+        const finish = async () => {
           if (settled) return;
           settled = true;
           clearTimeout(timeout);
           try {
             sock.ev.removeAllListeners("connection.update");
-          } catch {
-            /* */
+          } catch (error) {
+            // error-policy:J6 Listener removal is best-effort during logout teardown.
+            coreLogger.warn(`${LOG_PREFIX} Logout listener cleanup failed: ${String(error)}`);
           }
           try {
-            sock.end(undefined);
-          } catch {
-            /* */
+            await sock.end(undefined);
+          } catch (error) {
+            // error-policy:J6 Socket closure is best-effort after the logout result is known.
+            coreLogger.warn(`${LOG_PREFIX} Logout socket teardown failed: ${String(error)}`);
           }
           resolve();
         };
 
-        const timeout = setTimeout(finish, 10_000);
+        const timeout = setTimeout(() => void finish(), 10_000);
 
         sock.ev.on("connection.update", async (update) => {
           if (update.connection === "open") {
             try {
               await sock.logout();
             } catch {
+              // error-policy:J6 The remote session may already be logged out.
               // May fail if already logged out remotely.
             }
-            finish();
+            await finish();
           } else if (update.connection === "close") {
-            finish();
+            await finish();
           }
         });
       });
     } catch {
+      // error-policy:J6 Local auth deletion remains valid if the remote logout cannot connect.
       // If Baileys can't connect, just delete files anyway.
     }
   }

--- a/plugins/plugin-whatsapp/src/setup-routes.ts
+++ b/plugins/plugin-whatsapp/src/setup-routes.ts
@@ -32,13 +32,40 @@ import { isWhatsAppWebhookAuthorized, readWebhookRawBody } from "./webhook-auth.
 
 interface PairingSessionLike {
   start(): Promise<void>;
-  stop(): void;
+  stop(): Promise<void>;
   getStatus(): string;
 }
 
 const whatsappPairingSessions: Map<string, PairingSessionLike> = new Map();
+let pairingTransition: Promise<void> = Promise.resolve();
 
 const MAX_PAIRING_SESSIONS = 10;
+
+async function acquirePairingTransition(): Promise<() => void> {
+  const previous = pairingTransition;
+  let releaseTransition: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    releaseTransition = resolve;
+  });
+  pairingTransition = current;
+  await previous;
+  return () => {
+    releaseTransition?.();
+    if (pairingTransition === current) pairingTransition = Promise.resolve();
+  };
+}
+
+async function stopPairingSession(accountId: string): Promise<void> {
+  for (;;) {
+    const session = whatsappPairingSessions.get(accountId);
+    if (!session) return;
+    await session.stop();
+    if (whatsappPairingSessions.get(accountId) === session) {
+      whatsappPairingSessions.delete(accountId);
+      return;
+    }
+  }
+}
 
 function routeHost(req: RouteRequest): string {
   const host = req.headers?.host;
@@ -84,12 +111,16 @@ function getSetupService(runtime: IAgentRuntime): ConnectorSetupService | null {
 }
 
 /** Clean up disconnected / timed-out / errored sessions. */
-function cleanupStaleSessions(): void {
-  for (const [id, session] of whatsappPairingSessions) {
-    const status = session.getStatus();
-    if (status === "disconnected" || status === "timeout" || status === "error") {
-      session.stop();
-      whatsappPairingSessions.delete(id);
+async function cleanupStaleSessions(): Promise<void> {
+  for (const id of whatsappPairingSessions.keys()) {
+    const releaseTransition = await acquirePairingTransition();
+    try {
+      const status = whatsappPairingSessions.get(id)?.getStatus();
+      if (status === "disconnected" || status === "timeout" || status === "error") {
+        await stopPairingSession(id);
+      }
+    } finally {
+      releaseTransition();
     }
   }
 }
@@ -188,7 +219,7 @@ async function handlePair(
   res: RouteResponse,
   runtime: IAgentRuntime
 ): Promise<void> {
-  cleanupStaleSessions();
+  await cleanupStaleSessions();
 
   const setupService = getSetupService(runtime);
   const body = req.body as { accountId?: string } | null;
@@ -204,75 +235,80 @@ async function handlePair(
     res.status(400).json({ error: (err as Error).message });
     return;
   }
+  const releaseTransition = await acquirePairingTransition();
 
-  const isReplacing = whatsappPairingSessions.has(accountId);
-  if (!isReplacing && whatsappPairingSessions.size >= MAX_PAIRING_SESSIONS) {
-    res.status(429).json({
-      error: `Too many concurrent pairing sessions (max ${MAX_PAIRING_SESSIONS})`,
-    });
-    return;
-  }
+  try {
+    const isReplacing = whatsappPairingSessions.has(accountId);
+    if (!isReplacing && whatsappPairingSessions.size >= MAX_PAIRING_SESSIONS) {
+      res.status(429).json({
+        error: `Too many concurrent pairing sessions (max ${MAX_PAIRING_SESSIONS})`,
+      });
+      return;
+    }
 
-  const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
-  const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
-  whatsappPairingSessions.get(accountId)?.stop();
+    const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
+    const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
+    await stopPairingSession(accountId);
 
-  const session = new WhatsAppPairingSession({
-    authDir,
-    accountId,
-    onEvent: (event: WhatsAppPairingEvent) => {
-      setupService?.broadcastWs(event);
+    const session = new WhatsAppPairingSession({
+      authDir,
+      accountId,
+      onEvent: (event: WhatsAppPairingEvent) => {
+        setupService?.broadcastWs(event);
 
-      if (event.status === "connected") {
-        if (setupService) {
-          setupService.updateConfig((config) => {
-            if (!config.connectors) config.connectors = {};
-            const connectors = config.connectors as Record<string, Record<string, unknown>>;
-            const previousConfig = connectors.whatsapp;
-            if (accountId === "default") {
-              connectors.whatsapp = {
-                ...previousConfig,
+        if (event.status === "connected") {
+          if (setupService) {
+            setupService.updateConfig((config) => {
+              if (!config.connectors) config.connectors = {};
+              const connectors = config.connectors as Record<string, Record<string, unknown>>;
+              const previousConfig = connectors.whatsapp;
+              if (accountId === "default") {
+                connectors.whatsapp = {
+                  ...previousConfig,
+                  authDir,
+                  transport: "baileys",
+                  enabled: true,
+                };
+                return;
+              }
+              const accounts =
+                typeof previousConfig.accounts === "object" && previousConfig.accounts !== null
+                  ? { ...(previousConfig.accounts as Record<string, Record<string, unknown>>) }
+                  : {};
+              accounts[accountId] = {
+                ...(accounts[accountId] ?? {}),
                 authDir,
                 transport: "baileys",
                 enabled: true,
               };
-              return;
-            }
-            const accounts =
-              typeof previousConfig.accounts === "object" && previousConfig.accounts !== null
-                ? { ...(previousConfig.accounts as Record<string, Record<string, unknown>>) }
-                : {};
-            accounts[accountId] = {
-              ...(accounts[accountId] ?? {}),
-              authDir,
-              transport: "baileys",
-              enabled: true,
-            };
-            connectors.whatsapp = {
-              ...previousConfig,
-              accounts,
-              enabled: true,
-            };
-          });
+              connectors.whatsapp = {
+                ...previousConfig,
+                accounts,
+                enabled: true,
+              };
+            });
 
-          // Auto-populate owner contact so LifeOps can deliver reminders
-          const phoneNumber = event.phoneNumber;
-          setupService.setOwnerContact({
-            source: "whatsapp",
-            channelId: phoneNumber ?? undefined,
-          });
+            // Auto-populate owner contact so LifeOps can deliver reminders
+            const phoneNumber = event.phoneNumber;
+            setupService.setOwnerContact({
+              source: "whatsapp",
+              channelId: phoneNumber ?? undefined,
+            });
+          }
         }
-      }
-    },
-  });
+      },
+    });
 
-  whatsappPairingSessions.set(accountId, session);
+    whatsappPairingSessions.set(accountId, session);
 
-  try {
-    await session.start();
-    res.status(200).json({ ok: true, accountId, status: session.getStatus() });
-  } catch (err) {
-    res.status(500).json({ ok: false, error: String(err) });
+    try {
+      await session.start();
+      res.status(200).json({ ok: true, accountId, status: session.getStatus() });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: String(err) });
+    }
+  } finally {
+    releaseTransition();
   }
 }
 
@@ -282,7 +318,7 @@ async function handleStatus(
   res: RouteResponse,
   runtime: IAgentRuntime
 ): Promise<void> {
-  cleanupStaleSessions();
+  await cleanupStaleSessions();
 
   const setupService = getSetupService(runtime);
   const url = new URL(req.url ?? "/", `http://${routeHost(req)}`);
@@ -340,10 +376,11 @@ async function handlePairStop(
     return;
   }
 
-  const session = whatsappPairingSessions.get(accountId);
-  if (session) {
-    session.stop();
-    whatsappPairingSessions.delete(accountId);
+  const releaseTransition = await acquirePairingTransition();
+  try {
+    await stopPairingSession(accountId);
+  } finally {
+    releaseTransition();
   }
 
   res.status(200).json({ ok: true, accountId, status: "idle" });
@@ -370,48 +407,49 @@ async function handleDisconnect(
     return;
   }
 
-  const session = whatsappPairingSessions.get(accountId);
-  if (session) {
-    session.stop();
-    whatsappPairingSessions.delete(accountId);
-  }
-
-  const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
-
+  const releaseTransition = await acquirePairingTransition();
   try {
-    await whatsappLogout(workspaceDir, accountId);
-  } catch (logoutErr) {
-    console.warn(
-      `[whatsapp] Logout failed for ${accountId}, deleting auth files directly:`,
-      String(logoutErr)
-    );
-    const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
-    try {
-      fs.rmSync(authDir, { recursive: true, force: true });
-    } catch {
-      /* may not exist */
-    }
-  }
+    await stopPairingSession(accountId);
 
-  if (setupService) {
-    setupService.updateConfig((config) => {
-      const connectors = config.connectors as Record<string, unknown> | undefined;
-      if (connectors) {
-        if (accountId === "default") {
-          delete connectors.whatsapp;
-          return;
-        }
-        const whatsappConfig = connectors.whatsapp as Record<string, unknown> | undefined;
-        const accounts = whatsappConfig?.accounts as Record<string, unknown> | undefined;
-        if (accounts) {
-          delete accounts[accountId];
-        }
-        connectors.whatsapp = {
-          ...(whatsappConfig ?? {}),
-          ...(accounts ? { accounts } : {}),
-        };
+    const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
+
+    try {
+      await whatsappLogout(workspaceDir, accountId);
+    } catch (logoutErr) {
+      console.warn(
+        `[whatsapp] Logout failed for ${accountId}, deleting auth files directly:`,
+        String(logoutErr)
+      );
+      const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
+      try {
+        fs.rmSync(authDir, { recursive: true, force: true });
+      } catch {
+        /* may not exist */
       }
-    });
+    }
+
+    if (setupService) {
+      setupService.updateConfig((config) => {
+        const connectors = config.connectors as Record<string, unknown> | undefined;
+        if (connectors) {
+          if (accountId === "default") {
+            delete connectors.whatsapp;
+            return;
+          }
+          const whatsappConfig = connectors.whatsapp as Record<string, unknown> | undefined;
+          const accounts = whatsappConfig?.accounts as Record<string, unknown> | undefined;
+          if (accounts) {
+            delete accounts[accountId];
+          }
+          connectors.whatsapp = {
+            ...(whatsappConfig ?? {}),
+            ...(accounts ? { accounts } : {}),
+          };
+        }
+      });
+    }
+  } finally {
+    releaseTransition();
   }
 
   res.status(200).json({ ok: true, accountId });
@@ -471,12 +509,15 @@ export const whatsappSetupRoutes: Route[] = [
 /**
  * Stop all active pairing sessions. Called during shutdown cleanup.
  */
-export function stopAllPairingSessions(): void {
-  for (const session of whatsappPairingSessions.values()) {
+export async function stopAllPairingSessions(): Promise<void> {
+  for (const accountId of whatsappPairingSessions.keys()) {
+    const releaseTransition = await acquirePairingTransition();
     try {
-      session.stop();
+      await stopPairingSession(accountId);
     } catch {
-      /* non-fatal */
+      // error-policy:J6 Shutdown continues after a best-effort pairing teardown failure.
+    } finally {
+      releaseTransition();
     }
   }
   whatsappPairingSessions.clear();


### PR DESCRIPTION
# Relates to

Closes #22668.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@663176f21a9da5a539728278fe4d992ff1e8afd3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

A transient Baileys close schedules a new pairing socket. Deep review found that a queued internal restart could reset the stopped state, and callbacks from a replaced socket were not identity-fenced. A late callback could therefore mutate pairing state, persist stale credentials, or schedule another connection after `stop()`.

The repaired implementation uses a lifecycle epoch plus exact socket identity and serialized auth ownership:

- explicit `start()` creates a new epoch; internal reconnects retain it and cannot revive an invalidated epoch;
- `stop()` invalidates the epoch, detaches the owned socket before `.end()`, and clears the timer, making even a synchronous close callback inert;
- credential, QR, open, close, status, and restart-error paths accept only the current epoch/socket;
- asynchronous QR generation rechecks ownership after its await;
- a monotonic QR token prevents an older conversion from overwriting a newer QR from the same socket;
- admitted credential writes and asynchronous socket teardown are observed and drained before auth reload, replacement, logout, or deletion;
- both production route stacks serialize pairing transitions, including simultaneous first-pair requests and the global session cap;
- a legitimate explicit start after stop remains supported without allowing an older in-flight restart to join it.

# Sync with develop

- [x] Rebased onto `b3db7664696bbf210d749017b57fbba76e9de389` with zero conflicts.
- [x] Exact reviewed head: `71321243175821f7d0815ecdb6d8df14e7040db4`.

# Testing

```text
focused lifecycle and production-route suites
2 files, 33 pass, 0 fail

full plugin-whatsapp suite, one worker
15 files, 121 pass, 0 fail

bun run --cwd plugins/plugin-whatsapp typecheck
pass

bun run --cwd plugins/plugin-whatsapp build
Node bundle and declarations pass

biome check <two changed files>
pass

git diff --check origin/develop...HEAD
pass
```

The deterministic production-path suite covers stop during an in-flight restart, normal transient restart, an older gated restart racing a later explicit start, late close/open events from a replaced socket, delayed QR completion after stop, same-socket out-of-order QR conversion, stale credential events, same-turn admitted credential save before transient close, multiple admitted saves queued behind a gated write before replacement, synchronous close emitted by `end()`, delayed and rejected asynchronous teardown, logout deletion ordering, route replacement/logout ordering, and simultaneous first-pair requests.

A real exact-head Baileys session connected to the supported WhatsApp service and received a live QR. Awaiting `stop()` on that event detached the socket immediately, called and settled `socket.end()` exactly once, left the websocket closed/closing, emitted zero later lifecycle events over six seconds, and left zero non-stdio active handles. The QR capability was never printed or persisted, no account was paired, and isolated auth state was removed.

# Evidence Gate

<!-- evidence-head:71321243175821f7d0815ecdb6d8df14e7040db4 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector lifecycle; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector lifecycle; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible application flow or pixels changed; the supported-target proof is a real network lifecycle artifact.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head deterministic and real-network validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22667-pr22667-final-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, planner, or reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Real Baileys/WhatsApp QR stop and transport-quiescence artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22667-pr22667-final-live-baileys.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

The live proof intentionally did not scan the QR or attach a human WhatsApp account. It validates the real connection, QR, stop, socket teardown, and process-quiescence boundary without mutating an account.

AI provider/model: Anthropic / claude-sonnet-5; OpenAI / gpt-5.6-sol  
Client / agent tooling: Claude Code; Codex Desktop multi-agent review  
Contribution skill revision: original `elizaOS/eliza@663176f21a9da5a539728278fe4d992ff1e8afd3:packages/skills/skills/contribute-to-eliza`; reviewer repair used no contribution skill  
Attribution status: self-reported  
— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
