### PR TITLE
fix(plugin-google-workspace): validate explicit Gmail accountId before send

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -47,6 +47,10 @@ function runtimeStub(options: {
     registerProvider: vi.fn(),
     evaluatePolicy: vi.fn(),
     listAccounts: vi.fn(async () => options.accounts ?? []),
+    getAccount: vi.fn(
+      async (_provider: string, accountId: string) =>
+        (options.accounts ?? []).find((account) => account.id === accountId) ?? null
+    ),
   };
   const runtime = {
     agentId: "00000000-0000-0000-0000-000000000001",
@@ -210,8 +214,10 @@ describe("gmail send handler", () => {
     );
   });
 
-  it("honors an explicit target accountId over account discovery", async () => {
-    const { runtime, sendGmailMessage } = runtimeStub({ accounts: [] });
+  it("honors an explicit target accountId when it is connected and send-capable", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [{ ...CONNECTED_ACCOUNT, id: "acct_explicit" }],
+    });
     const registration = createGmailMessageConnector(runtime);
 
     const outcome = await invokeSend(
@@ -225,6 +231,32 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).toHaveBeenCalledWith(
       expect.objectContaining({ accountId: "acct_explicit" })
     );
+  });
+
+  it("rejects an explicit accountId that is not connected and send-capable", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [
+        {
+          id: "acct_readonly",
+          status: "connected",
+          metadata: { grantedCapabilities: ["gmail.read"] },
+        },
+      ],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com", accountId: "acct_readonly" },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_ACCOUNT_UNAVAILABLE",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
   it("refuses structurally when no connected account can send", async () => {

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -8,9 +8,12 @@
  */
 import {
   CONNECTOR_ACCOUNT_SERVICE_TYPE,
+  type ConnectorAccount,
+  ConnectorAccountManager,
   type Content,
   getConnectorAccountManager,
   type IAgentRuntime,
+  InMemoryConnectorAccountStorage,
   type MessageConnectorRegistration,
   type SendHandlerOutcome,
   type TargetInfo,
@@ -22,6 +25,7 @@ import {
   GMAIL_MESSAGE_SOURCE,
   isEmailAddress,
 } from "./gmail-message-connector.js";
+import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 const SHADOW_ID = "00000000-0000-0000-0000-0000000000e7";
 
@@ -45,7 +49,18 @@ function runtimeStub(options: {
     vi.fn(async () => ({ messageId: "sent_1", threadId: "thread_1", labelIds: ["SENT"] }));
   const accountManager = {
     registerProvider: vi.fn(),
-    evaluatePolicy: vi.fn(),
+    evaluatePolicy: vi.fn(async (policy, context: { accountId?: string }) => {
+      const account = (options.accounts ?? []).find(
+        (candidate) => candidate.id === context.accountId
+      );
+      const allowed = account?.status === "connected";
+      return {
+        allowed,
+        provider: "google",
+        account: allowed ? (account as unknown as ConnectorAccount) : undefined,
+        policy,
+      };
+    }),
     listAccounts: vi.fn(async () => options.accounts ?? []),
     getAccount: vi.fn(
       async (_provider: string, accountId: string) =>
@@ -62,6 +77,55 @@ function runtimeStub(options: {
     getEntityById: vi.fn(async (id: string) =>
       options.entity && id === options.entity.id ? options.entity : null
     ),
+  } as unknown as IAgentRuntime;
+  return { runtime, sendGmailMessage };
+}
+
+async function runtimeWithRealAccountPolicy(options: {
+  accessGate: ConnectorAccount["accessGate"];
+  verifiedOwner?: boolean;
+}): Promise<{
+  runtime: IAgentRuntime;
+  sendGmailMessage: ReturnType<typeof vi.fn>;
+}> {
+  const storage = new InMemoryConnectorAccountStorage();
+  const account: ConnectorAccount = {
+    id: "acct_policy",
+    provider: "google",
+    role: options.accessGate === "owner_binding" ? "OWNER" : "AGENT",
+    purpose: ["messaging"],
+    accessGate: options.accessGate,
+    status: "connected",
+    externalId: "google/user@example.com",
+    displayHandle: "user@example.com",
+    createdAt: 1,
+    updatedAt: 1,
+    metadata: { grantedCapabilities: ["gmail.send"] },
+  };
+  await storage.upsertAccount(account);
+  if (options.verifiedOwner) {
+    storage.upsertOwnerBindingForTest({
+      id: "binding-1",
+      identityId: "00000000-0000-0000-0000-0000000000cc",
+      connector: "google",
+      externalId: account.externalId as string,
+      displayHandle: account.displayHandle as string,
+      instanceId: "",
+      verifiedAt: 2,
+    });
+  }
+  const manager = new ConnectorAccountManager(undefined, storage);
+  const sendGmailMessage = vi.fn(async () => ({
+    messageId: "sent_policy",
+    threadId: "thread_policy",
+  }));
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getService: vi.fn((serviceType: string) => {
+      if (serviceType === GOOGLE_SERVICE_NAME) return { sendGmailMessage };
+      if (serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE) return manager;
+      return null;
+    }),
   } as unknown as IAgentRuntime;
   return { runtime, sendGmailMessage };
 }
@@ -233,22 +297,101 @@ describe("gmail send handler", () => {
     );
   });
 
-  it("rejects an explicit accountId that is not connected and send-capable", async () => {
-    const { runtime, sendGmailMessage } = runtimeStub({
-      accounts: [
+  it.each<[string, AccountStub[]]>([
+    ["missing", []],
+    [
+      "disconnected",
+      [
         {
-          id: "acct_readonly",
+          id: "acct_explicit",
+          status: "disabled",
+          metadata: { grantedCapabilities: ["gmail.send"] },
+        },
+      ],
+    ],
+    [
+      "read-only",
+      [
+        {
+          id: "acct_explicit",
           status: "connected",
           metadata: { grantedCapabilities: ["gmail.read"] },
         },
       ],
+    ],
+  ])("rejects an explicit accountId when it is %s", async (_case, accounts) => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts,
     });
     const registration = createGmailMessageConnector(runtime);
 
     const outcome = await invokeSend(
       registration,
       runtime,
-      { channelId: "shadow@example.com", accountId: "acct_readonly" },
+      { channelId: "shadow@example.com", accountId: "acct_explicit" },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_ACCOUNT_UNAVAILABLE",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(["owner_binding", "manual_approval", "disabled"] as const)(
+    "rejects a send-capable explicit account behind an unauthorized %s gate",
+    async (accessGate) => {
+      const { runtime, sendGmailMessage } = await runtimeWithRealAccountPolicy({
+        accessGate,
+      });
+      const registration = createGmailMessageConnector(runtime);
+
+      const outcome = await invokeSend(
+        registration,
+        runtime,
+        { channelId: "shadow@example.com", accountId: "acct_policy" },
+        { text: "hello" }
+      );
+
+      expect(outcome).toMatchObject({
+        kind: "not_delivered",
+        code: "GMAIL_ACCOUNT_UNAVAILABLE",
+      });
+      expect(sendGmailMessage).not.toHaveBeenCalled();
+    }
+  );
+
+  it("allows a send-capable owner account after its binding is verified", async () => {
+    const { runtime, sendGmailMessage } = await runtimeWithRealAccountPolicy({
+      accessGate: "owner_binding",
+      verifiedOwner: true,
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com", accountId: "acct_policy" },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "acct_policy" })
+    );
+  });
+
+  it("excludes an unverified owner account from implicit account discovery", async () => {
+    const { runtime, sendGmailMessage } = await runtimeWithRealAccountPolicy({
+      accessGate: "owner_binding",
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
       { text: "hello" }
     );
 

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -9,15 +9,18 @@
  * entityId) is used as-is — a typed address is unambiguous; an entity-store
  * UUID resolves through the entity's stored email handles (component data).
  * Account routing is `connector`-scoped: the handler honors an explicit
- * target accountId, else the sole connected gmail-send-capable Google
- * account, and refuses with a structural not_delivered when the account
- * choice is ambiguous or absent. Subject comes from `content.metadata.subject`
+ * target accountId, else the sole policy-authorized, gmail-send-capable Google
+ * account, and refuses with a structural not_delivered when the account choice
+ * is unauthorized, ambiguous, or absent. Subject comes from `content.metadata.subject`
  * when the planner supplies one, else the first line of the body clipped to a
  * sane header length. Registered by the Google connector-account provider at
  * plugin init.
  */
 import {
   type ConnectorAccount,
+  type ConnectorAccountAccessGate,
+  type ConnectorAccountPurpose,
+  type ConnectorAccountStatus,
   type Content,
   getConnectorAccountManager,
   type IAgentRuntime,
@@ -35,6 +38,9 @@ const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SUBJECT_MAX_LENGTH = 78;
 const EMAIL_COMPONENT_KEYS = ["email", "emailAddress"] as const;
+const GMAIL_SEND_ACCOUNT_STATUSES: ConnectorAccountStatus[] = ["connected"];
+const GMAIL_SEND_ACCOUNT_PURPOSES: ConnectorAccountPurpose[] = ["messaging"];
+const GMAIL_SEND_ACCOUNT_ACCESS_GATES: ConnectorAccountAccessGate[] = ["open", "owner_binding"];
 
 /** True when the value is a deliverable literal email address. */
 export function isEmailAddress(value: unknown): value is string {
@@ -74,28 +80,57 @@ function accountSupportsGmailSend(account: ConnectorAccount): boolean {
   return granted.some((capability) => capability === "gmail.send");
 }
 
+async function accountIsAuthorizedForGmailSend(
+  runtime: IAgentRuntime,
+  account: ConnectorAccount
+): Promise<boolean> {
+  if (!accountSupportsGmailSend(account)) return false;
+  const evaluation = await getConnectorAccountManager(runtime).evaluatePolicy(
+    {
+      provider: GOOGLE_SERVICE_NAME,
+      statuses: GMAIL_SEND_ACCOUNT_STATUSES,
+      purposes: GMAIL_SEND_ACCOUNT_PURPOSES,
+      accessGates: GMAIL_SEND_ACCOUNT_ACCESS_GATES,
+      required: true,
+    },
+    { accountId: account.id, purpose: "messaging" }
+  );
+  return evaluation.allowed && evaluation.account?.id === account.id;
+}
+
 async function resolveGmailAccountId(
   runtime: IAgentRuntime,
   requested: string | undefined
 ): Promise<{ accountId: string } | { error: SendHandlerOutcome }> {
   if (requested?.trim()) {
     const accountId = requested.trim();
-    const accounts = await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME);
-    const account = accounts.find((candidate) => candidate.id === accountId);
-    if (!account || !accountSupportsGmailSend(account)) {
+    const manager = getConnectorAccountManager(runtime);
+    const account = await manager.getAccount(GOOGLE_SERVICE_NAME, accountId);
+    if (
+      !account ||
+      account.id !== accountId ||
+      !(await accountIsAuthorizedForGmailSend(runtime, account))
+    ) {
       return {
         error: {
           kind: "not_delivered",
           code: "GMAIL_ACCOUNT_UNAVAILABLE",
-          message: "The requested Google account is not connected with the gmail.send capability.",
+          message:
+            "The requested Google account is not connected and authorized with the gmail.send capability.",
         },
       };
     }
     return { accountId };
   }
-  const accounts = (
-    await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME)
-  ).filter(accountSupportsGmailSend);
+  const listedAccounts =
+    await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME);
+  const authorized = await Promise.all(
+    listedAccounts.map(async (account) => ({
+      account,
+      allowed: await accountIsAuthorizedForGmailSend(runtime, account),
+    }))
+  );
+  const accounts = authorized.filter(({ allowed }) => allowed).map(({ account }) => account);
   const sole = accounts.length === 1 ? accounts[0] : undefined;
   if (sole) {
     return { accountId: sole.id };

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -79,7 +79,19 @@ async function resolveGmailAccountId(
   requested: string | undefined
 ): Promise<{ accountId: string } | { error: SendHandlerOutcome }> {
   if (requested?.trim()) {
-    return { accountId: requested.trim() };
+    const accountId = requested.trim();
+    const accounts = await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME);
+    const account = accounts.find((candidate) => candidate.id === accountId);
+    if (!account || !accountSupportsGmailSend(account)) {
+      return {
+        error: {
+          kind: "not_delivered",
+          code: "GMAIL_ACCOUNT_UNAVAILABLE",
+          message: "The requested Google account is not connected with the gmail.send capability.",
+        },
+      };
+    }
+    return { accountId };
   }
   const accounts = (
     await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME)


### PR DESCRIPTION
# Relates to

No existing issue. This closes an account-selection authorization gap in the Gmail `MessageConnector` send path.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` (`652f6b41b332ae20f7a4a58488f77d2d4e5f3d4b`).
- [x] Exact-head package tests, typecheck, build, and static checks pass.
- [x] Failure behavior is proven at the real connector-account policy seam before transport invocation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `gpt-5.6-sol`; `anthropic/claude-sonnet-5`; `OpenAI GPT-5 (review/repair)`
<!-- attribution-row:client -->
- Agent tooling: `Codex`; `Claude Code`; `Codex (review/repair)`
<!-- attribution-row:skill-revision -->
- Skill path: repository `AGENTS.md` and `plugins/plugin-google-workspace/CLAUDE.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported original contribution; maintainer review repair recorded here`

# Sync with develop

- [x] Rebased onto current `origin/develop` at `652f6b41b332ae20f7a4a58488f77d2d4e5f3d4b`; zero conflicts.
- [x] Original Svector-anu commit/authorship preserved as `ae722e3ec8aefd2ed36d0e162ff91b8808969708`.
- [x] Maintainer repair is separate commit `21828203322a054bf468e59022ff657bdc27de9c`.

# Risks

Contained to the Gmail send connector and its tests. The connector now performs one exact Google-account lookup and canonical policy evaluation before sending. Implicit account discovery evaluates each candidate; account counts are expected to be small. No public API changes.

# Background

## What does this PR do?

Previously an explicit `target.accountId` bypassed connected-account discovery entirely and was passed directly to `sendGmailMessage`. The submitted change correctly rejected missing, disconnected, and non-`gmail.send` accounts.

Deep review found a second authorization gap: raw status/capability checks still accepted accounts behind `disabled`, `manual_approval`, `pairing`, or unverified `owner_binding` access gates. The generic MESSAGE owner-binding gate cannot resolve this case because the message connector source is `gmail`, while the account provider key is `google`.

The repaired connector resolves the exact `google` account ID, requires the `gmail.send` capability, and calls `ConnectorAccountManager.evaluatePolicy` with connected status, messaging purpose, and allowed `open|owner_binding` gates. Canonical policy evaluation verifies owner bindings. The same policy applies to implicit account discovery, preventing an unauthorized account from becoming the apparent sole default.

## What kind of change is this?

Security-sensitive bug fix (non-breaking).

# Documentation changes needed?

No public documentation change is required.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/gmail-message-connector.test.ts` exercises the real send handler and real in-memory `ConnectorAccountManager` policy implementation. It proves:

- exact connected/send-capable account delivery;
- missing, disconnected, and read-only explicit IDs fail closed;
- unverified owner-binding, manual-approval, and disabled accounts never reach transport;
- a verified owner binding is accepted;
- unauthorized accounts are excluded from implicit discovery;
- existing ambiguity, recipient, subject, and receipt contracts remain intact.

## Detailed testing steps

Exact repaired head `21828203322a054bf468e59022ff657bdc27de9c`:

```text
$ bunx vitest run src/gmail-message-connector.test.ts
Test Files  1 passed (1)
Tests       20 passed (20)

$ bun run test
Test Files  20 passed (20)
Tests       206 passed (206)

$ bun run typecheck
$ tsc --noEmit
(clean, exit 0)

$ bun run build
@elizaos/plugin-google-workspace build finished

$ bunx @biomejs/biome check src/gmail-message-connector.ts src/gmail-message-connector.test.ts
Checked 2 files. No fixes applied.

$ git diff --check origin/develop...HEAD
(clean)
```

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:21828203322a054bf468e59022ff657bdc27de9c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — backend connector authorization only; no visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — backend connector authorization only; no visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — deterministic account-policy and transport-call assertions are the applicable evidence.
<!-- evidence-row:backend-logs -->
- [x] Exact-head 20-case connector transcript and 206-case package transcript above; denied cases assert `sendGmailMessage` was never called.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no prompt, provider, model, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real in-memory connector-account rows and owner-binding records drive canonical policy evaluation in the regression tests.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered output.

# Evidence Details

## Real LLM-call trajectory

N/A — no LLM-facing behavior changed.

## Backend + frontend logs

The exact-head test transcripts above are the backend evidence. Every denied authorization case asserts zero Gmail transport calls. No frontend is involved.

## Screenshots (before / after) + video walkthrough

N/A — no UI surface.

## Audio / voice walkthrough

N/A — no audio behavior.

## Known gaps / failures

- No live Gmail message was sent: doing so would create an irreversible external side effect. The production `MessageConnector` handler, canonical account manager, in-memory account storage, owner-binding records, and mocked final Google transport seam are exercised together.
- Full-repository `bun run verify` was not run; exact package test/typecheck/build and touched static gates are green.

AI provider/model: OpenAI gpt-5.6-sol; Anthropic claude-sonnet-5; OpenAI GPT-5 review repair
Client / agent tooling: Codex; Claude Code
Attribution status: self-reported original contribution; maintainer repair recorded
