### PR TITLE
test(ui): align managed cloud settings fixture

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -189,7 +189,6 @@ async function snap(page, name) {
 // The MVP-visible hub rows, in expected registry order per group.
 const VISIBLE_SECTIONS = [
   "identity",
-  "ai-model",
   "voice",
   "connectors",
   "appearance",
@@ -198,6 +197,9 @@ const VISIBLE_SECTIONS = [
   "cloud-overview",
 ];
 const HIDDEN_SECTIONS = [
+  // The fixture boots a managed-cloud runtime, where provider selection is
+  // owned by the managed agent rather than the local Models & Providers tab.
+  "ai-model",
   "capabilities",
   "apps",
   "background",
@@ -235,10 +237,12 @@ for (const id of VISIBLE_SECTIONS) {
   );
 }
 for (const id of HIDDEN_SECTIONS) {
+  const reason =
+    id === "ai-model" ? "managed-cloud runtime" : "Developer Mode off";
   assert(
     (await p.locator(`[data-testid="desktop-settings-item-${id}"]`).count()) ===
       0,
-    `rail hides the "${id}" item (Developer Mode off)`,
+    `rail hides the "${id}" item (${reason})`,
   );
 }
 assert(


### PR DESCRIPTION
## Summary

- align the Settings browser fixture with its declared managed-cloud runtime
- require the local Models & Providers section to stay hidden on that surface
- keep the visibility assertion reason explicit in the E2E output

Refs #22733.

## Verification

- `bun run --cwd packages/ui test:settings-e2e` (12 captures, zero page errors)
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui typecheck`

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this regression repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
