### PR TITLE
fix(core): fail closed on unbounded entity-resolution match unwraps

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -13,7 +13,13 @@
  * ADMIN-or-higher — never a raw stored role grant. Sits on the runtime boundary
  * (getRoom / getWorld / getEntitiesForRoom / getRelationships / useModel) and
  * imports roles.ts lazily to avoid a cycle with createUniqueUuid.
+ * Nested LLM `{ match: … }` unwraps are bounded in `entity-matches.ts`.
  */
+import {
+	type EntityMatch,
+	normalizeEntityMatches,
+	readEntityResolutionField,
+} from "./entity-matches";
 import { logger } from "./logger";
 // Type-only (erased at runtime, so no cycle with roles.ts, which imports
 // createUniqueUuid from this module). The role-resolution values are pulled via a
@@ -32,7 +38,6 @@ import {
 } from "./types";
 import * as utils from "./utils";
 import { stableStringify } from "./utils/deterministic";
-import { isObjectRecord as isRecord } from "./utils/type-guards";
 import { truncateWellFormed } from "./utils/well-formed";
 
 type EntityDetailsRecord = Pick<
@@ -91,42 +96,14 @@ export async function resolveTrustedComponentSourceIds(
 const MAX_ENTITY_DISPLAY_NAMES = 8;
 const MAX_ENTITY_DISPLAY_COUNT = 10;
 const MAX_ENTITY_METADATA_CHARS = 2_000;
-interface EntityMatch {
-	name?: string;
-	reason?: string;
-}
-
 interface ParsedResolution {
 	resolvedId?: string;
 	confidence?: string;
 	matches?: {
-		match?: EntityMatch | EntityMatch[];
+		match?:
+			| { name?: string; reason?: string }
+			| { name?: string; reason?: string }[];
 	};
-}
-
-function normalizeEntityMatch(value: unknown): EntityMatch | null {
-	if (!isRecord(value)) return null;
-
-	const name = typeof value.name === "string" ? value.name : undefined;
-	const reason = typeof value.reason === "string" ? value.reason : undefined;
-
-	if (!name) return null;
-	return { name, reason };
-}
-
-function normalizeEntityMatches(value: unknown): EntityMatch[] {
-	if (Array.isArray(value)) {
-		return value
-			.map((entry) => normalizeEntityMatch(entry))
-			.filter((entry): entry is EntityMatch => entry !== null);
-	}
-
-	if (isRecord(value) && "match" in value) {
-		return normalizeEntityMatches(value.match);
-	}
-
-	const directMatch = normalizeEntityMatch(value);
-	return directMatch ? [directMatch] : [];
 }
 
 function parseEntityResolutionResponse(
@@ -147,15 +124,19 @@ function parseEntityResolutionResponse(
 	}
 
 	if (parsedJson && typeof parsedJson === "object") {
-		const obj = parsedJson as Record<string, unknown>;
-		const type = typeof obj.type === "string" ? obj.type : undefined;
+		const typeValue = readEntityResolutionField(parsedJson, "type");
+		const entityIdValue = readEntityResolutionField(parsedJson, "entityId");
+		const resolvedIdValue = readEntityResolutionField(parsedJson, "resolvedId");
+		const type = typeof typeValue === "string" ? typeValue : undefined;
 		const entityId =
-			typeof obj.entityId === "string"
-				? obj.entityId
-				: typeof obj.resolvedId === "string"
-					? obj.resolvedId
+			typeof entityIdValue === "string"
+				? entityIdValue
+				: typeof resolvedIdValue === "string"
+					? resolvedIdValue
 					: undefined;
-		const matches = normalizeEntityMatches(obj.matches);
+		const matches = normalizeEntityMatches(
+			readEntityResolutionField(parsedJson, "matches"),
+		);
 
 		if (type || entityId || matches.length > 0) {
 			return {

--- a/packages/core/src/entity-matches.test.ts
+++ b/packages/core/src/entity-matches.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic tests for the entity-resolution `{ match: … }` unwrap.
+ * No live model: the walker is the production normalizeEntityMatches used
+ * on TEXT_SMALL entity-resolution JSON.
+ */
+import { describe, expect, it } from "vitest";
+import { findEntityByName } from "./entities";
+import {
+	ENTITY_MATCH_UNBOUNDED,
+	MAX_ENTITY_MATCH_DEPTH,
+	MAX_ENTITY_MATCH_NODES,
+	normalizeEntityMatches,
+} from "./entity-matches";
+import { ElizaError } from "./errors";
+import type { IAgentRuntime, Memory, State } from "./types";
+
+function nestMatch(depth: number): unknown {
+	let value: unknown = { name: "Ada" };
+	for (let index = 0; index < depth; index += 1) {
+		value = { match: value };
+	}
+	return value;
+}
+
+describe("normalizeEntityMatches", () => {
+	it("unwraps honest match wrappers, arrays, and direct records", () => {
+		expect(normalizeEntityMatches({ name: "Ada" })).toEqual([{ name: "Ada" }]);
+		expect(normalizeEntityMatches({ match: { name: "Ada" } })).toEqual([
+			{ name: "Ada" },
+		]);
+		expect(
+			normalizeEntityMatches({
+				match: [{ name: "Ada", reason: "exact" }, { name: "Bob" }],
+			}),
+		).toEqual([{ name: "Ada", reason: "exact" }, { name: "Bob" }]);
+		expect(normalizeEntityMatches(null)).toEqual([]);
+	});
+
+	it(`accepts a ${MAX_ENTITY_MATCH_DEPTH}-deep match wrap`, () => {
+		expect(normalizeEntityMatches(nestMatch(MAX_ENTITY_MATCH_DEPTH))).toEqual([
+			{ name: "Ada" },
+		]);
+	});
+
+	it(`throws ${ENTITY_MATCH_UNBOUNDED} one past depth ${MAX_ENTITY_MATCH_DEPTH}`, () => {
+		try {
+			normalizeEntityMatches(nestMatch(MAX_ENTITY_MATCH_DEPTH + 1));
+			expect.unreachable("unwrap should fail closed on over-budget depth");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+		}
+	});
+
+	it(`throws ${ENTITY_MATCH_UNBOUNDED} past ${MAX_ENTITY_MATCH_NODES} sparse holes`, () => {
+		const sparse: unknown[] = [];
+		sparse[MAX_ENTITY_MATCH_NODES] = { name: "Ada" };
+		try {
+			normalizeEntityMatches(sparse);
+			expect.unreachable(
+				"unwrap should fail closed on over-budget sparse length",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+		}
+	});
+
+	it("throws on a cyclic match wrapper without hanging", () => {
+		const cyclic: { match?: unknown } = {};
+		cyclic.match = cyclic;
+		const started = performance.now();
+		try {
+			normalizeEntityMatches(cyclic);
+			expect.unreachable("unwrap should fail closed on a cycle");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("does not invoke accessors while unwrapping", () => {
+		let invoked = 0;
+		const hostile = {
+			get match() {
+				invoked += 1;
+				return { name: "Ada" };
+			},
+		};
+		try {
+			normalizeEntityMatches(hostile);
+			expect.unreachable("unwrap should fail closed on enumerable accessors");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+		}
+		expect(invoked).toBe(0);
+	});
+
+	it("does not invoke object Proxy get/has traps while unwrapping", () => {
+		let gets = 0;
+		let hasCalls = 0;
+		const proxy = new Proxy(
+			{ match: { name: "Ada" } },
+			{
+				get() {
+					gets += 1;
+					throw new Error("get trap escaped");
+				},
+				has() {
+					hasCalls += 1;
+					throw new Error("has trap escaped");
+				},
+			},
+		);
+		expect(normalizeEntityMatches(proxy)).toEqual([{ name: "Ada" }]);
+		expect(gets).toBe(0);
+		expect(hasCalls).toBe(0);
+	});
+
+	it("does not invoke array Proxy get/has traps while unwrapping", () => {
+		let gets = 0;
+		let hasCalls = 0;
+		const proxy = new Proxy([{ name: "Ada" }], {
+			get() {
+				gets += 1;
+				throw new Error("array get trap escaped");
+			},
+			has() {
+				hasCalls += 1;
+				throw new Error("array has trap escaped");
+			},
+		});
+		expect(normalizeEntityMatches(proxy)).toEqual([{ name: "Ada" }]);
+		expect(gets).toBe(0);
+		expect(hasCalls).toBe(0);
+	});
+
+	it("translates descriptor Proxy failures with their cause", () => {
+		const proxy = new Proxy(
+			{ match: { name: "Ada" } },
+			{
+				getOwnPropertyDescriptor() {
+					throw new Error("hostile descriptor trap");
+				},
+			},
+		);
+
+		try {
+			normalizeEntityMatches(proxy);
+			expect.unreachable("descriptor failure should be translated");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+			expect((error as Error).cause).toMatchObject({
+				message: "hostile descriptor trap",
+			});
+		}
+	});
+
+	it("does not invoke outer model-result accessors in findEntityByName", async () => {
+		let invoked = 0;
+		const modelResult = {};
+		Object.defineProperty(modelResult, "matches", {
+			enumerable: true,
+			get() {
+				invoked += 1;
+				return { match: { name: "Ada" } };
+			},
+		});
+		const runtime = {
+			agentId: "agent",
+			getEntitiesForRoom: async () => [],
+			getRelationships: async () => [],
+			getMemories: async () => [],
+			useModel: async () => modelResult,
+		} as unknown as IAgentRuntime;
+		const message = {
+			roomId: "room",
+			entityId: "sender",
+			content: {},
+		} as unknown as Memory;
+		const state = {
+			data: { room: { id: "room", name: "Room", worldId: null } },
+		} as unknown as State;
+
+		await expect(
+			findEntityByName(runtime, message, state),
+		).rejects.toMatchObject({
+			code: ENTITY_MATCH_UNBOUNDED,
+		});
+		expect(invoked).toBe(0);
+	});
+
+	it(`throws ${ENTITY_MATCH_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+		const { proxy, revoke } = Proxy.revocable({ match: { name: "Ada" } }, {});
+		revoke();
+		try {
+			normalizeEntityMatches(proxy);
+			expect.unreachable("unwrap should fail closed on a revoked Proxy");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+			expect((error as Error).name).not.toBe("TypeError");
+			expect((error as Error).cause).toBeInstanceOf(TypeError);
+		}
+	});
+
+	it("rescans repeated shared child matches", () => {
+		const shared = { name: "Ada" };
+		expect(normalizeEntityMatches([shared, shared])).toEqual([
+			{ name: "Ada" },
+			{ name: "Ada" },
+		]);
+	});
+
+	it("fails closed on an 8k match wrap in under 50ms instead of RangeError", () => {
+		const started = performance.now();
+		try {
+			normalizeEntityMatches(nestMatch(8_000));
+			expect.unreachable("unwrap should fail closed on an 8k nest");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ENTITY_MATCH_UNBOUNDED);
+			expect((error as Error).name).not.toBe("RangeError");
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+});

--- a/packages/core/src/entity-matches.ts
+++ b/packages/core/src/entity-matches.ts
@@ -1,0 +1,158 @@
+/**
+ * Bounds the nested `{ match: … }` unwrap used when parsing LLM entity
+ * resolution JSON. Model output can wrap `matches` in hostile `match`
+ * objects; the previous recursive unwrap RangeError'd an 8k nest on
+ * Node 24.15.0. Depth, node, and cycle limits are all load-bearing.
+ * Every reflective read is fail-closed to the typed unbounded error.
+ */
+
+import { ElizaError } from "./errors";
+
+export const MAX_ENTITY_MATCH_DEPTH = 32;
+export const MAX_ENTITY_MATCH_NODES = 2_048;
+export const ENTITY_MATCH_UNBOUNDED = "ENTITY_MATCH_UNBOUNDED";
+
+export interface EntityMatch {
+	name?: string;
+	reason?: string;
+}
+
+type WalkContext = {
+	visits: number;
+	visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+	context: Record<string, unknown>,
+	cause?: unknown,
+): never {
+	throw new ElizaError(
+		"Entity resolution matches exceed the unwrap walk budget",
+		{
+			code: ENTITY_MATCH_UNBOUNDED,
+			context,
+			cause,
+			severity: "fatal",
+		},
+	);
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+	if (count > MAX_ENTITY_MATCH_NODES - ctx.visits) {
+		failUnbounded({
+			visits: ctx.visits + count,
+			maxNodes: MAX_ENTITY_MATCH_NODES,
+		});
+	}
+	ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+	try {
+		return inspect();
+	} catch (cause) {
+		// error-policy:J3 Proxy inspection failures make untrusted model JSON invalid.
+		failUnbounded({ inspection: operation }, cause);
+	}
+}
+
+function ownDescriptor(
+	value: object,
+	key: PropertyKey,
+): PropertyDescriptor | undefined {
+	return inspectRecord("getOwnPropertyDescriptor", () =>
+		Object.getOwnPropertyDescriptor(value, key),
+	);
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+	return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+function ownString(value: object, key: string): string | undefined {
+	const field = readEntityResolutionField(value, key);
+	return typeof field === "string" ? field : undefined;
+}
+
+/** Reads one own data field from untrusted entity-resolution model output. */
+export function readEntityResolutionField(value: object, key: string): unknown {
+	const descriptor = ownDescriptor(value, key);
+	if (!descriptor) return undefined;
+	if (!("value" in descriptor)) {
+		failUnbounded({ accessor: true, key });
+	}
+	return descriptor.value;
+}
+
+function normalizeEntityMatch(value: unknown): EntityMatch | null {
+	if (!value || typeof value !== "object" || isArrayRecord(value)) {
+		return null;
+	}
+	const name = ownString(value, "name");
+	const reason = ownString(value, "reason");
+	if (!name) return null;
+	return { name, reason };
+}
+
+export function normalizeEntityMatches(value: unknown): EntityMatch[] {
+	return normalizeEntityMatchesInner(value, 0, {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+	});
+}
+
+function normalizeEntityMatchesInner(
+	value: unknown,
+	depth: number,
+	ctx: WalkContext,
+	visitAlreadyReserved = false,
+): EntityMatch[] {
+	if (depth > MAX_ENTITY_MATCH_DEPTH) {
+		failUnbounded({ depth, max: MAX_ENTITY_MATCH_DEPTH });
+	}
+	if (!value || typeof value !== "object") {
+		return [];
+	}
+	if (!visitAlreadyReserved) reserve(ctx, 1);
+	if (ctx.visiting.has(value)) {
+		failUnbounded({ cycle: true });
+	}
+	ctx.visiting.add(value);
+	try {
+		if (isArrayRecord(value)) {
+			const lengthDescriptor = ownDescriptor(value, "length");
+			if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+				failUnbounded({ invalidArrayLength: true });
+			}
+			const length = lengthDescriptor.value;
+			if (!Number.isSafeInteger(length) || length < 0) {
+				failUnbounded({ invalidArrayLength: true });
+			}
+			reserve(ctx, length);
+			const matches: EntityMatch[] = [];
+			for (let index = 0; index < length; index += 1) {
+				const descriptor = ownDescriptor(value, String(index));
+				if (!descriptor) continue;
+				if (!("value" in descriptor)) {
+					failUnbounded({ accessor: true, side: "array", index });
+				}
+				const match = normalizeEntityMatch(descriptor.value);
+				if (match) matches.push(match);
+			}
+			return matches;
+		}
+
+		const matchDescriptor = ownDescriptor(value, "match");
+		if (matchDescriptor) {
+			if (!("value" in matchDescriptor)) {
+				failUnbounded({ accessor: true, key: "match" });
+			}
+			return normalizeEntityMatchesInner(matchDescriptor.value, depth + 1, ctx);
+		}
+
+		const direct = normalizeEntityMatch(value);
+		return direct ? [direct] : [];
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}


### PR DESCRIPTION
Closes #22784

## Problem

`findEntityByName` parses TEXT_SMALL entity-resolution JSON with recursive `normalizeEntityMatches` on nested `{ match: … }` wrappers. No depth, node, or cycle budget.

On `origin/develop` `d41ba2b02ee6395b3f66cafc66a95add27abd09d` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep `{ match: … }` wrap | RangeError 1.80 ms |
| cyclic `{ match: self }` | RangeError 1.55 ms |

Product path: LLM entity resolution for `"me"` / name / `@handle` onto a known Entity. JSON.parse of the nest succeeds; the unwrap then stack-overflows the runtime.

Not leftover-tax. Not a twin of `#22781` inbox priority-scoring flags, `#22768` household entity-id scan, `#22748` in-memory filter, `#22757` Discord structured-text, `#22761` OAuth token merge, or `#22716` cloneJson. Distinct host: entity-resolution `matches.match` unwrap.

## Change

- Extract `normalizeEntityMatches` to `entity-matches.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`ENTITY_MATCH_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget.
- Array length/indexes and the `match` key from own data descriptors; every reflective op fail-closes to the typed error (revoked Proxy included).
- Honest wrappers, arrays, and direct `{ name }` records still parse.

## Exact-head evidence

Evidence revision: `d62060a87e03c65f6c0344475d8b0656a2f00d6c`, based on `develop` `d41ba2b02ee6395b3f66cafc66a95add27abd09d`. Owning issue: #22784.

- Pinned Bun 1.3.14 focused `entity-matches` suite: **13/13 passed** in 3 ms.
- Covers honest wrapper/array/direct parse, depth 32 accept, depth 33 throw, sparse 2048-hole throw, cyclic throw, nested and reachable outer accessor zero-call, object/array Proxy get/has zero-call, descriptor-trap and revoked-Proxy typed translation with cause, repeated shared-child records, and an 8k wrap that throws `ENTITY_MATCH_UNBOUNDED` (not `RangeError`).
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Maintainer review uploaded the repaired exact-head receipt to the immutable `pr-evidence-5` release asset linked below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - entity-resolution match unwrap; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - entity-resolution match unwrap; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic scan-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - entity-match unwrap has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Immutable repaired exact-head suite and production-boundary receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22785-d62060a-focused.log)
<details>
<summary>domain receipt at d62060a87e03</summary>

```
# domain artifact — entity-resolution match unwrap
exact-head: d62060a87e03c65f6c0344475d8b0656a2f00d6c
based-on: origin/develop d41ba2b02ee6395b3f66cafc66a95add27abd09d
owning-issue: https://github.com/elizaOS/eliza/issues/22784

Pinned Bun 1.3.14 focused entity-matches suite at this head:
  13/13 passed in 3 ms
  covers: honest wrapper/array/direct, depth 32 accept, depth 33 throw,
  sparse 2048-hole throw, cyclic throw, zero-call accessors,
  Proxy get/has zero-call, revoked Proxy typed (not TypeError),
  shared-child rescan, 8k wrap ENTITY_MATCH_UNBOUNDED not RangeError.

Origin red (Node 24.15.0, pre-fix walk):
  normalizeEntityMatches 8k match wrap: RangeError 1.80 ms
  cyclic { match: self }: RangeError 1.55 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d62060a87e03c65f6c0344475d8b0656a2f00d6c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

