### PR TITLE
fix(cloud): refresh current core mock contracts

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
@@ -1,0 +1,62 @@
+/**
+ * Fail-loud stand-ins for core exports that DB-free cloud tests bind only
+ * through unreachable transitive module paths.
+ */
+
+function unavailable(name: string): never {
+  throw new Error(`@elizaos/core ${name} is outside this test path`);
+}
+
+function unavailableFunction(name: string): (...args: unknown[]) => never {
+  return () => unavailable(name);
+}
+
+function unavailableConstructor(name: string) {
+  return class {
+    constructor() {
+      unavailable(name);
+    }
+  };
+}
+
+function unavailableObject(name: string): object {
+  return new Proxy(Object.create(null), {
+    get: () => unavailable(name),
+    set: () => unavailable(name),
+  });
+}
+
+export const canRequesterMutateDocument = unavailableFunction(
+  "canRequesterMutateDocument",
+);
+export const ChannelType = unavailableObject("ChannelType");
+export const DatabaseAdapter = unavailableConstructor("DatabaseAdapter");
+export const decryptedCharacter = unavailableFunction("decryptedCharacter");
+export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = Symbol(
+  "DOCUMENT_LIST_QUERY_CAPABILITY_VERSION outside this test path",
+);
+export const documentMutationSnapshotMatches = unavailableFunction(
+  "documentMutationSnapshotMatches",
+);
+export const documentRoleHasGlobalVisibility = unavailableFunction(
+  "documentRoleHasGlobalVisibility",
+);
+export const encryptedCharacter = unavailableFunction("encryptedCharacter");
+export const logger = unavailableObject("logger");
+export const normalizePairingPageOptions = unavailableFunction(
+  "normalizePairingPageOptions",
+);
+export const Service = unavailableConstructor("Service");
+export const validateDocumentFragmentQueryParams = unavailableFunction(
+  "validateDocumentFragmentQueryParams",
+);
+export const validateDocumentListQueryParams = unavailableFunction(
+  "validateDocumentListQueryParams",
+);
+export const validateDocumentRequesterContext = unavailableFunction(
+  "validateDocumentRequesterContext",
+);
+export const validateQueryEntitiesPagination = unavailableFunction(
+  "validateQueryEntitiesPagination",
+);
+export const validateUuid = unavailableFunction("validateUuid");

--- a/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import * as coreTestContract from "../../../../src/stubs/elizaos-core-test-contract";
 
 const fakeLogger = {
   logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
@@ -11,11 +12,34 @@ const fakeLogger = {
 class MockElizaError extends Error {}
 mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
+  canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
+  ChannelType: coreTestContract.ChannelType,
+  DatabaseAdapter: coreTestContract.DatabaseAdapter,
+  decryptedCharacter: coreTestContract.decryptedCharacter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
+    coreTestContract.DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  documentMutationSnapshotMatches:
+    coreTestContract.documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility:
+    coreTestContract.documentRoleHasGlobalVisibility,
+  encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
+  logger: coreTestContract.logger,
+  normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
   redactSensitiveText: (text: string) => text,
+  Service: coreTestContract.Service,
+  validateDocumentFragmentQueryParams:
+    coreTestContract.validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams:
+    coreTestContract.validateDocumentListQueryParams,
+  validateDocumentRequesterContext:
+    coreTestContract.validateDocumentRequesterContext,
+  validateQueryEntitiesPagination:
+    coreTestContract.validateQueryEntitiesPagination,
+  validateUuid: coreTestContract.validateUuid,
 }));
 
 import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { decode, encode } from "@msgpack/msgpack";
+import * as coreTestContract from "../../../../src/stubs/elizaos-core-test-contract";
 
 // Break the logger -> @elizaos/core transitive import chain (repo-standard
 // test isolation for cloud-api unit tests). Logic under test is untouched.
@@ -21,11 +22,34 @@ class MockElizaError extends Error {}
 mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/cloud-shared/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
+  canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
+  ChannelType: coreTestContract.ChannelType,
+  DatabaseAdapter: coreTestContract.DatabaseAdapter,
+  decryptedCharacter: coreTestContract.decryptedCharacter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
+    coreTestContract.DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  documentMutationSnapshotMatches:
+    coreTestContract.documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility:
+    coreTestContract.documentRoleHasGlobalVisibility,
+  encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
+  logger: coreTestContract.logger,
+  normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (args: unknown) => args,
   redactSensitiveText: (text: string) => text,
+  Service: coreTestContract.Service,
+  validateDocumentFragmentQueryParams:
+    coreTestContract.validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams:
+    coreTestContract.validateDocumentListQueryParams,
+  validateDocumentRequesterContext:
+    coreTestContract.validateDocumentRequesterContext,
+  validateQueryEntitiesPagination:
+    coreTestContract.validateQueryEntitiesPagination,
+  validateUuid: coreTestContract.validateUuid,
 }));
 
 import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";

--- a/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
+++ b/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
@@ -20,6 +20,7 @@ import * as realJwt from "@/lib/voice-session/jwt";
 import * as realSessionRegistry from "@/lib/voice-session/session-registry";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import * as workerCoreStub from "../../../src/stubs/elizaos-core";
+import * as coreTestContract from "../../../src/stubs/elizaos-core-test-contract";
 
 const realCloudWorkerErrorsExports = { ...realCloudWorkerErrors };
 const realJwtExports = { ...realJwt };
@@ -55,11 +56,34 @@ const apiRoot = new URL("../../../src", import.meta.url).href;
 // the DB-free unit lane (matches the sibling mint-consent route test).
 mock.module("@elizaos/core", () => ({
   ...workerCoreStub,
+  canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
+  ChannelType: coreTestContract.ChannelType,
+  DatabaseAdapter: coreTestContract.DatabaseAdapter,
+  decryptedCharacter: coreTestContract.decryptedCharacter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
+    coreTestContract.DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  documentMutationSnapshotMatches:
+    coreTestContract.documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility:
+    coreTestContract.documentRoleHasGlobalVisibility,
+  encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: workerCoreStub.ElizaError,
   isElizaError: workerCoreStub.isElizaError,
   isSensitiveKeyName: () => false,
+  logger: coreTestContract.logger,
+  normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
   redactSensitiveText: workerCoreStub.redactSensitiveText,
+  Service: coreTestContract.Service,
+  validateDocumentFragmentQueryParams:
+    coreTestContract.validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams:
+    coreTestContract.validateDocumentListQueryParams,
+  validateDocumentRequesterContext:
+    coreTestContract.validateDocumentRequesterContext,
+  validateQueryEntitiesPagination:
+    coreTestContract.validateQueryEntitiesPagination,
+  validateUuid: coreTestContract.validateUuid,
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -14,6 +14,7 @@ import {
   mock,
   test,
 } from "bun:test";
+import * as coreTestContract from "../../../../src/stubs/elizaos-core-test-contract";
 
 const requireAuthOrApiKeyWithOrg = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
@@ -133,9 +134,32 @@ mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
 }));
 
 mock.module("@elizaos/core", () => ({
+  canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
+  ChannelType: coreTestContract.ChannelType,
+  DatabaseAdapter: coreTestContract.DatabaseAdapter,
+  decryptedCharacter: coreTestContract.decryptedCharacter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
+    coreTestContract.DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  documentMutationSnapshotMatches:
+    coreTestContract.documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility:
+    coreTestContract.documentRoleHasGlobalVisibility,
+  encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
+  logger: coreTestContract.logger,
+  normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactSensitiveText: (text: string) => text,
+  Service: coreTestContract.Service,
+  validateDocumentFragmentQueryParams:
+    coreTestContract.validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams:
+    coreTestContract.validateDocumentListQueryParams,
+  validateDocumentRequesterContext:
+    coreTestContract.validateDocumentRequesterContext,
+  validateQueryEntitiesPagination:
+    coreTestContract.validateQueryEntitiesPagination,
+  validateUuid: coreTestContract.validateUuid,
 }));
 
 mock.module("@/lib/auth", () => ({


### PR DESCRIPTION
Closes #22720.
Closes #22758.

## What changed

PR #22773 repaired the credits mocks, but its exact final integration still failed `audit:mock-module-exports` with four newly reachable `@elizaos/core` export gaps. This corrective adds a test-only fail-loud core contract helper and explicitly supplies all sixteen bound exports in the four affected whole-module mocks. It does not widen or rewrite the 102-instance baseline.

The stand-ins throw if an unreachable function, constructor, or object property is used, so the repair cannot silently mask a production path. The ordinary voice tests continue to exercise their real route/session behavior.

## Review focus

- `packages/cloud/api/src/stubs/elizaos-core-test-contract.ts`
- the `@elizaos/core` mock factories in the four changed voice tests
- no production module, package export, dependency, or baseline file changes

## Validation

Final head `edce2122c4945003b22a516f7dece2b2334b4787` is rebased on `develop` `20ee04d10bf63177a06592356f3897c4a10bd4f4`.

- affected tests in separate Bun processes: 91 pass, 0 fail
- mock-export audit self-tests: 18 pass, 0 fail
- full mock-export audit: 3,280 mocks / 652 test files / exactly 102 ratcheted findings / 0 violations
- Biome: 5 files clean
- cloud API TypeScript `--noEmit`: pass
- Worker dry-run: pass at the exact final head

# Evidence Gate

<!-- evidence-head:edce2122c4945003b22a516f7dece2b2334b4787 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only contract repair; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only contract repair; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] [Cloud typecheck and Worker dry-run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22803-edce-typecheck.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic test contract; no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head affected suites, 91/91](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22803-edce-affected.log); full mock-export audit PASS: 3,280 mocks / 652 files / 102 ratcheted findings / 0 violations (command result recorded inline above)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Risk and rollback

Risk is limited to test module replacement semantics. The helper is imported only by tests and fails loudly on unexpected use. Rollback is the single commit, but doing so restores a repository verification failure and allows whole-module mocks to drift from their bound export contract.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->




