### PR TITLE
fix(plugin-inmemorydb): fail closed on unbounded component-data filters

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -9,7 +9,8 @@
  *
  * Implements the full batch-first interface from `@elizaos/core`'s
  * `DatabaseAdapter`; there are no single-item helpers — call sites use the
- * batch APIs (`createEntities`, `getMemoriesByIds`, etc.).
+ * batch APIs (`createEntities`, `getMemoriesByIds`, etc.). Nested
+ * `componentDataFilter` matching is bounded in `data-contains-filter.ts`.
  */
 
 import { randomUUID } from "node:crypto";
@@ -66,6 +67,7 @@ import {
   type World,
   withinCreatedAtWindow,
 } from "@elizaos/core";
+import { dataContainsFilter } from "./data-contains-filter";
 import { EphemeralHNSW } from "./hnsw";
 import { COLLECTIONS, type IStorage } from "./types";
 
@@ -104,38 +106,6 @@ interface StoredRelationship {
   tags?: string[];
   metadata?: Metadata;
   createdAt?: string;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function dataContainsFilter(value: unknown, filter: Record<string, unknown> | undefined): boolean {
-  if (!filter) return true;
-  if (!isPlainObject(value)) return false;
-
-  for (const [key, expected] of Object.entries(filter)) {
-    const actual = value[key];
-    if (isPlainObject(expected)) {
-      if (!dataContainsFilter(actual, expected)) return false;
-      continue;
-    }
-    if (Array.isArray(expected)) {
-      if (!Array.isArray(actual)) return false;
-      for (const expectedItem of expected) {
-        const found = actual.some((actualItem) =>
-          isPlainObject(expectedItem)
-            ? dataContainsFilter(actualItem, expectedItem)
-            : actualItem === expectedItem
-        );
-        if (!found) return false;
-      }
-      continue;
-    }
-    if (actual !== expected) return false;
-  }
-
-  return true;
 }
 
 interface StoredCacheEntry<T = unknown> {

--- a/plugins/plugin-inmemorydb/data-contains-filter.test.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.test.ts
@@ -133,6 +133,13 @@ describe("dataContainsFilter", () => {
     }
   );
 
+  it("bounds cumulative array-containment comparisons", () => {
+    const actual = Array.from({ length: 1_000 }, (_, index) => index);
+    const expected = Array.from({ length: 1_000 }, (_, index) => index + 2_000);
+
+    expectUnbounded(() => dataContainsFilter({ items: actual }, { items: expected }));
+  });
+
   it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
     const nest = nestObj(8_000);
     const started = performance.now();

--- a/plugins/plugin-inmemorydb/data-contains-filter.test.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.test.ts
@@ -20,6 +20,16 @@ function nestObj(depth: number): Record<string, unknown> {
   return value;
 }
 
+function expectUnbounded(operation: () => unknown): void {
+  try {
+    operation();
+    expect.unreachable("filter should fail closed");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe(INMEMORY_FILTER_UNBOUNDED);
+  }
+}
+
 describe("dataContainsFilter", () => {
   it("matches an honest nested record", () => {
     expect(dataContainsFilter({ a: { b: 1 }, extra: true }, { a: { b: 1 } })).toBe(true);
@@ -82,6 +92,46 @@ describe("dataContainsFilter", () => {
     expect(dataContainsFilter(hostile, { safe: 1 })).toBe(true);
     expect(invoked).toBe(0);
   });
+
+  it.each(["filter", "value"] as const)(
+    "fails closed without invoking enumerable %s accessors",
+    (side) => {
+      let invoked = 0;
+      const accessor = Object.defineProperty({}, "role", {
+        enumerable: true,
+        get() {
+          invoked += 1;
+          return "admin";
+        },
+      });
+
+      const value = side === "value" ? accessor : { role: "user" };
+      const filter = side === "filter" ? accessor : { role: "admin" };
+      expectUnbounded(() => dataContainsFilter(value, filter));
+      expect(invoked).toBe(0);
+    }
+  );
+
+  it.each(["filter", "value"] as const)(
+    "fails closed without invoking array-element %s accessors",
+    (side) => {
+      let invoked = 0;
+      const accessor: unknown[] = [];
+      Object.defineProperty(accessor, "0", {
+        enumerable: true,
+        get() {
+          invoked += 1;
+          return "admin";
+        },
+      });
+      accessor.length = 1;
+
+      const value = { roles: side === "value" ? accessor : ["admin"] };
+      const filter = { roles: side === "filter" ? accessor : ["admin"] };
+      expectUnbounded(() => dataContainsFilter(value, filter));
+      expect(invoked).toBe(0);
+    }
+  );
 
   it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
     const nest = nestObj(8_000);

--- a/plugins/plugin-inmemorydb/data-contains-filter.test.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Deterministic tests for the in-memory component-data filter bound. No live
+ * database: the matcher is the production walk used by getEntities.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  dataContainsFilter,
+  INMEMORY_FILTER_UNBOUNDED,
+  MAX_INMEMORY_FILTER_DEPTH,
+  MAX_INMEMORY_FILTER_NODES,
+} from "./data-contains-filter";
+
+function nestObj(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { leaf: true };
+  for (let index = 0; index < depth; index += 1) {
+    value = { k: value };
+  }
+  return value;
+}
+
+describe("dataContainsFilter", () => {
+  it("matches an honest nested record", () => {
+    expect(dataContainsFilter({ a: { b: 1 }, extra: true }, { a: { b: 1 } })).toBe(true);
+    expect(dataContainsFilter({ a: { b: 2 } }, { a: { b: 1 } })).toBe(false);
+  });
+
+  it(`accepts a ${MAX_INMEMORY_FILTER_DEPTH}-deep nest`, () => {
+    const nest = nestObj(MAX_INMEMORY_FILTER_DEPTH);
+    expect(dataContainsFilter(nest, nest)).toBe(true);
+  });
+
+  it(`throws ${INMEMORY_FILTER_UNBOUNDED} one past depth ${MAX_INMEMORY_FILTER_DEPTH}`, () => {
+    const nest = nestObj(MAX_INMEMORY_FILTER_DEPTH + 1);
+    try {
+      dataContainsFilter(nest, nest);
+      expect.unreachable("filter should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(INMEMORY_FILTER_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${INMEMORY_FILTER_UNBOUNDED} past ${MAX_INMEMORY_FILTER_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_INMEMORY_FILTER_NODES] = { leaf: true };
+    const value = { items: sparse };
+    const filter = { items: sparse };
+    try {
+      dataContainsFilter(value, filter);
+      expect.unreachable("filter should fail closed on over-budget sparse length");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(INMEMORY_FILTER_UNBOUNDED);
+    }
+  });
+
+  it("throws on a cyclic filter without hanging", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const started = performance.now();
+    try {
+      dataContainsFilter(cyclic, cyclic);
+      expect.unreachable("filter should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(INMEMORY_FILTER_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while matching", () => {
+    let invoked = 0;
+    const hostile = {
+      safe: 1,
+      get trap(): Record<string, unknown> {
+        invoked += 1;
+        return nestObj(20_000);
+      },
+    };
+    expect(dataContainsFilter(hostile, { safe: 1 })).toBe(true);
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const nest = nestObj(8_000);
+    const started = performance.now();
+    try {
+      dataContainsFilter(nest, nest);
+      expect.unreachable("filter should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(INMEMORY_FILTER_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-inmemorydb/data-contains-filter.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.ts
@@ -1,0 +1,132 @@
+/**
+ * Bounds the nested component-data filter walk used by InMemoryDatabaseAdapter.
+ * Stored component `data` and query `componentDataFilter` are untrusted JSON;
+ * the previous recursive matcher RangeError'd an 8k nest on Node 24.15.0.
+ * Depth, node, and cycle limits are all load-bearing.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_INMEMORY_FILTER_DEPTH = 32;
+export const MAX_INMEMORY_FILTER_NODES = 2_048;
+export const INMEMORY_FILTER_UNBOUNDED = "INMEMORY_FILTER_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visitingValues: WeakSet<object>;
+  visitingFilters: WeakSet<object>;
+};
+
+function failUnbounded(context: Record<string, unknown>): never {
+  throw new ElizaError("In-memory component filter exceeds the match walk budget", {
+    code: INMEMORY_FILTER_UNBOUNDED,
+    context,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_INMEMORY_FILTER_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_INMEMORY_FILTER_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function ownEnumerableDataEntries(value: object): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [];
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string") continue;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !("value" in descriptor)) continue;
+    entries.push([key, descriptor.value]);
+  }
+  return entries;
+}
+
+function enter(value: object, set: "visitingValues" | "visitingFilters", ctx: WalkContext): void {
+  if (ctx[set].has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx[set].add(value);
+}
+
+export function dataContainsFilter(
+  value: unknown,
+  filter: Record<string, unknown> | undefined
+): boolean {
+  if (!filter) return true;
+  return dataContainsFilterInner(value, filter, 0, {
+    visits: 0,
+    visitingValues: new WeakSet<object>(),
+    visitingFilters: new WeakSet<object>(),
+  });
+}
+
+function dataContainsFilterInner(
+  value: unknown,
+  filter: Record<string, unknown>,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): boolean {
+  if (depth > MAX_INMEMORY_FILTER_DEPTH) {
+    failUnbounded({ depth, max: MAX_INMEMORY_FILTER_DEPTH });
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (!isPlainObject(value)) return false;
+
+  enter(value, "visitingValues", ctx);
+  enter(filter, "visitingFilters", ctx);
+  try {
+    const expectedEntries = ownEnumerableDataEntries(filter);
+    reserve(ctx, expectedEntries.length);
+    for (const [key, expected] of expectedEntries) {
+      const actualDescriptor = Object.getOwnPropertyDescriptor(value, key);
+      const actual =
+        actualDescriptor && "value" in actualDescriptor ? actualDescriptor.value : undefined;
+
+      if (isPlainObject(expected)) {
+        if (!dataContainsFilterInner(actual, expected, depth + 1, ctx, true)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (Array.isArray(expected)) {
+        if (!Array.isArray(actual)) return false;
+        reserve(ctx, expected.length + actual.length);
+        for (let expectedIndex = 0; expectedIndex < expected.length; expectedIndex += 1) {
+          if (!(expectedIndex in expected)) continue;
+          const expectedItem = expected[expectedIndex];
+          let found = false;
+          for (let actualIndex = 0; actualIndex < actual.length; actualIndex += 1) {
+            if (!(actualIndex in actual)) continue;
+            const actualItem = actual[actualIndex];
+            const matched = isPlainObject(expectedItem)
+              ? dataContainsFilterInner(actualItem, expectedItem, depth + 1, ctx, true)
+              : actualItem === expectedItem;
+            if (matched) {
+              found = true;
+              break;
+            }
+          }
+          if (!found) return false;
+        }
+        continue;
+      }
+
+      if (actual !== expected) return false;
+    }
+    return true;
+  } finally {
+    ctx.visitingFilters.delete(filter);
+    ctx.visitingValues.delete(value);
+  }
+}

--- a/plugins/plugin-inmemorydb/data-contains-filter.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.ts
@@ -139,6 +139,9 @@ function dataContainsFilterInner(
             if (!("value" in actualDescriptor)) {
               failUnbounded({ accessor: true, side: "value" });
             }
+            // Containment is a Cartesian search, so input-slot accounting alone
+            // does not bound the number of comparisons.
+            reserve(ctx, 1);
             const actualItem = actualDescriptor.value;
             const matched = isPlainObject(expectedItem)
               ? dataContainsFilterInner(actualItem, expectedItem, depth + 1, ctx, true)

--- a/plugins/plugin-inmemorydb/data-contains-filter.ts
+++ b/plugins/plugin-inmemorydb/data-contains-filter.ts
@@ -44,10 +44,30 @@ function ownEnumerableDataEntries(value: object): Array<[string, unknown]> {
   for (const key of Reflect.ownKeys(value)) {
     if (typeof key !== "string") continue;
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (!descriptor?.enumerable || !("value" in descriptor)) continue;
+    if (!descriptor?.enumerable) continue;
+    if (!("value" in descriptor)) {
+      failUnbounded({ accessor: true, side: "filter" });
+    }
     entries.push([key, descriptor.value]);
   }
   return entries;
+}
+
+function ownDataValue(value: object, key: string, side: "filter" | "value"): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) {
+    failUnbounded({ accessor: true, side });
+  }
+  return descriptor.value;
+}
+
+function arrayLength(value: unknown[], side: "filter" | "value"): number {
+  const length = ownDataValue(value, "length", side);
+  if (!Number.isSafeInteger(length) || (length as number) < 0) {
+    failUnbounded({ arrayLength: true, side });
+  }
+  return length as number;
 }
 
 function enter(value: object, set: "visitingValues" | "visitingFilters", ctx: WalkContext): void {
@@ -88,9 +108,7 @@ function dataContainsFilterInner(
     const expectedEntries = ownEnumerableDataEntries(filter);
     reserve(ctx, expectedEntries.length);
     for (const [key, expected] of expectedEntries) {
-      const actualDescriptor = Object.getOwnPropertyDescriptor(value, key);
-      const actual =
-        actualDescriptor && "value" in actualDescriptor ? actualDescriptor.value : undefined;
+      const actual = ownDataValue(value, key, "value");
 
       if (isPlainObject(expected)) {
         if (!dataContainsFilterInner(actual, expected, depth + 1, ctx, true)) {
@@ -101,14 +119,27 @@ function dataContainsFilterInner(
 
       if (Array.isArray(expected)) {
         if (!Array.isArray(actual)) return false;
-        reserve(ctx, expected.length + actual.length);
-        for (let expectedIndex = 0; expectedIndex < expected.length; expectedIndex += 1) {
-          if (!(expectedIndex in expected)) continue;
-          const expectedItem = expected[expectedIndex];
+        const expectedLength = arrayLength(expected, "filter");
+        const actualLength = arrayLength(actual, "value");
+        reserve(ctx, expectedLength + actualLength);
+        for (let expectedIndex = 0; expectedIndex < expectedLength; expectedIndex += 1) {
+          const expectedDescriptor = Object.getOwnPropertyDescriptor(
+            expected,
+            String(expectedIndex)
+          );
+          if (!expectedDescriptor) continue;
+          if (!("value" in expectedDescriptor)) {
+            failUnbounded({ accessor: true, side: "filter" });
+          }
+          const expectedItem = expectedDescriptor.value;
           let found = false;
-          for (let actualIndex = 0; actualIndex < actual.length; actualIndex += 1) {
-            if (!(actualIndex in actual)) continue;
-            const actualItem = actual[actualIndex];
+          for (let actualIndex = 0; actualIndex < actualLength; actualIndex += 1) {
+            const actualDescriptor = Object.getOwnPropertyDescriptor(actual, String(actualIndex));
+            if (!actualDescriptor) continue;
+            if (!("value" in actualDescriptor)) {
+              failUnbounded({ accessor: true, side: "value" });
+            }
+            const actualItem = actualDescriptor.value;
             const matched = isPlainObject(expectedItem)
               ? dataContainsFilterInner(actualItem, expectedItem, depth + 1, ctx, true)
               : actualItem === expectedItem;

--- a/plugins/plugin-inmemorydb/query-entities.test.ts
+++ b/plugins/plugin-inmemorydb/query-entities.test.ts
@@ -122,4 +122,23 @@ describe("plugin-inmemorydb queryEntities", () => {
       })
     ).rejects.toThrow(`queryEntities ${field} must be a non-negative safe integer`);
   });
+
+  it("fails closed on accessor-bearing component filters before returning entities", async () => {
+    let invoked = 0;
+    const filter = Object.defineProperty({}, "role", {
+      enumerable: true,
+      get() {
+        invoked += 1;
+        return "admin";
+      },
+    });
+
+    await expect(
+      adapter.queryEntities({
+        entityIds: [entityOne, entityTwo],
+        componentDataFilter: filter,
+      })
+    ).rejects.toMatchObject({ code: "INMEMORY_FILTER_UNBOUNDED" });
+    expect(invoked).toBe(0);
+  });
 });

--- a/plugins/plugin-inmemorydb/query-entities.test.ts
+++ b/plugins/plugin-inmemorydb/query-entities.test.ts
@@ -141,4 +141,30 @@ describe("plugin-inmemorydb queryEntities", () => {
     ).rejects.toMatchObject({ code: "INMEMORY_FILTER_UNBOUNDED" });
     expect(invoked).toBe(0);
   });
+
+  it("fails closed on an 8k filter at the real query boundary", async () => {
+    const hostile = nestObj(8_000);
+    await adapter.createComponents([
+      component(
+        "40000000-0000-0000-0000-000000000004" as UUID,
+        entityThree,
+        "profile",
+        worldOne,
+        hostile
+      ),
+    ]);
+
+    await expect(
+      adapter.queryEntities({
+        entityIds: [entityThree],
+        componentDataFilter: hostile,
+      })
+    ).rejects.toMatchObject({ code: "INMEMORY_FILTER_UNBOUNDED" });
+  });
 });
+
+function nestObj(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { leaf: true };
+  for (let index = 0; index < depth; index += 1) value = { k: value };
+  return value;
+}


### PR DESCRIPTION
Closes #22751

## Problem

`InMemoryDatabaseAdapter.getEntities` matches `component.data` against `componentDataFilter` with an unbounded recursive walk.

On `origin/develop`, that matcher has no depth, node, or cycle budget.

**Origin red (exact walk, pinned Node 24.15.0):**

| Input | Node 24.15.0 |
|---|---|
| 8k-deep object nest | RangeError 8.05 ms |
| 20k-deep object nest | RangeError 8.45 ms |
| cyclic `{ self }` | RangeError 7.31 ms |

Product path: `getEntities({ componentDataFilter })` over stored component JSON. A hostile nest RangeErrors the in-memory adapter instead of returning a typed miss.

Not leftover-tax. Not a twin of `#22737` blocked-object-key, `#22744` Gmail MIME, `#22716` workflow clone, `#22707` goal prompt-value, or `#22709` jsonb sanitize. Distinct host: in-memory component-data filter.

## Change

- Extract `dataContainsFilter` to `data-contains-filter.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`INMEMORY_FILTER_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors in filters, stored objects, or array elements fail closed without invocation. Sparse holes consume the node budget.
- Honest nested records still match as before.

## Exact-head evidence

Evidence revision: `bfba81eefd89868c852c5ec192daeff4fbdcf593`, based on `develop` `7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea`. Rebased onto current develop. Owning issue: #22751.

- Pinned Bun 1.3.14 focused helper + real `queryEntities` suites: **20/20 passed**; full package: **39/39 passed**.
- Cumulatively charges Cartesian array-containment comparisons so the 2048-node budget also bounds work.\n- Covers honest match, depth 32 accept, depth 33 throw, sparse 2048-hole throw, cyclic throw, zero-call object and array accessors on both filter/value sides, the real `queryEntities` accessor and 8k-depth failure boundaries, and an 8k nest that throws `INMEMORY_FILTER_UNBOUNDED` (not `RangeError`).
- Biome on the four changed files: clean.
- `git diff --check`: clean.

Fork contributors cannot upload to the maintainer `pr-evidence` release (HTTP 404). Domain receipt is the pasted exact-head transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - in-memory adapter filter; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - in-memory adapter filter; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic filter-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - in-memory adapter has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head focused suite and production-boundary receipt
<details>
<summary>22748 domain receipt at bfba81eefd89</summary>

```
#22748 domain artifact — in-memory componentDataFilter walk
exact-head: bfba81eefd89868c852c5ec192daeff4fbdcf593
based-on: origin/develop 7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea
owning-issue: https://github.com/elizaOS/eliza/issues/22751

Pinned Bun 1.3.14 focused data-contains-filter suite at this head:
  helper + real queryEntities: 20/20 passed; full package: 39/39 passed
  covers: honest match, depth 32 accept, depth 33 throw,
  sparse 2048-hole throw, cyclic throw, zero-call object/array
  accessors on filter and value sides, real queryEntities rejection,
  8k nest INMEMORY_FILTER_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  dataContainsFilter 8k nest: RangeError 8.05 ms
  dataContainsFilter 20k nest: RangeError 8.45 ms
  cyclic filter/value: RangeError 7.31 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bfba81eefd89868c852c5ec192daeff4fbdcf593 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

