### PR TITLE
fix(calendar): bound Google Calendar event sync pagination

### DIFF
--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -214,6 +214,7 @@ type GoogleCalendarSyncBatch = {
 const CALENDAR_FEED_FRESHNESS_MS = 60_000;
 const DEFAULT_ICS_SYNC_LEASE_MS = 30_000;
 const CALENDAR_SOURCE_UNSUPPORTED = "CALENDAR_SOURCE_UNSUPPORTED";
+export const MAX_GOOGLE_CALENDAR_PAGES = 100;
 
 type CalendarSecretsService = {
   getGlobal(key: string): Promise<string | null>;
@@ -2979,8 +2980,24 @@ export class CalendarService extends Service {
     const seenPageTokens = new Set<string>();
     let pageToken: string | undefined;
     let nextSyncToken: string | null = null;
+    let pageCount = 0;
 
     do {
+      pageCount += 1;
+      if (pageCount > MAX_GOOGLE_CALENDAR_PAGES) {
+        throw new ElizaError(
+          "Google Calendar event pagination exceeded maximum page limit.",
+          {
+            code: "GOOGLE_CALENDAR_PAGE_LIMIT_EXCEEDED",
+            context: {
+              accountId: args.accountId,
+              calendarId: args.calendarId,
+              maxPages: MAX_GOOGLE_CALENDAR_PAGES,
+            },
+            severity: "fatal",
+          },
+        );
+      }
       const page = await listEventPage({
         accountId: args.accountId,
         calendarId: args.calendarId,

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -214,7 +214,10 @@ type GoogleCalendarSyncBatch = {
 const CALENDAR_FEED_FRESHNESS_MS = 60_000;
 const DEFAULT_ICS_SYNC_LEASE_MS = 30_000;
 const CALENDAR_SOURCE_UNSUPPORTED = "CALENDAR_SOURCE_UNSUPPORTED";
-export const MAX_GOOGLE_CALENDAR_PAGES = 100;
+// Keep the page cap as a pathological-work backstop; the retained-event bound
+// is the normal product/memory boundary for full and incremental syncs.
+export const MAX_GOOGLE_CALENDAR_PAGES = 1_000;
+export const MAX_GOOGLE_CALENDAR_EVENTS = 10_000;
 
 type CalendarSecretsService = {
   getGlobal(key: string): Promise<string | null>;
@@ -3008,6 +3011,20 @@ export class CalendarService extends Service {
           ? { syncToken: args.syncToken }
           : { timeMin: args.timeMin, timeMax: args.timeMax }),
       });
+      if (page.events.length > MAX_GOOGLE_CALENDAR_EVENTS - events.length) {
+        throw new ElizaError(
+          "Google Calendar event sync exceeded the retained event limit.",
+          {
+            code: "GOOGLE_CALENDAR_EVENT_LIMIT_EXCEEDED",
+            context: {
+              accountId: args.accountId,
+              calendarId: args.calendarId,
+              maxEvents: MAX_GOOGLE_CALENDAR_EVENTS,
+            },
+            severity: "fatal",
+          },
+        );
+      }
       events.push(...page.events);
       if (page.nextSyncToken) {
         nextSyncToken = page.nextSyncToken;

--- a/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
+++ b/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
@@ -1,5 +1,5 @@
 /**
- * Multi-account prune scoping — real PGlite.
+ * Multi-account prune scoping and Google sync bounds — real PGlite.
  *
  * Every Google account names its default calendar "primary", so two connected
  * accounts produce cached events with identical (agent_id, provider, side,
@@ -26,6 +26,10 @@ import type {
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  MAX_GOOGLE_CALENDAR_EVENTS,
+  MAX_GOOGLE_CALENDAR_PAGES,
+} from "../src/service/CalendarService.js";
 import {
   type CalendarHostGate,
   CalendarRepository,
@@ -482,7 +486,118 @@ describe("CalendarService feed sync — two Google accounts, both named 'primary
         message:
           "Google Calendar event pagination exceeded maximum page limit.",
       });
-      expect(pageCount).toBe(100);
+      expect(pageCount).toBe(MAX_GOOGLE_CALENDAR_PAGES);
+    } finally {
+      (runtime as { getService: (name: string) => unknown }).getService = (
+        name: string,
+      ) => (name === "google" ? originalGoogleService : null);
+    }
+  });
+
+  it("accepts the final legal Google Calendar page and exact event limit", async () => {
+    expect(MAX_GOOGLE_CALENDAR_PAGES).toBe(1_000);
+    expect(MAX_GOOGLE_CALENDAR_EVENTS).toBe(10_000);
+    let pageCount = 0;
+    const originalGoogleService = runtime.getService?.("google");
+    (runtime as { getService: (name: string) => unknown }).getService = (
+      name: string,
+    ) =>
+      name === "google"
+        ? {
+            listEventPage: async () => {
+              pageCount += 1;
+              const isFinal = pageCount === MAX_GOOGLE_CALENDAR_PAGES;
+              return {
+                events:
+                  pageCount <= 4
+                    ? Array.from({ length: 2_500 }, (_, index) => ({
+                        id: `event-${pageCount}-${index}`,
+                        calendarId: "primary",
+                      }))
+                    : [],
+                nextPageToken: isFinal ? null : `page-token-${pageCount}`,
+                nextSyncToken: isFinal ? "sync-final" : null,
+              };
+            },
+          }
+        : null;
+
+    try {
+      const batch = await (
+        calendar as unknown as {
+          loadGoogleCalendarSyncBatch(args: {
+            accountId: string;
+            calendarId: string;
+            timeMin: string;
+            timeMax: string;
+            timeZone: string;
+          }): Promise<{ events: unknown[]; nextSyncToken: string | null }>;
+        }
+      ).loadGoogleCalendarSyncBatch({
+        accountId: "account-a",
+        calendarId: "primary",
+        timeMin: WINDOW_MIN,
+        timeMax: WINDOW_MAX,
+        timeZone: "UTC",
+      });
+
+      expect(pageCount).toBe(MAX_GOOGLE_CALENDAR_PAGES);
+      expect(batch.events).toHaveLength(MAX_GOOGLE_CALENDAR_EVENTS);
+      expect(batch.nextSyncToken).toBe("sync-final");
+    } finally {
+      (runtime as { getService: (name: string) => unknown }).getService = (
+        name: string,
+      ) => (name === "google" ? originalGoogleService : null);
+    }
+  });
+
+  it("rejects retained Google Calendar events before appending an overflowing page", async () => {
+    let pageCount = 0;
+    const originalGoogleService = runtime.getService?.("google");
+    (runtime as { getService: (name: string) => unknown }).getService = (
+      name: string,
+    ) =>
+      name === "google"
+        ? {
+            listEventPage: async () => {
+              pageCount += 1;
+              return {
+                events: Array.from(
+                  { length: pageCount <= 4 ? 2_500 : 1 },
+                  (_, index) => ({
+                    id: `event-${pageCount}-${index}`,
+                    calendarId: "primary",
+                  }),
+                ),
+                nextPageToken:
+                  pageCount === 5 ? null : `page-token-${pageCount}`,
+                nextSyncToken: null,
+              };
+            },
+          }
+        : null;
+
+    try {
+      await expect(
+        (
+          calendar as unknown as {
+            loadGoogleCalendarSyncBatch(args: {
+              accountId: string;
+              calendarId: string;
+              timeMin: string;
+              timeMax: string;
+              timeZone: string;
+            }): Promise<unknown>;
+          }
+        ).loadGoogleCalendarSyncBatch({
+          accountId: "account-a",
+          calendarId: "primary",
+          timeMin: WINDOW_MIN,
+          timeMax: WINDOW_MAX,
+          timeZone: "UTC",
+        }),
+      ).rejects.toMatchObject({ code: "GOOGLE_CALENDAR_EVENT_LIMIT_EXCEEDED" });
+      expect(pageCount).toBe(5);
     } finally {
       (runtime as { getService: (name: string) => unknown }).getService = (
         name: string,

--- a/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
+++ b/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
@@ -442,4 +442,51 @@ describe("CalendarService feed sync — two Google accounts, both named 'primary
     expect(grantsById.get("evt-a-1")).toBe(GRANT_A.id);
     expect(grantsById.get("evt-b-1")).toBe(GRANT_B.id);
   });
+
+  it("rejects Google Calendar event sync pagination exceeding the maximum page limit", async () => {
+    await clearEvents();
+    let pageCount = 0;
+    const originalGoogleService = runtime.getService?.("google");
+    (runtime as { getService: (name: string) => unknown }).getService = (
+      name: string,
+    ) =>
+      name === "google"
+        ? {
+            listEventPage: async () => {
+              pageCount += 1;
+              return {
+                events: [],
+                nextPageToken: `page-token-${pageCount}`,
+                nextSyncToken: null,
+              };
+            },
+          }
+        : null;
+
+    try {
+      const feed = await calendar.getCalendarFeed(
+        INTERNAL_URL,
+        {
+          grantId: GRANT_A.id,
+          calendarId: "primary",
+          timeMin: WINDOW_MIN,
+          timeMax: WINDOW_MAX,
+          forceSync: true,
+        },
+        new Date("2026-06-02T12:00:00.000Z"),
+      );
+
+      expect(feed.state).toBe("partial");
+      expect(feed.sources[0]?.error).toMatchObject({
+        code: "GOOGLE_CALENDAR_PAGE_LIMIT_EXCEEDED",
+        message:
+          "Google Calendar event pagination exceeded maximum page limit.",
+      });
+      expect(pageCount).toBe(100);
+    } finally {
+      (runtime as { getService: (name: string) => unknown }).getService = (
+        name: string,
+      ) => (name === "google" ? originalGoogleService : null);
+    }
+  });
 });


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- skill_revision: elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza -->
<!-- evidence-head:a2c0757a0d787a37f1198a25f6fdf532398587a7 -->

## Summary

Bounds Google Calendar full and incremental sync without rejecting legitimate large calendars or retaining an unbounded number of events.

- Keeps the repository-canonical `1,000`-page limit as a pathological-work backstop.
- Adds an independent `10,000` retained-event limit, checked with overflow-safe subtraction before appending a page.
- Preserves opaque page-token cycle detection and final-page `nextSyncToken` handling.
- Surfaces typed `ElizaError` codes for page and event exhaustion; the feed boundary reports a visible partial-source failure instead of silent truncation.

The submitted `100`-page-only approach was repaired because Google permits up to 2,500 events per page: it could reject valid calendars while still allowing roughly 250,000 retained events. The repaired split bound matches the managed Calendar path and the repository's Google-workspace pagination policy.

Closes #22682.

## Contract research

- [Google Calendar `events.list`](https://developers.google.com/workspace/calendar/api/v3/reference/events/list): `maxResults` may be up to 2,500, `nextPageToken` is the continuation token, and `nextSyncToken` is returned only on the final page.

## Verification

Exact repaired head: `a2c0757a0d787a37f1198a25f6fdf532398587a7`, rebased onto `803ba404dbcc539d967d13f8e65c85374a5e3d55` (`develop`).

| Check | Result |
|---|---|
| Real PGlite + production sync method | 7/7 passed: runaway pages, exact 1,000th page, exact 10,000 events, 10,001st pre-append rejection, and account-prune isolation |
| Mutation proof | Disabling the event guard makes the overflow regression fail; restoring the submitted 100-page value is pinned by the exact 1,000-page assertion |
| Calendar package aggregate | 54 files / 525 tests passed, 4 skipped; 10 suites were setup-blocked only by sparse-checkout missing UI dependencies (`lucide-react`, `react-syntax-highlighter`), with no assertion failures |
| Declaration build | `tsc6 --noCheck -p tsconfig.build.json` passed |
| Full typecheck attempt | Reached the workspace graph; blocked only by sparse-checkout missing unrelated UI/Drizzle packages, with no changed-file diagnostic |
| Biome + diff check | Passed on both changed files; `git diff --check` clean |
| Live Google account | N/A: no Google Calendar credentials were available; deterministic production-method pagination and real PGlite boundary evidence cover this non-UI resource-bound change |

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only pagination and resource-bound change with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only pagination and resource-bound change with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only deterministic sync-bound change.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head validation receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22677-pr22677-backend-v2.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or rendered behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic connector pagination; no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-limit domain artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22677-pr22677-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

## Contribution provenance

- Original implementation: `byt61`.
- Review and repair: OpenAI `gpt-5.6-sol` via Codex Desktop multi-agent.

Skill path: `elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza` • Exact head: `a2c0757a0d787a37f1198a25f6fdf532398587a7`
