### PR TITLE
fix(agent-skills): preserve punctuated safe URLs

### DIFF
--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
@@ -77,6 +77,21 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 		);
 	});
 
+	it("keeps safe bare URLs clean before terminal prose punctuation", () => {
+		expect(flagsExternalUrl("See https://github.com, then continue")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com; then continue")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com!")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com...")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com…")).toBe(false);
+		expect(flagsExternalUrl("See {https://github.com}")).toBe(false);
+	});
+
+	it("does not let terminal punctuation hide external or userinfo hosts", () => {
+		expect(flagsExternalUrl("See https://github.com.evil.com,")).toBe(true);
+		expect(flagsExternalUrl("See https://github.com@evil.com!")).toBe(true);
+		expect(flagsExternalUrl("See https://evil.com/path;query,")).toBe(true);
+	});
+
 	it("honors additional safe domains and their subdomains", () => {
 		expect(
 			flagsExternalUrl("Fetch https://cdn.example.org/a", ["example.org"]),
@@ -156,6 +171,43 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 			).resolves.toBe(true);
 			expect(service.getSkillScanStatus("untrusted")).toBe("warning");
 			expect(service.setSkillEnabled("untrusted", true)).toBe(false);
+		} finally {
+			await service.stop();
+		}
+	});
+
+	it("keeps a direct-URL install enabled when a safe bare URL ends a clause", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(
+					"---\nname: trusted\ndescription: install boundary\n---\nVisit https://github.com, then return.",
+					{ headers: { "content-type": "text/markdown" } },
+				),
+		),
+	);
+		const runtime = {
+			getSetting: vi.fn(() => undefined),
+			logger: {
+				debug: vi.fn(),
+				error: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+		const service = await AgentSkillsService.start(runtime, {
+			autoLoad: false,
+			storage: new MemorySkillStore(),
+		});
+
+		try {
+			await expect(
+				service.installFromUrl("https://skills.example/trusted.md", {
+					slug: "trusted",
+				}),
+			).resolves.toBe(true);
+			expect(service.getSkillScanStatus("trusted")).toBeNull();
+			expect(service.setSkillEnabled("trusted", true)).toBe(true);
 		} finally {
 			await service.stop();
 		}

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.test.ts
@@ -78,17 +78,24 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 	});
 
 	it("keeps safe bare URLs clean before terminal prose punctuation", () => {
+		expect(flagsExternalUrl("See https://github.com.")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com., then continue")).toBe(
+			false,
+		);
 		expect(flagsExternalUrl("See https://github.com, then continue")).toBe(false);
 		expect(flagsExternalUrl("See https://github.com; then continue")).toBe(false);
 		expect(flagsExternalUrl("See https://github.com!")).toBe(false);
+		expect(flagsExternalUrl("See https://github.com:")).toBe(false);
 		expect(flagsExternalUrl("See https://github.com...")).toBe(false);
 		expect(flagsExternalUrl("See https://github.com…")).toBe(false);
 		expect(flagsExternalUrl("See {https://github.com}")).toBe(false);
 	});
 
 	it("does not let terminal punctuation hide external or userinfo hosts", () => {
+		expect(flagsExternalUrl("See https://github.com.evil.com.")).toBe(true);
 		expect(flagsExternalUrl("See https://github.com.evil.com,")).toBe(true);
 		expect(flagsExternalUrl("See https://github.com@evil.com!")).toBe(true);
+		expect(flagsExternalUrl("See https://github.com@evil.com:")).toBe(true);
 		expect(flagsExternalUrl("See https://evil.com/path;query,")).toBe(true);
 	});
 
@@ -181,7 +188,7 @@ describe("markdown scanner md-external-url safe-domain allowlist", () => {
 			"fetch",
 			vi.fn(async () =>
 				new Response(
-					"---\nname: trusted\ndescription: install boundary\n---\nVisit https://github.com, then return.",
+					"---\nname: trusted\ndescription: install boundary\n---\nVisit https://github.com. Then https://github.com., and finally https://github.com:",
 					{ headers: { "content-type": "text/markdown" } },
 				),
 		),

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
@@ -41,6 +41,9 @@ const DEFAULT_SAFE_DOMAINS: ReadonlyArray<string> = [
 /** URL tokens in prose: scheme through the first stopping delimiter. */
 const URL_TOKEN_PATTERN = /https?:\/\/[^\s)\]"'<>]+/gi;
 
+/** Terminal punctuation that commonly follows a bare URL in prose. */
+const TRAILING_PROSE_PUNCTUATION = /(?:[,;!}]|\.{2,}|…)+$/u;
+
 /**
  * A host is safe iff it equals a listed domain or is a subdomain of one
  * (`host === safe` or `host.endsWith("." + safe)`). This deliberately rejects
@@ -65,10 +68,13 @@ function isSafeHost(host: string, safeDomains: ReadonlyArray<string>): boolean {
 function parseUrlToken(
 	token: string,
 ): { host: string; hasUserinfo: boolean } {
-	const authority = token.replace(/^https?:\/\//i, "").split(/[/?#]/, 1)[0];
+	const normalizedToken = token.replace(TRAILING_PROSE_PUNCTUATION, "");
+	const authority = normalizedToken
+		.replace(/^https?:\/\//i, "")
+		.split(/[/?#]/, 1)[0];
 	const hasUserinfoDelimiter = authority.lastIndexOf("@") >= 0;
 	try {
-		const url = new URL(token);
+		const url = new URL(normalizedToken);
 		return {
 			host: url.hostname,
 			hasUserinfo:

--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.ts
@@ -42,7 +42,7 @@ const DEFAULT_SAFE_DOMAINS: ReadonlyArray<string> = [
 const URL_TOKEN_PATTERN = /https?:\/\/[^\s)\]"'<>]+/gi;
 
 /** Terminal punctuation that commonly follows a bare URL in prose. */
-const TRAILING_PROSE_PUNCTUATION = /(?:[,;!}]|\.{2,}|…)+$/u;
+const TRAILING_PROSE_PUNCTUATION = /[.,;!:}…]+$/u;
 
 /**
  * A host is safe iff it equals a listed domain or is a subdomain of one


### PR DESCRIPTION
Closes #22807.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## What changed

The structured URL scanner from #22770 correctly rejects suffix and userinfo spoofs, but it treated terminal prose punctuation as part of a bare hostname. Common clauses such as `See https://github.com, then continue` became warnings, and warning status prevented enabling an otherwise safe installed skill.

This corrective removes only terminal period, comma, semicolon, colon, exclamation, closing-brace, and ellipsis forms before WHATWG parsing. Tokenization still retains those characters until the end, so punctuation inside userinfo or before an attacker host cannot hide the effective host.

## Validation

- focused scanner/install boundary: 16 pass, 0 fail
- full plugin package: 304 pass, 0 fail across 27 files
- typecheck: pass
- build and declaration emit: pass
- Biome: 2 changed files clean
- adversarial controls cover suffix/userinfo/ports/IPv6/punycode/percent encoding/scheme case plus punctuated external hosts

# Evidence Gate

<!-- evidence-head:6f5d71b25753b40585115ae3d6a32b3b9474f068 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend scanner contract; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend scanner contract; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual workflow.
<!-- evidence-row:backend-logs -->
- [x] [22811-22807-backend-6f5d71b2-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22811-22807-backend-6f5d71b2-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic scanner behavior; no model path.
<!-- evidence-row:domain-artifacts -->
- [x] [22811-22807-domain-6f5d71b2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22811-22807-domain-6f5d71b2.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Risk and rollback

The normalization is limited to terminal prose punctuation. External-host and userinfo counter-controls prove the scanner remains fail-closed. Rollback is the single commit, but doing so restores false-positive warnings that disable legitimate skills.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bad793372ea9a08fd91c97c8cd9dfc34fc84a24c:packages/skills/skills/contribute-to-eliza"} -->



