### PR TITLE
fix(plugin-workflow): enforce cumulative JSON clone budgets

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-json.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   cloneJson,
+  MAX_WORKFLOW_JSON_BYTES,
   MAX_WORKFLOW_JSON_DEPTH,
   MAX_WORKFLOW_JSON_NODES,
   WORKFLOW_JSON_UNBOUNDED,
@@ -89,6 +90,29 @@ describe('cloneJson', () => {
     });
     expectUnbounded(() => cloneJson(accessor));
     expect(calls).toBe(0);
+  });
+
+  test('charges sparse slots cumulatively across nested arrays', () => {
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    first.length = Math.floor(MAX_WORKFLOW_JSON_NODES / 2);
+    second.length = Math.floor(MAX_WORKFLOW_JSON_NODES / 2);
+
+    expectUnbounded(() => cloneJson({ first, second }));
+  });
+
+  test(`bounds normalized JSON at ${MAX_WORKFLOW_JSON_BYTES} UTF-8 bytes`, () => {
+    const atLimit = 'x'.repeat(MAX_WORKFLOW_JSON_BYTES - 2);
+    expect(cloneJson(atLimit)).toBe(atLimit);
+    expectUnbounded(() => cloneJson(`${atLimit}x`));
+
+    const objectValue = 'x'.repeat(MAX_WORKFLOW_JSON_BYTES - 14);
+    expect(cloneJson({ payload: objectValue })).toEqual({ payload: objectValue });
+    expectUnbounded(() => cloneJson({ payload: `${objectValue}x` }));
+
+    const escapedAtLimit = '\u0000'.repeat((MAX_WORKFLOW_JSON_BYTES - 2) / 6);
+    expect(cloneJson(escapedAtLimit)).toBe(escapedAtLimit);
+    expectUnbounded(() => cloneJson(`${escapedAtLimit}\u0000`));
   });
 
   test('never invokes custom or Proxy-synthesized JSON hooks', () => {

--- a/plugins/plugin-workflow/src/services/workflow-json.ts
+++ b/plugins/plugin-workflow/src/services/workflow-json.ts
@@ -10,6 +10,8 @@ import { WorkflowApiError } from '../types/index';
 export const MAX_WORKFLOW_JSON_DEPTH = 64;
 /** Logical values copied by one workflow clone. */
 export const MAX_WORKFLOW_JSON_NODES = 10_000;
+/** Maximum UTF-8 size of the normalized JSON value, matching the HTTP boundary. */
+export const MAX_WORKFLOW_JSON_BYTES = 2_000_000;
 export const WORKFLOW_JSON_UNBOUNDED = 'WORKFLOW_JSON_UNBOUNDED';
 const OMIT = Symbol('workflow-json-omit');
 
@@ -19,6 +21,7 @@ function failUnbounded(message: string): never {
 
 interface CloneContext {
   ancestors: WeakSet<object>;
+  bytes: number;
   visits: number;
 }
 
@@ -34,10 +37,51 @@ function reflectOrFail<T>(operation: () => T): T {
   }
 }
 
-function unsupportedValue(location: CloneLocation): null | typeof OMIT {
-  if (location === 'array') return null;
+function unsupportedValue(location: CloneLocation, context: CloneContext): null | typeof OMIT {
+  if (location === 'array') {
+    chargeBytes(context, 4);
+    return null;
+  }
   if (location === 'object') return OMIT;
   failUnbounded('Workflow JSON root is not serializable');
+}
+
+function chargeBytes(context: CloneContext, bytes: number): void {
+  if (bytes > MAX_WORKFLOW_JSON_BYTES - context.bytes) {
+    failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_BYTES} serialized bytes`);
+  }
+  context.bytes += bytes;
+}
+
+/** Charge the exact UTF-8 byte length produced by JSON string serialization. */
+function chargeJsonString(context: CloneContext, value: string): void {
+  chargeBytes(context, 2);
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x09) {
+      chargeBytes(context, 2);
+    } else if (code === 0x0a || code === 0x0c || code === 0x0d) {
+      chargeBytes(context, 2);
+    } else if (code <= 0x1f) {
+      chargeBytes(context, 6);
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        chargeBytes(context, 4);
+        index += 1;
+      } else {
+        chargeBytes(context, 6);
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      chargeBytes(context, 6);
+    } else if (code <= 0x7f) {
+      chargeBytes(context, 1);
+    } else if (code <= 0x7ff) {
+      chargeBytes(context, 2);
+    } else {
+      chargeBytes(context, 3);
+    }
+  }
 }
 
 function cloneJsonValue(
@@ -54,15 +98,28 @@ function cloneJsonValue(
     failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
   }
 
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+  if (value === null) {
+    chargeBytes(context, 4);
+    return value;
+  }
+  if (typeof value === 'string') {
+    chargeJsonString(context, value);
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    chargeBytes(context, value ? 4 : 5);
     return value;
   }
   if (typeof value === 'number') {
-    if (!Number.isFinite(value)) return null;
+    if (!Number.isFinite(value)) {
+      chargeBytes(context, 4);
+      return null;
+    }
+    chargeBytes(context, String(value === 0 ? 0 : value).length);
     return value === 0 ? 0 : value;
   }
   if (value === undefined || typeof value === 'function' || typeof value === 'symbol') {
-    return unsupportedValue(location);
+    return unsupportedValue(location, context);
   }
   if (typeof value === 'bigint') {
     failUnbounded('Workflow JSON may not contain bigint values');
@@ -92,7 +149,13 @@ function cloneJsonValue(
       dateTime = undefined;
     }
     if (dateTime !== undefined) {
-      return Number.isFinite(dateTime) ? Date.prototype.toISOString.call(value) : null;
+      if (!Number.isFinite(dateTime)) {
+        chargeBytes(context, 4);
+        return null;
+      }
+      const iso = Date.prototype.toISOString.call(value);
+      chargeJsonString(context, iso);
+      return iso;
     }
 
     if (reflectOrFail(() => Array.isArray(value))) {
@@ -107,6 +170,7 @@ function cloneJsonValue(
       ) {
         failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
       }
+      chargeBytes(context, 2 + Math.max(0, length - 1));
       const snapshot = new Array<unknown>(length);
       for (let index = 0; index < length; index += 1) {
         const descriptor = reflectOrFail(() =>
@@ -115,9 +179,16 @@ function cloneJsonValue(
         if (descriptor && ('get' in descriptor || 'set' in descriptor)) {
           failUnbounded('Workflow JSON may not contain accessors');
         }
-        snapshot[index] = descriptor
-          ? cloneJsonValue(descriptor.value, depth + 1, 'array', context)
-          : null;
+        if (descriptor) {
+          snapshot[index] = cloneJsonValue(descriptor.value, depth + 1, 'array', context);
+        } else {
+          context.visits += 1;
+          if (context.visits > MAX_WORKFLOW_JSON_NODES) {
+            failUnbounded(`Workflow JSON exceeds ${MAX_WORKFLOW_JSON_NODES} logical values`);
+          }
+          chargeBytes(context, 4);
+          snapshot[index] = null;
+        }
       }
       return snapshot;
     }
@@ -129,7 +200,9 @@ function cloneJsonValue(
     // Drizzle inspects ordinary object prototypes when binding jsonb values, so
     // retain Object.prototype while defining every key as an own data property
     // (`__proto__` included) instead of using assignment setters.
+    chargeBytes(context, 2);
     const snapshot: Record<string, unknown> = {};
+    let includedProperties = 0;
     for (const key of keys) {
       if (typeof key !== 'string') continue;
       const descriptor = reflectOrFail(() => Object.getOwnPropertyDescriptor(value, key));
@@ -139,6 +212,10 @@ function cloneJsonValue(
       }
       const entry = cloneJsonValue(descriptor.value, depth + 1, 'object', context);
       if (entry === OMIT) continue;
+      if (includedProperties > 0) chargeBytes(context, 1);
+      chargeJsonString(context, key);
+      chargeBytes(context, 1);
+      includedProperties += 1;
       Object.defineProperty(snapshot, key, {
         value: entry,
         enumerable: true,
@@ -159,6 +236,7 @@ function cloneJsonValue(
 export function cloneJson<T>(value: T): T {
   const snapshot = cloneJsonValue(value, 0, 'root', {
     ancestors: new WeakSet<object>(),
+    bytes: 0,
     visits: 0,
   });
   if (snapshot === OMIT) failUnbounded('Workflow JSON root is not serializable');


### PR DESCRIPTION
Closes #22729

## Problem

Merged #22716 added a descriptor-only workflow JSON snapshot, but its structural ceiling was not cumulative for sparse arrays: holes were prechecked per array yet never charged to the shared visit budget. Multiple legal sparse arrays could therefore allocate and scan far beyond 10,000 logical values. A single large string also bypassed the depth/node limits because normalized serialized size was unbounded.

## Change

- Charge every sparse hole against the same cumulative logical-node budget as present array values.
- Enforce a 2,000,000-byte ceiling matching the workflow HTTP boundary.
- Count the exact UTF-8 bytes JSON serialization produces, including keys, punctuation, escapes, surrogate pairs, lone surrogates, normalized nulls, Dates, and numbers, without invoking caller getters, prototypes, or serializers.
- Add cumulative sparse-array and exact byte-boundary regressions.

## Exact-head verification

Head: `ccf427598c368212d8a8fcc7eae55d7ca92e1ea1`
Base: `809bd6e74a85289ab3222ed5ad9eb0bda3a2a360`

Executed with Bun 1.3.14 and Node 24.15.0 in a scrubbed sandbox where credential files were unreadable and outbound network was denied:

- plugin-workflow unit lane: **91/91 pass**
- focused helper plus real PGlite lifecycle: **18/18 pass**
- package typecheck: pass
- package build: pass
- changed-file Biome: pass
- `git diff --check`: pass
- sandbox/worktree SHA-256 byte identity confirmed for both repaired files after the final rebase

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend JSON persistence boundary; no rendered pixels.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend JSON persistence boundary; no rendered pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic non-visual boundary.
<!-- evidence-row:backend-logs -->
- [x] N/A - exact command receipt is captured in the domain artifact below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22730-workflow-json-domain-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22730-workflow-json-domain-v2.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered output.

## Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ccf427598c368212d8a8fcc7eae55d7ca92e1ea1 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues/review-22229-22271]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza"} -->





