### PR TITLE
fix(sql): bound sanitized JSON output size

### DIFF
--- a/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
@@ -1,8 +1,7 @@
 /**
  * Integration tests for log create/get/delete against a real isolated
  * PGlite/Postgres adapter, covering the `limit`/legacy-`count` param
- * contract, JSON-body escaping (backslashes, NUL stripping), and filtering
- * by type.
+ * contract, JSON-body escaping and output bounds, and filtering by type.
  */
 import {
   type AgentRuntime,
@@ -16,7 +15,11 @@ import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";
 import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
-import { MAX_SQL_JSON_SANITIZE_DEPTH, SQL_JSON_SANITIZE_UNBOUNDED } from "../../sanitize-json";
+import {
+  MAX_SQL_JSON_SANITIZE_DEPTH,
+  MAX_SQL_JSON_SANITIZE_STRING_BYTES,
+  SQL_JSON_SANITIZE_UNBOUNDED,
+} from "../../sanitize-json";
 import { logTable } from "../../schema";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
@@ -181,6 +184,26 @@ describe("Log Integration Tests", () => {
       const logs = await adapter.getLogs({
         roomId: testRoomId,
         type: "unbounded_test",
+      });
+      expect(logs).toHaveLength(0);
+    });
+
+    it("rejects an oversized scalar before the real adapter inserts a log", async () => {
+      await expect(
+        adapter.log({
+          body: { text: "x".repeat(MAX_SQL_JSON_SANITIZE_STRING_BYTES + 1) },
+          entityId: testEntityId,
+          roomId: testRoomId,
+          type: "oversized_scalar_test",
+        })
+      ).rejects.toMatchObject({
+        code: "DB_INSERT_FAILED",
+        cause: expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED }),
+      });
+
+      const logs = await adapter.getLogs({
+        roomId: testRoomId,
+        type: "oversized_scalar_test",
       });
       expect(logs).toHaveLength(0);
     });

--- a/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
@@ -4,7 +4,8 @@
  * parameter, so JSON escaping is already handled by the serializer;
  * `sanitizeJsonObject` must therefore only strip NUL characters (PostgreSQL/
  * PGlite jsonb rejects the escape JSON.stringify emits for them), break
- * circular references, and fail closed past a nesting ceiling — nothing else.
+ * circular references, and fail closed past structural or serialized-size
+ * ceilings — nothing else.
  * A prior implementation also doubled
  * every backslash not followed by an allowlisted escape character and
  * mangled non-hex unicode-escape sequences, so a Windows path like
@@ -14,8 +15,12 @@
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
+  MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS,
+  MAX_SQL_JSON_SANITIZE_BYTES,
   MAX_SQL_JSON_SANITIZE_DEPTH,
+  MAX_SQL_JSON_SANITIZE_KEY_BYTES,
   MAX_SQL_JSON_SANITIZE_NODES,
+  MAX_SQL_JSON_SANITIZE_STRING_BYTES,
   SQL_JSON_SANITIZE_UNBOUNDED,
   sanitizeJsonObject,
 } from "../../sanitize-json";
@@ -81,6 +86,45 @@ describe("sanitizeJsonObject", () => {
     expect(sanitizeJsonObject(Number.NaN)).toBeNull();
     expect(sanitizeJsonObject(Number.POSITIVE_INFINITY)).toBeNull();
     expect(sanitizeJsonObject(Number.NEGATIVE_INFINITY)).toBeNull();
+  });
+
+  it("fails closed before copying oversized string, key, and BigInt projections", () => {
+    expect(() =>
+      sanitizeJsonObject("x".repeat(MAX_SQL_JSON_SANITIZE_STRING_BYTES + 1))
+    ).toThrowError(expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED }));
+    expect(() =>
+      sanitizeJsonObject({ ["k".repeat(MAX_SQL_JSON_SANITIZE_KEY_BYTES + 1)]: true })
+    ).toThrowError(expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED }));
+    expect(() =>
+      sanitizeJsonObject(10n ** BigInt(MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS))
+    ).toThrowError(expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED }));
+  });
+
+  it("accounts for escaped UTF-8 bytes and aggregate JSON syntax", () => {
+    const escapedUnit = "\\";
+    expect(() =>
+      sanitizeJsonObject(escapedUnit.repeat(MAX_SQL_JSON_SANITIZE_STRING_BYTES / 2 + 1))
+    ).toThrowError(expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED }));
+
+    const aggregate = Array.from({ length: 5 }, (_, index) => ({
+      index,
+      body: "x".repeat(Math.floor(MAX_SQL_JSON_SANITIZE_BYTES / 5)),
+    }));
+    expect(() => sanitizeJsonObject(aggregate)).toThrowError(
+      expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED })
+    );
+  });
+
+  it("preserves valid Unicode and exact-budget-adjacent values", () => {
+    const value = `before😀${"x".repeat(1_024)}after`;
+    expect(sanitizeJsonObject(value)).toBe(value);
+    expect(JSON.parse(JSON.stringify(sanitizeJsonObject({ value })))).toEqual({ value });
+
+    const exactBudget = "x".repeat(MAX_SQL_JSON_SANITIZE_BYTES - 2);
+    expect(sanitizeJsonObject(exactBudget)).toBe(exactBudget);
+    expect(() => sanitizeJsonObject(`${exactBudget}x`)).toThrowError(
+      expect.objectContaining({ code: SQL_JSON_SANITIZE_UNBOUNDED })
+    );
   });
 
   it("recurses into arrays and objects", () => {

--- a/plugins/plugin-sql/src/sanitize-json.ts
+++ b/plugins/plugin-sql/src/sanitize-json.ts
@@ -1,7 +1,8 @@
 /**
  * Shared jsonb sanitizer for SQL writes. Strips NULs (PostgreSQL rejects
  * JSON.stringify's `\u0000` escape), breaks cycles, and fails closed on
- * hostile nesting so a log/memory body cannot RangeError the adapter.
+ * hostile nesting and output size so a log/memory body cannot exhaust the
+ * adapter before its jsonb bind.
  *
  * `utils.ts`, `utils.node.ts`, and `utils.browser.ts` re-export this so the
  * three platform builds cannot drift.
@@ -12,7 +13,18 @@ import { ElizaError } from "@elizaos/core";
 export const MAX_SQL_JSON_SANITIZE_DEPTH = 64;
 /** Logical values copied into one jsonb bind before the write fails closed. */
 export const MAX_SQL_JSON_SANITIZE_NODES = 10_000;
+/** Maximum UTF-8 bytes in the JSON text passed to one jsonb bind. */
+export const MAX_SQL_JSON_SANITIZE_BYTES = 1_048_576;
+/** Maximum escaped UTF-8 bytes contributed by one string value. */
+export const MAX_SQL_JSON_SANITIZE_STRING_BYTES = MAX_SQL_JSON_SANITIZE_BYTES;
+/** Maximum escaped UTF-8 bytes contributed by one property key. */
+export const MAX_SQL_JSON_SANITIZE_KEY_BYTES = 65_536;
+/** Maximum decimal digits projected from one BigInt value. */
+export const MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS = 4_096;
 export const SQL_JSON_SANITIZE_UNBOUNDED = "SQL_JSON_SANITIZE_UNBOUNDED";
+
+const BIGINT_DECIMAL_LIMIT = 10n ** BigInt(MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS);
+const NUL = String.fromCharCode(0);
 
 function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
   throw new ElizaError("sql json sanitize exceeded its safe structural budget", {
@@ -26,6 +38,73 @@ function failUnbounded(context: Record<string, unknown>, cause?: unknown): never
 interface SanitizeContext {
   seen: WeakSet<object>;
   visits: number;
+  bytes: number;
+}
+
+function chargeBytes(context: SanitizeContext, bytes: number, reason: string): void {
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    failUnbounded({ reason, bytes: "invalid" });
+  }
+  context.bytes += bytes;
+  if (context.bytes > MAX_SQL_JSON_SANITIZE_BYTES) {
+    failUnbounded({
+      reason: "serialized-bytes",
+      bytes: context.bytes,
+      max: MAX_SQL_JSON_SANITIZE_BYTES,
+      source: reason,
+    });
+  }
+}
+
+/**
+ * Count the exact UTF-8 bytes JSON.stringify emits inside a quoted string.
+ * This scans without allocating an encoded copy and stops at the scalar bound.
+ */
+function measureJsonStringBytes(value: string, max: number, reason: string): number {
+  if (value.length > max) {
+    failUnbounded({ reason, codeUnits: value.length, max });
+  }
+
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit === 0) continue;
+
+    if (codeUnit === 0x22 || codeUnit === 0x5c) {
+      bytes += 2;
+    } else if (codeUnit <= 0x1f) {
+      bytes +=
+        codeUnit === 0x08 ||
+        codeUnit === 0x09 ||
+        codeUnit === 0x0a ||
+        codeUnit === 0x0c ||
+        codeUnit === 0x0d
+          ? 2
+          : 6;
+    } else if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else {
+        // Well-formed JSON.stringify escapes a lone surrogate as `\ud800`.
+        bytes += 6;
+      }
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      bytes += 6;
+    } else {
+      bytes += 3;
+    }
+
+    if (bytes > max) {
+      failUnbounded({ reason, bytes, max });
+    }
+  }
+  return bytes + 2;
 }
 
 function reflectOrFail<T>(operation: () => T, reason: string): T {
@@ -46,7 +125,7 @@ export function sanitizeJsonObject(
   value: unknown,
   seen: WeakSet<object> = new WeakSet<object>()
 ): unknown {
-  return sanitizeJsonValue(value, { seen, visits: 0 }, 0);
+  return sanitizeJsonValue(value, { seen, visits: 0, bytes: 0 }, 0);
 }
 
 function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: number): unknown {
@@ -63,6 +142,7 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
   }
 
   if (value === null || value === undefined) {
+    chargeBytes(context, 4, value === null ? "null" : "undefined");
     return value;
   }
 
@@ -73,19 +153,43 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
     // backslashes and control characters correctly; re-escaping them here
     // would corrupt already-escaped strings (e.g. "C:\Users") on a
     // write/read round-trip.
-    return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
+    chargeBytes(
+      context,
+      measureJsonStringBytes(value, MAX_SQL_JSON_SANITIZE_STRING_BYTES, "string-bytes"),
+      "string"
+    );
+    return value.includes(NUL) ? value.replaceAll(NUL, "") : value;
   }
 
   if (typeof value === "bigint") {
-    return value.toString();
+    if (value >= BIGINT_DECIMAL_LIMIT || value <= -BIGINT_DECIMAL_LIMIT) {
+      failUnbounded({
+        reason: "bigint-digits",
+        max: MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS,
+      });
+    }
+    const projected = value.toString();
+    chargeBytes(
+      context,
+      measureJsonStringBytes(projected, MAX_SQL_JSON_SANITIZE_STRING_BYTES, "bigint-bytes"),
+      "bigint"
+    );
+    return projected;
   }
 
   if (typeof value === "number") {
+    chargeBytes(context, Number.isFinite(value) ? String(value).length : 4, "number");
     return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "boolean") {
+    chargeBytes(context, value ? 4 : 5, "boolean");
+    return value;
   }
 
   if (typeof value === "object") {
     if (context.seen.has(value)) {
+      chargeBytes(context, 4, "cycle");
       return null;
     }
     context.seen.add(value);
@@ -101,7 +205,17 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
       dateTimestamp = undefined;
     }
     if (dateTimestamp !== undefined) {
-      return Number.isFinite(dateTimestamp) ? Date.prototype.toISOString.call(value) : null;
+      if (!Number.isFinite(dateTimestamp)) {
+        chargeBytes(context, 4, "invalid-date");
+        return null;
+      }
+      const iso = Date.prototype.toISOString.call(value);
+      chargeBytes(
+        context,
+        measureJsonStringBytes(iso, MAX_SQL_JSON_SANITIZE_STRING_BYTES, "date-bytes"),
+        "date"
+      );
+      return iso;
     }
 
     if (reflectOrFail(() => Array.isArray(value), "array-check")) {
@@ -122,6 +236,7 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
         });
       }
       const result: unknown[] = [];
+      chargeBytes(context, 2 + Math.max(0, length - 1), "array-syntax");
       for (let index = 0; index < length; index += 1) {
         const descriptor = reflectOrFail(
           () => Object.getOwnPropertyDescriptor(value, String(index)),
@@ -140,6 +255,8 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
       failUnbounded({ reason: "object-keys", keys: keys.length, max: MAX_SQL_JSON_SANITIZE_NODES });
     }
     const result = Object.create(null) as Record<string, unknown>;
+    chargeBytes(context, 2, "object-syntax");
+    let serializedProperties = 0;
     for (const key of keys) {
       if (typeof key !== "string") continue;
       const descriptor = reflectOrFail(
@@ -150,7 +267,15 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
       if ("get" in descriptor || "set" in descriptor) {
         failUnbounded({ reason: "object-accessor" });
       }
-      const sanitizedKey = key.replace(new RegExp(String.fromCharCode(0), "g"), "");
+      chargeBytes(
+        context,
+        measureJsonStringBytes(key, MAX_SQL_JSON_SANITIZE_KEY_BYTES, "key-bytes") +
+          1 +
+          (serializedProperties > 0 ? 1 : 0),
+        "object-property-syntax"
+      );
+      serializedProperties += 1;
+      const sanitizedKey = key.includes(NUL) ? key.replaceAll(NUL, "") : key;
       const sanitizedValue = sanitizeJsonValue(descriptor.value, context, depth + 1);
       if (sanitizedKey === "toJSON" && typeof sanitizedValue === "function") {
         failUnbounded({ reason: "custom-toJSON" });
@@ -168,5 +293,8 @@ function sanitizeJsonValue(value: unknown, context: SanitizeContext, depth: numb
     return result;
   }
 
+  // JSON.stringify omits these values in objects and writes null in arrays.
+  // Charging four bytes is conservative without changing their legacy shape.
+  chargeBytes(context, 4, typeof value);
   return value;
 }

--- a/plugins/plugin-sql/src/utils.browser.ts
+++ b/plugins/plugin-sql/src/utils.browser.ts
@@ -16,8 +16,12 @@ export function resolvePgliteDir(_dir?: string, _fallbackDir?: string): string {
 }
 
 export {
+  MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS,
+  MAX_SQL_JSON_SANITIZE_BYTES,
   MAX_SQL_JSON_SANITIZE_DEPTH,
+  MAX_SQL_JSON_SANITIZE_KEY_BYTES,
   MAX_SQL_JSON_SANITIZE_NODES,
+  MAX_SQL_JSON_SANITIZE_STRING_BYTES,
   SQL_JSON_SANITIZE_UNBOUNDED,
   sanitizeJsonObject,
 } from "./sanitize-json.ts";

--- a/plugins/plugin-sql/src/utils.node.ts
+++ b/plugins/plugin-sql/src/utils.node.ts
@@ -64,8 +64,12 @@ export function resolvePgliteDir(dir?: string, fallbackDir?: string): string {
 }
 
 export {
+  MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS,
+  MAX_SQL_JSON_SANITIZE_BYTES,
   MAX_SQL_JSON_SANITIZE_DEPTH,
+  MAX_SQL_JSON_SANITIZE_KEY_BYTES,
   MAX_SQL_JSON_SANITIZE_NODES,
+  MAX_SQL_JSON_SANITIZE_STRING_BYTES,
   SQL_JSON_SANITIZE_UNBOUNDED,
   sanitizeJsonObject,
 } from "./sanitize-json.ts";

--- a/plugins/plugin-sql/src/utils.ts
+++ b/plugins/plugin-sql/src/utils.ts
@@ -66,8 +66,12 @@ export function resolvePgliteDir(dir?: string, fallbackDir?: string): string {
 }
 
 export {
+  MAX_SQL_JSON_SANITIZE_BIGINT_DIGITS,
+  MAX_SQL_JSON_SANITIZE_BYTES,
   MAX_SQL_JSON_SANITIZE_DEPTH,
+  MAX_SQL_JSON_SANITIZE_KEY_BYTES,
   MAX_SQL_JSON_SANITIZE_NODES,
+  MAX_SQL_JSON_SANITIZE_STRING_BYTES,
   SQL_JSON_SANITIZE_UNBOUNDED,
   sanitizeJsonObject,
 } from "./sanitize-json.ts";


### PR DESCRIPTION
# Relates to

Closes #22732

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and was rebased onto the live `origin/develop` head before push.
- [x] Focused behavioral tests, real PGlite no-insert proof, pinned Biome, and diff check pass.
- [x] Evidence demonstrates scalar and aggregate bounds fail before database mutation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased without conflicts onto `d946f9c54c405dac483c84af7ed7118150d17f5e` immediately before final validation and push.
- [x] Final candidate head: `c416f1c93eb0ead33715efc1f604c6c8b553c8f4`.

# What changed

- Enforce a 1 MiB aggregate UTF-8 JSON-text budget before a jsonb bind.
- Bound individual escaped string values, property keys, and decimal BigInt projections.
- Count JSON syntax and escaping without allocating an encoded copy; fail with the existing typed `SQL_JSON_SANITIZE_UNBOUNDED` error.
- Preserve NUL stripping, dates, finite values, cycles, descriptor defenses, Unicode, and the node/depth ceilings.
- Export the same budget constants from Node, browser, and default utility surfaces.

# Testing

- Exact-head sanitizer suite: 22/22 pass.
- Exact-head real PGlite adapter regression: oversized scalar rejected and zero matching log rows inserted.
- Pinned Biome 2.5.8 on all six changed files: pass.
- `git diff --check`: pass.
- Package typecheck was attempted in the sparse author checkout and stopped only on missing unchanged optional dependency declarations (`drizzle-kit`, `@neondatabase/serverless`, `ws`, `@types/pg`); no changed-file diagnostic was emitted.
- Bun printed every focused assertion and the real PGlite PASS, then retained the repository coverage footer/open handle; processes were bounded only after terminal test results appeared.

# Evidence Gate

<!-- evidence-head:c416f1c93eb0ead33715efc1f604c6c8b553c8f4 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend SQL serialization boundary; no rendered UI changes.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend SQL serialization boundary; no rendered UI changes.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no visual workflow; the real adapter path is captured in backend evidence.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22743-backend-c416f1c9-v4.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend or network surface changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic serialization and database authority; no model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22743-domain-c416f1c9-v4.txt
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no visual surface.`

# Risk and rollback

The new limits are fail-closed before SQL mutation. Payloads that exceed the explicit budget now receive the existing typed sanitizer failure instead of allocating and binding an unbounded jsonb value. Rollback is the single commit, but doing so reopens the resource-bound gap. No schema, migration, dependency, API, or deployment configuration changes are included.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->
