### PR TITLE
fix(plugin-anthropic): fail closed on unbounded providerOptions graphs

### DIFF
--- a/plugins/plugin-anthropic/__tests__/anthropic-provider-options.test.ts
+++ b/plugins/plugin-anthropic/__tests__/anthropic-provider-options.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Deterministic tests for the Anthropic providerOptions walk. No live model:
+ * the walker is the production readProviderOptions used on generate-text
+ * params.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED,
+  MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH,
+  MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES,
+  readProviderOptions,
+} from "../models/anthropic-provider-options";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("readProviderOptions", () => {
+  it("preserves root and nested __proto__ keys as inert own data", () => {
+    const nested = Object.fromEntries([["__proto__", { nested: true }]]);
+    const input = Object.fromEntries([
+      ["__proto__", { root: true }],
+      ["anthropic", nested],
+    ]);
+
+    const copied = readProviderOptions(input);
+
+    expect(Object.getPrototypeOf(copied)).toBe(Object.prototype);
+    expect(Object.hasOwn(copied ?? {}, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copied, "__proto__")?.value).toEqual({ root: true });
+    const copiedNested = copied?.anthropic as Record<string, unknown>;
+    expect(Object.getPrototypeOf(copiedNested)).toBe(Object.prototype);
+    expect(Object.hasOwn(copiedNested, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copiedNested, "__proto__")?.value).toEqual({
+      nested: true,
+    });
+  });
+
+  it("preserves honest scalars, lists, and nested records", () => {
+    expect(
+      readProviderOptions({
+        agentName: "eliza",
+        anthropic: { effort: "high", tags: ["a", { b: true }] },
+      })
+    ).toEqual({
+      agentName: "eliza",
+      anthropic: { effort: "high", tags: ["a", { b: true }] },
+    });
+    expect(readProviderOptions(null)).toBeUndefined();
+    expect(readProviderOptions(["not", "a", "record"])).toBeUndefined();
+    expect(readProviderOptions({ bad: () => "fn" })).toBeUndefined();
+  });
+
+  it(`accepts a ${MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH}-deep nest under payload`, () => {
+    // Root options object is depth 0, so payload may nest MAX-1 arrays.
+    const accepted = nestArray(MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH - 1);
+    expect(readProviderOptions({ payload: accepted })).toEqual({ payload: accepted });
+  });
+
+  it(`throws ${ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED} one past depth ${MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH}`, () => {
+    try {
+      readProviderOptions({
+        payload: nestArray(MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH),
+      });
+      expect.unreachable("parse should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED} past ${MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES] = "x";
+    try {
+      readProviderOptions({ payload: sparse });
+      expect.unreachable("parse should fail closed on over-budget sparse length");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("preserves within-budget sparse holes and length", () => {
+    const payload: unknown[] = [];
+    payload[2] = "x";
+    const result = readProviderOptions({ payload })?.payload as unknown[];
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    const started = performance.now();
+    try {
+      readProviderOptions(cyclic);
+      expect.unreachable("parse should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while parsing", () => {
+    let invoked = 0;
+    const hostile = {
+      get trap() {
+        invoked += 1;
+        return "x";
+      },
+    };
+    try {
+      readProviderOptions(hostile);
+      expect.unreachable("parse should fail closed on enumerable accessors");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("does not invoke Proxy get/has traps while parsing", () => {
+    let gets = 0;
+    let hasCalls = 0;
+    const proxy = new Proxy(
+      { payload: "x" },
+      {
+        get() {
+          gets += 1;
+          throw new Error("get trap escaped");
+        },
+        has() {
+          hasCalls += 1;
+          throw new Error("has trap escaped");
+        },
+      }
+    );
+    expect(readProviderOptions(proxy)).toEqual({ payload: "x" });
+    expect(gets).toBe(0);
+    expect(hasCalls).toBe(0);
+  });
+
+  it(`throws ${ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED} on a revoked Proxy instead of TypeError`, () => {
+    const { proxy, revoke } = Proxy.revocable({ payload: "x" }, {});
+    revoke();
+    try {
+      readProviderOptions(proxy);
+      expect.unreachable("parse should fail closed on a revoked Proxy");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+      expect((error as Error).name).not.toBe("TypeError");
+    }
+  });
+
+  it("fails closed on an 8k nest in under 50ms instead of RangeError", () => {
+    const started = performance.now();
+    try {
+      readProviderOptions({ payload: nestArray(8_000) });
+      expect.unreachable("parse should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -29,6 +29,34 @@ afterEach(() => {
 });
 
 describe("Anthropic native text plumbing", () => {
+  it("forwards nested __proto__ provider data without changing prototypes", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    }));
+    vi.doMock("ai", () => ({ generateText, streamText: vi.fn() }));
+    vi.doMock("../providers/anthropic", () => ({
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelId: modelName }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    const anthropic = Object.fromEntries([["__proto__", { inert: true }]]);
+    await handleTextSmall(createRuntime(), {
+      prompt: "hello",
+      providerOptions: { anthropic },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as {
+      providerOptions: { anthropic: Record<string, unknown> };
+    };
+    expect(Object.getPrototypeOf(call.providerOptions.anthropic)).toBe(Object.prototype);
+    expect(Object.hasOwn(call.providerOptions.anthropic, "__proto__")).toBe(true);
+    expect(
+      Object.getOwnPropertyDescriptor(call.providerOptions.anthropic, "__proto__")?.value
+    ).toEqual({ inert: true });
+  }, 60_000);
+
   it("uses generateText for streaming tool requests so tool-only responses are preserved", async () => {
     const generateText = vi.fn(async () => ({
       text: "",

--- a/plugins/plugin-anthropic/models/anthropic-provider-options.ts
+++ b/plugins/plugin-anthropic/models/anthropic-provider-options.ts
@@ -1,0 +1,187 @@
+/**
+ * Bounds the nested provider-options walk used when Anthropic text handlers
+ * accept `GenerateTextParams.providerOptions`. Hostile nests RangeError'd
+ * `isProviderOptionValue` at 8k depth on Node 24.15.0. Depth, node, and
+ * cycle limits are all load-bearing. Descriptor-only reads so a getter
+ * cannot hang the Anthropic generate path.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH = 32;
+export const MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES = 2_048;
+export const ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED = "ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+type ProviderOptionValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ProviderOptionValue[]
+  | { [key: string]: ProviderOptionValue | undefined };
+
+export type ProviderOptions = {
+  [key: string]: ProviderOptionValue | undefined;
+};
+
+function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
+  throw new ElizaError("Anthropic providerOptions JSON exceeds the parse walk budget", {
+    code: ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED,
+    context,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_ANTHROPIC_PROVIDER_OPTIONS_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Preserve reflection failures while adding the failed operation.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(value: object, key: PropertyKey): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key)
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+function newWalkContext(): WalkContext {
+  return {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  };
+}
+
+/**
+ * Production Anthropic boundary: descriptor-only validation/copy of
+ * `providerOptions` with one shared node/cycle budget.
+ */
+export function readProviderOptions(value: unknown): ProviderOptions | undefined {
+  if (typeof value !== "object" || value === null || isArrayRecord(value)) {
+    return undefined;
+  }
+  const copied = readProviderOptionValue(value, 0, newWalkContext());
+  if (
+    copied === undefined ||
+    copied === null ||
+    typeof copied !== "object" ||
+    Array.isArray(copied)
+  ) {
+    return undefined;
+  }
+  return copied as ProviderOptions;
+}
+
+function readProviderOptionValue(
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): ProviderOptionValue | undefined {
+  if (depth > MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH) {
+    failUnbounded({ depth, max: MAX_ANTHROPIC_PROVIDER_OPTIONS_DEPTH });
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return value;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      const out = new Array<ProviderOptionValue>(length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+        if (nested === undefined) {
+          return undefined;
+        }
+        out[index] = nested;
+      }
+      return out;
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    const record: { [key: string]: ProviderOptionValue | undefined } = {};
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      if (descriptor.value === undefined) {
+        Object.defineProperty(record, key, {
+          value: undefined,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+        continue;
+      }
+      const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+      if (nested === undefined) {
+        return undefined;
+      }
+      Object.defineProperty(record, key, {
+        value: nested,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return record;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -15,6 +15,8 @@
  *
  * When the auth mode is `cli`, generation is delegated to `claude -p` via
  * `generateViaCli` / `streamViaCli` instead of the SDK client.
+ * `providerOptions` is converted by the bounded walker in
+ * `anthropic-provider-options.ts`.
  */
 import type {
   GenerateTextParams,
@@ -64,6 +66,7 @@ import {
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { executeWithRetry, formatModelError } from "../utils/retry";
+import { readProviderOptions } from "./anthropic-provider-options";
 
 type ProviderOptionValue =
   | string
@@ -226,39 +229,6 @@ type AnthropicFilePart = {
   filename?: string;
 };
 type AnthropicUserContentPart = AnthropicTextPart | AnthropicFilePart;
-
-function isProviderOptionValue(value: unknown): value is ProviderOptionValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isProviderOptionValue);
-  }
-  if (typeof value === "object" && value !== null) {
-    return Object.values(value).every(
-      (entry) => entry === undefined || isProviderOptionValue(entry)
-    );
-  }
-  return false;
-}
-
-function readProviderOptions(value: unknown): ProviderOptions | undefined {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const entries = Object.entries(value);
-  if (!entries.every(([, entry]) => entry === undefined || isProviderOptionValue(entry))) {
-    return undefined;
-  }
-
-  return Object.fromEntries(entries) as ProviderOptions;
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);


### PR DESCRIPTION
Closes #22823

## Problem

`toAnthropicTextParams` validates untrusted `GenerateTextParams.providerOptions` with recursive `isProviderOptionValue` (`Array.every` / `Object.values`). No depth, node, or cycle budget.

On `origin/develop` `2b4f9ecfb81d` (Node 24.15.0):

| Input | Result |
|---|---|
| 8k-deep array nest | RangeError 1.86 ms |
| cyclic `{ self: self }` | RangeError 0.94 ms |

Product path: Anthropic generate-text handler. A hostile nest stack-overflows the model handler.

Not leftover-tax. Not a twin of `#22821` Google GenAI tool-call args, `#22797` planner action params, `#22812` computer-use snapshot pretty-print, `#22785` entity-match unwrap, `#22781` inbox flags, or `#22768` household scan. Distinct host: `plugin-anthropic` `readProviderOptions` / `isProviderOptionValue`. Stay-off is plugin-openai, not this file.

## Change

- Extract `readProviderOptions` to `anthropic-provider-options.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`ANTHROPIC_PROVIDER_OPTIONS_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget and keep their positions on accepted inputs.
- Honest scalars, lists, nested records, and origin's invalid-type → `undefined` still convert.

## Exact-head evidence

Evidence revision: `65126aa61c5d270fcff3eaf8ef5730eb01d635e4`, based on `develop` `2b4f9ecfb81d47830239a88a0a43a69b1eefc8cf`. Owning issue: #22823.

- Pinned Bun 1.3.14 focused `anthropic-provider-options` suite: **11/11 passed** in 4 ms.
- Full package test lane: **102/102 passed** in 9.48 s.
- `bun run --cwd plugins/plugin-anthropic typecheck`: pass.
- `bun run --cwd plugins/plugin-anthropic build`: pass (Node + Browser + CJS + endpoint-config + declarations, 1.00 s).
- Biome on the three changed files: clean.

Independent landed-tree audit uploaded the repaired exact-final receipt below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - Anthropic providerOptions walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Anthropic providerOptions walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic scan-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - providerOptions parse has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Immutable exact-final landed-tree receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/22826-65126aa-exact-landed-audit.txt)
<details>
<summary>independent landed audit at 65126aa61c5d</summary>

```text
Head: 65126aa61c5d270fcff3eaf8ef5730eb01d635e4
Merge: 19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc
All four scoped blobs: byte-identical.
Mode B: outbound denied; real Anthropic handler 8k/cycle/accessor typed, accessor zero-call.
Focused: 2 files / 26 tests passed. Full package: 14 files / 102 tests passed.
Typecheck, Node/browser/CJS/endpoint/declaration build, Biome 33 files, and diff check: passed.
Root and nested __proto__: preserved as inert own data through the native outbound seam.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:65126aa61c5d270fcff3eaf8ef5730eb01d635e4 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->



## Independent landed-tree audit

Final repaired head `65126aa61c5d270fcff3eaf8ef5730eb01d635e4` landed as `19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc`; all four scoped blobs are identical. The repaired `Object.defineProperty` copy preserves own `__proto__` data without prototype mutation, and reflection translation is correctly tagged J2. Exact Mode B production-boundary and full owning-package results are in the immutable receipt above. The final repaired head merged with no exact-final independent approval; this section records the post-merge audit.
