### PR TITLE
fix(plugin-personal-assistant): fail closed on unbounded household entity scans

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Deterministic tests for the household audit entity-ID scan. No live
+ * runtime: the walker is the production recordContainsAnyEntity used on
+ * stored event inputs/decisions.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  HOUSEHOLD_ENTITY_SCAN_UNBOUNDED,
+  MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH,
+  MAX_HOUSEHOLD_ENTITY_SCAN_NODES,
+  recordContainsAnyEntity,
+} from "./household-entity-scan";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "target";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+function nestObj(depth: number): unknown {
+  let value: unknown = { id: "target" };
+  for (let index = 0; index < depth; index += 1) {
+    value = { nested: value };
+  }
+  return value;
+}
+
+const audience = new Set(["target"]);
+
+describe("recordContainsAnyEntity", () => {
+  it("finds honest nested entity ids and misses others", () => {
+    expect(recordContainsAnyEntity("target", audience)).toBe(true);
+    expect(recordContainsAnyEntity("other", audience)).toBe(false);
+    expect(recordContainsAnyEntity({ id: "target" }, audience)).toBe(true);
+    expect(recordContainsAnyEntity(["x", { id: "target" }], audience)).toBe(
+      true,
+    );
+    expect(recordContainsAnyEntity({ nested: { id: "nope" } }, audience)).toBe(
+      false,
+    );
+  });
+
+  it(`accepts a ${MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH}-deep array nest`, () => {
+    expect(
+      recordContainsAnyEntity(
+        nestArray(MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH),
+        audience,
+      ),
+    ).toBe(true);
+    expect(
+      recordContainsAnyEntity(
+        nestObj(MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH - 1),
+        audience,
+      ),
+    ).toBe(true);
+  });
+
+  it(`throws ${HOUSEHOLD_ENTITY_SCAN_UNBOUNDED} one past depth ${MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH}`, () => {
+    try {
+      recordContainsAnyEntity(
+        nestArray(MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH + 1),
+        audience,
+      );
+      expect.unreachable("scan should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${HOUSEHOLD_ENTITY_SCAN_UNBOUNDED} past ${MAX_HOUSEHOLD_ENTITY_SCAN_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_HOUSEHOLD_ENTITY_SCAN_NODES] = "target";
+    try {
+      recordContainsAnyEntity(sparse, audience);
+      expect.unreachable(
+        "scan should fail closed on over-budget sparse length",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+    }
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { nested?: unknown } = {};
+    cyclic.nested = cyclic;
+    const started = performance.now();
+    try {
+      recordContainsAnyEntity(cyclic, audience);
+      expect.unreachable("scan should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while scanning", () => {
+    let invoked = 0;
+    const hostile = {
+      id: "other",
+      get trap() {
+        invoked += 1;
+        return "target";
+      },
+    };
+    try {
+      recordContainsAnyEntity(hostile, audience);
+      expect.unreachable("scan should fail closed on enumerable accessors");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("does not invoke array get or has traps", () => {
+    let directReads = 0;
+    let membershipChecks = 0;
+    const hostile = new Proxy(["target"], {
+      get() {
+        directReads += 1;
+        throw new Error("array values must be inspected through descriptors");
+      },
+      has() {
+        membershipChecks += 1;
+        throw new Error(
+          "array membership must be inspected through descriptors",
+        );
+      },
+    });
+
+    expect(recordContainsAnyEntity(hostile, audience)).toBe(true);
+    expect(directReads).toBe(0);
+    expect(membershipChecks).toBe(0);
+  });
+
+  it("translates hostile Proxy inspection failures", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("hostile ownKeys trap");
+        },
+      },
+    );
+
+    try {
+      recordContainsAnyEntity(hostile, audience);
+      expect.unreachable("scan should translate Proxy inspection failures");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+      expect((error as Error).cause).toBeInstanceOf(Error);
+    }
+  });
+
+  it("allows repeated references that are not cycles", () => {
+    const shared = { id: "other" };
+    expect(
+      recordContainsAnyEntity({ left: shared, right: shared }, audience),
+    ).toBe(false);
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      recordContainsAnyEntity(nestArray(8_000), audience);
+      expect.unreachable("scan should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.test.ts
@@ -5,13 +5,14 @@
  */
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-
 import {
   HOUSEHOLD_ENTITY_SCAN_UNBOUNDED,
+  householdExportAuditVisibleToAudience,
   MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH,
   MAX_HOUSEHOLD_ENTITY_SCAN_NODES,
   recordContainsAnyEntity,
 } from "./household-entity-scan";
+import type { HouseholdAuditRecord } from "./types";
 
 function nestArray(depth: number): unknown {
   let value: unknown = "target";
@@ -140,6 +141,21 @@ describe("recordContainsAnyEntity", () => {
     expect(membershipChecks).toBe(0);
   });
 
+  it(`throws ${HOUSEHOLD_ENTITY_SCAN_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+    const { proxy, revoke } = Proxy.revocable(["target"], {});
+    revoke();
+    try {
+      recordContainsAnyEntity(proxy, audience);
+      expect.unreachable("scan should fail closed on a revoked Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+      expect((error as Error).name).not.toBe("TypeError");
+      expect((error as Error).cause).toBeInstanceOf(TypeError);
+      expect(String((error as Error).cause)).toMatch(/IsArray/);
+    }
+  });
+
   it("translates hostile Proxy inspection failures", () => {
     const hostile = new Proxy(
       {},
@@ -178,5 +194,52 @@ describe("recordContainsAnyEntity", () => {
       expect((error as Error).name).not.toBe("RangeError");
     }
     expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("scans nested entity ids on the household exportFor audit payload", () => {
+    const event: Pick<HouseholdAuditRecord, "inputs" | "decision" | "ownerId"> =
+      {
+        ownerId: "owner-other",
+        inputs: {
+          householdId: "household:default",
+          affectedPartyEntityIds: ["partner"],
+          nested: { audience: ["x", { entityId: "target" }] },
+        },
+        decision: { activatedAgreementId: "agr-1" },
+      };
+    expect(
+      householdExportAuditVisibleToAudience(event, audience, {
+        isOwner: false,
+        principalEntityId: "principal",
+      }),
+    ).toBe(true);
+    expect(
+      householdExportAuditVisibleToAudience(
+        { ...event, inputs: { householdId: "household:default" } },
+        audience,
+        { isOwner: false, principalEntityId: "principal" },
+      ),
+    ).toBe(false);
+    expect(
+      householdExportAuditVisibleToAudience(
+        { ...event, inputs: { householdId: "household:default" } },
+        audience,
+        { isOwner: true, principalEntityId: "principal" },
+      ),
+    ).toBe(true);
+
+    try {
+      householdExportAuditVisibleToAudience(
+        { ...event, inputs: nestArray(8_000) as Record<string, unknown> },
+        audience,
+        { isOwner: false, principalEntityId: "principal" },
+      );
+      expect.unreachable(
+        "exportFor audit scan should fail closed on 8k inputs",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(HOUSEHOLD_ENTITY_SCAN_UNBOUNDED);
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.ts
@@ -1,0 +1,150 @@
+/**
+ * Bounds the household audit walk that searches stored event `inputs` /
+ * `decision` graphs for audience entity IDs. A hostile nest RangeError'd
+ * recordContainsAnyEntity at 8k depth on Node 24.15.0. Depth, node, and
+ * cycle limits are all load-bearing.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH = 32;
+export const MAX_HOUSEHOLD_ENTITY_SCAN_NODES = 2_048;
+export const HOUSEHOLD_ENTITY_SCAN_UNBOUNDED =
+  "HOUSEHOLD_ENTITY_SCAN_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  throw new ElizaError("Household entity scan exceeds the record-walk budget", {
+    code: HOUSEHOLD_ENTITY_SCAN_UNBOUNDED,
+    context,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_HOUSEHOLD_ENTITY_SCAN_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_HOUSEHOLD_ENTITY_SCAN_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J3 Proxy inspection failures make an untrusted stored record invalid.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(
+  value: object,
+  key: PropertyKey,
+): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+}
+
+function isArrayRecord(value: object): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+export function recordContainsAnyEntity(
+  value: unknown,
+  entityIds: ReadonlySet<string>,
+): boolean {
+  return recordContainsAnyEntityInner(value, entityIds, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+function recordContainsAnyEntityInner(
+  value: unknown,
+  entityIds: ReadonlySet<string>,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false,
+): boolean {
+  if (depth > MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH) {
+    failUnbounded({ depth, max: MAX_HOUSEHOLD_ENTITY_SCAN_DEPTH });
+  }
+  if (typeof value === "string") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return entityIds.has(value);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array" });
+        }
+        if (
+          recordContainsAnyEntityInner(
+            descriptor.value,
+            entityIds,
+            depth + 1,
+            ctx,
+            true,
+          )
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const entries: unknown[] = [];
+    for (const key of inspectRecord("ownKeys", () => Reflect.ownKeys(value))) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object" });
+      }
+      entries.push(descriptor.value);
+    }
+    reserve(ctx, entries.length);
+    for (const entry of entries) {
+      if (
+        recordContainsAnyEntityInner(entry, entityIds, depth + 1, ctx, true)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/household-entity-scan.ts
@@ -2,7 +2,9 @@
  * Bounds the household audit walk that searches stored event `inputs` /
  * `decision` graphs for audience entity IDs. A hostile nest RangeError'd
  * recordContainsAnyEntity at 8k depth on Node 24.15.0. Depth, node, and
- * cycle limits are all load-bearing.
+ * cycle limits are all load-bearing. Every reflective read is fail-closed
+ * to the typed unbounded error; array length and indexes come from own
+ * data descriptors so Proxy get/has traps cannot hang the export path.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -69,6 +71,23 @@ export function recordContainsAnyEntity(
     visits: 0,
     visiting: new WeakSet<object>(),
   });
+}
+
+/**
+ * Visibility predicate used by `HouseholdCoordinationService.exportFor`
+ * when filtering audit rows for a non-owner principal.
+ */
+export function householdExportAuditVisibleToAudience(
+  event: { inputs: unknown; decision: unknown; ownerId: string },
+  audience: ReadonlySet<string>,
+  options: { isOwner: boolean; principalEntityId: string },
+): boolean {
+  return (
+    options.isOwner ||
+    recordContainsAnyEntity(event.inputs, audience) ||
+    recordContainsAnyEntity(event.decision, audience) ||
+    event.ownerId === options.principalEntityId
+  );
 }
 
 function recordContainsAnyEntityInner(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
@@ -2,7 +2,8 @@
  * Household coordination policy over the runtime graph, approval queue, and
  * commitment ledger. The service turns mutable scheduling discussions into
  * version-pinned proposals and activates an agreement only after every named
- * adult approves those exact proposal bytes.
+ * adult approves those exact proposal bytes. Audit-record entity scans are
+ * bounded in `household-entity-scan.ts`.
  */
 import crypto from "node:crypto";
 import {
@@ -41,6 +42,7 @@ import {
   ensureHouseholdGrantExpiryWarning,
   type HouseholdGrantExpiryWarningReceipt,
 } from "./grant-expiry-warning.js";
+import { recordContainsAnyEntity } from "./household-entity-scan.js";
 import { HouseholdCoordinationRepository } from "./repository.js";
 import {
   DEFAULT_HOUSEHOLD_ID,
@@ -242,20 +244,6 @@ function nonNegativeInteger(value: number, field: string, minimum = 0): number {
     );
   }
   return value;
-}
-
-function recordContainsAnyEntity(
-  value: unknown,
-  entityIds: ReadonlySet<string>,
-): boolean {
-  if (typeof value === "string") return entityIds.has(value);
-  if (Array.isArray(value)) {
-    return value.some((entry) => recordContainsAnyEntity(entry, entityIds));
-  }
-  if (!value || typeof value !== "object") return false;
-  return Object.values(value).some((entry) =>
-    recordContainsAnyEntity(entry, entityIds),
-  );
 }
 
 function latestProposalVersions(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
@@ -42,7 +42,7 @@ import {
   ensureHouseholdGrantExpiryWarning,
   type HouseholdGrantExpiryWarningReceipt,
 } from "./grant-expiry-warning.js";
-import { recordContainsAnyEntity } from "./household-entity-scan.js";
+import { householdExportAuditVisibleToAudience } from "./household-entity-scan.js";
 import { HouseholdCoordinationRepository } from "./repository.js";
 import {
   DEFAULT_HOUSEHOLD_ID,
@@ -2954,12 +2954,11 @@ export class HouseholdCoordinationService {
               : DEFAULT_HOUSEHOLD_ID;
         return eventHouseholdId === householdId;
       })
-      .filter(
-        (event) =>
-          isOwner ||
-          recordContainsAnyEntity(event.inputs, audience) ||
-          recordContainsAnyEntity(event.decision, audience) ||
-          event.ownerId === principalEntityId,
+      .filter((event) =>
+        householdExportAuditVisibleToAudience(event, audience, {
+          isOwner,
+          principalEntityId,
+        }),
       )
       .map((event): HouseholdAuditRecord => {
         if (isOwner) return event;


### PR DESCRIPTION
Closes #22767

## Problem

Household audit listing walks stored event `inputs` and `decision` graphs with `recordContainsAnyEntity` looking for audience entity IDs. No depth, node, or cycle budget.

On `origin/develop` `d946f9c54c40` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep array nest | RangeError 0.85 ms |
| 20k-deep array nest | RangeError 0.69 ms |
| cyclic `{ nested: self }` | RangeError 0.78 ms |

Product path: household coordination audit filter. JSON.parse of the nest succeeds; the scanner then stack-overflows the PA household service.

Not leftover-tax. Not a twin of `#22748` in-memory `componentDataFilter`, `#22757` Discord structured-text, `#22761` OAuth token merge, `#22744` Gmail MIME, `#22737` blocked-object-key, or `#22707` goal prompt-value. Distinct host: household audit entity-id scan.

## Change

- Extract `recordContainsAnyEntity` to `household-entity-scan.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`HOUSEHOLD_ENTITY_SCAN_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget.
- Array length/indexes from own data descriptors; every reflective op fail-closes to the typed error (revoked Proxy included).
- `exportFor` audit filter goes through `householdExportAuditVisibleToAudience`.
- Honest nested entity-id records still match. Honest shared references still rescan.

## Exact-head evidence

Evidence revision: `a8937363436bb17a247cf9237c7f9abce83969f8`, based on `a3ede0c91e2ac1d7e46c62909778afb604aa02ba`. Owning issue: #22767.

- Pinned Bun 1.3.14 focused `household-entity-scan` suite: **12/12 passed** in 6 ms.
- Covers honest match/miss, depth 32 accept, depth 33 throw, sparse 2048-hole throw, cyclic throw, accessor zero-call, array Proxy get/has zero-call, revoked Proxy typed (not leaked TypeError/IsArray), hostile Proxy error translation with preserved cause, repeated shared references, exportFor audit-path visible/hidden/owner plus 8k `inputs` fail-closed, and an 8k nest that throws `HOUSEHOLD_ENTITY_SCAN_UNBOUNDED` (not `RangeError`).
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Maintainer review uploaded the `4ced87da5735` receipt to the immutable `pr-evidence-5` release asset linked below. The Shaw CR extras at this head are the inline domain receipt.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - household audit record walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - household audit record walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic scan-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - household entity scan has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Immutable 4ced87da5735 suite receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22768-4ced87d-focused.log)
<details>
<summary>domain receipt at 7e0afe015ce9</summary>

```
# domain artifact — household entity-id record scan (Shaw CR repair)
exact-head: a8937363436bb17a247cf9237c7f9abce83969f8
parent: a3ede0c91e2ac1d7e46c62909778afb604aa02ba
owning-issue: https://github.com/elizaOS/eliza/issues/22767

Pinned Bun 1.3.14 focused household-entity-scan suite at this head:
  12/12 passed in 6 ms
  covers: honest match/miss, depth 32 accept, depth 33 throw,
  sparse 2048-hole throw, cyclic throw, zero-call accessors,
  Proxy get/has zero-call, revoked Proxy typed (not TypeError/IsArray),
  hostile ownKeys cause-preserving translation, shared-ref rescan,
  exportFor audit-path visible/hidden/owner plus 8k inputs fail-closed,
  8k nest HOUSEHOLD_ENTITY_SCAN_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  recordContainsAnyEntity 8k array nest: RangeError 0.85 ms
  recordContainsAnyEntity 20k array nest: RangeError 0.69 ms
  cyclic record: RangeError 0.78 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

Original contribution:

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a8937363436bb17a247cf9237c7f9abce83969f8 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->


