### PR TITLE
fix(plugin-capacitor-bridge): complete transcript route object authorization after #22441

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
@@ -173,6 +173,24 @@ describe("iOS bridge — transcripts route object scope", () => {
 		expect(runtime.deleteMemory).not.toHaveBeenCalled();
 	});
 
+	it("canonicalizes an uppercase UUID before lookup and object authorization", async () => {
+		const transcriptId = "00000000-0000-0000-0000-0000000000bc" as UUID;
+		await runtime.createMemory(transcriptMemory(transcriptId), "transcripts");
+
+		const { status, json } = await call(
+			backend,
+			"GET",
+			`/api/transcripts/${transcriptId.toUpperCase()}`,
+		);
+		expect(status).toBe(200);
+		expect(json).toEqual(
+			expect.objectContaining({
+				transcript: expect.objectContaining({ id: transcriptId }),
+			}),
+		);
+		expect(runtime.getMemoryById).toHaveBeenCalledWith(transcriptId);
+	});
+
 	it("does not treat transcript-shaped content in another memory table as a transcript", async () => {
 		const spoofId = "00000000-0000-0000-0000-0000000000b3" as UUID;
 		const spoof = transcriptMemory(spoofId);

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleDirectCoreRoute, type IosBridgeBackend } from "./bridge.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
@@ -28,29 +28,58 @@ function createFakeRuntime(): IAgentRuntime {
 			const cap = params.count ?? params.limit;
 			return typeof cap === "number" ? rows.slice(0, cap) : rows;
 		},
-		async getMemoryById(id: UUID): Promise<Memory | null> {
+		getMemoryById: vi.fn(async (id: UUID): Promise<Memory | null> => {
 			for (const rows of tables.values()) {
 				const found = rows.find((m) => m.id === id);
 				if (found) return found;
 			}
 			return null;
-		},
+		}),
 		async createMemory(memory: Memory, tableName: string): Promise<UUID> {
 			const rows = tables.get(tableName) ?? [];
 			rows.push(memory);
 			tables.set(tableName, rows);
 			return memory.id as UUID;
 		},
-		async deleteMemory(id: UUID): Promise<void> {
+		deleteMemory: vi.fn(async (id: UUID): Promise<void> => {
 			for (const rows of tables.values()) {
 				const idx = rows.findIndex((m) => m.id === id);
 				if (idx >= 0) rows.splice(idx, 1);
 			}
-		},
-		async updateMemory(): Promise<boolean> {
-			return true;
-		},
+		}),
+		updateMemory: vi.fn(async (): Promise<boolean> => true),
 	} as unknown as IAgentRuntime;
+}
+
+function transcriptMemory(
+	id: UUID,
+	agentId: UUID = AGENT_ID,
+	transcriptId: string = id,
+): Memory {
+	const transcript = {
+		id: transcriptId,
+		title: "Scoped transcript",
+		createdAt: 1_000,
+		durationMs: 10,
+		segments: [],
+		source: "voice-session",
+		scope: "owner-private",
+		status: "ready",
+		speakerCount: 0,
+	};
+	return {
+		id,
+		entityId: agentId,
+		roomId: agentId,
+		agentId,
+		createdAt: transcript.createdAt,
+		content: { text: transcript.title, transcript: JSON.stringify(transcript) },
+		metadata: {
+			type: "custom",
+			source: "transcript",
+			transcriptId: id,
+		},
+	};
 }
 
 function makeBackend(runtime: IAgentRuntime): IosBridgeBackend {
@@ -112,6 +141,139 @@ describe("iOS bridge — transcripts route object scope", () => {
 		expect(status).toBe(404);
 		// The unrelated memory must survive.
 		expect(await runtime.getMemoryById(MESSAGE_ID)).not.toBeNull();
+	});
+
+	it("rejects an invalid UUID before the storage adapter", async () => {
+		const { status, json } = await call(
+			backend,
+			"DELETE",
+			"/api/transcripts/not-a-uuid",
+		);
+		expect(status).toBe(400);
+		expect(json).toEqual({ error: "invalid transcript id: expected UUID" });
+		expect(runtime.getMemoryById).not.toHaveBeenCalled();
+		expect(runtime.deleteMemory).not.toHaveBeenCalled();
+	});
+
+	it("does not delete another agent's transcript from the global memory id space", async () => {
+		const otherAgent = "00000000-0000-0000-0000-0000000000bb" as UUID;
+		const otherId = "00000000-0000-0000-0000-0000000000b2" as UUID;
+		await runtime.createMemory(
+			transcriptMemory(otherId, otherAgent),
+			"transcripts",
+		);
+
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${otherId}`,
+		);
+		expect(status).toBe(404);
+		expect(await runtime.getMemoryById(otherId)).not.toBeNull();
+		expect(runtime.deleteMemory).not.toHaveBeenCalled();
+	});
+
+	it("does not treat transcript-shaped content in another memory table as a transcript", async () => {
+		const spoofId = "00000000-0000-0000-0000-0000000000b3" as UUID;
+		const spoof = transcriptMemory(spoofId);
+		delete spoof.metadata;
+		await runtime.createMemory(spoof, "messages");
+
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${spoofId}`,
+		);
+		expect(status).toBe(404);
+		expect(await runtime.getMemoryById(spoofId)).not.toBeNull();
+		expect(runtime.deleteMemory).not.toHaveBeenCalled();
+	});
+
+	it("rejects transcript metadata whose embedded transcript id does not match", async () => {
+		const rowId = "00000000-0000-0000-0000-0000000000b4" as UUID;
+		await runtime.createMemory(
+			transcriptMemory(rowId, AGENT_ID, "00000000-0000-0000-0000-0000000000ff"),
+			"transcripts",
+		);
+
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${rowId}`,
+		);
+		expect(status).toBe(404);
+		expect(await runtime.getMemoryById(rowId)).not.toBeNull();
+		expect(runtime.deleteMemory).not.toHaveBeenCalled();
+	});
+
+	it("rejects transcript metadata whose persisted id does not match the row", async () => {
+		const rowId = "00000000-0000-0000-0000-0000000000b6" as UUID;
+		const row = transcriptMemory(rowId);
+		if (!row.metadata) throw new Error("test transcript metadata missing");
+		row.metadata.transcriptId = "00000000-0000-0000-0000-0000000000ff";
+		await runtime.createMemory(row, "transcripts");
+
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${rowId}`,
+		);
+		expect(status).toBe(404);
+		expect(await runtime.getMemoryById(rowId)).not.toBeNull();
+		expect(runtime.deleteMemory).not.toHaveBeenCalled();
+	});
+
+	it("revalidates scope immediately before the generic id-only delete", async () => {
+		const replacementId = "00000000-0000-0000-0000-0000000000b5" as UUID;
+		await runtime.createMemory(transcriptMemory(replacementId), "transcripts");
+		const getMemoryById = runtime.getMemoryById.bind(runtime);
+		let reads = 0;
+		runtime.getMemoryById = vi.fn(async (id: UUID) => {
+			reads += 1;
+			if (reads === 2) {
+				await runtime.deleteMemory(id);
+				const replacement = transcriptMemory(id);
+				delete replacement.metadata;
+				await runtime.createMemory(replacement, "messages");
+			}
+			return getMemoryById(id);
+		});
+
+		const { status } = await call(
+			backend,
+			"DELETE",
+			`/api/transcripts/${replacementId}`,
+		);
+		expect(status).toBe(404);
+		expect(await getMemoryById(replacementId)).not.toBeNull();
+	});
+
+	it("revalidates scope immediately before the generic id-only update", async () => {
+		const replacementId = "00000000-0000-0000-0000-0000000000b7" as UUID;
+		await runtime.createMemory(transcriptMemory(replacementId), "transcripts");
+		const getMemoryById = runtime.getMemoryById.bind(runtime);
+		let reads = 0;
+		runtime.getMemoryById = vi.fn(async (id: UUID) => {
+			reads += 1;
+			if (reads === 2) {
+				await runtime.deleteMemory(id);
+				const replacement = transcriptMemory(id);
+				delete replacement.metadata;
+				await runtime.createMemory(replacement, "messages");
+			}
+			return getMemoryById(id);
+		});
+
+		const result = await handleDirectCoreRoute(
+			backend,
+			"PUT",
+			`/api/transcripts/${replacementId}`,
+			{ body: JSON.stringify({ title: "must not overwrite replacement" }) },
+		);
+		if (!result) throw new Error("update returned null");
+		expect(result.status).toBe(404);
+		expect(await getMemoryById(replacementId)).not.toBeNull();
+		expect(runtime.updateMemory).not.toHaveBeenCalled();
 	});
 
 	it("DELETE still removes a real transcript", async () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.transcripts.encoding.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.transcripts.encoding.test.ts
@@ -110,12 +110,13 @@ describe("iOS /api/transcripts/:id encoding", () => {
 			return null;
 		};
 		const backend = makeBackend(runtime);
+		const id = "00000000-0000-0000-0000-0000000000c1";
 		const { status, json } = await call(
 			backend,
 			"GET",
-			"/api/transcripts/t%2D1",
+			`/api/transcripts/${id.replaceAll("-", "%2D")}`,
 		);
-		expect(seen).toEqual(["t-1"]);
+		expect(seen).toEqual([id]);
 		expect(status).toBe(404);
 		expect(json).toEqual({ error: "not found" });
 	});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -25,6 +25,7 @@ import {
 	type StreamChunkCallback,
 	stringToUuid,
 	type UUID,
+	validateUuid,
 } from "@elizaos/core";
 import {
 	buildBrandEnvAliases,
@@ -1547,15 +1548,57 @@ interface UpdateTranscriptRequestBody {
 }
 
 /** Parse the stored {@link Transcript} back out of a memory row's content blob. */
-function rowToTranscript(row: Memory): Transcript | null {
+function rowToTranscript(row: Memory, expectedId?: UUID): Transcript | null {
 	const raw = (row.content as { transcript?: unknown }).transcript;
 	if (typeof raw !== "string") return null;
 	try {
 		const parsed: unknown = JSON.parse(raw);
-		return parsed && typeof parsed === "object" ? (parsed as Transcript) : null;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+			return null;
+		const transcript = parsed as Partial<Transcript>;
+		if (
+			typeof transcript.id !== "string" ||
+			(expectedId !== undefined && transcript.id !== expectedId) ||
+			typeof transcript.title !== "string" ||
+			typeof transcript.createdAt !== "number" ||
+			!Number.isFinite(transcript.createdAt) ||
+			typeof transcript.durationMs !== "number" ||
+			!Number.isFinite(transcript.durationMs) ||
+			!Array.isArray(transcript.segments) ||
+			typeof transcript.source !== "string" ||
+			typeof transcript.scope !== "string" ||
+			typeof transcript.status !== "string" ||
+			typeof transcript.speakerCount !== "number" ||
+			!Number.isFinite(transcript.speakerCount)
+		) {
+			return null;
+		}
+		return transcript as Transcript;
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Authorize a transcript row returned by the global memory-id lookup. The SQL
+ * adapter does not scope `getMemoryById` by agent or expose the memory table,
+ * so the persisted transcript markers and embedded id are part of this route's
+ * object-capability boundary.
+ */
+function transcriptFromOwnedMemory(
+	runtime: IAgentRuntime,
+	row: Memory | null,
+	id: UUID,
+): Transcript | null {
+	if (!row || row.agentId !== runtime.agentId) return null;
+	if (
+		row.metadata?.type !== "custom" ||
+		row.metadata.source !== TRANSCRIPT_METADATA_TYPE ||
+		row.metadata.transcriptId !== id
+	) {
+		return null;
+	}
+	return rowToTranscript(row, id);
 }
 
 function transcriptMemoryMetadata(transcript: Transcript): MemoryMetadata {
@@ -1601,6 +1644,7 @@ async function listTranscripts(
 ): Promise<TranscriptSummary[]> {
 	const rows = await runtime.getMemories({
 		tableName: TRANSCRIPTS_TABLE,
+		agentId: runtime.agentId as UUID,
 		roomId,
 		count: limit,
 		orderBy: "createdAt",
@@ -1619,7 +1663,7 @@ async function getTranscript(
 	id: UUID,
 ): Promise<Transcript | null> {
 	const row = await runtime.getMemoryById(id);
-	return row ? rowToTranscript(row) : null;
+	return transcriptFromOwnedMemory(runtime, row, id);
 }
 
 async function persistTranscript(
@@ -1661,10 +1705,6 @@ function decodePathComponent(raw: string): string | null {
 	}
 }
 
-function decodeTranscriptId(raw: string): UUID | null {
-	return decodePathComponent(raw) as UUID | null;
-}
-
 async function handleTranscriptsRoute(
 	runtime: IAgentRuntime,
 	method: string,
@@ -1703,11 +1743,15 @@ async function handleTranscriptsRoute(
 
 	const idMatch = pathname.match(/^\/api\/transcripts\/([^/]+)$/);
 	if (!idMatch) return null;
-	const id = decodeTranscriptId(idMatch[1] ?? "");
-	if (id === null) {
+	const decodedId = decodePathComponent(idMatch[1] ?? "");
+	if (decodedId === null) {
 		return jsonResponse(400, {
 			error: "invalid transcript id: malformed URL encoding",
 		});
+	}
+	const id = validateUuid(decodedId);
+	if (id === null) {
+		return jsonResponse(400, { error: "invalid transcript id: expected UUID" });
 	}
 
 	if (method === "GET") {
@@ -1724,6 +1768,12 @@ async function handleTranscriptsRoute(
 		// and removed with a 200.
 		const existing = await getTranscript(runtime, id);
 		if (!existing) return jsonResponse(404, { error: "not found" });
+		// Re-authorize immediately before the generic id-only delete. The public
+		// runtime storage contract has no atomic predicate-delete operation, so
+		// this detects replacements after route admission while minimizing the
+		// residual interval before the destructive call.
+		const current = await getTranscript(runtime, id);
+		if (!current) return jsonResponse(404, { error: "not found" });
 		await runtime.deleteMemory(id);
 		return jsonResponse(200, { ok: true });
 	}
@@ -1739,10 +1789,16 @@ async function handleTranscriptsRoute(
 		const existing = await getTranscript(runtime, id);
 		if (!existing) return jsonResponse(404, { error: "not found" });
 
-		const segments = patch.segments ?? existing.segments;
+		// Re-authorize immediately before the generic id-only update. The public
+		// runtime storage contract has no atomic predicate-update operation, so
+		// this detects replacements after route admission while minimizing the
+		// residual interval before the destructive write.
+		const current = await getTranscript(runtime, id);
+		if (!current) return jsonResponse(404, { error: "not found" });
+		const segments = patch.segments ?? current.segments;
 		const next: Transcript = {
-			...existing,
-			title: patch.title?.trim() || existing.title,
+			...current,
+			title: patch.title?.trim() || current.title,
 			segments,
 			durationMs: transcriptDurationMs(segments),
 			speakerCount: transcriptSpeakerCount(segments),

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1749,7 +1749,11 @@ async function handleTranscriptsRoute(
 			error: "invalid transcript id: malformed URL encoding",
 		});
 	}
-	const id = validateUuid(decodedId);
+	// UUID text is case-insensitive, while persisted transcript ids are emitted
+	// by crypto.randomUUID() in lowercase and compared as capability strings.
+	// Canonicalize before both storage lookup and marker comparisons so an
+	// uppercase spelling cannot turn an existing authorized object into a 404.
+	const id = validateUuid(decodedId.toLowerCase());
 	if (id === null) {
 		return jsonResponse(400, { error: "invalid transcript id: expected UUID" });
 	}


### PR DESCRIPTION
# Relates to

Closes #22741
Context / predecessor: #22441 (`bdde29e5f19df115cc89548bc4819e39d7b38e70`)

This is delegated follow-up work. The maintainer (Shaw / lalalune) filed #22741 as a post-merge blocker and asked an eligible contributor to open the PR from a preserved, already-validated branch (frozen head `9f3a397959831d14d43fd45c91fa5ede772c3f0d`, which superseded the earlier `0e13851c...`). This PR carries that validated tree plus the reviewer repair documented below.

Definition of Done:

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the owning package's test, typecheck, build, and Biome gates were run and are green (see Evidence).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c238162fca59b9d4be8024b4a7b00a96b4d691e0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Reviewer rebased the two-commit authorization and UUID-canonicalization series onto `origin/develop` (`26ad70a7e0f9b62a22ef2231fa2719ef99ad556a`); zero conflicts and unchanged patch content.
- [x] Owning-package gates pass post-sync. Full-repo `bun run verify` was not run end-to-end on this constrained host; the focused package gates (test/typecheck/build/lint) plus `git diff --check` are all green and reported below. See **Known gaps / failures**.

# Risks

Low. The change is scoped to three files under `plugins/plugin-capacitor-bridge/src/ios/` and only hardens authorization on the mirrored `/api/transcripts*` routes. It adds pre-storage UUID validation and object-capability checks; it does not alter the successful CRUD contract or the malformed-percent-encoding behavior, both of which remain covered by unchanged assertions.

# Background

## What does this PR do?

Completes transcript-route object authorization after #22441. PR #22441 scoped the transcript DELETE, but the production memory-id lookup (`getMemoryById`) is a global key space that the SQL adapter does not scope by agent, and malformed non-UUID path IDs still reached the storage adapter. This follow-up closes those gaps:

- **UUID validation before any storage access.** The `:id` path component is percent-decoded, then validated with `validateUuid`. A malformed non-UUID id returns `400 { "error": "invalid transcript id: expected UUID" }` and never touches the storage adapter.
- **Object-capability authorization on the fetched row.** `transcriptFromOwnedMemory` requires the row to belong to the active agent (`row.agentId === runtime.agentId`) AND carry the persisted custom/transcript metadata marker (`metadata.type === "custom"`, `metadata.source === "transcript"`) AND have `metadata.transcriptId === id`. `rowToTranscript` additionally re-parses the embedded transcript blob and requires its `id` to equal the requested id, plus a fully typed shape (title/createdAt/durationMs/segments/source/scope/status/speakerCount). Any mismatch yields `404`.
- **Agent-scoped listing.** `listTranscripts` now passes `agentId: runtime.agentId` to `getMemories`.
- **Time-of-check/time-of-use revalidation before the generic id-only mutation.** Immediately before both the id-only `deleteMemory` and the id-only `updateMemory`, the route re-authorizes the current stored row and (for PUT) derives the outgoing transcript from that second authoritative read. If the row was replaced after admission, the request returns `404` and performs zero route mutation. The public runtime storage contract has no atomic predicate-delete/predicate-update seam, so the narrow residual interval is documented in-line rather than papered over with an invented API.

## What kind of change is this?

Bug fix (non-breaking security hardening of an existing route).

# Documentation changes needed?

No. Behavior of the documented CRUD contract is preserved; only unauthorized/malformed inputs are newly rejected.

# Testing

## Where should a reviewer start?

`plugins/plugin-capacitor-bridge/src/ios/bridge.transcript-scope.test.ts` and `bridge.transcripts.encoding.test.ts`. Run the focused lane and the full iOS bridge lane (commands below).

## Detailed testing steps

From the repo root (pinned Bun `1.3.14`):

```bash
cd plugins/plugin-capacitor-bridge
bun test src/ios/bridge.transcript-scope.test.ts src/ios/bridge.transcripts.encoding.test.ts   # focused authorization + encoding lane
bun test src/ios/                                                                               # full iOS bridge lane
bun run typecheck                                                                               # tsc --noEmit -p tsconfig.build.json
bunx @biomejs/biome check src/ios/bridge.ts src/ios/bridge.transcript-scope.test.ts src/ios/bridge.transcripts.encoding.test.ts
```

The regression tests prove, on the real route handler with a fake in-memory runtime that mirrors the global `getMemoryById` key space:

- malformed non-UUID path IDs are rejected with `400` **before** any storage-adapter access (`getMemoryById`/`deleteMemory` are never called);
- a cross-agent row in the global id space is rejected (`404`, not deleted);
- transcript-shaped content in another memory table without the durable metadata marker is rejected (`404`);
- an embedded-transcript-id / requested-id mismatch is rejected (`404`);
- a persisted `metadata.transcriptId` / row-id mismatch is rejected (`404`);
- the admission→delete revalidation path rejects a row replaced after admission (`404`, zero route delete);
- the admission→update revalidation path rejects a row replaced after admission (`404`, zero route `updateMemory`);
- the positive DELETE path still removes a real transcript; positive GET/POST/PUT CRUD and malformed-percent-encoding behavior are unchanged.

# Evidence Gate

<!-- evidence-head:04643ca503e07ad3926f89d9639e5dd8a39046a6 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend HTTP route authorization; no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend HTTP route authorization; no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - backend HTTP route authorization; no rendered UI surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact-head network-denied focused route validation JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22752-04643ca5-focused.json)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend surface in this change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changes; this is route authorization`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [exact-head network-denied full iOS validation JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22752-04643ca5-ios.json)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Reviewer repair

Exact reviewed head `04643ca503e07ad3926f89d9639e5dd8a39046a6` additionally canonicalizes valid uppercase UUID path spellings before storage lookup and strict capability-marker comparisons. `validateUuid` accepts UUID text case-insensitively, while transcript ids created by `crypto.randomUUID()` are lowercase; without canonicalization, the same authorized object addressed in uppercase incorrectly returned 404. A positive real-route regression now proves uppercase input resolves to the canonical stored id.

Current exact-head network-denied gates: focused authorization + encoding 18/18 across 4 suites; full iOS bridge lane 88/88 across 22 suites; package typecheck; production build; Biome; and diff check. Outbound network was explicitly unavailable.

# Evidence Details

## Real LLM-call trajectory

`N/A - route authorization change; no live-model behavior is exercised.`

## Backend + frontend logs

The current exact-head validation log is attached above; the original carried-head output remains embedded inline below for provenance.

Original carried-head focused authorization + encoding log — **17 pass / 0 fail, 57 assertions**:

<details>
<summary>bun test src/ios/bridge.transcript-scope.test.ts src/ios/bridge.transcripts.encoding.test.ts</summary>

```
bun test v1.3.14 (0d9b296a)

src/ios/bridge.transcripts.encoding.test.ts:
(pass) iOS /api/transcripts/:id encoding > GET /api/transcripts list is untouched
(pass) iOS /api/transcripts/:id encoding > POST /api/transcripts create is untouched
(pass) iOS /api/transcripts/:id encoding > canonical percent-encoded id still reaches transcript lookup
(pass) iOS /api/transcripts/:id encoding > rejects malformed % with 400 before transcript lookup
(pass) iOS /api/transcripts/:id encoding > rejects malformed %2 with 400 before transcript lookup
(pass) iOS /api/transcripts/:id encoding > rejects malformed %ZZ with 400 before transcript lookup
(pass) iOS /api/transcripts/:id encoding > rejects malformed %E0%A4 with 400 before transcript lookup

src/ios/bridge.transcript-scope.test.ts:
(pass) iOS bridge — transcripts route object scope > GET refuses an id that is not a transcript
(pass) iOS bridge — transcripts route object scope > DELETE refuses an id that is not a transcript, and does not delete it
(pass) iOS bridge — transcripts route object scope > rejects an invalid UUID before the storage adapter
(pass) iOS bridge — transcripts route object scope > does not delete another agent's transcript from the global memory id space
(pass) iOS bridge — transcripts route object scope > does not treat transcript-shaped content in another memory table as a transcript
(pass) iOS bridge — transcripts route object scope > rejects transcript metadata whose embedded transcript id does not match
(pass) iOS bridge — transcripts route object scope > rejects transcript metadata whose persisted id does not match the row
(pass) iOS bridge — transcripts route object scope > revalidates scope immediately before the generic id-only delete
(pass) iOS bridge — transcripts route object scope > revalidates scope immediately before the generic id-only update
(pass) iOS bridge — transcripts route object scope > DELETE still removes a real transcript

 17 pass
 0 fail
 57 expect() calls
Ran 17 tests across 2 files. [1214.00ms]
```

</details>

Original carried-head full iOS bridge log — **84 pass / 0 fail, 227 assertions, 7 files**:

<details>
<summary>bun test src/ios/</summary>

```
 84 pass
 0 fail
 227 expect() calls
Ran 84 tests across 7 files. [1372.00ms]
```

</details>

Typecheck (green), Biome on the 3 changed files (green), `git diff --check` (green):

<details>
<summary>typecheck / biome / diff --check</summary>

```
$ tsc --noEmit -p tsconfig.build.json
# (no diagnostics; exit 0)

$ bunx @biomejs/biome check src/ios/bridge.ts src/ios/bridge.transcript-scope.test.ts src/ios/bridge.transcripts.encoding.test.ts
Checked 3 files in 190ms. No fixes applied.

$ git diff --check origin/develop HEAD
# (clean: no whitespace errors or conflict markers)
```

</details>

Package build (`@elizaos/plugin-capacitor-bridge`) via Turbo: **5 successful, 5 total** (tsup ESM build + declaration emit succeeded).

## Screenshots (before / after) + video walkthrough

`N/A - backend HTTP route authorization; no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - this changes transcript-route authorization only, not audio/TTS/STT round-trip behavior.`

## Known gaps / failures

- Full-repo `bun run verify` was not run end-to-end on this constrained Raspberry Pi host (it drives the entire Turbo workspace). Instead, the owning package's focused gates were run and are green: network-denied focused test lane (18/18), full iOS lane (88/88), `tsc` typecheck, Biome on the three changed files, package Turbo build, and `git diff --check`. The diff is strictly limited to three files under `plugins/plugin-capacitor-bridge/src/ios/`, so cross-package gates are not implicated.
- Exact-head validation is attached as a release artifact and linked in the Evidence Gate.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c238162fca59b9d4be8024b4a7b00a96b4d691e0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c238162fca59b9d4be8024b4a7b00a96b4d691e0:packages/skills/skills/contribute-to-eliza"} -->




