### PR TITLE
fix(plugin-openai): sanitize forced toolChoice name in Cerebras mode

### DIFF
--- a/plugins/plugin-openai/__tests__/cerebras-forced-toolchoice.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-forced-toolchoice.shape.test.ts
@@ -152,4 +152,54 @@ describe("Cerebras forced toolChoice name sanitization (#22663)", () => {
     expect(call.toolChoice).toEqual({ type: "tool", toolName: "math.factorial" });
     expect(toolKeys).toContain(call.toolChoice?.toolName);
   });
+
+  it("keeps a caller-keyed ToolSet and its forced choice verbatim in Cerebras mode", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+    const toolChoice = { type: "tool", toolName: "math.factorial" } as const;
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "compute",
+      tools: {
+        "math.factorial": {
+          description: "caller-owned AI SDK tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      },
+      toolChoice,
+    } as never);
+
+    const call = capturedCall();
+    expect(Object.keys(call.tools ?? {})).toEqual(["math.factorial"]);
+    expect(call.toolChoice).toBe(toolChoice);
+  });
+
+  it("fails closed when two source names collapse to one Cerebras tool key", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "compute",
+        tools: [
+          { name: "math.factorial", parameters: { type: "object" } },
+          { name: "math:factorial", parameters: { type: "object" } },
+        ],
+        toolChoice: "required",
+      } as never)
+    ).rejects.toMatchObject({ code: "OPENAI_TOOL_NAME_COLLISION" });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("preserves __proto__ as an own tool key instead of mutating the registry", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.openai.com/v1");
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "invoke",
+      tools: [{ name: "__proto__", parameters: { type: "object" } }],
+      toolChoice: { type: "tool", name: "__proto__" },
+    } as never);
+
+    const call = capturedCall();
+    expect(Object.keys(call.tools ?? {})).toEqual(["__proto__"]);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "__proto__" });
+  });
 });

--- a/plugins/plugin-openai/__tests__/cerebras-forced-toolchoice.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-forced-toolchoice.shape.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression shape test for forced `toolChoice` name sanitization in Cerebras
+ * mode. Exercises the real `handleTextSmall` path against a mocked `ai` SDK
+ * (`generateText`), no network, and asserts the outbound wire args keep the
+ * forced tool name consistent with the registered tool-set key.
+ *
+ * The defect (#22663): native array tools are registered under a
+ * Cerebras-sanitized key (`math.factorial` -> `math_factorial`), but a forced
+ * `toolChoice.toolName` was left unsanitized, so the AI SDK/provider rejected
+ * the call (NoSuchTool / 400) even though the tool was supplied. The invariant
+ * proven here is `toolChoice.toolName ∈ Object.keys(tools)`.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const aiMocks = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  streamText: vi.fn(),
+}));
+
+// Handlers read env (Cerebras mode, model) lazily via `runtime.getSetting` /
+// `process.env` at call time, so a static import is safe and lets the heavy
+// module compile during collection instead of inside a test's timeout window.
+import { handleTextSmall } from "../models/text";
+
+vi.mock("ai", () => ({
+  generateText: aiMocks.generateText,
+  streamText: aiMocks.streamText,
+  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  Output: {
+    object: () => ({ name: "object", responseFormat: Promise.resolve({ type: "json" }) }),
+    json: () => ({ name: "json", responseFormat: Promise.resolve({ type: "json" }) }),
+  },
+}));
+
+vi.mock("../providers", () => ({
+  createOpenAIClient: () => ({
+    chat: (modelName: string) => ({ modelName }),
+    responses: (modelName: string) => ({ modelName }),
+  }),
+}));
+
+const ENV_KEYS_TO_CLEAR = [
+  "ELIZA_PROVIDER",
+  "CEREBRAS_API_KEY",
+  "OPENAI_SMALL_MODEL",
+  "SMALL_MODEL",
+] as const;
+
+function createRuntime(): IAgentRuntime {
+  const runtime = {
+    character: { name: "Ada", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+    getSetting: vi.fn(() => undefined),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+interface CapturedCall {
+  tools?: Record<string, unknown>;
+  toolChoice?: { type?: string; toolName?: string };
+}
+
+function capturedCall(): CapturedCall {
+  return aiMocks.generateText.mock.calls[0][0] as CapturedCall;
+}
+
+beforeEach(() => {
+  vi.stubEnv("OPENAI_API_KEY", "test-key");
+  vi.stubEnv("OPENAI_SMALL_MODEL", "gpt-oss-120b");
+  for (const key of ENV_KEYS_TO_CLEAR) {
+    vi.stubEnv(key, undefined);
+  }
+  aiMocks.generateText.mockResolvedValue({
+    text: "ok",
+    finishReason: "stop",
+    usage: { inputTokens: 1, outputTokens: 1 },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("Cerebras forced toolChoice name sanitization (#22663)", () => {
+  it("sanitizes a dotted forced toolName to match the registered Cerebras tool key", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "compute",
+      tools: [{ name: "math.factorial", parameters: { type: "object" } }],
+      toolChoice: { type: "tool", name: "math.factorial" },
+    } as never);
+
+    const call = capturedCall();
+    const toolKeys = Object.keys(call.tools ?? {});
+    // The registered wire key is sanitized for Cerebras's grammar compiler.
+    expect(toolKeys).toEqual(["math_factorial"]);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "math_factorial" });
+    // The invariant that was violated: forced name must be a registered tool.
+    expect(toolKeys).toContain(call.toolChoice?.toolName);
+  });
+
+  it("sanitizes a colon forced toolName (explicit toolName field) in Cerebras mode", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "invoke",
+      tools: [{ name: "srv:tool", parameters: { type: "object" } }],
+      toolChoice: { type: "tool", toolName: "srv:tool" },
+    } as never);
+
+    const call = capturedCall();
+    const toolKeys = Object.keys(call.tools ?? {});
+    expect(toolKeys).toEqual(["srv_tool"]);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "srv_tool" });
+    expect(toolKeys).toContain(call.toolChoice?.toolName);
+  });
+
+  it("sanitizes a forced toolName supplied via the function.name shape in Cerebras mode", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "invoke",
+      tools: [{ name: "a.b.c", parameters: { type: "object" } }],
+      toolChoice: { type: "function", function: { name: "a.b.c" } },
+    } as never);
+
+    const call = capturedCall();
+    const toolKeys = Object.keys(call.tools ?? {});
+    expect(toolKeys).toEqual(["a_b_c"]);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "a_b_c" });
+    expect(toolKeys).toContain(call.toolChoice?.toolName);
+  });
+
+  it("leaves a dotted forced toolName intact for non-Cerebras providers", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://api.openai.com/v1");
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "compute",
+      tools: [{ name: "math.factorial", parameters: { type: "object" } }],
+      toolChoice: { type: "tool", name: "math.factorial" },
+    } as never);
+
+    const call = capturedCall();
+    const toolKeys = Object.keys(call.tools ?? {});
+    // Non-Cerebras: names pass through verbatim on both sides.
+    expect(toolKeys).toEqual(["math.factorial"]);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "math.factorial" });
+    expect(toolKeys).toContain(call.toolChoice?.toolName);
+  });
+});

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1171,7 +1171,21 @@ function restoreRecordArgToolCalls(
   });
 }
 
-function normalizeToolChoice(toolChoice: unknown): ToolChoice<ToolSet> | undefined {
+/**
+ * Resolves a forced-tool `toolChoice` to the AI SDK's `{ type: "tool",
+ * toolName }` shape. In Cerebras mode the forced name is passed through the
+ * SAME `sanitizeFunctionNameForCerebras` transform that `normalizeNativeTools`
+ * applies to the registered tool key, so a dotted/colon name like
+ * `math.factorial` forced via `toolChoice` still matches its wire key
+ * `math_factorial`. Without this the AI SDK rejects the request with NoSuchTool
+ * / 400 even though the tool was supplied (only the array-tools path is
+ * affected; an object `ToolSet` is keyed verbatim). Non-Cerebras names pass
+ * through unchanged.
+ */
+function normalizeToolChoice(
+  toolChoice: unknown,
+  options: { cerebrasMode?: boolean } = {}
+): ToolChoice<ToolSet> | undefined {
   if (!toolChoice) {
     return undefined;
   }
@@ -1183,14 +1197,24 @@ function normalizeToolChoice(toolChoice: unknown): ToolChoice<ToolSet> | undefin
     return toolChoice;
   }
 
+  const forcedToolName = (name: string): ToolChoice<ToolSet> => ({
+    type: "tool",
+    toolName: options.cerebrasMode ? sanitizeFunctionNameForCerebras(name) : name,
+  });
+
   const choice = asRecord(toolChoice);
   if (choice.type === "tool") {
+    // A well-formed `{ type: "tool", toolName }` is passed through by reference
+    // for non-Cerebras callers, preserving the existing wire-identity contract;
+    // Cerebras mode reconstructs it with the sanitized name.
     if (typeof choice.toolName === "string" && choice.toolName.length > 0) {
-      return toolChoice as ToolChoice<ToolSet>;
+      return options.cerebrasMode
+        ? forcedToolName(choice.toolName)
+        : (toolChoice as ToolChoice<ToolSet>);
     }
     const toolName = firstString(choice.toolName, choice.name);
     if (toolName) {
-      return { type: "tool", toolName };
+      return forcedToolName(toolName);
     }
   }
 
@@ -1198,13 +1222,13 @@ function normalizeToolChoice(toolChoice: unknown): ToolChoice<ToolSet> | undefin
     const fn = asRecord(choice.function);
     const toolName = firstString(fn.name);
     if (toolName) {
-      return { type: "tool", toolName };
+      return forcedToolName(toolName);
     }
   }
 
   const namedTool = firstString(choice.name);
   if (namedTool) {
-    return { type: "tool", toolName: namedTool };
+    return forcedToolName(namedTool);
   }
 
   return toolChoice as ToolChoice<ToolSet>;
@@ -2178,7 +2202,9 @@ async function generateTextByModelType(
     cerebrasMode,
   });
   const normalizedTools = normalizedToolResult.tools;
-  const normalizedToolChoice = normalizeToolChoice(paramsWithAttachments.toolChoice);
+  const normalizedToolChoice = normalizeToolChoice(paramsWithAttachments.toolChoice, {
+    cerebrasMode,
+  });
   const normalizedMessages = normalizeNativeMessages(paramsWithAttachments.messages);
   const wireMessages = dropDuplicateLeadingSystemMessage(normalizedMessages, systemPrompt);
   const effectiveMessages =

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -165,6 +165,8 @@ interface PreparedStructuredOutput {
 interface NormalizedNativeToolsResult {
   tools?: ToolSet;
   recordArgTransformsByTool: Record<string, RecordArgTransform[]>;
+  /** Original array-tool name to the exact key registered with the AI SDK. */
+  toolNameMap?: ReadonlyMap<string, string>;
 }
 
 const TEXT_NANO_MODEL_TYPE = ModelType.TEXT_NANO as ModelTypeName;
@@ -693,7 +695,9 @@ function normalizeNativeToolsForCall(
     return { tools: tools as ToolSet, recordArgTransformsByTool };
   }
 
-  const toolSet: Record<string, unknown> = {};
+  const toolSet: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  const toolNameMap = new Map<string, string>();
+  const originalNameByRegisteredName = new Map<string, string>();
 
   // Cerebras's grammar compiler treats strictness as request-wide, not
   // per-tool: one non-strict (or unflagged) tool downgrades every tool in the
@@ -768,6 +772,19 @@ function normalizeNativeToolsForCall(
     // sanitized name, which the runtime resolves through its action registry —
     // any caller relying on dotted action names should pre-sanitize.
     const registeredName = options.cerebrasMode ? sanitizeFunctionNameForCerebras(name) : name;
+    const collidingOriginalName = originalNameByRegisteredName.get(registeredName);
+    if (collidingOriginalName !== undefined && collidingOriginalName !== name) {
+      throw new ElizaError("[OpenAI] Native tool names collide after provider normalization.", {
+        code: "OPENAI_TOOL_NAME_COLLISION",
+        context: {
+          registeredName,
+          toolNames: [collidingOriginalName, name],
+        },
+        severity: "ephemeral",
+      });
+    }
+    originalNameByRegisteredName.set(registeredName, name);
+    toolNameMap.set(name, registeredName);
     if (recordArgTransforms.length > 0) {
       recordArgTransformsByTool[registeredName] = recordArgTransforms;
     }
@@ -786,6 +803,7 @@ function normalizeNativeToolsForCall(
   return {
     tools: Object.keys(toolSet).length > 0 ? (toolSet as ToolSet) : undefined,
     recordArgTransformsByTool,
+    toolNameMap,
   };
 }
 
@@ -1174,17 +1192,14 @@ function restoreRecordArgToolCalls(
 /**
  * Resolves a forced-tool `toolChoice` to the AI SDK's `{ type: "tool",
  * toolName }` shape. In Cerebras mode the forced name is passed through the
- * SAME `sanitizeFunctionNameForCerebras` transform that `normalizeNativeTools`
- * applies to the registered tool key, so a dotted/colon name like
- * `math.factorial` forced via `toolChoice` still matches its wire key
- * `math_factorial`. Without this the AI SDK rejects the request with NoSuchTool
- * / 400 even though the tool was supplied (only the array-tools path is
- * affected; an object `ToolSet` is keyed verbatim). Non-Cerebras names pass
- * through unchanged.
+ * exact registered key returned by array-tool normalization. Object `ToolSet`
+ * callers already own their keys and therefore pass through verbatim. This
+ * keeps a dotted/colon source name aligned with its Cerebras wire key without
+ * applying provider rewriting to the distinct object-tool contract.
  */
 function normalizeToolChoice(
   toolChoice: unknown,
-  options: { cerebrasMode?: boolean } = {}
+  options: { toolNameMap?: ReadonlyMap<string, string> } = {}
 ): ToolChoice<ToolSet> | undefined {
   if (!toolChoice) {
     return undefined;
@@ -1199,16 +1214,16 @@ function normalizeToolChoice(
 
   const forcedToolName = (name: string): ToolChoice<ToolSet> => ({
     type: "tool",
-    toolName: options.cerebrasMode ? sanitizeFunctionNameForCerebras(name) : name,
+    toolName: options.toolNameMap?.get(name) ?? name,
   });
 
   const choice = asRecord(toolChoice);
   if (choice.type === "tool") {
-    // A well-formed `{ type: "tool", toolName }` is passed through by reference
-    // for non-Cerebras callers, preserving the existing wire-identity contract;
-    // Cerebras mode reconstructs it with the sanitized name.
+    // A well-formed object-tool choice passes through by reference. Array-tool
+    // callers reconstruct it only when normalization changed its registered key.
     if (typeof choice.toolName === "string" && choice.toolName.length > 0) {
-      return options.cerebrasMode
+      const registeredName = options.toolNameMap?.get(choice.toolName);
+      return registeredName !== undefined && registeredName !== choice.toolName
         ? forcedToolName(choice.toolName)
         : (toolChoice as ToolChoice<ToolSet>);
     }
@@ -2203,7 +2218,7 @@ async function generateTextByModelType(
   });
   const normalizedTools = normalizedToolResult.tools;
   const normalizedToolChoice = normalizeToolChoice(paramsWithAttachments.toolChoice, {
-    cerebrasMode,
+    toolNameMap: normalizedToolResult.toolNameMap,
   });
   const normalizedMessages = normalizeNativeMessages(paramsWithAttachments.messages);
   const wireMessages = dropDuplicateLeadingSystemMessage(normalizedMessages, systemPrompt);


### PR DESCRIPTION
# Relates to

Closes #22663 when the live-provider evidence below is complete.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`; `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`; `Codex Desktop multi-agent review`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0bf4826f0026b81e8edfb9d23f470f644254f298:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

Cerebras array-tool normalization rewrites grammar-unsafe names such as `math.factorial` to `math_factorial`, but a forced `toolChoice` retained the source name. The AI SDK requires a forced `toolName` to identify a key in the supplied tool set, so the request failed before useful inference.

The submitted repair applied the Cerebras sanitizer to every forced name. Deep review found that approach broke the distinct caller-keyed `ToolSet` path, whose keys are deliberately preserved verbatim. The repaired implementation instead returns the exact source-to-registered mapping from array-tool normalization and resolves forced choices through that mapping. It also rejects two source names that collapse to one provider key and uses a null-prototype registry so `__proto__` remains an own tool key.

This matches the [AI SDK tool-choice contract](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling) and Cerebras's [tool-calling contract](https://inference-docs.cerebras.ai/capabilities/tool-use), where the returned/called function name indexes the registered function set.

# Verification

Exact head: `17b45f444ef829aa97f6b238b138dbf4880088f4`

Base: `35bf309548b43e0466c38debf9dcbf868aa93b49`

- Exact focused production handler: 7/7.
- Exact plugin typecheck, Biome, and diff-check: pass.
- Related native plumbing, well-formed wire, Cerebras strictness, and forced-choice suites on the identical repaired tree before the base-only rebase: 51/51.
- Node/browser/endpoint builds and declarations on that identical repaired tree: pass.
- Captured invariants: array `math.factorial -> math_factorial`; object ToolSet `math.factorial` remains verbatim and preserves choice identity; collisions throw `OPENAI_TOOL_NAME_COLLISION` before `generateText`; `__proto__` is an own key.

# Evidence Gate

<!-- evidence-head:17b45f444ef829aa97f6b238b138dbf4880088f4 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - server/runtime provider wire behavior; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server/runtime provider wire behavior; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow; live model trajectory remains required below.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head and related-suite validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22669-pr22669-backend-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Exact-head real Cerebras forced-tool trajectory](https://github.com/elizaOS/eliza/pull/22669#issuecomment-5351106175): `gpt-oss-120b` accepted source `math.factorial`, forced registered key `math_factorial`, and returned `math_factorial` with `{ "n": 6 }` and finish reason `tool-calls`; no credential material is included.
<!-- evidence-row:domain-artifacts -->
- [x] [Captured exact wire-shape matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22669-pr22669-domain-artifact.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text/layout changed.

# Disposition

The live-provider evidence hold is resolved on the exact rebased head. A real Cerebras call exercised the production handler and returned the forced sanitized tool key; deterministic focused tests, typecheck, Biome, and diff check also pass.

AI provider/model: Anthropic / claude-opus-4-8; OpenAI / gpt-5.6-sol
Client / agent tooling: pi-coding-agent; Codex Desktop multi-agent review
Contribution skill revision: elizaOS/eliza@0bf4826f0026b81e8edfb9d23f470f644254f298:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->


