### PR TITLE
fix(core): fail closed on unbounded planner action-parameter graphs

### DIFF
--- a/packages/core/src/action-parameter-value.test.ts
+++ b/packages/core/src/action-parameter-value.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Deterministic tests for the planner action-parameter walk. No live model:
+ * the walker is the production toActionParameterValue used on untrusted
+ * `{ params }` JSON.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	ACTION_PARAMETER_UNBOUNDED,
+	MAX_ACTION_PARAMETER_DEPTH,
+	MAX_ACTION_PARAMETER_NODES,
+	toActionParameterValue,
+} from "./action-parameter-value";
+import { ElizaError } from "./errors";
+
+function nestArray(depth: number): unknown {
+	let value: unknown = "x";
+	for (let index = 0; index < depth; index += 1) {
+		value = [value];
+	}
+	return value;
+}
+
+describe("toActionParameterValue", () => {
+	it("preserves honest scalars, lists, and nested records", () => {
+		expect(toActionParameterValue("ok")).toBe("ok");
+		expect(toActionParameterValue(3)).toBe(3);
+		expect(toActionParameterValue(true)).toBe(true);
+		expect(toActionParameterValue(null)).toBe(null);
+		expect(toActionParameterValue(["1", { b: true }])).toEqual([
+			"1",
+			{ b: true },
+		]);
+		expect(toActionParameterValue({ a: ["1", { b: true }] })).toEqual({
+			a: ["1", { b: true }],
+		});
+	});
+
+	it(`accepts a ${MAX_ACTION_PARAMETER_DEPTH}-deep array nest`, () => {
+		expect(
+			toActionParameterValue(nestArray(MAX_ACTION_PARAMETER_DEPTH)),
+		).toEqual(nestArray(MAX_ACTION_PARAMETER_DEPTH));
+	});
+
+	it(`throws ${ACTION_PARAMETER_UNBOUNDED} one past depth ${MAX_ACTION_PARAMETER_DEPTH}`, () => {
+		try {
+			toActionParameterValue(nestArray(MAX_ACTION_PARAMETER_DEPTH + 1));
+			expect.unreachable("parse should fail closed on over-budget depth");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+	});
+
+	it(`throws ${ACTION_PARAMETER_UNBOUNDED} past ${MAX_ACTION_PARAMETER_NODES} sparse holes`, () => {
+		const sparse: unknown[] = [];
+		sparse[MAX_ACTION_PARAMETER_NODES] = "x";
+		try {
+			toActionParameterValue(sparse);
+			expect.unreachable(
+				"parse should fail closed on over-budget sparse length",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+	});
+
+	it("throws on a cyclic record without hanging", () => {
+		const cyclic: { self?: unknown } = {};
+		cyclic.self = cyclic;
+		const started = performance.now();
+		try {
+			toActionParameterValue(cyclic);
+			expect.unreachable("parse should fail closed on a cycle");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("does not invoke accessors while parsing", () => {
+		let invoked = 0;
+		const hostile = {
+			get trap() {
+				invoked += 1;
+				return "x";
+			},
+		};
+		try {
+			toActionParameterValue(hostile);
+			expect.unreachable("parse should fail closed on enumerable accessors");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+		expect(invoked).toBe(0);
+	});
+
+	it("does not invoke array Proxy get/has traps while parsing", () => {
+		let gets = 0;
+		let hasCalls = 0;
+		const proxy = new Proxy(["x"], {
+			get() {
+				gets += 1;
+				throw new Error("get trap escaped");
+			},
+			has() {
+				hasCalls += 1;
+				throw new Error("has trap escaped");
+			},
+		});
+		expect(toActionParameterValue(proxy)).toEqual(["x"]);
+		expect(gets).toBe(0);
+		expect(hasCalls).toBe(0);
+	});
+
+	it(`throws ${ACTION_PARAMETER_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+		const { proxy, revoke } = Proxy.revocable(["x"], {});
+		revoke();
+		try {
+			toActionParameterValue(proxy);
+			expect.unreachable("parse should fail closed on a revoked Proxy");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).name).not.toBe("TypeError");
+			expect((error as Error).cause).toBeInstanceOf(TypeError);
+			expect(String((error as Error).cause)).toMatch(/IsArray/);
+		}
+	});
+
+	it("rescans honest shared child values after the parent frame returns", () => {
+		const shared = { b: true };
+		expect(toActionParameterValue({ a: shared, c: shared })).toEqual({
+			a: { b: true },
+			c: { b: true },
+		});
+	});
+
+	it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+		const started = performance.now();
+		try {
+			toActionParameterValue(nestArray(8_000));
+			expect.unreachable("parse should fail closed on an 8k nest");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).name).not.toBe("RangeError");
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+});

--- a/packages/core/src/action-parameter-value.test.ts
+++ b/packages/core/src/action-parameter-value.test.ts
@@ -66,6 +66,28 @@ describe("toActionParameterValue", () => {
 		}
 	});
 
+	it("preserves within-budget sparse holes and length", () => {
+		const value: unknown[] = [];
+		value[2] = "x";
+		const result = toActionParameterValue(value) as unknown[];
+		expect(result).toHaveLength(3);
+		expect(0 in result).toBe(false);
+		expect(1 in result).toBe(false);
+		expect(Object.hasOwn(result, "2")).toBe(true);
+		expect(result[2]).toBe("x");
+	});
+
+	it("converts explicit undefined slots to null without collapsing length", () => {
+		const value: unknown[] = [undefined, undefined, "x"];
+		const result = toActionParameterValue(value) as unknown[];
+		expect(result).toHaveLength(3);
+		expect(0 in result).toBe(true);
+		expect(1 in result).toBe(true);
+		expect(result[0]).toBe(null);
+		expect(result[1]).toBe(null);
+		expect(result[2]).toBe("x");
+	});
+
 	it("throws on a cyclic record without hanging", () => {
 		const cyclic: { self?: unknown } = {};
 		cyclic.self = cyclic;
@@ -281,6 +303,18 @@ describe("parseActionParams", () => {
 			expect((error as Error).name).not.toBe("RangeError");
 		}
 		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("preserves sparse holes through parseActionParams", () => {
+		const payload: unknown[] = [];
+		payload[2] = "x";
+		const result = parseActionParams({
+			params: { ACT: { payload } },
+		}).get("ACT")?.payload as unknown[];
+		expect(result).toHaveLength(3);
+		expect(0 in result).toBe(false);
+		expect(1 in result).toBe(false);
+		expect(result[2]).toBe("x");
 	});
 
 	it("shares the node budget across the whole params graph", () => {

--- a/packages/core/src/action-parameter-value.test.ts
+++ b/packages/core/src/action-parameter-value.test.ts
@@ -1,7 +1,7 @@
 /**
  * Deterministic tests for the planner action-parameter walk. No live model:
- * the walker is the production toActionParameterValue used on untrusted
- * `{ params }` JSON.
+ * the walker is the production parseActionParams / toActionParameterValue
+ * used on untrusted `{ params }` JSON.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -10,6 +10,7 @@ import {
 	MAX_ACTION_PARAMETER_NODES,
 	toActionParameterValue,
 } from "./action-parameter-value";
+import { parseActionParams } from "./actions";
 import { ElizaError } from "./errors";
 
 function nestArray(depth: number): unknown {
@@ -149,5 +150,154 @@ describe("toActionParameterValue", () => {
 			expect((error as Error).name).not.toBe("RangeError");
 		}
 		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("translates a getOwnPropertyDescriptor trap to ACTION_PARAMETER_UNBOUNDED", () => {
+		const hostile = new Proxy(
+			{ payload: "x" },
+			{
+				getOwnPropertyDescriptor() {
+					throw new Error("descriptor trap escaped");
+				},
+			},
+		);
+		try {
+			toActionParameterValue(hostile);
+			expect.unreachable("parse should fail closed on a descriptor trap");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).message).not.toContain("trap escaped");
+		}
+	});
+});
+
+describe("parseActionParams", () => {
+	it("parses honest wrapped and unwrapped action param records", () => {
+		expect(
+			parseActionParams({
+				params: { SHELL_COMMAND: { command: "ls" } },
+			}).get("SHELL_COMMAND"),
+		).toEqual({ command: "ls" });
+		expect(
+			parseActionParams({ SHELL_COMMAND: { command: "ls" } }).get(
+				"SHELL_COMMAND",
+			),
+		).toEqual({ command: "ls" });
+		expect(parseActionParams("{ not json").size).toBe(0);
+	});
+
+	it("does not invoke action-slot accessors", () => {
+		let invoked = 0;
+		const hostile = {
+			params: {
+				get ACT() {
+					invoked += 1;
+					return { payload: "x" };
+				},
+			},
+		};
+		try {
+			parseActionParams(hostile);
+			expect.unreachable("parse should fail closed on action-slot accessors");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+		expect(invoked).toBe(0);
+	});
+
+	it("does not invoke parameter-slot accessors", () => {
+		let invoked = 0;
+		const hostile = {
+			params: {
+				ACT: {
+					get payload() {
+						invoked += 1;
+						return ["x"];
+					},
+				},
+			},
+		};
+		try {
+			parseActionParams(hostile);
+			expect.unreachable(
+				"parse should fail closed on parameter-slot accessors",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+		expect(invoked).toBe(0);
+	});
+
+	it("does not invoke Proxy get/has traps on the production boundary", () => {
+		let gets = 0;
+		let hasCalls = 0;
+		const proxy = new Proxy(
+			{ params: { ACT: { payload: "x" } } },
+			{
+				get() {
+					gets += 1;
+					throw new Error("get trap escaped");
+				},
+				has() {
+					hasCalls += 1;
+					throw new Error("has trap escaped");
+				},
+			},
+		);
+		expect(parseActionParams(proxy).get("ACT")).toEqual({ payload: "x" });
+		expect(gets).toBe(0);
+		expect(hasCalls).toBe(0);
+	});
+
+	it(`throws ${ACTION_PARAMETER_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+		const { proxy, revoke } = Proxy.revocable(
+			{ params: { ACT: { payload: "x" } } },
+			{},
+		);
+		revoke();
+		try {
+			parseActionParams(proxy);
+			expect.unreachable("parse should fail closed on a revoked Proxy");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).name).not.toBe("TypeError");
+		}
+	});
+
+	it("fails closed on an 8k nest through parseActionParams", () => {
+		const started = performance.now();
+		try {
+			parseActionParams({
+				params: { ACT: { payload: nestArray(8_000) } },
+			});
+			expect.unreachable("production parse should fail closed on an 8k nest");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).name).not.toBe("RangeError");
+		}
+		expect(performance.now() - started).toBeLessThan(50);
+	});
+
+	it("shares the node budget across the whole params graph", () => {
+		const left: unknown[] = [];
+		const right: unknown[] = [];
+		left[1_200] = "x";
+		right[1_200] = "y";
+		try {
+			parseActionParams({
+				params: { A: { p: left }, B: { p: right } },
+			});
+			expect.unreachable(
+				"shared budget should fail closed across action slots",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
 	});
 });

--- a/packages/core/src/action-parameter-value.test.ts
+++ b/packages/core/src/action-parameter-value.test.ts
@@ -10,8 +10,9 @@ import {
 	MAX_ACTION_PARAMETER_NODES,
 	toActionParameterValue,
 } from "./action-parameter-value";
-import { parseActionParams } from "./actions";
+import { parseActionParams, validateActionParams } from "./actions";
 import { ElizaError } from "./errors";
+import type { Action, ActionParameters } from "./types";
 
 function nestArray(depth: number): unknown {
 	let value: unknown = "x";
@@ -86,6 +87,23 @@ describe("toActionParameterValue", () => {
 		expect(result[0]).toBe(null);
 		expect(result[1]).toBe(null);
 		expect(result[2]).toBe("x");
+	});
+
+	it("translates hostile primitive conversion and preserves its cause", () => {
+		const conversionFailure = new Error("hostile primitive conversion");
+		const hostile = new Proxy(() => undefined, {
+			get() {
+				throw conversionFailure;
+			},
+		});
+		try {
+			toActionParameterValue(hostile);
+			expect.unreachable("primitive conversion should fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+			expect((error as Error).cause).toBe(conversionFailure);
+		}
 	});
 
 	it("throws on a cyclic record without hanging", () => {
@@ -317,6 +335,26 @@ describe("parseActionParams", () => {
 		expect(result[2]).toBe("x");
 	});
 
+	it("preserves __proto__ keys as inert own model data", () => {
+		const params = parseActionParams(
+			'{"params":{"ACT":{"__proto__":{"polluted":true},"payload":{"__proto__":{"nested":true}}}}}',
+		).get("ACT") as ActionParameters;
+		expect(Object.getPrototypeOf(params)).toBe(Object.prototype);
+		expect(Object.hasOwn(params, "__proto__")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(params, "__proto__")?.value).toEqual(
+			{ polluted: true },
+		);
+		expect((params as Record<string, unknown>).polluted).toBeUndefined();
+
+		const payload = params.payload as ActionParameters;
+		expect(Object.getPrototypeOf(payload)).toBe(Object.prototype);
+		expect(Object.hasOwn(payload, "__proto__")).toBe(true);
+		expect(
+			Object.getOwnPropertyDescriptor(payload, "__proto__")?.value,
+		).toEqual({ nested: true });
+		expect((payload as Record<string, unknown>).nested).toBeUndefined();
+	});
+
 	it("shares the node budget across the whole params graph", () => {
 		const left: unknown[] = [];
 		const right: unknown[] = [];
@@ -333,5 +371,24 @@ describe("parseActionParams", () => {
 			expect(error).toBeInstanceOf(ElizaError);
 			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
 		}
+	});
+});
+
+describe("validateActionParams", () => {
+	it("does not swallow an over-budget JSON array during string coercion", () => {
+		const action = {
+			name: "ACT",
+			parameters: [
+				{
+					name: "items",
+					required: true,
+					schema: { type: "array", items: { type: "string" } },
+				},
+			],
+		} as Action;
+		const value = `[${Array.from({ length: MAX_ACTION_PARAMETER_NODES + 1 }, () => '"x"').join(",")}]`;
+		expect(() => validateActionParams(action, { items: value })).toThrowError(
+			expect.objectContaining({ code: ACTION_PARAMETER_UNBOUNDED }),
+		);
 	});
 });

--- a/packages/core/src/action-parameter-value.ts
+++ b/packages/core/src/action-parameter-value.ts
@@ -3,8 +3,9 @@
  * `{ params }` JSON. Planner output can nest arrays and objects; the previous
  * recursive map RangeError'd an 8k nest on Node 24.15.0. Depth, node, and
  * cycle limits are all load-bearing. Every reflective read is fail-closed
- * to the typed unbounded error; array length and indexes come from own
- * data descriptors so Proxy get/has traps cannot hang the planner.
+ * to the typed unbounded error; array length, indexes, and record keys come
+ * from own data descriptors so Proxy get/has traps cannot hang the planner.
+ * `parseActionParams` shares one walk budget across the whole params graph.
  */
 
 import { ElizaError } from "./errors";
@@ -63,13 +64,158 @@ function isArrayRecord(value: unknown): value is unknown[] {
 	return inspectRecord("isArray", () => Array.isArray(value));
 }
 
+function ownEnumerableStringDataEntries(
+	value: object,
+	ctx: WalkContext,
+): Array<[string, unknown]> {
+	const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+	reserve(ctx, keys.length);
+	const entries: Array<[string, unknown]> = [];
+	for (const key of keys) {
+		if (typeof key !== "string") continue;
+		const descriptor = ownDescriptor(value, key);
+		if (!descriptor?.enumerable) continue;
+		if (!("value" in descriptor)) {
+			failUnbounded({ accessor: true, side: "object", key });
+		}
+		entries.push([key, descriptor.value]);
+	}
+	return entries;
+}
+
+function newWalkContext(): WalkContext {
+	return {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+	};
+}
+
 export function toActionParameterValue(
 	value: unknown,
 ): ActionParameters[string] {
-	return toActionParameterValueInner(value, 0, {
-		visits: 0,
-		visiting: new WeakSet<object>(),
-	});
+	return toActionParameterValueInner(value, 0, newWalkContext());
+}
+
+/**
+ * Production planner boundary: descriptor-only traversal of the model
+ * `{ params }` graph with one shared node/cycle budget.
+ */
+export function parseActionParams(
+	paramsInput: unknown,
+): Map<string, ActionParameters> {
+	const parsed =
+		typeof paramsInput === "string"
+			? parseActionParamsJson(paramsInput)
+			: (paramsInput ?? null);
+	if (parsed === null || parsed === undefined) {
+		return new Map();
+	}
+	return parseActionParamsRecord(parsed, newWalkContext());
+}
+
+function parseActionParamsJson(input: string): unknown | null {
+	const trimmed = input.trim();
+	if (!trimmed) {
+		return null;
+	}
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch {
+		// error-policy:J3 action parameters cross an untrusted model boundary;
+		// malformed JSON is an explicit invalid result.
+		return null;
+	}
+}
+
+function parseActionParamsRecord(
+	parsed: unknown,
+	ctx: WalkContext,
+): Map<string, ActionParameters> {
+	if (!parsed || typeof parsed !== "object") {
+		return new Map();
+	}
+	if (isArrayRecord(parsed)) {
+		return new Map();
+	}
+	reserve(ctx, 1);
+	if (ctx.visiting.has(parsed)) {
+		failUnbounded({ cycle: true });
+	}
+	ctx.visiting.add(parsed);
+	try {
+		const rootEntries = ownEnumerableStringDataEntries(parsed, ctx);
+		const paramsSlot = rootEntries.find(([key]) => key === "params");
+		if (paramsSlot) {
+			const paramsValue = paramsSlot[1];
+			if (
+				paramsValue &&
+				typeof paramsValue === "object" &&
+				!isArrayRecord(paramsValue)
+			) {
+				return collectActionParams(paramsValue, ctx);
+			}
+		}
+		return collectActionsFromEntries(rootEntries, ctx);
+	} finally {
+		ctx.visiting.delete(parsed);
+	}
+}
+
+function collectActionParams(
+	candidate: object,
+	ctx: WalkContext,
+): Map<string, ActionParameters> {
+	if (ctx.visiting.has(candidate)) {
+		failUnbounded({ cycle: true });
+	}
+	ctx.visiting.add(candidate);
+	try {
+		return collectActionsFromEntries(
+			ownEnumerableStringDataEntries(candidate, ctx),
+			ctx,
+		);
+	} finally {
+		ctx.visiting.delete(candidate);
+	}
+}
+
+function collectActionsFromEntries(
+	actionEntries: Array<[string, unknown]>,
+	ctx: WalkContext,
+): Map<string, ActionParameters> {
+	const result = new Map<string, ActionParameters>();
+	for (const [actionName, paramsValue] of actionEntries) {
+		if (!paramsValue || typeof paramsValue !== "object") {
+			continue;
+		}
+		if (isArrayRecord(paramsValue)) {
+			continue;
+		}
+		if (ctx.visiting.has(paramsValue)) {
+			failUnbounded({ cycle: true });
+		}
+		ctx.visiting.add(paramsValue);
+		try {
+			const params: ActionParameters = {};
+			for (const [paramName, paramValue] of ownEnumerableStringDataEntries(
+				paramsValue,
+				ctx,
+			)) {
+				params[paramName] = toActionParameterValueInner(
+					paramValue,
+					0,
+					ctx,
+					true,
+				);
+			}
+			if (Object.keys(params).length > 0) {
+				result.set(actionName.trim().toUpperCase(), params);
+			}
+		} finally {
+			ctx.visiting.delete(paramsValue);
+		}
+	}
+	return result;
 }
 
 function toActionParameterValueInner(
@@ -125,17 +271,7 @@ function toActionParameterValueInner(
 			return out as ActionParameters[string];
 		}
 
-		const entries: Array<[string, unknown]> = [];
-		for (const key of inspectRecord("ownKeys", () => Reflect.ownKeys(value))) {
-			if (typeof key !== "string") continue;
-			const descriptor = ownDescriptor(value, key);
-			if (!descriptor?.enumerable) continue;
-			if (!("value" in descriptor)) {
-				failUnbounded({ accessor: true, side: "object", key });
-			}
-			entries.push([key, descriptor.value]);
-		}
-		reserve(ctx, entries.length);
+		const entries = ownEnumerableStringDataEntries(value, ctx);
 		const normalized: ActionParameters = {};
 		for (const [key, entry] of entries) {
 			normalized[key] = toActionParameterValueInner(

--- a/packages/core/src/action-parameter-value.ts
+++ b/packages/core/src/action-parameter-value.ts
@@ -257,15 +257,18 @@ function toActionParameterValueInner(
 				failUnbounded({ invalidArrayLength: true });
 			}
 			reserve(ctx, length);
-			const out: ActionParameters[string][] = [];
+			const out = new Array<ActionParameters[string]>(length);
 			for (let index = 0; index < length; index += 1) {
 				const descriptor = ownDescriptor(value, String(index));
 				if (!descriptor) continue;
 				if (!("value" in descriptor)) {
 					failUnbounded({ accessor: true, side: "array", index });
 				}
-				out.push(
-					toActionParameterValueInner(descriptor.value, depth + 1, ctx, true),
+				out[index] = toActionParameterValueInner(
+					descriptor.value,
+					depth + 1,
+					ctx,
+					true,
 				);
 			}
 			return out as ActionParameters[string];

--- a/packages/core/src/action-parameter-value.ts
+++ b/packages/core/src/action-parameter-value.ts
@@ -46,9 +46,22 @@ function inspectRecord<T>(operation: string, inspect: () => T): T {
 	try {
 		return inspect();
 	} catch (cause) {
-		// error-policy:J3 Proxy inspection failures make untrusted model JSON invalid.
+		// error-policy:J2 Preserve the reflective failure as the typed boundary cause.
 		failUnbounded({ inspection: operation }, cause);
 	}
+}
+
+function defineDataProperty(
+	target: ActionParameters,
+	key: string,
+	value: ActionParameters[string],
+): void {
+	Object.defineProperty(target, key, {
+		value,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
 }
 
 function ownDescriptor(
@@ -201,11 +214,10 @@ function collectActionsFromEntries(
 				paramsValue,
 				ctx,
 			)) {
-				params[paramName] = toActionParameterValueInner(
-					paramValue,
-					0,
-					ctx,
-					true,
+				defineDataProperty(
+					params,
+					paramName,
+					toActionParameterValueInner(paramValue, 0, ctx, true),
 				);
 			}
 			if (Object.keys(params).length > 0) {
@@ -239,7 +251,8 @@ function toActionParameterValueInner(
 		return value;
 	}
 	if (!value || typeof value !== "object") {
-		return String(value);
+		if (!visitAlreadyReserved) reserve(ctx, 1);
+		return inspectRecord("primitiveToString", () => String(value));
 	}
 	if (!visitAlreadyReserved) reserve(ctx, 1);
 	if (ctx.visiting.has(value)) {
@@ -277,11 +290,10 @@ function toActionParameterValueInner(
 		const entries = ownEnumerableStringDataEntries(value, ctx);
 		const normalized: ActionParameters = {};
 		for (const [key, entry] of entries) {
-			normalized[key] = toActionParameterValueInner(
-				entry,
-				depth + 1,
-				ctx,
-				true,
+			defineDataProperty(
+				normalized,
+				key,
+				toActionParameterValueInner(entry, depth + 1, ctx, true),
 			);
 		}
 		return normalized;

--- a/packages/core/src/action-parameter-value.ts
+++ b/packages/core/src/action-parameter-value.ts
@@ -1,0 +1,152 @@
+/**
+ * Bounds the nested action-parameter walk used when parsing untrusted model
+ * `{ params }` JSON. Planner output can nest arrays and objects; the previous
+ * recursive map RangeError'd an 8k nest on Node 24.15.0. Depth, node, and
+ * cycle limits are all load-bearing. Every reflective read is fail-closed
+ * to the typed unbounded error; array length and indexes come from own
+ * data descriptors so Proxy get/has traps cannot hang the planner.
+ */
+
+import { ElizaError } from "./errors";
+import type { ActionParameters } from "./types";
+
+export const MAX_ACTION_PARAMETER_DEPTH = 32;
+export const MAX_ACTION_PARAMETER_NODES = 2_048;
+export const ACTION_PARAMETER_UNBOUNDED = "ACTION_PARAMETER_UNBOUNDED";
+
+type WalkContext = {
+	visits: number;
+	visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+	context: Record<string, unknown>,
+	cause?: unknown,
+): never {
+	throw new ElizaError("Action parameter JSON exceeds the parse walk budget", {
+		code: ACTION_PARAMETER_UNBOUNDED,
+		context,
+		cause,
+		severity: "fatal",
+	});
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+	if (count > MAX_ACTION_PARAMETER_NODES - ctx.visits) {
+		failUnbounded({
+			visits: ctx.visits + count,
+			maxNodes: MAX_ACTION_PARAMETER_NODES,
+		});
+	}
+	ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+	try {
+		return inspect();
+	} catch (cause) {
+		// error-policy:J3 Proxy inspection failures make untrusted model JSON invalid.
+		failUnbounded({ inspection: operation }, cause);
+	}
+}
+
+function ownDescriptor(
+	value: object,
+	key: PropertyKey,
+): PropertyDescriptor | undefined {
+	return inspectRecord("getOwnPropertyDescriptor", () =>
+		Object.getOwnPropertyDescriptor(value, key),
+	);
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+	return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+export function toActionParameterValue(
+	value: unknown,
+): ActionParameters[string] {
+	return toActionParameterValueInner(value, 0, {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+	});
+}
+
+function toActionParameterValueInner(
+	value: unknown,
+	depth: number,
+	ctx: WalkContext,
+	visitAlreadyReserved = false,
+): ActionParameters[string] {
+	if (depth > MAX_ACTION_PARAMETER_DEPTH) {
+		failUnbounded({ depth, max: MAX_ACTION_PARAMETER_DEPTH });
+	}
+	if (value === null || value === undefined) {
+		return null;
+	}
+	if (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) {
+		if (!visitAlreadyReserved) reserve(ctx, 1);
+		return value;
+	}
+	if (!value || typeof value !== "object") {
+		return String(value);
+	}
+	if (!visitAlreadyReserved) reserve(ctx, 1);
+	if (ctx.visiting.has(value)) {
+		failUnbounded({ cycle: true });
+	}
+	ctx.visiting.add(value);
+	try {
+		if (isArrayRecord(value)) {
+			const lengthDescriptor = ownDescriptor(value, "length");
+			if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+				failUnbounded({ invalidArrayLength: true });
+			}
+			const length = lengthDescriptor.value;
+			if (!Number.isSafeInteger(length) || length < 0) {
+				failUnbounded({ invalidArrayLength: true });
+			}
+			reserve(ctx, length);
+			const out: ActionParameters[string][] = [];
+			for (let index = 0; index < length; index += 1) {
+				const descriptor = ownDescriptor(value, String(index));
+				if (!descriptor) continue;
+				if (!("value" in descriptor)) {
+					failUnbounded({ accessor: true, side: "array", index });
+				}
+				out.push(
+					toActionParameterValueInner(descriptor.value, depth + 1, ctx, true),
+				);
+			}
+			return out as ActionParameters[string];
+		}
+
+		const entries: Array<[string, unknown]> = [];
+		for (const key of inspectRecord("ownKeys", () => Reflect.ownKeys(value))) {
+			if (typeof key !== "string") continue;
+			const descriptor = ownDescriptor(value, key);
+			if (!descriptor?.enumerable) continue;
+			if (!("value" in descriptor)) {
+				failUnbounded({ accessor: true, side: "object", key });
+			}
+			entries.push([key, descriptor.value]);
+		}
+		reserve(ctx, entries.length);
+		const normalized: ActionParameters = {};
+		for (const [key, entry] of entries) {
+			normalized[key] = toActionParameterValueInner(
+				entry,
+				depth + 1,
+				ctx,
+				true,
+			);
+		}
+		return normalized;
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -12,8 +12,10 @@
  * Sits between the action catalog and the message loop's model call, and also
  * acts as the barrel re-exporting the action sub-modules (extractor pipeline,
  * JSON model output, subaction promotion/dispatch, recent-context,
- * resolve-action-args).
+ * resolve-action-args). Nested model `params` graphs are bounded in
+ * `action-parameter-value.ts`.
  */
+import { toActionParameterValue } from "./action-parameter-value.ts";
 import { testSchemaPattern } from "./actions/validate-tool-args.ts";
 import { allActionDocs } from "./generated/action-docs.ts";
 import type {
@@ -459,33 +461,6 @@ function parseActionParamsJson(input: string): Record<string, unknown> | null {
 		// malformed JSON is an explicit invalid result.
 		return null;
 	}
-}
-
-function toActionParameterValue(value: unknown): ActionParameters[string] {
-	if (value === null || value === undefined) {
-		return null;
-	}
-	if (
-		typeof value === "string" ||
-		typeof value === "number" ||
-		typeof value === "boolean"
-	) {
-		return value as ActionParameterValue;
-	}
-
-	if (Array.isArray(value)) {
-		return value.map((entry) => toActionParameterValue(entry));
-	}
-
-	if (value && typeof value === "object") {
-		const normalized: ActionParameters = {};
-		for (const [key, entry] of Object.entries(value)) {
-			normalized[key] = toActionParameterValue(entry);
-		}
-		return normalized;
-	}
-
-	return value === undefined ? null : String(value);
 }
 
 export function validateActionParams(

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -15,7 +15,10 @@
  * resolve-action-args). Nested model `params` graphs are bounded in
  * `action-parameter-value.ts`.
  */
-import { toActionParameterValue } from "./action-parameter-value.ts";
+import {
+	parseActionParams,
+	toActionParameterValue,
+} from "./action-parameter-value.ts";
 import { testSchemaPattern } from "./actions/validate-tool-args.ts";
 import { allActionDocs } from "./generated/action-docs.ts";
 import type {
@@ -403,65 +406,7 @@ function formatParameterType(schema: ActionParameterSchema): string {
 	}
 }
 
-export function parseActionParams(
-	paramsInput: unknown,
-): Map<string, ActionParameters> {
-	const parsed =
-		typeof paramsInput === "string"
-			? parseActionParamsJson(paramsInput)
-			: (paramsInput ?? null);
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		return new Map();
-	}
-
-	const record = parsed as Record<string, unknown>;
-	const candidate =
-		record.params &&
-		typeof record.params === "object" &&
-		!Array.isArray(record.params)
-			? (record.params as Record<string, unknown>)
-			: record;
-	const result = new Map<string, ActionParameters>();
-
-	for (const [actionName, paramsValue] of Object.entries(candidate)) {
-		if (
-			!paramsValue ||
-			typeof paramsValue !== "object" ||
-			Array.isArray(paramsValue)
-		) {
-			continue;
-		}
-
-		const params: ActionParameters = {};
-		for (const [paramName, paramValue] of Object.entries(paramsValue)) {
-			params[paramName] = toActionParameterValue(paramValue);
-		}
-
-		if (Object.keys(params).length > 0) {
-			result.set(actionName.trim().toUpperCase(), params);
-		}
-	}
-
-	return result;
-}
-
-function parseActionParamsJson(input: string): Record<string, unknown> | null {
-	const trimmed = input.trim();
-	if (!trimmed) {
-		return null;
-	}
-
-	try {
-		const parsed = JSON.parse(trimmed);
-		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-			? (parsed as Record<string, unknown>)
-			: null;
-	} catch {
-		// error-policy:J3 action parameters cross an untrusted model boundary;
-		// malformed JSON is an explicit invalid result.
-		return null;
-	}
-}
+export { parseActionParams };
 
 export function validateActionParams(
 	action: Action,

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -479,14 +479,15 @@ function coerceActionParamValue(
 	}
 
 	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		let parsed: unknown;
 		try {
-			const parsed = JSON.parse(trimmed);
-			if (Array.isArray(parsed)) {
-				return parsed.map((entry) => toActionParameterValue(entry));
-			}
+			parsed = JSON.parse(trimmed) as unknown;
 		} catch {
 			// error-policy:J3 This field accepts either a JSON array or its documented
 			// delimited-string form; malformed JSON remains untrusted string input.
+		}
+		if (Array.isArray(parsed)) {
+			return toActionParameterValue(parsed);
 		}
 	}
 


### PR DESCRIPTION
Closes #22796

## Problem

`parseActionParams` walks untrusted model `{ params }` JSON with recursive `toActionParameterValue`. No depth, node, or cycle budget.

On `origin/develop` `6c1d0a12c910` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep array nest | RangeError 1.72 ms |
| cyclic `{ self: self }` | RangeError 1.42 ms |
| `value[2] = "x"` via `value.map` | length 3, holes at 0 and 1 |

Product path: planner action-parameter parse for the message loop. JSON.parse of the nest succeeds; the walk then stack-overflows the planner.

Not leftover-tax. Not a twin of `#22785` entity-resolution match unwrap, `#22781` inbox priority-scoring flags, `#22768` household entity-id scan, `#22716` cloneJson, or `#22748` in-memory filter. Distinct host: planner `toActionParameterValue` / `parseActionParams`.

## Change

- Extract `toActionParameterValue` / production `parseActionParams` to `action-parameter-value.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`ACTION_PARAMETER_UNBOUNDED`).
- Descriptor-only reads on the whole `{ params }` graph (action slots and parameter slots); enumerable accessors fail closed without invocation. Sparse holes consume the node budget and keep their positions on accepted inputs.
- One shared walk budget across the parsed params graph.
- Array length/indexes and record keys from own data descriptors; every reflective op fail-closes to the typed error (revoked Proxy included).
- Hostile primitive conversion is budgeted and translated with its original cause. Own `__proto__` keys are inert enumerable data rather than prototype mutation.
- JSON-array string coercion parses inside the J3 boundary, then normalizes the full array once outside it so aggregate-budget failures cannot be swallowed.
- Honest scalars, lists, nested records, within-budget sparse arrays, and explicit-`undefined` slots still parse with develop's positional meaning.

## Exact-head evidence

Evidence revision: `802188ad0763f5df5be68788e8ca64f11751ff80`, based on `develop` `6c1d0a12c910721a7bd492ae47af26a3f90431f5`. Owning issue: #22796.

- Pinned Bun 1.3.14 focused `action-parameter-value` suite: **24/24 passed**.
- Covers honest scalar/list/record parse, depth 32 accept, depth 33 throw, over-budget sparse throw, **within-budget sparse hole/length compatibility**, **explicit-`undefined` → null without collapsing length**, cyclic throw, accessor zero-call, Proxy get/has zero-call, revoked Proxy typed, GOPD trap, shared-child rescan, production `parseActionParams` action-slot and parameter-slot accessor zero-call, production Proxy/revoked Proxy, 8k nest through `parseActionParams`, production sparse holes, and a shared node budget across action slots.
- Focused parser plus existing production message-routing compatibility: **96/96 passed**.
- Core package typecheck: clean.
- Node/browser/edge/testing builds and declarations: clean.
- Biome on the three changed files: clean.
- `git diff --check`: clean.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - planner action-parameter walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - planner action-parameter walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic scan-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - action-parameter parse has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 802188ad0763</summary>

```
# domain artifact — planner parseActionParams production boundary
exact-head: 802188ad0763f5df5be68788e8ca64f11751ff80
based-on: origin/develop 6c1d0a12c910721a7bd492ae47af26a3f90431f5
owning-issue: https://github.com/elizaOS/eliza/issues/22796

Pinned Bun 1.3.14 focused action-parameter-value suite at this head:
  24/24 passed in 6 ms
  covers: helper honest/depth/sparse-over-budget/sparse-holes/explicit-undefined/cycle/accessor/Proxy/revoked/shared/8k,
  GOPD trap, parseActionParams wrapped/unwrapped honest,
  action-slot accessor zero-call, parameter-slot accessor zero-call,
  production Proxy get/has zero-call, revoked Proxy typed,
  8k nest through parseActionParams, production sparse holes,
  shared node budget across action slots.

Origin red (Node 24.15.0, pre-fix walk):
  toActionParameterValue 8k array nest: RangeError 1.72 ms
  cyclic { self: self }: RangeError 1.42 ms
  value[2]="x" via value.map: length 3, holes at 0 and 1

This head (Bun 1.3.14):
  8k nest: ElizaError ACTION_PARAMETER_UNBOUNDED 0.91 ms (not RangeError)
  cyclic { self: self }: ElizaError ACTION_PARAMETER_UNBOUNDED 0.13 ms
  value[2]="x": length 3, holes at 0 and 1, "x" at 2
  [undefined, undefined, "x"]: length 3, null, null, "x"
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:802188ad0763f5df5be68788e8ca64f11751ff80 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->