### PR TITLE
fix(ui): bound cumulative GenUI snapshot bytes

### DIFF
--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -676,10 +676,11 @@ export function validateElizaGenUiSpec(
     ancestors: new WeakSet<object>(),
     halted: false,
     bytes: 0,
-    maxBytes:
-      Number.isSafeInteger(options.maxJsonBytes) && options.maxJsonBytes >= 0
-        ? options.maxJsonBytes
-        : 0,
+    // Preserve the public option's existing numeric comparison semantics:
+    // fractional limits naturally admit only integral byte counts below them,
+    // and Infinity remains an explicit unbounded override. Negative and NaN
+    // limits already failed the final size check and therefore fail here too.
+    maxBytes: options.maxJsonBytes >= 0 ? options.maxJsonBytes : 0,
   });
   if (issues.length > 0) return { ok: false, errors: issues };
   if (!validateJsonSize(snapshot, issues, options))

--- a/packages/ui/src/genui/validator.ts
+++ b/packages/ui/src/genui/validator.ts
@@ -87,22 +87,95 @@ function isSafeImageSrc(value: string): boolean {
   }
 }
 
+type SnapshotContext = {
+  visits: number;
+  ancestors: WeakSet<object>;
+  halted: boolean;
+  bytes: number;
+  maxBytes: number;
+};
+
+function chargeSnapshotBytes(
+  ctx: SnapshotContext,
+  issues: ElizaGenUiValidationIssue[],
+  bytes: number,
+  path: string,
+  componentId?: string,
+): boolean {
+  if (bytes <= ctx.maxBytes - ctx.bytes) {
+    ctx.bytes += bytes;
+    return true;
+  }
+  addIssue(issues, {
+    code: "too_large",
+    message: `Generated UI JSON must be at most ${ctx.maxBytes} bytes.`,
+    componentId,
+    path,
+  });
+  ctx.halted = true;
+  return false;
+}
+
+/** Charge the exact UTF-8 bytes produced by JSON string serialization. */
+function chargeSnapshotString(
+  ctx: SnapshotContext,
+  issues: ElizaGenUiValidationIssue[],
+  value: string,
+  path: string,
+  componentId?: string,
+): boolean {
+  if (!chargeSnapshotBytes(ctx, issues, 2, path, componentId)) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    let bytes: number;
+    if (
+      code === 0x22 ||
+      code === 0x5c ||
+      code === 0x08 ||
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0c ||
+      code === 0x0d
+    ) {
+      bytes = 2;
+    } else if (code <= 0x1f) {
+      bytes = 6;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes = 4;
+        index += 1;
+      } else {
+        bytes = 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes = 6;
+    } else if (code <= 0x7f) {
+      bytes = 1;
+    } else if (code <= 0x7ff) {
+      bytes = 2;
+    } else {
+      bytes = 3;
+    }
+    if (!chargeSnapshotBytes(ctx, issues, bytes, path, componentId)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function snapshotUnsafeFields(
   value: unknown,
   issues: ElizaGenUiValidationIssue[],
   path: string,
   componentId?: string,
   depth = 0,
-  ctx: {
-    visits: number;
-    ancestors: WeakSet<object>;
-    halted: boolean;
-    maxCodeUnits: number;
-  } = {
+  ctx: SnapshotContext = {
     visits: 0,
     ancestors: new WeakSet<object>(),
     halted: false,
-    maxCodeUnits: DEFAULT_MAX_JSON_BYTES,
+    bytes: 0,
+    maxBytes: DEFAULT_MAX_JSON_BYTES,
   },
 ): unknown {
   if (ctx.halted) return undefined;
@@ -127,15 +200,32 @@ function snapshotUnsafeFields(
     ctx.halted = true;
     return undefined;
   }
-  if (typeof value === "string" && value.length > ctx.maxCodeUnits) {
-    addIssue(issues, {
-      code: "too_large",
-      message: "Generated UI contains a string larger than its JSON budget.",
-      componentId,
+  if (value === null) {
+    return chargeSnapshotBytes(ctx, issues, 4, path, componentId)
+      ? value
+      : undefined;
+  }
+  if (typeof value === "string") {
+    return chargeSnapshotString(ctx, issues, value, path, componentId)
+      ? value
+      : undefined;
+  }
+  if (typeof value === "boolean") {
+    return chargeSnapshotBytes(ctx, issues, value ? 4 : 5, path, componentId)
+      ? value
+      : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = value === 0 ? 0 : value;
+    return chargeSnapshotBytes(
+      ctx,
+      issues,
+      String(normalized).length,
       path,
-    });
-    ctx.halted = true;
-    return undefined;
+      componentId,
+    )
+      ? normalized
+      : undefined;
   }
   if (
     value === undefined ||
@@ -153,9 +243,7 @@ function snapshotUnsafeFields(
     ctx.halted = true;
     return undefined;
   }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
+  if (typeof value !== "object") return value;
   if (ctx.ancestors.has(value)) {
     addIssue(issues, {
       code: "unbounded_nest",
@@ -206,6 +294,17 @@ function snapshotUnsafeFields(
         ctx.halted = true;
         return undefined;
       }
+      if (
+        !chargeSnapshotBytes(
+          ctx,
+          issues,
+          2 + Math.max(0, length - 1),
+          path,
+          componentId,
+        )
+      ) {
+        return undefined;
+      }
       const snapshot = new Array<unknown>(length);
       for (let index = 0; index < length; index += 1) {
         const descriptor = Object.getOwnPropertyDescriptor(
@@ -235,22 +334,16 @@ function snapshotUnsafeFields(
       }
       return snapshot;
     }
+    if (!chargeSnapshotBytes(ctx, issues, 2, path, componentId)) {
+      return undefined;
+    }
     const snapshot = Object.create(null) as Record<string, unknown>;
+    let includedProperties = 0;
     for (const key of Reflect.ownKeys(value)) {
       if (ctx.halted) return undefined;
       if (typeof key !== "string") continue;
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (!descriptor?.enumerable) continue;
-      if (key.length > ctx.maxCodeUnits) {
-        addIssue(issues, {
-          code: "too_large",
-          message: "Generated UI contains a key larger than its JSON budget.",
-          componentId,
-          path,
-        });
-        ctx.halted = true;
-        return undefined;
-      }
       if ("get" in descriptor || "set" in descriptor) {
         addIssue(issues, {
           code: "unbounded_nest",
@@ -269,6 +362,21 @@ function snapshotUnsafeFields(
           path: `${path}/${key}`,
         });
       }
+      if (
+        (includedProperties > 0 &&
+          !chargeSnapshotBytes(ctx, issues, 1, path, componentId)) ||
+        !chargeSnapshotString(
+          ctx,
+          issues,
+          key,
+          `${path}/${key}`,
+          componentId,
+        ) ||
+        !chargeSnapshotBytes(ctx, issues, 1, path, componentId)
+      ) {
+        return undefined;
+      }
+      includedProperties += 1;
       const entry = snapshotUnsafeFields(
         descriptor.value,
         issues,
@@ -567,7 +675,11 @@ export function validateElizaGenUiSpec(
     visits: 0,
     ancestors: new WeakSet<object>(),
     halted: false,
-    maxCodeUnits: options.maxJsonBytes,
+    bytes: 0,
+    maxBytes:
+      Number.isSafeInteger(options.maxJsonBytes) && options.maxJsonBytes >= 0
+        ? options.maxJsonBytes
+        : 0,
   });
   if (issues.length > 0) return { ok: false, errors: issues };
   if (!validateJsonSize(snapshot, issues, options))

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -223,6 +223,22 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
     }
   });
 
+  it("preserves fractional and infinite public byte-limit overrides", () => {
+    const spec = specWithData({ payload: "ok" });
+    const exactBytes = new TextEncoder().encode(JSON.stringify(spec)).length;
+
+    expect(
+      validateElizaGenUiSpec(spec, { maxJsonBytes: exactBytes - 0.5 }).ok,
+    ).toBe(false);
+    expect(
+      validateElizaGenUiSpec(spec, { maxJsonBytes: exactBytes + 0.5 }).ok,
+    ).toBe(true);
+    expect(
+      validateElizaGenUiSpec(spec, { maxJsonBytes: Number.POSITIVE_INFINITY })
+        .ok,
+    ).toBe(true);
+  });
+
   it("translates hostile reflection traps instead of throwing", () => {
     const data = new Proxy(
       {},

--- a/packages/ui/src/genui/validator.unbounded.test.ts
+++ b/packages/ui/src/genui/validator.unbounded.test.ts
@@ -4,7 +4,7 @@
  * cases pin deep, wide, sparse, accessor, and hostile-reflection inputs against
  * the real exported validator without replacing its production walk.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   MAX_GENUI_UNSAFE_FIELD_DEPTH,
   MAX_GENUI_UNSAFE_FIELD_NODES,
@@ -171,6 +171,55 @@ describe("validateElizaGenUiSpec unbounded nests", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.spec).toEqual(JSON.parse(JSON.stringify(input)));
+    }
+  });
+
+  it("rejects cumulative string bytes before the final stringify", () => {
+    const stringify = vi.spyOn(JSON, "stringify");
+    try {
+      const data = Object.fromEntries(
+        Array.from({ length: 40 }, (_, index) => [
+          `value${index}`,
+          "x".repeat(2_000),
+        ]),
+      );
+      const result = validateElizaGenUiSpec(specWithData(data));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({ code: "too_large" }),
+        );
+      }
+      expect(stringify).not.toHaveBeenCalled();
+    } finally {
+      stringify.mockRestore();
+    }
+  });
+
+  it("accounts for exact ASCII, escape, and UTF-16 JSON boundaries", () => {
+    const empty = specWithData({ payload: "" });
+    const emptyBytes = new TextEncoder().encode(JSON.stringify(empty)).length;
+    for (const [value, serializedBytes] of [
+      ["xxxx", 4],
+      ["\u0000", 6],
+      ["😀", 4],
+      ["\ud800", 6],
+    ] as const) {
+      expect(
+        validateElizaGenUiSpec(specWithData({ payload: value }), {
+          maxJsonBytes: emptyBytes + serializedBytes,
+        }).ok,
+      ).toBe(true);
+      const over = validateElizaGenUiSpec(
+        specWithData({ payload: `${value}x` }),
+        { maxJsonBytes: emptyBytes + serializedBytes },
+      );
+      expect(over.ok).toBe(false);
+      if (!over.ok) {
+        expect(over.errors).toContainEqual(
+          expect.objectContaining({ code: "too_large" }),
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- cumulatively charge the exact UTF-8 bytes of the JSON snapshot before serialization
- preserve descriptor-only traversal and fail-closed accessor, cycle, prototype, primitive, and reflection behavior
- cover cumulative allocation plus ASCII, escaped-control, surrogate-pair, and lone-surrogate boundaries

Closes #22735
Follow-up to #22711.

## Exact-head evidence

Head: `43e7183c0b6946f51d057a90b1179ba3864e5944`
Base: `59a46704e03d60746beb7a972c3c5251e856d765`

Fresh disposable sandbox, scrubbed environment, network denied, writes restricted to sandbox:

- `vitest validator.unbounded.test.ts validator.fuzz.test.ts`: 17/17 passed
- Biome changed-file check: passed
- SHA-256 identity between reviewed worktree and sandbox:
  - validator: `0908570c20676f46c2633aa56797581e7b40d97fe39a95181dad1b9808de981a`
  - tests: `f334181861fb9a891ec6ca4883b2d93b473301ff80d0f90303bad109f14fdaa1`
- `packages/ui` typecheck: passed in the exact-head network-denied sandbox\n- `packages/ui` build:dist:unlocked: passed; 46 runtime exports verified
- Full exact-head receipt: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22739-genui-byte-bound.txt

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Unit/adversarial behavior | 17/17 focused tests passed |
| Exact byte-bound behavior | Accepts exact limits and rejects one byte over for ASCII, NUL escaping, emoji, and lone surrogate |
| Pre-serialization bound | Cumulative oversized values reject before the final `JSON.stringify` spy is called |
| UI screenshots/video | N/A: validation-only safety correction; no rendered view or styling change |
| Backend/network logs | N/A: pure in-process validator with sandbox network denied |

## Reviewer reproduction

`bun x vitest run packages/ui/src/genui/validator.unbounded.test.ts packages/ui/src/genui/validator.fuzz.test.ts --coverage.enabled=false`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - validator TypeScript has no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - validator TypeScript has no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic validator has no visual interaction
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure in-process validator has no backend service
<!-- evidence-row:frontend-logs -->
- [ ] N/A - validator unit tests start no frontend application
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt or planner behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [22739-genui-byte-bound.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22739-genui-byte-bound.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered output exists to inspect

## Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:43e7183c0b6946f51d057a90b1179ba3864e5944 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues/review-22229-22271]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza"} -->


