### PR TITLE
test(slack): prove terminal directory pagination page

### DIFF
--- a/plugins/plugin-slack/src/policy.test.ts
+++ b/plugins/plugin-slack/src/policy.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ResolvedSlackAccount, SlackAccountConfig } from "./accounts";
 import {
+  MAX_SLACK_DIRECTORY_PAGES,
   SlackAccountPolicyResolver,
   type SlackInboundEventContext,
   SlackPolicyConfigurationError,
@@ -602,6 +603,7 @@ describe("SlackAccountPolicyResolver event policy", () => {
     ).rejects.toThrowError(
       /channel directory exceeds the 250-page safety limit/,
     );
+    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
   });
 
   it("rejects user directory pagination exceeding the maximum page limit", async () => {
@@ -628,5 +630,70 @@ describe("SlackAccountPolicyResolver event policy", () => {
         { client, accountId: "test-acc" },
       ),
     ).rejects.toThrowError(/user directory exceeds the 250-page safety limit/);
+    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
+  });
+
+  it("accepts a channel found on the final legal directory page", async () => {
+    let callCount = 0;
+    const client = {
+      conversations: {
+        list: vi.fn().mockImplementation(async () => {
+          callCount += 1;
+          const isFinal = callCount === MAX_SLACK_DIRECTORY_PAGES;
+          return {
+            channels: isFinal ? [{ id: CHANNEL, name: "ops" }] : [],
+            response_metadata: {
+              next_cursor: isFinal ? "" : `cursor-${callCount}`,
+            },
+          };
+        }),
+        info: vi.fn(),
+      },
+      users: { list: vi.fn().mockResolvedValue({ members: [] }) },
+    } as unknown as SlackPolicyDirectoryClient;
+
+    const compiled = await resolver(
+      { groupPolicy: "allowlist", channels: { ops: true } },
+      { client, accountId: "test-acc" },
+    );
+
+    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
+    await expect(
+      compiled.authorize(event({ channelId: CHANNEL, userId: ALICE })),
+    ).resolves.toMatchObject({ allowed: true });
+  });
+
+  it("accepts a user found on the final legal directory page", async () => {
+    let callCount = 0;
+    const client = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+        info: vi.fn(),
+      },
+      users: {
+        list: vi.fn().mockImplementation(async () => {
+          callCount += 1;
+          const isFinal = callCount === MAX_SLACK_DIRECTORY_PAGES;
+          return {
+            members: isFinal ? [{ id: ALICE, name: "alice" }] : [],
+            response_metadata: {
+              next_cursor: isFinal ? "" : `cursor-${callCount}`,
+            },
+          };
+        }),
+      },
+    } as unknown as SlackPolicyDirectoryClient;
+
+    const compiled = await resolver(
+      { dm: { policy: "allowlist", allowFrom: ["alice"] } },
+      { client, accountId: "test-acc" },
+    );
+
+    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
+    await expect(
+      compiled.authorize(
+        event({ channelId: DM, userId: ALICE, channelType: "im" }),
+      ),
+    ).resolves.toMatchObject({ allowed: true });
   });
 });


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2115b515e3789a2da80de593d9778068506b91d5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:cfe14d6951bd8e21e19adc85927c8b6d40375db6 -->

## Summary

Restores the terminal-page and exact-request-count regressions independently validated for #22687 but dropped by a concurrent contributor force-rebase immediately before that PR merged.

- Proves both channel and user names can resolve on legal page 250.
- Proves a continuing cursor is rejected before request 251.
- Pins the relationship between the page backstop and the pre-existing 50,000-entry / requested-200-per-page contract.

This is test-only follow-up evidence for the already-merged production fix `2115b515e3789a2da80de593d9778068506b91d5`. Closes #22690.

## Verification

- Exact production policy resolver: 25/25 passed.
- Full plugin on the identical test tree before the base-only refresh: 7 files / 154 tests passed.
- Slack package typecheck passed.
- Changed-file Biome and diff check passed.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only backend change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only backend change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic test-only change.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head validation receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22691-pr22691-backend-v2.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Pagination contract artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22691-pr22691-domain-v2.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

Authored and validated by OpenAI `gpt-5.6-sol` via Codex Desktop multi-agent after the #22687 publication race.
