### PR TITLE
fix(plugin-inbox): reject impossible after:/before: calendar dates

### DIFF
--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -69,6 +69,16 @@ describe("parseGmailDateBoundary", () => {
     expect(parseGmailDateBoundary("2026-13-02")).toBeNull();
     expect(parseGmailDateBoundary("nope")).toBeNull();
   });
+
+  it("rejects calendar-impossible days instead of letting Date.UTC roll them over", () => {
+    // Date.UTC(2026, 1, 31) is 2026-03-03. Month 13 already returns null;
+    // day 31 in a 30-day month was accepted and shifted the after:/before:
+    // search window to a later real day.
+    expect(parseGmailDateBoundary("2026-02-31")).toBeNull();
+    expect(parseGmailDateBoundary("2026-04-31")).toBeNull();
+    expect(parseGmailDateBoundary("2025-02-29")).toBeNull();
+    expect(parseGmailDateBoundary("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+  });
 });
 
 describe("normalizeOptionalMessageIdArray", () => {
@@ -220,6 +230,20 @@ describe("normalizeGmailSearchQueryMatches — standalone OR", () => {
       normalizeGmailSearchQueryMatches("from:alice OR OR from:bob", fromBob),
     ).toBe(true);
     expect(normalizeGmailSearchQueryMatches("OR OR", fromBob)).toBe(false);
+  });
+
+  it("does not treat after:2026-02-31 as after March 3", () => {
+    const marchThird = gmailMessage({
+      id: "m-mar3",
+      subject: "March standup",
+      receivedAt: "2026-03-03T12:00:00.000Z",
+    });
+    expect(
+      normalizeGmailSearchQueryMatches("after:2026-02-31", marchThird),
+    ).toBe(false);
+    expect(
+      normalizeGmailSearchQueryMatches("after:2026-03-03", marchThird),
+    ).toBe(true);
   });
 
   it("filters end-to-end through filterGmailMessagesBySearch", () => {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -79,6 +79,19 @@ describe("parseGmailDateBoundary", () => {
     expect(parseGmailDateBoundary("2025-02-29")).toBeNull();
     expect(parseGmailDateBoundary("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
   });
+
+  it("preserves literal UTC years from 0000 through 0099", () => {
+    const yearZeroLeapDay = parseGmailDateBoundary("0000-02-29");
+    const yearNinetyNineEnd = parseGmailDateBoundary("0099-12-31");
+
+    expect(new Date(yearZeroLeapDay as number).toISOString()).toBe(
+      "0000-02-29T00:00:00.000Z",
+    );
+    expect(new Date(yearNinetyNineEnd as number).toISOString()).toBe(
+      "0099-12-31T00:00:00.000Z",
+    );
+    expect(parseGmailDateBoundary("0000-02-30")).toBeNull();
+  });
 });
 
 describe("normalizeOptionalMessageIdArray", () => {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -116,7 +116,18 @@ export function parseGmailDateBoundary(value: string): number | null {
   ) {
     return null;
   }
-  return Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+  // Date.UTC overflows impossible days (Feb 31 → Mar 3). Round-trip Y/M/D
+  // so after:/before: cannot silently shift onto a later real calendar day.
+  const utc = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+  const parsed = new Date(utc);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return utc;
 }
 
 export function splitMailboxLikeList(value: string): string[] {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -116,10 +116,12 @@ export function parseGmailDateBoundary(value: string): number | null {
   ) {
     return null;
   }
-  // Date.UTC overflows impossible days (Feb 31 → Mar 3). Round-trip Y/M/D
-  // so after:/before: cannot silently shift onto a later real calendar day.
-  const utc = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
-  const parsed = new Date(utc);
+  // Date.UTC overflows impossible days (Feb 31 → Mar 3) and remaps years
+  // 0–99 onto 1900–1999. Set the full year explicitly before round-tripping
+  // so every accepted four-digit year keeps its literal UTC meaning.
+  const parsed = new Date(0);
+  parsed.setUTCFullYear(year, month - 1, day);
+  const utc = parsed.getTime();
   if (
     parsed.getUTCFullYear() !== year ||
     parsed.getUTCMonth() !== month - 1 ||

--- a/plugins/plugin-inbox/test/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/test/gmail-normalize.test.ts
@@ -92,4 +92,11 @@ describe("parseGmailDateBoundary", () => {
     expect(parseGmailDateBoundary("2026-06-40")).toBeNull();
     expect(parseGmailDateBoundary("garbage")).toBeNull();
   });
+
+  it("rejects calendar-impossible days instead of letting Date.UTC roll them over", () => {
+    expect(parseGmailDateBoundary("2026-02-31")).toBeNull();
+    expect(parseGmailDateBoundary("2026-04-31")).toBeNull();
+    expect(parseGmailDateBoundary("2025-02-29")).toBeNull();
+    expect(parseGmailDateBoundary("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+  });
 });

--- a/plugins/plugin-inbox/test/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/test/gmail-normalize.test.ts
@@ -99,4 +99,17 @@ describe("parseGmailDateBoundary", () => {
     expect(parseGmailDateBoundary("2025-02-29")).toBeNull();
     expect(parseGmailDateBoundary("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
   });
+
+  it("preserves literal UTC years from 0000 through 0099", () => {
+    const yearZeroLeapDay = parseGmailDateBoundary("0000-02-29");
+    const yearNinetyNineEnd = parseGmailDateBoundary("0099-12-31");
+
+    expect(new Date(yearZeroLeapDay as number).toISOString()).toBe(
+      "0000-02-29T00:00:00.000Z",
+    );
+    expect(new Date(yearNinetyNineEnd as number).toISOString()).toBe(
+      "0099-12-31T00:00:00.000Z",
+    );
+    expect(parseGmailDateBoundary("0000-02-30")).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #22825

# Owning issue

This PR fixes the impossible-date rollover and the independently found low-year regression tracked in #22825. Related historical parser fixes: #22179, #18831, #19224, and #19611.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Exact-head Mode B validation after sync: focused Gmail normalization 27/27; full plugin-inbox 221 passed / 2 skipped; typecheck, complete build, Biome, and diff check passed.
- [x] A reviewer can confirm the change from the failing-then-passing tests below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Build
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `1f8a95937c1d35615f4cfa23f3c4a855f1adeed0`; zero conflicts.
- [x] Focused Gmail normalization 27/27, full plugin-inbox 221 passed / 2 skipped, typecheck, complete build, Biome, and diff check pass at this head.

# Risks

Low. Date-only parser for Gmail `after:` / `before:` local search. Valid calendar days including leap-day `2024-02-29` still parse to the same UTC midnight epoch. Impossible days (`2026-02-31`, `2026-04-31`, `2025-02-29`) now return `null` like month 13 already did, so the existing unparseable-date substring fallback applies instead of a silently shifted window.

# Background

## What does this PR do?

`parseGmailDateBoundary` accepted any `YYYY-MM-DD` with month 1–12 and day 1–31, then called `Date.UTC`. JavaScript overflows impossible days: `Date.UTC(2026, 1, 31)` is `2026-03-03T00:00:00.000Z` because February 2026 has 28 days. Inbox search then treated `after:2026-02-31` as `after:2026-03-03`, so a March 3 message matched.

Measured on Node 24.15.0 (repository-pinned):

| input | `Date.UTC` result |
| --- | --- |
| `2026-02-31` | `2026-03-03T00:00:00.000Z` (epoch `1772496000000`) |
| `2026-04-31` | `2026-05-01T00:00:00.000Z` |
| `2025-02-29` | `2025-03-01T00:00:00.000Z` |
| `2024-02-29` | `2024-02-29T00:00:00.000Z` (valid leap day) |

The month-13 / day-40 checks already returned null. Day 31 in a 30-day month did not.

The fix constructs UTC midnight with `new Date(0)` plus `setUTCFullYear`, then round-trips Y/M/D. This rejects rollover dates without JavaScript's special `Date.UTC` remapping of literal years 0000 through 0099. No new numeric ceiling.

## What kind of change is this?

Bug fix (non-breaking): Gmail `after:` / `before:` local filter no longer shifts onto a later real calendar day.

# Documentation changes needed?

No. Existing tests already documented "null on invalid".

# Testing

## Where should a reviewer start?

`plugins/plugin-inbox/src/inbox/gmail-normalize.ts` (`parseGmailDateBoundary`) and the two gmail-normalize test files.

## Detailed testing steps

```bash
cd plugins/plugin-inbox
bunx vitest run --config ./vitest.config.ts src/inbox/gmail-normalize.test.ts test/gmail-normalize.test.ts
bunx @biomejs/biome check src/inbox/gmail-normalize.ts src/inbox/gmail-normalize.test.ts test/gmail-normalize.test.ts
```

The tests assert:

- `parseGmailDateBoundary("2026-02-31")` is `null` (was epoch `1772496000000` / March 3)
- `parseGmailDateBoundary("2026-04-31")` and `"2025-02-29"` are `null`
- leap day `2024-02-29` still parses
- `after:2026-02-31` does not match a message received `2026-03-03T12:00:00.000Z`
- `after:2026-03-03` still matches that message

Before the fix, against current `develop`:

```text
FAIL  src/inbox/gmail-normalize.test.ts > parseGmailDateBoundary > rejects calendar-impossible days instead of letting Date.UTC roll them over
AssertionError: expected 1772496000000 to be null

FAIL  src/inbox/gmail-normalize.test.ts > normalizeGmailSearchQueryMatches — standalone OR > does not treat after:2026-02-31 as after March 3
AssertionError: expected true to be false
```

After the fix, same files: `Test Files  2 passed (2) / Tests  25 passed (25)`.

# Evidence Gate

<!-- evidence-head:be4a0d133142be3250b1a13fcc9da50a3808de2d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Gmail date parser; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Gmail date parser; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Gmail credential path; deterministic parser tests are the production-path receipt.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Immutable repaired exact-head production-boundary and full-gate receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/22815-be4a0d-exact-validation.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, planner, or action behavior changed.

## Backend + frontend logs

N/A - no live Google credential or UI path. Deterministic parser receipt:

<details>
<summary>exact-head focused suite at be4a0d133142be3250b1a13fcc9da50a3808de2d</summary>

```text
Head: be4a0d133142be3250b1a13fcc9da50a3808de2d
Base: 1f8a95937c1d35615f4cfa23f3c4a855f1adeed0
Focused: 2 files / 27 tests passed after rebase.
Biome on the three changed files: passed.
git diff --check: passed.
Negative control (unfixed develop): parseGmailDateBoundary("2026-02-31") returned 1772496000000 (2026-03-03T00:00:00.000Z); after:2026-02-31 matched a March 3 message.
Measured overflow: Date.UTC(2026, 1, 31) → 2026-03-03 (February 2026 has 28 days, so the overflow is 3 calendar days, not a round ceiling).
Reviewed file SHA-256:
  gmail-normalize.ts 51948ce82ba2ac009483f1219eeadf44d9422f175030e1b57ea61c2b8ce34eef
  src/inbox/gmail-normalize.test.ts c85c486500279cd0f040c5d65fff9e2002bca76efcef9446c1b026bea508854c
  test/gmail-normalize.test.ts a1229fa064fb143af55c91bb9a6e02571bbd4f2daa34ef52f6119e5cd362c9ea
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - Gmail date parser; no rendered UI.

# Known gaps / failures

None in the owning package gates. The repaired exact head passed focused and full tests, typecheck, the complete JS/view/declaration build, Biome, and diff check in the no-secret network-denied reviewer VM.
AI provider/model: xai / grok-4.6
Client / agent tooling: grok-build
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza
Attribution status: self-reported
— [inbox-gmail-date-boundary]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-build","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-eliza"} -->



## Reviewer-authored low-year repair

Independent review reproduced that the first revision returned null for valid `0000-02-29` and `0099-12-31`. Exact head `be4a0d133142be3250b1a13fcc9da50a3808de2d` uses `setUTCFullYear`, preserves those literal UTC years, rejects `0000-02-30`, and retains the original impossible-modern-date rejection. Because this is a substantive reviewer-authored repair, final approval and merge require a distinct reviewer.
