### PR TITLE
fix(plugin-google-workspace): fail closed on unbounded OAuth token nests

### DIFF
--- a/plugins/plugin-google-workspace/src/credential-resolver.ts
+++ b/plugins/plugin-google-workspace/src/credential-resolver.ts
@@ -8,6 +8,7 @@
  * from the account and credential records so token rotation invalidates the
  * cache. The many accepted credential-type spellings exist to interoperate with
  * however the OAuth store or cloud flow labeled the persisted tokens.
+ * Nested `tokens`/`oauthTokens` JSON is bounded in `oauth-credential-merge.ts`.
  */
 import {
   CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
@@ -31,6 +32,7 @@ import {
   CORE_SECRETS_SERVICE_TYPE,
   credentialRefRecordsFromMetadata,
 } from "./connector-credential-refs.js";
+import { mergeCredentialObject } from "./oauth-credential-merge.js";
 import type {
   GoogleAuthClient,
   GoogleAuthResolutionRequest,
@@ -662,38 +664,6 @@ function mergeCredentialValue(
   }
 
   applyRecordExpiry(credentials, record);
-}
-
-function mergeCredentialObject(credentials: Credentials, value: unknown): void {
-  const record = asRecord(value);
-  if (!record) return;
-
-  const nested = asRecord(record.tokens) ?? asRecord(record.oauthTokens);
-  if (nested) {
-    mergeCredentialObject(credentials, nested);
-  }
-
-  const accessToken = readStringFromRecord(record, "access_token", "accessToken");
-  const refreshToken = readStringFromRecord(record, "refresh_token", "refreshToken");
-  const idToken = readStringFromRecord(record, "id_token", "idToken");
-  const tokenType = readStringFromRecord(record, "token_type", "tokenType");
-  const scope = readStringFromRecord(record, "scope");
-  const expiry = record.expiry_date ?? record.expiryDate ?? record.expires_at ?? record.expiresAt;
-
-  if (accessToken) credentials.access_token = accessToken;
-  if (refreshToken) credentials.refresh_token = refreshToken;
-  if (idToken) credentials.id_token = idToken;
-  if (tokenType) credentials.token_type = tokenType;
-  if (Array.isArray(record.scopes)) {
-    credentials.scope = record.scopes
-      .filter((item): item is string => typeof item === "string")
-      .join(" ");
-  } else if (scope) {
-    credentials.scope = scope;
-  }
-
-  const expiryDate = parseExpiry(expiry);
-  if (expiryDate) credentials.expiry_date = expiryDate;
 }
 
 function parseMaybeJson(value: string): unknown | undefined {

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Deterministic tests for the Google OAuth nested-token merge bound. No live
+ * Google API: the walker is the production credential flatten.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED,
+  MAX_OAUTH_CREDENTIAL_DEPTH,
+  MAX_OAUTH_CREDENTIAL_NODES,
+  mergeCredentialObject,
+  type OauthCredentialFields,
+} from "./oauth-credential-merge";
+
+function nestTokens(depth: number): unknown {
+  let value: unknown = { access_token: "tok" };
+  for (let index = 0; index < depth; index += 1) {
+    value = { tokens: value };
+  }
+  return value;
+}
+
+describe("mergeCredentialObject", () => {
+  it("flattens honest nested token objects", () => {
+    const credentials: OauthCredentialFields = {};
+    mergeCredentialObject(credentials, {
+      tokens: { access_token: "a", refresh_token: "r" },
+    });
+    expect(credentials.access_token).toBe("a");
+    expect(credentials.refresh_token).toBe("r");
+  });
+
+  it(`accepts a ${MAX_OAUTH_CREDENTIAL_DEPTH}-deep tokens nest`, () => {
+    const credentials: OauthCredentialFields = {};
+    mergeCredentialObject(credentials, nestTokens(MAX_OAUTH_CREDENTIAL_DEPTH));
+    expect(credentials.access_token).toBe("tok");
+  });
+
+  it(`throws ${GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED} one past depth ${MAX_OAUTH_CREDENTIAL_DEPTH}`, () => {
+    try {
+      mergeCredentialObject({}, nestTokens(MAX_OAUTH_CREDENTIAL_DEPTH + 1));
+      expect.unreachable("merge should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED} past ${MAX_OAUTH_CREDENTIAL_NODES} sparse scopes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_OAUTH_CREDENTIAL_NODES] = "scope";
+    try {
+      mergeCredentialObject({}, { access_token: "a", scopes: sparse });
+      expect.unreachable("merge should fail closed on over-budget sparse scopes");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+    }
+  });
+
+  it("throws on a cyclic tokens object without hanging", () => {
+    const cyclic: { tokens?: unknown } = {};
+    cyclic.tokens = cyclic;
+    const started = performance.now();
+    try {
+      mergeCredentialObject({}, cyclic);
+      expect.unreachable("merge should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while merging", () => {
+    let invoked = 0;
+    const hostile = {
+      access_token: "a",
+      get tokens() {
+        invoked += 1;
+        return nestTokens(20_000);
+      },
+    };
+    const credentials: OauthCredentialFields = {};
+    mergeCredentialObject(credentials, hostile);
+    expect(invoked).toBe(0);
+    expect(credentials.access_token).toBe("a");
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      mergeCredentialObject({}, nestTokens(8_000));
+      expect.unreachable("merge should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -12,12 +12,12 @@ export const MAX_OAUTH_CREDENTIAL_NODES = 2_048;
 export const GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED = "GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED";
 
 export type OauthCredentialFields = {
-  access_token?: string;
-  refresh_token?: string;
-  id_token?: string;
-  token_type?: string;
-  scope?: string;
-  expiry_date?: number;
+  access_token?: string | null;
+  refresh_token?: string | null;
+  id_token?: string | null;
+  token_type?: string | null;
+  scope?: string | null;
+  expiry_date?: number | null;
 };
 
 type WalkContext = {

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -1,0 +1,151 @@
+/**
+ * Bounds the nested `tokens`/`oauthTokens` walk that flattens untrusted
+ * Google OAuth credential JSON onto `Auth.Credentials`. A hostile nest
+ * RangeError'd mergeCredentialObject at 8k depth on Node 24.15.0. Depth,
+ * node, and cycle limits are all load-bearing.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_OAUTH_CREDENTIAL_DEPTH = 32;
+export const MAX_OAUTH_CREDENTIAL_NODES = 2_048;
+export const GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED = "GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED";
+
+export type OauthCredentialFields = {
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+  token_type?: string;
+  scope?: string;
+  expiry_date?: number;
+};
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(context: Record<string, unknown>): never {
+  throw new ElizaError("Google OAuth credential JSON exceeds the token-merge walk budget", {
+    code: GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED,
+    context,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_OAUTH_CREDENTIAL_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_OAUTH_CREDENTIAL_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function dataValue(value: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor || !("value" in descriptor)) return undefined;
+  return descriptor.value;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readStringFromRecord(record: object, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = nonEmptyString(dataValue(record, key));
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function parseExpiry(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 0 && value < 10_000_000_000 ? value * 1000 : value;
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "string" && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return parseExpiry(numeric);
+    }
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
+}
+
+export function mergeCredentialObject(credentials: OauthCredentialFields, value: unknown): void {
+  mergeCredentialObjectInner(credentials, value, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+function mergeCredentialObjectInner(
+  credentials: OauthCredentialFields,
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): void {
+  if (depth > MAX_OAUTH_CREDENTIAL_DEPTH) {
+    failUnbounded({ depth, max: MAX_OAUTH_CREDENTIAL_DEPTH });
+  }
+  const record = asRecord(value);
+  if (!record) return;
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(record)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(record);
+  try {
+    const nested =
+      asRecord(dataValue(record, "tokens")) ?? asRecord(dataValue(record, "oauthTokens"));
+    if (nested) {
+      mergeCredentialObjectInner(credentials, nested, depth + 1, ctx);
+    }
+
+    const accessToken = readStringFromRecord(record, "access_token", "accessToken");
+    const refreshToken = readStringFromRecord(record, "refresh_token", "refreshToken");
+    const idToken = readStringFromRecord(record, "id_token", "idToken");
+    const tokenType = readStringFromRecord(record, "token_type", "tokenType");
+    const scope = readStringFromRecord(record, "scope");
+    const expiry =
+      dataValue(record, "expiry_date") ??
+      dataValue(record, "expiryDate") ??
+      dataValue(record, "expires_at") ??
+      dataValue(record, "expiresAt");
+
+    if (accessToken) credentials.access_token = accessToken;
+    if (refreshToken) credentials.refresh_token = refreshToken;
+    if (idToken) credentials.id_token = idToken;
+    if (tokenType) credentials.token_type = tokenType;
+    const scopes = dataValue(record, "scopes");
+    if (Array.isArray(scopes)) {
+      reserve(ctx, scopes.length);
+      credentials.scope = scopes
+        .filter((item): item is string => typeof item === "string")
+        .join(" ");
+    } else if (scope) {
+      credentials.scope = scope;
+    }
+
+    const expiryDate = parseExpiry(expiry);
+    if (expiryDate) credentials.expiry_date = expiryDate;
+  } finally {
+    ctx.visiting.delete(record);
+  }
+}


### PR DESCRIPTION
Closes #22759

## Problem

`DefaultGoogleCredentialResolver` flattens persisted OAuth JSON through recursive `tokens` / `oauthTokens` nesting in `mergeCredentialObject`.

On `origin/develop` `693be0fc1954` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep `tokens` nest | RangeError 1.68 ms |
| 20k-deep `tokens` nest | RangeError 1.73 ms |
| cyclic `{ tokens: self }` | RangeError 1.24 ms |

Product path: connector-account credential resolve before Gmail/Calendar/Drive clients. JSON.parse of the nest succeeds; the merge then stack-overflows.

Not leftover-tax. Not a twin of `#22757` Discord structured-text, `#22744` Gmail MIME, `#22737` blocked-object-key, `#22748` in-memory filter, `#22716` workflow clone, or `#22707` goal prompt-value. Distinct host: Google OAuth nested-token flatten.

Did not touch HARD_SKIP `connector-account-provider.ts` or `src/chat/service.ts`.

## Change

- Extract `mergeCredentialObject` to `oauth-credential-merge.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED`).
- Descriptor-only reads (accessors are never invoked). Sparse `scopes` consume the node budget.
- Honest nested token objects still flatten onto `Auth.Credentials`.

## Exact-head evidence

Evidence revision: `8387758d69c5e16cc9b9f201281de731cc5ba276`, based on `develop` `693be0fc19542033981e59fca25412fe5c90ac3e`. Owning issue: #22759.

- Pinned Bun 1.3.14 focused `oauth-credential-merge` suite: **7/7 passed** in 3 ms.
- Covers honest flatten, depth 32 accept, depth 33 throw, sparse scopes throw, cyclic throw, zero-call accessors, and an 8k nest that throws `GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED` (not `RangeError`).
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Fork contributors cannot upload to the maintainer `pr-evidence` release (HTTP 404). Domain receipt is the pasted exact-head transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - OAuth credential flatten; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - OAuth credential flatten; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic merge-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - credential merge has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head focused suite and production-boundary receipt
<details>
<summary>domain receipt at dbc8e39683db</summary>

```
# domain artifact — Google OAuth nested-token merge
exact-head: 8387758d69c5e16cc9b9f201281de731cc5ba276
based-on: origin/develop 693be0fc19542033981e59fca25412fe5c90ac3e
owning-issue: https://github.com/elizaOS/eliza/issues/22759

Pinned Bun 1.3.14 focused oauth-credential-merge suite at this head:
  7/7 passed in 3 ms
  covers: honest flatten, depth 32 accept, depth 33 throw,
  sparse scopes throw, cyclic throw, zero-call accessors,
  8k nest GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  mergeCredentialObject 8k tokens nest: RangeError 1.68 ms
  mergeCredentialObject 20k tokens nest: RangeError 1.73 ms
  cyclic tokens: RangeError 1.24 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8387758d69c5e16cc9b9f201281de731cc5ba276 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
