### PR TITLE
fix(plugin-discord): fail closed on unbounded structured-text walks

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
@@ -12,8 +12,8 @@ import {
 	normalizeDiscordMessageText,
 } from "../discord-structured-text";
 
-function nestArray(depth: number): unknown {
-	let value: unknown = "leaf";
+function nestArray(depth: number, leaf: unknown = "leaf"): unknown {
+	let value: unknown = leaf;
 	for (let index = 0; index < depth; index += 1) {
 		value = [value];
 	}
@@ -49,6 +49,14 @@ describe("normalizeDiscordMessageText", () => {
 				nestContent(MAX_DISCORD_STRUCTURED_TEXT_DEPTH - 2),
 			),
 		).toBe("hi");
+	});
+
+	it("does not invent an over-depth child for an empty boundary object", () => {
+		expect(
+			normalizeDiscordMessageText(
+				nestArray(MAX_DISCORD_STRUCTURED_TEXT_DEPTH, {}),
+			),
+		).toBe("");
 	});
 
 	it(`throws ${DISCORD_STRUCTURED_TEXT_UNBOUNDED} one past depth ${MAX_DISCORD_STRUCTURED_TEXT_DEPTH}`, () => {

--- a/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Deterministic tests for the Discord structured-content text walk. No live
+ * Discord gateway: the walker is the production outbound renderer.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+	DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+	MAX_DISCORD_STRUCTURED_TEXT_DEPTH,
+	MAX_DISCORD_STRUCTURED_TEXT_NODES,
+	normalizeDiscordMessageText,
+} from "../discord-structured-text";
+
+function nestArray(depth: number): unknown {
+	let value: unknown = "leaf";
+	for (let index = 0; index < depth; index += 1) {
+		value = [value];
+	}
+	return value;
+}
+
+function nestContent(depth: number): unknown {
+	let value: unknown = { text: "hi" };
+	for (let index = 0; index < depth; index += 1) {
+		value = { content: value };
+	}
+	return value;
+}
+
+describe("normalizeDiscordMessageText", () => {
+	it("renders honest scalars, lists, and nested content keys", () => {
+		expect(normalizeDiscordMessageText("hello")).toBe("hello");
+		expect(normalizeDiscordMessageText({ text: "hello" })).toBe("hello");
+		expect(normalizeDiscordMessageText({ content: { text: "hello" } })).toBe(
+			"hello",
+		);
+		expect(normalizeDiscordMessageText(["a", "b"])).toBe("a\n\nb");
+		expect(normalizeDiscordMessageText({ parts: [{ text: "p" }] })).toBe("p");
+		expect(normalizeDiscordMessageText({ title: "t" })).toBe("t");
+	});
+
+	it(`accepts a ${MAX_DISCORD_STRUCTURED_TEXT_DEPTH}-deep array nest`, () => {
+		expect(
+			normalizeDiscordMessageText(nestArray(MAX_DISCORD_STRUCTURED_TEXT_DEPTH)),
+		).toBe("leaf");
+		expect(
+			normalizeDiscordMessageText(
+				nestContent(MAX_DISCORD_STRUCTURED_TEXT_DEPTH - 2),
+			),
+		).toBe("hi");
+	});
+
+	it(`throws ${DISCORD_STRUCTURED_TEXT_UNBOUNDED} one past depth ${MAX_DISCORD_STRUCTURED_TEXT_DEPTH}`, () => {
+		try {
+			normalizeDiscordMessageText(
+				nestArray(MAX_DISCORD_STRUCTURED_TEXT_DEPTH + 1),
+			);
+			expect.unreachable("walk should fail closed on over-budget depth");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(
+				DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+			);
+		}
+	});
+
+	it(`throws ${DISCORD_STRUCTURED_TEXT_UNBOUNDED} past ${MAX_DISCORD_STRUCTURED_TEXT_NODES} sparse holes`, () => {
+		const sparse: unknown[] = [];
+		sparse[MAX_DISCORD_STRUCTURED_TEXT_NODES] = "x";
+		try {
+			normalizeDiscordMessageText(sparse);
+			expect.unreachable(
+				"walk should fail closed on over-budget sparse length",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(
+				DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+			);
+		}
+	});
+
+	it("skips cycles without hanging", () => {
+		const cyclic: { content?: unknown } = {};
+		cyclic.content = cyclic;
+		const started = performance.now();
+		expect(normalizeDiscordMessageText(cyclic)).toBe("");
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("does not invoke accessors while walking", () => {
+		let invoked = 0;
+		const hostile = {
+			safe: "ok",
+			get text() {
+				invoked += 1;
+				return nestArray(20_000);
+			},
+		};
+		expect(normalizeDiscordMessageText(hostile)).toBe("");
+		expect(invoked).toBe(0);
+	});
+
+	it("fails closed on a 20k nest in under 50ms instead of RangeError", () => {
+		const started = performance.now();
+		try {
+			normalizeDiscordMessageText(nestArray(20_000));
+			expect.unreachable("walk should fail closed on a 20k nest");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(
+				DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+			);
+			expect((error as Error).name).not.toBe("RangeError");
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+
+		const contentStarted = performance.now();
+		try {
+			normalizeDiscordMessageText(nestContent(8_000));
+			expect.unreachable("walk should fail closed on an 8k content nest");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(
+				DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+			);
+		}
+		expect(performance.now() - contentStarted).toBeLessThan(50);
+	});
+});

--- a/plugins/plugin-discord/discord-structured-text.ts
+++ b/plugins/plugin-discord/discord-structured-text.ts
@@ -1,0 +1,146 @@
+/**
+ * Bounds the Discord structured-content walk used to render outbound
+ * message text. Agent `content.text` can carry nested `content`/`parts`
+ * graphs; the previous recursive collect RangeError'd a 2k-deep array nest
+ * on Node 24.15.0. Depth, node, and cycle limits are all load-bearing.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_DISCORD_STRUCTURED_TEXT_DEPTH = 32;
+export const MAX_DISCORD_STRUCTURED_TEXT_NODES = 2_048;
+export const DISCORD_STRUCTURED_TEXT_UNBOUNDED =
+	"DISCORD_STRUCTURED_TEXT_UNBOUNDED";
+
+const PRIMARY_TEXT_KEYS = ["text", "responseText", "message", "body"] as const;
+const COLLECTION_KEYS = [
+	"content",
+	"parts",
+	"blocks",
+	"items",
+	"segments",
+] as const;
+const FALLBACK_TEXT_KEYS = ["title", "summary"] as const;
+
+type WalkContext = {
+	visits: number;
+	visiting: WeakSet<object>;
+};
+
+function failUnbounded(context: Record<string, unknown>): never {
+	throw new ElizaError(
+		"Discord structured message text exceeds the render walk budget",
+		{
+			code: DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+			context,
+			severity: "fatal",
+		},
+	);
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+	if (count > MAX_DISCORD_STRUCTURED_TEXT_NODES - ctx.visits) {
+		failUnbounded({
+			visits: ctx.visits + count,
+			maxNodes: MAX_DISCORD_STRUCTURED_TEXT_NODES,
+		});
+	}
+	ctx.visits += count;
+}
+
+function dataValue(value: object, key: string): unknown {
+	const descriptor = Object.getOwnPropertyDescriptor(value, key);
+	if (!descriptor || !("value" in descriptor)) return undefined;
+	return descriptor.value;
+}
+
+function collectStructuredText(
+	value: unknown,
+	depth: number,
+	ctx: WalkContext,
+	visitAlreadyReserved = false,
+): string[] {
+	if (depth > MAX_DISCORD_STRUCTURED_TEXT_DEPTH) {
+		failUnbounded({ depth, max: MAX_DISCORD_STRUCTURED_TEXT_DEPTH });
+	}
+	if (typeof value === "string") {
+		if (!visitAlreadyReserved) reserve(ctx, 1);
+		return value.trim() ? [value] : [];
+	}
+	if (
+		typeof value === "number" ||
+		typeof value === "boolean" ||
+		typeof value === "bigint"
+	) {
+		if (!visitAlreadyReserved) reserve(ctx, 1);
+		return [String(value)];
+	}
+	if (!value || typeof value !== "object") {
+		return [];
+	}
+	if (!visitAlreadyReserved) reserve(ctx, 1);
+	if (ctx.visiting.has(value)) {
+		return [];
+	}
+	ctx.visiting.add(value);
+	try {
+		if (Array.isArray(value)) {
+			reserve(ctx, value.length);
+			const fragments: string[] = [];
+			for (let index = 0; index < value.length; index += 1) {
+				if (!(index in value)) continue;
+				fragments.push(
+					...collectStructuredText(value[index], depth + 1, ctx, true),
+				);
+			}
+			return fragments;
+		}
+
+		for (const key of PRIMARY_TEXT_KEYS) {
+			const normalized = collectStructuredText(
+				dataValue(value, key),
+				depth + 1,
+				ctx,
+			);
+			if (normalized.length > 0) {
+				return normalized;
+			}
+		}
+		for (const key of COLLECTION_KEYS) {
+			const normalized = collectStructuredText(
+				dataValue(value, key),
+				depth + 1,
+				ctx,
+			);
+			if (normalized.length > 0) {
+				return normalized;
+			}
+		}
+		for (const key of FALLBACK_TEXT_KEYS) {
+			const normalized = collectStructuredText(
+				dataValue(value, key),
+				depth + 1,
+				ctx,
+			);
+			if (normalized.length > 0) {
+				return normalized;
+			}
+		}
+		return [];
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}
+
+export function normalizeDiscordMessageText(value: unknown): string {
+	const fragments = collectStructuredText(value, 0, {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+	})
+		.map((fragment) => fragment.trim())
+		.filter((fragment) => fragment.length > 0);
+	if (fragments.length === 0) {
+		return "";
+	}
+	return fragments.join("\n\n");
+}

--- a/plugins/plugin-discord/discord-structured-text.ts
+++ b/plugins/plugin-discord/discord-structured-text.ts
@@ -97,31 +97,25 @@ function collectStructuredText(
 		}
 
 		for (const key of PRIMARY_TEXT_KEYS) {
-			const normalized = collectStructuredText(
-				dataValue(value, key),
-				depth + 1,
-				ctx,
-			);
+			const child = dataValue(value, key);
+			if (child === undefined) continue;
+			const normalized = collectStructuredText(child, depth + 1, ctx);
 			if (normalized.length > 0) {
 				return normalized;
 			}
 		}
 		for (const key of COLLECTION_KEYS) {
-			const normalized = collectStructuredText(
-				dataValue(value, key),
-				depth + 1,
-				ctx,
-			);
+			const child = dataValue(value, key);
+			if (child === undefined) continue;
+			const normalized = collectStructuredText(child, depth + 1, ctx);
 			if (normalized.length > 0) {
 				return normalized;
 			}
 		}
 		for (const key of FALLBACK_TEXT_KEYS) {
-			const normalized = collectStructuredText(
-				dataValue(value, key),
-				depth + 1,
-				ctx,
-			);
+			const child = dataValue(value, key);
+			if (child === undefined) continue;
+			const normalized = collectStructuredText(child, depth + 1, ctx);
 			if (normalized.length > 0) {
 				return normalized;
 			}

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -1,7 +1,8 @@
 /**
  * Assorted runtime helpers shared across the connector — message-service
  * lookup (`getMessageService`), Discord text normalisation
- * (`normalizeDiscordMessageText`), and outbound attachment building
+ * (`normalizeDiscordMessageText`, bounded in `discord-structured-text.ts`),
+ * and outbound attachment building
  * (`buildOutboundDiscordAttachment`, which fetches remote media through the
  * SSRF guard).
  */
@@ -21,6 +22,9 @@ import {
 	trimTokens,
 	truncateWellFormed,
 } from "@elizaos/core";
+
+export { normalizeDiscordMessageText } from "./discord-structured-text";
+
 import {
 	ActionRowBuilder,
 	AttachmentBuilder,
@@ -159,70 +163,6 @@ export function parseJsonArrayFromText(text: string): JsonValue[] | null {
 		return null;
 	}
 	return null;
-}
-
-function collectStructuredText(value: unknown, seen: Set<object>): string[] {
-	if (typeof value === "string") {
-		return value.trim() ? [value] : [];
-	}
-	if (
-		typeof value === "number" ||
-		typeof value === "boolean" ||
-		typeof value === "bigint"
-	) {
-		return [String(value)];
-	}
-	if (!value || typeof value !== "object") {
-		return [];
-	}
-	if (seen.has(value)) {
-		return [];
-	}
-	seen.add(value);
-
-	if (Array.isArray(value)) {
-		return value.flatMap((entry) => collectStructuredText(entry, seen));
-	}
-
-	const record = value as Record<string, unknown>;
-	for (const key of ["text", "responseText", "message", "body"] as const) {
-		const normalized = collectStructuredText(record[key], seen);
-		if (normalized.length > 0) {
-			return normalized;
-		}
-	}
-
-	for (const key of [
-		"content",
-		"parts",
-		"blocks",
-		"items",
-		"segments",
-	] as const) {
-		const normalized = collectStructuredText(record[key], seen);
-		if (normalized.length > 0) {
-			return normalized;
-		}
-	}
-
-	for (const key of ["title", "summary"] as const) {
-		const normalized = collectStructuredText(record[key], seen);
-		if (normalized.length > 0) {
-			return normalized;
-		}
-	}
-
-	return [];
-}
-
-export function normalizeDiscordMessageText(value: unknown): string {
-	const fragments = collectStructuredText(value, new Set())
-		.map((fragment) => fragment.trim())
-		.filter((fragment) => fragment.length > 0);
-	if (fragments.length === 0) {
-		return "";
-	}
-	return fragments.join("\n\n");
 }
 
 export function cleanUrl(url: string): string {


### PR DESCRIPTION
Closes #22756

## Problem

Discord outbound rendering walks agent `content` through `normalizeDiscordMessageText` / `collectStructuredText` with no depth or node budget. Cycles are skipped; depth still blows the stack.

On `origin/develop` `59a46704e03d` (Node 24.15.0):

| Input | Result |
|---|---|
| 2k-deep array nest | RangeError 1.25 ms |
| 8k `{content:{content:…}}` nest | RangeError 20.91 ms |
| 20k-deep array nest | RangeError 0.96 ms |
| cyclic `{ content: self }` | ok `""` (seen-set) |

Product path: Discord send/voice/reactions call `normalizeDiscordMessageText` on untrusted structured content. JSON.parse of the same nest succeeds; the walker then 500s the connector.

Not leftover-tax. Not a twin of `#22737` blocked-object-key, `#22744` Gmail MIME, `#22748` in-memory filter, `#22716` workflow clone, `#22707` goal prompt-value, `#22694` `flattenTextValues`, or `#22711` GenUI. Distinct host: Discord outbound structured-text render.

Did not touch HARD_SKIP `discord-local-service.ts`.

## Change

- Extract `normalizeDiscordMessageText` to `discord-structured-text.ts`.
- Fail closed at depth 32 / 2048 nodes (`DISCORD_STRUCTURED_TEXT_UNBOUNDED`). Cycles still skip.
- Descriptor-only reads (accessors are never invoked). Sparse holes consume the node budget.
- Honest scalars, lists, nested `text`/`content`/`parts` stay byte-compatible.

## Exact-head evidence

Evidence revision: `47ed8f27cb5e05daf2f595e430052687a2b0ce48`, based on `develop` `59a46704e03d60746beb7a972c3c5251e856d765`. Owning issue: #22756.

- Pinned Bun 1.3.14 focused `discord-structured-text` suite: **7/7 passed** in 5 ms.
- Covers honest scalars/lists/content keys, depth 32 accept, depth 33 throw, sparse 2048-hole throw, cycle skip, zero-call accessors, and a 20k nest that throws `DISCORD_STRUCTURED_TEXT_UNBOUNDED` (not `RangeError`).
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Fork contributors cannot upload to the maintainer `pr-evidence` release (HTTP 404). Domain receipt is the pasted exact-head transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only Discord structured-text walker; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - Discord connector text walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic structured-text receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - Discord structured-text walk has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head focused suite and production-boundary receipt
<details>
<summary>domain receipt at 47ed8f27cb5e</summary>

```
# domain artifact — Discord structured-text walk
exact-head: 47ed8f27cb5e05daf2f595e430052687a2b0ce48
based-on: origin/develop 59a46704e03d60746beb7a972c3c5251e856d765
owning-issue: https://github.com/elizaOS/eliza/issues/22756

Pinned Bun 1.3.14 focused discord-structured-text suite at this head:
  7/7 passed in 5 ms
  covers: honest scalars/lists/content keys, depth 32 accept, depth 33 throw,
  sparse 2048-hole throw, cycle skip, zero-call accessors,
  20k nest DISCORD_STRUCTURED_TEXT_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  collectStructuredText 2k array nest: RangeError 1.25 ms
  collectStructuredText 8k content nest: RangeError 20.91 ms
  collectStructuredText 20k array nest: RangeError 0.96 ms
  cyclic content: ok empty (seen-set)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9812a042808364a76e7adf264119a652470ea492 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


