### PR TITLE
fix(plugin-x): align discovery engagement dedup write key with its guard read

### DIFF
--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -1,5 +1,10 @@
-/** Exercises discovery-cycle session binding and fail-closed read behavior with deterministic provider fakes. */
-import type { IAgentRuntime } from "@elizaos/core";
+/** Exercises discovery-cycle session binding, fail-closed read behavior, and the engagement dedup guard (#22710) with deterministic provider fakes. */
+import {
+  createUniqueUuid,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { ClientBase, TwitterAccountSession } from "./base";
 import { TwitterDiscoveryClient } from "./discovery";
@@ -17,6 +22,7 @@ type DiscoveryHarness = {
     tweets: unknown[],
     session: TwitterAccountSession,
   ): Promise<number>;
+  delay(ms: number): Promise<void>;
 };
 
 function makeRuntime(): IAgentRuntime {
@@ -160,5 +166,180 @@ describe("TwitterDiscoveryClient session integrity", () => {
     await expect(discovery.discoverContent()).rejects.toMatchObject({
       code: "X_DISCOVERY_READ_FAILED",
     });
+  });
+});
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+type EngagementRuntimeHandle = {
+  runtime: IAgentRuntime;
+  memories: Map<string, Memory>;
+};
+
+/**
+ * Map-backed runtime whose `getMemoryById`/`createMemory` share one store, so a
+ * dedup marker written by `saveEngagementMemory` is observable by the
+ * `processTweets` guard on the following cycle — the exact read/write agreement
+ * that #22710 broke.
+ */
+function makeEngagementRuntime(
+  replyText = "a thoughtful reply",
+): EngagementRuntimeHandle {
+  const memories = new Map<string, Memory>();
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Agent", topics: ["agents"] },
+    getSetting: () => undefined,
+    reportError: vi.fn(),
+    getMemoryById: vi.fn(async (id: UUID) => memories.get(id) ?? null),
+    createMemory: vi.fn(async (memory: Memory) => {
+      if (memory.id && !memories.has(memory.id)) {
+        memories.set(memory.id, memory);
+      }
+      return memory.id as UUID;
+    }),
+    ensureWorldExists: vi.fn(async () => {}),
+    updateWorld: vi.fn(async () => {}),
+    ensureRoomExists: vi.fn(async () => {}),
+    ensureConnection: vi.fn(async () => {}),
+    useModel: vi.fn(async () => replyText),
+  } as unknown as IAgentRuntime;
+  return { runtime, memories };
+}
+
+function makeEngagementClient(): {
+  client: ClientBase;
+  session: TwitterAccountSession;
+  likeTweet: ReturnType<typeof vi.fn>;
+  sendTweet: ReturnType<typeof vi.fn>;
+  sendQuoteTweet: ReturnType<typeof vi.fn>;
+} {
+  const profile = {
+    id: "account-a",
+    username: "account-a",
+    screenName: "Account A",
+    bio: "",
+    nicknames: [],
+  };
+  const likeTweet = vi.fn(async () => {});
+  const sendTweet = vi.fn(async () => {});
+  const sendQuoteTweet = vi.fn(async () => {});
+  const api = { likeTweet, sendTweet, sendQuoteTweet };
+  const session = { client: api as never, profile, revision: 1 };
+  return {
+    client: {
+      accountId: "default",
+      twitterClient: api,
+      withAuthenticatedSession: vi.fn(),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+    } as unknown as ClientBase,
+    session,
+    likeTweet,
+    sendTweet,
+    sendQuoteTweet,
+  };
+}
+
+function scoredTweet(
+  engagementType: "like" | "reply" | "quote" | "skip",
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    tweet: {
+      id: "1750000000000000001",
+      userId: "9001",
+      username: "builder",
+      name: "Builder",
+      text: "agents are the future",
+      conversationId: "1750000000000000001",
+      ...overrides,
+    },
+    relevanceScore: 0.6,
+    engagementType,
+  };
+}
+
+describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
+  it("engages a discovered tweet once and short-circuits on the next cycle", async () => {
+    const { runtime, memories } = makeEngagementRuntime();
+    const { client, session, likeTweet } = makeEngagementClient();
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    vi.spyOn(discovery, "delay").mockResolvedValue(undefined);
+
+    const tweets = [scoredTweet("like")];
+    const first = await discovery.processTweets(tweets, session);
+    // The guard's read key must resolve to the memory the write produced.
+    const guardHit = await runtime.getMemoryById(
+      createUniqueUuid(runtime, "1750000000000000001"),
+    );
+    const second = await discovery.processTweets(tweets, session);
+
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+    expect(guardHit).not.toBeNull();
+    expect(likeTweet).toHaveBeenCalledTimes(1);
+    expect(likeTweet).toHaveBeenCalledWith("1750000000000000001");
+    // Exactly one dedup marker persisted; the engagement type stays in metadata.
+    expect(memories.size).toBe(1);
+    const stored = [...memories.values()][0];
+    expect(
+      (stored.content.metadata as { engagementType?: string }).engagementType,
+    ).toBe("like");
+  });
+
+  it("does not retry a 403-skipped tweet on the following cycle", async () => {
+    const { runtime } = makeEngagementRuntime();
+    const { client, session, likeTweet } = makeEngagementClient();
+    likeTweet.mockRejectedValueOnce(new Error("Request failed with code 403"));
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    vi.spyOn(discovery, "delay").mockResolvedValue(undefined);
+
+    const tweets = [scoredTweet("like")];
+    // First cycle: the like call is denied (403) and a skip marker is written.
+    await discovery.processTweets(tweets, session);
+    const skipMarker = await runtime.getMemoryById(
+      createUniqueUuid(runtime, "1750000000000000001"),
+    );
+    // Second cycle: the guard must find the skip marker and not retry.
+    await discovery.processTweets(tweets, session);
+
+    expect(skipMarker).not.toBeNull();
+    const skipMeta = skipMarker?.content.metadata as {
+      engagementType?: string;
+    };
+    expect(skipMeta.engagementType).toBe("skip");
+    expect(likeTweet).toHaveBeenCalledTimes(1);
+  });
+
+  it("replies to a discovered tweet once across cycles", async () => {
+    const { runtime } = makeEngagementRuntime("welcome to the timeline");
+    const { client, session, sendTweet, likeTweet } = makeEngagementClient();
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    vi.spyOn(discovery, "delay").mockResolvedValue(undefined);
+
+    const tweets = [scoredTweet("reply")];
+    const first = await discovery.processTweets(tweets, session);
+    const second = await discovery.processTweets(tweets, session);
+
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+    expect(sendTweet).toHaveBeenCalledTimes(1);
+    expect(sendTweet).toHaveBeenCalledWith(
+      "welcome to the timeline",
+      "1750000000000000001",
+    );
+    expect(likeTweet).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -1018,8 +1018,17 @@ Quote tweet:`;
         conversationId: tweet.conversationId || tweet.id,
       });
 
+      // Dedup marker: key the memory by the bare tweet id so the
+      // `processTweets` guard (which reads `createUniqueUuid(runtime, tweet.id)`)
+      // finds this write on the next cycle. A suffixed `${tweet.id}-${type}` key
+      // is never read back, so it silently let discovery re-like/re-reply/re-quote
+      // — and re-retry 403-skipped tweets — every cycle (#22710). Each discovered
+      // tweet gets exactly one engagement type per cycle, and `createMemorySafe`
+      // treats a duplicate-key write as a no-op, so this stays idempotent. The
+      // engagement type remains in `content.metadata.engagementType` for
+      // reporting.
       const memory: Memory = {
-        id: createUniqueUuid(this.runtime, `${tweet.id}-${engagementType}`),
+        id: createUniqueUuid(this.runtime, tweet.id),
         entityId: context.entityId,
         content: {
           text: `${engagementType} tweet from @${tweet.username}: ${tweet.text}`,


### PR DESCRIPTION
# Relates to

Closes #22710

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and package checks were run after sync; the only failure is
      an unrelated pre-existing blocker recorded under **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after test evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5ce4d5931cbb4b16d6bbc822871665a427560366:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`1516f51aac`); zero conflicts.
- [x] Package `test`, `typecheck`, and `lint:check` pass post-sync. Repo-wide
      `bun run verify` was not run to completion on this constrained host; the
      focused owning-package gates are attached instead (see **Known gaps**).

# Risks

Low. The change is a one-line memory-key correction plus regression tests, fully
contained in `plugins/plugin-x/src/discovery.ts`. It reduces outbound X API side
effects (no behavior widened). The dedup key now matches the existing
interactions-loop convention, and `createMemorySafe` already treats duplicate
writes as no-ops, so the marker stays idempotent.

# Background

## What does this PR do?

`TwitterDiscoveryClient.processTweets` (`plugins/plugin-x/src/discovery.ts`)
guards against re-engaging a discovered tweet by reading a memory keyed
`createUniqueUuid(runtime, tweet.id)`. But the engagement receipt it writes via
`saveEngagementMemory` was stored under a **different** key,
`createUniqueUuid(runtime, ` + "`${tweet.id}-${engagementType}`" + `)`. The guard
therefore never found its own writes, so **every discovery cycle re-liked,
re-replied to, and re-quoted the same tweets**. On the real X API this produces
duplicate outbound side effects (repeat likes, duplicate replies/quote tweets),
wastes rate-limit quota, and risks spam/rate-limit bans. The same mismatch also
defeated the 403 "skip" marker written on permission errors, so
protected/restricted tweets were retried each cycle too.

The interactions loop is the correct contrast: its `isTweetProcessed` read and
its mention-memory write both use `createUniqueUuid(runtime, tweet.id)`.
Discovery was the outlier that wrote a suffixed key but read the unsuffixed one.

**Fix:** key the dedup marker by the bare `tweet.id`, matching the read key and
the interactions convention. Each discovered tweet gets exactly one engagement
type per cycle, and `createMemorySafe` treats a duplicate-key write as a no-op,
so the write remains idempotent. The engagement type is preserved in
`content.metadata.engagementType` for reporting.

Diff (behavioral change is a single key):

```diff
-        id: createUniqueUuid(this.runtime, `${tweet.id}-${engagementType}`),
+        id: createUniqueUuid(this.runtime, tweet.id),
```

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior is
internal to the discovery loop; the fix restores the intended dedup contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/discovery.test.ts` — three new regression cases under
`TwitterDiscoveryClient engagement dedup (#22710)`:

1. **engages a discovered tweet once and short-circuits on the next cycle** —
   drives `processTweets` twice over a Map-backed runtime; asserts `likeTweet`
   is called exactly once, the guard memory at `createUniqueUuid(runtime,
   tweet.id)` is found, exactly one marker persisted, and `engagementType`
   survives in metadata.
2. **does not retry a 403-skipped tweet on the following cycle** — first cycle
   rejects the like with a `403`; asserts the skip marker is written under the
   read key and the like is not retried on the second cycle.
3. **replies to a discovered tweet once across cycles** — proves the same dedup
   holds on the reply path (`sendTweet` called once across two cycles).

## Detailed testing steps

```bash
bun run --cwd packages/core build          # generate keyword data + declarations
bun install
node node_modules/.bin/vitest run plugins/plugin-x/src/discovery.test.ts
bun run --cwd plugins/plugin-x typecheck
bun run --cwd plugins/plugin-x lint:check
```

# Evidence Gate

<!-- evidence-head:281043284285f3027586c07eb296d1157c2c0b68 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is an internal autonomous-loop bug fix in plugins/plugin-x.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is an internal autonomous-loop bug fix in plugins/plugin-x.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; deterministic vitest before/after output is attached instead.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs (structured logger lines from the real `processTweets` code path, captured by vitest):

<details><summary>BEFORE fix — same tweet re-engaged every cycle</summary>

```
 Info       Liked tweet: 1750000000000000001 (score: 0.60)
 Info       Liked tweet: 1750000000000000001 (score: 0.60)      <- duplicate like on cycle 2 (guard read key != write key)
 Warn       Permission denied (403) for tweet 1750000000000000001 ... Skipping.
 Info       Liked tweet: 1750000000000000001 (score: 0.60)      <- 403 skip marker not honored, re-liked next cycle
 Info       Replied to tweet: 1750000000000000001
 Info       Replied to tweet: 1750000000000000001               <- duplicate reply on cycle 2
 ❗ src/discovery.test.ts (6 tests | 3 failed)
      Tests  3 failed | 3 passed (6)
```

</details>

<details><summary>AFTER fix — each tweet engaged exactly once, second cycle short-circuits</summary>

```
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > engages a discovered tweet once and short-circuits on the next cycle
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > does not retry a 403-skipped tweet on the following cycle
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > replies to a discovered tweet once across cycles
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model/provider behavior changed; the LLM reply/quote generation path is untouched and stubbed deterministically in the regression test.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact (the persisted dedup memory row asserted by the regression test):

<details><summary>Dedup memory row shape asserted after one engagement</summary>

```
 memory.id            = createUniqueUuid(runtime, tweet.id)   // now matches the guard read key
 memories.size        = 1                                     // exactly one marker persisted per tweet/cycle
 content.metadata     = { tweetId, engagementType, source: "discovery", accountId, isDryRun }
 engagementType       = "like"  (and "skip" on the 403 path)  // retained for reporting
 second-cycle read    = getMemoryById(createUniqueUuid(runtime, tweet.id)) -> found -> short-circuit
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change. The reply/quote text
generation call is unchanged and is stubbed in tests to isolate the dedup
contract.`

## Backend + frontend logs

**BEFORE FIX** — `vitest run src/discovery.test.ts` (bug reproduced): the same
tweet is engaged twice per pair of cycles, and the 403-skipped tweet is
re-liked. Three new tests fail.

```
 Info       Liked tweet: 1750000000000000001 (score: 0.60)
 Info       Liked tweet: 1750000000000000001 (score: 0.60)     <- duplicate like (cycle 2)
 Warn       Permission denied (403) for tweet 1750000000000000001 ... Skipping.
 Info       Liked tweet: 1750000000000000001 (score: 0.60)     <- 403-skip marker not honored, re-liked next cycle
 Info       Replied to tweet: 1750000000000000001
 Info       Replied to tweet: 1750000000000000001              <- duplicate reply (cycle 2)
 ❯ src/discovery.test.ts (6 tests | 3 failed)
     × engages a discovered tweet once and short-circuits on the next cycle
     × does not retry a 403-skipped tweet on the following cycle
     × replies to a discovered tweet once across cycles
      Tests  3 failed | 3 passed (6)
```

**AFTER FIX** — `vitest run src/discovery.test.ts --reporter=verbose`: each tweet
engaged exactly once; the second cycle short-circuits on the dedup guard.

```
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > engages a discovered tweet once and short-circuits on the next cycle
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > does not retry a 403-skipped tweet on the following cycle
 ✓ TwitterDiscoveryClient engagement dedup (#22710) > replies to a discovered tweet once across cycles
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full artifacts (immutable attachment URLs) are linked in the evidence rows bound
to the exact head via `scripts/pr-evidence.mjs`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface in this change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- **Full `bun run verify` not completed on this host.** The repo-wide gate builds
  the entire workspace graph, which exceeds this constrained environment's time
  budget. The owning package's `test`, `typecheck`, and `lint:check` all pass
  and are attached.
- **`plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts` fails under
  `vitest`** because it is authored against the `bun:test` runner
  (`import ... from "bun:test"`), which vitest cannot import. This is
  pre-existing on `origin/develop` (confirmed by `git stash` + re-run with my
  changes removed) and unrelated to this fix. All other 240 plugin-x tests pass
  (13 skipped).

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@5ce4d5931cbb4b16d6bbc822871665a427560366:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@5ce4d5931cbb4b16d6bbc822871665a427560366:packages/skills/skills/contribute-to-eliza"} -->


