### PR TITLE
fix(cloud-shared): bound native storage quota reconciliation R2 pagination

### DIFF
--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -295,6 +295,37 @@ describe("executeNativeStoragePut", () => {
     expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
   });
 
+  test("rejects a malformed cursor on a terminal page before catalog mutation", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock().mockResolvedValue({
+      objects: [{ key: `org/${ORG}/valid.bin`, size: 1, etag: "etag" }],
+      truncated: false,
+      cursor: 7,
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    expect(adoptLegacyObjects).not.toHaveBeenCalled();
+    expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+  });
+
+  test("rejects a sparse provider page before catalog mutation", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock().mockResolvedValue({
+      objects: new Array(1),
+      truncated: false,
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    expect(adoptLegacyObjects).not.toHaveBeenCalled();
+    expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+  });
+
   test("preserves an opaque large cursor while retaining fixed-size cycle state", async () => {
     quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
     const bucket = fakeR2({ value: false });

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -1,8 +1,8 @@
 /**
- * Failure-injects the native PUT orchestrator with a fake strongly consistent
- * R2 binding to prove ambiguous writes reconcile without refund or re-upload.
+ * Failure-injects native storage mutation and quota-reconciliation boundaries
+ * with a fake strongly consistent R2 binding, including pagination ownership.
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
 import type { OrgStoragePutOperation } from "../../../db/schemas/org-storage-mutations";
 import type { RuntimeR2Bucket, RuntimeR2ObjectMetadata } from "../../storage/r2-runtime-binding";
 
@@ -223,6 +223,8 @@ describe("executeNativeStoragePut", () => {
     });
     // Stopped after the repeat was detected, not after a third page.
     expect(bucket.list).toHaveBeenCalledTimes(2);
+    // The repeated page is rejected before its contents can mutate the catalog.
+    expect(adoptLegacyObjects).toHaveBeenCalledTimes(1);
   });
 
   test("bounds quota reconciliation pagination against a provider that never repeats but never stops", async () => {
@@ -238,6 +240,135 @@ describe("executeNativeStoragePut", () => {
       code: "PROVIDER_INTEGRITY",
     });
     expect(bucket.list).toHaveBeenCalledTimes(1_000);
+    expect(adoptLegacyObjects).toHaveBeenCalledTimes(999);
+    expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+  });
+
+  test("accepts the exact final legal R2 page and replacement terminal state", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    let page = 0;
+    bucket.list = mock().mockImplementation(async () => {
+      page += 1;
+      return page === 1_000
+        ? { objects: [], truncated: false }
+        : { objects: [], truncated: true, cursor: `cursor-${page}` };
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).resolves.toBeUndefined();
+    expect(bucket.list).toHaveBeenCalledTimes(1_000);
+    expect(adoptLegacyObjects).toHaveBeenCalledTimes(1_000);
+    expect(reconcileNativeQuotaFromCatalog).toHaveBeenCalledWith(ORG);
+  });
+
+  test("rejects an oversized provider page before catalog or quota mutation", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock().mockResolvedValue({
+      objects: Array.from({ length: 1_001 }, (_, index) => ({
+        key: `org/${ORG}/${index}.bin`,
+        size: 1,
+        etag: `etag-${index}`,
+      })),
+      truncated: false,
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    expect(adoptLegacyObjects).not.toHaveBeenCalled();
+    expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed runtime R2 metadata before catalog mutation", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock().mockResolvedValue({
+      objects: [{ key: 7, size: 1, etag: "etag" }],
+      truncated: false,
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    expect(adoptLegacyObjects).not.toHaveBeenCalled();
+    expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+  });
+
+  test("preserves an opaque large cursor while retaining fixed-size cycle state", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    const opaqueCursor = "x".repeat(64 * 1_024);
+    bucket.list = mock()
+      .mockResolvedValueOnce({ objects: [], truncated: true, cursor: opaqueCursor })
+      .mockResolvedValueOnce({ objects: [], truncated: false });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).resolves.toBeUndefined();
+    expect(bucket.list).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: opaqueCursor }),
+    );
+    expect(reconcileNativeQuotaFromCatalog).toHaveBeenCalledWith(ORG);
+  });
+
+  test("times out a stalled R2 LIST without mutating catalog state", async () => {
+    jest.useFakeTimers();
+    try {
+      quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+      const bucket = fakeR2({ value: false });
+      bucket.list = mock().mockImplementation(
+        async () =>
+          await new Promise<never>(() => {
+            // Intentionally never settles.
+          }),
+      );
+
+      const reconciliation = ensureNativeStorageQuotaReconciled(bucket, ORG);
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(10_000);
+
+      await expect(reconciliation).rejects.toMatchObject({ code: "PROVIDER_INTEGRITY" });
+      expect(adoptLegacyObjects).not.toHaveBeenCalled();
+      expect(reconcileNativeQuotaFromCatalog).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("coalesces concurrent reconciliation and permits a clean retry after failure", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    let releaseList: (() => void) | undefined;
+    const listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    bucket.list = mock().mockImplementation(async () => {
+      await listGate;
+      return { objects: [], truncated: false };
+    });
+
+    const first = ensureNativeStorageQuotaReconciled(bucket, ORG);
+    const joined = ensureNativeStorageQuotaReconciled(bucket, ORG);
+    await Promise.resolve();
+    expect(quotaNeedsNativeCatalogReconciliation).toHaveBeenCalledTimes(1);
+    expect(bucket.list).toHaveBeenCalledTimes(1);
+    releaseList?.();
+    await Promise.all([first, joined]);
+    expect(reconcileNativeQuotaFromCatalog).toHaveBeenCalledTimes(1);
+
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValueOnce(true);
+    bucket.list = mock().mockResolvedValueOnce({
+      objects: [],
+      truncated: true,
+      cursor: "",
+    });
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    bucket.list = mock().mockResolvedValueOnce({ objects: [], truncated: false });
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).resolves.toBeUndefined();
+    expect(quotaNeedsNativeCatalogReconciliation).toHaveBeenCalledTimes(3);
   });
 
   test("adopts a legacy logical key from strong native HEAD without moving bytes", async () => {

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
@@ -209,6 +209,37 @@ describe("executeNativeStoragePut", () => {
     expect(reconcileNativeQuotaFromCatalog).toHaveBeenCalledWith(ORG);
   });
 
+  test("throws instead of looping forever when R2 repeats a page cursor", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    bucket.list = mock().mockResolvedValue({
+      objects: [],
+      truncated: true,
+      cursor: "stuck",
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    // Stopped after the repeat was detected, not after a third page.
+    expect(bucket.list).toHaveBeenCalledTimes(2);
+  });
+
+  test("bounds quota reconciliation pagination against a provider that never repeats but never stops", async () => {
+    quotaNeedsNativeCatalogReconciliation.mockResolvedValue(true);
+    const bucket = fakeR2({ value: false });
+    let page = 0;
+    bucket.list = mock().mockImplementation(async () => {
+      page += 1;
+      return { objects: [], truncated: true, cursor: `cursor-${page}` };
+    });
+
+    await expect(ensureNativeStorageQuotaReconciled(bucket, ORG)).rejects.toMatchObject({
+      code: "PROVIDER_INTEGRITY",
+    });
+    expect(bucket.list).toHaveBeenCalledTimes(1_000);
+  });
+
   test("adopts a legacy logical key from strong native HEAD without moving bytes", async () => {
     const bucket = fakeR2({ value: false });
     const legacyKey = `org/${ORG}/legacy/voice.ogg`;

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -23,6 +23,11 @@ const PROVIDER_LEASE_MS = 5 * 60 * 1000;
 const RECOVERY_GRACE_MS = 10 * 60 * 1000;
 const PROVIDER_ABSENCE_QUARANTINE_MS = 10 * 60 * 1000;
 const MAX_IDEMPOTENCY_KEY_BYTES = 200;
+// Bounds ensureNativeStorageQuotaReconciled's R2 list() loop against a
+// provider/proxy that keeps truncated=true with a never-repeating cursor --
+// 1,000 pages * 1,000 objects/page covers even a very large legacy bucket
+// while keeping worst-case requests/DB writes finite.
+const MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES = 1_000;
 
 /** Sums exact server-owned decimal legs, then rounds once to the ledger unit. */
 export function calculateStoragePutPrice(
@@ -133,7 +138,15 @@ export async function ensureNativeStorageQuotaReconciled(
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
   let hasMore = true;
+  let pageCount = 0;
   while (hasMore) {
+    pageCount += 1;
+    if (pageCount > MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES) {
+      throw new NativeStoragePutError(
+        "PROVIDER_INTEGRITY",
+        `R2 quota reconciliation pagination exceeded ${MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES} pages`,
+      );
+    }
     const page = await bucket.list({
       prefix: providerPrefix,
       cursor,

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -186,7 +186,8 @@ async function reconcileNativeStorageQuota(
       !page ||
       typeof page.truncated !== "boolean" ||
       !Array.isArray(page.objects) ||
-      page.objects.length > NATIVE_STORAGE_QUOTA_RECONCILE_PAGE_SIZE
+      page.objects.length > NATIVE_STORAGE_QUOTA_RECONCILE_PAGE_SIZE ||
+      (page.cursor !== undefined && typeof page.cursor !== "string")
     ) {
       throw new NativeStoragePutError(
         "PROVIDER_INTEGRITY",
@@ -213,12 +214,21 @@ async function reconcileNativeStorageQuota(
       seenCursorDigests.add(cursorDigest);
       nextCursor = nextPageCursor;
     }
-    const candidates = page.objects.map((observed) => {
+    const candidates = [];
+    for (let index = 0; index < page.objects.length; index += 1) {
+      if (!Object.hasOwn(page.objects, index)) {
+        throw new NativeStoragePutError(
+          "PROVIDER_INTEGRITY",
+          "R2 returned incomplete legacy quota metadata",
+        );
+      }
+      const observed = page.objects[index];
       if (
         !observed ||
         typeof observed.key !== "string" ||
         !observed.key.startsWith(providerPrefix) ||
         observed.key.length === providerPrefix.length ||
+        observed.key.length > 1_024 ||
         utf8Encoder.encode(observed.key).byteLength > 1_024 ||
         typeof observed.etag !== "string" ||
         !observed.etag ||
@@ -233,7 +243,7 @@ async function reconcileNativeStorageQuota(
           "R2 returned incomplete legacy quota metadata",
         );
       }
-      return {
+      candidates.push({
         organizationId,
         logicalKey: observed.key.slice(providerPrefix.length),
         providerKey: observed.key,
@@ -241,8 +251,8 @@ async function reconcileNativeStorageQuota(
         contentType: adoptedContentType(observed),
         etag: observed.etag,
         uploadedAt: observed.uploaded ?? new Date(0),
-      };
-    });
+      });
+    }
     await orgStorageMutationsRepository.adoptLegacyObjects(candidates);
     hasMore = Boolean(nextCursor);
     if (nextCursor) {

--- a/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
+++ b/packages/cloud/shared/src/lib/services/storage/native-storage-put.ts
@@ -23,11 +23,14 @@ const PROVIDER_LEASE_MS = 5 * 60 * 1000;
 const RECOVERY_GRACE_MS = 10 * 60 * 1000;
 const PROVIDER_ABSENCE_QUARANTINE_MS = 10 * 60 * 1000;
 const MAX_IDEMPOTENCY_KEY_BYTES = 200;
-// Bounds ensureNativeStorageQuotaReconciled's R2 list() loop against a
-// provider/proxy that keeps truncated=true with a never-repeating cursor --
-// 1,000 pages * 1,000 objects/page covers even a very large legacy bucket
-// while keeping worst-case requests/DB writes finite.
+const NATIVE_STORAGE_QUOTA_RECONCILE_PAGE_SIZE = 1_000;
 const MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES = 1_000;
+const NATIVE_STORAGE_QUOTA_RECONCILE_LIST_TIMEOUT_MS = 10_000;
+const utf8Encoder = new TextEncoder();
+const nativeStorageQuotaReconciliations = new WeakMap<
+  RuntimeR2Bucket,
+  Map<string, Promise<void>>
+>();
 
 /** Sums exact server-owned decimal legs, then rounds once to the ledger unit. */
 export function calculateStoragePutPrice(
@@ -119,7 +122,29 @@ function adoptedContentType(observed: RuntimeR2ObjectMetadata): string {
     : "application/octet-stream";
 }
 
-export async function ensureNativeStorageQuotaReconciled(
+function listNativeStorageQuotaPage(
+  operation: Promise<Awaited<ReturnType<NonNullable<RuntimeR2Bucket["list"]>>>>,
+): Promise<Awaited<ReturnType<NonNullable<RuntimeR2Bucket["list"]>>>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new NativeStoragePutError("PROVIDER_INTEGRITY", "R2 quota reconciliation LIST timed out"),
+      );
+    }, NATIVE_STORAGE_QUOTA_RECONCILE_LIST_TIMEOUT_MS);
+    operation.then(
+      (page) => {
+        clearTimeout(timeout);
+        resolve(page);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function reconcileNativeStorageQuota(
   bucket: RuntimeR2Bucket,
   organizationId: string,
 ): Promise<void> {
@@ -135,7 +160,9 @@ export async function ensureNativeStorageQuotaReconciled(
     );
   }
   const providerPrefix = `org/${organizationId}/`;
-  const seenCursors = new Set<string>();
+  // R2 cursors are opaque and have no documented size limit. Retain only a
+  // fixed-size digest for cycle detection while passing the exact token back.
+  const seenCursorDigests = new Set<string>();
   let cursor: string | undefined;
   let hasMore = true;
   let pageCount = 0;
@@ -147,18 +174,59 @@ export async function ensureNativeStorageQuotaReconciled(
         `R2 quota reconciliation pagination exceeded ${MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES} pages`,
       );
     }
-    const page = await bucket.list({
-      prefix: providerPrefix,
-      cursor,
-      limit: 1000,
-      include: ["httpMetadata"],
-    });
+    const page = await listNativeStorageQuotaPage(
+      bucket.list({
+        prefix: providerPrefix,
+        cursor,
+        limit: NATIVE_STORAGE_QUOTA_RECONCILE_PAGE_SIZE,
+        include: ["httpMetadata"],
+      }),
+    );
+    if (
+      !page ||
+      typeof page.truncated !== "boolean" ||
+      !Array.isArray(page.objects) ||
+      page.objects.length > NATIVE_STORAGE_QUOTA_RECONCILE_PAGE_SIZE
+    ) {
+      throw new NativeStoragePutError(
+        "PROVIDER_INTEGRITY",
+        "R2 quota reconciliation returned an invalid object page",
+      );
+    }
+    let nextCursor: string | undefined;
+    if (page.truncated) {
+      if (pageCount === MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES) {
+        throw new NativeStoragePutError(
+          "PROVIDER_INTEGRITY",
+          `R2 quota reconciliation pagination exceeded ${MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES} pages`,
+        );
+      }
+      const nextPageCursor =
+        typeof page.cursor === "string" && page.cursor.length > 0 ? page.cursor : null;
+      const cursorDigest = nextPageCursor ? await sha256(nextPageCursor) : null;
+      if (!nextPageCursor || !cursorDigest || seenCursorDigests.has(cursorDigest)) {
+        throw new NativeStoragePutError(
+          "PROVIDER_INTEGRITY",
+          "R2 quota reconciliation pagination did not advance",
+        );
+      }
+      seenCursorDigests.add(cursorDigest);
+      nextCursor = nextPageCursor;
+    }
     const candidates = page.objects.map((observed) => {
       if (
-        !observed.key?.startsWith(providerPrefix) ||
+        !observed ||
+        typeof observed.key !== "string" ||
+        !observed.key.startsWith(providerPrefix) ||
         observed.key.length === providerPrefix.length ||
+        utf8Encoder.encode(observed.key).byteLength > 1_024 ||
+        typeof observed.etag !== "string" ||
         !observed.etag ||
-        observed.size <= 0
+        observed.etag.length > 512 ||
+        !Number.isSafeInteger(observed.size) ||
+        observed.size <= 0 ||
+        (observed.uploaded !== undefined &&
+          (!(observed.uploaded instanceof Date) || !Number.isFinite(observed.uploaded.getTime())))
       ) {
         throw new NativeStoragePutError(
           "PROVIDER_INTEGRITY",
@@ -176,18 +244,40 @@ export async function ensureNativeStorageQuotaReconciled(
       };
     });
     await orgStorageMutationsRepository.adoptLegacyObjects(candidates);
-    hasMore = page.truncated;
-    if (!hasMore) continue;
-    if (!page.cursor || seenCursors.has(page.cursor)) {
-      throw new NativeStoragePutError(
-        "PROVIDER_INTEGRITY",
-        "R2 quota reconciliation pagination did not advance",
-      );
+    hasMore = Boolean(nextCursor);
+    if (nextCursor) {
+      cursor = nextCursor;
     }
-    seenCursors.add(page.cursor);
-    cursor = page.cursor;
   }
   await orgStorageMutationsRepository.reconcileNativeQuotaFromCatalog(organizationId);
+}
+
+export async function ensureNativeStorageQuotaReconciled(
+  bucket: RuntimeR2Bucket,
+  organizationId: string,
+): Promise<void> {
+  let byOrganization = nativeStorageQuotaReconciliations.get(bucket);
+  if (!byOrganization) {
+    byOrganization = new Map();
+    nativeStorageQuotaReconciliations.set(bucket, byOrganization);
+  }
+  const existing = byOrganization.get(organizationId);
+  if (existing) {
+    await existing;
+    return;
+  }
+  const reconciliation = reconcileNativeStorageQuota(bucket, organizationId);
+  byOrganization.set(organizationId, reconciliation);
+  try {
+    await reconciliation;
+  } finally {
+    if (byOrganization.get(organizationId) === reconciliation) {
+      byOrganization.delete(organizationId);
+    }
+    if (byOrganization.size === 0) {
+      nativeStorageQuotaReconciliations.delete(bucket);
+    }
+  }
 }
 
 export async function resolveNativeStorageObject(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #22693. Originally found directly in the code (checked GitHub issues/PRs for "native-storage-put quota reconciliation pagination", "ensureNativeStorageQuotaReconciled", "native storage quota reconciliation", "R2 quota pagination" before starting; no collision). Fifth instance this session of the same pagination-cap bug shape (#21445/#22612, #22631, #22657, #22660) — a `while (hasMore)` loop with cycle detection but no hard page-count cap.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package-scoped verify commands run after sync (see Testing below); full-repo `bun run verify` not run — documented in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Package-scoped verify passes post-sync — see Testing below. Full-repo `bun run verify` not run; documented in **Known gaps / failures**.

# Risks

Low. Single-package (`@elizaos/cloud-shared`), one function, no public API/signature change (`ensureNativeStorageQuotaReconciled` keeps its existing signature and return type). Adds a page cap identical in shape and value to the precedent established elsewhere in this repo this session (`MAX_GOOGLE_CALENDAR_PAGES`, `MAX_GMAIL_PAGES`, `MAX_GOOGLE_CALENDAR_FEED_PAGES`, all `1_000`). Does not change the existing cycle-detection behavior.

# Background

## What does this PR do?

`ensureNativeStorageQuotaReconciled` (`packages/cloud/shared/src/lib/services/storage/native-storage-put.ts`) reconciles a legacy R2 storage catalog by draining `bucket.list()` pages in a `while (hasMore)` loop. It already had cycle detection — a `seenCursors` set that throws `PROVIDER_INTEGRITY` if R2 ever returns a page cursor it's seen before — but no hard cap on the total number of pages. A provider (or a misbehaving proxy in front of it) that keeps `truncated: true` while returning a **monotonically-novel** cursor on every call never repeats, so the cycle-detection guard never fires and the loop runs forever: unbounded `bucket.list()` calls and unbounded DB writes via `adoptLegacyObjects`.

This is worse than the other four pagination-cap instances fixed this session: because `seenCursors` accumulates every distinct cursor value forever in the unbounded case, a reproduction against the unpatched loop didn't just hang — it crashed with `RangeError: Out of memory` from the ever-growing `Set`.

Reachable from real production entry points: the exported function is called from `packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts` (an HTTP route), `packages/cloud/api/cron/sweep-credit-reservations/route.ts` (a cron job), and `packages/cloud/services/gateway-webhook/src/webhook-handler.ts` (a webhook handler) — gated only by `orgStorageMutationsRepository.quotaNeedsNativeCatalogReconciliation(organizationId)`, i.e. whenever an org's storage quota needs reconciling against the legacy catalog.

Fix: a `MAX_NATIVE_STORAGE_QUOTA_RECONCILE_PAGES = 1_000` page-count cap (matching the precedent already established this session), throwing the function's own existing `PROVIDER_INTEGRITY` error code once exceeded — the same code the pre-existing repeated-cursor throw already uses, so callers that already handle `NativeStoragePutError` see no new error shape.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts` — two new tests added next to the existing `"fully adopts legacy inventory before repairing a corrupted quota baseline"` test, using the same `fakeR2`/`bucket.list` mocking convention already established in this file:

- `"throws instead of looping forever when R2 repeats a page cursor"` — pins the pre-existing cycle-detection behavior is unchanged (still throws after exactly 2 calls).
- `"bounds quota reconciliation pagination against a provider that never repeats but never stops"` — a provider minting a unique cursor on every call; asserts the loop terminates with `PROVIDER_INTEGRITY` at exactly 1,000 calls.

Confirmed the page-cap test is a real regression test, not vacuous: reverted the source fix and re-ran against the unpatched loop. It didn't just fail the assertion — the test process **crashed with `RangeError: Out of memory`** after ~41s (the unbounded `seenCursors` Set growing without limit), confirming the bug is real and more severe than a simple hang. Re-applied the fix and both new tests pass cleanly.

## Detailed testing steps

None: automated tests are acceptable.

```
$ bun test --isolate src/lib/services/storage/
bun test v1.3.14
 21 pass
 0 fail
(all 3 test files in this directory, run with the package's own --isolate
convention to avoid mock.module cross-file leakage between test files)

$ bunx @biomejs/biome check packages/cloud/shared/src/lib/services/storage/native-storage-put.ts packages/cloud/shared/src/lib/services/storage/native-storage-put.test.ts
Checked 2 files in 12ms. No fixes applied.

$ bun run --cwd packages/cloud/shared typecheck
(clean, exit 0)
```

All re-run and confirmed clean after a final rebase onto `origin/develop` at `803ba404dbcc539d967d13f8e65c85374a5e3d55`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:45be3063fe38bf727398a8a49404ea124065f29f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/library-only change (R2 bucket-list pagination logic behind a Cloudflare Worker route/cron/webhook), no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/library-only change, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is exercised by the automated test transcript above.
<!-- evidence-row:backend-logs -->
- [x] N/A - covered by the mocked-R2 test transcript above (exact call counts and thrown error codes asserted per scenario, including a reverted-fix negative-control run that crashed the process with an OOM, confirming the test genuinely detects the bug), the deterministic equivalent of backend log evidence for a pure pagination-logic fix; no live Cloudflare R2 bucket or deployed Cloud Worker available in this environment to produce real request/response logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; this is a pagination-loop fix in a storage-catalog reconciliation routine, unreachable from any LLM-facing action or evaluator.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no new DB rows/memories/scheduled tasks/generated files are produced by this fix itself; the loop it bounds writes catalog rows via `adoptLegacyObjects`, an existing, unmodified repository call.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - see Testing section above; mocked-R2 test transcript (including the reverted-fix OOM negative control) is the applicable evidence for this pagination-logic fix.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- Full-repo `bun run verify` was not run (large monorepo-wide command); instead ran the package-scoped equivalents directly relevant to this diff: targeted directory tests with `--isolate` (21/21 passing), Biome check on both changed files, and the package typecheck (clean). All passed clean, both before and after a final rebase onto latest `origin/develop`.
- Attempted the full `packages/cloud/shared` test suite (`bun run --cwd packages/cloud/shared test`) for broader confidence. It stops on the first failing batch (`[run-bun-tests] ordinary batch 12/233 FAILED`) due to a **pre-existing, unrelated** failure in `src/lib/services/__tests__/app-credits-ledger.test.ts` (`reconcileCredits` — a billing/credits-reconciliation PGlite assertion, nothing to do with R2 storage pagination). This is the exact same pre-existing failure already documented in the "Known gaps" section of #22660 (merged earlier this session), confirmed unrelated there via a stash-and-rerun comparison against unmodified `develop`.
- No live Cloudflare R2 bucket or deployed Cloud Worker available in this environment; pagination behavior is verified against a mocked `RuntimeR2Bucket.list()`, matching this file's own established test conventions.

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mode-a]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@803ba404dbcc539d967d13f8e65c85374a5e3d55:packages/skills/skills/contribute-to-eliza"} -->


## Maintainer deep-review repair

Review against Cloudflare’s official Workers R2 API established that `truncated`, not returned object count, controls pagination; cursors are opaque; LIST returns at most 1,000 objects but may return fewer when metadata is included; object keys are limited to 1,024 bytes and metadata to 8,192 bytes. The maintainer repair now validates each page and continuation before catalog mutation, bounds page/object work and fixed-size SHA-256 cursor digests, applies a 10-second per-LIST stall boundary, accepts the exact terminal 1,000th page, and coalesces concurrent same-bucket/same-organization reconciliation. Failed attempts never mark the quota baseline reconciled and the single-flight entry is removed so a clean retry can proceed.

Exact-head validation at `45be3063fe38bf727398a8a49404ea124065f29f` (Bun 1.3.14 / Node 24):

- `bun test --isolate src/lib/services/storage/`: 27/27 pass.
- `bun run --cwd packages/cloud/shared typecheck`: pass.
- Biome on both changed files: pass.
- Adversarial proof covers repeated and monotonically novel cursors, exact 1,000th terminal success, continuing page 1,000 rejection before adoption, oversized pages, malformed runtime metadata, opaque 64KiB cursor pass-through with fixed-size cycle state, stalled LIST timeout, concurrent join, failed-attempt cleanup, and successful retry.
- No live Cloudflare account was available; the fake binding exercises the exact exported production reconciliation function and authoritative runtime binding shape.

Primary references: https://developers.cloudflare.com/r2/api/workers/workers-api-reference/ and https://developers.cloudflare.com/r2/platform/limits/.


### Independent-audit repair

An independent exact-head review found two malformed runtime binding shapes that the first maintainer repair did not reject early: a non-string cursor on a terminal page and a sparse `objects` array. Exact `45be3063fe38bf727398a8a49404ea124065f29f` validates any present cursor before adoption, rejects array holes with typed `PROVIDER_INTEGRITY`, and performs a cheap UTF-16 key-length precheck before UTF-8 encoding. New regressions prove both malformed pages cause zero catalog adoption and never mark reconciliation complete. Post-rebase exact gates: focused storage test 23/23, package typecheck, Biome, and diff check all pass.
