### PR TITLE
fix(plugin-discord): ignore stale events from a replaced local RPC socket

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
@@ -90,12 +90,24 @@ describe("DiscordLocalService stale local-socket events", () => {
 		const second = ensure();
 		expect(sockets).toHaveLength(2);
 
-		// The first (now-superseded) socket's close event arrives late.
+		const serviceState = service as never as {
+			socket: FakeSocket | null;
+			readBuffer: Buffer;
+			lastError: string | null;
+		};
+		serviceState.readBuffer = Buffer.from("replacement");
+		serviceState.lastError = "replacement-state";
+
+		// Every callback from the first (now-superseded) socket arrives late.
+		sockets[0].emit("connect");
+		sockets[0].emit("data", Buffer.from("stale"));
+		sockets[0].emit("error", new Error("stale error"));
 		sockets[0].emit("close");
 
-		expect((service as never as { socket: FakeSocket | null }).socket).toBe(
-			sockets[1],
-		);
+		expect(serviceState.socket).toBe(sockets[1]);
+		expect(serviceState.readBuffer.toString()).toBe("replacement");
+		expect(serviceState.lastError).toBe("replacement-state");
+		expect(sockets[0].write).not.toHaveBeenCalled();
 
 		sockets[1].emit("error", new Error("second failed"));
 		await expect(second).rejects.toThrow("second failed");
@@ -116,5 +128,50 @@ describe("DiscordLocalService stale local-socket events", () => {
 		expect(
 			(service as never as { socket: FakeSocket | null }).socket,
 		).toBeNull();
+	});
+
+	it("clears a superseded reconnect timer without replacing the live socket", async () => {
+		vi.useFakeTimers();
+		const service = makeService();
+		const state = service as never as {
+			ensureRpcConnection(): Promise<void>;
+			session: { accessToken: string; scopes: string[] } | null;
+			reconnectTimer: NodeJS.Timeout | null;
+			socket: FakeSocket | null;
+		};
+		state.session = { accessToken: "persisted", scopes: [] };
+
+		const first = state.ensureRpcConnection();
+		sockets[0].emit("close");
+		await expect(first).rejects.toThrow("connection closed");
+		expect(state.reconnectTimer).not.toBeNull();
+
+		const second = state.ensureRpcConnection();
+		expect(state.socket).toBe(sockets[1]);
+		await vi.advanceTimersByTimeAsync(3_000);
+
+		expect(sockets).toHaveLength(2);
+		expect(state.socket).toBe(sockets[1]);
+		expect(state.reconnectTimer).toBeNull();
+		sockets[1].emit("error", new Error("second failed"));
+		await expect(second).rejects.toThrow("second failed");
+	});
+
+	it("stop detaches the socket and rejects an in-flight connection", async () => {
+		const service = makeService();
+		const state = service as never as {
+			ensureRpcConnection(): Promise<void>;
+			socket: FakeSocket | null;
+			readyPromise: Promise<void> | null;
+		};
+
+		const connecting = state.ensureRpcConnection();
+		const socket = sockets[0];
+		await service.stop();
+
+		await expect(connecting).rejects.toThrow("service stopped");
+		expect(state.socket).toBeNull();
+		expect(state.readyPromise).toBeNull();
+		expect(socket.destroyed).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
@@ -69,6 +69,10 @@ function makeService(): InstanceType<typeof DiscordLocalService> {
 
 describe("DiscordLocalService stale local-socket events", () => {
 	beforeEach(() => {
+		// The local IPC service intentionally supports macOS only. Exercise that
+		// production path on Linux CI instead of failing before the fake socket is
+		// created; restoreAllMocks() returns the host platform after each test.
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 		process.env.DISCORD_IPC_DIR = "/tmp";
 	});
 

--- a/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-local-service-stale-socket.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression coverage for a stale-socket race in DiscordLocalService's local
+ * RPC IPC connection: a socket replaced by a newer ensureRpcConnection() call
+ * can still deliver a delayed "close"/"error"/"data" event after the
+ * replacement is already live. Unguarded, that stale event nulled out
+ * `this.socket` (the CURRENT, live connection) and rejected pending
+ * requests that belong to the replacement -- the same bug class fixed today
+ * in plugin-native-gateway (#22554), plugin-elizacloud (#22593), and
+ * plugin-whatsapp (#22568).
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class FakeSocket extends EventEmitter {
+	destroyed = false;
+	write = vi.fn(() => true);
+	destroy(): this {
+		this.destroyed = true;
+		return this;
+	}
+}
+
+const sockets: FakeSocket[] = [];
+
+vi.mock("node:net", () => ({
+	default: {
+		createConnection: () => {
+			const socket = new FakeSocket();
+			sockets.push(socket);
+			return socket;
+		},
+	},
+}));
+
+vi.mock("node:fs", async () => {
+	const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+	return { ...actual, default: { ...actual, existsSync: () => true } };
+});
+
+vi.mock("@elizaos/core", () => ({
+	ChannelType: {},
+	ContentType: {},
+	Service: class Service {
+		runtime: unknown;
+		constructor(runtime?: unknown) {
+			this.runtime = runtime;
+		}
+	},
+	createMessageMemory: vi.fn(),
+	createUniqueUuid: vi.fn(),
+	logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+	resolveStateDir: () => "/tmp",
+	stringToUuid: vi.fn(),
+}));
+
+// Import after the mocks above are registered so the module under test picks
+// them up.
+const { DiscordLocalService } = await import("../discord-local-service.ts");
+
+function makeService(): InstanceType<typeof DiscordLocalService> {
+	return new DiscordLocalService({
+		getSetting(key: string) {
+			if (key === "DISCORD_LOCAL_CLIENT_ID") return "client";
+			if (key === "DISCORD_LOCAL_CLIENT_SECRET") return "secret";
+			return undefined;
+		},
+	} as never);
+}
+
+describe("DiscordLocalService stale local-socket events", () => {
+	beforeEach(() => {
+		process.env.DISCORD_IPC_DIR = "/tmp";
+	});
+
+	afterEach(() => {
+		sockets.length = 0;
+		vi.restoreAllMocks();
+	});
+
+	it("does not let a stale close from a replaced socket clear the live connection", async () => {
+		const service = makeService();
+		const ensure = (
+			service as never as { ensureRpcConnection(): Promise<void> }
+		).ensureRpcConnection.bind(service);
+
+		const first = ensure();
+		sockets[0].emit("error", new Error("first failed"));
+		await expect(first).rejects.toThrow("first failed");
+
+		const second = ensure();
+		expect(sockets).toHaveLength(2);
+
+		// The first (now-superseded) socket's close event arrives late.
+		sockets[0].emit("close");
+
+		expect((service as never as { socket: FakeSocket | null }).socket).toBe(
+			sockets[1],
+		);
+
+		sockets[1].emit("error", new Error("second failed"));
+		await expect(second).rejects.toThrow("second failed");
+	});
+
+	it("nulls the socket on a close with no reconnect pending, so a fresh connect attempt is not blocked", async () => {
+		const service = makeService();
+		const ensure = (
+			service as never as { ensureRpcConnection(): Promise<void> }
+		).ensureRpcConnection.bind(service);
+
+		const first = ensure();
+		sockets[0].emit("error", new Error("first failed"));
+		await expect(first).rejects.toThrow("first failed");
+		// No persisted session -> no accessToken -> no reconnect scheduled.
+		sockets[0].emit("close");
+
+		expect(
+			(service as never as { socket: FakeSocket | null }).socket,
+		).toBeNull();
+	});
+});

--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -913,6 +913,7 @@ export class DiscordLocalService extends Service {
 		this.readBuffer = Buffer.alloc(0);
 
 		socket.on("connect", () => {
+			if (this.socket !== socket) return;
 			this.connectedIpcPath = ipcPath;
 			this.writeFrame(IPC_OP_HANDSHAKE, {
 				v: 1,
@@ -921,26 +922,34 @@ export class DiscordLocalService extends Service {
 		});
 
 		socket.on("data", (chunk: Buffer) => {
+			if (this.socket !== socket) return;
 			this.handleSocketData(chunk);
 		});
 
 		socket.on("close", () => {
+			if (this.socket !== socket) return;
 			const error = new Error("Discord local RPC connection closed");
 			this.connected = false;
 			this.authenticated = false;
 			this.connectedIpcPath = null;
-			this.socket = null;
 			this.rejectPendingRequests(error);
 			this.readyReject?.(error);
 			this.readyReject = null;
 			this.readyResolve = null;
 			this.readyPromise = null;
 			if (this.session?.accessToken) {
-				this.scheduleReconnect();
+				// Leave this.socket pointing at the dead socket until the reconnect
+				// timer's own identity check (scheduleReconnect) either fires or is
+				// superseded by a genuinely new connection -- nulling it here would
+				// make that check compare against null and never reconnect.
+				this.scheduleReconnect(socket);
+			} else {
+				this.socket = null;
 			}
 		});
 
 		socket.on("error", (error) => {
+			if (this.socket !== socket) return;
 			this.lastError = error.message;
 			this.connectedIpcPath = null;
 			this.readyReject?.(error);
@@ -953,16 +962,20 @@ export class DiscordLocalService extends Service {
 		await this.readyPromise;
 	}
 
-	private scheduleReconnect(): void {
+	private scheduleReconnect(expectedSocket: net.Socket): void {
 		if (this.reconnectTimer) {
 			clearTimeout(this.reconnectTimer);
 		}
-		this.reconnectTimer = setTimeout(() => {
+		const timer = setTimeout(() => {
+			if (this.reconnectTimer !== timer || this.socket !== expectedSocket)
+				return;
 			this.reconnectTimer = null;
+			this.socket = null;
 			void this.ensureAuthenticated().catch((error) => {
 				this.lastError = error instanceof Error ? error.message : String(error);
 			});
 		}, 3_000);
+		this.reconnectTimer = timer;
 	}
 
 	private handleSocketData(chunk: Buffer): void {

--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -530,9 +530,15 @@ export class DiscordLocalService extends Service {
 		this.connected = false;
 		this.authenticated = false;
 		this.connectedIpcPath = null;
-		this.rejectPendingRequests(new Error("Discord local service stopped"));
-		this.socket?.destroy();
+		const error = new Error("Discord local service stopped");
+		this.rejectPendingRequests(error);
+		this.readyReject?.(error);
+		this.readyReject = null;
+		this.readyResolve = null;
+		this.readyPromise = null;
+		const socket = this.socket;
 		this.socket = null;
+		socket?.destroy();
 	}
 
 	isConnected(): boolean {
@@ -967,9 +973,9 @@ export class DiscordLocalService extends Service {
 			clearTimeout(this.reconnectTimer);
 		}
 		const timer = setTimeout(() => {
-			if (this.reconnectTimer !== timer || this.socket !== expectedSocket)
-				return;
+			if (this.reconnectTimer !== timer) return;
 			this.reconnectTimer = null;
+			if (this.socket !== expectedSocket) return;
 			this.socket = null;
 			void this.ensureAuthenticated().catch((error) => {
 				this.lastError = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
# Relates to

Closes #22673.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`, `Claude Code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository review workflow; no contribution skill revision was recorded by the original contributors`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

Events from an old Discord desktop IPC socket could mutate the global connection state after a newer socket replaced it. The submitted repair correctly bound `connect`, `data`, `close`, and `error` listeners to their socket and added reconnect identity checks.

Deep review found two remaining lifecycle leaks and repaired them:

- a superseded reconnect timer returned before clearing its own stored handle;
- `stop()` destroyed the socket without rejecting/resetting an in-flight `readyPromise`, leaving a caller hung and allowing synchronous teardown callbacks to observe the socket as current.

The exact head now clears a fired timer before its socket-identity branch, rejects and resets the pending handshake, detaches the socket, and only then destroys it. Stale connect/data/error/close callbacks remain effect-free, while an authoritative close without a persisted session still clears the socket.

# Sync with develop

- [x] Transplanted the two PR commits onto current `develop` `51925e577f28c273a7f4d38dce8499440b039e64`; the contributor branch contained obsolete historical merge commits that conflicted with their squash equivalents.
- [x] Exact repaired and accepted head: `a110433becfcbca254e118b5f046fc03c383ec5d`.

# Testing

```text
vitest discord-local-service-stale-socket
4 pass, 0 fail

plugin-discord production build
Node bundle, user-account-scraper subpath, declarations: pass

biome check <two changed files>
pass

plugin-discord typecheck
pass after building its workspace declaration prerequisites

git diff --check
pass
```

Mutation proof restored the submitted stop/timer semantics: the timer test retained a stale handle and the stop test timed out after 1,000ms on the unresolved handshake. The repaired exact head passes both.

The exact head was also exercised against the running macOS Discord desktop app's real `discord-ipc-0` endpoint. Two genuine READY handshakes established a replacement socket; delayed connect, READY/data, error, and close events injected from the superseded socket left the replacement connected and its buffer/diagnostics unchanged. Stopping during a third real handshake rejected promptly with `Discord local service stopped`; after the reconnect interval, the socket, reconnect timer, and ready promise all remained null.

# Evidence Gate

<!-- evidence-head:a110433becfcbca254e118b5f046fc03c383ec5d -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend macOS IPC connector lifecycle; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend macOS IPC connector lifecycle; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no application pixels changed; the supported-target IPC lifecycle receipt is attached under domain artifacts.
<!-- evidence-row:backend-logs -->
- [x] [22672-pr22672-d45ce-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22672-pr22672-d45ce-validation.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, planner, or reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22672-pr22672-d45ce-live-ipc.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22672-pr22672-d45ce-live-ipc.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Known gaps / failures

No implementation or evidence gap is known at the current head. The existing changes-requested review predates the exact-head live desktop receipt and should be re-dispositioned by its reviewer.

AI provider/model: OpenAI / gpt-5.6-sol; Anthropic / claude-sonnet-5
Client / agent tooling: Codex; Claude Code; Codex Desktop multi-agent review
Contribution skill revision: N/A - repository review workflow; no contribution skill revision recorded
Attribution status: self-reported
— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
## Maintainer exact-head portability repair

Current head `a110433becfcbca254e118b5f046fc03c383ec5d` adds only a deterministic test-harness platform spy. The production `discord-local-service.ts` blob is unchanged from the live macOS IPC receipt at parent `d45ce4c87316e71c5ce90b8b50fe0e6fdd8fe978`. Before the repair, the committed test failed 4/4 on Linux at `requireConfig()` without creating a fake socket. With `process.platform` explicitly mocked to the supported `darwin` target, Linux CI exercises all four socket replacement/stop/reconnect races and passes 4/4.

```text
Pinned Bun 1.3.14 / Node 24.15.0
vitest run discord-local-service-stale-socket.test.ts: 4 passed, 0 failed
Biome check changed test: pass
git diff --check: pass
```

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - GitHub review workflow; contribution skill not used
Attribution status: self-reported
— [codex-round2-connectors]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - GitHub review workflow; contribution skill not used"} -->