### PR TITLE
fix(cloud): finish fail-closed numeric census

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
@@ -5,8 +5,45 @@
 import { describe, expect, test } from "bun:test";
 import {
   CorruptDirectWalletSlippageError,
+  parseDirectWalletMetadataNumber,
   parseDirectWalletSlippageBps,
 } from "../direct-wallet-payments";
+
+describe("parseDirectWalletMetadataNumber", () => {
+  test("refuses corrupt token decimals before confirmation can enqueue a malformed sweep", () => {
+    for (const value of [undefined, "garbage", Number.NaN, -1, 1.5, 256]) {
+      expect(() =>
+        parseDirectWalletMetadataNumber({
+          paymentId: "pay-corrupt",
+          field: "token_decimals",
+          value,
+          integer: true,
+          max: 255,
+        }),
+      ).toThrow("Direct wallet payment has corrupt numeric metadata");
+    }
+  });
+
+  test("accepts canonical token decimals and an explicit missing-field default", () => {
+    expect(
+      parseDirectWalletMetadataNumber({
+        paymentId: "pay-valid",
+        field: "token_decimals",
+        value: 18,
+        integer: true,
+        max: 255,
+      }),
+    ).toBe(18);
+    expect(
+      parseDirectWalletMetadataNumber({
+        paymentId: "pay-valid",
+        field: "bonus_credits",
+        value: undefined,
+        defaultValue: 0,
+      }),
+    ).toBe(0);
+  });
+});
 
 describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {
   test("missing / undefined / null is the legitimate stable-token default of 0", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/tts-first-line-cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tts-first-line-cache.test.ts
@@ -3,8 +3,24 @@ import { describe, expect, test } from "bun:test";
 import {
   fingerprintCloudVoiceSettings,
   hashCloudCacheKey,
+  parseTtsCacheByteAggregate,
   shouldBypassCloudFirstLineCache,
 } from "../tts-first-line-cache";
+
+describe("parseTtsCacheByteAggregate", () => {
+  test("accepts non-negative safe byte totals", () => {
+    expect(parseTtsCacheByteAggregate(0)).toBe(0);
+    expect(parseTtsCacheByteAggregate("4096")).toBe(4096);
+  });
+
+  test("refuses corrupt totals instead of evicting every cache entry from NaN", () => {
+    for (const value of [undefined, "garbage", Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5]) {
+      expect(() => parseTtsCacheByteAggregate(value)).toThrow(
+        "TTS first-line cache returned a corrupt byte aggregate",
+      );
+    }
+  });
+});
 
 describe("hashCloudCacheKey", () => {
   test("changes when any key field changes (regression: F3 voice-swap safety)", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
@@ -304,3 +304,28 @@ test("settle refuses a zero-amount request instead of settling for nothing", asy
   );
   expect(settle).not.toHaveBeenCalled();
 });
+
+test("public projection refuses corrupt stored amount and fee values", () => {
+  expect(() =>
+    x402PaymentRequestsService.toView(
+      paymentRecord({
+        metadata: {
+          kind: "x402_payment_request",
+          amountUsd: "garbage",
+        },
+      }) as never,
+    ),
+  ).toThrow(/corrupt amountUsd/i);
+
+  expect(() =>
+    x402PaymentRequestsService.toView(
+      paymentRecord({
+        metadata: {
+          kind: "x402_payment_request",
+          amountUsd: 0.05,
+          platformFeeUsd: "garbage",
+        },
+      }) as never,
+    ),
+  ).toThrow(/corrupt platformFeeUsd/i);
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -513,6 +513,21 @@ describe("linkedinAdsProvider", () => {
     expect(result.metrics?.cpm).toBeCloseTo((19.91833 / 171) * 1000, 4);
   });
 
+  test("fails closed when LinkedIn returns a corrupt spend metric", async () => {
+    enqueue({
+      elements: [{ ...ANALYTICS_FIXTURE.elements[0], costInLocalCurrency: "not-a-number" }],
+    });
+
+    const result = await linkedinAdsProvider.getCampaignMetrics(
+      credentials,
+      "507404993/603407684/145282384",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.metrics).toBeUndefined();
+    expect(result.error).toContain("invalid analytics metric");
+  });
+
   test("propagates LinkedIn API errors as failed results without partial success", async () => {
     enqueue(
       { message: "Not enough permissions to access: adCampaignGroups.CREATE", status: 403 },

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -1,6 +1,8 @@
-// LinkedIn Marketing API integration (versioned REST) -
-// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns
+/**
+ * Implements the versioned LinkedIn Marketing API advertising provider.
+ */
 
+import { ElizaError } from "@elizaos/core";
 import { logger } from "../../../utils/logger";
 import { downloadAdMedia, mediaFileName } from "../media-utils";
 import type {
@@ -332,16 +334,42 @@ function analyticsDate(date: Date): string {
   return `(year:${date.getUTCFullYear()},month:${date.getUTCMonth() + 1},day:${date.getUTCDate()})`;
 }
 
+function parseAnalyticsMetric(field: string, value: string | number | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    throw new ElizaError("LinkedIn returned an invalid analytics metric", {
+      code: "LINKEDIN_ANALYTICS_INVALID_METRIC",
+      context: { field },
+    });
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new ElizaError("LinkedIn returned an invalid analytics metric", {
+      code: "LINKEDIN_ANALYTICS_INVALID_METRIC",
+      context: { field },
+    });
+  }
+  return parsed;
+}
+
 function sumAnalytics(elements: LinkedInAnalyticsElement[]): CampaignMetrics {
   let spend = 0;
   let impressions = 0;
   let clicks = 0;
   let conversions = 0;
   for (const element of elements) {
-    spend += Number(element.costInLocalCurrency ?? 0) || 0;
-    impressions += element.impressions ?? 0;
-    clicks += element.clicks ?? element.landingPageClicks ?? 0;
-    conversions += (element.externalWebsiteConversions ?? 0) + (element.oneClickLeads ?? 0);
+    spend += parseAnalyticsMetric("costInLocalCurrency", element.costInLocalCurrency);
+    impressions += parseAnalyticsMetric("impressions", element.impressions);
+    clicks += parseAnalyticsMetric(
+      element.clicks === null || element.clicks === undefined ? "landingPageClicks" : "clicks",
+      element.clicks ?? element.landingPageClicks,
+    );
+    conversions +=
+      parseAnalyticsMetric("externalWebsiteConversions", element.externalWebsiteConversions) +
+      parseAnalyticsMetric("oneClickLeads", element.oneClickLeads);
   }
   return {
     spend,

--- a/packages/cloud/shared/src/lib/services/app-analytics.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.test.ts
@@ -185,3 +185,38 @@ describe("AppAnalyticsService.buildSessionAnalytics", () => {
     expect(analytics.sessions[0]?.exitPath).toBe("/b");
   });
 });
+
+describe("AppAnalyticsService.calculateAppPricing", () => {
+  test("applies a valid custom inference markup", () => {
+    const service = new AppAnalyticsService();
+
+    expect(
+      service.calculateAppPricing({
+        baseCost: 2,
+        app: {
+          custom_pricing_enabled: true,
+          inference_markup_percentage: 25,
+        } as never,
+      }),
+    ).toEqual({
+      baseCost: 2,
+      markup: 0.5,
+      finalCost: 2.5,
+      markupPercentage: 25,
+    });
+  });
+
+  test("fails closed when an enabled app has a corrupt markup", () => {
+    const service = new AppAnalyticsService();
+
+    expect(() =>
+      service.calculateAppPricing({
+        baseCost: 2,
+        app: {
+          custom_pricing_enabled: true,
+          inference_markup_percentage: Number.NaN,
+        } as never,
+      }),
+    ).toThrow("Corrupt app monetization inference_markup_percentage");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-analytics.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.ts
@@ -7,6 +7,7 @@
 import { type AppRequest, appsRepository, type NewAppAnalytics } from "../../db/repositories/apps";
 import type { App } from "../types";
 import { logger } from "../utils/logger";
+import { computeInferenceCharge } from "./app-credit-math";
 
 export interface AppSessionRow {
   sessionId: string;
@@ -363,15 +364,18 @@ export class AppAnalyticsService {
       };
     }
 
-    const markupPercentage = Number(app.inference_markup_percentage ?? 0);
-    const markup = baseCost * (markupPercentage / 100);
-    const finalCost = baseCost + markup;
+    const charge = computeInferenceCharge(baseCost, {
+      monetizationEnabled: true,
+      platformOffsetAmount: 0,
+      purchaseSharePercentage: 0,
+      inferenceMarkupPercentage: app.inference_markup_percentage,
+    });
 
     return {
       baseCost,
-      markup,
-      finalCost,
-      markupPercentage,
+      markup: charge.creatorMarkup,
+      finalCost: charge.totalCost,
+      markupPercentage: charge.markupPercentage,
     };
   }
 

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -1,4 +1,5 @@
 /** Coordinates verified direct-wallet settlement, crediting, invoicing, and durable sweeping. */
+import { ElizaError } from "@elizaos/core";
 import {
   createAssociatedTokenAccountInstruction,
   createTransferCheckedInstruction,
@@ -585,6 +586,34 @@ function payerProofTypedDataOf(
   };
 }
 
+export function parseDirectWalletMetadataNumber(params: {
+  paymentId: string;
+  field: string;
+  value: unknown;
+  defaultValue?: number;
+  integer?: boolean;
+  max?: number;
+}): number {
+  const value = params.value ?? params.defaultValue;
+  const parsed =
+    (typeof value === "number" || typeof value === "string") && String(value).trim() !== ""
+      ? Number(value)
+      : Number.NaN;
+  if (
+    !Number.isFinite(parsed) ||
+    parsed < 0 ||
+    (params.integer && !Number.isInteger(parsed)) ||
+    (params.max !== undefined && parsed > params.max)
+  ) {
+    throw new ElizaError("Direct wallet payment has corrupt numeric metadata", {
+      code: "DIRECT_WALLET_CORRUPT_NUMERIC_METADATA",
+      context: { paymentId: params.paymentId, field: params.field },
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
+
 function directMetadata(payment: CryptoPayment): {
   metadata: Record<string, unknown>;
   network: DirectWalletNetwork;
@@ -634,9 +663,20 @@ function directMetadata(payment: CryptoPayment): {
         ? (rawTokenAddress as Hex)
         : null,
     tokenMint: typeof metadata.token_mint === "string" ? metadata.token_mint : null,
-    tokenDecimals: Number(metadata.token_decimals ?? 0),
+    tokenDecimals: parseDirectWalletMetadataNumber({
+      paymentId: payment.id,
+      field: "token_decimals",
+      value: metadata.token_decimals,
+      integer: true,
+      max: 255,
+    }),
     expectedTokenUnits: BigInt(String(metadata.expected_token_units ?? "0")),
-    bonusCredits: Number(metadata.bonus_credits ?? 0),
+    bonusCredits: parseDirectWalletMetadataNumber({
+      paymentId: payment.id,
+      field: "bonus_credits",
+      value: metadata.bonus_credits,
+      defaultValue: 0,
+    }),
     slippageBps: parseDirectWalletSlippageBps(metadata.slippage_bps),
     payerProofMessage: String(metadata.payer_proof_message ?? ""),
     payerProofTypedData: payerProofTypedDataOf(metadata),
@@ -1746,7 +1786,12 @@ export class DirectWalletPaymentsService {
       blockNumber: payment.block_number,
       expectedAmount: payment.expected_amount,
       creditsToAdd: payment.credits_to_add,
-      bonusCredits: Number(metadata.bonus_credits ?? 0),
+      bonusCredits: parseDirectWalletMetadataNumber({
+        paymentId: payment.id,
+        field: "bonus_credits",
+        value: metadata.bonus_credits,
+        defaultValue: 0,
+      }),
       expiresAt: payment.expires_at.toISOString(),
       confirmedAt: payment.confirmed_at?.toISOString() ?? null,
       explorerUrl,
@@ -2370,7 +2415,13 @@ export class DirectWalletPaymentsService {
           /not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i.test(msg);
 
         const attempts =
-          Number((metadataOf(payment) as Record<string, unknown>).verify_attempts ?? 0) + 1;
+          parseDirectWalletMetadataNumber({
+            paymentId: payment.id,
+            field: "verify_attempts",
+            value: (metadataOf(payment) as Record<string, unknown>).verify_attempts,
+            defaultValue: 0,
+            integer: true,
+          }) + 1;
 
         const bumpVerifyAttempts = () =>
           dbWrite

--- a/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
+++ b/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
@@ -30,6 +30,7 @@
  */
 
 import crypto from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import { and, eq, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import {
@@ -61,6 +62,21 @@ const BYPASS_MODELS: ReadonlySet<string> = new Set([
   "eleven_flash_v2_5_realtime",
   "eleven_multilingual_v2_realtime",
 ]);
+
+export function parseTtsCacheByteAggregate(value: unknown): number {
+  const parsed =
+    (typeof value === "number" || typeof value === "string") && String(value).trim() !== ""
+      ? Number(value)
+      : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new ElizaError("TTS first-line cache returned a corrupt byte aggregate", {
+      code: "TTS_CACHE_CORRUPT_BYTE_AGGREGATE",
+      context: { field: "total_bytes" },
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
 
 // ---------------------------------------------------------------------------
 // Types — must mirror the local cache's `FirstLineCacheKey` exactly so the
@@ -419,7 +435,7 @@ export class CloudFirstLineCacheService {
       .select({ total: sql<number>`COALESCE(SUM(${ttsFirstLineCache.byteSize}), 0)` })
       .from(ttsFirstLineCache)
       .where(eq(ttsFirstLineCache.scope, scope));
-    const currentBytes = Number(total?.total ?? 0);
+    const currentBytes = parseTtsCacheByteAggregate(total?.total ?? 0);
     if (currentBytes <= this.maxBytesPerScope) return 0;
 
     // Pull the oldest-accessed rows and remove them until we're under budget.

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -183,6 +183,31 @@ export class X402PaymentRequestError extends Error {
   }
 }
 
+function parseStoredPaymentAmount(params: {
+  paymentId: string;
+  field: string;
+  value: unknown;
+  allowZero?: boolean;
+}): number {
+  const parsed =
+    (typeof params.value === "number" || typeof params.value === "string") &&
+    String(params.value).trim() !== ""
+      ? Number(params.value)
+      : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 0 || (!params.allowZero && parsed === 0)) {
+    logger.error("[x402-payment-requests] refusing to project corrupt payment amount", {
+      paymentRequestId: params.paymentId,
+      field: params.field,
+    });
+    throw new X402PaymentRequestError(
+      `Payment request ${params.paymentId} has a corrupt ${params.field}`,
+      500,
+      "corrupt_amount",
+    );
+  }
+  return parsed;
+}
+
 function normalizeNetwork(raw?: string): NetworkConfig {
   const env = getCloudAwareEnv();
   const value = raw?.trim() || env.X402_NETWORK || "base";
@@ -381,7 +406,11 @@ async function triggerChannelCallback(
   });
   if (!authorized) return;
 
-  const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add ?? 0);
+  const amountUsd = parseStoredPaymentAmount({
+    paymentId: payment.id,
+    field: "amountUsd",
+    value: metadata.amountUsd ?? payment.credits_to_add,
+  });
   const source = stringValue(channel, "source") ?? "payment";
   const text =
     status === "paid"
@@ -830,14 +859,36 @@ class X402PaymentRequestsService {
 
   toView(payment: CryptoPayment): X402PaymentRequestView {
     const metadata = metadataOf(payment);
+    const amountUsd = parseStoredPaymentAmount({
+      paymentId: payment.id,
+      field: "amountUsd",
+      value: metadata.amountUsd ?? payment.credits_to_add,
+    });
+    const platformFeeUsd = parseStoredPaymentAmount({
+      paymentId: payment.id,
+      field: "platformFeeUsd",
+      value: metadata.platformFeeUsd ?? 0,
+      allowZero: true,
+    });
+    const serviceFeeUsd = parseStoredPaymentAmount({
+      paymentId: payment.id,
+      field: "serviceFeeUsd",
+      value: metadata.serviceFeeUsd ?? 0,
+      allowZero: true,
+    });
+    const totalChargedUsd = parseStoredPaymentAmount({
+      paymentId: payment.id,
+      field: "totalChargedUsd",
+      value: metadata.totalChargedUsd ?? amountUsd + platformFeeUsd + serviceFeeUsd,
+    });
     return {
       id: payment.id,
       status: payment.status,
       paid: payment.status === "confirmed",
-      amountUsd: Number(metadata.amountUsd ?? payment.credits_to_add ?? 0),
-      platformFeeUsd: Number(metadata.platformFeeUsd ?? 0),
-      serviceFeeUsd: Number(metadata.serviceFeeUsd ?? 0),
-      totalChargedUsd: Number(metadata.totalChargedUsd ?? 0),
+      amountUsd,
+      platformFeeUsd,
+      serviceFeeUsd,
+      totalChargedUsd,
       network: payment.network,
       asset: payment.token_address ?? "",
       payTo: payment.payment_address,


### PR DESCRIPTION
# Relates to

Closes #13415.

- [x] Targets `develop` and was rebased onto `origin/develop`.
- [x] Focused tests, cloud-shared typecheck, Biome, and the repository verify gate were run; exact results are recorded below.
- [x] The corrupt-input tests make the changed behavior reviewable without relying on source inspection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@867fb8b29148dbb30e2273aa0273038e92a0ffaf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun run verify` completed after sync, subject to the exact result below.

# Risks

Medium. These are fail-closed changes on money, provider analytics, and cache-maintenance boundaries. Corrupt stored/provider values now produce explicit errors instead of fabricated zero, `NaN`, malformed sweep data, or destructive cache eviction.

# Background

## What does this PR do?

Finishes the live high-risk fallback census with five residual fixes:

- app custom-pricing reuses the canonical inference-charge validator;
- LinkedIn analytics rejects corrupt spend/count metrics;
- x402 public/callback projections reject corrupt stored amounts and fees;
- direct-wallet settlement/status/retry metadata validates decimals, bonuses, and retry counts;
- TTS cache eviction rejects corrupt aggregate byte counts.

Post-fix live census over 524 production service files: 438 syntactic candidate files, 1,267 catch/promise-catch matches, 628 J1-J7 policy annotations, and zero server-side `console.*` calls. The remaining bare `Number(... ?? 0)` matches are confined to SQL/reporting aggregates, regex-derived calendar fields, and domain renewal's immediately validated missing-price branch; none feeds billing, auth, tenant, provisioning, or domain mutation without validation.

| Path | Previous verdict | Final verdict |
| --- | --- | --- |
| `app-analytics.ts` custom pricing | corrupt markup could produce `NaN` pricing | fixed: canonical inference-charge validator |
| `advertising/providers/linkedin.ts` analytics aggregation | corrupt provider metrics silently became zero | fixed: typed fail-closed provider result |
| `x402-payment-requests.ts` view/callback projection | corrupt stored amounts/fees became `NaN` or zero | fixed: structured `corrupt_amount` refusal |
| `direct-wallet-payments.ts` metadata projection | corrupt decimals/bonus/retry values flowed into sweep/status/recovery | fixed: typed finite/domain validation |
| `tts-first-line-cache.ts` eviction aggregate | corrupt total became `NaN` and could evict every row | fixed: non-negative safe-integer boundary |

## What kind of change is this?

Bug fixes (non-breaking, fail-closed validation).

# Documentation changes needed?

N/A - runtime validation and regression tests document the contracts; no user-facing configuration changed.

# Testing

## Where should a reviewer start?

Run the focused command below and inspect the corrupt-input test names and structured error output.

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/services/app-analytics.test.ts \
  packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts \
  packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts \
  packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts \
  packages/cloud/shared/src/lib/services/__tests__/tts-first-line-cache.test.ts
bun test packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
bun run --cwd packages/cloud/shared typecheck
bun run verify
```

Focused non-PGlite command: 55 passed, 0 failed. The direct-wallet atomic PGlite suite passed in its isolated process; combining it with suites that install Bun module mocks is intentionally not used as evidence because those mocks contaminate the DB module.

# Evidence Gate

<!-- evidence-head:867fb8b29148dbb30e2273aa0273038e92a0ffaf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic service-unit boundary; focused output and structured x402 rejection logs are summarized below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider-model, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - deterministic service-unit boundary; returned DTOs and typed errors are asserted by the focused suites.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Backend: focused suites exercise valid values and corrupt `NaN`, non-numeric, negative, fractional, oversized, missing amount, and missing metadata cases. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - server-only cloud-shared changes.

## Audio / voice walkthrough

N/A - TTS audio generation is unchanged; only corrupt cache-byte aggregate handling changed.

## Known gaps / failures

No product-path gap. One combined Bun test invocation was rejected as evidence after a mock-module collision made the later PGlite suite see a mocked `dbWrite`; each affected suite passes in isolation, which matches the repository's isolated test runner contract.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@867fb8b29148dbb30e2273aa0273038e92a0ffaf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@867fb8b29148dbb30e2273aa0273038e92a0ffaf:packages/skills/skills/contribute-to-eliza"} -->
