### PR TITLE
test(ui): complete home locale client stub

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
@@ -75,7 +75,8 @@ const stubWeatherDeps = {
       { filter: /^api-client-stub$/, namespace: "home-locale-stub" },
       () => ({
         contents:
-          "export const client = { fetch: async () => ({ lat: 37.77, lon: -122.42 }) };",
+          "export const client = { getBaseUrl: () => '', fetch: async () => ({ lat: 37.77, lon: -122.42 }) };" +
+          "export function ElizaClient() { return client; }",
         loader: "js",
       }),
     );


### PR DESCRIPTION
## Summary

- export the fixture-compatible `ElizaClient` constructor from the Home locale inline API stub
- supply the required `getBaseUrl()` boundary on the shared fixture client
- restore locale clock/weather rendering after the dependency refresh

Refs #22733.

## Verification

- `bun run --cwd packages/ui test:home-locale-e2e` (en-US/de-DE clock and weather, two captures, zero page errors)
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui typecheck`

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this regression repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
