### PR TITLE
fix(app-core): stop steward sidecar from resurrecting a process after stop()

### DIFF
--- a/packages/app-core/src/services/steward-sidecar-stop-restart-race.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-stop-restart-race.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Verifies stop() prevents an in-flight crash-restart's spawnProcess() from
+ * resurrecting a child process for a sidecar the caller already tore down.
+ * Mirrors the equivalent WhatsAppPairingSession fix/test
+ * (plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts).
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./steward-sidecar/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./steward-sidecar/helpers")>();
+  return {
+    ...actual,
+    allocateFirstFreeLoopbackPort: vi.fn(async (port: number) => port),
+  };
+});
+
+vi.mock("./steward-sidecar/process-management", () => ({
+  findStewardEntryPoint: vi.fn(async () => "/fake/entry.js"),
+  pipeOutput: vi.fn(),
+}));
+
+vi.mock("./steward-sidecar/health-check", () => ({
+  waitForHealthy: vi.fn(async () => undefined),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+import * as childProcess from "node:child_process";
+import { StewardSidecar } from "./steward-sidecar";
+import { allocateFirstFreeLoopbackPort } from "./steward-sidecar/helpers";
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    kill: ReturnType<typeof vi.fn>;
+    stdout: null;
+    stderr: null;
+    pid: number;
+  };
+  child.kill = vi.fn();
+  child.stdout = null;
+  child.stderr = null;
+  child.pid = 4242;
+  return child;
+}
+
+beforeEach(() => {
+  // Force the Node child_process branch regardless of the runtime this
+  // suite happens to execute under.
+  vi.stubGlobal("Bun", undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function makeSidecar() {
+  return new StewardSidecar({
+    dataDir: "/tmp/steward-sidecar-test",
+    stewardEntryPoint: "/fake/entry.js",
+  });
+}
+
+describe("StewardSidecar stop/restart race", () => {
+  it("does not spawn a process when stop() runs during an in-flight crash-restart", async () => {
+    vi.useFakeTimers();
+
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let portCalls = 0;
+    vi.mocked(allocateFirstFreeLoopbackPort).mockImplementation(
+      async (port: number) => {
+        portCalls++;
+        if (portCalls === 1) {
+          // The restart's spawnProcess() is now mid-flight -- hold it open so
+          // stop() can run while it's still blocked here.
+          await gate;
+        }
+        return port;
+      },
+    );
+    vi.mocked(childProcess.spawn).mockImplementation(
+      () => fakeChild() as never,
+    );
+
+    const sidecar = makeSidecar();
+    // Drive the crash-restart path directly, the same way a real crash would
+    // (handleCrash is private; cast to invoke it for this test).
+    await (
+      sidecar as unknown as {
+        handleCrash: (code: number | null) => Promise<void>;
+      }
+    ).handleCrash(1);
+
+    await vi.advanceTimersByTimeAsync(1_000); // INITIAL_BACKOFF_MS
+    expect(portCalls).toBe(1);
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+
+    await sidecar.stop();
+    releaseGate?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+  });
+
+  it("still restarts normally when stop() is never called", async () => {
+    vi.useFakeTimers();
+    vi.mocked(childProcess.spawn).mockImplementation(
+      () => fakeChild() as never,
+    );
+
+    const sidecar = makeSidecar();
+    await (
+      sidecar as unknown as {
+        handleCrash: (code: number | null) => Promise<void>;
+      }
+    ).handleCrash(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app-core/src/services/steward-sidecar-stop-restart-race.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-stop-restart-race.test.ts
@@ -1,8 +1,6 @@
 /**
- * Verifies stop() prevents an in-flight crash-restart's spawnProcess() from
- * resurrecting a child process for a sidecar the caller already tore down.
- * Mirrors the equivalent WhatsAppPairingSession fix/test
- * (plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts).
+ * Verifies Steward child-process ownership across overlapping stop, start,
+ * and crash-restart operations with deterministic mocked process boundaries.
  */
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +21,16 @@ vi.mock("./steward-sidecar/process-management", () => ({
 
 vi.mock("./steward-sidecar/health-check", () => ({
   waitForHealthy: vi.fn(async () => undefined),
+}));
+
+vi.mock("./steward-sidecar/wallet-setup", () => ({
+  ensureWalletSetup: vi.fn(async () => ({
+    tenantId: "tenant",
+    tenantApiKey: "tenant-key",
+    agentId: "agent",
+    agentToken: "agent-token",
+    walletAddress: "0x1234",
+  })),
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -83,6 +91,7 @@ describe("StewardSidecar stop/restart race", () => {
           // The restart's spawnProcess() is now mid-flight -- hold it open so
           // stop() can run while it's still blocked here.
           await gate;
+          return port + 1;
         }
         return port;
       },
@@ -109,6 +118,84 @@ describe("StewardSidecar stop/restart race", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(childProcess.spawn).not.toHaveBeenCalled();
+    expect(sidecar.getStatus().state).toBe("stopped");
+    expect(sidecar.getApiBase()).toBe("http://127.0.0.1:3200");
+  });
+
+  it("does not let an obsolete restart resume after stop() followed by start()", async () => {
+    vi.useFakeTimers();
+
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let portCalls = 0;
+    vi.mocked(allocateFirstFreeLoopbackPort).mockImplementation(
+      async (port: number) => {
+        portCalls++;
+        if (portCalls === 1) {
+          await gate;
+          return port + 1;
+        }
+        return port;
+      },
+    );
+    vi.mocked(childProcess.spawn).mockImplementation(
+      () => fakeChild() as never,
+    );
+
+    const sidecar = makeSidecar();
+    await (
+      sidecar as unknown as {
+        handleCrash: (code: number | null) => Promise<void>;
+      }
+    ).handleCrash(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(portCalls).toBe(1);
+
+    await sidecar.stop();
+    const startPromise = sidecar.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await startPromise;
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+    expect(sidecar.getStatus().state).toBe("running");
+
+    releaseGate?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+    expect(sidecar.getStatus().state).toBe("running");
+    expect(sidecar.getApiBase()).toBe("http://127.0.0.1:3200");
+  });
+
+  it("coalesces overlapping start() calls into one child process", async () => {
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    vi.mocked(allocateFirstFreeLoopbackPort).mockImplementation(
+      async (port: number) => {
+        await gate;
+        return port;
+      },
+    );
+    vi.mocked(childProcess.spawn).mockImplementation(
+      () => fakeChild() as never,
+    );
+
+    const sidecar = makeSidecar();
+    const firstStart = sidecar.start();
+    const secondStart = sidecar.start();
+    releaseGate?.();
+
+    const [firstStatus, secondStatus] = await Promise.all([
+      firstStart,
+      secondStart,
+    ]);
+
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+    expect(firstStatus.state).toBe("running");
+    expect(secondStatus.state).toBe("running");
   });
 
   it("still restarts normally when stop() is never called", async () => {

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -377,6 +377,13 @@ export class StewardSidecar {
       `[StewardSidecar] Spawning steward on port ${this.config.port} (entryPoint=${entryPoint}, dataDir=${this.config.dataDir})`,
     );
 
+    // stop() may have run while the awaits above (entry-point resolution,
+    // port allocation) were in flight -- don't spawn a process for a
+    // sidecar the caller already tore down.
+    if (this.stopping) {
+      return;
+    }
+
     const bun = getBunRuntime();
     if (bun) {
       const proc = bun.spawn(["bun", "run", entryPoint], {

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -109,6 +109,8 @@ export class StewardSidecar {
     exited?: Promise<number>;
   } | null = null;
   private stopping = false;
+  private lifecycleGeneration = 0;
+  private startPromise: Promise<StewardSidecarStatus> | null = null;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private credentials: StewardCredentials | null = null;
   private healthCheckAbort: AbortController | null = null;
@@ -146,26 +148,61 @@ export class StewardSidecar {
       return this.status;
     }
 
+    if (this.startPromise) {
+      return this.startPromise;
+    }
+
+    const generation = ++this.lifecycleGeneration;
+    const startPromise = this.startLifecycle(generation);
+    this.startPromise = startPromise;
+
+    try {
+      return await startPromise;
+    } finally {
+      if (this.startPromise === startPromise) {
+        this.startPromise = null;
+      }
+    }
+  }
+
+  private async startLifecycle(
+    generation: number,
+  ): Promise<StewardSidecarStatus> {
     this.stopping = false;
     this.updateStatus({ state: "starting", error: null });
 
     try {
       await this.ensureDataDir();
       await this.loadOrCreateCredentials();
-      await this.spawnProcess();
+      if (!(await this.spawnProcess(generation))) {
+        return this.status;
+      }
 
       const abort = new AbortController();
       this.healthCheckAbort = abort;
       await waitForHealthy(this.getApiBase(), abort);
-      this.healthCheckAbort = null;
+      if (this.healthCheckAbort === abort) {
+        this.healthCheckAbort = null;
+      }
+      if (!this.isLifecycleActive(generation)) {
+        return this.status;
+      }
 
-      this.credentials = await ensureWalletSetup(
+      const credentials = await ensureWalletSetup(
         this.credentials,
         this.getApiBase(),
         this.config.masterPassword,
         this.config.dataDir,
-        (p) => this.updateStatus(p),
+        (p) => {
+          if (this.isLifecycleActive(generation)) {
+            this.updateStatus(p);
+          }
+        },
       );
+      if (!this.isLifecycleActive(generation)) {
+        return this.status;
+      }
+      this.credentials = credentials;
 
       this.updateStatus({
         state: "running",
@@ -175,6 +212,9 @@ export class StewardSidecar {
 
       return this.status;
     } catch (err) {
+      if (!this.isLifecycleActive(generation)) {
+        return this.status;
+      }
       const error = err instanceof Error ? err.message : String(err);
       this.updateStatus({ state: "error", error });
       throw err;
@@ -184,6 +224,8 @@ export class StewardSidecar {
   /** Stop the Steward sidecar process gracefully. */
   async stop(): Promise<void> {
     this.stopping = true;
+    const generation = ++this.lifecycleGeneration;
+    this.startPromise = null;
 
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
@@ -195,33 +237,38 @@ export class StewardSidecar {
       this.healthCheckAbort = null;
     }
 
-    if (this.process) {
+    const processToStop = this.process;
+    if (processToStop) {
       try {
-        this.process.kill("SIGTERM");
+        processToStop.kill("SIGTERM");
         const timeout = setTimeout(() => {
           try {
-            this.process?.kill("SIGKILL");
+            processToStop.kill("SIGKILL");
           } catch {
             // already dead
           }
         }, 5_000);
 
-        if (this.process.exited) {
-          await this.process.exited;
+        if (processToStop.exited) {
+          await processToStop.exited;
         }
         clearTimeout(timeout);
       } catch {
         // process already dead
       }
-      this.process = null;
+      if (this.process === processToStop) {
+        this.process = null;
+      }
     }
 
-    this.updateStatus({
-      state: "stopped",
-      port: null,
-      pid: null,
-      startedAt: null,
-    });
+    if (this.lifecycleGeneration === generation) {
+      this.updateStatus({
+        state: "stopped",
+        port: null,
+        pid: null,
+        startedAt: null,
+      });
+    }
   }
 
   /** Restart the sidecar (stop + start). */
@@ -328,7 +375,7 @@ export class StewardSidecar {
     }
   }
 
-  private async spawnProcess(): Promise<void> {
+  private async spawnProcess(generation: number): Promise<boolean> {
     const entryPoint =
       this.config.stewardEntryPoint || (await findStewardEntryPoint());
 
@@ -340,6 +387,9 @@ export class StewardSidecar {
 
     const preferredPort = this.config.port;
     const allocatedPort = await allocateFirstFreeLoopbackPort(preferredPort);
+    if (!this.isLifecycleActive(generation)) {
+      return false;
+    }
     if (allocatedPort !== preferredPort) {
       logger.warn(
         `[StewardSidecar] Port ${preferredPort} is busy; using ${allocatedPort} instead`,
@@ -376,13 +426,6 @@ export class StewardSidecar {
     logger.info(
       `[StewardSidecar] Spawning steward on port ${this.config.port} (entryPoint=${entryPoint}, dataDir=${this.config.dataDir})`,
     );
-
-    // stop() may have run while the awaits above (entry-point resolution,
-    // port allocation) were in flight -- don't spawn a process for a
-    // sidecar the caller already tore down.
-    if (this.stopping) {
-      return;
-    }
 
     const bun = getBunRuntime();
     if (bun) {
@@ -456,10 +499,14 @@ export class StewardSidecar {
         }
       });
     }
+
+    return true;
   }
 
   private async handleCrash(exitCode: number | null): Promise<void> {
     if (this.stopping) return;
+
+    const generation = this.lifecycleGeneration;
 
     this.status.restartCount += 1;
 
@@ -484,15 +531,22 @@ export class StewardSidecar {
     this.updateStatus({ state: "restarting", pid: null });
 
     this.restartTimer = setTimeout(async () => {
-      if (this.stopping) return;
+      if (!this.isLifecycleActive(generation)) return;
 
       try {
-        await this.spawnProcess();
+        if (!(await this.spawnProcess(generation))) {
+          return;
+        }
 
         const abort = new AbortController();
         this.healthCheckAbort = abort;
         await waitForHealthy(this.getApiBase(), abort);
-        this.healthCheckAbort = null;
+        if (this.healthCheckAbort === abort) {
+          this.healthCheckAbort = null;
+        }
+        if (!this.isLifecycleActive(generation)) {
+          return;
+        }
 
         // ensureWalletSetup is intentionally skipped on crash restart:
         // credentials (tenant, agent, wallet) are created on first launch
@@ -505,10 +559,17 @@ export class StewardSidecar {
           error: null,
         });
       } catch (err) {
+        if (!this.isLifecycleActive(generation)) {
+          return;
+        }
         const error = err instanceof Error ? err.message : String(err);
         this.updateStatus({ state: "error", error });
       }
     }, backoff);
+  }
+
+  private isLifecycleActive(generation: number): boolean {
+    return !this.stopping && this.lifecycleGeneration === generation;
   }
 
   private updateStatus(partial: Partial<StewardSidecarStatus>): void {


### PR DESCRIPTION
# Relates to

No existing issue. This fixes a StewardSidecar lifecycle race found while auditing asynchronous stop/restart ownership.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` (`8b561696a0bfe61793af3d4d8a06928ee6f61647`).
- [x] Focused exact-head proof and static checks are recorded below.
- [x] The regression is deterministic and observable from process counts, status, and API port state.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`; `OpenAI GPT-5 (review/repair)`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`; `Codex (review/repair)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1b7a049d6812b2e45110d4e5629a66de1c498aa0:packages/skills/skills/contribute-to-eliza` (original contribution); repository `AGENTS.md`/`packages/app-core/CLAUDE.md` (review repair)
<!-- attribution-row:status -->
- Provenance status: `self-reported original contribution; maintainer review repair recorded here`

# Sync with develop

- [x] Rebased onto current `origin/develop` at `8b561696a0bfe61793af3d4d8a06928ee6f61647`; zero conflicts.
- [x] Original contributor commit and authorship remain intact as `1beee73548184db262abf5fa7b8001f078d8b58f`.
- [x] Maintainer repair is a separate commit, `2cae254df023cde622b4b2af48968d1527378a63`.

# Risks

Low-to-moderate lifecycle change, contained to `@elizaos/app-core`. There is no public signature change. Start calls are now single-flight; stop invalidates in-flight start/restart generations; stale continuations cannot spawn a child, change the selected port, clear a newer process, or overwrite newer status. The Bun and Node spawn paths share the same generation fence.

# Background

## What does this PR do?

`StewardSidecar.spawnProcess()` awaits entry-point discovery and loopback-port allocation before spawning. Previously, `stop()` could run during either await and return while the obsolete continuation later spawned Steward.

The originally submitted boolean re-check prevented that raw spawn in one interleaving, but still allowed the restart callback to continue into health polling and overwrite `stopped`; a later `start()` could reset the boolean and revive obsolete work; and stale port allocation could mutate `config.port` before the guard.

The repaired implementation assigns each lifecycle a monotonically increasing generation. `stop()` invalidates the active generation. Every asynchronous continuation checks ownership before mutating state, spawning, or publishing a healthy/error result. Concurrent `start()` calls share one start promise. `stop()` also captures the exact process it owns so a delayed teardown cannot kill or clear a newer process.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change is required.

# Testing

## Where should a reviewer start?

`packages/app-core/src/services/steward-sidecar-stop-restart-race.test.ts` now proves four lifecycle contracts:

1. `stop()` during a gated crash restart causes no spawn, preserves `stopped`, and rejects a stale alternate-port mutation.
2. A stop-then-start ABA sequence permits only the new lifecycle to spawn and keeps its API port/status authoritative.
3. Two overlapping `start()` calls coalesce into one child process.
4. Ordinary crash recovery still spawns when no stop occurs.

## Detailed testing steps

Exact repaired head `2cae254df023cde622b4b2af48968d1527378a63`:

```text
$ node ../scripts/run-vitest.mjs run --config vitest.config.ts src/services/steward-sidecar-stop-restart-race.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

$ bunx @biomejs/biome check src/services/steward-sidecar.ts src/services/steward-sidecar-stop-restart-race.test.ts
Checked 2 files. No fixes applied.

$ git diff --check origin/develop...HEAD
(clean)
```

The submitted exact head `01c80884bc7509478c0566379f8f309e28d41287` also had contributor-recorded package evidence: focused 14/14, full app-core Vitest 243 passed / 1 skipped files and 2013 passed / 20 skipped tests, typecheck clean, and touched Biome clean. The repair only extends the same two source/test files.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:2cae254df023cde622b4b2af48968d1527378a63 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — backend child-process lifecycle only; no visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — backend child-process lifecycle only; no visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — deterministic process/status assertions are the applicable artifact.
<!-- evidence-row:backend-logs -->
- [x] Exact-head test transcript above proves child spawn count, stopped/running status, and authoritative port across adversarial interleavings.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database or generated artifact; the domain artifact is OS child-process ownership, verified by the deterministic harness.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered output.

# Evidence Details

## Real LLM-call trajectory

N/A — no LLM-facing behavior.

## Backend + frontend logs

Backend lifecycle evidence is the exact-head four-case deterministic test transcript. No frontend is involved.

## Screenshots (before / after) + video walkthrough

N/A — no UI surface.

## Audio / voice walkthrough

N/A — no audio behavior.

## Known gaps / failures

- No live Steward binary was available. The test gates the real asynchronous seam (port allocation) and observes the Node child-process spawn boundary; the shared fence precedes both Node and Bun spawn branches.
- In this isolated repair clone, exact package typecheck could not resolve unrelated optional workspace modules (`@elizaos/plugin-*`, Capacitor modules) and the full package runner eventually hit an unrelated zero-test import failure. It was stopped after printing the already-disclosed nested `build.mjs` exit-1 line. These environment failures are outside both touched files. The contributor's clean package typecheck/full-suite evidence applies to the submitted tree; exact repair proof is the focused 4/4 test plus Biome and diff checks above.
- Full-repository `bun run verify` was not rerun in the isolated review clone.

AI provider/model: anthropic / claude-sonnet-5; OpenAI / GPT-5 review repair
Client / agent tooling: Claude Code; Codex
Attribution status: self-reported original contribution; maintainer repair recorded
