### PR TITLE
fix(agent): fail closed on over-budget connector config writes

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -519,6 +519,7 @@ describe("connector account routes", () => {
       redactConfigSecrets: (value) => value,
       isBlockedObjectKey: (key) =>
         key === "__proto__" || key === "constructor" || key === "prototype",
+      hasBlockedObjectKeyDeep: () => false,
       cloneWithoutBlockedObjectKeys: (value) => value,
     });
     expect(configHandled).toBe(false);

--- a/packages/agent/src/api/connector-routes.test.ts
+++ b/packages/agent/src/api/connector-routes.test.ts
@@ -7,6 +7,12 @@
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import {
+  cloneWithoutBlockedObjectKeys,
+  hasBlockedObjectKeyDeep,
+  MAX_BLOCKED_OBJECT_DEPTH,
+  MAX_BLOCKED_OBJECT_NODES,
+} from "./blocked-object-keys";
 import type { ConnectorRouteContext } from "./connector-routes";
 import { handleConnectorRoutes } from "./connector-routes";
 
@@ -46,7 +52,8 @@ function createHarness(options: {
     redactConfigSecrets: (value) => value,
     isBlockedObjectKey: (key) =>
       key === "__proto__" || key === "constructor" || key === "prototype",
-    cloneWithoutBlockedObjectKeys: (value) => value,
+    hasBlockedObjectKeyDeep,
+    cloneWithoutBlockedObjectKeys,
     onConnectorDisconnect: options.onConnectorDisconnect,
   };
 
@@ -216,5 +223,92 @@ describe("connector routes", () => {
     await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
     expect(captured.status).toBe(200);
     expect(state.config.connectors?.["custom-connector"]).toBeUndefined();
+  });
+
+  it("POST /api/connectors rejects an over-depth config with 400 instead of letting the walk budget escape", async () => {
+    let config: Record<string, unknown> = { leaf: true };
+    for (let i = 0; i < MAX_BLOCKED_OBJECT_DEPTH + 8; i += 1) {
+      config = { a: config };
+    }
+    const saveElizaConfig = vi.fn();
+    const { ctx, captured, state } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: { name: "telegram", config },
+      saveElizaConfig,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual({
+      error: "Connector config contains a blocked object key",
+    });
+    expect(state.config.connectors?.telegram).toBeUndefined();
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/connectors rejects an over-node sparse config the same way", async () => {
+    const saveElizaConfig = vi.fn();
+    const { ctx, captured, state } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: {
+        name: "telegram",
+        config: { items: new Array(MAX_BLOCKED_OBJECT_NODES + 10) },
+      },
+      saveElizaConfig,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(400);
+    expect(state.config.connectors?.telegram).toBeUndefined();
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/connectors rejects a config carrying a blocked key instead of silently stripping it", async () => {
+    const saveElizaConfig = vi.fn();
+    const { ctx, captured, state } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: {
+        name: "telegram",
+        config: JSON.parse(
+          '{"enabled":true,"nested":{"__proto__":{"polluted":1},"keep":2}}',
+        ),
+      },
+      saveElizaConfig,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(400);
+    expect(state.config.connectors?.telegram).toBeUndefined();
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/connectors still persists an honest config byte-compatibly", async () => {
+    const honest = {
+      enabled: true,
+      token: "t",
+      channels: ["a", "b"],
+      limits: { rpm: 60, burst: 5 },
+    };
+    const saveElizaConfig = vi.fn();
+    const { ctx, captured, state } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: { name: "telegram", config: honest },
+      saveElizaConfig,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(200);
+    expect(JSON.stringify(state.config.connectors?.telegram)).toBe(
+      JSON.stringify(honest),
+    );
+    expect(saveElizaConfig).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/agent/src/api/connector-routes.ts
+++ b/packages/agent/src/api/connector-routes.ts
@@ -39,6 +39,13 @@ export interface ConnectorRouteContext {
     config: Record<string, unknown>,
   ) => Record<string, unknown>;
   isBlockedObjectKey: (key: string) => boolean;
+  /**
+   * Fail-closed companion to `cloneWithoutBlockedObjectKeys`. The clone throws
+   * the walk-budget error rather than returning a partial object, so callers
+   * must run this first and reject; otherwise the error escapes to the route
+   * kernel and becomes a 500.
+   */
+  hasBlockedObjectKeyDeep: (value: unknown) => boolean;
   cloneWithoutBlockedObjectKeys: <T>(value: T) => T;
   /** Optional host-supplied callback fired on every disconnect path. */
   onConnectorDisconnect?: (connectorName: string) => Promise<void> | void;
@@ -117,6 +124,7 @@ export async function handleConnectorRoutes(
     saveElizaConfig,
     redactConfigSecrets,
     isBlockedObjectKey,
+    hasBlockedObjectKeyDeep,
     cloneWithoutBlockedObjectKeys,
     onConnectorDisconnect,
   } = ctx;
@@ -143,6 +151,10 @@ export async function handleConnectorRoutes(
       return true;
     }
     const { name: connectorName, config } = parsed.data;
+    if (hasBlockedObjectKeyDeep(config)) {
+      error(res, "Connector config contains a blocked object key", 400);
+      return true;
+    }
     if (!state.config.connectors) state.config.connectors = {};
     const previousConnector = state.config.connectors[connectorName];
     state.config.connectors[connectorName] = cloneWithoutBlockedObjectKeys(

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -419,6 +419,7 @@ import { handleRuntimeSwitchRoutes } from "./runtime-switch-routes.ts";
 import {
   cloneWithoutBlockedObjectKeys,
   decodePathComponent,
+  hasBlockedObjectKeyDeep,
   hasPersistedFirstRunState,
   isUuidLike,
   patchTouchesProviderSelection,
@@ -2830,6 +2831,7 @@ async function handleRequest(
       saveElizaConfig,
       redactConfigSecrets,
       isBlockedObjectKey,
+      hasBlockedObjectKeyDeep,
       cloneWithoutBlockedObjectKeys,
     })
   ) {


### PR DESCRIPTION
# Relates to

Closes #22775. Residual of #22749 on the connector surface its problem statement named; #22764 correctly closed the OpenAI-compat path and is untouched here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the single failure is unrelated and pre-existing — recorded verbatim in **Known gaps** below.
- [x] A reviewer can confirm the change works without reading the code, from the before/after handler evidence below.

<!-- evidence-head:5073206507f0c4b095725a5ae0c6fdeaa642e92c -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

**Low.** One guard call on one route, plus a context field.

- The only behavioral delta is that a connector config exceeding the walk budget now gets a 400 instead of throwing past the handler into a 500. Nothing that previously persisted stops persisting.
- The walk pair is injected through `ConnectorRouteContext` rather than imported directly, so the existing mobile stub seam (`app-core/src/platform/empty-node-module.ts`) is preserved exactly as it is for `cloneWithoutBlockedObjectKeys`.
- `hasBlockedObjectKeyDeep` is pure and allocation-bounded; it already runs on every OpenAI-compat and MCP write, so this adds no new class of work to the request path.
- Honest configs are unaffected — pinned by a byte-compatibility test.

**One deliberate behavior change beyond the 500, stated plainly.** `hasBlockedObjectKeyDeep` returns `true` both for an over-budget graph and for a config that actually contains a blocked key, so a connector config carrying `__proto__` now gets a 400 instead of being silently stripped and saved:

```text
BEFORE  config {"enabled":true,"nested":{"__proto__":{"polluted":1},"keep":2}}
        -> 200, persisted {"telegram":{"enabled":true,"nested":{"keep":2}}}

AFTER   same config
        -> 400 "Connector config contains a blocked object key", nothing persisted
```

No existing test asserted the strip-and-persist behavior. Rejecting is what both sibling surfaces already do (`chat-routes.ts:4642` returns 400 with the same wording; `resolveMcpServersRejection` returns `Server "x" contains blocked object keys`), and silently persisting a config that differs from what the caller sent is the kind of quiet degrade the repository error policy rules out. Flagging it because it is a real semantic change and the choice is a maintainer's to make — see the note at the end for the narrower swap if strict backward compatibility is preferred.

# Background

## What does this PR do?

`POST /api/connectors` called `cloneWithoutBlockedObjectKeys` without the `hasBlockedObjectKeyDeep` guard that every other caller pairs it with.

The clone deliberately does **not** catch `BLOCKED_OBJECT_GRAPH_UNBOUNDED` — returning a partial object would defeat the point — so it is only safe to call after the guard has rejected. `hasBlockedObjectKeyDeep` is the half that catches and fails closed to `true`.

| Caller | Guard | Clone |
|---|---|---|
| OpenAI-compat chat | `chat-routes.ts:4642` | `:4655` ✅ |
| MCP single/bulk config write | `resolveMcpServersRejection` → `server-helpers-mcp.ts:27` | `routes-mcp.ts:343`/`:432` ✅ |
| **Connector config write** | **none** | **`connector-routes.ts:148`** ❌ |

So an over-depth or over-node config threw straight past `handleConnectorRoutes` into `routeKernel.translateFailure` (`server.ts:3810-3815`), which answers `error(res, msg, 500)` — the exact failure mode the walk bound exists to remove.

`PostConnectorRequestSchema` accepts an arbitrary config record and does not bound depth, and the 1 MB body cap is no defense: a 40-deep nest is ~200 bytes.

## What kind of change is this?

Bug fix (non-breaking). `ConnectorRouteContext` gains one required field; both in-repo construction sites are updated in this PR.

# Documentation changes needed?

No. No public type, route, or environment surface changes.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/connector-routes.ts` (the guard), then the three new cases at the end of `packages/agent/src/api/connector-routes.test.ts`.

Note that the route harness previously stubbed `cloneWithoutBlockedObjectKeys: (value) => value` — an identity function that can never throw, which is why the gap survived the existing suite. The harness now supplies the **real** walk pair, so the guard is exercised rather than mocked away.

## Detailed testing steps

**Before/after on the real handler.** Driving `handleConnectorRoutes` with a `MAX_BLOCKED_OBJECT_DEPTH + 8` config; only `res`/`json`/`error`/`readJsonBody` plumbing is supplied, the sanitizer and handler are real:

```text
BEFORE (develop c2831a01cc, contains #22764 as 5e3c1c6bdf):
C POST /api/connectors = ESCAPED THROW BLOCKED_OBJECT_GRAPH_UNBOUNDED | responses so far: []

AFTER (this branch):
C POST /api/connectors = completed; responses: [["error",400,"Connector config contains a blocked object key"]]
```

`responses: []` is the defect: the handler wrote no response at all before the error escaped.

**Mutation proof.** Removing only the guard block, leaving the tests untouched:

```text
× POST /api/connectors rejects an over-depth config with 400 instead of letting the walk budget escape
  Serialized Error: { code: 'BLOCKED_OBJECT_GRAPH_UNBOUNDED', context: { depth: 33, max: 32 }, severity: 'fatal' }
× POST /api/connectors rejects an over-node sparse config the same way
  Serialized Error: { code: 'BLOCKED_OBJECT_GRAPH_UNBOUNDED', context: { visits: 100012, maxNodes: 100000 }, severity: 'fatal' }

Test Files  1 failed (1)
     Tests  2 failed | 8 passed (10)
```

Exactly the two defect-encoding tests fail, with the escaped error itself as the failure. The byte-compatibility test passes either way, so it is not pinning the guard.

**Suites.**

```text
connector-routes.test.ts                      10/10 pass
+ connector-account-routes{,.durable,.limit}
+ connector-health + blocked-object-keys        6 files / 71 tests pass
bun run --cwd packages/agent typecheck          pass
bunx biome check <4 changed files>              pass
git diff --check                                clean
```

# Known gaps / failures

- **`bun run verify` fails on one unrelated, pre-existing package.** Verbatim:

  ```text
  @elizaos/plugin-maps:typecheck: test/scenarios/maps.save-coordinate-live.scenario.ts(10,26): error TS2307: Cannot find module '@elizaos/scenario-runner/schema' or its corresponding type declarations.
  @elizaos/plugin-maps:typecheck: test/scenarios/maps.save-coordinate-live.scenario.ts(107,25): error TS7006: Parameter 'ctx' implicitly has an 'any' type.
  @elizaos/plugin-maps:typecheck: test/scenarios/maps.save-coordinate-live.scenario.ts(109,12): error TS7006: Parameter 'entry' implicitly has an 'any' type.

  Tasks:    338 successful, 358 total
   Time:    7m44.919s
  Failed:   @elizaos/plugin-maps#typecheck
  ```

  Confirmed pre-existing and unrelated: checked out clean `origin/develop` at `c00ba4afa1` with none of this branch's changes present and ran `bun run --cwd plugins/plugin-maps typecheck` — identical three errors. This branch touches only `packages/agent`. `@elizaos/scenario-runner`'s subpath export maps `./*` to `./dist/*.d.ts`, and there is no `dist/schema.d.ts` or `src/schema.ts`; the scenario file added by `31fcff077e` imports `@elizaos/scenario-runner/schema`. Every other one of the 358 tasks passed, including `@elizaos/agent`. A fix looks to be in flight already — open PR #22359 touches `packages/scenario-runner/schema/index.d.ts` and `index.js`, the shim this import needs — so I have not filed a separate issue for it.

# Note for the reviewer

The narrow guard is deliberate over the alternative of making `cloneWithoutBlockedObjectKeys` fail closed itself. The clone must return a value, so failing closed inside it would mean either a nullable return (changing every caller) or a silent partial object (the thing the bound exists to prevent). Guarding at the route matches the two call sites that already do it.

**If you would rather keep strict backward compatibility** for blocked-key configs — 400 only for the over-budget case, still strip-and-persist a config containing `__proto__` — the swap is to drop the guard and instead wrap the clone in a `try`/`catch` on `BLOCKED_OBJECT_GRAPH_UNBOUNDED`. That is a smaller behavioral delta but it puts a catch in a route handler and breaks the guard-then-clone symmetry with the other two surfaces, which is why I did not lead with it. Say the word and I will push it.

Separately, if a `sanitizeOrReject` helper that fuses the pair — so a fourth route cannot repeat this omission — is wanted, that is a clean follow-up and I am happy to take it.

# Receipt disclosure

No device-signed receipt footer is attached. `terms-preflight --project eliza` is green (`Terms verified: 2026-08-18.1 · license d0590837a439`), but `run-receipt finish` requires a trace server-run id and object digest from `run-receipt trace`, and that step was returning `private request intake status request returned HTTP 403`. The only startable run belonged to a prior session whose private trace I could not inspect, and `trace` uploads permanently, so I did not run it. Using the legacy self-reported footer instead.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-only connector route with no UI pixels

<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-only connector route with no UI pixels

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - nonvisual request boundary; exact handler transcript is attached

<!-- evidence-row:backend-logs -->
- [x] [22782-backend-log-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22782-backend-log-v3.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation or planner behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [22782-domain-artifact-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22782-domain-artifact-v3.txt)

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
— [kenjohnscreates]
<!-- eliza-computer-attribution:v1 -->




