### PR TITLE
fix(personal-assistant): bind completion attribution timestamp

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.completion-attribution.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.completion-attribution.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Deterministic domain-boundary coverage for completed occurrence attribution.
+ * The harness uses the real definitions service with injected repository
+ * collaborators and verifies the timestamp produced by the mutation boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { LifeOpsOccurrence } from "../../contracts/index.js";
+import type { LifeOpsContext } from "../lifeops-context.js";
+import {
+  type DefinitionsDeps,
+  DefinitionsDomain,
+} from "./definitions-service.js";
+
+describe("DefinitionsDomain completion attribution", () => {
+  it("attributes completion with the authoritative mutation timestamp", async () => {
+    const completedAt = "2026-08-19T22:15:00.000Z";
+    const occurrence = {
+      id: "occurrence-1",
+      agentId: "agent-1",
+      definitionId: "definition-1",
+      occurrenceKey: "2026-08-19",
+      state: "pending",
+      snoozedUntil: null,
+      completionPayload: null,
+      updatedAt: "2026-08-19T21:00:00.000Z",
+    } as unknown as LifeOpsOccurrence;
+    const view = { occurrence: { id: occurrence.id } };
+    const repository = {
+      updateOccurrence: vi.fn(async (updated: LifeOpsOccurrence) => {
+        // Persistence adapters may serialize the generic JSON payload. Event
+        // attribution must retain the typed timestamp created before this call.
+        (updated as { completionPayload: unknown }).completionPayload = null;
+      }),
+      getOccurrenceView: vi.fn(async () => view),
+      attributeBriefItemEngagement: vi.fn(async () => null),
+    };
+    const ctx = {
+      agentId: () => "agent-1",
+      repository,
+      recordAudit: vi.fn(async () => undefined),
+      runtime: { reportError: vi.fn() },
+    } as unknown as LifeOpsContext;
+    const deps = {
+      getFreshOccurrence: vi.fn(async () => ({
+        definition: { id: "definition-1" },
+        occurrence,
+      })),
+      awardWebsiteAccessGrant: vi.fn(async () => undefined),
+      refreshDefinitionOccurrences: vi.fn(async () => undefined),
+      syncWebsiteAccessState: vi.fn(async () => undefined),
+      resolveReminderEscalation: vi.fn(async () => undefined),
+    } as unknown as DefinitionsDeps;
+
+    const result = await new DefinitionsDomain(ctx, deps).completeOccurrence(
+      occurrence.id,
+      {},
+      new Date(completedAt),
+    );
+
+    expect(result).toBe(view);
+    expect(repository.attributeBriefItemEngagement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventAt: completedAt,
+        domainEventId: `occurrence_completed:${occurrence.id}:${completedAt}`,
+      }),
+    );
+    expect(deps.resolveReminderEscalation).toHaveBeenCalledWith(
+      expect.objectContaining({ resolvedAt: completedAt }),
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
@@ -493,7 +493,7 @@ export class DefinitionsDomain {
         metadata: cloneRecord(request.metadata),
         previousState: occurrence.state,
       },
-      updatedAt: now.toISOString(),
+      updatedAt: completedAt,
     };
     await this.ctx.repository.updateOccurrence(updatedOccurrence);
     await this.ctx.recordAudit(
@@ -519,7 +519,7 @@ export class DefinitionsDomain {
     await this.deps.resolveReminderEscalation({
       ownerType: "occurrence",
       ownerId: updatedOccurrence.id,
-      resolvedAt: now.toISOString(),
+      resolvedAt: completedAt,
       resolution: "completed",
       note: normalizeOptionalString(request.note) ?? null,
     });


### PR DESCRIPTION
Closes #22718.

Captures the completion timestamp once at the mutation boundary and reuses it for the persisted payload, reminder resolution, completion event, and deterministic event id. The regression test deliberately clears the generic completion payload after persistence and proves attribution still uses the captured timestamp.

Validation:
- focused completion-attribution test: 1 passed, 3 assertions
- mutation check: changing eventAt to a fresh timestamp makes the regression test fail
- personal-assistant typecheck, lint, and build: passed
- `bun run verify` on combined current-develop integration: 360/360 Turbo tasks passed; all repository audits passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->