### PR TITLE
fix(personal-assistant): keep occurrence completion timestamp typed

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
@@ -482,12 +482,13 @@ export class DefinitionsDomain {
         `occurrence cannot be completed from state ${occurrence.state}`,
       );
     }
+    const completedAt = now.toISOString();
     const updatedOccurrence: LifeOpsOccurrence = {
       ...occurrence,
       state: "completed",
       snoozedUntil: null,
       completionPayload: {
-        completedAt: now.toISOString(),
+        completedAt,
         note: normalizeOptionalString(request.note) ?? null,
         metadata: cloneRecord(request.metadata),
         previousState: occurrence.state,
@@ -536,8 +537,8 @@ export class DefinitionsDomain {
           source: "life",
           sourceId: updatedOccurrence.id,
           eventType: "completed",
-          eventAt: updatedOccurrence.completionPayload.completedAt,
-          domainEventId: `occurrence_completed:${updatedOccurrence.id}:${updatedOccurrence.completionPayload.completedAt}`,
+          eventAt: completedAt,
+          domainEventId: `occurrence_completed:${updatedOccurrence.id}:${completedAt}`,
           weight: 1,
           metadata: {
             definitionId: updatedOccurrence.definitionId,


### PR DESCRIPTION
## Summary

- reuse the authoritative `completedAt` value produced from the method clock
- persist the same value in the completion payload
- use that typed value for brief-engagement attribution and its idempotency key

Fixes #22724

## Testing

- `bun run --cwd plugins/plugin-personal-assistant typecheck`
- `bun run --cwd plugins/plugin-personal-assistant lint:check`
- `node packages/scripts/run-vitest.mjs run --config packages/scripts/vitest/integration.config.ts plugins/plugin-personal-assistant/test/life-action-effect-receipts.integration.test.ts -t "binds complete, skip, and snooze"` (1 passed, 3 skipped)

The unfiltered four-test file also ran: the occurrence transition cases passed, while two pre-existing receipt tests failed in unrelated create/delete paths (`effectReceipts` absent and `lifeops.owner.delete` returned instead of `lifeops.definition.delete`).

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Typed boundary | Package typecheck passes |
| Formatting/lint | 1,671 files checked; no fixes |
| Real persistence path | PGlite occurrence complete/skip/snooze integration passes |
| UI/screenshots/video | N/A — no UI or rendered behavior changed |
| External/native integration | N/A — no connector or native path changed |

---
AI assistance: OpenAI Codex (GPT-5)