### PR TITLE
fix(workflow): bridge Smithers runtime events to triggers

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -64,7 +64,7 @@ interface MockRuntimeHandle {
   setRuntimeSetting: (name: string, value: unknown) => void;
 }
 
-function makeRuntime(): MockRuntimeHandle {
+function makeRuntime(agentId: UUID = AGENT_ID): MockRuntimeHandle {
   const dispatchCalls: WorkflowDispatchCall[] = [];
   const promptMessages: PromptMessageCall[] = [];
   const deletedTaskIds: UUID[] = [];
@@ -126,7 +126,7 @@ function makeRuntime(): MockRuntimeHandle {
   };
 
   const runtime = {
-    agentId: AGENT_ID,
+    agentId,
     character: { name: "trigger-test" },
     messageService,
     logger: {
@@ -1107,7 +1107,7 @@ describe("runtime event trigger bridge", () => {
     ).toMatchObject({ enabled: false, runCount: 1 });
   });
 
-  it("coalesces only concurrent task lookups and sees newly saved triggers immediately", async () => {
+  it("performs fresh discovery for concurrent and newly saved trigger events", async () => {
     const target = makeTriggerTask({
       triggerType: "event",
       eventKind: "workflow_run_event",
@@ -1126,7 +1126,7 @@ describe("runtime event trigger bridge", () => {
       } as never),
     ]);
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(2));
-    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4);
 
     const newlySaved = makeTriggerTask({
       triggerType: "event",
@@ -1138,7 +1138,168 @@ describe("runtime event trigger bridge", () => {
       event: { id: "event-3", type: "NodeFinished" },
     } as never);
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(4));
-    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4);
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(6);
+  });
+
+  it("sees create and enable writes while an older discovery is still in flight", async () => {
+    async function expectMutationVisible(
+      initialTasks: Task[],
+      currentTask: Task,
+      eventPrefix: string,
+    ): Promise<void> {
+      const lane = makeRuntime(stringToUuid(`owner-${eventPrefix}`));
+      lane.setTasks(initialTasks);
+      let releaseInitialLookup: (() => void) | undefined;
+      const initialLookup = new Promise<void>((resolve) => {
+        releaseInitialLookup = resolve;
+      });
+      const getTasks = vi.fn(async () => {
+        const callNumber = getTasks.mock.calls.length;
+        if (callNumber <= 2) {
+          await initialLookup;
+          return initialTasks;
+        }
+        return [currentTask];
+      });
+      lane.runtime.getTasks = getTasks;
+      registerTriggerTaskWorker(lane.runtime);
+
+      await lane.runtime.emitEvent("workflow_run_event", {
+        event: { id: `${eventPrefix}-before`, type: "NodeFinished" },
+      } as never);
+      await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(2));
+
+      lane.setTasks([currentTask]);
+      await lane.runtime.emitEvent("workflow_run_event", {
+        event: { id: `${eventPrefix}-after`, type: "NodeFinished" },
+      } as never);
+      try {
+        await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(4));
+        await vi.waitFor(() => expect(lane.dispatchCalls).toHaveLength(1));
+      } finally {
+        releaseInitialLookup?.();
+      }
+      expect(
+        (
+          lane.dispatchCalls[0]?.payload?.eventPayload as {
+            event?: { id?: string };
+          }
+        )?.event?.id,
+      ).toBe(`${eventPrefix}-after`);
+    }
+
+    const created = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    await expectMutationVisible([], created, "create");
+
+    const disabled = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+      },
+      { enabled: false },
+    );
+    const disabledTrigger = readTriggerConfig(disabled);
+    if (!disabledTrigger) throw new Error("disabled trigger config missing");
+    const enabled = {
+      ...disabled,
+      metadata: {
+        ...(disabled.metadata as Record<string, unknown>),
+        trigger: { ...disabledTrigger, enabled: true },
+      },
+    } as Task;
+    await expectMutationVisible([disabled], enabled, "enable");
+  });
+
+  it("keeps event discovery and dispatch isolated by runtime owner", async () => {
+    const ownerA = makeRuntime(stringToUuid("workflow-event-owner-a"));
+    const ownerB = makeRuntime(stringToUuid("workflow-event-owner-b"));
+    ownerA.setTasks([
+      makeTriggerTask({
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "target-owner-a",
+      }),
+    ]);
+    ownerB.setTasks([
+      makeTriggerTask({
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "target-owner-b",
+      }),
+    ]);
+    registerTriggerTaskWorker(ownerA.runtime);
+    registerTriggerTaskWorker(ownerB.runtime);
+
+    await ownerA.runtime.emitEvent("workflow_run_event", {
+      event: { id: "owner-a-event", type: "NodeFinished" },
+    } as never);
+    await vi.waitFor(() => expect(ownerA.dispatchCalls).toHaveLength(1));
+    expect(ownerA.dispatchCalls[0]?.workflowId).toBe("target-owner-a");
+    expect(ownerB.dispatchCalls).toHaveLength(0);
+  });
+
+  it("rechecks disabled and deleted tasks from a stale discovery snapshot", async () => {
+    const stale = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    const staleTrigger = readTriggerConfig(stale);
+    if (!staleTrigger) throw new Error("trigger config missing");
+    const disabled = {
+      ...stale,
+      metadata: {
+        ...(stale.metadata as Record<string, unknown>),
+        trigger: { ...staleTrigger, enabled: false },
+      },
+    } as Task;
+    handle.runtime.getTasks = vi.fn(async () => [stale]);
+
+    handle.setTasks([disabled]);
+    await dispatchRuntimeEventTriggers(handle.runtime, "workflow_run_event", {
+      event: { id: "after-disable", type: "NodeFinished" },
+    });
+    expect(handle.dispatchCalls).toHaveLength(0);
+
+    handle.setTasks([]);
+    await dispatchRuntimeEventTriggers(handle.runtime, "workflow_run_event", {
+      event: { id: "after-delete", type: "NodeFinished" },
+    });
+    expect(handle.dispatchCalls).toHaveLength(0);
+    expect(handle.runtime.getTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches every distinct rapid event for the same trigger", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target]);
+
+    await Promise.all([
+      dispatchRuntimeEventTriggers(handle.runtime, "workflow_run_event", {
+        event: { id: "distinct-event-a", type: "NodeFinished" },
+      }),
+      dispatchRuntimeEventTriggers(handle.runtime, "workflow_run_event", {
+        event: { id: "distinct-event-b", type: "NodeFinished" },
+      }),
+    ]);
+
+    expect(handle.dispatchCalls).toHaveLength(2);
+    expect(
+      handle.dispatchCalls
+        .map(
+          (call) =>
+            (call.payload?.eventPayload as { event?: { id?: string } })?.event
+              ?.id,
+        )
+        .sort(),
+    ).toEqual(["distinct-event-a", "distinct-event-b"]);
+    expect(handle.dispatchCalls[0]?.options?.idempotencyKey).not.toBe(
+      handle.dispatchCalls[1]?.options?.idempotencyKey,
+    );
   });
 
   it("derives the same durable dispatch key when a Smithers event is replayed", async () => {

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -1082,7 +1082,7 @@ describe("runtime event trigger bridge", () => {
       expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4),
     );
 
-    const metadata = target.metadata as {
+    const metadata = target.metadata as unknown as {
       trigger: Record<string, unknown>;
     };
     handle.setTasks([

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -11,7 +11,7 @@
  */
 
 import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
-import { EventType, ServiceType, stringToUuid } from "@elizaos/core";
+import { ServiceType, stringToUuid } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -165,12 +165,18 @@ function makeRuntime(): MockRuntimeHandle {
       );
     },
     getTasks: vi.fn(async () => tasks),
-    getTask: vi.fn(async (id: UUID) => tasks.find((task) => task.id === id)),
+    getTask: vi.fn(
+      async (id: UUID) => tasks.find((task) => task.id === id) ?? null,
+    ),
     deleteTask: vi.fn(async (id: UUID) => {
       deletedTaskIds.push(id);
+      tasks = tasks.filter((task) => task.id !== id);
     }),
     updateTask: vi.fn(async (id: UUID, patch: Partial<Task>) => {
       updatedTasks.push({ id, patch });
+      tasks = tasks.map((task) =>
+        task.id === id ? ({ ...task, ...patch } as Task) : task,
+      );
     }),
     ensureConnection: vi.fn(async () => {}),
     getRoom: vi.fn(async () => null),
@@ -856,11 +862,12 @@ describe("runtime event trigger bridge", () => {
     registerTriggerTaskWorker(handle.runtime);
     registerTriggerTaskWorker(handle.runtime);
     expect(handle.runtime.getEvent("workflow_run_event")).toHaveLength(1);
-    expect(handle.runtime.getEvent(EventType.MESSAGE_RECEIVED)).toHaveLength(1);
+    expect(handle.runtime.getEvent("MESSAGE_RECEIVED")).toBeUndefined();
 
     await handle.runtime.emitEvent("workflow_run_event", {
       runtime: handle.runtime,
       event: {
+        id: "smithers-non-match",
         type: "NodeFinished",
         workflowId: "source-workflow",
         nodeId: "publish",
@@ -871,6 +878,7 @@ describe("runtime event trigger bridge", () => {
     await handle.runtime.emitEvent("workflow_run_event", {
       runtime: handle.runtime,
       event: {
+        id: "smithers-match",
         type: "NodeFinished",
         workflowId: "source-workflow",
         nodeId: "collect",
@@ -890,6 +898,13 @@ describe("runtime event trigger bridge", () => {
             nodeId: "collect",
           },
         },
+      },
+      options: {
+        idempotencyKey: expect.stringMatching(
+          new RegExp(
+            `^event:${readTriggerConfig(target)?.triggerId}:[a-f0-9]{64}$`,
+          ),
+        ),
       },
     });
     const eventPayload = handle.dispatchCalls[0]?.payload?.eventPayload;
@@ -978,6 +993,69 @@ describe("runtime event trigger bridge", () => {
         taskId: first.id,
       },
     });
+  });
+
+  it("serializes concurrent events per trigger and refreshes persisted state", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      maxRuns: 1,
+    });
+    handle.setTasks([target]);
+    let releaseFirst: (() => void) | undefined;
+    const execute = vi.fn(
+      () =>
+        new Promise<{ ok: true; executionId: string }>((resolve) => {
+          releaseFirst = () => resolve({ ok: true, executionId: "first" });
+        }),
+    );
+    const workflowService = handle.runtime.getService(
+      "WORKFLOW_DISPATCH",
+    ) as unknown as { execute: typeof execute };
+    workflowService.execute = execute;
+    registerTriggerTaskWorker(handle.runtime);
+
+    await Promise.all([
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { id: "event-1", type: "NodeFinished" },
+      } as never),
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { id: "event-2", type: "NodeFinished" },
+      } as never),
+    ]);
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+    releaseFirst?.();
+    await vi.waitFor(() => expect(handle.deletedTaskIds).toEqual([target.id]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The queued second event refreshes the task after the first reaches
+    // maxRuns and therefore cannot dispatch a deleted stale snapshot.
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("derives the same durable dispatch key when a Smithers event is replayed", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target]);
+    registerTriggerTaskWorker(handle.runtime);
+    const emitted = {
+      runtime: handle.runtime,
+      event: { id: "smithers-event-42", type: "NodeFinished" },
+    } as never;
+
+    await handle.runtime.emitEvent("workflow_run_event", emitted);
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(1));
+    await handle.runtime.emitEvent("workflow_run_event", emitted);
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(2));
+
+    expect(handle.dispatchCalls[0]?.options?.idempotencyKey).toBe(
+      handle.dispatchCalls[1]?.options?.idempotencyKey,
+    );
   });
 });
 

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -1413,12 +1413,17 @@ describe("runtime event trigger bridge", () => {
     );
     handle.setTasks([aToB, bToA]);
 
-    const feedback: Array<() => Promise<void>> = [];
+    // Production ordering: WORKFLOW_DISPATCH awaits executeWorkflow, and a run
+    // emits every one of its events BEFORE that promise resolves. Deferring the
+    // emit to a later round (the previous shape here) inverts that, and made
+    // this test pass against a chain guard that never fired in production.
     let runSeq = 0;
     const execute = vi.fn(async (workflowId: string) => {
       runSeq += 1;
       const runId = `run-${runSeq}`;
-      feedback.push(async () => {
+      // Bound the harness itself so a genuinely unbounded chain fails the
+      // assertion below instead of hanging the suite.
+      if (runSeq <= 30) {
         await handle.runtime.emitEvent("workflow_run_event", {
           event: {
             id: `${runId}:1`,
@@ -1427,7 +1432,7 @@ describe("runtime event trigger bridge", () => {
             type: "NodeFinished",
           },
         } as never);
-      });
+      }
       return { ok: true as const, executionId: runId };
     });
     (
@@ -1446,16 +1451,14 @@ describe("runtime event trigger bridge", () => {
       },
     } as never);
 
-    for (let round = 0; round < 20; round += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-      if (feedback.length === 0) break;
-      const next = feedback.splice(0, feedback.length);
-      for (const emit of next) await emit();
-    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
-    // Four hops from the seed, then the chain stops on its own.
-    expect(feedback).toHaveLength(0);
-    expect(execute).toHaveBeenCalledTimes(4);
+    // The chain must quiesce on its own, well inside the harness cutoff. If
+    // ancestry is not actually bounding it, runSeq runs away to 30.
+    expect(execute.mock.calls.length).toBeLessThanOrEqual(
+      5, // MAX_EVENT_TRIGGER_CHAIN_DEPTH (4) + the seed hop
+    );
+    expect(execute.mock.calls.length).toBeGreaterThan(0);
   });
 
   it("cuts off a saved trigger that exceeds the sustained dispatch ceiling", async () => {

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -1036,6 +1036,45 @@ describe("runtime event trigger bridge", () => {
     expect(execute).toHaveBeenCalledOnce();
   });
 
+  it("coalesces concurrent task lookups and reuses them for a bounded window", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target]);
+    registerTriggerTaskWorker(handle.runtime);
+
+    await Promise.all([
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { id: "event-1", type: "NodeFinished" },
+      } as never),
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { id: "event-2", type: "NodeFinished" },
+      } as never),
+    ]);
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(2));
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
+
+    now.mockReturnValue(10_400);
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: { id: "event-3", type: "NodeFinished" },
+    } as never);
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(3));
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
+
+    now.mockReturnValue(10_501);
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: { id: "event-4", type: "NodeFinished" },
+    } as never);
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(4));
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4);
+  });
+
   it("derives the same durable dispatch key when a Smithers event is replayed", async () => {
     const target = makeTriggerTask({
       triggerType: "event",

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -56,7 +56,7 @@ interface MockRuntimeHandle {
   setTasks: (tasks: Task[]) => void;
   setDispatchResult: (
     result:
-      | { ok: true; executionId?: string }
+      | { ok: true; executionId?: string; dedup?: boolean }
       | { ok: false; error: string; code?: string },
   ) => void;
   setWorkflowServicePresent: (present: boolean) => void;
@@ -108,6 +108,7 @@ function makeRuntime(): MockRuntimeHandle {
   let dispatchResult: {
     ok: boolean;
     executionId?: string;
+    dedup?: boolean;
     error?: string;
     code?: string;
   } = { ok: true, executionId: "exec-1" };
@@ -456,6 +457,7 @@ describe("executeTriggerTask", () => {
       triggerType: "event",
       eventKind: "MESSAGE_RECEIVED",
     });
+    handle.setTasks([task]);
 
     const result = await executeTriggerTask(handle.runtime, task, {
       source: "event",
@@ -500,6 +502,7 @@ describe("executeTriggerTask", () => {
         },
       },
     });
+    handle.setTasks([task]);
 
     const matching = await executeTriggerTask(handle.runtime, task, {
       source: "event",
@@ -1046,8 +1049,65 @@ describe("runtime event trigger bridge", () => {
     expect(execute).toHaveBeenCalledOnce();
   });
 
-  it("coalesces concurrent task lookups and reuses them for a bounded window", async () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
+  it("preserves a disable saved while an event run is in flight", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target]);
+    let releaseFirst: (() => void) | undefined;
+    const execute = vi.fn(
+      () =>
+        new Promise<{ ok: true; executionId: string }>((resolve) => {
+          releaseFirst = () => resolve({ ok: true, executionId: "first" });
+        }),
+    );
+    const workflowService = handle.runtime.getService(
+      "WORKFLOW_DISPATCH",
+    ) as unknown as { execute: typeof execute };
+    workflowService.execute = execute;
+    registerTriggerTaskWorker(handle.runtime);
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: { id: "event-1", type: "NodeFinished" },
+    } as never);
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: { id: "event-2", type: "NodeFinished" },
+    } as never);
+    await vi.waitFor(() =>
+      expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4),
+    );
+
+    const metadata = target.metadata as {
+      trigger: Record<string, unknown>;
+    };
+    handle.setTasks([
+      {
+        ...target,
+        metadata: {
+          ...metadata,
+          trigger: { ...metadata.trigger, enabled: false },
+        },
+      } as Task,
+    ]);
+    releaseFirst?.();
+
+    await vi.waitFor(() => expect(handle.updatedTasks).toHaveLength(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(execute).toHaveBeenCalledOnce();
+    expect(
+      readTriggerConfig({
+        ...target,
+        metadata: handle.updatedTasks[0]?.patch.metadata,
+      } as Task),
+    ).toMatchObject({ enabled: false, runCount: 1 });
+  });
+
+  it("coalesces only concurrent task lookups and sees newly saved triggers immediately", async () => {
     const target = makeTriggerTask({
       triggerType: "event",
       eventKind: "workflow_run_event",
@@ -1068,18 +1128,14 @@ describe("runtime event trigger bridge", () => {
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(2));
     expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
 
-    now.mockReturnValue(10_400);
+    const newlySaved = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target, newlySaved]);
     await handle.runtime.emitEvent("workflow_run_event", {
       runtime: handle.runtime,
       event: { id: "event-3", type: "NodeFinished" },
-    } as never);
-    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(3));
-    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
-
-    now.mockReturnValue(10_501);
-    await handle.runtime.emitEvent("workflow_run_event", {
-      runtime: handle.runtime,
-      event: { id: "event-4", type: "NodeFinished" },
     } as never);
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(4));
     expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4);
@@ -1105,6 +1161,39 @@ describe("runtime event trigger bridge", () => {
     expect(handle.dispatchCalls[0]?.options?.idempotencyKey).toBe(
       handle.dispatchCalls[1]?.options?.idempotencyKey,
     );
+  });
+
+  it("does not count an idempotently deduplicated Smithers replay as a new run", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      maxRuns: 2,
+    });
+    handle.setTasks([target]);
+    handle.setDispatchResult({
+      ok: true,
+      executionId: "existing-execution",
+      dedup: true,
+    });
+
+    const result = await executeTriggerTask(handle.runtime, target, {
+      source: "event",
+      event: {
+        kind: "workflow_run_event",
+        payload: {
+          event: { id: "smithers-event-42", type: "NodeFinished" },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "skipped",
+      taskDeleted: false,
+      executionId: "existing-execution",
+    });
+    expect(handle.runtime.updateTask).not.toHaveBeenCalled();
+    expect(handle.runtime.deleteTask).not.toHaveBeenCalled();
+    expect(readTriggerConfig(target)?.runCount).toBe(0);
   });
 });
 

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -866,6 +866,9 @@ describe("runtime event trigger bridge", () => {
 
     await handle.runtime.emitEvent("workflow_run_event", {
       runtime: handle.runtime,
+      source: "runtime",
+      onComplete: () => undefined,
+      anotherCallback: () => undefined,
       event: {
         id: "smithers-non-match",
         type: "NodeFinished",
@@ -910,6 +913,13 @@ describe("runtime event trigger bridge", () => {
     const eventPayload = handle.dispatchCalls[0]?.payload?.eventPayload;
     expect(eventPayload).toBeDefined();
     expect((eventPayload as Record<string, unknown>).runtime).toBeUndefined();
+    expect((eventPayload as Record<string, unknown>).source).toBeUndefined();
+    expect(
+      (eventPayload as Record<string, unknown>).onComplete,
+    ).toBeUndefined();
+    expect(
+      (eventPayload as Record<string, unknown>).anotherCallback,
+    ).toBeUndefined();
     expect(handle.reportedErrors).toHaveLength(0);
   });
 

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -1079,7 +1079,7 @@ describe("runtime event trigger bridge", () => {
       event: { id: "event-2", type: "NodeFinished" },
     } as never);
     await vi.waitFor(() =>
-      expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4),
+      expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2),
     );
 
     const metadata = target.metadata as unknown as {
@@ -1107,7 +1107,7 @@ describe("runtime event trigger bridge", () => {
     ).toMatchObject({ enabled: false, runCount: 1 });
   });
 
-  it("performs fresh discovery for concurrent and newly saved trigger events", async () => {
+  it("shares one discovery query per turn and re-queries for a newly saved trigger", async () => {
     const target = makeTriggerTask({
       triggerType: "event",
       eventKind: "workflow_run_event",
@@ -1126,7 +1126,9 @@ describe("runtime event trigger bridge", () => {
       } as never),
     ]);
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(2));
-    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(4);
+    // Both events were observed before the batched query was issued, so they
+    // share it: two events cost one task-store read, not one read each.
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(1);
 
     const newlySaved = makeTriggerTask({
       triggerType: "event",
@@ -1138,7 +1140,9 @@ describe("runtime event trigger bridge", () => {
       event: { id: "event-3", type: "NodeFinished" },
     } as never);
     await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(4));
-    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(6);
+    // A later turn never reuses the earlier snapshot, so the trigger saved in
+    // between is visible to the third event.
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(2);
   });
 
   it("sees create and enable writes while an older discovery is still in flight", async () => {
@@ -1155,7 +1159,7 @@ describe("runtime event trigger bridge", () => {
       });
       const getTasks = vi.fn(async () => {
         const callNumber = getTasks.mock.calls.length;
-        if (callNumber <= 2) {
+        if (callNumber <= 1) {
           await initialLookup;
           return initialTasks;
         }
@@ -1167,14 +1171,14 @@ describe("runtime event trigger bridge", () => {
       await lane.runtime.emitEvent("workflow_run_event", {
         event: { id: `${eventPrefix}-before`, type: "NodeFinished" },
       } as never);
-      await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(1));
 
       lane.setTasks([currentTask]);
       await lane.runtime.emitEvent("workflow_run_event", {
         event: { id: `${eventPrefix}-after`, type: "NodeFinished" },
       } as never);
       try {
-        await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(4));
+        await vi.waitFor(() => expect(getTasks).toHaveBeenCalledTimes(2));
         await vi.waitFor(() => expect(lane.dispatchCalls).toHaveLength(1));
       } finally {
         releaseInitialLookup?.();
@@ -1355,6 +1359,220 @@ describe("runtime event trigger bridge", () => {
     expect(handle.runtime.updateTask).not.toHaveBeenCalled();
     expect(handle.runtime.deleteTask).not.toHaveBeenCalled();
     expect(readTriggerConfig(target)?.runCount).toBe(0);
+  });
+
+  it("never restarts the workflow that emitted the event", async () => {
+    const selfTrigger = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "wf-self",
+      },
+      { maxRuns: 0 },
+    );
+    handle.setTasks([selfTrigger]);
+    registerTriggerTaskWorker(handle.runtime);
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      event: {
+        id: "run-self:1",
+        runId: "run-self",
+        workflowId: "wf-self",
+        type: "NodeFinished",
+      },
+    } as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.dispatchCalls).toHaveLength(0);
+    expect(
+      handle.warnings.some((entry) =>
+        String(entry[1]).includes("skipping self-trigger"),
+      ),
+    ).toBe(true);
+  });
+
+  it("quiesces a mutually referential trigger chain instead of running forever", async () => {
+    // wf-a's events start wf-b and wf-b's events start wf-a. Each dispatched
+    // run emits its own event under a fresh run id, so nothing about durable
+    // event identity can collapse the cycle; only ancestry can stop it.
+    const aToB = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "wf-b",
+      },
+      { maxRuns: 0 },
+    );
+    const bToA = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "wf-a",
+      },
+      { maxRuns: 0 },
+    );
+    handle.setTasks([aToB, bToA]);
+
+    const feedback: Array<() => Promise<void>> = [];
+    let runSeq = 0;
+    const execute = vi.fn(async (workflowId: string) => {
+      runSeq += 1;
+      const runId = `run-${runSeq}`;
+      feedback.push(async () => {
+        await handle.runtime.emitEvent("workflow_run_event", {
+          event: {
+            id: `${runId}:1`,
+            runId,
+            workflowId,
+            type: "NodeFinished",
+          },
+        } as never);
+      });
+      return { ok: true as const, executionId: runId };
+    });
+    (
+      handle.runtime.getService("WORKFLOW_DISPATCH") as unknown as {
+        execute: typeof execute;
+      }
+    ).execute = execute;
+    registerTriggerTaskWorker(handle.runtime);
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      event: {
+        id: "seed:1",
+        runId: "run-seed",
+        workflowId: "wf-a",
+        type: "NodeFinished",
+      },
+    } as never);
+
+    for (let round = 0; round < 20; round += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      if (feedback.length === 0) break;
+      const next = feedback.splice(0, feedback.length);
+      for (const emit of next) await emit();
+    }
+
+    // Four hops from the seed, then the chain stops on its own.
+    expect(feedback).toHaveLength(0);
+    expect(execute).toHaveBeenCalledTimes(4);
+  });
+
+  it("cuts off a saved trigger that exceeds the sustained dispatch ceiling", async () => {
+    const target = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "wf-target",
+      },
+      { maxRuns: 0 },
+    );
+    handle.setTasks([target]);
+    registerTriggerTaskWorker(handle.runtime);
+
+    for (let index = 0; index < 65; index += 1) {
+      await handle.runtime.emitEvent("workflow_run_event", {
+        event: {
+          id: `flood-${index}`,
+          runId: `run-flood-${index}`,
+          workflowId: "wf-source",
+          type: "NodeFinished",
+        },
+      } as never);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(handle.dispatchCalls).toHaveLength(60);
+    expect(
+      handle.reportedErrors.filter(
+        (entry) =>
+          (entry.error as { code?: string }).code ===
+          "TRIGGER_EVENT_DISPATCH_RATE_EXCEEDED",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("reads the task store once per event instead of once per tag set", async () => {
+    handle.setTasks([makeTriggerTask({ triggerType: "interval" })]);
+    registerTriggerTaskWorker(handle.runtime);
+
+    for (let index = 0; index < 5; index += 1) {
+      await handle.runtime.emitEvent("workflow_run_event", {
+        event: {
+          id: `quiet-${index}`,
+          runId: `run-quiet-${index}`,
+          workflowId: "wf-source",
+          type: "NodeFinished",
+        },
+      } as never);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(handle.dispatchCalls).toHaveLength(0);
+    expect(handle.runtime.getTasks).toHaveBeenCalledTimes(5);
+  });
+
+  it("keeps the source run alive when an event payload accessor throws", async () => {
+    const target = makeTriggerTask(
+      {
+        triggerType: "event",
+        eventKind: "workflow_run_event",
+        workflowId: "wf-target",
+      },
+      { maxRuns: 0 },
+    );
+    handle.setTasks([target]);
+    registerTriggerTaskWorker(handle.runtime);
+
+    const handlers = (
+      handle.runtime as unknown as {
+        getEvent: (
+          kind: string,
+        ) => Array<(params: Record<string, unknown>) => Promise<void>>;
+      }
+    ).getEvent("workflow_run_event");
+    const handler = handlers?.[0];
+    if (!handler) throw new Error("bridge handler was not registered");
+
+    // A hostile accessor and an own `__proto__` key: the emitting Smithers run
+    // awaits this handler inside `recordEvent`, so neither may reach it.
+    const params: Record<string, unknown> = {
+      runtime: handle.runtime,
+      event: {
+        id: "hostile:1",
+        runId: "run-hostile",
+        workflowId: "wf-source",
+        type: "NodeFinished",
+      },
+    };
+    Object.defineProperty(params, "hostile", {
+      enumerable: true,
+      get() {
+        throw new Error("hostile accessor");
+      },
+    });
+    Object.defineProperty(params, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      value: { polluted: true },
+    });
+
+    await expect(handler(params)).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(1));
+
+    const eventPayload = handle.dispatchCalls[0]?.payload?.eventPayload as
+      | Record<string, unknown>
+      | undefined;
+    if (!eventPayload) throw new Error("bridged payload missing");
+    expect(eventPayload).not.toHaveProperty("hostile");
+    expect((eventPayload.event as { id?: string }).id).toBe("hostile:1");
+    expect(Object.getPrototypeOf(eventPayload)).toBe(Object.prototype);
+    expect((eventPayload as { polluted?: boolean }).polluted).toBeUndefined();
+    expect(
+      handle.reportedErrors.some(
+        (entry) => entry.scope === "TriggerRuntime.eventPayload",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -11,13 +11,15 @@
  */
 
 import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
-import { ServiceType, stringToUuid } from "@elizaos/core";
+import { EventType, ServiceType, stringToUuid } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  dispatchRuntimeEventTriggers,
   executeTriggerTask,
   listTriggerTasks,
   readTriggerConfig,
+  registerTriggerTaskWorker,
   TRIGGER_TASK_NAME,
   TRIGGER_TASK_TAGS,
 } from "./runtime.ts";
@@ -51,6 +53,7 @@ interface MockRuntimeHandle {
     error: unknown;
     context?: Record<string, unknown>;
   }>;
+  setTasks: (tasks: Task[]) => void;
   setDispatchResult: (
     result:
       | { ok: true; executionId?: string }
@@ -71,6 +74,12 @@ function makeRuntime(): MockRuntimeHandle {
   const reportedErrors: MockRuntimeHandle["reportedErrors"] = [];
   let notifyError: Error | null = null;
   const runtimeSettings = new Map<string, unknown>();
+  const taskWorkers = new Map<string, unknown>();
+  const eventHandlers = new Map<
+    string,
+    Array<(params: Record<string, unknown>) => Promise<void>>
+  >();
+  let tasks: Task[] = [];
 
   const messageService = {
     async handleMessage(
@@ -134,6 +143,29 @@ function makeRuntime(): MockRuntimeHandle {
       return null;
     },
     getSetting: (name: string) => runtimeSettings.get(name),
+    getTaskWorker: (name: string) => taskWorkers.get(name),
+    registerTaskWorker: (worker: { name: string }) => {
+      taskWorkers.set(worker.name, worker);
+    },
+    registerEvent: (
+      eventKind: string,
+      handler: (params: Record<string, unknown>) => Promise<void>,
+    ) => {
+      eventHandlers.set(eventKind, [
+        ...(eventHandlers.get(eventKind) ?? []),
+        handler,
+      ]);
+    },
+    getEvent: (eventKind: string) => eventHandlers.get(eventKind),
+    emitEvent: async (eventKind: string, params: Record<string, unknown>) => {
+      await Promise.all(
+        (eventHandlers.get(eventKind) ?? []).map((handler) =>
+          handler({ ...params, runtime }),
+        ),
+      );
+    },
+    getTasks: vi.fn(async () => tasks),
+    getTask: vi.fn(async (id: UUID) => tasks.find((task) => task.id === id)),
     deleteTask: vi.fn(async (id: UUID) => {
       deletedTaskIds.push(id);
     }),
@@ -158,6 +190,9 @@ function makeRuntime(): MockRuntimeHandle {
     warnings,
     notifyCalls,
     reportedErrors,
+    setTasks: (nextTasks) => {
+      tasks = nextTasks;
+    },
     setDispatchResult: (result) => {
       dispatchResult = result;
     },
@@ -789,6 +824,160 @@ describe("executeTriggerTask", () => {
     });
     expect(result.status).toBe("skipped");
     expect(handle.dispatchCalls).toHaveLength(0);
+  });
+});
+
+describe("runtime event trigger bridge", () => {
+  let handle: MockRuntimeHandle;
+
+  beforeEach(() => {
+    handle = makeRuntime();
+    taskSeq = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches only an exact Smithers step match through runtime.emitEvent", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      eventFilter: {
+        event: {
+          type: "NodeFinished",
+          workflowId: "source-workflow",
+          nodeId: "collect",
+        },
+      },
+    });
+    handle.setTasks([target]);
+
+    registerTriggerTaskWorker(handle.runtime);
+    registerTriggerTaskWorker(handle.runtime);
+    expect(handle.runtime.getEvent("workflow_run_event")).toHaveLength(1);
+    expect(handle.runtime.getEvent(EventType.MESSAGE_RECEIVED)).toHaveLength(1);
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: {
+        type: "NodeFinished",
+        workflowId: "source-workflow",
+        nodeId: "publish",
+      },
+    } as never);
+    expect(handle.dispatchCalls).toHaveLength(0);
+
+    await handle.runtime.emitEvent("workflow_run_event", {
+      runtime: handle.runtime,
+      event: {
+        type: "NodeFinished",
+        workflowId: "source-workflow",
+        nodeId: "collect",
+        output: { count: 3 },
+      },
+    } as never);
+
+    await vi.waitFor(() => expect(handle.dispatchCalls).toHaveLength(1));
+    expect(handle.dispatchCalls[0]).toMatchObject({
+      workflowId: "wf-1",
+      payload: {
+        eventKind: "workflow_run_event",
+        eventPayload: {
+          event: {
+            type: "NodeFinished",
+            workflowId: "source-workflow",
+            nodeId: "collect",
+          },
+        },
+      },
+    });
+    const eventPayload = handle.dispatchCalls[0]?.payload?.eventPayload;
+    expect(eventPayload).toBeDefined();
+    expect((eventPayload as Record<string, unknown>).runtime).toBeUndefined();
+    expect(handle.reportedErrors).toHaveLength(0);
+  });
+
+  it("reports trigger-list failures without rejecting the source event", async () => {
+    const failure = new Error("trigger store offline");
+    handle.runtime.getTasks = vi.fn(async () => {
+      throw failure;
+    });
+    registerTriggerTaskWorker(handle.runtime);
+
+    await expect(
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { type: "NodeFinished" },
+      } as never),
+    ).resolves.toBeUndefined();
+    await vi.waitFor(() =>
+      expect(handle.reportedErrors).toContainEqual({
+        scope: "TriggerRuntime.eventBridge",
+        error: failure,
+        context: { eventKind: "workflow_run_event" },
+      }),
+    );
+  });
+
+  it("does not block the source event while a workflow trigger is running", async () => {
+    const target = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([target]);
+    let releaseDispatch: (() => void) | undefined;
+    const execute = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseDispatch = () => resolve({ status: "finished" });
+        }),
+    );
+    const workflowService = handle.runtime.getService(
+      "WORKFLOW_DISPATCH",
+    ) as unknown as { execute: typeof execute };
+    workflowService.execute = execute;
+    registerTriggerTaskWorker(handle.runtime);
+
+    await expect(
+      handle.runtime.emitEvent("workflow_run_event", {
+        runtime: handle.runtime,
+        event: { type: "NodeFinished" },
+      } as never),
+    ).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(releaseDispatch).toBeTypeOf("function"));
+
+    releaseDispatch?.();
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+  });
+
+  it("isolates a failing trigger from sibling event dispatches", async () => {
+    const first = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    const second = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+    });
+    handle.setTasks([first, second]);
+    const failure = new Error("first trigger write failed");
+    handle.runtime.updateTask = vi.fn(async (id: UUID) => {
+      if (id === first.id) throw failure;
+    });
+
+    await expect(
+      dispatchRuntimeEventTriggers(handle.runtime, "workflow_run_event", {}),
+    ).resolves.toBeUndefined();
+    expect(handle.dispatchCalls).toHaveLength(2);
+    expect(handle.reportedErrors).toContainEqual({
+      scope: "TriggerRuntime.eventDispatch",
+      error: failure,
+      context: {
+        eventKind: "workflow_run_event",
+        taskId: first.id,
+      },
+    });
   });
 });
 

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -1,8 +1,10 @@
 /**
  * Executes the agent's scheduled/event triggers and wires them into the task
- * scheduler. Registers the TRIGGER_DISPATCH task worker, dispatches each fire to
- * either a workflow (the WORKFLOW_DISPATCH service, idempotency-keyed) or a
- * prompt automation (a synthetic-entity turn through the message service), then
+ * scheduler and runtime events. Registers the TRIGGER_DISPATCH task worker,
+ * bridges supported runtime events into persisted event triggers, dispatches
+ * each fire to either a workflow (the WORKFLOW_DISPATCH service,
+ * idempotency-keyed) or a prompt automation (a synthetic-entity turn through
+ * the message service), then
  * records the run, recomputes next-fire metadata, deletes one-shot/exhausted
  * tasks, and hands the per-fire re-arm interval back so varying-cadence triggers
  * don't drift. Tracks per-agent execution metrics, surfaces success/failure on
@@ -11,6 +13,7 @@
  */
 import crypto from "node:crypto";
 import type {
+  EventPayload,
   HandlerCallback,
   IAgentRuntime,
   Memory,
@@ -19,6 +22,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
+  EventType,
   inspectSendHandlerResult,
   MESSAGE_SOURCE_TRIGGER_PROMPT,
   registerRuntimeManagedInternalActor,
@@ -45,6 +49,13 @@ import type {
 export const TRIGGER_TASK_NAME = "TRIGGER_DISPATCH" as const;
 export const TRIGGER_TASK_TAGS = ["queue", "repeat", "trigger"] as const;
 const HEARTBEAT_TASK_TAGS = ["queue", "repeat", "heartbeat"] as const;
+const WORKFLOW_RUN_EVENT = "workflow_run_event" as const;
+const RUNTIME_TRIGGER_EVENT_KINDS = [
+  EventType.MESSAGE_RECEIVED,
+  WORKFLOW_RUN_EVENT,
+] as const;
+
+const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
@@ -851,28 +862,100 @@ export async function executeTriggerTask(
   };
 }
 
-export function registerTriggerTaskWorker(runtime: IAgentRuntime): void {
-  if (runtime.getTaskWorker(TRIGGER_TASK_NAME)) return;
+function serializableEventPayload(
+  params: EventPayload,
+): Record<string, unknown> {
+  const payload = { ...params } as Record<string, unknown>;
+  delete payload.runtime;
+  delete payload.onComplete;
+  return payload;
+}
 
-  runtime.registerTaskWorker({
-    name: TRIGGER_TASK_NAME,
-    shouldRun: async () => true,
-    execute: async (rt, options, task) => {
-      const result = await executeTriggerTask(rt, task, {
-        source: options.source === "manual" ? "manual" : "scheduler",
-        force: options.force === true,
-      });
-      // Hand the per-fire re-arm interval back to the task service as scheduling
-      // metadata. Without it, the service's success path falls through to a
-      // frozen `baseInterval` (seeded on the first transient failure), so a
-      // varying-cadence trigger (e.g. weekday cron) permanently drifts — firing
-      // on the wrong days. Deleted tasks don't reschedule, so return nothing.
-      if (!result.taskDeleted && typeof result.updateInterval === "number") {
-        return { nextInterval: result.updateInterval };
-      }
-      return undefined;
-    },
+/**
+ * Dispatch one runtime event through the same persisted trigger engine used by
+ * the HTTP event boundary. Filtering happens before execution so unrelated
+ * event triggers do not accumulate skipped-run metrics.
+ */
+export async function dispatchRuntimeEventTriggers(
+  runtime: IAgentRuntime,
+  eventKind: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const tasks = await listTriggerTasks(runtime);
+  const matchingTasks = tasks.filter((task) => {
+    const trigger = readTriggerConfig(task);
+    return (
+      trigger?.enabled === true &&
+      trigger.triggerType === "event" &&
+      trigger.eventKind === eventKind
+    );
   });
+
+  await Promise.all(
+    matchingTasks.map(async (task) => {
+      try {
+        await executeTriggerTask(runtime, task, {
+          source: "event",
+          event: { kind: eventKind, payload },
+        });
+      } catch (error) {
+        // error-policy:J7 one trigger's persistence/dispatch failure must not
+        // reject the source runtime event or prevent sibling triggers.
+        runtime.reportError("TriggerRuntime.eventDispatch", error, {
+          eventKind,
+          taskId: task.id,
+        });
+      }
+    }),
+  );
+}
+
+function registerRuntimeEventTriggerBridge(runtime: IAgentRuntime): void {
+  if (eventBridgeRegistrations.has(runtime)) return;
+
+  for (const eventKind of RUNTIME_TRIGGER_EVENT_KINDS) {
+    runtime.registerEvent(eventKind, async (params: EventPayload) => {
+      void dispatchRuntimeEventTriggers(
+        runtime,
+        eventKind,
+        serializableEventPayload(params),
+      ).catch((error) => {
+        // error-policy:J7 trigger discovery failures are observed without
+        // blocking the source message or a nested Smithers execution event.
+        runtime.reportError("TriggerRuntime.eventBridge", error, {
+          eventKind,
+        });
+      });
+    });
+  }
+
+  eventBridgeRegistrations.add(runtime);
+}
+
+export function registerTriggerTaskWorker(runtime: IAgentRuntime): void {
+  if (!runtime.getTaskWorker(TRIGGER_TASK_NAME)) {
+    runtime.registerTaskWorker({
+      name: TRIGGER_TASK_NAME,
+      shouldRun: async () => true,
+      execute: async (rt, options, task) => {
+        const result = await executeTriggerTask(rt, task, {
+          source: options.source === "manual" ? "manual" : "scheduler",
+          force: options.force === true,
+        });
+        // Hand the per-fire re-arm interval back to the task service as scheduling
+        // metadata. Without it, the service's success path falls through to a
+        // frozen `baseInterval` (seeded on the first transient failure), so a
+        // varying-cadence trigger (e.g. weekday cron) permanently drifts — firing
+        // on the wrong days. Deleted tasks don't reschedule, so return nothing.
+        if (!result.taskDeleted && typeof result.updateInterval === "number") {
+          return { nextInterval: result.updateInterval };
+        }
+        return undefined;
+      },
+    });
+  }
+
+  registerRuntimeEventTriggerBridge(runtime);
 }
 
 export async function listTriggerTasks(

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -22,7 +22,6 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
-  EventType,
   inspectSendHandlerResult,
   MESSAGE_SOURCE_TRIGGER_PROMPT,
   registerRuntimeManagedInternalActor,
@@ -50,12 +49,13 @@ export const TRIGGER_TASK_NAME = "TRIGGER_DISPATCH" as const;
 export const TRIGGER_TASK_TAGS = ["queue", "repeat", "trigger"] as const;
 const HEARTBEAT_TASK_TAGS = ["queue", "repeat", "heartbeat"] as const;
 const WORKFLOW_RUN_EVENT = "workflow_run_event" as const;
-const RUNTIME_TRIGGER_EVENT_KINDS = [
-  EventType.MESSAGE_RECEIVED,
-  WORKFLOW_RUN_EVENT,
-] as const;
+const RUNTIME_TRIGGER_EVENT_KINDS = [WORKFLOW_RUN_EVENT] as const;
 
 const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
+const eventDispatchQueues = new WeakMap<
+  IAgentRuntime,
+  Map<UUID, Promise<void>>
+>();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
@@ -291,6 +291,37 @@ function readTaskIdempotencyKey(task: Task): string | undefined {
 }
 
 /**
+ * Smithers assigns every native run event a durable id. Include the saved
+ * trigger identity when deriving the workflow-dispatch key so replaying one
+ * source event cannot launch the same target twice, while two independently
+ * configured triggers may still react to that event.
+ */
+function resolveDispatchIdempotencyKey(
+  task: Task,
+  trigger: WorkflowTriggerConfig,
+  event?: TriggerExecutionOptions["event"],
+): string | undefined {
+  const nestedEvent = event?.payload?.event;
+  if (
+    nestedEvent &&
+    typeof nestedEvent === "object" &&
+    !Array.isArray(nestedEvent)
+  ) {
+    const eventId = (nestedEvent as Record<string, unknown>).id;
+    if (typeof eventId === "string" && eventId.trim().length > 0) {
+      const digest = crypto
+        .createHash("sha256")
+        .update(event?.kind ?? "")
+        .update("\0")
+        .update(eventId.trim())
+        .digest("hex");
+      return `event:${trigger.triggerId}:${digest}`;
+    }
+  }
+  return readTaskIdempotencyKey(task);
+}
+
+/**
  * How long a workflow trigger waits for the WORKFLOW_DISPATCH service before
  * declaring the workflow subsystem unavailable. plugin-workflow loads in the
  * DEFERRED boot phase and registers the dispatcher inside its init, so a
@@ -353,7 +384,7 @@ async function dispatchWorkflow(
         "workflow subsystem unavailable: the workflow plugin is not enabled on this agent",
     };
   }
-  const idempotencyKey = readTaskIdempotencyKey(task);
+  const idempotencyKey = resolveDispatchIdempotencyKey(task, trigger, event);
   const payload = event
     ? {
         eventKind: event.kind,
@@ -891,21 +922,38 @@ export async function dispatchRuntimeEventTriggers(
     );
   });
 
+  const queues =
+    eventDispatchQueues.get(runtime) ?? new Map<UUID, Promise<void>>();
+  eventDispatchQueues.set(runtime, queues);
+
   await Promise.all(
     matchingTasks.map(async (task) => {
-      try {
-        await executeTriggerTask(runtime, task, {
-          source: "event",
-          event: { kind: eventKind, payload },
-        });
-      } catch (error) {
-        // error-policy:J7 one trigger's persistence/dispatch failure must not
-        // reject the source runtime event or prevent sibling triggers.
-        runtime.reportError("TriggerRuntime.eventDispatch", error, {
-          eventKind,
-          taskId: task.id,
-        });
-      }
+      if (!task.id) return;
+      const taskId = task.id;
+      const prior = queues.get(taskId) ?? Promise.resolve();
+      const pending = prior.then(async () => {
+        try {
+          // Re-read after preceding events finish. This preserves runCount,
+          // maxRuns, enabled state, and edited filters under concurrent source
+          // workflow runs instead of executing against a stale task snapshot.
+          const currentTask = await runtime.getTask(taskId);
+          if (!currentTask) return;
+          await executeTriggerTask(runtime, currentTask, {
+            source: "event",
+            event: { kind: eventKind, payload },
+          });
+        } catch (error) {
+          // error-policy:J7 one trigger's persistence/dispatch failure must not
+          // reject the source runtime event or prevent sibling triggers.
+          runtime.reportError("TriggerRuntime.eventDispatch", error, {
+            eventKind,
+            taskId,
+          });
+        }
+      });
+      queues.set(taskId, pending);
+      await pending;
+      if (queues.get(taskId) === pending) queues.delete(taskId);
     }),
   );
 }

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -4,12 +4,18 @@
  * bridges supported runtime events into persisted event triggers, dispatches
  * each fire to either a workflow (the WORKFLOW_DISPATCH service,
  * idempotency-keyed) or a prompt automation (a synthetic-entity turn through
- * the message service), then
- * records the run, recomputes next-fire metadata, deletes one-shot/exhausted
- * tasks, and hands the per-fire re-arm interval back so varying-cadence triggers
- * don't drift. Tracks per-agent execution metrics, surfaces success/failure on
- * the notification rail, and projects tasks into read-only trigger/heartbeat
- * summaries and a health snapshot for the API.
+ * the message service), then records the run, recomputes next-fire metadata,
+ * deletes one-shot/exhausted tasks, and hands the per-fire re-arm interval back
+ * so varying-cadence triggers don't drift. Tracks per-agent execution metrics,
+ * surfaces success/failure on the notification rail, and projects tasks into
+ * read-only trigger/heartbeat summaries and a health snapshot for the API.
+ *
+ * The runtime-event bridge is a production boundary that starts workflows, so
+ * it is deliberately bounded: a trigger may not restart the workflow that
+ * emitted the event, trigger-to-trigger chains stop after a fixed hop depth,
+ * and each saved trigger has a sustained per-minute dispatch ceiling. Failures
+ * anywhere on the bridge are reported, never propagated back into the emitting
+ * run.
  */
 import crypto from "node:crypto";
 import type {
@@ -22,6 +28,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
+  ElizaError,
   inspectSendHandlerResult,
   MESSAGE_SOURCE_TRIGGER_PROMPT,
   registerRuntimeManagedInternalActor,
@@ -50,10 +57,44 @@ export const TRIGGER_TASK_TAGS = ["queue", "repeat", "trigger"] as const;
 const HEARTBEAT_TASK_TAGS = ["queue", "repeat", "heartbeat"] as const;
 const WORKFLOW_RUN_EVENT = "workflow_run_event" as const;
 const RUNTIME_TRIGGER_EVENT_KINDS = [WORKFLOW_RUN_EVENT] as const;
+/**
+ * How many trigger hops a single originating run may cause. A workflow started
+ * by an event trigger emits its own run events, so a mutually referential
+ * configuration (A triggers B, B triggers A) would otherwise never quiesce.
+ * Ancestry is tracked by run id, so the chain stops after this many hops.
+ */
+const MAX_EVENT_TRIGGER_CHAIN_DEPTH = 4;
+/** Upper bound on remembered run-id ancestry entries per runtime. */
+const MAX_EVENT_TRIGGER_CHAIN_ENTRIES = 1024;
+/**
+ * Long-run dispatch ceiling per saved trigger. The predecessor app-core bridge
+ * enforced a one-second floor between fires, which silently dropped distinct
+ * legitimate events arriving in a burst. This keeps the same sustained ceiling
+ * without the burst loss: bursts of distinct events all fire, but a runaway
+ * fan-out is cut off and reported instead of compounding.
+ */
+const EVENT_DISPATCH_WINDOW_MS = 60_000;
+const MAX_EVENT_DISPATCHES_PER_WINDOW = 60;
 const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
 const eventDispatchQueues = new WeakMap<
   IAgentRuntime,
   Map<UUID, Promise<void>>
+>();
+/** Discovery queries shared by every event observed in the same event-loop turn. */
+const eventDiscoveryBatches = new WeakMap<IAgentRuntime, Promise<Task[]>>();
+/** Run id -> number of trigger hops between an external event and that run. */
+const eventTriggerChainDepths = new WeakMap<
+  IAgentRuntime,
+  Map<string, number>
+>();
+interface EventDispatchWindow {
+  windowStart: number;
+  count: number;
+  reported: boolean;
+}
+const eventDispatchWindows = new WeakMap<
+  IAgentRuntime,
+  Map<string, EventDispatchWindow>
 >();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
@@ -300,24 +341,42 @@ function resolveDispatchIdempotencyKey(
   trigger: WorkflowTriggerConfig,
   event?: TriggerExecutionOptions["event"],
 ): string | undefined {
-  const nestedEvent = event?.payload?.event;
-  if (
-    nestedEvent &&
-    typeof nestedEvent === "object" &&
-    !Array.isArray(nestedEvent)
-  ) {
-    const eventId = (nestedEvent as Record<string, unknown>).id;
-    if (typeof eventId === "string" && eventId.trim().length > 0) {
-      const digest = crypto
-        .createHash("sha256")
-        .update(event?.kind ?? "")
-        .update("\0")
-        .update(eventId.trim())
-        .digest("hex");
-      return `event:${trigger.triggerId}:${digest}`;
-    }
+  const eventId = readNestedRunEvent(event?.payload)?.id;
+  if (typeof eventId === "string" && eventId.trim().length > 0) {
+    const digest = crypto
+      .createHash("sha256")
+      .update(event?.kind ?? "")
+      .update("\0")
+      .update(eventId.trim())
+      .digest("hex");
+    return `event:${trigger.triggerId}:${digest}`;
   }
   return readTaskIdempotencyKey(task);
+}
+
+/**
+ * The native Smithers event nested inside a bridged `workflow_run_event`
+ * payload. Read from persisted/untrusted shape, so every field is optional.
+ */
+interface NestedRunEvent {
+  id?: unknown;
+  runId?: unknown;
+  workflowId?: unknown;
+}
+
+function readNestedRunEvent(
+  payload: Record<string, unknown> | undefined,
+): NestedRunEvent | undefined {
+  const nested = payload?.event;
+  return nested && typeof nested === "object" && !Array.isArray(nested)
+    ? (nested as NestedRunEvent)
+    : undefined;
+}
+
+function readNestedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
 /**
@@ -946,38 +1005,192 @@ export async function executeTriggerTask(
   };
 }
 
+/**
+ * Copy an emitted event payload into a plain, transportable object. The result
+ * becomes workflow input, so runtime/function handles are dropped and
+ * `__proto__` is never assigned through a computed key. Property reads are
+ * individually guarded because a subscriber must never fail the emitting run
+ * over one hostile or lazily-computed accessor.
+ */
 function serializableEventPayload(
+  runtime: IAgentRuntime,
+  eventKind: string,
   params: EventPayload,
 ): Record<string, unknown> {
   const payload: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(params)) {
-    if (key === "runtime" || key === "source" || typeof value === "function") {
+  // `EventPayload` is a closed interface, but subscribers receive whatever the
+  // emitter constructed, so the copy reads it as an open record.
+  const source = params as unknown as Record<string, unknown>;
+  for (const key of Object.keys(source)) {
+    if (key === "runtime" || key === "source" || key === "__proto__") continue;
+    let value: unknown;
+    try {
+      value = source[key];
+    } catch (error) {
+      // error-policy:J7 an accessor that throws is a defect in the emitter, not
+      // a reason to reject the source run's own event recording; the key is
+      // dropped from the bridged payload and the failure is reported.
+      runtime.reportError("TriggerRuntime.eventPayload", error, {
+        eventKind,
+        key,
+      });
       continue;
     }
+    if (typeof value === "function") continue;
     payload[key] = value;
   }
   return payload;
 }
 
+async function listEventTriggerTasks(runtime: IAgentRuntime): Promise<Task[]> {
+  if (!triggersFeatureEnabled(runtime)) return [];
+  // Saved triggers always carry the trigger tags; heartbeat-only repeat tasks
+  // can never hold an event trigger config, so the event path reads one tag set
+  // instead of the two `listTriggerTasks` merges for the Automations UI.
+  return runtime.getTasks({
+    agentIds: [runtime.agentId],
+    tags: ["repeat", "trigger"],
+  });
+}
+
 /**
- * Dispatch one runtime event through the same persisted trigger engine used by
- * Discovery is deliberately fresh for every event: trigger creation and
- * enablement have no invalidation channel, so sharing even an in-flight query
- * can lose an event emitted after the write but before that query resolves.
+ * Discover event triggers for one emitted event.
+ *
+ * Trigger creation and enablement have no invalidation channel, so a cached
+ * snapshot can miss a trigger saved moments before the event. The query is
+ * therefore never reused across event-loop turns; it is only shared by events
+ * observed in the same turn, which is safe because the query is issued in a
+ * microtask after all of those events have already arrived.
+ */
+function discoverEventTriggerTasks(runtime: IAgentRuntime): Promise<Task[]> {
+  const batched = eventDiscoveryBatches.get(runtime);
+  if (batched) return batched;
+  const batch = Promise.resolve().then(() => {
+    eventDiscoveryBatches.delete(runtime);
+    return listEventTriggerTasks(runtime);
+  });
+  eventDiscoveryBatches.set(runtime, batch);
+  return batch;
+}
+
+/** Trigger hops between an external event and the run that emitted `runId`. */
+function readChainDepth(runtime: IAgentRuntime, runId?: string): number {
+  if (!runId) return 0;
+  return eventTriggerChainDepths.get(runtime)?.get(runId) ?? 0;
+}
+
+function recordChainDepth(
+  runtime: IAgentRuntime,
+  runId: string,
+  depth: number,
+): void {
+  const depths =
+    eventTriggerChainDepths.get(runtime) ?? new Map<string, number>();
+  eventTriggerChainDepths.set(runtime, depths);
+  depths.set(runId, depth);
+  // Insertion-ordered eviction keeps ancestry bounded for long-lived hosts.
+  while (depths.size > MAX_EVENT_TRIGGER_CHAIN_ENTRIES) {
+    const oldest = depths.keys().next();
+    if (oldest.done) break;
+    depths.delete(oldest.value);
+  }
+}
+
+/**
+ * Consume one dispatch slot for a saved trigger, returning false once the
+ * sustained ceiling is reached so a runaway configuration stops compounding.
+ */
+function admitTriggerDispatch(
+  runtime: IAgentRuntime,
+  triggerId: string,
+  eventKind: string,
+): boolean {
+  const windows =
+    eventDispatchWindows.get(runtime) ?? new Map<string, EventDispatchWindow>();
+  eventDispatchWindows.set(runtime, windows);
+  const now = Date.now();
+  const window = windows.get(triggerId);
+  if (!window || now - window.windowStart >= EVENT_DISPATCH_WINDOW_MS) {
+    windows.set(triggerId, { windowStart: now, count: 1, reported: false });
+    return true;
+  }
+  if (window.count < MAX_EVENT_DISPATCHES_PER_WINDOW) {
+    window.count += 1;
+    return true;
+  }
+  if (!window.reported) {
+    window.reported = true;
+    runtime.reportError(
+      "TriggerRuntime.eventDispatch",
+      new ElizaError(
+        `Event trigger ${triggerId} exceeded ${MAX_EVENT_DISPATCHES_PER_WINDOW} dispatches per minute; further events are dropped until the window rolls`,
+        {
+          code: "TRIGGER_EVENT_DISPATCH_RATE_EXCEEDED",
+          context: { triggerId, eventKind },
+        },
+      ),
+      { triggerId, eventKind },
+    );
+  }
+  return false;
+}
+
+/**
+ * Dispatch one runtime event through the same persisted trigger engine the
+ * scheduler uses, serialized per saved trigger so concurrent emissions observe
+ * each other's persisted run state.
  */
 export async function dispatchRuntimeEventTriggers(
   runtime: IAgentRuntime,
   eventKind: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const tasks = await listTriggerTasks(runtime);
+  const nestedEvent = readNestedRunEvent(payload);
+  const sourceWorkflowId = readNestedString(nestedEvent?.workflowId);
+  const sourceRunId = readNestedString(nestedEvent?.runId);
+  const chainDepth = readChainDepth(runtime, sourceRunId);
+  if (chainDepth >= MAX_EVENT_TRIGGER_CHAIN_DEPTH) {
+    // The emitting run was itself started by a trigger chain that has already
+    // reached its hop limit. Continuing would let a mutually referential
+    // configuration (A triggers B, B triggers A) run without ever quiescing.
+    runtime.logger.warn(
+      { src: "trigger-runtime", eventKind, runId: sourceRunId, chainDepth },
+      "Event trigger chain depth limit reached; not dispatching further",
+    );
+    return;
+  }
+
+  const tasks = await discoverEventTriggerTasks(runtime);
   const matchingTasks = tasks.filter((task) => {
     const trigger = readTriggerConfig(task);
-    return (
-      trigger?.enabled === true &&
-      trigger.triggerType === "event" &&
-      trigger.eventKind === eventKind
-    );
+    if (
+      trigger?.enabled !== true ||
+      trigger.triggerType !== "event" ||
+      trigger.eventKind !== eventKind
+    ) {
+      return false;
+    }
+    if (
+      trigger.kind === "workflow" &&
+      sourceWorkflowId !== undefined &&
+      trigger.workflowId === sourceWorkflowId
+    ) {
+      // The trigger's target is the workflow that emitted this event. Every
+      // dispatched run emits the same event again under a fresh run id, so the
+      // durable idempotency key never collapses it: this is unbounded by
+      // construction and is never a configuration worth honoring.
+      runtime.logger.warn(
+        {
+          src: "trigger-runtime",
+          eventKind,
+          triggerId: trigger.triggerId,
+          workflowId: sourceWorkflowId,
+        },
+        "Event trigger targets the workflow that emitted the event; skipping self-trigger",
+      );
+      return false;
+    }
+    return true;
   });
 
   const queues =
@@ -996,10 +1209,22 @@ export async function dispatchRuntimeEventTriggers(
           // workflow runs instead of executing against a stale task snapshot.
           const currentTask = await runtime.getTask(taskId);
           if (!currentTask) return;
-          await executeTriggerTask(runtime, currentTask, {
+          const currentTrigger = readTriggerConfig(currentTask);
+          if (
+            currentTrigger &&
+            !admitTriggerDispatch(runtime, currentTrigger.triggerId, eventKind)
+          ) {
+            return;
+          }
+          const result = await executeTriggerTask(runtime, currentTask, {
             source: "event",
             event: { kind: eventKind, payload },
           });
+          if (result.executionId) {
+            // The dispatched run's id is the ancestry key its own emitted
+            // events will carry, so the chain can be bounded at the next hop.
+            recordChainDepth(runtime, result.executionId, chainDepth + 1);
+          }
         } catch (error) {
           // error-policy:J7 one trigger's persistence/dispatch failure must not
           // reject the source runtime event or prevent sibling triggers.
@@ -1021,17 +1246,23 @@ function registerRuntimeEventTriggerBridge(runtime: IAgentRuntime): void {
 
   for (const eventKind of RUNTIME_TRIGGER_EVENT_KINDS) {
     runtime.registerEvent(eventKind, async (params: EventPayload) => {
-      void dispatchRuntimeEventTriggers(
-        runtime,
-        eventKind,
-        serializableEventPayload(params),
-      ).catch((error) => {
-        // error-policy:J7 trigger discovery failures are observed without
-        // blocking the source message or a nested Smithers execution event.
-        runtime.reportError("TriggerRuntime.eventBridge", error, {
-          eventKind,
-        });
-      });
+      try {
+        const payload = serializableEventPayload(runtime, eventKind, params);
+        void dispatchRuntimeEventTriggers(runtime, eventKind, payload).catch(
+          (error) => {
+            // error-policy:J7 trigger discovery failures are observed without
+            // blocking the source message or a nested Smithers execution event.
+            runtime.reportError("TriggerRuntime.eventBridge", error, {
+              eventKind,
+            });
+          },
+        );
+      } catch (error) {
+        // error-policy:J7 the handler is awaited by `emitEvent`, which the
+        // Smithers service awaits inside `recordEvent`. Any synchronous failure
+        // here would fail the emitting workflow run, so it is reported instead.
+        runtime.reportError("TriggerRuntime.eventBridge", error, { eventKind });
+      }
     });
   }
 

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -668,6 +668,8 @@ export async function executeTriggerTask(
   let errorMessage = "";
   let workflowExecutionId: string | undefined;
   let workflowGone = false;
+  const dispatchedWorkflowId =
+    trigger.kind === "workflow" ? trigger.workflowId : undefined;
 
   const result =
     trigger.kind === "workflow"
@@ -842,7 +844,7 @@ export async function executeTriggerTask(
   const workflowStillGone =
     workflowGone &&
     triggerToPersist.kind === "workflow" &&
-    triggerToPersist.workflowId === trigger.workflowId;
+    triggerToPersist.workflowId === dispatchedWorkflowId;
   const shouldDeleteTask =
     workflowStillGone ||
     updatedTrigger.triggerType === "once" ||

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -55,10 +55,6 @@ const eventDispatchQueues = new WeakMap<
   IAgentRuntime,
   Map<UUID, Promise<void>>
 >();
-interface RuntimeEventTaskLookup {
-  pending?: Promise<Task[]>;
-}
-const eventTaskLookups = new WeakMap<IAgentRuntime, RuntimeEventTaskLookup>();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
@@ -963,35 +959,18 @@ function serializableEventPayload(
   return payload;
 }
 
-async function listRuntimeEventTasks(runtime: IAgentRuntime): Promise<Task[]> {
-  const lookup = eventTaskLookups.get(runtime) ?? {};
-  eventTaskLookups.set(runtime, lookup);
-  let pending = lookup.pending;
-  if (!pending) {
-    pending = listTriggerTasks(runtime);
-    lookup.pending = pending;
-  }
-  try {
-    return await pending;
-  } finally {
-    // Share only a lookup that is currently in flight. Retaining the result,
-    // even briefly, can lose a native event for a trigger saved or enabled
-    // between two Smithers steps because that trigger would never be queued.
-    if (lookup.pending === pending) lookup.pending = undefined;
-  }
-}
-
 /**
  * Dispatch one runtime event through the same persisted trigger engine used by
- * the HTTP event boundary. Event-kind filtering happens before queueing; the
- * exact payload filter is rechecked on the freshly loaded task at execution.
+ * Discovery is deliberately fresh for every event: trigger creation and
+ * enablement have no invalidation channel, so sharing even an in-flight query
+ * can lose an event emitted after the write but before that query resolves.
  */
 export async function dispatchRuntimeEventTriggers(
   runtime: IAgentRuntime,
   eventKind: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const tasks = await listRuntimeEventTasks(runtime);
+  const tasks = await listTriggerTasks(runtime);
   const matchingTasks = tasks.filter((task) => {
     const trigger = readTriggerConfig(task);
     return (

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -50,19 +50,15 @@ export const TRIGGER_TASK_TAGS = ["queue", "repeat", "trigger"] as const;
 const HEARTBEAT_TASK_TAGS = ["queue", "repeat", "heartbeat"] as const;
 const WORKFLOW_RUN_EVENT = "workflow_run_event" as const;
 const RUNTIME_TRIGGER_EVENT_KINDS = [WORKFLOW_RUN_EVENT] as const;
-const RUNTIME_EVENT_TASK_CACHE_TTL_MS = 500;
-
 const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
 const eventDispatchQueues = new WeakMap<
   IAgentRuntime,
   Map<UUID, Promise<void>>
 >();
-interface RuntimeEventTaskCache {
+interface RuntimeEventTaskLookup {
   pending?: Promise<Task[]>;
-  refreshedAt: number;
-  tasks?: Task[];
 }
-const eventTaskCaches = new WeakMap<IAgentRuntime, RuntimeEventTaskCache>();
+const eventTaskLookups = new WeakMap<IAgentRuntime, RuntimeEventTaskLookup>();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
@@ -369,7 +365,7 @@ async function dispatchWorkflow(
   trigger: WorkflowTriggerConfig,
   event?: TriggerExecutionOptions["event"],
 ): Promise<
-  | { ok: true; executionId?: string }
+  | { ok: true; executionId?: string; dedup?: boolean }
   | { ok: false; error: string; code?: string }
 > {
   if (!trigger.workflowId) {
@@ -402,7 +398,11 @@ async function dispatchWorkflow(
     idempotencyKey,
   });
   return result.ok
-    ? { ok: true, executionId: result.executionId }
+    ? {
+        ok: true,
+        executionId: result.executionId,
+        ...(result.dedup === true ? { dedup: true } : {}),
+      }
     : {
         ok: false,
         error: result.error ?? "workflow execution failed",
@@ -673,6 +673,19 @@ export async function executeTriggerTask(
     trigger.kind === "workflow"
       ? await dispatchWorkflow(runtime, task, trigger, options.event)
       : await dispatchPrompt(runtime, trigger, task.roomId);
+  if (result.ok === true && "dedup" in result && result.dedup === true) {
+    // The workflow dispatcher has already accepted this native event identity.
+    // A replay is not a new trigger run: recording it would inflate runCount,
+    // emit a duplicate success notification, and could prematurely exhaust
+    // maxRuns even though no second workflow execution was started.
+    recordExecutionMetric(runtime.agentId, "skipped", Date.now());
+    return {
+      status: "skipped",
+      taskDeleted: false,
+      trigger: taskToTriggerSummary(task),
+      executionId: result.executionId,
+    };
+  }
   if (result.ok === true) {
     // Only workflow dispatch carries an execution id; prompt dispatch types it
     // as `undefined`, so this reads `string | undefined` without a cast.
@@ -775,10 +788,39 @@ export async function executeTriggerTask(
     }
   }
 
+  let taskToPersist = task;
+  let triggerToPersist = trigger;
+  if (options.source === "event") {
+    const currentTask = await runtime.getTask(task.id);
+    if (!currentTask) {
+      const finishedAt = Date.now();
+      recordExecutionMetric(runtime.agentId, status, finishedAt);
+      return {
+        status,
+        error: errorMessage || undefined,
+        taskDeleted: true,
+        executionId: workflowExecutionId,
+      };
+    }
+    const currentTrigger = readTriggerConfig(currentTask);
+    if (!currentTrigger) {
+      const finishedAt = Date.now();
+      recordExecutionMetric(runtime.agentId, status, finishedAt);
+      return {
+        status,
+        error: errorMessage || undefined,
+        taskDeleted: false,
+        executionId: workflowExecutionId,
+      };
+    }
+    taskToPersist = currentTask;
+    triggerToPersist = currentTrigger;
+  }
+
   const finishedAt = Date.now();
   const runRecord: TriggerRunRecord = {
     triggerRunId: stringToUuid(crypto.randomUUID()),
-    triggerId: trigger.triggerId,
+    triggerId: triggerToPersist.triggerId,
     taskId: task.id,
     startedAt,
     finishedAt,
@@ -790,21 +832,25 @@ export async function executeTriggerTask(
   };
 
   const updatedTrigger: TriggerConfig = {
-    ...trigger,
-    runCount: trigger.runCount + 1,
+    ...triggerToPersist,
+    runCount: triggerToPersist.runCount + 1,
     lastRunAtIso: new Date(finishedAt).toISOString(),
     lastStatus: status,
     lastError: errorMessage || undefined,
   };
 
+  const workflowStillGone =
+    workflowGone &&
+    triggerToPersist.kind === "workflow" &&
+    triggerToPersist.workflowId === trigger.workflowId;
   const shouldDeleteTask =
-    workflowGone ||
+    workflowStillGone ||
     updatedTrigger.triggerType === "once" ||
     (typeof updatedTrigger.maxRuns === "number" &&
       updatedTrigger.maxRuns > 0 &&
       updatedTrigger.runCount >= updatedTrigger.maxRuns);
 
-  const existingMetadata = taskMetadata(task);
+  const existingMetadata = taskMetadata(taskToPersist);
   const nextMetadata = buildTriggerMetadata({
     existingMetadata,
     trigger: updatedTrigger,
@@ -861,13 +907,15 @@ export async function executeTriggerTask(
   }
 
   await runtime.updateTask(task.id, {
-    description: metadataToPersist.trigger?.displayName ?? task.description,
+    description:
+      metadataToPersist.trigger?.displayName ?? taskToPersist.description,
     metadata: metadataToPersist,
   });
 
   const updatedTask: Task = {
-    ...task,
-    description: metadataToPersist.trigger?.displayName ?? task.description,
+    ...taskToPersist,
+    description:
+      metadataToPersist.trigger?.displayName ?? taskToPersist.description,
     metadata: metadataToPersist,
   };
   const triggerSummary = taskToTriggerSummary(updatedTask);
@@ -913,32 +961,21 @@ function serializableEventPayload(
   return payload;
 }
 
-async function listCachedRuntimeEventTasks(
-  runtime: IAgentRuntime,
-): Promise<Task[]> {
-  const now = Date.now();
-  const cache = eventTaskCaches.get(runtime) ?? { refreshedAt: 0 };
-  eventTaskCaches.set(runtime, cache);
-  if (
-    cache.tasks &&
-    now - cache.refreshedAt >= 0 &&
-    now - cache.refreshedAt < RUNTIME_EVENT_TASK_CACHE_TTL_MS
-  ) {
-    return cache.tasks;
-  }
-  let pending = cache.pending;
+async function listRuntimeEventTasks(runtime: IAgentRuntime): Promise<Task[]> {
+  const lookup = eventTaskLookups.get(runtime) ?? {};
+  eventTaskLookups.set(runtime, lookup);
+  let pending = lookup.pending;
   if (!pending) {
-    pending = listTriggerTasks(runtime).then((tasks) => {
-      cache.tasks = tasks;
-      cache.refreshedAt = Date.now();
-      return tasks;
-    });
-    cache.pending = pending;
+    pending = listTriggerTasks(runtime);
+    lookup.pending = pending;
   }
   try {
     return await pending;
   } finally {
-    if (cache.pending === pending) cache.pending = undefined;
+    // Share only a lookup that is currently in flight. Retaining the result,
+    // even briefly, can lose a native event for a trigger saved or enabled
+    // between two Smithers steps because that trigger would never be queued.
+    if (lookup.pending === pending) lookup.pending = undefined;
   }
 }
 
@@ -952,7 +989,7 @@ export async function dispatchRuntimeEventTriggers(
   eventKind: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const tasks = await listCachedRuntimeEventTasks(runtime);
+  const tasks = await listRuntimeEventTasks(runtime);
   const matchingTasks = tasks.filter((task) => {
     const trigger = readTriggerConfig(task);
     return (

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -50,12 +50,19 @@ export const TRIGGER_TASK_TAGS = ["queue", "repeat", "trigger"] as const;
 const HEARTBEAT_TASK_TAGS = ["queue", "repeat", "heartbeat"] as const;
 const WORKFLOW_RUN_EVENT = "workflow_run_event" as const;
 const RUNTIME_TRIGGER_EVENT_KINDS = [WORKFLOW_RUN_EVENT] as const;
+const RUNTIME_EVENT_TASK_CACHE_TTL_MS = 500;
 
 const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
 const eventDispatchQueues = new WeakMap<
   IAgentRuntime,
   Map<UUID, Promise<void>>
 >();
+interface RuntimeEventTaskCache {
+  pending?: Promise<Task[]>;
+  refreshedAt: number;
+  tasks?: Task[];
+}
+const eventTaskCaches = new WeakMap<IAgentRuntime, RuntimeEventTaskCache>();
 
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
@@ -902,6 +909,35 @@ function serializableEventPayload(
   return payload;
 }
 
+async function listCachedRuntimeEventTasks(
+  runtime: IAgentRuntime,
+): Promise<Task[]> {
+  const now = Date.now();
+  const cache = eventTaskCaches.get(runtime) ?? { refreshedAt: 0 };
+  eventTaskCaches.set(runtime, cache);
+  if (
+    cache.tasks &&
+    now - cache.refreshedAt >= 0 &&
+    now - cache.refreshedAt < RUNTIME_EVENT_TASK_CACHE_TTL_MS
+  ) {
+    return cache.tasks;
+  }
+  let pending = cache.pending;
+  if (!pending) {
+    pending = listTriggerTasks(runtime).then((tasks) => {
+      cache.tasks = tasks;
+      cache.refreshedAt = Date.now();
+      return tasks;
+    });
+    cache.pending = pending;
+  }
+  try {
+    return await pending;
+  } finally {
+    if (cache.pending === pending) cache.pending = undefined;
+  }
+}
+
 /**
  * Dispatch one runtime event through the same persisted trigger engine used by
  * the HTTP event boundary. Filtering happens before execution so unrelated
@@ -912,7 +948,7 @@ export async function dispatchRuntimeEventTriggers(
   eventKind: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const tasks = await listTriggerTasks(runtime);
+  const tasks = await listCachedRuntimeEventTasks(runtime);
   const matchingTasks = tasks.filter((task) => {
     const trigger = readTriggerConfig(task);
     return (

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -903,9 +903,13 @@ export async function executeTriggerTask(
 function serializableEventPayload(
   params: EventPayload,
 ): Record<string, unknown> {
-  const payload = { ...params } as Record<string, unknown>;
-  delete payload.runtime;
-  delete payload.onComplete;
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "runtime" || key === "source" || typeof value === "function") {
+      continue;
+    }
+    payload[key] = value;
+  }
   return payload;
 }
 
@@ -940,8 +944,8 @@ async function listCachedRuntimeEventTasks(
 
 /**
  * Dispatch one runtime event through the same persisted trigger engine used by
- * the HTTP event boundary. Filtering happens before execution so unrelated
- * event triggers do not accumulate skipped-run metrics.
+ * the HTTP event boundary. Event-kind filtering happens before queueing; the
+ * exact payload filter is rechecked on the freshly loaded task at execution.
  */
 export async function dispatchRuntimeEventTriggers(
   runtime: IAgentRuntime,

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -1074,20 +1074,28 @@ function discoverEventTriggerTasks(runtime: IAgentRuntime): Promise<Task[]> {
 }
 
 /** Trigger hops between an external event and the run that emitted `runId`. */
-function readChainDepth(runtime: IAgentRuntime, runId?: string): number {
-  if (!runId) return 0;
-  return eventTriggerChainDepths.get(runtime)?.get(runId) ?? 0;
+// Ancestry is keyed on the WORKFLOW id, not the run id. Keying on the run id
+// could never work: WORKFLOW_DISPATCH awaits executeWorkflow, and a run emits
+// every one of its events before that promise resolves — so the child's events
+// were always dispatched before its depth was recorded, and readChainDepth
+// returned 0 forever. The workflow id is known before dispatch, so recording
+// against it actually bounds the chain.
+function readChainDepth(runtime: IAgentRuntime, workflowId?: string): number {
+  if (!workflowId) return 0;
+  return eventTriggerChainDepths.get(runtime)?.get(workflowId) ?? 0;
 }
 
 function recordChainDepth(
   runtime: IAgentRuntime,
-  runId: string,
+  workflowId: string,
   depth: number,
 ): void {
   const depths =
     eventTriggerChainDepths.get(runtime) ?? new Map<string, number>();
   eventTriggerChainDepths.set(runtime, depths);
-  depths.set(runId, depth);
+  // Keep the deepest observed depth for this workflow: a later shallower hop
+  // must not reset a chain that has already gone deep.
+  depths.set(workflowId, Math.max(depths.get(workflowId) ?? 0, depth));
   // Insertion-ordered eviction keeps ancestry bounded for long-lived hosts.
   while (depths.size > MAX_EVENT_TRIGGER_CHAIN_ENTRIES) {
     const oldest = depths.keys().next();
@@ -1148,13 +1156,19 @@ export async function dispatchRuntimeEventTriggers(
   const nestedEvent = readNestedRunEvent(payload);
   const sourceWorkflowId = readNestedString(nestedEvent?.workflowId);
   const sourceRunId = readNestedString(nestedEvent?.runId);
-  const chainDepth = readChainDepth(runtime, sourceRunId);
+  const chainDepth = readChainDepth(runtime, sourceWorkflowId);
   if (chainDepth >= MAX_EVENT_TRIGGER_CHAIN_DEPTH) {
     // The emitting run was itself started by a trigger chain that has already
     // reached its hop limit. Continuing would let a mutually referential
     // configuration (A triggers B, B triggers A) run without ever quiescing.
     runtime.logger.warn(
-      { src: "trigger-runtime", eventKind, runId: sourceRunId, chainDepth },
+      {
+        src: "trigger-runtime",
+        eventKind,
+        workflowId: sourceWorkflowId,
+        runId: sourceRunId,
+        chainDepth,
+      },
       "Event trigger chain depth limit reached; not dispatching further",
     );
     return;
@@ -1210,21 +1224,39 @@ export async function dispatchRuntimeEventTriggers(
           const currentTask = await runtime.getTask(taskId);
           if (!currentTask) return;
           const currentTrigger = readTriggerConfig(currentTask);
+          // Evaluate the filter BEFORE consuming a dispatch slot. A workflow
+          // emitting NodeStarted/NodeFinished for every node would otherwise
+          // burn the whole per-minute ceiling on events that were never going
+          // to fire, and drop the one the trigger actually exists for.
+          if (
+            currentTrigger?.triggerType === "event" &&
+            !eventFilterMatches(currentTrigger.eventFilter, payload)
+          ) {
+            return;
+          }
           if (
             currentTrigger &&
             !admitTriggerDispatch(runtime, currentTrigger.triggerId, eventKind)
           ) {
             return;
           }
-          const result = await executeTriggerTask(runtime, currentTask, {
+          // Recorded BEFORE dispatch: the target workflow emits its events
+          // inside executeTriggerTask, so anything written afterwards arrives
+          // too late to bound the next hop.
+          if (
+            currentTrigger?.kind === "workflow" &&
+            currentTrigger.workflowId
+          ) {
+            recordChainDepth(
+              runtime,
+              currentTrigger.workflowId,
+              chainDepth + 1,
+            );
+          }
+          await executeTriggerTask(runtime, currentTask, {
             source: "event",
             event: { kind: eventKind, payload },
           });
-          if (result.executionId) {
-            // The dispatched run's id is the ancestry key its own emitted
-            // events will carry, so the chain can be bounded at the next hop.
-            recordChainDepth(runtime, result.executionId, chainDepth + 1);
-          }
         } catch (error) {
           // error-policy:J7 one trigger's persistence/dispatch failure must not
           // reject the source runtime event or prevent sibling triggers.

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -13,6 +13,7 @@ import { readFile } from "node:fs/promises";
 import { ModelType, type Plugin, type Route } from "@elizaos/core";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
+import { registerTriggerTaskWorker } from "../../agent/src/triggers/runtime.ts";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
@@ -248,6 +249,9 @@ async function main(): Promise<void> {
     characterName: "DeviceE2EHostAgent",
     plugins: [proxy, mediaRoutesPlugin, ...workflowPlugins],
   });
+  if (process.env.ELIZA_UI_SMOKE_WORKFLOW_JOURNEY === "1") {
+    registerTriggerTaskWorker(runtimeResult.runtime);
+  }
   if (process.env.ELIZA_UI_SMOKE_RUBY_HIGH_JOURNEY === "1") {
     const rubyHighUrl = process.env.RUBY_HIGH_URL?.trim();
     if (!rubyHighUrl) {

--- a/packages/app-core/src/services/trigger-event-bridge.test.ts
+++ b/packages/app-core/src/services/trigger-event-bridge.test.ts
@@ -208,6 +208,7 @@ describe("startTriggerEventBridge", () => {
     expect(registered).toContain(EventType.MESSAGE_SENT);
     expect(registered).toContain(EventType.REACTION_RECEIVED);
     expect(registered).toContain(EventType.ENTITY_JOINED);
+    expect(registered).not.toContain("workflow_run_event");
 
     bridge.stop();
     expect(handle.registeredEventTypes()).toHaveLength(0);

--- a/packages/app-core/src/services/trigger-event-bridge.ts
+++ b/packages/app-core/src/services/trigger-event-bridge.ts
@@ -5,9 +5,9 @@
  * `executeTriggerTask` already handles `source: "event"` (see
  * `eliza/packages/agent/src/triggers/runtime.ts`), but nothing in the
  * runtime subscribes to `MESSAGE_RECEIVED` etc. and routes the payload
- * through it. Without this bridge, event-kind triggers can be created
- * and stored but will never fire from a real Discord / Telegram / WeChat
- * message.
+ * through it. Workflow-run events are deliberately owned by the agent trigger
+ * worker so standalone hosts and app hosts share one non-blocking Smithers
+ * bridge rather than dispatching the same saved trigger twice.
  *
  * On `start()` the bridge calls `runtime.registerEvent(eventType, handler)`
  * for every `EventType` in `EXPOSED_EVENTS`. Each handler:
@@ -43,7 +43,6 @@ import {
 } from "@elizaos/core";
 
 const DEFAULT_MIN_INTERVAL_MS = 1_000;
-const WORKFLOW_RUN_EVENT_TYPE = "workflow_run_event" as EventType;
 /** TTL for caching trigger task list to avoid repeated DB queries on high-frequency events. */
 const TRIGGER_CACHE_TTL_MS = 500;
 
@@ -58,7 +57,6 @@ export const EXPOSED_EVENTS: readonly EventType[] = [
   EventType.MESSAGE_SENT,
   EventType.REACTION_RECEIVED,
   EventType.ENTITY_JOINED,
-  WORKFLOW_RUN_EVENT_TYPE,
 ];
 
 export interface TriggerEventBridgeOptions {

--- a/packages/app/test/ui-smoke/workflow-real-local.spec.ts
+++ b/packages/app/test/ui-smoke/workflow-real-local.spec.ts
@@ -15,6 +15,7 @@ type WorkflowRecord = {
   id: string;
   name?: string;
   source?: string;
+  steps?: Array<{ id: string; label: string }>;
 };
 
 type WorkflowExecution = {
@@ -27,6 +28,7 @@ type WorkflowExecution = {
 
 type TriggerRecord = {
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   id: string;
   kind?: string;
   runCount?: number;
@@ -70,18 +72,43 @@ test.describe("real local workflow journey", () => {
   test("creates, triggers, runs, inspects, and reloads a Smithers workflow", async ({
     page,
   }) => {
+    const suffix = Date.now().toString(36);
+    const sourceName = `Native event source ${suffix}`;
+    const targetName = `Real browser digest ${suffix}`;
+
     await seedAppStorage(page);
     await openAppPath(page, "/automations");
     await expect(page.getByTestId("automations-shell")).toBeVisible({
       timeout: 60_000,
     });
 
+    const createSourceResponse = await page.request.post(
+      "/api/workflow/workflows",
+      {
+        data: {
+          name: sourceName,
+          source: SOURCE,
+          language: "tsx",
+          steps: [{ id: "run", label: "Run", kind: "task" }],
+        },
+      },
+    );
+    const createSourceText = await createSourceResponse.text();
+    expect(
+      createSourceResponse.status(),
+      `source creation failed: ${createSourceText}`,
+    ).toBe(201);
+    const sourceWorkflow = JSON.parse(createSourceText) as WorkflowRecord;
+    expect(sourceWorkflow.steps).toContainEqual(
+      expect.objectContaining({ id: "run" }),
+    );
+
     await page.getByRole("button", { name: "New automation" }).click();
     await page.getByRole("button", { name: "New workflow" }).click();
     await expect(page.getByTestId("workflow-studio")).toBeVisible();
     await expect(page.getByTestId("smithers-canvas")).toBeVisible();
 
-    await page.getByLabel("Workflow name").fill("Real browser digest");
+    await page.getByLabel("Workflow name").fill(targetName);
     await page.getByRole("button", { name: "Source" }).click();
     await page.getByTestId("smithers-source-editor").fill(SOURCE);
 
@@ -95,15 +122,40 @@ test.describe("real local workflow journey", () => {
     expect(createResponse.status()).toBe(201);
     const workflow = (await createResponse.json()) as WorkflowRecord;
     expect(workflow).toMatchObject({
-      name: "Real browser digest",
+      name: targetName,
       active: false,
     });
     expect(workflow.id).toBeTruthy();
     expect(workflow.source).toContain('from "smthrs/create"');
     expect(workflow.source).toContain("retries={2}");
 
+    const addWidgetResponse = await page.request.put(
+      `/api/workflow/workflows/${workflow.id}`,
+      {
+        data: {
+          ...workflow,
+          widgets: [
+            {
+              id: "message",
+              title: "Message",
+              surface: "both",
+              component: "markdown",
+              dataPath: "0.message",
+            },
+          ],
+        },
+      },
+    );
+    expect(
+      addWidgetResponse.ok(),
+      `widget manifest update failed: ${await addWidgetResponse.text()}`,
+    ).toBe(true);
+
     await page.getByRole("button", { name: "Add workflow trigger" }).click();
     await page.getByRole("button", { name: "Event" }).click();
+    await page.getByLabel("Event source").selectOption("step");
+    await page.getByLabel("Source workflow").selectOption(sourceWorkflow.id);
+    await page.getByLabel("Source step").selectOption("run");
     const createTriggerResponsePromise = page.waitForResponse(
       (response) =>
         response.request().method() === "POST" &&
@@ -122,7 +174,14 @@ test.describe("real local workflow journey", () => {
       (candidate) => candidate.workflowId === workflow.id,
     );
     expect(trigger).toMatchObject({
-      eventKind: "MESSAGE_RECEIVED",
+      eventKind: "workflow_run_event",
+      eventFilter: {
+        event: {
+          type: "NodeFinished",
+          workflowId: sourceWorkflow.id,
+          nodeId: "run",
+        },
+      },
       kind: "workflow",
       runCount: 0,
       workflowId: workflow.id,
@@ -138,14 +197,41 @@ test.describe("real local workflow journey", () => {
       })
       .toBe(true);
 
-    const triggerResponse = await page.request.post(
-      `/api/triggers/${trigger?.id}/execute`,
+    const activateSourceResponse = await page.request.post(
+      `/api/workflow/workflows/${sourceWorkflow.id}/activate`,
     );
-    const triggerResponseText = await triggerResponse.text();
+    const activateSourceText = await activateSourceResponse.text();
     expect(
-      triggerResponse.ok(),
-      `trigger execution failed: ${triggerResponse.status()} ${triggerResponseText}`,
+      activateSourceResponse.ok(),
+      `source activation failed: ${activateSourceResponse.status()} ${activateSourceText}`,
     ).toBe(true);
+
+    const sourceRunResponse = await page.request.post(
+      `/api/workflow/workflows/${sourceWorkflow.id}/run`,
+      { data: { input: { origin: "workflow-real-local" } } },
+    );
+    const sourceRunText = await sourceRunResponse.text();
+    expect(
+      sourceRunResponse.status(),
+      `source execution failed: ${sourceRunText}`,
+    ).toBe(202);
+
+    await expect
+      .poll(
+        async () => {
+          const response = await page.request.get(
+            `/api/workflow/workflows/${sourceWorkflow.id}/executions`,
+          );
+          const body = (await response.json()) as {
+            executions: WorkflowExecution[];
+          };
+          return body.executions.find(
+            (execution) => execution.mode === "manual",
+          )?.status;
+        },
+        { timeout: 120_000 },
+      )
+      .toBe("finished");
 
     let triggeredExecution: WorkflowExecution | undefined;
     await expect
@@ -169,6 +255,14 @@ test.describe("real local workflow journey", () => {
       finished: true,
       mode: "trigger",
     });
+    await expect
+      .poll(async () => {
+        const response = await page.request.get("/api/triggers");
+        const body = (await response.json()) as { triggers: TriggerRecord[] };
+        return body.triggers.find((candidate) => candidate.id === trigger?.id)
+          ?.runCount;
+      })
+      .toBe(1);
     const triggeredMessage = executionMessage(triggeredExecution);
     expect(triggeredMessage).toEqual(expect.any(String));
     if (!triggeredMessage)
@@ -214,6 +308,8 @@ test.describe("real local workflow journey", () => {
       /Real browser digest/,
       { timeout: 60_000 },
     );
-    await expect(page.getByTitle("Message")).toBeVisible();
+    await page.getByRole("button", { name: "Widgets" }).click();
+    await expect(page.getByText("Message", { exact: true })).toBeVisible();
+    await expect(page.getByText(manualMessage, { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
# Relates to

Closes #22575.

## What changed

- Registers `workflow_run_event` once per `AgentRuntime` in the canonical agent trigger worker, so standalone and app hosts use the same persisted trigger engine.
- Removes the duplicate app-core Smithers subscription while retaining its connector-event bridge.
- Lists trigger tasks with `agentIds: [runtime.agentId]`, re-reads each queued task before execution, and forwards the native Smithers event without runtime/function objects.
- Serializes events per saved trigger so concurrent emissions preserve current enabled/filter/run-count/max-run state.
- Derives a durable `WORKFLOW_DISPATCH` idempotency key from the saved trigger id plus Smithers native event id. Replays collapse; distinct triggers and distinct native events remain independent.
- Starts trigger processing without awaiting it from the Smithers emitter. Lookup and per-trigger failures go through `runtime.reportError`; one failed target neither rejects the source run nor blocks siblings.
- Extends the real local browser journey to create source/target Smithers workflows, save an exact-step trigger, run the source through the native service, and prove one target trigger execution plus `runCount === 1` after reload.

No second scheduler, HTTP loopback, Gateway protocol, or prose-based routing is introduced.

## Review correction

The predecessor head cached task snapshots for 500 ms and applied a one-second trigger throttle while awaiting the event handler. That could execute a just-disabled trigger, suppress distinct legitimate Smithers events, and delay the source run. Exact head replaces wall-clock admission with native event identity plus canonical dispatch idempotency and fresh serialized task state.

## Exact-head validation

Exact head: `314646e5751f143f474912e0c7ea64774acc79a3` (tree `f1061ac6e10d312dbbd50088938b2fdd1631a9dd`)

- Real local Chromium Smithers journey: 1/1 passed at the patch-identical predecessor `8babb894f38c3d76f15d88d2c545cb6eb97f3cf5` with recording, trace, screenshot, backend log, and persisted domain artifacts. It created source/target workflows, saved an exact-step trigger, observed one target execution in trigger mode with `runCount === 1`, ran manually, reloaded, and recovered source/widget state.
- Agent trigger runtime + scheduling suites: 42/42 passed at the rebased exact head, including fresh discovery, concurrent state refresh, disable/delete rechecks, runtime isolation, replay idempotency, and distinct rapid events.
- App-core trigger bridge suite: 12/12 passed at exact head.
- plugin-workflow isolated suite: 16/16 files passed at the patch-identical predecessor.
- plugin-workflow typecheck: passed at the patch-identical predecessor.
- Exact-head changed-file Biome and `git diff --check`: passed.
- Agent/app-core/app package typechecks were attempted and remain blocked by missing optional/native workspace build artifacts outside this patch (Capacitor and optional plugin exports); no diagnostic names a changed implementation file.
- Predecessor-capture validation receipt (source patch-identical after rebase): https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-exact-head-validation.md

### Rebased-head source verification

- Base `61af9b80a81dc3dc0548841efff18e7532745438` is an ancestor; branch is 7 ahead and 0 behind.
- `git range-diff` maps all seven commits as patch-identical; the full branch diff SHA-256 remains `cab7e52cbe461f4854b8d0dc899ba539349cfe3d1dacab5ad618ebc1278bf7ae`.
- Agent trigger runtime: 40/40 passed at current head; plugin-workflow: 16/16 isolated files and typecheck passed at current head; app-core bridge: 12/12 passed at the patch-identical predecessor.
- Full-source Biome passed for agent (971 files), app-core (353), and app configured lint (312); whole-branch `git diff --check` passed.
- Existing release artifacts below were captured at the patch-identical predecessor `8babb894...`; they are preserved as predecessor evidence, not relabeled as a fresh capture at the rewritten commit.

### Known gaps after rebase

- Keep this PR draft until unrestricted `bun install`, owning typecheck/build, root `bun run verify`, CI checks, and any required fresh exact-head Chromium capture pass.
- Agent build compiled TypeScript, then sparse package-dist preparation lacked `/plugin-contacts`; app-core build could not acquire its loopback package-build lock because this sandbox rejects `listen 127.0.0.1` with `EPERM`.
- Agent/app-core/app typechecks were attempted and report unrelated missing optional/workspace packages; no diagnostic names a changed trigger, bridge, or journey file.

## Risks

Medium. This is a production event boundary that can start workflows. The native event-id key and per-task queue deliberately replace lossy time throttling; exact native browser evidence and independent exact-head review remain required before merge.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@81c4999b69e46ab98abc3e8adb09c6050e53ab5b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:fbec50fa7e53d66bad07597a3fd76324a9ac81cb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - production UI source and styling are unchanged; the app edit is the exact-head acceptance journey.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-test-finished-1.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-video.webm
<!-- evidence-row:backend-logs -->
- [x] [22790-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-backend.log)

```text
Agent trigger runtime on e9341686a16c: 1 test file passed; 36 tests passed; 0 failed.
App-core event bridge: 1 test file passed; 12 tests passed; 0 failed.
Native workflow package: all 16 isolated files passed, including runner, dispatch idempotency, lifecycle, and owner isolation.
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] [22790-trace.zip](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-trace.zip)

```text
Chromium created source and target Smithers workflows and saved an exact-step workflow_run_event trigger.
The source ran through the real local native workflow service; the target execution completed in trigger mode.
After reload, the persisted trigger reported runCount 1 and the workflow widget remained inspectable.
```
</details>
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic test model; no provider, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [22790-exact-head-validation.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22790-exact-head-validation.md)

```text
Source artifact: native Smithers run reached the selected source step and emitted its durable event id.
Target artifact: exactly one new target execution was observed with execution mode trigger.
Trigger artifact: canonical saved task reloaded with runCount exactly 1; no duplicate target execution existed.
```
</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no production UI pixels changed; the exact-head final frame was manually inspected and is attached.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@81c4999b69e46ab98abc3e8adb09c6050e53ab5b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— recover_22575
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@81c4999b69e46ab98abc3e8adb09c6050e53ab5b:packages/skills/skills/contribute-to-eliza"} -->








