### PR TITLE
test(ui): complete core cloud fixture stubs

### DIFF
--- a/packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs
+++ b/packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs
@@ -217,7 +217,19 @@ export const Buffer = {
   alloc: () => ({}),
   byteLength: () => 0,
 };
-export const promises = {};
+export const promises = {
+  access: anyfn,
+  readFile: anyfn,
+  writeFile: anyfn,
+  mkdir: anyfn,
+  rm: anyfn,
+  cp: anyfn,
+  symlink: anyfn,
+  readdir: anyfn,
+  stat: anyfn,
+  unlink: anyfn,
+  rmdir: anyfn,
+};
 export const existsSync = () => false;
 export const readFileSync = anyfn;
 export const writeFileSync = anyfn;
@@ -243,6 +255,12 @@ export const mkdir = anyfn;
 export const stat = anyfn;
 export const readdir = () => [];
 export const isIP = () => 0;
+export class BlockList {
+  addSubnet() {}
+  check() {
+    return false;
+  }
+}
 export const statfsSync = anyfn;
 export const cp = anyfn;
 export const unlinkSync = anyfn;
@@ -370,7 +388,7 @@ const context = await browser.newContext({
 });
 const page = await context.newPage();
 page.on("pageerror", (err) => {
-  console.log("  [pageerror]", err.message?.slice(0, 500));
+  console.log("  [pageerror]", err.stack?.slice(0, 2_000));
 });
 
 let shot = 0;

--- a/packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs
+++ b/packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs
@@ -264,7 +264,19 @@ export const Buffer = {
   alloc: () => ({}),
   byteLength: () => 0,
 };
-export const promises = {};
+export const promises = {
+  access: anyfn,
+  readFile: anyfn,
+  writeFile: anyfn,
+  mkdir: anyfn,
+  rm: anyfn,
+  cp: anyfn,
+  symlink: anyfn,
+  readdir: anyfn,
+  stat: anyfn,
+  unlink: anyfn,
+  rmdir: anyfn,
+};
 export const existsSync = () => false;
 export const readFileSync = anyfn;
 export const writeFileSync = anyfn;
@@ -299,6 +311,12 @@ export const mkdir = anyfn;
 export const stat = anyfn;
 export const readdir = () => [];
 export const isIP = () => 0;
+export class BlockList {
+  addSubnet() {}
+  check() {
+    return false;
+  }
+}
 export const statfsSync = anyfn;
 export const cp = anyfn;
 export class AsyncLocalStorage {


### PR DESCRIPTION
## Summary

- expose the current `node:net` `BlockList` contract in the credentials and cloud-settings browser fixtures
- expose the `node:fs.promises` method shape that core binds during module initialization
- retain fail-closed browser behavior and print full page-error stacks for actionable fixture failures

Refs #22733

## Validation

- `bun run --cwd packages/ui test:credentials-e2e` — ALL GREEN, 14 captures
- `bun run --cwd packages/ui test:slop-removal-e2e` — ALL CHECKS PASSED, 29 captures
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui lint` — pass with 5 pre-existing `noDocumentCookie` warnings

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was used for this regression repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
