### PR TITLE
fix(capacitor-bridge): bound model download with timeout and stream teardown

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -46,6 +46,7 @@ import {
 } from "@elizaos/shared/transcripts";
 import {
 	closeDownloadWriter,
+	teardownFailedDownload,
 	writeDownloadChunk,
 } from "../shared/download-writer.ts";
 import {
@@ -3228,15 +3229,13 @@ async function runNativeModelDownload(
 			error: failure instanceof Error ? failure.message : String(failure),
 		});
 		try {
-			await reader?.cancel();
+			await teardownFailedDownload({
+				reader,
+				writer,
+				removePartial: () => rmSync(partialPath, { force: true }),
+			});
 		} catch {
-			// error-policy:J6 best-effort teardown of the failed response stream.
-		}
-		writer?.destroy();
-		try {
-			rmSync(partialPath, { force: true });
-		} catch {
-			// error-policy:J6 best-effort teardown of the failed partial file.
+			// error-policy:J6 best-effort teardown after preserving the download failure.
 		}
 		throw failure;
 	} finally {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -60,6 +60,7 @@ import {
 	resolveStoredModelPath,
 	toStoredModelPath,
 } from "../shared/local-inference-stored-path.ts";
+import { createModelDownloadDeadline } from "../shared/model-download-deadline.ts";
 import {
 	type StdioBridgeRequestFrame as BridgeRequest,
 	type StdioBridgeResponseFrame as BridgeResponse,
@@ -3176,26 +3177,41 @@ async function runNativeModelDownload(
 		localInferenceDownloadsPath(),
 		`${model.id}.part`,
 	);
-	const response = await fetch(modelDownloadUrl(model), { redirect: "follow" });
-	if (!response.ok) {
-		throw new Error(
-			`Failed to download ${model.id}: HTTP ${response.status} ${response.statusText}`,
-		);
-	}
-	if (!response.body) {
-		throw new Error(`Failed to download ${model.id}: response body is empty`);
-	}
-	const contentLength =
-		positiveInteger(response.headers.get("content-length")) ?? totalEstimate;
-	updateNativeDownloadJob(model.id, { total: contentLength });
-	const writer = createWriteStream(partialPath);
+	const deadline = createModelDownloadDeadline({
+		label: `iOS model download ${model.id}`,
+	});
+	let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+	let writer: ReturnType<typeof createWriteStream> | undefined;
 	let received = 0;
 	try {
-		const reader = response.body.getReader();
+		const response = await fetch(modelDownloadUrl(model), {
+			redirect: "follow",
+			signal: deadline.signal,
+		});
+		deadline.noteProgress();
+		if (!response.ok) {
+			try {
+				await response.body?.cancel();
+			} catch {
+				// error-policy:J6 best-effort teardown of a rejected response body.
+			}
+			throw new Error(
+				`Failed to download ${model.id}: HTTP ${response.status} ${response.statusText}`,
+			);
+		}
+		if (!response.body) {
+			throw new Error(`Failed to download ${model.id}: response body is empty`);
+		}
+		const contentLength =
+			positiveInteger(response.headers.get("content-length")) ?? totalEstimate;
+		updateNativeDownloadJob(model.id, { total: contentLength });
+		writer = createWriteStream(partialPath);
+		reader = response.body.getReader();
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
 			if (!value) continue;
+			deadline.noteProgress();
 			received += value.byteLength;
 			await writeDownloadChunk(writer, value);
 			const elapsedSeconds = Math.max(1, (Date.now() - startedMs) / 1000);
@@ -3230,13 +3246,26 @@ async function runNativeModelDownload(
 			etaMs: 0,
 		});
 	} catch (error) {
+		const failure = deadline.failure(error);
 		updateNativeDownloadJob(model.id, {
 			state: "failed",
-			error: error instanceof Error ? error.message : String(error),
+			error: failure instanceof Error ? failure.message : String(failure),
 		});
-		writer.destroy();
-		rmSync(partialPath, { force: true });
-		throw error;
+		try {
+			await reader?.cancel();
+		} catch {
+			// error-policy:J6 best-effort teardown of the failed response stream.
+		}
+		writer?.destroy();
+		try {
+			rmSync(partialPath, { force: true });
+		} catch {
+			// error-policy:J6 best-effort teardown of the failed partial file.
+		}
+		throw failure;
+	} finally {
+		reader?.releaseLock();
+		deadline.dispose();
 	}
 }
 

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -45,6 +45,10 @@ import {
 	transcriptSpeakerCount,
 } from "@elizaos/shared/transcripts";
 import {
+	closeDownloadWriter,
+	writeDownloadChunk,
+} from "../shared/download-writer.ts";
+import {
 	createWriteStream,
 	existsSync,
 	mkdirSync,
@@ -3134,34 +3138,6 @@ function updateNativeDownloadJob(
 	return next;
 }
 
-function writeDownloadChunk(
-	writer: ReturnType<typeof createWriteStream>,
-	chunk: Uint8Array,
-): Promise<void> {
-	return new Promise((resolve, reject) => {
-		writer.write(Buffer.from(chunk), (error: Error | null | undefined) => {
-			if (error) reject(error);
-			else resolve();
-		});
-	});
-}
-
-function closeDownloadWriter(
-	writer: ReturnType<typeof createWriteStream>,
-): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const onError = (error: Error): void => {
-			writer.off("error", onError);
-			reject(error);
-		};
-		writer.once("error", onError);
-		writer.end(() => {
-			writer.off("error", onError);
-			resolve();
-		});
-	});
-}
-
 async function runNativeModelDownload(
 	model: NativeCatalogModelEntry,
 ): Promise<void> {
@@ -3213,7 +3189,7 @@ async function runNativeModelDownload(
 			if (!value) continue;
 			deadline.noteProgress();
 			received += value.byteLength;
-			await writeDownloadChunk(writer, value);
+			await writeDownloadChunk(writer, value, deadline.signal);
 			const elapsedSeconds = Math.max(1, (Date.now() - startedMs) / 1000);
 			const bytesPerSec = Math.round(received / elapsedSeconds);
 			const remaining = Math.max(0, contentLength - received);
@@ -3224,7 +3200,7 @@ async function runNativeModelDownload(
 					bytesPerSec > 0 ? Math.round((remaining / bytesPerSec) * 1000) : null,
 			});
 		}
-		await closeDownloadWriter(writer);
+		await closeDownloadWriter(writer, deadline.signal);
 		const targetPath = nativeModelTargetPath(model);
 		renameSync(partialPath, targetPath);
 		const stats = statSync(targetPath);

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
@@ -15,6 +15,7 @@ const ENV_KEYS = [
 	"ELIZA_LOCAL_LLAMA",
 	"ELIZA_BIONIC_HOST_DELEGATED",
 	"ELIZA_BIONIC_INFERENCE_SOCK",
+	"ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD",
 ];
 const saved: Record<string, string | undefined> = {};
 
@@ -39,6 +40,7 @@ describe("ensureMobileDeviceBridgeInferenceHandlers — dead-bridge gating (#112
 			saved[k] = process.env[k];
 			delete process.env[k];
 		}
+		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD = "1";
 	});
 	afterEach(() => {
 		for (const k of ENV_KEYS) {
@@ -80,10 +82,12 @@ describe("ensureMobileDeviceBridgeInferenceHandlers — dead-bridge gating (#112
 		expect(runtime.registerModel).toHaveBeenCalled();
 	});
 
-	it("exports RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS with 10-minute bound", async () => {
-		const { RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS } = await import(
-			"./mobile-device-bridge-bootstrap"
-		);
-		expect(RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS).toBe(600_000);
+	it("exports progressive and absolute model-download bounds", async () => {
+		const {
+			RECOMMENDED_MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+			RECOMMENDED_MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+		} = await import("./mobile-device-bridge-bootstrap");
+		expect(RECOMMENDED_MODEL_DOWNLOAD_IDLE_TIMEOUT_MS).toBe(300_000);
+		expect(RECOMMENDED_MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS).toBe(86_400_000);
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
@@ -79,4 +79,11 @@ describe("ensureMobileDeviceBridgeInferenceHandlers — dead-bridge gating (#112
 		// TEXT_SMALL + TEXT_LARGE at minimum register through the served path.
 		expect(runtime.registerModel).toHaveBeenCalled();
 	});
+
+	it("exports RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS with 10-minute bound", async () => {
+		const { RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS } = await import(
+			"./mobile-device-bridge-bootstrap"
+		);
+		expect(RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS).toBe(600_000);
+	});
 });

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -11,13 +11,11 @@
 
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import {
-	createWriteStream,
 	existsSync,
 	linkSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
-	renameSync,
 	statSync,
 	symlinkSync,
 	unlinkSync,
@@ -26,8 +24,6 @@ import type { Server as HttpServer, IncomingMessage } from "node:http";
 import net from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
 import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
@@ -48,7 +44,12 @@ import {
 	type TextEmbeddingParams,
 } from "@elizaos/core";
 import { imageUrlToBase64 } from "./image-url-to-base64.ts";
+import { downloadHttpModel } from "./shared/http-model-download.ts";
 import { resolveStoredModelPath } from "./shared/local-inference-stored-path.ts";
+import {
+	MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+	MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+} from "./shared/model-download-deadline.ts";
 
 const DEVICE_BRIDGE_PATH = "/api/local-inference/device-bridge";
 const PROVIDER = "capacitor-llama";
@@ -1258,7 +1259,10 @@ const RECOMMENDED_MODELS: Record<
 	},
 };
 
-export const RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS = 600_000;
+export {
+	MODEL_DOWNLOAD_IDLE_TIMEOUT_MS as RECOMMENDED_MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+	MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS as RECOMMENDED_MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+};
 
 const inflightDownloads = new Map<string, Promise<string>>();
 
@@ -1312,51 +1316,16 @@ async function downloadRecommendedModelFor(
 	const promise = (async () => {
 		const url = buildHfResolveUrl(model);
 		const stagingPath = `${finalPath}.part`;
-		try {
-			unlinkSync(stagingPath);
-		} catch {
-			// error-policy:J6 best-effort teardown — clear a leftover `.part` from a
-			// prior interrupted download before staging; absent is fine.
-		}
 		logger.info(
 			`[mobile-device-bridge] Auto-downloading recommended ${slot} model ${model.id} from ${url}`,
 		);
-		const response = await fetch(url, {
-			redirect: "follow",
-			signal: AbortSignal.timeout(RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS),
+		const stagedSize = await downloadHttpModel({
+			url,
+			stagingPath,
+			finalPath,
+			label: `[mobile-device-bridge] Recommended-model download (${slot})`,
+			expectedSizeBytes: model.expectedSizeBytes,
 		});
-		if (!response.ok || !response.body) {
-			throw new Error(
-				`[mobile-device-bridge] Recommended-model download failed (${slot}): HTTP ${response.status} ${response.statusText} from ${url}`,
-			);
-		}
-		try {
-			await pipeline(
-				Readable.fromWeb(response.body as never),
-				createWriteStream(stagingPath),
-			);
-		} catch (streamError) {
-			try {
-				unlinkSync(stagingPath);
-			} catch {
-				// error-policy:J6 best-effort teardown — clear the partial file
-				// when pipeline streaming fails or times out.
-			}
-			throw streamError;
-		}
-		const stagedSize = statSync(stagingPath).size;
-		if (model.expectedSizeBytes && stagedSize !== model.expectedSizeBytes) {
-			try {
-				unlinkSync(stagingPath);
-			} catch {
-				// error-policy:J6 best-effort teardown — remove the size-mismatched
-				// partial before throwing; the throw below is the real failure.
-			}
-			throw new Error(
-				`[mobile-device-bridge] Downloaded ${model.ggufFile} size ${stagedSize} != expected ${model.expectedSizeBytes}; aborting and removing partial file.`,
-			);
-		}
-		renameSync(stagingPath, finalPath);
 		logger.info(
 			`[mobile-device-bridge] Auto-download complete: ${finalPath} (${stagedSize} bytes)`,
 		);

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -1258,6 +1258,8 @@ const RECOMMENDED_MODELS: Record<
 	},
 };
 
+export const RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS = 600_000;
+
 const inflightDownloads = new Map<string, Promise<string>>();
 
 function buildHfResolveUrl(model: RecommendedModel): string {
@@ -1319,16 +1321,29 @@ async function downloadRecommendedModelFor(
 		logger.info(
 			`[mobile-device-bridge] Auto-downloading recommended ${slot} model ${model.id} from ${url}`,
 		);
-		const response = await fetch(url, { redirect: "follow" });
+		const response = await fetch(url, {
+			redirect: "follow",
+			signal: AbortSignal.timeout(RECOMMENDED_MODEL_DOWNLOAD_TIMEOUT_MS),
+		});
 		if (!response.ok || !response.body) {
 			throw new Error(
 				`[mobile-device-bridge] Recommended-model download failed (${slot}): HTTP ${response.status} ${response.statusText} from ${url}`,
 			);
 		}
-		await pipeline(
-			Readable.fromWeb(response.body as never),
-			createWriteStream(stagingPath),
-		);
+		try {
+			await pipeline(
+				Readable.fromWeb(response.body as never),
+				createWriteStream(stagingPath),
+			);
+		} catch (streamError) {
+			try {
+				unlinkSync(stagingPath);
+			} catch {
+				// error-policy:J6 best-effort teardown — clear the partial file
+				// when pipeline streaming fails or times out.
+			}
+			throw streamError;
+		}
 		const stagedSize = statSync(stagingPath).size;
 		if (model.expectedSizeBytes && stagedSize !== model.expectedSizeBytes) {
 			try {

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
@@ -5,7 +5,11 @@
 
 import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { closeDownloadWriter, writeDownloadChunk } from "./download-writer.ts";
+import {
+	closeDownloadWriter,
+	teardownFailedDownload,
+	writeDownloadChunk,
+} from "./download-writer.ts";
 
 class GatedWriter extends Writable {
 	writeCallback: ((error?: Error | null) => void) | undefined;
@@ -31,6 +35,25 @@ class FailingWriter extends Writable {
 		callback: (error?: Error | null) => void,
 	): void {
 		callback(new Error("disk write failed"));
+	}
+}
+
+class GatedDestroyWriter extends Writable {
+	destroyCallback: ((error?: Error | null) => void) | undefined;
+
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void,
+	): void {
+		callback();
+	}
+
+	override _destroy(
+		_error: Error | null,
+		callback: (error?: Error | null) => void,
+	): void {
+		this.destroyCallback = callback;
 	}
 }
 
@@ -85,5 +108,31 @@ describe("abort-aware model download writer", () => {
 		await closed;
 		expect(writer.destroyed).toBe(true);
 		expect(writer.closed).toBe(true);
+	});
+
+	it("cancels the reader and closes the writer before removing a partial", async () => {
+		const events: string[] = [];
+		const reader = {
+			cancel: async () => {
+				events.push("reader-cancelled");
+			},
+		};
+		const writer = new GatedDestroyWriter();
+		writer.once("close", () => events.push("writer-closed"));
+		const teardown = teardownFailedDownload({
+			reader,
+			writer,
+			removePartial: () => events.push("partial-removed"),
+		});
+		await Promise.resolve();
+		expect(events).toEqual(["reader-cancelled"]);
+		expect(writer.destroyCallback).toBeTypeOf("function");
+		writer.destroyCallback?.();
+		await teardown;
+		expect(events).toEqual([
+			"reader-cancelled",
+			"writer-closed",
+			"partial-removed",
+		]);
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Exercises abort-aware model file writes with real Node Writable lifecycle
+ * behavior and deliberately gated write and flush callbacks.
+ */
+
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { closeDownloadWriter, writeDownloadChunk } from "./download-writer.ts";
+
+class GatedWriter extends Writable {
+	writeCallback: ((error?: Error | null) => void) | undefined;
+	finalCallback: ((error?: Error | null) => void) | undefined;
+
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void,
+	): void {
+		this.writeCallback = callback;
+	}
+
+	override _final(callback: (error?: Error | null) => void): void {
+		this.finalCallback = callback;
+	}
+}
+
+describe("abort-aware model download writer", () => {
+	it("destroys and rejects a write whose filesystem callback stalls", async () => {
+		const controller = new AbortController();
+		const writer = new GatedWriter();
+		const pending = writeDownloadChunk(
+			writer,
+			new Uint8Array([1]),
+			controller.signal,
+		);
+		controller.abort(new Error("write deadline"));
+
+		await expect(pending).rejects.toThrow("write deadline");
+		expect(writer.destroyed).toBe(true);
+		expect(writer.closed).toBe(true);
+	});
+
+	it("destroys and rejects a close whose filesystem flush stalls", async () => {
+		const controller = new AbortController();
+		const writer = new GatedWriter();
+		writer.writeCallback = undefined;
+		const write = writeDownloadChunk(
+			writer,
+			new Uint8Array([1]),
+			controller.signal,
+		);
+		writer.writeCallback?.();
+		await write;
+		const close = closeDownloadWriter(writer, controller.signal);
+		expect(writer.finalCallback).toBeTypeOf("function");
+		controller.abort(new Error("close deadline"));
+
+		await expect(close).rejects.toThrow("close deadline");
+		expect(writer.destroyed).toBe(true);
+		expect(writer.closed).toBe(true);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.test.ts
@@ -24,6 +24,16 @@ class GatedWriter extends Writable {
 	}
 }
 
+class FailingWriter extends Writable {
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void,
+	): void {
+		callback(new Error("disk write failed"));
+	}
+}
+
 describe("abort-aware model download writer", () => {
 	it("destroys and rejects a write whose filesystem callback stalls", async () => {
 		const controller = new AbortController();
@@ -56,6 +66,23 @@ describe("abort-aware model download writer", () => {
 		controller.abort(new Error("close deadline"));
 
 		await expect(close).rejects.toThrow("close deadline");
+		expect(writer.destroyed).toBe(true);
+		expect(writer.closed).toBe(true);
+	});
+
+	it("handles the error event emitted after a write callback failure", async () => {
+		const writer = new FailingWriter();
+		const closed = new Promise<void>((resolve) =>
+			writer.once("close", resolve),
+		);
+		await expect(
+			writeDownloadChunk(
+				writer,
+				new Uint8Array([1]),
+				new AbortController().signal,
+			),
+		).rejects.toThrow("disk write failed");
+		await closed;
 		expect(writer.destroyed).toBe(true);
 		expect(writer.closed).toBe(true);
 	});

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
@@ -1,0 +1,104 @@
+/**
+ * Makes filesystem write and flush operations obey the same abort signal as
+ * the network side of a model download.
+ */
+
+import type { Writable } from "node:stream";
+
+function abortReason(signal: AbortSignal): Error {
+	return signal.reason instanceof Error
+		? signal.reason
+		: new Error("Model download was aborted");
+}
+
+export function writeDownloadChunk(
+	writer: Writable,
+	chunk: Uint8Array,
+	signal: AbortSignal,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let aborting = false;
+		const settle = (error?: Error | null): void => {
+			if (settled || aborting) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			if (error) reject(error);
+			else resolve();
+		};
+		const onAbort = (): void => {
+			if (aborting) return;
+			aborting = true;
+			const reason = abortReason(signal);
+			if (writer.closed) {
+				settled = true;
+				reject(reason);
+				return;
+			}
+			writer.once("close", () => {
+				if (settled) return;
+				settled = true;
+				reject(reason);
+			});
+			writer.destroy();
+		};
+		if (signal.aborted) {
+			onAbort();
+			return;
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+		try {
+			writer.write(chunk, (error: Error | null | undefined) => settle(error));
+		} catch (error) {
+			settle(error instanceof Error ? error : new Error(String(error)));
+		}
+	});
+}
+
+export function closeDownloadWriter(
+	writer: Writable,
+	signal: AbortSignal,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let aborting = false;
+		const settle = (error?: Error | null): void => {
+			if (settled || aborting) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			writer.off("error", onError);
+			if (error) reject(error);
+			else resolve();
+		};
+		const onError = (error: Error): void => settle(error);
+		const onAbort = (): void => {
+			if (aborting) return;
+			aborting = true;
+			const reason = abortReason(signal);
+			if (writer.closed) {
+				settled = true;
+				writer.off("error", onError);
+				reject(reason);
+				return;
+			}
+			writer.once("close", () => {
+				if (settled) return;
+				settled = true;
+				writer.off("error", onError);
+				reject(reason);
+			});
+			writer.destroy();
+		};
+		if (signal.aborted) {
+			onAbort();
+			return;
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+		writer.once("error", onError);
+		try {
+			writer.end(() => settle());
+		} catch (error) {
+			settle(error instanceof Error ? error : new Error(String(error)));
+		}
+	});
+}

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
@@ -23,8 +23,19 @@ export function writeDownloadChunk(
 			if (settled || aborting) return;
 			settled = true;
 			signal.removeEventListener("abort", onAbort);
+			writer.off("error", onError);
 			if (error) reject(error);
 			else resolve();
+		};
+		const onError = (error: Error): void => {
+			if (settled || aborting) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			// Keep handling any follow-up error emitted during auto-destroy. The
+			// listener is removed only after the stream has actually closed.
+			writer.once("close", () => writer.off("error", onError));
+			writer.destroy();
+			reject(error);
 		};
 		const onAbort = (): void => {
 			if (aborting) return;
@@ -32,12 +43,14 @@ export function writeDownloadChunk(
 			const reason = abortReason(signal);
 			if (writer.closed) {
 				settled = true;
+				writer.off("error", onError);
 				reject(reason);
 				return;
 			}
 			writer.once("close", () => {
 				if (settled) return;
 				settled = true;
+				writer.off("error", onError);
 				reject(reason);
 			});
 			writer.destroy();
@@ -47,8 +60,14 @@ export function writeDownloadChunk(
 			return;
 		}
 		signal.addEventListener("abort", onAbort, { once: true });
+		writer.on("error", onError);
 		try {
-			writer.write(chunk, (error: Error | null | undefined) => settle(error));
+			writer.write(chunk, (error: Error | null | undefined) => {
+				// Node emits `error` after invoking the write callback with the same
+				// failure. Keep the listener installed so that event cannot escape as
+				// an uncaught process exception; `onError` owns rejection.
+				if (!error) settle();
+			});
 		} catch (error) {
 			settle(error instanceof Error ? error : new Error(String(error)));
 		}

--- a/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/download-writer.ts
@@ -5,6 +5,16 @@
 
 import type { Writable } from "node:stream";
 
+interface CancelableDownloadReader {
+	cancel(reason?: unknown): Promise<unknown>;
+}
+
+interface FailedDownloadTeardownOptions {
+	reader?: CancelableDownloadReader;
+	writer?: Writable;
+	removePartial(): void;
+}
+
 function abortReason(signal: AbortSignal): Error {
 	return signal.reason instanceof Error
 		? signal.reason
@@ -120,4 +130,32 @@ export function closeDownloadWriter(
 			settle(error instanceof Error ? error : new Error(String(error)));
 		}
 	});
+}
+
+function destroyDownloadWriter(writer: Writable): Promise<void> {
+	if (writer.closed) return Promise.resolve();
+	return new Promise((resolve) => {
+		const onError = (): void => {
+			// The original download failure remains authoritative while destroy
+			// drains any follow-up stream error through the close boundary.
+		};
+		writer.on("error", onError);
+		writer.once("close", () => {
+			writer.off("error", onError);
+			resolve();
+		});
+		writer.destroy();
+	});
+}
+
+export async function teardownFailedDownload({
+	reader,
+	writer,
+	removePartial,
+}: FailedDownloadTeardownOptions): Promise<void> {
+	await Promise.allSettled([
+		reader?.cancel(),
+		writer ? destroyDownloadWriter(writer) : undefined,
+	]);
+	removePartial();
 }

--- a/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
@@ -58,7 +58,7 @@ afterEach(async () => {
 
 describe("downloadHttpModel", () => {
 	it("allows a progressive transfer to outlive one idle window", async () => {
-		const chunks = ["one", "two", "three", "four", "five"];
+		const chunks = Array.from({ length: 25 }, (_, index) => `chunk-${index};`);
 		const { url } = await listen((_request, response) => {
 			let index = 0;
 			const interval = setInterval(() => {
@@ -68,7 +68,7 @@ describe("downloadHttpModel", () => {
 					clearInterval(interval);
 					response.end();
 				}
-			}, 60);
+			}, 50);
 		});
 		const target = paths();
 
@@ -76,11 +76,11 @@ describe("downloadHttpModel", () => {
 			url,
 			...target,
 			label: "slow model",
-			idleTimeoutMs: 150,
-			totalTimeoutMs: 2_000,
+			idleTimeoutMs: 1_000,
+			totalTimeoutMs: 5_000,
 		});
 
-		expect(bytes).toBe(19);
+		expect(bytes).toBe(Buffer.byteLength(chunks.join("")));
 		expect(readFileSync(target.finalPath, "utf8")).toBe(chunks.join(""));
 		expect(existsSync(target.stagingPath)).toBe(false);
 	});

--- a/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
@@ -33,6 +33,16 @@ function paths(): { stagingPath: string; finalPath: string } {
 	};
 }
 
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 500,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate() && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 afterEach(async () => {
 	await Promise.all(
 		servers.splice(0).map(
@@ -93,19 +103,15 @@ describe("downloadHttpModel", () => {
 				totalTimeoutMs: 2_000,
 			}),
 		).rejects.toThrow("header stall made no progress for 100ms");
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		await waitFor(() => requestClosed);
 		expect(requestClosed).toBe(true);
 		expect(existsSync(target.stagingPath)).toBe(false);
 		expect(existsSync(target.finalPath)).toBe(false);
 	});
 
 	it("cancels a stalled body and removes its partial file", async () => {
-		let responseClosed = false;
 		const { url } = await listen((_request, response) => {
 			response.write("partial");
-			response.once("close", () => {
-				responseClosed = true;
-			});
 		});
 		const target = paths();
 
@@ -118,8 +124,6 @@ describe("downloadHttpModel", () => {
 				totalTimeoutMs: 2_000,
 			}),
 		).rejects.toThrow("body stall made no progress for 100ms");
-		await new Promise((resolve) => setTimeout(resolve, 20));
-		expect(responseClosed).toBe(true);
 		expect(existsSync(target.stagingPath)).toBe(false);
 		expect(existsSync(target.finalPath)).toBe(false);
 	});

--- a/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/http-model-download.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Exercises the production HTTP-to-file model downloader against real local
+ * sockets, streams, timers, and filesystem artifacts.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { downloadHttpModel } from "./http-model-download.ts";
+
+const servers: Server[] = [];
+const tempDirs: string[] = [];
+
+async function listen(
+	handler: Parameters<typeof createServer>[0],
+): Promise<{ server: Server; url: string }> {
+	const server = createServer(handler);
+	servers.push(server);
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("missing port");
+	return { server, url: `http://127.0.0.1:${address.port}/model.gguf` };
+}
+
+function paths(): { stagingPath: string; finalPath: string } {
+	const dir = mkdtempSync(path.join(os.tmpdir(), "capacitor-model-download-"));
+	tempDirs.push(dir);
+	return {
+		stagingPath: path.join(dir, "model.gguf.part"),
+		finalPath: path.join(dir, "model.gguf"),
+	};
+}
+
+afterEach(async () => {
+	await Promise.all(
+		servers.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+					server.closeAllConnections();
+				}),
+		),
+	);
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
+});
+
+describe("downloadHttpModel", () => {
+	it("allows a progressive transfer to outlive one idle window", async () => {
+		const chunks = ["one", "two", "three", "four", "five"];
+		const { url } = await listen((_request, response) => {
+			let index = 0;
+			const interval = setInterval(() => {
+				const chunk = chunks[index++];
+				if (chunk) response.write(chunk);
+				if (index === chunks.length) {
+					clearInterval(interval);
+					response.end();
+				}
+			}, 60);
+		});
+		const target = paths();
+
+		const bytes = await downloadHttpModel({
+			url,
+			...target,
+			label: "slow model",
+			idleTimeoutMs: 150,
+			totalTimeoutMs: 2_000,
+		});
+
+		expect(bytes).toBe(19);
+		expect(readFileSync(target.finalPath, "utf8")).toBe(chunks.join(""));
+		expect(existsSync(target.stagingPath)).toBe(false);
+	});
+
+	it("aborts a request that never returns headers", async () => {
+		let requestClosed = false;
+		const { url } = await listen((request) => {
+			request.once("close", () => {
+				requestClosed = true;
+			});
+		});
+		const target = paths();
+
+		await expect(
+			downloadHttpModel({
+				url,
+				...target,
+				label: "header stall",
+				idleTimeoutMs: 100,
+				totalTimeoutMs: 2_000,
+			}),
+		).rejects.toThrow("header stall made no progress for 100ms");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(requestClosed).toBe(true);
+		expect(existsSync(target.stagingPath)).toBe(false);
+		expect(existsSync(target.finalPath)).toBe(false);
+	});
+
+	it("cancels a stalled body and removes its partial file", async () => {
+		let responseClosed = false;
+		const { url } = await listen((_request, response) => {
+			response.write("partial");
+			response.once("close", () => {
+				responseClosed = true;
+			});
+		});
+		const target = paths();
+
+		await expect(
+			downloadHttpModel({
+				url,
+				...target,
+				label: "body stall",
+				idleTimeoutMs: 100,
+				totalTimeoutMs: 2_000,
+			}),
+		).rejects.toThrow("body stall made no progress for 100ms");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(responseClosed).toBe(true);
+		expect(existsSync(target.stagingPath)).toBe(false);
+		expect(existsSync(target.finalPath)).toBe(false);
+	});
+
+	it("removes a partial file when the peer drops the body", async () => {
+		const { url } = await listen((_request, response) => {
+			response.writeHead(200, { "content-length": "100" });
+			response.write("partial");
+			setTimeout(() => response.destroy(), 25);
+		});
+		const target = paths();
+
+		await expect(
+			downloadHttpModel({
+				url,
+				...target,
+				label: "dropped model",
+				idleTimeoutMs: 500,
+				totalTimeoutMs: 2_000,
+			}),
+		).rejects.toThrow();
+		expect(existsSync(target.stagingPath)).toBe(false);
+		expect(existsSync(target.finalPath)).toBe(false);
+	});
+
+	it("rejects a size mismatch before the atomic rename", async () => {
+		const { url } = await listen((_request, response) => response.end("short"));
+		const target = paths();
+
+		await expect(
+			downloadHttpModel({
+				url,
+				...target,
+				label: "wrong-size model",
+				expectedSizeBytes: 10,
+				idleTimeoutMs: 500,
+				totalTimeoutMs: 2_000,
+			}),
+		).rejects.toThrow("size 5 != expected 10");
+		expect(existsSync(target.stagingPath)).toBe(false);
+		expect(existsSync(target.finalPath)).toBe(false);
+	});
+
+	it("enforces the absolute backstop even while bytes keep arriving", async () => {
+		const { url } = await listen((_request, response) => {
+			const interval = setInterval(() => response.write("x"), 25);
+			response.once("close", () => clearInterval(interval));
+		});
+		const target = paths();
+
+		await expect(
+			downloadHttpModel({
+				url,
+				...target,
+				label: "endless model",
+				idleTimeoutMs: 200,
+				totalTimeoutMs: 120,
+			}),
+		).rejects.toThrow();
+		expect(existsSync(target.stagingPath)).toBe(false);
+		expect(existsSync(target.finalPath)).toBe(false);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/shared/http-model-download.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/http-model-download.ts
@@ -1,0 +1,91 @@
+/**
+ * Streams recommended model artifacts into an atomic staging file while
+ * bounding both inactivity and pathological total transfer duration.
+ */
+
+import { createWriteStream, renameSync, rmSync, statSync } from "node:fs";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+	createModelDownloadDeadline,
+	MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+	MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+} from "./model-download-deadline.ts";
+
+interface HttpModelDownloadOptions {
+	url: string;
+	stagingPath: string;
+	finalPath: string;
+	label: string;
+	expectedSizeBytes?: number;
+	idleTimeoutMs?: number;
+	totalTimeoutMs?: number;
+}
+
+/** Download one model through the same fetch-to-file path used in production. */
+export async function downloadHttpModel({
+	url,
+	stagingPath,
+	finalPath,
+	label,
+	expectedSizeBytes,
+	idleTimeoutMs = MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+	totalTimeoutMs = MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+}: HttpModelDownloadOptions): Promise<number> {
+	rmSync(stagingPath, { force: true });
+	const deadline = createModelDownloadDeadline({
+		label,
+		idleTimeoutMs,
+		totalTimeoutMs,
+	});
+
+	try {
+		const response = await fetch(url, {
+			redirect: "follow",
+			signal: deadline.signal,
+		});
+		deadline.noteProgress();
+		if (!response.ok || !response.body) {
+			try {
+				await response.body?.cancel();
+			} catch {
+				// error-policy:J6 best-effort teardown of a rejected response body.
+			}
+			throw new Error(
+				`${label} failed: HTTP ${response.status} ${response.statusText} from ${url}`,
+			);
+		}
+
+		const progress = new Transform({
+			transform(chunk: Buffer, _encoding, callback) {
+				deadline.noteProgress();
+				callback(null, chunk);
+			},
+		});
+		await pipeline(
+			Readable.fromWeb(response.body as never),
+			progress,
+			createWriteStream(stagingPath),
+			{ signal: deadline.signal },
+		);
+
+		const stagedSize = statSync(stagingPath).size;
+		if (expectedSizeBytes && stagedSize !== expectedSizeBytes) {
+			throw new Error(
+				`${label} size ${stagedSize} != expected ${expectedSizeBytes}`,
+			);
+		}
+		renameSync(stagingPath, finalPath);
+		return stagedSize;
+	} catch (error) {
+		const failure = deadline.failure(error);
+		try {
+			rmSync(stagingPath, { force: true });
+		} catch {
+			// error-policy:J6 best-effort teardown of a failed staged download.
+		}
+		throw failure;
+	} finally {
+		deadline.dispose();
+	}
+}

--- a/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.test.ts
@@ -1,0 +1,39 @@
+/** Verifies both model-download deadline timers abort and dispose deterministically. */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createModelDownloadDeadline } from "./model-download-deadline.ts";
+
+afterEach(() => vi.useRealTimers());
+
+describe("createModelDownloadDeadline", () => {
+	it("clears both idle and absolute timers when disposed", () => {
+		vi.useFakeTimers();
+		const deadline = createModelDownloadDeadline({
+			label: "model",
+			idleTimeoutMs: 100,
+			totalTimeoutMs: 200,
+		});
+		expect(vi.getTimerCount()).toBe(2);
+		deadline.noteProgress();
+		expect(vi.getTimerCount()).toBe(2);
+		deadline.dispose();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("reports the absolute deadline reason despite recent progress", () => {
+		vi.useFakeTimers();
+		const deadline = createModelDownloadDeadline({
+			label: "model",
+			idleTimeoutMs: 100,
+			totalTimeoutMs: 50,
+		});
+		vi.advanceTimersByTime(40);
+		deadline.noteProgress();
+		vi.advanceTimersByTime(10);
+		expect(deadline.signal.aborted).toBe(true);
+		expect(deadline.failure(new Error("fallback"))).toEqual(
+			new Error("model exceeded the 50ms total deadline"),
+		);
+		deadline.dispose();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.ts
@@ -33,8 +33,17 @@ export function createModelDownloadDeadline({
 	assertPositiveTimeout(idleTimeoutMs, "idleTimeoutMs");
 	assertPositiveTimeout(totalTimeoutMs, "totalTimeoutMs");
 	const idleController = new AbortController();
+	const totalController = new AbortController();
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	let disposed = false;
 	const noteProgress = (): void => {
+		if (
+			disposed ||
+			idleController.signal.aborted ||
+			totalController.signal.aborted
+		) {
+			return;
+		}
 		if (idleTimer !== undefined) clearTimeout(idleTimer);
 		idleTimer = setTimeout(() => {
 			idleController.abort(
@@ -44,9 +53,15 @@ export function createModelDownloadDeadline({
 		idleTimer.unref?.();
 	};
 	noteProgress();
+	const totalTimer = setTimeout(() => {
+		totalController.abort(
+			new Error(`${label} exceeded the ${totalTimeoutMs}ms total deadline`),
+		);
+	}, totalTimeoutMs);
+	totalTimer.unref?.();
 	const signal = AbortSignal.any([
 		idleController.signal,
-		AbortSignal.timeout(totalTimeoutMs),
+		totalController.signal,
 	]);
 	return {
 		signal,
@@ -54,7 +69,9 @@ export function createModelDownloadDeadline({
 		failure: (error) =>
 			signal.aborted && signal.reason instanceof Error ? signal.reason : error,
 		dispose: () => {
+			disposed = true;
 			if (idleTimer !== undefined) clearTimeout(idleTimer);
+			clearTimeout(totalTimer);
 		},
 	};
 }

--- a/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/model-download-deadline.ts
@@ -1,0 +1,60 @@
+/**
+ * Composes progress-sensitive and absolute deadlines for multi-gigabyte model
+ * downloads shared by the Android bootstrap and iOS foreground fallback.
+ */
+
+export const MODEL_DOWNLOAD_IDLE_TIMEOUT_MS = 300_000;
+export const MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS = 86_400_000;
+
+interface ModelDownloadDeadlineOptions {
+	label: string;
+	idleTimeoutMs?: number;
+	totalTimeoutMs?: number;
+}
+
+export interface ModelDownloadDeadline {
+	signal: AbortSignal;
+	noteProgress(): void;
+	failure(error: unknown): unknown;
+	dispose(): void;
+}
+
+function assertPositiveTimeout(value: number, name: string): void {
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new RangeError(`${name} must be a positive safe integer`);
+	}
+}
+
+export function createModelDownloadDeadline({
+	label,
+	idleTimeoutMs = MODEL_DOWNLOAD_IDLE_TIMEOUT_MS,
+	totalTimeoutMs = MODEL_DOWNLOAD_TOTAL_TIMEOUT_MS,
+}: ModelDownloadDeadlineOptions): ModelDownloadDeadline {
+	assertPositiveTimeout(idleTimeoutMs, "idleTimeoutMs");
+	assertPositiveTimeout(totalTimeoutMs, "totalTimeoutMs");
+	const idleController = new AbortController();
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	const noteProgress = (): void => {
+		if (idleTimer !== undefined) clearTimeout(idleTimer);
+		idleTimer = setTimeout(() => {
+			idleController.abort(
+				new Error(`${label} made no progress for ${idleTimeoutMs}ms`),
+			);
+		}, idleTimeoutMs);
+		idleTimer.unref?.();
+	};
+	noteProgress();
+	const signal = AbortSignal.any([
+		idleController.signal,
+		AbortSignal.timeout(totalTimeoutMs),
+	]);
+	return {
+		signal,
+		noteProgress,
+		failure: (error) =>
+			signal.aborted && signal.reason instanceof Error ? signal.reason : error,
+		dispose: () => {
+			if (idleTimer !== undefined) clearTimeout(idleTimer);
+		},
+	};
+}


### PR DESCRIPTION
## Summary

- Replace the unsafe fixed 10-minute whole-download timeout with two explicit bounds for multi-gigabyte models: 5 minutes without byte progress and a 24-hour absolute backstop.
- Apply one deadline across request headers, the complete response body, and file output. Android uses a signal-aware `pipeline`; the iOS foreground fallback also makes each file write and final flush abort-aware and waits for writer closure before partial-file cleanup.
- Preserve valid slow downloads by resetting only the idle deadline on headers/body chunks. Keep the native iOS background `URLSession` transport unchanged: its OS-owned task is intentionally long-lived and already has start/status/cancel/resume with bounded host calls.
- Validate staged size where known, atomically rename successful downloads, and remove `.part` files on HTTP, body, file, size, or deadline failure.

## Contract research

- Node `stream/promises.pipeline(..., { signal })` destroys the pipeline streams when aborted: https://nodejs.org/api/stream.html#streampipelinestreams-options
- Node abort composition/reasons: https://nodejs.org/api/globals.html#class-abortsignal
- Fetch abort after headers also aborts response-body consumption: https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
- Bun documents abortable `fetch` and Node stream compatibility: https://bun.sh/docs/api/fetch and https://bun.sh/docs/runtime/nodejs-apis

## Exact-head verification

Evidence revision: `b91ca672f69427b2183085c6a98b7431bb9025fd`

- Focused production download, Android gating, deadline, gated writer, and iOS bridge suites on pinned Bun `1.3.14`: **55 passed / 0 failed, 183 assertions**.
- Real loopback HTTP + filesystem integration proves progressive transfer beyond one idle window, no-header timeout, stalled-body timeout, peer-drop cleanup, size mismatch cleanup, and absolute deadline despite continuous bytes.
- Real Node `Writable` regressions deliberately stall `_write` and `_final`; abort destroys the writer, waits for `close`, preserves the deadline reason, and lets the caller cancel the reader/remove the partial.
- A real `_write(callback(error))` regression proves the callback error and subsequent Writable `error` event are contained, the promise rejects, and auto-destroy reaches `close` without an uncaught process error.
- Extracted reader-stall teardown orchestration proves reader cancellation and writer `close` both complete before the partial file is removed.
- Fake-timer lifecycle regression proves both timers are live, progress replaces only the idle timer, and `dispose()` clears both timers deterministically.
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck`: passed.
- Biome on all 9 changed files: passed.
- `git diff --check`: passed.

The 12 focused network/file/timer cases were also repeated three consecutive times on pinned Bun `1.3.14` (36/36) after widening the progressive-transfer timing margin. The host Node remains `23.3.0`, rather than the repository-pinned Node `24.15.0`.

## Evidence matrix

- Visual screenshots/video: **N/A — no UI or rendered behavior changed.**
- Native background downloader capture: **N/A — the Swift `URLSession` background transport is unchanged.**
- iOS foreground Bun fallback: exercised at its network/file/timer production boundaries with real sockets, streams, writers, and filesystem artifacts; no physical-device capture is attached.

Contribution-attribution: OpenAI/gpt-5.6-sol via Codex Desktop multi-agent
