### PR TITLE
fix(plugin-mcp): fail closed on unbounded MCP tool schemas

### DIFF
--- a/plugins/plugin-mcp/__tests__/service-resilience.test.ts
+++ b/plugins/plugin-mcp/__tests__/service-resilience.test.ts
@@ -187,6 +187,17 @@ describe("tool schema failure containment", () => {
     await expect(service.fetchToolsList("remote")).rejects.toThrow("compatibility regression");
   });
 
+  it("omits a schema whose provider rewrite expands past the retained byte cap", async () => {
+    const service = makeToolService([
+      { name: "expanded", inputSchema: { type: "string", pattern: "x".repeat(262_055) } },
+      { name: "healthy", inputSchema: { type: "object" } },
+    ]);
+
+    await expect(service.fetchToolsList("remote")).resolves.toEqual([
+      expect.objectContaining({ name: "healthy" }),
+    ]);
+  });
+
   it.each(["openai/gpt-5", "openrouter/auto"])(
     "omits an unbounded schema even when %s needs no compatibility rewrite",
     async (modelProvider) => {

--- a/plugins/plugin-mcp/__tests__/service-resilience.test.ts
+++ b/plugins/plugin-mcp/__tests__/service-resilience.test.ts
@@ -5,6 +5,7 @@
  * Deterministic unit harness — real service instances with stubbed
  * connection internals.
  */
+import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { McpService } from "../src/service";
 import type { McpConnection, McpServerConfig } from "../src/types";
@@ -16,6 +17,16 @@ type ResilienceInternals = {
   initializeConnection: (name: string, config: McpServerConfig) => Promise<void>;
   updateServerConnections: (configs: Record<string, McpServerConfig>) => Promise<void>;
   setupTransportHandlers: (name: string, connection: McpConnection, state: unknown) => void;
+};
+
+type ToolListInternals = {
+  runtime: IAgentRuntime;
+  connections: Map<string, McpConnection>;
+  compatibilityInitialized: boolean;
+  applyToolCompatibility: (schema: Record<string, unknown>) => Record<string, unknown>;
+  fetchToolsList: (
+    serverName: string
+  ) => Promise<Array<{ name: string; inputSchema?: Record<string, unknown> }>>;
 };
 
 const STDIO_A: McpServerConfig = { type: "stdio", command: "bun", args: ["a.mjs"] };
@@ -124,4 +135,74 @@ describe("HTTP transport error tolerance", () => {
     expect(connection.server.status).toBe("disconnected");
     expect(connection.server.error).toContain("ECONNREFUSED");
   });
+});
+
+describe("tool schema failure containment", () => {
+  function makeToolService(
+    tools: unknown[],
+    modelProvider = "google/gemini-pro"
+  ): ToolListInternals {
+    const service = new McpService() as unknown as ToolListInternals;
+    service.runtime = {
+      character: { settings: { MODEL_PROVIDER: modelProvider } },
+    } as unknown as IAgentRuntime;
+    service.connections.set("remote", {
+      server: { name: "remote", status: "connected", config: "{}", error: "" },
+      client: { listTools: vi.fn(async () => ({ tools })) },
+      transport: {},
+    } as unknown as McpConnection);
+    return service;
+  }
+
+  it("omits one cyclic schema while retaining and transforming its healthy sibling", async () => {
+    const cyclic: Record<string, unknown> = { type: "array" };
+    cyclic.items = cyclic;
+    const service = makeToolService([
+      { name: "hostile", inputSchema: cyclic },
+      {
+        name: "healthy",
+        inputSchema: {
+          type: "object",
+          properties: { tags: { type: "array", maxItems: 4, items: { type: "string" } } },
+        },
+      },
+    ]);
+
+    const tools = await service.fetchToolsList("remote");
+    expect(tools.map((tool) => tool.name)).toEqual(["healthy"]);
+    expect(tools[0]?.inputSchema).toMatchObject({
+      properties: {
+        tags: { description: expect.stringContaining("4") },
+      },
+    });
+  });
+
+  it("rethrows an unexpected compatibility failure", async () => {
+    const service = makeToolService([{ name: "tool", inputSchema: { type: "object" } }]);
+    service.compatibilityInitialized = true;
+    service.applyToolCompatibility = () => {
+      throw new TypeError("compatibility regression");
+    };
+
+    await expect(service.fetchToolsList("remote")).rejects.toThrow("compatibility regression");
+  });
+
+  it.each(["openai/gpt-5", "openrouter/auto"])(
+    "omits an unbounded schema even when %s needs no compatibility rewrite",
+    async (modelProvider) => {
+      const cyclic: Record<string, unknown> = { type: "array" };
+      cyclic.items = cyclic;
+      const service = makeToolService(
+        [
+          { name: "hostile", inputSchema: cyclic },
+          { name: "healthy", inputSchema: { type: "object" } },
+        ],
+        modelProvider
+      );
+
+      await expect(service.fetchToolsList("remote")).resolves.toEqual([
+        expect.objectContaining({ name: "healthy" }),
+      ]);
+    }
+  );
 });

--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -157,7 +157,7 @@ describe("MCP tool compatibility", () => {
     }
   });
 
-  it("skips the budget when the provider does not apply fixup", () => {
+  it("enforces the budget when the provider does not apply fixup", () => {
     const compatibility = new OpenAIMcpCompatibility({
       provider: "openai",
       modelId: "gpt-4o",
@@ -165,6 +165,6 @@ describe("MCP tool compatibility", () => {
     });
     const cyclic = { type: "array", items: undefined as unknown };
     cyclic.items = cyclic;
-    expect(compatibility.transformToolSchema(cyclic as never)).toBe(cyclic);
+    expect(() => compatibility.transformToolSchema(cyclic as never)).toThrowError(ElizaError);
   });
 });

--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -5,7 +5,7 @@
  * Also covers the fail-closed budget on attacker-controlled tool inputSchema
  * graphs: cyclic `items` used to RangeError `processSchema`.
  */
-import { ElizaError } from "@elizaos/core/errors";
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { GoogleMcpCompatibility } from "../src/tool-compatibility/providers/google.ts";
 import { OpenAIMcpCompatibility } from "../src/tool-compatibility/providers/openai.ts";
@@ -166,5 +166,18 @@ describe("MCP tool compatibility", () => {
     const cyclic = { type: "array", items: undefined as unknown };
     cyclic.items = cyclic;
     expect(() => compatibility.transformToolSchema(cyclic as never)).toThrowError(ElizaError);
+  });
+
+  it("rejects a provider rewrite that expands beyond the retained-schema byte cap", () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    expect(() =>
+      compatibility.transformToolSchema({
+        type: "string",
+        pattern: "x".repeat(262_055),
+      })
+    ).toThrowError(ElizaError);
   });
 });

--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -1,9 +1,19 @@
 /**
  * Regression coverage for provider-specific MCP schema transformations using
  * deterministic JSON Schema inputs and no external MCP server.
+ *
+ * Also covers the fail-closed budget on attacker-controlled tool inputSchema
+ * graphs: cyclic `items` used to RangeError `processSchema`.
  */
+import { ElizaError } from "@elizaos/core/errors";
 import { describe, expect, it } from "vitest";
 import { GoogleMcpCompatibility } from "../src/tool-compatibility/providers/google.ts";
+import { OpenAIMcpCompatibility } from "../src/tool-compatibility/providers/openai.ts";
+import {
+  MAX_MCP_SCHEMA_DEPTH,
+  MAX_MCP_SCHEMA_NODES,
+  MCP_TOOL_SCHEMA_UNBOUNDED,
+} from "../src/utils/schema-budget.ts";
 
 describe("MCP tool compatibility", () => {
   it("preserves zero upper bounds in Google descriptions", () => {
@@ -36,5 +46,125 @@ describe("MCP tool compatibility", () => {
       type: "array",
       description: expect.stringContaining("0"),
     });
+  });
+
+  it("still rewrites an honest nested object/array schema", () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    const transformed = compatibility.transformToolSchema({
+      type: "object",
+      properties: {
+        tags: {
+          type: "array",
+          maxItems: 4,
+          items: { type: "string", maxLength: 32 },
+        },
+      },
+    });
+    expect(transformed.properties?.tags).toMatchObject({
+      type: "array",
+      description: expect.stringContaining("4"),
+    });
+  });
+
+  it(`throws ${MCP_TOOL_SCHEMA_UNBOUNDED} one past depth ${MAX_MCP_SCHEMA_DEPTH}`, () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    let schema: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < MAX_MCP_SCHEMA_DEPTH + 1; i++) {
+      schema = { type: "array", items: schema };
+    }
+    expect(() => compatibility.transformToolSchema(schema as never)).toThrowError(ElizaError);
+    try {
+      compatibility.transformToolSchema(schema as never);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(MCP_TOOL_SCHEMA_UNBOUNDED);
+    }
+  });
+
+  it(`accepts a ${MAX_MCP_SCHEMA_DEPTH - 1}-deep items nest`, () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    // Each `{ type, items }` wrapper plus the leaf `type` string consumes a
+    // depth slot; MAX wrappers puts the leaf string one past the budget.
+    let schema: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < MAX_MCP_SCHEMA_DEPTH - 1; i++) {
+      schema = { type: "array", items: schema };
+    }
+    const transformed = compatibility.transformToolSchema(schema as never);
+    expect(transformed.type).toBe("array");
+  });
+
+  it(`throws ${MCP_TOOL_SCHEMA_UNBOUNDED} past ${MAX_MCP_SCHEMA_NODES} nodes`, () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    const properties: Record<string, { type: "string" }> = {};
+    // root + properties-object + N property schemas; N = MAX_MCP_SCHEMA_NODES
+    // is one past the 2 + N budget.
+    for (let i = 0; i < MAX_MCP_SCHEMA_NODES; i++) {
+      properties[`k${i}`] = { type: "string" };
+    }
+    expect(() =>
+      compatibility.transformToolSchema({
+        type: "object",
+        properties,
+      })
+    ).toThrowError(ElizaError);
+  });
+
+  it("throws MCP_TOOL_SCHEMA_UNBOUNDED on a cyclic items graph, not RangeError", () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    const cyclic = { type: "array", items: undefined as unknown };
+    cyclic.items = cyclic;
+    expect(() => compatibility.transformToolSchema(cyclic as never)).toThrowError(ElizaError);
+    try {
+      compatibility.transformToolSchema(cyclic as never);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(MCP_TOOL_SCHEMA_UNBOUNDED);
+      expect(error).not.toBeInstanceOf(RangeError);
+    }
+  });
+
+  it("does not RangeError a 20k items nest", () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+    let schema: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < 20_000; i++) {
+      schema = { type: "array", items: schema };
+    }
+    expect(() => compatibility.transformToolSchema(schema as never)).toThrowError(ElizaError);
+    try {
+      compatibility.transformToolSchema(schema as never);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(MCP_TOOL_SCHEMA_UNBOUNDED);
+      expect(error).not.toBeInstanceOf(RangeError);
+    }
+  });
+
+  it("skips the budget when the provider does not apply fixup", () => {
+    const compatibility = new OpenAIMcpCompatibility({
+      provider: "openai",
+      modelId: "gpt-4o",
+      supportsStructuredOutputs: true,
+    });
+    const cyclic = { type: "array", items: undefined as unknown };
+    cyclic.items = cyclic;
+    expect(compatibility.transformToolSchema(cyclic as never)).toBe(cyclic);
   });
 });

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -15,7 +15,14 @@
  * restartConnection to the action and route layers. Tool input schemas are
  * rewritten per model provider via the tool-compatibility layer.
  */
-import { ElizaError, fetchWithSsrfGuard, type IAgentRuntime, logger, Service } from "@elizaos/core";
+import {
+  ElizaError,
+  fetchWithSsrfGuard,
+  type IAgentRuntime,
+  isElizaError,
+  logger,
+  Service,
+} from "@elizaos/core";
 import { validateMcpServerConfig } from "@elizaos/core/security/mcp-server-config";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -52,6 +59,7 @@ import {
   type StdioMcpServerConfig,
 } from "./types";
 import { buildMcpProviderData } from "./utils/mcp";
+import { assertMcpJsonSchemaBudget, MCP_TOOL_SCHEMA_UNBOUNDED } from "./utils/schema-budget";
 
 /** Route every MCP HTTP request through core's DNS-pinned SSRF transport. */
 export async function guardedMcpFetch(input: string | URL, init?: RequestInit): Promise<Response> {
@@ -523,6 +531,9 @@ export class McpService extends Service {
             tool.inputSchema as JSONSchema7
           ) as typeof tool.inputSchema;
         } catch (error) {
+          if (!isElizaError(error) || error.code !== MCP_TOOL_SCHEMA_UNBOUNDED) {
+            throw error;
+          }
           // error-policy:J3 attacker-controlled MCP tool inputSchema; omit the
           // tool rather than RangeError the listing loop or forward the graph.
           logger.warn(
@@ -637,6 +648,9 @@ export class McpService extends Service {
   }
 
   public applyToolCompatibility(toolSchema: JSONSchema7): JSONSchema7 {
+    // This boundary applies even when the current provider needs no rewrite:
+    // selection later JSON-stringifies the retained schema for the model.
+    assertMcpJsonSchemaBudget(toolSchema);
     if (!this.compatibilityInitialized) {
       this.initializeToolCompatibility();
     }

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -510,7 +510,7 @@ export class McpService extends Service {
 
     const response = await connection.client.listTools();
 
-    const tools = (response?.tools ?? []).map((tool) => {
+    const tools = (response?.tools ?? []).flatMap((tool) => {
       const processedTool = { ...tool };
 
       if (tool.inputSchema) {
@@ -518,12 +518,27 @@ export class McpService extends Service {
           this.initializeToolCompatibility();
         }
 
-        processedTool.inputSchema = this.applyToolCompatibility(
-          tool.inputSchema as JSONSchema7
-        ) as typeof tool.inputSchema;
+        try {
+          processedTool.inputSchema = this.applyToolCompatibility(
+            tool.inputSchema as JSONSchema7
+          ) as typeof tool.inputSchema;
+        } catch (error) {
+          // error-policy:J3 attacker-controlled MCP tool inputSchema; omit the
+          // tool rather than RangeError the listing loop or forward the graph.
+          logger.warn(
+            {
+              src: "plugin:mcp:service",
+              serverName,
+              tool: tool.name,
+              error,
+            },
+            "MCP tool schema rejected as unbounded"
+          );
+          return [];
+        }
       }
 
-      return processedTool;
+      return [processedTool];
     });
 
     return tools;

--- a/plugins/plugin-mcp/src/tool-compatibility/base.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/base.ts
@@ -5,9 +5,14 @@
  * dropped constraints into the description so the model still sees them.
  * detectModelProvider infers the provider (openai/anthropic/google/openrouter)
  * and capability flags from the runtime's model id.
+ *
+ * MCP tool `inputSchema` is attacker-controlled. The walk is gated on the
+ * same byte/depth/node budget as Ajv compile so a cyclic or deeply nested
+ * schema cannot RangeError the event loop.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { JSONSchema7 } from "json-schema";
+import { assertMcpJsonSchemaBudget } from "../utils/schema-budget";
 
 export interface StringConstraints {
   minLength?: number;
@@ -67,6 +72,7 @@ export abstract class McpToolCompatibility {
       return toolSchema;
     }
 
+    assertMcpJsonSchemaBudget(toolSchema);
     return this.processSchema(toolSchema);
   }
 

--- a/plugins/plugin-mcp/src/tool-compatibility/base.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/base.ts
@@ -68,11 +68,11 @@ export abstract class McpToolCompatibility {
   abstract shouldApply(): boolean;
 
   public transformToolSchema(toolSchema: JSONSchema7): JSONSchema7 {
+    assertMcpJsonSchemaBudget(toolSchema);
     if (!this.shouldApply()) {
       return toolSchema;
     }
 
-    assertMcpJsonSchemaBudget(toolSchema);
     return this.processSchema(toolSchema);
   }
 

--- a/plugins/plugin-mcp/src/tool-compatibility/base.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/base.ts
@@ -73,7 +73,11 @@ export abstract class McpToolCompatibility {
       return toolSchema;
     }
 
-    return this.processSchema(toolSchema);
+    const processed = this.processSchema(toolSchema);
+    // Rewrites can expand removed constraints into prose, so the retained
+    // schema needs the same bound as the untrusted input.
+    assertMcpJsonSchemaBudget(processed);
+    return processed;
   }
 
   protected processSchema(schema: JSONSchema7): JSONSchema7 {

--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -193,4 +193,27 @@ describe("assertMcpJsonSchemaBudget", () => {
       expect((error as ElizaError).code).toBe(MCP_TOOL_SCHEMA_UNBOUNDED);
     }
   });
+
+  it("rejects a huge sparse array before whole-graph serialization", () => {
+    const sparse: unknown[] = [];
+    sparse.length = 1_000_000_000;
+    expect(() => assertMcpJsonSchemaBudget(sparse)).toThrowError(ElizaError);
+  });
+
+  it("rejects giant primitive text during traversal", () => {
+    expect(() =>
+      assertMcpJsonSchemaBudget({ type: "string", description: "x".repeat(300_000) })
+    ).toThrowError(/serialized size/);
+  });
+
+  it("rejects a throwing schema accessor as unsafe input", () => {
+    const schema = { type: "object" } as Record<string, unknown>;
+    Object.defineProperty(schema, "properties", {
+      enumerable: true,
+      get: () => {
+        throw new Error("getter escaped");
+      },
+    });
+    expect(() => assertMcpJsonSchemaBudget(schema)).toThrowError(/not safely traversable/);
+  });
 });

--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -3,8 +3,15 @@
  * They cover fenced/prose-wrapped JSON extraction, JSON5 leniency, and schema checks for tool-call arguments.
  */
 
+import { ElizaError } from "@elizaos/core/errors";
 import { describe, expect, it } from "vitest";
-import { parseJSON, parseStructuredModelOutput, validateJsonSchema } from "../json";
+import {
+  assertMcpJsonSchemaBudget,
+  MCP_TOOL_SCHEMA_UNBOUNDED,
+  parseJSON,
+  parseStructuredModelOutput,
+  validateJsonSchema,
+} from "../json";
 
 describe("parseJSON", () => {
   it("parses a plain JSON object", () => {
@@ -162,6 +169,28 @@ describe("validateJsonSchema", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toMatch(/nesting depth/);
+    }
+  });
+});
+
+describe("assertMcpJsonSchemaBudget", () => {
+  it("accepts a small object schema", () => {
+    expect(() =>
+      assertMcpJsonSchemaBudget({
+        type: "object",
+        properties: { name: { type: "string" } },
+      })
+    ).not.toThrow();
+  });
+
+  it("throws MCP_TOOL_SCHEMA_UNBOUNDED on a cyclic graph", () => {
+    const cyclic: Record<string, unknown> = { type: "array" };
+    cyclic.items = cyclic;
+    expect(() => assertMcpJsonSchemaBudget(cyclic)).toThrowError(ElizaError);
+    try {
+      assertMcpJsonSchemaBudget(cyclic);
+    } catch (error) {
+      expect((error as ElizaError).code).toBe(MCP_TOOL_SCHEMA_UNBOUNDED);
     }
   });
 });

--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -3,7 +3,7 @@
  * They cover fenced/prose-wrapped JSON extraction, JSON5 leniency, and schema checks for tool-call arguments.
  */
 
-import { ElizaError } from "@elizaos/core/errors";
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   assertMcpJsonSchemaBudget,
@@ -206,14 +206,58 @@ describe("assertMcpJsonSchemaBudget", () => {
     ).toThrowError(/serialized size/);
   });
 
-  it("rejects a throwing schema accessor as unsafe input", () => {
+  it("rejects a schema accessor without invoking it", () => {
     const schema = { type: "object" } as Record<string, unknown>;
+    let reads = 0;
     Object.defineProperty(schema, "properties", {
       enumerable: true,
       get: () => {
-        throw new Error("getter escaped");
+        reads += 1;
+        return {};
       },
     });
-    expect(() => assertMcpJsonSchemaBudget(schema)).toThrowError(/not safely traversable/);
+    expect(() => assertMcpJsonSchemaBudget(schema)).toThrowError(/contains an accessor/);
+    expect(reads).toBe(0);
+  });
+
+  it("rejects custom toJSON before it can synthesize an unbounded second graph", () => {
+    let calls = 0;
+    const schema = { type: "object" };
+    Object.defineProperty(schema, "toJSON", {
+      get: () => {
+        calls += 1;
+        return () => ({ description: "x".repeat(1_000_000) });
+      },
+    });
+    expect(() => assertMcpJsonSchemaBudget(schema)).toThrowError(/custom toJSON/);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects an inherited toJSON accessor without invoking it", () => {
+    const original = Object.getOwnPropertyDescriptor(Object.prototype, "toJSON");
+    let calls = 0;
+    let caught: unknown;
+    Object.defineProperty(Object.prototype, "toJSON", {
+      configurable: true,
+      get: () => {
+        calls += 1;
+        return () => ({ description: "x".repeat(300_000) });
+      },
+    });
+    try {
+      assertMcpJsonSchemaBudget({ type: "object" });
+    } catch (error) {
+      caught = error;
+    } finally {
+      if (original) {
+        Object.defineProperty(Object.prototype, "toJSON", original);
+      } else {
+        delete (Object.prototype as { toJSON?: unknown }).toJSON;
+      }
+    }
+
+    expect(caught).toBeInstanceOf(ElizaError);
+    expect((caught as ElizaError).message).toMatch(/custom toJSON/);
+    expect(calls).toBe(0);
   });
 });

--- a/plugins/plugin-mcp/src/utils/json.ts
+++ b/plugins/plugin-mcp/src/utils/json.ts
@@ -5,62 +5,23 @@
  * Ajv. Used on the untrusted-model-output boundary in the selection flow.
  *
  * MCP tool `inputSchema` is attacker-controlled. A byte, depth, and node budget
- * limits compile work; each schema then uses an isolated Ajv so untrusted `$id`
- * values cannot poison process-wide state. Compile and evaluation failures are
- * translated to an invalid-schema result at this boundary.
+ * limits compile work and the tool-compatibility rewrite; each schema then uses
+ * an isolated Ajv so untrusted `$id` values cannot poison process-wide state.
+ * Compile and evaluation failures are translated to an invalid-schema result
+ * at this boundary.
  */
 import Ajv from "ajv";
 import JSON5 from "json5";
+import { getMcpJsonSchemaBudgetError } from "./schema-budget";
 
-const MAX_MCP_SCHEMA_JSON_BYTES = 256 * 1024;
-const MAX_MCP_SCHEMA_DEPTH = 32;
-const MAX_MCP_SCHEMA_NODES = 2048;
-
-function walkSchema(node: unknown, depth: number, acc: { nodes: number }): string | undefined {
-  if (depth > MAX_MCP_SCHEMA_DEPTH) {
-    return `MCP JSON schema nesting depth exceeds ${MAX_MCP_SCHEMA_DEPTH}`;
-  }
-  if (node === null || typeof node !== "object") {
-    return undefined;
-  }
-
-  acc.nodes += 1;
-  if (acc.nodes > MAX_MCP_SCHEMA_NODES) {
-    return `MCP JSON schema node count exceeds ${MAX_MCP_SCHEMA_NODES}`;
-  }
-
-  if (!Array.isArray(node) && (node as Record<string, unknown>).$async === true) {
-    return "MCP JSON schema uses unsupported asynchronous validation";
-  }
-
-  for (const value of Array.isArray(node) ? node : Object.values(node)) {
-    const error = walkSchema(value, depth + 1, acc);
-    if (error) {
-      return error;
-    }
-  }
-  return undefined;
-}
-
-export function getMcpJsonSchemaBudgetError(schema: unknown): string | undefined {
-  let serialized: string | undefined;
-  try {
-    serialized = JSON.stringify(schema);
-  } catch {
-    // error-policy:J3 schema preflight returns an explicit invalid result below
-    return "MCP JSON schema is not JSON-serializable";
-  }
-
-  if (serialized === undefined) {
-    return "MCP JSON schema is not JSON-serializable";
-  }
-  const bytes = Buffer.byteLength(serialized);
-  if (bytes > MAX_MCP_SCHEMA_JSON_BYTES) {
-    return `MCP JSON schema serialized size ${bytes} exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
-  }
-
-  return walkSchema(schema, 0, { nodes: 0 });
-}
+export {
+  assertMcpJsonSchemaBudget,
+  getMcpJsonSchemaBudgetError,
+  MAX_MCP_SCHEMA_DEPTH,
+  MAX_MCP_SCHEMA_JSON_BYTES,
+  MAX_MCP_SCHEMA_NODES,
+  MCP_TOOL_SCHEMA_UNBOUNDED,
+} from "./schema-budget";
 
 export function parseJSON<T>(input: string): T {
   let cleanedInput = input.replace(/^```(?:json)?\s*|\s*```$/g, "").trim();

--- a/plugins/plugin-mcp/src/utils/schema-budget.ts
+++ b/plugins/plugin-mcp/src/utils/schema-budget.ts
@@ -14,12 +14,26 @@ export const MAX_MCP_SCHEMA_NODES = 2048;
 /** Stable code when a tool `inputSchema` exceeds the MCP schema budget. */
 export const MCP_TOOL_SCHEMA_UNBOUNDED = "MCP_TOOL_SCHEMA_UNBOUNDED";
 
-function walkSchema(node: unknown, depth: number, acc: { nodes: number }): string | undefined {
+interface SchemaBudgetAccumulator {
+  nodes: number;
+  primitiveBytes: number;
+}
+
+function addPrimitiveBytes(value: string, acc: SchemaBudgetAccumulator): string | undefined {
+  acc.primitiveBytes += Buffer.byteLength(value);
+  if (acc.primitiveBytes > MAX_MCP_SCHEMA_JSON_BYTES) {
+    return `MCP JSON schema serialized size exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
+  }
+  return undefined;
+}
+
+function walkSchema(
+  node: unknown,
+  depth: number,
+  acc: SchemaBudgetAccumulator
+): string | undefined {
   if (depth > MAX_MCP_SCHEMA_DEPTH) {
     return `MCP JSON schema nesting depth exceeds ${MAX_MCP_SCHEMA_DEPTH}`;
-  }
-  if (node === null || typeof node !== "object") {
-    return undefined;
   }
 
   acc.nodes += 1;
@@ -27,20 +41,46 @@ function walkSchema(node: unknown, depth: number, acc: { nodes: number }): strin
     return `MCP JSON schema node count exceeds ${MAX_MCP_SCHEMA_NODES}`;
   }
 
+  if (typeof node === "string") {
+    return addPrimitiveBytes(node, acc);
+  }
+  if (node === null || typeof node !== "object") {
+    return undefined;
+  }
+
   if (!Array.isArray(node) && (node as Record<string, unknown>).$async === true) {
     return "MCP JSON schema uses unsupported asynchronous validation";
   }
 
-  for (const value of Array.isArray(node) ? node : Object.values(node)) {
-    const error = walkSchema(value, depth + 1, acc);
-    if (error) {
-      return error;
+  if (Array.isArray(node)) {
+    for (const value of node) {
+      const error = walkSchema(value, depth + 1, acc);
+      if (error) return error;
+    }
+  } else {
+    for (const key in node as Record<string, unknown>) {
+      if (!Object.hasOwn(node, key)) continue;
+      const keyError = addPrimitiveBytes(key, acc);
+      if (keyError) return keyError;
+      const error = walkSchema((node as Record<string, unknown>)[key], depth + 1, acc);
+      if (error) return error;
     }
   }
   return undefined;
 }
 
 export function getMcpJsonSchemaBudgetError(schema: unknown): string | undefined {
+  try {
+    // Bound topology and raw string/key bytes before JSON.stringify. This keeps
+    // deep, cyclic, broad, sparse, and giant-string graphs from making the byte
+    // measurement itself the unbounded operation.
+    const walkError = walkSchema(schema, 0, { nodes: 0, primitiveBytes: 0 });
+    if (walkError) return walkError;
+  } catch {
+    // error-policy:J3 hostile accessors/proxies are not valid JSON Schema.
+    return "MCP JSON schema is not safely traversable";
+  }
+
   let serialized: string | undefined;
   try {
     serialized = JSON.stringify(schema);
@@ -57,7 +97,7 @@ export function getMcpJsonSchemaBudgetError(schema: unknown): string | undefined
     return `MCP JSON schema serialized size ${bytes} exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
   }
 
-  return walkSchema(schema, 0, { nodes: 0 });
+  return undefined;
 }
 
 /**

--- a/plugins/plugin-mcp/src/utils/schema-budget.ts
+++ b/plugins/plugin-mcp/src/utils/schema-budget.ts
@@ -5,7 +5,7 @@
  * rewrite so a cyclic or deeply nested `inputSchema` cannot stack-overflow
  * the agent event loop. This module has no Ajv import.
  */
-import { ElizaError } from "@elizaos/core/errors";
+import { ElizaError } from "@elizaos/core";
 
 export const MAX_MCP_SCHEMA_JSON_BYTES = 256 * 1024;
 export const MAX_MCP_SCHEMA_DEPTH = 32;
@@ -16,15 +16,40 @@ export const MCP_TOOL_SCHEMA_UNBOUNDED = "MCP_TOOL_SCHEMA_UNBOUNDED";
 
 interface SchemaBudgetAccumulator {
   nodes: number;
-  primitiveBytes: number;
+  serializedBytes: number;
+  seen: WeakSet<object>;
 }
 
-function addPrimitiveBytes(value: string, acc: SchemaBudgetAccumulator): string | undefined {
-  acc.primitiveBytes += Buffer.byteLength(value);
-  if (acc.primitiveBytes > MAX_MCP_SCHEMA_JSON_BYTES) {
+function addSerializedBytes(bytes: number, acc: SchemaBudgetAccumulator): string | undefined {
+  acc.serializedBytes += bytes;
+  if (acc.serializedBytes > MAX_MCP_SCHEMA_JSON_BYTES) {
     return `MCP JSON schema serialized size exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
   }
   return undefined;
+}
+
+function addSerializedString(value: string, acc: SchemaBudgetAccumulator): string | undefined {
+  const remaining = MAX_MCP_SCHEMA_JSON_BYTES - acc.serializedBytes;
+  // UTF-8 uses at least one byte per UTF-16 code unit. Reject giant strings
+  // before Buffer.byteLength or JSON escaping has to scan the whole value.
+  if (value.length > remaining) {
+    return `MCP JSON schema serialized size exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
+  }
+  return addSerializedBytes(Buffer.byteLength(JSON.stringify(value)), acc);
+}
+
+function hasUnsafeToJsonHook(value: object): boolean {
+  let owner: object | null = value;
+  while (owner) {
+    const descriptor = Object.getOwnPropertyDescriptor(owner, "toJSON");
+    if (descriptor) {
+      // JSON.stringify performs an inherited Get before testing callability.
+      // Inspect descriptors only: an accessor must never run during preflight.
+      return !("value" in descriptor) || typeof descriptor.value === "function";
+    }
+    owner = Object.getPrototypeOf(owner);
+  }
+  return false;
 }
 
 function walkSchema(
@@ -42,59 +67,101 @@ function walkSchema(
   }
 
   if (typeof node === "string") {
-    return addPrimitiveBytes(node, acc);
+    return addSerializedString(node, acc);
   }
-  if (node === null || typeof node !== "object") {
-    return undefined;
+  if (node === null) {
+    return addSerializedBytes(4, acc);
+  }
+  if (typeof node === "boolean") {
+    return addSerializedBytes(node ? 4 : 5, acc);
+  }
+  if (typeof node === "number") {
+    if (!Number.isFinite(node)) return "MCP JSON schema contains a non-JSON number";
+    return addSerializedBytes(Buffer.byteLength(JSON.stringify(node)), acc);
+  }
+  if (typeof node !== "object") {
+    return "MCP JSON schema contains a non-JSON value";
   }
 
-  if (!Array.isArray(node) && (node as Record<string, unknown>).$async === true) {
-    return "MCP JSON schema uses unsupported asynchronous validation";
+  if (acc.seen.has(node)) {
+    return "MCP JSON schema is not JSON-serializable";
   }
+  acc.seen.add(node);
 
   if (Array.isArray(node)) {
-    for (const value of node) {
-      const error = walkSchema(value, depth + 1, acc);
+    if (Object.getPrototypeOf(node) !== Array.prototype) {
+      return "MCP JSON schema is not plain JSON data";
+    }
+    if (node.length > MAX_MCP_SCHEMA_NODES - acc.nodes) {
+      return `MCP JSON schema node count exceeds ${MAX_MCP_SCHEMA_NODES}`;
+    }
+    if (hasUnsafeToJsonHook(node)) {
+      return "MCP JSON schema contains a custom toJSON function";
+    }
+    let error = addSerializedBytes(2 + Math.max(0, node.length - 1), acc);
+    if (error) return error;
+    for (let index = 0; index < node.length; index++) {
+      const descriptor = Object.getOwnPropertyDescriptor(node, String(index));
+      if (!descriptor) {
+        error = addSerializedBytes(4, acc);
+      } else if (!("value" in descriptor)) {
+        return "MCP JSON schema contains an accessor";
+      } else {
+        error = walkSchema(descriptor.value, depth + 1, acc);
+      }
       if (error) return error;
     }
   } else {
+    const prototype = Object.getPrototypeOf(node);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return "MCP JSON schema is not plain JSON data";
+    }
+    if (hasUnsafeToJsonHook(node)) {
+      return "MCP JSON schema contains a custom toJSON function";
+    }
+    const asyncFlag = Object.getOwnPropertyDescriptor(node, "$async");
+    if (asyncFlag && "value" in asyncFlag && asyncFlag.value === true) {
+      return "MCP JSON schema uses unsupported asynchronous validation";
+    }
+    let error = addSerializedBytes(2, acc);
+    if (error) return error;
+    let entries = 0;
     for (const key in node as Record<string, unknown>) {
       if (!Object.hasOwn(node, key)) continue;
-      const keyError = addPrimitiveBytes(key, acc);
-      if (keyError) return keyError;
-      const error = walkSchema((node as Record<string, unknown>)[key], depth + 1, acc);
+      const descriptor = Object.getOwnPropertyDescriptor(node, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) return "MCP JSON schema contains an accessor";
+      if (entries > 0) {
+        error = addSerializedBytes(1, acc);
+        if (error) return error;
+      }
+      entries += 1;
+      error = addSerializedString(key, acc);
+      if (error) return error;
+      error = addSerializedBytes(1, acc);
+      if (error) return error;
+      error = walkSchema(descriptor.value, depth + 1, acc);
       if (error) return error;
     }
   }
+  acc.seen.delete(node);
   return undefined;
 }
 
 export function getMcpJsonSchemaBudgetError(schema: unknown): string | undefined {
   try {
-    // Bound topology and raw string/key bytes before JSON.stringify. This keeps
-    // deep, cyclic, broad, sparse, and giant-string graphs from making the byte
-    // measurement itself the unbounded operation.
-    const walkError = walkSchema(schema, 0, { nodes: 0, primitiveBytes: 0 });
+    // Measure JSON tokens during the bounded descriptor walk. This keeps deep,
+    // cyclic, broad, sparse, giant-string, and accessor-backed graphs from
+    // making a later whole-schema JSON.stringify the unbounded operation.
+    const walkError = walkSchema(schema, 0, {
+      nodes: 0,
+      serializedBytes: 0,
+      seen: new WeakSet(),
+    });
     if (walkError) return walkError;
   } catch {
     // error-policy:J3 hostile accessors/proxies are not valid JSON Schema.
     return "MCP JSON schema is not safely traversable";
-  }
-
-  let serialized: string | undefined;
-  try {
-    serialized = JSON.stringify(schema);
-  } catch {
-    // error-policy:J3 schema preflight returns an explicit invalid result below
-    return "MCP JSON schema is not JSON-serializable";
-  }
-
-  if (serialized === undefined) {
-    return "MCP JSON schema is not JSON-serializable";
-  }
-  const bytes = Buffer.byteLength(serialized);
-  if (bytes > MAX_MCP_SCHEMA_JSON_BYTES) {
-    return `MCP JSON schema serialized size ${bytes} exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
   }
 
   return undefined;

--- a/plugins/plugin-mcp/src/utils/schema-budget.ts
+++ b/plugins/plugin-mcp/src/utils/schema-budget.ts
@@ -1,0 +1,75 @@
+/**
+ * Byte, depth, and node budget for attacker-controlled MCP JSON Schema.
+ *
+ * Shared by Ajv compile (`validateJsonSchema`) and the tool-compatibility
+ * rewrite so a cyclic or deeply nested `inputSchema` cannot stack-overflow
+ * the agent event loop. This module has no Ajv import.
+ */
+import { ElizaError } from "@elizaos/core/errors";
+
+export const MAX_MCP_SCHEMA_JSON_BYTES = 256 * 1024;
+export const MAX_MCP_SCHEMA_DEPTH = 32;
+export const MAX_MCP_SCHEMA_NODES = 2048;
+
+/** Stable code when a tool `inputSchema` exceeds the MCP schema budget. */
+export const MCP_TOOL_SCHEMA_UNBOUNDED = "MCP_TOOL_SCHEMA_UNBOUNDED";
+
+function walkSchema(node: unknown, depth: number, acc: { nodes: number }): string | undefined {
+  if (depth > MAX_MCP_SCHEMA_DEPTH) {
+    return `MCP JSON schema nesting depth exceeds ${MAX_MCP_SCHEMA_DEPTH}`;
+  }
+  if (node === null || typeof node !== "object") {
+    return undefined;
+  }
+
+  acc.nodes += 1;
+  if (acc.nodes > MAX_MCP_SCHEMA_NODES) {
+    return `MCP JSON schema node count exceeds ${MAX_MCP_SCHEMA_NODES}`;
+  }
+
+  if (!Array.isArray(node) && (node as Record<string, unknown>).$async === true) {
+    return "MCP JSON schema uses unsupported asynchronous validation";
+  }
+
+  for (const value of Array.isArray(node) ? node : Object.values(node)) {
+    const error = walkSchema(value, depth + 1, acc);
+    if (error) {
+      return error;
+    }
+  }
+  return undefined;
+}
+
+export function getMcpJsonSchemaBudgetError(schema: unknown): string | undefined {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(schema);
+  } catch {
+    // error-policy:J3 schema preflight returns an explicit invalid result below
+    return "MCP JSON schema is not JSON-serializable";
+  }
+
+  if (serialized === undefined) {
+    return "MCP JSON schema is not JSON-serializable";
+  }
+  const bytes = Buffer.byteLength(serialized);
+  if (bytes > MAX_MCP_SCHEMA_JSON_BYTES) {
+    return `MCP JSON schema serialized size ${bytes} exceeds ${MAX_MCP_SCHEMA_JSON_BYTES}`;
+  }
+
+  return walkSchema(schema, 0, { nodes: 0 });
+}
+
+/**
+ * Fail closed before any recursive MCP schema walk.
+ */
+export function assertMcpJsonSchemaBudget(schema: unknown): void {
+  const error = getMcpJsonSchemaBudgetError(schema);
+  if (error) {
+    throw new ElizaError(error, {
+      code: MCP_TOOL_SCHEMA_UNBOUNDED,
+      context: { reason: error },
+      severity: "fatal",
+    });
+  }
+}


### PR DESCRIPTION
## Problem

MCP `tools/list` returns attacker-controlled `inputSchema` values. elizaOS recursively rewrites those schemas for some model providers and later serializes every retained schema into tool-selection prompts. The compatibility walk had no byte, depth, or node budget, so deeply nested or cyclic graphs could overflow or consume unbounded work.

The MCP tools contract defines `inputSchema` as JSON Schema, and servers/annotations remain untrusted: https://modelcontextprotocol.io/specification/2025-06-18/server/tools. ECMAScript requires `JSON.stringify` to throw on cycles, so serialization is not itself a safe preflight: https://tc39.es/ecma262/multipage/structured-data.html#sec-json.stringify.

## Change

- Share one 256 KiB / depth 32 / 2048-value schema budget between Ajv validation and tool compatibility.
- Measure exact serialized tokens during one bounded data-descriptor walk, with a cheap string-length gate before UTF-8/escaping work. Cyclic, deep, broad, sparse, giant-string, accessor-backed, custom-`toJSON`, and proxy-like inputs therefore fail closed before whole-graph serialization becomes the unbounded operation.
- Enforce the budget for every retained tool schema, including OpenAI structured-output and OpenRouter paths that require no compatibility rewrite but still serialize schemas later.
- Revalidate provider rewrite output because folding removed constraints into descriptions can expand an accepted input beyond the retained-schema byte cap.
- Omit only the tool that throws typed `MCP_TOOL_SCHEMA_UNBOUNDED`; unexpected compatibility/programming errors are rethrown instead of being mislabeled and silently swallowed.
- Preserve healthy sibling tools and their provider-specific rewrite.

## Exact-head evidence

Evidence revision: `68f6c9965ad5d8f85687227286a82623bb2a9ea0`

- Pinned Bun `1.3.14`: **48 passed / 0 failed, 79 assertions** across the real `McpService.fetchToolsList` boundary, provider compatibility, and shared JSON/Ajv budget suites.
- Real `McpService` instance with a stub MCP client proves a cyclic tool is omitted while a healthy sibling remains and receives the Google rewrite.
- The same production service boundary proves no-rewrite OpenAI GPT-5 and OpenRouter paths reject an unbounded schema.
- The production service boundary also proves a Google rewrite that crosses 256 KiB is omitted while its healthy sibling remains.
- An injected unexpected `TypeError` is rethrown, proving the catch is restricted to the expected typed boundary failure.
- Adversarial regressions cover: exact depth boundary, 2048-value boundary, cyclic graph, 20,000-deep graph, billion-length sparse array, 300 KiB primitive text, accessor rejection without invocation, own and inherited custom `toJSON` rejection without invocation, rewrite expansion, and honest nested object/array schemas.
- Pinned 20,000-depth preflight is ~1.6–2.4 ms after repair (the original serialize-first path measured ~417 ms in the same checkout).
- Strict TypeScript over all plugin source plus the changed tests, using the built `@elizaos/core` declarations: passed.
- Biome on all 7 changed files: passed.
- `git diff --check`: passed.

Full workspace install/typecheck was not represented by the isolated sparse review checkout because omitted workspaces prevent the root workspace install. No UI, model output, or rendered behavior changed; screenshots/video/live-model trajectory are N/A. The production service/tool-list artifact is asserted directly above.

## Provenance

Original contribution:

- AI provider/model: xAI / grok-4.6
- Client / agent tooling: Grok CLI via cmux
- Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
- Attribution status: self-reported

Reviewer repair contribution-attribution: OpenAI/gpt-5.6-sol via Codex Desktop multi-agent

<!-- evidence-head:68f6c9965ad5d8f85687227286a82623bb2a9ea0 -->