### PR TITLE
fix(agent): preserve tied memory feed cursors

### DIFF
--- a/packages/agent/src/api/memory-browse-pagination.test.ts
+++ b/packages/agent/src/api/memory-browse-pagination.test.ts
@@ -216,6 +216,76 @@ describe("memory viewer incremental pagination (#22061)", () => {
     expect(response).toMatchObject({ count: 50, hasMore: true });
   });
 
+  test("pages every tied-timestamp feed row exactly once with the id cursor", async () => {
+    const createdAt = 1_700_000_000_000;
+    const rows = Array.from({ length: 120 }, (_, i) =>
+      makeRow(i, `tied row ${i}`, OTHER, createdAt),
+    );
+    const { runtime } = makeRuntime({ messages: rows });
+    const seen: string[] = [];
+    let path = "/api/memories/feed?type=messages&limit=50";
+
+    for (let pageNumber = 0; pageNumber < 3; pageNumber++) {
+      const page = await get(runtime, path);
+      const memories = page.memories as Array<{
+        id: string;
+        createdAt: number;
+      }>;
+      seen.push(...memories.map((memory) => memory.id));
+      if (pageNumber < 2) expect(page.hasMore).toBe(true);
+      const last = memories.at(-1);
+      if (page.hasMore === false || !last) break;
+      path = `/api/memories/feed?type=messages&limit=50&before=${last.createdAt}&beforeId=${last.id}`;
+    }
+
+    expect(seen).toHaveLength(120);
+    expect(new Set(seen).size).toBe(120);
+    expect(new Set(seen)).toEqual(new Set(rows.map((row) => row.id ?? "")));
+  });
+
+  test("rejects an id cursor without a valid timestamp pair", async () => {
+    const { runtime } = makeRuntime({ messages: [] });
+    await expect(
+      get(
+        runtime,
+        `/api/memories/feed?type=messages&beforeId=${makeRow(1, "").id}`,
+      ),
+    ).rejects.toThrow("beforeId must be a UUID paired with before");
+  });
+
+  test("does not replay a concurrent tied-timestamp insert on an older page", async () => {
+    const createdAt = 1_700_000_000_000;
+    const rows = Array.from({ length: 60 }, (_, i) =>
+      makeRow(i, `original ${i}`, OTHER, createdAt),
+    );
+    const { runtime } = makeRuntime({ messages: rows });
+    const first = await get(
+      runtime,
+      "/api/memories/feed?type=messages&limit=50",
+    );
+    const firstMemories = first.memories as Array<{
+      id: string;
+      createdAt: number;
+    }>;
+    const cursor = firstMemories.at(-1);
+    expect(cursor).toBeDefined();
+
+    rows.push(makeRow(100, "concurrent newer tie", OTHER, createdAt));
+    const second = await get(
+      runtime,
+      `/api/memories/feed?type=messages&limit=50&before=${cursor?.createdAt}&beforeId=${cursor?.id}`,
+    );
+    const secondIds = (second.memories as Array<{ id: string }>).map(
+      (memory) => memory.id,
+    );
+
+    expect(secondIds).toHaveLength(10);
+    expect(secondIds).not.toContain(makeRow(100, "").id);
+    expect(
+      new Set([...firstMemories.map((memory) => memory.id), ...secondIds]).size,
+    ).toBe(60);
+  });
+
   test("terminates after one request when a table is truly exhausted", async () => {
     const { runtime, getMemories } = makeRuntime({
       messages: [makeRow(0, "needle"), makeRow(1, "hay")],

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -831,6 +831,7 @@ async function fetchMemoriesFromTables(
     /** Stop after this many eligible rows per table. */
     target: number;
     before?: number;
+    beforeId?: UUID;
     searchQuery?: string;
   },
 ): Promise<TaggedMemory[]> {
@@ -856,7 +857,10 @@ async function fetchMemoriesFromTables(
   const tableResults = await Promise.all(
     tables.map(async (tableName) => {
       const eligible: TaggedMemory[] = [];
-      let cursor: { createdAt: number; id: UUID } | undefined;
+      let cursor: { createdAt: number; id: UUID } | undefined =
+        params.before !== undefined && params.beforeId !== undefined
+          ? { createdAt: params.before, id: params.beforeId }
+          : undefined;
       let batchSize = 200;
       let scannedRows = 0;
 
@@ -885,7 +889,9 @@ async function fetchMemoriesFromTables(
           tableName,
           limit: queryLimit,
           cursor,
-          end: params.before,
+          // Timestamp-only callers retain the original strict-before filter.
+          // A tuple cursor is already the complete exclusive boundary.
+          end: params.beforeId === undefined ? params.before : undefined,
           textContains,
           includeEmbedding: false, // browse feed discards embeddings
         });
@@ -938,11 +944,17 @@ async function fetchMemoriesFromTables(
           ) {
             continue;
           }
-          if (
-            params.before !== undefined &&
-            memoryCreatedAt(tagged) >= params.before
-          ) {
-            continue;
+          if (params.before !== undefined) {
+            const createdAt = memoryCreatedAt(tagged);
+            if (createdAt > params.before) continue;
+            if (createdAt === params.before) {
+              if (
+                params.beforeId === undefined ||
+                compareMemoryIds(tagged.id ?? "", params.beforeId) >= 0
+              ) {
+                continue;
+              }
+            }
           }
           if (
             searchQuery &&
@@ -1169,6 +1181,14 @@ export async function handleMemoryRoutes(
       error(res, "before must be a Unix timestamp in milliseconds", 400);
       return true;
     }
+    const beforeIdParam = url.searchParams.get("beforeId");
+    if (
+      beforeIdParam !== null &&
+      (before === undefined || !UUID_REGEX.test(beforeIdParam))
+    ) {
+      error(res, "beforeId must be a UUID paired with before", 400);
+      return true;
+    }
     const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));
     if (!tableFilter.ok) {
       error(res, tableFilter.message, 400);
@@ -1180,6 +1200,7 @@ export async function handleMemoryRoutes(
       tables,
       target: limit + 1,
       before,
+      beforeId: beforeIdParam === null ? undefined : (beforeIdParam as UUID),
     });
 
     allMemories.sort(byNewestFirst);

--- a/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-diagnostics-interactions.spec.ts
@@ -137,3 +137,87 @@ test("memory viewer queries memory data and the Browse toggle switches the surfa
     });
   }
 });
+
+test("memory feed loads every tied-timestamp row with the tuple cursor", async ({
+  page,
+}, testInfo) => {
+  await hideChatOverlay(page);
+  const createdAt = Date.parse("2026-01-01T00:00:00.000Z");
+  const memoryId = (index: number) =>
+    `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+  const feedRequests: URL[] = [];
+
+  await page.route("**/api/memories/feed**", async (route) => {
+    const url = new URL(route.request().url());
+    feedRequests.push(url);
+    const beforeId = url.searchParams.get("beforeId");
+    const indexes = beforeId
+      ? Array.from({ length: 20 }, (_, index) => 19 - index)
+      : Array.from({ length: 50 }, (_, index) => 69 - index);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        memories: indexes.map((index) => ({
+          id: memoryId(index),
+          type: "messages",
+          text: `Tied memory ${index}`,
+          entityId: "entity-smoke-memory",
+          roomId: "room-smoke-memory",
+          agentId: "agent-smoke-memory",
+          createdAt,
+          metadata: null,
+          source: "ui-smoke",
+        })),
+        count: indexes.length,
+        limit: 50,
+        hasMore: beforeId === null,
+      }),
+    });
+  });
+
+  await openAppPath(page, "/apps/memories");
+  await expect(page.getByTestId("memory-feed")).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.getByTestId(/^memory-card-/)).toHaveCount(50);
+  if (process.env.E2E_RECORD === "1") {
+    const desktopViewport = page.viewportSize();
+    await page.screenshot({
+      path: testInfo.outputPath("memory-feed-tied-cursor-before-desktop.png"),
+      fullPage: true,
+    });
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.screenshot({
+      path: testInfo.outputPath("memory-feed-tied-cursor-before-mobile.png"),
+      fullPage: true,
+    });
+    if (desktopViewport) await page.setViewportSize(desktopViewport);
+  }
+  await page.getByRole("button", { name: "Load older" }).click();
+  await expect(page.getByTestId(/^memory-card-/)).toHaveCount(70);
+  const oldestMemory = page.getByText("Tied memory 0");
+  await oldestMemory.scrollIntoViewIfNeeded();
+  await expect(oldestMemory).toBeVisible();
+
+  const cursorRequests = feedRequests.filter((request) =>
+    request.searchParams.has("beforeId"),
+  );
+  expect(cursorRequests).toHaveLength(1);
+  expect(cursorRequests[0]?.searchParams.get("before")).toBe(String(createdAt));
+  expect(cursorRequests[0]?.searchParams.get("beforeId")).toBe(memoryId(20));
+
+  if (process.env.E2E_RECORD === "1") {
+    const desktopViewport = page.viewportSize();
+    await page.screenshot({
+      path: testInfo.outputPath("memory-feed-tied-cursor-after-desktop.png"),
+      fullPage: true,
+    });
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.screenshot({
+      path: testInfo.outputPath("memory-feed-tied-cursor-after-mobile.png"),
+      fullPage: true,
+    });
+    if (desktopViewport) await page.setViewportSize(desktopViewport);
+  }
+});

--- a/packages/ui/src/api/client-chat-memory-feed.test.ts
+++ b/packages/ui/src/api/client-chat-memory-feed.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Verifies the typed memory-feed client carries the complete stable cursor to
+ * the real request transport without relying on a live agent.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false, getPlatform: () => "web" },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+import { ElizaClient } from "./client-base";
+import "./client-chat";
+
+describe("memory feed client cursor", () => {
+  it("serializes both timestamp and id tie-breaker", async () => {
+    const urls: string[] = [];
+    const client = new ElizaClient("http://agent.example:31337");
+    client.setRequestTransport({
+      request: async (url) => {
+        urls.push(url);
+        return new Response(
+          JSON.stringify({
+            memories: [],
+            count: 0,
+            limit: 50,
+            hasMore: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await client.getMemoryFeed({
+      type: "messages",
+      limit: 50,
+      before: 200,
+      beforeId: "00000000-0000-4000-8000-000000000123",
+    });
+
+    expect(urls).toHaveLength(1);
+    const url = new URL(urls[0] ?? "");
+    expect(url.pathname).toBe("/api/memories/feed");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      type: "messages",
+      limit: "50",
+      before: "200",
+      beforeId: "00000000-0000-4000-8000-000000000123",
+    });
+  });
+});

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -1591,6 +1591,7 @@ ElizaClient.prototype.getMemoryFeed = async function (
     params.set("limit", String(query.limit));
   if (typeof query?.before === "number")
     params.set("before", String(query.before));
+  if (query?.beforeId) params.set("beforeId", query.beforeId);
   const qs = params.toString();
   return this.fetch(`/api/memories/feed${qs ? `?${qs}` : ""}`);
 };

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -689,6 +689,8 @@ export interface MemoryFeedQuery {
   type?: string;
   limit?: number;
   before?: number;
+  /** ID tie-breaker paired with `before` for an exclusive stable cursor. */
+  beforeId?: string;
 }
 
 export interface MemoryFeedResponse {

--- a/packages/ui/src/api/ios-local-agent-kernel.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.test.ts
@@ -628,6 +628,60 @@ describe("handleIosLocalAgentRequest", () => {
     });
   });
 
+  it("pages tied-timestamp local memories without skips or duplicates", async () => {
+    const localStorage = stubLocalStorage();
+    vi.stubGlobal("window", { localStorage });
+    localStorage.setItem(
+      "eliza:ios-local-agent:conversations:v1",
+      JSON.stringify({
+        conversations: [
+          {
+            id: "conv-tied",
+            title: "Tied",
+            roomId: "room-tied",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            messages: Array.from({ length: 5 }, (_, index) => ({
+              id: `message-${index}`,
+              role: "assistant",
+              text: `tied ${index}`,
+              timestamp: 200,
+            })),
+          },
+        ],
+      }),
+    );
+
+    const seen: string[] = [];
+    let path = "/api/memories/feed?limit=2";
+    for (let pageNumber = 0; pageNumber < 3; pageNumber++) {
+      const page = (await getJson(path)) as {
+        memories: Array<{ id: string; createdAt: number }>;
+        hasMore: boolean;
+      };
+      seen.push(...page.memories.map((memory) => memory.id));
+      const last = page.memories.at(-1);
+      if (!page.hasMore || !last) break;
+      path = `/api/memories/feed?limit=2&before=${last.createdAt}&beforeId=${last.id}`;
+    }
+
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(5);
+    expect(new Set(seen)).toEqual(
+      new Set(Array.from({ length: 5 }, (_, index) => `message-${index}`)),
+    );
+
+    const unpaired = await handleIosLocalAgentRequest(
+      new Request(
+        "http://127.0.0.1:31337/api/memories/feed?beforeId=message-1",
+      ),
+    );
+    expect(unpaired.status).toBe(400);
+    await expect(unpaired.json()).resolves.toEqual({
+      error: "beforeId must be a non-empty ID paired with before",
+    });
+  });
+
   it("resets local iOS agent state and keeps the kernel running", async () => {
     const localStorage = stubLocalStorage();
     vi.stubGlobal("window", { localStorage });

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -708,6 +708,12 @@ const MEMORY_FEED_MAX_LIMIT = 100;
 const MEMORY_BROWSE_DEFAULT_LIMIT = 50;
 const MEMORY_BROWSE_MAX_LIMIT = 200;
 
+function compareLocalMemoryIds(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
 function positiveIntegerParam(value: string | null, fallback: number): number {
   const parsed = integerFromUnknown(value);
   return parsed !== null && parsed > 0 ? parsed : fallback;
@@ -745,7 +751,12 @@ function localMemoryFeedItems(): MemoryBrowseItem[] {
       });
     }
   }
-  items.sort((a, b) => b.createdAt - a.createdAt);
+  items.sort((a, b) => {
+    const timestampOrder = b.createdAt - a.createdAt;
+    return timestampOrder !== 0
+      ? timestampOrder
+      : compareLocalMemoryIds(b.id, a.id);
+  });
   return items;
 }
 
@@ -786,11 +797,28 @@ function handleLocalMemoriesRoute(
         400,
       );
     }
+    const beforeIdParam = url.searchParams.get("beforeId");
+    const beforeId = beforeIdParam?.trim();
+    if (
+      beforeIdParam !== null &&
+      (before === undefined || !beforeId || beforeId.length > 512)
+    ) {
+      return json(
+        { error: "beforeId must be a non-empty ID paired with before" },
+        400,
+      );
+    }
     let items = localMemoryTypeHasRows(url.searchParams.get("type"))
       ? localMemoryFeedItems()
       : [];
     if (before !== undefined) {
-      items = items.filter((item) => item.createdAt < before);
+      items = items.filter(
+        (item) =>
+          item.createdAt < before ||
+          (beforeId !== undefined &&
+            item.createdAt === before &&
+            compareLocalMemoryIds(item.id, beforeId) < 0),
+      );
     }
     const page = items.slice(0, limit);
     return json({

--- a/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.interface.test.tsx
@@ -149,6 +149,64 @@ describe("MemoryViewerView interface contract", () => {
     );
   });
 
+  it("loads older tied-timestamp rows with the full tuple cursor", async () => {
+    clientMock.getMemoryFeed
+      .mockResolvedValueOnce({
+        memories: [
+          {
+            id: "feed-newer",
+            type: "messages",
+            text: "newer tied row",
+            source: "client_chat",
+            createdAt: 200,
+            entityId: "entity-1",
+            roomId: "room-1",
+          },
+          {
+            id: "feed-cursor",
+            type: "messages",
+            text: "cursor tied row",
+            source: "client_chat",
+            createdAt: 200,
+            entityId: "entity-1",
+            roomId: "room-1",
+          },
+        ],
+        count: 2,
+        limit: 50,
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        memories: [
+          {
+            id: "feed-older-tie",
+            type: "messages",
+            text: "older tied row",
+            source: "client_chat",
+            createdAt: 200,
+            entityId: "entity-1",
+            roomId: "room-1",
+          },
+        ],
+        count: 1,
+        limit: 50,
+        hasMore: false,
+      });
+
+    const user = userEvent.setup();
+    render(<MemoryViewerView />);
+    await user.click(await screen.findByRole("button", { name: "Load older" }));
+
+    await waitFor(() =>
+      expect(clientMock.getMemoryFeed).toHaveBeenCalledTimes(2),
+    );
+    expect(clientMock.getMemoryFeed).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ before: 200, beforeId: "feed-cursor" }),
+    );
+    expect(await screen.findByText("older tied row")).not.toBeNull();
+  });
+
   it("points the empty feed forward with Ask Eliza", async () => {
     clientMock.getMemoryStats.mockResolvedValue({ total: 0, byType: {} });
     clientMock.getMemoryFeed.mockResolvedValue({

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -311,7 +311,10 @@ function MemoryFeedPanel({ typeFilter }: { typeFilter: readonly string[] }) {
   }, []);
 
   const loadFeed = useCallback(
-    async (before?: number, options?: { silent?: boolean }) => {
+    async (
+      before?: { createdAt: number; id: string },
+      options?: { silent?: boolean },
+    ) => {
       if (loadingMore.current && before) return;
       if (before) loadingMore.current = true;
       else if (!options?.silent) setLoading(true);
@@ -321,7 +324,8 @@ function MemoryFeedPanel({ typeFilter }: { typeFilter: readonly string[] }) {
         const result: MemoryFeedResponse = await client.getMemoryFeed({
           type: serverTypeParam(typeFilter),
           limit: FEED_PAGE_SIZE,
-          before,
+          before: before?.createdAt,
+          beforeId: before?.id,
         });
         const memories = filterMemoriesByTypes(result.memories, typeFilter);
         if (before) {
@@ -366,7 +370,7 @@ function MemoryFeedPanel({ typeFilter }: { typeFilter: readonly string[] }) {
 
   const loadMore = () => {
     const last = feed[feed.length - 1];
-    if (last) void loadFeed(last.createdAt);
+    if (last) void loadFeed({ createdAt: last.createdAt, id: last.id });
   };
 
   if (loading && feed.length === 0) {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -257,6 +257,43 @@ describe("iOS bridge — memories view routes", () => {
 		}
 	});
 
+	it("pages every tied-timestamp feed row exactly once with the id cursor", async () => {
+		const createdAt = 1_700_000_000_000;
+		for (let i = 0; i < 120; i++) {
+			await seedMemory("messages", `tied ${i}`, createdAt);
+		}
+
+		const seen: string[] = [];
+		let path = "/api/memories/feed?type=messages&limit=50";
+		for (let pageNumber = 0; pageNumber < 3; pageNumber++) {
+			const page = await call(backend, "GET", path);
+			const memories = page.json.memories as Array<{
+				id: string;
+				createdAt: number;
+			}>;
+			seen.push(...memories.map((memory) => memory.id));
+			if (pageNumber < 2) expect(page.json.hasMore).toBe(true);
+			const last = memories.at(-1);
+			if (page.json.hasMore === false || !last) break;
+			path = `/api/memories/feed?type=messages&limit=50&before=${last.createdAt}&beforeId=${last.id}`;
+		}
+
+		expect(seen).toHaveLength(120);
+		expect(new Set(seen).size).toBe(120);
+	});
+
+	it("rejects an id cursor without its timestamp pair", async () => {
+		const result = await call(
+			backend,
+			"GET",
+			`/api/memories/feed?beforeId=${crypto.randomUUID()}`,
+		);
+		expect(result.status).toBe(400);
+		expect(result.json).toEqual({
+			error: "beforeId must be a UUID paired with before",
+		});
+	});
+
 	it("feed type filter scopes to a single table", async () => {
 		await seedMemory("messages", "a message", 1_000);
 		await seedMemory("facts", "a fact", 2_000);

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1263,6 +1263,7 @@ async function fetchMemoriesFromTables(
 		tables?: readonly string[];
 		target: number;
 		before?: number;
+		beforeId?: UUID;
 		searchQuery?: string;
 	},
 ): Promise<TaggedMemory[]> {
@@ -1280,7 +1281,10 @@ async function fetchMemoriesFromTables(
 	const perTableMemories = await Promise.all(
 		tables.map(async (tableName) => {
 			const eligible: TaggedMemory[] = [];
-			let cursor: { createdAt: number; id: UUID } | undefined;
+			let cursor: { createdAt: number; id: UUID } | undefined =
+				params.before !== undefined && params.beforeId !== undefined
+					? { createdAt: params.before, id: params.beforeId }
+					: undefined;
 			let batchSize = 200;
 			let scannedRows = 0;
 			for (;;) {
@@ -1308,7 +1312,7 @@ async function fetchMemoriesFromTables(
 					tableName,
 					limit: queryLimit,
 					cursor,
-					end: params.before,
+					end: params.beforeId === undefined ? params.before : undefined,
 					textContains,
 					includeEmbedding: false,
 				});
@@ -1360,11 +1364,17 @@ async function fetchMemoriesFromTables(
 					) {
 						continue;
 					}
-					if (
-						params.before !== undefined &&
-						memoryCreatedAt(tagged) >= params.before
-					) {
-						continue;
+					if (params.before !== undefined) {
+						const createdAt = memoryCreatedAt(tagged);
+						if (createdAt > params.before) continue;
+						if (createdAt === params.before) {
+							if (
+								params.beforeId === undefined ||
+								compareMemoryIds(tagged.id ?? "", params.beforeId) >= 0
+							) {
+								continue;
+							}
+						}
 					}
 					if (
 						searchQuery &&
@@ -1417,12 +1427,21 @@ async function handleMemoriesFeedRoute(
 			error: "before must be a Unix timestamp in milliseconds",
 		});
 	}
+	const beforeIdParam = queryParam(query, "beforeId");
+	const beforeId =
+		beforeIdParam === null ? undefined : validateUuid(beforeIdParam);
+	if (beforeIdParam !== null && (before === undefined || beforeId === null)) {
+		return jsonResponse(400, {
+			error: "beforeId must be a UUID paired with before",
+		});
+	}
 	const tables = resolveMemoryTableFilter(queryParam(query, "type"));
 
 	const allMemories = await fetchMemoriesFromTables(runtime, {
 		tables,
 		target: limit + 1,
 		before,
+		beforeId: beforeId ?? undefined,
 	});
 
 	allMemories.sort(byNewestFirst);


### PR DESCRIPTION
# Relates to

Closes #22721. Relates to #22061 and the original contributor work repaired in #22254.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused verification is recorded below and the exact unrelated repository-gate blocker is documented.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `develop` at `b4a3b0c291b83d371457aa667b579ea3c1c25af2`; zero conflicts.
- [x] `bun run verify` reached 336/358 successful Turbo tasks and failed only in the unrelated `@elizaos/plugin-maps#typecheck` task documented below.

# Risks

Low. The public feed query gains an optional ID tie-breaker paired with the existing timestamp. Timestamp-only callers retain their previous strict-before behavior. The principal risk is cursor-order parity, covered at agent, Capacitor, local-kernel, client, component, and browser boundaries.

# Background

## What does this PR do?

The memory feed previously exposed only `before=<createdAt>` even though storage orders equal timestamps by ID. More than one page of rows sharing a millisecond caused page 2 to exclude every remaining tied row. This carries the stable `(createdAt,id)` cursor through the agent route, Capacitor mirror, typed client/UI, and local iOS kernel. It also verifies no skips, duplicates, or replay of a concurrent newer tied insert.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user documentation change is needed; this is a backward-compatible pagination correction.

# Testing

## Where should a reviewer start?

Start with `packages/agent/src/api/memory-browse-pagination.test.ts`, then the matching Capacitor route regression and the recorded browser flow in `apps-diagnostics-interactions.spec.ts`.

## Detailed testing steps

- Run the five focused Vitest files listed in Evidence Details; all 58 tests pass.
- Run UI and Capacitor package typechecks; both pass.
- Run the recordable Chromium test and inspect its network trace: the second request carries the final first-page timestamp and ID, and the UI grows from 50 to 70 unique cards including `Tied memory 0`.

# Evidence Gate

<!-- evidence-head:fdb25f4bc6ed76c7222442833073ea7e169388e6 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-pr22731-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-pr22731-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-pr22731-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - the successful deterministic route emits no structured log; exact route-test JSON is attached under domain artifacts
<!-- evidence-row:frontend-logs -->
- [x] [22731-pr22731-frontend-network.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-pr22731-frontend-network.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, provider, prompt, model, or LLM behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] [22731-fdb25f4b-focused-v4.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-fdb25f4b-focused-v4.txt)
<!-- evidence-row:ocr-review -->
- [x] [22731-pr22731-after-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22731-pr22731-after-ocr.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

The successful route boundary intentionally emits no backend log. The exact-head Vitest JSON report exercises the real handler against an adapter-shaped store. The Playwright trace contains the frontend request, response, and appended state.

## Screenshots (before / after) + video walkthrough

Captured evidence is attached above; the fresh exact-head focused receipt records the final rebase and coexistence checks.

## Known gaps / failures

- `bun run verify` reached 336/358 successful Turbo tasks, then failed in unchanged `plugins/plugin-maps/test/scenarios/maps.save-coordinate-live.scenario.ts`: it cannot resolve `@elizaos/scenario-runner/schema`, with downstream implicit-`any` diagnostics for `ctx` and `entry`. The PR does not touch plugin-maps or scenario-runner.
- After the repository build populated workspace exports, standalone agent, UI, and Capacitor typechecks all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues-review-22254]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza"} -->

