### PR TITLE
fix(plugin-google-workspace): make credential merges atomic

### DIFF
--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
@@ -90,6 +90,58 @@ describe("mergeCredentialObject", () => {
     }
   });
 
+  it("translates a revoked root proxy without changing existing credentials", () => {
+    const credentials: OauthCredentialFields = {
+      access_token: "existing-access",
+      scope: "existing.scope",
+    };
+    const before = { ...credentials };
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    try {
+      mergeCredentialObject(credentials, proxy);
+      expect.unreachable("revoked root proxy should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(TypeError);
+    }
+
+    expect(credentials).toEqual(before);
+  });
+
+  it("does not invoke ordinary source get or has traps", () => {
+    let gets = 0;
+    let hasChecks = 0;
+    const source = new Proxy(
+      {
+        access_token: "safe-access",
+        refresh_token: "safe-refresh",
+      },
+      {
+        get() {
+          gets += 1;
+          throw new Error("ordinary get must not run");
+        },
+        has() {
+          hasChecks += 1;
+          throw new Error("ordinary has must not run");
+        },
+      }
+    );
+    const credentials: OauthCredentialFields = {};
+
+    mergeCredentialObject(credentials, source);
+
+    expect(credentials).toMatchObject({
+      access_token: "safe-access",
+      refresh_token: "safe-refresh",
+    });
+    expect(gets).toBe(0);
+    expect(hasChecks).toBe(0);
+  });
+
   it("translates hostile scope descriptor reflection without invoking access", () => {
     const reflectionError = new Error("descriptor reflection denied");
     const scopes = new Proxy(["gmail.read"], {
@@ -105,6 +157,73 @@ describe("mergeCredentialObject", () => {
       expect(error).toBeInstanceOf(ElizaError);
       expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
       expect((error as Error & { cause?: unknown }).cause).toBe(reflectionError);
+    }
+  });
+
+  it("leaves existing credentials unchanged when a late reflection failure aborts the walk", () => {
+    const credentials: OauthCredentialFields = {
+      access_token: "existing-access",
+      refresh_token: "existing-refresh",
+      scope: "existing.scope",
+      expiry_date: 123,
+    };
+    const before = { ...credentials };
+    const reflectionError = new Error("late descriptor reflection denied");
+    const scopes = new Proxy(["gmail.read"], {
+      getOwnPropertyDescriptor() {
+        throw reflectionError;
+      },
+    });
+
+    try {
+      mergeCredentialObject(credentials, {
+        tokens: {
+          access_token: "staged-access",
+          refresh_token: "staged-refresh",
+        },
+        scopes,
+      });
+      expect.unreachable("late reflection failure should abort the whole merge");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as Error & { cause?: unknown }).cause).toBe(reflectionError);
+    }
+
+    expect(credentials).toEqual(before);
+  });
+
+  it("uses fixed serializable context for an invalid reflected scope length", () => {
+    const credentialControlledLength = {
+      access_token: "must-not-enter-error-context",
+    };
+    const scopes = new Proxy([], {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "length") {
+          return {
+            configurable: false,
+            enumerable: false,
+            value: credentialControlledLength,
+            writable: true,
+          };
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+
+    try {
+      mergeCredentialObject({}, { scopes });
+      expect.unreachable("invalid reflected length should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
+      expect((error as ElizaError).context).toEqual({
+        operation: "readScopes",
+        reason: "invalidLength",
+      });
+      expect(JSON.stringify((error as ElizaError).context)).not.toContain(
+        credentialControlledLength.access_token
+      );
     }
   });
 

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -93,7 +93,7 @@ function readStringFromRecord(record: object, ...keys: string[]): string | undef
 function readScopeArray(scopes: unknown[], ctx: WalkContext): string {
   const length = dataValue(scopes, "length");
   if (!Number.isSafeInteger(length) || (length as number) < 0) {
-    failUnbounded({ invalidScopesLength: length });
+    failUnbounded({ operation: "readScopes", reason: "invalidLength" });
   }
   reserve(ctx, length as number);
 
@@ -138,10 +138,12 @@ function parseExpiry(value: unknown): number | undefined {
 }
 
 export function mergeCredentialObject(credentials: OauthCredentialFields, value: unknown): void {
-  mergeCredentialObjectInner(credentials, value, 0, {
+  const staged: OauthCredentialFields = {};
+  mergeCredentialObjectInner(staged, value, 0, {
     visits: 0,
     visiting: new WeakSet<object>(),
   });
+  Object.assign(credentials, staged);
 }
 
 function mergeCredentialObjectInner(


### PR DESCRIPTION
Fixes #22829.

## Problem

The bounded Google OAuth credential walker committed accepted fields directly to the destination while it was still inspecting untrusted input. A late typed reflection failure could therefore leave an earlier token partially committed. Its invalid-scope-length diagnostic also retained the credential-controlled reflected value in structured error context.

## Change

- Stage accepted credential fields in a private object and commit them only after the complete bounded walk succeeds.
- Replace the reflected invalid length in `ElizaError.context` with fixed `operation` and `reason` fields.
- Preserve nested-then-outer precedence, sparse-scope behavior, successful outputs, depth/node/cycle limits, and typed causes.
- Add production-boundary regressions for late-failure rollback, revoked root and scope proxies, hostile reflection, sanitized context, and zero ordinary source `get`/`has` calls.

## Exact-head evidence

Evidence revision: `e27a9d05705614537f9dcf7e2e9b059cd9123f73`, based on `develop` `b844d26f88950afc3a6c2c0771548a38d34cfa4a`.

- Focused credential merge suite: **16/16 passed**.
- Full `@elizaos/plugin-google-workspace` suite: **22 files / 244 tests passed**.
- Package typecheck: passed.
- Package build: passed.
- Biome on both changed files: passed.
- `git diff --check origin/develop...HEAD`: passed.

No live Google credentials, external API calls, or credential values were used. Tests use bounded synthetic placeholders only. This PR is draft-held for independent exact-head security review before merge.

## Evidence Gate

<!-- evidence-head:e27a9d05705614537f9dcf7e2e9b059cd9123f73 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only OAuth credential merge; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only OAuth credential merge; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production deployment or external API call; exact-head deterministic package gates are listed inline.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external artifact; exact-head atomic rollback and sanitized-context receipts are deterministic tests listed inline.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-cortex-plugins]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
