### PR TITLE
fix(plugin-workflow): fail closed on unbounded workflow JSON clones

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
@@ -6,6 +6,7 @@ import type { IAgentRuntime, Task, UUID } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
 import * as schema from '../../src/db/schema';
 import { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
+import { WORKFLOW_JSON_UNBOUNDED } from '../../src/services/workflow-json';
 import type {
   WorkflowDefinition,
   WorkflowDefinitionResponse,
@@ -104,6 +105,27 @@ afterEach(async () => {
 });
 
 describe('embedded native workflow lifecycle', () => {
+  test('rejects unsafe workflow JSON before persistence or accessor execution', async () => {
+    const { service } = await harness();
+    let calls = 0;
+    const inputSchema = Object.defineProperty({}, 'secret', {
+      enumerable: true,
+      get() {
+        calls += 1;
+        return 'value';
+      },
+    });
+
+    await expect(
+      service.createWorkflow({ ...definition('Unsafe'), inputSchema, id: 'unsafe' })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      response: { code: WORKFLOW_JSON_UNBOUNDED },
+    });
+    expect(calls).toBe(0);
+    expect((await service.listWorkflows()).data).toHaveLength(0);
+  });
+
   test('creates, schedules, revises, restores, and deletes a Smithers workflow', async () => {
     const { service, tasks } = await harness();
     const created = await service.createWorkflow({ ...definition('Original'), id: 'review' });

--- a/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   cloneJson,
   MAX_WORKFLOW_JSON_DEPTH,
+  MAX_WORKFLOW_JSON_NODES,
   WORKFLOW_JSON_UNBOUNDED,
 } from '../../src/services/workflow-json';
 import { WorkflowApiError } from '../../src/types/index';
@@ -59,8 +60,111 @@ describe('cloneJson', () => {
   });
 
   test('does not RangeError an 8k object nest', () => {
-    const t0 = performance.now();
     expectUnbounded(() => cloneJson(nestObject(8000)));
-    expect(performance.now() - t0).toBeLessThan(50);
+  });
+
+  test('accepts a shared DAG while rejecting a true ancestor cycle', () => {
+    const shared = { value: 1 };
+    const cloned = cloneJson({ left: shared, right: shared });
+    expect(cloned).toEqual({ left: { value: 1 }, right: { value: 1 } });
+    expect(cloned.left).not.toBe(cloned.right);
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.child = { parent: cyclic };
+    expectUnbounded(() => cloneJson(cyclic));
+  });
+
+  test('rejects sparse logical work and accessors before invoking them', () => {
+    const sparse: unknown[] = [];
+    sparse.length = MAX_WORKFLOW_JSON_NODES + 1;
+    expectUnbounded(() => cloneJson(sparse));
+
+    let calls = 0;
+    const accessor = Object.defineProperty({}, 'secret', {
+      enumerable: true,
+      get() {
+        calls += 1;
+        return 'value';
+      },
+    });
+    expectUnbounded(() => cloneJson(accessor));
+    expect(calls).toBe(0);
+  });
+
+  test('never invokes custom or Proxy-synthesized JSON hooks', () => {
+    let calls = 0;
+    const custom = {
+      toJSON() {
+        calls += 1;
+        return { expanded: 'x'.repeat(1_000_000) };
+      },
+    };
+    expectUnbounded(() => cloneJson(custom));
+
+    const proxy = new Proxy(
+      { safe: true },
+      {
+        get(target, key, receiver) {
+          calls += 1;
+          return key === 'toJSON' ? () => ({ expanded: true }) : Reflect.get(target, key, receiver);
+        },
+      }
+    );
+    expect(cloneJson(proxy)).toEqual({ safe: true });
+    expect(calls).toBe(0);
+  });
+
+  test('contains hostile reflection without inspecting the thrown value', () => {
+    const hostile = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('secondary trap');
+        },
+      }
+    );
+    const value = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw hostile;
+        },
+      }
+    );
+    expectUnbounded(() => cloneJson(value));
+  });
+
+  test('does not traverse input prototypes and preserves __proto__ as data', () => {
+    let prototypeReads = 0;
+    const value = new Proxy(
+      JSON.parse('{"__proto__":{"kept":true},"safe":1}') as Record<string, unknown>,
+      {
+        getPrototypeOf() {
+          prototypeReads += 1;
+          return Object.prototype;
+        },
+      }
+    );
+    const cloned = cloneJson(value) as Record<string, unknown>;
+
+    expect(prototypeReads).toBe(0);
+    expect(Object.hasOwn(cloned, '__proto__')).toBe(true);
+    expect(JSON.parse(JSON.stringify(cloned))).toEqual(
+      JSON.parse('{"__proto__":{"kept":true},"safe":1}')
+    );
+  });
+
+  test('preserves ordinary JSON clone normalization', () => {
+    const input = {
+      omitted: undefined,
+      nonFinite: Number.POSITIVE_INFINITY,
+      date: new Date('2026-08-20T00:00:00.000Z'),
+      array: [undefined, Number.NaN, -0],
+    };
+    expect(cloneJson(input)).toEqual({
+      nonFinite: null,
+      date: '2026-08-20T00:00:00.000Z',
+      array: [null, null, 0],
+    });
   });
 });

--- a/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
@@ -1,0 +1,66 @@
+/** Deterministic coverage for the bounded workflow JSON clone. */
+import { describe, expect, test } from 'bun:test';
+import {
+  cloneJson,
+  MAX_WORKFLOW_JSON_DEPTH,
+  WORKFLOW_JSON_UNBOUNDED,
+} from '../../src/services/workflow-json';
+import { WorkflowApiError } from '../../src/types/index';
+
+function nestObject(depth: number): unknown {
+  let value: unknown = 'leaf';
+  for (let i = 0; i < depth; i++) {
+    value = { child: value };
+  }
+  return value;
+}
+
+function expectUnbounded(fn: () => unknown): WorkflowApiError {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkflowApiError);
+    expect(error).not.toBeInstanceOf(RangeError);
+    const typed = error as WorkflowApiError;
+    expect(typed.statusCode).toBe(400);
+    expect((typed.response as { code?: string } | undefined)?.code).toBe(WORKFLOW_JSON_UNBOUNDED);
+    return typed;
+  }
+  throw new Error('expected WORKFLOW_JSON_UNBOUNDED');
+}
+
+describe('cloneJson', () => {
+  test('clones honest workflow-shaped records', () => {
+    const input = {
+      name: 'Review',
+      language: 'tsx',
+      source: "import { createSmithers } from 'smthrs/create';",
+      steps: [{ id: 'run', label: 'Run' }],
+      inputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+    };
+    expect(cloneJson(input)).toEqual(input);
+    expect(cloneJson(input)).not.toBe(input);
+  });
+
+  test(`accepts a ${MAX_WORKFLOW_JSON_DEPTH}-deep object nest`, () => {
+    expect(cloneJson(nestObject(MAX_WORKFLOW_JSON_DEPTH))).toEqual(
+      nestObject(MAX_WORKFLOW_JSON_DEPTH)
+    );
+  });
+
+  test(`throws ${WORKFLOW_JSON_UNBOUNDED} one past depth ${MAX_WORKFLOW_JSON_DEPTH}`, () => {
+    expectUnbounded(() => cloneJson(nestObject(MAX_WORKFLOW_JSON_DEPTH + 1)));
+  });
+
+  test('throws on cyclic objects instead of TypeError', () => {
+    const cyclic: Record<string, unknown> = { name: 'loop' };
+    cyclic.self = cyclic;
+    expectUnbounded(() => cloneJson(cyclic));
+  });
+
+  test('does not RangeError an 8k object nest', () => {
+    const t0 = performance.now();
+    expectUnbounded(() => cloneJson(nestObject(8000)));
+    expect(performance.now() - t0).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -41,6 +41,7 @@ import {
   runSmithersWorkflow,
   validateSmithersSource,
 } from './smithers-runtime';
+import { cloneJson } from './workflow-json';
 
 export const EMBEDDED_WORKFLOW_SERVICE_TYPE = 'embedded_workflow_service';
 export const WORKFLOW_TASK_KIND = 'workflow';
@@ -66,10 +67,6 @@ type RunListener = (event: WorkflowRunEvent) => void;
 
 function nowIso(): string {
   return new Date().toISOString();
-}
-
-function cloneJson<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function approvalPrompt(payload: Record<string, unknown>): string | undefined {

--- a/plugins/plugin-workflow/src/services/workflow-json.ts
+++ b/plugins/plugin-workflow/src/services/workflow-json.ts
@@ -1,0 +1,51 @@
+/**
+ * Bounded JSON clone for workflow persist/execute paths. Create/update and
+ * run input clone untrusted graphs (`inputSchema`, trigger payload) with
+ * `JSON.stringify`; a hostile nest RangeErrors Node before the route can
+ * translate the failure. Walk first, then stringify.
+ */
+import { WorkflowApiError } from '../types/index';
+
+/** Nesting ceiling. Honest workflow records are a handful of objects deep. */
+export const MAX_WORKFLOW_JSON_DEPTH = 64;
+export const WORKFLOW_JSON_UNBOUNDED = 'WORKFLOW_JSON_UNBOUNDED';
+
+function failUnbounded(message: string): never {
+  throw new WorkflowApiError(message, 400, { code: WORKFLOW_JSON_UNBOUNDED });
+}
+
+function assertBoundedJson(value: unknown, depth: number, seen: WeakSet<object>): void {
+  if (depth > MAX_WORKFLOW_JSON_DEPTH) {
+    failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_DEPTH} nesting depth`);
+  }
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+  if (seen.has(value)) {
+    failUnbounded('Workflow JSON contains a cyclic object');
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      assertBoundedJson(entry, depth + 1, seen);
+    }
+    return;
+  }
+  for (const entry of Object.values(value as Record<string, unknown>)) {
+    assertBoundedJson(entry, depth + 1, seen);
+  }
+}
+
+/**
+ * Structured clone used by persist/execute. Fails closed on hostile depth or
+ * cycles instead of letting `JSON.stringify` RangeError the request.
+ */
+export function cloneJson<T>(value: T): T {
+  assertBoundedJson(value, 0, new WeakSet<object>());
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch (error) {
+    // error-policy:J3 stringify still rejects BigInt/undefined-only graphs
+    failUnbounded(error instanceof Error ? error.message : 'Workflow JSON is not serializable');
+  }
+}

--- a/plugins/plugin-workflow/src/services/workflow-json.ts
+++ b/plugins/plugin-workflow/src/services/workflow-json.ts
@@ -1,51 +1,166 @@
 /**
  * Bounded JSON clone for workflow persist/execute paths. Create/update and
  * run input clone untrusted graphs (`inputSchema`, trigger payload) with
- * `JSON.stringify`; a hostile nest RangeErrors Node before the route can
- * translate the failure. Walk first, then stringify.
+ * `JSON.stringify`; a hostile nest or reflective object can throw before the
+ * route translates the failure. Build one trusted JSON snapshot instead.
  */
 import { WorkflowApiError } from '../types/index';
 
 /** Nesting ceiling. Honest workflow records are a handful of objects deep. */
 export const MAX_WORKFLOW_JSON_DEPTH = 64;
+/** Logical values copied by one workflow clone. */
+export const MAX_WORKFLOW_JSON_NODES = 10_000;
 export const WORKFLOW_JSON_UNBOUNDED = 'WORKFLOW_JSON_UNBOUNDED';
+const OMIT = Symbol('workflow-json-omit');
 
 function failUnbounded(message: string): never {
   throw new WorkflowApiError(message, 400, { code: WORKFLOW_JSON_UNBOUNDED });
 }
 
-function assertBoundedJson(value: unknown, depth: number, seen: WeakSet<object>): void {
+interface CloneContext {
+  ancestors: WeakSet<object>;
+  visits: number;
+}
+
+type CloneLocation = 'root' | 'array' | 'object';
+
+function reflectOrFail<T>(operation: () => T): T {
+  try {
+    return operation();
+  } catch {
+    // error-policy:J3 reflection failures are invalid workflow JSON; do not
+    // inspect an attacker-thrown value while translating the boundary error.
+    failUnbounded('Workflow JSON could not be inspected safely');
+  }
+}
+
+function unsupportedValue(location: CloneLocation): null | typeof OMIT {
+  if (location === 'array') return null;
+  if (location === 'object') return OMIT;
+  failUnbounded('Workflow JSON root is not serializable');
+}
+
+function cloneJsonValue(
+  value: unknown,
+  depth: number,
+  location: CloneLocation,
+  context: CloneContext
+): unknown | typeof OMIT {
   if (depth > MAX_WORKFLOW_JSON_DEPTH) {
     failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_DEPTH} nesting depth`);
   }
-  if (value === null || typeof value !== 'object') {
-    return;
+  context.visits += 1;
+  if (context.visits > MAX_WORKFLOW_JSON_NODES) {
+    failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
   }
-  if (seen.has(value)) {
+
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    return value === 0 ? 0 : value;
+  }
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol') {
+    return unsupportedValue(location);
+  }
+  if (typeof value === 'bigint') {
+    failUnbounded('Workflow JSON may not contain bigint values');
+  }
+
+  if (context.ancestors.has(value)) {
     failUnbounded('Workflow JSON contains a cyclic object');
   }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      assertBoundedJson(entry, depth + 1, seen);
+  context.ancestors.add(value);
+  try {
+    const toJsonDescriptor = reflectOrFail(() => Object.getOwnPropertyDescriptor(value, 'toJSON'));
+    if (
+      toJsonDescriptor &&
+      ('get' in toJsonDescriptor ||
+        'set' in toJsonDescriptor ||
+        typeof toJsonDescriptor.value === 'function')
+    ) {
+      failUnbounded('Workflow JSON may not define custom serialization');
     }
-    return;
-  }
-  for (const entry of Object.values(value as Record<string, unknown>)) {
-    assertBoundedJson(entry, depth + 1, seen);
+
+    let dateTime: number | undefined;
+    try {
+      // The native brand check is constant-work and does not traverse a
+      // caller-controlled prototype chain as `instanceof Date` would.
+      dateTime = Date.prototype.getTime.call(value);
+    } catch {
+      dateTime = undefined;
+    }
+    if (dateTime !== undefined) {
+      return Number.isFinite(dateTime) ? Date.prototype.toISOString.call(value) : null;
+    }
+
+    if (reflectOrFail(() => Array.isArray(value))) {
+      const lengthDescriptor = reflectOrFail(() =>
+        Object.getOwnPropertyDescriptor(value, 'length')
+      );
+      const length = lengthDescriptor?.value;
+      if (
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        length > MAX_WORKFLOW_JSON_NODES - context.visits
+      ) {
+        failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
+      }
+      const snapshot = new Array<unknown>(length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = reflectOrFail(() =>
+          Object.getOwnPropertyDescriptor(value, String(index))
+        );
+        if (descriptor && ('get' in descriptor || 'set' in descriptor)) {
+          failUnbounded('Workflow JSON may not contain accessors');
+        }
+        snapshot[index] = descriptor
+          ? cloneJsonValue(descriptor.value, depth + 1, 'array', context)
+          : null;
+      }
+      return snapshot;
+    }
+
+    const keys = reflectOrFail(() => Reflect.ownKeys(value));
+    if (keys.length > MAX_WORKFLOW_JSON_NODES - context.visits) {
+      failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
+    }
+    // Drizzle inspects ordinary object prototypes when binding jsonb values, so
+    // retain Object.prototype while defining every key as an own data property
+    // (`__proto__` included) instead of using assignment setters.
+    const snapshot: Record<string, unknown> = {};
+    for (const key of keys) {
+      if (typeof key !== 'string') continue;
+      const descriptor = reflectOrFail(() => Object.getOwnPropertyDescriptor(value, key));
+      if (!descriptor?.enumerable) continue;
+      if ('get' in descriptor || 'set' in descriptor) {
+        failUnbounded('Workflow JSON may not contain accessors');
+      }
+      const entry = cloneJsonValue(descriptor.value, depth + 1, 'object', context);
+      if (entry === OMIT) continue;
+      Object.defineProperty(snapshot, key, {
+        value: entry,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return snapshot;
+  } finally {
+    context.ancestors.delete(value);
   }
 }
 
 /**
- * Structured clone used by persist/execute. Fails closed on hostile depth or
- * cycles instead of letting `JSON.stringify` RangeError the request.
+ * JSON clone used by persist/execute. It preserves ordinary JSON semantics but
+ * never invokes input getters, prototypes, or custom serializers.
  */
 export function cloneJson<T>(value: T): T {
-  assertBoundedJson(value, 0, new WeakSet<object>());
-  try {
-    return JSON.parse(JSON.stringify(value)) as T;
-  } catch (error) {
-    // error-policy:J3 stringify still rejects BigInt/undefined-only graphs
-    failUnbounded(error instanceof Error ? error.message : 'Workflow JSON is not serializable');
-  }
+  const snapshot = cloneJsonValue(value, 0, 'root', {
+    ancestors: new WeakSet<object>(),
+    visits: 0,
+  });
+  if (snapshot === OMIT) failUnbounded('Workflow JSON root is not serializable');
+  return snapshot as T;
 }


### PR DESCRIPTION
## Problem

`EmbeddedWorkflowService.createWorkflow` / `updateWorkflow` clone the caller graph with `JSON.parse(JSON.stringify(...))` after name/language/step checks. `inputSchema` and extra nested fields are untrusted.

On `origin/develop` `1516f51aac12` (Node 24.15.0):

- `JSON.stringify` of an 8k-deep object nest **RangeErrors in 8.32 ms**.
- A cyclic object throws an untyped `TypeError` (`Converting circular structure to JSON`).

That happens inside `normalizeWorkflow` before the route can return 400. Bun 1.3.14's deeper stack hid the 8k nest.

Not leftover-tax. Not a twin of `#22700` / `#22702` / `#22692` / `#22694` / `#22695` / `#22707` / `#22709` / `#22711`. Distinct host: plugin-workflow persist/execute clone.

Did not touch HARD_SKIP `workbench-todos.ts`.

## Change

- Extract `cloneJson` to `workflow-json.ts`.
- Fail closed at depth 64 and on cycles with `WorkflowApiError(400, { code: WORKFLOW_JSON_UNBOUNDED })` **before** stringify.
- Honest workflow records preserve JSON clone semantics, including optional-field omission, array null normalization, finite numbers, Dates, DAGs, and own `__proto__` data.

## Exact-head evidence

Evidence revision: `eddbb4281709dc4b8b62f37a6916894e1c03a364`, based on `develop` `02b05385b3`.

- Pinned Bun 1.3.14: full owning unit lane **89/89**; focused helper plus real PGlite lifecycle **16/16**.
- Covers honest clone, depth/node/cycle bounds, sparse work, DAGs, zero-call accessors/serializers/prototypes, hostile reflection, JSON normalization, and a real createWorkflow zero-persistence failure.
- Biome on the three changed files: clean.
- `git diff --check`: clean.

No UI. Screenshots/video/OCR/trajectory N/A; this is a deterministic persist-path bound.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend workflow JSON boundary; no rendered pixels.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend workflow JSON boundary; no rendered pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic persistence boundary; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - in-process workflow persistence boundary; the exact service/database receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact bounded-clone and PGlite artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22716-pr22716-domain.txt).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered output.

## Maintainer repair

The submitted depth-only preflight retained a second unbounded stringify walk, eager getters, sparse-array bypass, global-seen DAG rejection, custom serializers, and a wall-clock assertion. Exact repaired head `eddbb4281709dc4b8b62f37a6916894e1c03a364` builds one bounded descriptor-only JSON snapshot and proves the real EmbeddedWorkflowService rejects before persistence. Exact 89/89 unit tests, typecheck, build, Biome, diff, and evidence gates pass. Repair attribution: OpenAI/gpt-5.6-sol via Codex Desktop multi-agent.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:eddbb4281709dc4b8b62f37a6916894e1c03a364 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->



