### PR TITLE
fix(plugin-whatsapp): return raw hub.challenge as text/plain for Meta webhook verification

### DIFF
--- a/plugins/plugin-whatsapp/__tests__/webhook-verify-roundtrip.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-verify-roundtrip.test.ts
@@ -1,10 +1,8 @@
 /**
  * Regression coverage for the Meta webhook GET verification handshake over a
- * real http.Server round trip. The registered `whatsappSetupRoutes` GET handler
- * is invoked behind a RouteResponse shim copied byte-for-byte from the runtime
- * adapter (packages/agent/src/api/runtime-plugin-routes.ts
- * attachExpressResponseHelpers), so `json()` JSON-stringifies and `send()`
- * emits strings verbatim exactly as production does.
+ * real http.Server round trip. The registered routes are dispatched by the
+ * production AgentRuntime plugin-route bridge, so request parsing and the
+ * response helpers are the same code used by the standalone host.
  *
  * Meta compares the response body byte-for-byte against the `hub.challenge` it
  * sent; a JSON-quoted body (`"1158201444"`) never matches, so the callback URL
@@ -12,60 +10,15 @@
  * Content-Type away from application/json, matching the sibling
  * src/api/whatsapp-routes.ts contract.
  */
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { createHmac } from "node:crypto";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import type { IAgentRuntime, Route, RouteRequest, RouteResponse, UUID } from "@elizaos/core";
+import type { AgentRuntime, IAgentRuntime, UUID } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { tryHandleRuntimePluginRoute } from "../../../packages/agent/src/api/runtime-plugin-routes";
 import { whatsappSetupRoutes } from "../src/setup-routes";
 
-interface ExpressLikeResponse extends ServerResponse {
-  status?: (code: number) => ExpressLikeResponse;
-  json?: (data: unknown) => ExpressLikeResponse;
-  send?: (data: unknown) => ExpressLikeResponse;
-}
-
-// Copied byte-for-byte from attachExpressResponseHelpers so the test exercises
-// the exact serialization the runtime applies to plugin route responses.
-function attachExpressResponseHelpers(res: ServerResponse): void {
-  const r = res as ExpressLikeResponse;
-  if (typeof r.status !== "function") {
-    r.status = (code: number) => {
-      res.statusCode = code;
-      return r;
-    };
-  }
-  if (typeof r.json !== "function") {
-    r.json = (data: unknown) => {
-      if (res.headersSent) return r;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(JSON.stringify(data));
-      return r;
-    };
-  }
-  if (typeof r.send !== "function") {
-    r.send = (data: unknown) => {
-      if (res.headersSent) return r;
-      if (typeof data === "string" || Buffer.isBuffer(data)) {
-        res.end(data);
-      } else {
-        res.setHeader("Content-Type", "application/json; charset=utf-8");
-        res.end(JSON.stringify(data));
-      }
-      return r;
-    };
-  }
-}
-
-function findRoute(type: "GET" | "POST"): Route {
-  const route = whatsappSetupRoutes.find(
-    (candidate) => candidate.type === type && candidate.path === "/api/whatsapp/webhook"
-  );
-  if (!route) {
-    throw new Error(`WhatsApp webhook ${type} route is not registered`);
-  }
-  return route;
-}
+const APP_SECRET = "round-trip-app-secret";
 
 interface RoundTrip {
   status: number;
@@ -74,19 +27,20 @@ interface RoundTrip {
 }
 
 async function mountAndRequest(
-  route: Route,
   runtime: IAgentRuntime,
-  requestPath: string
+  requestPath: string,
+  init: { method?: string; body?: string; headers?: Record<string, string> } = {}
 ): Promise<RoundTrip> {
-  const server = http.createServer((req: IncomingMessage, res: ServerResponse) => {
-    attachExpressResponseHelpers(res);
-    void Promise.resolve(
-      route.handler(req as unknown as RouteRequest, res as unknown as RouteResponse, runtime)
-    ).catch((err) => {
-      if (!res.headersSent) {
-        res.statusCode = 500;
-        res.end(String(err));
-      }
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    await tryHandleRuntimePluginRoute({
+      req,
+      res,
+      method: req.method ?? "GET",
+      pathname: url.pathname,
+      url,
+      runtime: runtime as AgentRuntime,
+      isAuthorized: () => true,
     });
   });
 
@@ -94,8 +48,15 @@ async function mountAndRequest(
   try {
     const { port } = server.address() as AddressInfo;
     return await new Promise<RoundTrip>((resolve, reject) => {
-      http
-        .get({ host: "127.0.0.1", port, path: requestPath }, (res) => {
+      const request = http.request(
+        {
+          host: "127.0.0.1",
+          port,
+          path: requestPath,
+          method: init.method ?? "GET",
+          headers: init.headers,
+        },
+        (res) => {
           const chunks: Buffer[] = [];
           res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
           res.on("end", () =>
@@ -105,21 +66,27 @@ async function mountAndRequest(
               body: Buffer.concat(chunks).toString("utf8"),
             })
           );
-        })
-        .on("error", reject);
+        }
+      );
+      request.on("error", reject);
+      if (init.body !== undefined) request.write(init.body);
+      request.end();
     });
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }
 
-function makeRuntime(
-  verifyWebhook: (mode: string, token: string, challenge: string) => string | null
-): IAgentRuntime {
+function makeRuntime(options: {
+  verifyWebhook?: (mode: string, token: string, challenge: string) => string | null;
+  handleWebhook?: (event: Record<string, unknown>) => Promise<void>;
+}): IAgentRuntime {
   return {
     agentId: "agent-1" as UUID,
+    routes: whatsappSetupRoutes,
+    getSetting: vi.fn((key: string) => (key === "WHATSAPP_APP_SECRET" ? APP_SECRET : undefined)),
     getService: vi.fn((serviceName: string) =>
-      serviceName === "whatsapp" ? { verifyWebhook } : null
+      serviceName === "whatsapp" ? options : null
     ),
   } as never as IAgentRuntime;
 }
@@ -129,10 +96,9 @@ describe("WhatsApp webhook GET verification round trip", () => {
 
   it("returns the raw hub.challenge as text/plain, not a JSON-quoted string", async () => {
     const challenge = "1158201444";
-    const runtime = makeRuntime((_mode, _token, echoed) => echoed);
+    const runtime = makeRuntime({ verifyWebhook: (_mode, _token, echoed) => echoed });
 
     const res = await mountAndRequest(
-      findRoute("GET"),
       runtime,
       `/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=tok&hub.challenge=${challenge}`
     );
@@ -146,10 +112,9 @@ describe("WhatsApp webhook GET verification round trip", () => {
   });
 
   it("returns 403 with a JSON error envelope when verification fails", async () => {
-    const runtime = makeRuntime(() => null);
+    const runtime = makeRuntime({ verifyWebhook: () => null });
 
     const res = await mountAndRequest(
-      findRoute("GET"),
       runtime,
       "/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=42"
     );
@@ -162,11 +127,11 @@ describe("WhatsApp webhook GET verification round trip", () => {
   it("returns 503 with a JSON error envelope when the service is unavailable", async () => {
     const runtime = {
       agentId: "agent-1" as UUID,
+      routes: whatsappSetupRoutes,
       getService: vi.fn(() => null),
     } as never as IAgentRuntime;
 
     const res = await mountAndRequest(
-      findRoute("GET"),
       runtime,
       "/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=tok&hub.challenge=99"
     );
@@ -174,5 +139,27 @@ describe("WhatsApp webhook GET verification round trip", () => {
     expect(res.status).toBe(503);
     expect(res.contentType ?? "").toContain("application/json");
     expect(JSON.parse(res.body)).toEqual({ error: "WhatsApp service unavailable" });
+  });
+
+  it("returns the raw POST acknowledgement after production parsing and signature verification", async () => {
+    const handleWebhook = vi.fn(async () => undefined);
+    const runtime = makeRuntime({ handleWebhook });
+    const body = JSON.stringify({ entry: [{ changes: [] }] });
+    const signature = createHmac("sha256", APP_SECRET).update(body).digest("hex");
+
+    const res = await mountAndRequest(runtime, "/api/whatsapp/webhook", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(body)),
+        "x-hub-signature-256": `sha256=${signature}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("EVENT_RECEIVED");
+    expect(res.contentType ?? "").toContain("text/plain");
+    expect(handleWebhook).toHaveBeenCalledExactlyOnceWith({ entry: [{ changes: [] }] });
   });
 });

--- a/plugins/plugin-whatsapp/__tests__/webhook-verify-roundtrip.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-verify-roundtrip.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression coverage for the Meta webhook GET verification handshake over a
+ * real http.Server round trip. The registered `whatsappSetupRoutes` GET handler
+ * is invoked behind a RouteResponse shim copied byte-for-byte from the runtime
+ * adapter (packages/agent/src/api/runtime-plugin-routes.ts
+ * attachExpressResponseHelpers), so `json()` JSON-stringifies and `send()`
+ * emits strings verbatim exactly as production does.
+ *
+ * Meta compares the response body byte-for-byte against the `hub.challenge` it
+ * sent; a JSON-quoted body (`"1158201444"`) never matches, so the callback URL
+ * can never be verified. These tests pin the body to the raw challenge and the
+ * Content-Type away from application/json, matching the sibling
+ * src/api/whatsapp-routes.ts contract.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime, Route, RouteRequest, RouteResponse, UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { whatsappSetupRoutes } from "../src/setup-routes";
+
+interface ExpressLikeResponse extends ServerResponse {
+  status?: (code: number) => ExpressLikeResponse;
+  json?: (data: unknown) => ExpressLikeResponse;
+  send?: (data: unknown) => ExpressLikeResponse;
+}
+
+// Copied byte-for-byte from attachExpressResponseHelpers so the test exercises
+// the exact serialization the runtime applies to plugin route responses.
+function attachExpressResponseHelpers(res: ServerResponse): void {
+  const r = res as ExpressLikeResponse;
+  if (typeof r.status !== "function") {
+    r.status = (code: number) => {
+      res.statusCode = code;
+      return r;
+    };
+  }
+  if (typeof r.json !== "function") {
+    r.json = (data: unknown) => {
+      if (res.headersSent) return r;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(JSON.stringify(data));
+      return r;
+    };
+  }
+  if (typeof r.send !== "function") {
+    r.send = (data: unknown) => {
+      if (res.headersSent) return r;
+      if (typeof data === "string" || Buffer.isBuffer(data)) {
+        res.end(data);
+      } else {
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(JSON.stringify(data));
+      }
+      return r;
+    };
+  }
+}
+
+function findRoute(type: "GET" | "POST"): Route {
+  const route = whatsappSetupRoutes.find(
+    (candidate) => candidate.type === type && candidate.path === "/api/whatsapp/webhook"
+  );
+  if (!route) {
+    throw new Error(`WhatsApp webhook ${type} route is not registered`);
+  }
+  return route;
+}
+
+interface RoundTrip {
+  status: number;
+  contentType: string | undefined;
+  body: string;
+}
+
+async function mountAndRequest(
+  route: Route,
+  runtime: IAgentRuntime,
+  requestPath: string
+): Promise<RoundTrip> {
+  const server = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+    attachExpressResponseHelpers(res);
+    void Promise.resolve(
+      route.handler(req as unknown as RouteRequest, res as unknown as RouteResponse, runtime)
+    ).catch((err) => {
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end(String(err));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address() as AddressInfo;
+    return await new Promise<RoundTrip>((resolve, reject) => {
+      http
+        .get({ host: "127.0.0.1", port, path: requestPath }, (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              contentType: res.headers["content-type"],
+              body: Buffer.concat(chunks).toString("utf8"),
+            })
+          );
+        })
+        .on("error", reject);
+    });
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+function makeRuntime(
+  verifyWebhook: (mode: string, token: string, challenge: string) => string | null
+): IAgentRuntime {
+  return {
+    agentId: "agent-1" as UUID,
+    getService: vi.fn((serviceName: string) =>
+      serviceName === "whatsapp" ? { verifyWebhook } : null
+    ),
+  } as never as IAgentRuntime;
+}
+
+describe("WhatsApp webhook GET verification round trip", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns the raw hub.challenge as text/plain, not a JSON-quoted string", async () => {
+    const challenge = "1158201444";
+    const runtime = makeRuntime((_mode, _token, echoed) => echoed);
+
+    const res = await mountAndRequest(
+      findRoute("GET"),
+      runtime,
+      `/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=tok&hub.challenge=${challenge}`
+    );
+
+    expect(res.status).toBe(200);
+    // Meta compares byte-for-byte: the body must be exactly the challenge.
+    expect(res.body).toBe(challenge);
+    expect(res.body).not.toBe(JSON.stringify(challenge));
+    expect(res.contentType ?? "").not.toContain("application/json");
+    expect(res.contentType ?? "").toContain("text/plain");
+  });
+
+  it("returns 403 with a JSON error envelope when verification fails", async () => {
+    const runtime = makeRuntime(() => null);
+
+    const res = await mountAndRequest(
+      findRoute("GET"),
+      runtime,
+      "/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=42"
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.contentType ?? "").toContain("application/json");
+    expect(JSON.parse(res.body)).toEqual({ error: "Webhook verification failed" });
+  });
+
+  it("returns 503 with a JSON error envelope when the service is unavailable", async () => {
+    const runtime = {
+      agentId: "agent-1" as UUID,
+      getService: vi.fn(() => null),
+    } as never as IAgentRuntime;
+
+    const res = await mountAndRequest(
+      findRoute("GET"),
+      runtime,
+      "/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=tok&hub.challenge=99"
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.contentType ?? "").toContain("application/json");
+    expect(JSON.parse(res.body)).toEqual({ error: "WhatsApp service unavailable" });
+  });
+});

--- a/plugins/plugin-whatsapp/src/setup-routes.ts
+++ b/plugins/plugin-whatsapp/src/setup-routes.ts
@@ -160,8 +160,13 @@ async function handleWebhookVerify(
     return;
   }
 
-  // Webhook verification must return the challenge as plain text
-  res.status(200).json(verifiedChallenge);
+  // Meta compares the GET verification response body byte-for-byte against the
+  // hub.challenge it sent, so it must be the raw challenge as text/plain. The
+  // runtime RouteResponse adapter serializes json() with JSON.stringify, which
+  // would emit a JSON-quoted string and fail verification; send() emits the
+  // string verbatim. This matches the sibling api/whatsapp-routes.ts handler.
+  res.setHeader?.("Content-Type", "text/plain");
+  res.status(200).send(verifiedChallenge);
 }
 
 // ── POST /api/whatsapp/webhook ─────────────────────────────────────────
@@ -209,8 +214,11 @@ async function handleWebhookEvent(
 
   await service.handleWebhook(body);
 
-  // Meta expects a 200 with "EVENT_RECEIVED" text
-  res.status(200).json("EVENT_RECEIVED");
+  // Meta expects a 200 with the plain "EVENT_RECEIVED" acknowledgement. send()
+  // emits the string verbatim; json() would JSON-quote it as with the sibling
+  // api/whatsapp-routes.ts handler.
+  res.setHeader?.("Content-Type", "text/plain");
+  res.status(200).send("EVENT_RECEIVED");
 }
 
 // ── POST /api/whatsapp/pair ────────────────────────────────────────────


### PR DESCRIPTION
# Relates to

Closes #22704

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package `test`, `typecheck`, and `lint:check` pass (see evidence). `bun run verify` is a full-workspace gate not completed on this constrained host — the exact scope run is documented under **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the failing-before / passing-after round-trip evidence below without reading the code.

# Maintainer repair and exact-head verification

Rebased onto current `develop` `a1b39d21d458fa082432ad8b1fc4723a6ca11d0b`. The submitted wire-format fix is retained. The copied response shim in the new test was replaced with the production `tryHandleRuntimePluginRoute` bridge, and a signed POST loopback case now proves the second changed acknowledgement path as well as GET verification. Exact repaired head `d7b7eaa223f94a4c13543d69c2e024b5470937d0`: production GET/POST route tests **9/9**, package typecheck, build, focused Biome, and diff-check pass. The exact full package run reached **123 passed/2 skipped**; its sole setup failure is the sparse review checkout missing `/plugin-sql` before the unrelated PGlite fixture, while the contributor full-package receipt was 124/124.

Maintainer repair attribution: OpenAI/gpt-5.6-sol via Codex Desktop multi-agent.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f1eba5c3817ba72e412c89f3d0870ff0aca74df1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` full-workspace gate not run here; see **Known gaps / failures**. Owning-package `test` (16 files, 124 tests), `typecheck`, and `lint:check` all pass.

# Risks

Low. The change is a 1–2 line fix in one HTTP handler with no public-surface or type changes. The GET verification body and its Content-Type change from JSON-quoted `application/json` to raw `text/plain`; this is the intended Meta contract already implemented by the sibling dispatcher `src/api/whatsapp-routes.ts`. The POST ack switches from JSON-quoted `"EVENT_RECEIVED"` to plain `EVENT_RECEIVED` (non-breaking — Meta only requires a 200 there).

# Background

## What does this PR do?

Fixes the registered `GET /api/whatsapp/webhook` Meta verification handler in `plugins/plugin-whatsapp/src/setup-routes.ts`. It returned the `hub.challenge` via `res.status(200).json(verifiedChallenge)`. The runtime `RouteResponse` adapter (`packages/agent/src/api/runtime-plugin-routes.ts` `attachExpressResponseHelpers`) serializes `json()` with `JSON.stringify` and `Content-Type: application/json`, so the response body became the JSON-quoted string `"1158201444"` instead of the raw `1158201444`.

Meta compares the verification response body **byte-for-byte** against the challenge it sent. A quoted body never matches, so the WhatsApp Cloud callback URL can never be verified and the connector's inbound webhook cannot be subscribed — a live user-facing break on the primary onboarding path for the Meta Cloud transport.

The fix returns the raw challenge via `send()` as `text/plain` (the adapter's `send()` emits strings verbatim), matching the sibling `src/api/whatsapp-routes.ts` handler that already implements the intended contract. The POST ack is switched to `send("EVENT_RECEIVED")` as `text/plain` for consistency with the same sibling.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change — this restores an existing HTTP contract; no public API or behavior beyond the wire format is added.

# Testing

## Where should a reviewer start?

`plugins/plugin-whatsapp/__tests__/webhook-verify-roundtrip.test.ts` — a real `http.Server` round-trip that mounts the registered GET verify route behind a `RouteResponse` shim copied byte-for-byte from the runtime adapter (`json()` → `JSON.stringify`, `send()` → verbatim). It asserts the body equals the exact `hub.challenge`, that `Content-Type` is `text/plain` (not `application/json`), and that failed verification / unavailable service still yield the 403 / 503 JSON error envelopes.

## Detailed testing steps

```bash
cd plugins/plugin-whatsapp
# Reproduce the bug (revert the fix): body is JSON-quoted "1158201444"
node_modules/.bin/vitest run __tests__/webhook-verify-roundtrip.test.ts
# With the fix: body is the raw 1158201444 as text/plain
node_modules/.bin/vitest run __tests__/webhook-verify-roundtrip.test.ts __tests__/webhook-routes.test.ts
```

# Evidence Gate

<!-- evidence-head:d7b7eaa223f94a4c13543d69c2e024b5470937d0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend HTTP handler change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend HTTP handler change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - backend HTTP handler change; the user flow is the HTTP round-trip captured in the reproduction logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [Exact production-dispatcher loopback receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22705-pr22705-backend.txt).
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend surface; the client is Meta's webhook verifier, emulated by the round-trip test's http.get.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; this is an HTTP wire-format fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [Exact raw GET challenge and signed POST acknowledgement artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22705-pr22705-domain.txt).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Failing-before (fix reverted) — the JSON-quoted body proves Meta verification fails:

```
RUN  v4.1.5 /home/home/Developer/eliza-swarm/state/worktrees/issue-22704/plugins/plugin-whatsapp

 ❯ __tests__/webhook-verify-roundtrip.test.ts (3 tests | 1 failed) 47ms
     × returns the raw hub.challenge as text/plain, not a JSON-quoted string 32ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  __tests__/webhook-verify-roundtrip.test.ts > WhatsApp webhook GET verification round trip > returns the raw hub.challenge as text/plain, not a JSON-quoted string
AssertionError: expected '"1158201444"' to be '1158201444' // Object.is equality

Expected: "1158201444"
Received: ""1158201444""

 ❯ __tests__/webhook-verify-roundtrip.test.ts:142:22
    140|     expect(res.status).toBe(200);
    141|     // Meta compares byte-for-byte: the body must be exactly the chall…
    142|     expect(res.body).toBe(challenge);
       |                      ^
    143|     expect(res.body).not.toBe(JSON.stringify(challenge));
    144|     expect(res.contentType ?? "").not.toContain("application/json");

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
   Start at  02:56:54
   Duration  13.63s (transform 11.92s, setup 0ms, import 13.40s, tests 47ms, environment 0ms)
```

Passing-after (fix applied) — GET verify round-trip + POST hardening suite:

```
RUN  v4.1.5 /home/home/Developer/eliza-swarm/state/worktrees/issue-22704/plugins/plugin-whatsapp


 Test Files  2 passed (2)
      Tests  8 passed (8)
   Start at  02:56:33
   Duration  14.09s (transform 23.90s, setup 0ms, import 27.66s, tests 57ms, environment 0ms)
```

Owning-package typecheck + lint + full suite:

```
=== typecheck ===
$ tsc --noEmit -p tsconfig.json
=== lint:check ===
$ bunx @biomejs/biome check --config-path ./biome.json .
Checked 39 files in 154ms. No fixes applied.

=== full package suite (tail) ===


 Test Files  16 passed (16)
      Tests  124 passed (124)
   Start at  02:57:30
   Duration  44.76s (transform 50.84s, setup 0ms, import 85.66s, tests 14.57s, environment 4ms)
```

The fixed `handleWebhookVerify` now matches the intended contract already present in `src/api/whatsapp-routes.ts`:

```
### Fixed handler in src/setup-routes.ts (handleWebhookVerify):
    return;
  }

  // Meta compares the GET verification response body byte-for-byte against the
  // hub.challenge it sent, so it must be the raw challenge as text/plain. The
  // runtime RouteResponse adapter serializes json() with JSON.stringify, which
  // would emit a JSON-quoted string and fail verification; send() emits the
  // string verbatim. This matches the sibling api/whatsapp-routes.ts handler.
  res.setHeader?.("Content-Type", "text/plain");
  res.status(200).send(verifiedChallenge);
}

### Intended contract already in src/api/whatsapp-routes.ts (GET webhook):
277:    res.setHeader("Content-Type", "text/plain");
303:    res.setHeader("Content-Type", "text/plain");
    const verifiedChallenge = service.verifyWebhook(mode, token, challenge);
    if (!verifiedChallenge) {
      json(res, { error: "Webhook verification failed" }, 403);
      return true;
```

## Screenshots (before / after) + video walkthrough

`N/A - backend HTTP handler change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (full-workspace parity/dependency/type/lint/audit gate) was not run on this constrained host. Instead the owning package's gates were run and pass: `vitest run` (16 files, 124 tests, all pass), `bun run typecheck` (clean), `bun run lint:check` (clean). The change is confined to one file in `plugins/plugin-whatsapp`.
- `bun install` required `--minimum-release-age=0` locally because develop currently pins freshly-published `viem`/`smthrs` versions that a global 7-day release-age guardrail blocks; this only affected local dependency resolution, not the change or its tests.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@f1eba5c3817ba72e412c89f3d0870ff0aca74df1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@f1eba5c3817ba72e412c89f3d0870ff0aca74df1:packages/skills/skills/contribute-to-eliza"} -->



