### PR TITLE
fix(mcp): bound registry marketplace search pagination

### DIFF
--- a/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
+++ b/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMcpServerDetails,
+  MAX_MCP_MARKETPLACE_PAGES,
   McpMarketplaceError,
   searchMcpMarketplace,
 } from "../src/mcp-marketplace.js";
@@ -266,6 +267,58 @@ describe("MCP marketplace client", () => {
       "https://registry.modelcontextprotocol.io/v0/servers?version=latest&limit=50&cursor=next-page",
       expect.any(Object)
     );
+  });
+
+  it("allows a match on the final page in the request budget", async () => {
+    let callIndex = 0;
+    fetchMock.mockImplementation(async () => {
+      callIndex += 1;
+      if (callIndex === MAX_MCP_MARKETPLACE_PAGES) {
+        return jsonResponse(
+          registryPage([
+            {
+              name: "io.example/final-page",
+              title: "Last Page Match",
+              description: "Found at the bounded edge",
+              version: "1.0.0",
+            },
+          ])
+        );
+      }
+      return jsonResponse(registryPage([], `page-cursor-${callIndex}`));
+    });
+
+    await expect(searchMcpMarketplace("last page", 1)).resolves.toEqual({
+      results: [expect.objectContaining({ name: "io.example/final-page" })],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_MCP_MARKETPLACE_PAGES);
+  });
+
+  it("rejects a pagination cursor cycle before refetching it", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse(registryPage([], "repeated-cursor")));
+
+    await expect(searchMcpMarketplace("unmatched-query", 10)).rejects.toMatchObject({
+      code: "invalid_response",
+      message: expect.stringContaining("repeated a pagination cursor"),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects MCP registry pagination exceeding the maximum page limit", async () => {
+    let callIndex = 0;
+    fetchMock.mockImplementation(async () => {
+      callIndex += 1;
+      return jsonResponse(registryPage([], `runaway-cursor-${callIndex}`));
+    });
+
+    await expect(searchMcpMarketplace("unmatched-query", 10)).rejects.toMatchObject({
+      code: "invalid_response",
+      message: expect.stringContaining(
+        `pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`
+      ),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_MCP_MARKETPLACE_PAGES);
   });
 
   it("rejects declared and streamed responses over the configured byte cap", async () => {

--- a/plugins/plugin-mcp/src/mcp-marketplace.ts
+++ b/plugins/plugin-mcp/src/mcp-marketplace.ts
@@ -9,6 +9,9 @@ export const DEFAULT_MCP_MARKETPLACE_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_MCP_MARKETPLACE_TIMEOUT_MS = 2 * 60_000;
 const MAX_MCP_MARKETPLACE_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_MCP_MARKETPLACE_RESULTS = 50;
+// This is a request-count backstop for pathological tiny/empty pages. The
+// byte and deadline budgets normally bind first for a legitimate catalog.
+export const MAX_MCP_MARKETPLACE_PAGES = 200;
 
 export type McpMarketplaceErrorCode =
   | "aborted"
@@ -494,8 +497,13 @@ export async function searchMcpMarketplace(
   const pageLimit = normalizedQuery ? MAX_MCP_MARKETPLACE_RESULTS : requestedLimit;
   let cursor: string | undefined;
   const seenCursors = new Set<string>();
+  let pageCount = 0;
 
   do {
+    pageCount += 1;
+    if (pageCount > MAX_MCP_MARKETPLACE_PAGES) {
+      invalidResponse(`MCP registry pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`);
+    }
     const page = await fetchRegistryJson(
       createSearchUrl(pageLimit, cursor),
       parseListResponse,


### PR DESCRIPTION
## Summary

Adds a bounded request-count backstop to `searchMcpMarketplace` without breaking legitimate searches that use the marketplace client’s documented larger byte/time budgets.

- Stops pathological tiny/empty continuation chains after 200 fetched pages.
- Preserves the existing exact opaque-cursor forwarding and repeated-cursor cycle rejection.
- Keeps the shared response-byte budget and one end-to-end deadline authoritative; for normal Registry pages those limits bind before the page backstop.
- Returns a typed `invalid_response` failure rather than silently returning an incomplete healthy result.
- Proves a legitimate match is accepted on the final allowed page, a cursor cycle is rejected before a third request, and a unique-cursor runaway performs exactly 200 requests before rejection.

## Why the submitted 50-page limit was repaired

The official [MCP Registry OpenAPI contract](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml) defines `metadata.nextCursor` as an opaque continuation value that consumers must forward exactly; it does not define a 50-page catalog maximum. The official [aggregator documentation](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx) likewise describes cursor pagination for the full catalog.

A live production-path check showed that the current latest catalog already has valid results beyond page 50: exact code found `com.jampolls.hub/mcp-server` on request 60 in 5.5 seconds using the public 8 MiB / 120 s override. The submitted 50-page constant rejected that valid documented use. The repaired 200-page ceiling remains finite while sitting above the normal reach of the maximum 8 MiB response budget, so it targets pathological small pages rather than ordinary catalog growth.

## Exact-head verification

Exact head: `d0b6d9116365877ee46a9f7d1dc6790a5b43fb66`, rebased on `d2ecb03d704720e4427297a7be5ac683024aa948`.

- `bun run --cwd plugins/plugin-mcp test` — 15/15 files, 100 passed, 3 skipped.
- `bun run --cwd plugins/plugin-mcp typecheck` — clean.
- `bun run --cwd plugins/plugin-mcp build` — Node ESM, Node CJS, and declarations built successfully.
- Biome on both changed files — clean.
- `git diff --check upstream/develop...HEAD` — clean.
- Live exact-source Registry exercise — 60 real `fetch` calls, one correct `Jampolls` result, 5.5 s; no mocks.

The isolated reviewer host reports Bun 1.4.0-canary.1 / Node 23.3.0 rather than the repository-pinned Bun 1.3.14 / Node 24.15.0; the contributor separately reported 98 passed / 3 skipped plus clean package typecheck on the original proposal.

## Evidence

Non-visual Node marketplace boundary change: screenshots/video are N/A. The exact live Registry result and full package/runtime receipts above are the relevant production evidence.

Reviewed and repaired with OpenAI Codex (gpt-5.6-sol) via the Codex desktop multi-agent workflow.