### PR TITLE
fix(security): harden remote forwarding boundaries

### DIFF
--- a/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
@@ -10,9 +10,33 @@
 import { describe, expect, test } from "vitest";
 import {
   buildForwardHeaders,
+  buildRemoteTargetUrl,
   redactPushTokenRequestUrl,
   shouldForwardToRemoteTarget,
 } from "./remote-forwarder.ts";
+
+describe("buildRemoteTargetUrl", () => {
+  test("keeps the configured origin for absolute-form request targets", () => {
+    const target = buildRemoteTargetUrl(
+      "https://attacker.invalid/api/cloud/login?next=1",
+      "http://127.0.0.1:31337",
+    );
+
+    expect(target.origin).toBe("http://127.0.0.1:31337");
+    expect(target.pathname).toBe("/api/cloud/login");
+    expect(target.search).toBe("?next=1");
+  });
+
+  test("treats a double-slash pathname as a path, not a network-path reference", () => {
+    const target = buildRemoteTargetUrl(
+      "http://controller.invalid//attacker.invalid/api/cloud/login",
+      "https://target.local:8443",
+    );
+
+    expect(target.origin).toBe("https://target.local:8443");
+    expect(target.pathname).toBe("//attacker.invalid/api/cloud/login");
+  });
+});
 
 test("legacy push-token URLs are redacted before agent diagnostics", () => {
   expect(

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.ts
@@ -51,6 +51,19 @@ export function shouldForwardToRemoteTarget(
   );
 }
 
+/** Build a target URL without allowing request-controlled text to select its origin. */
+export function buildRemoteTargetUrl(
+  requestUrl: string,
+  remoteApiBase: string,
+): URL {
+  const incoming = new URL(requestUrl, "http://controller.invalid");
+  const target = new URL(remoteApiBase);
+  target.pathname = incoming.pathname;
+  target.search = incoming.search;
+  target.hash = "";
+  return target;
+}
+
 // Per RFC 7230 §6.1, hop-by-hop headers MUST NOT be forwarded by an
 // intermediary. Re-using an upstream `Connection: keep-alive` or stale
 // `Transfer-Encoding` against the target's connection corrupts framing.
@@ -131,8 +144,8 @@ export async function forwardRemoteCloudMutation(
     return true;
   }
 
-  const targetUrl = new URL(
-    `${url.pathname}${url.search}`,
+  const targetUrl = buildRemoteTargetUrl(
+    req.url ?? "/",
     snapshot.remoteApiBase,
   );
   // The raw target URL above remains authoritative for compatibility, but any

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts
@@ -25,7 +25,9 @@ const VOLUME_ID = 7777;
 let sshExec: ExecFn;
 let mkfsCommands: string[];
 let mountCommands: string[];
+let waitCommands: string[];
 let getVolumeCalls: number;
+let linuxDevice: string;
 
 const fakeApi = {
   getVolume: async (_id: number) => {
@@ -38,7 +40,7 @@ const fakeApi = {
     return {
       id: VOLUME_ID,
       server: HCLOUD_SERVER_ID,
-      linux_device: "/dev/disk/by-id/scsi-0HC_Volume_7777",
+      linux_device: linuxDevice,
       location: { name: "fsn1" },
     };
   },
@@ -87,6 +89,7 @@ function makeExec(blkid: () => Promise<string>): ExecFn {
       mountCommands.push(cmd);
       return "";
     }
+    if (cmd.includes("seq 1 30")) waitCommands.push(cmd);
     // waitScript ([ -b ... ]) and mkdir -p both resolve cleanly.
     return "";
   };
@@ -96,7 +99,9 @@ describe("HetznerVolumeService.attachToNode filesystem probe (#13415)", () => {
   beforeEach(() => {
     mkfsCommands = [];
     mountCommands = [];
+    waitCommands = [];
     getVolumeCalls = 0;
+    linuxDevice = "/dev/disk/by-id/scsi-0HC_Volume_7777";
   });
 
   afterEach(() => {
@@ -143,5 +148,19 @@ describe("HetznerVolumeService.attachToNode filesystem probe (#13415)", () => {
     // The critical assertion: the failed probe did NOT fall through to mkfs.
     expect(mkfsCommands.length).toBe(0);
     expect(mountCommands.length).toBe(0);
+  });
+
+  it("shell-quotes an API-returned device path in the wait diagnostic", async () => {
+    linuxDevice = "/dev/x'; touch /tmp/provider-command-injection; #";
+    sshExec = makeExec(async () => "ext4\n");
+    const svc = new HetznerVolumeService();
+
+    await svc.attachToNode(VOLUME_ID, node, key);
+
+    expect(waitCommands).toHaveLength(1);
+    expect(waitCommands[0]).toContain(
+      `'device /dev/x'"'"'; touch /tmp/provider-command-injection; # did not appear'`,
+    );
+    expect(waitCommands[0]).not.toContain('echo "device');
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.ts
@@ -22,6 +22,7 @@
 
 import type { DockerNode } from "../../../db/schemas/docker-nodes";
 import { logger } from "../../utils/logger";
+import { shellQuote } from "../docker-sandbox-utils";
 import { DockerSSHClient } from "../docker-ssh";
 import {
   getHetznerCloudClient,
@@ -238,7 +239,8 @@ export class HetznerVolumeService {
 
     // Wait briefly for the device node to appear after attach. udev
     // sometimes lags by a second or two.
-    const waitScript = `for i in $(seq 1 30); do [ -b ${shellQuote(devicePath)} ] && exit 0; sleep 1; done; echo "device ${devicePath} did not appear" >&2; exit 1`;
+    const missingDeviceMessage = shellQuote(`device ${devicePath} did not appear`);
+    const waitScript = `for i in $(seq 1 30); do [ -b ${shellQuote(devicePath)} ] && exit 0; sleep 1; done; printf '%s\n' ${missingDeviceMessage} >&2; exit 1`;
     await ssh.exec(waitScript, 60_000);
 
     // Skip mkfs if the device already has a filesystem. The `|| true` makes
@@ -264,10 +266,6 @@ export class HetznerVolumeService {
       30_000,
     );
   }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 let cached: HetznerVolumeService | null = null;


### PR DESCRIPTION
# Relates to

Addresses the critical findings tracked by #22087:

- https://github.com/elizaOS/eliza/security/code-scanning/1085
- https://github.com/elizaOS/eliza/security/code-scanning/953

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run install:light`, the relevant exact-head package gates, and `bun run verify` were run after sync.
- [x] A reviewer can confirm both boundary invariants from the adversarial regression tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e84324c969c702a8c60520f75c3a893b992e4412:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop` at `b844d26f88950afc3a6c2c0771548a38d34cfa4a`; zero conflicts; PR-owned bytes are unchanged.
- [x] The pre-rebase exact `bun run verify` passed all 360 workspace lint/typecheck tasks and repository audits. The rebased exact head repeated both focused suites (15/15 and 4/4), changed-file Biome, and `git diff --check`; hosted exact Quality is pending.

# Risks

Low. The remote forwarder retains the same route and query semantics while constructing the destination with an origin that request text cannot replace. Hetzner volume orchestration retains the same commands and timeout behavior while using the shared shell-quoting helper for the complete diagnostic message.

# Background

## What does this PR do?

- Constructs remote-forwarding URLs by assigning only request path/query fields onto the configured target URL, so absolute-form or network-path-like request text cannot select the upstream origin.
- Uses the existing audited shell-quoting helper for both a provider-returned device path and the complete missing-device diagnostic passed to SSH.
- Adds adversarial regression coverage for both trust boundaries.

## What kind of change is this?

Bug fixes (non-breaking security hardening).

# Documentation changes needed?

No. These changes enforce existing internal boundary contracts and do not change a public API or operator workflow.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/runtime-mode/remote-forwarder.test.ts`
- `packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts`

## Detailed testing steps

At exact head `e84324c969c702a8c60520f75c3a893b992e4412`:

- `bunx vitest run packages/agent/src/api/runtime-mode/remote-forwarder.test.ts --coverage.enabled=false` — 15 passed.
- `bun test packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts` — 4 passed.
- `bun run --cwd packages/agent typecheck` — passed.
- `bun run --cwd packages/cloud/shared typecheck` — passed.
- `bun run --cwd packages/agent lint:check` — 970 files checked, passed.
- `bun run --cwd packages/cloud/shared lint:check` — 2,137 files checked, passed.
- `bun run verify` — passed; 360/360 workspace tasks and all repository audits passed.

# Evidence Gate

<!-- evidence-head:e84324c969c702a8c60520f75c3a893b992e4412 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side security hardening with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side security hardening with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction flow or visual behavior changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic boundary tests directly exercise URL construction and the real volume attach orchestration with mocked external transports; no live backend deployment is changed by this PR.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, scheduled task, wallet, media, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - the relevant evidence is the deterministic adversarial test output summarized above; no frontend surface is involved.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- An additional full `bun run build` completed the workspace compilation and web application bundle, then remained idle in the desktop packaging stage for more than ten minutes with no child process or CPU activity; it was stopped. This does not affect the exact-head package tests, typechecks, or lint gates above.
- The scheduled/manual CodeQL workflow must be dispatched on the merged `develop` SHA to provide scanner acceptance and close or reclassify the linked alerts.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e84324c969c702a8c60520f75c3a893b992e4412:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e84324c969c702a8c60520f75c3a893b992e4412:packages/skills/skills/contribute-to-eliza"} -->

