### PR TITLE
fix(plugin-google-workspace): fail closed on accessor-backed MIME fields

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
@@ -5,6 +5,8 @@
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 
+import type { GoogleApiClientFactory } from "./client-factory";
+import { GoogleGmailClient } from "./gmail";
 import {
   extractGmailMimeBody,
   GMAIL_MIME_PART_UNBOUNDED,
@@ -71,7 +73,7 @@ describe("walkGmailMimeParts", () => {
     expect(performance.now() - started).toBeLessThan(50);
   });
 
-  it("does not invoke accessors while walking", () => {
+  it("fails closed on accessor-backed parts without invoking them", () => {
     let invoked = 0;
     const hostile: GmailMimePartLike = {
       mimeType: "multipart/mixed",
@@ -80,7 +82,127 @@ describe("walkGmailMimeParts", () => {
         return nestMime(20_000).parts ?? [];
       },
     };
-    walkGmailMimeParts(hostile, () => {});
+    try {
+      walkGmailMimeParts(hostile, () => {});
+      expect.unreachable("walk should fail closed on accessor-backed parts");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on accessor-backed child slots without invoking them", () => {
+    let invoked = 0;
+    const children: GmailMimePartLike[] = [];
+    Object.defineProperty(children, 0, {
+      configurable: true,
+      enumerable: true,
+      get(): GmailMimePartLike {
+        invoked += 1;
+        return { mimeType: "text/plain", body: { data: "x" } };
+      },
+    });
+    try {
+      walkGmailMimeParts({ mimeType: "multipart/mixed", parts: children }, () => {});
+      expect.unreachable("walk should fail closed on accessor-backed child slots");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on accessor-backed mimeType without invoking it", () => {
+    let invoked = 0;
+    const hostile = {
+      get mimeType(): string {
+        invoked += 1;
+        return "text/plain";
+      },
+      body: { data: "secret" },
+    };
+    try {
+      extractGmailMimeBody(hostile, "text/plain", (part) => part.body?.data ?? "");
+      expect.unreachable("extract should fail closed on accessor-backed mimeType");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on accessor-backed body data without invoking it", () => {
+    let invoked = 0;
+    const body = {};
+    Object.defineProperty(body, "data", {
+      configurable: true,
+      enumerable: true,
+      get(): string {
+        invoked += 1;
+        return "secret";
+      },
+    });
+    try {
+      extractGmailMimeBody(
+        { mimeType: "text/plain", body: body as { data?: string | null } },
+        "text/plain",
+        (part) => part.body?.data ?? ""
+      );
+      expect.unreachable("extract should fail closed on accessor-backed body data");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("does not use in or index-get on child arrays", () => {
+    let invoked = 0;
+    const child: GmailMimePartLike = { mimeType: "text/plain", body: { data: "ok" } };
+    const children = new Proxy([child], {
+      has(): boolean {
+        invoked += 1;
+        return true;
+      },
+      get(target, property, receiver) {
+        if (property !== "length") invoked += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const body = extractGmailMimeBody(
+      { mimeType: "multipart/mixed", parts: children },
+      "text/plain",
+      (part) => part.body?.data ?? ""
+    );
+    expect(body).toBe("ok");
+    expect(invoked).toBe(0);
+  });
+
+  it("passes visitors an own-data snapshot so collector body reads stay accessor-free", () => {
+    let invoked = 0;
+    const body = {};
+    Object.defineProperty(body, "data", {
+      configurable: true,
+      enumerable: true,
+      get(): string {
+        invoked += 1;
+        return "secret";
+      },
+    });
+    try {
+      walkGmailMimeParts(
+        { mimeType: "text/plain", body: body as { data?: string | null } },
+        (node) => {
+          void node.body?.data;
+          return false;
+        }
+      );
+      expect.unreachable("walk should fail closed before the visitor sees accessor body data");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+    }
     expect(invoked).toBe(0);
   });
 
@@ -138,5 +260,41 @@ describe("walkGmailMimeParts", () => {
       expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
     }
     expect(performance.now() - extractStarted).toBeLessThan(50);
+  });
+});
+
+describe("GoogleGmailClient.getGmailMessageDetail MIME bound", () => {
+  it("fails closed on a 20k MIME nest without RangeError", async () => {
+    const fakeGmail = {
+      users: {
+        messages: {
+          get: async () => ({
+            data: {
+              id: "msg_hostile",
+              threadId: "thread_hostile",
+              snippet: "nested",
+              payload: nestMime(20_000),
+            },
+          }),
+        },
+      },
+    };
+    const factory = {
+      gmail: async () => fakeGmail,
+    } as unknown as GoogleApiClientFactory;
+    const client = new GoogleGmailClient(factory);
+    const started = performance.now();
+    try {
+      await client.getGmailMessageDetail({
+        accountId: "acct_1",
+        messageId: "msg_hostile",
+      });
+      expect.unreachable("getGmailMessageDetail should fail closed on a 20k MIME nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
   });
 });

--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.test.ts
@@ -16,6 +16,27 @@ import {
   walkGmailMimeParts,
 } from "./gmail-mime-parts";
 
+function gmailClientForPayload(payload: unknown): GoogleGmailClient {
+  const fakeGmail = {
+    users: {
+      messages: {
+        get: async () => ({
+          data: {
+            id: "msg_hostile",
+            threadId: "thread_hostile",
+            snippet: "nested",
+            payload,
+          },
+        }),
+      },
+    },
+  };
+  const factory = {
+    gmail: async () => fakeGmail,
+  } as unknown as GoogleApiClientFactory;
+  return new GoogleGmailClient(factory);
+}
+
 function nestMime(depth: number): GmailMimePartLike {
   let part: GmailMimePartLike = { mimeType: "text/plain", body: { data: "leaf" } };
   for (let index = 0; index < depth; index += 1) {
@@ -206,6 +227,86 @@ describe("walkGmailMimeParts", () => {
     expect(invoked).toBe(0);
   });
 
+  it("does not inspect later accessor siblings after DFS abort-on-match", () => {
+    let invoked = 0;
+    const children: GmailMimePartLike[] = [{ mimeType: "text/plain", body: { data: "a" } }];
+    Object.defineProperty(children, 1, {
+      configurable: true,
+      enumerable: true,
+      get(): GmailMimePartLike {
+        invoked += 1;
+        return { mimeType: "text/html", body: { data: "b" } };
+      },
+    });
+    const seen: Array<string | null | undefined> = [];
+    walkGmailMimeParts({ mimeType: "multipart/mixed", parts: children }, (part) => {
+      seen.push(part.mimeType);
+      return part.mimeType === "text/plain";
+    });
+    expect(seen).toEqual(["multipart/mixed", "text/plain"]);
+    expect(invoked).toBe(0);
+  });
+
+  it("extracts the first body without reading a later accessor sibling", () => {
+    let invoked = 0;
+    const children: GmailMimePartLike[] = [{ mimeType: "text/plain", body: { data: "first" } }];
+    Object.defineProperty(children, 1, {
+      configurable: true,
+      enumerable: true,
+      get(): GmailMimePartLike {
+        invoked += 1;
+        return { mimeType: "text/plain", body: { data: "second" } };
+      },
+    });
+    const body = extractGmailMimeBody(
+      { mimeType: "multipart/mixed", parts: children },
+      "text/plain",
+      (part) => part.body?.data ?? ""
+    );
+    expect(body).toBe("first");
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on a hostile getOwnPropertyDescriptor trap", () => {
+    const hostile = new Proxy(
+      { mimeType: "text/plain", body: { data: "x" } },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("descriptor trap");
+        },
+      }
+    );
+    try {
+      walkGmailMimeParts(hostile, () => {});
+      expect.unreachable("walk should fail closed on a descriptor trap");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as ElizaError).context).toMatchObject({
+        reflection: "getOwnPropertyDescriptor",
+      });
+      expect((error as Error).cause).toBeInstanceOf(Error);
+    }
+  });
+
+  it("fails closed on a revoked parts array Proxy", () => {
+    const { proxy, revoke } = Proxy.revocable(
+      [{ mimeType: "text/plain", body: { data: "x" } }],
+      {}
+    );
+    revoke();
+    try {
+      walkGmailMimeParts({ mimeType: "multipart/mixed", parts: proxy }, () => {});
+      expect.unreachable("walk should fail closed on a revoked parts Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as ElizaError).context).toMatchObject({
+        reflection: "Array.isArray",
+      });
+    }
+  });
+
   it("aborts remaining siblings once visit returns true", () => {
     const seen: Array<string | null | undefined> = [];
     walkGmailMimeParts(
@@ -265,24 +366,7 @@ describe("walkGmailMimeParts", () => {
 
 describe("GoogleGmailClient.getGmailMessageDetail MIME bound", () => {
   it("fails closed on a 20k MIME nest without RangeError", async () => {
-    const fakeGmail = {
-      users: {
-        messages: {
-          get: async () => ({
-            data: {
-              id: "msg_hostile",
-              threadId: "thread_hostile",
-              snippet: "nested",
-              payload: nestMime(20_000),
-            },
-          }),
-        },
-      },
-    };
-    const factory = {
-      gmail: async () => fakeGmail,
-    } as unknown as GoogleApiClientFactory;
-    const client = new GoogleGmailClient(factory);
+    const client = gmailClientForPayload(nestMime(20_000));
     const started = performance.now();
     try {
       await client.getGmailMessageDetail({
@@ -296,5 +380,73 @@ describe("GoogleGmailClient.getGmailMessageDetail MIME bound", () => {
       expect((error as Error).name).not.toBe("RangeError");
     }
     expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke an inherited body getter on the octet-stream fallback", async () => {
+    let invoked = 0;
+    const proto: object = {};
+    Object.defineProperty(proto, "body", {
+      configurable: true,
+      get(): { data: string } {
+        invoked += 1;
+        return { data: "secret" };
+      },
+    });
+    const payload = Object.create(proto) as GmailMimePartLike;
+    payload.mimeType = "application/octet-stream";
+    const detail = await gmailClientForPayload(payload).getGmailMessageDetail({
+      accountId: "acct_1",
+      messageId: "msg_hostile",
+    });
+    expect(invoked).toBe(0);
+    expect(detail?.bodyText).toBe("nested");
+  });
+
+  it("fails closed on a hostile descriptor trap at getGmailMessageDetail", async () => {
+    const payload = new Proxy(
+      { mimeType: "text/plain", body: { data: "x" } },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("descriptor trap");
+        },
+      }
+    );
+    try {
+      await gmailClientForPayload(payload).getGmailMessageDetail({
+        accountId: "acct_1",
+        messageId: "msg_hostile",
+      });
+      expect.unreachable("getGmailMessageDetail should fail closed on a descriptor trap");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as ElizaError).context).toMatchObject({
+        reflection: "getOwnPropertyDescriptor",
+      });
+    }
+  });
+
+  it("fails closed on a revoked parts Proxy at getGmailMessageDetail", async () => {
+    const { proxy, revoke } = Proxy.revocable(
+      [{ mimeType: "text/plain", body: { data: "x" } }],
+      {}
+    );
+    revoke();
+    try {
+      await gmailClientForPayload({
+        mimeType: "multipart/mixed",
+        parts: proxy,
+      }).getGmailMessageDetail({
+        accountId: "acct_1",
+        messageId: "msg_hostile",
+      });
+      expect.unreachable("getGmailMessageDetail should fail closed on a revoked parts Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GMAIL_MIME_PART_UNBOUNDED);
+      expect((error as ElizaError).context).toMatchObject({
+        reflection: "Array.isArray",
+      });
+    }
   });
 });

--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
@@ -24,11 +24,12 @@ type WalkContext = {
 
 type OwnData = { found: false } | { found: true; value: unknown };
 
-function failUnbounded(context: Record<string, unknown>): never {
+function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
   throw new ElizaError("Gmail MIME part tree exceeds the ingest walk budget", {
     code: GMAIL_MIME_PART_UNBOUNDED,
     context,
     severity: "fatal",
+    ...(cause !== undefined ? { cause } : {}),
   });
 }
 
@@ -43,7 +44,13 @@ function reserve(ctx: WalkContext, count: number): void {
 }
 
 function ownData(object: object, key: PropertyKey, field: string): OwnData {
-  const descriptor = Object.getOwnPropertyDescriptor(object, key);
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(object, key);
+  } catch (cause) {
+    // error-policy:J2 hostile descriptor traps become typed MIME fail-closed.
+    failUnbounded({ reflection: "getOwnPropertyDescriptor", field }, cause);
+  }
   if (!descriptor) return { found: false };
   if (!Object.hasOwn(descriptor, "value")) {
     failUnbounded({ accessor: field });
@@ -51,7 +58,16 @@ function ownData(object: object, key: PropertyKey, field: string): OwnData {
   return { found: true, value: descriptor.value };
 }
 
-function snapshotMimePart(part: object): GmailMimePartLike {
+function isMimeChildArray(value: unknown): value is unknown[] {
+  try {
+    return Array.isArray(value);
+  } catch (cause) {
+    // error-policy:J2 revoked or trapping arrays become typed MIME fail-closed.
+    failUnbounded({ reflection: "Array.isArray", field: "parts" }, cause);
+  }
+}
+
+export function snapshotGmailMimePart(part: object): GmailMimePartLike {
   const mime = ownData(part, "mimeType", "mimeType");
   const bodyOwn = ownData(part, "body", "body");
   const snapshot: GmailMimePartLike = {};
@@ -77,24 +93,27 @@ function snapshotMimePart(part: object): GmailMimePartLike {
   return snapshot;
 }
 
-function childParts(part: object, ctx: WalkContext): object[] {
+function forEachMimeChild(
+  part: object,
+  ctx: WalkContext,
+  visitChild: (child: object) => boolean
+): boolean {
   const partsOwn = ownData(part, "parts", "parts");
-  if (!partsOwn.found) return [];
+  if (!partsOwn.found) return false;
+  if (!isMimeChildArray(partsOwn.value)) return false;
   const children = partsOwn.value;
-  if (!Array.isArray(children)) return [];
   const lengthOwn = ownData(children, "length", "parts.length");
   const length = lengthOwn.found ? lengthOwn.value : 0;
   if (typeof length !== "number" || !Number.isInteger(length) || length < 0) {
     failUnbounded({ field: "parts.length", length });
   }
   reserve(ctx, length);
-  const out: object[] = [];
   for (let index = 0; index < length; index += 1) {
     const slot = ownData(children, index, "parts[]");
     if (!slot.found || !slot.value || typeof slot.value !== "object") continue;
-    out.push(slot.value);
+    if (visitChild(slot.value)) return true;
   }
-  return out;
+  return false;
 }
 
 /**
@@ -126,14 +145,11 @@ function walkGmailMimePartsInner(
   }
   ctx.visiting.add(part);
   try {
-    const snapshot = snapshotMimePart(part);
+    const snapshot = snapshotGmailMimePart(part);
     if (visit(snapshot) === true) return true;
-    for (const child of childParts(part, ctx)) {
-      if (walkGmailMimePartsInner(child, depth + 1, ctx, visit, true)) {
-        return true;
-      }
-    }
-    return false;
+    return forEachMimeChild(part, ctx, (child) =>
+      walkGmailMimePartsInner(child, depth + 1, ctx, visit, true)
+    );
   } finally {
     ctx.visiting.delete(part);
   }
@@ -173,15 +189,20 @@ function extractGmailMimeBodyInner(
   }
   ctx.visiting.add(part);
   try {
-    const snapshot = snapshotMimePart(part);
+    const snapshot = snapshotGmailMimePart(part);
     if (snapshot.mimeType === mimeType && typeof snapshot.body?.data === "string") {
       return readBody(snapshot);
     }
-    for (const child of childParts(part, ctx)) {
+    let found = "";
+    forEachMimeChild(part, ctx, (child) => {
       const nested = extractGmailMimeBodyInner(child, mimeType, readBody, depth + 1, ctx, true);
-      if (nested) return nested;
-    }
-    return "";
+      if (nested) {
+        found = nested;
+        return true;
+      }
+      return false;
+    });
+    return found;
   } finally {
     ctx.visiting.delete(part);
   }

--- a/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
+++ b/plugins/plugin-google-workspace/src/gmail-mime-parts.ts
@@ -2,7 +2,7 @@
  * Bounds the Gmail MIME `parts` tree before ingest walks it. Gmail API
  * payloads carry untrusted nested multipart from hostile mail; the previous
  * recursive collect/extract RangeError'd a 20k nest on Node 24.15.0.
- * Depth, node, and cycle limits are all load-bearing.
+ * Depth, node, cycle, and own-data-descriptor limits are all load-bearing.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -22,6 +22,8 @@ type WalkContext = {
   visiting: WeakSet<object>;
 };
 
+type OwnData = { found: false } | { found: true; value: unknown };
+
 function failUnbounded(context: Record<string, unknown>): never {
   throw new ElizaError("Gmail MIME part tree exceeds the ingest walk budget", {
     code: GMAIL_MIME_PART_UNBOUNDED,
@@ -40,9 +42,65 @@ function reserve(ctx: WalkContext, count: number): void {
   ctx.visits += count;
 }
 
+function ownData(object: object, key: PropertyKey, field: string): OwnData {
+  const descriptor = Object.getOwnPropertyDescriptor(object, key);
+  if (!descriptor) return { found: false };
+  if (!Object.hasOwn(descriptor, "value")) {
+    failUnbounded({ accessor: field });
+  }
+  return { found: true, value: descriptor.value };
+}
+
+function snapshotMimePart(part: object): GmailMimePartLike {
+  const mime = ownData(part, "mimeType", "mimeType");
+  const bodyOwn = ownData(part, "body", "body");
+  const snapshot: GmailMimePartLike = {};
+  if (mime.found) {
+    snapshot.mimeType = mime.value as string | null | undefined;
+  }
+  if (!bodyOwn.found) return snapshot;
+  if (bodyOwn.value == null) {
+    snapshot.body = bodyOwn.value as null | undefined;
+    return snapshot;
+  }
+  if (typeof bodyOwn.value !== "object") {
+    snapshot.body = undefined;
+    return snapshot;
+  }
+  const data = ownData(bodyOwn.value, "data", "body.data");
+  snapshot.body = {
+    data:
+      !data.found || data.value == null || typeof data.value === "string"
+        ? ((data.found ? data.value : undefined) as string | null | undefined)
+        : undefined,
+  };
+  return snapshot;
+}
+
+function childParts(part: object, ctx: WalkContext): object[] {
+  const partsOwn = ownData(part, "parts", "parts");
+  if (!partsOwn.found) return [];
+  const children = partsOwn.value;
+  if (!Array.isArray(children)) return [];
+  const lengthOwn = ownData(children, "length", "parts.length");
+  const length = lengthOwn.found ? lengthOwn.value : 0;
+  if (typeof length !== "number" || !Number.isInteger(length) || length < 0) {
+    failUnbounded({ field: "parts.length", length });
+  }
+  reserve(ctx, length);
+  const out: object[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const slot = ownData(children, index, "parts[]");
+    if (!slot.found || !slot.value || typeof slot.value !== "object") continue;
+    out.push(slot.value);
+  }
+  return out;
+}
+
 /**
  * Depth-first visit of a Gmail MIME part tree. `visit` returning true aborts
- * the remaining walk (used when extract has already found a body).
+ * the remaining walk (used when extract has already found a body). Visitors
+ * receive an own-data snapshot so they never read accessors on the raw part.
  */
 export function walkGmailMimeParts(
   part: GmailMimePartLike | undefined,
@@ -53,7 +111,7 @@ export function walkGmailMimeParts(
 }
 
 function walkGmailMimePartsInner(
-  part: GmailMimePartLike,
+  part: object,
   depth: number,
   ctx: WalkContext,
   visit: (part: GmailMimePartLike) => boolean | undefined,
@@ -68,16 +126,9 @@ function walkGmailMimePartsInner(
   }
   ctx.visiting.add(part);
   try {
-    if (visit(part) === true) return true;
-    const partsDescriptor = Object.getOwnPropertyDescriptor(part, "parts");
-    if (!partsDescriptor || !("value" in partsDescriptor)) return false;
-    const children = partsDescriptor.value;
-    if (!Array.isArray(children)) return false;
-    reserve(ctx, children.length);
-    for (let index = 0; index < children.length; index += 1) {
-      if (!(index in children)) continue;
-      const child = children[index];
-      if (!child || typeof child !== "object") continue;
+    const snapshot = snapshotMimePart(part);
+    if (visit(snapshot) === true) return true;
+    for (const child of childParts(part, ctx)) {
       if (walkGmailMimePartsInner(child, depth + 1, ctx, visit, true)) {
         return true;
       }
@@ -106,7 +157,7 @@ export function extractGmailMimeBody(
 }
 
 function extractGmailMimeBodyInner(
-  part: GmailMimePartLike,
+  part: object,
   mimeType: string,
   readBody: (part: GmailMimePartLike) => string,
   depth: number,
@@ -122,28 +173,11 @@ function extractGmailMimeBodyInner(
   }
   ctx.visiting.add(part);
   try {
-    const directBody = Object.getOwnPropertyDescriptor(part, "body");
-    const mimeDescriptor = Object.getOwnPropertyDescriptor(part, "mimeType");
-    const mime = mimeDescriptor && "value" in mimeDescriptor ? mimeDescriptor.value : part.mimeType;
-    if (
-      mime === mimeType &&
-      directBody &&
-      "value" in directBody &&
-      directBody.value &&
-      typeof (directBody.value as { data?: unknown }).data === "string"
-    ) {
-      return readBody(part);
+    const snapshot = snapshotMimePart(part);
+    if (snapshot.mimeType === mimeType && typeof snapshot.body?.data === "string") {
+      return readBody(snapshot);
     }
-
-    const partsDescriptor = Object.getOwnPropertyDescriptor(part, "parts");
-    if (!partsDescriptor || !("value" in partsDescriptor)) return "";
-    const children = partsDescriptor.value;
-    if (!Array.isArray(children)) return "";
-    reserve(ctx, children.length);
-    for (let index = 0; index < children.length; index += 1) {
-      if (!(index in children)) continue;
-      const child = children[index];
-      if (!child || typeof child !== "object") continue;
+    for (const child of childParts(part, ctx)) {
       const nested = extractGmailMimeBodyInner(child, mimeType, readBody, depth + 1, ctx, true);
       if (nested) return nested;
     }

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -11,7 +11,11 @@
 import { ElizaError } from "@elizaos/core";
 import type { gmail_v1 } from "googleapis";
 import type { GoogleApiClientFactory } from "./client-factory.js";
-import { extractGmailMimeBody, walkGmailMimeParts } from "./gmail-mime-parts.js";
+import {
+  extractGmailMimeBody,
+  snapshotGmailMimePart,
+  walkGmailMimeParts,
+} from "./gmail-mime-parts.js";
 import type {
   GoogleAccountRef,
   GoogleEmailAddress,
@@ -1006,10 +1010,14 @@ function extractGoogleGmailBody(payload: gmail_v1.Schema$MessagePart | undefined
   if (htmlText) {
     return htmlText;
   }
-  const directBody = payload?.body?.data;
+  if (!payload) {
+    return "";
+  }
+  const snapshot = snapshotGmailMimePart(payload);
+  const directBody = snapshot.body?.data;
   if (typeof directBody === "string") {
     const decoded = decodeBase64Url(directBody);
-    return payload?.mimeType === "text/html" ? htmlToPlainText(decoded) : decoded.trim();
+    return snapshot.mimeType === "text/html" ? htmlToPlainText(decoded) : decoded.trim();
   }
   return "";
 }


### PR DESCRIPTION
# Relates to

Closes #22774
Follow-up to #22744 / #22750.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests and Biome on the three changed files were run after sync. Full root `bun run verify` was not rerun; exact-head plugin typecheck and build passed, alongside the focused 21/21 production-boundary suite and Biome/diff-check.
- [x] A reviewer can confirm the change from the focused suite and production-path receipt below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Build
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `faef8c31d7b3441a9732d71da947bd25119530ec`; zero conflicts.
- [x] Focused `gmail-mime-parts` suite 21/21 and Biome on the two files pass at this head.

# Risks

Low. Bounded Gmail MIME ingest only. Honest data-descriptor payloads keep historical DFS/empty-sibling extract order. Accessor-backed fields now fail closed instead of being skipped or read through getters.

# Background

## What does this PR do?

#22744 bounded MIME depth, node count, and cycles, but still used ordinary property reads, `in`, and index-get on untrusted Gmail parts. Hostile accessors/proxies could still run during `walkGmailMimeParts` / `extractGmailMimeBody` / `GoogleGmailClient.getGmailMessageDetail`.

This snapshots `mimeType`, `body.data`, `parts`, `parts.length`, and child slots through own data descriptors only and throws typed `GMAIL_MIME_PART_UNBOUNDED` on accessor-backed fields without invoking them. Visitors receive the snapshot so collector `node.body?.data` reads cannot hit the raw object.

## What kind of change is this?

Bug fix (non-breaking): fail-closed security residual after #22744.

# Documentation changes needed?

No. Package comment already points ingest at `gmail-mime-parts.ts`.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/gmail-mime-parts.ts` and `src/gmail-mime-parts.test.ts`.

## Detailed testing steps

```bash
cd plugins/plugin-google-workspace
bun run test src/gmail-mime-parts.test.ts
bunx @biomejs/biome check src/gmail-mime-parts.ts src/gmail-mime-parts.test.ts
```

# Evidence Gate

<!-- evidence-head:aca9af583fc7c032a1a158e18c0d93ebaf777703 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side Gmail MIME ingest; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side Gmail MIME ingest; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] [Expanded owning-package log at byte-identical reviewed predecessor d87fcba (234/234)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22776-d87fcba-package.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - Gmail MIME ingest has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head focused Vitest JSON (21/21)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22776-aca9-focused.json); [develop negative control](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22776-negative-inherited.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered pixels.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, planner, or action behavior changed.

## Backend + frontend logs

N/A - no live Google credential or UI path. Deterministic production-client boundary and exact test receipts:

<details>
<summary>#22774 independent exact-head execution at aca9af583fc7c032a1a158e18c0d93ebaf777703</summary>

```text
Head: aca9af583fc7c032a1a158e18c0d93ebaf777703
Base: faef8c31d7b3441a9732d71da947bd25119530ec
Boundary: dedicated no-secret Lima VM; tests ran under unshare network namespace with outbound denied and loopback enabled.
Focused: 3 suites / 21 tests passed.
Owning package at byte-identical reviewed predecessor d87fcba9: 22 files / 234 tests passed; scoped exact-head gates were rerun after the final rebase.
Plugin typecheck: passed.
Plugin build: passed.
Biome on all three changed files: passed.
git diff --check: passed.
Negative control: the inherited-accessor public-boundary regression fails on pre-fix code, receiving hostile body text instead of the safe snippet. A prior rebased-head attempt had 20/21 semantic passes and only exceeded the pre-existing 50 ms timing assertion under VM contention; the disclosed rerun passed 21/21, and the final aca9 head independently passed 21/21.
Reviewed file SHA-256:
  gmail-mime-parts.ts d97a29f05562e8cadfe12ad54af2d581dcff692f052967177ced58f298422c6e
  gmail-mime-parts.test.ts acb015b28f08f1726684880a160d28e622d02c1fffafd70b688e388f82d9a95f
  gmail.ts ab5a76fe3d468c4e3359bada127627152cb84b5ea79074e9f4a421bc250985e1
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - server-side Gmail MIME ingest; no rendered UI.

# Known gaps / failures

Full workspace `bun run verify` was not rerun. Exact-head plugin `tsc --noEmit`, plugin build, focused production-boundary tests, Biome, and diff-check all pass; the immutable receipt is linked above.

Did not touch HARD_SKIP `connector-account-provider.ts` or `src/chat/service.ts`.

AI provider/model: xai / grok-4.6
Client / agent tooling: Grok Build
Skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza
Attribution status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok-build
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-build-eliza-audit]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-build","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0EX2CNV2N2RWPDJEFS312WA","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-20T06:17:24.411Z","completed_at":"2026-08-20T06:59:19.475Z","skill_sha256":"59db26bc04b23ba8bdbb865c63affc4193118625382ce7036e5823657f27027a","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T06:17:28.919Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"45b91cd89488ecfe688b028ff90087325380560bc94823aea31f07dde220707f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"91fcc311-4d59-4926-b0fa-ca7fbd5b8ffa","object_id":"sha256:45b91cd89488ecfe688b028ff90087325380560bc94823aea31f07dde220707f","sha256":"45b91cd89488ecfe688b028ff90087325380560bc94823aea31f07dde220707f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"6scrZndS7B0l-j4_h2nKSuGo0vl6uXI7zIwuCGNaNj4P5F9QMvvRxMyJUA1_vXcMFanyUSQxyDNw8lye0nWdDA"}} -->

