### PR TITLE
fix(core): linear-scan first-sentence abbreviation boundaries

### DIFF
--- a/packages/core/src/__tests__/dynamic-prompt-json-mode.test.ts
+++ b/packages/core/src/__tests__/dynamic-prompt-json-mode.test.ts
@@ -1,8 +1,9 @@
 /**
  * Exercises AgentRuntime.dynamicPromptExecFromState: structured model calls
- * request JSON-object response format, a validation failure feeds a corrective
- * [REPAIR] context into the reroll, and exhausted retries return null while an
- * explicit caller response format is preserved. Runs against a bare
+ * request JSON-object response format, structured callbacks drain before a
+ * retry, a validation failure feeds corrective [REPAIR] context into the
+ * reroll, and exhausted retries return null while an explicit caller response
+ * format is preserved. Runs against a bare
  * AgentRuntime (no DB adapter, logModelCall stubbed) with a registered vi.fn()
  * model handler — fully deterministic, no live model.
  */
@@ -28,6 +29,77 @@ function makeRuntime(): AgentRuntime {
 }
 
 describe("AgentRuntime.dynamicPromptExecFromState", () => {
+	it("drains an older structured callback before starting a retry", async () => {
+		const runtime = makeRuntime();
+		let attempt = 0;
+		const handler = vi.fn(
+			async (
+				_runtime,
+				params: { onStreamChunk?: (chunk: string) => Promise<void> | void },
+			) => {
+				attempt += 1;
+				if (attempt === 1) {
+					await params.onStreamChunk?.("text: old\nother: x\n");
+					return '{"wrong":"retry"}';
+				}
+				await params.onStreamChunk?.("text: new.\n");
+				return '{"text":"new."}';
+			},
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			handler,
+			"eliza-local-inference",
+			100,
+		);
+		let releaseOld: (() => void) | undefined;
+		const oldGate = new Promise<void>((resolve) => {
+			releaseOld = resolve;
+		});
+		let markOldEntered: (() => void) | undefined;
+		const oldEntered = new Promise<void>((resolve) => {
+			markOldEntered = resolve;
+		});
+		const delivered: Array<{ chunk: string; revision: number | undefined }> =
+			[];
+
+		const resultPromise = runtime.dynamicPromptExecFromState({
+			params: { prompt: "Return text." },
+			schema: [
+				{
+					field: "text",
+					description: "Reply",
+					required: true,
+					streamField: true,
+				},
+				{ field: "other", description: "Non-streamed metadata" },
+			],
+			options: {
+				modelType: ModelType.TEXT_LARGE,
+				maxRetries: 1,
+				contextCheckLevel: 0,
+				onStreamChunk: async (chunk, _messageId, _accumulated, revision) => {
+					delivered.push({ chunk, revision });
+					if (delivered.length === 1) {
+						markOldEntered?.();
+						await oldGate;
+					}
+				},
+			},
+		});
+
+		await oldEntered;
+		await Promise.resolve();
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(delivered.map(({ chunk }) => chunk)).toEqual(["old"]);
+
+		releaseOld?.();
+		expect(await resultPromise).toEqual({ text: "new." });
+		expect(handler).toHaveBeenCalledTimes(2);
+		expect(delivered.map(({ chunk }) => chunk)).toEqual(["old", "new."]);
+		expect(delivered[0]?.revision).not.toBe(delivered[1]?.revision);
+	});
+
 	it("requests JSON-object mode for structured model calls", async () => {
 		const runtime = makeRuntime();
 		let seenParams: unknown;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -6734,6 +6734,7 @@ export class AgentRuntime implements IAgentRuntime {
 			// live mutable object, not this placeholder.
 			let recordingStateRef: { recorded: boolean } = { recorded: false };
 			let attemptPreparationFailed = false;
+			let drainStructuredStreamCallbacks: (() => Promise<void>) | undefined;
 
 			try {
 				const binaryModels: string[] = [
@@ -6880,11 +6881,30 @@ export class AgentRuntime implements IAgentRuntime {
 					shouldStream &&
 					paramsAsStreaming?.streamStructured === true &&
 					structuredStreamFields.length === 0;
-				const downstreamChunk = (chunk: string, accumulated?: string): void => {
-					void (async () => {
-						if (paramsChunk) await paramsChunk(chunk, msgId, accumulated);
-						if (ctxChunk) await ctxChunk(chunk, msgId, accumulated);
-					})();
+				let downstreamDelivery = Promise.resolve();
+				let downstreamDeliveryError: unknown;
+				let downstreamDeliveryFailed = false;
+				const downstreamChunk = (
+					chunk: string,
+					accumulated?: string,
+					streamRevision?: number,
+				): void => {
+					downstreamDelivery = downstreamDelivery
+						.then(async () => {
+							if (downstreamDeliveryFailed) return;
+							if (paramsChunk)
+								await paramsChunk(chunk, msgId, accumulated, streamRevision);
+							if (ctxChunk)
+								await ctxChunk(chunk, msgId, accumulated, streamRevision);
+						})
+						.then(undefined, (error: unknown) => {
+							downstreamDeliveryFailed = true;
+							downstreamDeliveryError = error;
+						});
+				};
+				drainStructuredStreamCallbacks = async () => {
+					await downstreamDelivery;
+					if (downstreamDeliveryFailed) throw downstreamDeliveryError;
 				};
 				const structuredExtractor =
 					structuredStreamFields.length > 0 &&
@@ -6893,8 +6913,8 @@ export class AgentRuntime implements IAgentRuntime {
 								skeleton: paramsAsStreaming.responseSkeleton,
 								streamFields: structuredStreamFields,
 								unordered: true,
-								onChunk: (chunk, _field, accumulated) =>
-									downstreamChunk(chunk, accumulated),
+								onChunk: (chunk, _field, accumulated, streamRevision) =>
+									downstreamChunk(chunk, accumulated, streamRevision),
 								...(abortSignal ? { abortSignal } : {}),
 							})
 						: undefined;
@@ -7309,6 +7329,7 @@ export class AgentRuntime implements IAgentRuntime {
 					}
 					await flushGuardedStream();
 					structuredExtractor?.flush();
+					await drainStructuredStreamCallbacks();
 
 					const trajStreamEnd = getTrajectoryContext();
 					await this.invokePipelineHooks(
@@ -7456,6 +7477,7 @@ export class AgentRuntime implements IAgentRuntime {
 				if (handlerDeliveredStream) {
 					await flushGuardedStream();
 					structuredExtractor?.flush();
+					await drainStructuredStreamCallbacks();
 					const trajStreamEnd = getTrajectoryContext();
 					await this.invokePipelineHooks(
 						"model_stream_end",
@@ -7668,6 +7690,20 @@ export class AgentRuntime implements IAgentRuntime {
 				);
 				return resultRef.current as R;
 			} catch (error) {
+				const streamCallbackResult =
+					await drainStructuredStreamCallbacks?.().then(
+						() => ({ failed: false as const }),
+						(deliveryError: unknown) => ({
+							failed: true as const,
+							error: deliveryError,
+						}),
+					);
+				if (
+					streamCallbackResult?.failed === true &&
+					streamCallbackResult.error !== error
+				) {
+					throw streamCallbackResult.error;
+				}
 				if (attemptPreparationFailed) {
 					recordInferenceSpan(
 						`model-preprocess:${String(modelType)}`,
@@ -8365,6 +8401,28 @@ export class AgentRuntime implements IAgentRuntime {
 
 		// Extractor is created once and persists across retries
 		let extractor: DynamicPromptStreamExtractor | undefined;
+		let structuredPromptDelivery = Promise.resolve();
+		let structuredPromptDeliveryError: unknown;
+		let structuredPromptDeliveryFailed = false;
+		const enqueueStructuredPromptDelivery = (
+			deliver: () => void | Promise<void>,
+		): void => {
+			structuredPromptDelivery = structuredPromptDelivery
+				.then(async () => {
+					if (structuredPromptDeliveryFailed) return;
+					await deliver();
+				})
+				.then(undefined, (error: unknown) => {
+					structuredPromptDeliveryFailed = true;
+					structuredPromptDeliveryError = error;
+				});
+		};
+		const drainStructuredPromptDelivery = async (): Promise<void> => {
+			await structuredPromptDelivery;
+			if (structuredPromptDeliveryFailed) {
+				throw structuredPromptDeliveryError;
+			}
+		};
 		let contextLevel: 0 | 1 | 2 | 3 = defaultContextCheckLevel;
 		const perFieldCodes = new Map<string, string>();
 
@@ -8557,11 +8615,20 @@ export class AgentRuntime implements IAgentRuntime {
 						...(options.abortSignal
 							? { abortSignal: options.abortSignal }
 							: {}),
-						onChunk: (chunk, _field, accumulated) => {
-							void options.onStreamChunk?.(chunk, undefined, accumulated);
+						onChunk: (chunk, _field, accumulated, streamRevision) => {
+							enqueueStructuredPromptDelivery(() =>
+								options.onStreamChunk?.(
+									chunk,
+									undefined,
+									accumulated,
+									streamRevision,
+								),
+							);
 						},
 						onEvent: (event) => {
-							void options.onStreamEvent?.(event, undefined);
+							enqueueStructuredPromptDelivery(() =>
+								options.onStreamEvent?.(event, undefined),
+							);
 						},
 					});
 				}
@@ -8757,6 +8824,7 @@ ${section_end}`;
 			// Check for cancellation before request
 			if (options.abortSignal?.aborted) {
 				extractor?.signalError("Cancelled by user");
+				await drainStructuredPromptDelivery();
 				delete (state as Record<string, unknown>)._smartRetryContext;
 				this.clearStructuredOutputFailureState(state);
 				return null;
@@ -8800,6 +8868,7 @@ ${section_end}`;
 
 				if (options.abortSignal?.aborted) {
 					extractor?.signalError("Cancelled by user");
+					await drainStructuredPromptDelivery();
 					delete (state as Record<string, unknown>)._smartRetryContext;
 					this.clearStructuredOutputFailureState(state);
 					return null;
@@ -8823,6 +8892,7 @@ ${section_end}`;
 						);
 						if (aborted) {
 							extractor?.signalError("Cancelled by user");
+							await drainStructuredPromptDelivery();
 							delete (state as Record<string, unknown>)._smartRetryContext;
 							this.clearStructuredOutputFailureState(state);
 							return null;
@@ -8831,6 +8901,7 @@ ${section_end}`;
 
 					// Signal retry to extractor if it exists
 					if (extractor) {
+						await drainStructuredPromptDelivery();
 						extractor.signalRetry(currentRetry);
 						extractor.reset();
 					}
@@ -9005,6 +9076,7 @@ ${section_end}`;
 				if (extractor) {
 					extractor.flush();
 				}
+				await drainStructuredPromptDelivery();
 
 				metric.successfulAttempts++;
 				if (
@@ -9180,6 +9252,7 @@ ${section_end}`;
 
 			if (options.abortSignal?.aborted) {
 				extractor?.signalError("Cancelled by user");
+				await drainStructuredPromptDelivery();
 				delete (state as Record<string, unknown>)._smartRetryContext;
 				this.clearStructuredOutputFailureState(state);
 				return null;
@@ -9203,6 +9276,7 @@ ${section_end}`;
 					);
 					if (aborted) {
 						extractor?.signalError("Cancelled by user");
+						await drainStructuredPromptDelivery();
 						delete (state as Record<string, unknown>)._smartRetryContext;
 						this.clearStructuredOutputFailureState(state);
 						return null;
@@ -9212,6 +9286,7 @@ ${section_end}`;
 				// Signal retry to extractor
 				let smartRetryContextNext: string | undefined;
 				if (extractor) {
+					await drainStructuredPromptDelivery();
 					const { validatedFields } = extractor.signalRetry(currentRetry);
 					const diagnosis = extractor.diagnose();
 
@@ -9299,6 +9374,7 @@ ${section_end}`;
 				`Failed after ${maxRetries} retries. ${diagnosticParts.length > 0 ? diagnosticParts.join("; ") : "unknown error"}`,
 			);
 		}
+		await drainStructuredPromptDelivery();
 
 		const finalFailureMessage = `dynamicPromptExecFromState failed after ${maxRetries} retries [${modelSchemaKey}]`;
 		const finalFailureSummary = `${metric.successfulAttempts}/${metric.totalAttempts} successful`;

--- a/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
@@ -41,6 +41,72 @@ const responseSkeleton: ResponseSkeleton = {
 };
 
 describe("AgentRuntime structured streaming", () => {
+	it("serializes structured callbacks and drains them before resolving", async () => {
+		const runtime = makeRuntime();
+		const orderedSkeleton: ResponseSkeleton = {
+			spans: [
+				{ kind: "literal", value: '{"messageToUser":' },
+				{ kind: "free-string", key: "messageToUser" },
+				{ kind: "literal", value: "}" },
+			],
+		};
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let markFirstEntered: (() => void) | undefined;
+		const firstEntered = new Promise<void>((resolve) => {
+			markFirstEntered = resolve;
+		});
+		const received: string[] = [];
+		const raw = '{"messageToUser":"first second"}';
+		const handler = vi.fn(async (_runtime, params: unknown) => {
+			const streamingParams = params as {
+				onStreamChunk?: (chunk: string) => Promise<void> | void;
+			};
+			await streamingParams.onStreamChunk?.('{"messageToUser":"first ');
+			await streamingParams.onStreamChunk?.('second"}');
+			return raw;
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			handler,
+			"eliza-local-inference",
+		);
+
+		let resolved = false;
+		const resultPromise = runWithStreamingContext(
+			{
+				messageId: "message-ordered",
+				onStreamChunk: async (chunk) => {
+					received.push(chunk);
+					if (received.length === 1) {
+						markFirstEntered?.();
+						await firstGate;
+					}
+				},
+			},
+			() =>
+				runtime.useModel(ModelType.RESPONSE_HANDLER, {
+					messages: [],
+					streamStructured: true,
+					responseSkeleton: orderedSkeleton,
+				}),
+		).then((result) => {
+			resolved = true;
+			return result;
+		});
+
+		await firstEntered;
+		await Promise.resolve();
+		expect(received).toEqual(["first "]);
+		expect(resolved).toBe(false);
+
+		releaseFirst?.();
+		expect(await resultPromise).toBe(raw);
+		expect(received).toEqual(["first ", "second"]);
+	});
+
 	it("holds local structured envelopes when no response field is approved for streaming", async () => {
 		const runtime = makeRuntime();
 		const streamed: Array<[string, string | undefined]> = [];

--- a/packages/core/src/services/message.run-terminal-owner.test.ts
+++ b/packages/core/src/services/message.run-terminal-owner.test.ts
@@ -76,6 +76,11 @@ function makeRuntime(options: {
 	factsGate?: Promise<void>;
 	onFactsStarted?: () => void;
 	streamText?: string;
+	streamEvents?: Array<{
+		chunk: string;
+		accumulated: string;
+		streamRevision?: number;
+	}>;
 	ttsGate?: Promise<void>;
 	onTtsStarted?: () => void;
 }): {
@@ -88,10 +93,19 @@ function makeRuntime(options: {
 		responseHandlerFieldRegistry.register(evaluator);
 	}
 	const terminalPayloads: Array<Record<string, unknown>> = [];
-	const useModel = vi.fn(async (modelType: string) => {
+	const useModel = vi.fn(async (modelType: string, _params?: unknown) => {
 		if (modelType === ModelType.TEXT_EMBEDDING) return [0.1, 0.2, 0.3];
 		if (modelType === ModelType.RESPONSE_HANDLER) {
-			if (options.streamText) {
+			if (options.streamEvents) {
+				for (const event of options.streamEvents) {
+					await getStreamingContext()?.onStreamChunk(
+						event.chunk,
+						undefined,
+						event.accumulated,
+						event.streamRevision,
+					);
+				}
+			} else if (options.streamText) {
 				await getStreamingContext()?.onStreamChunk(
 					options.streamText,
 					undefined,
@@ -99,7 +113,9 @@ function makeRuntime(options: {
 				);
 			}
 			return stage1Reply(
-				options.streamText ?? "Delivery is ready.",
+				options.streamText ??
+					options.streamEvents?.at(-1)?.accumulated ??
+					"Delivery is ready.",
 				options.facts,
 			);
 		}
@@ -243,5 +259,35 @@ describe("DefaultMessageService run-terminal owner", () => {
 			useModel.mock.calls.filter(([type]) => type === ModelType.TEXT_TO_SPEECH),
 		).toHaveLength(2);
 		expect(terminalPayloads).toHaveLength(1);
+	});
+
+	it("replays authoritative first-sentence state after a structured retry", async () => {
+		const { runtime, useModel } = makeRuntime({
+			streamEvents: [
+				{ chunk: "Prof", accumulated: "Prof" },
+				{
+					chunk: ".) arrived.",
+					accumulated: "Okay.) arrived.",
+					streamRevision: 1,
+				},
+			],
+		});
+		const service = new DefaultMessageService();
+
+		await service.handleMessage(
+			runtime,
+			inputMessage("speak the retried result"),
+			async () => [],
+			{ onStreamChunk: async () => undefined },
+		);
+		await drainPostDeliveryTasks(runtime);
+
+		const speechParams = useModel.mock.calls
+			.filter(([type]) => type === ModelType.TEXT_TO_SPEECH)
+			.map(([, params]) => params);
+		expect(speechParams).toMatchObject([
+			{ text: "Okay.)" },
+			{ text: "arrived." },
+		]);
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -335,8 +335,8 @@ import {
 import { modelProviderErrorDetail } from "../utils/model-errors";
 import { readEnv } from "../utils/read-env";
 import {
+	createFirstSentenceStreamTracker,
 	extractFirstSentence,
-	hasFirstSentence,
 } from "../utils/text-splitting";
 import { isObjectRecord as isRecord } from "../utils/type-guards";
 import { truncateWellFormed } from "../utils/well-formed";
@@ -12251,9 +12251,39 @@ export class DefaultMessageService implements IMessageService {
 				// The `streamTextFallback` path exists for action handlers or other
 				// call sites that don't provide `accumulated` (raw token streams).
 				let firstSentenceSent = false;
+				let firstSentenceChecked = false;
 				let firstSentenceText = "";
+				const firstSentenceTracker = createFirstSentenceStreamTracker();
 				let streamTextFallback = "";
 				let runTerminalOwner: MessageRunTerminalOwner | undefined;
+				const acceptFirstSentence = (first: string): void => {
+					firstSentenceChecked = true;
+					if (first.length <= 5) return;
+					firstSentenceSent = true;
+					firstSentenceText = first;
+					// Audio does not stall the text stream, but its model capture
+					// remains owned by the run-terminal barrier.
+					const deliverVoice = () =>
+						deliverFirstSentenceVoice(
+							runtime,
+							first,
+							callback,
+							options?.abortSignal,
+						);
+					if (!runTerminalOwner) {
+						throw new ElizaError(
+							"Voice streaming requires a live run terminal owner",
+							{
+								code: "RUN_TERMINAL_OWNER_REQUIRED",
+								context: {
+									messageId: message.id,
+									roomId: message.roomId,
+								},
+							},
+						);
+					}
+					runTerminalOwner.track("first-sentence-voice", deliverVoice);
+				};
 				// Envelope-echo latch for this turn's stream: once the accumulated
 				// text reads as envelope material, every downstream chunk consumer
 				// (model_stream_chunk hook re-emission, first-sentence TTS, the
@@ -12267,7 +12297,7 @@ export class DefaultMessageService implements IMessageService {
 				const userOnStreamChunk = options?.onStreamChunk;
 				const wrappedOnStreamChunk: StreamChunkCallback | undefined =
 					userOnStreamChunk
-						? async (chunk, messageId, accumulated) => {
+						? async (chunk, messageId, accumulated, streamRevision) => {
 								// Sensitive turns deliver once through the final callback,
 								// where the audience is re-read. Streaming bytes cannot be
 								// recalled if room membership changes mid-generation.
@@ -12310,46 +12340,27 @@ export class DefaultMessageService implements IMessageService {
 								// the local-inference voice loop is a separate layer, see its
 								// JSDoc). Only run detection when `accumulated` is present:
 								// raw-token streams (no accumulated) may contain partial
-								// structured output that would garble hasFirstSentence() and
+								// structured output that would garble sentence detection and
 								// TTS.
 								if (
-									!firstSentenceSent &&
+									!firstSentenceChecked &&
 									accumulated !== undefined &&
-									hasFirstSentence(streamText)
+									firstSentenceTracker.push(
+										chunk,
+										accumulated,
+										streamRevision,
+									) !== undefined
 								) {
 									const { first } = extractFirstSentence(streamText);
-									if (first.length > 5) {
-										firstSentenceSent = true;
-										firstSentenceText = first;
-										// Audio does not stall the text stream, but its model capture
-										// remains owned by the run-terminal barrier.
-										const deliverVoice = () =>
-											deliverFirstSentenceVoice(
-												runtime,
-												first,
-												callback,
-												opts.abortSignal,
-											);
-										if (!runTerminalOwner) {
-											throw new ElizaError(
-												"Voice streaming requires a live run terminal owner",
-												{
-													code: "RUN_TERMINAL_OWNER_REQUIRED",
-													context: {
-														messageId: message.id,
-														roomId: message.roomId,
-													},
-												},
-											);
-										}
-										runTerminalOwner.track(
-											"first-sentence-voice",
-											deliverVoice,
-										);
-									}
+									acceptFirstSentence(first);
 								}
 
-								await userOnStreamChunk(chunk, messageId, accumulated);
+								await userOnStreamChunk(
+									chunk,
+									messageId,
+									accumulated,
+									streamRevision,
+								);
 							}
 						: undefined;
 
@@ -12589,6 +12600,15 @@ export class DefaultMessageService implements IMessageService {
 					);
 
 					const result = await processingPromise;
+					if (
+						!firstSentenceChecked &&
+						firstSentenceTracker.finish() !== undefined &&
+						result.responseContent?.text
+					) {
+						acceptFirstSentence(
+							extractFirstSentence(result.responseContent.text).first,
+						);
+					}
 
 					// Voice: Handle the rest of the message
 					if (firstSentenceSent && result.responseContent?.text) {

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -1047,11 +1047,16 @@ export interface ActionContext {
  *   Present when the emission originates from a structured field extractor.
  *   Undefined for raw-token streams (useModel without an extractor) where no
  *   field-level accumulation exists.
+ * @param streamRevision - Monotonically allocated structured-extractor attempt
+ *   number. A change means `accumulated` restarted and consumers must discard
+ *   incremental state from the preceding attempt. Undefined for raw-token
+ *   streams.
  */
 export type StreamChunkCallback = (
 	chunk: string,
 	messageId?: string,
 	accumulated?: string,
+	streamRevision?: number,
 ) => void | Promise<void>;
 
 /**

--- a/packages/core/src/utils/__tests__/streaming-field-events.test.ts
+++ b/packages/core/src/utils/__tests__/streaming-field-events.test.ts
@@ -182,6 +182,29 @@ describe("StructuredFieldStreamExtractor emits the clean text-field delta (#9174
 		const accumulated = chunks.map(([, , acc]) => acc);
 		expect(accumulated.at(-1)).toBe("Hey! Good to see you again.");
 	});
+
+	it("marks emissions from a retried extractor with a new revision", () => {
+		const revisions: Array<number | undefined> = [];
+		const extractor = new StructuredFieldStreamExtractor({
+			level: 0,
+			schema: replySchema,
+			streamFields: ["text"],
+			onChunk: (_chunk, _field, _accumulated, revision) =>
+				revisions.push(revision),
+		});
+
+		feed(extractor, "text: first attempt\n");
+		extractor.signalRetry(1);
+		extractor.reset();
+		feed(extractor, "text: second attempt\n");
+		extractor.flush();
+
+		expect(revisions).toHaveLength(2);
+		expect(revisions.every((revision) => typeof revision === "number")).toBe(
+			true,
+		);
+		expect(revisions[1]).not.toBe(revisions[0]);
+	});
 });
 
 describe("ResponseSkeletonStreamExtractor", () => {
@@ -249,6 +272,27 @@ describe("ResponseSkeletonStreamExtractor", () => {
 		// Streamed incrementally (one emission per pushed token), not once at the end.
 		expect(chunks.length).toBeGreaterThan(1);
 		expect(accumulated.at(-1)).toBe("Hello there, friend.");
+	});
+
+	it("marks passthrough emissions after retry with a new revision", () => {
+		const revisions: Array<number | undefined> = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (_chunk, _field, _accumulated, revision) =>
+				revisions.push(revision),
+		});
+
+		extractor.push("first attempt");
+		extractor.signalRetry(1);
+		extractor.push("second attempt");
+		extractor.flush();
+
+		expect(revisions).toHaveLength(2);
+		expect(revisions.every((revision) => typeof revision === "number")).toBe(
+			true,
+		);
+		expect(revisions[1]).not.toBe(revisions[0]);
 	});
 
 	it("keeps envelope-shaped output on the structured path (no control-field leak)", () => {

--- a/packages/core/src/utils/streaming.test.ts
+++ b/packages/core/src/utils/streaming.test.ts
@@ -113,4 +113,17 @@ describe("createStreamingContext", () => {
 		await context.onStreamChunk("ignored");
 		expect(receivedChunks).toEqual(["first ", "second"]);
 	});
+
+	it("forwards the structured-stream revision to the downstream callback", async () => {
+		const callback = vi.fn();
+		const context = createStreamingContext(
+			new MarkableExtractor(),
+			callback,
+			"msg-revision",
+		);
+
+		await context.onStreamChunk("new", "msg-revision", "new", 7);
+
+		expect(callback).toHaveBeenCalledWith("new", "msg-revision", "new", 7);
+	});
 });

--- a/packages/core/src/utils/streaming.ts
+++ b/packages/core/src/utils/streaming.ts
@@ -191,6 +191,16 @@ export type FieldState =
 	| "complete" // Field content extracted
 	| "invalid"; // Validation codes didn't match
 
+let streamRevisionSequence = 0;
+
+function allocateStreamRevision(): number {
+	streamRevisionSequence =
+		streamRevisionSequence === Number.MAX_SAFE_INTEGER
+			? 1
+			: streamRevisionSequence + 1;
+	return streamRevisionSequence;
+}
+
 /**
  * Configuration for StructuredFieldStreamExtractor.
  */
@@ -207,7 +217,12 @@ export interface StructuredFieldStreamExtractorConfig
 	 * WHY accumulated: consumers (voice detection, client-side merge) need the
 	 * full field text to avoid re-deriving it from deltas.
 	 */
-	onChunk: (chunk: string, field?: string, accumulated?: string) => void;
+	onChunk: (
+		chunk: string,
+		field?: string,
+		accumulated?: string,
+		streamRevision?: number,
+	) => void;
 	/** Rich event callback for sophisticated consumers */
 	onEvent?: (event: StreamEvent) => void;
 	/** Abort signal for cancellation */
@@ -249,6 +264,7 @@ export class StructuredFieldStreamExtractor implements IStreamExtractor {
 	private validatedFields: Set<string> = new Set();
 	private fieldStates: Map<string, FieldState> = new Map();
 	private state: ExtractorState = "streaming";
+	private streamRevision = allocateStreamRevision();
 	private readonly streamFieldSet: Set<string>;
 	/**
 	 * The top-level field whose value bytes are currently arriving — tracked for
@@ -318,6 +334,7 @@ export class StructuredFieldStreamExtractor implements IStreamExtractor {
 	}
 
 	reset(): void {
+		this.streamRevision = allocateStreamRevision();
 		this.lineBuffer = "";
 		this.currentField = null;
 		this.currentTrackedField = null;
@@ -543,7 +560,7 @@ export class StructuredFieldStreamExtractor implements IStreamExtractor {
 		if (content.length < previouslyEmitted.length) {
 			this.emittedContent.set(field, content);
 			if (content) {
-				this.config.onChunk(content, field, content);
+				this.config.onChunk(content, field, content, this.streamRevision);
 				this.emitEvent({
 					eventType: "chunk",
 					field,
@@ -556,7 +573,7 @@ export class StructuredFieldStreamExtractor implements IStreamExtractor {
 
 		const newContent = content.substring(previouslyEmitted.length);
 		if (newContent) {
-			this.config.onChunk(newContent, field, content);
+			this.config.onChunk(newContent, field, content, this.streamRevision);
 			this.emitEvent({
 				eventType: "chunk",
 				field,
@@ -602,6 +619,7 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 	private formatDecided = false;
 	private passthrough = false;
 	private passthroughEmitted = "";
+	private streamRevision = allocateStreamRevision();
 	private readonly streamFieldSet: Set<string>;
 	private readonly maxKeyPatternLength: number;
 
@@ -609,7 +627,12 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 		private readonly config: {
 			skeleton: ResponseSkeleton;
 			streamFields: string[];
-			onChunk: (chunk: string, field?: string, accumulated?: string) => void;
+			onChunk: (
+				chunk: string,
+				field?: string,
+				accumulated?: string,
+				streamRevision?: number,
+			) => void;
 			onEvent?: (event: StreamEvent) => void;
 			abortSignal?: AbortSignal;
 			unordered?: boolean;
@@ -677,6 +700,7 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 	}
 
 	reset(): void {
+		this.streamRevision = allocateStreamRevision();
 		this.buffer = "";
 		this.spanIndex = 0;
 		this.activeStringField = null;
@@ -720,7 +744,12 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 		const chunk = this.buffer;
 		this.buffer = "";
 		this.passthroughEmitted += chunk;
-		this.config.onChunk(chunk, undefined, this.passthroughEmitted);
+		this.config.onChunk(
+			chunk,
+			undefined,
+			this.passthroughEmitted,
+			this.streamRevision,
+		);
 	}
 
 	signalRetry(retryCount: number): { validatedFields: string[] } {
@@ -1047,7 +1076,7 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 			return;
 		}
 		this.emittedContent.set(field, next);
-		this.config.onChunk(chunk, field, next);
+		this.config.onChunk(chunk, field, next, this.streamRevision);
 		this.emitEvent({
 			eventType: "chunk",
 			field,
@@ -1326,12 +1355,13 @@ export function createStreamingContext(
 			chunk: string,
 			msgId?: string,
 			accumulated?: string,
+			streamRevision?: number,
 		) => {
 			if (extractor.done) return;
 			const textToStream = extractor.push(chunk);
 			if (textToStream) {
 				retryState.appendText(textToStream);
-				await onStreamChunk(textToStream, msgId, accumulated);
+				await onStreamChunk(textToStream, msgId, accumulated, streamRevision);
 			}
 		},
 		messageId,

--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -115,3 +115,16 @@ describe("hasFirstSentence", () => {
 		expect(hasFirstSentence("See e.g. the")).toBe(false);
 	});
 });
+
+describe("extractFirstSentence quadratic abbreviation runs", () => {
+	it("scans stacked title abbreviations in linear time", () => {
+		const stacked = "Mr. ".repeat(40_000);
+		const started = performance.now();
+		const result = extractFirstSentence(stacked);
+		const elapsed = performance.now() - started;
+		expect(result.complete).toBe(false);
+		expect(result.first.startsWith("Mr.")).toBe(true);
+		// Origin spent ~16s on this input (substring+regex per period).
+		expect(elapsed).toBeLessThan(200);
+	});
+});

--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -5,7 +5,12 @@
  * mid-abbreviation.
  */
 import { describe, expect, it } from "vitest";
-import { extractFirstSentence, hasFirstSentence } from "./text-splitting.ts";
+import {
+	createFirstSentenceScanner,
+	createFirstSentenceStreamTracker,
+	extractFirstSentence,
+	hasFirstSentence,
+} from "./text-splitting.ts";
 
 describe("extractFirstSentence", () => {
 	it("does not split inside dotted abbreviations (e.g. / i.e.)", () => {
@@ -89,6 +94,16 @@ describe("extractFirstSentence", () => {
 		expect(r.first).toBe("No boundary here");
 		expect(r.rest).toBe("");
 	});
+
+	it("preserves Unicode text while recognizing Unicode whitespace", () => {
+		const spaced = extractFirstSentence("Café.\u00a0Après.");
+		expect(spaced).toEqual({
+			first: "Café.",
+			rest: "Après.",
+			complete: true,
+		});
+		expect(extractFirstSentence("你好。下一句。").complete).toBe(false);
+	});
 });
 
 describe("hasFirstSentence", () => {
@@ -117,14 +132,161 @@ describe("hasFirstSentence", () => {
 });
 
 describe("extractFirstSentence quadratic abbreviation runs", () => {
-	it("scans stacked title abbreviations in linear time", () => {
+	it("scans stacked title abbreviations without finding a false boundary", () => {
 		const stacked = "Mr. ".repeat(40_000);
-		const started = performance.now();
 		const result = extractFirstSentence(stacked);
-		const elapsed = performance.now() - started;
 		expect(result.complete).toBe(false);
 		expect(result.first.startsWith("Mr.")).toBe(true);
-		// Origin spent ~16s on this input (substring+regex per period).
-		expect(elapsed).toBeLessThan(200);
+	});
+});
+
+describe("createFirstSentenceScanner", () => {
+	it("scans abbreviation-heavy streaming deltas only once", () => {
+		const scanner = createFirstSentenceScanner();
+		let boundary: number | undefined;
+		for (let index = 0; index < 40_000; index += 1) {
+			boundary = scanner.push("Mr. ");
+		}
+		expect(boundary).toBeUndefined();
+		expect(scanner.push("Done.")).toBeUndefined();
+		expect(scanner.push("", true)).toBe(160_005);
+	});
+
+	it("does not early-emit a dotted abbreviation split across chunks", () => {
+		const scanner = createFirstSentenceScanner();
+		expect(scanner.push("See e.")).toBeUndefined();
+		expect(scanner.push("g. the docs.")).toBeUndefined();
+		expect(scanner.push("", true)).toBe(18);
+	});
+
+	it("resolves an ambiguous dotted prefix when the next chunk is not an abbreviation", () => {
+		const scanner = createFirstSentenceScanner();
+		expect(scanner.push("e.")).toBeUndefined();
+		expect(scanner.push(" Next sentence.")).toBe(2);
+
+		const quoted = createFirstSentenceScanner();
+		expect(quoted.push("e.")).toBeUndefined();
+		expect(quoted.push('" Next sentence.')).toBe(3);
+	});
+
+	it("preserves title state across arbitrary chunk boundaries", () => {
+		const scanner = createFirstSentenceScanner();
+		const chunks = ["D", "r.", " Smith arrived", ". Next."];
+		let accumulated = "";
+		let boundary: number | undefined;
+		for (const chunk of chunks) {
+			accumulated += chunk;
+			boundary = scanner.push(chunk);
+			if (boundary !== undefined) break;
+		}
+		expect(accumulated.slice(0, boundary)).toBe("Dr. Smith arrived.");
+	});
+
+	it.each([
+		["Hello.", '" Next.', 'Hello."'],
+		["Stop!", ") Next.", "Stop!)"],
+		["What?", "” Next.", "What?”"],
+	])(
+		"includes a closer delivered after terminal %s",
+		(first, second, expected) => {
+			const scanner = createFirstSentenceScanner();
+			expect(scanner.push(first)).toBeUndefined();
+			const boundary = scanner.push(second);
+			expect(`${first}${second}`.slice(0, boundary)).toBe(expected);
+		},
+	);
+
+	it("defers terminal punctuation that becomes a decimal continuation", () => {
+		const scanner = createFirstSentenceScanner();
+		expect(scanner.push("Version 1.")).toBeUndefined();
+		const second = "2 is stable.";
+		const boundary = scanner.push(second);
+		expect(`Version 1.${second}`.slice(0, boundary)).toBe(
+			"Version 1.2 is stable.",
+		);
+	});
+
+	it("consumes closers split across multiple chunks and resolves punctuation at EOF", () => {
+		const scanner = createFirstSentenceScanner();
+		expect(scanner.push("Hello.")).toBeUndefined();
+		expect(scanner.push('"')).toBeUndefined();
+		expect(scanner.push(") Next.")).toBe(8);
+
+		const atEof = createFirstSentenceScanner();
+		expect(atEof.push("Finished.")).toBeUndefined();
+		expect(atEof.push("", true)).toBe(9);
+	});
+
+	it("matches direct semantics at every split and one-code-unit chunking", () => {
+		const cases = [
+			"Hello. Next.",
+			'Hello.") Next.',
+			"Version 1.2 is stable. Next.",
+			"See e.g. the docs. Next.",
+			"Dr. Smith arrived! Next.",
+			"Café.\u00a0Après.",
+			"你好。下一句。",
+		];
+
+		for (const text of cases) {
+			const expected = createFirstSentenceScanner().push(text, true);
+			for (let split = 0; split <= text.length; split += 1) {
+				const scanner = createFirstSentenceScanner();
+				const beforeSplit = scanner.push(text.slice(0, split));
+				expect(beforeSplit ?? scanner.push(text.slice(split), true)).toBe(
+					expected,
+				);
+			}
+
+			const scanner = createFirstSentenceScanner();
+			let actual: number | undefined;
+			for (let offset = 0; offset < text.length; offset += 1) {
+				actual = scanner.push(text[offset]);
+				if (actual !== undefined) break;
+			}
+			expect(actual ?? scanner.push("", true)).toBe(expected);
+		}
+	});
+});
+
+describe("createFirstSentenceStreamTracker", () => {
+	it("ignores a late callback from an older structured-stream revision", () => {
+		const tracker = createFirstSentenceStreamTracker();
+		expect(tracker.push("Mr.", "Mr.", 1)).toBeUndefined();
+		expect(tracker.push("Done.", "Done.", 2)).toBeUndefined();
+		expect(tracker.push(" stale.", "Mr. stale.", 1)).toBeUndefined();
+		expect(tracker.finish()).toBe(5);
+	});
+
+	it("reconciles equal-length prefix rewrites instead of trusting the delta", () => {
+		const tracker = createFirstSentenceStreamTracker();
+		expect(tracker.push("Mr", "Mr")).toBeUndefined();
+		// The suffix and total length still look append-only, but the authoritative
+		// producer replaced the prefix while retrying. Replaying "Go." finds the
+		// boundary that stale "Mr." abbreviation state would suppress.
+		expect(tracker.push(".", "Go.", 1)).toBeUndefined();
+		expect(tracker.finish()).toBe(3);
+	});
+
+	it("resets and replays authoritative accumulation after a structured retry", () => {
+		const tracker = createFirstSentenceStreamTracker();
+		expect(tracker.push("Mr", "Mr")).toBeUndefined();
+		expect(
+			tracker.push("Dr. Jones arrived.", "Dr. Jones arrived."),
+		).toBeUndefined();
+		expect(tracker.finish()).toBe(18);
+	});
+
+	it("keeps abbreviation-heavy authoritative streaming append-only", () => {
+		const tracker = createFirstSentenceStreamTracker();
+		let accumulated = "";
+		for (let index = 0; index < 40_000; index += 1) {
+			const chunk = "Mr. ";
+			accumulated += chunk;
+			expect(tracker.push(chunk, accumulated)).toBeUndefined();
+		}
+		accumulated += "Done.";
+		expect(tracker.push("Done.", accumulated)).toBeUndefined();
+		expect(tracker.finish()).toBe(160_005);
 	});
 });

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -1,88 +1,83 @@
 /**
  * Splits text into the first sentence and the rest of the text.
  * Handles common abbreviations to avoid false positives.
+ *
+ * The walk is linear. Origin called `text.substring(0, i).match(/([\w.]+)$/)`
+ * at every abbreviation-period, which is O(n²) on stacked titles
+ * (`"Mr. ".repeat(n)`). Reply/TTS early-emit calls this on streaming model
+ * text; a hostile or degenerate abbreviation run hung the turn.
  */
+
+const ABBREVIATIONS = new Set([
+	"mr",
+	"mrs",
+	"ms",
+	"dr",
+	"prof",
+	"sr",
+	"jr",
+	"st",
+	"vs",
+	"etc",
+	"e.g",
+	"i.e",
+]);
+
+const SENTENCE_END = new Set([".", "?", "!"]);
+const BOUNDARY_FOLLOWERS = new Set([
+	'"',
+	"'",
+	"\u201D",
+	"\u2019",
+	")",
+	"]",
+	"}",
+]);
+const TRAILING_CLOSERS = "\"'\u201D\u2019)]}";
+
+function isAsciiWordChar(ch: string): boolean {
+	return (
+		(ch >= "A" && ch <= "Z") ||
+		(ch >= "a" && ch <= "z") ||
+		(ch >= "0" && ch <= "9") ||
+		ch === "_"
+	);
+}
+
+function isBoundaryFollower(ch: string | undefined): boolean {
+	return ch === undefined || /\s/.test(ch) || BOUNDARY_FOLLOWERS.has(ch);
+}
+
 export function extractFirstSentence(text: string): {
 	first: string;
 	rest: string;
 	/** Whether a sentence boundary was actually found in `text`. */
 	complete: boolean;
 } {
-	// Regex for finding sentence boundaries.
-	// Looks for a period, question mark, or exclamation mark followed by a space or end of string.
-	const abbreviations = [
-		"Mr",
-		"Mrs",
-		"Ms",
-		"Dr",
-		"Prof",
-		"Sr",
-		"Jr",
-		"St",
-		"vs",
-		"etc",
-		"e.g",
-		"i.e",
-	];
-
+	let lastWord = "";
 	let boundaryIndex = -1;
 
-	// Simple iteration to find the first valid boundary
 	for (let i = 0; i < text.length; i++) {
 		const char = text[i];
-		if (".?!".includes(char)) {
-			// Check if it's followed by a space, closing delimiter, or end of string
-			const nextChar = text[i + 1];
-			if (
-				nextChar === undefined ||
-				/\s/.test(nextChar) ||
-				nextChar === '"' ||
-				nextChar === "'" ||
-				nextChar === "\u201D" ||
-				nextChar === "\u2019" ||
-				nextChar === ")" ||
-				nextChar === "]" ||
-				nextChar === "}"
-			) {
-				// Potential boundary. Check prior context for abbreviations.
-				// We look at the word preceding the punctuation.
-				const preText = text.substring(0, i);
-				// Include "." in the preceding word so dotted abbreviations match.
-				// \w excludes ".", so the old \b(\w+)$ extracted only "g" from
-				// "e.g" — the "e.g"/"i.e" list entries were dead and those got split
-				// mid-token (the first-sentence / TTS early-emit path chopped "e.g."
-				// into "e."). Strip a trailing dot before comparing to the list.
-				// No prefix anchor: leftmost matching captures the maximal trailing
-				// [\w.] run, and any other char (space, quote, paren, asterisk, dash)
-				// or start-of-string delimits it — a (?:^|\s) anchor rejected
-				// punctuation-preceded abbreviations ('"Dr' / '(Mr') that the
-				// original \b handled, chopping mid-name.
-				const lastWordMatch = preText.match(/([\w.]+)$/);
-
-				let isAbbreviation = false;
-				if (lastWordMatch) {
-					const lastWord = lastWordMatch[1].replace(/\.$/, "");
-					// Case insensitive check
-					if (
-						abbreviations.some(
-							(abbr) => abbr.toLowerCase() === lastWord.toLowerCase(),
-						)
-					) {
-						isAbbreviation = true;
-					}
+		if (SENTENCE_END.has(char) && isBoundaryFollower(text[i + 1])) {
+			// Include "." in the preceding word so dotted abbreviations match.
+			// Strip a trailing dot before comparing to the list (e.g. "e.g.").
+			const word = lastWord.endsWith(".") ? lastWord.slice(0, -1) : lastWord;
+			if (!ABBREVIATIONS.has(word.toLowerCase())) {
+				boundaryIndex = i + 1;
+				while (
+					boundaryIndex < text.length &&
+					TRAILING_CLOSERS.includes(text[boundaryIndex])
+				) {
+					boundaryIndex++;
 				}
-
-				if (!isAbbreviation) {
-					boundaryIndex = i + 1;
-					while (
-						boundaryIndex < text.length &&
-						"\"'\u201D\u2019)]}".includes(text[boundaryIndex])
-					) {
-						boundaryIndex++;
-					}
-					break;
-				}
+				break;
 			}
+		}
+		if (isAsciiWordChar(char) || char === ".") {
+			lastWord += char;
+		} else {
+			lastWord = "";
 		}
 	}
 

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -1,11 +1,7 @@
 /**
- * Splits text into the first sentence and the rest of the text.
- * Handles common abbreviations to avoid false positives.
- *
- * The walk is linear. Origin called `text.substring(0, i).match(/([\w.]+)$/)`
- * at every abbreviation-period, which is O(n²) on stacked titles
- * (`"Mr. ".repeat(n)`). Reply/TTS early-emit calls this on streaming model
- * text; a hostile or degenerate abbreviation run hung the turn.
+ * Finds first-sentence boundaries for direct and incremental text consumers.
+ * The scanner preserves abbreviation, decimal, closer, and Unicode-whitespace
+ * semantics while keeping reply/TTS streaming work linear in appended input.
  */
 
 const ABBREVIATIONS = new Set([
@@ -48,40 +44,177 @@ function isBoundaryFollower(ch: string | undefined): boolean {
 	return ch === undefined || /\s/.test(ch) || BOUNDARY_FOLLOWERS.has(ch);
 }
 
+export interface FirstSentenceScanner {
+	/**
+	 * Scan only the newly appended text. Returns the absolute boundary offset
+	 * once a complete first sentence is found.
+	 */
+	push(chunk: string, endOfInput?: boolean): number | undefined;
+}
+
+export interface FirstSentenceStreamTracker {
+	/** Scan one authoritative structured-field delta and its accumulation. */
+	push(
+		chunk: string,
+		accumulated: string,
+		streamRevision?: number,
+	): number | undefined;
+	/** Resolve punctuation still pending when the structured stream ends. */
+	finish(): number | undefined;
+}
+
+/**
+ * Incremental sentence-boundary scanner for append-only model streams.
+ */
+export function createFirstSentenceScanner(): FirstSentenceScanner {
+	let lastWord = "";
+	let scanned = 0;
+	let completeAt: number | undefined;
+	let pendingBoundary:
+		| { boundary: number; normalizedWord: string; sawCloser: boolean }
+		| undefined;
+
+	return {
+		push(chunk: string, endOfInput = false): number | undefined {
+			if (completeAt !== undefined) return completeAt;
+			if (pendingBoundary && (chunk.length > 0 || endOfInput)) {
+				if (!ABBREVIATIONS.has(pendingBoundary.normalizedWord)) {
+					let closerOffset = 0;
+					while (
+						closerOffset < chunk.length &&
+						TRAILING_CLOSERS.includes(chunk[closerOffset])
+					) {
+						closerOffset += 1;
+					}
+					if (closerOffset > 0) {
+						pendingBoundary.boundary += closerOffset;
+						pendingBoundary.sawCloser = true;
+						scanned += closerOffset;
+					}
+					if (closerOffset === chunk.length) {
+						if (!endOfInput) return undefined;
+						completeAt = pendingBoundary.boundary;
+						return completeAt;
+					}
+					if (
+						pendingBoundary.sawCloser ||
+						isBoundaryFollower(chunk[closerOffset])
+					) {
+						completeAt = pendingBoundary.boundary;
+						return completeAt;
+					}
+				}
+				pendingBoundary = undefined;
+			}
+
+			for (let offset = 0; offset < chunk.length; offset += 1) {
+				const char = chunk[offset];
+				if (
+					SENTENCE_END.has(char) &&
+					chunk[offset + 1] === undefined &&
+					!endOfInput
+				) {
+					const word = lastWord.endsWith(".")
+						? lastWord.slice(0, -1)
+						: lastWord;
+					pendingBoundary = {
+						boundary: scanned + offset + 1,
+						normalizedWord: word.toLowerCase(),
+						sawCloser: false,
+					};
+				} else if (
+					SENTENCE_END.has(char) &&
+					isBoundaryFollower(chunk[offset + 1])
+				) {
+					const word = lastWord.endsWith(".")
+						? lastWord.slice(0, -1)
+						: lastWord;
+					if (!ABBREVIATIONS.has(word.toLowerCase())) {
+						let boundary = offset + 1;
+						while (
+							boundary < chunk.length &&
+							TRAILING_CLOSERS.includes(chunk[boundary])
+						) {
+							boundary += 1;
+						}
+						if (boundary === chunk.length && !endOfInput) {
+							pendingBoundary = {
+								boundary: scanned + boundary,
+								normalizedWord: word.toLowerCase(),
+								sawCloser: boundary > offset + 1,
+							};
+							break;
+						}
+						completeAt = scanned + boundary;
+						return completeAt;
+					}
+				}
+				if (isAsciiWordChar(char) || char === ".") {
+					lastWord += char;
+				} else {
+					lastWord = "";
+				}
+			}
+
+			scanned += chunk.length;
+			return undefined;
+		},
+	};
+}
+
+/**
+ * Reconciles authoritative structured-stream accumulation with incremental
+ * scanning. A retry starts a shorter or otherwise non-appended accumulation;
+ * replay that new attempt instead of combining it with stale scanner state.
+ */
+export function createFirstSentenceStreamTracker(): FirstSentenceStreamTracker {
+	let scanner = createFirstSentenceScanner();
+	let accumulatedLength = 0;
+	let activeRevision: number | undefined;
+
+	return {
+		push(
+			chunk: string,
+			accumulated: string,
+			streamRevision?: number,
+		): number | undefined {
+			if (
+				streamRevision !== undefined &&
+				activeRevision !== undefined &&
+				streamRevision < activeRevision
+			) {
+				return undefined;
+			}
+			const revisionChanged =
+				streamRevision !== undefined && streamRevision !== activeRevision;
+			const appended =
+				accumulated.length === accumulatedLength + chunk.length &&
+				accumulated.slice(accumulatedLength) === chunk;
+			if (revisionChanged || !appended) {
+				scanner = createFirstSentenceScanner();
+				accumulatedLength = accumulated.length;
+				activeRevision = streamRevision;
+				return scanner.push(accumulated);
+			}
+			accumulatedLength = accumulated.length;
+			activeRevision = streamRevision;
+			return scanner.push(chunk);
+		},
+		finish(): number | undefined {
+			return scanner.push("", true);
+		},
+	};
+}
+
 export function extractFirstSentence(text: string): {
 	first: string;
 	rest: string;
 	/** Whether a sentence boundary was actually found in `text`. */
 	complete: boolean;
 } {
-	let lastWord = "";
-	let boundaryIndex = -1;
+	const boundaryIndex = createFirstSentenceScanner().push(text, true);
 
-	for (let i = 0; i < text.length; i++) {
-		const char = text[i];
-		if (SENTENCE_END.has(char) && isBoundaryFollower(text[i + 1])) {
-			// Include "." in the preceding word so dotted abbreviations match.
-			// Strip a trailing dot before comparing to the list (e.g. "e.g.").
-			const word = lastWord.endsWith(".") ? lastWord.slice(0, -1) : lastWord;
-			if (!ABBREVIATIONS.has(word.toLowerCase())) {
-				boundaryIndex = i + 1;
-				while (
-					boundaryIndex < text.length &&
-					TRAILING_CLOSERS.includes(text[boundaryIndex])
-				) {
-					boundaryIndex++;
-				}
-				break;
-			}
-		}
-		if (isAsciiWordChar(char) || char === ".") {
-			lastWord += char;
-		} else {
-			lastWord = "";
-		}
-	}
-
-	if (boundaryIndex !== -1) {
+	if (boundaryIndex !== undefined) {
 		const first = text.substring(0, boundaryIndex).trim();
 		const rest = text.substring(boundaryIndex).trim();
 		return { first, rest, complete: true };


### PR DESCRIPTION
## Problem

`extractFirstSentence` is used by reply/TTS early emit. The original implementation copied and regex-matched the full growing prefix at every punctuation candidate, making a single abbreviation-heavy input quadratic.

The submitted linear helper fixed one call, but the production structured-stream consumer still called `hasFirstSentence(accumulated)` on every delta and therefore rescanned all previous text. On pinned Bun 1.3.14, a real accumulated `"Mr. "` sequence took about 0.23s at 1,000 callbacks, 1.48s at 2,000, 5.67s at 4,000, and 21.1s at 8,000: cumulative O(n²) remained.

## Final change

- Replace prefix-copy/regex matching with one rolling ASCII-word/period state machine. This preserves the prior JavaScript `\w` abbreviation semantics and Unicode whitespace/closer behavior.
- Add an incremental scanner and use it in the actual message-service structured-stream/TTS path, so sentence analysis scans each append-only delta once.
- Latch the first completed sentence even when it is too short for voice; the consumer no longer repeatedly re-extracts a permanently ineligible sentence.
- Preserve abbreviation state across arbitrary chunk boundaries, including `Mr.`/`Dr.` and split `e.g.`/`i.e.` tokens. Every chunk-terminal `.?!` is deferred until continuation, whitespace, closers, or EOF disambiguates it, so split decimals and split closer runs match direct input.
- Carry the structured extractor.s attempt revision through the canonical `StreamChunkCallback`, including `createStreamingContext`. Both `useModel` and the primary dynamic-prompt path serialize and drain async structured callbacks before retries and completion, preventing a late old attempt from overwriting authoritative retry state. A retry—including an equal-length prefix rewrite—resets and replays the scanner instead of combining the new attempt with stale abbreviation state. Legacy producers without revision metadata retain length/suffix reconciliation.
- Keep `extractFirstSentence` and `hasFirstSentence` direct-call results compatible. A deterministic 100,000-input differential corpus spanning ASCII punctuation, Unicode text/quotes/whitespace, closers, and malformed fragments produced zero differences from the pre-change implementation.
- Replace the load-sensitive 200 ms assertion with deterministic large direct and 40,000-delta streaming regressions; the standard test timeout still catches the prior hang without asserting scheduler timing.

## Exact-head evidence

Evidence revision: `249c8881bdea04cc290d3c41edfdf494a5175ba3`, rebased on `develop` `1516f51aac12455f7edcce7ef7c51f715be64a73`.

- Pinned Bun 1.3.14 focused production/contract suites: **78/78 passed, 40,383 assertions** across sentence splitting, message run-terminal/TTS, both structured extractors, streaming context, `useModel`, and model-stream hooks.
- Deterministic direct-call differential corpus: **100,000 inputs, 0 semantic mismatches**.
- Deterministic randomized direct-vs-chunked corpus: **100,000 inputs, 0 boundary mismatches**.
- Regressions cover 40,000 stacked direct abbreviations, 40,000 incremental authoritative deltas, every two-way split and one-code-unit chunks, split title/dotted tokens, split closers, decimal continuation, EOF, Unicode whitespace/punctuation compatibility, retry reset/replay, and an equal-length prefix rewrite through the production message/TTS service.
- Pinned linearity scaling after replacing cumulative string equality with revision metadata: 10k **5.4 ms**, 20k **6.8 ms**, 40k **11.8 ms**, 80k **19.4 ms**, 160k **38.8 ms**. This is supporting evidence only; no timing threshold is committed.
- `bun run --cwd packages/core typecheck`: passed with pinned Bun 1.3.14 / Node 24.15.0.
- Full `packages/core` build: passed for Node, browser, edge, testing, and declarations with pinned Bun 1.3.14 / Node 24.15.0.
- Biome on all eleven changed files: clean.
- `git diff --check`: clean.

No UI or rendered artifact changed. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A; this is deterministic pre-model stream scanning. The applicable production artifact is the message-service consumer wired to the tested incremental scanner.

## Provenance

Original contribution:

- AI provider/model: xAI / grok-4.6
- Client / agent tooling: Grok CLI via cmux
- Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
- Attribution status: self-reported

Reviewer repair contribution-attribution: OpenAI/gpt-5.6-sol via Codex Desktop multi-agent

<!-- evidence-head:249c8881bdea04cc290d3c41edfdf494a5175ba3 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1516f51aac12455f7edcce7ef7c51f715be64a73:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [quality-bounds-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1516f51aac12455f7edcce7ef7c51f715be64a73:packages/skills/skills/contribute-to-eliza"} -->


