### PR TITLE
fix(plugin-google-workspace): fail closed on unbounded Gmail MIME nests

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Deterministic tests for the Gmail MIME part-tree bound. No live Gmail API
+ * or model: the walker is the production ingest used by collect/extract.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractGmailMimeBody,
+  GMAIL_MIME_PART_UNBOUNDED,
+  type GmailMimePartLike,
+  MAX_GMAIL_MIME_DEPTH,
+  MAX_GMAIL_MIME_NODES,
+  walkGmailMimeParts,
+} from "./gmail-mime-parts";
+
+function nestMime(depth: number): GmailMimePartLike {
+  let part: GmailMimePartLike = { mimeType: "text/plain", body: { data: "leaf" } };
+  for (let index = 0; index < depth; index += 1) {
+    part = { mimeType: "multipart/mixed", parts: [part] };
+  }
+  return part;
+}
+
+describe("walkGmailMimeParts", () => {
+  it(`accepts a ${MAX_GMAIL_MIME_DEPTH}-deep MIME nest`, () => {
+    const visits: string[] = [];
+    walkGmailMimeParts(nestMime(MAX_GMAIL_MIME_DEPTH), (part) => {
+      visits.push(part.mimeType ?? "");
+    });
+    expect(visits).toHaveLength(MAX_GMAIL_MIME_DEPTH + 1);
+    expect(visits.at(-1)).toBe("text/plain");
+  });
+
+  it(`throws ${GMAIL_MIME_PART_UNBOUNDED} one past depth ${MAX_GMAIL_MIME_DEPTH}`, () => {
+    try {
+      walkGmailMimeParts(nestMime(MAX_GMAIL_MIME_DEPTH + 1), () => {});
+      expect.unreachable("walk should fail closed on over-budget MIME depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${GMAIL_MIME_PART_UNBOUNDED} past ${MAX_GMAIL_MIME_NODES} sparse holes`, () => {
+    const sparse: GmailMimePartLike[] = [];
+    sparse[MAX_GMAIL_MIME_NODES] = {
+      mimeType: "text/plain",
+      body: { data: "x" },
+    };
+    try {
+      walkGmailMimeParts({ mimeType: "multipart/mixed", parts: sparse }, () => {});
+      expect.unreachable("walk should fail closed on over-budget sparse parts");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+  });
+
+  it("throws on a cyclic MIME part without hanging", () => {
+    const cyclic: GmailMimePartLike = { mimeType: "multipart/mixed", parts: [] };
+    cyclic.parts = [cyclic];
+    const started = performance.now();
+    try {
+      walkGmailMimeParts(cyclic, () => {});
+      expect.unreachable("walk should fail closed on a MIME cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while walking", () => {
+    let invoked = 0;
+    const hostile: GmailMimePartLike = {
+      mimeType: "multipart/mixed",
+      get parts(): GmailMimePartLike[] {
+        invoked += 1;
+        return nestMime(20_000).parts ?? [];
+      },
+    };
+    walkGmailMimeParts(hostile, () => {});
+    expect(invoked).toBe(0);
+  });
+
+  it("aborts remaining siblings once visit returns true", () => {
+    const seen: Array<string | null | undefined> = [];
+    walkGmailMimeParts(
+      {
+        mimeType: "multipart/mixed",
+        parts: [
+          { mimeType: "text/plain", body: { data: "a" } },
+          { mimeType: "text/html", body: { data: "b" } },
+        ],
+      },
+      (part) => {
+        seen.push(part.mimeType);
+        return part.mimeType === "text/plain";
+      }
+    );
+    expect(seen).toEqual(["multipart/mixed", "text/plain"]);
+  });
+
+  it("skips an empty matching child and takes a later sibling", () => {
+    const body = extractGmailMimeBody(
+      {
+        mimeType: "multipart/mixed",
+        parts: [
+          { mimeType: "text/plain", body: { data: "" } },
+          { mimeType: "text/plain", body: { data: "second" } },
+        ],
+      },
+      "text/plain",
+      (part) => part.body?.data ?? ""
+    );
+    expect(body).toBe("second");
+  });
+
+  it("fails closed on a 20k MIME nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      walkGmailMimeParts(nestMime(20_000), () => {});
+      expect.unreachable("walk should fail closed on a 20k MIME nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+
+    const extractStarted = performance.now();
+    try {
+      extractGmailMimeBody(nestMime(20_000), "text/plain", () => "x");
+      expect.unreachable("extract should fail closed on a 20k MIME nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(performance.now() - extractStarted).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
@@ -1,0 +1,154 @@
+/**
+ * Bounds the Gmail MIME `parts` tree before ingest walks it. Gmail API
+ * payloads carry untrusted nested multipart from hostile mail; the previous
+ * recursive collect/extract RangeError'd a 20k nest on Node 24.15.0.
+ * Depth, node, and cycle limits are all load-bearing.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_GMAIL_MIME_DEPTH = 32;
+export const MAX_GMAIL_MIME_NODES = 2_048;
+export const GMAIL_MIME_PART_UNBOUNDED = "GMAIL_MIME_PART_UNBOUNDED";
+
+export type GmailMimePartLike = {
+  mimeType?: string | null;
+  body?: { data?: string | null } | null;
+  parts?: GmailMimePartLike[] | null;
+};
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(context: Record<string, unknown>): never {
+  throw new ElizaError("Gmail MIME part tree exceeds the ingest walk budget", {
+    code: GMAIL_MIME_PART_UNBOUNDED,
+    context,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_GMAIL_MIME_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_GMAIL_MIME_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+/**
+ * Depth-first visit of a Gmail MIME part tree. `visit` returning true aborts
+ * the remaining walk (used when extract has already found a body).
+ */
+export function walkGmailMimeParts(
+  part: GmailMimePartLike | undefined,
+  visit: (part: GmailMimePartLike) => boolean | undefined
+): void {
+  if (!part) return;
+  walkGmailMimePartsInner(part, 0, { visits: 0, visiting: new WeakSet<object>() }, visit);
+}
+
+function walkGmailMimePartsInner(
+  part: GmailMimePartLike,
+  depth: number,
+  ctx: WalkContext,
+  visit: (part: GmailMimePartLike) => boolean | undefined,
+  visitAlreadyReserved = false
+): boolean {
+  if (depth > MAX_GMAIL_MIME_DEPTH) {
+    failUnbounded({ depth, max: MAX_GMAIL_MIME_DEPTH });
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(part)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(part);
+  try {
+    if (visit(part) === true) return true;
+    const partsDescriptor = Object.getOwnPropertyDescriptor(part, "parts");
+    if (!partsDescriptor || !("value" in partsDescriptor)) return false;
+    const children = partsDescriptor.value;
+    if (!Array.isArray(children)) return false;
+    reserve(ctx, children.length);
+    for (let index = 0; index < children.length; index += 1) {
+      if (!(index in children)) continue;
+      const child = children[index];
+      if (!child || typeof child !== "object") continue;
+      if (walkGmailMimePartsInner(child, depth + 1, ctx, visit, true)) {
+        return true;
+      }
+    }
+    return false;
+  } finally {
+    ctx.visiting.delete(part);
+  }
+}
+
+/**
+ * First MIME body whose type matches, in the historical DFS order: a matching
+ * node is returned without walking its children; an empty decoded body does
+ * not hide later siblings.
+ */
+export function extractGmailMimeBody(
+  part: GmailMimePartLike | undefined,
+  mimeType: string,
+  readBody: (part: GmailMimePartLike) => string
+): string {
+  if (!part) return "";
+  return extractGmailMimeBodyInner(part, mimeType, readBody, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+function extractGmailMimeBodyInner(
+  part: GmailMimePartLike,
+  mimeType: string,
+  readBody: (part: GmailMimePartLike) => string,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): string {
+  if (depth > MAX_GMAIL_MIME_DEPTH) {
+    failUnbounded({ depth, max: MAX_GMAIL_MIME_DEPTH });
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(part)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(part);
+  try {
+    const directBody = Object.getOwnPropertyDescriptor(part, "body");
+    const mimeDescriptor = Object.getOwnPropertyDescriptor(part, "mimeType");
+    const mime = mimeDescriptor && "value" in mimeDescriptor ? mimeDescriptor.value : part.mimeType;
+    if (
+      mime === mimeType &&
+      directBody &&
+      "value" in directBody &&
+      directBody.value &&
+      typeof (directBody.value as { data?: unknown }).data === "string"
+    ) {
+      return readBody(part);
+    }
+
+    const partsDescriptor = Object.getOwnPropertyDescriptor(part, "parts");
+    if (!partsDescriptor || !("value" in partsDescriptor)) return "";
+    const children = partsDescriptor.value;
+    if (!Array.isArray(children)) return "";
+    reserve(ctx, children.length);
+    for (let index = 0; index < children.length; index += 1) {
+      if (!(index in children)) continue;
+      const child = children[index];
+      if (!child || typeof child !== "object") continue;
+      const nested = extractGmailMimeBodyInner(child, mimeType, readBody, depth + 1, ctx, true);
+      if (nested) return nested;
+    }
+    return "";
+  } finally {
+    ctx.visiting.delete(part);
+  }
+}

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -5,10 +5,13 @@
  * mutation, subscription-header extraction, and sender-filter/unsubscribe
  * helpers. Maps Gmail API payloads into the plugin's `GoogleGmail*` DTOs. Each
  * method acquires a scoped googleapis client from `GoogleApiClientFactory`.
+ * MIME `parts` trees are bounded in `gmail-mime-parts.ts` so a hostile nest
+ * cannot RangeError ingest.
  */
 import { ElizaError } from "@elizaos/core";
 import type { gmail_v1 } from "googleapis";
 import type { GoogleApiClientFactory } from "./client-factory.js";
+import { extractGmailMimeBody, walkGmailMimeParts } from "./gmail-mime-parts.js";
 import type {
   GoogleAccountRef,
   GoogleEmailAddress,
@@ -734,18 +737,16 @@ function collectMessagePart(
   part: gmail_v1.Schema$MessagePart,
   body: Pick<GoogleMessageSummary, "bodyHtml" | "bodyText">
 ): void {
-  const data = part.body?.data ? decodeBase64Url(part.body.data) : undefined;
+  walkGmailMimeParts(part, (node) => {
+    const data = node.body?.data ? decodeBase64Url(node.body.data) : undefined;
 
-  if (data && part.mimeType === "text/plain" && !body.bodyText) {
-    body.bodyText = data;
-  }
-  if (data && part.mimeType === "text/html" && !body.bodyHtml) {
-    body.bodyHtml = data;
-  }
-
-  for (const child of part.parts ?? []) {
-    collectMessagePart(child, body);
-  }
+    if (data && node.mimeType === "text/plain" && !body.bodyText) {
+      body.bodyText = data;
+    }
+    if (data && node.mimeType === "text/html" && !body.bodyHtml) {
+      body.bodyHtml = data;
+    }
+  });
 }
 
 function encodeMessage(input: GoogleSendEmailInput): string {
@@ -1017,21 +1018,12 @@ function extractGoogleGmailBodyByMime(
   payload: gmail_v1.Schema$MessagePart | undefined,
   mimeType: "text/plain" | "text/html"
 ): string {
-  if (!payload) {
-    return "";
-  }
-  const directBody = payload.body?.data;
-  if (payload.mimeType === mimeType && typeof directBody === "string") {
+  return extractGmailMimeBody(payload, mimeType, (node) => {
+    const directBody = node.body?.data;
+    if (typeof directBody !== "string") return "";
     const decoded = decodeBase64Url(directBody);
     return mimeType === "text/html" ? htmlToPlainText(decoded) : decoded.trim();
-  }
-  for (const part of payload.parts ?? []) {
-    const nested = extractGoogleGmailBodyByMime(part, mimeType);
-    if (nested) {
-      return nested;
-    }
-  }
-  return "";
+  });
 }
 
 function htmlToPlainText(value: string): string {


### PR DESCRIPTION
Closes #22750

## Problem

Gmail ingest walks untrusted MIME `parts` trees in `collectMessagePart` and `extractGoogleGmailBodyByMime`. `getGmailMessageDetail` and `mapMessage(..., includeBody)` call those walkers on Gmail API payloads.

On `origin/develop`, that walk has no depth, node, or cycle budget. **JSON.parse of a 20k-deep `parts` nest succeeds**; the ingest then stack-overflows.

**Origin red (exact walk, pinned Bun 1.3.14 / Node 24.15.0):**

| Input | Bun 1.3.14 | Node 24.15.0 |
|---|---|---|
| 20k-deep MIME `parts` nest | (deeper stack; 40k RangeError 4.19 ms) | RangeError 3.07 ms |
| cyclic `part.parts = [part]` | RangeError 4.80 ms | RangeError |
| `JSON.parse` of the same 20k nest | ok 0.85 ms | ok 0.89 ms |

Product path: `GoogleGmailClient.getGmailMessageDetail` → `extractGoogleGmailBody(payload)` RangeErrors before a typed Gmail error.

Not leftover-tax. Not a twin of `#22737` blocked-object-key, `#22716` workflow JSON clone, `#22707` goal prompt-value, `#22711` GenUI, `#22692` MCP schema, or `#22709` jsonb sanitize. Distinct host: Gmail MIME `parts` ingest.

Did not touch HARD_SKIP `connector-account-provider.ts` or `src/chat/service.ts`.

## Change

- Extract `walkGmailMimeParts` / `extractGmailMimeBody` to `gmail-mime-parts.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`GMAIL_MIME_PART_UNBOUNDED`).
- Descriptor-only `parts` reads (accessors are never invoked). Sparse holes consume the node budget.
- Empty matching children still skip to later siblings (byte-compatible extract order).

## Exact-head evidence

Evidence revision: `637e3dd1dc6c014e75cc745a86044d5be2abfef3`, based on `develop` `dcc1ec5dd6273fcba483ef6fea7479b2c2ab0f50`. Rebased onto current develop. Owning issue: #22750.

- Pinned Bun 1.3.14 focused `gmail-mime-parts` suite: **8/8 passed** in 4 ms.
- Covers honest depth-32 accept, depth 33 throw, sparse 2048-hole throw, cyclic part throw, zero-call accessors, empty-child sibling skip, abort-on-match, and a 20k nest that throws `GMAIL_MIME_PART_UNBOUNDED` (not `RangeError`).
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Maintainer exact-head review uploaded the raw production-boundary receipt to the immutable `pr-evidence-5` release asset linked below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side Gmail MIME ingest; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side Gmail MIME ingest; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic MIME-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - Gmail MIME ingest has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Immutable exact-head focused suite and production-boundary receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22744-637e3dd-focused.log)
<details>
<summary>22744 domain receipt at 637e3dd1dc6c</summary>

```
#22744 domain artifact — Gmail MIME part walk
exact-head: 637e3dd1dc6c014e75cc745a86044d5be2abfef3
based-on: origin/develop dcc1ec5dd6273fcba483ef6fea7479b2c2ab0f50
owning-issue: https://github.com/elizaOS/eliza/issues/22750

Pinned Bun 1.3.14 focused gmail-mime-parts suite at this head:
  8/8 passed in 4 ms
  covers: depth 32 accept, depth 33 throw, sparse 2048-hole throw,
  cyclic part throw, zero-call accessors, empty-child sibling skip,
  abort-on-match, 20k nest GMAIL_MIME_PART_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  collectMessagePart 20k MIME nest: RangeError 3.07 ms
  cyclic part.parts=[part]: RangeError 4.80 ms
  JSON.parse of same 20k nest: ok 0.89 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:637e3dd1dc6c014e75cc745a86044d5be2abfef3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
