### PR TITLE
fix(plugin-codex-cli): fail closed on unbounded tool-call argument JSON

### DIFF
--- a/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
@@ -3,6 +3,7 @@
  * SSE parser, tool-schema translation, and CodexBackend request/stream handling
  * driven by a fake fetch (no live model or network).
  */
+import { ElizaError } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { __INTERNAL_buildCodexGenerateParams, codexCliPlugin } from "../index";
 import {
@@ -12,6 +13,7 @@ import {
   isExpired,
 } from "../src/codex-auth";
 import { CodexBackend, translateMessagesToCodexInput } from "../src/codex-backend";
+import { CODEX_JSON_UNBOUNDED } from "../src/codex-json-value";
 import { parseSSE } from "../src/sse-parser";
 import { toOpenAITool } from "../src/tool-format-openai";
 
@@ -271,6 +273,35 @@ describe("CodexBackend", () => {
       tools: [{ type: "function", name: "lookup" }],
       tool_choice: { type: "function", name: "lookup" },
     });
+  });
+
+  it("fails closed on an 8k nested function-call arguments JSON", async () => {
+    let nested = '"x"';
+    for (let index = 0; index < 8_000; index += 1) {
+      nested = `[${nested}]`;
+    }
+    const encoded = JSON.stringify(nested);
+    const backend = new CodexBackend({
+      authPath: "/tmp/auth.json",
+      jitterMaxMs: 0,
+      loadAuth: async () => auth,
+      fetchImpl: (async () =>
+        sseResponse([
+          'event: response.output_item.added\ndata: {"item":{"id":"item_1","type":"function_call","call_id":"call_1","name":"lookup"}}\n\n',
+          `event: response.output_item.done\ndata: {"item":{"id":"item_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":${encoded}}}\n\n`,
+          'event: response.completed\ndata: {"response":{"stop_reason":"tool_calls"}}\n\n',
+        ])) as typeof fetch,
+    });
+    const started = performance.now();
+    try {
+      await backend.generate({ prompt: "hello" });
+      expect.unreachable("generate should fail closed on an 8k tool-arg nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(200);
   });
 
   it("never forwards temperature or max_output_tokens (the codex backend 400s on them)", async () => {

--- a/plugins/plugin-codex-cli/__tests__/codex-json-value.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-json-value.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Deterministic tests for the Codex SSE tool-call JSON type-guard. No live
+ * model: the walker is the production isJsonRecord used after JSON.parse of
+ * function-call arguments.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_JSON_UNBOUNDED,
+  isJsonRecord,
+  isJsonValue,
+  MAX_CODEX_JSON_DEPTH,
+  MAX_CODEX_JSON_NODES,
+} from "../src/codex-json-value";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+function nestJson(depth: number): string {
+  let value = '"x"';
+  for (let index = 0; index < depth; index += 1) {
+    value = `[${value}]`;
+  }
+  return value;
+}
+
+describe("isJsonValue / isJsonRecord", () => {
+  it("accepts honest scalars, lists, and nested records", () => {
+    expect(isJsonValue("ok")).toBe(true);
+    expect(isJsonValue(3)).toBe(true);
+    expect(isJsonValue(true)).toBe(true);
+    expect(isJsonValue(null)).toBe(true);
+    expect(isJsonValue(["1", { b: true }])).toBe(true);
+    expect(isJsonRecord({ q: "x" })).toBe(true);
+    expect(isJsonRecord(null)).toBe(false);
+    expect(isJsonValue(undefined)).toBe(false);
+    expect(isJsonValue(() => "x")).toBe(false);
+  });
+
+  it(`accepts a ${MAX_CODEX_JSON_DEPTH}-deep array nest`, () => {
+    expect(isJsonValue(nestArray(MAX_CODEX_JSON_DEPTH))).toBe(true);
+  });
+
+  it(`throws ${CODEX_JSON_UNBOUNDED} one past depth ${MAX_CODEX_JSON_DEPTH}`, () => {
+    try {
+      isJsonValue(nestArray(MAX_CODEX_JSON_DEPTH + 1));
+      expect.unreachable("parse should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${CODEX_JSON_UNBOUNDED} past ${MAX_CODEX_JSON_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_CODEX_JSON_NODES] = "x";
+    try {
+      isJsonValue(sparse);
+      expect.unreachable("parse should fail closed on over-budget sparse length");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+    }
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    const started = performance.now();
+    try {
+      isJsonRecord(cyclic);
+      expect.unreachable("parse should fail closed on a cycle");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+
+  it("does not invoke accessors while checking", () => {
+    let invoked = 0;
+    const hostile = {
+      get trap() {
+        invoked += 1;
+        return "x";
+      },
+    };
+    try {
+      isJsonRecord(hostile);
+      expect.unreachable("parse should fail closed on enumerable accessors");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+    }
+    expect(invoked).toBe(0);
+  });
+
+  it("fails closed on a JSON.parse 8k nest instead of RangeError", () => {
+    const parsed = JSON.parse(nestJson(8_000)) as unknown;
+    const started = performance.now();
+    try {
+      isJsonRecord(parsed);
+      expect.unreachable("parse should fail closed on an 8k nest");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CODEX_JSON_UNBOUNDED);
+      expect((error as Error).name).not.toBe("RangeError");
+    }
+    expect(performance.now() - started).toBeLessThan(50);
+  });
+});

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -9,8 +9,11 @@
  * base URL is restricted to chatgpt.com or localhost to prevent token
  * exfiltration, and temperature/max_output_tokens are never sent because the
  * gpt-5.x reasoning models reject them with a 400.
+ * Function-call `arguments` JSON is type-checked by the bounded walker in
+ * `codex-json-value.ts`.
  */
-import { logger, type ChatMessage, type JsonValue, type ToolCall, type ToolDefinition } from "@elizaos/core";
+import { ElizaError, logger, type ChatMessage, type JsonValue, type ToolCall, type ToolDefinition } from "@elizaos/core";
+import { CODEX_JSON_UNBOUNDED, isJsonRecord } from "./codex-json-value";
 import { parseSSE } from "./sse-parser";
 import { toOpenAITool, type OpenAITool } from "./tool-format-openai";
 import {
@@ -391,18 +394,6 @@ function recordProperty(record: Record<string, unknown>, key: string): Record<st
   return isRecord(value) ? value : undefined;
 }
 
-function isJsonRecord(value: unknown): value is Record<string, JsonValue> {
-  if (!isRecord(value)) return false;
-  return Object.values(value).every(isJsonValue);
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (value === null) return true;
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return true;
-  if (Array.isArray(value)) return value.every(isJsonValue);
-  return isJsonRecord(value);
-}
-
 async function consumeResponseStream(
   body: ReadableStream<Uint8Array>,
   abortSignal?: AbortSignal,
@@ -487,8 +478,14 @@ async function consumeResponseStream(
                 } else {
                   parsed = {};
                 }
-              } catch {
-                // keep raw string
+              } catch (cause) {
+                if (
+                  cause instanceof ElizaError &&
+                  cause.code === CODEX_JSON_UNBOUNDED
+                ) {
+                  throw cause;
+                }
+                // error-policy:J3 malformed function-call JSON stays the raw string.
               }
               toolCalls.push({ id: call.id, name: call.name, arguments: parsed, type: "function" });
               if (itemId) activeByItemId.delete(itemId);

--- a/plugins/plugin-codex-cli/src/codex-json-value.ts
+++ b/plugins/plugin-codex-cli/src/codex-json-value.ts
@@ -1,0 +1,151 @@
+/**
+ * Bounds the nested JSON type-guard used when Codex SSE function-call
+ * `arguments` are JSON.parsed. Hostile nests RangeError'd `isJsonValue` at 8k
+ * depth on Node 24.15.0 after JSON.parse succeeded. Depth, node, and cycle
+ * limits are all load-bearing. Descriptor-only reads so a getter cannot hang
+ * the Codex generate path.
+ */
+
+import { ElizaError, type JsonValue } from "@elizaos/core";
+
+export const MAX_CODEX_JSON_DEPTH = 32;
+export const MAX_CODEX_JSON_NODES = 2_048;
+export const CODEX_JSON_UNBOUNDED = "CODEX_JSON_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  throw new ElizaError("Codex tool-call JSON exceeds the parse walk budget", {
+    code: CODEX_JSON_UNBOUNDED,
+    context,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_CODEX_JSON_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_CODEX_JSON_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(
+  value: object,
+  key: PropertyKey,
+): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+/**
+ * Production Codex tool-arg boundary: descriptor-only JSON record check with
+ * one shared node/cycle budget. Throws CODEX_JSON_UNBOUNDED instead of
+ * RangeError; returns false for non-JSON values.
+ */
+export function isJsonRecord(value: unknown): value is Record<string, JsonValue> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  return walkJsonValue(value, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+export function isJsonValue(value: unknown): value is JsonValue {
+  return walkJsonValue(value, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
+}
+
+function walkJsonValue(value: unknown, depth: number, ctx: WalkContext): boolean {
+  if (depth > MAX_CODEX_JSON_DEPTH) {
+    failUnbounded({ depth, max: MAX_CODEX_JSON_DEPTH });
+  }
+  if (typeof value === "function") {
+    return false;
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    reserve(ctx, 1);
+    return true;
+  }
+  if (value === undefined || typeof value !== "object") {
+    return false;
+  }
+  reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        if (!walkJsonValue(descriptor.value, depth + 1, ctx)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      if (!walkJsonValue(descriptor.value, depth + 1, ctx)) {
+        return false;
+      }
+    }
+    return true;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}


### PR DESCRIPTION
Closes #22835

## Problem

`CodexBackend` JSON.parses untrusted SSE `function_call.arguments` then type-guards them with recursive `isJsonValue` (`Array.every` / `Object.values`). No depth, node, or cycle budget.

On `origin/develop` `b844d26f8895` (Node 24.15.0):

| Input | Result |
|---|---|
| JSON.parse 8k-deep array nest | succeeds 1.09 ms |
| `isJsonValue` on that nest | RangeError 1.37 ms |
| cyclic `{ self: self }` | RangeError 1.12 ms |

Product path: Codex generate-text tool-call extraction. The JSON.parse `catch` would swallow a typed unbounded failure into the raw string unless it is rethrown.

Not leftover-tax. Not a twin of `#22821` Google GenAI tool-call args, `#22826` Anthropic providerOptions, `#22797` planner action params, or `#22812` computer-use snapshots. Distinct host: `plugin-codex-cli` `isJsonRecord` after SSE JSON.parse. Stay-off is plugin-openai, not this plugin (Codex is the ChatGPT-subscription peer).

## Change

- Extract `isJsonValue` / `isJsonRecord` to `codex-json-value.ts`.
- Fail closed at depth 32 / 2048 nodes / first cycle (`CODEX_JSON_UNBOUNDED`).
- Descriptor-only reads; enumerable accessors fail closed without invocation. Sparse holes consume the node budget.
- Malformed JSON still stays the raw argument string; unbounded graphs rethrow.

## Exact-head evidence

Evidence revision: `00555938e67667cd6090915403eb1a12d3aa8b75`, based on `develop` `b844d26f8895`. Owning issue: #22835.

- Pinned Bun 1.3.14 package test lane: **18/18 passed** in 5 ms (7 walker + 11 backend, including `CodexBackend.generate` 8k nest).
- `bun run --cwd plugins/plugin-codex-cli typecheck`: pass.
- `bun run --cwd plugins/plugin-codex-cli build`: pass (Node + Browser + declarations, 0.90 s).

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - Codex tool-call JSON walk; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Codex tool-call JSON walk; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head independent backend receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/pr-22836-00555938-backend-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - tool-call JSON parse has no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 00555938e676</summary>

```
# domain artifact — Codex SSE function-call arguments production boundary
exact-head: 00555938e67667cd6090915403eb1a12d3aa8b75
based-on: origin/develop b844d26f8895
owning-issue: https://github.com/elizaOS/eliza/issues/22835

Pinned Bun 1.3.14 at this exact head:
  bun run --cwd plugins/plugin-codex-cli test: 18/18 passed
  bun run --cwd plugins/plugin-codex-cli typecheck: pass
  bun run --cwd plugins/plugin-codex-cli build: pass (0.90s)

Origin red (Node 24.15.0, pre-fix walk):
  JSON.parse 8k array nest: ok 1.09 ms
  isJsonValue on that nest: RangeError 1.37 ms
  cyclic { self: self }: RangeError 1.12 ms

This head:
  isJsonRecord(JSON.parse(8k nest)): ElizaError CODEX_JSON_UNBOUNDED
  CodexBackend.generate 8k arguments SSE: ElizaError CODEX_JSON_UNBOUNDED (not swallowed)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:00555938e67667cd6090915403eb1a12d3aa8b75 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
