### PR TITLE
fix(plugin-computeruse): fail closed on unbounded snapshot pretty-prints

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/computer-use-plain-data.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-plain-data.test.ts
@@ -7,6 +7,7 @@ import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+  MAX_COMPUTER_USE_PLAIN_DATA_CHARS,
   MAX_COMPUTER_USE_PLAIN_DATA_DEPTH,
   MAX_COMPUTER_USE_PLAIN_DATA_NODES,
   renderPlainData,
@@ -115,6 +116,55 @@ describe("stringifyData / renderPlainData", () => {
     expect(renderPlainData(proxy)).toContain("x");
     expect(gets).toBe(0);
     expect(hasCalls).toBe(0);
+  });
+
+  it("preserves sparse list positions while distinguishing explicit undefined", () => {
+    const sparse = new Array(3) as unknown[];
+    sparse[2] = "x";
+
+    expect(renderPlainData(sparse)).toBe("items[3]:\n\n\n- x");
+    expect(renderPlainData([undefined, undefined, "x"])).toBe(
+      "items[3]:\n- none\n- none\n- x",
+    );
+  });
+
+  it("rejects callable proxies without invoking conversion traps", () => {
+    let invoked = 0;
+    const hostile = new Proxy(() => undefined, {
+      get(_target, key) {
+        if (key === Symbol.toPrimitive) invoked += 1;
+        return undefined;
+      },
+    });
+
+    try {
+      renderPlainData(hostile);
+      expect.unreachable("print should fail closed on hostile conversion");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+      expect(invoked).toBe(0);
+    }
+  });
+
+  it("accepts the exact output boundary and rejects larger content", () => {
+    expect(
+      stringifyData("x".repeat(MAX_COMPUTER_USE_PLAIN_DATA_CHARS)),
+    ).toHaveLength(MAX_COMPUTER_USE_PLAIN_DATA_CHARS);
+    expect(() =>
+      stringifyData("x".repeat(MAX_COMPUTER_USE_PLAIN_DATA_CHARS + 1)),
+    ).toThrowError(
+      expect.objectContaining({ code: COMPUTER_USE_PLAIN_DATA_UNBOUNDED }),
+    );
+    expect(() =>
+      renderPlainData({
+        snapshot: "x".repeat(MAX_COMPUTER_USE_PLAIN_DATA_CHARS),
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: COMPUTER_USE_PLAIN_DATA_UNBOUNDED }),
+    );
   });
 
   it(`throws ${COMPUTER_USE_PLAIN_DATA_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {

--- a/plugins/plugin-computeruse/src/__tests__/computer-use-plain-data.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-plain-data.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Deterministic tests for the computer-use snapshot pretty-print walk. No
+ * live browser: the walker is the production stringifyData used on action
+ * `content`.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+  MAX_COMPUTER_USE_PLAIN_DATA_DEPTH,
+  MAX_COMPUTER_USE_PLAIN_DATA_NODES,
+  renderPlainData,
+  stringifyData,
+} from "../services/computer-use-plain-data";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("stringifyData / renderPlainData", () => {
+  it("pretty-prints honest scalars, lists, and records", () => {
+    expect(stringifyData("plain")).toBe("plain");
+    expect(renderPlainData(null)).toBe("none");
+    expect(renderPlainData({ a: ["b", { c: 1 }] })).toContain("items[2]:");
+    expect(renderPlainData({ a: ["b", { c: 1 }] })).toContain("c: 1");
+  });
+
+  it(`accepts a ${MAX_COMPUTER_USE_PLAIN_DATA_DEPTH}-deep array nest`, () => {
+    expect(
+      renderPlainData(nestArray(MAX_COMPUTER_USE_PLAIN_DATA_DEPTH)),
+    ).toContain("x");
+  });
+
+  it(`throws ${COMPUTER_USE_PLAIN_DATA_UNBOUNDED} one past depth ${MAX_COMPUTER_USE_PLAIN_DATA_DEPTH}`, () => {
+    try {
+      renderPlainData(nestArray(MAX_COMPUTER_USE_PLAIN_DATA_DEPTH + 1));
+      expect.unreachable("print should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+    }
+  });
+
+  it(`throws ${COMPUTER_USE_PLAIN_DATA_UNBOUNDED} past ${MAX_COMPUTER_USE_PLAIN_DATA_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_COMPUTER_USE_PLAIN_DATA_NODES] = "x";
+    try {
+      renderPlainData(sparse);
+      expect.unreachable(
+        "print should fail closed on over-budget sparse length",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+    }
+  });
+
+  it("throws on a cyclic snapshot without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    const started = performance.now();
+    try {
+      renderPlainData(cyclic);
+      expect.unreachable("print should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while printing", () => {
+    let invoked = 0;
+    const hostile = {
+      get trap() {
+        invoked += 1;
+        return "x";
+      },
+    };
+    try {
+      renderPlainData(hostile);
+      expect.unreachable("print should fail closed on enumerable accessors");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("does not invoke array Proxy get/has traps", () => {
+    let gets = 0;
+    let hasCalls = 0;
+    const proxy = new Proxy(["x"], {
+      get() {
+        gets += 1;
+        throw new Error("get trap escaped");
+      },
+      has() {
+        hasCalls += 1;
+        throw new Error("has trap escaped");
+      },
+    });
+    expect(renderPlainData(proxy)).toContain("x");
+    expect(gets).toBe(0);
+    expect(hasCalls).toBe(0);
+  });
+
+  it(`throws ${COMPUTER_USE_PLAIN_DATA_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+    const { proxy, revoke } = Proxy.revocable(["x"], {});
+    revoke();
+    try {
+      renderPlainData(proxy);
+      expect.unreachable("print should fail closed on a revoked Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+      expect((error as Error).name).not.toBe("TypeError");
+    }
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      renderPlainData(nestArray(8_000));
+      expect.unreachable("print should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(
+        COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      );
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import * as browser from "../platform/browser.js";
+import { MAX_COMPUTER_USE_PLAIN_DATA_CHARS } from "../services/computer-use-plain-data.js";
 
 vi.mock("../platform/browser.js", () => {
   const state = (url = "about:blank") => ({
@@ -129,6 +130,23 @@ describe("ComputerUseService browser command dispatch", () => {
       InstanceType<typeof ComputerUseService>["executeBrowserAction"]
     >[0]);
     expect(result.success).toBe(false);
+  });
+
+  it("fails closed before publishing an over-budget browser state", async () => {
+    vi.mocked(browser.getBrowserState).mockResolvedValueOnce({
+      url: "about:blank",
+      title: "x".repeat(MAX_COMPUTER_USE_PLAIN_DATA_CHARS),
+      isOpen: true,
+      is_open: true,
+    });
+
+    const result = await service.executeBrowserAction({ action: "state" });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Computer-use snapshot exceeds the plain-data walk budget",
+    });
+    expect(result).not.toHaveProperty("content");
   });
 
   it.each(["file:///etc/passwd", "https://user:password@example.com/private"])(

--- a/plugins/plugin-computeruse/src/services/computer-use-plain-data.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-plain-data.ts
@@ -1,0 +1,164 @@
+/**
+ * Bounds the nested snapshot pretty-print used when ComputerUseService
+ * serializes browser/window state into action `content`. Hostile nests
+ * RangeError'd `renderPlainData` at 8k depth on Node 24.15.0. Depth, node,
+ * and cycle limits are all load-bearing. Descriptor-only reads so a getter
+ * cannot hang the computer-use action path.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_COMPUTER_USE_PLAIN_DATA_DEPTH = 32;
+export const MAX_COMPUTER_USE_PLAIN_DATA_NODES = 2_048;
+export const COMPUTER_USE_PLAIN_DATA_UNBOUNDED =
+  "COMPUTER_USE_PLAIN_DATA_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  throw new ElizaError(
+    "Computer-use snapshot exceeds the plain-data walk budget",
+    {
+      code: COMPUTER_USE_PLAIN_DATA_UNBOUNDED,
+      context,
+      cause,
+      severity: "fatal",
+    },
+  );
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_COMPUTER_USE_PLAIN_DATA_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_COMPUTER_USE_PLAIN_DATA_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J3 Proxy inspection failures make an untrusted snapshot invalid.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(
+  value: object,
+  key: PropertyKey,
+): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+export function stringifyData(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return renderPlainData(value);
+}
+
+export function renderPlainData(value: unknown): string {
+  return renderPlainDataInner(value, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+function renderPlainDataInner(
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false,
+): string {
+  if (depth > MAX_COMPUTER_USE_PLAIN_DATA_DEPTH) {
+    failUnbounded({ depth, max: MAX_COMPUTER_USE_PLAIN_DATA_DEPTH });
+  }
+  if (value === null || value === undefined) {
+    return "none";
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return String(value);
+  }
+  if (typeof value !== "object") {
+    return String(value);
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  const prefix = "  ".repeat(depth);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      if (length === 0) {
+        return "items[0]:";
+      }
+      const lines: string[] = [`items[${length}]:`];
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        lines.push(
+          `${prefix}- ${renderPlainDataInner(descriptor.value, depth + 1, ctx, true)}`,
+        );
+      }
+      return lines.join("\n");
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    const lines: string[] = [];
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      const nestedValue = descriptor.value;
+      if (nestedValue && typeof nestedValue === "object") {
+        lines.push(
+          `${key}:\n${renderPlainDataInner(nestedValue, depth + 1, ctx, true)}`,
+        );
+      } else {
+        lines.push(
+          `${key}: ${renderPlainDataInner(nestedValue, depth + 1, ctx, true)}`,
+        );
+      }
+    }
+    return lines.join("\n");
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}

--- a/plugins/plugin-computeruse/src/services/computer-use-plain-data.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-plain-data.ts
@@ -10,6 +10,7 @@ import { ElizaError } from "@elizaos/core";
 
 export const MAX_COMPUTER_USE_PLAIN_DATA_DEPTH = 32;
 export const MAX_COMPUTER_USE_PLAIN_DATA_NODES = 2_048;
+export const MAX_COMPUTER_USE_PLAIN_DATA_CHARS = 64 * 1_024;
 export const COMPUTER_USE_PLAIN_DATA_UNBOUNDED =
   "COMPUTER_USE_PLAIN_DATA_UNBOUNDED";
 
@@ -43,11 +44,20 @@ function reserve(ctx: WalkContext, count: number): void {
   ctx.visits += count;
 }
 
+function requireBoundedOutput(length: number): void {
+  if (length > MAX_COMPUTER_USE_PLAIN_DATA_CHARS) {
+    failUnbounded({
+      outputChars: length,
+      maxChars: MAX_COMPUTER_USE_PLAIN_DATA_CHARS,
+    });
+  }
+}
+
 function inspectRecord<T>(operation: string, inspect: () => T): T {
   try {
     return inspect();
   } catch (cause) {
-    // error-policy:J3 Proxy inspection failures make an untrusted snapshot invalid.
+    // error-policy:J2 Preserve the reflection/conversion cause in the typed boundary error.
     failUnbounded({ inspection: operation }, cause);
   }
 }
@@ -67,6 +77,7 @@ function isArrayRecord(value: unknown): value is unknown[] {
 
 export function stringifyData(value: unknown): string {
   if (typeof value === "string") {
+    requireBoundedOutput(value.length);
     return value;
   }
   return renderPlainData(value);
@@ -97,10 +108,12 @@ function renderPlainDataInner(
     typeof value === "boolean"
   ) {
     if (!visitAlreadyReserved) reserve(ctx, 1);
-    return String(value);
+    const rendered = String(value);
+    requireBoundedOutput(rendered.length);
+    return rendered;
   }
   if (typeof value !== "object") {
-    return String(value);
+    failUnbounded({ unsupportedType: typeof value });
   }
   if (!visitAlreadyReserved) reserve(ctx, 1);
   if (ctx.visiting.has(value)) {
@@ -123,15 +136,29 @@ function renderPlainDataInner(
         return "items[0]:";
       }
       const lines: string[] = [`items[${length}]:`];
+      let outputChars = lines[0].length;
       for (let index = 0; index < length; index += 1) {
         const descriptor = ownDescriptor(value, String(index));
-        if (!descriptor) continue;
+        if (!descriptor) {
+          // Preserve the prior Array#map rendering: a sparse slot contributes
+          // one blank line while still consuming the bounded traversal budget.
+          outputChars += 1;
+          requireBoundedOutput(outputChars);
+          lines.push("");
+          continue;
+        }
         if (!("value" in descriptor)) {
           failUnbounded({ accessor: true, side: "array", index });
         }
-        lines.push(
-          `${prefix}- ${renderPlainDataInner(descriptor.value, depth + 1, ctx, true)}`,
+        const nested = renderPlainDataInner(
+          descriptor.value,
+          depth + 1,
+          ctx,
+          true,
         );
+        outputChars += 1 + prefix.length + 2 + nested.length;
+        requireBoundedOutput(outputChars);
+        lines.push(`${prefix}- ${nested}`);
       }
       return lines.join("\n");
     }
@@ -139,6 +166,7 @@ function renderPlainDataInner(
     const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
     reserve(ctx, keys.length);
     const lines: string[] = [];
+    let outputChars = 0;
     for (const key of keys) {
       if (typeof key !== "string") continue;
       const descriptor = ownDescriptor(value, key);
@@ -147,14 +175,16 @@ function renderPlainDataInner(
         failUnbounded({ accessor: true, side: "object", key });
       }
       const nestedValue = descriptor.value;
+      const nested = renderPlainDataInner(nestedValue, depth + 1, ctx, true);
+      const separator =
+        nestedValue && typeof nestedValue === "object" ? ":\n" : ": ";
+      const lineLength = key.length + separator.length + nested.length;
+      outputChars += (lines.length === 0 ? 0 : 1) + lineLength;
+      requireBoundedOutput(outputChars);
       if (nestedValue && typeof nestedValue === "object") {
-        lines.push(
-          `${key}:\n${renderPlainDataInner(nestedValue, depth + 1, ctx, true)}`,
-        );
+        lines.push(`${key}:\n${nested}`);
       } else {
-        lines.push(
-          `${key}: ${renderPlainDataInner(nestedValue, depth + 1, ctx, true)}`,
-        );
+        lines.push(`${key}: ${nested}`);
       }
     }
     return lines.join("\n");

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -6,7 +6,8 @@
  *
  * This is the single seam between the agent-facing action surface and the platform
  * drivers: it resolves the active driver, enforces the approval gate before
- * executing input, and caches per-turn scene state.
+ * executing input, and caches per-turn scene state. Snapshot pretty-print for
+ * action `content` is bounded in `computer-use-plain-data.ts`.
  */
 import os from "node:os";
 import path from "node:path";
@@ -157,6 +158,7 @@ import type {
   WindowActionParams,
   WindowActionResult,
 } from "../types.js";
+import { stringifyData } from "./computer-use-plain-data.js";
 
 const MAX_RECENT_ACTIONS = 10;
 const BROWSER_NOT_OPEN_ERROR = "Browser not open";
@@ -283,40 +285,6 @@ function commandParameters<TParams extends object>(
   parameters: Record<string, unknown>,
 ): Omit<TParams, "action"> {
   return parameters as Omit<TParams, "action">;
-}
-
-function stringifyData(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  return renderPlainData(value);
-}
-
-function renderPlainData(value: unknown, indent = 0): string {
-  const prefix = "  ".repeat(indent);
-  if (value === null || value === undefined) {
-    return "none";
-  }
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return "items[0]:";
-    }
-    return [
-      `items[${value.length}]:`,
-      ...value.map((item) => `${prefix}- ${renderPlainData(item, indent + 1)}`),
-    ].join("\n");
-  }
-  if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([key, nestedValue]) => {
-        if (nestedValue && typeof nestedValue === "object") {
-          return `${key}:\n${renderPlainData(nestedValue, indent + 1)}`;
-        }
-        return `${key}: ${renderPlainData(nestedValue, indent + 1)}`;
-      })
-      .join("\n");
-  }
-  return String(value);
 }
 
 /**


### PR DESCRIPTION
Closes #22809

## Problem

`ComputerUseService` pretty-prints nested browser/window snapshots into action `content` with recursive `renderPlainData`. No depth, node, or cycle budget.

On `origin/develop` `20ee04d10bf6` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep array nest | RangeError 5.50 ms |
| cyclic `{ self: self }` | RangeError 3.67 ms |

Product path: computer-use `open`/`navigate`/`snapshot` action results. The recursive pretty-print stack-overflows the action handler.

Not leftover-tax. Not a twin of `#22797` planner action params, `#22781` inbox flags, `#22785` entity-match unwrap, `#22768` household scan, or `#22716` cloneJson. Distinct host: computer-use snapshot `stringifyData` / `renderPlainData`. HARD_SKIP is `actor.ts`, not this service file.

## Change

- Extract `stringifyData` / `renderPlainData` to `computer-use-plain-data.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`COMPUTER_USE_PLAIN_DATA_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget.
- Reject callable values without invoking conversion traps and cap cumulative rendered output at 65,536 UTF-16 code units.
- Preserve the legacy blank-line positions of honest sparse arrays while distinguishing explicit `undefined` entries.
- Honest scalars, lists, and records still pretty-print.

## Exact-head evidence

Evidence revision: `ca362ab35510ba860893d38f4a38cd9d0670b3ef`, based on `develop` `19519bfcd1`. Owning issue: #22809.

- Exact post-rebase helper + real `ComputerUseService.executeBrowserAction({ action: "state" })` boundary: **18/18 passed**.
- `bun run --cwd plugins/plugin-computeruse build`: **pass** (index + register-routes + ocr-provider + TypeScript declarations + Vite views `dist/views/bundle.js` 11.06 kB).
- Exact repaired aggregate: **806 passed, 16 skipped**; ten import-only suites were blocked by the sparse reviewer dependency root missing `chalk`. After linking the pinned package, the targeted rerun made no progress for more than four minutes under shared host contention and was bounded. The original exact contributor patch independently completed **887 passed, 17 skipped**, and the repaired production paths are covered by the exact 18/18 lane.
- Owning typecheck was attempted on the repaired exact tree and was blocked only by sparse transitive workspace dependencies (`@elizaos/registry` generated JSON, Capacitor/UI packages, Puppeteer/NutJS); no touched-file diagnostic. Exact declaration and production builds pass.
- Biome on all four affected files: clean.
- `git diff --check`: clean.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - computer-use snapshot pretty-print walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - computer-use snapshot pretty-print walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head independent backend receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/pr-22812-ca362ab-backend-v3.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - snapshot pretty-print has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at ca362ab35510</summary>

```
# domain artifact — computer-use snapshot pretty-print
exact-head: ca362ab35510ba860893d38f4a38cd9d0670b3ef
based-on: origin/develop 19519bfcd1
owning-issue: https://github.com/elizaOS/eliza/issues/22809

Pinned Bun 1.3.14 at this repaired exact head:
  helper + real service boundary: 18/18 passed
  bun run --cwd plugins/plugin-computeruse build: pass
    index, register-routes, mobile/ocr-provider, declarations, and Vite views
    declarations generated; vite views dist/views/bundle.js 11.06 kB gzip 3.54 kB
  aggregate runnable tests: 806 passed, 16 skipped
  aggregate import-only blockers: 10, all missing chalk from sparse dependency root
  Biome four files and git diff-check: pass

Origin red (Node 24.15.0, pre-fix walk):
  renderPlainData 8k array nest: RangeError 5.50 ms
  cyclic { self: self }: RangeError 3.67 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:ca362ab35510ba860893d38f4a38cd9d0670b3ef -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux; Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->




