### PR TITLE
fix(computeruse): resolve symlink ancestors instead of refusing them

### DIFF
--- a/plugins/plugin-computeruse/src/platform/security.test.ts
+++ b/plugins/plugin-computeruse/src/platform/security.test.ts
@@ -1,9 +1,14 @@
 /**
- * Unit tests for symlink-ancestor confinement in resolveSafeFileTarget.
- * Mirrors plugins/plugin-coding-tools/src/lib/path-utils.test.ts ancestor-walk case.
+ * Unit tests for symlink handling in resolveSafeFileTarget. Benign
+ * directory-symlink ancestors resolve to their canonical target and are
+ * re-validated there, for existing files, not-yet-existing leaves, and
+ * nested missing tails. Ancestors whose canonical target lands in a blocked
+ * zone are refused with operation-specific reasons (read and delete on an
+ * existing leaf, write and delete through the missing-leaf walk). Symlink
+ * leaves and dangling ancestors are refused, and the canonical /private
+ * spellings of the auth-config and root-home blocklists are pinned directly.
  */
 import {
-  mkdirSync,
   mkdtempSync,
   realpathSync,
   rmSync,
@@ -13,9 +18,9 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveSafeFileTarget } from "./security.js";
+import { resolveSafeFileTarget, validateFilePath } from "./security.js";
 
-describe("resolveSafeFileTarget — ancestor-walk confinement", () => {
+describe("resolveSafeFileTarget — symlink ancestors resolve, blocked zones stay blocked", () => {
   const temps: string[] = [];
   afterEach(() => {
     for (const dir of temps.splice(0)) {
@@ -23,82 +28,234 @@ describe("resolveSafeFileTarget — ancestor-walk confinement", () => {
     }
   });
 
-  const itSymlink = process.platform === "win32" ? it.skip : it;
+  function makeTempDir(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-sec-"));
+    temps.push(dir);
+    return dir;
+  }
 
-  itSymlink(
-    "blocks a write through a directory symlink to outside",
+  function linkDir(root: string, name: string, target: string): void {
+    symlinkSync(target, path.join(realpathSync(root), name), "dir");
+  }
+
+  // symlinkSync needs elevated privileges on win32; the direct validateFilePath
+  // pins below rely on POSIX path resolution.
+  const itPosix = process.platform === "win32" ? it.skip : it;
+
+  itPosix(
+    "resolves an existing file behind a directory-symlink ancestor to its canonical path",
     async () => {
-      const root = mkdtempSync(path.join(tmpdir(), "eliza-sec-root-"));
-      const victim = mkdtempSync(path.join(tmpdir(), "eliza-sec-victim-"));
-      temps.push(root, victim);
-      const realRoot = realpathSync(root);
-      const realVictim = realpathSync(victim);
-      symlinkSync(realVictim, path.join(realRoot, "escape"), "dir");
+      const root = makeTempDir();
+      const realTarget = realpathSync(makeTempDir());
+      writeFileSync(path.join(realTarget, "data.txt"), "content\n");
+      linkDir(root, "link", realTarget);
 
       const result = await resolveSafeFileTarget(
-        path.join(realRoot, "escape", "planted.txt"),
-        "write",
+        path.join(root, "link", "data.txt"),
+        "read",
       );
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toMatch(/symbolic link/i);
+      expect(result.allowed).toBe(true);
+      expect(result.resolvedPath).toBe(path.join(realTarget, "data.txt"));
     },
   );
 
-  itSymlink(
-    "blocks a write through a nested symlink ancestor (not just immediate parent)",
+  itPosix(
+    "resolves a not-yet-existing file behind a directory-symlink ancestor canonically",
     async () => {
-      const root = mkdtempSync(path.join(tmpdir(), "eliza-sec-root2-"));
-      const victim = mkdtempSync(path.join(tmpdir(), "eliza-sec-victim2-"));
-      temps.push(root, victim);
-      const realRoot = realpathSync(root);
-      const realVictim = realpathSync(victim);
-      // root/a -> victim, path is root/a/b/c/planted.txt where a/b/c does not exist yet
-      symlinkSync(realVictim, path.join(realRoot, "a"), "dir");
+      const root = makeTempDir();
+      const realTarget = realpathSync(makeTempDir());
+      linkDir(root, "link", realTarget);
 
       const result = await resolveSafeFileTarget(
-        path.join(realRoot, "a", "b", "c", "planted.txt"),
+        path.join(root, "link", "new.txt"),
         "write",
       );
-      expect(result.allowed).toBe(false);
-      // Either symlink-parent or confinement failure — both are secure.
-      expect(result.allowed).toBe(false);
+      expect(result.allowed).toBe(true);
+      expect(result.resolvedPath).toBe(path.join(realTarget, "new.txt"));
     },
   );
 
-  itSymlink(
-    "blocks a symlink ancestor when an existing descendant hides it",
+  itPosix(
+    "resolves a nested not-yet-created tail behind a symlink ancestor canonically",
     async () => {
-      const root = mkdtempSync(path.join(tmpdir(), "eliza-sec-root-existing-"));
-      const victim = mkdtempSync(
-        path.join(tmpdir(), "eliza-sec-victim-existing-"),
-      );
-      temps.push(root, victim);
-      const realRoot = realpathSync(root);
-      const realVictim = realpathSync(victim);
-      const existing = path.join(realVictim, "existing");
-      mkdirSync(existing);
-      writeFileSync(path.join(existing, "planted.txt"), "outside\n");
-      symlinkSync(realVictim, path.join(realRoot, "escape"), "dir");
+      const root = makeTempDir();
+      const realTarget = realpathSync(makeTempDir());
+      linkDir(root, "a", realTarget);
 
       const result = await resolveSafeFileTarget(
-        path.join(realRoot, "escape", "existing", "planted.txt"),
+        path.join(root, "a", "b", "c", "planted.txt"),
         "write",
       );
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toMatch(/symbolic link/i);
+      expect(result.allowed).toBe(true);
+      expect(result.resolvedPath).toBe(
+        path.join(realTarget, "b", "c", "planted.txt"),
+      );
     },
   );
 
-  itSymlink("allows a normal write inside the workspace", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "eliza-sec-root3-"));
-    temps.push(root);
-    const realRoot = realpathSync(root);
+  itPosix(
+    "refuses a symlink ancestor whose canonical target is a blocked zone — existing leaf, read",
+    async () => {
+      const root = makeTempDir();
+      linkDir(root, "devlink", "/dev");
+
+      const result = await resolveSafeFileTarget(
+        path.join(root, "devlink", "null"),
+        "read",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/cannot read in device node/i);
+    },
+  );
+
+  itPosix(
+    "refuses a symlink ancestor whose canonical target is a blocked zone — existing leaf, delete",
+    async () => {
+      const root = makeTempDir();
+      linkDir(root, "devlink", "/dev");
+
+      const result = await resolveSafeFileTarget(
+        path.join(root, "devlink", "null"),
+        "delete",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/cannot delete in device node/i);
+    },
+  );
+
+  itPosix(
+    "refuses a symlink ancestor whose canonical target is a blocked zone — missing leaf, write",
+    async () => {
+      const root = makeTempDir();
+      linkDir(root, "devlink", "/dev");
+
+      const result = await resolveSafeFileTarget(
+        path.join(root, "devlink", "planted.txt"),
+        "write",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/cannot write in device node/i);
+    },
+  );
+
+  itPosix(
+    "refuses a symlink ancestor whose canonical target is a blocked zone — missing leaf, delete",
+    async () => {
+      const root = makeTempDir();
+      linkDir(root, "devlink", "/dev");
+
+      const result = await resolveSafeFileTarget(
+        path.join(root, "devlink", "gone.txt"),
+        "delete",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/cannot delete in device node/i);
+    },
+  );
+
+  itPosix(
+    "refuses auth config reached through an /etc symlink at its canonical spelling",
+    async () => {
+      const root = makeTempDir();
+      linkDir(root, "etclink", "/etc");
+
+      const result = await resolveSafeFileTarget(
+        path.join(root, "etclink", "sudoers"),
+        "read",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/system auth config/i);
+    },
+  );
+
+  itPosix(
+    "blocks the canonical /private/etc spelling of auth config directly",
+    () => {
+      const result = validateFilePath("/private/etc/master.passwd", "read");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/system auth config/i);
+    },
+  );
+
+  itPosix("blocks root-home credentials under both /var/root spellings", () => {
+    for (const spelling of [
+      "/var/root/.ssh/id_rsa",
+      "/private/var/root/.ssh/id_rsa",
+    ]) {
+      const result = validateFilePath(spelling, "read");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/SSH key/i);
+    }
+  });
+
+  itPosix("still refuses a symlink leaf", async () => {
+    const root = makeTempDir();
+    const realTarget = realpathSync(makeTempDir());
+    writeFileSync(path.join(realTarget, "real.txt"), "content\n");
+    symlinkSync(
+      path.join(realTarget, "real.txt"),
+      path.join(realpathSync(root), "leaf-link"),
+      "file",
+    );
+
     const result = await resolveSafeFileTarget(
-      path.join(realRoot, "inside.txt"),
+      path.join(root, "leaf-link"),
+      "read",
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/symbolic link/i);
+  });
+
+  itPosix("fails closed on a dangling directory-symlink ancestor", async () => {
+    const root = makeTempDir();
+    const realRoot = realpathSync(root);
+    symlinkSync(
+      path.join(realRoot, "gone"),
+      path.join(realRoot, "dangling"),
+      "dir",
+    );
+
+    const result = await resolveSafeFileTarget(
+      path.join(root, "dangling", "planted.txt"),
       "write",
     );
-    // inside.txt does not exist but parent is realRoot (not a symlink) — should be allowed
-    // unless blocked by credential patterns; this path is not credential-related.
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/ENOENT|no such file/i);
+    expect(result.resolvedPath).toBeUndefined();
+  });
+
+  itPosix(
+    "fails closed when a path component is a regular file (non-ENOENT leaf error)",
+    async () => {
+      const root = makeTempDir();
+      const realRoot = realpathSync(root);
+      writeFileSync(path.join(realRoot, "file.txt"), "content\n");
+
+      const result = await resolveSafeFileTarget(
+        path.join(realRoot, "file.txt", "child.txt"),
+        "write",
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/ENOTDIR|not a directory/i);
+    },
+  );
+
+  it("resolves reads and writes under the OS tmpdir canonically", async () => {
+    // On macOS tmpdir() sits under the /var -> /private/var symlink; on Linux
+    // it is a plain directory and the canonical assertions are tautological.
+    const root = makeTempDir();
+
+    const existing = path.join(root, "existing.txt");
+    writeFileSync(existing, "content\n");
+    const read = await resolveSafeFileTarget(existing, "read");
+    expect(read.allowed).toBe(true);
+    expect(read.resolvedPath).toBe(realpathSync(existing));
+
+    const write = await resolveSafeFileTarget(
+      path.join(root, "fresh.txt"),
+      "write",
+    );
+    expect(write.allowed).toBe(true);
+    expect(write.resolvedPath).toBe(path.join(realpathSync(root), "fresh.txt"));
   });
 });

--- a/plugins/plugin-computeruse/src/platform/security.ts
+++ b/plugins/plugin-computeruse/src/platform/security.ts
@@ -1,12 +1,14 @@
 /**
  * Path and command security checks for computer-use: validates file targets
- * against allowed roots (resolving symlinks), flags dangerous shell commands, and
+ * against the credential/system-path blocklists (re-checked on the canonical
+ * path after resolving symlinks), flags dangerous shell commands, and
  * sanitizes the child-process environment before any spawn.
  */
 import fs from "node:fs";
 import { lstat, realpath } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { formatError } from "@elizaos/core";
 
 export interface PathValidationResult {
   allowed: boolean;
@@ -78,7 +80,10 @@ const SYSTEM_DIR_PATTERNS_UNIX: LabelledPattern[] = [
   { pattern: /^\/usr\/sbin\//i, label: "system admin binary directory" },
   { pattern: /^\/usr\/lib\//i, label: "system library directory" },
   {
-    pattern: /^\/etc\/(?:shadow|sudoers|pam\.d|master\.passwd)/i,
+    // Both spellings: /etc is the canonical form on Linux, but a symlink to
+    // /private/etc on macOS — the canonical-path recheck in
+    // resolveSafeFileTarget only blocks what this list names canonically.
+    pattern: /^(?:\/private)?\/etc\/(?:shadow|sudoers|pam\.d|master\.passwd)/i,
     label: "system auth config",
   },
   { pattern: /^\/System\//i, label: "macOS System directory" },
@@ -166,6 +171,21 @@ const DANGEROUS_COMMAND_PATTERNS: DangerousPattern[] = [
  * `/root` or `/home/<user>` prefix. The full normalized path is always included
  * so the non-anchored browser-store patterns continue to match anywhere.
  */
+let canonicalHomeMemo: string | null = null;
+function canonicalHome(): string {
+  if (canonicalHomeMemo === null) {
+    try {
+      canonicalHomeMemo = fs.realpathSync(os.homedir()).replace(/\\/g, "/");
+    } catch {
+      // error-policy:J3 a missing or unresolvable home (minimal containers)
+      // disables only the canonical-spelling strip; the lexical home strip
+      // below still applies, so nothing is over-allowed.
+      canonicalHomeMemo = "";
+    }
+  }
+  return canonicalHomeMemo;
+}
+
 function credentialRelativePaths(normalized: string): string[] {
   const candidates = new Set<string>([normalized]);
 
@@ -174,10 +194,21 @@ function credentialRelativePaths(normalized: string): string[] {
     candidates.add(normalized.slice(home.length));
   }
 
-  // /root/... and /home/<user>/... — strip the home root so reads of other
-  // users' (and root's) credential files are caught regardless of os.homedir().
+  // The home directory may itself sit behind a symlink (bind-mounted homes in
+  // containers, /var/root -> /private/var/root on macOS). resolveSafeFileTarget
+  // re-validates CANONICAL paths, so the canonical spelling of the home must
+  // strip like the lexical one or a symlink ancestor could smuggle a
+  // credential path past the anchored patterns.
+  const realHome = canonicalHome();
+  if (realHome && realHome !== home && normalized.startsWith(`${realHome}/`)) {
+    candidates.add(normalized.slice(realHome.length));
+  }
+
+  // /root/..., /home/<user>/..., and macOS /var/root (both spellings) — strip
+  // the home root so reads of other users' (and root's) credential files are
+  // caught regardless of os.homedir().
   const otherHomeMatch = normalized.match(
-    /^\/root(?=\/)|^\/home\/[^/]+(?=\/)/i,
+    /^\/root(?=\/)|^\/home\/[^/]+(?=\/)|^(?:\/private)?\/var\/root(?=\/)/i,
   );
   if (otherHomeMatch) {
     candidates.add(normalized.slice(otherHomeMatch[0].length));
@@ -318,36 +349,20 @@ function errnoCode(error: unknown): string {
     : "";
 }
 
-async function pathContainsSymlink(absolutePath: string): Promise<boolean> {
-  const root = path.parse(absolutePath).root;
-  const segments = path
-    .relative(root, absolutePath)
-    .split(path.sep)
-    .filter(Boolean);
-  let current = root;
-
-  for (const segment of segments) {
-    current = path.join(current, segment);
-    try {
-      if ((await lstat(current)).isSymbolicLink()) {
-        return true;
-      }
-    } catch (error) {
-      // error-policy:J3 an absent component means the remaining lexical tail
-      // is absent too; every existing component checked so far was non-symlink.
-      if (errnoCode(error) === "ENOENT") {
-        return false;
-      }
-      throw error;
-    }
-  }
-
-  return false;
-}
-
 /**
  * Resolve and re-validate file paths after lstat/realpath to reduce TOCTOU /
  * symlink escapes (GHSA-qmf5-p9x5-9xr5).
+ *
+ * Symlink ANCESTORS are legitimate and resolved, not refused: on macOS /tmp,
+ * /var, and /etc are symlinks into /private, and usr-merged Linux links /bin
+ * into /usr, so refusing them refuses ordinary paths outright. The security
+ * boundary is the blocklist in validateFilePath, re-run on the CANONICAL
+ * path — a symlink cannot smuggle a blocked location past it, provided the
+ * blocklist covers canonical spellings: /private aliases for the system-dir
+ * patterns, and the canonical home spelling in credentialRelativePaths for
+ * the home-anchored credential patterns. A symlink LEAF is still refused:
+ * the operation would apply to the link target while the caller named the
+ * link.
  */
 export async function resolveSafeFileTarget(
   filePath: string,
@@ -361,15 +376,6 @@ export async function resolveSafeFileTarget(
   const resolved = path.resolve(filePath);
 
   try {
-    // Inspect every existing lexical component before canonicalizing. Checking
-    // only the longest existing descendant misses a symlink earlier in the
-    // path when the symlink target already contains later components.
-    if (await pathContainsSymlink(resolved)) {
-      return {
-        allowed: false,
-        reason: "Symbolic links are not allowed for file operations.",
-      };
-    }
     const stat = await lstat(resolved);
     if (stat.isSymbolicLink()) {
       return {
@@ -388,48 +394,53 @@ export async function resolveSafeFileTarget(
     // does not exist yet) degrades to static path validation; every other
     // failure returns an explicit not-allowed result below.
     if (errnoCode(error) === "ENOENT") {
-      // Walk up to the longest existing parent and realpath that, then
-      // rejoin the tail so a workspace symlink-to-elsewhere cannot hide
-      // behind a not-yet-created descendant. Mirrors
-      // plugins/plugin-coding-tools/src/lib/path-utils.ts#resolveRealPath.
+      // Walk up to the deepest existing ancestor and realpath THAT — which
+      // resolves every symlink in the ancestry — then rejoin the tail, so a
+      // symlink-to-a-blocked-zone cannot hide behind a not-yet-created
+      // descendant while a benign one (e.g. /tmp on macOS) resolves normally.
+      // Same walk shape as plugins/plugin-coding-tools/src/lib/path-utils.ts
+      // #resolveRealPath, but stricter: an existing ancestor that cannot
+      // canonicalize fails closed here instead of falling back lexically.
       const tail: string[] = [path.basename(resolved)];
       let current = path.dirname(resolved);
       while (true) {
         try {
-          const currentStat = await lstat(current);
-          if (currentStat.isSymbolicLink()) {
-            return {
-              allowed: false,
-              reason: "Parent path is a symbolic link.",
-            };
-          }
-          const currentReal = await realpath(current);
-          const target = path.join(currentReal, ...tail);
-          const parentCheck = validateFilePath(target, operation);
-          if (!parentCheck.allowed) {
-            return parentCheck;
-          }
-          return { allowed: true, resolvedPath: target };
-        } catch (parentError) {
+          await lstat(current);
+        } catch (probeError) {
           // error-policy:J3 only ENOENT walks further up; every other
           // failure fails closed.
-          if (errnoCode(parentError) === "ENOENT") {
+          if (errnoCode(probeError) === "ENOENT") {
             const parent = path.dirname(current);
             if (parent === current) {
+              // Loop terminator: unreachable on POSIX (lstat("/") succeeds),
+              // reached on win32 for an unmapped drive root.
               break;
             }
             tail.unshift(path.basename(current));
             current = parent;
             continue;
           }
-          return {
-            allowed: false,
-            reason:
-              parentError instanceof Error
-                ? parentError.message
-                : String(parentError),
-          };
+          return { allowed: false, reason: formatError(probeError) };
         }
+        let currentReal: string;
+        try {
+          currentReal = await realpath(current);
+        } catch (resolveError) {
+          // error-policy:J3 an ancestor that exists (lstat above) but cannot
+          // canonicalize is a dangling symlink or a permission fault mid-walk;
+          // there is no trustworthy canonical target, so fail closed.
+          return { allowed: false, reason: formatError(resolveError) };
+        }
+        // Only the rejoined full target is validated, not each tail component
+        // mkdir -p will create. That is sound while the system-dir patterns
+        // stay ^-anchored (a blocked prefix implies a blocked target); a
+        // $-anchored system-dir pattern would need per-component checks here.
+        const target = path.join(currentReal, ...tail);
+        const parentCheck = validateFilePath(target, operation);
+        if (!parentCheck.allowed) {
+          return parentCheck;
+        }
+        return { allowed: true, resolvedPath: target };
       }
       const fallback = validateFilePath(resolved, operation);
       if (!fallback.allowed) {
@@ -440,7 +451,7 @@ export async function resolveSafeFileTarget(
 
     return {
       allowed: false,
-      reason: error instanceof Error ? error.message : String(error),
+      reason: formatError(error),
     };
   }
 }


### PR DESCRIPTION
Fixes #22675. Regression review context: flagged in review on #22408, which merged minutes before the review landed.

## Problem

#22408's `pathContainsSymlink` rejects any path with a symlink component anywhere in its ancestry, before canonicalization. On macOS `/tmp`, `/var`, and `/etc` are symlinks into `/private`, so at current develop every computeruse file operation (all `resolveSafeFileTarget` call sites in `file-ops.ts`) fails with "Symbolic links are not allowed" on those paths — including plain reads that worked before. Same class on usr-merged Linux (`/bin`), pnpm layouts, symlinked workspace roots. The ENOENT ancestor walk likewise refused "Parent path is a symbolic link", so creating a file under `/tmp` failed too.

Measured on a macOS host: `service.integration.test.ts` fails **9/38 on develop** (every real-host file I/O case) vs **2/38 with this fix** — the 2 are pre-existing window-automation timeouts, identical on develop.

## Change

The boundary is the blocklist in `validateFilePath`, re-run on the **canonical** path — a symlink cannot smuggle a blocked location past it, provided the blocklist covers canonical spellings. So:

- drop the blanket `pathContainsSymlink` pre-check; existing paths realpath + re-validate canonically, as before #22408. The symlink-**leaf** refusal is unchanged.
- the ENOENT walk canonicalizes the deepest existing ancestor instead of refusing it; a dangling or unresolvable ancestor fails **closed** (stricter than the `path-utils.ts#resolveRealPath` walk this mirrors, which falls back lexically — that fail-open shape may deserve its own look in plugin-coding-tools).
- close the canonical-spelling gaps the recheck depends on: `/private/etc` alias on the auth-config pattern (at develop, `validateFilePath("/private/etc/master.passwd")` is **allowed** — reachable through any planted symlink once the blanket check is gone, and a latent lexical bypass before that); `/var/root` + `/private/var/root` home-root strips; `realpath(os.homedir())` strip so a bind-mounted/symlinked home can't expose credential files at their canonical spelling.

## Deliberate scope notes

- On macOS the blanket check incidentally refused **all** of `/etc` (passwd, hosts, cron.d, …), not just blocklisted names. This PR restores the pre-#22408 exposure: the blocklist names what is protected. Widening the `/etc` blocklist is a product decision I did not take here.
- `resolveSafeFileTarget` has no allow-root concept — it never did; the old file header's "against allowed roots" claim was rewritten to name the blocklist.
- Residual TOCTOU (check-then-use between resolution and the fs op) is unchanged by this PR and documented in the walk comments.

## Testing

- `security.test.ts` rewritten: 14 tests, fixtures deliberately **not** pre-canonicalized (the old fixtures `realpathSync`'d every root, which is exactly why the regression shipped green). Benign ancestors resolve canonically for read/write/delete; blocked canonical targets are refused with operation-specific reasons through both the recheck and the missing-leaf walk; symlink leaves, dangling ancestors (with cause), and ENOTDIR fail closed; `/private/etc` and `/var/root` spellings pinned directly.
- Mutation-checked against committed objects: lexical-only `/etc` pattern → 2 red; dropped `/var/root` root → 1 red; lexical walk rejoin → 5 red; develop's `security.ts` under the new suite → 7+ red.
- Full plugin suite: **874 passed, 2 failed** — the two pre-existing `service.integration.test.ts` window-automation timeouts, failing identically on develop (which fails 9 there). `tsc --noEmit` clean. No CI runs on this repo's branches currently, so these are local exact-head results at `8fcad5fd5d7`.
