### PR TITLE
fix(plugin-google-workspace): avoid OAuth scope accessors

### DIFF
--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -634,6 +634,44 @@ describe("google plugin", () => {
     );
   });
 
+  it("preserves nested token precedence and scopes through the resolver boundary", async () => {
+    const storage = createCredentialStorage({
+      records: [
+        {
+          credentialType: "oauth.tokens",
+          value: JSON.stringify({
+            tokens: {
+              access_token: "nested-access",
+              refresh_token: "nested-refresh",
+              scope: "nested.scope",
+            },
+            accessToken: "outer-access",
+            scopes: ["gmail.read", "drive.readonly"],
+          }),
+        },
+      ],
+    });
+    const resolver = new DefaultGoogleCredentialResolver({
+      storage,
+      clientId: "google-client",
+      clientSecret: "google-secret",
+    });
+
+    const client = await resolver.getAuthClient({
+      provider: "google",
+      accountId: "acct_google_1",
+      capabilities: ["gmail.read"],
+      scopes: scopesForGoogleCapabilities(["gmail.read"]),
+      reason: "unit-test",
+    });
+
+    expect(client.credentials).toMatchObject({
+      access_token: "outer-access",
+      refresh_token: "nested-refresh",
+      scope: "gmail.read drive.readonly",
+    });
+  });
+
   it("does not keep unsafe OAuth client cache entries when no credential version is exposed", async () => {
     const storage = createCredentialStorage({
       records: [

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
@@ -59,6 +59,45 @@ describe("mergeCredentialObject", () => {
     }
   });
 
+  it("does not invoke indexed scope accessors and fails closed", () => {
+    let invoked = 0;
+    const scopes = ["gmail.read"];
+    Object.defineProperty(scopes, "1", {
+      enumerable: true,
+      get() {
+        invoked += 1;
+        return "drive.readonly";
+      },
+    });
+
+    expect(() => mergeCredentialObject({}, { scopes })).toThrowError(
+      expect.objectContaining({ code: GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED })
+    );
+    expect(invoked).toBe(0);
+  });
+
+  it("preserves sparse scopes and nested-then-outer token precedence", () => {
+    const scopes: unknown[] = ["gmail.read", 42, "drive.readonly"];
+    delete scopes[1];
+    const credentials: OauthCredentialFields = {};
+
+    mergeCredentialObject(credentials, {
+      tokens: {
+        access_token: "nested-access",
+        refresh_token: "nested-refresh",
+        scope: "nested.scope",
+      },
+      accessToken: "outer-access",
+      scopes,
+    });
+
+    expect(credentials).toMatchObject({
+      access_token: "outer-access",
+      refresh_token: "nested-refresh",
+      scope: "gmail.read drive.readonly",
+    });
+  });
+
   it("throws on a cyclic tokens object without hanging", () => {
     const cyclic: { tokens?: unknown } = {};
     cyclic.tokens = cyclic;

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -69,6 +69,27 @@ function readStringFromRecord(record: object, ...keys: string[]): string | undef
   return undefined;
 }
 
+function readScopeArray(scopes: unknown[], ctx: WalkContext): string {
+  const length = dataValue(scopes, "length");
+  if (!Number.isSafeInteger(length) || (length as number) < 0) {
+    failUnbounded({ invalidScopesLength: length });
+  }
+  reserve(ctx, length as number);
+
+  const values: string[] = [];
+  for (let index = 0; index < (length as number); index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(scopes, String(index));
+    if (!descriptor) continue;
+    if (!("value" in descriptor)) {
+      failUnbounded({ accessor: `scopes[${index}]` });
+    }
+    if (typeof descriptor.value === "string") {
+      values.push(descriptor.value);
+    }
+  }
+  return values.join(" ");
+}
+
 function parseExpiry(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value > 0 && value < 10_000_000_000 ? value * 1000 : value;
@@ -135,10 +156,7 @@ function mergeCredentialObjectInner(
     if (tokenType) credentials.token_type = tokenType;
     const scopes = dataValue(record, "scopes");
     if (Array.isArray(scopes)) {
-      reserve(ctx, scopes.length);
-      credentials.scope = scopes
-        .filter((item): item is string => typeof item === "string")
-        .join(" ");
+      credentials.scope = readScopeArray(scopes, ctx);
     } else if (scope) {
       credentials.scope = scope;
     }


### PR DESCRIPTION
Closes #22783

Corrects the residual descriptor-safety gap in #22761 while preserving @ss251's original bounded-walk contribution and #22759 linkage.

## Problem

The merged OAuth credential walker used `scopes.filter(...).join(...)`. That ordinary indexed read invokes an accessor-backed scope slot despite #22759's descriptor-only, accessors-never-run acceptance contract.

## Change

- Read the array length and present scope slots through own data descriptors.
- Keep sparse slots charged to the existing cumulative node budget.
- Fail with `GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED` on an indexed accessor without invoking it.
- Preserve string filtering, joined scope bytes, and nested-then-outer token precedence.
- Exercise the real `DefaultGoogleCredentialResolver.getAuthClient()` boundary with persisted nested JSON.

## Exact-head and landed-tree evidence

Final PR head: `2334ebafac2bdba43b70c7b1cfcb5b222a53d9ec`, based on `develop` `faef8c31d7b3441a9732d71da947bd25119530ec`; landed merge: `b67f45292715b3ee4bcd2723ae47bd73e1f72450`. Post-merge blob audit confirms all three scoped files are byte-identical head to merge.

- Network-denied Mode B focused tests: **10/10 passed** across the walker and resolver boundary.
- `plugin-google-workspace` typecheck: PASS.
- `plugin-google-workspace` build: PASS.
- Biome on all three changed files: PASS.
- `git diff --check`: PASS.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - credential parsing has no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - credential parsing has no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact landed-tree plugin build log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22793-b67-build.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact landed walker JSON (9/9)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22793-b67-merge.json); [real resolver boundary JSON (1/1, 34 skipped)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22793-b67-boundary.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels.

## Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues-review-22254]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:2334ebafac2bdba43b70c7b1cfcb5b222a53d9ec -->
