### PR TITLE
fix(agent-skills): expose bounded install cancellation failures

### DIFF
--- a/plugins/plugin-agent-skills/README.md
+++ b/plugins/plugin-agent-skills/README.md
@@ -247,6 +247,20 @@ const content = await service.readReference('my-skill', 'api-docs.md');
 // Install a skill from registry
 await service.install('pdf-processing');
 
+// Every catalog, GitHub, and direct-URL install has one deadline spanning its
+// fetches and body reads. It inherits the service fetchTimeoutMs by default;
+// override it, propagate caller cancellation, or explicitly opt out with null.
+const controller = new AbortController();
+const installed = await service.installFromUrl('https://example.com/SKILL.md', {
+  signal: controller.signal,
+  downloadTimeoutMs: 10_000,
+  // Opt in when the caller needs the typed timeout/cancellation failure.
+  throwOnDownloadError: true,
+});
+await service.installFromGitHub('owner/repo', {
+  downloadTimeoutMs: null,
+});
+
 // Check storage mode
 if (service.isMemoryMode()) {
   // Load skill from content (memory mode only)

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -1,14 +1,18 @@
 /**
  * Overflow coverage for Agent Skills package downloads. The deterministic
- * stream harness proves exact-cap acceptance, overflow cancellation and lock
- * release, UTF-8 decoding, and the real direct-URL installer's fail-closed
- * behavior without touching the network or filesystem.
+ * stream and loopback harnesses prove exact-cap acceptance, missing-body and
+ * stalled-body failure, cancellation and lock release, UTF-8 decoding, and
+ * fail-closed behavior through every remote installer.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemorySkillStore } from "../storage";
 import {
+	createSkillDownloadLifecycle,
+	DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS,
 	MAX_SKILL_PACKAGE_BYTES,
 	readCappedSkillPackage,
 	readCappedSkillText,
@@ -47,6 +51,25 @@ function openOverflowStream(
 				onCancel();
 			},
 		}),
+	);
+}
+
+function stalledResponse(
+	content: string | Uint8Array = "partial",
+	onCancel: () => void | Promise<void> = () => {},
+): Response {
+	const bytes =
+		typeof content === "string" ? new TextEncoder().encode(content) : content;
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(bytes);
+			},
+			cancel() {
+				onCancel();
+			},
+		}),
+		{ headers: { "content-type": "text/markdown" } },
 	);
 }
 
@@ -104,10 +127,116 @@ describe("readCappedSkillPackage", () => {
 		expect(cancel).toHaveBeenCalledOnce();
 	});
 
-	it("returns empty bytes for a response without a body", async () => {
+	it("rejects a response without a body as a typed boundary failure", async () => {
 		await expect(
 			readCappedSkillPackage(new Response(null)),
-		).resolves.toEqual(new Uint8Array());
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_MISSING_BODY",
+			context: { boundary: "skill-package-download" },
+		});
+	});
+
+	it("applies the default deadline and supports explicit override or opt-out", () => {
+		const defaultLifecycle = createSkillDownloadLifecycle();
+		expect(defaultLifecycle.timeoutMs).toBe(DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS);
+		defaultLifecycle.dispose();
+
+		const overridden = createSkillDownloadLifecycle({ downloadTimeoutMs: 123 });
+		expect(overridden.timeoutMs).toBe(123);
+		overridden.dispose();
+
+		const optedOut = createSkillDownloadLifecycle({ downloadTimeoutMs: null });
+		expect(optedOut.timeoutMs).toBeNull();
+		expect(optedOut.signal.aborted).toBe(false);
+		optedOut.dispose();
+	});
+
+	it("rejects invalid deadline overrides", () => {
+		expect(() =>
+			createSkillDownloadLifecycle({ downloadTimeoutMs: 0 }),
+		).toThrow(
+			expect.objectContaining({ code: "SKILL_DOWNLOAD_INVALID_TIMEOUT" }),
+		);
+	});
+
+	it("cancels a stalled body with the typed deadline error", async () => {
+		const cancel = vi.fn();
+		const response = stalledResponse("partial", cancel);
+		const lifecycle = createSkillDownloadLifecycle({ downloadTimeoutMs: 25 });
+
+		try {
+			await expect(
+				readCappedSkillPackage(response, { signal: lifecycle.signal }),
+			).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_TIMEOUT",
+				context: { timeoutMs: 25 },
+			});
+			expect(cancel).toHaveBeenCalledOnce();
+			expect(response.body?.locked).toBe(false);
+		} finally {
+			lifecycle.dispose();
+		}
+	});
+
+	it("preserves caller cancellation as the authoritative error", async () => {
+		const caller = new AbortController();
+		const cancel = vi.fn(async () => {
+			throw new Error("transport cancel failed");
+		});
+		const response = stalledResponse("partial", cancel);
+		const lifecycle = createSkillDownloadLifecycle({
+			signal: caller.signal,
+			downloadTimeoutMs: null,
+		});
+		const read = readCappedSkillPackage(response, {
+			signal: lifecycle.signal,
+		});
+		caller.abort(new Error("caller stopped waiting"));
+
+		try {
+			await expect(read).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_ABORTED",
+				cause: expect.objectContaining({ message: "caller stopped waiting" }),
+			});
+			expect(cancel).toHaveBeenCalledOnce();
+		} finally {
+			lifecycle.dispose();
+		}
+	});
+
+	it("propagates caller cancellation through the direct-URL installer", async () => {
+		let installSignal: AbortSignal | undefined;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: unknown, init?: RequestInit) => {
+				installSignal = init?.signal;
+				return stalledResponse("partial");
+			}),
+		);
+		const caller = new AbortController();
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+		const install = service.installFromUrl(
+			"https://skills.example/cancelled.md",
+			{
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+				throwOnDownloadError: true,
+			},
+		);
+		caller.abort(new Error("request owner stopped waiting"));
+
+		await expect(install).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "request owner stopped waiting",
+			}),
+		});
+		expect(installSignal?.aborted).toBe(true);
+		expect(storage.getPackage("cancelled")).toBeUndefined();
 	});
 
 	it("decodes a capped SKILL.md body as UTF-8", async () => {
@@ -146,5 +275,126 @@ describe("readCappedSkillPackage", () => {
 		).resolves.toBe(false);
 		expect(cancel).toHaveBeenCalledOnce();
 		expect(storage.getPackage("oversized")).toBeUndefined();
+	});
+
+	it("fails a real direct-URL install without persisting a missing body", async () => {
+		vi.stubGlobal("fetch", vi.fn(async () => new Response(null)));
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.installFromUrl("https://skills.example/missing.md", {
+				slug: "missing",
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_MISSING_BODY",
+			context: { boundary: "skill-package-download" },
+		});
+		expect(storage.getPackage("missing")).toBeUndefined();
+	});
+
+	it("uses one deadline for catalog resolution and a stalled package body", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			if (init?.signal) signals.push(init.signal);
+			if (fetchMock.mock.calls.length === 1) {
+				return new Response(
+					JSON.stringify({ latestVersion: { version: "1.0.0" } }),
+					{ headers: { "content-type": "application/json" } },
+				);
+			}
+			return stalledResponse(new Uint8Array([80, 75]));
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.install("catalog-stall", {
+				downloadTimeoutMs: 25,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_TIMEOUT",
+			context: { timeoutMs: 25 },
+		});
+		expect(signals).toHaveLength(2);
+		expect(signals[0]).toBe(signals[1]);
+		expect(storage.getPackage("catalog-stall")).toBeUndefined();
+	});
+
+	it("does not persist GitHub SKILL.md when its README stalls", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			if (init?.signal) signals.push(init.signal);
+			if (fetchMock.mock.calls.length === 1) {
+				return new Response(
+					"---\nname: github-stall\ndescription: test\n---\n# Test\n",
+				);
+			}
+			return stalledResponse("# partial readme");
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.installFromGitHub("owner/github-stall", {
+				downloadTimeoutMs: 25,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_TIMEOUT",
+			context: { timeoutMs: 25 },
+		});
+		expect(signals).toHaveLength(2);
+		expect(signals[0]).toBe(signals[1]);
+		expect(storage.getPackage("github-stall")).toBeUndefined();
+	});
+
+	it("bounds a real loopback response that sends headers and then stalls", async () => {
+		const server = createServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/markdown" });
+			response.write("---\nname: loopback-stall\n");
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const { port } = server.address() as AddressInfo;
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+		const startedAt = Date.now();
+
+		try {
+			await expect(
+				service.installFromUrl(`http://127.0.0.1:${port}/loopback-stall.md`, {
+					downloadTimeoutMs: 75,
+					throwOnDownloadError: true,
+				}),
+			).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_TIMEOUT",
+				context: { timeoutMs: 75 },
+			});
+			expect(Date.now() - startedAt).toBeLessThan(1_500);
+			expect(storage.getPackage("loopback-stall")).toBeUndefined();
+		} finally {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			);
+		}
 	});
 });

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -5,14 +5,15 @@
  * fail-closed behavior through every remote installer.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemorySkillStore } from "../storage";
 import {
 	createSkillDownloadLifecycle,
 	DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS,
+	MAX_SKILL_DOWNLOAD_TIMEOUT_MS,
 	MAX_SKILL_PACKAGE_BYTES,
 	readCappedSkillPackage,
 	readCappedSkillText,
@@ -151,9 +152,16 @@ describe("readCappedSkillPackage", () => {
 		optedOut.dispose();
 	});
 
-	it("rejects invalid deadline overrides", () => {
+	it.each([
+		0,
+		-1,
+		0.5,
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		MAX_SKILL_DOWNLOAD_TIMEOUT_MS + 1,
+	])("rejects invalid deadline override %s", (downloadTimeoutMs) => {
 		expect(() =>
-			createSkillDownloadLifecycle({ downloadTimeoutMs: 0 }),
+			createSkillDownloadLifecycle({ downloadTimeoutMs }),
 		).toThrow(
 			expect.objectContaining({ code: "SKILL_DOWNLOAD_INVALID_TIMEOUT" }),
 		);

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -13,6 +13,9 @@ export const MAX_SKILL_PACKAGE_BYTES = 10 * 1024 * 1024;
 /** Default wall-clock deadline shared by every request in one install. */
 export const DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS = 30_000;
 
+/** Largest delay Node can schedule without overflowing its timer implementation. */
+export const MAX_SKILL_DOWNLOAD_TIMEOUT_MS = 2_147_483_647;
+
 /** Per-install controls for the shared download lifecycle. */
 export interface SkillDownloadLifecycleOptions {
 	/** Abort the download when its caller no longer needs the result. */
@@ -88,10 +91,12 @@ export function createSkillDownloadLifecycle(
 			: options.downloadTimeoutMs;
 	if (
 		timeoutMs !== null &&
-		(!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+		(!Number.isInteger(timeoutMs) ||
+			timeoutMs <= 0 ||
+			timeoutMs > MAX_SKILL_DOWNLOAD_TIMEOUT_MS)
 	) {
 		throw new ElizaError(
-			"Skill download timeout must be a positive finite number or null",
+			"Skill download timeout must be a positive bounded integer or null",
 			{
 				code: "SKILL_DOWNLOAD_INVALID_TIMEOUT",
 				context: { downloadTimeoutMs: timeoutMs },

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -10,12 +10,144 @@ import { ElizaError } from "@elizaos/core";
 /** Maximum zip / SKILL.md download size (10MB). */
 export const MAX_SKILL_PACKAGE_BYTES = 10 * 1024 * 1024;
 
+/** Default wall-clock deadline shared by every request in one install. */
+export const DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/** Per-install controls for the shared download lifecycle. */
+export interface SkillDownloadLifecycleOptions {
+	/** Abort the download when its caller no longer needs the result. */
+	signal?: AbortSignal;
+	/** Override the 30-second default deadline; `null` explicitly disables it. */
+	downloadTimeoutMs?: number | null;
+}
+
+const SKILL_DOWNLOAD_ERROR_CODES = new Set([
+	"SKILL_DOWNLOAD_ABORTED",
+	"SKILL_DOWNLOAD_INVALID_TIMEOUT",
+	"SKILL_DOWNLOAD_MISSING_BODY",
+	"SKILL_DOWNLOAD_TIMEOUT",
+	"SKILL_PACKAGE_INVALID_UTF8",
+	"SKILL_PACKAGE_TOO_LARGE",
+]);
+
+/** One signal and deadline spanning every request and body read in an install. */
+export interface SkillDownloadLifecycle {
+	readonly signal: AbortSignal;
+	readonly timeoutMs: number | null;
+	dispose(): void;
+	throwIfAborted(cause?: unknown): void;
+}
+
+function cancellationError(cause?: unknown): ElizaError {
+	return new ElizaError("Skill download was cancelled by its caller", {
+		code: "SKILL_DOWNLOAD_ABORTED",
+		context: { boundary: "skill-package-download" },
+		cause,
+		severity: "ephemeral",
+	});
+}
+
+function timeoutError(timeoutMs: number): ElizaError {
+	return new ElizaError(
+		`Skill download exceeded its ${timeoutMs}ms deadline`,
+		{
+			code: "SKILL_DOWNLOAD_TIMEOUT",
+			context: { boundary: "skill-package-download", timeoutMs },
+			severity: "ephemeral",
+		},
+	);
+}
+
+/** Normalize an aborted signal without replacing its authoritative typed reason. */
+export function skillDownloadAbortError(
+	signal: AbortSignal,
+	cause?: unknown,
+): ElizaError {
+	return signal.reason instanceof ElizaError
+		? signal.reason
+		: cancellationError(cause ?? signal.reason);
+}
+
+/** Identify typed failures owned by the untrusted package-download boundary. */
+export function isSkillDownloadError(error: unknown): error is ElizaError {
+	return (
+		error instanceof ElizaError && SKILL_DOWNLOAD_ERROR_CODES.has(error.code)
+	);
+}
+
+/**
+ * Create the single abort lifecycle used by one catalog, GitHub, or URL install.
+ * The caller must dispose it immediately after all network bodies are consumed.
+ */
+export function createSkillDownloadLifecycle(
+	options: SkillDownloadLifecycleOptions = {},
+): SkillDownloadLifecycle {
+	const timeoutMs =
+		options.downloadTimeoutMs === undefined
+			? DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS
+			: options.downloadTimeoutMs;
+	if (
+		timeoutMs !== null &&
+		(!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+	) {
+		throw new ElizaError(
+			"Skill download timeout must be a positive finite number or null",
+			{
+				code: "SKILL_DOWNLOAD_INVALID_TIMEOUT",
+				context: { downloadTimeoutMs: timeoutMs },
+			},
+		);
+	}
+
+	const controller = new AbortController();
+	const abortFromCaller = (): void => {
+		if (!controller.signal.aborted) {
+			controller.abort(cancellationError(options.signal?.reason));
+		}
+	};
+	if (options.signal?.aborted) {
+		abortFromCaller();
+	} else {
+		options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+		// Close the check/listen race if the caller aborted between both steps.
+		if (options.signal?.aborted) abortFromCaller();
+	}
+
+	const timeoutSignal =
+		timeoutMs === null ? undefined : AbortSignal.timeout(timeoutMs);
+	const abortFromTimeout = (): void => {
+		if (!controller.signal.aborted && timeoutMs !== null) {
+			controller.abort(timeoutError(timeoutMs));
+		}
+	};
+	if (timeoutSignal?.aborted) {
+		abortFromTimeout();
+	} else {
+		timeoutSignal?.addEventListener("abort", abortFromTimeout, { once: true });
+	}
+
+	return {
+		signal: controller.signal,
+		timeoutMs,
+		dispose() {
+			timeoutSignal?.removeEventListener("abort", abortFromTimeout);
+			options.signal?.removeEventListener("abort", abortFromCaller);
+		},
+		throwIfAborted(cause?: unknown) {
+			if (controller.signal.aborted) {
+				throw skillDownloadAbortError(controller.signal, cause);
+			}
+		},
+	};
+}
+
 /**
  * Read a skill install body under {@link MAX_SKILL_PACKAGE_BYTES}.
  * Throws `Package too large (max 10MB)` once the running total exceeds the cap.
  */
 export async function readCappedSkillPackage(
 	response: Response,
+	options: { signal?: AbortSignal } = {},
 ): Promise<Uint8Array> {
 	const tooLarge = (receivedBytes: number): ElizaError =>
 		new ElizaError(
@@ -23,21 +155,44 @@ export async function readCappedSkillPackage(
 			{
 				code: "SKILL_PACKAGE_TOO_LARGE",
 				context: {
+					boundary: "skill-package-download",
 					maxBytes: MAX_SKILL_PACKAGE_BYTES,
 					receivedBytes,
 				},
 			},
 		);
+	if (options.signal?.aborted) {
+		throw skillDownloadAbortError(options.signal);
+	}
 	const body = response.body;
 	if (!body) {
-		return new Uint8Array();
+		throw new ElizaError("Skill download response did not include a body", {
+			code: "SKILL_DOWNLOAD_MISSING_BODY",
+			context: { boundary: "skill-package-download" },
+		});
 	}
 	const reader = body.getReader();
 	const chunks: Uint8Array[] = [];
 	let total = 0;
+	let removeAbortListener: (() => void) | undefined;
+	const abortPromise = options.signal
+		? new Promise<never>((_resolve, reject) => {
+				const onAbort = (): void => {
+					reject(skillDownloadAbortError(options.signal as AbortSignal));
+				};
+				options.signal?.addEventListener("abort", onAbort, { once: true });
+				removeAbortListener = () =>
+					options.signal?.removeEventListener("abort", onAbort);
+				// Close the check/listen race before the first potentially stalled read.
+				if (options.signal?.aborted) onAbort();
+			})
+		: undefined;
 	try {
 		for (;;) {
-			const { done, value } = await reader.read();
+			const read = reader.read();
+			const { done, value } = abortPromise
+				? await Promise.race([read, abortPromise])
+				: await read;
 			if (done) break;
 			if (!value?.byteLength) continue;
 			total += value.byteLength;
@@ -51,7 +206,21 @@ export async function readCappedSkillPackage(
 			}
 			chunks.push(value);
 		}
+	} catch (cause) {
+		if (options.signal?.aborted) {
+			try {
+				const cancellation = reader.cancel(options.signal.reason);
+				void Promise.resolve(cancellation).catch(() => {
+					// error-policy:J6 cancellation is best-effort after abort wins.
+				});
+			} catch {
+				// error-policy:J6 synchronous stream cancellation is teardown-only.
+			}
+			throw skillDownloadAbortError(options.signal, cause);
+		}
+		throw cause;
 	} finally {
+		removeAbortListener?.();
 		try {
 			reader.releaseLock();
 		} catch {
@@ -70,8 +239,9 @@ export async function readCappedSkillPackage(
 /** Decode a capped install download as UTF-8 text (SKILL.md / README.md). */
 export async function readCappedSkillText(
 	response: Response,
+	options: { signal?: AbortSignal } = {},
 ): Promise<string> {
-	const bytes = await readCappedSkillPackage(response);
+	const bytes = await readCappedSkillPackage(response, options);
 	try {
 		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 	} catch (cause) {
@@ -79,7 +249,10 @@ export async function readCappedSkillText(
 		// silently replacing invalid bytes and changing the package contents.
 		throw new ElizaError("Skill package text is not valid UTF-8", {
 			code: "SKILL_PACKAGE_INVALID_UTF8",
-			context: { byteLength: bytes.byteLength },
+			context: {
+				boundary: "skill-package-download",
+				byteLength: bytes.byteLength,
+			},
 			cause,
 		});
 	}

--- a/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.fetch-timeout.test.ts
@@ -239,7 +239,7 @@ describe("AgentSkillsService fetch timeouts", () => {
 		expect(fetchMock.mock.calls[0][1]).toMatchObject({ signal: undefined });
 	});
 
-	it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+	it.each([0, -1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
 		"rejects invalid service deadline %s",
 		async (fetchTimeoutMs) => {
 			await expect(
@@ -249,7 +249,7 @@ describe("AgentSkillsService fetch timeouts", () => {
 					storage: new MemorySkillStore(),
 				}),
 			).rejects.toThrow(
-				"fetchTimeoutMs must be a positive finite number or null",
+				"fetchTimeoutMs must be a positive bounded integer or null",
 			);
 		},
 	);
@@ -277,13 +277,14 @@ describe("AgentSkillsService fetch timeouts", () => {
 				localService.getCatalog({ forceRefresh: true }),
 			).resolves.toEqual([]);
 			expect(performance.now() - startedAt).toBeLessThan(2_000);
+			const requestCountAfterTimeout = requestCount;
 
 			// A timed-out catalog fetch enters the existing cooldown even when a
 			// caller forces refresh, so retries cannot hammer an unhealthy registry.
 			await expect(
 				localService.getCatalog({ forceRefresh: true }),
 			).resolves.toEqual([]);
-			expect(requestCount).toBe(1);
+			expect(requestCount).toBe(requestCountAfterTimeout);
 		} finally {
 			await endpoint.close();
 		}

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -58,8 +58,13 @@ import type {
 import { SKILL_SOURCE_PRECEDENCE } from "../types";
 import { binaryExistsInPath } from "./bin-lookup";
 import {
+	createSkillDownloadLifecycle,
+	DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS,
+	isSkillDownloadError,
 	readCappedSkillPackage,
 	readCappedSkillText,
+	type SkillDownloadLifecycle,
+	skillDownloadAbortError,
 } from "./skill-package-bytes";
 
 // ============================================================
@@ -82,7 +87,6 @@ const CACHE_TTL = {
  */
 const FETCH_ERROR_COOLDOWN = 1000 * 60 * 5;
 const MAX_CATALOG_PAGES = 100;
-const DEFAULT_REGISTRY_FETCH_TIMEOUT_MS = 30_000;
 
 class CatalogPaginationError extends Error {
 	constructor(message: string) {
@@ -119,6 +123,20 @@ function sanitizeSlug(slug: string): string {
 		throw new Error(`Invalid skill slug: ${slug}`);
 	}
 	return sanitized;
+}
+
+async function fetchInstallResource(
+	url: string,
+	lifecycle: SkillDownloadLifecycle,
+	init: RequestInit = {},
+): Promise<Response> {
+	lifecycle.throwIfAborted();
+	try {
+		return await fetch(url, { ...init, signal: lifecycle.signal });
+	} catch (cause) {
+		lifecycle.throwIfAborted(cause);
+		throw cause;
+	}
 }
 
 // ============================================================
@@ -287,7 +305,7 @@ export class AgentSkillsService extends Service {
 		}
 		this.fetchTimeoutMs =
 			configuredFetchTimeout === undefined
-				? DEFAULT_REGISTRY_FETCH_TIMEOUT_MS
+				? DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS
 				: configuredFetchTimeout;
 
 		// Registry I/O is opt-in during startup. getSetting() may preserve the
@@ -1834,9 +1852,10 @@ export class AgentSkillsService extends Service {
 	private fetchSkillResource(
 		input: string | URL,
 		init: RequestInit = {},
+		deadlineManaged = false,
 	): Promise<Response> {
 		const timeoutSignal =
-			this.fetchTimeoutMs === null
+			deadlineManaged || this.fetchTimeoutMs === null
 				? undefined
 				: AbortSignal.timeout(this.fetchTimeoutMs);
 		const signal =
@@ -1896,6 +1915,7 @@ export class AgentSkillsService extends Service {
 				const url = `${this.apiBase}/api/v1/skills?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`;
 				const response = await this.fetchSkillResource(url, {
 					headers: { Accept: "application/json" },
+					signal: options.signal,
 				});
 
 				if (!response.ok) {
@@ -1951,6 +1971,9 @@ export class AgentSkillsService extends Service {
 
 			return entries;
 		} catch (error) {
+			if (options.signal?.aborted) {
+				throw skillDownloadAbortError(options.signal, error);
+			}
 			this.lastFetchErrorAt = Date.now();
 			this.runtime.logger.warn(
 				`AgentSkills: Catalog fetch failed (will retry after cooldown): ${error}`,
@@ -1988,6 +2011,7 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/search?q=${encodeURIComponent(query)}&limit=${limit}`;
 			const response = await this.fetchSkillResource(url, {
 				headers: { Accept: "application/json" },
+				signal: options.signal,
 			});
 
 			if (!response.ok) {
@@ -2001,6 +2025,9 @@ export class AgentSkillsService extends Service {
 
 			return results;
 		} catch (error) {
+			if (options.signal?.aborted) {
+				throw skillDownloadAbortError(options.signal, error);
+			}
 			this.runtime.logger.error(`AgentSkills: Search error: ${error}`);
 			return this.searchCache.get(cacheKey)?.data || [];
 		}
@@ -2012,6 +2039,14 @@ export class AgentSkillsService extends Service {
 	async getSkillDetails(
 		slug: string,
 		options: CacheOptions = {},
+	): Promise<SkillDetails | null> {
+		return this.getSkillDetailsWithDeadline(slug, options, false);
+	}
+
+	private async getSkillDetailsWithDeadline(
+		slug: string,
+		options: CacheOptions,
+		deadlineManaged: boolean,
 	): Promise<SkillDetails | null> {
 		const safeSlug = sanitizeSlug(slug);
 		const ttl = options.notOlderThan ?? CACHE_TTL.SKILL_DETAILS;
@@ -2028,7 +2063,8 @@ export class AgentSkillsService extends Service {
 			const url = `${this.apiBase}/api/v1/skills/${safeSlug}`;
 			const response = await this.fetchSkillResource(url, {
 				headers: { Accept: "application/json" },
-			});
+				signal: options.signal,
+			}, deadlineManaged);
 
 			if (!response.ok) {
 				if (response.status === 404) return null;
@@ -2040,6 +2076,9 @@ export class AgentSkillsService extends Service {
 
 			return details;
 		} catch (error) {
+			if (options.signal?.aborted) {
+				throw skillDownloadAbortError(options.signal, error);
+			}
 			this.runtime.logger.error(`AgentSkills: Details fetch error: ${error}`);
 			return this.detailsCache.get(safeSlug)?.data || null;
 		}
@@ -2229,24 +2268,40 @@ export class AgentSkillsService extends Service {
 				`AgentSkills: Installing ${safeSlug}@${version}...`,
 			);
 
-			// Get skill details
-			const details = await this.getSkillDetails(safeSlug);
-			if (!details) {
-				throw new Error(`Skill "${safeSlug}" not found`);
+			const lifecycle = createSkillDownloadLifecycle({
+				signal: options.signal,
+				downloadTimeoutMs:
+					options.downloadTimeoutMs === undefined
+						? this.fetchTimeoutMs
+						: options.downloadTimeoutMs,
+			});
+			let resolvedVersion: string;
+			let zipBuffer: Uint8Array;
+			try {
+				// Catalog resolution and package bytes share one wall-clock deadline.
+				const details = await this.getSkillDetailsWithDeadline(safeSlug, {
+					signal: lifecycle.signal,
+				}, true);
+				if (!details) {
+					throw new Error(`Skill "${safeSlug}" not found`);
+				}
+
+				resolvedVersion =
+					version === "latest" ? details.latestVersion.version : version;
+
+				const downloadUrl = `${this.apiBase}/api/v1/download?slug=${safeSlug}&version=${resolvedVersion}`;
+				const response = await fetchInstallResource(downloadUrl, lifecycle);
+
+				if (!response.ok) {
+					throw new Error(`Download failed: ${response.status}`);
+				}
+
+				zipBuffer = await readCappedSkillPackage(response, {
+					signal: lifecycle.signal,
+				});
+			} finally {
+				lifecycle.dispose();
 			}
-
-			const resolvedVersion =
-				version === "latest" ? details.latestVersion.version : version;
-
-			// Download
-			const downloadUrl = `${this.apiBase}/api/v1/download?slug=${safeSlug}&version=${resolvedVersion}`;
-			const response = await this.fetchSkillResource(downloadUrl);
-
-			if (!response.ok) {
-				throw new Error(`Download failed: ${response.status}`);
-			}
-
-			const zipBuffer = await readCappedSkillPackage(response);
 
 			// Extract and save based on storage type
 			if (this.storage instanceof MemorySkillStore) {
@@ -2277,6 +2332,9 @@ export class AgentSkillsService extends Service {
 			return true;
 		} catch (error) {
 			this.runtime.logger.error(`AgentSkills: Install error: ${error}`);
+			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
+				throw error;
+			}
 			return false;
 		}
 	}
@@ -2357,34 +2415,49 @@ export class AgentSkillsService extends Service {
 			const basePath = skillPath ? `${skillPath}/` : "";
 			const rawBase = `https://raw.githubusercontent.com/${owner}/${repoName}/${branch}/${basePath}`;
 
-			// Download SKILL.md
-			const skillMdUrl = `${rawBase}SKILL.md`;
-			const response = await this.fetchSkillResource(skillMdUrl);
-
-			if (!response.ok) {
-				throw new Error(
-					`Failed to fetch SKILL.md: ${response.status} from ${skillMdUrl}`,
-				);
-			}
-
-			const skillMdContent = await readCappedSkillText(response);
-
-			// Create a minimal skill package
-			const files: Array<{ name: string; content: string | Uint8Array }> = [
-				{ name: "SKILL.md", content: skillMdContent },
-			];
-
-			// Try to fetch README.md if it exists (optional)
+			const lifecycle = createSkillDownloadLifecycle({
+				signal: options.signal,
+				downloadTimeoutMs:
+					options.downloadTimeoutMs === undefined
+						? this.fetchTimeoutMs
+						: options.downloadTimeoutMs,
+			});
+			let files: Array<{ name: string; content: string | Uint8Array }>;
 			try {
-				const readmeUrl = `${rawBase}README.md`;
-				const readmeResponse = await this.fetchSkillResource(readmeUrl);
-				if (readmeResponse.ok) {
-					const readmeContent = await readCappedSkillText(readmeResponse);
-					files.push({ name: "README.md", content: readmeContent });
+				// Required and optional GitHub resources consume the same deadline.
+				const skillMdUrl = `${rawBase}SKILL.md`;
+				const response = await fetchInstallResource(skillMdUrl, lifecycle);
+
+				if (!response.ok) {
+					throw new Error(
+						`Failed to fetch SKILL.md: ${response.status} from ${skillMdUrl}`,
+					);
 				}
-			} catch {
-				// error-policy:J4 README enrichment is optional; a timeout or missing
-				// file leaves the installed skill visibly without that extra file.
+
+				const skillMdContent = await readCappedSkillText(response, {
+					signal: lifecycle.signal,
+				});
+				files = [{ name: "SKILL.md", content: skillMdContent }];
+
+				try {
+					const readmeUrl = `${rawBase}README.md`;
+					const readmeResponse = await fetchInstallResource(readmeUrl, lifecycle);
+					if (readmeResponse.ok) {
+						const readmeContent = await readCappedSkillText(readmeResponse, {
+							signal: lifecycle.signal,
+						});
+						files.push({ name: "README.md", content: readmeContent });
+					}
+				} catch (cause) {
+					lifecycle.throwIfAborted(cause);
+					if (isSkillDownloadError(cause) || !(cause instanceof TypeError)) {
+						throw cause;
+					}
+					// error-policy:J4 an optional README transport failure leaves the
+					// installed package visibly without README.md; required SKILL.md is intact.
+				}
+			} finally {
+				lifecycle.dispose();
 			}
 
 			// Save to storage
@@ -2422,6 +2495,9 @@ export class AgentSkillsService extends Service {
 			return true;
 		} catch (error) {
 			this.runtime.logger.error(`AgentSkills: GitHub install error: ${error}`);
+			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
+				throw error;
+			}
 			return false;
 		}
 	}
@@ -2434,14 +2510,6 @@ export class AgentSkillsService extends Service {
 		options: InstallSkillOptions & { slug?: string } = {},
 	): Promise<boolean> {
 		try {
-			const response = await this.fetchSkillResource(url);
-
-			if (!response.ok) {
-				throw new Error(`Failed to fetch: ${response.status}`);
-			}
-
-			const contentType = response.headers.get("content-type") || "";
-
 			// Determine slug from URL or options
 			const urlPath = new URL(url).pathname;
 			const derivedSlug =
@@ -2453,11 +2521,38 @@ export class AgentSkillsService extends Service {
 					?.replace(/\.(md|zip)$/i, "") ||
 				"skill";
 			const safeSlug = sanitizeSlug(derivedSlug);
+			const lifecycle = createSkillDownloadLifecycle({
+				signal: options.signal,
+				downloadTimeoutMs:
+					options.downloadTimeoutMs === undefined
+						? this.fetchTimeoutMs
+						: options.downloadTimeoutMs,
+			});
+			let zipBuffer: Uint8Array | undefined;
+			let skillMdContent: string | undefined;
+			try {
+				const response = await fetchInstallResource(url, lifecycle);
 
-			if (contentType.includes("application/zip") || url.endsWith(".zip")) {
+				if (!response.ok) {
+					throw new Error(`Failed to fetch: ${response.status}`);
+				}
+
+				const contentType = response.headers.get("content-type") || "";
+				if (contentType.includes("application/zip") || url.endsWith(".zip")) {
+					zipBuffer = await readCappedSkillPackage(response, {
+						signal: lifecycle.signal,
+					});
+				} else {
+					skillMdContent = await readCappedSkillText(response, {
+						signal: lifecycle.signal,
+					});
+				}
+			} finally {
+				lifecycle.dispose();
+			}
+
+			if (zipBuffer) {
 				// Handle zip package
-				const zipBuffer = await readCappedSkillPackage(response);
-
 				if (this.storage instanceof MemorySkillStore) {
 					await (this.storage as MemorySkillStore).loadFromZip(
 						safeSlug,
@@ -2471,10 +2566,12 @@ export class AgentSkillsService extends Service {
 				}
 			} else {
 				// Assume it's a SKILL.md file
-				const content = await readCappedSkillText(response);
+				if (skillMdContent === undefined) {
+					throw new Error("Skill download did not produce package content");
+				}
 
 				const files: Array<{ name: string; content: string | Uint8Array }> = [
-					{ name: "SKILL.md", content },
+					{ name: "SKILL.md", content: skillMdContent },
 				];
 
 				if (this.storage instanceof MemorySkillStore) {
@@ -2511,6 +2608,9 @@ export class AgentSkillsService extends Service {
 			return true;
 		} catch (error) {
 			this.runtime.logger.error(`AgentSkills: URL install error: ${error}`);
+			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
+				throw error;
+			}
 			return false;
 		}
 	}

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -61,6 +61,7 @@ import {
 	createSkillDownloadLifecycle,
 	DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS,
 	isSkillDownloadError,
+	MAX_SKILL_DOWNLOAD_TIMEOUT_MS,
 	readCappedSkillPackage,
 	readCappedSkillText,
 	type SkillDownloadLifecycle,
@@ -299,9 +300,13 @@ export class AgentSkillsService extends Service {
 		if (
 			configuredFetchTimeout !== undefined &&
 			configuredFetchTimeout !== null &&
-			(!Number.isFinite(configuredFetchTimeout) || configuredFetchTimeout <= 0)
+			(!Number.isInteger(configuredFetchTimeout) ||
+				configuredFetchTimeout <= 0 ||
+				configuredFetchTimeout > MAX_SKILL_DOWNLOAD_TIMEOUT_MS)
 		) {
-			throw new Error("fetchTimeoutMs must be a positive finite number or null");
+			throw new Error(
+				"fetchTimeoutMs must be a positive bounded integer or null",
+			);
 		}
 		this.fetchTimeoutMs =
 			configuredFetchTimeout === undefined

--- a/plugins/plugin-agent-skills/src/types.ts
+++ b/plugins/plugin-agent-skills/src/types.ts
@@ -308,6 +308,9 @@ export interface CacheOptions {
 
 	/** Bypass cache entirely */
 	forceRefresh?: boolean;
+
+	/** Cancel an in-flight registry request when the caller is no longer waiting. */
+	signal?: AbortSignal;
 }
 
 /**
@@ -336,6 +339,22 @@ export interface InstallSkillOptions {
 
 	/** Force reinstall even if already installed */
 	force?: boolean;
+
+	/** Cancel all requests and body reads in this install lifecycle. */
+	signal?: AbortSignal;
+
+	/**
+	 * Wall-clock deadline shared by all network requests and body reads in this
+	 * install. Defaults to the service `fetchTimeoutMs`; `null` explicitly
+	 * disables the deadline for this install.
+	 */
+	downloadTimeoutMs?: number | null;
+
+	/**
+	 * Rethrow typed download-boundary failures instead of returning `false`.
+	 * Defaults to `false` to preserve the established boolean install API.
+	 */
+	throwOnDownloadError?: boolean;
 }
 
 // ============================================================


### PR DESCRIPTION
# Relates to

Closes #22297.
Closes #22300.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop` `282a6cf538c43cbbe3078a98ea8ba9bcda5f2d85` with zero conflicts.
- [x] `bun install` completed under Bun 1.3.14 and Node 24.15.0; the package gates pass at the exact head. The unrelated root verifier failure is recorded below.
- [x] A reviewer can confirm missing-body rejection, caller cancellation, shared deadline behavior, stream teardown, and absent partial persistence from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@de026436678c74ae55d5a25a895787b7410ad3df:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop` `282a6cf538c43cbbe3078a98ea8ba9bcda5f2d85`; zero conflicts.
- [x] Focused and complete package tests, package typecheck, Biome, build/declaration emit, and diff hygiene pass at exact head `64dc0b91f916842a0629dbe0ce378ac7cb86b446`.
- [ ] Root `bun run verify` reaches the repository-wide Turbo lane and then fails in unchanged `@elizaos/core` because its generated consumer cannot resolve `@elizaos/core/edge`; the same isolated core build reproduces this base failure. No core file is changed here.

# Risks

Low-to-medium and bounded to remote Agent Skills installation. Existing callers retain the boolean success API by default. Callers that need an authoritative typed timeout, cancellation, missing-body, size, or UTF-8 failure opt in with `throwOnDownloadError`. A per-install override inherits the service deadline by default and can explicitly disable it with `downloadTimeoutMs: null`.

# Background

## What does this PR do?

PR #22296 bounded retained package bytes but treated a response with no body as a healthy empty byte sequence. PR #22652 added service-level fetch timeouts, but the public install methods still had no per-call cancellation contract and could only collapse the owning timeout/cancellation failure to `false`.

This change:

- rejects a missing body with typed `SKILL_DOWNLOAD_MISSING_BODY`;
- creates one install-wide lifecycle spanning catalog resolution, package fetches, GitHub SKILL/README reads, and direct-URL body reads;
- composes caller cancellation with the service deadline and per-call override/opt-out;
- normalizes timeout and caller cancellation to typed `ElizaError` codes without allowing stream-cancel teardown to mask the owner;
- preserves the legacy boolean result by default while adding `throwOnDownloadError` for callers that need the typed boundary failure; and
- prevents persistence after missing-body, timeout, or cancellation failure.

## What kind of change is this?

Bug fix with additive, backward-compatible installation options.

# Documentation changes needed?

The package README documents caller cancellation, inherited/per-call deadlines, explicit opt-out, and typed-failure opt-in.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts`, followed by the lifecycle plumbing in `skill-package-bytes.ts` and the three public install methods in `skills.ts`.

## Detailed testing steps

```text
$ bun run --cwd plugins/plugin-agent-skills test
Test Files  26 passed (26)
Tests       281 passed (281)

$ bun run --cwd plugins/plugin-agent-skills typecheck
$ tsc --noEmit
exit 0

$ bun run --cwd plugins/plugin-agent-skills lint:check
Checked 65 files. No fixes applied.

$ bun run --cwd plugins/plugin-agent-skills build
ESM Build success; declaration emit exit 0

$ git diff --check origin/develop...HEAD
exit 0
```

# Evidence Gate

<!-- evidence-head:64dc0b91f916842a0629dbe0ce378ac7cb86b446 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side response-stream lifecycle with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side response-stream lifecycle with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction; the real loopback server and package artifacts are recorded below.
<!-- evidence-row:backend-logs -->
- [x] [22722-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22722-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or trajectory behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22722-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22722-domain-artifacts.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is deterministic download-boundary behavior and does not call a model.

## Backend + frontend logs

Backend: exact-head focused and complete Vitest/package gate transcript above. Frontend: N/A because the frontend is not involved.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no audio or voice behavior.

## Known gaps / failures

- Root `bun run verify` currently fails after 137 successful Turbo tasks when unchanged `@elizaos/core` runs its generated consumer check: `consumer.mts(1,101): error TS2307: Cannot find module '@elizaos/core/edge'`. Running `bun run --cwd packages/core build` alone reproduces the same base failure. This PR changes only `plugins/plugin-agent-skills` and its README/types/tests.
- No external registry credential is required: the authoritative transport evidence uses a real local Node HTTP server that sends headers and partial bytes and deliberately never completes the body.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@de026436678c74ae55d5a25a895787b7410ad3df:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-22300-agent-skills-download-lifecycle]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@de026436678c74ae55d5a25a895787b7410ad3df:packages/skills/skills/contribute-to-eliza"} -->


