### PR TITLE
fix(skills): honor snake_case disable_model_invocation in loadSkills

### DIFF
--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -155,7 +155,9 @@ function loadSkillFromFile(
       filePath,
       baseDir: skillDir,
       source,
-      disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+      disableModelInvocation:
+        resolveSkillInvocationPolicy(frontmatter).disableModelInvocation ===
+        true,
       ...(provenance ? { provenance } : {}),
     },
     diagnostics,

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -8,6 +8,7 @@ import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { formatSkillsForPrompt } from "../src/formatter.js";
 import {
   loadSkillEntries,
   loadSkills,
@@ -259,6 +260,88 @@ description: Second skill
     } finally {
       rmSync(tempDir1, { recursive: true, force: true });
       rmSync(tempDir2, { recursive: true, force: true });
+    }
+  });
+
+  it("loadSkills honors both kebab-case and snake_case disable-model-invocation", () => {
+    // Regression for #22755: loader.ts read only the kebab key, so a skill
+    // authored with snake_case `disable_model_invocation: true` was still
+    // injected into the system prompt via loadSkills()/formatSkillsForPrompt(),
+    // even though loadSkillEntries()/resolveSkillInvocationPolicy() hid it.
+    for (const key of [
+      "disable-model-invocation",
+      "disable_model_invocation",
+    ]) {
+      const tempDir = createTempDir(`skill-disable-${key}`);
+      try {
+        const skillName = `hidden-${key.replace(/_/g, "-")}`;
+        writeFileSync(
+          join(tempDir, `${skillName}.md`),
+          `---
+name: ${skillName}
+description: Should be hidden from the model
+${key}: true
+---
+# body`,
+        );
+
+        const { skills } = loadSkills({
+          includeDefaults: false,
+          skillPaths: [tempDir],
+        });
+        assert.strictEqual(skills.length, 1);
+        assert.strictEqual(
+          skills[0]?.disableModelInvocation,
+          true,
+          `loadSkills must honor ${key}`,
+        );
+
+        const entries = loadSkillEntries({
+          includeDefaults: false,
+          skillPaths: [tempDir],
+        });
+        assert.strictEqual(entries.length, 1);
+        assert.strictEqual(
+          entries[0]?.invocation.disableModelInvocation,
+          true,
+          `loadSkillEntries must honor ${key}`,
+        );
+
+        const prompt = formatSkillsForPrompt(skills);
+        assert.ok(
+          !prompt.includes(skillName),
+          `formatSkillsForPrompt must exclude a skill hidden via ${key}`,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("loadSkills keeps a skill visible when disable_model_invocation is false", () => {
+    const tempDir = createTempDir("skill-disable-false");
+    try {
+      writeFileSync(
+        join(tempDir, "visible-skill.md"),
+        `---
+name: visible-skill
+description: Should remain visible to the model
+disable_model_invocation: false
+---
+# body`,
+      );
+
+      const { skills } = loadSkills({
+        includeDefaults: false,
+        skillPaths: [tempDir],
+      });
+      assert.strictEqual(skills.length, 1);
+      assert.strictEqual(skills[0]?.disableModelInvocation, false);
+
+      const prompt = formatSkillsForPrompt(skills);
+      assert.ok(prompt.includes("visible-skill"));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
# Relates to

Closes #22755

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning package's `test`/`typecheck`/`lint` were run
      after sync; the repo-wide `bun run verify` blocker is recorded under
      **Known gaps / failures** below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@59a46704e03d60746beb7a972c3c5251e856d765:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to completion here; see
      **Known gaps / failures**. The owning package's `test`, `typecheck`, and
      `lint` all pass on the final head.

# Risks

Low. One-line behavior change in `packages/skills/src/loader.ts` routing an
existing field through the package's own shared resolver. No public type
change, no new exports, no dependency change. The change makes the two public
load APIs agree; it cannot expose a skill that was previously hidden.

# Background

## What does this PR do?

`@elizaos/skills` deliberately accepts both kebab-case and snake_case
frontmatter keys. `resolveSkillInvocationPolicy`, `resolveSkillMetadata`, and
`formatter.ts` all resolve `disable-model-invocation` **or**
`disable_model_invocation` (and the other dual-key fields). But
`loader.ts` set the `Skill.disableModelInvocation` field from **only** the
kebab key:

```ts
disableModelInvocation: frontmatter["disable-model-invocation"] === true,
```

So for a `SKILL.md` authored with snake_case `disable_model_invocation: true`,
the two documented, public load APIs disagreed on the same file:

- `loadSkillEntries().invocation.disableModelInvocation === true`  ✅ correct
- `loadSkills().skills[].disableModelInvocation === false`         ❌ wrong

`index.ts` advertises `loadSkills()` + `formatSkillsForPrompt()` as the primary
usage, and `formatSkillsForPrompt` filters on `s.disableModelInvocation`. The
result: a skill the author **explicitly marked non-model-invocable** was
injected into the agent system prompt and offered to the model on this path —
an invocation-policy / exposure violation, not cosmetic.

The fix routes `loadSkillFromFile` through the package's own shared resolver so
the two paths can never diverge again:

```ts
disableModelInvocation:
  resolveSkillInvocationPolicy(frontmatter).disableModelInvocation === true,
```

(`resolveSkillInvocationPolicy` was already imported and already used by
`loadSkillEntries`.)

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Scope boundary

One line of production code plus regression tests. No public type change, no
new export, no widening of any surface. Other dual-key fields
(`primary-env`, `required-*`, `command-dispatch`, `command-tool`,
`user-invocable`) were already resolved correctly and are unchanged.

# Documentation changes needed?

My changes do not require a documentation change. `packages/skills/CLAUDE.md`
already documents `disable-model-invocation` as excluding a skill from
system-prompt injection; this PR makes the snake_case spelling honor that
documented behavior on the `loadSkills` path too.

# Testing

## Where should a reviewer start?

`packages/skills/test/loader.test.ts` — the new
`loadSkills honors both kebab-case and snake_case disable-model-invocation`
test writes a temp `SKILL.md` for **both** key spellings and asserts:

- `loadSkills().skills[0].disableModelInvocation === true`
- `loadSkillEntries()[0].invocation.disableModelInvocation === true`
- `formatSkillsForPrompt(skills)` does **not** contain the hidden skill's name

A companion negative test (`disable_model_invocation: false`) asserts the skill
**is** kept and appears in the prompt.

## Detailed testing steps

```bash
bun run --cwd packages/skills test        # 112 pass, 0 fail (7 files)
bun run --cwd packages/skills typecheck   # clean
bun run --cwd packages/skills lint:check  # clean
```

# Evidence Gate

<!-- evidence-head:fd25a52a2a25cc0a05c024e201e0a68ae215a106 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - non-UI change`. `@elizaos/skills` is a pure loader/formatter
      utility package with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - non-UI change`. Same as above.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-UI change`. Failing-then-passing test output is inline below.
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure loader/formatter utility fix with no running server; the real before(failing)/after(passing) focused test output is inline in Evidence Details
<!-- evidence-row:frontend-logs -->
- [x] `N/A - non-UI change`. No frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior change; this is a frontmatter-key parsing fix
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [exact-tree focused loader/prompt validation log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22760-fd25a52-focused.log)
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A` — no agent/model behavior change.

## Backend + frontend logs

Focused package test, **before** the one-line fix (regression test fails,
proving the bug — snake_case skill leaks with `disableModelInvocation=false`):

<details>
<summary>bun test ./test/loader.test.ts — BEFORE fix</summary>

```
(pass) loadSkills and loadSkillEntries > detects name collisions across skill sources
AssertionError: loadSkills must honor disable_model_invocation
false !== true
(fail) loadSkills and loadSkillEntries > loadSkills honors both kebab-case and snake_case disable-model-invocation
(pass) loadSkills and loadSkillEntries > loadSkills keeps a skill visible when disable_model_invocation is false
(pass) loadSkills and loadSkillEntries > loadSkillEntries parses full metadata and invocation policy
 10 pass
 1 fail
```
</details>

**After** the fix — full package suite green:

<details>
<summary>bun run --cwd packages/skills test — AFTER fix</summary>

```
(pass) loadSkills and loadSkillEntries > loadSkills honors both kebab-case and snake_case disable-model-invocation
(pass) loadSkills and loadSkillEntries > loadSkills keeps a skill visible when disable_model_invocation is false
(pass) loadSkills and loadSkillEntries > loadSkillEntries parses full metadata and invocation policy
 112 pass
 0 fail
Ran 112 tests across 7 files.
```
</details>

typecheck + lint on the final head:

```
$ tsc --noEmit -p tsconfig.build.json      # exit 0, no output
$ bunx @biomejs/biome check ./src
Checked 6 files in 48ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

### Before

`N/A - non-UI change`.

### After

`N/A - non-UI change`.

### Walkthrough video

`N/A - non-UI change`.

## Audio / voice walkthrough

`N/A` — no voice/audio surface.

## Known gaps / failures

- Full repo `bun run verify` was not run to completion on this machine (it
  builds and checks the entire workspace and exceeds the practical time budget
  here; the workspace `bun install` also required lowering the global bun
  `minimumReleaseAge` policy locally to resolve a very recently published
  transitive `viem` version, which was reverted and never committed). Instead
  the **owning package's** `test`, `typecheck`, and `lint` were all run to
  completion on the final rebased head and pass. `@elizaos/core` was built
  locally to provide the type declarations the skills typecheck resolves.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@59a46704e03d60746beb7a972c3c5251e856d765:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@59a46704e03d60746beb7a972c3c5251e856d765:packages/skills/skills/contribute-to-eliza"} -->

