### PR TITLE
test(ui): stub BlockList in hosting fixture

### DIFF
--- a/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
+++ b/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
@@ -233,6 +233,12 @@ export const mkdir = anyfn;
 export const stat = anyfn;
 export const readdir = () => [];
 export const isIP = () => 0;
+export class BlockList {
+  addSubnet() {}
+  check() {
+    return false;
+  }
+}
 export const statfsSync = anyfn;
 export const cp = anyfn;
 export const unlinkSync = anyfn;


### PR DESCRIPTION
## Summary

- add the newly reachable `node:net` `BlockList` named export to the frontend-hosting browser fixture
- keep the inert browser stub fail closed by returning `false` from `check()`
- restore the UI Core Fixture E2E bundle path after the dependency refresh

Refs #22733.

## Verification

- `bun run --cwd packages/ui test:frontend-hosting-e2e` (real mock-cloud lifecycle, 13 captures, `ALL GREEN`)
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui typecheck`

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this regression repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
