### PR TITLE
fix(agent-skills): preserve cancellation at stream completion

### DIFF
--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -194,7 +194,7 @@ describe("readCappedSkillPackage", () => {
 		const response = stalledResponse("partial", cancel);
 		const lifecycle = createSkillDownloadLifecycle({
 			signal: caller.signal,
-			downloadTimeoutMs: null,
+			downloadTimeoutMs: 1_000,
 		});
 		const read = readCappedSkillPackage(response, {
 			signal: lifecycle.signal,
@@ -207,6 +207,41 @@ describe("readCappedSkillPackage", () => {
 				cause: expect.objectContaining({ message: "caller stopped waiting" }),
 			});
 			expect(cancel).toHaveBeenCalledOnce();
+		} finally {
+			lifecycle.dispose();
+		}
+	});
+
+	it("lets caller cancellation win when the body closes in the same turn", async () => {
+		const caller = new AbortController();
+		let pullCount = 0;
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				pull(controller) {
+					if (pullCount++ === 0) {
+						controller.enqueue(new TextEncoder().encode("complete"));
+						return;
+					}
+					controller.close();
+					caller.abort(new Error("caller stopped at completion"));
+				},
+			}),
+		);
+		const lifecycle = createSkillDownloadLifecycle({
+			signal: caller.signal,
+			downloadTimeoutMs: null,
+		});
+
+		try {
+			await expect(
+				readCappedSkillPackage(response, { signal: lifecycle.signal }),
+			).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_ABORTED",
+				cause: expect.objectContaining({
+					message: "caller stopped at completion",
+				}),
+			});
+			expect(response.body?.locked).toBe(false);
 		} finally {
 			lifecycle.dispose();
 		}
@@ -305,6 +340,38 @@ describe("readCappedSkillPackage", () => {
 		expect(storage.getPackage("missing")).toBeUndefined();
 	});
 
+	it("cancels an unused non-success body without masking boolean compatibility", async () => {
+		const cancel = vi.fn(async () => {
+			throw new Error("discard failed");
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								controller.enqueue(new TextEncoder().encode("partial error"));
+							},
+							cancel,
+						}),
+						{ status: 502 },
+					),
+			),
+		);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.installFromUrl("https://skills.example/unavailable.md"),
+		).resolves.toBe(false);
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("unavailable")).toBeUndefined();
+	});
+
 	it("uses one deadline for catalog resolution and a stalled package body", async () => {
 		const signals: AbortSignal[] = [];
 		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
@@ -336,6 +403,46 @@ describe("readCappedSkillPackage", () => {
 		expect(signals).toHaveLength(2);
 		expect(signals[0]).toBe(signals[1]);
 		expect(storage.getPackage("catalog-stall")).toBeUndefined();
+	});
+
+	it("bounds a stalled catalog-details body before package fetch or persistence", async () => {
+		let requestCount = 0;
+		const server = createServer((_request, response) => {
+			requestCount += 1;
+			response.writeHead(200, { "content-type": "application/json" });
+			response.write('{"latestVersion":');
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const { port } = server.address() as AddressInfo;
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			registryUrl: `http://127.0.0.1:${port}`,
+			storage,
+		});
+		const startedAt = Date.now();
+
+		try {
+			await expect(
+				service.install("metadata-stall", {
+					downloadTimeoutMs: 75,
+					throwOnDownloadError: true,
+				}),
+			).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_TIMEOUT",
+				context: { timeoutMs: 75 },
+			});
+			expect(Date.now() - startedAt).toBeLessThan(1_500);
+			expect(requestCount).toBe(1);
+			expect(storage.getPackage("metadata-stall")).toBeUndefined();
+		} finally {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			);
+		}
 	});
 
 	it("does not persist GitHub SKILL.md when its README stalls", async () => {

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -650,14 +650,14 @@ describe("readCappedSkillPackage", () => {
 		try {
 			await expect(
 				service.install("metadata-stall", {
-					downloadTimeoutMs: 75,
+					downloadTimeoutMs: 500,
 					throwOnDownloadError: true,
 				}),
 			).rejects.toMatchObject({
 				code: "SKILL_DOWNLOAD_TIMEOUT",
-				context: { timeoutMs: 75 },
+				context: { timeoutMs: 500 },
 			});
-			expect(Date.now() - startedAt).toBeLessThan(1_500);
+			expect(Date.now() - startedAt).toBeLessThan(2_500);
 			expect(requestCount).toBe(1);
 			expect(storage.getPackage("metadata-stall")).toBeUndefined();
 		} finally {

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -74,6 +74,23 @@ function stalledResponse(
 	);
 }
 
+function unusedErrorResponse(
+	status: number,
+	onCancel: () => void | Promise<void>,
+): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("partial error"));
+			},
+			cancel() {
+				return onCancel();
+			},
+		}),
+		{ status },
+	);
+}
+
 function createRuntime(): IAgentRuntime {
 	return {
 		getSetting: vi.fn(() => undefined),
@@ -247,6 +264,24 @@ describe("readCappedSkillPackage", () => {
 		}
 	});
 
+	it("cancels an unread body when its signal is already aborted", async () => {
+		const caller = new AbortController();
+		const cancel = vi.fn();
+		const response = stalledResponse("unread", cancel);
+		caller.abort(new Error("caller stopped before consumption"));
+
+		await expect(
+			readCappedSkillPackage(response, { signal: caller.signal }),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "caller stopped before consumption",
+			}),
+		});
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(response.body?.locked).toBe(false);
+	});
+
 	it("propagates caller cancellation through the direct-URL installer", async () => {
 		let installSignal: AbortSignal | undefined;
 		vi.stubGlobal(
@@ -280,6 +315,32 @@ describe("readCappedSkillPackage", () => {
 		});
 		expect(installSignal?.aborted).toBe(true);
 		expect(storage.getPackage("cancelled")).toBeUndefined();
+	});
+
+	it("keeps caller cancellation boolean-compatible unless typed errors are requested", async () => {
+		const cancel = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => stalledResponse("partial", cancel)),
+		);
+		const caller = new AbortController();
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+		const install = service.installFromUrl(
+			"https://skills.example/boolean-cancelled.md",
+			{
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+			},
+		);
+		caller.abort(new Error("legacy caller stopped waiting"));
+
+		await expect(install).resolves.toBe(false);
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("boolean-cancelled")).toBeUndefined();
 	});
 
 	it("decodes a capped SKILL.md body as UTF-8", async () => {
@@ -366,10 +427,172 @@ describe("readCappedSkillPackage", () => {
 		});
 
 		await expect(
-			service.installFromUrl("https://skills.example/unavailable.md"),
+			service.installFromUrl("https://skills.example/unavailable.md", {
+				throwOnDownloadError: true,
+			}),
 		).resolves.toBe(false);
 		expect(cancel).toHaveBeenCalledOnce();
 		expect(storage.getPackage("unavailable")).toBeUndefined();
+	});
+
+	it.each([200, 502])(
+		"lets caller cancellation win when fetch settles with status %s",
+		async (status) => {
+			const caller = new AbortController();
+			const cancel = vi.fn();
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => {
+					const response = unusedErrorResponse(status, cancel);
+					caller.abort(new Error("caller stopped as headers settled"));
+					return response;
+				}),
+			);
+			const storage = new MemorySkillStore();
+			const service = await AgentSkillsService.start(createRuntime(), {
+				autoLoad: false,
+				storage,
+			});
+
+			await expect(
+				service.installFromUrl("https://skills.example/settled.md", {
+					signal: caller.signal,
+					downloadTimeoutMs: null,
+					throwOnDownloadError: true,
+				}),
+			).rejects.toMatchObject({
+				code: "SKILL_DOWNLOAD_ABORTED",
+				cause: expect.objectContaining({
+					message: "caller stopped as headers settled",
+				}),
+			});
+			expect(cancel).toHaveBeenCalledOnce();
+			expect(storage.getPackage("settled")).toBeUndefined();
+		},
+	);
+
+	it("preserves catalog cancellation over a same-turn non-success status", async () => {
+		const caller = new AbortController();
+		const cancel = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				const response = unusedErrorResponse(502, cancel);
+				caller.abort(new Error("catalog owner stopped as headers settled"));
+				return response;
+			}),
+		);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.install("catalog-cancelled", {
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "catalog owner stopped as headers settled",
+			}),
+		});
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("catalog-cancelled")).toBeUndefined();
+	});
+
+	it("does not cache catalog details that complete with caller cancellation", async () => {
+		const caller = new AbortController();
+		let requestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				requestCount += 1;
+				if (requestCount === 1) {
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							pull(controller) {
+								controller.enqueue(
+									new TextEncoder().encode(
+										'{"latestVersion":{"version":"1.0.0"}}',
+									),
+								);
+								controller.close();
+								caller.abort(new Error("catalog owner stopped at completion"));
+							},
+						}),
+						{ headers: { "content-type": "application/json" } },
+					);
+				}
+				return new Response(
+					JSON.stringify({ latestVersion: { version: "2.0.0" } }),
+					{ headers: { "content-type": "application/json" } },
+				);
+			}),
+		);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.install("catalog-completion-cancelled", {
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "catalog owner stopped at completion",
+			}),
+		});
+
+		await expect(
+			service.getSkillDetails("catalog-completion-cancelled"),
+		).resolves.toMatchObject({ latestVersion: { version: "2.0.0" } });
+		expect(requestCount).toBe(2);
+		expect(storage.getPackage("catalog-completion-cancelled")).toBeUndefined();
+	});
+
+	it("does not persist GitHub SKILL.md when cancellation settles with a missing README", async () => {
+		const caller = new AbortController();
+		const cancel = vi.fn();
+		const fetchMock = vi.fn(async () => {
+			if (fetchMock.mock.calls.length === 1) {
+				return new Response(
+					"---\nname: github-readme-cancelled\ndescription: test\n---\n# Test\n",
+				);
+			}
+			const response = unusedErrorResponse(404, cancel);
+			caller.abort(new Error("caller stopped as README settled"));
+			return response;
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.installFromGitHub("owner/github-readme-cancelled", {
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "caller stopped as README settled",
+			}),
+		});
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("github-readme-cancelled")).toBeUndefined();
 	});
 
 	it("uses one deadline for catalog resolution and a stalled package body", async () => {

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -198,6 +198,11 @@ export async function readCappedSkillPackage(
 			const { done, value } = abortPromise
 				? await Promise.race([read, abortPromise])
 				: await read;
+			// A stream can close and abort its owner in the same pull. Cancellation
+			// remains authoritative until the consumer has observed completion.
+			if (options.signal?.aborted) {
+				throw skillDownloadAbortError(options.signal);
+			}
 			if (done) break;
 			if (!value?.byteLength) continue;
 			total += value.byteLength;
@@ -212,6 +217,7 @@ export async function readCappedSkillPackage(
 			chunks.push(value);
 		}
 	} catch (cause) {
+		// error-policy:J1 translate cancellation at the response-body boundary.
 		if (options.signal?.aborted) {
 			try {
 				const cancellation = reader.cancel(options.signal.reason);

--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.ts
@@ -78,6 +78,22 @@ export function isSkillDownloadError(error: unknown): error is ElizaError {
 	);
 }
 
+/** Best-effort teardown for a response body the install will not consume. */
+export function cancelUnusedSkillDownloadBody(
+	response: Response,
+	reason?: unknown,
+): void {
+	if (!response.body) return;
+	try {
+		const cancellation = response.body.cancel(reason);
+		void Promise.resolve(cancellation).catch(() => {
+			// error-policy:J6 rejection while discarding an unused response is teardown-only.
+		});
+	} catch {
+		// error-policy:J6 synchronous cancellation of an unused response is teardown-only.
+	}
+}
+
 /**
  * Create the single abort lifecycle used by one catalog, GitHub, or URL install.
  * The caller must dispose it immediately after all network bodies are consumed.
@@ -167,6 +183,7 @@ export async function readCappedSkillPackage(
 			},
 		);
 	if (options.signal?.aborted) {
+		cancelUnusedSkillDownloadBody(response, options.signal.reason);
 		throw skillDownloadAbortError(options.signal);
 	}
 	const body = response.body;

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -135,8 +135,21 @@ async function fetchInstallResource(
 	try {
 		return await fetch(url, { ...init, signal: lifecycle.signal });
 	} catch (cause) {
+		// error-policy:J1 translate lifecycle ownership at the fetch boundary.
 		lifecycle.throwIfAborted(cause);
 		throw cause;
+	}
+}
+
+function cancelUnusedInstallBody(response: Response): void {
+	if (!response.body) return;
+	try {
+		const cancellation = response.body.cancel();
+		void Promise.resolve(cancellation).catch(() => {
+			// error-policy:J6 rejection while discarding an unused response is teardown-only.
+		});
+	} catch {
+		// error-policy:J6 synchronous cancellation of an unused response is teardown-only.
 	}
 }
 
@@ -2072,6 +2085,7 @@ export class AgentSkillsService extends Service {
 			}, deadlineManaged);
 
 			if (!response.ok) {
+				cancelUnusedInstallBody(response);
 				if (response.status === 404) return null;
 				throw new Error(`Details fetch failed: ${response.status}`);
 			}
@@ -2298,6 +2312,7 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(downloadUrl, lifecycle);
 
 				if (!response.ok) {
+					cancelUnusedInstallBody(response);
 					throw new Error(`Download failed: ${response.status}`);
 				}
 
@@ -2336,6 +2351,8 @@ export class AgentSkillsService extends Service {
 			);
 			return true;
 		} catch (error) {
+			// error-policy:J1 preserve the legacy boolean install boundary while
+			// allowing explicitly requested typed download failures to cross it.
 			this.runtime.logger.error(`AgentSkills: Install error: ${error}`);
 			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
 				throw error;
@@ -2434,6 +2451,7 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(skillMdUrl, lifecycle);
 
 				if (!response.ok) {
+					cancelUnusedInstallBody(response);
 					throw new Error(
 						`Failed to fetch SKILL.md: ${response.status} from ${skillMdUrl}`,
 					);
@@ -2452,6 +2470,8 @@ export class AgentSkillsService extends Service {
 							signal: lifecycle.signal,
 						});
 						files.push({ name: "README.md", content: readmeContent });
+					} else {
+						cancelUnusedInstallBody(readmeResponse);
 					}
 				} catch (cause) {
 					lifecycle.throwIfAborted(cause);
@@ -2499,6 +2519,8 @@ export class AgentSkillsService extends Service {
 			);
 			return true;
 		} catch (error) {
+			// error-policy:J1 preserve the legacy boolean install boundary while
+			// allowing explicitly requested typed download failures to cross it.
 			this.runtime.logger.error(`AgentSkills: GitHub install error: ${error}`);
 			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
 				throw error;
@@ -2539,6 +2561,7 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(url, lifecycle);
 
 				if (!response.ok) {
+					cancelUnusedInstallBody(response);
 					throw new Error(`Failed to fetch: ${response.status}`);
 				}
 
@@ -2612,6 +2635,8 @@ export class AgentSkillsService extends Service {
 			);
 			return true;
 		} catch (error) {
+			// error-policy:J1 preserve the legacy boolean install boundary while
+			// allowing explicitly requested typed download failures to cross it.
 			this.runtime.logger.error(`AgentSkills: URL install error: ${error}`);
 			if (options.throwOnDownloadError && isSkillDownloadError(error)) {
 				throw error;

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -58,6 +58,7 @@ import type {
 import { SKILL_SOURCE_PRECEDENCE } from "../types";
 import { binaryExistsInPath } from "./bin-lookup";
 import {
+	cancelUnusedSkillDownloadBody,
 	createSkillDownloadLifecycle,
 	DEFAULT_SKILL_DOWNLOAD_TIMEOUT_MS,
 	isSkillDownloadError,
@@ -133,23 +134,16 @@ async function fetchInstallResource(
 ): Promise<Response> {
 	lifecycle.throwIfAborted();
 	try {
-		return await fetch(url, { ...init, signal: lifecycle.signal });
+		const response = await fetch(url, { ...init, signal: lifecycle.signal });
+		if (lifecycle.signal.aborted) {
+			cancelUnusedSkillDownloadBody(response, lifecycle.signal.reason);
+			lifecycle.throwIfAborted();
+		}
+		return response;
 	} catch (cause) {
 		// error-policy:J1 translate lifecycle ownership at the fetch boundary.
 		lifecycle.throwIfAborted(cause);
 		throw cause;
-	}
-}
-
-function cancelUnusedInstallBody(response: Response): void {
-	if (!response.body) return;
-	try {
-		const cancellation = response.body.cancel();
-		void Promise.resolve(cancellation).catch(() => {
-			// error-policy:J6 rejection while discarding an unused response is teardown-only.
-		});
-	} catch {
-		// error-policy:J6 synchronous cancellation of an unused response is teardown-only.
 	}
 }
 
@@ -2083,14 +2077,21 @@ export class AgentSkillsService extends Service {
 				headers: { Accept: "application/json" },
 				signal: options.signal,
 			}, deadlineManaged);
+			if (options.signal?.aborted) {
+				cancelUnusedSkillDownloadBody(response, options.signal.reason);
+				throw skillDownloadAbortError(options.signal);
+			}
 
 			if (!response.ok) {
-				cancelUnusedInstallBody(response);
+				cancelUnusedSkillDownloadBody(response);
 				if (response.status === 404) return null;
 				throw new Error(`Details fetch failed: ${response.status}`);
 			}
 
 			const details = (await response.json()) as SkillDetails;
+			if (options.signal?.aborted) {
+				throw skillDownloadAbortError(options.signal);
+			}
 			this.detailsCache.set(safeSlug, { data: details, cachedAt: Date.now() });
 
 			return details;
@@ -2312,7 +2313,8 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(downloadUrl, lifecycle);
 
 				if (!response.ok) {
-					cancelUnusedInstallBody(response);
+					cancelUnusedSkillDownloadBody(response, lifecycle.signal.reason);
+					lifecycle.throwIfAborted();
 					throw new Error(`Download failed: ${response.status}`);
 				}
 
@@ -2451,7 +2453,8 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(skillMdUrl, lifecycle);
 
 				if (!response.ok) {
-					cancelUnusedInstallBody(response);
+					cancelUnusedSkillDownloadBody(response, lifecycle.signal.reason);
+					lifecycle.throwIfAborted();
 					throw new Error(
 						`Failed to fetch SKILL.md: ${response.status} from ${skillMdUrl}`,
 					);
@@ -2471,7 +2474,11 @@ export class AgentSkillsService extends Service {
 						});
 						files.push({ name: "README.md", content: readmeContent });
 					} else {
-						cancelUnusedInstallBody(readmeResponse);
+						cancelUnusedSkillDownloadBody(
+							readmeResponse,
+							lifecycle.signal.reason,
+						);
+						lifecycle.throwIfAborted();
 					}
 				} catch (cause) {
 					lifecycle.throwIfAborted(cause);
@@ -2561,7 +2568,8 @@ export class AgentSkillsService extends Service {
 				const response = await fetchInstallResource(url, lifecycle);
 
 				if (!response.ok) {
-					cancelUnusedInstallBody(response);
+					cancelUnusedSkillDownloadBody(response, lifecycle.signal.reason);
+					lifecycle.throwIfAborted();
 					throw new Error(`Failed to fetch: ${response.status}`);
 				}
 


### PR DESCRIPTION
# Relates to

Closes #22300. Follow-up to merged #22722 after independent second-wave review.

# Background

The merged reader raced `reader.read()` against the install abort signal, but
did not re-check ownership after a read settled. A stream could close and abort
its caller in the same pull, letting successful completion win. Non-success
response bodies were also discarded without cancellation.

Independent review of this follow-up found the same ownership gap one boundary
earlier: cancellation delivered as `fetch()` or catalog JSON settled could
leave a 2xx body unread, let a non-2xx or optional README result mask the caller
abort, or cache catalog details from a canceled request.

# Changes

- Re-check the install signal after every body-read settlement, before accepting
  `done` or bytes.
- Cancel unread bodies when cancellation already owns the response.
- Preserve caller cancellation when 2xx or non-2xx fetches settle in the same
  turn, including optional GitHub README and catalog-details paths.
- Do not cache catalog details whose JSON body completes with cancellation.
- Best-effort cancel unused non-success catalog, package, GitHub SKILL/README,
  and direct-URL bodies without masking their owning result.
- Preserve the established boolean API unless `throwOnDownloadError` explicitly
  requests typed download failures.
- Add deterministic same-turn read/fetch/JSON cancellation, cache, teardown,
  boolean-compatibility, partial-persistence, and real loopback coverage.

# Sync with develop

- Base: `a3ede0c91e2ac1d7e46c62909778afb604aa02ba`.
- Exact head: `08d0aef9b1271f6f74bf68b1c9e4206b9fb07f57`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a3ede0c91e2ac1d7e46c62909778afb604aa02ba:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Testing

Exact final head `08d0aef9b1271f6f74bf68b1c9e4206b9fb07f57`, rebased onto
`a3ede0c91e2ac1d7e46c62909778afb604aa02ba`:

The live PR head and independently tested local commit have the identical Git
tree `3cae2e1661849c411eacf4853d7444474db701ab`; their commit IDs differ only
because a concurrent agent completed the same rebase first.

```text
$ bun run --cwd plugins/plugin-agent-skills test -- --maxWorkers=2
Test Files  27 passed (27); Tests  311 passed (311)

$ bun run --cwd plugins/plugin-agent-skills typecheck
exit 0

$ bun run --cwd plugins/plugin-agent-skills lint:check
Checked 66 files. No fixes applied.

$ bun run --cwd plugins/plugin-agent-skills build
ESM build and TypeScript declaration emit passed.

$ git diff --check origin/develop...HEAD
exit 0
```

Root `bun run verify` was attempted repeatedly in the isolated source-light
worktree. It is not claimed green because concurrent workspace installs left
its dependency overlay with missing/broken Vite `picomatch` and package `tsup`
links; before that environment failure, the gate reached 208 successful Turbo
tasks. The owning package's exact-tree tests, typecheck, lint, build, and diff
checks above are green.

# Evidence Gate

<!-- evidence-head:08d0aef9b1271f6f74bf68b1c9e4206b9fb07f57 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side response-stream lifecycle with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side response-stream lifecycle with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction; deterministic and real loopback evidence is below.
<!-- evidence-row:backend-logs -->
- [x] [22738-backend-exact-08d0.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22738-backend-exact-08d0.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or trajectory behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22738-domain-artifacts-exact-08d0.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22738-domain-artifacts-exact-08d0.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a3ede0c91e2ac1d7e46c62909778afb604aa02ba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review-22738-final]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a3ede0c91e2ac1d7e46c62909778afb604aa02ba:packages/skills/skills/contribute-to-eliza"} -->



