### PR TITLE
fix(plugin-google-workspace): translate reflection failures

### DIFF
--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
@@ -76,6 +76,52 @@ describe("mergeCredentialObject", () => {
     expect(invoked).toBe(0);
   });
 
+  it("translates revoked scope proxies to the typed boundary failure", () => {
+    const { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+
+    try {
+      mergeCredentialObject({}, { scopes: proxy });
+      expect.unreachable("revoked scope proxy should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(TypeError);
+    }
+  });
+
+  it("translates hostile scope descriptor reflection without invoking access", () => {
+    const reflectionError = new Error("descriptor reflection denied");
+    const scopes = new Proxy(["gmail.read"], {
+      getOwnPropertyDescriptor() {
+        throw reflectionError;
+      },
+    });
+
+    try {
+      mergeCredentialObject({}, { scopes });
+      expect.unreachable("hostile scope descriptor should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error & { cause?: unknown }).cause).toBe(reflectionError);
+    }
+  });
+
+  it("translates revoked expiry reflection to the typed boundary failure", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    try {
+      mergeCredentialObject({}, { expiry_date: proxy });
+      expect.unreachable("revoked expiry proxy should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(TypeError);
+    }
+  });
+
   it("preserves sparse scopes and nested-then-outer token precedence", () => {
     const scopes: unknown[] = ["gmail.read", 42, "drive.readonly"];
     delete scopes[1];

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -25,10 +25,11 @@ type WalkContext = {
   visiting: WeakSet<object>;
 };
 
-function failUnbounded(context: Record<string, unknown>): never {
+function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
   throw new ElizaError("Google OAuth credential JSON exceeds the token-merge walk budget", {
     code: GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED,
     context,
+    ...(cause === undefined ? {} : { cause }),
     severity: "fatal",
   });
 }
@@ -43,14 +44,34 @@ function reserve(ctx: WalkContext, count: number): void {
   ctx.visits += count;
 }
 
+function isArray(value: object): value is unknown[] {
+  try {
+    return Array.isArray(value);
+  } catch (cause) {
+    // error-policy:J2 Translate reflection failure at the credential boundary
+    // while preserving the engine or Proxy error that caused it.
+    failUnbounded({ operation: "isArray" }, cause);
+  }
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
+  return value && typeof value === "object" && !isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
 }
 
+function dataDescriptor(value: object, key: string): PropertyDescriptor | undefined {
+  try {
+    return Object.getOwnPropertyDescriptor(value, key);
+  } catch (cause) {
+    // error-policy:J2 Translate reflection failure at the credential boundary
+    // while preserving the engine or Proxy error that caused it.
+    failUnbounded({ operation: "getOwnPropertyDescriptor", key }, cause);
+  }
+}
+
 function dataValue(value: object, key: string): unknown {
-  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  const descriptor = dataDescriptor(value, key);
   if (!descriptor || !("value" in descriptor)) return undefined;
   return descriptor.value;
 }
@@ -78,7 +99,7 @@ function readScopeArray(scopes: unknown[], ctx: WalkContext): string {
 
   const values: string[] = [];
   for (let index = 0; index < (length as number); index += 1) {
-    const descriptor = Object.getOwnPropertyDescriptor(scopes, String(index));
+    const descriptor = dataDescriptor(scopes, String(index));
     if (!descriptor) continue;
     if (!("value" in descriptor)) {
       failUnbounded({ accessor: `scopes[${index}]` });
@@ -91,21 +112,29 @@ function readScopeArray(scopes: unknown[], ctx: WalkContext): string {
 }
 
 function parseExpiry(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value > 0 && value < 10_000_000_000 ? value * 1000 : value;
-  }
-  if (value instanceof Date) {
-    return value.getTime();
-  }
-  if (typeof value === "string" && value.trim()) {
-    const numeric = Number(value);
-    if (Number.isFinite(numeric)) {
-      return parseExpiry(numeric);
+  try {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value > 0 && value < 10_000_000_000 ? value * 1000 : value;
     }
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? undefined : parsed;
+    // `instanceof` performs prototype reflection and `getTime` validates the
+    // receiver's internal slot, either of which can reject a hostile Proxy.
+    if (value instanceof Date) {
+      return value.getTime();
+    }
+    if (typeof value === "string" && value.trim()) {
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) {
+        return parseExpiry(numeric);
+      }
+      const parsed = Date.parse(value);
+      return Number.isNaN(parsed) ? undefined : parsed;
+    }
+    return undefined;
+  } catch (cause) {
+    // error-policy:J2 Expiry reflection is part of the same credential boundary;
+    // retain its underlying Proxy or invalid-receiver failure.
+    failUnbounded({ operation: "parseExpiry" }, cause);
   }
-  return undefined;
 }
 
 export function mergeCredentialObject(credentials: OauthCredentialFields, value: unknown): void {
@@ -155,7 +184,7 @@ function mergeCredentialObjectInner(
     if (idToken) credentials.id_token = idToken;
     if (tokenType) credentials.token_type = tokenType;
     const scopes = dataValue(record, "scopes");
-    if (Array.isArray(scopes)) {
+    if (scopes && typeof scopes === "object" && isArray(scopes)) {
       credentials.scope = readScopeArray(scopes, ctx);
     } else if (scope) {
       credentials.scope = scope;


### PR DESCRIPTION
# Relates to

Closes #22804.

- [x] Targets `develop` from the current `origin/develop` base with zero conflicts.
- [x] Exact-head Quality run `32351268508` passes.
- [x] The focused transcript below lets a reviewer confirm the boundary behavior.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop` at authoring time; zero conflicts.
- [x] Exact-head `Quality` run `32351268508` passes.

# Risks

Low. The patch only translates JavaScript reflection failures at the Google OAuth credential boundary into the existing typed fail-closed error. Honest arrays retain their existing behavior.

# Background

## What does this PR do?

It closes the residual boundary gap found in the post-merge audit of #22793. Revoked or hostile Proxy values can make `Array.isArray`, `Object.getOwnPropertyDescriptor`, and Date expiry reflection throw. Those raw exceptions are now translated to `GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED`, with the original error retained as `cause`.

## What kind of change is this?

Bug fix, non-breaking.

# Documentation changes needed?

No. This preserves the documented typed-failure contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts`

## Detailed testing steps

`bunx vitest run --maxWorkers=1`

Result at exact head: 240 pass, 0 fail across 22 files, including revoked-scope Proxy, hostile descriptor, and revoked-expiry cases. Package typecheck and build pass. `bunx biome check` passed for both changed files, and `git diff --check` passed.

# Evidence Gate

<!-- evidence-head:f9e616ff87b3c3f7a1be940f6bbf2f37122668e6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI or interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] [Exact 240-test/typecheck/build transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22813-backend-full-f9e616ff.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact adversarial contract artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22813-domain-f9e616ff.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changes.

## Backend + frontend logs

[Exact 240-test/typecheck/build transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22813-backend-full-f9e616ff.txt)

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

Exact-head hosted Quality run `32351268508` passes. Package tests (240/240), typecheck, build, Biome, and patch integrity pass. The first concurrent full suite had 239 tests pass and one unrelated existing MIME wall-clock assertion miss by 0.29 ms (50.29 ms against `<50 ms`); the MIME file then passed isolated at 33 ms, and the reduced-contention full suite passed all 240 tests. This timing flake is disclosed in the immutable backend artifact.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-computer-use]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
