### PR TITLE
fix(core): constrain provider integration error codes

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -88,6 +88,12 @@ digests, request digest, opaque account, capability, operation, input digest,
 and post-authorization chronology. Provider payloads and secrets never belong
 in requests, decisions, confirmations, errors, or receipts.
 
+Policy denials and execution failures use the exported canonical
+`CAPABILITY_POLICY_DENIAL_CODES` and `CAPABILITY_EXECUTION_ERROR_CODES`
+classifications. Adapters must map provider-specific status, prose, and payloads
+to those values; arbitrary provider error text is rejected at normalization and
+must not be forwarded through public error context.
+
 ### Bounded pairing operator reads
 
 `PairingService` keeps its existing complete-array methods (`listPendingRequests`

--- a/packages/core/src/types/provider-integrations.test.ts
+++ b/packages/core/src/types/provider-integrations.test.ts
@@ -352,6 +352,47 @@ describe("provider integration contracts", () => {
 		expect(serializedErrors.join("\n")).not.toContain(sentinel);
 	});
 
+	it("rejects provider-controlled policy and execution codes without leaking them", () => {
+		const sentinel = "secret-token-sentinel";
+		const selected = bound();
+		const deniedPolicy = decision(selected, {
+			outcome: "denied",
+			reasonCode: "risk_policy_denied",
+		});
+		delete deniedPolicy.confirmation;
+		expect(normalizeCapabilityPolicyDecision(deniedPolicy)).toMatchObject({
+			outcome: "denied",
+			reasonCode: "risk_policy_denied",
+		});
+		const serializedErrors: string[] = [];
+		for (const normalize of [
+			() =>
+				normalizeCapabilityPolicyDecision({
+					...deniedPolicy,
+					reasonCode: sentinel,
+				}),
+			() =>
+				normalizeCapabilityExecutionOutcome(
+					{
+						contractVersion: VERSION,
+						status: "error",
+						code: sentinel,
+						retryable: false,
+					},
+					(value) => value,
+				),
+		]) {
+			try {
+				normalize();
+			} catch (error) {
+				serializedErrors.push(JSON.stringify(error));
+			}
+		}
+
+		expect(serializedErrors).toHaveLength(2);
+		expect(serializedErrors.join("\n")).not.toContain(sentinel);
+	});
+
 	it("sanitizes malformed nested effect proof errors", async () => {
 		const authorization = await allowedAuthorization();
 		const sentinel = "secret-token-sentinel";
@@ -782,11 +823,11 @@ describe("provider integration contracts", () => {
 				{
 					contractVersion: VERSION,
 					status: "error",
-					code: "UPSTREAM_SCHEMA_DRIFT",
+					code: "schema_drift",
 					retryable: false,
 				},
 				normalizeString,
 			),
-		).toMatchObject({ status: "error", code: "UPSTREAM_SCHEMA_DRIFT" });
+		).toMatchObject({ status: "error", code: "schema_drift" });
 	});
 });

--- a/packages/core/src/types/provider-integrations.ts
+++ b/packages/core/src/types/provider-integrations.ts
@@ -47,6 +47,30 @@ export const CAPABILITY_UNAVAILABLE_CODES = [
 export type CapabilityUnavailableCode =
 	(typeof CAPABILITY_UNAVAILABLE_CODES)[number];
 
+export const CAPABILITY_POLICY_DENIAL_CODES = [
+	"account_policy_denied",
+	"capability_policy_denied",
+	"organization_policy_denied",
+	"risk_policy_denied",
+	"user_policy_denied",
+] as const;
+export type CapabilityPolicyDenialCode =
+	(typeof CAPABILITY_POLICY_DENIAL_CODES)[number];
+
+export const CAPABILITY_EXECUTION_ERROR_CODES = [
+	"authentication_failed",
+	"authorization_failed",
+	"conflict",
+	"invalid_request",
+	"provider_error",
+	"rate_limited",
+	"schema_drift",
+	"timeout",
+	"unknown_error",
+] as const;
+export type CapabilityExecutionErrorCode =
+	(typeof CAPABILITY_EXECUTION_ERROR_CODES)[number];
+
 export interface ConnectedAccountCapability {
 	capabilityId: string;
 	riskLevel: CapabilityRiskLevel;
@@ -122,7 +146,7 @@ export type CapabilityPolicyDecision =
 	  })
 	| (CapabilityPolicyDecisionBase & {
 			outcome: "denied";
-			reasonCode: string;
+			reasonCode: CapabilityPolicyDenialCode;
 	  })
 	| (CapabilityPolicyDecisionBase & {
 			outcome: "unavailable";
@@ -206,7 +230,7 @@ export type CapabilityExecutionOutcome<T> =
 	| {
 			contractVersion: typeof PROVIDER_INTEGRATION_CONTRACT_VERSION;
 			status: "error";
-			code: string;
+			code: CapabilityExecutionErrorCode;
 			retryable: boolean;
 	  };
 
@@ -773,7 +797,11 @@ export function normalizeCapabilityPolicyDecision(
 			return Object.freeze({
 				...base,
 				outcome: "denied",
-				reasonCode: nonEmptyString(raw.reasonCode, "reasonCode", 128),
+				reasonCode: enumValue(
+					raw.reasonCode,
+					CAPABILITY_POLICY_DENIAL_CODES,
+					"reasonCode",
+				),
 			});
 		case "unavailable":
 			exactKeys(
@@ -1395,7 +1423,7 @@ export function normalizeCapabilityExecutionOutcome<T>(
 			return Object.freeze({
 				contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
 				status: "error",
-				code: nonEmptyString(raw.code, "code", 128),
+				code: enumValue(raw.code, CAPABILITY_EXECUTION_ERROR_CODES, "code"),
 				retryable: booleanValue(raw.retryable, "retryable"),
 			});
 		default:


### PR DESCRIPTION
Closes #22734.

## Summary

Post-merge review of #22643 found that policy denial `reasonCode` and execution outcome `error.code` accepted arbitrary bounded provider text. A provider-controlled sentinel could therefore cross the provider-neutral boundary and appear verbatim in serialized `ElizaError.context`, contrary to the contract's no-provider-payload/no-secret invariant.

This follow-up:

- exports finite canonical `CAPABILITY_POLICY_DENIAL_CODES` and `CAPABILITY_EXECUTION_ERROR_CODES` classifications;
- narrows the corresponding public TypeScript fields to those classifications;
- rejects arbitrary provider prose, status, and credential-shaped values through the existing sanitized enum boundary;
- documents the adapter obligation to map private provider failures to canonical categories; and
- adds an adversarial sentinel test that reaches both validators and proves the raw value is absent from serialized errors, plus a positive canonical-denial control.

## Sync and verification

Exact head: `ce57fffa9a26cfd13807b9d0cd4b7de286a63ade`

Rebased onto `origin/develop@809bd6e74a85289ab3222ed5ad9eb0bda3a2a360` immediately before push.

```text
bun test packages/core/src/types/provider-integrations.test.ts --coverage-reporter=lcov
21 pass, 0 fail, 84 assertions
provider-integrations.ts: 100% line coverage

bun run --cwd packages/core typecheck
PASS

bunx biome check packages/core/README.md packages/core/src/types/provider-integrations.ts packages/core/src/types/provider-integrations.test.ts
PASS - no fixes

git diff --check origin/develop...HEAD
PASS
```

## Evidence Gate

<!-- evidence-head:ce57fffa9a26cfd13807b9d0cd4b7de286a63ade -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive surface or external integration changed
<!-- evidence-row:backend-logs -->
- [x] [Exact-head core typecheck transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22747-ce57-typecheck.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, action, or runtime execution behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head adversarial contract transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22747-ce57-tests.log) - arbitrary policy and execution sentinels are rejected and absent from both captured `ElizaError` values; canonical `risk_policy_denied` round-trips
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct post-merge audit remediation; no contribution skill was invoked`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-postmerge-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - direct post-merge audit remediation; no contribution skill was invoked"} -->
