### PR TITLE
fix(shared): fail closed on unbounded config logic expressions

### DIFF
--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -3,12 +3,17 @@
  * validation. The deterministic harness exercises the exported helpers and
  * validation runner directly without UI or network dependencies.
  */
+import { ElizaError } from "@elizaos/core/errors";
 import { describe, expect, it } from "vitest";
 import {
   builtInValidators,
   evaluateFieldVisibility,
+  evaluateLogicExpression,
   getByPath,
   isConfigKeySatisfied,
+  LOGIC_EXPRESSION_UNBOUNDED,
+  MAX_LOGIC_EXPRESSION_DEPTH,
+  MAX_LOGIC_EXPRESSION_NODES,
   runValidation,
   setByPath,
 } from "./config-catalog.js";
@@ -141,5 +146,70 @@ describe("config-catalog built-in validators", () => {
         {},
       ),
     ).toEqual({ valid: false, errors: ["Must be a finite number"] });
+  });
+});
+
+describe("evaluateLogicExpression budget", () => {
+  it("still evaluates an honest and/or/not tree", () => {
+    expect(
+      evaluateLogicExpression(
+        {
+          and: [{ path: "/ready" }, { not: { path: "/hidden" } }],
+        },
+        { ready: true, hidden: false },
+      ),
+    ).toBe(true);
+  });
+
+  it(`throws ${LOGIC_EXPRESSION_UNBOUNDED} one past depth ${MAX_LOGIC_EXPRESSION_DEPTH}`, () => {
+    let expr: Record<string, unknown> = { path: "/x" };
+    for (let i = 0; i < MAX_LOGIC_EXPRESSION_DEPTH + 1; i++) {
+      expr = { not: expr };
+    }
+    expect(() => evaluateLogicExpression(expr as never, {})).toThrowError(
+      ElizaError,
+    );
+    try {
+      evaluateLogicExpression(expr as never, {});
+    } catch (error) {
+      expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_UNBOUNDED);
+      expect(error).not.toBeInstanceOf(RangeError);
+    }
+  });
+
+  it(`accepts a ${MAX_LOGIC_EXPRESSION_DEPTH}-deep not nest`, () => {
+    let expr: Record<string, unknown> = { path: "/x" };
+    for (let i = 0; i < MAX_LOGIC_EXPRESSION_DEPTH; i++) {
+      expr = { not: expr };
+    }
+    expect(evaluateLogicExpression(expr as never, {})).toBe(
+      MAX_LOGIC_EXPRESSION_DEPTH % 2 === 1,
+    );
+  });
+
+  it(`throws ${LOGIC_EXPRESSION_UNBOUNDED} past ${MAX_LOGIC_EXPRESSION_NODES} nodes`, () => {
+    const expr = {
+      and: Array.from({ length: MAX_LOGIC_EXPRESSION_NODES }, () => ({
+        path: "/x",
+      })),
+    };
+    // Truthy children so `and.every` cannot short-circuit before the cap.
+    expect(() =>
+      evaluateLogicExpression(expr, { x: true }),
+    ).toThrowError(ElizaError);
+  });
+
+  it("throws LOGIC_EXPRESSION_UNBOUNDED on a cyclic and graph, not RangeError", () => {
+    const cyclic: { and: unknown[] } = { and: [] };
+    cyclic.and.push(cyclic);
+    expect(() => evaluateLogicExpression(cyclic as never, {})).toThrowError(
+      ElizaError,
+    );
+    try {
+      evaluateLogicExpression(cyclic as never, {});
+    } catch (error) {
+      expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_UNBOUNDED);
+      expect(error).not.toBeInstanceOf(RangeError);
+    }
   });
 });

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -3,7 +3,7 @@
  * validation. The deterministic harness exercises the exported helpers and
  * validation runner directly without UI or network dependencies.
  */
-import { ElizaError } from "@elizaos/core/errors";
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   builtInValidators,
@@ -11,9 +11,12 @@ import {
   evaluateLogicExpression,
   getByPath,
   isConfigKeySatisfied,
+  LOGIC_EXPRESSION_INVALID,
   LOGIC_EXPRESSION_UNBOUNDED,
   MAX_LOGIC_EXPRESSION_DEPTH,
   MAX_LOGIC_EXPRESSION_NODES,
+  MAX_LOGIC_EXPRESSION_PATH_LENGTH,
+  MAX_LOGIC_EXPRESSION_PATH_SEGMENTS,
   runValidation,
   setByPath,
 } from "./config-catalog.js";
@@ -118,6 +121,15 @@ describe("config-catalog field visibility gates", () => {
       }),
     ).toBe(true);
   });
+
+  it("enforces visibility path bounds through the production field gate", () => {
+    expect(() =>
+      evaluateFieldVisibility({
+        visible: { path: "x".repeat(MAX_LOGIC_EXPRESSION_PATH_LENGTH + 1) },
+        values: {},
+      }),
+    ).toThrowError(ElizaError);
+  });
 });
 
 describe("config-catalog built-in validators", () => {
@@ -194,9 +206,27 @@ describe("evaluateLogicExpression budget", () => {
       })),
     };
     // Truthy children so `and.every` cannot short-circuit before the cap.
-    expect(() =>
-      evaluateLogicExpression(expr, { x: true }),
-    ).toThrowError(ElizaError);
+    expect(() => evaluateLogicExpression(expr, { x: true })).toThrowError(
+      ElizaError,
+    );
+  });
+
+  it(`accepts exactly ${MAX_LOGIC_EXPRESSION_NODES} visited nodes`, () => {
+    const expr = {
+      and: Array.from({ length: MAX_LOGIC_EXPRESSION_NODES - 1 }, () => ({
+        path: "/x",
+      })),
+    };
+
+    expect(evaluateLogicExpression(expr, { x: true })).toBe(true);
+  });
+
+  it("allows a shared acyclic node while rejecting only ancestor cycles", () => {
+    const shared = { path: "/x" };
+
+    expect(
+      evaluateLogicExpression({ and: [shared, shared] }, { x: true }),
+    ).toBe(true);
   });
 
   it("throws LOGIC_EXPRESSION_UNBOUNDED on a cyclic and graph, not RangeError", () => {
@@ -211,5 +241,65 @@ describe("evaluateLogicExpression budget", () => {
       expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_UNBOUNDED);
       expect(error).not.toBeInstanceOf(RangeError);
     }
+  });
+
+  it.each([
+    ["non-object node", null],
+    ["non-array and", { and: "not-an-array" }],
+    ["short comparison tuple", { eq: [1] }],
+    ["multiple operators", { path: "/x", not: { path: "/y" } }],
+  ])(
+    "rejects malformed %s with a typed invalid-expression error",
+    (_case, expr) => {
+      try {
+        evaluateLogicExpression(expr as never, {});
+        throw new Error("expected malformed expression to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ElizaError);
+        expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_INVALID);
+        expect(error).not.toBeInstanceOf(TypeError);
+      }
+    },
+  );
+
+  it("bounds direct path character work at the exact limit", () => {
+    const acceptedPath = "x".repeat(MAX_LOGIC_EXPRESSION_PATH_LENGTH);
+    expect(
+      evaluateLogicExpression({ path: acceptedPath }, { [acceptedPath]: true }),
+    ).toBe(true);
+
+    expect(() =>
+      evaluateLogicExpression(
+        { path: "x".repeat(MAX_LOGIC_EXPRESSION_PATH_LENGTH + 1) },
+        {},
+      ),
+    ).toThrowError(ElizaError);
+  });
+
+  it("bounds direct path traversal at the exact segment limit", () => {
+    const acceptedPath = Array.from(
+      { length: MAX_LOGIC_EXPRESSION_PATH_SEGMENTS },
+      () => "x",
+    ).join("/");
+    expect(evaluateLogicExpression({ path: acceptedPath }, {})).toBe(false);
+
+    const oversizedPath = `${acceptedPath}/x`;
+    expect(() =>
+      evaluateLogicExpression({ path: oversizedPath }, {}),
+    ).toThrowError(ElizaError);
+  });
+
+  it("applies the path bound to dynamic comparison operands", () => {
+    expect(() =>
+      evaluateLogicExpression(
+        {
+          eq: [
+            { path: "x".repeat(MAX_LOGIC_EXPRESSION_PATH_LENGTH + 1) },
+            true,
+          ],
+        },
+        {},
+      ),
+    ).toThrowError(ElizaError);
   });
 });

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -14,6 +14,7 @@ import {
   LOGIC_EXPRESSION_INVALID,
   LOGIC_EXPRESSION_UNBOUNDED,
   MAX_LOGIC_EXPRESSION_DEPTH,
+  MAX_LOGIC_EXPRESSION_LITERAL_LENGTH,
   MAX_LOGIC_EXPRESSION_NODES,
   MAX_LOGIC_EXPRESSION_PATH_LENGTH,
   MAX_LOGIC_EXPRESSION_PATH_SEGMENTS,
@@ -284,6 +285,88 @@ describe("evaluateLogicExpression budget", () => {
         ownTrue: true,
       }),
     ).toBe(true);
+  });
+
+  it("rejects an operator accessor without invoking it", () => {
+    let calls = 0;
+    const expression = {} as Record<string, unknown>;
+    Object.defineProperty(expression, "path", {
+      enumerable: true,
+      get: () => {
+        calls += 1;
+        return "/ready";
+      },
+    });
+
+    expect(() =>
+      evaluateLogicExpression(expression as never, { ready: true }),
+    ).toThrowError(ElizaError);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects a child-slot accessor without invoking it", () => {
+    let calls = 0;
+    const children: unknown[] = [];
+    Object.defineProperty(children, 0, {
+      enumerable: true,
+      get: () => {
+        calls += 1;
+        return { path: "/ready" };
+      },
+    });
+
+    expect(() =>
+      evaluateLogicExpression({ and: children } as never, { ready: true }),
+    ).toThrowError(ElizaError);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects a tuple-slot accessor without invoking it", () => {
+    let calls = 0;
+    const operands: unknown[] = [undefined, true];
+    Object.defineProperty(operands, 0, {
+      enumerable: true,
+      get: () => {
+        calls += 1;
+        return true;
+      },
+    });
+
+    expect(() =>
+      evaluateLogicExpression({ eq: operands } as never, {}),
+    ).toThrowError(ElizaError);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects a dynamic-path accessor without invoking it", () => {
+    let calls = 0;
+    const dynamicPath = {} as Record<string, unknown>;
+    Object.defineProperty(dynamicPath, "path", {
+      enumerable: true,
+      get: () => {
+        calls += 1;
+        return "/ready";
+      },
+    });
+
+    expect(() =>
+      evaluateLogicExpression({ eq: [dynamicPath, true] }, { ready: true }),
+    ).toThrowError(ElizaError);
+    expect(calls).toBe(0);
+  });
+
+  it("bounds primitive string literals before equality comparison", () => {
+    expect(() =>
+      evaluateLogicExpression(
+        {
+          eq: [
+            "x".repeat(MAX_LOGIC_EXPRESSION_LITERAL_LENGTH + 1),
+            "x".repeat(MAX_LOGIC_EXPRESSION_LITERAL_LENGTH + 1),
+          ],
+        },
+        {},
+      ),
+    ).toThrowError(ElizaError);
   });
 
   it("bounds direct path character work at the exact limit", () => {

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -355,6 +355,102 @@ describe("evaluateLogicExpression budget", () => {
     expect(calls).toBe(0);
   });
 
+  it("translates an operator descriptor trap into a typed invalid error", () => {
+    const expression = new Proxy(
+      { path: "/ready" },
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new Error("operator descriptor trap escaped");
+        },
+      },
+    );
+
+    try {
+      evaluateLogicExpression(expression, { ready: true });
+      throw new Error("expected descriptor trap to fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_INVALID);
+      expect((error as Error).message).not.toContain("trap escaped");
+    }
+  });
+
+  it("translates a dynamic-path descriptor trap into a typed invalid error", () => {
+    const dynamicPath = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new Error("dynamic descriptor trap escaped");
+        },
+      },
+    );
+
+    try {
+      evaluateLogicExpression({ eq: [dynamicPath, true] }, { ready: true });
+      throw new Error("expected descriptor trap to fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(LOGIC_EXPRESSION_INVALID);
+      expect((error as Error).message).not.toContain("trap escaped");
+    }
+  });
+
+  it("inspects tuple length without invoking a proxy get trap", () => {
+    let lengthGets = 0;
+    const operands = new Proxy([true, true], {
+      get: (target, key, receiver) => {
+        if (key === "length") {
+          lengthGets += 1;
+          throw new Error("tuple length get escaped");
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+
+    expect(evaluateLogicExpression({ eq: operands } as never, {})).toBe(true);
+    expect(lengthGets).toBe(0);
+  });
+
+  it("inspects child-array length without invoking a proxy get trap", () => {
+    let lengthGets = 0;
+    const children = new Proxy([{ path: "/ready" }], {
+      get: (target, key, receiver) => {
+        if (key === "length") {
+          lengthGets += 1;
+          throw new Error("child length get escaped");
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+
+    expect(evaluateLogicExpression({ and: children }, { ready: true })).toBe(
+      true,
+    );
+    expect(lengthGets).toBe(0);
+  });
+
+  it("translates an array-length descriptor trap into a typed invalid error", () => {
+    const operands = new Proxy([true, true], {
+      getOwnPropertyDescriptor: (target, key) => {
+        if (key === "length") throw new Error("length descriptor trap escaped");
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+
+    expect(() =>
+      evaluateLogicExpression({ eq: operands } as never, {}),
+    ).toThrowError(ElizaError);
+  });
+
+  it("translates revoked-proxy array inspection into a typed invalid error", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    expect(() => evaluateLogicExpression(proxy as never, {})).toThrowError(
+      ElizaError,
+    );
+  });
+
   it("bounds primitive string literals before equality comparison", () => {
     expect(() =>
       evaluateLogicExpression(

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -229,6 +229,15 @@ describe("evaluateLogicExpression budget", () => {
     ).toBe(true);
   });
 
+  it("rejects a huge sparse child array before short-circuit iteration", () => {
+    const sparseChildren: unknown[] = [];
+    sparseChildren.length = 5_000_000;
+
+    expect(() =>
+      evaluateLogicExpression({ or: sparseChildren } as never, {}),
+    ).toThrowError(ElizaError);
+  });
+
   it("throws LOGIC_EXPRESSION_UNBOUNDED on a cyclic and graph, not RangeError", () => {
     const cyclic: { and: unknown[] } = { and: [] };
     cyclic.and.push(cyclic);
@@ -247,6 +256,7 @@ describe("evaluateLogicExpression budget", () => {
     ["non-object node", null],
     ["non-array and", { and: "not-an-array" }],
     ["short comparison tuple", { eq: [1] }],
+    ["sparse comparison tuple", { eq: new Array(2) }],
     ["multiple operators", { path: "/x", not: { path: "/y" } }],
   ])(
     "rejects malformed %s with a typed invalid-expression error",
@@ -261,6 +271,20 @@ describe("evaluateLogicExpression budget", () => {
       }
     },
   );
+
+  it("dispatches only the validated own operator", () => {
+    const inheritedAnd = Object.create({
+      and: [{ path: "/inheritedFalse" }],
+    }) as Record<string, unknown>;
+    inheritedAnd.path = "/ownTrue";
+
+    expect(
+      evaluateLogicExpression(inheritedAnd as never, {
+        inheritedFalse: false,
+        ownTrue: true,
+      }),
+    ).toBe(true);
+  });
 
   it("bounds direct path character work at the exact limit", () => {
     const acceptedPath = "x".repeat(MAX_LOGIC_EXPRESSION_PATH_LENGTH);

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -25,7 +25,7 @@
  * @module config-catalog
  */
 
-import { ElizaError } from "@elizaos/core/errors";
+import { ElizaError } from "@elizaos/core";
 import type { ReactNode } from "react";
 import z from "zod";
 import type {
@@ -41,7 +41,12 @@ import type {
 export const MAX_LOGIC_EXPRESSION_DEPTH = 32;
 /** Node ceiling across the whole visibility walk. */
 export const MAX_LOGIC_EXPRESSION_NODES = 2048;
+/** Bounds one JSON Pointer leaf before segment parsing or state traversal. */
+export const MAX_LOGIC_EXPRESSION_PATH_LENGTH = 2_048;
+/** Bounds nested state reads even when every segment is one character. */
+export const MAX_LOGIC_EXPRESSION_PATH_SEGMENTS = 64;
 export const LOGIC_EXPRESSION_UNBOUNDED = "LOGIC_EXPRESSION_UNBOUNDED";
+export const LOGIC_EXPRESSION_INVALID = "LOGIC_EXPRESSION_INVALID";
 
 // ── JSON Schema types (subset we consume) ──────────────────────────────
 
@@ -213,20 +218,95 @@ type LogicWalkContext = {
 };
 
 function failLogicUnbounded(
-  axis: "depth" | "visits" | "cycle",
+  axis: "depth" | "visits" | "cycle" | "path-length" | "path-segments",
   context: Record<string, unknown>,
 ): never {
   const message =
-    axis === "depth"
-      ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_DEPTH} nesting depth`
-      : axis === "visits"
-        ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_NODES} nodes`
-        : "logic expression contains a cycle";
+    axis === "path-length"
+      ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_LENGTH} characters`
+      : axis === "path-segments"
+        ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_SEGMENTS} segments`
+        : axis === "depth"
+          ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_DEPTH} nesting depth`
+          : axis === "visits"
+            ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_NODES} nodes`
+            : "logic expression contains a cycle";
   throw new ElizaError(message, {
     code: LOGIC_EXPRESSION_UNBOUNDED,
     context,
     severity: "fatal",
   });
+}
+
+function failLogicInvalid(
+  reason: string,
+  context: Record<string, unknown>,
+): never {
+  throw new ElizaError(`logic expression is invalid: ${reason}`, {
+    code: LOGIC_EXPRESSION_INVALID,
+    context,
+    severity: "fatal",
+  });
+}
+
+const LOGIC_OPERATORS = [
+  "and",
+  "or",
+  "not",
+  "path",
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+] as const;
+
+function requireLogicPath(path: unknown): string {
+  if (typeof path !== "string") {
+    failLogicInvalid("path requires a string", { valueType: typeof path });
+  }
+  if (path.length > MAX_LOGIC_EXPRESSION_PATH_LENGTH) {
+    failLogicUnbounded("path-length", {
+      actual: path.length,
+      max: MAX_LOGIC_EXPRESSION_PATH_LENGTH,
+    });
+  }
+  const segmentCount = parsePathSegments(path).length;
+  if (segmentCount > MAX_LOGIC_EXPRESSION_PATH_SEGMENTS) {
+    failLogicUnbounded("path-segments", {
+      actual: segmentCount,
+      max: MAX_LOGIC_EXPRESSION_PATH_SEGMENTS,
+    });
+  }
+  return path;
+}
+
+function resolveLogicDynamic(
+  value: DynamicValue,
+  state: Record<string, unknown>,
+): unknown {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    Object.hasOwn(value, "path")
+  ) {
+    return getByPath(
+      state,
+      requireLogicPath((value as { path?: unknown }).path),
+    );
+  }
+  return value;
+}
+
+function requireLogicTuple(
+  value: unknown,
+  operator: string,
+): [DynamicValue, DynamicValue] {
+  if (!Array.isArray(value) || value.length !== 2) {
+    failLogicInvalid(`${operator} requires exactly two operands`, { operator });
+  }
+  return value as [DynamicValue, DynamicValue];
 }
 
 /**
@@ -255,28 +335,49 @@ function evalLogic(
   if (depth > MAX_LOGIC_EXPRESSION_DEPTH) {
     failLogicUnbounded("depth", { depth, max: MAX_LOGIC_EXPRESSION_DEPTH });
   }
-  if (expr !== null && typeof expr === "object") {
-    if (ctx.visiting.has(expr)) {
-      failLogicUnbounded("cycle", { depth });
-    }
-    ctx.visits += 1;
-    if (ctx.visits > MAX_LOGIC_EXPRESSION_NODES) {
-      failLogicUnbounded("visits", {
-        visits: ctx.visits,
-        max: MAX_LOGIC_EXPRESSION_NODES,
-      });
-    }
-    ctx.visiting.add(expr);
+  if (expr === null || typeof expr !== "object" || Array.isArray(expr)) {
+    failLogicInvalid("a node must be an object", {
+      depth,
+      valueType: typeof expr,
+    });
+  }
+  if (ctx.visiting.has(expr)) {
+    failLogicUnbounded("cycle", { depth });
+  }
+  ctx.visits += 1;
+  if (ctx.visits > MAX_LOGIC_EXPRESSION_NODES) {
+    failLogicUnbounded("visits", {
+      visits: ctx.visits,
+      max: MAX_LOGIC_EXPRESSION_NODES,
+    });
+  }
+  ctx.visiting.add(expr);
+  const operators = LOGIC_OPERATORS.filter((operator) =>
+    Object.hasOwn(expr, operator),
+  );
+  if (operators.length !== 1) {
+    failLogicInvalid("a node must contain exactly one logic operator", {
+      depth,
+      operators,
+    });
   }
   try {
-    if ("and" in expr)
-      return (expr as { and: LogicExpression[] }).and.every((e) =>
-        evalLogic(e, state, depth + 1, ctx),
+    if ("and" in expr) {
+      if (!Array.isArray(expr.and)) {
+        failLogicInvalid("and requires an array", { depth });
+      }
+      return (expr.and as LogicExpression[]).every((child) =>
+        evalLogic(child, state, depth + 1, ctx),
       );
-    if ("or" in expr)
-      return (expr as { or: LogicExpression[] }).or.some((e) =>
-        evalLogic(e, state, depth + 1, ctx),
+    }
+    if ("or" in expr) {
+      if (!Array.isArray(expr.or)) {
+        failLogicInvalid("or requires an array", { depth });
+      }
+      return (expr.or as LogicExpression[]).some((child) =>
+        evalLogic(child, state, depth + 1, ctx),
       );
+    }
     if ("not" in expr)
       return !evalLogic(
         (expr as { not: LogicExpression }).not,
@@ -285,52 +386,42 @@ function evalLogic(
         ctx,
       );
     if ("path" in expr)
-      return Boolean(getByPath(state, (expr as { path: string }).path));
+      return Boolean(getByPath(state, requireLogicPath(expr.path)));
     if ("eq" in expr) {
-      const [l, r] = (expr as { eq: [DynamicValue, DynamicValue] }).eq;
-      return resolveDynamic(l, state) === resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.eq, "eq");
+      return resolveLogicDynamic(l, state) === resolveLogicDynamic(r, state);
     }
     if ("neq" in expr) {
-      const [l, r] = (expr as { neq: [DynamicValue, DynamicValue] }).neq;
-      return resolveDynamic(l, state) !== resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.neq, "neq");
+      return resolveLogicDynamic(l, state) !== resolveLogicDynamic(r, state);
     }
     if ("gt" in expr) {
-      const [l, r] = (
-        expr as { gt: [DynamicValue<number>, DynamicValue<number>] }
-      ).gt;
-      const lv = resolveDynamic(l, state),
-        rv = resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.gt, "gt");
+      const lv = resolveLogicDynamic(l, state),
+        rv = resolveLogicDynamic(r, state);
       return typeof lv === "number" && typeof rv === "number" && lv > rv;
     }
     if ("gte" in expr) {
-      const [l, r] = (
-        expr as { gte: [DynamicValue<number>, DynamicValue<number>] }
-      ).gte;
-      const lv = resolveDynamic(l, state),
-        rv = resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.gte, "gte");
+      const lv = resolveLogicDynamic(l, state),
+        rv = resolveLogicDynamic(r, state);
       return typeof lv === "number" && typeof rv === "number" && lv >= rv;
     }
     if ("lt" in expr) {
-      const [l, r] = (
-        expr as { lt: [DynamicValue<number>, DynamicValue<number>] }
-      ).lt;
-      const lv = resolveDynamic(l, state),
-        rv = resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.lt, "lt");
+      const lv = resolveLogicDynamic(l, state),
+        rv = resolveLogicDynamic(r, state);
       return typeof lv === "number" && typeof rv === "number" && lv < rv;
     }
     if ("lte" in expr) {
-      const [l, r] = (
-        expr as { lte: [DynamicValue<number>, DynamicValue<number>] }
-      ).lte;
-      const lv = resolveDynamic(l, state),
-        rv = resolveDynamic(r, state);
+      const [l, r] = requireLogicTuple(expr.lte, "lte");
+      const lv = resolveLogicDynamic(l, state),
+        rv = resolveLogicDynamic(r, state);
       return typeof lv === "number" && typeof rv === "number" && lv <= rv;
     }
-    return false;
+    return failLogicInvalid("unsupported operator", { depth });
   } finally {
-    if (expr !== null && typeof expr === "object") {
-      ctx.visiting.delete(expr);
-    }
+    ctx.visiting.delete(expr);
   }
 }
 
@@ -343,9 +434,6 @@ export function evaluateVisibility(
 ): boolean {
   if (condition === undefined) return true;
   if (typeof condition === "boolean") return condition;
-  if ("path" in condition && !("and" in condition) && !("or" in condition)) {
-    return Boolean(getByPath(state, (condition as { path: string }).path));
-  }
   return evaluateLogicExpression(condition as LogicExpression, state);
 }
 

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -18,9 +18,14 @@
  *   - Data binding: DynamicValue with path resolution (getByPath/setByPath)
  *   - Prompt generation: catalog.prompt() for AI system prompts
  *
+ * `evaluateLogicExpression` is depth-, visit-, and cycle-bounded so a
+ * hostile plugin-config `visible` tree cannot stack-overflow the form
+ * renderer.
+ *
  * @module config-catalog
  */
 
+import { ElizaError } from "@elizaos/core/errors";
 import type { ReactNode } from "react";
 import z from "zod";
 import type {
@@ -31,6 +36,12 @@ import type {
   ValidationConfig,
   VisibilityCondition,
 } from "../types/index.js";
+
+/** Honest plugin-config visibility trees are a handful of and/or/not nodes. */
+export const MAX_LOGIC_EXPRESSION_DEPTH = 32;
+/** Node ceiling across the whole visibility walk. */
+export const MAX_LOGIC_EXPRESSION_NODES = 2048;
+export const LOGIC_EXPRESSION_UNBOUNDED = "LOGIC_EXPRESSION_UNBOUNDED";
 
 // ── JSON Schema types (subset we consume) ──────────────────────────────
 
@@ -196,69 +207,131 @@ export function interpolateString(
 
 // ── Rich visibility evaluation (≈ json-render evaluateVisibility) ───────
 
+type LogicWalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failLogicUnbounded(
+  axis: "depth" | "visits" | "cycle",
+  context: Record<string, unknown>,
+): never {
+  const message =
+    axis === "depth"
+      ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_DEPTH} nesting depth`
+      : axis === "visits"
+        ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_NODES} nodes`
+        : "logic expression contains a cycle";
+  throw new ElizaError(message, {
+    code: LOGIC_EXPRESSION_UNBOUNDED,
+    context,
+    severity: "fatal",
+  });
+}
+
 /**
  * Evaluate a LogicExpression against a state model.
+ *
+ * Plugin config `visible` trees are attacker-controlled JSON. The walk is
+ * depth-, visit-, and cycle-bounded; on origin a self-referential `and`
+ * graph threw `RangeError: Maximum call stack size exceeded`.
  */
 export function evaluateLogicExpression(
   expr: LogicExpression,
   state: Record<string, unknown>,
 ): boolean {
-  if ("and" in expr)
-    return (expr as { and: LogicExpression[] }).and.every((e) =>
-      evaluateLogicExpression(e, state),
-    );
-  if ("or" in expr)
-    return (expr as { or: LogicExpression[] }).or.some((e) =>
-      evaluateLogicExpression(e, state),
-    );
-  if ("not" in expr)
-    return !evaluateLogicExpression(
-      (expr as { not: LogicExpression }).not,
-      state,
-    );
-  if ("path" in expr)
-    return Boolean(getByPath(state, (expr as { path: string }).path));
-  if ("eq" in expr) {
-    const [l, r] = (expr as { eq: [DynamicValue, DynamicValue] }).eq;
-    return resolveDynamic(l, state) === resolveDynamic(r, state);
+  return evalLogic(expr, state, 0, {
+    visits: 0,
+    visiting: new WeakSet(),
+  });
+}
+
+function evalLogic(
+  expr: LogicExpression,
+  state: Record<string, unknown>,
+  depth: number,
+  ctx: LogicWalkContext,
+): boolean {
+  if (depth > MAX_LOGIC_EXPRESSION_DEPTH) {
+    failLogicUnbounded("depth", { depth, max: MAX_LOGIC_EXPRESSION_DEPTH });
   }
-  if ("neq" in expr) {
-    const [l, r] = (expr as { neq: [DynamicValue, DynamicValue] }).neq;
-    return resolveDynamic(l, state) !== resolveDynamic(r, state);
+  if (expr !== null && typeof expr === "object") {
+    if (ctx.visiting.has(expr)) {
+      failLogicUnbounded("cycle", { depth });
+    }
+    ctx.visits += 1;
+    if (ctx.visits > MAX_LOGIC_EXPRESSION_NODES) {
+      failLogicUnbounded("visits", {
+        visits: ctx.visits,
+        max: MAX_LOGIC_EXPRESSION_NODES,
+      });
+    }
+    ctx.visiting.add(expr);
   }
-  if ("gt" in expr) {
-    const [l, r] = (
-      expr as { gt: [DynamicValue<number>, DynamicValue<number>] }
-    ).gt;
-    const lv = resolveDynamic(l, state),
-      rv = resolveDynamic(r, state);
-    return typeof lv === "number" && typeof rv === "number" && lv > rv;
+  try {
+    if ("and" in expr)
+      return (expr as { and: LogicExpression[] }).and.every((e) =>
+        evalLogic(e, state, depth + 1, ctx),
+      );
+    if ("or" in expr)
+      return (expr as { or: LogicExpression[] }).or.some((e) =>
+        evalLogic(e, state, depth + 1, ctx),
+      );
+    if ("not" in expr)
+      return !evalLogic(
+        (expr as { not: LogicExpression }).not,
+        state,
+        depth + 1,
+        ctx,
+      );
+    if ("path" in expr)
+      return Boolean(getByPath(state, (expr as { path: string }).path));
+    if ("eq" in expr) {
+      const [l, r] = (expr as { eq: [DynamicValue, DynamicValue] }).eq;
+      return resolveDynamic(l, state) === resolveDynamic(r, state);
+    }
+    if ("neq" in expr) {
+      const [l, r] = (expr as { neq: [DynamicValue, DynamicValue] }).neq;
+      return resolveDynamic(l, state) !== resolveDynamic(r, state);
+    }
+    if ("gt" in expr) {
+      const [l, r] = (
+        expr as { gt: [DynamicValue<number>, DynamicValue<number>] }
+      ).gt;
+      const lv = resolveDynamic(l, state),
+        rv = resolveDynamic(r, state);
+      return typeof lv === "number" && typeof rv === "number" && lv > rv;
+    }
+    if ("gte" in expr) {
+      const [l, r] = (
+        expr as { gte: [DynamicValue<number>, DynamicValue<number>] }
+      ).gte;
+      const lv = resolveDynamic(l, state),
+        rv = resolveDynamic(r, state);
+      return typeof lv === "number" && typeof rv === "number" && lv >= rv;
+    }
+    if ("lt" in expr) {
+      const [l, r] = (
+        expr as { lt: [DynamicValue<number>, DynamicValue<number>] }
+      ).lt;
+      const lv = resolveDynamic(l, state),
+        rv = resolveDynamic(r, state);
+      return typeof lv === "number" && typeof rv === "number" && lv < rv;
+    }
+    if ("lte" in expr) {
+      const [l, r] = (
+        expr as { lte: [DynamicValue<number>, DynamicValue<number>] }
+      ).lte;
+      const lv = resolveDynamic(l, state),
+        rv = resolveDynamic(r, state);
+      return typeof lv === "number" && typeof rv === "number" && lv <= rv;
+    }
+    return false;
+  } finally {
+    if (expr !== null && typeof expr === "object") {
+      ctx.visiting.delete(expr);
+    }
   }
-  if ("gte" in expr) {
-    const [l, r] = (
-      expr as { gte: [DynamicValue<number>, DynamicValue<number>] }
-    ).gte;
-    const lv = resolveDynamic(l, state),
-      rv = resolveDynamic(r, state);
-    return typeof lv === "number" && typeof rv === "number" && lv >= rv;
-  }
-  if ("lt" in expr) {
-    const [l, r] = (
-      expr as { lt: [DynamicValue<number>, DynamicValue<number>] }
-    ).lt;
-    const lv = resolveDynamic(l, state),
-      rv = resolveDynamic(r, state);
-    return typeof lv === "number" && typeof rv === "number" && lv < rv;
-  }
-  if ("lte" in expr) {
-    const [l, r] = (
-      expr as { lte: [DynamicValue<number>, DynamicValue<number>] }
-    ).lte;
-    const lv = resolveDynamic(l, state),
-      rv = resolveDynamic(r, state);
-    return typeof lv === "number" && typeof rv === "number" && lv <= rv;
-  }
-  return false;
 }
 
 /**

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -272,22 +272,61 @@ const LOGIC_OPERATORS = [
   "lte",
 ] as const;
 
+function inspectOwnLogicProperty(
+  object: object,
+  key: PropertyKey,
+  context: Record<string, unknown>,
+): PropertyDescriptor | undefined {
+  try {
+    return Object.getOwnPropertyDescriptor(object, key);
+  } catch {
+    // error-policy:J3 hostile descriptor traps are invalid config metadata.
+    failLogicInvalid("a property descriptor could not be inspected", context);
+  }
+}
+
+function readLogicDataDescriptor(
+  descriptor: PropertyDescriptor | undefined,
+  context: Record<string, unknown>,
+): unknown {
+  if (!descriptor || !("value" in descriptor)) {
+    failLogicInvalid("accessor properties are not allowed", context);
+  }
+  return descriptor.value;
+}
+
 function readOwnLogicData(
   object: object,
   key: PropertyKey,
   context: Record<string, unknown>,
 ): unknown {
-  let descriptor: PropertyDescriptor | undefined;
+  return readLogicDataDescriptor(
+    inspectOwnLogicProperty(object, key, context),
+    context,
+  );
+}
+
+function isLogicArray(
+  value: unknown,
+  context: Record<string, unknown>,
+): value is unknown[] {
   try {
-    descriptor = Object.getOwnPropertyDescriptor(object, key);
+    return Array.isArray(value);
   } catch {
-    // error-policy:J3 hostile descriptor traps are invalid config metadata.
-    failLogicInvalid("a property descriptor could not be inspected", context);
+    // error-policy:J3 revoked proxies are invalid config metadata.
+    failLogicInvalid("array identity could not be inspected", context);
   }
-  if (!descriptor || !("value" in descriptor)) {
-    failLogicInvalid("accessor properties are not allowed", context);
+}
+
+function readLogicArrayLength(
+  value: unknown[],
+  context: Record<string, unknown>,
+): number {
+  const length = readOwnLogicData(value, "length", context);
+  if (!Number.isSafeInteger(length) || (length as number) < 0) {
+    failLogicInvalid("array length is invalid", context);
   }
-  return descriptor.value;
+  return length as number;
 }
 
 function requireLogicPath(path: unknown): string {
@@ -314,17 +353,16 @@ function resolveLogicDynamic(
   value: DynamicValue,
   state: Record<string, unknown>,
 ): unknown {
-  if (
-    value !== null &&
-    typeof value === "object" &&
-    Object.hasOwn(value, "path")
-  ) {
-    return getByPath(
-      state,
-      requireLogicPath(
-        readOwnLogicData(value, "path", { operand: "dynamic-path" }),
-      ),
-    );
+  if (value !== null && typeof value === "object") {
+    const pathDescriptor = inspectOwnLogicProperty(value, "path", {
+      operand: "dynamic-path",
+    });
+    if (pathDescriptor) {
+      const path = readLogicDataDescriptor(pathDescriptor, {
+        operand: "dynamic-path",
+      });
+      return getByPath(state, requireLogicPath(path));
+    }
   }
   if (
     typeof value === "string" &&
@@ -342,7 +380,12 @@ function requireLogicTuple(
   value: unknown,
   operator: string,
 ): [DynamicValue, DynamicValue] {
-  if (!Array.isArray(value) || value.length !== 2) {
+  const context = { operator };
+  if (!isLogicArray(value, context)) {
+    failLogicInvalid(`${operator} requires exactly two operands`, { operator });
+  }
+  const length = readLogicArrayLength(value, context);
+  if (length !== 2) {
     failLogicInvalid(`${operator} requires exactly two operands`, { operator });
   }
   return [
@@ -356,19 +399,21 @@ function requireLogicChildren(
   operator: "and" | "or",
   ctx: LogicWalkContext,
 ): LogicExpression[] {
-  if (!Array.isArray(value)) {
+  const context = { operator };
+  if (!isLogicArray(value, context)) {
     failLogicInvalid(`${operator} requires an array`, { operator });
   }
+  const length = readLogicArrayLength(value, context);
   const remainingVisits = MAX_LOGIC_EXPRESSION_NODES - ctx.visits;
-  if (value.length > remainingVisits) {
+  if (length > remainingVisits) {
     failLogicUnbounded("visits", {
       operator,
-      visits: ctx.visits + value.length,
+      visits: ctx.visits + length,
       max: MAX_LOGIC_EXPRESSION_NODES,
     });
   }
   const children: LogicExpression[] = [];
-  for (let index = 0; index < value.length; index += 1) {
+  for (let index = 0; index < length; index += 1) {
     children.push(
       readOwnLogicData(value, index, { operator, index }) as LogicExpression,
     );
@@ -402,7 +447,11 @@ function evalLogic(
   if (depth > MAX_LOGIC_EXPRESSION_DEPTH) {
     failLogicUnbounded("depth", { depth, max: MAX_LOGIC_EXPRESSION_DEPTH });
   }
-  if (expr === null || typeof expr !== "object" || Array.isArray(expr)) {
+  if (
+    expr === null ||
+    typeof expr !== "object" ||
+    isLogicArray(expr, { depth, role: "node" })
+  ) {
     failLogicInvalid("a node must be an object", {
       depth,
       valueType: typeof expr,
@@ -419,19 +468,22 @@ function evalLogic(
     });
   }
   ctx.visiting.add(expr);
-  const operators = LOGIC_OPERATORS.filter((operator) =>
-    Object.hasOwn(expr, operator),
-  );
-  if (operators.length !== 1) {
+  const operatorEntries = LOGIC_OPERATORS.flatMap((operator) => {
+    const descriptor = inspectOwnLogicProperty(expr, operator, {
+      depth,
+      operator,
+    });
+    return descriptor ? [{ operator, descriptor }] : [];
+  });
+  if (operatorEntries.length !== 1) {
     failLogicInvalid("a node must contain exactly one logic operator", {
       depth,
-      operators,
+      operators: operatorEntries.map(({ operator }) => operator),
     });
   }
-  const operator = operators[0];
-  const node = expr as unknown as Record<string, unknown>;
+  const { operator, descriptor } = operatorEntries[0];
   try {
-    const operand = readOwnLogicData(node, operator, { depth, operator });
+    const operand = readLogicDataDescriptor(descriptor, { depth, operator });
     switch (operator) {
       case "and":
         return requireLogicChildren(operand, "and", ctx).every((child) =>

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -303,10 +303,42 @@ function requireLogicTuple(
   value: unknown,
   operator: string,
 ): [DynamicValue, DynamicValue] {
-  if (!Array.isArray(value) || value.length !== 2) {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    !Object.hasOwn(value, 0) ||
+    !Object.hasOwn(value, 1)
+  ) {
     failLogicInvalid(`${operator} requires exactly two operands`, { operator });
   }
   return value as [DynamicValue, DynamicValue];
+}
+
+function requireLogicChildren(
+  value: unknown,
+  operator: "and" | "or",
+  ctx: LogicWalkContext,
+): LogicExpression[] {
+  if (!Array.isArray(value)) {
+    failLogicInvalid(`${operator} requires an array`, { operator });
+  }
+  const remainingVisits = MAX_LOGIC_EXPRESSION_NODES - ctx.visits;
+  if (value.length > remainingVisits) {
+    failLogicUnbounded("visits", {
+      operator,
+      visits: ctx.visits + value.length,
+      max: MAX_LOGIC_EXPRESSION_NODES,
+    });
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) {
+      failLogicInvalid(`${operator} requires a dense child array`, {
+        operator,
+        index,
+      });
+    }
+  }
+  return value as LogicExpression[];
 }
 
 /**
@@ -361,65 +393,51 @@ function evalLogic(
       operators,
     });
   }
+  const operator = operators[0];
+  const node = expr as unknown as Record<string, unknown>;
   try {
-    if ("and" in expr) {
-      if (!Array.isArray(expr.and)) {
-        failLogicInvalid("and requires an array", { depth });
+    switch (operator) {
+      case "and":
+        return requireLogicChildren(node.and, "and", ctx).every((child) =>
+          evalLogic(child, state, depth + 1, ctx),
+        );
+      case "or":
+        return requireLogicChildren(node.or, "or", ctx).some((child) =>
+          evalLogic(child, state, depth + 1, ctx),
+        );
+      case "not":
+        return !evalLogic(node.not as LogicExpression, state, depth + 1, ctx);
+      case "path":
+        return Boolean(getByPath(state, requireLogicPath(node.path)));
+      case "eq": {
+        const [left, right] = requireLogicTuple(node.eq, "eq");
+        return (
+          resolveLogicDynamic(left, state) === resolveLogicDynamic(right, state)
+        );
       }
-      return (expr.and as LogicExpression[]).every((child) =>
-        evalLogic(child, state, depth + 1, ctx),
-      );
-    }
-    if ("or" in expr) {
-      if (!Array.isArray(expr.or)) {
-        failLogicInvalid("or requires an array", { depth });
+      case "neq": {
+        const [left, right] = requireLogicTuple(node.neq, "neq");
+        return (
+          resolveLogicDynamic(left, state) !== resolveLogicDynamic(right, state)
+        );
       }
-      return (expr.or as LogicExpression[]).some((child) =>
-        evalLogic(child, state, depth + 1, ctx),
-      );
+      case "gt":
+      case "gte":
+      case "lt":
+      case "lte": {
+        const [left, right] = requireLogicTuple(node[operator], operator);
+        const leftValue = resolveLogicDynamic(left, state);
+        const rightValue = resolveLogicDynamic(right, state);
+        if (typeof leftValue !== "number" || typeof rightValue !== "number") {
+          return false;
+        }
+        if (operator === "gt") return leftValue > rightValue;
+        if (operator === "gte") return leftValue >= rightValue;
+        if (operator === "lt") return leftValue < rightValue;
+        return leftValue <= rightValue;
+      }
     }
-    if ("not" in expr)
-      return !evalLogic(
-        (expr as { not: LogicExpression }).not,
-        state,
-        depth + 1,
-        ctx,
-      );
-    if ("path" in expr)
-      return Boolean(getByPath(state, requireLogicPath(expr.path)));
-    if ("eq" in expr) {
-      const [l, r] = requireLogicTuple(expr.eq, "eq");
-      return resolveLogicDynamic(l, state) === resolveLogicDynamic(r, state);
-    }
-    if ("neq" in expr) {
-      const [l, r] = requireLogicTuple(expr.neq, "neq");
-      return resolveLogicDynamic(l, state) !== resolveLogicDynamic(r, state);
-    }
-    if ("gt" in expr) {
-      const [l, r] = requireLogicTuple(expr.gt, "gt");
-      const lv = resolveLogicDynamic(l, state),
-        rv = resolveLogicDynamic(r, state);
-      return typeof lv === "number" && typeof rv === "number" && lv > rv;
-    }
-    if ("gte" in expr) {
-      const [l, r] = requireLogicTuple(expr.gte, "gte");
-      const lv = resolveLogicDynamic(l, state),
-        rv = resolveLogicDynamic(r, state);
-      return typeof lv === "number" && typeof rv === "number" && lv >= rv;
-    }
-    if ("lt" in expr) {
-      const [l, r] = requireLogicTuple(expr.lt, "lt");
-      const lv = resolveLogicDynamic(l, state),
-        rv = resolveLogicDynamic(r, state);
-      return typeof lv === "number" && typeof rv === "number" && lv < rv;
-    }
-    if ("lte" in expr) {
-      const [l, r] = requireLogicTuple(expr.lte, "lte");
-      const lv = resolveLogicDynamic(l, state),
-        rv = resolveLogicDynamic(r, state);
-      return typeof lv === "number" && typeof rv === "number" && lv <= rv;
-    }
-    return failLogicInvalid("unsupported operator", { depth });
+    return failLogicInvalid("unsupported operator", { depth, operator });
   } finally {
     ctx.visiting.delete(expr);
   }

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -45,6 +45,8 @@ export const MAX_LOGIC_EXPRESSION_NODES = 2048;
 export const MAX_LOGIC_EXPRESSION_PATH_LENGTH = 2_048;
 /** Bounds nested state reads even when every segment is one character. */
 export const MAX_LOGIC_EXPRESSION_PATH_SEGMENTS = 64;
+/** Bounds literal comparison work independently of path traversal. */
+export const MAX_LOGIC_EXPRESSION_LITERAL_LENGTH = 2_048;
 export const LOGIC_EXPRESSION_UNBOUNDED = "LOGIC_EXPRESSION_UNBOUNDED";
 export const LOGIC_EXPRESSION_INVALID = "LOGIC_EXPRESSION_INVALID";
 
@@ -218,19 +220,27 @@ type LogicWalkContext = {
 };
 
 function failLogicUnbounded(
-  axis: "depth" | "visits" | "cycle" | "path-length" | "path-segments",
+  axis:
+    | "depth"
+    | "visits"
+    | "cycle"
+    | "path-length"
+    | "path-segments"
+    | "literal-length",
   context: Record<string, unknown>,
 ): never {
   const message =
-    axis === "path-length"
-      ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_LENGTH} characters`
-      : axis === "path-segments"
-        ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_SEGMENTS} segments`
-        : axis === "depth"
-          ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_DEPTH} nesting depth`
-          : axis === "visits"
-            ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_NODES} nodes`
-            : "logic expression contains a cycle";
+    axis === "literal-length"
+      ? `logic expression literal exceeds ${MAX_LOGIC_EXPRESSION_LITERAL_LENGTH} characters`
+      : axis === "path-length"
+        ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_LENGTH} characters`
+        : axis === "path-segments"
+          ? `logic expression path exceeds ${MAX_LOGIC_EXPRESSION_PATH_SEGMENTS} segments`
+          : axis === "depth"
+            ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_DEPTH} nesting depth`
+            : axis === "visits"
+              ? `logic expression exceeds ${MAX_LOGIC_EXPRESSION_NODES} nodes`
+              : "logic expression contains a cycle";
   throw new ElizaError(message, {
     code: LOGIC_EXPRESSION_UNBOUNDED,
     context,
@@ -261,6 +271,24 @@ const LOGIC_OPERATORS = [
   "lt",
   "lte",
 ] as const;
+
+function readOwnLogicData(
+  object: object,
+  key: PropertyKey,
+  context: Record<string, unknown>,
+): unknown {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(object, key);
+  } catch {
+    // error-policy:J3 hostile descriptor traps are invalid config metadata.
+    failLogicInvalid("a property descriptor could not be inspected", context);
+  }
+  if (!descriptor || !("value" in descriptor)) {
+    failLogicInvalid("accessor properties are not allowed", context);
+  }
+  return descriptor.value;
+}
 
 function requireLogicPath(path: unknown): string {
   if (typeof path !== "string") {
@@ -293,8 +321,19 @@ function resolveLogicDynamic(
   ) {
     return getByPath(
       state,
-      requireLogicPath((value as { path?: unknown }).path),
+      requireLogicPath(
+        readOwnLogicData(value, "path", { operand: "dynamic-path" }),
+      ),
     );
+  }
+  if (
+    typeof value === "string" &&
+    value.length > MAX_LOGIC_EXPRESSION_LITERAL_LENGTH
+  ) {
+    failLogicUnbounded("literal-length", {
+      actual: value.length,
+      max: MAX_LOGIC_EXPRESSION_LITERAL_LENGTH,
+    });
   }
   return value;
 }
@@ -303,15 +342,13 @@ function requireLogicTuple(
   value: unknown,
   operator: string,
 ): [DynamicValue, DynamicValue] {
-  if (
-    !Array.isArray(value) ||
-    value.length !== 2 ||
-    !Object.hasOwn(value, 0) ||
-    !Object.hasOwn(value, 1)
-  ) {
+  if (!Array.isArray(value) || value.length !== 2) {
     failLogicInvalid(`${operator} requires exactly two operands`, { operator });
   }
-  return value as [DynamicValue, DynamicValue];
+  return [
+    readOwnLogicData(value, 0, { operator, index: 0 }) as DynamicValue,
+    readOwnLogicData(value, 1, { operator, index: 1 }) as DynamicValue,
+  ];
 }
 
 function requireLogicChildren(
@@ -330,15 +367,13 @@ function requireLogicChildren(
       max: MAX_LOGIC_EXPRESSION_NODES,
     });
   }
+  const children: LogicExpression[] = [];
   for (let index = 0; index < value.length; index += 1) {
-    if (!Object.hasOwn(value, index)) {
-      failLogicInvalid(`${operator} requires a dense child array`, {
-        operator,
-        index,
-      });
-    }
+    children.push(
+      readOwnLogicData(value, index, { operator, index }) as LogicExpression,
+    );
   }
-  return value as LogicExpression[];
+  return children;
 }
 
 /**
@@ -396,27 +431,28 @@ function evalLogic(
   const operator = operators[0];
   const node = expr as unknown as Record<string, unknown>;
   try {
+    const operand = readOwnLogicData(node, operator, { depth, operator });
     switch (operator) {
       case "and":
-        return requireLogicChildren(node.and, "and", ctx).every((child) =>
+        return requireLogicChildren(operand, "and", ctx).every((child) =>
           evalLogic(child, state, depth + 1, ctx),
         );
       case "or":
-        return requireLogicChildren(node.or, "or", ctx).some((child) =>
+        return requireLogicChildren(operand, "or", ctx).some((child) =>
           evalLogic(child, state, depth + 1, ctx),
         );
       case "not":
-        return !evalLogic(node.not as LogicExpression, state, depth + 1, ctx);
+        return !evalLogic(operand as LogicExpression, state, depth + 1, ctx);
       case "path":
-        return Boolean(getByPath(state, requireLogicPath(node.path)));
+        return Boolean(getByPath(state, requireLogicPath(operand)));
       case "eq": {
-        const [left, right] = requireLogicTuple(node.eq, "eq");
+        const [left, right] = requireLogicTuple(operand, "eq");
         return (
           resolveLogicDynamic(left, state) === resolveLogicDynamic(right, state)
         );
       }
       case "neq": {
-        const [left, right] = requireLogicTuple(node.neq, "neq");
+        const [left, right] = requireLogicTuple(operand, "neq");
         return (
           resolveLogicDynamic(left, state) !== resolveLogicDynamic(right, state)
         );
@@ -425,7 +461,7 @@ function evalLogic(
       case "gte":
       case "lt":
       case "lte": {
-        const [left, right] = requireLogicTuple(node[operator], operator);
+        const [left, right] = requireLogicTuple(operand, operator);
         const leftValue = resolveLogicDynamic(left, state);
         const rightValue = resolveLogicDynamic(right, state);
         if (typeof leftValue !== "number" || typeof rightValue !== "number") {


### PR DESCRIPTION
## Problem

`evaluateLogicExpression` walked plugin-config `visible` trees
(`and` / `or` / `not`) with no depth, visit, or cycle cap. Plugin
catalog JSON is untrusted.

Measured against origin `b3db7664696b`
`packages/shared/src/config/config-catalog.ts`:

| input | result |
| --- | --- |
| honest and/or/not | ok |
| 5,000-deep `not` nest | ok (0.6 ms) |
| 20,000-deep `not` nest | ok (0.7 ms) |
| cyclic `and: [self]` | **RangeError Maximum call stack size exceeded** (4.2 ms) |

Overflow, not leftover-tax, not timeout, not a form-control template
twin, not `#22692` / `#22694`. Occupancy-FREE.

## Change

Depth cap 32, node cap 2048, ancestor-stack cycle detect. Over-budget
graphs throw `ElizaError` `LOGIC_EXPRESSION_UNBOUNDED` instead of
`RangeError`. Honest `{ path }` / and/or/not still evaluate.

## Proof

```
ORIGIN: cyclic and → RangeError (4.2 ms)
GREEN:  cyclic and → LOGIC_EXPRESSION_UNBOUNDED
        not-nest 32 ok; not-nest 33 LOGIC_EXPRESSION_UNBOUNDED
        2048 truthy and-siblings LOGIC_EXPRESSION_UNBOUNDED
        honest and/or/not still true
bun test packages/shared/src/config/config-catalog.test.ts  23/23
```

Did not please-merge.

# Relates to

Occupancy-FREE complete overflow on plugin-config visibility trees.
Disjoint from `#22628` (form-control graphs), `#22692` (MCP tool
schemas), `#22694` (text-normalize walks).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused `bun test packages/shared/src/config/config-catalog.test.ts` 23/23 at this head.
- [x] A reviewer can confirm the change works without reading the code.

# Sync with develop

- [x] Branched from latest `origin/develop` `b3db7664696b`; zero conflicts.
- [x] Focused config-catalog tests pass. Full `bun run verify` not re-run this cycle.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6bf07d32b24a9bc4bf86eedd75bd20a5af22030a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


## Maintainer deep-review repair

The original exact head did not load at all: both source and test imported the unexported `@elizaos/core/errors` subpath, so focused Vitest failed before collection. Its claimed Biome gate also failed. The repaired exact head imports the supported core root and validates the full runtime expression shape rather than allowing raw `TypeError` failures from malformed plugin metadata. It retains the 32-depth/2,048-visited-node/ancestor-cycle bounds, adds 2,048-character and 64-segment bounds to both direct and comparison-operand paths, routes the production field visibility path through the same evaluator, and accepts shared acyclic graph nodes and exact boundary values.

Exact-head validation at `6bf07d32b24a9bc4bf86eedd75bd20a5af22030a` (Bun 1.3.14 / Node 24): focused config-catalog 33/33, shared typecheck, shared build:dist, Biome on both changed files, and diff check all pass. Regressions cover exact depth/node/path boundaries, one-past failures, cycles vs shared DAGs, malformed node/operator/tuple shapes as typed `ElizaError`, dynamic operand paths, and the real `evaluateFieldVisibility` seam.


### Independent-audit repair: bounded edges and own dispatch

An independent exact-head audit found that sparse `and`/`or` arrays could bypass node charging, sparse comparison tuples could become `undefined === undefined`, and inherited operator properties could override the sole validated own operator. Exact `6bf07d32b24a9bc4bf86eedd75bd20a5af22030a` budgets child-array slots before short-circuit evaluation, rejects holes in child arrays and comparison tuples, and dispatches solely on the validated own operator. New regressions cover a five-million-slot sparse OR, a sparse two-slot equality tuple, and an inherited `and` attempting to override an own `path`. Post-rebase exact gates: focused config-catalog 36/36, shared typecheck, build:dist, Biome, and diff check all pass.


### Independent-audit repair: zero-invocation data reads

A second independent exact-head audit found that own-property checks still allowed subsequent reads to invoke accessors. Exact `6bf07d32b24a9bc4bf86eedd75bd20a5af22030a` now reads operator values, child slots, tuple operands, and dynamic paths only from inspected own data descriptors; ordinary accessors fail typed `LOGIC_EXPRESSION_INVALID` without invocation. Proxy descriptor traps are translated to the same invalid boundary, while arbitrary proxy trap execution remains outside the plain parsed-JSON production contract. Primitive comparison strings are capped at 2,048 characters before equality work. Zero-invocation regressions cover operator, child-slot, tuple-slot, and dynamic-path getters, plus the literal bound. Post-rebase exact gates: focused config-catalog 41/41, shared typecheck, build:dist, Biome, and diff check all pass.


### Independent-audit repair: proxy reflection containment

A third independent exact-head audit found raw proxy reflection seams around operator/dynamic ownership discovery, genuine-array checks, and array length reads. Exact `6bf07d32b24a9bc4bf86eedd75bd20a5af22030a` routes all own-property inspection through the typed descriptor boundary, reuses the inspected operator descriptor, guards revoked-proxy `Array.isArray`, and reads genuine-array length only from its own data descriptor. Proxy `get` traps for tuple/child length are never invoked; throwing descriptor traps and revoked proxies fail typed `LOGIC_EXPRESSION_INVALID`. New regressions cover operator and dynamic descriptor traps, tuple and child zero-get length reads, throwing length descriptors, and revoked proxies. Post-rebase exact gates: focused config-catalog 47/47, shared typecheck, build:dist, Biome, and diff check all pass.


### Final freshness validation

Independently cleared repair rebased from `4e4c053239c6ca8fb2f86c5b354cb434714d175a` onto live `develop` `46fd490241bd37f1a97fc224bb82d68250f5fac6`. The two-file repair diff is byte-identical across the rebase (SHA-256 `feb37df9ba645b1d10d56aefa147101b7662d363d206b80fbbd25498edcdbcab`). Final exact `6bf07d32b24a9bc4bf86eedd75bd20a5af22030a`: focused 47/47, shared typecheck, build:dist, Biome, and diff check all pass.
