### PR TITLE
fix(plugin-discord): close structured-text reflection gaps

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
@@ -9,8 +9,8 @@ import {
 	DISCORD_STRUCTURED_TEXT_UNBOUNDED,
 	MAX_DISCORD_STRUCTURED_TEXT_DEPTH,
 	MAX_DISCORD_STRUCTURED_TEXT_NODES,
-	normalizeDiscordMessageText,
 } from "../discord-structured-text";
+import { normalizeDiscordMessageText } from "../utils";
 
 function nestArray(depth: number, leaf: unknown = "leaf"): unknown {
 	let value: unknown = leaf;
@@ -108,6 +108,78 @@ describe("normalizeDiscordMessageText", () => {
 		};
 		expect(normalizeDiscordMessageText(hostile)).toBe("");
 		expect(invoked).toBe(0);
+	});
+
+	it("reads array entries by descriptor without invoking own or inherited accessors", () => {
+		let invoked = 0;
+		const ownAccessor = ["safe"];
+		Object.defineProperty(ownAccessor, "0", {
+			get() {
+				invoked += 1;
+				return "unsafe";
+			},
+		});
+
+		const inheritedAccessor = new Array<unknown>(1);
+		Object.setPrototypeOf(inheritedAccessor, {
+			get 0() {
+				invoked += 1;
+				return "unsafe";
+			},
+		});
+
+		expect(normalizeDiscordMessageText(ownAccessor)).toBe("");
+		expect(normalizeDiscordMessageText(inheritedAccessor)).toBe("");
+		expect(invoked).toBe(0);
+	});
+
+	it("does not invoke ordinary Proxy get or has traps", () => {
+		let gets = 0;
+		let hasChecks = 0;
+		const proxied = new Proxy(["safe"], {
+			get() {
+				gets += 1;
+				throw new Error("ordinary get must not run");
+			},
+			has() {
+				hasChecks += 1;
+				throw new Error("ordinary has must not run");
+			},
+		});
+
+		expect(normalizeDiscordMessageText(proxied)).toBe("safe");
+		expect(gets).toBe(0);
+		expect(hasChecks).toBe(0);
+	});
+
+	it("translates hostile reflection and revoked Proxies to the typed error", () => {
+		const hostile = new Proxy(
+			{},
+			{
+				getOwnPropertyDescriptor() {
+					throw new Error("hostile reflection");
+				},
+			},
+		);
+		const revocable = Proxy.revocable([], {});
+		revocable.revoke();
+
+		for (const value of [hostile, revocable.proxy]) {
+			try {
+				normalizeDiscordMessageText(value);
+				expect.unreachable("hostile Proxy should fail closed");
+			} catch (error) {
+				expect(error).toBeInstanceOf(ElizaError);
+				expect((error as ElizaError).code).toBe(
+					DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+				);
+			}
+		}
+	});
+
+	it("preserves duplicate suppression for repeated object references", () => {
+		const shared = { text: "once" };
+		expect(normalizeDiscordMessageText([shared, shared])).toBe("once");
 	});
 
 	it("fails closed on a 20k nest in under 50ms instead of RangeError", () => {

--- a/plugins/plugin-discord/discord-structured-text.ts
+++ b/plugins/plugin-discord/discord-structured-text.ts
@@ -24,7 +24,7 @@ const FALLBACK_TEXT_KEYS = ["title", "summary"] as const;
 
 type WalkContext = {
 	visits: number;
-	visiting: WeakSet<object>;
+	seen: WeakSet<object>;
 };
 
 function failUnbounded(context: Record<string, unknown>): never {
@@ -49,9 +49,38 @@ function reserve(ctx: WalkContext, count: number): void {
 }
 
 function dataValue(value: object, key: string): unknown {
-	const descriptor = Object.getOwnPropertyDescriptor(value, key);
+	let descriptor: PropertyDescriptor | undefined;
+	try {
+		descriptor = Object.getOwnPropertyDescriptor(value, key);
+	} catch (cause) {
+		throw new ElizaError(
+			"Discord structured message text could not be safely inspected",
+			{
+				code: DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+				context: { operation: "getOwnPropertyDescriptor", key },
+				cause,
+				severity: "fatal",
+			},
+		);
+	}
 	if (!descriptor || !("value" in descriptor)) return undefined;
 	return descriptor.value;
+}
+
+function isArray(value: object): boolean {
+	try {
+		return Array.isArray(value);
+	} catch (cause) {
+		throw new ElizaError(
+			"Discord structured message text could not be safely inspected",
+			{
+				code: DISCORD_STRUCTURED_TEXT_UNBOUNDED,
+				context: { operation: "isArray" },
+				cause,
+				severity: "fatal",
+			},
+		);
+	}
 }
 
 function collectStructuredText(
@@ -79,57 +108,56 @@ function collectStructuredText(
 		return [];
 	}
 	if (!visitAlreadyReserved) reserve(ctx, 1);
-	if (ctx.visiting.has(value)) {
+	if (ctx.seen.has(value)) {
 		return [];
 	}
-	ctx.visiting.add(value);
-	try {
-		if (Array.isArray(value)) {
-			reserve(ctx, value.length);
-			const fragments: string[] = [];
-			for (let index = 0; index < value.length; index += 1) {
-				if (!(index in value)) continue;
-				fragments.push(
-					...collectStructuredText(value[index], depth + 1, ctx, true),
-				);
-			}
-			return fragments;
+	ctx.seen.add(value);
+	if (isArray(value)) {
+		const length = dataValue(value, "length");
+		if (!Number.isSafeInteger(length) || (length as number) < 0) {
+			failUnbounded({ operation: "arrayLength", length });
 		}
+		reserve(ctx, length as number);
+		const fragments: string[] = [];
+		for (let index = 0; index < (length as number); index += 1) {
+			const child = dataValue(value, String(index));
+			if (child === undefined) continue;
+			fragments.push(...collectStructuredText(child, depth + 1, ctx, true));
+		}
+		return fragments;
+	}
 
-		for (const key of PRIMARY_TEXT_KEYS) {
-			const child = dataValue(value, key);
-			if (child === undefined) continue;
-			const normalized = collectStructuredText(child, depth + 1, ctx);
-			if (normalized.length > 0) {
-				return normalized;
-			}
+	for (const key of PRIMARY_TEXT_KEYS) {
+		const child = dataValue(value, key);
+		if (child === undefined) continue;
+		const normalized = collectStructuredText(child, depth + 1, ctx);
+		if (normalized.length > 0) {
+			return normalized;
 		}
-		for (const key of COLLECTION_KEYS) {
-			const child = dataValue(value, key);
-			if (child === undefined) continue;
-			const normalized = collectStructuredText(child, depth + 1, ctx);
-			if (normalized.length > 0) {
-				return normalized;
-			}
-		}
-		for (const key of FALLBACK_TEXT_KEYS) {
-			const child = dataValue(value, key);
-			if (child === undefined) continue;
-			const normalized = collectStructuredText(child, depth + 1, ctx);
-			if (normalized.length > 0) {
-				return normalized;
-			}
-		}
-		return [];
-	} finally {
-		ctx.visiting.delete(value);
 	}
+	for (const key of COLLECTION_KEYS) {
+		const child = dataValue(value, key);
+		if (child === undefined) continue;
+		const normalized = collectStructuredText(child, depth + 1, ctx);
+		if (normalized.length > 0) {
+			return normalized;
+		}
+	}
+	for (const key of FALLBACK_TEXT_KEYS) {
+		const child = dataValue(value, key);
+		if (child === undefined) continue;
+		const normalized = collectStructuredText(child, depth + 1, ctx);
+		if (normalized.length > 0) {
+			return normalized;
+		}
+	}
+	return [];
 }
 
 export function normalizeDiscordMessageText(value: unknown): string {
 	const fragments = collectStructuredText(value, 0, {
 		visits: 0,
-		visiting: new WeakSet<object>(),
+		seen: new WeakSet<object>(),
 	})
 		.map((fragment) => fragment.trim())
 		.filter((fragment) => fragment.length > 0);


### PR DESCRIPTION
Fixes #22756.

This is a corrective successor to merged #22757. Independent exact-tree review of its merged head `9812a042808364a76e7adf264119a652470ea492` found three residual production-boundary failures: array element accessors were invoked, revoked/hostile Proxy reflection leaked untyped errors, and repeated shared object references no longer retained the formatter's prior global duplicate suppression.

## What changed

- Read array length and entries only through own data descriptors; own and inherited index accessors are never invoked.
- Translate `Array.isArray` and `Object.getOwnPropertyDescriptor` Proxy/reflection failures to `DISCORD_STRUCTURED_TEXT_UNBOUNDED` with the original cause.
- Restore a global `WeakSet` for byte-compatible shared-reference and cycle suppression while preserving depth/node/sparse-array bounds.
- Exercise the production `utils` export used by Discord send, voice, reaction, and message formatting boundaries.

## Exact-head evidence

Evidence revision: `dc0d6a1ffb0f6d0ff2cfeee0deb9ab69558de927`, based on `develop` `723a82171572243e39c554a136faf6597e539975`.

- `bun test plugins/plugin-discord/__tests__/discord-structured-text.test.ts`: **12/12 passed, 35 assertions**.
- `bun run --cwd plugins/plugin-discord typecheck`: passed.
- `bun run --cwd plugins/plugin-discord build`: passed.
- Biome on both changed files: passed.
- `git diff --check origin/develop...HEAD`: passed.
- Patch-identical full plugin run before the final non-overlapping `develop` refresh: **693/694 passed**; the only failure was the unrelated first-case 60s timeout in `dm-gate-handle-message.test.ts`. Its isolated rerun passed **4/4** (the first import/transform completed in 76.2s on the loaded host).

## Review focus

Adversarial tests cover own/inherited array accessors, ordinary Proxy `get`/`has` traps, hostile descriptor reflection, revoked array Proxies, repeated shared references, cycles, sparse arrays, depth/node limits, and 20k/8k deep structures. This PR is intentionally draft-held for an independent SHA-locked review before merge.

## Evidence Gate

<!-- evidence-head:dc0d6a1ffb0f6d0ff2cfeee0deb9ab69558de927 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Discord structured-text formatter; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Discord structured-text formatter; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production deployment; exact-head deterministic production-export suite and package build are listed inline.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external artifact; exact-head adversarial formatter receipt is listed inline.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-cortex-plugins]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->