### PR TITLE
fix(gateway-discord): stop a stale connectBot() login failure from overwriting a legitimate disconnect status

### DIFF
--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -771,8 +771,14 @@ export class GatewayManager {
       this.isElizaAppLeader = false;
     }
 
+    // Revoke ownership before any awaited teardown. An in-flight login or
+    // Discord event must observe that shutdown owns the connection now and
+    // may not publish a late status or route an event.
+    const connectionsToClose = [...this.connections.entries()];
+    this.connections.clear();
+
     // Save session state and disconnect all bots
-    for (const [connectionId, conn] of this.connections) {
+    for (const [connectionId, conn] of connectionsToClose) {
       await this.saveSessionState(connectionId, conn);
       this.removeAllListeners(conn);
       // Reservations have no client until connectBot finishes.
@@ -819,7 +825,6 @@ export class GatewayManager {
       }
     }
 
-    this.connections.clear();
     logger.info("Gateway manager shutdown complete");
   }
 
@@ -1073,7 +1078,12 @@ export class GatewayManager {
       ),
     };
 
+    const previous = this.connections.get(assignment.connectionId);
     this.connections.set(assignment.connectionId, conn);
+    if (previous?.client) {
+      this.removeAllListeners(previous);
+      previous.client.destroy();
+    }
 
     const markConnectionReady = async (
       source: "client-ready" | "shard-ready" | "shard-resume",
@@ -1120,6 +1130,9 @@ export class GatewayManager {
       handler: (...args: T) => Promise<void>,
     ) => {
       const wrappedHandler = async (...args: T) => {
+        if (this.connections.get(assignment.connectionId) !== conn) {
+          return;
+        }
         try {
           await handler(...args);
         } catch (error) {
@@ -1369,21 +1382,18 @@ export class GatewayManager {
     try {
       await client.login(assignment.botToken);
     } catch (error) {
+      // A disconnect, replacement, or shutdown revokes ownership before it
+      // starts awaited teardown. The rejected login belongs to that stale
+      // client and must not log or publish a failure for the current owner.
+      if (this.connections.get(assignment.connectionId) !== conn) {
+        return;
+      }
+
       const errorMessage = sanitizeError(error);
       logger.error("Failed to login bot", {
         connectionId: assignment.connectionId,
         error: errorMessage,
       });
-
-      // disconnectBot() may have already torn this connection down (or a
-      // newer connectBot() call may have replaced it) while login() was in
-      // flight -- its own cleanup already ran. Don't double-clean a
-      // connection this invocation no longer owns, and don't overwrite a
-      // legitimate "disconnected" status (or a newer connection's status)
-      // with "error", which would incorrectly flag it for reassignment.
-      if (this.connections.get(assignment.connectionId) !== conn) {
-        return;
-      }
 
       // Releases the failed connection so it can be retried
       this.removeAllListeners(conn);
@@ -1404,13 +1414,15 @@ export class GatewayManager {
     if (!conn) return;
 
     logger.info("Disconnecting bot", { connectionId });
+    // Revoke ownership synchronously so a login rejection or queued Discord
+    // event cannot race the awaited session save and act as the live client.
+    this.connections.delete(connectionId);
     await this.saveSessionState(connectionId, conn);
     this.removeAllListeners(conn);
     // Reservations have no client until connectBot finishes.
     if (conn.client) {
       conn.client.destroy();
     }
-    this.connections.delete(connectionId);
     await this.updateConnectionStatus(connectionId, "disconnected");
   }
 

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -1375,6 +1375,16 @@ export class GatewayManager {
         error: errorMessage,
       });
 
+      // disconnectBot() may have already torn this connection down (or a
+      // newer connectBot() call may have replaced it) while login() was in
+      // flight -- its own cleanup already ran. Don't double-clean a
+      // connection this invocation no longer owns, and don't overwrite a
+      // legitimate "disconnected" status (or a newer connection's status)
+      // with "error", which would incorrectly flag it for reassignment.
+      if (this.connections.get(assignment.connectionId) !== conn) {
+        return;
+      }
+
       // Releases the failed connection so it can be retried
       this.removeAllListeners(conn);
       client.destroy();

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -1081,6 +1081,10 @@ export class GatewayManager {
     const previous = this.connections.get(assignment.connectionId);
     this.connections.set(assignment.connectionId, conn);
     if (previous?.client) {
+      // Same teardown contract as disconnectBot/shutdown: persist the
+      // superseded connection's counters before its client is destroyed, so a
+      // replacement does not silently discard guild and event totals.
+      await this.saveSessionState(assignment.connectionId, previous);
       this.removeAllListeners(previous);
       previous.client.destroy();
     }
@@ -1382,10 +1386,20 @@ export class GatewayManager {
     try {
       await client.login(assignment.botToken);
     } catch (error) {
-      // A disconnect, replacement, or shutdown revokes ownership before it
-      // starts awaited teardown. The rejected login belongs to that stale
-      // client and must not log or publish a failure for the current owner.
+      // error-policy:J1 transport boundary — a login failure for the current
+      // owner is published to the control plane as an "error" connection
+      // status so the next poll can reassign it.
+      //
+      // error-policy:J5 a disconnect, replacement, or shutdown revokes
+      // ownership before it starts awaited teardown, so this rejection belongs
+      // to a client that path already destroyed; disconnectBot/shutdown
+      // publishes the authoritative status for the slot and this stale
+      // rejection must not overwrite it.
       if (this.connections.get(assignment.connectionId) !== conn) {
+        logger.debug("Ignoring stale bot login rejection", {
+          connectionId: assignment.connectionId,
+          error: sanitizeError(error),
+        });
         return;
       }
 

--- a/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Verifies a stale connectBot() login failure can't overwrite the status of
+ * a connection that disconnectBot() (or a newer connectBot()) already took
+ * ownership of while login() was in flight.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import * as discordActual from "discord.js";
+
+const createdClients: FakeDiscordClient[] = [];
+let pendingLogin: (() => Promise<unknown>) | null = null;
+
+class FakeDiscordClient extends EventEmitter {
+  login = mock(() => (pendingLogin ? pendingLogin() : Promise.resolve()));
+  destroy = mock(() => undefined);
+  guilds = { cache: { size: 0 } };
+  user = undefined;
+
+  constructor() {
+    super();
+    createdClients.push(this);
+  }
+}
+
+// `mock.module` is process-global: spread the real discord.js module so this
+// file's partial mock (only `Client`) does not drop the other exports (e.g.
+// `Events`, `Partials`, `GatewayIntentBits`) for later test files in the same
+// run. No other test file in this package constructs a real `Client`.
+mock.module("discord.js", () => ({
+  ...discordActual,
+  Client: mock(() => new FakeDiscordClient()),
+}));
+
+const { GatewayManager } = await import("../src/gateway-manager");
+
+function statusPosts(fetchMock: ReturnType<typeof mock>) {
+  return fetchMock.mock.calls
+    .filter(([url]: [string]) => url.includes("/gateway/status"))
+    .map(([, init]: [string, RequestInit]) => JSON.parse(String(init.body)));
+}
+
+function makeManager() {
+  const manager = new GatewayManager({
+    podName: "test-pod",
+    elizaCloudUrl: "https://eliza.test",
+    gatewayBootstrapSecret: "secret",
+    project: "test",
+  });
+  // Bypass acquireToken(): stub the private auth fields directly.
+  (manager as unknown as { accessToken: string }).accessToken = "test-token";
+  (manager as unknown as { tokenExpiresAt: Date }).tokenExpiresAt = new Date(
+    Date.now() + 60_000,
+  );
+  return manager;
+}
+
+const ASSIGNMENT = {
+  connectionId: "conn-1",
+  organizationId: "org-1",
+  applicationId: "app-1",
+  botToken: "fake-token",
+  intents: 0,
+  characterId: null,
+};
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  createdClients.length = 0;
+  pendingLogin = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("connectBot / disconnectBot ownership race", () => {
+  test("does not overwrite a legitimate disconnect with an error status", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const manager = makeManager();
+    const gm = manager as unknown as {
+      connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
+      disconnectBot: (id: string) => Promise<void>;
+    };
+
+    let rejectLogin: ((err: Error) => void) | undefined;
+    pendingLogin = () =>
+      new Promise((_resolve, reject) => {
+        rejectLogin = reject;
+      });
+
+    const connectPromise = gm.connectBot(ASSIGNMENT);
+
+    // Disconnect while login() is still in flight -- this is the legitimate,
+    // caller-initiated teardown.
+    await gm.disconnectBot(ASSIGNMENT.connectionId);
+    expect(statusPosts(fetchMock).at(-1)).toMatchObject({
+      status: "disconnected",
+    });
+
+    // Now the destroyed client's login() rejects (as it would in reality
+    // once the underlying connection is torn down mid-handshake).
+    rejectLogin?.(new Error("destroyed mid-login"));
+    await connectPromise;
+
+    const posts = statusPosts(fetchMock);
+    expect(posts.map((p: { status: string }) => p.status)).not.toContain(
+      "error",
+    );
+    expect(posts.at(-1)).toMatchObject({ status: "disconnected" });
+  });
+
+  test("still reports error status when login fails with no concurrent disconnect", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const manager = makeManager();
+    const gm = manager as unknown as {
+      connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
+    };
+
+    let rejectLogin: ((err: Error) => void) | undefined;
+    pendingLogin = () =>
+      new Promise((_resolve, reject) => {
+        rejectLogin = reject;
+      });
+
+    const connectPromise = gm.connectBot(ASSIGNMENT);
+    rejectLogin?.(new Error("bad token"));
+    await connectPromise;
+
+    const posts = statusPosts(fetchMock);
+    expect(posts.at(-1)).toMatchObject({ status: "error" });
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
@@ -136,10 +136,31 @@ describe("connectBot / disconnectBot ownership race", () => {
       connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
     };
 
+    const teardownOrder: string[] = [];
+    const setex = mock(async (...args: unknown[]) => {
+      teardownOrder.push(`setex:${String(args[0])}`);
+      return "OK";
+    });
+    (manager as unknown as { redis: unknown }).redis = { setex };
+
     const firstLogin = deferred();
     pendingLogin = () => firstLogin.promise;
     const firstConnect = gm.connectBot(ASSIGNMENT);
     const firstClient = createdClients[0];
+    firstClient.destroy = mock(() => {
+      teardownOrder.push("destroy");
+      return undefined;
+    });
+    // Counters the superseded connection accumulated before it was replaced.
+    const firstConn = (
+      manager as unknown as {
+        connections: Map<string, { guildCount: number; eventsRouted: number }>;
+      }
+    ).connections.get(ASSIGNMENT.connectionId);
+    if (!firstConn) throw new Error("first connection was never registered");
+    firstConn.guildCount = 3;
+    firstConn.eventsRouted = 7;
+
     const queuedError = firstClient.listeners(
       discordActual.Events.Error,
     )[0] as (error: Error) => Promise<void>;
@@ -148,6 +169,18 @@ describe("connectBot / disconnectBot ownership race", () => {
     await gm.connectBot(ASSIGNMENT);
 
     expect(firstClient.destroy).toHaveBeenCalledTimes(1);
+    // The superseded connection's session state is persisted before its client
+    // is destroyed, exactly as disconnectBot and shutdown do.
+    expect(teardownOrder).toEqual([
+      `setex:discord:session:${ASSIGNMENT.connectionId}`,
+      "destroy",
+    ]);
+    const savedState = JSON.parse(String(setex.mock.calls[0]?.[2]));
+    expect(savedState).toMatchObject({
+      connectionId: ASSIGNMENT.connectionId,
+      guildCount: 3,
+      eventsRouted: 7,
+    });
     await queuedError(new Error("stale socket error"));
     firstLogin.reject(new Error("replaced login"));
     await firstConnect;

--- a/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
@@ -55,6 +55,16 @@ function makeManager() {
   return manager;
 }
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const ASSIGNMENT = {
   connectionId: "conn-1",
   organizationId: "org-1",
@@ -77,7 +87,7 @@ afterEach(() => {
 });
 
 describe("connectBot / disconnectBot ownership race", () => {
-  test("does not overwrite a legitimate disconnect with an error status", async () => {
+  test("revokes ownership before an awaited disconnect session save", async () => {
     const fetchMock = mock(async () => new Response(null, { status: 200 }));
     globalThis.fetch = fetchMock as typeof fetch;
 
@@ -85,6 +95,11 @@ describe("connectBot / disconnectBot ownership race", () => {
     const gm = manager as unknown as {
       connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
       disconnectBot: (id: string) => Promise<void>;
+    };
+
+    const save = deferred();
+    (manager as unknown as { redis: unknown }).redis = {
+      setex: mock(() => save.promise),
     };
 
     let rejectLogin: ((err: Error) => void) | undefined;
@@ -95,23 +110,83 @@ describe("connectBot / disconnectBot ownership race", () => {
 
     const connectPromise = gm.connectBot(ASSIGNMENT);
 
-    // Disconnect while login() is still in flight -- this is the legitimate,
-    // caller-initiated teardown.
-    await gm.disconnectBot(ASSIGNMENT.connectionId);
-    expect(statusPosts(fetchMock).at(-1)).toMatchObject({
-      status: "disconnected",
-    });
+    // The session save is deliberately stalled. Ownership must already be
+    // revoked even though disconnectBot() has not reached client.destroy().
+    const disconnectPromise = gm.disconnectBot(ASSIGNMENT.connectionId);
 
-    // Now the destroyed client's login() rejects (as it would in reality
-    // once the underlying connection is torn down mid-handshake).
+    // The old login fails while teardown is still awaiting the session save.
     rejectLogin?.(new Error("destroyed mid-login"));
     await connectPromise;
+    save.resolve();
+    await disconnectPromise;
 
     const posts = statusPosts(fetchMock);
     expect(posts.map((p: { status: string }) => p.status)).not.toContain(
       "error",
     );
     expect(posts.at(-1)).toMatchObject({ status: "disconnected" });
+  });
+
+  test("destroys a replaced client and ignores its queued error callback", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const manager = makeManager();
+    const gm = manager as unknown as {
+      connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
+    };
+
+    const firstLogin = deferred();
+    pendingLogin = () => firstLogin.promise;
+    const firstConnect = gm.connectBot(ASSIGNMENT);
+    const firstClient = createdClients[0];
+    const queuedError = firstClient.listeners(
+      discordActual.Events.Error,
+    )[0] as (error: Error) => Promise<void>;
+
+    pendingLogin = () => Promise.resolve();
+    await gm.connectBot(ASSIGNMENT);
+
+    expect(firstClient.destroy).toHaveBeenCalledTimes(1);
+    await queuedError(new Error("stale socket error"));
+    firstLogin.reject(new Error("replaced login"));
+    await firstConnect;
+
+    expect(statusPosts(fetchMock)).toEqual([]);
+  });
+
+  test("shutdown revokes ownership before destroying an in-flight login", async () => {
+    const shutdownResponse = deferred<Response>();
+    const fetchMock = mock(async (url: string) => {
+      if (url.includes("/gateway/shutdown")) return shutdownResponse.promise;
+      return new Response(null, { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const manager = makeManager();
+    const gm = manager as unknown as {
+      connectBot: (a: typeof ASSIGNMENT) => Promise<void>;
+    };
+
+    const login = deferred();
+    const save = deferred();
+    (manager as unknown as { redis: unknown }).redis = {
+      setex: mock(() => save.promise),
+      del: mock(() => Promise.resolve()),
+      srem: mock(() => Promise.resolve()),
+    };
+    pendingLogin = () => login.promise;
+    const connectPromise = gm.connectBot(ASSIGNMENT);
+    const shutdownPromise = manager.shutdown();
+
+    await Promise.resolve();
+    login.reject(new Error("shutdown destroyed login"));
+    await connectPromise;
+    expect(statusPosts(fetchMock)).toEqual([]);
+
+    save.resolve();
+    shutdownResponse.resolve(new Response(null, { status: 200 }));
+    await shutdownPromise;
   });
 
   test("still reports error status when login fails with no concurrent disconnect", async () => {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No existing issue — found directly in the code (checked GitHub issues/PRs for "gateway-manager connectBot disconnectBot" before starting; no collision). Third instance this session of an async-lifecycle race where a teardown method doesn't prevent an in-flight start/connect from acting on state it no longer owns — after #22667 (`WhatsAppPairingSession`) and #22671 (`StewardSidecar`), this one manifests as an incorrect status write racing a legitimate disconnect rather than a literal resurrected connection.

**Update:** maintainer review (`lalalune`, via `codex-root-review`) found the original single-guard fix incomplete — it revoked ownership too late relative to `disconnectBot`'s own awaited teardown, didn't tear down a client replaced without going through `disconnectBot`, and didn't fence already-attached event listeners on a stale client. The maintainer pushed a follow-up commit (`fix(gateway-discord): make bot ownership transitions atomic`) directly onto this branch closing all three gaps. I independently verified that commit (full package test suite, typecheck, Biome — all clean, see Testing below) and rebased it onto the latest `origin/develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package-scoped verify commands run after sync (see Testing below); full-repo `bun run verify` not run — documented in **Known gaps / failures**.
- [ ] A reviewer can confirm the change works without reading the code, from the evidence attached below — **see Known gaps: live-Discord-gateway proof is explicitly requested by the maintainer review and is not available in this environment.**

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1ea54b33d8837d1fdedf1ce20688a9dc2a31e47c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Note: the second commit on this branch (`fix(gateway-discord): make bot ownership transitions atomic`) was authored and pushed directly by maintainer review tooling (`moon <shawmakesmagic@gmail.com>` / `codex-root-review`, OpenAI gpt-5.6-sol via Codex Desktop), not by me. I independently reviewed and verified it before rebasing; provenance for that commit is self-reported by its own author in the review comment on this PR.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Package-scoped verify passes post-sync — see Testing below. Full-repo `bun run verify` not run; documented in **Known gaps / failures**.

# Risks

Low-to-moderate. Single-package (`@elizaos/gateway-discord`), touches `connectBot`, `disconnectBot`, `shutdown`, and the shared `createHandler` event-wrapper in `gateway-manager.ts` — a wider surface than the original single-guard fix, but every change is an additive ownership check or an ordering fix (revoke-before-await), not a behavioral change to the non-racing path. No public API/signature change. This is exactly the kind of connector-lifecycle change the maintainer review flags as needing live-target verification before merge — see Known gaps.

# Background

## What does this PR do?

**Original finding:** `GatewayManager.connectBot()` registers its `BotConnection` in `this.connections` synchronously, then has exactly one `await`: `client.login(...)`. If `disconnectBot()` (or a replacement `connectBot()`) ran while that `login()` was in flight, the original `connectBot()`'s `catch` block ran unconditionally, overwriting a legitimate `"disconnected"` status with `"error"` — silently flagging a deliberately-disconnected bot for reassignment.

**Maintainer's follow-up (this PR's current state):** the first-pass fix (a single `this.connections.get(id) !== conn` check in the login-failure catch) left three gaps:

1. **Ownership was revoked too late.** `disconnectBot` deleted the connection from `this.connections` only *after* `await this.saveSessionState(...)`. During that await window, a stale `connectBot`'s catch-block identity check would still see the old `conn` present and incorrectly conclude it still owned the slot. Fixed: `disconnectBot` now deletes synchronously, before any await. The same reordering applies to `shutdown()`, which now snapshots and clears `this.connections` before its teardown loop instead of clearing it at the end.
2. **A client replaced without going through `disconnectBot` was never torn down.** If a new `connectBot()` call overwrote an existing map entry for the same `connectionId` (e.g. a reassignment race), the previous `BotConnection`'s Discord.js client and listeners were simply dropped, leaking the live socket. Fixed: `connectBot` now captures the previous entry before overwriting the map and, if it had a client, removes its listeners and destroys it.
3. **Event listeners on a superseded client weren't fenced.** The original fix only guarded the login-failure catch; the ~15 other Discord.js event handlers (wrapped by the shared `createHandler`) had no ownership check, so a queued event from a stale-but-still-attached client could still fire and mutate state after the connection was superseded. Fixed: `createHandler`'s wrapper now checks `this.connections.get(assignment.connectionId) !== conn` before invoking the wrapped handler at all.

Same class of bug as `WhatsAppPairingSession` (#22667) and `StewardSidecar` (#22671) fixed earlier this session — a teardown method that doesn't prevent in-flight work from acting on state it no longer owns — but this iteration required a more complete "revoke ownership atomically, then tear down" pattern rather than a single point-of-failure guard, per the maintainer's review.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts` — 4 tests, using the `bun:test` `mock.module("discord.js", ...)` partial-mock convention already established in this package (spreading the real module so only `Client` is overridden):

1. `"revokes ownership before an awaited disconnect session save"` — stalls `redis.setex` (the awaited step inside `saveSessionState`) with a controllable deferred promise, confirms ownership is already revoked (a concurrent stale login failure posts no `"error"` status) even before that await resolves.
2. `"destroys a replaced client and ignores its queued error callback"` — starts a first `connectBot()` that never resolves login, captures its client's queued `Events.Error` handler, starts a second `connectBot()` for the same `connectionId`, confirms the first client's `destroy()` was called and that invoking its captured stale error handler afterward is a no-op (no status posted).
3. `"shutdown revokes ownership before destroying an in-flight login"` — starts an in-flight `connectBot()` concurrently with `shutdown()`, confirms the in-flight login's eventual rejection posts no status once shutdown has claimed ownership.
4. `"still reports error status when login fails with no concurrent disconnect"` — the original non-racing case, confirming the guards don't suppress legitimate failure reporting.

Confirmed test 1 (the original core repro) is a real regression test: reverted the source fix and re-ran — fails with the exact predicted incorrect `["disconnected", "error"]` status sequence. Independently re-verified the maintainer's expanded fix myself after rebasing onto latest `origin/develop`: full package suite, typecheck, and Biome all pass clean (see commands below) — I ran these myself rather than only trusting the review comment's reported numbers.

## Detailed testing steps

None: automated tests are acceptable.

```
$ bun test tests/connect-bot-race.test.ts
bun test v1.3.14
 4 pass
 0 fail

$ bunx @biomejs/biome check packages/cloud/services/gateway-discord/src/gateway-manager.ts packages/cloud/services/gateway-discord/tests/connect-bot-race.test.ts
Checked 2 files in 26ms. No fixes applied.

$ bun run --cwd packages/cloud/services/gateway-discord typecheck
$ tsc --noEmit
(clean, exit 0)

$ bun run --cwd packages/cloud/services/gateway-discord test
 146 pass
 0 fail
Ran 146 tests across 21 files.
```

All commands above were re-run and confirmed clean by me, independently, after rebasing the maintainer's commit onto `origin/develop` at `652f6b41b3` — this is not just a re-statement of the review comment's reported numbers.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:2ec7e98f3980372ee398b330b9e6392ba6b7d368 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/library-only change (Discord gateway connection-lifecycle logic), no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/library-only change, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is exercised by the automated test transcript above.
<!-- evidence-row:backend-logs -->
- [x] N/A - real backend logs from a live Discord gateway connection are explicitly requested by the maintainer review, but no Discord bot token, live gateway process, or Docker daemon is available in this environment to produce them (see Known gaps). The mocked-discord.js test transcript in the Testing section above (exact status-write sequence and client-teardown call counts asserted per scenario) is the evidence available from this environment instead.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; this is a Discord gateway connection-lifecycle race fix, unreachable from any LLM-facing action or evaluator.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, or generated files are produced by this code path; it manages an in-memory Discord.js client connection and posts status updates to the control plane's own status endpoint.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

See Known gaps below — this is the specific evidence the maintainer review is asking for and I cannot produce it in this environment.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- **The maintainer review explicitly requests live Discord gateway proof** (real bot token, real gateway process) covering disconnect, replacement, and shutdown during an in-flight login — confirming no stale status/event, no surviving old client, and that ordinary current-owner failures are still reported correctly. **This environment has no Discord bot token, no live gateway process, and no working Docker daemon**, so I cannot produce that evidence myself. What I *can* and did provide: independent re-verification of the maintainer's fix (full package test suite, typecheck, Biome, all rerun by me after rebasing — not just trusting the review comment's numbers) against a mocked `discord.js` `Client`. A reviewer or maintainer with access to a real Discord bot token and gateway process is needed to close this specific gap before merge, per the stated repository policy for connector-lifecycle changes.
- Full-repo `bun run verify` was not run (large monorepo-wide command); ran the package-scoped equivalents instead (all clean, see above). This package is independent (own lockfile/tsconfig, not part of the Turbo build) per its own `AGENTS.md`.

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@1ea54b33d8837d1fdedf1ce20688a9dc2a31e47c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mode-a]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@1ea54b33d8837d1fdedf1ce20688a9dc2a31e47c:packages/skills/skills/contribute-to-eliza"} -->



## Current-develop completion rerun

Exact head `2ec7e98f3980372ee398b330b9e6392ba6b7d368` is rebased cleanly onto current develop. Full package tests pass 146/146 (432 assertions); package typecheck passes after building the shared workspace; Biome, production bundle, and git diff --check pass. The live Discord acceptance remains open because this host exposes no Discord credential, gateway deployment, or Docker executable.

Completion/rebase review:
AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent completion
Contribution skill revision: N/A - repository completion workflow; no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository completion workflow; no contribution skill used"} -->