### PR TITLE
fix(core): bound pinned document pagination against infinite cursor loops

### DIFF
--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -25,6 +25,7 @@ export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
 export const DOCUMENT_LIST_MAX_TAGS = 32;
 export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
 export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
+export const DOCUMENT_LIST_MAX_PINNED_PAGES = 50;
 
 export interface DocumentListQueryCapableAdapter {
 	readonly documentListQueryCapability: typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -25,7 +25,8 @@ export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
 export const DOCUMENT_LIST_MAX_TAGS = 32;
 export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
 export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
-export const DOCUMENT_LIST_MAX_PINNED_PAGES = 50;
+export const DOCUMENT_LIST_MAX_PINNED_PAGES =
+	Math.floor(DOCUMENT_LIST_MAX_OFFSET / DOCUMENT_LIST_MAX_LIMIT) + 1;
 
 export interface DocumentListQueryCapableAdapter {
 	readonly documentListQueryCapability: typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
@@ -63,6 +64,118 @@ function invalidPagination(
 
 function isUuid(value: unknown): value is UUID {
 	return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function normalizeDocumentListCursor(
+	value: unknown,
+): DocumentListCursor | null {
+	if (value === null || typeof value !== "object") return null;
+	const cursor = value as Record<string, unknown>;
+	if (!Number.isSafeInteger(cursor.createdAt) || !isUuid(cursor.id)) {
+		return null;
+	}
+	const hasSnapshotCreatedAt = cursor.snapshotCreatedAt !== undefined;
+	const hasSnapshotId = cursor.snapshotId !== undefined;
+	if (hasSnapshotCreatedAt !== hasSnapshotId) return null;
+	if (!hasSnapshotCreatedAt) {
+		return { createdAt: cursor.createdAt as number, id: cursor.id };
+	}
+	if (
+		!Number.isSafeInteger(cursor.snapshotCreatedAt) ||
+		!isUuid(cursor.snapshotId)
+	) {
+		return null;
+	}
+	if (
+		(cursor.createdAt as number) > (cursor.snapshotCreatedAt as number) ||
+		((cursor.createdAt as number) === (cursor.snapshotCreatedAt as number) &&
+			(cursor.id as UUID).toLowerCase() >
+				(cursor.snapshotId as UUID).toLowerCase())
+	) {
+		return null;
+	}
+	return {
+		createdAt: cursor.createdAt as number,
+		id: cursor.id,
+		snapshotCreatedAt: cursor.snapshotCreatedAt as number,
+		snapshotId: cursor.snapshotId,
+	};
+}
+
+function invalidDocumentListResult(
+	message: string,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, {
+		code: "DOCUMENT_LIST_INVALID_RESULT",
+		context,
+		severity: "fatal",
+	});
+}
+
+/** Validates the bounded runtime result returned by a database adapter. */
+export function validateDocumentListQueryResult(
+	value: unknown,
+	params: DocumentListQueryParams,
+): asserts value is DocumentListQueryResult {
+	if (value === null || typeof value !== "object") {
+		invalidDocumentListResult("Document list adapter returned a non-object", {
+			resultType: typeof value,
+		});
+	}
+	const result = value as Record<string, unknown>;
+	for (const field of ["documents", "availableDocuments"] as const) {
+		const rows = result[field];
+		if (
+			!Array.isArray(rows) ||
+			rows.length > params.limit ||
+			rows.some((row) => row === null || typeof row !== "object")
+		) {
+			invalidDocumentListResult(
+				`Document list adapter returned invalid ${field}`,
+				{
+					field,
+					rowCount: Array.isArray(rows) ? rows.length : undefined,
+					maxRows: params.limit,
+				},
+			);
+		}
+	}
+	for (const field of [
+		"totalVisible",
+		"totalAvailable",
+		"totalMatched",
+	] as const) {
+		const count = result[field];
+		if (!Number.isSafeInteger(count) || (count as number) < 0) {
+			invalidDocumentListResult(
+				`Document list adapter returned invalid ${field}`,
+				{ field, count },
+			);
+		}
+	}
+	for (const [moreField, cursorField] of [
+		["hasMore", "nextCursor"],
+		["availableHasMore", "availableNextCursor"],
+	] as const) {
+		const hasMore = result[moreField];
+		const cursor = result[cursorField];
+		if (
+			typeof hasMore !== "boolean" ||
+			hasMore !== (cursor !== undefined) ||
+			(cursor !== undefined && !normalizeDocumentListCursor(cursor))
+		) {
+			invalidDocumentListResult(
+				`Document list adapter returned invalid ${cursorField}`,
+				{
+					moreField,
+					hasMore,
+					cursorField,
+					cursorType: cursor === null ? "null" : typeof cursor,
+				},
+			);
+		}
+	}
 }
 
 export function documentCreatedAt(memory: Memory): number {
@@ -528,29 +641,8 @@ export function validateDocumentListQueryParams(
 			{ offset: params.offset },
 		);
 	}
-	if (
-		params.cursor &&
-		(!Number.isSafeInteger(params.cursor.createdAt) ||
-			!isUuid(params.cursor.id))
-	) {
+	if (params.cursor && !normalizeDocumentListCursor(params.cursor)) {
 		invalidPagination("Document list cursor is invalid", {
-			cursor: params.cursor,
-		});
-	}
-	if (
-		params.cursor &&
-		((params.cursor.snapshotCreatedAt === undefined) !==
-			(params.cursor.snapshotId === undefined) ||
-			(params.cursor.snapshotCreatedAt !== undefined &&
-				(!Number.isSafeInteger(params.cursor.snapshotCreatedAt) ||
-					!isUuid(params.cursor.snapshotId))) ||
-			(params.cursor.snapshotCreatedAt !== undefined &&
-				(params.cursor.createdAt > params.cursor.snapshotCreatedAt ||
-					(params.cursor.createdAt === params.cursor.snapshotCreatedAt &&
-						params.cursor.id.toLowerCase() >
-							(params.cursor.snapshotId as UUID).toLowerCase()))))
-	) {
-		invalidPagination("Document list snapshot cursor is invalid", {
 			cursor: params.cursor,
 		});
 	}
@@ -817,5 +909,29 @@ export async function queryDocumentsWithCapability(
 ): Promise<DocumentListQueryResult> {
 	validateDocumentListQueryParams(params);
 	requireDocumentListQueryCapability(adapter);
-	return adapter.queryDocuments(params);
+	const result: unknown = await adapter.queryDocuments(params);
+	validateDocumentListQueryResult(result, params);
+	return {
+		documents: result.documents,
+		availableDocuments: result.availableDocuments,
+		totalVisible: result.totalVisible,
+		totalAvailable: result.totalAvailable,
+		totalMatched: result.totalMatched,
+		hasMore: result.hasMore,
+		availableHasMore: result.availableHasMore,
+		...(result.nextCursor
+			? {
+					nextCursor: normalizeDocumentListCursor(
+						result.nextCursor,
+					) as DocumentListCursor,
+				}
+			: {}),
+		...(result.availableNextCursor
+			? {
+					availableNextCursor: normalizeDocumentListCursor(
+						result.availableNextCursor,
+					) as DocumentListCursor,
+				}
+			: {}),
+	};
 }

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -1,4 +1,12 @@
+/**
+ * Exercises pinned-document provider pagination through the production service
+ * boundary with deterministic adapter responses.
+ */
 import { describe, expect, it, vi } from "vitest";
+import {
+	DOCUMENT_LIST_MAX_LIMIT,
+	DOCUMENT_LIST_MAX_PINNED_PAGES,
+} from "../../database/document-list-query";
 import { logger } from "../../logger";
 import { type Memory, MemoryType, type UUID } from "../../types";
 import {
@@ -24,6 +32,54 @@ function document(title: string, text: string, pinned = false): Memory {
 			pinned,
 		},
 	};
+}
+
+function runtimeWithDocumentQuery(
+	queryDocuments: ReturnType<typeof vi.fn>,
+	agentId = "00000000-0000-0000-0000-0000000000a1" as UUID,
+) {
+	return {
+		agentId,
+		adapter: {
+			documentListQueryCapability: 2,
+			queryDocuments,
+			queryDocumentFragments: vi.fn(async () => []),
+			getDocument: vi.fn(async () => null),
+			compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+			deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
+		},
+		getMemories: vi.fn(async () => []),
+		searchMemories: vi.fn(async () => []),
+		getModel: vi.fn(() => null),
+		reportError: vi.fn(),
+		logger: {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		},
+	};
+}
+
+function listPinnedDocuments(
+	service: DocumentService,
+	agentId = "00000000-0000-0000-0000-0000000000a1" as UUID,
+): Promise<Memory[]> {
+	return (
+		service as unknown as {
+			listPinnedDocumentsWithRequester(
+				resolveRequester: () => Promise<{
+					entityId: UUID;
+					roomIds: UUID[];
+					role: "RUNTIME";
+				}>,
+			): Promise<Memory[]>;
+		}
+	).listPinnedDocumentsWithRequester(async () => ({
+		entityId: agentId,
+		roomIds: [],
+		role: "RUNTIME",
+	}));
 }
 
 describe("pinned DOCUMENTS provider knowledge", () => {
@@ -152,6 +208,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 			totalMatched: 0,
 			documents: [],
 			availableDocuments: [],
+			availableHasMore: false,
 			hasMore: true,
 			nextCursor: {
 				createdAt: 1000,
@@ -204,6 +261,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 				totalMatched: 0,
 				documents: [],
 				availableDocuments: [],
+				availableHasMore: false,
 				hasMore: true,
 				nextCursor: {
 					createdAt: 1000 + callCount,
@@ -243,6 +301,155 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		).rejects.toMatchObject({
 			code: "DOCUMENT_LIST_PAGE_LIMIT_EXCEEDED",
 		});
-		expect(queryDocumentsMock).toHaveBeenCalledTimes(51); // 1 list + 50 pinned pages
+		expect(queryDocumentsMock).toHaveBeenCalledTimes(
+			1 + DOCUMENT_LIST_MAX_PINNED_PAGES,
+		);
+	});
+
+	it("rejects an oversized adapter page before filtering or retaining rows", async () => {
+		const oversizedPage = Array.from(
+			{ length: DOCUMENT_LIST_MAX_LIMIT + 1 },
+			(_, index) => document(`Pinned ${index}`, "bounded", true),
+		);
+		const queryDocumentsMock = vi.fn(async () => ({
+			totalVisible: oversizedPage.length,
+			totalAvailable: oversizedPage.length,
+			totalMatched: oversizedPage.length,
+			documents: oversizedPage,
+			availableDocuments: [],
+			availableHasMore: false,
+			hasMore: false,
+		}));
+		const service = new DocumentService(
+			runtimeWithDocumentQuery(queryDocumentsMock) as never,
+		);
+
+		await expect(listPinnedDocuments(service)).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_RESULT",
+		});
+		expect(queryDocumentsMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a malformed adapter cursor with a typed integrity failure", async () => {
+		const queryDocumentsMock = vi.fn(async () => ({
+			totalVisible: 0,
+			totalAvailable: 0,
+			totalMatched: 0,
+			documents: [],
+			availableDocuments: [],
+			availableHasMore: false,
+			hasMore: true,
+			nextCursor: { createdAt: 1, id: 7 },
+		}));
+		const service = new DocumentService(
+			runtimeWithDocumentQuery(queryDocumentsMock) as never,
+		);
+
+		await expect(listPinnedDocuments(service)).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_RESULT",
+		});
+		expect(queryDocumentsMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("detects a logical cursor cycle despite changing object shape", async () => {
+		let pinnedCalls = 0;
+		const cursor = {
+			createdAt: 1000,
+			id: "00000000-0000-0000-0000-0000000000c1" as UUID,
+		};
+		const queryDocumentsMock = vi.fn(async ({ limit }: { limit: number }) => {
+			if (limit !== DOCUMENT_LIST_MAX_LIMIT) {
+				return {
+					status: "ok",
+					totalVisible: 0,
+					totalAvailable: 0,
+					totalMatched: 0,
+					documents: [],
+					availableDocuments: [],
+					availableHasMore: false,
+					hasMore: false,
+				};
+			}
+			pinnedCalls += 1;
+			return {
+				status: "ok",
+				totalVisible: 0,
+				totalAvailable: 0,
+				totalMatched: 0,
+				documents: [],
+				availableDocuments: [],
+				availableHasMore: false,
+				hasMore: true,
+				nextCursor:
+					pinnedCalls === 1
+						? { ...cursor, ignoredAdapterField: "first" }
+						: {
+								ignoredAdapterField: `different-${pinnedCalls}`,
+								id: cursor.id,
+								createdAt: cursor.createdAt,
+							},
+			};
+		});
+		const service = new DocumentService(
+			runtimeWithDocumentQuery(queryDocumentsMock) as never,
+		);
+
+		await expect(listPinnedDocuments(service)).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_CURSOR_LOOP",
+		});
+		expect(pinnedCalls).toBe(2);
+		expect(queryDocumentsMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ cursor }),
+		);
+	});
+
+	it("accepts a pinned document returned on the final legal page", async () => {
+		let pinnedCalls = 0;
+		const finalPinned = document("Final rule", "ALWAYS VERIFY", true);
+		const queryDocumentsMock = vi.fn(async ({ limit }: { limit: number }) => {
+			if (limit !== DOCUMENT_LIST_MAX_LIMIT) {
+				return {
+					status: "ok",
+					totalVisible: 0,
+					totalAvailable: 0,
+					totalMatched: 0,
+					documents: [],
+					availableDocuments: [],
+					availableHasMore: false,
+					hasMore: false,
+				};
+			}
+			pinnedCalls += 1;
+			const isFinal = pinnedCalls === DOCUMENT_LIST_MAX_PINNED_PAGES;
+			return {
+				status: "ok",
+				totalVisible: 1,
+				totalAvailable: 1,
+				totalMatched: 1,
+				documents: isFinal ? [finalPinned] : [],
+				availableDocuments: [],
+				availableHasMore: false,
+				hasMore: !isFinal,
+				...(isFinal
+					? {}
+					: {
+							nextCursor: {
+								createdAt: 1000 + pinnedCalls,
+								id: `00000000-0000-0000-0000-${pinnedCalls
+									.toString(16)
+									.padStart(12, "0")}` as UUID,
+							},
+						}),
+			};
+		});
+		const service = new DocumentService(
+			runtimeWithDocumentQuery(queryDocumentsMock) as never,
+		);
+
+		const result = await listPinnedDocuments(service);
+
+		expect(pinnedCalls).toBe(DOCUMENT_LIST_MAX_PINNED_PAGES);
+		expect(result).toEqual([finalPinned]);
 	});
 });

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -142,4 +142,107 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		);
 		warn.mockRestore();
 	});
+
+	it("rejects repeating pagination cursors when listing pinned documents", async () => {
+		const agentId = "00000000-0000-0000-0000-0000000000a1" as UUID;
+		const queryDocumentsMock = vi.fn(async () => ({
+			status: "ok",
+			totalVisible: 0,
+			totalAvailable: 0,
+			totalMatched: 0,
+			documents: [],
+			availableDocuments: [],
+			hasMore: true,
+			nextCursor: {
+				createdAt: 1000,
+				id: "00000000-0000-0000-0000-0000000000c1" as UUID,
+			},
+		}));
+		const runtime = {
+			agentId,
+			adapter: {
+				documentListQueryCapability: 2,
+				queryDocuments: queryDocumentsMock,
+				queryDocumentFragments: vi.fn(async () => []),
+				getDocument: vi.fn(async () => null),
+				compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+				deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
+			},
+			getMemories: vi.fn(async () => []),
+			searchMemories: vi.fn(async () => []),
+			getModel: vi.fn(() => null),
+			reportError: vi.fn(),
+			logger: {
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+				debug: vi.fn(),
+			},
+		};
+		const service = new DocumentService(runtime as never);
+		const message = {
+			...document("query", "test query"),
+			entityId: agentId,
+		};
+
+		await expect(
+			service.composeProviderDocuments(message, { limit: 10 }),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_CURSOR_LOOP",
+		});
+	});
+
+	it("rejects pagination exceeding the maximum page limit when listing pinned documents", async () => {
+		const agentId = "00000000-0000-0000-0000-0000000000a1" as UUID;
+		let callCount = 0;
+		const queryDocumentsMock = vi.fn(async () => {
+			callCount += 1;
+			return {
+				status: "ok",
+				totalVisible: 0,
+				totalAvailable: 0,
+				totalMatched: 0,
+				documents: [],
+				availableDocuments: [],
+				hasMore: true,
+				nextCursor: {
+					createdAt: 1000 + callCount,
+					id: `00000000-0000-0000-0000-${callCount.toString(16).padStart(12, "0")}` as UUID,
+				},
+			};
+		});
+		const runtime = {
+			agentId,
+			adapter: {
+				documentListQueryCapability: 2,
+				queryDocuments: queryDocumentsMock,
+				queryDocumentFragments: vi.fn(async () => []),
+				getDocument: vi.fn(async () => null),
+				compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+				deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
+			},
+			getMemories: vi.fn(async () => []),
+			searchMemories: vi.fn(async () => []),
+			getModel: vi.fn(() => null),
+			reportError: vi.fn(),
+			logger: {
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+				debug: vi.fn(),
+			},
+		};
+		const service = new DocumentService(runtime as never);
+		const message = {
+			...document("query", "test query"),
+			entityId: agentId,
+		};
+
+		await expect(
+			service.composeProviderDocuments(message, { limit: 10 }),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_PAGE_LIMIT_EXCEEDED",
+		});
+		expect(queryDocumentsMock).toHaveBeenCalledTimes(51); // 1 list + 50 pinned pages
+	});
 });

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -20,6 +20,7 @@ import {
 	canRequesterMutateDocument,
 	DOCUMENT_LIST_MAX_LIMIT,
 	DOCUMENT_LIST_MAX_OFFSET,
+	DOCUMENT_LIST_MAX_PINNED_PAGES,
 	documentRoleHasGlobalVisibility,
 	isDocumentVisibleToRequester,
 	queryDocumentsWithCapability,
@@ -704,7 +705,23 @@ export class DocumentService extends Service {
 	): Promise<Memory[]> {
 		const pinnedDocuments: Memory[] = [];
 		let cursor: DocumentListCursor | undefined;
+		const seenCursors = new Set<string>();
+		let pageCount = 0;
 		do {
+			pageCount += 1;
+			if (pageCount > DOCUMENT_LIST_MAX_PINNED_PAGES) {
+				throw new ElizaError(
+					"Pinned document list exceeded maximum page limit",
+					{
+						code: "DOCUMENT_LIST_PAGE_LIMIT_EXCEEDED",
+						context: {
+							pageCount,
+							maxPages: DOCUMENT_LIST_MAX_PINNED_PAGES,
+						},
+						severity: "fatal",
+					},
+				);
+			}
 			const page = await this.listDocumentsDetailedWithRequester(
 				{
 					limit: DOCUMENT_LIST_MAX_LIMIT,
@@ -733,6 +750,18 @@ export class DocumentService extends Service {
 					},
 				);
 			}
+			const serializedCursor = JSON.stringify(page.nextCursor);
+			if (seenCursors.has(serializedCursor)) {
+				throw new ElizaError(
+					"Document list reported a repeating pagination cursor",
+					{
+						code: "DOCUMENT_LIST_CURSOR_LOOP",
+						context: { cursor: page.nextCursor },
+						severity: "fatal",
+					},
+				);
+			}
+			seenCursors.add(serializedCursor);
 			cursor = page.nextCursor;
 		} while (cursor);
 		return pinnedDocuments;

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -287,6 +287,15 @@ export async function resolveDocumentRequester(
 
 type DocumentRequesterResolver = () => Promise<DocumentRequester>;
 
+function documentListCursorKey(cursor: DocumentListCursor): string {
+	return [
+		cursor.createdAt,
+		cursor.id.toLowerCase(),
+		cursor.snapshotCreatedAt ?? "",
+		cursor.snapshotId?.toLowerCase() ?? "",
+	].join(":");
+}
+
 /**
  * Coalesces requester authorization only for one caller-owned read composition.
  * Rejections are evicted so a retry re-reads the authoritative role and room
@@ -750,7 +759,7 @@ export class DocumentService extends Service {
 					},
 				);
 			}
-			const serializedCursor = JSON.stringify(page.nextCursor);
+			const serializedCursor = documentListCursorKey(page.nextCursor);
 			if (seenCursors.has(serializedCursor)) {
 				throw new ElizaError(
 					"Document list reported a repeating pagination cursor",


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-sonnet-5`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b68a23b6a3f752f2c9d747c998c657bef3f69b28:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:bb402f2d97fb08d440f7a3926ae79580ae0b4405 -->

Closes #22696.

## Summary

Bounds pinned-document pagination to the existing public 10,000-offset contract (101 pages at 100 rows), rejects malformed/oversized adapter results before adoption, and rejects logical cursor cycles with typed `ElizaError` failures.

The submitted `JSON.stringify(nextCursor)` cycle key was not a reliable contract boundary: an adapter could return the same typed cursor with reordered properties or changing extra fields. The repaired implementation derives a stable key only from the four typed cursor fields (`createdAt`, `id`, `snapshotCreatedAt`, `snapshotId`).

## Review and repair

- Derives the page bound from `DOCUMENT_LIST_MAX_OFFSET` and `DOCUMENT_LIST_MAX_LIMIT`, allowing every currently addressable page instead of inventing a lower 5,000-row ceiling.
- Rejects a continuing page after legal page 101 before another adapter call.
- Validates adapter arrays, counts, booleans, cursor shape, and page lengths at the canonical `queryDocumentsWithCapability` boundary before filtering or retention.
- Reconstructs returned cursors from typed fields so adapter-only metadata is neither retained nor replayed.
- Detects logical cursor repetition independent of object property order or adapter-only metadata.
- Accepts a pinned document returned on the final legal page.
- Exercises the real private production service pagination seam with deterministic adapter responses.

## Exact-head verification

Exact reviewed head: `bb402f2d97fb08d440f7a3926ae79580ae0b4405`, rebased on `b68a23b6a3f752f2c9d747c998c657bef3f69b28`.

- Pinned-document + document-list + service-list focused Vitest: **37/37 passed**.
- `packages/core` typecheck: **passed**.
- Biome on all three changed files: **passed**.
- `git diff --check`: **passed**.
- Full core lane was attempted. It reached unrelated existing failures in `message-runtime-stage1.test.ts` and `action-retrieval.test.ts`, then was stopped during the long message-runtime lane; neither failing file nor its production surface is changed by this PR.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only pagination guard; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only pagination guard; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic in-process service boundary; no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic backend receipt:

```text
RUN v4.1.5 /private/tmp/eliza-review-22660
Test Files 3 passed (3); Tests 37 passed (37); Duration 7.96s
The suite asserts logical-cycle rejection, oversized-page rejection before filtering, malformed-cursor typed rejection, no adapter-only cursor replay, page-limit rejection before request 102, and retention of a document on legal page 101.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model selection, prompt, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this library guard produces no external artifact; its complete result is the typed return/error contract asserted in the exact-head backend receipt.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Provenance

Original implementation: Anthropic `claude-sonnet-5` via Claude Code. Review, repair, adversarial tests, and exact-head verification: OpenAI `gpt-5.6-sol` via Codex Desktop multi-agent.