### PR TITLE
fix(ui): keep completed-user chat at rest on cold boot

### DIFF
--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -23,7 +23,7 @@
  */
 
 import { cleanup, render, waitFor } from "@testing-library/react";
-import type * as React from "react";
+import { type ReactNode, useLayoutEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appState = vi.hoisted(() => ({
@@ -44,6 +44,15 @@ vi.mock("./state/notifications/notification-store", () => ({
 
 const conductorMock = vi.hoisted(() => ({
   mount: vi.fn(),
+  transcriptMounted: true,
+}));
+
+const shellControllerMock = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+}));
+
+const overlayMock = vi.hoisted(() => ({
+  handledReleases: 0,
 }));
 
 // The key mock: App imports FirstRunConductorMount from this module (its only
@@ -51,8 +60,20 @@ const conductorMock = vi.hoisted(() => ({
 // chat-overlay branch actually returns; the marker div (the real component
 // renders null) lets the tests assert WHERE it mounted.
 vi.mock("./first-run/use-first-run-conductor", () => ({
-  FirstRunConductorMount: () => {
+  FirstRunConductorMount: ({
+    onFirstRunTranscriptMounted,
+  }: {
+    onFirstRunTranscriptMounted?: () => void;
+  }) => {
     conductorMock.mount();
+    useLayoutEffect(() => {
+      if (
+        conductorMock.transcriptMounted &&
+        appState.firstRunComplete === false
+      ) {
+        onFirstRunTranscriptMounted?.();
+      }
+    }, [onFirstRunTranscriptMounted]);
     return <div data-testid="first-run-conductor-mount" />;
   },
   useFirstRunConductor: (): void => {
@@ -113,9 +134,7 @@ vi.mock("./hooks/useActivityEvents", () => ({
 }));
 
 vi.mock("./hooks", () => ({
-  BugReportProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  BugReportProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   useBugReportState: () => ({}),
   useContextMenu: () => ({
     closeSaveCommandModal: vi.fn(),
@@ -193,10 +212,35 @@ vi.mock("./config/boot-config-react.hooks", () => ({
 }));
 
 vi.mock("./components/shell/ShellControllerContext", () => ({
-  ShellControllerProvider: ({ children }: { children: React.ReactNode }) => (
+  ShellControllerProvider: ({ children }: { children: ReactNode }) => (
     <div data-testid="shell-controller-provider">{children}</div>
   ),
-  useShellControllerContext: () => null,
+}));
+
+vi.mock("./components/shell/ShellControllerContext.hooks", () => ({
+  useShellControllerContext: () => shellControllerMock.current,
+}));
+
+vi.mock("./components/shell/ChatOverlay", () => ({
+  ChatOverlay: ({
+    releaseFirstRunToFull,
+    onFirstRunReleaseHandled,
+  }: {
+    releaseFirstRunToFull: boolean;
+    onFirstRunReleaseHandled: () => void;
+  }) => {
+    useLayoutEffect(() => {
+      if (!releaseFirstRunToFull) return;
+      overlayMock.handledReleases += 1;
+      onFirstRunReleaseHandled();
+    }, [onFirstRunReleaseHandled, releaseFirstRunToFull]);
+    return (
+      <div
+        data-testid="chat-overlay"
+        data-release-first-run={String(releaseFirstRunToFull)}
+      />
+    );
+  },
 }));
 
 vi.mock("./components/shell/StartupScreen", () => ({
@@ -283,6 +327,9 @@ describe("App chat-overlay first-run composition", () => {
     appState.startupPhase = "first-run-required";
     window.history.replaceState(null, "", "/?shellMode=chat-overlay");
     conductorMock.mount.mockClear();
+    conductorMock.transcriptMounted = true;
+    shellControllerMock.current = null;
+    overlayMock.handledReleases = 0;
     notificationMock.init.mockClear();
   });
 
@@ -406,5 +453,79 @@ describe("App chat-overlay first-run composition", () => {
     // (behavioral no-op coverage: first-run/use-first-run-conductor.test.ts).
     expect(conductorMock.mount).toHaveBeenCalled();
     expect(queryByTestId("first-run-conductor-mount")).not.toBeNull();
+  });
+
+  it("does not release FULL when a controller mounts during a false first-run probe", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "ready";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+
+    const shell = render(<App />);
+    expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
+      "false",
+    );
+
+    appState.firstRunComplete = true;
+    shell.rerender(<App />);
+
+    expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
+      "false",
+    );
+    expect(overlayMock.handledReleases).toBe(0);
+  });
+
+  it("does not release FULL for a stale transcript from a prior first-run epoch", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+    // The production mount snapshots prior first-run ids and emits no mounted
+    // event until this epoch's conductor commits a new synthetic turn.
+    conductorMock.transcriptMounted = false;
+
+    const shell = render(<App />);
+    appState.firstRunComplete = true;
+    appState.startupPhase = "starting-runtime";
+    shell.rerender(<App />);
+
+    expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
+      "false",
+    );
+    expect(overlayMock.handledReleases).toBe(0);
+  });
+
+  it("releases one genuine conductor transcript to FULL after the overlay remounts", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+
+    const shell = render(<App />);
+    expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
+      "false",
+    );
+
+    // Runtime-target adoption temporarily removes the controller on the same
+    // committed edge that completes onboarding. The release lives above that
+    // remount, so no transient null controller can consume it.
+    shellControllerMock.current = null;
+    appState.firstRunComplete = true;
+    appState.startupPhase = "starting-runtime";
+    shell.rerender(<App />);
+    expect(shell.queryByTestId("chat-overlay")).toBeNull();
+
+    shellControllerMock.current = {};
+    shell.rerender(<App />);
+    expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
+      "false",
+    );
+    expect(overlayMock.handledReleases).toBe(1);
+
+    shell.rerender(<App />);
+    expect(overlayMock.handledReleases).toBe(1);
   });
 });

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@capacitor/keyboard", () => ({
 vi.mock("./bridge/electrobun-rpc", () => ({
   getElectrobunRendererRpc: vi.fn(() => undefined),
   invokeDesktopBridgeRequest: vi.fn(async () => ({ id: "window-1" })),
+  invokeDesktopBridgeRequestWithTimeout: vi.fn(async () => undefined),
   subscribeDesktopBridgeEvent: vi.fn(() => vi.fn()),
   openDesktopAppWindow: vi.fn(async () => ({ id: "window-1" })),
   openDesktopLauncherWindow: vi.fn(async () => ({ id: "launcher-1" })),
@@ -233,9 +234,11 @@ vi.mock("./components/shell/ShellControllerContext.hooks", () => ({
 
 vi.mock("./components/shell/ChatOverlay", () => ({
   ChatOverlay: ({
+    firstRunOpen,
     releaseFirstRunToFull,
     onFirstRunReleaseHandled,
   }: {
+    firstRunOpen: boolean;
     releaseFirstRunToFull: boolean;
     onFirstRunReleaseHandled: () => void;
   }) => {
@@ -247,6 +250,7 @@ vi.mock("./components/shell/ChatOverlay", () => ({
     return (
       <div
         data-testid="chat-overlay"
+        data-first-run-open={String(firstRunOpen)}
         data-release-first-run={String(releaseFirstRunToFull)}
       />
     );
@@ -500,6 +504,12 @@ describe("App chat-overlay first-run composition", () => {
     expect(shell.getByTestId("chat-overlay").dataset.releaseFirstRun).toBe(
       "false",
     );
+    expect(shell.getByTestId("chat-overlay").dataset.firstRunOpen).toBe(
+      "false",
+    );
+    expect(
+      shell.container.querySelector('[data-onboarding-hidden="true"]'),
+    ).toBeNull();
 
     appState.firstRunComplete = true;
     shell.rerender(<App />);
@@ -508,6 +518,21 @@ describe("App chat-overlay first-run composition", () => {
       "false",
     );
     expect(overlayMock.handledReleases).toBe(0);
+  });
+
+  it("keeps HALF authority for a genuine first-run-required shell", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+
+    const shell = render(<App />);
+
+    expect(shell.getByTestId("chat-overlay").dataset.firstRunOpen).toBe("true");
+    expect(
+      shell.container.querySelector('[data-onboarding-hidden="true"]'),
+    ).not.toBeNull();
   });
 
   it("does not release FULL for a stale transcript from a prior first-run epoch", () => {

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -393,6 +393,7 @@ describe("App chat-overlay first-run composition", () => {
     appState.firstRunComplete = false;
     appState.startupPhase = "first-run-required";
     appState.authPhase = "loading";
+    shellControllerMock.current = {};
 
     // 1. Onboarding: the shell paints (no StartupScreen gate).
     const shell = render(<App />);
@@ -432,6 +433,28 @@ describe("App chat-overlay first-run composition", () => {
     const shell = render(<App />);
     expect(shell.getByTestId("shell-controller-provider")).toBeTruthy();
 
+    appState.authPhase = "loading";
+    shell.rerender(<App />);
+
+    expect(shell.getByTestId("startup-screen")).toBeTruthy();
+    expect(shell.queryByTestId("shell-controller-provider")).toBeNull();
+  });
+
+  it("does not treat a non-authoritative false probe as auth-boundary authority", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
+    appState.authPhase = "authenticated";
+
+    const shell = render(<App />);
+    expect(shell.getByTestId("shell-controller-provider")).toBeTruthy();
+
+    // A normal post-onboarding probe must hold the shell. The preservation
+    // capability belongs only to a previously committed first-run shell; a
+    // false/incomplete value observed outside first-run-required cannot arm it.
+    appState.firstRunComplete = false;
+    shell.rerender(<App />);
+    appState.firstRunComplete = true;
     appState.authPhase = "loading";
     shell.rerender(<App />);
 

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -49,6 +49,7 @@ const conductorMock = vi.hoisted(() => ({
 
 const shellControllerMock = vi.hoisted(() => ({
   current: null as Record<string, unknown> | null,
+  generation: 0,
 }));
 
 const overlayMock = vi.hoisted(() => ({
@@ -62,18 +63,22 @@ const overlayMock = vi.hoisted(() => ({
 vi.mock("./first-run/use-first-run-conductor", () => ({
   FirstRunConductorMount: ({
     onFirstRunTranscriptMounted,
+    firstRunMountEpoch,
   }: {
-    onFirstRunTranscriptMounted?: () => void;
+    onFirstRunTranscriptMounted?: (epoch: number) => void;
+    firstRunMountEpoch?: number | null;
   }) => {
     conductorMock.mount();
     useLayoutEffect(() => {
       if (
         conductorMock.transcriptMounted &&
-        appState.firstRunComplete === false
+        appState.firstRunComplete === false &&
+        firstRunMountEpoch !== null &&
+        firstRunMountEpoch !== undefined
       ) {
-        onFirstRunTranscriptMounted?.();
+        onFirstRunTranscriptMounted?.(firstRunMountEpoch);
       }
-    }, [onFirstRunTranscriptMounted]);
+    }, [firstRunMountEpoch, onFirstRunTranscriptMounted]);
     return <div data-testid="first-run-conductor-mount" />;
   },
   useFirstRunConductor: (): void => {
@@ -213,7 +218,12 @@ vi.mock("./config/boot-config-react.hooks", () => ({
 
 vi.mock("./components/shell/ShellControllerContext", () => ({
   ShellControllerProvider: ({ children }: { children: ReactNode }) => (
-    <div data-testid="shell-controller-provider">{children}</div>
+    <div
+      key={shellControllerMock.generation}
+      data-testid="shell-controller-provider"
+    >
+      {children}
+    </div>
   ),
 }));
 
@@ -329,6 +339,7 @@ describe("App chat-overlay first-run composition", () => {
     conductorMock.mount.mockClear();
     conductorMock.transcriptMounted = true;
     shellControllerMock.current = null;
+    shellControllerMock.generation = 0;
     overlayMock.handledReleases = 0;
     notificationMock.init.mockClear();
   });
@@ -548,6 +559,50 @@ describe("App chat-overlay first-run composition", () => {
     );
     expect(overlayMock.handledReleases).toBe(1);
 
+    shell.rerender(<App />);
+    expect(overlayMock.handledReleases).toBe(1);
+  });
+
+  it("releases polling-mounted onboarding once the startup phase authorizes its epoch", () => {
+    appState.firstRunComplete = false;
+    appState.startupPhase = "polling-backend";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+
+    const shell = render(<App />);
+    expect(overlayMock.handledReleases).toBe(0);
+
+    appState.startupPhase = "first-run-required";
+    shell.rerender(<App />);
+    expect(overlayMock.handledReleases).toBe(0);
+
+    appState.firstRunComplete = true;
+    appState.startupPhase = "starting-runtime";
+    shell.rerender(<App />);
+
+    expect(overlayMock.handledReleases).toBe(1);
+    shell.rerender(<App />);
+    expect(overlayMock.handledReleases).toBe(1);
+  });
+
+  it("retains polling transcript authority across a provider parent remount", () => {
+    appState.firstRunComplete = false;
+    appState.startupPhase = "polling-backend";
+    appState.authPhase = "authenticated";
+    shellControllerMock.current = {};
+
+    const shell = render(<App />);
+    expect(conductorMock.mount).toHaveBeenCalled();
+
+    shellControllerMock.generation += 1;
+    shell.rerender(<App />);
+    appState.startupPhase = "first-run-required";
+    shell.rerender(<App />);
+    appState.firstRunComplete = true;
+    appState.startupPhase = "starting-runtime";
+    shell.rerender(<App />);
+
+    expect(overlayMock.handledReleases).toBe(1);
     shell.rerender(<App />);
     expect(overlayMock.handledReleases).toBe(1);
   });

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -93,7 +93,7 @@ describe("App standalone chat-overlay wiring", () => {
     expect(foundation).toContain("keepChatOpenAfterFirstRun");
     expect(foundation).toContain("const shouldMountWebChatPanel =");
     expect(foundation).toContain(
-      "const firstRunPinnedOpen = firstRunComplete === false;",
+      "const firstRunPinnedOpen = isAuthoritativeFirstRunOpen(",
     );
     expect(foundation).toContain("shouldMountWebChatPanel");
     expect(foundation).toContain("<ChatOverlayMount");

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -58,13 +58,13 @@ describe("App standalone chat-overlay wiring", () => {
     expect(APP_TSX).toContain("Chat overlay");
     expect(APP_TSX).toContain("<ChatOverlayMount");
     expect(APP_TSX).toContain(
-      "releaseFirstRunToFull={firstRunChatReleaseRef.current.releasePending}",
+      "releaseFirstRunToFull={firstRunChatRelease.releasePending}",
     );
     expect(APP_TSX).toContain(
-      "onFirstRunChatMounted={handleFirstRunChatMounted}",
+      "onFirstRunChatMounted={firstRunChatRelease.recordMountedChat}",
     );
     expect(APP_TSX).toContain(
-      "onFirstRunReleaseHandled={handleFirstRunReleaseHandled}",
+      "onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}",
     );
   });
 

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -48,11 +48,19 @@ const CHATVIEW_TSX = readFileSync(
   "utf8",
 );
 
+/**
+ * Collapses runs of whitespace so a JSX-wiring assertion stays true when the
+ * formatter reflows the element across lines. Only the token order matters.
+ */
+function collapseWhitespace(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
 describe("App standalone chat-overlay wiring", () => {
   it("mounts the chat overlay outside the full chat tab", () => {
     expect(APP_TSX).toContain('shellMode === "chat-overlay"');
-    expect(APP_TSX).toContain(
-      "<ShellFoundationMount\n          useWebChatPanel",
+    expect(collapseWhitespace(APP_TSX)).toContain(
+      "<ShellFoundationMount useWebChatPanel",
     );
     expect(APP_TSX).toContain("pointer-events-none fixed inset-0");
     // The floating glass chat remains available in the main shell, including
@@ -81,8 +89,8 @@ describe("App standalone chat-overlay wiring", () => {
     );
 
     expect(overlayShell).toContain("<GlassStyles />");
-    expect(overlayShell).toContain(
-      "<ShellFoundationMount\n          useWebChatPanel",
+    expect(collapseWhitespace(overlayShell)).toContain(
+      "<ShellFoundationMount useWebChatPanel",
     );
     expect(overlayShell).toContain(
       "releaseFirstRunToFull={releaseFirstRunToFull}",

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -51,7 +51,9 @@ const CHATVIEW_TSX = readFileSync(
 describe("App standalone chat-overlay wiring", () => {
   it("mounts the chat overlay outside the full chat tab", () => {
     expect(APP_TSX).toContain('shellMode === "chat-overlay"');
-    expect(APP_TSX).toContain("<ShellFoundationMount useWebChatPanel />");
+    expect(APP_TSX).toContain(
+      "<ShellFoundationMount\n          useWebChatPanel",
+    );
     expect(APP_TSX).toContain("pointer-events-none fixed inset-0");
     // The floating glass chat remains available in the main shell, including
     // the ambient /chat route.
@@ -70,7 +72,7 @@ describe("App standalone chat-overlay wiring", () => {
 
   it("opens the packaged desktop pill into the shared mobile chat composer", () => {
     const overlayShell = APP_TSX.slice(
-      APP_TSX.indexOf("function ChatOverlayShell()"),
+      APP_TSX.indexOf("function ChatOverlayShell({"),
       APP_TSX.indexOf("function TrayPopoverShell()"),
     );
     const foundation = APP_TSX.slice(
@@ -79,7 +81,12 @@ describe("App standalone chat-overlay wiring", () => {
     );
 
     expect(overlayShell).toContain("<GlassStyles />");
-    expect(overlayShell).toContain("<ShellFoundationMount useWebChatPanel />");
+    expect(overlayShell).toContain(
+      "<ShellFoundationMount\n          useWebChatPanel",
+    );
+    expect(overlayShell).toContain(
+      "releaseFirstRunToFull={releaseFirstRunToFull}",
+    );
     expect(overlayShell).not.toContain("useChatOverlayWindowBounds");
     expect(overlayShell).not.toContain("<AppBackground");
     expect(foundation).toContain("const firstRunJustCompleted =");
@@ -141,8 +148,12 @@ describe("App standalone chat-overlay wiring", () => {
       APP_TSX.indexOf('if (shellMode === "chat-overlay") {'),
       APP_TSX.indexOf('if (shellMode === "tray-popover") {'),
     );
-    expect(branch).toContain("<ChatOverlayShell />");
-    expect(branch).toContain("<FirstRunConductorMount />");
+    expect(branch).toContain("<ChatOverlayShell");
+    expect(branch).toContain("<FirstRunConductorMount");
+    expect(branch).toContain(
+      "releaseFirstRunToFull={firstRunChatRelease.releasePending}",
+    );
+    expect(branch).toContain("onFirstRunTranscriptMounted={");
     expect(branch).toContain("<ShellOverlays actionNotice={actionNotice} />");
   });
 

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -58,7 +58,10 @@ describe("App standalone chat-overlay wiring", () => {
     expect(APP_TSX).toContain("Chat overlay");
     expect(APP_TSX).toContain("<ChatOverlayMount");
     expect(APP_TSX).toContain(
-      "releaseFirstRunToFull={firstRunReleasePendingRef.current}",
+      "releaseFirstRunToFull={firstRunChatReleaseRef.current.releasePending}",
+    );
+    expect(APP_TSX).toContain(
+      "onFirstRunChatMounted={handleFirstRunChatMounted}",
     );
     expect(APP_TSX).toContain(
       "onFirstRunReleaseHandled={handleFirstRunReleaseHandled}",

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -61,7 +61,7 @@ describe("App standalone chat-overlay wiring", () => {
       "releaseFirstRunToFull={firstRunChatRelease.releasePending}",
     );
     expect(APP_TSX).toContain(
-      "onFirstRunChatMounted={firstRunChatRelease.recordMountedChat}",
+      "onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}",
     );
     expect(APP_TSX).toContain(
       "onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -321,10 +321,12 @@ function ChatOverlayShell({
   releaseFirstRunToFull,
   onFirstRunReleaseHandled,
   onFirstRunChatMounted,
+  firstRunMountEpoch,
 }: {
   releaseFirstRunToFull: boolean;
   onFirstRunReleaseHandled: () => void;
-  onFirstRunChatMounted: () => void;
+  onFirstRunChatMounted: (epoch: number) => void;
+  firstRunMountEpoch: number | null;
 }) {
   // The bar has no inline tab system, so "show a view" / "show the launcher"
   // intents open dedicated on-demand desktop windows instead (#9953 Phase 3).
@@ -361,6 +363,7 @@ function ChatOverlayShell({
           releaseFirstRunToFull={releaseFirstRunToFull}
           onFirstRunReleaseHandled={onFirstRunReleaseHandled}
           onFirstRunChatMounted={onFirstRunChatMounted}
+          firstRunMountEpoch={firstRunMountEpoch}
         />
       </div>
     </>
@@ -1854,12 +1857,14 @@ function ShellFoundationMount({
   releaseFirstRunToFull = false,
   onFirstRunReleaseHandled = () => {},
   onFirstRunChatMounted,
+  firstRunMountEpoch = null,
 }: {
   /** Desktop opens the same draggable chat surface as web, not a separate drawer. */
   useWebChatPanel?: boolean;
   releaseFirstRunToFull?: boolean;
   onFirstRunReleaseHandled?: () => void;
-  onFirstRunChatMounted?: () => void;
+  onFirstRunChatMounted?: (epoch: number) => void;
+  firstRunMountEpoch?: number | null;
 } = {}) {
   const controller = useShellControllerContext();
   const hasController = controller !== null;
@@ -2083,6 +2088,7 @@ function ShellFoundationMount({
         releaseFirstRunToFull={releaseFirstRunToFull}
         onFirstRunReleaseHandled={onFirstRunReleaseHandled}
         onFirstRunChatMounted={onFirstRunChatMounted}
+        firstRunMountEpoch={firstRunMountEpoch}
         onPilledChange={closeWebChatWhenPilled}
         onDetentChange={setShellHostDetent}
         onStateChange={syncNativeSurfaceState}
@@ -2164,6 +2170,7 @@ function ChatOverlayMount({
   releaseFirstRunToFull,
   onFirstRunReleaseHandled,
   onFirstRunChatMounted,
+  firstRunMountEpoch = null,
   onPilledChange,
   onDetentChange,
   onStateChange,
@@ -2172,7 +2179,8 @@ function ChatOverlayMount({
   fillHostAtHalf?: boolean;
   releaseFirstRunToFull: boolean;
   onFirstRunReleaseHandled: () => void;
-  onFirstRunChatMounted?: () => void;
+  onFirstRunChatMounted?: (epoch: number) => void;
+  firstRunMountEpoch?: number | null;
   onPilledChange?: (pilled: boolean) => void;
   onDetentChange?: (detent: "pill" | "input" | "half" | "full") => void;
   onStateChange?: (state: DesktopBottomBarSurfaceState) => void;
@@ -2194,10 +2202,14 @@ function ChatOverlayMount({
     isAuthorized: atLeast("USER"),
   });
   useLayoutEffect(() => {
-    if (controller && firstRunComplete === false) {
-      onFirstRunChatMounted?.();
+    if (
+      controller &&
+      firstRunComplete === false &&
+      firstRunMountEpoch !== null
+    ) {
+      onFirstRunChatMounted?.(firstRunMountEpoch);
     }
-  }, [controller, firstRunComplete, onFirstRunChatMounted]);
+  }, [controller, firstRunComplete, firstRunMountEpoch, onFirstRunChatMounted]);
   if (!controller) return null;
   // The live agent's name drives the composer placeholder ("Ask {name}").
   // Character name wins (what the user configured), then the running agent's
@@ -3047,11 +3059,14 @@ function AppContent() {
             releaseFirstRunToFull={firstRunChatRelease.releasePending}
             onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
             onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
+            firstRunMountEpoch={firstRunChatRelease.mountEpoch}
           />
           <FirstRunConductorMount
             onFirstRunTranscriptMounted={
               firstRunChatRelease.recordMountedTranscript
             }
+            firstRunMountEpoch={firstRunChatRelease.mountEpoch}
+            firstRunAuthorityEpoch={firstRunChatRelease.authorityEpoch}
           />
           <ModelStatusConductorMount />
           <BootRecoveryConductorMount />
@@ -3372,6 +3387,7 @@ function AppContent() {
           releaseFirstRunToFull={firstRunChatRelease.releasePending}
           onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
           onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
+          firstRunMountEpoch={firstRunChatRelease.mountEpoch}
         />
         {/* In-chat first-run conductor (headless) — while firstRunComplete is
             false it seeds the onboarding greeting + choices into the SAME live
@@ -3381,6 +3397,8 @@ function AppContent() {
           onFirstRunTranscriptMounted={
             firstRunChatRelease.recordMountedTranscript
           }
+          firstRunMountEpoch={firstRunChatRelease.mountEpoch}
+          firstRunAuthorityEpoch={firstRunChatRelease.authorityEpoch}
         />
         {/* In-chat model-status card (headless) — while the local text model is
             downloading/loading/missing/errored it seeds ONE live status turn

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2340,7 +2340,10 @@ function AppContent() {
   // Runtime-target adoption can remount the shell on the exact render where
   // first-run completes. Retain that completion edge above the remount and let
   // the next ChatOverlay acknowledge it after applying the FULL detent.
-  const firstRunChatRelease = useFirstRunChatRelease(firstRunComplete);
+  const firstRunChatRelease = useFirstRunChatRelease(
+    firstRunComplete,
+    startupCoordinator.phase,
+  );
 
   useEffect(() => {
     if (!isShellPaintableNow) return;
@@ -3336,13 +3339,17 @@ function AppContent() {
         <ChatOverlayMount
           releaseFirstRunToFull={firstRunChatRelease.releasePending}
           onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
-          onFirstRunChatMounted={firstRunChatRelease.recordMountedChat}
+          onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
         />
         {/* In-chat first-run conductor (headless) — while firstRunComplete is
             false it seeds the onboarding greeting + choices into the SAME live
             transcript the overlay renders and routes first-run picks to the
             headless finish use case. Renders null. */}
-        <FirstRunConductorMount />
+        <FirstRunConductorMount
+          onFirstRunTranscriptMounted={
+            firstRunChatRelease.recordMountedTranscript
+          }
+        />
         {/* In-chat model-status card (headless) — while the local text model is
             downloading/loading/missing/errored it seeds ONE live status turn
             with cancel / switch-to-cloud / retry controls. Renders null. */}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -186,6 +186,7 @@ import {
   useChatComposer,
   useChatInputRef,
 } from "./state/ChatComposerContext.hooks";
+import { isAuthoritativeFirstRunOpen } from "./state/first-run-chat-release";
 import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
@@ -1870,8 +1871,14 @@ function ShellFoundationMount({
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
   const shellPhase = controller?.phase;
-  const firstRunComplete = useAppSelector((state) => state.firstRunComplete);
-  const firstRunPinnedOpen = firstRunComplete === false;
+  const { firstRunComplete, startupPhase } = useAppSelectorShallow((state) => ({
+    firstRunComplete: state.firstRunComplete,
+    startupPhase: state.startupCoordinator.phase,
+  }));
+  const firstRunPinnedOpen = isAuthoritativeFirstRunOpen(
+    firstRunComplete,
+    startupPhase,
+  );
   // Completion updates the store before the half-height overlay can release
   // its first-run pin. Keep that mounted instance through the edge so its
   // shared transcript stays visible until the user deliberately folds to the
@@ -2186,12 +2193,17 @@ function ChatOverlayMount({
   onStateChange?: (state: DesktopBottomBarSurfaceState) => void;
 }): ReactNode {
   const controller = useShellControllerContext();
-  const { characterData, agentStatus, firstRunComplete } =
+  const { characterData, agentStatus, firstRunComplete, startupPhase } =
     useAppSelectorShallow((s) => ({
       characterData: s.characterData,
       agentStatus: s.agentStatus,
       firstRunComplete: s.firstRunComplete,
+      startupPhase: s.startupCoordinator.phase,
     }));
+  const firstRunOpen = isAuthoritativeFirstRunOpen(
+    firstRunComplete,
+    startupPhase,
+  );
   // #12087 Item 20: derive the slash-command authority from the authoritative
   // role instead of the fail-open defaults. Elevated (owner-only) commands
   // require OWNER; authenticated commands require rank ≥ USER. A remote
@@ -2202,14 +2214,10 @@ function ChatOverlayMount({
     isAuthorized: atLeast("USER"),
   });
   useLayoutEffect(() => {
-    if (
-      controller &&
-      firstRunComplete === false &&
-      firstRunMountEpoch !== null
-    ) {
+    if (controller && firstRunOpen && firstRunMountEpoch !== null) {
       onFirstRunChatMounted?.(firstRunMountEpoch);
     }
-  }, [controller, firstRunComplete, firstRunMountEpoch, onFirstRunChatMounted]);
+  }, [controller, firstRunMountEpoch, firstRunOpen, onFirstRunChatMounted]);
   if (!controller) return null;
   // The live agent's name drives the composer placeholder ("Ask {name}").
   // Character name wins (what the user configured), then the running agent's
@@ -2223,7 +2231,7 @@ function ChatOverlayMount({
       slash={slash}
       initialMode={initialMode}
       fillHostAtHalf={fillHostAtHalf}
-      firstRunOpen={firstRunComplete === false}
+      firstRunOpen={firstRunOpen}
       releaseFirstRunToFull={releaseFirstRunToFull}
       onFirstRunReleaseHandled={onFirstRunReleaseHandled}
       onPilledChange={onPilledChange}
@@ -2244,7 +2252,14 @@ function HomeScreenMount({
   initialSection?: "home" | "apps";
 }): ReactNode {
   const setTab = useAppSelector((s) => s.setTab);
-  const firstRunOpen = useAppSelector((s) => s.firstRunComplete === false);
+  const { firstRunComplete, startupPhase } = useAppSelectorShallow((state) => ({
+    firstRunComplete: state.firstRunComplete,
+    startupPhase: state.startupCoordinator.phase,
+  }));
+  const firstRunOpen = isAuthoritativeFirstRunOpen(
+    firstRunComplete,
+    startupPhase,
+  );
   const { views } = useAvailableViews();
   // Host apps can override the home screen via the `homeScreen` boot-config slot
   // (whitelabel seam); fall back to the built-in HomeScreen.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -186,17 +187,12 @@ import {
   useChatInputRef,
 } from "./state/ChatComposerContext.hooks";
 import {
-  acknowledgeFirstRunChatRelease,
-  createFirstRunChatReleaseState,
-  observeFirstRunCompletion,
-  recordMountedFirstRunChat,
-} from "./state/first-run-chat-release";
-import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
   shouldShowRemoteAgentPairingGate,
   topLevelAuthGateOwnsSurface,
 } from "./state/top-level-auth-gate";
+import { useFirstRunChatRelease } from "./state/use-first-run-chat-release";
 import {
   isBootstrapGateRequired,
   isLoopbackGatewayHost,
@@ -2177,7 +2173,7 @@ function ChatOverlayMount({
     isElevated: isOwner,
     isAuthorized: atLeast("USER"),
   });
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (controller && firstRunComplete === false) {
       onFirstRunChatMounted?.();
     }
@@ -2344,23 +2340,7 @@ function AppContent() {
   // Runtime-target adoption can remount the shell on the exact render where
   // first-run completes. Retain that completion edge above the remount and let
   // the next ChatOverlay acknowledge it after applying the FULL detent.
-  const firstRunChatReleaseRef = useRef(
-    createFirstRunChatReleaseState(firstRunComplete),
-  );
-  firstRunChatReleaseRef.current = observeFirstRunCompletion(
-    firstRunChatReleaseRef.current,
-    firstRunComplete,
-  );
-  const handleFirstRunChatMounted = useCallback(() => {
-    firstRunChatReleaseRef.current = recordMountedFirstRunChat(
-      firstRunChatReleaseRef.current,
-    );
-  }, []);
-  const handleFirstRunReleaseHandled = useCallback(() => {
-    firstRunChatReleaseRef.current = acknowledgeFirstRunChatRelease(
-      firstRunChatReleaseRef.current,
-    );
-  }, []);
+  const firstRunChatRelease = useFirstRunChatRelease(firstRunComplete);
 
   useEffect(() => {
     if (!isShellPaintableNow) return;
@@ -3354,9 +3334,9 @@ function AppContent() {
           behind stays live.
         */}
         <ChatOverlayMount
-          releaseFirstRunToFull={firstRunChatReleaseRef.current.releasePending}
-          onFirstRunReleaseHandled={handleFirstRunReleaseHandled}
-          onFirstRunChatMounted={handleFirstRunChatMounted}
+          releaseFirstRunToFull={firstRunChatRelease.releasePending}
+          onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
+          onFirstRunChatMounted={firstRunChatRelease.recordMountedChat}
         />
         {/* In-chat first-run conductor (headless) — while firstRunComplete is
             false it seeds the onboarding greeting + choices into the SAME live

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -317,7 +317,15 @@ function useShellMode(): AppShellMode {
  * window. Renders ONLY the waveform + pill + chat/voice overlay — no app
  * chrome — over a transparent background.
  */
-function ChatOverlayShell() {
+function ChatOverlayShell({
+  releaseFirstRunToFull,
+  onFirstRunReleaseHandled,
+  onFirstRunChatMounted,
+}: {
+  releaseFirstRunToFull: boolean;
+  onFirstRunReleaseHandled: () => void;
+  onFirstRunChatMounted: () => void;
+}) {
   // The bar has no inline tab system, so "show a view" / "show the launcher"
   // intents open dedicated on-demand desktop windows instead (#9953 Phase 3).
   useBarSurfaceWindows();
@@ -348,7 +356,12 @@ function ChatOverlayShell() {
         data-testid="chat-overlay-shell"
         className="pointer-events-none fixed inset-0 flex items-end justify-center bg-transparent"
       >
-        <ShellFoundationMount useWebChatPanel />
+        <ShellFoundationMount
+          useWebChatPanel
+          releaseFirstRunToFull={releaseFirstRunToFull}
+          onFirstRunReleaseHandled={onFirstRunReleaseHandled}
+          onFirstRunChatMounted={onFirstRunChatMounted}
+        />
       </div>
     </>
   );
@@ -1838,9 +1851,15 @@ function SecretsManagerModalMount(): ReactNode {
 
 function ShellFoundationMount({
   useWebChatPanel = false,
+  releaseFirstRunToFull = false,
+  onFirstRunReleaseHandled = () => {},
+  onFirstRunChatMounted,
 }: {
   /** Desktop opens the same draggable chat surface as web, not a separate drawer. */
   useWebChatPanel?: boolean;
+  releaseFirstRunToFull?: boolean;
+  onFirstRunReleaseHandled?: () => void;
+  onFirstRunChatMounted?: () => void;
 } = {}) {
   const controller = useShellControllerContext();
   const hasController = controller !== null;
@@ -2061,8 +2080,9 @@ function ShellFoundationMount({
       <ChatOverlayMount
         initialMode="input"
         fillHostAtHalf
-        releaseFirstRunToFull={false}
-        onFirstRunReleaseHandled={() => {}}
+        releaseFirstRunToFull={releaseFirstRunToFull}
+        onFirstRunReleaseHandled={onFirstRunReleaseHandled}
+        onFirstRunChatMounted={onFirstRunChatMounted}
         onPilledChange={closeWebChatWhenPilled}
         onDetentChange={setShellHostDetent}
         onStateChange={syncNativeSurfaceState}
@@ -2441,15 +2461,18 @@ function AppContent() {
     startupCoordinator.phase,
     firstRunComplete,
   );
-  // Record during render as well as in the settle effect below: stored-session
-  // adoption can complete onboarding in the same commit that first paints the
-  // shell, and the completion-edge probe must already see the shell as mounted
-  // on that render — the effect alone would run one commit too late.
-  if (isShellPaintableNow && !bootstrapGateHolds && firstRunOwnsAuthSurface) {
-    onboardingShellMountedRef.current = true;
-  }
-  useEffect(() => {
-    if (isShellPaintableNow && !bootstrapGateHolds && firstRunOwnsAuthSurface) {
+  // Only a committed shell may authorize this exception. A render-time ref
+  // write survives an interrupted render and could otherwise let a later auth
+  // probe expose shell providers even though onboarding never painted. Layout
+  // effects run before a user can complete the mounted onboarding UI, so the
+  // prior committed first-run frame is recorded before its completion edge.
+  useLayoutEffect(() => {
+    if (
+      isShellPaintableNow &&
+      !bootstrapGateHolds &&
+      firstRunOwnsAuthSurface &&
+      firstRunChatRelease.mountedOnboarding
+    ) {
       onboardingShellMountedRef.current = true;
     } else if (authState.phase !== "loading") {
       onboardingShellMountedRef.current = false;
@@ -2458,6 +2481,7 @@ function AppContent() {
     authState.phase,
     bootstrapGateHolds,
     firstRunOwnsAuthSurface,
+    firstRunChatRelease.mountedOnboarding,
     isShellPaintableNow,
   ]);
   const preserveMountedOnboardingShell =
@@ -3019,8 +3043,16 @@ function AppContent() {
     return (
       <BugReportProvider value={bugReport}>
         <ShellControllerProvider>
-          <ChatOverlayShell />
-          <FirstRunConductorMount />
+          <ChatOverlayShell
+            releaseFirstRunToFull={firstRunChatRelease.releasePending}
+            onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
+            onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
+          />
+          <FirstRunConductorMount
+            onFirstRunTranscriptMounted={
+              firstRunChatRelease.recordMountedTranscript
+            }
+          />
           <ModelStatusConductorMount />
           <BootRecoveryConductorMount />
           <ShellOverlays actionNotice={actionNotice} />

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -186,6 +186,12 @@ import {
   useChatInputRef,
 } from "./state/ChatComposerContext.hooks";
 import {
+  acknowledgeFirstRunChatRelease,
+  createFirstRunChatReleaseState,
+  observeFirstRunCompletion,
+  recordMountedFirstRunChat,
+} from "./state/first-run-chat-release";
+import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
   shouldShowRemoteAgentPairingGate,
@@ -2141,6 +2147,7 @@ function ChatOverlayMount({
   fillHostAtHalf = false,
   releaseFirstRunToFull,
   onFirstRunReleaseHandled,
+  onFirstRunChatMounted,
   onPilledChange,
   onDetentChange,
   onStateChange,
@@ -2149,6 +2156,7 @@ function ChatOverlayMount({
   fillHostAtHalf?: boolean;
   releaseFirstRunToFull: boolean;
   onFirstRunReleaseHandled: () => void;
+  onFirstRunChatMounted?: () => void;
   onPilledChange?: (pilled: boolean) => void;
   onDetentChange?: (detent: "pill" | "input" | "half" | "full") => void;
   onStateChange?: (state: DesktopBottomBarSurfaceState) => void;
@@ -2169,6 +2177,11 @@ function ChatOverlayMount({
     isElevated: isOwner,
     isAuthorized: atLeast("USER"),
   });
+  useEffect(() => {
+    if (controller && firstRunComplete === false) {
+      onFirstRunChatMounted?.();
+    }
+  }, [controller, firstRunComplete, onFirstRunChatMounted]);
   if (!controller) return null;
   // The live agent's name drives the composer placeholder ("Ask {name}").
   // Character name wins (what the user configured), then the running agent's
@@ -2331,16 +2344,22 @@ function AppContent() {
   // Runtime-target adoption can remount the shell on the exact render where
   // first-run completes. Retain that completion edge above the remount and let
   // the next ChatOverlay acknowledge it after applying the FULL detent.
-  const firstRunWasIncompleteRef = useRef(firstRunComplete === false);
-  const firstRunReleasePendingRef = useRef(false);
-  if (firstRunComplete === false) {
-    firstRunWasIncompleteRef.current = true;
-  } else if (firstRunComplete === true && firstRunWasIncompleteRef.current) {
-    firstRunWasIncompleteRef.current = false;
-    firstRunReleasePendingRef.current = true;
-  }
+  const firstRunChatReleaseRef = useRef(
+    createFirstRunChatReleaseState(firstRunComplete),
+  );
+  firstRunChatReleaseRef.current = observeFirstRunCompletion(
+    firstRunChatReleaseRef.current,
+    firstRunComplete,
+  );
+  const handleFirstRunChatMounted = useCallback(() => {
+    firstRunChatReleaseRef.current = recordMountedFirstRunChat(
+      firstRunChatReleaseRef.current,
+    );
+  }, []);
   const handleFirstRunReleaseHandled = useCallback(() => {
-    firstRunReleasePendingRef.current = false;
+    firstRunChatReleaseRef.current = acknowledgeFirstRunChatRelease(
+      firstRunChatReleaseRef.current,
+    );
   }, []);
 
   useEffect(() => {
@@ -3335,8 +3354,9 @@ function AppContent() {
           behind stays live.
         */}
         <ChatOverlayMount
-          releaseFirstRunToFull={firstRunReleasePendingRef.current}
+          releaseFirstRunToFull={firstRunChatReleaseRef.current.releasePending}
           onFirstRunReleaseHandled={handleFirstRunReleaseHandled}
+          onFirstRunChatMounted={handleFirstRunChatMounted}
         />
         {/* In-chat first-run conductor (headless) — while firstRunComplete is
             false it seeds the onboarding greeting + choices into the SAME live

--- a/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
@@ -631,6 +631,7 @@ describe("ChatOverlay first-run gating", () => {
       <ChatOverlay
         controller={waitingController}
         firstRunOpen={false}
+        releaseFirstRunToFull
         onStateChange={onStateChange}
       />,
     );
@@ -701,8 +702,14 @@ describe("ChatOverlay first-run gating", () => {
     expect(sheet.getAttribute("data-variant")).toBe("open");
     expect(overlay.getAttribute("data-open")).toBe("true");
 
-    // Onboarding completes: firstRunOpen falls true → false.
-    rerender(<ChatOverlay controller={controller} firstRunOpen={false} />);
+    // Onboarding completes with the parent's mounted transcript-epoch proof.
+    rerender(
+      <ChatOverlay
+        controller={controller}
+        firstRunOpen={false}
+        releaseFirstRunToFull
+      />,
+    );
     expect(sheet.getAttribute("data-variant")).toBe("open");
     expect(sheet.getAttribute("data-detent")).toBe("full");
     expect(overlay.getAttribute("data-open")).toBe("true");
@@ -727,6 +734,19 @@ describe("ChatOverlay first-run gating", () => {
     // The collapse gate is released: Escape closes the sheet again.
     fireEvent.keyDown(input, { key: "Escape" });
     expect(sheet.getAttribute("data-variant")).toBe("closed");
+  });
+
+  it("returns to INPUT when a false probe clears without mounted transcript authority", () => {
+    const controller = makeController();
+    const { rerender } = render(
+      <ChatOverlay controller={controller} firstRunOpen />,
+    );
+
+    rerender(<ChatOverlay controller={controller} firstRunOpen={false} />);
+
+    const sheet = screen.getByTestId("chat-sheet");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
+    expect(sheet.getAttribute("data-chat-state")).toBe("INPUT");
   });
 
   it("never auto-collapses a session where onboarding was not active", () => {

--- a/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
@@ -214,9 +214,10 @@ describe("ChatOverlay first-run gating", () => {
 
   it("uses the same visible half-height shell as post-onboarding chat", () => {
     const onStateChange = vi.fn();
-    render(
+    const controller = makeController();
+    const { rerender } = render(
       <ChatOverlay
-        controller={makeController()}
+        controller={controller}
         firstRunOpen
         onStateChange={onStateChange}
       />,
@@ -230,6 +231,18 @@ describe("ChatOverlay first-run gating", () => {
     expect(grabber.getAttribute("aria-disabled")).toBe("true");
     expect(screen.queryByTestId("chat-first-run-grabber")).toBeNull();
     expect(screen.getByTestId("chat-sheet-rim")).toBeTruthy();
+    // Onboarding owns the first card at the top of the transcript, so the
+    // ordinary-chat dissolve must not obscure its choice controls. Once the
+    // gate clears, the regular transcript owns that decorative fade again.
+    expect(screen.queryByTestId("chat-thread-top-fade")).toBeNull();
+    rerender(
+      <ChatOverlay
+        controller={controller}
+        firstRunOpen={false}
+        onStateChange={onStateChange}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
     expect(screen.getByTestId("chat-thread-top-fade")).toBeTruthy();
     expect(screen.queryByTestId("chat-maximize-restore-zone")).toBeNull();
   });

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -3887,9 +3887,18 @@ export function ChatOverlay({
       setMaximized(false);
       return;
     }
-    if (was || releaseFirstRunToFull) {
+    if (releaseFirstRunToFull) {
       goToDetent("full");
       onFirstRunReleaseHandled?.();
+      return;
+    }
+    if (was) {
+      // A bare false -> true status probe is not onboarding completion. Until
+      // the shell supplies mounted transcript-epoch authority, return to the
+      // regular compact composer instead of manufacturing a FULL release.
+      setFreeH(null);
+      setMode("input");
+      setMaximized(false);
     }
   }, [
     cloudLoginWaiting,

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -1699,8 +1699,12 @@ export function useFirstRunConductor(): void {
  */
 export function FirstRunConductorMount({
   onFirstRunTranscriptMounted,
+  firstRunMountEpoch = null,
+  firstRunAuthorityEpoch = null,
 }: {
-  onFirstRunTranscriptMounted?: () => void;
+  onFirstRunTranscriptMounted?: (epoch: number) => void;
+  firstRunMountEpoch?: number | null;
+  firstRunAuthorityEpoch?: number | null;
 } = {}): null {
   useFirstRunConductor();
   const firstRunIncomplete = useAppSelector(
@@ -1717,9 +1721,21 @@ export function FirstRunConductorMount({
       conversationMessages,
       firstRunIncomplete,
     );
-    if (!transcriptWasMounted && transcriptEpochRef.current.transcriptMounted) {
-      onFirstRunTranscriptMounted?.();
+    if (
+      firstRunMountEpoch !== null &&
+      ((!transcriptWasMounted &&
+        transcriptEpochRef.current.transcriptMounted) ||
+        (firstRunAuthorityEpoch === firstRunMountEpoch &&
+          transcriptEpochRef.current.transcriptMounted))
+    ) {
+      onFirstRunTranscriptMounted?.(firstRunMountEpoch);
     }
-  }, [conversationMessages, firstRunIncomplete, onFirstRunTranscriptMounted]);
+  }, [
+    conversationMessages,
+    firstRunAuthorityEpoch,
+    firstRunIncomplete,
+    firstRunMountEpoch,
+    onFirstRunTranscriptMounted,
+  ]);
   return null;
 }

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -75,7 +75,11 @@ import {
 import { getBootConfig } from "../config/boot-config";
 import { useBranding } from "../config/branding";
 import { APP_RESUME_EVENT } from "../events";
-import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
+import {
+  ACCENT_PRESETS,
+  useAppSelector,
+  useAppSelectorShallow,
+} from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
 import {
   claimCloudLoginWindow,
@@ -83,6 +87,10 @@ import {
   releaseClaimedCloudLoginWindow,
 } from "../state/cloud-login-launch";
 import { hasUsableStoredStewardToken } from "../state/cloud-steward-login";
+import {
+  createFirstRunTranscriptEpoch,
+  observeFirstRunTranscriptEpoch,
+} from "../state/first-run-transcript-epoch";
 import { startTutorial } from "../tutorial/tutorial-service";
 import { clearFirstRunTranscriptMessages } from "./clear-first-run-transcript";
 import {
@@ -1685,8 +1693,33 @@ export function useFirstRunConductor(): void {
   ]);
 }
 
-/** Mount point — call once inside the AppContext provider tree. Renders null. */
-export function FirstRunConductorMount(): null {
+/**
+ * Mount point for the conductor. The callback fires only after an active
+ * conductor has produced a first-run turn in the shared transcript.
+ */
+export function FirstRunConductorMount({
+  onFirstRunTranscriptMounted,
+}: {
+  onFirstRunTranscriptMounted?: () => void;
+} = {}): null {
   useFirstRunConductor();
+  const firstRunIncomplete = useAppSelector(
+    (state) => state.firstRunComplete === false,
+  );
+  const { conversationMessages } = useConversationMessages();
+  const transcriptEpochRef = React.useRef(
+    createFirstRunTranscriptEpoch(conversationMessages, firstRunIncomplete),
+  );
+  React.useLayoutEffect(() => {
+    const transcriptWasMounted = transcriptEpochRef.current.transcriptMounted;
+    transcriptEpochRef.current = observeFirstRunTranscriptEpoch(
+      transcriptEpochRef.current,
+      conversationMessages,
+      firstRunIncomplete,
+    );
+    if (!transcriptWasMounted && transcriptEpochRef.current.transcriptMounted) {
+      onFirstRunTranscriptMounted?.();
+    }
+  }, [conversationMessages, firstRunIncomplete, onFirstRunTranscriptMounted]);
   return null;
 }

--- a/packages/ui/src/state/first-run-chat-release.test.ts
+++ b/packages/ui/src/state/first-run-chat-release.test.ts
@@ -7,12 +7,20 @@ import { describe, expect, it } from "vitest";
 import {
   acknowledgeFirstRunChatRelease,
   createFirstRunChatReleaseState,
+  isAuthoritativeFirstRunOpen,
   observeFirstRunCompletion,
   recordMountedFirstRunOverlay,
   recordMountedFirstRunTranscript,
 } from "./first-run-chat-release";
 
 describe("first-run chat release tracking", () => {
+  it("opens onboarding only for an authoritative first-run phase", () => {
+    expect(isAuthoritativeFirstRunOpen(false, "first-run-required")).toBe(true);
+    expect(isAuthoritativeFirstRunOpen(false, "ready")).toBe(false);
+    expect(isAuthoritativeFirstRunOpen(true, "first-run-required")).toBe(false);
+    expect(isAuthoritativeFirstRunOpen(null, "first-run-required")).toBe(false);
+  });
+
   it("ignores a completed-user startup probe transition without a mounted chat", () => {
     let state = createFirstRunChatReleaseState(false, "ready");
     state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);

--- a/packages/ui/src/state/first-run-chat-release.test.ts
+++ b/packages/ui/src/state/first-run-chat-release.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure lifecycle regressions for retaining a full-detent release only after a
+ * real first-run chat mount, including the overlay-remount handoff.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  acknowledgeFirstRunChatRelease,
+  createFirstRunChatReleaseState,
+  observeFirstRunCompletion,
+  recordMountedFirstRunChat,
+} from "./first-run-chat-release";
+
+describe("first-run chat release tracking", () => {
+  it("ignores a completed-user startup probe transition without a mounted chat", () => {
+    let state = createFirstRunChatReleaseState(false);
+    state = observeFirstRunCompletion(state, true);
+
+    expect(state).toEqual({
+      observedIncomplete: false,
+      mountedWhileIncomplete: false,
+      releasePending: false,
+    });
+  });
+
+  it("retains a genuine mounted first-run completion across an overlay remount", () => {
+    let state = createFirstRunChatReleaseState(false);
+    state = recordMountedFirstRunChat(state);
+    state = observeFirstRunCompletion(state, true);
+
+    expect(state.releasePending).toBe(true);
+    state = acknowledgeFirstRunChatRelease(state);
+    expect(state.releasePending).toBe(false);
+  });
+
+  it("does not let a mount outside first run authorize a later release", () => {
+    let state = createFirstRunChatReleaseState(true);
+    state = recordMountedFirstRunChat(state);
+    state = observeFirstRunCompletion(state, false);
+    state = observeFirstRunCompletion(state, true);
+
+    expect(state.releasePending).toBe(false);
+  });
+});

--- a/packages/ui/src/state/first-run-chat-release.test.ts
+++ b/packages/ui/src/state/first-run-chat-release.test.ts
@@ -8,25 +8,30 @@ import {
   acknowledgeFirstRunChatRelease,
   createFirstRunChatReleaseState,
   observeFirstRunCompletion,
-  recordMountedFirstRunChat,
+  recordMountedFirstRunOverlay,
+  recordMountedFirstRunTranscript,
 } from "./first-run-chat-release";
 
 describe("first-run chat release tracking", () => {
   it("ignores a completed-user startup probe transition without a mounted chat", () => {
-    let state = createFirstRunChatReleaseState(false);
-    state = observeFirstRunCompletion(state, true);
+    let state = createFirstRunChatReleaseState(false, "ready");
+    state = recordMountedFirstRunOverlay(state);
+    state = recordMountedFirstRunTranscript(state);
+    state = observeFirstRunCompletion(state, true, "ready");
 
     expect(state).toEqual({
       observedIncomplete: false,
-      mountedWhileIncomplete: false,
+      overlayMountedWhileIncomplete: false,
+      transcriptMountedWhileIncomplete: false,
       releasePending: false,
     });
   });
 
   it("retains a genuine mounted first-run completion across an overlay remount", () => {
-    let state = createFirstRunChatReleaseState(false);
-    state = recordMountedFirstRunChat(state);
-    state = observeFirstRunCompletion(state, true);
+    let state = createFirstRunChatReleaseState(false, "first-run-required");
+    state = recordMountedFirstRunOverlay(state);
+    state = recordMountedFirstRunTranscript(state);
+    state = observeFirstRunCompletion(state, true, "starting-runtime");
 
     expect(state.releasePending).toBe(true);
     state = acknowledgeFirstRunChatRelease(state);
@@ -34,37 +39,61 @@ describe("first-run chat release tracking", () => {
   });
 
   it("does not let a mount outside first run authorize a later release", () => {
-    let state = createFirstRunChatReleaseState(true);
-    state = recordMountedFirstRunChat(state);
-    state = observeFirstRunCompletion(state, false);
-    state = observeFirstRunCompletion(state, true);
+    let state = createFirstRunChatReleaseState(true, "ready");
+    state = recordMountedFirstRunOverlay(state);
+    state = recordMountedFirstRunTranscript(state);
+    state = observeFirstRunCompletion(state, false, "ready");
+    state = observeFirstRunCompletion(state, true, "ready");
 
     expect(state.releasePending).toBe(false);
   });
 
   it("cancels a stale unacknowledged release when first run restarts", () => {
-    let state = createFirstRunChatReleaseState(false);
-    state = recordMountedFirstRunChat(state);
-    state = observeFirstRunCompletion(state, true);
+    let state = createFirstRunChatReleaseState(false, "first-run-required");
+    state = recordMountedFirstRunOverlay(state);
+    state = recordMountedFirstRunTranscript(state);
+    state = observeFirstRunCompletion(state, true, "ready");
     expect(state.releasePending).toBe(true);
 
-    state = observeFirstRunCompletion(state, false);
+    state = observeFirstRunCompletion(state, false, "first-run-required");
     expect(state).toEqual({
       observedIncomplete: true,
-      mountedWhileIncomplete: false,
+      overlayMountedWhileIncomplete: false,
+      transcriptMountedWhileIncomplete: false,
       releasePending: false,
     });
 
-    state = observeFirstRunCompletion(state, true);
+    state = observeFirstRunCompletion(state, true, "ready");
     expect(state.releasePending).toBe(false);
   });
 
   it("retains a mounted epoch across an unresolved probe", () => {
-    let state = createFirstRunChatReleaseState(false);
-    state = recordMountedFirstRunChat(state);
-    state = observeFirstRunCompletion(state, null);
-    state = observeFirstRunCompletion(state, true);
+    let state = createFirstRunChatReleaseState(false, "first-run-required");
+    state = recordMountedFirstRunOverlay(state);
+    state = recordMountedFirstRunTranscript(state);
+    state = observeFirstRunCompletion(state, null, "polling-backend");
+    state = observeFirstRunCompletion(state, true, "ready");
 
     expect(state.releasePending).toBe(true);
+  });
+
+  it("requires both the committed overlay and a real first-run transcript", () => {
+    const overlayOnly = observeFirstRunCompletion(
+      recordMountedFirstRunOverlay(
+        createFirstRunChatReleaseState(false, "first-run-required"),
+      ),
+      true,
+      "ready",
+    );
+    const transcriptOnly = observeFirstRunCompletion(
+      recordMountedFirstRunTranscript(
+        createFirstRunChatReleaseState(false, "first-run-required"),
+      ),
+      true,
+      "ready",
+    );
+
+    expect(overlayOnly.releasePending).toBe(false);
+    expect(transcriptOnly.releasePending).toBe(false);
   });
 });

--- a/packages/ui/src/state/first-run-chat-release.test.ts
+++ b/packages/ui/src/state/first-run-chat-release.test.ts
@@ -15,22 +15,24 @@ import {
 describe("first-run chat release tracking", () => {
   it("ignores a completed-user startup probe transition without a mounted chat", () => {
     let state = createFirstRunChatReleaseState(false, "ready");
-    state = recordMountedFirstRunOverlay(state);
-    state = recordMountedFirstRunTranscript(state);
+    state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);
+    state = recordMountedFirstRunTranscript(state, state.incompleteEpoch);
     state = observeFirstRunCompletion(state, true, "ready");
 
     expect(state).toEqual({
-      observedIncomplete: false,
-      overlayMountedWhileIncomplete: false,
-      transcriptMountedWhileIncomplete: false,
+      incompleteActive: false,
+      incompleteEpoch: 1,
+      authoritativeEpoch: null,
+      overlayMountedEpoch: null,
+      transcriptMountedEpoch: null,
       releasePending: false,
     });
   });
 
   it("retains a genuine mounted first-run completion across an overlay remount", () => {
     let state = createFirstRunChatReleaseState(false, "first-run-required");
-    state = recordMountedFirstRunOverlay(state);
-    state = recordMountedFirstRunTranscript(state);
+    state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);
+    state = recordMountedFirstRunTranscript(state, state.incompleteEpoch);
     state = observeFirstRunCompletion(state, true, "starting-runtime");
 
     expect(state.releasePending).toBe(true);
@@ -40,8 +42,8 @@ describe("first-run chat release tracking", () => {
 
   it("does not let a mount outside first run authorize a later release", () => {
     let state = createFirstRunChatReleaseState(true, "ready");
-    state = recordMountedFirstRunOverlay(state);
-    state = recordMountedFirstRunTranscript(state);
+    state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);
+    state = recordMountedFirstRunTranscript(state, state.incompleteEpoch);
     state = observeFirstRunCompletion(state, false, "ready");
     state = observeFirstRunCompletion(state, true, "ready");
 
@@ -50,16 +52,18 @@ describe("first-run chat release tracking", () => {
 
   it("cancels a stale unacknowledged release when first run restarts", () => {
     let state = createFirstRunChatReleaseState(false, "first-run-required");
-    state = recordMountedFirstRunOverlay(state);
-    state = recordMountedFirstRunTranscript(state);
+    state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);
+    state = recordMountedFirstRunTranscript(state, state.incompleteEpoch);
     state = observeFirstRunCompletion(state, true, "ready");
     expect(state.releasePending).toBe(true);
 
     state = observeFirstRunCompletion(state, false, "first-run-required");
     expect(state).toEqual({
-      observedIncomplete: true,
-      overlayMountedWhileIncomplete: false,
-      transcriptMountedWhileIncomplete: false,
+      incompleteActive: true,
+      incompleteEpoch: 2,
+      authoritativeEpoch: 2,
+      overlayMountedEpoch: null,
+      transcriptMountedEpoch: null,
       releasePending: false,
     });
 
@@ -69,8 +73,8 @@ describe("first-run chat release tracking", () => {
 
   it("retains a mounted epoch across an unresolved probe", () => {
     let state = createFirstRunChatReleaseState(false, "first-run-required");
-    state = recordMountedFirstRunOverlay(state);
-    state = recordMountedFirstRunTranscript(state);
+    state = recordMountedFirstRunOverlay(state, state.incompleteEpoch);
+    state = recordMountedFirstRunTranscript(state, state.incompleteEpoch);
     state = observeFirstRunCompletion(state, null, "polling-backend");
     state = observeFirstRunCompletion(state, true, "ready");
 
@@ -81,6 +85,7 @@ describe("first-run chat release tracking", () => {
     const overlayOnly = observeFirstRunCompletion(
       recordMountedFirstRunOverlay(
         createFirstRunChatReleaseState(false, "first-run-required"),
+        1,
       ),
       true,
       "ready",
@@ -88,6 +93,7 @@ describe("first-run chat release tracking", () => {
     const transcriptOnly = observeFirstRunCompletion(
       recordMountedFirstRunTranscript(
         createFirstRunChatReleaseState(false, "first-run-required"),
+        1,
       ),
       true,
       "ready",
@@ -95,5 +101,32 @@ describe("first-run chat release tracking", () => {
 
     expect(overlayOnly.releasePending).toBe(false);
     expect(transcriptOnly.releasePending).toBe(false);
+  });
+
+  it("promotes polling mounts into the authoritative first-run epoch", () => {
+    let state = createFirstRunChatReleaseState(false, "polling-backend");
+    const epoch = state.incompleteEpoch;
+    state = recordMountedFirstRunOverlay(state, epoch);
+    state = recordMountedFirstRunTranscript(state, epoch);
+
+    state = observeFirstRunCompletion(state, false, "first-run-required");
+    expect(state.authoritativeEpoch).toBe(epoch);
+    expect(state.overlayMountedEpoch).toBe(epoch);
+    expect(state.transcriptMountedEpoch).toBe(epoch);
+
+    state = observeFirstRunCompletion(state, true, "starting-runtime");
+    expect(state.releasePending).toBe(true);
+  });
+
+  it("rejects mount reports from a prior incomplete epoch", () => {
+    let state = createFirstRunChatReleaseState(false, "first-run-required");
+    const priorEpoch = state.incompleteEpoch;
+    state = observeFirstRunCompletion(state, true, "ready");
+    state = observeFirstRunCompletion(state, false, "first-run-required");
+    state = recordMountedFirstRunOverlay(state, priorEpoch);
+    state = recordMountedFirstRunTranscript(state, priorEpoch);
+    state = observeFirstRunCompletion(state, true, "ready");
+
+    expect(state.releasePending).toBe(false);
   });
 });

--- a/packages/ui/src/state/first-run-chat-release.test.ts
+++ b/packages/ui/src/state/first-run-chat-release.test.ts
@@ -41,4 +41,30 @@ describe("first-run chat release tracking", () => {
 
     expect(state.releasePending).toBe(false);
   });
+
+  it("cancels a stale unacknowledged release when first run restarts", () => {
+    let state = createFirstRunChatReleaseState(false);
+    state = recordMountedFirstRunChat(state);
+    state = observeFirstRunCompletion(state, true);
+    expect(state.releasePending).toBe(true);
+
+    state = observeFirstRunCompletion(state, false);
+    expect(state).toEqual({
+      observedIncomplete: true,
+      mountedWhileIncomplete: false,
+      releasePending: false,
+    });
+
+    state = observeFirstRunCompletion(state, true);
+    expect(state.releasePending).toBe(false);
+  });
+
+  it("retains a mounted epoch across an unresolved probe", () => {
+    let state = createFirstRunChatReleaseState(false);
+    state = recordMountedFirstRunChat(state);
+    state = observeFirstRunCompletion(state, null);
+    state = observeFirstRunCompletion(state, true);
+
+    expect(state.releasePending).toBe(true);
+  });
 });

--- a/packages/ui/src/state/first-run-chat-release.ts
+++ b/packages/ui/src/state/first-run-chat-release.ts
@@ -35,7 +35,14 @@ export function observeFirstRunCompletion(
 ): FirstRunChatReleaseState {
   if (firstRunComplete === false) {
     if (state.observedIncomplete) return state;
-    return { ...state, observedIncomplete: true };
+    // A new incomplete epoch invalidates an unconsumed release from the prior
+    // epoch. Otherwise a reset that hides the overlay before it acknowledges
+    // FULL can make a later probe-only false -> true transition reopen chat.
+    return {
+      observedIncomplete: true,
+      mountedWhileIncomplete: false,
+      releasePending: false,
+    };
   }
   if (firstRunComplete !== true || !state.observedIncomplete) return state;
   return {

--- a/packages/ui/src/state/first-run-chat-release.ts
+++ b/packages/ui/src/state/first-run-chat-release.ts
@@ -15,16 +15,26 @@ export interface FirstRunChatReleaseState {
   releasePending: boolean;
 }
 
+/** True only while the startup coordinator has committed to real onboarding. */
+export function isAuthoritativeFirstRunOpen(
+  firstRunComplete: boolean | null,
+  startupPhase: StartupPhaseValue,
+): boolean {
+  return firstRunComplete === false && startupPhase === "first-run-required";
+}
+
 export function createFirstRunChatReleaseState(
   firstRunComplete: boolean | null,
   startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseState {
   const incompleteActive = firstRunComplete === false;
   const incompleteEpoch = incompleteActive ? 1 : 0;
-  const authoritativeEpoch =
-    incompleteActive && startupPhase === "first-run-required"
-      ? incompleteEpoch
-      : null;
+  const authoritativeEpoch = isAuthoritativeFirstRunOpen(
+    firstRunComplete,
+    startupPhase,
+  )
+    ? incompleteEpoch
+    : null;
   return {
     incompleteActive,
     incompleteEpoch,

--- a/packages/ui/src/state/first-run-chat-release.ts
+++ b/packages/ui/src/state/first-run-chat-release.ts
@@ -1,0 +1,52 @@
+/**
+ * Tracks whether a first-run completion edge belongs to a chat that actually
+ * mounted. The shell keeps this state above runtime-target overlay remounts so
+ * a genuine onboarding transcript can still reopen at the full detent.
+ */
+
+export interface FirstRunChatReleaseState {
+  observedIncomplete: boolean;
+  mountedWhileIncomplete: boolean;
+  releasePending: boolean;
+}
+
+export function createFirstRunChatReleaseState(
+  firstRunComplete: boolean | null,
+): FirstRunChatReleaseState {
+  return {
+    observedIncomplete: firstRunComplete === false,
+    mountedWhileIncomplete: false,
+    releasePending: false,
+  };
+}
+
+/** Records the only event allowed to authorize a retained full-detent release. */
+export function recordMountedFirstRunChat(
+  state: FirstRunChatReleaseState,
+): FirstRunChatReleaseState {
+  if (!state.observedIncomplete || state.mountedWhileIncomplete) return state;
+  return { ...state, mountedWhileIncomplete: true };
+}
+
+/** Advances persisted first-run state without treating startup probes as UI. */
+export function observeFirstRunCompletion(
+  state: FirstRunChatReleaseState,
+  firstRunComplete: boolean | null,
+): FirstRunChatReleaseState {
+  if (firstRunComplete === false) {
+    if (state.observedIncomplete) return state;
+    return { ...state, observedIncomplete: true };
+  }
+  if (firstRunComplete !== true || !state.observedIncomplete) return state;
+  return {
+    observedIncomplete: false,
+    mountedWhileIncomplete: false,
+    releasePending: state.releasePending || state.mountedWhileIncomplete,
+  };
+}
+
+export function acknowledgeFirstRunChatRelease(
+  state: FirstRunChatReleaseState,
+): FirstRunChatReleaseState {
+  return state.releasePending ? { ...state, releasePending: false } : state;
+}

--- a/packages/ui/src/state/first-run-chat-release.ts
+++ b/packages/ui/src/state/first-run-chat-release.ts
@@ -7,9 +7,11 @@
 import type { StartupPhaseValue } from "./startup-coordinator";
 
 export interface FirstRunChatReleaseState {
-  observedIncomplete: boolean;
-  overlayMountedWhileIncomplete: boolean;
-  transcriptMountedWhileIncomplete: boolean;
+  incompleteActive: boolean;
+  incompleteEpoch: number;
+  authoritativeEpoch: number | null;
+  overlayMountedEpoch: number | null;
+  transcriptMountedEpoch: number | null;
   releasePending: boolean;
 }
 
@@ -17,33 +19,50 @@ export function createFirstRunChatReleaseState(
   firstRunComplete: boolean | null,
   startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseState {
+  const incompleteActive = firstRunComplete === false;
+  const incompleteEpoch = incompleteActive ? 1 : 0;
+  const authoritativeEpoch =
+    incompleteActive && startupPhase === "first-run-required"
+      ? incompleteEpoch
+      : null;
   return {
-    observedIncomplete:
-      firstRunComplete === false && startupPhase === "first-run-required",
-    overlayMountedWhileIncomplete: false,
-    transcriptMountedWhileIncomplete: false,
+    incompleteActive,
+    incompleteEpoch,
+    authoritativeEpoch,
+    overlayMountedEpoch: null,
+    transcriptMountedEpoch: null,
     releasePending: false,
   };
 }
 
-/** Records a committed overlay mount during an authoritative onboarding epoch. */
+/** Records a committed overlay mount during the current incomplete epoch. */
 export function recordMountedFirstRunOverlay(
   state: FirstRunChatReleaseState,
+  epoch: number,
 ): FirstRunChatReleaseState {
-  if (!state.observedIncomplete || state.overlayMountedWhileIncomplete) {
+  if (
+    !state.incompleteActive ||
+    epoch !== state.incompleteEpoch ||
+    state.overlayMountedEpoch === epoch
+  ) {
     return state;
   }
-  return { ...state, overlayMountedWhileIncomplete: true };
+  return { ...state, overlayMountedEpoch: epoch };
 }
 
 /** Records that the mounted conductor produced a real first-run transcript. */
 export function recordMountedFirstRunTranscript(
   state: FirstRunChatReleaseState,
+  epoch: number,
 ): FirstRunChatReleaseState {
-  if (!state.observedIncomplete || state.transcriptMountedWhileIncomplete) {
+  if (
+    !state.incompleteActive ||
+    epoch !== state.incompleteEpoch ||
+    state.transcriptMountedEpoch === epoch
+  ) {
     return state;
   }
-  return { ...state, transcriptMountedWhileIncomplete: true };
+  return { ...state, transcriptMountedEpoch: epoch };
 }
 
 /** Advances persisted first-run state without treating false probes as UI. */
@@ -53,29 +72,42 @@ export function observeFirstRunCompletion(
   startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseState {
   if (firstRunComplete === false) {
-    if (state.observedIncomplete) return state;
-    if (startupPhase !== "first-run-required") {
-      return state.releasePending ? { ...state, releasePending: false } : state;
+    if (!state.incompleteActive) {
+      const incompleteEpoch = state.incompleteEpoch + 1;
+      const authoritativeEpoch =
+        startupPhase === "first-run-required" ? incompleteEpoch : null;
+      return {
+        incompleteActive: true,
+        incompleteEpoch,
+        authoritativeEpoch,
+        overlayMountedEpoch: null,
+        transcriptMountedEpoch: null,
+        releasePending: false,
+      };
     }
-    // A new incomplete epoch invalidates an unconsumed release from the prior
-    // epoch. Otherwise a reset that hides the overlay before it acknowledges
-    // FULL can make a later probe-only false -> true transition reopen chat.
-    return {
-      observedIncomplete: true,
-      overlayMountedWhileIncomplete: false,
-      transcriptMountedWhileIncomplete: false,
-      releasePending: false,
-    };
+    if (
+      startupPhase === "first-run-required" &&
+      state.authoritativeEpoch !== state.incompleteEpoch
+    ) {
+      return {
+        ...state,
+        authoritativeEpoch: state.incompleteEpoch,
+      };
+    }
+    return state.releasePending ? { ...state, releasePending: false } : state;
   }
-  if (firstRunComplete !== true || !state.observedIncomplete) return state;
+  if (firstRunComplete !== true || !state.incompleteActive) return state;
+  const releaseAuthorized =
+    state.authoritativeEpoch === state.incompleteEpoch &&
+    state.overlayMountedEpoch === state.incompleteEpoch &&
+    state.transcriptMountedEpoch === state.incompleteEpoch;
   return {
-    observedIncomplete: false,
-    overlayMountedWhileIncomplete: false,
-    transcriptMountedWhileIncomplete: false,
-    releasePending:
-      state.releasePending ||
-      (state.overlayMountedWhileIncomplete &&
-        state.transcriptMountedWhileIncomplete),
+    incompleteActive: false,
+    incompleteEpoch: state.incompleteEpoch,
+    authoritativeEpoch: null,
+    overlayMountedEpoch: null,
+    transcriptMountedEpoch: null,
+    releasePending: state.releasePending || releaseAuthorized,
   };
 }
 

--- a/packages/ui/src/state/first-run-chat-release.ts
+++ b/packages/ui/src/state/first-run-chat-release.ts
@@ -1,54 +1,81 @@
 /**
- * Tracks whether a first-run completion edge belongs to a chat that actually
- * mounted. The shell keeps this state above runtime-target overlay remounts so
- * a genuine onboarding transcript can still reopen at the full detent.
+ * Tracks whether a first-run completion edge belongs to onboarding that was
+ * visibly mounted. The shell keeps this state above runtime-target overlay
+ * remounts so a genuine onboarding transcript can still reopen at FULL.
  */
+
+import type { StartupPhaseValue } from "./startup-coordinator";
 
 export interface FirstRunChatReleaseState {
   observedIncomplete: boolean;
-  mountedWhileIncomplete: boolean;
+  overlayMountedWhileIncomplete: boolean;
+  transcriptMountedWhileIncomplete: boolean;
   releasePending: boolean;
 }
 
 export function createFirstRunChatReleaseState(
   firstRunComplete: boolean | null,
+  startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseState {
   return {
-    observedIncomplete: firstRunComplete === false,
-    mountedWhileIncomplete: false,
+    observedIncomplete:
+      firstRunComplete === false && startupPhase === "first-run-required",
+    overlayMountedWhileIncomplete: false,
+    transcriptMountedWhileIncomplete: false,
     releasePending: false,
   };
 }
 
-/** Records the only event allowed to authorize a retained full-detent release. */
-export function recordMountedFirstRunChat(
+/** Records a committed overlay mount during an authoritative onboarding epoch. */
+export function recordMountedFirstRunOverlay(
   state: FirstRunChatReleaseState,
 ): FirstRunChatReleaseState {
-  if (!state.observedIncomplete || state.mountedWhileIncomplete) return state;
-  return { ...state, mountedWhileIncomplete: true };
+  if (!state.observedIncomplete || state.overlayMountedWhileIncomplete) {
+    return state;
+  }
+  return { ...state, overlayMountedWhileIncomplete: true };
 }
 
-/** Advances persisted first-run state without treating startup probes as UI. */
+/** Records that the mounted conductor produced a real first-run transcript. */
+export function recordMountedFirstRunTranscript(
+  state: FirstRunChatReleaseState,
+): FirstRunChatReleaseState {
+  if (!state.observedIncomplete || state.transcriptMountedWhileIncomplete) {
+    return state;
+  }
+  return { ...state, transcriptMountedWhileIncomplete: true };
+}
+
+/** Advances persisted first-run state without treating false probes as UI. */
 export function observeFirstRunCompletion(
   state: FirstRunChatReleaseState,
   firstRunComplete: boolean | null,
+  startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseState {
   if (firstRunComplete === false) {
     if (state.observedIncomplete) return state;
+    if (startupPhase !== "first-run-required") {
+      return state.releasePending ? { ...state, releasePending: false } : state;
+    }
     // A new incomplete epoch invalidates an unconsumed release from the prior
     // epoch. Otherwise a reset that hides the overlay before it acknowledges
     // FULL can make a later probe-only false -> true transition reopen chat.
     return {
       observedIncomplete: true,
-      mountedWhileIncomplete: false,
+      overlayMountedWhileIncomplete: false,
+      transcriptMountedWhileIncomplete: false,
       releasePending: false,
     };
   }
   if (firstRunComplete !== true || !state.observedIncomplete) return state;
   return {
     observedIncomplete: false,
-    mountedWhileIncomplete: false,
-    releasePending: state.releasePending || state.mountedWhileIncomplete,
+    overlayMountedWhileIncomplete: false,
+    transcriptMountedWhileIncomplete: false,
+    releasePending:
+      state.releasePending ||
+      (state.overlayMountedWhileIncomplete &&
+        state.transcriptMountedWhileIncomplete),
   };
 }
 

--- a/packages/ui/src/state/first-run-transcript-epoch.test.ts
+++ b/packages/ui/src/state/first-run-transcript-epoch.test.ts
@@ -1,0 +1,52 @@
+/** Verifies first-run transcript mount authority is scoped to one epoch. */
+
+import { describe, expect, it } from "vitest";
+import {
+  createFirstRunTranscriptEpoch,
+  observeFirstRunTranscriptEpoch,
+} from "./first-run-transcript-epoch";
+
+const staleTurn = { id: "first-run:greeting", source: "first_run" };
+
+describe("first-run transcript epochs", () => {
+  it("does not authorize a stale synthetic turn present at epoch entry", () => {
+    let state = createFirstRunTranscriptEpoch([staleTurn], false);
+    state = observeFirstRunTranscriptEpoch(state, [staleTurn], true);
+    state = observeFirstRunTranscriptEpoch(state, [staleTurn], true);
+
+    expect(state.transcriptMounted).toBe(false);
+  });
+
+  it("authorizes only a new first-run turn committed in the active epoch", () => {
+    let state = createFirstRunTranscriptEpoch([staleTurn], false);
+    state = observeFirstRunTranscriptEpoch(state, [staleTurn], true);
+    state = observeFirstRunTranscriptEpoch(
+      state,
+      [staleTurn, { id: "first-run:runtime", source: "first_run" }],
+      true,
+    );
+
+    expect(state.transcriptMounted).toBe(true);
+  });
+
+  it("requires another new turn after a completed epoch resets", () => {
+    let state = createFirstRunTranscriptEpoch([], true);
+    state = observeFirstRunTranscriptEpoch(
+      state,
+      [{ id: "first-run:runtime", source: "first_run" }],
+      true,
+    );
+    expect(state.transcriptMounted).toBe(true);
+
+    state = observeFirstRunTranscriptEpoch(state, [staleTurn], false);
+    state = observeFirstRunTranscriptEpoch(state, [staleTurn], true);
+    expect(state.transcriptMounted).toBe(false);
+
+    state = observeFirstRunTranscriptEpoch(
+      state,
+      [staleTurn, { id: "first-run:provider", source: "first_run" }],
+      true,
+    );
+    expect(state.transcriptMounted).toBe(true);
+  });
+});

--- a/packages/ui/src/state/first-run-transcript-epoch.ts
+++ b/packages/ui/src/state/first-run-transcript-epoch.ts
@@ -1,0 +1,59 @@
+/**
+ * Identifies a first-run transcript committed during the current incomplete
+ * epoch, excluding synthetic turns left over from an earlier mount.
+ */
+
+interface FirstRunTranscriptLike {
+  id: string;
+  source?: string;
+}
+
+export interface FirstRunTranscriptEpochState {
+  active: boolean;
+  baselineIds: ReadonlySet<string>;
+  transcriptMounted: boolean;
+}
+
+function firstRunIds(
+  messages: readonly FirstRunTranscriptLike[],
+): ReadonlySet<string> {
+  return new Set(
+    messages
+      .filter((message) => message.source === "first_run")
+      .map((message) => message.id),
+  );
+}
+
+export function createFirstRunTranscriptEpoch(
+  messages: readonly FirstRunTranscriptLike[],
+  incomplete: boolean,
+): FirstRunTranscriptEpochState {
+  return {
+    active: incomplete,
+    baselineIds: firstRunIds(messages),
+    transcriptMounted: false,
+  };
+}
+
+/** Advances committed transcript state and begins each incomplete epoch clean. */
+export function observeFirstRunTranscriptEpoch(
+  state: FirstRunTranscriptEpochState,
+  messages: readonly FirstRunTranscriptLike[],
+  incomplete: boolean,
+): FirstRunTranscriptEpochState {
+  if (!incomplete) {
+    return state.active || state.transcriptMounted
+      ? createFirstRunTranscriptEpoch(messages, false)
+      : state;
+  }
+  if (!state.active) return createFirstRunTranscriptEpoch(messages, true);
+  if (state.transcriptMounted) return state;
+
+  const producedCurrentEpochTurn = messages.some(
+    (message) =>
+      message.source === "first_run" && !state.baselineIds.has(message.id),
+  );
+  return producedCurrentEpochTurn
+    ? { ...state, transcriptMounted: true }
+    : state;
+}

--- a/packages/ui/src/state/use-first-run-chat-release.test.tsx
+++ b/packages/ui/src/state/use-first-run-chat-release.test.tsx
@@ -4,6 +4,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { type ReactNode, StrictMode } from "react";
 import { describe, expect, it } from "vitest";
+import type { StartupPhaseValue } from "./startup-coordinator";
 import { useFirstRunChatRelease } from "./use-first-run-chat-release";
 
 const strictWrapper = ({ children }: { children: ReactNode }) => (
@@ -14,7 +15,7 @@ describe("useFirstRunChatRelease", () => {
   it("does not release for an unmounted startup-probe transition", () => {
     const { result, rerender } = renderHook(
       ({ complete }: { complete: boolean | null }) =>
-        useFirstRunChatRelease(complete),
+        useFirstRunChatRelease(complete, "ready"),
       { initialProps: { complete: false }, wrapper: strictWrapper },
     );
 
@@ -25,11 +26,12 @@ describe("useFirstRunChatRelease", () => {
   it("retains one mounted completion across overlay remount and acknowledgement", () => {
     const { result, rerender } = renderHook(
       ({ complete }: { complete: boolean | null }) =>
-        useFirstRunChatRelease(complete),
+        useFirstRunChatRelease(complete, "first-run-required"),
       { initialProps: { complete: false }, wrapper: strictWrapper },
     );
 
-    act(() => result.current.recordMountedChat());
+    act(() => result.current.recordMountedOverlay());
+    act(() => result.current.recordMountedTranscript());
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
 
@@ -42,11 +44,12 @@ describe("useFirstRunChatRelease", () => {
   it("requires a new mounted chat after reset cancels a pending release", () => {
     const { result, rerender } = renderHook(
       ({ complete }: { complete: boolean | null }) =>
-        useFirstRunChatRelease(complete),
+        useFirstRunChatRelease(complete, "first-run-required"),
       { initialProps: { complete: false }, wrapper: strictWrapper },
     );
 
-    act(() => result.current.recordMountedChat());
+    act(() => result.current.recordMountedOverlay());
+    act(() => result.current.recordMountedTranscript());
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
 
@@ -56,8 +59,36 @@ describe("useFirstRunChatRelease", () => {
     expect(result.current.releasePending).toBe(false);
 
     rerender({ complete: false });
-    act(() => result.current.recordMountedChat());
+    act(() => result.current.recordMountedOverlay());
+    act(() => result.current.recordMountedTranscript());
     rerender({ complete: true });
+    expect(result.current.releasePending).toBe(true);
+  });
+
+  it("arms when the coordinator authoritatively enters first run after a false probe", () => {
+    const initialProps: {
+      complete: boolean | null;
+      phase: StartupPhaseValue;
+    } = { complete: false, phase: "ready" };
+    const { result, rerender } = renderHook(
+      ({
+        complete,
+        phase,
+      }: {
+        complete: boolean | null;
+        phase: StartupPhaseValue;
+      }) => useFirstRunChatRelease(complete, phase),
+      {
+        initialProps,
+        wrapper: strictWrapper,
+      },
+    );
+
+    rerender({ complete: false, phase: "first-run-required" });
+    act(() => result.current.recordMountedOverlay());
+    act(() => result.current.recordMountedTranscript());
+    rerender({ complete: true, phase: "starting-runtime" });
+
     expect(result.current.releasePending).toBe(true);
   });
 });

--- a/packages/ui/src/state/use-first-run-chat-release.test.tsx
+++ b/packages/ui/src/state/use-first-run-chat-release.test.tsx
@@ -31,9 +31,12 @@ describe("useFirstRunChatRelease", () => {
     );
 
     act(() => result.current.recordMountedOverlay());
+    expect(result.current.mountedOnboarding).toBe(false);
     act(() => result.current.recordMountedTranscript());
+    expect(result.current.mountedOnboarding).toBe(true);
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
+    expect(result.current.mountedOnboarding).toBe(false);
 
     act(() => result.current.acknowledgeRelease());
     expect(result.current.releasePending).toBe(false);

--- a/packages/ui/src/state/use-first-run-chat-release.test.tsx
+++ b/packages/ui/src/state/use-first-run-chat-release.test.tsx
@@ -11,6 +11,11 @@ const strictWrapper = ({ children }: { children: ReactNode }) => (
   <StrictMode>{children}</StrictMode>
 );
 
+function requireEpoch(epoch: number | null): number {
+  if (epoch === null) throw new Error("Expected an active first-run epoch");
+  return epoch;
+}
+
 describe("useFirstRunChatRelease", () => {
   it("does not release for an unmounted startup-probe transition", () => {
     const { result, rerender } = renderHook(
@@ -30,9 +35,17 @@ describe("useFirstRunChatRelease", () => {
       { initialProps: { complete: false }, wrapper: strictWrapper },
     );
 
-    act(() => result.current.recordMountedOverlay());
+    act(() =>
+      result.current.recordMountedOverlay(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
     expect(result.current.mountedOnboarding).toBe(false);
-    act(() => result.current.recordMountedTranscript());
+    act(() =>
+      result.current.recordMountedTranscript(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
     expect(result.current.mountedOnboarding).toBe(true);
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
@@ -51,8 +64,16 @@ describe("useFirstRunChatRelease", () => {
       { initialProps: { complete: false }, wrapper: strictWrapper },
     );
 
-    act(() => result.current.recordMountedOverlay());
-    act(() => result.current.recordMountedTranscript());
+    act(() =>
+      result.current.recordMountedOverlay(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
+    act(() =>
+      result.current.recordMountedTranscript(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
 
@@ -62,8 +83,16 @@ describe("useFirstRunChatRelease", () => {
     expect(result.current.releasePending).toBe(false);
 
     rerender({ complete: false });
-    act(() => result.current.recordMountedOverlay());
-    act(() => result.current.recordMountedTranscript());
+    act(() =>
+      result.current.recordMountedOverlay(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
+    act(() =>
+      result.current.recordMountedTranscript(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
     rerender({ complete: true });
     expect(result.current.releasePending).toBe(true);
   });
@@ -88,10 +117,44 @@ describe("useFirstRunChatRelease", () => {
     );
 
     rerender({ complete: false, phase: "first-run-required" });
-    act(() => result.current.recordMountedOverlay());
-    act(() => result.current.recordMountedTranscript());
+    act(() =>
+      result.current.recordMountedOverlay(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
+    act(() =>
+      result.current.recordMountedTranscript(
+        requireEpoch(result.current.mountEpoch),
+      ),
+    );
     rerender({ complete: true, phase: "starting-runtime" });
 
+    expect(result.current.releasePending).toBe(true);
+  });
+
+  it("retains polling mount evidence when first run becomes authoritative", () => {
+    const { result, rerender } = renderHook(
+      ({ complete, phase }: { complete: boolean; phase: StartupPhaseValue }) =>
+        useFirstRunChatRelease(complete, phase),
+      {
+        initialProps: { complete: false, phase: "polling-backend" },
+        wrapper: strictWrapper,
+      },
+    );
+
+    const pollingEpoch = result.current.mountEpoch;
+    expect(pollingEpoch).not.toBeNull();
+    act(() => result.current.recordMountedOverlay(requireEpoch(pollingEpoch)));
+    act(() =>
+      result.current.recordMountedTranscript(requireEpoch(pollingEpoch)),
+    );
+    expect(result.current.mountedOnboarding).toBe(false);
+
+    rerender({ complete: false, phase: "first-run-required" });
+    expect(result.current.authorityEpoch).toBe(pollingEpoch);
+    expect(result.current.mountedOnboarding).toBe(true);
+
+    rerender({ complete: true, phase: "starting-runtime" });
     expect(result.current.releasePending).toBe(true);
   });
 });

--- a/packages/ui/src/state/use-first-run-chat-release.test.tsx
+++ b/packages/ui/src/state/use-first-run-chat-release.test.tsx
@@ -1,0 +1,63 @@
+/** Verifies committed React lifecycle ownership of first-run chat releases. */
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { type ReactNode, StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+import { useFirstRunChatRelease } from "./use-first-run-chat-release";
+
+const strictWrapper = ({ children }: { children: ReactNode }) => (
+  <StrictMode>{children}</StrictMode>
+);
+
+describe("useFirstRunChatRelease", () => {
+  it("does not release for an unmounted startup-probe transition", () => {
+    const { result, rerender } = renderHook(
+      ({ complete }: { complete: boolean | null }) =>
+        useFirstRunChatRelease(complete),
+      { initialProps: { complete: false }, wrapper: strictWrapper },
+    );
+
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(false);
+  });
+
+  it("retains one mounted completion across overlay remount and acknowledgement", () => {
+    const { result, rerender } = renderHook(
+      ({ complete }: { complete: boolean | null }) =>
+        useFirstRunChatRelease(complete),
+      { initialProps: { complete: false }, wrapper: strictWrapper },
+    );
+
+    act(() => result.current.recordMountedChat());
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(true);
+
+    act(() => result.current.acknowledgeRelease());
+    expect(result.current.releasePending).toBe(false);
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(false);
+  });
+
+  it("requires a new mounted chat after reset cancels a pending release", () => {
+    const { result, rerender } = renderHook(
+      ({ complete }: { complete: boolean | null }) =>
+        useFirstRunChatRelease(complete),
+      { initialProps: { complete: false }, wrapper: strictWrapper },
+    );
+
+    act(() => result.current.recordMountedChat());
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(true);
+
+    rerender({ complete: false });
+    expect(result.current.releasePending).toBe(false);
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(false);
+
+    rerender({ complete: false });
+    act(() => result.current.recordMountedChat());
+    rerender({ complete: true });
+    expect(result.current.releasePending).toBe(true);
+  });
+});

--- a/packages/ui/src/state/use-first-run-chat-release.ts
+++ b/packages/ui/src/state/use-first-run-chat-release.ts
@@ -9,37 +9,65 @@ import {
   acknowledgeFirstRunChatRelease,
   createFirstRunChatReleaseState,
   observeFirstRunCompletion,
-  recordMountedFirstRunChat,
+  recordMountedFirstRunOverlay,
+  recordMountedFirstRunTranscript,
 } from "./first-run-chat-release";
+import type { StartupPhaseValue } from "./startup-coordinator";
 
 export interface FirstRunChatReleaseController {
   releasePending: boolean;
-  recordMountedChat: () => void;
+  recordMountedOverlay: () => void;
+  recordMountedTranscript: () => void;
   acknowledgeRelease: () => void;
 }
 
 export function useFirstRunChatRelease(
   firstRunComplete: boolean | null,
+  startupPhase: StartupPhaseValue,
 ): FirstRunChatReleaseController {
-  const lifecycleRef = useRef(createFirstRunChatReleaseState(firstRunComplete));
+  const lifecycleRef = useRef(
+    createFirstRunChatReleaseState(firstRunComplete, startupPhase),
+  );
   const [releasePending, setReleasePending] = useState(false);
 
   useLayoutEffect(() => {
     lifecycleRef.current = observeFirstRunCompletion(
       lifecycleRef.current,
       firstRunComplete,
+      startupPhase,
     );
     setReleasePending(lifecycleRef.current.releasePending);
-  }, [firstRunComplete]);
+  }, [firstRunComplete, startupPhase]);
 
-  const recordMountedChat = useCallback(() => {
-    lifecycleRef.current = recordMountedFirstRunChat(lifecycleRef.current);
-  }, []);
+  const recordMountedOverlay = useCallback(() => {
+    lifecycleRef.current = observeFirstRunCompletion(
+      lifecycleRef.current,
+      firstRunComplete,
+      startupPhase,
+    );
+    lifecycleRef.current = recordMountedFirstRunOverlay(lifecycleRef.current);
+  }, [firstRunComplete, startupPhase]);
+
+  const recordMountedTranscript = useCallback(() => {
+    lifecycleRef.current = observeFirstRunCompletion(
+      lifecycleRef.current,
+      firstRunComplete,
+      startupPhase,
+    );
+    lifecycleRef.current = recordMountedFirstRunTranscript(
+      lifecycleRef.current,
+    );
+  }, [firstRunComplete, startupPhase]);
 
   const acknowledgeRelease = useCallback(() => {
     lifecycleRef.current = acknowledgeFirstRunChatRelease(lifecycleRef.current);
     setReleasePending(lifecycleRef.current.releasePending);
   }, []);
 
-  return { releasePending, recordMountedChat, acknowledgeRelease };
+  return {
+    releasePending,
+    recordMountedOverlay,
+    recordMountedTranscript,
+    acknowledgeRelease,
+  };
 }

--- a/packages/ui/src/state/use-first-run-chat-release.ts
+++ b/packages/ui/src/state/use-first-run-chat-release.ts
@@ -1,0 +1,45 @@
+/**
+ * Owns committed first-run chat release state above overlay remounts. Lifecycle
+ * transitions run in layout effects or event callbacks so an interrupted React
+ * render cannot manufacture, consume, or reset a FULL-detent release.
+ */
+
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  acknowledgeFirstRunChatRelease,
+  createFirstRunChatReleaseState,
+  observeFirstRunCompletion,
+  recordMountedFirstRunChat,
+} from "./first-run-chat-release";
+
+export interface FirstRunChatReleaseController {
+  releasePending: boolean;
+  recordMountedChat: () => void;
+  acknowledgeRelease: () => void;
+}
+
+export function useFirstRunChatRelease(
+  firstRunComplete: boolean | null,
+): FirstRunChatReleaseController {
+  const lifecycleRef = useRef(createFirstRunChatReleaseState(firstRunComplete));
+  const [releasePending, setReleasePending] = useState(false);
+
+  useLayoutEffect(() => {
+    lifecycleRef.current = observeFirstRunCompletion(
+      lifecycleRef.current,
+      firstRunComplete,
+    );
+    setReleasePending(lifecycleRef.current.releasePending);
+  }, [firstRunComplete]);
+
+  const recordMountedChat = useCallback(() => {
+    lifecycleRef.current = recordMountedFirstRunChat(lifecycleRef.current);
+  }, []);
+
+  const acknowledgeRelease = useCallback(() => {
+    lifecycleRef.current = acknowledgeFirstRunChatRelease(lifecycleRef.current);
+    setReleasePending(lifecycleRef.current.releasePending);
+  }, []);
+
+  return { releasePending, recordMountedChat, acknowledgeRelease };
+}

--- a/packages/ui/src/state/use-first-run-chat-release.ts
+++ b/packages/ui/src/state/use-first-run-chat-release.ts
@@ -17,8 +17,10 @@ import type { StartupPhaseValue } from "./startup-coordinator";
 export interface FirstRunChatReleaseController {
   releasePending: boolean;
   mountedOnboarding: boolean;
-  recordMountedOverlay: () => void;
-  recordMountedTranscript: () => void;
+  mountEpoch: number | null;
+  authorityEpoch: number | null;
+  recordMountedOverlay: (epoch: number) => void;
+  recordMountedTranscript: (epoch: number) => void;
   acknowledgeRelease: () => void;
 }
 
@@ -31,14 +33,26 @@ export function useFirstRunChatRelease(
   );
   const [releasePending, setReleasePending] = useState(false);
   const [mountedOnboarding, setMountedOnboarding] = useState(false);
+  const [mountEpoch, setMountEpoch] = useState<number | null>(
+    lifecycleRef.current.incompleteActive
+      ? lifecycleRef.current.incompleteEpoch
+      : null,
+  );
+  const [authorityEpoch, setAuthorityEpoch] = useState<number | null>(
+    lifecycleRef.current.authoritativeEpoch,
+  );
 
   const syncMountedOnboarding = useCallback(() => {
     const lifecycle = lifecycleRef.current;
     setMountedOnboarding(
-      lifecycle.observedIncomplete &&
-        lifecycle.overlayMountedWhileIncomplete &&
-        lifecycle.transcriptMountedWhileIncomplete,
+      lifecycle.authoritativeEpoch === lifecycle.incompleteEpoch &&
+        lifecycle.overlayMountedEpoch === lifecycle.incompleteEpoch &&
+        lifecycle.transcriptMountedEpoch === lifecycle.incompleteEpoch,
     );
+    setMountEpoch(
+      lifecycle.incompleteActive ? lifecycle.incompleteEpoch : null,
+    );
+    setAuthorityEpoch(lifecycle.authoritativeEpoch);
   }, []);
 
   useLayoutEffect(() => {
@@ -51,27 +65,37 @@ export function useFirstRunChatRelease(
     syncMountedOnboarding();
   }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
 
-  const recordMountedOverlay = useCallback(() => {
-    lifecycleRef.current = observeFirstRunCompletion(
-      lifecycleRef.current,
-      firstRunComplete,
-      startupPhase,
-    );
-    lifecycleRef.current = recordMountedFirstRunOverlay(lifecycleRef.current);
-    syncMountedOnboarding();
-  }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
+  const recordMountedOverlay = useCallback(
+    (epoch: number) => {
+      lifecycleRef.current = observeFirstRunCompletion(
+        lifecycleRef.current,
+        firstRunComplete,
+        startupPhase,
+      );
+      lifecycleRef.current = recordMountedFirstRunOverlay(
+        lifecycleRef.current,
+        epoch,
+      );
+      syncMountedOnboarding();
+    },
+    [firstRunComplete, startupPhase, syncMountedOnboarding],
+  );
 
-  const recordMountedTranscript = useCallback(() => {
-    lifecycleRef.current = observeFirstRunCompletion(
-      lifecycleRef.current,
-      firstRunComplete,
-      startupPhase,
-    );
-    lifecycleRef.current = recordMountedFirstRunTranscript(
-      lifecycleRef.current,
-    );
-    syncMountedOnboarding();
-  }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
+  const recordMountedTranscript = useCallback(
+    (epoch: number) => {
+      lifecycleRef.current = observeFirstRunCompletion(
+        lifecycleRef.current,
+        firstRunComplete,
+        startupPhase,
+      );
+      lifecycleRef.current = recordMountedFirstRunTranscript(
+        lifecycleRef.current,
+        epoch,
+      );
+      syncMountedOnboarding();
+    },
+    [firstRunComplete, startupPhase, syncMountedOnboarding],
+  );
 
   const acknowledgeRelease = useCallback(() => {
     lifecycleRef.current = acknowledgeFirstRunChatRelease(lifecycleRef.current);
@@ -81,6 +105,8 @@ export function useFirstRunChatRelease(
   return {
     releasePending,
     mountedOnboarding,
+    mountEpoch,
+    authorityEpoch,
     recordMountedOverlay,
     recordMountedTranscript,
     acknowledgeRelease,

--- a/packages/ui/src/state/use-first-run-chat-release.ts
+++ b/packages/ui/src/state/use-first-run-chat-release.ts
@@ -16,6 +16,7 @@ import type { StartupPhaseValue } from "./startup-coordinator";
 
 export interface FirstRunChatReleaseController {
   releasePending: boolean;
+  mountedOnboarding: boolean;
   recordMountedOverlay: () => void;
   recordMountedTranscript: () => void;
   acknowledgeRelease: () => void;
@@ -29,6 +30,16 @@ export function useFirstRunChatRelease(
     createFirstRunChatReleaseState(firstRunComplete, startupPhase),
   );
   const [releasePending, setReleasePending] = useState(false);
+  const [mountedOnboarding, setMountedOnboarding] = useState(false);
+
+  const syncMountedOnboarding = useCallback(() => {
+    const lifecycle = lifecycleRef.current;
+    setMountedOnboarding(
+      lifecycle.observedIncomplete &&
+        lifecycle.overlayMountedWhileIncomplete &&
+        lifecycle.transcriptMountedWhileIncomplete,
+    );
+  }, []);
 
   useLayoutEffect(() => {
     lifecycleRef.current = observeFirstRunCompletion(
@@ -37,7 +48,8 @@ export function useFirstRunChatRelease(
       startupPhase,
     );
     setReleasePending(lifecycleRef.current.releasePending);
-  }, [firstRunComplete, startupPhase]);
+    syncMountedOnboarding();
+  }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
 
   const recordMountedOverlay = useCallback(() => {
     lifecycleRef.current = observeFirstRunCompletion(
@@ -46,7 +58,8 @@ export function useFirstRunChatRelease(
       startupPhase,
     );
     lifecycleRef.current = recordMountedFirstRunOverlay(lifecycleRef.current);
-  }, [firstRunComplete, startupPhase]);
+    syncMountedOnboarding();
+  }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
 
   const recordMountedTranscript = useCallback(() => {
     lifecycleRef.current = observeFirstRunCompletion(
@@ -57,7 +70,8 @@ export function useFirstRunChatRelease(
     lifecycleRef.current = recordMountedFirstRunTranscript(
       lifecycleRef.current,
     );
-  }, [firstRunComplete, startupPhase]);
+    syncMountedOnboarding();
+  }, [firstRunComplete, startupPhase, syncMountedOnboarding]);
 
   const acknowledgeRelease = useCallback(() => {
     lifecycleRef.current = acknowledgeFirstRunChatRelease(lifecycleRef.current);
@@ -66,6 +80,7 @@ export function useFirstRunChatRelease(
 
   return {
     releasePending,
+    mountedOnboarding,
     recordMountedOverlay,
     recordMountedTranscript,
     acknowledgeRelease,


### PR DESCRIPTION
# Relates to

Closes #22838.

- [x] Targets `develop` and was lease-guarded/restacked onto live `develop` `61af9b80a81dc3dc0548841efff18e7532745438` with zero touched-path conflicts.
- [ ] Root `bun run verify` is not complete; exact blockers are recorded below.
- [ ] Final bundle-first UI evidence is not complete; keep this PR draft and unmerged.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `1f79daf6179e0cdd07ceeb56c59a86ec08455eeb` has parent chain rooted at live `develop` `61af9b80a81dc3dc0548841efff18e7532745438`.
- [ ] `bun run verify` remains blocked by host disk/dependency pressure described below.

# Risks

Low-to-medium UI lifecycle risk. The change narrows the retained full-detent release to a chat that actually mounted while first run was incomplete. The principal regression risk is losing the genuine onboarding completion handoff across an overlay remount; focused state and real `ChatOverlay` tests cover that edge.

# Background

## What does this PR do?

Completed-user startup/probe transitions no longer impersonate a visibly mounted onboarding chat. The parent shell records whether the first-run chat actually mounted while incomplete, retains only that authorized completion edge across an overlay remount, and acknowledges it after the remounted overlay opens full. A completed-user cold boot therefore stays at the normal input/rest state.

## What kind of change is this?

Bug fix with focused lifecycle, component, shell-wiring, and production audit assertions.

# Documentation changes needed?

N/A - this repairs internal UI lifecycle behavior without changing a public contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/state/first-run-chat-release.ts`
- `packages/ui/src/App.tsx`
- `packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx`
- `packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts`

## Detailed testing steps

- Focused state plus real component completion/remount cases: 5/5 passed.
- App shell wiring suite: 15/15 passed.
- Full two-file lifecycle/component lane: 30/31 passed; the sole failure is the unchanged stale `chat-thread-top-fade` assertion, outside this five-file patch.
- Biome: 5/5 touched files clean.
- `@elizaos/ui` typecheck: passed.
- `@elizaos/ui` build and 46 runtime-export verification checks: passed.
- Prior pre-restack `/chat` production capture showed `data-chat-state=INPUT`, a mounted resting overlay, zero console/render/blue/hover/overflow findings, and packaged OCR `verified`. This is diagnostic only, not exact-head bundle evidence.

## Known gaps / failures

- Canonical `node scripts/evidence-review/run-matrix.mjs --only=app-audit --no-open` was attempted twice. Both runs completed their prerequisite view/core/shared builds and were then externally terminated with SIGTERM/exit 143 during `audit:app:capture`, with more than 3 GiB free and before any capture artifact or bundle was written.
- App typecheck initially lacked `@elizaos/app-core`; after building app-core it advanced to missing many other workspace dist packages through the shared dependency tree. No source-local type error in this patch was reported. A full dependency build/install was not safe under the host disk ceiling.
- Before/after desktop+mobile captures, walkthrough MP4, frontend/network logs, exact-head OCR, and a verified evidence bundle remain required before this draft can become mergeable.

# Evidence Gate

<!-- evidence-head:0ed72e401b6077f5cb16219a570b979ee1e54fc3 -->

<!-- evidence-row:before-screenshots -->
- [ ] Missing - exact-head before desktop and mobile screenshots are still required.
<!-- evidence-row:after-screenshots -->
- [ ] Missing - exact-head after desktop and mobile screenshots are still required.
<!-- evidence-row:walkthrough-video -->
- [ ] Missing - exact-head MP4 walkthrough is still required.
<!-- evidence-row:backend-logs -->
- [x] N/A - this patch changes client-only lifecycle state and does not fire a backend path.
<!-- evidence-row:frontend-logs -->
- [ ] Missing - exact-head frontend console and network logs are still required.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, schedule, wallet, chain, audio, or generated-domain artifact changes.
<!-- evidence-row:ocr-review -->
- [ ] Missing - exact-head packaged OCR output in a verified bundle is still required.

# Evidence Details

The earlier raw single-view capture was manually inspected and showed the completed-user `/chat` surface at rest with the underlying Today content unobscured. It is deliberately not attached as final evidence because `develop` advanced after capture and the current bundle-first contract requires a finalized exact-head bundle.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - direct repository implementation
Attribution status: self-reported
— [codex-cortex-wave-new]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - direct repository implementation"} -->

