### PR TITLE
fix(cloud): bound oauth2 provider fetches with timeout

### DIFF
--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -1,10 +1,7 @@
 /**
- * Error-policy regression for #13415: OAuth identity extraction must fail closed.
- * Drives the real handleOAuth2Callback (token exchange + userInfo fetch mocked at
- * the HTTP boundary; db/secrets/cache mocked) to prove a provider response with no
- * id/sub PROPAGATES a thrown error instead of fabricating an "unknown" platform
- * user id, while a minimal-but-valid response (id present, no email) still succeeds
- * — the failure and the legitimately-sparse case are distinguishable.
+ * Drives the production OAuth callback and refresh boundaries with deterministic
+ * HTTP, database, secret, and cache collaborators. The suite proves identity
+ * extraction fails closed and every provider request receives the shared deadline.
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -182,12 +179,20 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     expect(insertReturning).toHaveBeenCalledTimes(1);
   });
 
-  it("exports OAUTH2_REQUEST_TIMEOUT_MS with 15-second bound and passes signal to fetch", async () => {
-    const { handleOAuth2Callback, OAUTH2_REQUEST_TIMEOUT_MS } = await import("./oauth2");
+  it("applies the shared 15-second deadline to callback and refresh requests", async () => {
+    const { handleOAuth2Callback, OAUTH2_REQUEST_TIMEOUT_MS, refreshOAuth2Token } = await import(
+      "./oauth2"
+    );
     expect(OAUTH2_REQUEST_TIMEOUT_MS).toBe(15_000);
 
     userInfoBody = { id: "real-user-42" };
     const fetchedSignals: unknown[] = [];
+    const timeoutCalls: number[] = [];
+    const originalTimeout = AbortSignal.timeout;
+    AbortSignal.timeout = mock((milliseconds: number) => {
+      timeoutCalls.push(milliseconds);
+      return originalTimeout(milliseconds);
+    }) as typeof AbortSignal.timeout;
     globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
       fetchedSignals.push(init?.signal);
       const u = String(url);
@@ -200,11 +205,58 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
       throw new Error(`unexpected fetch ${u}`);
     }) as unknown as typeof globalThis.fetch;
 
-    await handleOAuth2Callback(provider, "auth-code", "state-token");
-    expect(fetchedSignals.length).toBeGreaterThanOrEqual(2);
-    for (const sig of fetchedSignals) {
-      expect(sig).toBeDefined();
-      expect(sig).toBeInstanceOf(AbortSignal);
+    try {
+      await handleOAuth2Callback(provider, "auth-code", "state-token");
+      await expect(refreshOAuth2Token(provider, "refresh-token")).resolves.toMatchObject({
+        accessToken: "at-123",
+      });
+      expect(timeoutCalls).toEqual([15_000, 15_000, 15_000]);
+      expect(fetchedSignals).toHaveLength(3);
+      for (const sig of fetchedSignals) {
+        expect(sig).toBeInstanceOf(AbortSignal);
+      }
+    } finally {
+      AbortSignal.timeout = originalTimeout;
+    }
+  });
+
+  it("propagates a provider deadline before storing callback credentials", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    const controller = new AbortController();
+    const timeoutCalls: number[] = [];
+    const originalTimeout = AbortSignal.timeout;
+    AbortSignal.timeout = mock((milliseconds: number) => {
+      timeoutCalls.push(milliseconds);
+      return controller.signal;
+    }) as typeof AbortSignal.timeout;
+    let markFetchStarted: (() => void) | undefined;
+    const fetchStarted = new Promise<void>((resolve) => {
+      markFetchStarted = resolve;
+    });
+    globalThis.fetch = mock(
+      async (_url: unknown, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          markFetchStarted?.();
+          const signal = init?.signal;
+          if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    try {
+      const pending = handleOAuth2Callback(provider, "auth-code", "state-token");
+      await fetchStarted;
+      controller.abort(new DOMException("OAuth provider deadline exceeded", "TimeoutError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+      expect(timeoutCalls).toEqual([15_000]);
+      expect(secretsCreateCalls).toHaveLength(0);
+      expect(insertReturning).not.toHaveBeenCalled();
+    } finally {
+      AbortSignal.timeout = originalTimeout;
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -181,4 +181,30 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     // The real id flowed through storage untouched (never coerced to "unknown").
     expect(insertReturning).toHaveBeenCalledTimes(1);
   });
+
+  it("exports OAUTH2_REQUEST_TIMEOUT_MS with 15-second bound and passes signal to fetch", async () => {
+    const { handleOAuth2Callback, OAUTH2_REQUEST_TIMEOUT_MS } = await import("./oauth2");
+    expect(OAUTH2_REQUEST_TIMEOUT_MS).toBe(15_000);
+
+    userInfoBody = { id: "real-user-42" };
+    const fetchedSignals: unknown[] = [];
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("/token")) {
+        return jsonResponse({ access_token: "at-123", token_type: "Bearer" });
+      }
+      if (u.includes("/userinfo")) {
+        return jsonResponse(userInfoBody);
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    await handleOAuth2Callback(provider, "auth-code", "state-token");
+    expect(fetchedSignals.length).toBeGreaterThanOrEqual(2);
+    for (const sig of fetchedSignals) {
+      expect(sig).toBeDefined();
+      expect(sig).toBeInstanceOf(AbortSignal);
+    }
+  });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -31,6 +31,13 @@ const STATE_TTL_SECONDS = 600; // 10 minutes
 export const OAUTH2_REQUEST_TIMEOUT_MS = 15_000;
 type PlatformCredentialSourceContext = (typeof platformCredentials.$inferSelect)["source_context"];
 
+function fetchOAuth2(input: string | URL, init?: RequestInit): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
+  });
+}
+
 /**
  * OAuth state stored in cache during authorization flow.
  */
@@ -430,11 +437,10 @@ async function exchangeCodeForTokens(
     body = new URLSearchParams(bodyParams).toString();
   }
 
-  const response = await fetch(provider.endpoints.token, {
+  const response = await fetchOAuth2(provider.endpoints.token, {
     method: "POST",
     headers,
     body,
-    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -483,32 +489,29 @@ async function fetchUserInfo(
 
   let response: Response;
   if (graphqlQuery) {
-    response = await fetch(provider.endpoints.userInfo, {
+    response = await fetchOAuth2(provider.endpoints.userInfo, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({ query: graphqlQuery }),
-      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   } else if (userInfoMethod === "POST") {
     // Some providers (e.g., Dropbox) require POST for user info
-    response = await fetch(provider.endpoints.userInfo, {
+    response = await fetchOAuth2(provider.endpoints.userInfo, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json",
       },
-      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   } else {
-    response = await fetch(provider.endpoints.userInfo, {
+    response = await fetchOAuth2(provider.endpoints.userInfo, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json",
       },
-      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   }
 
@@ -551,9 +554,7 @@ async function fetchTokenInfo(
     throw new Error(`No tokenInfo endpoint configured for ${provider.id}`);
   }
   const url = `${baseUrl.replace(/\/$/, "")}/${encodeURIComponent(accessToken)}`;
-  const response = await fetch(url, {
-    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
-  });
+  const response = await fetchOAuth2(url);
   if (!response.ok) {
     const errorText = await response.text();
     logger.error(`[OAuth2] Token info fetch failed for ${provider.id}`, {
@@ -1049,11 +1050,10 @@ export async function refreshOAuth2Token(
     body = new URLSearchParams(bodyParams).toString();
   }
 
-  const response = await fetch(provider.endpoints.token, {
+  const response = await fetchOAuth2(provider.endpoints.token, {
     method: "POST",
     headers,
     body,
-    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -28,6 +28,7 @@ import type { OAuthConnectionRole, OAuthStandardConnectionRole } from "../types"
 import { normalizeOAuthConnectionRole } from "../types";
 
 const STATE_TTL_SECONDS = 600; // 10 minutes
+export const OAUTH2_REQUEST_TIMEOUT_MS = 15_000;
 type PlatformCredentialSourceContext = (typeof platformCredentials.$inferSelect)["source_context"];
 
 /**
@@ -433,6 +434,7 @@ async function exchangeCodeForTokens(
     method: "POST",
     headers,
     body,
+    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -488,6 +490,7 @@ async function fetchUserInfo(
         Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({ query: graphqlQuery }),
+      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   } else if (userInfoMethod === "POST") {
     // Some providers (e.g., Dropbox) require POST for user info
@@ -497,6 +500,7 @@ async function fetchUserInfo(
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json",
       },
+      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   } else {
     response = await fetch(provider.endpoints.userInfo, {
@@ -504,6 +508,7 @@ async function fetchUserInfo(
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json",
       },
+      signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
     });
   }
 
@@ -546,7 +551,9 @@ async function fetchTokenInfo(
     throw new Error(`No tokenInfo endpoint configured for ${provider.id}`);
   }
   const url = `${baseUrl.replace(/\/$/, "")}/${encodeURIComponent(accessToken)}`;
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
+  });
   if (!response.ok) {
     const errorText = await response.text();
     logger.error(`[OAuth2] Token info fetch failed for ${provider.id}`, {
@@ -1046,6 +1053,7 @@ export async function refreshOAuth2Token(
     method: "POST",
     headers,
     body,
+    signal: AbortSignal.timeout(OAUTH2_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-sonnet-5`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e329a94fc04c997affb45f37206519fb098f795a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:51efc0a9f05772bdd762d4cb93eef0645e1ae7c2 -->

Closes #22699.

## Summary

Bounds every generic OAuth2 provider request—authorization-code exchange, user info (GET/POST/GraphQL), token metadata, and refresh—with one auditable 15-second deadline.

The submitted patch attached six separate timeout signals but tested only that two mocked callback fetches received some signal. The repaired implementation centralizes the deadline in `fetchOAuth2`, exercises both exported production paths, asserts the exact duration for token exchange/user info/refresh, and proves timeout propagation occurs before any credential secret or connection row is stored.

## Contract research

- WHATWG Fetch/MDN documents that aborting the request signal after headers but before body consumption makes body readers reject; the same signal therefore bounds both the initial fetch and `text()`/`json()` reads.
- Node 24 documents `AbortSignal.timeout(delay)` as an auto-aborting signal. A pinned Node 24 local HTTP receipt below independently proves both stalled-header and partial-body paths reject with `TimeoutError` and release sockets.

## Exact-head verification

Exact repaired head `51efc0a9f05772bdd762d4cb93eef0645e1ae7c2`, rebased on `e329a94fc04c997affb45f37206519fb098f795a`.

- Full OAuth service family: **11 files / 64 tests passed**, 290 assertions, pinned Bun 1.3.14.
- Focused callback/refresh boundary: **4/4 passed**, including exact 15,000ms wiring and abort-before-persistence.
- Biome on both changed files and `git diff --check`: **passed**.
- Cloud-shared typecheck was attempted. It reached the project but is blocked in this isolated dependency graph by duplicate Drizzle instances and missing unrelated plugin workspaces; neither changed file emitted a diagnostic.
- `build:core` rebuilt core successfully; the wider Turbo graph later failed only because the isolated checkout lacks the unrelated `tsup` executable for plugin-web-search.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-only OAuth transport change; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-only OAuth transport change; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Pinned Node 24 real-loopback deadline receipt:

```text
GET /headers: TimeoutError after 56ms with AbortSignal.timeout(50)
GET /body: headers and one partial JSON byte arrived, then TimeoutError after 53ms during response.json()
Server shutdown receipt: openSockets=0
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - OAuth credentials were deliberately not used; deterministic production-path tests prove the timeout rejects before secrets/rows are written.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Provenance

Original implementation: Anthropic `claude-sonnet-5` via Claude Code. Deep review, centralized repair, production-path tests, runtime research, and exact-head verification: OpenAI `gpt-5.6-sol` via Codex Desktop multi-agent.