### PR TITLE
test(ui): complete fixture client constructor coverage

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/browser-surface-error-api-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/browser-surface-error-api-stub.ts
@@ -36,3 +36,8 @@ export const client: Record<string, unknown> = {
   signBrowserSolanaMessage: reject,
   signBrowserWalletMessage: reject,
 };
+
+/** Supplies constructor imports while preserving the fixture's shared client. */
+export function ElizaClient() {
+  return client;
+}

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
@@ -1,10 +1,9 @@
-// Stub for `../../api` (and `../../api/client`) in the home-screen e2e.
-//
-// The REAL WidgetHost + home widgets bundle and render; only their data sources
-// are stubbed. Widgets that fetch lifeops routes call `client.getBaseUrl()` then
-// raw `window.fetch` (mocked in the fixture); the notification store calls typed
-// `client.*` methods, delegated here to the shared home-widget mock data so the
-// dashboard center renders with injected data.
+/**
+ * Stubs `../../api` and `../../api/client` for the home-screen E2E while the
+ * real WidgetHost and home widgets render. Widgets that fetch lifeops routes
+ * use the fixture's raw `window.fetch`; typed client methods delegate to shared
+ * home-widget mock data so the dashboard renders with injected data.
+ */
 
 import {
   homeWidgetApprovalsResponse,
@@ -27,6 +26,16 @@ export const client = {
   // Empty base → widgets fetch `/api/lifeops/...` which the window.fetch mock
   // (installed in the fixture) intercepts.
   getBaseUrl: () => "",
+  // Typed widget requests still pass through the fixture's window.fetch mock;
+  // mirror the production client's JSON boundary so constructor-based imports
+  // and the shared singleton observe the same seeded responses.
+  fetch: async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const response = await window.fetch(path, init);
+    if (!response.ok) {
+      throw new Error(`Fixture request failed with status ${response.status}`);
+    }
+    return (await response.json()) as T;
+  },
   // This fixture represents a local runtime whose text route is Cerebras. The
   // model-download widget must therefore skip the unrelated local text slot.
   getModelsConfig: async () => ({
@@ -81,3 +90,8 @@ export const client = {
   listConversations: async () => ({ conversations: [] }),
   getConversationMessages: async () => ({ messages: [] }),
 };
+
+/** Supplies constructor imports while preserving the fixture's shared client. */
+export function ElizaClient() {
+  return client;
+}


### PR DESCRIPTION
## Summary

- export the fixture-compatible `ElizaClient` constructor from the remaining UI API stubs
- preserve the singleton client used by each fixture
- route the home calendar widget's typed `client.fetch()` calls through the existing seeded `window.fetch` mock

Closes #22733.

## Verification

- `bun run --cwd packages/ui test:home-screen-e2e`
- `bun run --cwd packages/ui test:browser-surface-error-e2e`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui typecheck`
- audited every `*api-stub.ts` exporting `client` for an `ElizaClient` export

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this regression repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
