### PR TITLE
fix(ui): fail closed on unbounded GenUI unsafe-field walks

### DIFF
--- a/packages/ui/src/genui/types.ts
+++ b/packages/ui/src/genui/types.ts
@@ -96,7 +96,8 @@ export type ElizaGenUiValidationIssue = {
     | "unsafe_url"
     | "unsafe_field"
     | "too_large"
-    | "too_many_components";
+    | "too_many_components"
+    | "unbounded_nest";
   message: string;
   componentId?: string;
   path?: string;

--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -137,6 +137,22 @@ function snapshotUnsafeFields(
     ctx.halted = true;
     return undefined;
   }
+  if (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    typeof value === "bigint" ||
+    (typeof value === "number" && !Number.isFinite(value))
+  ) {
+    addIssue(issues, {
+      code: "invalid_spec",
+      message: "Generated UI values must use serializable JSON primitives.",
+      componentId,
+      path,
+    });
+    ctx.halted = true;
+    return undefined;
+  }
   if (!value || typeof value !== "object") {
     return value;
   }

--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -93,11 +93,19 @@ function validateUnsafeFields(
   path: string,
   componentId?: string,
   depth = 0,
-  ctx: { visits: number; ancestors: WeakSet<object> } = {
+  ctx: {
+    visits: number;
+    ancestors: WeakSet<object>;
+    halted: boolean;
+    maxCodeUnits: number;
+  } = {
     visits: 0,
     ancestors: new WeakSet<object>(),
+    halted: false,
+    maxCodeUnits: DEFAULT_MAX_JSON_BYTES,
   },
 ): void {
+  if (ctx.halted) return;
   if (depth > MAX_GENUI_UNSAFE_FIELD_DEPTH) {
     addIssue(issues, {
       code: "unbounded_nest",
@@ -105,6 +113,7 @@ function validateUnsafeFields(
       componentId,
       path,
     });
+    ctx.halted = true;
     return;
   }
   ctx.visits += 1;
@@ -115,6 +124,17 @@ function validateUnsafeFields(
       componentId,
       path,
     });
+    ctx.halted = true;
+    return;
+  }
+  if (typeof value === "string" && value.length > ctx.maxCodeUnits) {
+    addIssue(issues, {
+      code: "too_large",
+      message: "Generated UI contains a string larger than its JSON budget.",
+      componentId,
+      path,
+    });
+    ctx.halted = true;
     return;
   }
   if (!value || typeof value !== "object") {
@@ -127,14 +147,72 @@ function validateUnsafeFields(
       componentId,
       path,
     });
+    ctx.halted = true;
     return;
   }
   ctx.ancestors.add(value);
   try {
+    // JSON.stringify performs an ordinary Get of `toJSON`, including through
+    // the prototype chain. Inspect descriptors without invoking accessors so a
+    // hostile object cannot run code or synthesize a second, unbudgeted graph.
+    let prototype: object | null = value;
+    while (prototype) {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, "toJSON");
+      if (descriptor) {
+        if (
+          "get" in descriptor ||
+          "set" in descriptor ||
+          typeof descriptor.value === "function"
+        ) {
+          addIssue(issues, {
+            code: "unbounded_nest",
+            message:
+              "Generated UI values may not define custom JSON serialization.",
+            componentId,
+            path,
+          });
+          ctx.halted = true;
+          return;
+        }
+        break;
+      }
+      prototype = Object.getPrototypeOf(prototype);
+    }
+
     if (Array.isArray(value)) {
-      for (let index = 0; index < value.length; index += 1) {
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+      const length = lengthDescriptor?.value;
+      if (
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        length > MAX_GENUI_UNSAFE_FIELD_NODES - ctx.visits
+      ) {
+        addIssue(issues, {
+          code: "unbounded_nest",
+          message: `Generated UI value exceeds ${MAX_GENUI_UNSAFE_FIELD_NODES} nodes.`,
+          componentId,
+          path,
+        });
+        ctx.halted = true;
+        return;
+      }
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(
+          value,
+          String(index),
+        );
+        if (descriptor && ("get" in descriptor || "set" in descriptor)) {
+          addIssue(issues, {
+            code: "unbounded_nest",
+            message: "Generated UI values may not contain accessors.",
+            componentId,
+            path: `${path}/${index}`,
+          });
+          ctx.halted = true;
+          return;
+        }
         validateUnsafeFields(
-          value[index],
+          descriptor?.value,
           issues,
           `${path}/${index}`,
           componentId,
@@ -144,7 +222,30 @@ function validateUnsafeFields(
       }
       return;
     }
-    for (const [key, entry] of Object.entries(value)) {
+    for (const key in value) {
+      if (ctx.halted) return;
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (key.length > ctx.maxCodeUnits) {
+        addIssue(issues, {
+          code: "too_large",
+          message: "Generated UI contains a key larger than its JSON budget.",
+          componentId,
+          path,
+        });
+        ctx.halted = true;
+        return;
+      }
+      if ("get" in descriptor || "set" in descriptor) {
+        addIssue(issues, {
+          code: "unbounded_nest",
+          message: "Generated UI values may not contain accessors.",
+          componentId,
+          path: `${path}/${key}`,
+        });
+        ctx.halted = true;
+        return;
+      }
       if (UNSAFE_FIELD_NAMES.has(key)) {
         addIssue(issues, {
           code: "unsafe_field",
@@ -154,7 +255,7 @@ function validateUnsafeFields(
         });
       }
       validateUnsafeFields(
-        entry,
+        descriptor.value,
         issues,
         `${path}/${key}`,
         componentId,
@@ -162,6 +263,16 @@ function validateUnsafeFields(
         ctx,
       );
     }
+  } catch {
+    // error-policy:J3 proxies and racing descriptors are invalid input; the
+    // public validator never lets reflection failures escape.
+    addIssue(issues, {
+      code: "unbounded_nest",
+      message: "Generated UI value could not be inspected safely.",
+      componentId,
+      path,
+    });
+    ctx.halted = true;
   } finally {
     ctx.ancestors.delete(value);
   }
@@ -305,7 +416,6 @@ function validateComponent(
   if ("action" in record) {
     validateAction(record.action, issues, id, options);
   }
-  validateUnsafeFields(record, issues, path, id);
   childRefs.push(...collectChildRefs(record));
   return true;
 }
@@ -429,6 +539,13 @@ export function validateElizaGenUiSpec(
 ): ElizaGenUiValidationResult {
   const issues: ElizaGenUiValidationIssue[] = [];
   const options = normalizeValidationOptions(validationOptions);
+  validateUnsafeFields(value, issues, "", undefined, 0, {
+    visits: 0,
+    ancestors: new WeakSet<object>(),
+    halted: false,
+    maxCodeUnits: options.maxJsonBytes,
+  });
+  if (issues.length > 0) return { ok: false, errors: issues };
   if (!validateJsonSize(value, issues, options))
     return { ok: false, errors: issues };
   const record = asRecord(value);
@@ -442,8 +559,6 @@ export function validateElizaGenUiSpec(
   validateSpecHeader(record, issues);
   const components = validateComponentsArray(record, issues, options);
   if (components === null) return { ok: false, errors: issues };
-  validateUnsafeFields(record.data, issues, "data");
-  validateUnsafeFields(record.metadata, issues, "metadata");
   const refs = validateComponents(components, issues, options);
   validateReferences(record, refs.ids, refs.childRefs, issues);
   if (issues.length > 0) {

--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -87,7 +87,7 @@ function isSafeImageSrc(value: string): boolean {
   }
 }
 
-function validateUnsafeFields(
+function snapshotUnsafeFields(
   value: unknown,
   issues: ElizaGenUiValidationIssue[],
   path: string,
@@ -104,8 +104,8 @@ function validateUnsafeFields(
     halted: false,
     maxCodeUnits: DEFAULT_MAX_JSON_BYTES,
   },
-): void {
-  if (ctx.halted) return;
+): unknown {
+  if (ctx.halted) return undefined;
   if (depth > MAX_GENUI_UNSAFE_FIELD_DEPTH) {
     addIssue(issues, {
       code: "unbounded_nest",
@@ -114,7 +114,7 @@ function validateUnsafeFields(
       path,
     });
     ctx.halted = true;
-    return;
+    return undefined;
   }
   ctx.visits += 1;
   if (ctx.visits > MAX_GENUI_UNSAFE_FIELD_NODES) {
@@ -125,7 +125,7 @@ function validateUnsafeFields(
       path,
     });
     ctx.halted = true;
-    return;
+    return undefined;
   }
   if (typeof value === "string" && value.length > ctx.maxCodeUnits) {
     addIssue(issues, {
@@ -135,10 +135,10 @@ function validateUnsafeFields(
       path,
     });
     ctx.halted = true;
-    return;
+    return undefined;
   }
   if (!value || typeof value !== "object") {
-    return;
+    return value;
   }
   if (ctx.ancestors.has(value)) {
     addIssue(issues, {
@@ -148,35 +148,29 @@ function validateUnsafeFields(
       path,
     });
     ctx.halted = true;
-    return;
+    return undefined;
   }
   ctx.ancestors.add(value);
   try {
-    // JSON.stringify performs an ordinary Get of `toJSON`, including through
-    // the prototype chain. Inspect descriptors without invoking accessors so a
-    // hostile object cannot run code or synthesize a second, unbudgeted graph.
-    let prototype: object | null = value;
-    while (prototype) {
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, "toJSON");
-      if (descriptor) {
-        if (
-          "get" in descriptor ||
-          "set" in descriptor ||
-          typeof descriptor.value === "function"
-        ) {
-          addIssue(issues, {
-            code: "unbounded_nest",
-            message:
-              "Generated UI values may not define custom JSON serialization.",
-            componentId,
-            path,
-          });
-          ctx.halted = true;
-          return;
-        }
-        break;
-      }
-      prototype = Object.getPrototypeOf(prototype);
+    // JSON.stringify performs an ordinary Get of an own or inherited `toJSON`.
+    // The trusted snapshot below severs the input prototype chain; reject an
+    // own hook explicitly and never perform an ordinary Get on untrusted data.
+    const toJsonDescriptor = Object.getOwnPropertyDescriptor(value, "toJSON");
+    if (
+      toJsonDescriptor &&
+      ("get" in toJsonDescriptor ||
+        "set" in toJsonDescriptor ||
+        typeof toJsonDescriptor.value === "function")
+    ) {
+      addIssue(issues, {
+        code: "unbounded_nest",
+        message:
+          "Generated UI values may not define custom JSON serialization.",
+        componentId,
+        path,
+      });
+      ctx.halted = true;
+      return undefined;
     }
 
     if (Array.isArray(value)) {
@@ -194,8 +188,9 @@ function validateUnsafeFields(
           path,
         });
         ctx.halted = true;
-        return;
+        return undefined;
       }
+      const snapshot = new Array<unknown>(length);
       for (let index = 0; index < length; index += 1) {
         const descriptor = Object.getOwnPropertyDescriptor(
           value,
@@ -209,9 +204,9 @@ function validateUnsafeFields(
             path: `${path}/${index}`,
           });
           ctx.halted = true;
-          return;
+          return undefined;
         }
-        validateUnsafeFields(
+        const entry = snapshotUnsafeFields(
           descriptor?.value,
           issues,
           `${path}/${index}`,
@@ -219,11 +214,15 @@ function validateUnsafeFields(
           depth + 1,
           ctx,
         );
+        if (ctx.halted) return undefined;
+        if (descriptor) snapshot[index] = entry;
       }
-      return;
+      return snapshot;
     }
-    for (const key in value) {
-      if (ctx.halted) return;
+    const snapshot = Object.create(null) as Record<string, unknown>;
+    for (const key of Reflect.ownKeys(value)) {
+      if (ctx.halted) return undefined;
+      if (typeof key !== "string") continue;
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (!descriptor?.enumerable) continue;
       if (key.length > ctx.maxCodeUnits) {
@@ -234,7 +233,7 @@ function validateUnsafeFields(
           path,
         });
         ctx.halted = true;
-        return;
+        return undefined;
       }
       if ("get" in descriptor || "set" in descriptor) {
         addIssue(issues, {
@@ -244,7 +243,7 @@ function validateUnsafeFields(
           path: `${path}/${key}`,
         });
         ctx.halted = true;
-        return;
+        return undefined;
       }
       if (UNSAFE_FIELD_NAMES.has(key)) {
         addIssue(issues, {
@@ -254,7 +253,7 @@ function validateUnsafeFields(
           path: `${path}/${key}`,
         });
       }
-      validateUnsafeFields(
+      const entry = snapshotUnsafeFields(
         descriptor.value,
         issues,
         `${path}/${key}`,
@@ -262,7 +261,15 @@ function validateUnsafeFields(
         depth + 1,
         ctx,
       );
+      if (ctx.halted) return undefined;
+      Object.defineProperty(snapshot, key, {
+        value: entry,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
+    return snapshot;
   } catch {
     // error-policy:J3 proxies and racing descriptors are invalid input; the
     // public validator never lets reflection failures escape.
@@ -273,6 +280,7 @@ function validateUnsafeFields(
       path,
     });
     ctx.halted = true;
+    return undefined;
   } finally {
     ctx.ancestors.delete(value);
   }
@@ -539,16 +547,16 @@ export function validateElizaGenUiSpec(
 ): ElizaGenUiValidationResult {
   const issues: ElizaGenUiValidationIssue[] = [];
   const options = normalizeValidationOptions(validationOptions);
-  validateUnsafeFields(value, issues, "", undefined, 0, {
+  const snapshot = snapshotUnsafeFields(value, issues, "", undefined, 0, {
     visits: 0,
     ancestors: new WeakSet<object>(),
     halted: false,
     maxCodeUnits: options.maxJsonBytes,
   });
   if (issues.length > 0) return { ok: false, errors: issues };
-  if (!validateJsonSize(value, issues, options))
+  if (!validateJsonSize(snapshot, issues, options))
     return { ok: false, errors: issues };
-  const record = asRecord(value);
+  const record = asRecord(snapshot);
   if (!record) {
     addIssue(issues, {
       code: "invalid_spec",
@@ -564,7 +572,7 @@ export function validateElizaGenUiSpec(
   if (issues.length > 0) {
     return { ok: false, errors: issues };
   }
-  return { ok: true, spec: value as ElizaGenUiSpec };
+  return { ok: true, spec: snapshot as ElizaGenUiSpec };
 }
 
 export function assertValidElizaGenUiSpec(

--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -1,6 +1,8 @@
 /**
  * Validates a GenUI spec against the catalog: rejects unknown components and
- * disallowed action names before the renderer runs.
+ * disallowed action names before the renderer runs. Unsafe-field walks are
+ * depth-, work-, and cycle-bounded so a hostile `data`/`metadata` nest cannot
+ * RangeError the validator (which must never throw).
  */
 import {
   ELIZA_GENUI_ALLOWED_ACTION_PREFIXES,
@@ -18,6 +20,10 @@ import type {
 
 const DEFAULT_MAX_COMPONENTS = 200;
 const DEFAULT_MAX_JSON_BYTES = 65_536;
+/** Nesting ceiling for unsafe-field walks. Honest specs are a handful deep. */
+export const MAX_GENUI_UNSAFE_FIELD_DEPTH = 64;
+/** Node ceiling across one unsafe-field walk, including leaves. */
+export const MAX_GENUI_UNSAFE_FIELD_NODES = 2048;
 const UNSAFE_FIELD_NAMES = new Set([
   "script",
   "code",
@@ -86,26 +92,78 @@ function validateUnsafeFields(
   issues: ElizaGenUiValidationIssue[],
   path: string,
   componentId?: string,
+  depth = 0,
+  ctx: { visits: number; ancestors: WeakSet<object> } = {
+    visits: 0,
+    ancestors: new WeakSet<object>(),
+  },
 ): void {
-  if (!value || typeof value !== "object") {
-    return;
-  }
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => {
-      validateUnsafeFields(item, issues, `${path}/${index}`, componentId);
+  if (depth > MAX_GENUI_UNSAFE_FIELD_DEPTH) {
+    addIssue(issues, {
+      code: "unbounded_nest",
+      message: `Generated UI value exceeds ${MAX_GENUI_UNSAFE_FIELD_DEPTH} nesting depth.`,
+      componentId,
+      path,
     });
     return;
   }
-  for (const [key, entry] of Object.entries(value)) {
-    if (UNSAFE_FIELD_NAMES.has(key)) {
-      addIssue(issues, {
-        code: "unsafe_field",
-        message: `Generated UI field "${key}" is not allowed.`,
-        componentId,
-        path: `${path}/${key}`,
-      });
+  ctx.visits += 1;
+  if (ctx.visits > MAX_GENUI_UNSAFE_FIELD_NODES) {
+    addIssue(issues, {
+      code: "unbounded_nest",
+      message: `Generated UI value exceeds ${MAX_GENUI_UNSAFE_FIELD_NODES} nodes.`,
+      componentId,
+      path,
+    });
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (ctx.ancestors.has(value)) {
+    addIssue(issues, {
+      code: "unbounded_nest",
+      message: "Generated UI value contains a cyclic object.",
+      componentId,
+      path,
+    });
+    return;
+  }
+  ctx.ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        validateUnsafeFields(
+          value[index],
+          issues,
+          `${path}/${index}`,
+          componentId,
+          depth + 1,
+          ctx,
+        );
+      }
+      return;
     }
-    validateUnsafeFields(entry, issues, `${path}/${key}`, componentId);
+    for (const [key, entry] of Object.entries(value)) {
+      if (UNSAFE_FIELD_NAMES.has(key)) {
+        addIssue(issues, {
+          code: "unsafe_field",
+          message: `Generated UI field "${key}" is not allowed.`,
+          componentId,
+          path: `${path}/${key}`,
+        });
+      }
+      validateUnsafeFields(
+        entry,
+        issues,
+        `${path}/${key}`,
+        componentId,
+        depth + 1,
+        ctx,
+      );
+    }
+  } finally {
+    ctx.ancestors.delete(value);
   }
 }
 

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Deterministic coverage for the GenUI unsafe-field walk budget. The fuzz
+ * harness already requires `validateElizaGenUiSpec` never to throw; these
+ * cases pin the 4k/20k nests that RangeError on origin Node.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  MAX_GENUI_UNSAFE_FIELD_DEPTH,
+  MAX_GENUI_UNSAFE_FIELD_NODES,
+  validateElizaGenUiSpec,
+} from "./validator";
+
+function nestData(depth: number): unknown {
+  let value: unknown = { leaf: true };
+  for (let i = 0; i < depth; i++) {
+    value = { child: value };
+  }
+  return value;
+}
+
+function specWithData(data: unknown) {
+  return {
+    version: "0.1",
+    root: "root",
+    components: [{ id: "root", component: "Text", text: "ok" }],
+    data,
+  };
+}
+
+describe("validateElizaGenUiSpec unbounded nests", () => {
+  it("accepts a shallow honest data object", () => {
+    const result = validateElizaGenUiSpec(
+      specWithData({ title: "Sleep", hours: 8 }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it(`rejects a ${MAX_GENUI_UNSAFE_FIELD_DEPTH + 1}-deep data nest without throwing`, () => {
+    const result = validateElizaGenUiSpec(
+      specWithData(nestData(MAX_GENUI_UNSAFE_FIELD_DEPTH + 1)),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some((error) => error.code === "unbounded_nest"),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects a 4000-deep stringifyable nest without RangeError", () => {
+    const t0 = performance.now();
+    expect(() => {
+      const result = validateElizaGenUiSpec(specWithData(nestData(4000)));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(
+          result.errors.some((error) => error.code === "unbounded_nest"),
+        ).toBe(true);
+      }
+    }).not.toThrow();
+    expect(performance.now() - t0).toBeLessThan(50);
+  });
+
+  it(`rejects more than ${MAX_GENUI_UNSAFE_FIELD_NODES} sibling nodes`, () => {
+    const siblings: Record<string, string> = {};
+    for (let i = 0; i < MAX_GENUI_UNSAFE_FIELD_NODES; i++) {
+      siblings[`k${i}`] = "v";
+    }
+    const result = validateElizaGenUiSpec(specWithData(siblings));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some((error) => error.code === "unbounded_nest"),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -100,7 +100,7 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
     expect(calls).toBe(0);
   });
 
-  it("rejects inherited toJSON hooks without invoking them", () => {
+  it("severs inherited toJSON hooks without invoking them", () => {
     let calls = 0;
     const prototype = Object.create(null) as Record<string, unknown>;
     Object.defineProperty(prototype, "toJSON", {
@@ -112,8 +112,38 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
     const data = Object.create(prototype) as Record<string, unknown>;
     data.safe = true;
     const result = validateElizaGenUiSpec(specWithData(data));
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true);
     expect(calls).toBe(0);
+  });
+
+  it("snapshots a Proxy without invoking a synthesized toJSON or ordinary getters", () => {
+    let getCalls = 0;
+    const data = new Proxy(
+      { safe: true },
+      {
+        get(target, key, receiver) {
+          getCalls += 1;
+          if (key === "toJSON")
+            return () => ({ expanded: "x".repeat(100_000) });
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+
+    const result = validateElizaGenUiSpec(specWithData(data));
+    expect(result.ok).toBe(true);
+    expect(getCalls).toBe(0);
+  });
+
+  it("does not traverse an inherited prototype chain", () => {
+    let prototype: object | null = null;
+    for (let index = 0; index < 10_000; index += 1) {
+      prototype = Object.create(prototype);
+    }
+    const data = Object.create(prototype) as Record<string, unknown>;
+    data.safe = true;
+
+    expect(validateElizaGenUiSpec(specWithData(data)).ok).toBe(true);
   });
 
   it("translates hostile reflection traps instead of throwing", () => {

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -146,6 +146,34 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
     expect(validateElizaGenUiSpec(specWithData(data)).ok).toBe(true);
   });
 
+  it("rejects non-JSON primitives without retaining or executing callables", () => {
+    let calls = 0;
+    const callback = () => {
+      calls += 1;
+      return "executed";
+    };
+    for (const value of [
+      callback,
+      undefined,
+      Symbol("hidden"),
+      1n,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      const result = validateElizaGenUiSpec(specWithData({ value }));
+      expect(result.ok).toBe(false);
+    }
+    expect(calls).toBe(0);
+  });
+
+  it("returns an honest spec equivalent to its JSON round trip", () => {
+    const input = specWithData({ title: "Sleep", values: [1, true, null] });
+    const result = validateElizaGenUiSpec(input);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.spec).toEqual(JSON.parse(JSON.stringify(input)));
+    }
+  });
+
   it("translates hostile reflection traps instead of throwing", () => {
     const data = new Proxy(
       {},

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -1,7 +1,8 @@
 /**
  * Deterministic coverage for the GenUI unsafe-field walk budget. The fuzz
  * harness already requires `validateElizaGenUiSpec` never to throw; these
- * cases pin the 4k/20k nests that RangeError on origin Node.
+ * cases pin deep, wide, sparse, accessor, and hostile-reflection inputs against
+ * the real exported validator without replacing its production walk.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -48,7 +49,6 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
   });
 
   it("rejects a 4000-deep stringifyable nest without RangeError", () => {
-    const t0 = performance.now();
     expect(() => {
       const result = validateElizaGenUiSpec(specWithData(nestData(4000)));
       expect(result.ok).toBe(false);
@@ -58,7 +58,6 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
         ).toBe(true);
       }
     }).not.toThrow();
-    expect(performance.now() - t0).toBeLessThan(50);
   });
 
   it(`rejects more than ${MAX_GENUI_UNSAFE_FIELD_NODES} sibling nodes`, () => {
@@ -73,5 +72,61 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
         result.errors.some((error) => error.code === "unbounded_nest"),
       ).toBe(true);
     }
+  });
+
+  it("rejects a sparse array by logical slots before scanning it", () => {
+    const sparse: unknown[] = [];
+    sparse.length = 5_000_000;
+    const result = validateElizaGenUiSpec(specWithData(sparse));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ code: "unbounded_nest" }),
+      );
+    }
+  });
+
+  it("rejects accessors without invoking them", () => {
+    let calls = 0;
+    const data = Object.defineProperty({}, "secret", {
+      enumerable: true,
+      get() {
+        calls += 1;
+        return "value";
+      },
+    });
+    const result = validateElizaGenUiSpec(specWithData(data));
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects inherited toJSON hooks without invoking them", () => {
+    let calls = 0;
+    const prototype = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(prototype, "toJSON", {
+      get() {
+        calls += 1;
+        return () => ({ expanded: "x".repeat(100_000) });
+      },
+    });
+    const data = Object.create(prototype) as Record<string, unknown>;
+    data.safe = true;
+    const result = validateElizaGenUiSpec(specWithData(data));
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it("translates hostile reflection traps instead of throwing", () => {
+    const data = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("descriptor trap");
+        },
+      },
+    );
+    expect(() => validateElizaGenUiSpec(specWithData(data))).not.toThrow();
+    const result = validateElizaGenUiSpec(specWithData(data));
+    expect(result.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`validateUnsafeFields` walks agent-authored GenUI `data`, `metadata`, and component props with no depth, node, or cycle budget. The fuzz file already states the contract: `validateElizaGenUiSpec` **never throws**, including on deep trees.

On `origin/develop` `79347d360d9e` (Node 24.15.0):

- A 4k-deep `{child:{child:…}}` nest **stringifies** in ~3 ms (~40 KiB, under the 64 KiB spec cap).
- The same nest then **RangeErrors** inside `validateUnsafeFields` in ~3 ms.
- 5k–6k nests are the same: stringify succeeds, walk overflows.

Bun 1.3.14's deeper stack hid the 4k walk; Node is the production UI runtime.

Not leftover-tax. Not a twin of `#22700` `extractFirstSentence`, `#22702` `matchTagAt`, `#22692` MCP schema, `#22694` `flattenTextValues`, `#22695` `evaluateLogicExpression`, `#22707` goal prompt-value, or `#22709` SQL jsonb sanitize. Distinct host: GenUI spec validation before render.

## Change

- Bound the unsafe-field walk at depth 64 / 2048 nodes, and reject cycles.
- Report `unbounded_nest` as a validation issue (additive code). The function still never throws.
- Honest shallow specs stay valid. Existing fuzz suite still passes.

## Exact-head evidence

Evidence revision: `14090bb2fdd36f5049277003c1a1a5f17e47b2a2`, based on `develop` `728fa02717`.

- Pinned Bun 1.3.14: `validator.unbounded.test.ts` **4/4** + `validator.fuzz.test.ts` **2/2**.
- Covers honest data, depth 65 reject, 4000-deep stringifyable nest without RangeError (<50 ms), and 2048-sibling reject.
- Biome on the three changed files: clean.
- `git diff --check`: clean.

No rendered UI change. Screenshots/video/OCR/trajectory are N/A; this is a deterministic pre-render validator bound.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:14090bb2fdd36f5049277003c1a1a5f17e47b2a2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - pre-render validator only; no rendered output changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pre-render validator only; no rendered output changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic library validation boundary; no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - pure in-process pre-render validator; the exact execution receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - validation runs before rendering and does not emit browser network/console behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Adversarial production-boundary artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22711-pr22711-domain-v3.txt).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Maintainer repair

The submitted recursion cap was directionally correct but still enumerated and invoked every object accessor via `Object.entries` before the cap, serialized sparse/custom-`toJSON` graphs before validation, and used a wall-clock assertion. Exact repaired head `14090bb2fdd36f5049277003c1a1a5f17e47b2a2` moves a descriptor-only trusted snapshot before serialization and all later validation, charges sparse logical slots, rejects own accessors and severs inherited or Proxy-synthesized `toJSON` without invocation, catches reflection traps, rejects non-JSON primitives (including callables, bigint, and non-finite numbers), proves JSON round-trip equivalence, and halts at the first depth/node breach. Exact validator/fuzz tests are 14/14; UI publishable build, changed-file Biome, and diff-check pass. Sparse aggregate typecheck blockers are unrelated missing dependencies and do not reference changed files.

Repair attribution: OpenAI / gpt-5.6-sol via Codex Desktop multi-agent.
