### PR TITLE
fix(cloud): restore explicit mock export contracts

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
@@ -125,11 +125,15 @@ mock.module("@/lib/services/ai-billing-records", () => ({
 }));
 mock.module("@/lib/services/inference-admission-gate", () => ({
   isInferenceAdmissionDispatchMarkError: () => false,
+  warmInferenceAdmissionGate: async () => undefined,
+  warmInferenceRateLimitGate: async () => undefined,
 }));
 mock.module("@/lib/services/inference-billing-fast-path", () => ({
   InferenceBalanceCacheWarmingError: class extends Error {},
 }));
 mock.module("@/lib/services/shared-runtime/run-shared-agent-turn", () => ({
+  appendSharedInput: mock(),
+  appendSharedTurn: mock(),
   resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
   runSharedAgentTurn: async (input: {
     message: string;

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as realAgentGithubReturn from "@/lib/services/agent-github-return";
 
 const createLifeOpsGithubReturnResponse = mock(
   () => new Response("ok", { status: 200 }),
@@ -14,6 +15,8 @@ const createLifeOpsGithubReturnResponse = mock(
 
 mock.module("@/lib/services/agent-github-return", () => ({
   createLifeOpsGithubReturnResponse,
+  normalizePostMessageTargetOrigin:
+    realAgentGithubReturn.normalizePostMessageTargetOrigin,
 }));
 
 const route = (await import("./route")).default;

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts
@@ -43,13 +43,18 @@ mock.module("@/lib/services/shared-runtime/canonical-scoped-stream", () => ({
 }));
 
 mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  commitPersonalProvisionalHistoryConvergence: mock(),
   coordinateSharedConversationPrewarm: mock(),
   coordinateSharedLifecycleEvent: mock(),
+  preparePersonalProvisionalHistoryConvergence: mock(),
+  purgeSharedConversationRooms: mock(),
+  releasePersonalProvisionalHistoryConvergence: mock(),
 }));
 
 mock.module("@/lib/services/shared-runtime/personal-shared-agent", () => ({
   isPersonalSharedAgentId: () => false,
   personalSharedAgent: () => null,
+  personalSharedAgentId: () => "personal-agent",
 }));
 
 const { createInternalElizaConversationFetch } = await import(

--- a/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
@@ -8,10 +8,14 @@ import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 const fakeLogger = {
   logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
 };
+class MockElizaError extends Error {}
 mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
+  ElizaError: MockElizaError,
+  isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   redactLogArgs: (a: unknown) => a,
+  redactSensitiveText: (text: string) => text,
 }));
 
 import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";

--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -49,7 +49,9 @@ const findByIdAndOrg = mock(async () => sharedAgent);
 const findByIdInOrganization = mock(async () => linkedCharacter);
 
 mock.module("@/db/repositories/agent-sandboxes", () => ({
+  PRE_DELETE_BACKUP_RETENTION_MS: 0,
   agentSandboxesRepository: { findByIdAndOrg },
+  prepareAgentBackupInsertData: mock(),
 }));
 mock.module("@/db/repositories/characters", () => ({
   userCharactersRepository: { findByIdInOrganization },
@@ -59,6 +61,10 @@ mock.module("@/db/client", () => ({
 }));
 const warmInferenceAdmissionSnapshot = mock(async () => undefined);
 mock.module("@/lib/services/inference-admission-snapshot", () => ({
+  getInferenceAdmissionSnapshotCacheOnly: mock(),
+  InferenceAdmissionSnapshotCacheWarmingError: class extends Error {},
+  inferenceRateLimitConfig: mock(),
+  loadInferenceAdmissionSnapshot: mock(),
   warmInferenceAdmissionSnapshot,
 }));
 const warmInferenceAdmissionGate = mock(async () => undefined);

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -17,11 +17,15 @@ import { decode, encode } from "@msgpack/msgpack";
 const fakeLogger = {
   logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
 };
+class MockElizaError extends Error {}
 mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/cloud-shared/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
+  ElizaError: MockElizaError,
+  isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   redactLogArgs: (args: unknown) => args,
+  redactSensitiveText: (text: string) => text,
 }));
 
 import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";

--- a/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
+++ b/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
@@ -55,8 +55,11 @@ const apiRoot = new URL("../../../src", import.meta.url).href;
 // the DB-free unit lane (matches the sibling mint-consent route test).
 mock.module("@elizaos/core", () => ({
   ...workerCoreStub,
+  ElizaError: workerCoreStub.ElizaError,
+  isElizaError: workerCoreStub.isElizaError,
   isSensitiveKeyName: () => false,
   redactLogArgs: (a: unknown) => a,
+  redactSensitiveText: workerCoreStub.redactSensitiveText,
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -73,6 +76,10 @@ mock.module(`${sharedRoot}/lib/auth/workers-hono-auth.ts`, () => ({
 // provisioning-jobs-delete-enqueue.test.ts) still resolve them.
 const cloudWorkerErrorsStub = () => ({
   ...realCloudWorkerErrorsExports,
+  ApiError: realCloudWorkerErrors.ApiError,
+  AuthenticationError: realCloudWorkerErrors.AuthenticationError,
+  ForbiddenError: realCloudWorkerErrors.ForbiddenError,
+  ValidationError: realCloudWorkerErrors.ValidationError,
   jsonError: (
     c: { json: (body: unknown, status: number) => Response },
     status: number,

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -92,6 +92,25 @@ const realFetch = globalThis.fetch;
 const cacheGet = mock(async () => cachedVoiceResponse);
 const cacheHas = mock(async () => true);
 const cachePut = mock(async () => true);
+class MockElizaError extends Error {
+  code: string;
+  context?: Record<string, unknown>;
+  severity?: string;
+  constructor(
+    message: string,
+    options: {
+      code: string;
+      context?: Record<string, unknown>;
+      severity?: string;
+    },
+  ) {
+    super(message);
+    this.name = "ElizaError";
+    this.code = options.code;
+    this.context = options.context;
+    this.severity = options.severity;
+  }
+}
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   ApiError: class ApiError extends Error {
@@ -114,25 +133,9 @@ mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
 }));
 
 mock.module("@elizaos/core", () => ({
-  ElizaError: class ElizaError extends Error {
-    code: string;
-    context?: Record<string, unknown>;
-    severity?: string;
-    constructor(
-      message: string,
-      options: {
-        code: string;
-        context?: Record<string, unknown>;
-        severity?: string;
-      },
-    ) {
-      super(message);
-      this.name = "ElizaError";
-      this.code = options.code;
-      this.context = options.context;
-      this.severity = options.severity;
-    }
-  },
+  ElizaError: MockElizaError,
+  isElizaError: (error: unknown) => error instanceof MockElizaError,
+  redactSensitiveText: (text: string) => text,
 }));
 
 mock.module("@/lib/auth", () => ({

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-payment-required-resource.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-payment-required-resource.test.ts
@@ -35,6 +35,7 @@ mock.module("../x402-facilitator", () => ({
 const REAL_CLOUD_BINDINGS = { ...realCloudBindings };
 mock.module("../../runtime/cloud-bindings", () => ({
   ...REAL_CLOUD_BINDINGS,
+  getCloudBinding: realCloudBindings.getCloudBinding,
   getCloudAwareEnv: () => ({
     X402_NETWORK: "base",
     X402_RECIPIENT_ADDRESS: RECIPIENT,

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-hetzner-attestation.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-hetzner-attestation.test.ts
@@ -52,6 +52,7 @@ mock.module("./docker-ssh", () => ({
 
 mock.module("./node-disk-manager", () => ({
   ...realNodeDisk,
+  diskHealthVerdict: realNodeDiskNs.diskHealthVerdict,
   probeNodeDiskUsage: async () => null,
 }));
 

--- a/packages/scripts/audit-mock-module-exports.baseline.json
+++ b/packages/scripts/audit-mock-module-exports.baseline.json
@@ -52,10 +52,6 @@
     "count": 1
   },
   {
-    "finding": "[missing-export] packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts mock \"@/lib/services/shared-runtime/run-shared-agent-turn\" is missing bound export(s): appendSharedTurn",
-    "count": 1
-  },
-  {
     "finding": "[missing-export] packages/cloud/api/__tests__/stripe-event-clawback.test.ts mock \"@/lib/services/ai-billing\" is missing bound export(s): getAffiliatePayoutSourceId, reserveFlatUsageCredits",
     "count": 1
   },
@@ -132,10 +128,6 @@
     "count": 1
   },
   {
-    "finding": "[missing-export] packages/cloud/api/src/shared-runtime-conversation.test.ts mock \"@/lib/runtime/cloud-bindings\" is missing bound export(s): getCloudAwareEnv, getCloudBinding",
-    "count": 1
-  },
-  {
     "finding": "[missing-export] packages/cloud/api/v1/credits/checkout/route.json.test.ts mock \"@/db/helpers\" is missing bound export(s): dbWrite, writeTransaction",
     "count": 1
   },
@@ -164,10 +156,6 @@
     "count": 1
   },
   {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts mock \"@elizaos/core\" is missing bound export(s): ElizaError",
-    "count": 1
-  },
-  {
     "finding": "[missing-export] packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts mock \"@/db/client\" is missing bound export(s): db, dbRead, dbWrite, getDbConnectionInfo",
     "count": 1
   },
@@ -180,27 +168,11 @@
     "count": 1
   },
   {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts mock \"@/lib/services/inference-admission-snapshot\" is missing bound export(s): getInferenceAdmissionSnapshotCacheOnly, InferenceAdmissionSnapshotCacheWarmingError, inferenceRateLimitConfig",
-    "count": 1
-  },
-  {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts mock \"@elizaos/core\" is missing bound export(s): ElizaError",
-    "count": 1
-  },
-  {
     "finding": "[missing-export] packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts mock \"@/lib/cache/redis-factory\" is missing bound export(s): hasRedisConfig, isCloudflareWorkerRuntime",
     "count": 1
   },
   {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts mock \"@/lib/api/cloud-worker-errors\" is missing bound export(s): ApiError",
-    "count": 1
-  },
-  {
     "finding": "[missing-export] packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts mock \"@/lib/cache/redis-factory\" is missing bound export(s): isCloudflareWorkerRuntime",
-    "count": 1
-  },
-  {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts mock \"@elizaos/core\" is missing bound export(s): ElizaError",
     "count": 1
   },
   {
@@ -241,10 +213,6 @@
   },
   {
     "finding": "[missing-export] packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts mock \"@/lib/services/credits\" is missing bound export(s): APP_CHAT_RESERVATION_SETTLEMENT_MARKER, COST_BUFFER, creditsService, MIN_RESERVATION, ReservationNotFoundError",
-    "count": 1
-  },
-  {
-    "finding": "[missing-export] packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts mock \"@elizaos/core\" is missing bound export(s): canRequesterMutateDocument, ChannelType, DatabaseAdapter, decryptedCharacter, DOCUMENT_LIST_QUERY_CAPABILITY_VERSION, documentMutationSnapshotMatches, documentRoleHasGlobalVisibility, encryptedCharacter, isElizaError, logger, normalizePairingPageOptions, redactSensitiveText, Service, validateDocumentFragmentQueryParams, validateDocumentListQueryParams, validateDocumentRequesterContext, validateQueryEntitiesPagination, validateUuid",
     "count": 1
   },
   {


### PR DESCRIPTION
Closes #22720.

Restores the explicit exports required by Bun mock-module replacement semantics across cloud API and shared tests. It also removes eight stale ratchet entries without adding new baseline debt.

Validation:
- 10 changed test files: 123 passed, 500 assertions
- cloud API typecheck, production Worker dry-run, and lint: passed
- cloud shared typecheck and lint: passed
- mock-export audit self-tests: 18 passed
- repository mock-export audit: 3,279 mocks across 652 files passed; baseline reduced to 102 known instances
- `bun run verify` on combined current-develop integration: 360/360 Turbo tasks passed; all repository audits passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->