### PR TITLE
fix(coding-tools): fail closed on explicit shell workdirs

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -77,14 +77,11 @@ describePosixShell("shell plugin real local integration", () => {
   });
 
   it("executes a real command in the allowed directory and exposes it through the provider", async () => {
-    const result = await service.executeCommand(
-      'printf "live-shell" > output.txt',
-      "room-1",
-    );
-    expect(result.success).toBe(true);
+    const result = await service.executeCommand("touch output.txt", "room-1");
+    expect(result.success, JSON.stringify(result)).toBe(true);
     expect(
       readFileSync(path.join(allowedDirectory, "output.txt"), "utf8"),
-    ).toBe("live-shell");
+    ).toBe("");
 
     const provider = await shellHistoryProvider.get(
       runtime,
@@ -165,8 +162,11 @@ describePosixShell("shell plugin real local integration", () => {
   });
 
   it("resolves an explicit relative workdir from the service current directory", async () => {
-    const child = path.join(allowedDirectory, "relative-child");
+    const parent = path.join(allowedDirectory, "current-parent");
+    const child = path.join(parent, "relative-child");
+    mkdirSync(parent);
     mkdirSync(child);
+    expect(service.setCurrentDirectory(parent)).toBe(true);
 
     const result = await service.exec("pwd", { workdir: "relative-child" });
     const realChild = realpathSync(child);
@@ -174,6 +174,41 @@ describePosixShell("shell plugin real local integration", () => {
     expect(result.status).toBe("completed");
     expect(result.cwd).toBe(realChild);
     expect(result.aggregated.trim()).toBe(realChild);
+
+    const omitted = await service.exec("pwd");
+    const realParent = realpathSync(parent);
+    expect(omitted.status).toBe("completed");
+    expect(omitted.cwd).toBe(realParent);
+    expect(omitted.aggregated.trim()).toBe(realParent);
+
+    const absolute = await service.exec("pwd", { workdir: child });
+    expect(absolute.status).toBe("completed");
+    expect(absolute.cwd).toBe(realChild);
+    expect(absolute.aggregated.trim()).toBe(realChild);
+  });
+
+  it("rejects blank explicit workdirs without executing", async () => {
+    for (const workdir of ["", " ", "\t\n"]) {
+      const result = await service.exec("pwd", { workdir });
+      expect(result.status).toBe("failed");
+      expect(result.reason).toBe(
+        "Explicit workdir must be a non-empty string.",
+      );
+      expect(result.aggregated).toBe("");
+    }
+  });
+
+  it("returns structured failures for non-string runtime workdirs", async () => {
+    for (const workdir of [null, 42, { path: allowedDirectory }]) {
+      const result = await service.exec("pwd", {
+        workdir: workdir as unknown as string,
+      });
+      expect(result.status).toBe("failed");
+      expect(result.reason).toBe(
+        "Explicit workdir must be a non-empty string.",
+      );
+      expect(result.aggregated).toBe("");
+    }
   });
 
   it("rejects missing, dangling, and non-directory explicit workdirs", async () => {

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -3,7 +3,15 @@
  * spawned shell in a temp directory (no mocks) — command execution, session
  * tracking, and history-provider context injection.
  */
-import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { type IAgentRuntime, logger } from "@elizaos/core";
@@ -154,6 +162,46 @@ describePosixShell("shell plugin real local integration", () => {
     } finally {
       rmSync(outside, { recursive: true, force: true });
     }
+  });
+
+  it("resolves an explicit relative workdir from the service current directory", async () => {
+    const child = path.join(allowedDirectory, "relative-child");
+    mkdirSync(child);
+
+    const result = await service.exec("pwd", { workdir: "relative-child" });
+    const realChild = realpathSync(child);
+
+    expect(result.status).toBe("completed");
+    expect(result.cwd).toBe(realChild);
+    expect(result.aggregated.trim()).toBe(realChild);
+  });
+
+  it("rejects missing, dangling, and non-directory explicit workdirs", async () => {
+    const regularFile = path.join(allowedDirectory, "not-a-directory.txt");
+    const dangling = path.join(allowedDirectory, "dangling");
+    writeFileSync(regularFile, "not a cwd");
+    symlinkSync(path.join(allowedDirectory, "missing-target"), dangling);
+
+    for (const workdir of ["missing", "dangling", "not-a-directory.txt"]) {
+      const result = await service.exec("pwd", { workdir });
+      expect(result.status).toBe("failed");
+      expect(result.reason).toContain(
+        "unavailable or outside allowed directory",
+      );
+    }
+  });
+
+  it("does not execute from process cwd when an explicit default-root workdir is missing", async () => {
+    await service.stop();
+    delete process.env.SHELL_ALLOWED_DIRECTORY;
+    service = await ShellService.start(createRuntime(null));
+
+    const result = await service.exec("pwd", {
+      workdir: `missing-explicit-${Date.now()}`,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("unavailable or outside allowed directory");
   });
 
   it("surfaces a model-visible error instead of blank output when history retrieval throws", async () => {

--- a/plugins/plugin-coding-tools/src/shell/services/shellService.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/shellService.ts
@@ -52,7 +52,6 @@ import {
   getShellConfig,
   killSession,
   pad,
-  resolveWorkdir,
   sanitizeBinaryOutput,
   sliceLogLines,
   truncateMiddle,
@@ -573,12 +572,21 @@ export class ShellService extends Service {
           )
       : null;
 
-    // Resolve workdir
-    const rawWorkdir =
-      options.workdir?.trim() || this.currentDirectory || process.cwd();
-    const resolvedWorkdir = resolveWorkdir(rawWorkdir, warnings);
+    // An explicit cwd is command input, so it must reach the realpath boundary
+    // unchanged instead of degrading to an unrelated process directory.
+    const explicitWorkdir = options.workdir?.trim();
+    if (options.workdir !== undefined && !explicitWorkdir) {
+      return {
+        status: "failed",
+        exitCode: 1,
+        durationMs: 0,
+        aggregated: "",
+        reason: "Explicit workdir must not be empty.",
+      };
+    }
+    const requestedWorkdir = explicitWorkdir ?? this.currentDirectory;
     const validatedWorkdir = validatePath(
-      resolvedWorkdir,
+      requestedWorkdir,
       this.shellConfig.allowedDirectory,
       this.currentDirectory,
     );
@@ -588,7 +596,7 @@ export class ShellService extends Service {
         exitCode: 1,
         durationMs: 0,
         aggregated: "",
-        reason: `workdir is outside allowed directory: ${resolvedWorkdir}`,
+        reason: `workdir is unavailable or outside allowed directory: ${requestedWorkdir}`,
       };
     }
     const workdir = validatedWorkdir;

--- a/plugins/plugin-coding-tools/src/shell/services/shellService.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/shellService.ts
@@ -1,7 +1,6 @@
 /**
- * ShellService — the shell plugin's core command executor. Runs commands via
- * executeCommand() (simple, timeout-bounded) or exec() (PTY, background/yield,
- * session tracking), and manages live sessions through processAction().
+ * Executes compatibility shell commands with path confinement, output
+ * redaction, session tracking, and optional PTY/background behavior.
  *
  * Short-circuits in cloud mode and routes through SandboxManager under sandbox
  * mode; PTY spawn (@lydell/node-pty) is optional and degrades to cross-spawn
@@ -574,14 +573,16 @@ export class ShellService extends Service {
 
     // An explicit cwd is command input, so it must reach the realpath boundary
     // unchanged instead of degrading to an unrelated process directory.
-    const explicitWorkdir = options.workdir?.trim();
-    if (options.workdir !== undefined && !explicitWorkdir) {
+    const rawWorkdir: unknown = options.workdir;
+    const explicitWorkdir =
+      typeof rawWorkdir === "string" ? rawWorkdir.trim() : undefined;
+    if (rawWorkdir !== undefined && !explicitWorkdir) {
       return {
         status: "failed",
         exitCode: 1,
         durationMs: 0,
         aggregated: "",
-        reason: "Explicit workdir must not be empty.",
+        reason: "Explicit workdir must be a non-empty string.",
       };
     }
     const requestedWorkdir = explicitWorkdir ?? this.currentDirectory;

--- a/plugins/plugin-coding-tools/src/shell/utils/index.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/index.ts
@@ -46,7 +46,6 @@ export {
   killSession,
   pad,
   readEnvInt,
-  resolveWorkdir,
   sanitizeBinaryOutput,
   sliceLogLines,
   sliceUtf16Safe,

--- a/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
@@ -10,8 +10,7 @@ import type {
   SpawnOptions,
 } from "node:child_process";
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { truncateWellFormed } from "@elizaos/core";
 import {
@@ -157,39 +156,6 @@ export function coerceEnv(
     }
   }
   return record;
-}
-
-/**
- * Resolve working directory with fallback
- */
-export function resolveWorkdir(workdir: string, warnings: string[]): string {
-  const current = safeCwd();
-  const fallback = current ?? homedir();
-  try {
-    const stats = statSync(workdir);
-    if (stats.isDirectory()) {
-      return workdir;
-    }
-  } catch {
-    // error-policy:J4 designed degrade; an unavailable workdir falls back to the
-    // process cwd/home and the substitution is surfaced to the caller via the
-    // `warnings` array below (never silently swapped).
-  }
-  warnings.push(
-    `Warning: workdir "${workdir}" is unavailable; using "${fallback}".`,
-  );
-  return fallback;
-}
-
-function safeCwd(): string | null {
-  try {
-    const cwd = process.cwd();
-    return existsSync(cwd) ? cwd : null;
-  } catch {
-    // error-policy:J3 cwd probe; process.cwd() throws when the working
-    // directory was deleted out from under the process — null is the miss.
-    return null;
-  }
 }
 
 /**


### PR DESCRIPTION
Closes #22725

# Relates to

This repairs the documented `runtime.getService("shell").exec()` compatibility
surface after the realpath confinement merged in #22451.

- [x] Targets `develop` and is rebased with zero conflicts.
- [x] `bun install` completed with Bun 1.3.14.
- [x] Package tests, typecheck, lint, build, real-process regressions, and diff
      checks pass with the pinned Node 24.15.0 runtime.
- [x] A reviewer can reproduce the result from the commands below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c00ba4afa1119c1317a38b5c36c633518986409c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `c00ba4afa1119c1317a38b5c36c633518986409c`;
      zero conflicts.
- [x] Focused and package gates were rerun after the rebase with Node 24.15.0
      and Bun 1.3.14.

# Risks

Low. The change removes fallback execution: callers that supplied an invalid
explicit workdir now receive a structured failure instead of running in an
unrelated directory. Omitted workdirs retain the existing service-current-cwd
behavior. No public type or export changes.

# Background

## What does this PR do?

- Resolves an explicit relative `workdir` from `ShellService.currentDirectory`,
  not `process.cwd()`.
- Sends explicit paths directly through the existing realpath directory
  boundary.
- Rejects blank, non-string, missing, dangling, regular-file, and outside
  symlink workdirs without spawning a command.
- Removes the process-cwd/home fallback helper.
- Repairs the legacy real-shell fixture so the complete owning integration
  file exercises only command grammar that the compatibility service accepts.

## What kind of change is this?

Bug fix and security hardening with fail-closed compatibility semantics.

# Documentation changes needed?

No. The documented compatibility setting and public method signatures are
unchanged.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-coding-tools/src/shell/services/shellService.ts`
2. `plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts`
3. `plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts`

## Detailed testing steps

The focused real-path and package gates below passed using Node 24.15.0 and Bun
1.3.14. The complete package suite passed on the same change before the final
unrelated `develop` refresh; the last refresh changed only a UI E2E fixture,
after which the exact diff, evidence, and attribution gates were rerun:

```text
bun run --cwd plugins/plugin-coding-tools test
  38 files passed; 617 tests passed

bunx vitest run --config packages/scripts/vitest/real.config.ts \
  plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts \
  --coverage.enabled=false --reporter=dot
  1 file passed; 12 tests passed

bunx vitest run \
  plugins/plugin-coding-tools/src/shell/utils/pathUtils.validate-path.test.ts \
  --coverage.enabled=false --reporter=dot
  1 file passed; 7 tests passed

bun run --cwd plugins/plugin-coding-tools typecheck
bun run --cwd plugins/plugin-coding-tools lint:check
  Checked 106 files. No fixes applied.
bun run --cwd plugins/plugin-coding-tools build
git diff --check origin/develop...HEAD
```

The real tests spawn the production `ShellService` against real temporary
directories. They verify explicit-relative, explicit-absolute, omitted,
blank, runtime-invalid, missing, dangling, regular-file, default-root missing,
inside-symlink, and outside-symlink behavior.

# Evidence Gate

<!-- evidence-head:df38d9e483b9c161a83d30f73c79253fc5902010 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only shell boundary with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only shell boundary with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic shell-service boundary with no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server transport is changed; the production service process
      output and structured return values are exercised by the real suite.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-selection, or planner behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Real temporary directories, symlinks, files, spawned `pwd` output, and
      structured `ExecResult` values are created and inspected by the 12-test
      production-path suite above.

<details><summary>Exact real-process artifact summary</summary>

```text
explicit relative child: status=completed; cwd=realpath(current-parent/relative-child); stdout=cwd
omitted workdir: status=completed; cwd=realpath(current-parent); stdout=cwd
blank, non-string, missing, dangling, file, and outside symlink: status=failed; aggregated=""; no spawn
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic compatibility-service path resolution only.

## Backend + frontend logs

The real-process test result is included under **Testing**. Frontend logs are
N/A because no frontend path is involved.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior.

## Known gaps / failures

- An earlier pinned-runtime package run was invalidated by host-wide ENOSPC
  while other worktrees were active; it was discarded. The clean rerun passed.
- `bun run verify` passed all 360 workspace build/typecheck/lint tasks, then
  failed the repository mock-export audit on 21 stale cloud-credit baseline
  entries unrelated to this shell-only diff.
- No external credentials, device, protected environment, or live provider is
  required for this deterministic local compatibility boundary.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent
Contribution skill revision: elizaOS/eliza@c00ba4afa1119c1317a38b5c36c633518986409c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review-22742]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent","skill_revision":"elizaOS/eliza@c00ba4afa1119c1317a38b5c36c633518986409c:packages/skills/skills/contribute-to-eliza"} -->
