### PR TITLE
Polish hosted login and Shared gateway responses

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
@@ -42,6 +42,13 @@ const personalSharedFetch = mock(async (request: Request) => {
     service: "discord-gateway",
   });
   expect(request.headers.get("authorization")).toBeNull();
+  await expect(request.json()).resolves.toEqual({
+    platform: "discord",
+    discordUserId: "666666666666666666",
+    discordUsername: "tester",
+    messageId: "discord:555555555555555555",
+    message: "hello",
+  });
   return new Response(
     JSON.stringify({
       success: true,
@@ -81,7 +88,7 @@ beforeEach(() => {
   personalSharedFetch.mockClear();
 });
 
-test("forwards the Personal Shared account, prewarm, and runtime split", async () => {
+test("forwards a first Discord DM to Personal Shared account creation", async () => {
   const response = await app.request(
     "http://localhost/",
     {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -654,7 +654,7 @@ describe("personal Shared messaging deliveries", () => {
     expect(renewedSession).not.toBe(firstSession);
   });
 
-  test("uses the phone account without provisioning an agent row", async () => {
+  test("auto-registers a first phone message without provisioning an agent row", async () => {
     const response = await request(validPhone);
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
@@ -666,6 +666,14 @@ describe("personal Shared messaging deliveries", () => {
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(body.data.account.userId).toBe(
       "00000000-0000-4000-8000-000000000012",
+    );
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "00000000-0000-4000-8000-000000000011",
+        user_id: "00000000-0000-4000-8000-000000000012",
+      }),
+      namespace,
+      { warmConversation: true },
     );
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -689,7 +697,8 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
-  test("routes a linked Discord DM through the same personal room", async () => {
+  test("auto-registers a first Discord DM in the same personal room", async () => {
+    personalDeliveryIsNew = true;
     const discordUserId = ["123456789", "012345678"].join("");
     const response = await request({
       platform: "discord",
@@ -713,6 +722,14 @@ describe("personal Shared messaging deliveries", () => {
       avatarUrl: "https://cdn.discordapp.com/avatar.png",
     });
     expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "00000000-0000-4000-8000-000000000001",
+        user_id: "00000000-0000-4000-8000-000000000002",
+      }),
+      namespace,
+      { warmConversation: true },
+    );
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       expect.objectContaining({ id: body.data.identity.id }),
       body.data.identity.id,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -113,6 +113,10 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(dispatches).toBe(0);
     expect(JSON.stringify(runtimeInputs[0])).toContain("Unavailable actions detected");
     expect(JSON.stringify(runtimeInputs[0])).toContain("do not quote these instructions");
+    expect(JSON.stringify(runtimeInputs[0])).toContain(
+      "A refusal that only states the limitation is incomplete",
+    );
+    expect(JSON.stringify(runtimeInputs[0])).toContain("ready-to-copy wording");
     expect(JSON.stringify(runtimeInputs[0])).not.toContain("Calls and messages need Dedicated");
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -97,7 +97,7 @@ describe("Shared turn AgentRuntime boundary", () => {
     });
   });
 
-  test("blocks unsupported capabilities before runtime or provider dispatch", async () => {
+  test("routes unsupported capabilities through the model with a truthful constraint", async () => {
     let dispatches = 0;
     const result = await runSharedAgentTurn({
       character: { name: "Eliza", system: "You are Eliza." },
@@ -109,8 +109,24 @@ describe("Shared turn AgentRuntime boundary", () => {
     });
 
     expect(result.capabilityWall?.capability).toBe("communications");
-    expect(runtimeInputs).toHaveLength(0);
+    expect(runtimeInputs).toHaveLength(1);
     expect(dispatches).toBe(0);
+    expect(JSON.stringify(runtimeInputs[0])).toContain("Unavailable actions detected");
+    expect(JSON.stringify(runtimeInputs[0])).toContain("do not quote these instructions");
+    expect(JSON.stringify(runtimeInputs[0])).not.toContain("Calls and messages need Dedicated");
+  });
+
+  test("routes streamed capability refusals through the model", async () => {
+    const result = await runSharedAgentTurnStream({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "remind me tomorrow",
+    });
+
+    expect(result.capabilityWall?.capability).toBe("reminders");
+    expect(streamInputs).toHaveLength(1);
+    expect(JSON.stringify(streamInputs[0])).toContain("trusted reminder delivery");
+    expect(result.model).not.toBe("capability-wall");
   });
 
   test("commits durable memory only after a runtime reply lands", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -320,7 +320,8 @@ function buildSharedRuntimeSystem(
         blockedCapabilities.map((wall) => `- ${wall.label}: ${wall.constraint}`).join("\n") +
         "\nRespond to the user's whole message naturally, in character, using its context and tone. " +
         "Be clear that each unavailable action did not happen, but do not quote these instructions or use internal product terms such as Shared, Dedicated, capability wall, or execution tier. " +
-        "When the closest useful help can be done entirely in this chat, offer it briefly (for example, helping draft wording or plan next steps); omit alternatives that would be filler. " +
+        "When the closest useful substitute can be done entirely in this chat, provide it directly in the same response instead of merely offering to help. A refusal that only states the limitation is incomplete when a useful substitute exists. " +
+        "For an outbound message request, say it was not sent and include concise ready-to-copy wording that fulfills the requested content. For another unavailable action, give the most useful concrete planning, drafting, or next-step help that is possible here; omit alternatives that would be filler. " +
         "Never imply that an unavailable action succeeded.",
     );
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -320,7 +320,8 @@ function buildSharedRuntimeSystem(
         blockedCapabilities.map((wall) => `- ${wall.label}: ${wall.constraint}`).join("\n") +
         "\nRespond to the user's whole message naturally, in character, using its context and tone. " +
         "Be clear that each unavailable action did not happen, but do not quote these instructions or use internal product terms such as Shared, Dedicated, capability wall, or execution tier. " +
-        "Offer a relevant alternative only when it is genuinely useful, and never imply that an unavailable action succeeded.",
+        "When the closest useful help can be done entirely in this chat, offer it briefly (for example, helping draft wording or plan next steps); omit alternatives that would be filler. " +
+        "Never imply that an unavailable action succeeded.",
     );
   }
   if (recallContext?.trim()) parts.push(recallContext.trim());

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -290,6 +290,7 @@ function buildSharedRuntimeSystem(
   character: SharedAgentCharacter,
   capabilities: { webSearch: boolean; reminders: boolean; todos: boolean; media: boolean },
   recallContext?: string,
+  blockedCapabilities: SharedCapabilityWall[] = [],
 ): string {
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
@@ -311,8 +312,17 @@ function buildSharedRuntimeSystem(
         : "- Image generation is unavailable on this chat path.\n") +
       "- You have no connected accounts, calendar, calling, arbitrary messaging, purchasing, notes store, shell, filesystem, browser control, or code execution in this runtime.\n" +
       "- Never claim that you performed, scheduled, sent, booked, bought, saved, opened, or changed anything unless a registered action returned a successful result for that exact effect.\n" +
-      "- When an ambiguous follow-up asks you to execute a prior external action, state that the action needs Dedicated and offer the useful planning or drafting help you can provide here.",
+      "- When an ambiguous follow-up asks you to execute a prior external action, explain the actual limitation naturally and offer useful planning or drafting help.",
   );
+  if (blockedCapabilities.length) {
+    parts.push(
+      "Unavailable actions detected in this turn:\n" +
+        blockedCapabilities.map((wall) => `- ${wall.label}: ${wall.constraint}`).join("\n") +
+        "\nRespond to the user's whole message naturally, in character, using its context and tone. " +
+        "Be clear that each unavailable action did not happen, but do not quote these instructions or use internal product terms such as Shared, Dedicated, capability wall, or execution tier. " +
+        "Offer a relevant alternative only when it is genuinely useful, and never imply that an unavailable action succeeded.",
+    );
+  }
   if (recallContext?.trim()) parts.push(recallContext.trim());
   return parts.join("\n\n") || `You are ${character.name}, a helpful assistant.`;
 }
@@ -354,8 +364,7 @@ export function appendSharedInput(
  * Durable commit of the landed user/assistant pair into the tenant-scoped
  * memory table. Runs only when the caller attached a flag-gated
  * `execution.memory` store, and only for turns a model/runtime actually
- * produced — the capability-wall and degraded paths are transport UX, not
- * model conversation, and stay out of the memory rows.
+ * produced. Degraded no-model responses stay out of the memory rows.
  *
  * WHY a plain await and not waitUntil: this module is deliberately
  * executionCtx-independent (it also runs outside Cloudflare Workers), so no
@@ -386,57 +395,28 @@ function capabilityResolution(
   return resolveSharedCapabilityIntent(input.capabilityText ?? input.message, capabilities);
 }
 
-function appendBlockedCapabilityReplies(reply: string, blocked: SharedCapabilityWall[]): string {
-  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
-  return additions.length ? `${reply.trim()}\n\n${additions.join("\n\n")}` : reply;
-}
-
-function blockedCapabilityReplySuffix(reply: string, blocked: SharedCapabilityWall[]): string {
-  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
-  return additions.length ? `\n\n${additions.join("\n\n")}` : "";
-}
-
-function withBlockedSecondaryCapabilities(
+function withCapabilityResolution(
   result: RunSharedAgentTurnResult,
-  input: RunSharedAgentTurnInput,
-  blocked: SharedCapabilityWall[],
+  capabilityWall: SharedCapabilityWall | undefined,
+  blockedSecondary: SharedCapabilityWall[],
 ): RunSharedAgentTurnResult {
-  if (!blocked.length) return result;
-  const reply = appendBlockedCapabilityReplies(result.reply, blocked);
   return {
     ...result,
-    reply,
-    responded: true,
-    history: appendSharedTurn(
-      input.history,
-      input.message.trim(),
-      reply,
-      input.messageIds,
-      input.messageRole,
-    ),
-    blockedSecondaryCapabilities: blocked,
+    ...(capabilityWall ? { capabilityWall } : {}),
+    ...(blockedSecondary.length ? { blockedSecondaryCapabilities: blockedSecondary } : {}),
   };
 }
 
-function withBlockedSecondaryStream(
+function withStreamCapabilityResolution(
   result: RunSharedAgentTurnStreamResult,
-  blocked: SharedCapabilityWall[],
+  capabilityWall: SharedCapabilityWall | undefined,
+  blockedSecondary: SharedCapabilityWall[],
 ): RunSharedAgentTurnStreamResult {
-  if (!blocked.length || !result.parts) return result;
-  const source = result.parts;
-  const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
-    for await (const part of source) {
-      if (part.type === "text-delta") {
-        yield part;
-        continue;
-      }
-      const suffix = blockedCapabilityReplySuffix(part.text, blocked);
-      const text = `${part.text.trim()}${suffix}`;
-      if (suffix) yield { type: "text-delta", text: suffix };
-      yield { ...part, text };
-    }
-  })();
-  return { ...result, parts, blockedSecondaryCapabilities: blocked };
+  return {
+    ...result,
+    ...(capabilityWall ? { capabilityWall } : {}),
+    ...(blockedSecondary.length ? { blockedSecondaryCapabilities: blockedSecondary } : {}),
+  };
 }
 /**
  * Run one shared (container-free) turn for a simple agent. Returns a degraded
@@ -461,22 +441,6 @@ export async function runSharedAgentTurn(
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
-  if (capabilityWall) {
-    return {
-      reply: capabilityWall.reply,
-      history: appendSharedTurn(
-        input.history,
-        message,
-        capabilityWall.reply,
-        input.messageIds,
-        input.messageRole,
-      ),
-      model: "capability-wall",
-      degraded: false,
-      capabilityWall,
-    };
-  }
-
   const modelId = resolveSharedAgentTurnModel(input.character.model);
 
   if (!modelId) {
@@ -493,7 +457,7 @@ export async function runSharedAgentTurn(
   try {
     const execution = resolveRuntimeExecution(input);
     const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
-    turn = withBlockedSecondaryCapabilities(
+    turn = withCapabilityResolution(
       await runSharedElizaRuntimeTurn({
         ...input,
         character: {
@@ -507,13 +471,14 @@ export async function runSharedAgentTurn(
               media: actionsEnabled && Boolean(execution.media),
             },
             input.recallContext,
+            capabilityWall ? [capabilityWall] : blockedSecondary,
           ),
         },
         execution,
         agentKey: execution.agentKey,
         model: modelId,
       }),
-      input,
+      capabilityWall,
       blockedSecondary,
     );
   } catch (error) {
@@ -553,22 +518,6 @@ export async function runSharedAgentTurnStream(
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
-  if (capabilityWall) {
-    const reply = capabilityWall.reply;
-    const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
-      yield { type: "text-delta", text: reply };
-      yield { type: "finish", text: reply };
-    })();
-    return {
-      model: "capability-wall",
-      degraded: false,
-      reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
-      parts,
-      capabilityWall,
-    };
-  }
-
   const modelId = resolveSharedAgentTurnModel(input.character.model);
 
   if (!modelId) {
@@ -584,7 +533,7 @@ export async function runSharedAgentTurnStream(
   try {
     const execution = resolveRuntimeExecution(input);
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
-    return withBlockedSecondaryStream(
+    return withStreamCapabilityResolution(
       await runSharedElizaRuntimeTurnStream({
         ...input,
         character: {
@@ -598,12 +547,14 @@ export async function runSharedAgentTurnStream(
               media: actionsEnabled && Boolean(execution.media),
             },
             input.recallContext,
+            capabilityWall ? [capabilityWall] : blockedSecondary,
           ),
         },
         execution,
         agentKey: execution.agentKey,
         model: modelId,
       }),
+      capabilityWall,
       blockedSecondary,
     );
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -166,8 +166,8 @@ describe("Shared capability wall", () => {
 
   test("does not falsely claim voice and messaging require Dedicated", () => {
     const wall = resolveSharedCapabilityWall("call Mom");
-    expect(wall?.reply).toContain("connected voice and messaging channels");
-    expect(wall?.reply).not.toContain("Dedicated");
+    expect(wall?.constraint).toContain("current connected channel");
+    expect(wall?.constraint).not.toContain("Dedicated");
   });
 
   test.each(["channel", "voice"])(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -17,7 +17,12 @@ export type SharedDedicatedCapability =
 export interface SharedCapabilityWall {
   capability: SharedDedicatedCapability;
   label: string;
-  reply: string;
+  /**
+   * Factual runtime constraint supplied to the model and action receipt. This
+   * is deliberately not end-user copy: the model must express it naturally in
+   * the agent's voice and in the context of the actual request.
+   */
+  constraint: string;
 }
 
 export type SharedCapabilityResolution =
@@ -37,93 +42,93 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     label: "Reminders",
     pattern:
       /\b(?:remind\s+me|(?:set|create|add|schedule|cancel|delete|change|list|show)\b[\s\S]{0,36}\breminders?)\b/i,
-    reply:
-      "Reminders need Dedicated. I can still help you plan it here, but Shared can't schedule or deliver reminders.",
+    constraint:
+      "This transport has no trusted reminder delivery, so it cannot create, change, list, or deliver reminders.",
   },
   {
     capability: "todos",
     label: "Todos",
     pattern:
       /\b(?:add|create|make|write|show|list|get|update|edit|complete|finish|cancel|delete|remove|clear)\b[\s\S]{0,48}\b(?:to[ -]?dos?|task\s+list|checklist|my\s+tasks?)\b/i,
-    reply: "Todos are unavailable on this chat path right now. I didn't save or change anything.",
+    constraint:
+      "This chat path has no persistent todo storage, so it cannot read or change a checklist.",
   },
   {
     capability: "calendar",
     label: "Calendar",
     pattern:
       /\b(?:(?:add|create|book|schedule|cancel|delete|move|reschedule)\b[\s\S]{0,36}\b(?:calendar|events?|appointments?|meetings?)|(?:check|show|list|open)\b\s+(?:me\s+)?(?:(?:my|our|the|upcoming|next|today(?:'s)?|tomorrow(?:'s)?)\s+){0,2}(?:calendar|events?|appointments?|meetings?)|(?:check|show)\b\s+(?:me\s+)?(?:if|whether)\s+(?:(?:i|we)\s+have|there\s+(?:is|are))\s+(?:(?:any|some|an?)\s+)?(?:events?|appointments?|meetings?))\b/i,
-    reply:
-      "Calendar actions need Dedicated. I can help plan the event here, but Shared can't read or change your calendar.",
+    constraint:
+      "No calendar account or calendar action is available in this runtime, so it cannot read or change calendar data.",
   },
   {
     capability: "bookings",
     label: "Bookings",
     pattern:
       /\b(?:(?:can|could|would|will)\s+you\s+)?(?:(?:book|reserve)\s+(?:it|that|this)|(?:book|reserve)\b[\s\S]{0,48}\b(?:flights?|tables?|restaurants?|reservations?|hotels?|rooms?|tickets?|dinner|lunch|appointments?)|make\b[\s\S]{0,36}\b(?:reservations?|bookings?))\b/i,
-    reply:
-      "Bookings need Dedicated. I can research options and help you choose, but Shared can't make the reservation or purchase.",
+    constraint:
+      "No booking action is available in this runtime, so it cannot make or change a reservation.",
   },
   {
     capability: "communications",
     label: "Calls and messages",
     pattern:
       /(?:(?<=^|[.!?;,]\s*|\b(?:and\s+)?then\s+|\band\s+|\bto\s+|\bplease\s+|\b(?:can|could|would|will)\s+you\s+)(?:email|call|text|message|dm)\s+(?!(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|\bsend\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
-    reply:
-      "I can talk with you and reply through Eliza's connected voice and messaging channels. I can't initiate a separate call, email, text, or DM to another person from this session.",
+    constraint:
+      "This session can reply in its current connected channel but cannot initiate a separate call, email, text, or DM to another person.",
   },
   {
     capability: "purchases",
     label: "Purchases",
     pattern:
       /\b(?:(?:can|could|would|will)\s+you\s+)?(?:order|buy|purchase)\b[\s\S]{0,48}\b(?:food|groceries|meal|dinner|lunch|breakfast|item|product|gift|flowers|bottle|coffee|pizza|tickets?)\b/i,
-    reply:
-      "Purchases need Dedicated. I can compare options here, but Shared can't place an order or buy anything.",
+    constraint:
+      "No purchasing action is available in this runtime, so it cannot place an order or buy anything.",
   },
   {
     capability: "notes",
     label: "Notes",
     pattern:
       /\b(?:create|save|add|store|write|read|show|list|open|delete|remove|update|edit)\b[\s\S]{0,28}\bnotes?\b/i,
-    reply:
-      "Persistent notes need Dedicated. I can remember this conversation, but Shared doesn't manage a separate notes store.",
+    constraint:
+      "This runtime has no separate persistent notes store, so it cannot read or change notes.",
   },
   {
     capability: "cloud-apps",
     label: "Cloud apps",
     pattern:
       /\b(?:connect|open|read|send|search|manage|update|upload|download)\b[\s\S]{0,36}\b(?:gmail|google\s+drive|google\s+docs?|slack|notion|dropbox|microsoft\s+365|outlook)\b/i,
-    reply: "Connected apps need Dedicated. Shared can't access or act inside external accounts.",
+    constraint:
+      "No external app account is connected in this runtime, so it cannot access or act inside one.",
   },
   {
     capability: "shell",
     label: "Shell",
     pattern:
       /\b(?:run|execute|start)\b[\s\S]{0,20}\b(?:a\s+)?(?:shell|terminal|command|script|npm|bun|git|docker)\b/i,
-    reply:
-      "Running commands needs Dedicated. I can reason about commands here, but Shared has no shell.",
+    constraint: "This runtime has no shell and cannot execute commands or scripts.",
   },
   {
     capability: "filesystem",
     label: "Files",
     pattern:
       /\b(?:read|open|edit|write|create|delete|remove|move|rename|upload|download|search)\b[\s\S]{0,28}\b(?:files?|folders?|directories|workspace|path)\b/i,
-    reply:
-      "File access needs Dedicated. Shared can use text you paste here, but it can't read or change a filesystem.",
+    constraint: "This runtime has no filesystem access and cannot read or change files.",
   },
   {
     capability: "browser-control",
     label: "Browser control",
     pattern:
       /\b(?:open|navigate|visit|click|fill|submit|scroll|control|log\s*in)\b[\s\S]{0,32}\b(?:browser|website|webpage|page|tab|form)\b/i,
-    reply: "Browser control needs Dedicated. Shared can't operate websites or a browser session.",
+    constraint: "This runtime has no browser control and cannot operate websites or browser tabs.",
   },
   {
     capability: "coding-runtime",
     label: "Coding workspace",
     pattern:
       /\b(?:run|execute|test|build|compile|deploy|debug|fix|refactor)\b[\s\S]{0,36}\b(?:repository|repo|codebase|project|workspace|tests?|build)\b/i,
-    reply:
-      "A coding workspace needs Dedicated. I can write and explain code here, but Shared can't execute or edit a repository.",
+    constraint:
+      "This runtime has no coding workspace and cannot execute, test, deploy, or edit a repository.",
   },
 ];
 
@@ -156,8 +161,8 @@ function isEnabled(
 }
 
 function wallFor(match: CapabilityMatch): SharedCapabilityWall {
-  const { capability, label, reply } = match.rule;
-  return { capability, label, reply };
+  const { capability, label, constraint } = match.rule;
+  return { capability, label, constraint };
 }
 
 function startsInNonExecutionClause(text: string, index: number): boolean {
@@ -235,7 +240,7 @@ export function capabilityWallActionResult(wall: SharedCapabilityWall) {
   return {
     actionName: "DEDICATED_CAPABILITY_REQUIRED" as const,
     success: false as const,
-    text: wall.reply,
+    text: wall.constraint,
     values: {
       capability: wall.capability,
       currentExecutionTier: "shared" as const,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
@@ -49,7 +49,7 @@ describe("Shared runtime capability components", () => {
     expect(result.text).toContain(REQUEST_DEDICATED_UPGRADE_ACTION);
   });
 
-  test("returns a review handoff without provisioning or charging", async () => {
+  test("returns a structured review handoff for an in-character continuation", async () => {
     const action = createRequestDedicatedUpgradeAction("personal:user/1");
     const delivered: string[] = [];
     const result = await action.handler(
@@ -69,6 +69,8 @@ describe("Shared runtime capability components", () => {
       mutationPerformed: false,
       requiresUserConfirmation: true,
     });
-    expect(delivered[0]).toContain("Nothing has been activated or charged");
+    expect(result.text).toContain("no mutation or charge was performed");
+    expect(delivered).toEqual([]);
+    expect(action.suppressPostActionContinuation).not.toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
@@ -141,9 +141,8 @@ export function createRequestDedicatedUpgradeAction(agentId: string): Action {
     contexts: ["general"],
     roleGate: { minRole: "GUEST" },
     suppressEarlyReply: true,
-    suppressPostActionContinuation: true,
     description:
-      "Give the user the explicit review link for moving this Shared agent to Dedicated when they ask for coding, shell, browser control, connected accounts, or another unavailable advanced capability. This action does not purchase, provision, or activate anything.",
+      "Return the explicit review link for moving this Shared agent to Dedicated when the user asks for coding, shell, browser control, connected accounts, or another unavailable advanced capability. After this action, explain the result naturally in the agent's voice. This action does not purchase, provision, or activate anything.",
     parameters: [
       {
         name: "capability",
@@ -158,7 +157,7 @@ export function createRequestDedicatedUpgradeAction(agentId: string): Action {
       _message: Memory,
       _state?: State,
       handlerOptions?: unknown,
-      callback?: HandlerCallback,
+      _callback?: HandlerCallback,
     ): Promise<ActionResult> => {
       const parameters = readParameters(handlerOptions);
       const capability =
@@ -166,8 +165,9 @@ export function createRequestDedicatedUpgradeAction(agentId: string): Action {
           ? parameters.capability.trim().slice(0, 160)
           : "advanced capabilities";
       const upgradePath = `/cloud/agents/${encodeURIComponent(agentId)}`;
-      const text = `Shared can't perform ${capability}. You can review Dedicated capabilities, price, and confirmation here: ${upgradePath}. Nothing has been activated or charged.`;
-      await callback?.({ text });
+      // This is a structured tool receipt, not end-user copy. The normal
+      // post-action model continuation turns it into an in-character response.
+      const text = `Dedicated review available for ${capability} at ${upgradePath}; no mutation or charge was performed and explicit user confirmation is required.`;
       return {
         success: true,
         text,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -793,7 +793,7 @@ describe("SharedRuntimeChatService", () => {
     const blockedCommunication = {
       capability: "communications",
       label: "Calls and messages",
-      reply: "I can't initiate a separate email.",
+      constraint: "This session cannot initiate a separate email.",
     };
     streamTurn = {
       degraded: false,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -213,8 +213,12 @@ function turnActionResults(
   return results.length ? results : undefined;
 }
 
-function isProviderFreeTurn(turn: Pick<RunSharedAgentTurnResult, "capabilityWall">): boolean {
-  return Boolean(turn.capabilityWall);
+function isProviderFreeTurn(
+  turn: Pick<RunSharedAgentTurnResult, "capabilityWall" | "model">,
+): boolean {
+  // Capability refusals now run through the agent model so they stay in
+  // character. Retain compatibility for replayed legacy wall-only turns.
+  return Boolean(turn.capabilityWall && turn.model === "capability-wall");
 }
 
 /** Terminal result of a landed shared turn, durably replayable by claim key. */

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
@@ -278,7 +278,7 @@ describe("buildTurnSummary compaction", () => {
         capabilityWall: {
           capability: "reminders",
           label: "Reminders",
-          reply: "Reminders need Dedicated — but I can draft the reminder text for you.",
+          constraint: "This transport has no trusted reminder delivery.",
         },
       }),
       ...identity,
@@ -286,6 +286,25 @@ describe("buildTurnSummary compaction", () => {
     expect(summary.finishReason).toBe("capability-wall");
     expect(summary.stages).toEqual([{ name: "capability-wall", tool: "reminders" }]);
     expect(JSON.stringify(summary)).not.toContain("Dedicated");
+  });
+
+  test("records model-backed capability responses as model plus wall", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({
+        model: "gpt-oss-120b",
+        capabilityWall: {
+          capability: "reminders",
+          label: "Reminders",
+          constraint: "This transport has no trusted reminder delivery.",
+        },
+      }),
+      ...identity,
+    });
+    expect(summary.finishReason).toBe("capability-wall");
+    expect(summary.stages).toEqual([
+      { name: "model" },
+      { name: "capability-wall", tool: "reminders" },
+    ]);
   });
 
   test("classifies the designed no-model unavailable state as degraded", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
@@ -139,6 +139,7 @@ export function buildTurnSummary(input: BuildTurnSummaryInput): SharedTurnSummar
   const stages: SharedTurnTraceStage[] = [];
   if (result.capabilityWall) {
     finishReason = "capability-wall";
+    if (result.model !== "capability-wall") stages.push({ name: "model" });
     stages.push({ name: "capability-wall", tool: result.capabilityWall.capability });
   } else if (result.degraded) {
     finishReason = "degraded";

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
@@ -19,10 +19,13 @@ import {
 } from "./steward-oauth-pkce.js";
 
 const STORAGE_KEY = "steward.oauth.pkce.verifier";
+const COOKIE_KEY = "steward_oauth_pkce_verifier";
 
 afterEach(() => {
   window.sessionStorage.removeItem(STORAGE_KEY);
   window.localStorage.removeItem(STORAGE_KEY);
+  // biome-ignore lint/suspicious/noDocumentCookie: deterministic cleanup for the cookie-fallback test
+  document.cookie = `${COOKIE_KEY}=; Path=/; Max-Age=0`;
 });
 
 describe("steward-oauth-pkce", () => {
@@ -138,6 +141,42 @@ describe("steward-oauth-pkce", () => {
       expect(removed).toBe(false);
       expect(consumeStewardPkceVerifier()).toBe("local-verifier");
       expect(removed).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: previousWindow,
+      });
+    }
+  });
+
+  it("falls back to a short-lived same-site cookie when Web Storage is unavailable", () => {
+    const previousWindow = globalThis.window;
+    const restrictedWindow = Object.create(previousWindow) as Window;
+    Object.defineProperty(restrictedWindow, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Access denied", "SecurityError");
+      },
+    });
+    Object.defineProperty(restrictedWindow, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Access denied", "SecurityError");
+      },
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: restrictedWindow,
+    });
+
+    try {
+      expect(storeStewardPkceVerifier("cookie-verifier", "cookie-state")).toBe(
+        true,
+      );
+      expect(document.cookie).toContain(`${COOKIE_KEY}=`);
+      expect(peekStewardOAuthState()).toBe("cookie-state");
+      expect(consumeStewardPkceVerifier()).toBe("cookie-verifier");
+      expect(document.cookie).not.toContain(`${COOKIE_KEY}=`);
     } finally {
       Object.defineProperty(globalThis, "window", {
         configurable: true,

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
@@ -15,6 +15,7 @@
 export type StewardOAuthProvider = "google" | "discord" | "github" | "twitter";
 
 const STEWARD_PKCE_VERIFIER_STORAGE_KEY = "steward.oauth.pkce.verifier";
+const STEWARD_PKCE_VERIFIER_COOKIE_KEY = "steward_oauth_pkce_verifier";
 const STEWARD_PKCE_VERIFIER_TTL_MS = 10 * 60 * 1000;
 const PKCE_VERIFIER_BYTES = 48;
 const OAUTH_STATE_BYTES = 32;
@@ -91,6 +92,19 @@ export function storeStewardPkceVerifier(
   } catch {
     // same as above
   }
+  // Some privacy-focused browser profiles discard Web Storage while bouncing
+  // through an external identity provider. Keep the same short-lived record in
+  // a SameSite cookie so the callback can still prove state + PKCE ownership.
+  // It is deleted as soon as the verifier is consumed and never leaves the
+  // first-party Eliza origin.
+  try {
+    // biome-ignore lint/suspicious/noDocumentCookie: broad browser support is required for the Web Storage fallback
+    document.cookie = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=${encodeURIComponent(stored)}; Path=/; Max-Age=${Math.floor(STEWARD_PKCE_VERIFIER_TTL_MS / 1000)}; SameSite=Lax${window.location.protocol === "https:" ? "; Secure" : ""}`;
+    storedAnywhere =
+      readStoredPkceRecordFromCookie() !== null || storedAnywhere;
+  } catch {
+    // cookies disabled
+  }
   return storedAnywhere;
 }
 
@@ -100,7 +114,8 @@ export function consumeStewardPkceVerifier(): string | null {
     () => window.sessionStorage,
   );
   const localVerifier = consumeStoredPkceVerifier(() => window.localStorage);
-  return sessionVerifier ?? localVerifier;
+  const cookieVerifier = consumeStoredPkceVerifierFromCookie();
+  return sessionVerifier ?? localVerifier ?? cookieVerifier;
 }
 
 /**
@@ -113,7 +128,35 @@ export function peekStewardOAuthState(): string | null {
   if (typeof window === "undefined") return null;
   const sessionRecord = readStoredPkceRecord(() => window.sessionStorage);
   const localRecord = readStoredPkceRecord(() => window.localStorage);
-  return sessionRecord?.state ?? localRecord?.state ?? null;
+  const cookieRecord = readStoredPkceRecordFromCookie();
+  return (
+    sessionRecord?.state ?? localRecord?.state ?? cookieRecord?.state ?? null
+  );
+}
+
+function readStoredPkceRecordFromCookie(): StoredPkceVerifier | null {
+  try {
+    const prefix = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=`;
+    const value = document.cookie
+      .split(";")
+      .map((part) => part.trim())
+      .find((part) => part.startsWith(prefix))
+      ?.slice(prefix.length);
+    return value ? parseStoredPkceRecord(decodeURIComponent(value)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function consumeStoredPkceVerifierFromCookie(): string | null {
+  const record = readStoredPkceRecordFromCookie();
+  try {
+    // biome-ignore lint/suspicious/noDocumentCookie: delete the compatibility cookie synchronously on consume
+    document.cookie = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=; Path=/; Max-Age=0; SameSite=Lax${window.location.protocol === "https:" ? "; Secure" : ""}`;
+  } catch {
+    // cookies disabled
+  }
+  return record?.verifier ?? null;
 }
 
 function consumeStoredPkceVerifier(getStorage: () => Storage): string | null {
@@ -135,27 +178,31 @@ function readStoredPkceRecord(
     const storage = getStorage();
     const value = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     if (!value) return null;
-    try {
-      const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
-      if (
-        typeof parsed.verifier === "string" &&
-        typeof parsed.expiresAt === "number" &&
-        parsed.expiresAt >= Date.now()
-      ) {
-        return {
-          verifier: parsed.verifier,
-          ...(typeof parsed.state === "string" ? { state: parsed.state } : {}),
-          expiresAt: parsed.expiresAt,
-        };
-      }
-      return null;
-    } catch {
-      // Pre-JSON blobs stored the bare verifier string; they carry no state,
-      // so the callback's required state match fails for them by design.
-      return null;
-    }
+    return parseStoredPkceRecord(value);
   } catch {
     // error-policy:J4 web storage unavailable -> no stored record
+    return null;
+  }
+}
+
+function parseStoredPkceRecord(value: string): StoredPkceVerifier | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
+    if (
+      typeof parsed.verifier === "string" &&
+      typeof parsed.expiresAt === "number" &&
+      parsed.expiresAt >= Date.now()
+    ) {
+      return {
+        verifier: parsed.verifier,
+        ...(typeof parsed.state === "string" ? { state: parsed.state } : {}),
+        expiresAt: parsed.expiresAt,
+      };
+    }
+    return null;
+  } catch {
+    // Pre-JSON blobs stored the bare verifier string; they carry no state,
+    // so the callback's required state match fails for them by design.
     return null;
   }
 }

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
@@ -65,6 +65,24 @@ afterEach(() => {
 });
 
 describe("LoginPage accessibility", () => {
+  it("owns a dark full-viewport canvas instead of leaking the light document background", async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <LoginPage />
+        </MemoryRouter>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const fill = screen.getByTestId("login-safe-area-fill");
+    expect(fill.className).toContain("z-0");
+    expect(fill.className).toContain("bg-bg");
+    expect(fill.parentElement?.className).toContain("isolate");
+    expect(fill.parentElement?.className).toContain("bg-bg");
+  });
+
   it("exposes a main landmark and touch-sized legal links", async () => {
     await act(async () => {
       render(

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -56,7 +56,7 @@ function LoginBackground({ children }: { children: React.ReactNode }) {
         className="pointer-events-none fixed inset-0 z-[-1] bg-bg"
       />
       <div
-        className="flex h-full min-h-0 w-full flex-col px-4"
+        className="flex h-full min-h-0 w-full flex-col px-4 sm:px-6"
         style={{
           paddingTop: "max(env(safe-area-inset-top, 0px), 1rem)",
           paddingBottom: "max(env(safe-area-inset-bottom, 0px), 1rem)",
@@ -71,7 +71,7 @@ function LoginBackground({ children }: { children: React.ReactNode }) {
             1080×1240) where the OAuth / wallet rows fell below an unscrollable
             fold — see login-page.safe-area.test.tsx. */}
         <div className="relative z-10 flex min-h-0 flex-1 flex-col items-center overflow-y-auto">
-          <div className="my-auto w-full max-w-md shrink-0 rounded-xl border border-border bg-card p-6 text-txt md:p-8 motion-safe:animate-[shell-overlay-in_320ms_cubic-bezier(0.16,1,0.3,1)]">
+          <div className="my-auto w-full max-w-lg shrink-0 rounded-2xl border border-border bg-card p-6 text-txt shadow-[0_32px_96px_-40px_rgba(0,0,0,0.58)] sm:p-8 motion-safe:animate-[shell-overlay-in_320ms_cubic-bezier(0.16,1,0.3,1)]">
             {children}
           </div>
         </div>
@@ -201,7 +201,7 @@ function PublicLoginPage(): React.JSX.Element {
 
   return (
     <LoginBackground>
-      <main className="space-y-8">
+      <main className="space-y-7">
         <div className="space-y-3 text-center">
           <img
             src={`${BRAND_PATHS.logos}/${LOGO_FILES.elizaLockupWhite}`}

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -38,7 +38,7 @@ function StewardLoginSectionFallback() {
 
 function LoginBackground({ children }: { children: React.ReactNode }) {
   return (
-    <div className="theme-cloud relative h-[100dvh] min-h-0 overflow-hidden text-txt">
+    <div className="theme-cloud relative isolate h-[100dvh] min-h-0 overflow-hidden bg-bg text-txt">
       {/* SAFE-AREA FILL (installed iOS PWA): the `bg-bg` fill is a `fixed
           inset-0` underlay, NOT a `min-h-[100dvh]` slab. On the installed
           standalone PWA the body is non-fixed (base.css / styles.css lockdown),
@@ -53,7 +53,7 @@ function LoginBackground({ children }: { children: React.ReactNode }) {
       <div
         aria-hidden="true"
         data-testid="login-safe-area-fill"
-        className="pointer-events-none fixed inset-0 z-[-1] bg-bg"
+        className="pointer-events-none fixed inset-0 z-0 bg-bg"
       />
       <div
         className="flex h-full min-h-0 w-full flex-col px-4 sm:px-6"

--- a/packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx
@@ -57,11 +57,11 @@ export function LoginOptionsSkeleton({
       <GhostRow animated={animated} className="mx-auto h-4 w-3/4" />
       {/* "or continue with" divider row. */}
       <GhostRow animated={animated} className="mx-auto h-4 w-32" />
-      {/* OAuth grid: Google + Discord side by side, GitHub full width. */}
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      {/* OAuth grid: one compact row on wide cards, stacked on mobile. */}
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
         <GhostRow animated={animated} className="h-touch" />
         <GhostRow animated={animated} className="h-touch" />
-        <GhostRow animated={animated} className="h-touch sm:col-span-2" />
+        <GhostRow animated={animated} className="h-touch" />
       </div>
       {/* "or sign in with a wallet" divider row. */}
       <GhostRow animated={animated} className="mx-auto h-4 w-32" />

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1971,7 +1971,7 @@ export default function StewardLoginSection() {
       )}
 
       {hasOAuthProviders && (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           {providers.google && (
             <Button
               variant="ghost"
@@ -2006,7 +2006,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("github")}
               disabled={isLoading}
-              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:col-span-2"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
             >
               {loading === "github" ? (
                 <Spinner />


### PR DESCRIPTION
## Summary
- make the hosted login canvas truly dark edge-to-edge and keep the full auth card reachable on short viewports
- lock first-message phone and Discord account creation with route-level coverage
- route unsupported Shared actions through the model with truthful, conversational constraints instead of canned product-tier text
- require the model to directly provide the closest useful in-chat substitute rather than stopping at a bare refusal
- preserve capability-wall diagnostics without leaking internal tier language to users

## Validation
- 82 login Vitest tests
- 47 cross-host sign-out/session synchronization tests
- 29 isolated phone/Discord first-message route tests
- 142 Shared runtime, capability-wall, reminder, chat, and trace tests
- 57 focused final-prompt/runtime/trace tests
- UI, Cloud Shared, and Cloud API typechecks
- Biome on all changed files
- production API health, Railway service health, real-Chrome login verification, and live Blooio/iMessage probes

## Production evidence
- Cloudflare Worker version: `10d52194-7acf-4fc4-ad32-258b99a3a2ef`
- Cloudflare Pages deployment: `https://32afbf50.eliza-app.pages.dev`
- Railway agent-server deployment: `a57f4085-9630-4095-b67b-fd1d31fe6421`
- Railway image: `sha256:32ae86f9e13ff80a25585183799455de6aeb8d6ccf38f6b7c96413a946529a39`

Live Blooio/iMessage evidence: reminders create and deliver end-to-end; unsupported email execution now responds accurately and supplies ready-to-copy wording without internal Shared/Dedicated terminology.

This is the exact `origin/main` production composite corresponding to the develop-targeted implementation PR #22816.