### PR TITLE
fix(cloud): restore credits mock export contracts

### DIFF
--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -119,6 +119,12 @@ let ledger = makeLedgerReservation(100, 0.015);
 const admissionCalls: Array<Record<string, unknown>> = [];
 
 mock.module("@/lib/services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: {
     createAnonymousReservation: mock(
       () => makeLedgerReservation(0, 0).reservation,

--- a/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
@@ -52,6 +52,12 @@ mock.module("@/lib/services/users", () => ({
   usersService: { getWithOrganization: mock(async () => null) },
 }));
 mock.module("@/lib/services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: {
     addCredits,
     getTransactionByStripePaymentIntent: mock(async () => null),

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -90,6 +90,12 @@ class MockInsufficientCreditsError extends Error {
   }
 }
 mock.module("@/lib/services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   InsufficientCreditsError: MockInsufficientCreditsError,
 }));
 const speechToText = mock(

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -171,6 +171,12 @@ mock.module("@/lib/services/credits", () => {
     required = 0;
   }
   return {
+    assertCreditRefundWithinReservation: () => {
+      throw new Error("credit refund assertion is outside this test path");
+    },
+    assertValidCreditSettlementCosts: () => {
+      throw new Error("credit settlement assertion is outside this test path");
+    },
     InsufficientCreditsError,
   };
 });

--- a/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
@@ -96,6 +96,12 @@ mock.module("./services/characters/characters", () => ({
 }));
 // Remaining steward-sync imports (auth.ts pulls the real module); inert stubs.
 mock.module("./services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: { addCredits: async () => ({ success: true }) },
 }));
 mock.module("./services/organizations", () => ({

--- a/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
@@ -56,6 +56,12 @@ mock.module("../../db/repositories/users", () => ({
 
 mock.module("./credits", () => ({
   APP_CHAT_RESERVATION_SETTLEMENT_MARKER: "app-chat-settlement",
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: {},
   InsufficientCreditsError: class InsufficientCreditsError extends Error {},
   MIN_RESERVATION: 0.0001,

--- a/packages/cloud/shared/src/lib/services/proxy/engine.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.error-policy.test.ts
@@ -39,6 +39,8 @@ mock.module("../../auth", () => ({
 
 mock.module("../credits", () => ({
   ...realCredits,
+  assertCreditRefundWithinReservation: realCredits.assertCreditRefundWithinReservation,
+  assertValidCreditSettlementCosts: realCredits.assertValidCreditSettlementCosts,
   creditsService: { ...realCredits.creditsService, reserve },
 }));
 

--- a/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
@@ -30,6 +30,12 @@ mock.module("./services/characters/characters", () => ({
 
 // steward-sync's other service imports; inert stubs so the module loads.
 mock.module("./services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: { addCredits: async () => ({ success: true }) },
 }));
 mock.module("./services/organizations", () => ({

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -55,6 +55,12 @@ const finalUserWithOrg = {
 };
 
 mock.module("./services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: { addCredits: async () => ({ success: true }) },
 }));
 mock.module("./services/organizations", () => ({

--- a/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
@@ -73,6 +73,12 @@ mock.module("./services/steward-tenant-config", () => ({
 }));
 
 mock.module("./services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: {
     addCredits: async () => ({ success: true }),
   },

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -27,6 +27,12 @@ const finalUserWithOrg = {
 };
 
 mock.module("./services/credits", () => ({
+  assertCreditRefundWithinReservation: () => {
+    throw new Error("credit refund assertion is outside this test path");
+  },
+  assertValidCreditSettlementCosts: () => {
+    throw new Error("credit settlement assertion is outside this test path");
+  },
   creditsService: {
     addCredits: (params: unknown) => addCreditsImpl(params),
   },


### PR DESCRIPTION
# Relates to

Fixes #22758.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6962b360120d9724911991910da8808fe89ea4b0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `b4a3b0c291b83d371457aa667b579ea3c1c25af2`; zero conflicts.
- [x] [exact-head Quality run 32343024182](https://github.com/elizaOS/eliza/actions/runs/32343024182), including repository verification, succeeded.

# Risks

Low. Test-only mock contracts and the existing audit ratchet change; no production billing, credits, voice, or Steward behavior changes.

# Background

## What does this PR do?

The credits service added two settlement assertion exports. Eleven whole-module Bun mocks omitted them, making the mock-export audit report 11 new findings and 10 stale rows. This PR explicitly supplies both exports in every affected mock. Ten inert mocks throw if the supposedly unreachable assertions execute; the proxy error-policy test binds the real implementations. The pre-existing 102-row debt baseline remains byte-for-byte unchanged.

## What kind of change is this?

Test-contract bug fix.

# Documentation changes needed?

No; production APIs and behavior are unchanged.

# Testing

## Where should a reviewer start?

Compare the credits mock in `chat-stream-credit-leak.test.ts` and the real-binding variant in `services/proxy/engine.error-policy.test.ts`.

## Detailed testing steps

- Eleven affected test files run in isolated Bun processes — 115 pass, 1 skip, 0 fail, 556 assertions.
- `bun test packages/scripts/audit-mock-module-exports.test.mjs` — 18/18 pass.
- `node packages/scripts/audit-mock-module-exports.mjs` — pass: 3,279 mocks / 652 test files / 102 ratcheted findings.
- Cloud API typecheck and build are covered by the exact-head Quality run.
- Cloud API lint is covered by the exact-head Quality run.
- Cloud shared typecheck is covered by the exact-head Quality run.
- Cloud shared lint is covered by the exact-head Quality run.

# Evidence Gate

<!-- evidence-head:6962b360120d9724911991910da8808fe89ea4b0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only diff with no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only diff with no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only mock contract change; isolated test and audit output is recorded in Testing
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no production domain state changes; the mock-export audit result is recorded in Testing
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

## Known gaps / failures

Exact-head Quality run 32343024182 succeeded. Isolated execution is required because Bun `mock.module` replacements are process-global and these files intentionally mock overlapping modules differently.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6962b360120d9724911991910da8808fe89ea4b0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6962b360120d9724911991910da8808fe89ea4b0:packages/skills/skills/contribute-to-eliza"} -->



