### PR TITLE
fix(plugin-google-genai): fail closed on unbounded tool-call argument graphs

### DIFF
--- a/plugins/plugin-google-genai/__tests__/google-genai-json-value.test.ts
+++ b/plugins/plugin-google-genai/__tests__/google-genai-json-value.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Deterministic tests for the Google GenAI tool-call JSON walk. No live
+ * model: the walker is the production toJsonValue / toToolArguments used
+ * on untrusted `functionCall.args`.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  GOOGLE_GENAI_JSON_UNBOUNDED,
+  MAX_GOOGLE_GENAI_JSON_DEPTH,
+  MAX_GOOGLE_GENAI_JSON_NODES,
+  toJsonValue,
+  toToolArguments,
+} from "../models/google-genai-json-value";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("toJsonValue", () => {
+  it("preserves honest scalars, lists, and nested records", () => {
+    expect(toJsonValue("ok")).toBe("ok");
+    expect(toJsonValue(3)).toBe(3);
+    expect(toJsonValue(Number.NaN)).toBe(null);
+    expect(toJsonValue(true)).toBe(true);
+    expect(toJsonValue(null)).toBe(null);
+    expect(toJsonValue(["1", { b: true }])).toEqual(["1", { b: true }]);
+    expect(toJsonValue({ a: ["1", { b: true }] })).toEqual({
+      a: ["1", { b: true }],
+    });
+  });
+
+  it("omits undefined object keys and stringifies present undefined array slots", () => {
+    expect(toJsonValue({ a: 1, b: undefined })).toEqual({ a: 1 });
+    expect(toJsonValue([undefined, "x"])).toEqual(["undefined", "x"]);
+  });
+
+  it(`accepts a ${MAX_GOOGLE_GENAI_JSON_DEPTH}-deep array nest`, () => {
+    expect(toJsonValue(nestArray(MAX_GOOGLE_GENAI_JSON_DEPTH))).toEqual(
+      nestArray(MAX_GOOGLE_GENAI_JSON_DEPTH),
+    );
+  });
+
+  it(`throws ${GOOGLE_GENAI_JSON_UNBOUNDED} one past depth ${MAX_GOOGLE_GENAI_JSON_DEPTH}`, () => {
+    try {
+      toJsonValue(nestArray(MAX_GOOGLE_GENAI_JSON_DEPTH + 1));
+      expect.unreachable("parse should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${GOOGLE_GENAI_JSON_UNBOUNDED} past ${MAX_GOOGLE_GENAI_JSON_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_GOOGLE_GENAI_JSON_NODES] = "x";
+    try {
+      toJsonValue(sparse);
+      expect.unreachable(
+        "parse should fail closed on over-budget sparse length",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+    }
+  });
+
+  it("preserves within-budget sparse holes and length", () => {
+    const value: unknown[] = [];
+    value[2] = "x";
+    const result = toJsonValue(value) as unknown[];
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    const started = performance.now();
+    try {
+      toJsonValue(cyclic);
+      expect.unreachable("parse should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while parsing", () => {
+    let invoked = 0;
+    const hostile = {
+      get trap() {
+        invoked += 1;
+        return "x";
+      },
+    };
+    try {
+      toJsonValue(hostile);
+      expect.unreachable("parse should fail closed on enumerable accessors");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("does not invoke array Proxy get/has traps while parsing", () => {
+    let gets = 0;
+    let hasCalls = 0;
+    const proxy = new Proxy(["x"], {
+      get() {
+        gets += 1;
+        throw new Error("get trap escaped");
+      },
+      has() {
+        hasCalls += 1;
+        throw new Error("has trap escaped");
+      },
+    });
+    expect(toJsonValue(proxy)).toEqual(["x"]);
+    expect(gets).toBe(0);
+    expect(hasCalls).toBe(0);
+  });
+
+  it(`throws ${GOOGLE_GENAI_JSON_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+    const { proxy, revoke } = Proxy.revocable(["x"], {});
+    revoke();
+    try {
+      toJsonValue(proxy);
+      expect.unreachable("parse should fail closed on a revoked Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+      expect((error as Error).name).not.toBe("TypeError");
+    }
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      toJsonValue(nestArray(8_000));
+      expect.unreachable("parse should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});
+
+describe("toToolArguments", () => {
+  it("parses honest tool-call argument records", () => {
+    expect(toToolArguments({ command: "ls", n: 1 })).toEqual({
+      command: "ls",
+      n: 1,
+    });
+    expect(toToolArguments(["not", "a", "record"])).toEqual({});
+    expect(toToolArguments(null)).toEqual({});
+  });
+
+  it("does not invoke parameter-slot accessors", () => {
+    let invoked = 0;
+    const hostile = {
+      get payload() {
+        invoked += 1;
+        return ["x"];
+      },
+    };
+    try {
+      toToolArguments(hostile);
+      expect.unreachable(
+        "parse should fail closed on parameter-slot accessors",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on an 8k nest through toToolArguments", () => {
+    const started = performance.now();
+    try {
+      toToolArguments({ payload: nestArray(8_000) });
+      expect.unreachable("production parse should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_GENAI_JSON_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("preserves sparse holes through toToolArguments", () => {
+    const payload: unknown[] = [];
+    payload[2] = "x";
+    const result = toToolArguments({ payload }).payload as unknown[];
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+});

--- a/plugins/plugin-google-genai/__tests__/google-genai-json-value.test.ts
+++ b/plugins/plugin-google-genai/__tests__/google-genai-json-value.test.ts
@@ -186,6 +186,62 @@ describe("toToolArguments", () => {
     expect(invoked).toBe(0);
   });
 
+  it("preserves an own __proto__ key without mutating the output prototype", () => {
+    const args = {} as Record<string, unknown>;
+    Object.defineProperty(args, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+    });
+
+    const result = toToolArguments(args);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.hasOwn(result, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(result, "__proto__")?.value).toEqual(
+      { polluted: true },
+    );
+    expect(
+      (Object.prototype as { polluted?: boolean }).polluted,
+    ).toBeUndefined();
+  });
+
+  it("rejects callable Proxies without invoking conversion or reflection traps", () => {
+    let calls = 0;
+    const callable = new Proxy(() => "unsafe", {
+      apply() {
+        calls += 1;
+        throw new Error("call trap escaped");
+      },
+      get() {
+        calls += 1;
+        throw new Error("get trap escaped");
+      },
+      ownKeys() {
+        calls += 1;
+        throw new Error("ownKeys trap escaped");
+      },
+    });
+
+    expect(() => toToolArguments({ payload: callable })).toThrowError(
+      expect.objectContaining({ code: GOOGLE_GENAI_JSON_UNBOUNDED }),
+    );
+    expect(calls).toBe(0);
+  });
+
+  it("does not invoke hostile custom conversion methods", () => {
+    let calls = 0;
+    const hostile = {
+      toString() {
+        calls += 1;
+        throw new Error("toString escaped");
+      },
+    };
+
+    expect(() => toToolArguments({ payload: hostile })).toThrowError(
+      expect.objectContaining({ code: GOOGLE_GENAI_JSON_UNBOUNDED }),
+    );
+    expect(calls).toBe(0);
+  });
+
   it("fails closed on an 8k nest through toToolArguments", () => {
     const started = performance.now();
     try {

--- a/plugins/plugin-google-genai/models/google-genai-json-value.ts
+++ b/plugins/plugin-google-genai/models/google-genai-json-value.ts
@@ -1,0 +1,164 @@
+/**
+ * Bounds the nested JSON walk used when Google GenAI tool-call `args` are
+ * converted into elizaOS `JsonValue`. Hostile nests RangeError'd
+ * `toJsonValue` at 8k depth on Node 24.15.0. Depth, node, and cycle limits
+ * are all load-bearing. Descriptor-only reads so a getter cannot hang the
+ * Gemini text-handler tool-call path.
+ */
+
+import { ElizaError, type JsonValue } from "@elizaos/core";
+
+export const MAX_GOOGLE_GENAI_JSON_DEPTH = 32;
+export const MAX_GOOGLE_GENAI_JSON_NODES = 2_048;
+export const GOOGLE_GENAI_JSON_UNBOUNDED = "GOOGLE_GENAI_JSON_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  throw new ElizaError(
+    "Google GenAI tool-call JSON exceeds the parse walk budget",
+    {
+      code: GOOGLE_GENAI_JSON_UNBOUNDED,
+      context,
+      cause,
+      severity: "fatal",
+    },
+  );
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_GOOGLE_GENAI_JSON_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_GOOGLE_GENAI_JSON_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J3 Proxy inspection failures make untrusted tool-call JSON invalid.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(
+  value: object,
+  key: PropertyKey,
+): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !isArrayRecord(value));
+}
+
+function newWalkContext(): WalkContext {
+  return {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  };
+}
+
+/**
+ * Production tool-call boundary: descriptor-only conversion of Gemini
+ * `functionCall.args` with one shared node/cycle budget.
+ */
+export function toToolArguments(value: unknown): Record<string, JsonValue> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const jsonValue = toJsonValueInner(value, 0, newWalkContext());
+  return isRecord(jsonValue) ? (jsonValue as Record<string, JsonValue>) : {};
+}
+
+export function toJsonValue(value: unknown): JsonValue {
+  return toJsonValueInner(value, 0, newWalkContext());
+}
+
+function toJsonValueInner(
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false,
+): JsonValue {
+  if (depth > MAX_GOOGLE_GENAI_JSON_DEPTH) {
+    failUnbounded({ depth, max: MAX_GOOGLE_GENAI_JSON_DEPTH });
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return Number.isFinite(value) ? value : null;
+  }
+  if (value === undefined || typeof value !== "object") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return String(value);
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      const out = new Array<JsonValue>(length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        out[index] = toJsonValueInner(descriptor.value, depth + 1, ctx, true);
+      }
+      return out;
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    const record: Record<string, JsonValue> = {};
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      if (descriptor.value === undefined) continue;
+      record[key] = toJsonValueInner(descriptor.value, depth + 1, ctx, true);
+    }
+    return record;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}

--- a/plugins/plugin-google-genai/models/google-genai-json-value.ts
+++ b/plugins/plugin-google-genai/models/google-genai-json-value.ts
@@ -46,7 +46,7 @@ function inspectRecord<T>(operation: string, inspect: () => T): T {
   try {
     return inspect();
   } catch (cause) {
-    // error-policy:J3 Proxy inspection failures make untrusted tool-call JSON invalid.
+    // error-policy:J2 Preserve the failed inspection as the typed boundary cause.
     failUnbounded({ inspection: operation }, cause);
   }
 }
@@ -112,6 +112,10 @@ function toJsonValueInner(
     if (!visitAlreadyReserved) reserve(ctx, 1);
     return Number.isFinite(value) ? value : null;
   }
+  if (typeof value === "function") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    failUnbounded({ unsupportedType: "function" });
+  }
   if (value === undefined || typeof value !== "object") {
     if (!visitAlreadyReserved) reserve(ctx, 1);
     return String(value);
@@ -155,7 +159,18 @@ function toJsonValueInner(
         failUnbounded({ accessor: true, side: "object", key });
       }
       if (descriptor.value === undefined) continue;
-      record[key] = toJsonValueInner(descriptor.value, depth + 1, ctx, true);
+      const converted = toJsonValueInner(
+        descriptor.value,
+        depth + 1,
+        ctx,
+        true,
+      );
+      Object.defineProperty(record, key, {
+        value: converted,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
     return record;
   } finally {

--- a/plugins/plugin-google-genai/models/text.ts
+++ b/plugins/plugin-google-genai/models/text.ts
@@ -15,6 +15,8 @@
  * reason, and token usage into a single object that is returned as a
  * string-with-attached-fields (`GoogleTextModelResult`) whenever the caller
  * passed messages/tools/toolChoice/responseSchema, else as plain text.
+ * Tool-call `args` are converted by the bounded walker in
+ * `google-genai-json-value.ts`.
  */
 import type {
   GenerateTextParams,
@@ -46,6 +48,7 @@ import {
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { countTokens } from "../utils/tokenization";
+import { toToolArguments } from "./google-genai-json-value";
 
 const TEXT_NANO_MODEL_TYPE = ModelType.TEXT_NANO as string;
 const TEXT_MEDIUM_MODEL_TYPE = ModelType.TEXT_MEDIUM as string;
@@ -351,44 +354,6 @@ function getModelNameForType(
     default:
       return getLargeModel(runtime);
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
-function toJsonValue(value: unknown): JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "boolean"
-  ) {
-    return value;
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : null;
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => toJsonValue(entry));
-  }
-  if (isRecord(value)) {
-    const record: Record<string, JsonValue> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      if (entry !== undefined) {
-        record[key] = toJsonValue(entry);
-      }
-    }
-    return record;
-  }
-  return String(value);
-}
-
-function toToolArguments(value: unknown): Record<string, JsonValue> {
-  if (!isRecord(value)) {
-    return {};
-  }
-  const jsonValue = toJsonValue(value);
-  return isRecord(jsonValue) ? (jsonValue as Record<string, JsonValue>) : {};
 }
 
 function readGoogleText(response: GoogleGenerateContentResponse): string {


### PR DESCRIPTION
Closes #22820

## Problem

`normalizeGoogleToolCalls` converts untrusted Gemini `functionCall.args` with recursive `toJsonValue`. No depth, node, or cycle budget.

On `origin/develop` `6c1d0a12c910` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep array nest | RangeError 1.62 ms |
| cyclic `{ self: self }` | RangeError 3.01 ms |
| enumerable getter | getter runs |

Product path: Google GenAI text-handler tool-call extraction. JSON.parse of the nest succeeds; the walk then stack-overflows the model handler.

Not leftover-tax. Not a twin of `#22797` planner action params, `#22812` computer-use snapshot pretty-print, `#22785` entity-match unwrap, `#22781` inbox flags, or `#22768` household scan. Distinct host: `plugin-google-genai` `toJsonValue` / `toToolArguments`. Stay-off is plugin-openai, not this file.

## Change

- Extract `toJsonValue` / `toToolArguments` to `google-genai-json-value.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`GOOGLE_GENAI_JSON_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget and keep their positions on accepted inputs.
- Honest scalars, lists, nested records, and origin's undefined-key omission still convert.

## Exact-head evidence

Evidence revision: exact final PR head `4d3a87be04e9d94b0d4c252c4b79e723e8fd16f3`, based on `develop` `5b5fe50dbf78eea3f0f590906e2afcdeca9d22bf`; landed as `2b4f9ecfb81d47830239a88a0a43a69b1eefc8cf`. All three scoped landed blobs are identical to the final PR head. Owning issue: #22820.

- Pinned Bun 1.3.14 focused `google-genai-json-value` suite: **18/18 passed** (6 ms test time).
- Reviewer-only production `handleTextSmall` boundary regressions: **5/5 passed** (10 ms), covering accessor non-invocation, callable Proxy rejection, own `__proto__`, cumulative shallow-sibling budget, and typed Proxy reflection failures.
- Full package test lane: **108 passed, 2 skipped** (110) in 36.67 s.
- `bun run --cwd plugins/plugin-google-genai typecheck`: pass.
- `bun run --cwd plugins/plugin-google-genai build`: pass (Node + Browser + CJS + declarations, 5.29 s).
- Biome on the three changed files: clean.
- `git diff --check`: clean.
- Exact tests ran in a deny-default sandbox with external network blocked; loopback was permitted only for the package's real SDK boundary fixture.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - Google GenAI tool-call JSON walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Google GenAI tool-call JSON walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic scan-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - tool-call JSON parse has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22821-domain-final.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22821-domain-final.txt)

```
# domain artifact — Google GenAI tool-call args production boundary
exact-head: 4d3a87be04e9d94b0d4c252c4b79e723e8fd16f3
based-on: origin/develop 5b5fe50dbf78eea3f0f590906e2afcdeca9d22bf
landed-merge: 2b4f9ecfb81d47830239a88a0a43a69b1eefc8cf
owning-issue: https://github.com/elizaOS/eliza/issues/22820

Pinned Bun 1.3.14 at this exact head:
  focused google-genai-json-value: 18/18 passed (6 ms test time)
  reviewer-only handleTextSmall production boundary: 5/5 passed (10 ms)
  bun run --cwd plugins/plugin-google-genai test: 108 passed, 2 skipped (110) in 36.67s
  bun run --cwd plugins/plugin-google-genai typecheck: pass
  bun run --cwd plugins/plugin-google-genai build: pass (5.29s)
  Biome on all 3 changed files: pass
  git diff --check: pass
  sandbox: deny-default, external network blocked, loopback only for SDK fixture

Origin red (Node 24.15.0, pre-fix walk):
  toJsonValue 8k array nest: RangeError 1.62 ms
  cyclic { self: self }: RangeError 3.01 ms
  enumerable getter: getter runs

This head (Bun 1.3.14):
  8k nest: ElizaError GOOGLE_GENAI_JSON_UNBOUNDED (not RangeError)
  cyclic: ElizaError GOOGLE_GENAI_JSON_UNBOUNDED 0.12 ms
  enumerable getter: 0 calls, typed unbounded
  toToolArguments 8k nest: ElizaError GOOGLE_GENAI_JSON_UNBOUNDED 0.18 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:4d3a87be04e9d94b0d4c252c4b79e723e8fd16f3 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

