### PR TITLE
fix(core): fail closed on unbounded text-normalize walks

### DIFF
--- a/packages/core/src/utils/prompt-batcher/shared.test.ts
+++ b/packages/core/src/utils/prompt-batcher/shared.test.ts
@@ -1,5 +1,7 @@
 /**
- * Prompt-batcher shared helpers. sanitizeIdentifier must yield a valid
+ * Deterministic coverage for prompt-batcher shared helpers. Character context
+ * assembly must fail closed when text normalization rejects hostile input;
+ * sanitizeIdentifier must yield a valid
  * identifier (prefix when it can't start with a letter/underscore); retry count
  * is clamped to 0..2; getSourceMessageId derives a stable per-platform dedup key
  * (so the same inbound message isn't batched twice); and rollingAverage folds a
@@ -7,7 +9,13 @@
  */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../../types/memory";
+import type { IAgentRuntime } from "../../types/runtime";
 import {
+	MAX_TEXT_NORMALIZE_EDGES,
+	TEXT_NORMALIZE_UNBOUNDED,
+} from "../text-normalize.ts";
+import {
+	buildCharacterContext,
 	clampRetryCount,
 	getSourceMessageId,
 	hasMeaningfulSectionDrift,
@@ -15,6 +23,19 @@ import {
 	rollingAverage,
 	sanitizeIdentifier,
 } from "./shared.ts";
+
+describe("buildCharacterContext", () => {
+	it("fails closed when hostile character metadata exceeds the work budget", () => {
+		const topics = new Array(MAX_TEXT_NORMALIZE_EDGES + 1);
+		const runtime = {
+			character: { name: "Bounded Agent", topics, bio: [], style: {} },
+		} as unknown as IAgentRuntime;
+
+		expect(() => buildCharacterContext(runtime)).toThrowError(
+			expect.objectContaining({ code: TEXT_NORMALIZE_UNBOUNDED }),
+		);
+	});
+});
 
 describe("sanitizeIdentifier", () => {
 	it("replaces non-identifier chars and guarantees a valid leading char", () => {

--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -17,6 +17,7 @@ import { ElizaError } from "../errors.ts";
 import {
 	flattenTextValues,
 	MAX_TEXT_NORMALIZE_DEPTH,
+	MAX_TEXT_NORMALIZE_EDGES,
 	MAX_TEXT_NORMALIZE_NODES,
 	TEXT_NORMALIZE_UNBOUNDED,
 	toMultilineText,
@@ -245,6 +246,33 @@ describe("flattenTextValues budget", () => {
 			(_, i) => `v${i}`,
 		);
 		expect(() => flattenTextValues(siblings)).toThrowError(ElizaError);
+	});
+
+	it("counts sparse array holes against the work budget", () => {
+		const sparse = new Array(MAX_TEXT_NORMALIZE_EDGES + 1);
+		expect(() => flattenTextValues(sparse)).toThrowError(
+			expect.objectContaining({ code: TEXT_NORMALIZE_UNBOUNDED }),
+		);
+	});
+
+	it("does not eagerly read object properties beyond the work budget", () => {
+		let outOfBudgetGetterRead = false;
+		const value: Record<string, unknown> = {};
+		for (let index = 0; index < MAX_TEXT_NORMALIZE_NODES; index += 1) {
+			value[`value${index}`] = "kept";
+		}
+		Object.defineProperty(value, "outOfBudget", {
+			enumerable: true,
+			get() {
+				outOfBudgetGetterRead = true;
+				return "must not be read";
+			},
+		});
+
+		expect(() => flattenTextValues(value)).toThrowError(
+			expect.objectContaining({ code: TEXT_NORMALIZE_UNBOUNDED }),
+		);
+		expect(outOfBudgetGetterRead).toBe(false);
 	});
 
 	it("does not RangeError a 20k array nest", () => {

--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -13,7 +13,14 @@
 
 import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
-import { flattenTextValues, toMultilineText } from "./text-normalize";
+import { ElizaError } from "../errors.ts";
+import {
+	flattenTextValues,
+	MAX_TEXT_NORMALIZE_DEPTH,
+	MAX_TEXT_NORMALIZE_NODES,
+	TEXT_NORMALIZE_UNBOUNDED,
+	toMultilineText,
+} from "./text-normalize";
 
 describe("flattenTextValues", () => {
 	describe("strings", () => {
@@ -201,5 +208,52 @@ describe("toMultilineText", () => {
 	it("returns an empty string when nothing survives", () => {
 		expect(toMultilineText(null)).toBe("");
 		expect(toMultilineText([null, "  ", {}])).toBe("");
+	});
+});
+
+describe("flattenTextValues budget", () => {
+	function nestArray(depth: number): unknown {
+		let value: unknown = "leaf";
+		for (let i = 0; i < depth; i++) {
+			value = [value];
+		}
+		return value;
+	}
+
+	it(`accepts a ${MAX_TEXT_NORMALIZE_DEPTH}-deep array nest`, () => {
+		expect(flattenTextValues(nestArray(MAX_TEXT_NORMALIZE_DEPTH))).toEqual([
+			"leaf",
+		]);
+	});
+
+	it(`throws ${TEXT_NORMALIZE_UNBOUNDED} one past depth ${MAX_TEXT_NORMALIZE_DEPTH}`, () => {
+		expect(() =>
+			flattenTextValues(nestArray(MAX_TEXT_NORMALIZE_DEPTH + 1)),
+		).toThrowError(ElizaError);
+		try {
+			flattenTextValues(nestArray(MAX_TEXT_NORMALIZE_DEPTH + 1));
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(TEXT_NORMALIZE_UNBOUNDED);
+			expect(error).not.toBeInstanceOf(RangeError);
+		}
+	});
+
+	it(`throws ${TEXT_NORMALIZE_UNBOUNDED} past ${MAX_TEXT_NORMALIZE_NODES} nodes`, () => {
+		const siblings = Array.from(
+			{ length: MAX_TEXT_NORMALIZE_NODES },
+			(_, i) => `v${i}`,
+		);
+		expect(() => flattenTextValues(siblings)).toThrowError(ElizaError);
+	});
+
+	it("does not RangeError a 20k array nest", () => {
+		expect(() => flattenTextValues(nestArray(20_000))).toThrowError(ElizaError);
+		try {
+			flattenTextValues(nestArray(20_000));
+		} catch (error) {
+			expect((error as ElizaError).code).toBe(TEXT_NORMALIZE_UNBOUNDED);
+			expect(error).not.toBeInstanceOf(RangeError);
+		}
 	});
 });

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -5,7 +5,53 @@
  * human-readable text blocks. Keeping this logic in one place makes prompt
  * construction more predictable and avoids each caller inventing slightly
  * different null/array/object coercion rules.
+ *
+ * The walk is depth-, visit-, and cycle-bounded. Provider output and memory
+ * metadata can carry a hostile nest; on origin a 20k-deep array threw
+ * `RangeError: Maximum call stack size exceeded`. Cycles still skip the
+ * back-edge (existing contract). Over-budget graphs throw `ElizaError`
+ * `TEXT_NORMALIZE_UNBOUNDED`.
  */
+
+import { ElizaError } from "../errors.ts";
+
+/** Nesting ceiling. Honest prompt values are a handful of objects deep. */
+export const MAX_TEXT_NORMALIZE_DEPTH = 64;
+/** Node ceiling across the whole flatten, including leaves. */
+export const MAX_TEXT_NORMALIZE_NODES = 2048;
+
+export const TEXT_NORMALIZE_UNBOUNDED = "TEXT_NORMALIZE_UNBOUNDED";
+
+type WalkContext = {
+	visits: number;
+	ancestors: WeakSet<object>;
+};
+
+function failUnbounded(
+	axis: "depth" | "visits",
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(
+		axis === "depth"
+			? `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_DEPTH} nesting depth`
+			: `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_NODES} nodes`,
+		{
+			code: TEXT_NORMALIZE_UNBOUNDED,
+			context,
+			severity: "fatal",
+		},
+	);
+}
+
+function reserveVisit(ctx: WalkContext): void {
+	ctx.visits += 1;
+	if (ctx.visits > MAX_TEXT_NORMALIZE_NODES) {
+		failUnbounded("visits", {
+			visits: ctx.visits,
+			max: MAX_TEXT_NORMALIZE_NODES,
+		});
+	}
+}
 
 /**
  * Flatten a mixed nested value into text fragments.
@@ -18,24 +64,33 @@
  * - Scalars are stringified
  */
 export function flattenTextValues(value: unknown): string[] {
-	return flattenTextValuesWithAncestors(value, new WeakSet());
+	return flattenTextValuesWithAncestors(value, 0, {
+		visits: 0,
+		ancestors: new WeakSet(),
+	});
 }
 
 function flattenTextValuesWithAncestors(
 	value: unknown,
-	ancestors: WeakSet<object>,
+	depth: number,
+	ctx: WalkContext,
 ): string[] {
+	if (depth > MAX_TEXT_NORMALIZE_DEPTH) {
+		failUnbounded("depth", { depth, max: MAX_TEXT_NORMALIZE_DEPTH });
+	}
+	reserveVisit(ctx);
+
 	if (Array.isArray(value)) {
-		if (ancestors.has(value)) {
+		if (ctx.ancestors.has(value)) {
 			return [];
 		}
-		ancestors.add(value);
+		ctx.ancestors.add(value);
 		try {
 			return value.flatMap((item) =>
-				flattenTextValuesWithAncestors(item, ancestors),
+				flattenTextValuesWithAncestors(item, depth + 1, ctx),
 			);
 		} finally {
-			ancestors.delete(value);
+			ctx.ancestors.delete(value);
 		}
 	}
 
@@ -58,22 +113,23 @@ function flattenTextValuesWithAncestors(
 	}
 
 	if (typeof value === "object") {
-		if (ancestors.has(value)) {
+		if (ctx.ancestors.has(value)) {
 			return [];
 		}
-		ancestors.add(value);
+		ctx.ancestors.add(value);
 		try {
 			return Object.entries(value as Record<string, unknown>).flatMap(
 				([key, inner]) => {
 					const innerText = flattenTextValuesWithAncestors(
 						inner,
-						ancestors,
+						depth + 1,
+						ctx,
 					).join(", ");
 					return innerText ? [`${key}: ${innerText}`] : [];
 				},
 			);
 		} finally {
-			ancestors.delete(value);
+			ctx.ancestors.delete(value);
 		}
 	}
 

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -6,11 +6,9 @@
  * construction more predictable and avoids each caller inventing slightly
  * different null/array/object coercion rules.
  *
- * The walk is depth-, visit-, and cycle-bounded. Provider output and memory
- * metadata can carry a hostile nest; on origin a 20k-deep array threw
- * `RangeError: Maximum call stack size exceeded`. Cycles still skip the
- * back-edge (existing contract). Over-budget graphs throw `ElizaError`
- * `TEXT_NORMALIZE_UNBOUNDED`.
+ * The walk is depth-, work-, and cycle-bounded because provider output and
+ * memory metadata can carry hostile nests or sparse collections. Cycles skip
+ * the back-edge; over-budget graphs fail closed with a typed error.
  */
 
 import { ElizaError } from "../errors.ts";
@@ -19,22 +17,27 @@ import { ElizaError } from "../errors.ts";
 export const MAX_TEXT_NORMALIZE_DEPTH = 64;
 /** Node ceiling across the whole flatten, including leaves. */
 export const MAX_TEXT_NORMALIZE_NODES = 2048;
+/** Collection-edge ceiling, including sparse holes and inherited keys. */
+export const MAX_TEXT_NORMALIZE_EDGES = 2048;
 
 export const TEXT_NORMALIZE_UNBOUNDED = "TEXT_NORMALIZE_UNBOUNDED";
 
 type WalkContext = {
 	visits: number;
+	edges: number;
 	ancestors: WeakSet<object>;
 };
 
 function failUnbounded(
-	axis: "depth" | "visits",
+	axis: "depth" | "visits" | "edges",
 	context: Record<string, unknown>,
 ): never {
 	throw new ElizaError(
 		axis === "depth"
 			? `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_DEPTH} nesting depth`
-			: `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_NODES} nodes`,
+			: axis === "visits"
+				? `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_NODES} nodes`
+				: `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_EDGES} collection edges`,
 		{
 			code: TEXT_NORMALIZE_UNBOUNDED,
 			context,
@@ -53,6 +56,16 @@ function reserveVisit(ctx: WalkContext): void {
 	}
 }
 
+function reserveEdge(ctx: WalkContext): void {
+	ctx.edges += 1;
+	if (ctx.edges > MAX_TEXT_NORMALIZE_EDGES) {
+		failUnbounded("edges", {
+			edges: ctx.edges,
+			max: MAX_TEXT_NORMALIZE_EDGES,
+		});
+	}
+}
+
 /**
  * Flatten a mixed nested value into text fragments.
  *
@@ -66,6 +79,7 @@ function reserveVisit(ctx: WalkContext): void {
 export function flattenTextValues(value: unknown): string[] {
 	return flattenTextValuesWithAncestors(value, 0, {
 		visits: 0,
+		edges: 0,
 		ancestors: new WeakSet(),
 	});
 }
@@ -86,9 +100,16 @@ function flattenTextValuesWithAncestors(
 		}
 		ctx.ancestors.add(value);
 		try {
-			return value.flatMap((item) =>
-				flattenTextValuesWithAncestors(item, depth + 1, ctx),
-			);
+			const fragments: string[] = [];
+			for (let index = 0; index < value.length; index += 1) {
+				// Holes still consume work even though they do not contribute text.
+				reserveEdge(ctx);
+				if (!(index in value)) continue;
+				fragments.push(
+					...flattenTextValuesWithAncestors(value[index], depth + 1, ctx),
+				);
+			}
+			return fragments;
 		} finally {
 			ctx.ancestors.delete(value);
 		}
@@ -118,16 +139,21 @@ function flattenTextValuesWithAncestors(
 		}
 		ctx.ancestors.add(value);
 		try {
-			return Object.entries(value as Record<string, unknown>).flatMap(
-				([key, inner]) => {
-					const innerText = flattenTextValuesWithAncestors(
-						inner,
-						depth + 1,
-						ctx,
-					).join(", ");
-					return innerText ? [`${key}: ${innerText}`] : [];
-				},
-			);
+			const fragments: string[] = [];
+			const record = value as Record<string, unknown>;
+			for (const key in record) {
+				// Count inherited enumeration too so a hostile prototype cannot evade the
+				// work cap. Output remains restricted to enumerable own properties.
+				reserveEdge(ctx);
+				if (!Object.hasOwn(record, key)) continue;
+				const innerText = flattenTextValuesWithAncestors(
+					record[key],
+					depth + 1,
+					ctx,
+				).join(", ");
+				if (innerText) fragments.push(`${key}: ${innerText}`);
+			}
+			return fragments;
 		} finally {
 			ctx.ancestors.delete(value);
 		}


### PR DESCRIPTION
# Relates to

Hardens the unbounded prompt/context text walk described in this PR. The affected production caller is `buildCharacterContext`, which normalizes character topics, bio, style, documents, and knowledge before prompt batching.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

## Problem

`flattenTextValues` recursively walked provider- and memory-derived graphs with cycle detection but no depth or work ceiling. A 20,000-deep array raised `RangeError` rather than a typed boundary failure.

The first submitted cap still had two bypasses found during independent review:

- `Array.prototype.flatMap` skipped sparse holes, so an array with millions of indexes consumed unbounded time while recording only one visited node.
- `Object.entries` eagerly read every enumerable value before the recursive node budget ran, so all getters and allocation work occurred before rejection.

Exact negative-control observations at submitted head `60cea3f0dd3f11f4a4a48028a3e16fd6470f67d3`:

| hostile input | submitted result |
| --- | --- |
| 5,000,000-hole array | accepted after 118.5 ms; no budget error |
| object with 10,000 enumerable getters | all 10,000 getters ran before `TEXT_NORMALIZE_UNBOUNDED` |

## Final change

- Maximum nesting depth: 64.
- Maximum visited nodes: 2,048.
- Maximum collection edges: 2,048, including sparse array holes and inherited enumerable keys.
- Numeric array traversal preserves the prior indexed-value semantics while charging holes to the work budget.
- Object traversal reads own enumerable values lazily, so values beyond the decisive budget are never accessed.
- Active-path cycle detection still skips back-edges; repeated non-cyclic references remain supported.
- Over-budget input fails closed with `ElizaError` code `TEXT_NORMALIZE_UNBOUNDED`.
- The real `buildCharacterContext` production caller has a regression proving the typed failure propagates before model dispatch.

The maintained file header now documents the invariant rather than change history.

## Exact-head validation

Evidence head: `396f9e2176db2dcc48b654fbb76e4b58228bf934`, rebased on `origin/develop` `3e5907a37fda0498b43830b7dbd585c52ca1cc04`.

- Pinned Bun 1.3.14 focused suites: **36/36 pass**, 70 assertions.
- `bun run --cwd packages/core typecheck`: pass under pinned Node 24.
- `bun run --cwd packages/core build`: pass for Node, browser, edge, testing bundle, declarations, and packed edge import verification.
- Biome on all three changed files: clean.
- `git diff --check`: clean.
- Repaired live probes: the 5,000,000-hole input rejects typed in about 1.03 ms after 2,049 charged edges; the 10,000-getter input rejects after 2,048 getter reads, with no out-of-budget getter access.

Focused coverage includes exact depth boundary, node boundary, sparse-edge boundary, eager-getter prevention, 20,000-depth non-`RangeError`, circular objects/arrays, repeated DAG references, cross-realm and spoofed Dates, ordinary arrays/objects/scalars, and production character-context rejection.

## Evidence gate

<!-- evidence-head:396f9e2176db2dcc48b654fbb76e4b58228bf934 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core prompt-assembly library only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - core prompt-assembly library only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact negative-control and repaired production-path receipts are recorded above; no deployed service is required for this pure deterministic boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - valid prompt text is unchanged, while hostile over-budget metadata is rejected before model dispatch; a live model cannot add evidence for the pre-dispatch boundary.
<!-- evidence-row:domain-artifacts -->
- [x] The direct `buildCharacterContext` regression and exact live probe outputs are the applicable artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Risks and compatibility

No public signature or valid-value formatting changed. The limits are additive fail-closed boundaries for hostile or operationally unreasonable graphs. Arrays retain indexed order and inherited indexed-value behavior; objects retain enumerable-own-string-key output and ordering. Browser and edge bundles were built because the helper is shared core code.

## Contribution provenance

- Original contribution: xAI / grok-4.6, Grok CLI via cmux, self-reported by `ss251`.
- Maintainer repair and validation: OpenAI / gpt-5.6-sol, Codex desktop, self-reported.
- Original contribution skill revision: `elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@015767b4c399c918879e65df6444f84d25b5c307:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-security-audio-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@015767b4c399c918879e65df6444f84d25b5c307:packages/skills/skills/contribute-to-eliza"} -->