### PR TITLE
fix(agent-skills): preserve cancellation during catalog teardown

### DIFF
--- a/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-package-bytes.test.ts
@@ -504,6 +504,37 @@ describe("readCappedSkillPackage", () => {
 		expect(storage.getPackage("catalog-cancelled")).toBeUndefined();
 	});
 
+	it("preserves catalog cancellation when 404 body teardown aborts the caller", async () => {
+		const caller = new AbortController();
+		const cancel = vi.fn(() => {
+			caller.abort(new Error("owner stopped during 404 teardown"));
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => unusedErrorResponse(404, cancel)),
+		);
+		const storage = new MemorySkillStore();
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage,
+		});
+
+		await expect(
+			service.install("catalog-404-cancelled", {
+				signal: caller.signal,
+				downloadTimeoutMs: null,
+				throwOnDownloadError: true,
+			}),
+		).rejects.toMatchObject({
+			code: "SKILL_DOWNLOAD_ABORTED",
+			cause: expect.objectContaining({
+				message: "owner stopped during 404 teardown",
+			}),
+		});
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(storage.getPackage("catalog-404-cancelled")).toBeUndefined();
+	});
+
 	it("does not cache catalog details that complete with caller cancellation", async () => {
 		const caller = new AbortController();
 		let requestCount = 0;

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -2084,6 +2084,9 @@ export class AgentSkillsService extends Service {
 
 			if (!response.ok) {
 				cancelUnusedSkillDownloadBody(response);
+				if (options.signal?.aborted) {
+					throw skillDownloadAbortError(options.signal);
+				}
 				if (response.status === 404) return null;
 				throw new Error(`Details fetch failed: ${response.status}`);
 			}


### PR DESCRIPTION
Closes #22805

Follow-up to #22738 and #22300.

## What changed

- Re-check caller cancellation immediately after tearing down an unused catalog-details error body.
- Preserve typed SKILL_DOWNLOAD_ABORTED ownership before the 404 not-found return or generic status failure.
- Cover the public install() boundary with a streaming 404 whose synchronous cancel hook aborts the caller; assert one cancellation and no persistence.

## Validation

Validated exact head 590fec400e12e2a7ef3ce026647ee32b2dc93b2d:

- focused cancellation lifecycle: 32/32 passed
- complete serialized plugin suite: 27 files, 312/312 passed
- package typecheck: passed
- package bundle and declaration emit: passed
- Biome on both changed files: passed
- git diff --check: passed

UI, model, device, and external-integration evidence are N/A: this is a deterministic backend cancellation/persistence boundary exercised through the public installer.

<!-- evidence-head:590fec400e12e2a7ef3ce026647ee32b2dc93b2d -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@1fc59e00927df83e24fb73c5bb9780683da7ea30:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cancellation boundary with no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cancellation boundary with no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic public-installer regression has no interactive UI flow

<!-- evidence-row:backend-logs -->
- [x] [22806-pr22806-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22806-pr22806-focused.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, action, provider, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no durable database, memory, scheduler, wallet, generated-file, or device artifact is produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual or text surface changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1fc59e00927df83e24fb73c5bb9780683da7ea30:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1fc59e00927df83e24fb73c5bb9780683da7ea30:packages/skills/skills/contribute-to-eliza"} -->

