### PR TITLE
fix(agent): keep sanitizer array reads descriptor-only

### DIFF
--- a/packages/agent/src/api/blocked-object-keys.test.ts
+++ b/packages/agent/src/api/blocked-object-keys.test.ts
@@ -3,6 +3,8 @@
  * key stripping plus the depth/node/cycle bound that fails closed instead of
  * RangeErroring OpenAI-compat chat JSON. No live model.
  */
+
+import type http from "node:http";
 import { ElizaError } from "@elizaos/core";
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
@@ -14,6 +16,7 @@ import {
   MAX_BLOCKED_OBJECT_DEPTH,
   MAX_BLOCKED_OBJECT_NODES,
 } from "./blocked-object-keys";
+import { type ChatRouteContext, handleChatRoutes } from "./chat-routes";
 
 function nestArray(depth: number): unknown {
   let value: unknown = "leaf";
@@ -144,7 +147,7 @@ describe("blocked object key sanitization", () => {
     expect(clean).toEqual({ safe: 1 });
   });
 
-  it("does not invoke numeric array accessors while walking", () => {
+  it("fails closed without invoking numeric array accessors", () => {
     let invoked = 0;
     const array = ["safe"];
     Object.defineProperty(array, "1", {
@@ -155,13 +158,29 @@ describe("blocked object key sanitization", () => {
       },
     });
 
-    expect(hasBlockedObjectKeyDeep(array)).toBe(false);
-    const clean = cloneWithoutBlockedObjectKeys(array);
-
+    expect(hasBlockedObjectKeyDeep(array)).toBe(true);
+    expect(() => cloneWithoutBlockedObjectKeys(array)).toThrowError(
+      expect.objectContaining({ code: BLOCKED_OBJECT_GRAPH_UNBOUNDED }),
+    );
     expect(invoked).toBe(0);
-    expect(clean).toHaveLength(2);
-    expect(clean[0]).toBe("safe");
-    expect(Object.hasOwn(clean, 1)).toBe(false);
+  });
+
+  it("does not invoke ordinary property traps while walking array elements", () => {
+    let invoked = 0;
+    const hostile = new Proxy(["safe"], {
+      get() {
+        invoked += 1;
+        throw new Error("ordinary array reads must not run");
+      },
+      has() {
+        invoked += 1;
+        throw new Error("array membership checks must not run");
+      },
+    });
+
+    expect(hasBlockedObjectKeyDeep(hostile)).toBe(false);
+    expect(cloneWithoutBlockedObjectKeys(hostile)).toEqual(["safe"]);
+    expect(invoked).toBe(0);
   });
 
   it("accepts a realistic broad chat history", () => {
@@ -191,10 +210,36 @@ describe("blocked object key sanitization", () => {
     }
   });
 
-  it("rejects a 20k nest accepted by JSON.parse as blocked", () => {
+  it("returns the existing OpenAI-compat 400 for a parsed 20k nest", async () => {
     const body = JSON.parse(
       `${"[".repeat(20_000)}${"]".repeat(20_000)}`,
     ) as unknown;
-    expect(hasBlockedObjectKeyDeep(body)).toBe(true);
+    const responses: Array<{ data: unknown; status?: number }> = [];
+    const req = { headers: {} } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    const handled = await handleChatRoutes({
+      req,
+      res,
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      readJsonBody: async <T extends object>() => body as T,
+      json: (_response, data, status) => responses.push({ data, status }),
+      error: () => expect.unreachable("blocked input uses the JSON responder"),
+      state: {} as ChatRouteContext["state"],
+    });
+
+    expect(handled).toBe(true);
+    expect(responses).toEqual([
+      {
+        data: {
+          error: {
+            message: "Request body contains a blocked object key",
+            type: "invalid_request_error",
+          },
+        },
+        status: 400,
+      },
+    ]);
   });
 });

--- a/packages/agent/src/api/blocked-object-keys.ts
+++ b/packages/agent/src/api/blocked-object-keys.ts
@@ -80,6 +80,31 @@ function ownEnumerableStringKeys(value: object): string[] {
   return keys;
 }
 
+function ownArrayLength(value: unknown[]): number {
+  const descriptor = Object.getOwnPropertyDescriptor(value, "length");
+  if (
+    !descriptor ||
+    !("value" in descriptor) ||
+    !Number.isSafeInteger(descriptor.value) ||
+    descriptor.value < 0
+  ) {
+    failBlockedObjectGraphUnbounded({ invalidArrayLength: true });
+  }
+  return descriptor.value;
+}
+
+function ownArrayElement(
+  value: unknown[],
+  index: number,
+): PropertyDescriptor | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) {
+    failBlockedObjectGraphUnbounded({ arrayAccessor: true, index });
+  }
+  return descriptor;
+}
+
 function walkHasBlockedObjectKey(
   value: unknown,
   depth: number,
@@ -99,13 +124,11 @@ function walkHasBlockedObjectKey(
   enterBlockedObjectContainer(value, ctx);
   try {
     if (Array.isArray(value)) {
-      reserveBlockedObjectVisits(ctx, value.length);
-      for (let index = 0; index < value.length; index += 1) {
-        const descriptor = Object.getOwnPropertyDescriptor(
-          value,
-          String(index),
-        );
-        if (!descriptor || !("value" in descriptor)) continue;
+      const length = ownArrayLength(value);
+      reserveBlockedObjectVisits(ctx, length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownArrayElement(value, index);
+        if (!descriptor) continue;
         if (walkHasBlockedObjectKey(descriptor.value, depth + 1, ctx, true)) {
           return true;
         }
@@ -148,15 +171,13 @@ function cloneWithoutBlockedObjectKeysWalk<T>(
   enterBlockedObjectContainer(value, ctx);
   try {
     if (Array.isArray(value)) {
-      reserveBlockedObjectVisits(ctx, value.length);
+      const length = ownArrayLength(value);
+      reserveBlockedObjectVisits(ctx, length);
       const next: unknown[] = [];
-      next.length = value.length;
-      for (let index = 0; index < value.length; index += 1) {
-        const descriptor = Object.getOwnPropertyDescriptor(
-          value,
-          String(index),
-        );
-        if (!descriptor || !("value" in descriptor)) continue;
+      next.length = length;
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownArrayElement(value, index);
+        if (!descriptor) continue;
         next[index] = cloneWithoutBlockedObjectKeysWalk(
           descriptor.value,
           depth + 1,


### PR DESCRIPTION
## Summary

- inspect array length and numeric elements through own descriptors only
- fail closed on numeric array accessors without invoking them
- retain sparse-hole budgeting and add a real OpenAI-compatible 400 boundary regression

This is the scoped post-merge correction for the residual found after #22737.

Closes #22749

## Exact-head evidence

Head: `904c68393c8e3b6408bca219808564a196b5e38f` (changed blobs byte-identical to independently reviewed `a202d52b4a8171e68b392a73dd34927167923c26`)

- `bun test packages/agent/src/api/blocked-object-keys.test.ts` — 13/13 pass
- `bun run --cwd packages/agent typecheck` — pass
- `bun run --cwd packages/agent build` — pass
- `bunx biome check packages/agent/src/api/blocked-object-keys.ts packages/agent/src/api/blocked-object-keys.test.ts` — pass
- `git diff --check` — pass

## Provenance

<!-- evidence-head:904c68393c8e3b6408bca219808564a196b5e38f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-only sanitizer; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-only sanitizer; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic server-only path

<!-- evidence-row:backend-logs -->
- [x] [22764-pr22764-rebase-backend-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22764-pr22764-rebase-backend-log.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation

<!-- evidence-row:domain-artifacts -->
- [x] [22764-pr22764-rebase-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22764-pr22764-rebase-evidence.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
Yes - scoped implementation and adversarial review

<!-- attribution-row:models -->
openai/gpt-5.6-sol

<!-- attribution-row:client -->
Codex Desktop

<!-- attribution-row:skill-revision -->
elizaOS/eliza@f6ae9e441ed4a4d52836df4290fe6dfd2eb73ea1:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
Self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f6ae9e441ed4a4d52836df4290fe6dfd2eb73ea1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cortex-wave-mid]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f6ae9e441ed4a4d52836df4290fe6dfd2eb73ea1:packages/skills/skills/contribute-to-eliza"} -->



