### PR TITLE
fix(plugin-google-workspace): make credential merge failures atomic

### DIFF
--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts
@@ -3,7 +3,7 @@
  * Google API: the walker is the production credential flatten.
  */
 import { ElizaError } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED,
@@ -90,6 +90,46 @@ describe("mergeCredentialObject", () => {
     }
   });
 
+  it("translates revoked root proxies to the typed boundary failure", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    expect(() => mergeCredentialObject({}, proxy)).toThrowError(
+      expect.objectContaining({ code: GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED })
+    );
+  });
+
+  it("never invokes source Proxy get or has traps", () => {
+    let getInvocations = 0;
+    let hasInvocations = 0;
+    const source = new Proxy(
+      {
+        tokens: { refresh_token: "nested-refresh" },
+        access_token: "outer-access",
+      },
+      {
+        get() {
+          getInvocations += 1;
+          throw new Error("get trap must not run");
+        },
+        has() {
+          hasInvocations += 1;
+          throw new Error("has trap must not run");
+        },
+      }
+    );
+    const credentials: OauthCredentialFields = {};
+
+    mergeCredentialObject(credentials, source);
+
+    expect(credentials).toEqual({
+      access_token: "outer-access",
+      refresh_token: "nested-refresh",
+    });
+    expect(getInvocations).toBe(0);
+    expect(hasInvocations).toBe(0);
+  });
+
   it("translates hostile scope descriptor reflection without invoking access", () => {
     const reflectionError = new Error("descriptor reflection denied");
     const scopes = new Proxy(["gmail.read"], {
@@ -105,6 +145,53 @@ describe("mergeCredentialObject", () => {
       expect(error).toBeInstanceOf(ElizaError);
       expect((error as ElizaError).code).toBe(GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED);
       expect((error as Error & { cause?: unknown }).cause).toBe(reflectionError);
+    }
+  });
+
+  it("does not commit partial credentials when reflection fails late", () => {
+    const reflectionError = new Error("scope reflection denied");
+    const scopes = new Proxy(["gmail.read"], {
+      getOwnPropertyDescriptor() {
+        throw reflectionError;
+      },
+    });
+    const credentials: OauthCredentialFields = { refresh_token: "existing-refresh" };
+
+    expect(() =>
+      mergeCredentialObject(credentials, {
+        access_token: "uncommitted-access",
+        refresh_token: "uncommitted-refresh",
+        scopes,
+      })
+    ).toThrowError(expect.objectContaining({ code: GOOGLE_OAUTH_CREDENTIAL_UNBOUNDED }));
+    expect(credentials).toEqual({ refresh_token: "existing-refresh" });
+  });
+
+  it("does not retain an invalid scope length value in error context", () => {
+    const sensitiveLength = { access_token: "must-not-enter-context" };
+    const scopes: unknown[] = [];
+    const nativeDescriptor = Object.getOwnPropertyDescriptor;
+    const descriptorSpy = vi
+      .spyOn(Object, "getOwnPropertyDescriptor")
+      .mockImplementation((target, key) => {
+        if (target === scopes && key === "length") {
+          return { value: sensitiveLength };
+        }
+        return nativeDescriptor(target, key);
+      });
+
+    try {
+      mergeCredentialObject({}, { scopes });
+      expect.unreachable("invalid scope length should fail closed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).context).toEqual({
+        operation: "readScopeArray",
+        reason: "invalidLength",
+      });
+      expect(JSON.stringify((error as ElizaError).context)).not.toContain("must-not-enter-context");
+    } finally {
+      descriptorSpy.mockRestore();
     }
   });
 

--- a/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
+++ b/plugins/plugin-google-workspace/src/oauth-credential-merge.ts
@@ -93,7 +93,8 @@ function readStringFromRecord(record: object, ...keys: string[]): string | undef
 function readScopeArray(scopes: unknown[], ctx: WalkContext): string {
   const length = dataValue(scopes, "length");
   if (!Number.isSafeInteger(length) || (length as number) < 0) {
-    failUnbounded({ invalidScopesLength: length });
+    // Do not copy the untrusted credential value into diagnostic context.
+    failUnbounded({ operation: "readScopeArray", reason: "invalidLength" });
   }
   reserve(ctx, length as number);
 
@@ -138,10 +139,19 @@ function parseExpiry(value: unknown): number | undefined {
 }
 
 export function mergeCredentialObject(credentials: OauthCredentialFields, value: unknown): void {
-  mergeCredentialObjectInner(credentials, value, 0, {
+  // Stage every field so a failure discovered late in the walk cannot leave a
+  // caller with a partially accepted credential set.
+  const staged: OauthCredentialFields = {};
+  mergeCredentialObjectInner(staged, value, 0, {
     visits: 0,
     visiting: new WeakSet<object>(),
   });
+  if (staged.access_token !== undefined) credentials.access_token = staged.access_token;
+  if (staged.refresh_token !== undefined) credentials.refresh_token = staged.refresh_token;
+  if (staged.id_token !== undefined) credentials.id_token = staged.id_token;
+  if (staged.token_type !== undefined) credentials.token_type = staged.token_type;
+  if (staged.scope !== undefined) credentials.scope = staged.scope;
+  if (staged.expiry_date !== undefined) credentials.expiry_date = staged.expiry_date;
 }
 
 function mergeCredentialObjectInner(


### PR DESCRIPTION
# Relates to

Closes #22829.
Refs #22804 and #22813.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

Independent post-merge review of #22813 found that a reflection failure discovered after ordinary fields were read could throw the correct typed error while leaving those fields written into the caller's destination object. The same review found that the invalid-array-length diagnostic retained the untrusted length value directly in serializable `ElizaError.context`.

This corrective patch:

- stages all six supported credential fields and commits them only after the entire bounded walk succeeds;
- replaces the credential-controlled invalid-length context value with fixed `operation` and `reason` fields;
- proves revoked root/scope proxy handling and proves source `get`/`has` traps are never invoked;
- preserves original reflection exceptions as `cause`, ordinary nested-then-outer precedence, sparse scopes, and the existing depth/node budgets.

# Reviewer walkthrough

Start at `plugins/plugin-google-workspace/src/oauth-credential-merge.test.ts`:

1. `does not commit partial credentials when reflection fails late` starts with an existing refresh token, exposes valid replacement tokens before a hostile scope descriptor, and verifies the destination is unchanged after the typed failure.
2. `does not retain an invalid scope length value in error context` injects a token-shaped object at the defensive length boundary and verifies only fixed context survives.
3. Revoked-root and `get`/`has` trap fixtures exercise the exported production merge boundary, not a stand-in helper.

# Exact-head verification

Evidence head: `c8ccb872d6a78cbc3462b733950cdf20bd23bc28`

- Focused boundary suite: **16 passed, 0 failed, 37 assertions**.
- Full `@elizaos/plugin-google-workspace` suite: **22 files, 244 tests passed**.
- Package typecheck: passed.
- Package lint: **47 files checked, no fixes**.
- Package build: passed; declarations generated.
- `git diff --check origin/develop...HEAD`: passed.
- Fresh isolated `bun install`: passed; 6,654 packages installed.
- Root `bun run verify`: passed through all final audit gates, including 145-workspace dependency checks, Turbo typecheck/lint, build-model audits, 9,118-file focused-test audit, and 3,280 mock-module checks.

# Evidence Gate

<!-- evidence-head:c8ccb872d6a78cbc3462b733950cdf20bd23bc28 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic credential boundary with no interactive UI.
<!-- evidence-row:backend-logs -->
- [x] [Root exact-head verify transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22829-verify-c8ccb872.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Focused credential-boundary transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22829-focused-c8ccb872.txt) and [full owning-package transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/22829-full-c8ccb872.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Risk

Low and bounded to the credential-flattening helper. Successful inputs produce the same six field values and precedence as before. The only externally observable changes are that failed input no longer partially mutates the destination and diagnostic context no longer retains the rejected length value.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review-22813]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@19519bfcd112799c89a3fb7eac7ab8fa77bfe1dc:packages/skills/skills/contribute-to-eliza"} -->
