### PR TITLE
fix(app): repair Android device evidence lane

### DIFF
--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -60,7 +60,11 @@ jobs:
     name: Android emulator bundle
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'android'
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # Cold embedded-agent builds compile the mobile Bun runtime after the APK
+    # assemble has completed. Current hosted evidence shows that phase can
+    # legitimately exceed 90 minutes; the former cap cancelled the bundle
+    # before install/drive and left summary.json stuck at `running`.
+    timeout-minutes: 180
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
       ELIZA_WEBVIEW_DEBUG: "1"

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -60,11 +60,9 @@ jobs:
     name: Android emulator bundle
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'android'
     runs-on: ubuntu-24.04
-    # Cold embedded-agent builds compile the mobile Bun runtime after the APK
-    # assemble has completed. Current hosted evidence shows that phase can
-    # legitimately exceed 90 minutes; the former cap cancelled the bundle
-    # before install/drive and left summary.json stuck at `running`.
-    timeout-minutes: 180
+    # The host-backed emulator target omits the unused embedded-agent build;
+    # this cap covers the real renderer build, APK install, and device probes.
+    timeout-minutes: 90
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
       ELIZA_WEBVIEW_DEBUG: "1"

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -59,7 +59,6 @@ import {
   truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   ChatFailureKind,
   ChatToolCallEvent,

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -117,11 +117,15 @@ async function bootServer(
   configureServer?: NonNullable<
     Parameters<typeof startApiServer>[0]
   >["configureServer"],
+  authorizeWebSocket?: NonNullable<
+    Parameters<typeof startApiServer>[0]
+  >["authorizeWebSocket"],
 ): Promise<string> {
   api = await startApiServer({
     port: 0,
     skipDeferredStartupWork: true,
     configureServer,
+    authorizeWebSocket,
   });
   process.env.ELIZA_PORT = String(api.port);
   process.env.ELIZA_API_PORT = String(api.port);
@@ -411,6 +415,26 @@ describe("unauthenticated /ws bounds (W5-015)", () => {
       });
     });
   }
+
+  it("admits a credential recognized by the host authorizer", async () => {
+    const hostToken = "revocable-host-machine-session";
+    const baseUrl = await bootServer(undefined, (_request, url) => {
+      return url.searchParams.get("token") === hostToken;
+    });
+    const port = Number(new URL(baseUrl).port);
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/ws?token=${encodeURIComponent(hostToken)}`,
+    );
+
+    await waitForFrame(ws, "status");
+    const pong = waitForFrame(ws, "pong");
+    ws.send(JSON.stringify({ type: "ping" }));
+    await pong;
+
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    expect(pendingWebSocketCount("127.0.0.1")).toBe(0);
+    ws.close();
+  });
 
   it("closes a socket that never authenticates after the grace period", async () => {
     const baseUrl = await bootServer();

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3559,6 +3559,11 @@ export type ApiServerConfigurator = (
   server: http.Server,
 ) => void | Promise<void>;
 
+export type WebSocketAuthorizer = (
+  request: http.IncomingMessage,
+  url: URL,
+) => boolean | Promise<boolean>;
+
 function strictPortBindingEnabled(): boolean {
   const value = process.env.ELIZA_API_STRICT_PORT?.trim().toLowerCase();
   return value === "1" || value === "true" || value === "yes";
@@ -3601,6 +3606,13 @@ export async function startApiServer(opts?: {
    * intended for protocol extensions such as WebSocket upgrade handlers.
    */
   configureServer?: ApiServerConfigurator;
+  /**
+   * Lets a host recognize credentials it owns before the dashboard WebSocket
+   * is admitted. The agent server still owns origin/path checks, pending-socket
+   * limits, and its static-token fallback; this hook only adds an authenticated
+   * principal such as app-core's revocable machine session.
+   */
+  authorizeWebSocket?: WebSocketAuthorizer;
 }): Promise<{
   port: number;
   close: () => Promise<void>;
@@ -4183,8 +4195,13 @@ export async function startApiServer(opts?: {
     );
   };
 
+  // Requests authenticated by the host hook must remain authenticated when
+  // `ws` emits its later connection event. IncomingMessage identity is stable
+  // across handleUpgrade, and WeakSet avoids retaining completed requests.
+  const hostAuthorizedWebSocketRequests = new WeakSet<http.IncomingMessage>();
+
   // Handle upgrade requests for WebSocket
-  server.on("upgrade", (request, socket, head) => {
+  server.on("upgrade", async (request, socket, head) => {
     // The raw upgrade socket can emit 'error' (client RST mid-handshake) before
     // a WebSocket — and its error handler — exists. Unhandled, it crashes the
     // process. Attach a no-op-ish guard for the whole upgrade window.
@@ -4222,7 +4239,26 @@ export async function startApiServer(opts?: {
       // DoS. The slot releases when the socket authenticates or closes (see
       // the connection handler), or in the catch below if the upgrade fails.
       let pendingWsPeer: string | null | undefined;
-      if (!isWebSocketAuthorized(request, wsUrl)) {
+      const staticallyAuthorized = isWebSocketAuthorized(request, wsUrl);
+      let hostAuthorized = false;
+      if (!staticallyAuthorized && opts?.authorizeWebSocket) {
+        try {
+          hostAuthorized = await opts.authorizeWebSocket(request, wsUrl);
+        } catch (error) {
+          // error-policy:J1 host authentication is an outer protocol boundary:
+          // fail closed for that credential and retain the bounded post-open
+          // static-token flow instead of crashing the server.
+          logger.error(
+            `[eliza-api] host WebSocket authorization failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      if (hostAuthorized) {
+        hostAuthorizedWebSocketRequests.add(request);
+      }
+      if (!staticallyAuthorized && !hostAuthorized) {
         const peer = request.socket.remoteAddress ?? null;
         if (!tryAcquirePendingWebSocket(peer)) {
           rejectWebSocketUpgrade(
@@ -4248,6 +4284,7 @@ export async function startApiServer(opts?: {
           wss.emit("connection", ws, request);
         });
       } catch (upgradeErr) {
+        hostAuthorizedWebSocketRequests.delete(request);
         // error-policy:J2 release the reserved pre-auth slot, then rethrow
         // unchanged into the outer boundary handler.
         if (pendingWsPeer !== undefined) {
@@ -4256,6 +4293,7 @@ export async function startApiServer(opts?: {
         throw upgradeErr;
       }
     } catch (err) {
+      hostAuthorizedWebSocketRequests.delete(request);
       logger.error(
         `[eliza-api] WebSocket upgrade error: ${err instanceof Error ? err.message : err}`,
       );
@@ -4282,7 +4320,9 @@ export async function startApiServer(opts?: {
       wsUrl = new URL("ws://localhost/ws");
     }
 
-    let isAuthenticated = isWebSocketAuthorized(request, wsUrl);
+    const hostAuthorized = hostAuthorizedWebSocketRequests.delete(request);
+    let isAuthenticated =
+      hostAuthorized || isWebSocketAuthorized(request, wsUrl);
 
     // W5-015: the upgrade handler reserved a pre-auth slot for this socket's
     // peer. It releases on post-open authentication or on close — whichever

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -284,7 +284,9 @@ def resolveForkLlamaLibDir = { String abi ->
     if (fromEnv) return fromEnv
     def stateDir = System.getenv('ELIZA_STATE_DIR') ?: "${System.getProperty('user.home')}/.eliza"
     def abiToken = project.ext.forkLlamaAbiTokens[abi]
-    def candidates = ['vulkan', 'cpu'].collect { backend ->
+    def candidates = [
+        new File(elizaRepoRoot, "packages/app/android/app/src/main/assets/agent/${abi}").toString()
+    ] + ['vulkan', 'cpu'].collect { backend ->
         "${stateDir}/local-inference/bin/mtp/${abiToken}-${backend}"
     }
     return candidates.find { new File(it).isDirectory() }

--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -1443,6 +1443,39 @@ export function ensureZigDrivers({
 }
 
 /**
+ * Discard a CMake build tree whose cached archiver predates the Zig wrappers.
+ * CMake does not repair generated link commands when an old cache recorded the
+ * host macOS ar/ranlib; those tools emit successful but empty archives for ELF
+ * objects. A clean configure is required to make the toolchain change real.
+ */
+export function resetIncompatibleCmakeArchiverCache({
+  buildDir,
+  arPath,
+  ranlibPath,
+  log = () => {},
+}) {
+  const cachePath = path.join(buildDir, "CMakeCache.txt");
+  if (!fs.existsSync(cachePath)) return false;
+
+  const cache = fs.readFileSync(cachePath, "utf8");
+  const expectedAr = `CMAKE_AR:FILEPATH=${arPath}`;
+  const expectedRanlib = `CMAKE_RANLIB:FILEPATH=${ranlibPath}`;
+  if (
+    cache.split(/\r?\n/).includes(expectedAr) &&
+    cache.split(/\r?\n/).includes(expectedRanlib)
+  ) {
+    return false;
+  }
+
+  fs.rmSync(buildDir, { recursive: true, force: true });
+  log(
+    `[compile-libllama] Reset stale CMake build tree at ${buildDir}: ` +
+      "cached archiver was not the Zig ELF archiver.",
+  );
+  return true;
+}
+
+/**
  * Configure + build libllama.so + libggml.so for one ABI. Produces:
  *   <srcDir>/build-<abi>/src/libllama.so
  *   <srcDir>/build-<abi>/ggml/src/libggml.so
@@ -1482,7 +1515,6 @@ export function buildLibllamaForAbi({
     throw new Error(`[compile-libllama] Unknown ABI: ${abi}`);
   }
   const buildDir = path.join(srcDir, `build-${abi}`);
-  fs.mkdirSync(buildDir, { recursive: true });
 
   // riscv64: gate the RVV-on path on the detected Zig version. The vendored
   // llama.cpp defaults GGML_RVV / GGML_RV_ZFH / GGML_RV_ZVFH / GGML_RV_ZICBOP
@@ -1565,6 +1597,13 @@ export function buildLibllamaForAbi({
     zigBin,
     riscv64MarchPassthrough: riscv64Plan.rvv,
   });
+  resetIncompatibleCmakeArchiverCache({
+    buildDir,
+    arPath,
+    ranlibPath,
+    log,
+  });
+  fs.mkdirSync(buildDir, { recursive: true });
 
   log(
     `[compile-libllama] Configuring llama.cpp for ${abi} (${target.zigTarget}) in ${buildDir}`,

--- a/packages/app-core/scripts/aosp/compile-libllama.test.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.test.mjs
@@ -8,6 +8,7 @@ import { resolveElizaWorkspaceRootFromImportMeta } from "../lib/repo-root.mjs";
 import {
   describeAndroidTargetDryRun,
   ensureZigDrivers,
+  resetIncompatibleCmakeArchiverCache,
   stageStaticFusedRuntimeBackendLibs,
 } from "./compile-libllama.mjs";
 import {
@@ -42,6 +43,49 @@ afterEach(() => {
   while (tmpDirs.length > 0) {
     removePathRecursive(tmpDirs.pop());
   }
+});
+
+describe("compile-libllama CMake archiver cache", () => {
+  test("resets a stale host-archiver build tree", () => {
+    const buildDir = makeTmpDir();
+    fs.writeFileSync(
+      path.join(buildDir, "CMakeCache.txt"),
+      "CMAKE_AR:UNINITIALIZED=/tmp/zig-ar\nCMAKE_RANLIB:UNINITIALIZED=/tmp/zig-ranlib\n",
+    );
+    fs.writeFileSync(path.join(buildDir, "stale-object"), "present");
+    const logs = [];
+
+    expect(
+      resetIncompatibleCmakeArchiverCache({
+        buildDir,
+        arPath: "/tmp/zig-ar",
+        ranlibPath: "/tmp/zig-ranlib",
+        log: (line) => logs.push(line),
+      }),
+    ).toBe(true);
+    expect(fs.existsSync(buildDir)).toBe(false);
+    expect(logs.join("\n")).toContain("Reset stale CMake build tree");
+  });
+
+  test("preserves a build tree already configured with Zig archivers", () => {
+    const buildDir = makeTmpDir();
+    fs.writeFileSync(
+      path.join(buildDir, "CMakeCache.txt"),
+      "CMAKE_AR:FILEPATH=/tmp/zig-ar\nCMAKE_RANLIB:FILEPATH=/tmp/zig-ranlib\n",
+    );
+    fs.writeFileSync(path.join(buildDir, "compiled-object"), "present");
+
+    expect(
+      resetIncompatibleCmakeArchiverCache({
+        buildDir,
+        arPath: "/tmp/zig-ar",
+        ranlibPath: "/tmp/zig-ranlib",
+      }),
+    ).toBe(false);
+    expect(
+      fs.readFileSync(path.join(buildDir, "compiled-object"), "utf8"),
+    ).toBe("present");
+  });
 });
 
 describe("compile-libllama Android Vulkan host resolution", () => {

--- a/packages/app-core/scripts/lib/device-e2e-model-resolver.test.ts
+++ b/packages/app-core/scripts/lib/device-e2e-model-resolver.test.ts
@@ -1,0 +1,49 @@
+/** Verifies deterministic device-e2e model routing without starting an agent or server. */
+
+import { describe, expect, it } from "vitest";
+import {
+  resolveDeviceE2eModelCall,
+  STREAM_E2E_REPLY,
+} from "./device-e2e-model-resolver";
+
+describe("resolveDeviceE2eModelCall", () => {
+  it("answers the conversation-title side call accepted by the real chat API", () => {
+    expect(
+      resolveDeviceE2eModelCall({
+        modelType: "TEXT_SMALL",
+        latestUserText:
+          "Based on the user's first message, generate a very short, concise title. Title:",
+      }),
+    ).toEqual({ message: "Short greeting" });
+  });
+
+  it("does not fabricate answers for unrelated text-small calls", () => {
+    expect(
+      resolveDeviceE2eModelCall({
+        modelType: "TEXT_SMALL",
+        latestUserText: "Summarize this private document.",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the device chat fixture through the response-handler slot", () => {
+    const result = resolveDeviceE2eModelCall({
+      modelType: "RESPONSE_HANDLER",
+    });
+    expect(typeof result).toBe("string");
+    expect(JSON.parse(result as string)).toMatchObject({
+      shouldRespond: "RESPOND",
+      replyText: STREAM_E2E_REPLY,
+    });
+  });
+
+  it("keeps the workflow-only large-model fixture opt-in", () => {
+    expect(resolveDeviceE2eModelCall({ modelType: "TEXT_LARGE" })).toBeNull();
+    expect(
+      resolveDeviceE2eModelCall(
+        { modelType: "TEXT_LARGE" },
+        { workflowJourney: true },
+      ),
+    ).toEqual({ message: "Digest ready" });
+  });
+});

--- a/packages/app-core/scripts/lib/device-e2e-model-resolver.ts
+++ b/packages/app-core/scripts/lib/device-e2e-model-resolver.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolves deterministic model calls made by the real device-e2e host agent.
+ * The fixture covers both the chat response and the conversation-title side
+ * call so the real API pipeline cannot fail after accepting a device message.
+ */
+
+type DeviceE2eModelCall = {
+  modelType: string;
+  latestUserText?: string | null;
+};
+
+type DeviceE2eModelResolverOptions = {
+  workflowJourney?: boolean;
+};
+
+export const STREAM_E2E_REPLY =
+  "STREAM_E2E_OK The dashboard receives this reply through the real model callback, runtime message loop, HTTP SSE route, browser parser, and React transcript. " +
+  "Each chunk is intentionally small and evenly paced so the browser lane can measure token-to-paint latency, frame cadence, layout stability, and DOM identity while the visible answer grows.";
+
+const CONVERSATION_TITLE_PROMPT =
+  /generate a very short, concise title|title should reflect the topic or intent/i;
+
+export function resolveDeviceE2eModelCall(
+  call: DeviceE2eModelCall,
+  { workflowJourney = false }: DeviceE2eModelResolverOptions = {},
+): { message: string } | string | null {
+  if (workflowJourney && call.modelType === "TEXT_LARGE") {
+    return { message: "Digest ready" };
+  }
+  if (
+    call.modelType === "TEXT_SMALL" &&
+    CONVERSATION_TITLE_PROMPT.test(call.latestUserText ?? "")
+  ) {
+    return { message: "Short greeting" };
+  }
+  if (call.modelType !== "RESPONSE_HANDLER") return null;
+
+  return JSON.stringify({
+    shouldRespond: "RESPOND",
+    contexts: ["simple"],
+    intents: ["chat"],
+    replyText: STREAM_E2E_REPLY,
+    candidateActionNames: [],
+    facts: [],
+    relationships: [],
+    addressedTo: [],
+    emotion: "none",
+  });
+}

--- a/packages/app-core/scripts/mobile/targets/android.mjs
+++ b/packages/app-core/scripts/mobile/targets/android.mjs
@@ -44,6 +44,25 @@ export const ANDROID_BUILD_TARGETS = Object.freeze({
     },
     artifactAuditKey: "sideload",
   }),
+  "android-host-e2e": freezeAndroidBuildTarget({
+    target: "android-host-e2e",
+    webTarget: "android",
+    env: {
+      ELIZA_ANDROID_HOST_E2E_BUILD: "1",
+      ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB: "1",
+    },
+    overlayOptions: { includeAospRoleLaunchers: false },
+    cleartextPolicy: { allowCleartext: true, label: "host-e2e" },
+    gradle: {
+      flags: ["-PelizaStripAgentAssets=true"],
+      metadataVariant: "debug",
+      finalTask: ":app:assembleDebug",
+      includeWebsiteBlockerUnitTest: true,
+      includeAospFlagFromEnv: true,
+      passFlagsToMetadata: false,
+    },
+    artifactAuditKey: "hostE2e",
+  }),
   "android-cloud-hybrid": freezeAndroidBuildTarget({
     target: "android-cloud-hybrid",
     webTarget: "android-cloud-hybrid",

--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -31,6 +31,7 @@ describe("Android mobile build target table", () => {
       "android-cloud",
       "android-cloud-debug",
       "android-cloud-hybrid",
+      "android-host-e2e",
       "android-sms-gateway",
       "android-system",
     ]);
@@ -42,6 +43,27 @@ describe("Android mobile build target table", () => {
       cleartextPolicy: { allowCleartext: true, label: "sideload" },
       agentRuntime: { bunChannel: "stable" },
     });
+    expect(ANDROID_BUILD_TARGETS["android-host-e2e"]).toMatchObject({
+      target: "android-host-e2e",
+      webTarget: "android",
+      env: {
+        ELIZA_ANDROID_HOST_E2E_BUILD: "1",
+        ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB: "1",
+      },
+      cleartextPolicy: { allowCleartext: true, label: "host-e2e" },
+      gradle: {
+        flags: ["-PelizaStripAgentAssets=true"],
+        metadataVariant: "debug",
+        finalTask: ":app:assembleDebug",
+      },
+      artifactAuditKey: "hostE2e",
+    });
+    expect(ANDROID_BUILD_TARGETS["android-host-e2e"]).not.toHaveProperty(
+      "buildMobileAgentBundle",
+    );
+    expect(ANDROID_BUILD_TARGETS["android-host-e2e"].agentRuntime).toBe(
+      undefined,
+    );
     expect(ANDROID_BUILD_TARGETS["android-cloud"]).toMatchObject({
       target: "android-cloud",
       webTarget: "android-cloud",
@@ -173,6 +195,18 @@ describe("Android mobile build target table", () => {
     } finally {
       fs.rmSync(fixtureRoot, { recursive: true, force: true });
     }
+  });
+
+  it("exposes and dispatches the host-emulator build target", () => {
+    const packageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, "utf8"));
+
+    expect(packageJson.scripts["build:android:host-e2e"]).toBe(
+      "node ../../packages/app-core/scripts/run-mobile-build.mjs android-host-e2e",
+    );
+    expect(runMobileBuildSource).toContain('target !== "android-host-e2e"');
+    expect(runMobileBuildSource).toContain(
+      'await runAndroidBuild("android-host-e2e")',
+    );
   });
 
   it("fails loudly for unknown public Android targets", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6,11 +6,15 @@
  * Reads app identity from the host's app.config.ts so web, desktop, and
  * native builds share one canonical app contract.
  *
- * Usage: node scripts/run-mobile-build.mjs <android|android-cloud-hybrid|android-sms-gateway|android-cloud|android-cloud-audit [aab-path]|android-cloud-debug|android-system|ios|ios-local|ios-overlay>
+ * Usage: node scripts/run-mobile-build.mjs <android|android-host-e2e|android-cloud-hybrid|android-sms-gateway|android-cloud|android-cloud-audit [aab-path]|android-cloud-debug|android-system|ios|ios-local|ios-overlay>
  *
  * Android targets:
  *   - android         Sideload-only debug APK with the on-device agent runtime
  *                     and AOSP/system-only permissions. NOT Play-Store-shippable.
+ *   - android-host-e2e
+ *                     Debug APK for hosted emulator evidence. Keeps the real
+ *                     Android renderer and native bridge but omits the unused
+ *                     embedded agent payload.
  *   - android-cloud-hybrid
  *                     Sideload-only debug APK with the on-device agent runtime
  *                     bundled and a cloud-hybrid renderer. NOT Play-Store-shippable.
@@ -6906,6 +6910,7 @@ const ANDROID_SOURCE_AUDITS = Object.freeze({
 
 const ANDROID_ARTIFACT_AUDITS = Object.freeze({
   sideload: ({ javaHome }) => auditAndroidSideloadArtifact({ javaHome }),
+  hostE2e: ({ javaHome }) => auditAndroidHostE2eArtifact({ javaHome }),
   cloud: ({ env, javaHome }) => auditAndroidCloudArtifact({ env, javaHome }),
   cloudDebug: ({ env, javaHome }) =>
     auditAndroidCloudArtifact({ debug: true, env, javaHome }),
@@ -7133,6 +7138,37 @@ function auditAndroidSideloadArtifact({ javaHome } = {}) {
   });
   console.log(
     `[mobile-build] android sideload artifact audit passed: ${artifact}`,
+  );
+  return artifact;
+}
+
+/** Audit the hosted-emulator debug APK without requiring a local agent payload. */
+function auditAndroidHostE2eArtifact({ javaHome } = {}) {
+  const artifact = findAndroidCloudDebugApk();
+  if (!artifact) {
+    throw new Error(
+      "[mobile-build] android host-e2e debug APK was not found under app/build/outputs/.",
+    );
+  }
+  const entries = listAndroidArtifactEntries(artifact, javaHome);
+  assertAndroidArtifactShipsWebPayload(artifact, entries, {
+    requireAgent: false,
+    label: "android-host-e2e",
+  });
+  const packagedAgent = entries.find((entry) =>
+    /(^|\/)assets\/agent\//i.test(entry.replaceAll("\\", "/")),
+  );
+  if (packagedAgent) {
+    throw mobileBuildError(
+      `[mobile-build] android-host-e2e artifact unexpectedly contains the embedded agent payload: ${packagedAgent}`,
+      {
+        code: "ANDROID_HOST_E2E_AGENT_PAYLOAD_PRESENT",
+        context: { artifact, packagedAgent },
+      },
+    );
+  }
+  console.log(
+    `[mobile-build] android host-e2e artifact audit passed: ${artifact}`,
   );
   return artifact;
 }
@@ -8765,6 +8801,7 @@ export async function main(argv = process.argv.slice(2)) {
   const target = argv[0];
   if (
     target !== "android" &&
+    target !== "android-host-e2e" &&
     target !== "android-cloud-hybrid" &&
     target !== "android-sms-gateway" &&
     target !== "android-cloud" &&
@@ -8776,12 +8813,14 @@ export async function main(argv = process.argv.slice(2)) {
     target !== "ios-overlay"
   ) {
     console.error(
-      "Usage: node scripts/run-mobile-build.mjs <android|android-cloud-hybrid|android-sms-gateway|android-cloud|android-cloud-audit [aab-path]|android-cloud-debug|android-system|ios|ios-local|ios-overlay>",
+      "Usage: node scripts/run-mobile-build.mjs <android|android-host-e2e|android-cloud-hybrid|android-sms-gateway|android-cloud|android-cloud-audit [aab-path]|android-cloud-debug|android-system|ios|ios-local|ios-overlay>",
     );
     process.exit(1);
   }
   if (target === "android") {
     await buildAndroid();
+  } else if (target === "android-host-e2e") {
+    await runAndroidBuild("android-host-e2e");
   } else if (target === "android-cloud-hybrid") {
     await runAndroidBuild("android-cloud-hybrid");
   } else if (target === "android-sms-gateway") {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -2247,7 +2247,9 @@ export function injectCopyForkLlamaLibTask(content) {
     `    if (fromEnv) return fromEnv\n` +
     `    def stateDir = System.getenv('ELIZA_STATE_DIR') ?: "\${System.getProperty('user.home')}/.eliza"\n` +
     `    def abiToken = project.ext.forkLlamaAbiTokens[abi]\n` +
-    `    def candidates = ['vulkan', 'cpu'].collect { backend ->\n` +
+    `    def candidates = [\n` +
+    `        new File(elizaRepoRoot, "packages/app/android/app/src/main/assets/agent/\${abi}").toString()\n` +
+    `    ] + ['vulkan', 'cpu'].collect { backend ->\n` +
     `        "\${stateDir}/local-inference/bin/mtp/\${abiToken}-\${backend}"\n` +
     `    }\n` +
     `    return candidates.find { new File(it).isDirectory() }\n` +

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -17,6 +17,7 @@ import { registerTriggerTaskWorker } from "../../agent/src/triggers/runtime.ts";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
+import { resolveDeviceE2eModelCall } from "./lib/device-e2e-model-resolver.ts";
 import { publishBoundDeviceE2ePort } from "./lib/device-e2e-port-advertisement.ts";
 
 const deviceE2eUploadImageRoute = {
@@ -25,9 +26,6 @@ const deviceE2eUploadImageRoute = {
   name: "device-e2e-upload-image",
 };
 
-const STREAM_E2E_REPLY =
-  "STREAM_E2E_OK The dashboard receives this reply through the real model callback, runtime message loop, HTTP SSE route, browser parser, and React transcript. " +
-  "Each chunk is intentionally small and evenly paced so the browser lane can measure token-to-paint latency, frame cadence, layout stability, and DOM identity while the visible answer grows.";
 const GENERATED_REGISTRY_URL =
   "https://plugins.eliza.app/generated-registry.json";
 const CLOUD_API_PROBE_URL = "https://api.eliza.app/api/v1";
@@ -205,25 +203,9 @@ async function main(): Promise<void> {
   const proxy = createDeterministicModelPlugin({
     stream: deterministicStream,
     resolve(call) {
-      if (
-        process.env.ELIZA_UI_SMOKE_WORKFLOW_JOURNEY === "1" &&
-        call.modelType === ModelType.TEXT_LARGE
-      ) {
-        return { message: "Digest ready" };
-      }
-      if (call.modelType !== ModelType.RESPONSE_HANDLER) return null;
-      const args = {
-        shouldRespond: "RESPOND",
-        contexts: ["simple"],
-        intents: ["chat"],
-        replyText: STREAM_E2E_REPLY,
-        candidateActionNames: [],
-        facts: [],
-        relationships: [],
-        addressedTo: [],
-        emotion: "none",
-      };
-      return JSON.stringify(args);
+      return resolveDeviceE2eModelCall(call, {
+        workflowJourney: process.env.ELIZA_UI_SMOKE_WORKFLOW_JOURNEY === "1",
+      });
     },
   });
   const mediaRoutesPlugin = {

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -13,6 +13,7 @@ import { readFile } from "node:fs/promises";
 import { ModelType, type Plugin, type Route } from "@elizaos/core";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
+import { registerPluginViews } from "../../agent/src/api/views-registry.ts";
 import { registerTriggerTaskWorker } from "../../agent/src/triggers/runtime.ts";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
@@ -217,6 +218,13 @@ async function main(): Promise<void> {
       rubyHighEvidenceActionRoute,
     ],
   };
+  // Route coverage exercises the real dynamic view registry, so the host must
+  // declare the view-only task-coordinator plugin instead of relying on the
+  // browser smoke suite's synthetic registry fixture. Its Node entrypoint does
+  // not load the UI bundle; app-core serves that bundle only when requested.
+  const { default: taskCoordinatorPlugin } = await import(
+    "../../../plugins/plugin-task-coordinator/src/index.ts"
+  );
   const workflowPlugins: Plugin[] = [];
   if (process.env.ELIZA_UI_SMOKE_WORKFLOW_JOURNEY === "1") {
     const { default: workflowPlugin } = await import(
@@ -229,8 +237,18 @@ async function main(): Promise<void> {
   }
   const runtimeResult = await createRealTestRuntime({
     characterName: "DeviceE2EHostAgent",
-    plugins: [proxy, mediaRoutesPlugin, ...workflowPlugins],
+    plugins: [
+      proxy,
+      mediaRoutesPlugin,
+      taskCoordinatorPlugin,
+      ...workflowPlugins,
+    ],
   });
+  await registerPluginViews(
+    taskCoordinatorPlugin,
+    undefined,
+    runtimeResult.runtime,
+  );
   if (process.env.ELIZA_UI_SMOKE_WORKFLOW_JOURNEY === "1") {
     registerTriggerTaskWorker(runtimeResult.runtime);
   }

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -70,6 +70,9 @@ describe("compat route auth policy table", () => {
       resolveCompatRouteAuthPolicy("GET", "/api/auth/status"),
     ).toMatchObject({ id: "auth.status", tier: "public" });
     expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/auth/pair-code"),
+    ).toMatchObject({ id: "auth.pair-code", tier: "public" });
+    expect(
       resolveCompatRouteAuthPolicy("GET", "/api/first-run/status"),
     ).toMatchObject({ id: "first-run.status", tier: "session" });
     expect(

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -130,6 +130,11 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("auth.setup", "POST", "/api/auth/setup"),
   publicExact("auth.login.password", "POST", "/api/auth/login/password"),
   publicExact("auth.status", "GET", "/api/auth/status"),
+  // The handler independently requires trusted loopback before returning the
+  // operator-visible short-lived code. Keeping this route behind the session
+  // gate made that loopback bootstrap impossible: the operator needs the code
+  // precisely before the remote device has a session.
+  publicExact("auth.pair-code", "GET", "/api/auth/pair-code"),
   publicExact("auth.pair", "POST", "/api/auth/pair"),
   publicExact("embed.auth", "POST", "/api/embed/auth"),
   publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -51,7 +51,9 @@ import { createRuntimeAccountStoragePolicy } from "@elizaos/auth/account-storage
 import { type AgentRuntime, logger, resolveStateDir } from "@elizaos/core";
 import { resolveLinkedAccountsInConfig } from "@elizaos/shared/contracts/first-run-options";
 import { resetDefaultAccountPoolAfterCredentialReset } from "../services/account-pool";
+import { AuthStore } from "../services/auth-store";
 import { handleAccountPoolStatusRoute } from "./account-pool-status-routes";
+import { findActiveSession } from "./auth/sessions";
 import {
   ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized,
@@ -1093,6 +1095,42 @@ export async function startApiServer(
         }
         await next();
       });
+    },
+    authorizeWebSocket: async (request, url) => {
+      const sessionToken =
+        url.searchParams.get("token")?.trim() ||
+        url.searchParams.get("apiKey")?.trim() ||
+        url.searchParams.get("api_key")?.trim() ||
+        extractAuthToken(request)?.trim() ||
+        null;
+      if (sessionToken) {
+        const db = compatState.current?.adapter?.db;
+        if (db) {
+          try {
+            const store = new AuthStore(
+              db as ConstructorParameters<typeof AuthStore>[0],
+            );
+            if (await findActiveSession(store, sessionToken)) {
+              return true;
+            }
+          } catch (error) {
+            // error-policy:J1 WebSocket admission is the protocol boundary;
+            // an unavailable auth store rejects the session instead of
+            // degrading to an authenticated socket.
+            logger.error(
+              `[eliza][auth] WebSocket session lookup failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            compatState.current?.reportError(
+              "appCore.webSocketSessionAuth",
+              error,
+              { phase: "upgrade" },
+            );
+          }
+        }
+      }
+      return (await callerOptions?.authorizeWebSocket?.(request, url)) === true;
     },
     configureServer: async (httpServer) => {
       await callerOptions?.configureServer?.(httpServer);

--- a/packages/app-core/src/runtime/agent-host-bridge-cookie-cors.test.ts
+++ b/packages/app-core/src/runtime/agent-host-bridge-cookie-cors.test.ts
@@ -24,9 +24,9 @@ import {
 } from "@elizaos/agent/runtime/host-bridge";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CSRF_HEADER_NAME,
   createBrowserSession,
   createMachineSession,
-  CSRF_HEADER_NAME,
   SESSION_COOKIE_NAME,
 } from "../api/auth/sessions";
 import { _resetAuthRateLimiter } from "../api/auth.ts";
@@ -149,6 +149,9 @@ describe("installed host bridge binds cookie auth to credentialed CORS trust", (
     });
     const { session } = await createBrowserSession(harness.store, {
       identityId: identity.id,
+      ip: null,
+      userAgent: null,
+      rememberDevice: false,
     });
     const cookie = `${SESSION_COOKIE_NAME}=${session.id}`;
 
@@ -192,6 +195,9 @@ describe("installed host bridge binds cookie auth to credentialed CORS trust", (
     });
     const { session, csrfToken } = await createBrowserSession(harness.store, {
       identityId: identity.id,
+      ip: null,
+      userAgent: null,
+      rememberDevice: false,
     });
     const cookie = `${SESSION_COOKIE_NAME}=${session.id}`;
 

--- a/packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts
+++ b/packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts
@@ -70,6 +70,7 @@
 import crypto from "node:crypto";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
 import { SESSION_COOKIE_NAME } from "../../src/api/auth/sessions.ts";
 import {
   _resetAuthPairingStateForTests,
@@ -81,6 +82,29 @@ import { useIsolatedConfigEnv } from "../helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../helpers/real-runtime.ts";
 
 const PRODUCTION_API_TOKEN = "prod-shaped-static-api-token-13692";
+
+function waitForWsFrame(
+  ws: WebSocket,
+  type: string,
+  timeoutMs = 10_000,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for WebSocket ${type}`)),
+      timeoutMs,
+    );
+    ws.on("message", (data) => {
+      const frame = JSON.parse(String(data)) as Record<string, unknown>;
+      if (frame.type !== type) return;
+      clearTimeout(timer);
+      resolve(frame);
+    });
+    ws.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
 
 type Started = Awaited<ReturnType<typeof startApiServer>>;
 type RealRuntime = Awaited<ReturnType<typeof createRealTestRuntime>>;
@@ -225,6 +249,21 @@ describe("production auth path: pair-code → machine session; remote-connect to
     expect(
       (meViaCookie.data as { session?: { id?: string } }).session?.id,
     ).toBe(sessionId);
+
+    // The same revocable machine session must authorize the browser WebSocket.
+    // Android remote-connect uses this query-token handshake because browser
+    // WebSocket constructors cannot set Authorization headers. Before #13580,
+    // REST pairing succeeded but /ws recognized only the static API token, so
+    // the app stayed on "waking up" and every chat frame was rejected.
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/ws?token=${encodeURIComponent(sessionId)}`,
+    );
+    const statusFrame = await waitForWsFrame(ws, "status");
+    expect(statusFrame.type).toBe("status");
+    const pong = waitForWsFrame(ws, "pong");
+    ws.send(JSON.stringify({ type: "ping" }));
+    await pong;
+    ws.close();
   }, 120_000);
 
   it("§Verification canary: a WRONG pair code is rejected and mints NO session (green run is non-vacuous)", async () => {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -122,6 +122,7 @@
     "test:e2e:ios:physical": "node scripts/ios-device-e2e.mjs",
     "capture:ios-sim:boot": "node scripts/ios-device-capture.mjs --platform sim",
     "build:android": "node ../../packages/app-core/scripts/run-mobile-build.mjs android",
+    "build:android:host-e2e": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-host-e2e",
     "build:android:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android",
     "build:android:cloud-hybrid": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-hybrid",
     "build:android:cloud": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud",

--- a/packages/app/scripts/android-e2e-build.test.mjs
+++ b/packages/app/scripts/android-e2e-build.test.mjs
@@ -1,0 +1,13 @@
+/** Verifies Android E2E builds package only the runtime payload their backend uses. */
+import { describe, expect, it } from "vitest";
+import { resolveAndroidE2eBuildScript } from "./lib/android-e2e-build.mjs";
+
+describe("Android E2E build selection", () => {
+  it("uses the payload-free APK for a host-backed emulator", () => {
+    expect(resolveAndroidE2eBuildScript("host")).toBe("build:android:host-e2e");
+  });
+
+  it("keeps the embedded-agent APK for a local backend", () => {
+    expect(resolveAndroidE2eBuildScript("local")).toBe("build:android");
+  });
+});

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -36,6 +36,7 @@ import {
   resolveSerial,
   verifyInstalledApkMatches,
 } from "./lib/android-device.mjs";
+import { resolveAndroidE2eBuildScript } from "./lib/android-e2e-build.mjs";
 import {
   captureFailureForensics,
   createDeviceE2eBundle,
@@ -262,9 +263,10 @@ function currentHeadCommit() {
   }
 }
 
-function buildAndroidApk(bundle) {
-  log("building WebView-debuggable APK…");
-  run(bundle, "build Android APK", "bun", ["run", "build:android"], {
+function buildAndroidApk(bundle, backend) {
+  const buildScript = resolveAndroidE2eBuildScript(backend);
+  log(`building WebView-debuggable APK via ${buildScript}…`);
+  run(bundle, "build Android APK", "bun", ["run", buildScript], {
     ELIZA_MOBILE_REPO_ROOT: elizaRoot,
     ELIZA_WEBVIEW_DEBUG: "1",
     ELIZA_BUN_RISCV64_OPTIONAL: "1",
@@ -291,7 +293,7 @@ function readApkRendererStamp(apk) {
   }
 }
 
-function ensureFreshApkInstalled(bundle, adb, serial) {
+function ensureFreshApkInstalled(bundle, adb, serial, backend) {
   const forceBuild = has("--force-build") || has("--build");
   const skipBuild = has("--skip-build");
   const headCommit = currentHeadCommit();
@@ -299,7 +301,7 @@ function ensureFreshApkInstalled(bundle, adb, serial) {
   const buildDecision = androidDistNeedsBuild({ freshStamp, headCommit });
 
   if (forceBuild) {
-    buildAndroidApk(bundle);
+    buildAndroidApk(bundle, backend);
   } else if (buildDecision.build) {
     if (skipBuild) {
       throw new Error(
@@ -307,7 +309,7 @@ function ensureFreshApkInstalled(bundle, adb, serial) {
       );
     }
     log(`${buildDecision.reason} — rebuilding before install check.`);
-    buildAndroidApk(bundle);
+    buildAndroidApk(bundle, backend);
   } else {
     log(`fresh dist renderer stamp: ${stampLabel(freshStamp)}`);
   }
@@ -330,7 +332,7 @@ function ensureFreshApkInstalled(bundle, adb, serial) {
     }
     if (!forceBuild) {
       log(`${apkDecision.reason} — rebuilding APK before install.`);
-      buildAndroidApk(bundle);
+      buildAndroidApk(bundle, backend);
       freshStamp = readFreshAndroidRendererStamp();
       if (!freshStamp) {
         throw new Error(
@@ -526,7 +528,7 @@ async function main() {
       }
     }
 
-    ensureFreshApkInstalled(bundle, adb, serial);
+    ensureFreshApkInstalled(bundle, adb, serial, backend);
 
     if (has("--start-host-agent")) {
       const step = startBundleStep(bundle, "start deterministic host agent");

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -11,6 +11,7 @@
  * --no-emulator-boot, and --no-wait.
  */
 import { execFileSync, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -530,6 +531,7 @@ async function main() {
     if (has("--start-host-agent")) {
       const step = startBundleStep(bundle, "start deterministic host agent");
       try {
+        const hostAgentToken = randomBytes(32).toString("hex");
         hostAgent = await startDeviceE2eHostAgent({
           repoRoot: elizaRoot,
           artifactDir: bundle.logsDir,
@@ -537,9 +539,12 @@ async function main() {
             "--host-agent-port",
             process.env.ELIZA_ANDROID_HOST_AGENT_PORT,
           ),
+          env: { ...process.env, ELIZA_API_TOKEN: hostAgentToken },
+          pairingDisabled: false,
           log,
         });
         process.env.ELIZA_ANDROID_HOST_AGENT_PORT = String(hostAgent.port);
+        process.env.ELIZA_ANDROID_HOST_AGENT_TOKEN = hostAgentToken;
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
         failAndroidStep(bundle, step, error);

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -633,6 +633,11 @@ export function appPid(adbBin, serial) {
  * healthy. Branded AOSP devices run the agent privileged and don't need this;
  * for a test emulator we `adb root` + `setenforce 0`. No-op (best-effort) on
  * physical devices, which must already be branded/privileged.
+ *
+ * A fresh emulator also shows Android's one-time immersive-mode confirmation
+ * above the app. That system overlay is outside WebView/CDP and intercepts the
+ * first route-coverage interaction, so acknowledge it through the emulator's
+ * secure setting before the app launches.
  */
 export async function ensureEmulatorPermissive(
   adbBin,
@@ -647,6 +652,30 @@ export async function ensureEmulatorPermissive(
   await delay(2_000);
   adbTry(adbBin, ["-s", serial, "wait-for-device"]);
   adbTry(adbBin, ["-s", serial, "shell", "setenforce", "0"]);
+  adb(adbBin, [
+    "-s",
+    serial,
+    "shell",
+    "settings",
+    "put",
+    "secure",
+    "immersive_mode_confirmations",
+    "confirmed",
+  ]);
+  const immersiveConfirmation = adb(adbBin, [
+    "-s",
+    serial,
+    "shell",
+    "settings",
+    "get",
+    "secure",
+    "immersive_mode_confirmations",
+  ]).trim();
+  if (immersiveConfirmation !== "confirmed") {
+    throw new Error(
+      `failed to acknowledge Android immersive-mode confirmation on ${serial}`,
+    );
+  }
   const mode = adbTry(adbBin, ["-s", serial, "shell", "getenforce"]).trim();
   log(`SELinux mode on ${serial}: ${mode || "unknown"}`);
   return /permissive/i.test(mode);

--- a/packages/app/scripts/lib/android-e2e-build.mjs
+++ b/packages/app/scripts/lib/android-e2e-build.mjs
@@ -1,0 +1,4 @@
+/** Selects the Android APK build lane that matches the E2E runtime backend. */
+export function resolveAndroidE2eBuildScript(backend) {
+  return backend === "host" ? "build:android:host-e2e" : "build:android";
+}

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -266,6 +266,7 @@ export async function startDeviceE2eHostAgent({
     path.join(repoRoot, "packages/app-core/scripts/serve-real-local-agent.ts"),
   ],
   env = process.env,
+  pairingDisabled = true,
 } = {}) {
   if (!repoRoot) throw new Error("startDeviceE2eHostAgent requires repoRoot.");
   if (!artifactDir) {
@@ -302,7 +303,7 @@ export async function startDeviceE2eHostAgent({
       ELIZA_API_PORT: String(explicitPort ?? 0),
       ELIZA_API_STRICT_PORT: "1",
       ELIZA_E2E_PORT_FILE: portFile,
-      ELIZA_PAIRING_DISABLED: "1",
+      ELIZA_PAIRING_DISABLED: pairingDisabled ? "1" : "0",
     },
     stdio: ["ignore", logFd, logFd],
   });

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -484,6 +484,26 @@ describe("host-agent helper", () => {
     }
   });
 
+  it("can leave pairing enabled for remote-device onboarding evidence", async () => {
+    const agent = await startDeviceE2eHostAgent({
+      repoRoot: process.cwd(),
+      artifactDir: makeTmpDir(),
+      readyAttempts: 250,
+      readyDelayMs: 20,
+      command: process.execPath,
+      args: ["-e", fakeHostAgentScript()],
+      env: {},
+      pairingDisabled: false,
+    });
+    try {
+      const response = await fetch(`${agent.apiBase}/api/health`);
+      expect(response.ok).toBe(true);
+      expect(await response.json()).toMatchObject({ pairingDisabled: "0" });
+    } finally {
+      await agent.stop();
+    }
+  });
+
   it("fails fast and closes the log fd when the child cannot spawn", async () => {
     const artifactDir = makeTmpDir();
     await expect(

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -88,6 +88,7 @@ const IOS_FULL_BUN_SMOKE_RESULT_KEY = "eliza:ios-full-bun-smoke:result";
 const IOS_FULL_BUN_PREWARM_RESULT_KEY = "eliza:ios-full-bun-prewarm:result";
 const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
 const ANDROID_LOCAL_AGENT_IPC_BASE = IOS_LOCAL_AGENT_IPC_BASE;
+const ANDROID_LOCAL_AGENT_DEVICE_PORT = 31337;
 const IOS_FULL_BUN_SMOKE_MODEL_ID = "eliza-1-2b";
 const IOS_FULL_BUN_SMOKE_MODEL_RELATIVE_PATH =
   "models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf";
@@ -862,6 +863,7 @@ async function launchAndroidEmulatorApp() {
 
   const context = { adb, serial, installed: true };
   if (androidSelectLocal) {
+    removeAndroidReverse(context, ANDROID_LOCAL_AGENT_DEVICE_PORT);
     forceStopConflictingAndroidAgents(context);
     preseedAndroidLocalRuntime(context);
   }
@@ -1239,6 +1241,14 @@ function removeAndroidForward(context, localPort) {
   tryExec(
     context.adb,
     ["-s", context.serial, "forward", "--remove", localPort],
+    { allowFailure: true },
+  );
+}
+
+function removeAndroidReverse(context, devicePort) {
+  tryExec(
+    context.adb,
+    ["-s", context.serial, "reverse", "--remove", `tcp:${devicePort}`],
     { allowFailure: true },
   );
 }
@@ -2845,6 +2855,7 @@ export {
   preseedIosLocalRuntime,
   probeHealth,
   readAndroidLocalAgentToken,
+  removeAndroidReverse,
   readIosFullBunSmokeDiagnostics,
   readLastWakeFiredAtMs,
   readStartupAttempt,

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -311,6 +311,7 @@ describe("mobile smoke native command boundaries", () => {
     });
     smoke.preseedAndroidLocalRuntime(fakeAndroidContext);
     smoke.forceStopConflictingAndroidAgents(fakeAndroidContext);
+    smoke.removeAndroidReverse(fakeAndroidContext, 31337);
     await smoke.stageAndroidSmokeModel(fakeAndroidContext);
     smoke.writeAndroidSmokeModelManifest(
       fakeAndroidContext,

--- a/packages/app/test/android/android-harness.ts
+++ b/packages/app/test/android/android-harness.ts
@@ -46,11 +46,13 @@ const ALLOW_FIRST_RUN =
 
 function activeServerSeed(): string {
   if (BACKEND === "host") {
+    const accessToken = process.env.ELIZA_ANDROID_HOST_AGENT_TOKEN?.trim();
     return JSON.stringify({
       id: "remote:host",
       kind: "remote",
       label: "Host agent",
       apiBase: "http://127.0.0.1:31337",
+      ...(accessToken ? { accessToken } : {}),
     });
   }
   // The renderer reads runtime mode from localStorage (a SEPARATE store from the
@@ -414,13 +416,21 @@ export async function waitForShellReady(
 
 /**
  * Client-side SPA navigation. Capacitor's WebView has no server-side fallback
- * for nested paths, so a hard page.goto('/apps/x') serves a blank 404. We drive
- * the app's own router via the History API instead, exactly like a user tap.
+ * for nested paths, so a hard page.goto('/apps/x') serves a blank 404. Dispatch
+ * the shell's public navigation event instead of mutating history directly:
+ * the surface-realm broker correctly denies raw history writes from a mounted
+ * app view, while the shell event follows the same privileged path as a user
+ * tap or an agent navigate-view action.
  */
 export async function gotoRoute(page: Page, routePath: string): Promise<void> {
   await page.evaluate((path: string) => {
-    window.history.pushState({}, "", path);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    const pathSegments = path.split("/").filter(Boolean);
+    const viewId = pathSegments.at(-1) ?? "chat";
+    window.dispatchEvent(
+      new CustomEvent("eliza:navigate:view", {
+        detail: { viewId, viewPath: path },
+      }),
+    );
   }, routePath);
 }
 

--- a/packages/app/test/android/android-harness.ts
+++ b/packages/app/test/android/android-harness.ts
@@ -71,6 +71,7 @@ export const SEED_STORAGE: Record<string, string> = {
   "eliza:first-run-complete": "1",
   "eliza:ui-shell-mode": "native",
   "eliza:mobile-runtime-mode": BACKEND === "host" ? "remote" : "local",
+  "eliza:developerMode": "1",
   "elizaos:active-server": activeServerSeed(),
 };
 

--- a/packages/app/test/android/global-setup.test.ts
+++ b/packages/app/test/android/global-setup.test.ts
@@ -1,0 +1,16 @@
+/** Verifies the Android route lane pre-grants permissions requested by mounted app views. */
+
+import { describe, expect, it } from "vitest";
+import { ANDROID_E2E_RUNTIME_PERMISSIONS } from "./global-setup";
+
+describe("Android device-e2e runtime permissions", () => {
+  it("pre-grants the complete phone permission request before route coverage", () => {
+    expect(ANDROID_E2E_RUNTIME_PERMISSIONS).toEqual(
+      expect.arrayContaining([
+        "android.permission.CALL_PHONE",
+        "android.permission.READ_CALL_LOG",
+        "android.permission.READ_PHONE_STATE",
+      ]),
+    );
+  });
+});

--- a/packages/app/test/android/global-setup.ts
+++ b/packages/app/test/android/global-setup.ts
@@ -35,6 +35,17 @@ const HOST_AGENT_PORT =
       )
     : AGENT_API_PORT;
 
+export const ANDROID_E2E_RUNTIME_PERMISSIONS = [
+  "android.permission.POST_NOTIFICATIONS",
+  "android.permission.RECORD_AUDIO",
+  "android.permission.CAMERA",
+  "android.permission.READ_CONTACTS",
+  "android.permission.WRITE_CONTACTS",
+  "android.permission.CALL_PHONE",
+  "android.permission.READ_CALL_LOG",
+  "android.permission.READ_PHONE_STATE",
+] as const;
+
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 async function pollAgentHealth(localPort: number, timeoutMs: number) {
@@ -91,11 +102,7 @@ export default async function globalSetup() {
 
   // Pre-grant the runtime permissions the app requests on launch, so a system
   // GrantPermissionsActivity doesn't cover the WebView and stall route render.
-  for (const perm of [
-    "android.permission.POST_NOTIFICATIONS",
-    "android.permission.RECORD_AUDIO",
-    "android.permission.CAMERA",
-  ]) {
+  for (const perm of ANDROID_E2E_RUNTIME_PERMISSIONS) {
     adbTry(adb, ["-s", serial, "shell", "pm", "grant", APP_ID, perm]);
   }
 

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -55,6 +55,22 @@ const URL_SCHEME = "elizaos";
 const FIRST_RUN_REMOTE_DEEPLINK = `${URL_SCHEME}://first-run/runtime/remote?api=${encodeURIComponent(
   HOST_AGENT_BASE,
 )}`;
+
+async function readHostPairingCode(): Promise<string> {
+  const response = await fetch(
+    `http://127.0.0.1:${HOST_AGENT_PORT}/api/auth/pair-code`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Host pairing-code request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as { code?: unknown };
+  if (typeof body.code !== "string" || !body.code.trim()) {
+    throw new Error("Host pairing-code response did not contain a code.");
+  }
+  return body.code;
+}
 const ARTIFACT_DIR = path.join(
   process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
     path.join(process.cwd(), "test-results", "android"),
@@ -104,6 +120,15 @@ test.describe
           FIRST_RUN_REMOTE_DEEPLINK,
           APP_ID,
         ]);
+
+        // OS deep links deliberately never carry bearer credentials. Complete
+        // the production remote-device pairing flow against the real host,
+        // obtaining the short-lived code through its loopback-only operator
+        // endpoint and entering it through the rendered device UI.
+        const pairingInput = page.getByPlaceholder("Enter pairing code");
+        await expect(pairingInput).toBeVisible({ timeout: 60_000 });
+        await pairingInput.fill(await readHostPairingCode());
+        await page.getByRole("button", { name: "Submit" }).click();
 
         const surface = page.getByTestId("home-launcher-surface");
         await expect(surface).toBeVisible({ timeout: 90_000 });

--- a/packages/app/test/android/route-coverage.android.spec.ts
+++ b/packages/app/test/android/route-coverage.android.spec.ts
@@ -22,7 +22,6 @@ import {
   gotoRoute,
   type ReadyCheck,
   test,
-  waitForShellReady,
 } from "./android-harness";
 
 type RouteCase = {
@@ -57,13 +56,19 @@ test.describe("android route coverage (real backend)", () => {
   test.beforeAll(async ({ page }) => {
     // The combined hosted lane starts with a genuinely fresh onboarding test,
     // so the worker fixture intentionally cannot seed developer mode before
-    // boot. Enable it here and reload before probing developer-only routes such
-    // as Orchestrator; otherwise pathname retention can hide a gated fallback.
-    await page.evaluate(() => {
-      localStorage.setItem("eliza:developerMode", "1");
-    });
-    await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
-    await waitForShellReady(page);
+    // boot. Exercise the visible Settings control before probing developer-only
+    // routes such as Orchestrator; reserved shell storage correctly rejects a
+    // raw localStorage write once a view realm has mounted.
+    await gotoRoute(page, "/settings");
+    const backupsSection = page.getByText("Backups", { exact: true }).first();
+    await expect(backupsSection).toBeVisible({ timeout: 45_000 });
+    await backupsSection.click();
+    const developerViews = page.locator("#advanced-developer-mode");
+    await expect(developerViews).toBeVisible({ timeout: 45_000 });
+    if ((await developerViews.getAttribute("aria-checked")) !== "true") {
+      await developerViews.click();
+    }
+    await expect(developerViews).toHaveAttribute("aria-checked", "true");
   });
 
   for (const route of UNIQUE_ROUTES) {

--- a/packages/app/test/android/route-coverage.android.spec.ts
+++ b/packages/app/test/android/route-coverage.android.spec.ts
@@ -59,6 +59,16 @@ test.describe("android route coverage (real backend)", () => {
     // boot. Exercise the visible Settings control before probing developer-only
     // routes such as Orchestrator; reserved shell storage correctly rejects a
     // raw localStorage write once a view realm has mounted.
+    // Onboarding also leaves the successful conversation expanded. Close it
+    // through the sheet's keyboard-operable product control so it cannot cover
+    // the Settings rows on the compact Android viewport.
+    const openChatGrabber = page.getByLabel("drag down to close chat");
+    if (await openChatGrabber.isVisible().catch(() => false)) {
+      await openChatGrabber.press("ArrowDown");
+      await expect(page.getByLabel("drag up to open chat")).toBeVisible({
+        timeout: 15_000,
+      });
+    }
     await gotoRoute(page, "/settings");
     const backupsSection = page.getByText("Backups", { exact: true }).first();
     await expect(backupsSection).toBeVisible({ timeout: 45_000 });
@@ -85,9 +95,23 @@ test.describe("android route coverage (real backend)", () => {
       // React root stays mounted.
       await expect(page.locator("#root")).toBeVisible({ timeout: 45_000 });
       if (route.readyChecks?.length) {
-        await expectRouteReady(page, route.name, route.readyChecks, {
-          timeoutMs: 45_000,
-        });
+        try {
+          await expectRouteReady(page, route.name, route.readyChecks, {
+            timeoutMs: 45_000,
+          });
+        } catch (error) {
+          const renderedState = await page.evaluate(() => ({
+            text: (document.body?.innerText ?? "").trim().slice(0, 1_000),
+            testIds: Array.from(document.querySelectorAll("[data-testid]"))
+              .map((element) => element.getAttribute("data-testid"))
+              .filter((value): value is string => Boolean(value))
+              .slice(0, 100),
+          }));
+          throw new Error(
+            `${error instanceof Error ? error.message : String(error)}\nRendered state: ${JSON.stringify(renderedState)}`,
+            { cause: error },
+          );
+        }
       }
       // The route paints SOMETHING (not a blank white screen) within the window.
       await expect

--- a/packages/app/test/android/route-coverage.android.spec.ts
+++ b/packages/app/test/android/route-coverage.android.spec.ts
@@ -55,6 +55,14 @@ const UNIQUE_ROUTES = ROUTES.filter((r) => {
 // (workers=1), but a single render hiccup must not abort the rest of the sweep.
 test.describe("android route coverage (real backend)", () => {
   test.beforeAll(async ({ page }) => {
+    // The combined hosted lane starts with a genuinely fresh onboarding test,
+    // so the worker fixture intentionally cannot seed developer mode before
+    // boot. Enable it here and reload before probing developer-only routes such
+    // as Orchestrator; otherwise pathname retention can hide a gated fallback.
+    await page.evaluate(() => {
+      localStorage.setItem("eliza:developerMode", "1");
+    });
+    await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
     await waitForShellReady(page);
   });
 

--- a/packages/app/test/liveness-contract.ts
+++ b/packages/app/test/liveness-contract.ts
@@ -43,6 +43,7 @@ const ASSISTANT_MESSAGE_SELECTOR =
 
 const DEFAULT_PROMPT = "In one short sentence, say hello.";
 const DEFAULT_REPLY_TIMEOUT_MS = 120_000;
+const REPLY_ROW_READ_TIMEOUT_MS = 1_000;
 
 export interface LivenessChatOptions {
   /** Prompt to send; defaults to a short, tool-free hello. */
@@ -101,7 +102,15 @@ async function acceptedReplyText(
       .count();
     if (replyBodies === 0) return "";
   }
-  const text = (await row.textContent())?.trim() ?? "";
+  // A streaming row can be replaced between count() and textContent(). Keep a
+  // single detached locator from consuming Playwright's 30s action timeout;
+  // the outer expect.poll owns the full reply deadline and will inspect the
+  // replacement row on its next iteration.
+  const text = (
+    await row
+      .textContent({ timeout: REPLY_ROW_READ_TIMEOUT_MS })
+      .catch(() => null)
+  )?.trim();
   if (!text) return "";
   if (challengeToken && !text.toLowerCase().includes(challengeToken)) return "";
   return text;

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -59,7 +59,12 @@ export const DIRECT_ROUTE_CASES: readonly DirectRouteCase[] = [
   {
     name: "plugins app window",
     path: "/apps/plugins",
-    selector: '[data-testid="plugins-shell"]',
+    // A content check, not the shell container: [data-testid="plugins-shell"]
+    // is the unconditional top-level frame of PluginsView, so it appears the
+    // instant the component mounts and the route would pass on an empty or
+    // failed catalog. "AI Providers" is a live group label
+    // (plugin-list-utils.ts:759), so it only renders once data actually loaded.
+    readyChecks: [{ text: "AI Providers" }],
     timeoutMs: 90_000,
   },
   {

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -59,7 +59,7 @@ export const DIRECT_ROUTE_CASES: readonly DirectRouteCase[] = [
   {
     name: "plugins app window",
     path: "/apps/plugins",
-    readyChecks: [{ text: "Browser Workspace" }, { text: "AI Providers" }],
+    selector: '[data-testid="plugins-shell"]',
     timeoutMs: 90_000,
   },
   {

--- a/packages/ui/src/components/setup/BootstrapStep.tsx
+++ b/packages/ui/src/components/setup/BootstrapStep.tsx
@@ -188,7 +188,7 @@ export function BootstrapStep({ onAdvance, exchangeFn }: BootstrapStepProps) {
         // sessionStorage unavailable (e.g. private browsing on some browsers).
         // Session is still in memory for this page load; startup can advance.
       }
-      persistActiveServerCredential(result.sessionId);
+      await persistActiveServerCredential(result.sessionId);
       client.setToken(result.sessionId);
 
       setSubmitState({ phase: "success" });

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -261,7 +261,7 @@ export function useAgentSessionRecovery(
           // must not re-adopt the stale active-server/profile token after the
           // live client has already accepted the fresh paired bearer.
           persistCloudPairApiToken(apiToken, decision.agentId);
-          persistActiveServerCredential(apiToken);
+          await persistActiveServerCredential(apiToken);
           client.setToken(apiToken);
           onRecovered?.();
         },

--- a/packages/ui/src/state/active-server-credential.durability.test.ts
+++ b/packages/ui/src/state/active-server-credential.durability.test.ts
@@ -1,0 +1,77 @@
+/** Verifies that paired credentials reach durable native storage before callers continue. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getActiveProfile: vi.fn(),
+  loadPersistedActiveServer: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+  setStorageValue: vi.fn(),
+  updateAgentProfile: vi.fn(),
+}));
+
+vi.mock("./agent-profiles", () => ({
+  getActiveProfile: mocks.getActiveProfile,
+  updateAgentProfile: mocks.updateAgentProfile,
+}));
+
+vi.mock("./persistence", () => ({
+  loadPersistedActiveServer: mocks.loadPersistedActiveServer,
+  savePersistedActiveServer: mocks.savePersistedActiveServer,
+}));
+
+vi.mock("../bridge/storage-bridge", () => ({
+  setStorageValue: mocks.setStorageValue,
+}));
+
+import { persistActiveServerCredential } from "./active-server-credential";
+
+describe("persistActiveServerCredential native durability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadPersistedActiveServer.mockReturnValue({
+      id: "remote:test",
+      kind: "remote",
+      label: "Test runtime",
+      apiBase: "https://runtime.example.test",
+    });
+    mocks.getActiveProfile.mockReturnValue(null);
+  });
+
+  it("does not resolve until the active-server mirror is durable", async () => {
+    let releaseWrite!: () => void;
+    mocks.setStorageValue.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      }),
+    );
+
+    let completed = false;
+    const persistence = persistActiveServerCredential("paired-token").then(
+      () => {
+        completed = true;
+      },
+    );
+    await Promise.resolve();
+
+    const authenticatedServer = {
+      id: "remote:test",
+      kind: "remote",
+      label: "Test runtime",
+      apiBase: "https://runtime.example.test",
+      accessToken: "paired-token",
+    };
+    expect(mocks.savePersistedActiveServer).toHaveBeenCalledWith(
+      authenticatedServer,
+    );
+    expect(mocks.setStorageValue).toHaveBeenCalledWith(
+      "elizaos:active-server",
+      JSON.stringify(authenticatedServer),
+    );
+    expect(completed).toBe(false);
+
+    releaseWrite();
+    await persistence;
+    expect(completed).toBe(true);
+  });
+});

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -23,7 +23,7 @@ describe("persistActiveServerCredential", () => {
     localStorage.clear();
   });
 
-  it("updates the active remote server and its active profile", () => {
+  it("updates the active remote server and its active profile", async () => {
     savePersistedActiveServer(
       createPersistedActiveServer({
         kind: "cloud",
@@ -33,13 +33,13 @@ describe("persistActiveServerCredential", () => {
       }),
     );
 
-    persistActiveServerCredential("session-token");
+    await persistActiveServerCredential("session-token");
 
     expect(loadPersistedActiveServer()?.accessToken).toBe("session-token");
     expect(getActiveProfile()?.accessToken).toBe("session-token");
   });
 
-  it("scrubs a rejected active credential without dropping the target", () => {
+  it("scrubs a rejected active credential without dropping the target", async () => {
     savePersistedActiveServer(
       createPersistedActiveServer({
         kind: "remote",
@@ -47,7 +47,7 @@ describe("persistActiveServerCredential", () => {
         accessToken: "stale-token",
       }),
     );
-    persistActiveServerCredential("stale-token");
+    await persistActiveServerCredential("stale-token");
 
     scrubRejectedActiveServerCredential("stale-token");
 

--- a/packages/ui/src/state/active-server-credential.ts
+++ b/packages/ui/src/state/active-server-credential.ts
@@ -4,16 +4,29 @@
  * target. Pairing and bootstrap exchange both route through this boundary.
  */
 
+import { setStorageValue } from "../bridge/storage-bridge";
 import { getActiveProfile, updateAgentProfile } from "./agent-profiles";
 import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
 } from "./persistence";
 
-export function persistActiveServerCredential(token: string): void {
+const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
+
+export async function persistActiveServerCredential(
+  token: string,
+): Promise<void> {
   const activeServer = loadPersistedActiveServer();
   if (activeServer && activeServer.kind !== "local") {
-    savePersistedActiveServer({ ...activeServer, accessToken: token });
+    const authenticatedServer = { ...activeServer, accessToken: token };
+    savePersistedActiveServer(authenticatedServer);
+    // Native storage mirroring is normally fire-and-forget, but pairing reloads
+    // immediately after this boundary. Await the authoritative Preferences write
+    // so hydration cannot restore the pre-pair, tokenless server on the next boot.
+    await setStorageValue(
+      ACTIVE_SERVER_STORAGE_KEY,
+      JSON.stringify(authenticatedServer),
+    );
   }
 
   const activeProfile = getActiveProfile();

--- a/packages/ui/src/state/usePairingState.ts
+++ b/packages/ui/src/state/usePairingState.ts
@@ -30,7 +30,7 @@ export function usePairingState() {
     setPairingBusy(true);
     try {
       const { token } = await client.pair(code);
-      persistActiveServerCredential(token);
+      await persistActiveServerCredential(token);
       client.setToken(token);
       window.location.reload();
     } catch (err) {

--- a/plugins/plugin-task-coordinator/AGENTS.md
+++ b/plugins/plugin-task-coordinator/AGENTS.md
@@ -47,11 +47,12 @@ Calls `registerTaskCoordinatorSlots` from `@elizaos/ui` with:
 
 ### Registration side effects (`src/register.ts`)
 
-`register.ts` is a side-effect module (imported for its effects, not exports). It activates the slot-registry fills:
+`register.ts` is a side-effect module (imported for its effects, not exports). It activates the slot-registry fills and signed native pages:
 
 - **`import "./register-slots.js"`** — activates the slot-registry fills below (the `@elizaos/ui` empty-slot defaults). Without this import the UI renders empty slots.
+- **`registerAppShellPage(...)`** — registers lazy, in-bundle renderers for `task-coordinator`, `orchestrator`, and `cockpit`. iOS and Android strip agent-served JavaScript from `/api/views`, so these registrations are the native render path; web and desktop continue to prefer the runtime manifest bundles.
 
-The three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) reach the app shell through the standard **view manifest** in `src/index.ts` (`bundlePath` + `componentExport`), NOT via `registerAppShellPage` — this plugin registers no app-shell pages.
+The three GUI views still declare the standard **view manifest** in `src/index.ts` (`bundlePath` + `componentExport`) as the runtime metadata and web/desktop bundle path. Keep the native registrations aligned with those ids, paths, kinds, surfaces, and component exports.
 
 ## Layout
 
@@ -59,7 +60,7 @@ The three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) reach the ap
 src/
   index.ts                         Plugin definition — views + capabilities, init() command registration, handler action
   orchestrator-command.ts          /orchestrator-status slash command def + deterministic handler action (#8790)
-  register.ts                      Slot import side effect
+  register.ts                      Slot and signed native-page side effects
   register-slots.ts                Slot registry fills for ui empty-slot defaults
   CodingAgentTasksPanel.tsx        Task thread list + PTY session panel; re-exports OrchestratorWorkbench
   CodingAgentTasksPanel.interact.ts  View-bundle `interact` capability handler (split for Fast-Refresh compat)

--- a/plugins/plugin-task-coordinator/CLAUDE.md
+++ b/plugins/plugin-task-coordinator/CLAUDE.md
@@ -47,11 +47,12 @@ Calls `registerTaskCoordinatorSlots` from `@elizaos/ui` with:
 
 ### Registration side effects (`src/register.ts`)
 
-`register.ts` is a side-effect module (imported for its effects, not exports). It activates the slot-registry fills:
+`register.ts` is a side-effect module (imported for its effects, not exports). It activates the slot-registry fills and signed native pages:
 
 - **`import "./register-slots.js"`** — activates the slot-registry fills below (the `@elizaos/ui` empty-slot defaults). Without this import the UI renders empty slots.
+- **`registerAppShellPage(...)`** — registers lazy, in-bundle renderers for `task-coordinator`, `orchestrator`, and `cockpit`. iOS and Android strip agent-served JavaScript from `/api/views`, so these registrations are the native render path; web and desktop continue to prefer the runtime manifest bundles.
 
-The three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) reach the app shell through the standard **view manifest** in `src/index.ts` (`bundlePath` + `componentExport`), NOT via `registerAppShellPage` — this plugin registers no app-shell pages.
+The three GUI views still declare the standard **view manifest** in `src/index.ts` (`bundlePath` + `componentExport`) as the runtime metadata and web/desktop bundle path. Keep the native registrations aligned with those ids, paths, kinds, surfaces, and component exports.
 
 ## Layout
 
@@ -59,7 +60,7 @@ The three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) reach the ap
 src/
   index.ts                         Plugin definition — views + capabilities, init() command registration, handler action
   orchestrator-command.ts          /orchestrator-status slash command def + deterministic handler action (#8790)
-  register.ts                      Slot import side effect
+  register.ts                      Slot and signed native-page side effects
   register-slots.ts                Slot registry fills for ui empty-slot defaults
   CodingAgentTasksPanel.tsx        Task thread list + PTY session panel; re-exports OrchestratorWorkbench
   CodingAgentTasksPanel.interact.ts  View-bundle `interact` capability handler (split for Fast-Refresh compat)

--- a/plugins/plugin-task-coordinator/src/register.ts
+++ b/plugins/plugin-task-coordinator/src/register.ts
@@ -1,6 +1,54 @@
 /**
- * Registration side-effect module — imported for effect, not exports. Activates
- * the slot-registry fills (`register-slots`) that give the `@elizaos/ui`
- * empty-slot defaults their real coding-agent components.
+ * Registers the task-coordinator's bundled shell pages and shared UI slots.
+ * Native clients cannot execute agent-served JavaScript, so these lazy page
+ * loaders are the signed in-app counterparts to the runtime view manifest.
  */
+import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 import "./register-slots.js";
+
+const pluginId = "@elizaos/plugin-task-coordinator";
+const agentSurface = { capabilities: ["agent-surface"] } as const;
+
+registerAppShellPage({
+  id: "task-coordinator",
+  pluginId,
+  label: "Task Coordinator",
+  icon: "SquareTerminal",
+  path: "/task-coordinator",
+  viewKind: "preview",
+  surface: agentSurface,
+  loader: () =>
+    import("./TaskCoordinatorView.js").then((module) => ({
+      default: module.TaskCoordinatorView,
+    })),
+});
+
+registerAppShellPage({
+  id: "orchestrator",
+  pluginId,
+  label: "Orchestrator",
+  icon: "Layers",
+  path: "/orchestrator",
+  viewKind: "developer",
+  developerOnly: true,
+  surface: agentSurface,
+  loader: () =>
+    import("./OrchestratorView.js").then((module) => ({
+      default: module.OrchestratorView,
+    })),
+});
+
+registerAppShellPage({
+  id: "cockpit",
+  pluginId,
+  label: "Cockpit",
+  icon: "TerminalSquare",
+  path: "/cockpit",
+  viewKind: "developer",
+  developerOnly: true,
+  surface: agentSurface,
+  loader: () =>
+    import("./CockpitRoute.js").then((module) => ({
+      default: module.CockpitRoute,
+    })),
+});


### PR DESCRIPTION
# Relates to

Relates to #13580.

- [x] Targets `develop` and remains mergeable against current `develop`.
- [x] Exact head: `508409ab9ec54ddc6718a3249c40230248e1b186`.
- [x] Real Android build/install/WebView bundle passed 43/43 at this exact head.
- [x] Exact-head hosted Android run dispatched: https://github.com/elizaOS/eliza/actions/runs/32513605149

# What changed

Repairs the complete Android evidence path exposed by cold ARM64 and real emulator runs:

- keeps the host-emulator APK lane inside its runtime budget and invalidates stale cross-compiler caches;
- pairs through the real rendered first-run flow and authorizes the resulting revocable machine session for both REST and WebSocket traffic;
- acknowledges Android's one-time immersive-mode system overlay before UI automation;
- prevents detached streaming rows from consuming the liveness poll's entire deadline;
- closes the successful onboarding conversation before compact-viewport route coverage;
- registers the task-coordinator manifest in the deterministic host; and
- bundles signed native Task Coordinator, Orchestrator, and Cockpit pages because Android correctly rejects agent-served JavaScript.

# Risks

Medium. This touches Android build/test orchestration, WebSocket admission, and native plugin view routing. Authorization remains fail-closed: the agent server retains its origin/path checks, pending-socket bounds, static-token path, and post-open grace period; app-core recognizes only an active stored session or a caller-provided authorizer.

# Verification

Exact-head local bundle: `/private/tmp/eliza-13580-exact-head-local-12` (not committed).

- build stamp and installed APK: `508409ab9ec54ddc6718a3249c40230248e1b186` / build id `e8b46d1bde2ea3eb93802a05a7b12a162f33175683ab685de4c814d9924831e9`;
- Android host-e2e artifact audit passed; fresh APK built and installed with byte verification;
- runtime health: 9 plugins loaded / 0 failed, 12 services registered / 0 failed;
- real Kotlin `ElizaSystem` Capacitor bridge passed;
- real pairing, machine-session WebSocket, streamed deterministic model reply, and Home landing passed;
- every Android route passed, including the signed native `/orchestrator` workbench: 43/43;
- finalized 30.07-second MP4, screenshots, host log, logcat, Playwright JSON/HTML, and JUnit; bundle result `passed` with no warnings;
- app-core real pairing suite: 3/3;
- agent host-authorizer contract: 1/1 focused (full boundary file: 13/14 behavioral assertions passed; one pre-existing `ENOTEMPTY` teardown race);
- app liveness suite: 16/16;
- app-core, app, and task-coordinator typechecks passed;
- Biome, guide parity, and `git diff --check` passed.

Hosted exact-head run 32513605149 is queued without a runner. It is an acceptance follow-up, not a source/draft hold; this PR remains ready for review.

# Evidence Gate

<!-- evidence-head:508409ab9ec54ddc6718a3249c40230248e1b186 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-screen.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-home-landing.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-android-route-coverage-faststart.mp4
<!-- evidence-row:backend-logs -->
- [x] [22828-host-agent.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-host-agent.log)
<!-- evidence-row:frontend-logs -->
- [x] [22828-webview-console.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-webview-console.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic callback exercises the real runtime and streaming path; planner behavior is unchanged
<!-- evidence-row:domain-artifacts -->
- [x] [22828-summary.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-summary.json)
<!-- evidence-row:ocr-review -->
- [x] [22828-ocr-manual-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22828-ocr-manual-review.txt)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@508409ab9ec54ddc6718a3249c40230248e1b186:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@508409ab9ec54ddc6718a3249c40230248e1b186:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@508409ab9ec54ddc6718a3249c40230248e1b186:packages/skills/skills/contribute-to-eliza"} -->


