### PR TITLE
fix(cloud): enforce canonical Shared timing durations

### DIFF
--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -98,11 +98,23 @@ describe("eliza sse bridge", () => {
   test("bounds and allowlists Server-Timing without retaining descriptions", () => {
     expect(
       parseElizaServerTiming(
-        'turn_claim;dur=4.44;desc="tenant-secret", provider;desc="cerebras", injected;dur=1;desc="raw", turn_hydrate;dur=700001, turn_admission;dur=-2',
+        'turn_claim;dur=4.4;desc="tenant-secret", provider;desc="cerebras", injected;dur=1;desc="raw", turn_hydrate;dur=700001, turn_admission;dur=-2',
       ),
     ).toEqual({ metrics: { turn_claim: 4.4 }, provider: "cerebras" });
     expect(parseElizaServerTiming(`turn_claim;dur=1,${"x".repeat(2_100)}`)).toBeNull();
     expect(parseElizaServerTiming('provider;desc="attacker-controlled"')).toBeNull();
+  });
+
+  test("rejects non-canonical Server-Timing duration representations", () => {
+    for (const duration of ["0x10", "1e3", "+1", "01", ".5", "1.", "1.25"]) {
+      expect(parseElizaServerTiming(`turn_claim;dur=${duration}`)).toBeNull();
+    }
+    expect(parseElizaServerTiming("turn_claim;dur=0")).toEqual({
+      metrics: { turn_claim: 0 },
+    });
+    expect(parseElizaServerTiming("turn_claim;dur=600000.0")).toEqual({
+      metrics: { turn_claim: 600000 },
+    });
   });
 
   test("decodes local runtime token frames without replaying fullText", async () => {

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -35,6 +35,7 @@ export const VOICE_STREAM_PROTOCOL = "delta-v2" as const;
 const MAX_SERVER_TIMING_HEADER_CHARS = 2_048;
 const MAX_SERVER_TIMING_ENTRIES = 16;
 const MAX_SERVER_TIMING_DURATION_MS = 10 * 60 * 1_000;
+const CANONICAL_SERVER_TIMING_DURATION = /^(?:0|[1-9]\d{0,5})(?:\.\d)?$/;
 const SERVER_TIMING_METRICS = [
   "parse",
   "bridge",
@@ -93,6 +94,7 @@ export function parseElizaServerTiming(raw: string | null): ElizaServerTimingRec
       .find((param) => param.toLowerCase().startsWith("dur="))
       ?.slice(4);
     if (!durationText) continue;
+    if (!CANONICAL_SERVER_TIMING_DURATION.test(durationText)) continue;
     const duration = Number(durationText);
     if (!Number.isFinite(duration) || duration < 0 || duration > MAX_SERVER_TIMING_DURATION_MS) {
       continue;


### PR DESCRIPTION
Closes #22792.

## Summary

Follow-up to merged #22765. The Shared voice SSE bridge claimed to accept canonical bounded `Server-Timing` values, but JavaScript `Number(...)` also admitted hexadecimal, exponent, signed, leading-zero, and excess-precision encodings at the HTTP boundary.

This narrow follow-up:

- admits only the integer or one-decimal duration grammar emitted by the Shared route;
- preserves the existing 600000ms maximum and metric/provider allowlists; and
- adds adversarial rejection cases for non-canonical numeric forms.

The unrelated default-character attribution changes from #22765 are intentionally left unchanged; this PR makes no persona or product-policy decision.

## Sync and verification

Exact head: `1a119a480daf8c4c3656e2df88e2a8d107a7acb8`

Rebased onto `origin/develop@a3ede0c91e2ac1d7e46c62909778afb604aa02ba` immediately before push.

```text
bun test eliza-sse-bridge.test.ts (coverage disabled in an external temporary bunfig)
25 pass, 0 fail, 64 assertions

bun run --cwd packages/cloud/shared typecheck
PASS

bunx biome check <2 changed files>
PASS - no fixes

git diff --check origin/develop...HEAD
PASS
```

## Evidence Gate

<!-- evidence-head:1a119a480daf8c4c3656e2df88e2a8d107a7acb8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend parser only; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend parser only; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive surface or external integration changed
<!-- evidence-row:backend-logs -->
- [x] [Exact-head Cloud Shared typecheck transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22795-1a11-typecheck.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend execution path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, action, or runtime execution behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head adversarial parser transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22795-1a11-tests.log) - valid canonical controls pass; hexadecimal, exponent, signed, leading-zero, incomplete, and excess-precision encodings are rejected
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct post-merge audit remediation; no contribution skill was invoked`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-postmerge-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - direct post-merge audit remediation; no contribution skill was invoked"} -->