### PR TITLE
fix(discord): reject own array accessors

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-structured-text.test.ts
@@ -110,7 +110,7 @@ describe("normalizeDiscordMessageText", () => {
 		expect(invoked).toBe(0);
 	});
 
-	it("reads array entries by descriptor without invoking own or inherited accessors", () => {
+	it("fails typed on own array accessors without invoking them", () => {
 		let invoked = 0;
 		const ownAccessor = ["safe"];
 		Object.defineProperty(ownAccessor, "0", {
@@ -120,6 +120,14 @@ describe("normalizeDiscordMessageText", () => {
 			},
 		});
 
+		expect(() => normalizeDiscordMessageText(ownAccessor)).toThrowError(
+			expect.objectContaining({ code: DISCORD_STRUCTURED_TEXT_UNBOUNDED }),
+		);
+		expect(invoked).toBe(0);
+	});
+
+	it("skips inherited array accessors without invoking them", () => {
+		let invoked = 0;
 		const inheritedAccessor = new Array<unknown>(1);
 		Object.setPrototypeOf(inheritedAccessor, {
 			get 0() {
@@ -128,7 +136,6 @@ describe("normalizeDiscordMessageText", () => {
 			},
 		});
 
-		expect(normalizeDiscordMessageText(ownAccessor)).toBe("");
 		expect(normalizeDiscordMessageText(inheritedAccessor)).toBe("");
 		expect(invoked).toBe(0);
 	});

--- a/plugins/plugin-discord/discord-structured-text.ts
+++ b/plugins/plugin-discord/discord-structured-text.ts
@@ -48,7 +48,11 @@ function reserve(ctx: WalkContext, count: number): void {
 	ctx.visits += count;
 }
 
-function dataValue(value: object, key: string): unknown {
+function dataValue(
+	value: object,
+	key: string,
+	rejectAccessor = false,
+): unknown {
 	let descriptor: PropertyDescriptor | undefined;
 	try {
 		descriptor = Object.getOwnPropertyDescriptor(value, key);
@@ -63,7 +67,13 @@ function dataValue(value: object, key: string): unknown {
 			},
 		);
 	}
-	if (!descriptor || !("value" in descriptor)) return undefined;
+	if (!descriptor) return undefined;
+	if (!("value" in descriptor)) {
+		if (rejectAccessor) {
+			failUnbounded({ operation: "arrayAccessor", key });
+		}
+		return undefined;
+	}
 	return descriptor.value;
 }
 
@@ -113,14 +123,14 @@ function collectStructuredText(
 	}
 	ctx.seen.add(value);
 	if (isArray(value)) {
-		const length = dataValue(value, "length");
+		const length = dataValue(value, "length", true);
 		if (!Number.isSafeInteger(length) || (length as number) < 0) {
 			failUnbounded({ operation: "arrayLength", length });
 		}
 		reserve(ctx, length as number);
 		const fragments: string[] = [];
 		for (let index = 0; index < (length as number); index += 1) {
-			const child = dataValue(value, String(index));
+			const child = dataValue(value, String(index), true);
 			if (child === undefined) continue;
 			fragments.push(...collectStructuredText(child, depth + 1, ctx, true));
 		}


### PR DESCRIPTION
Closes #22802.

Corrective follow-up to merged #22794 / #22798. The prior patch prevented array getters from executing, but silently treated an own accessor slot as a sparse hole despite #22798's explicit typed-rejection requirement.

## Change

- Reject own array length/slot accessor descriptors with `DISCORD_STRUCTURED_TEXT_UNBOUNDED` without invoking them.
- Preserve inherited accessor and ordinary object-accessor zero-call skip behavior.
- Preserve sparse/node/depth bounds, duplicate/cycle suppression, and honest output bytes.
- Exercise the production `utils` export used by Discord outbound callers.

## Exact-head validation

Final landed head `e4380cc26356f24568c6a8f1904c723051e887ce`, based on `develop` `450f2310849ae33727884c3a23ce3bcd98a4bc03`. Both scoped blobs are byte-identical to the independently executed pre-rebase head `ec99a58c36ec853ec8f07a626fc9d2e497b10867`, so its immutable execution receipts apply to the final bytes.

- Dedicated no-secret Lima VM, `unshare` network namespace, outbound denied.
- Rebased-head focused production-export suite: 13/13 PASS. The Discord source/test blobs are byte-identical to the reviewed pre-rebase blobs; the intervening base delta changes only four `plugin-agent-skills` files.
- Rebased-head plugin build: PASS.\n- Biome on both changed files: PASS.
- `git diff --check`: PASS.
- Plugin typecheck reports three missing optional-workspace errors, byte-for-byte identical to the `develop` control (SHA-256 `7edbb1e706278fbaa879a76e61506bc6970652e31e12d07cdd9a1448fdb3a4be`).
- Negative control on landed #22794: own index accessor returns `{threw:false,result:"",invoked:0}` instead of the required typed error.

## Evidence Gate

<!-- evidence-head:e4380cc26356f24568c6a8f1904c723051e887ce -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only formatter behavior; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only formatter behavior; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] [Rebased-head build and Biome log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22802-e438-build-biome.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Rebased-head focused production-export log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22802-e438-focused.log); [typecheck/control-identical receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/22802-ec99-typecheck.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - review corrective
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - review corrective
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - review corrective"} -->
