### PR TITLE
fix(coding-tools): gate destructive shell separators

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -3215,6 +3215,120 @@ describe("destructive-bulk confirm gate", () => {
     },
   );
 
+  it.each([
+    ["line feed", "\n"],
+    ["carriage return", "\r"],
+    ["background separator", " & "],
+  ])(
+    "blocks an unconfirmed recursive delete after an unquoted %s",
+    async (_name, separator) => {
+      const { command, target } = await createRecursiveDeleteCommand();
+      const { runtime } = await makeRuntime();
+      try {
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(undefined, "inspect, then clean up the old projects"),
+          undefined,
+          { command: `printf safe${separator}${command}` },
+        );
+        expect(result.success).toBe(false);
+        expect(result.text).toContain("needs_confirmation");
+        expect(result.data).toMatchObject({
+          destructive_reason: "recursive delete",
+        });
+        expect(await pathExists(target)).toBe(true);
+      } finally {
+        await fs.rm(target, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not gate destructive-looking heredoc data",
+    async () => {
+      const { runtime } = await makeRuntime();
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "print this example without running it"),
+        undefined,
+        { command: "cat <<'EOF'\nrm -rf ./data\nEOF" },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("rm -rf ./data");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not let parameter expansion text hide a recursive delete",
+    async () => {
+      const { command, target } = await createRecursiveDeleteCommand();
+      const { runtime } = await makeRuntime();
+      try {
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(undefined, "inspect, then clean up the old projects"),
+          undefined,
+          {
+            command: `printf '%s' \${review_unset:-<<EOF}\n${command}\nEOF`,
+          },
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.text).toContain("needs_confirmation");
+        expect(result.data).toMatchObject({
+          destructive_reason: "recursive delete",
+        });
+        expect(await pathExists(target)).toBe(true);
+      } finally {
+        await fs.rm(target, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "gates executable lines after arithmetic shifts and continued heredoc terminators",
+    async () => {
+      const commandShapes = [
+        (command: string) =>
+          `review_slots[1<<2]=ready\n${command}\n2]=ready\n:`,
+        (command: string) => `printf '%s' $[1<<2]\n${command}\n2]\n:`,
+        (command: string) =>
+          `cat <<EOF\nsafe payload\nEO\\\nF\n${command}\nEOF\n:`,
+      ];
+
+      for (const shape of commandShapes) {
+        const syntaxProbe = await execFileAsync("/bin/bash", [
+          "--noprofile",
+          "--norc",
+          "-c",
+          shape("printf shell-boundary"),
+        ]);
+        expect(syntaxProbe.stdout).toContain("shell-boundary");
+
+        const { command, target } = await createRecursiveDeleteCommand();
+        const { runtime } = await makeRuntime();
+        try {
+          const result = await shellAction.handler?.(
+            runtime,
+            makeMessage(undefined, "inspect, then clean up the old projects"),
+            undefined,
+            { command: shape(command) },
+          );
+
+          expect(result.success).toBe(false);
+          expect(result.text).toContain("needs_confirmation");
+          expect(result.data).toMatchObject({
+            destructive_reason: "recursive delete",
+          });
+          expect(await pathExists(target)).toBe(true);
+        } finally {
+          await fs.rm(target, { recursive: true, force: true });
+        }
+      }
+    },
+  );
+
   it("runs the same command when confirm=true", async () => {
     const { command, target } = await createRecursiveDeleteCommand();
     const { runtime } = await makeRuntime();

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -74,6 +74,17 @@ describe("classifyDestructiveCommand — fires", () => {
     const v = classifyDestructiveCommand("ls && rm -rf ./data");
     expect(v.destructive).toBe(true);
   });
+  it.each([
+    ["line feed", "printf safe\nrm -rf ./data"],
+    ["carriage return", "printf safe\rrm -rf ./data"],
+    ["background separator", "printf safe & rm -rf ./data"],
+  ])("recursive rm hidden behind an unquoted %s", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./data"],
+    });
+  });
   it("forced glob delete", () => {
     expect(
       classifyDestructiveCommand("rm -f /var/log/app/*.log").destructive,
@@ -128,6 +139,100 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
   it("quoted rm -rf inside a string argument does not fire", () => {
     expect(
       classifyDestructiveCommand('echo "rm -rf would be bad"').destructive,
+    ).toBe(false);
+  });
+  it.each([
+    ["line feed", "printf 'safe\nrm -rf ./data'"],
+    ["carriage return", "printf 'safe\rrm -rf ./data'"],
+    ["ampersand", "printf 'safe & rm -rf ./data'"],
+    ["escaped ampersand", "printf safe \\& rm -rf ./data"],
+    ["escaped line feed", "printf safe \\\nrm -rf ./data"],
+    ["file-descriptor redirect", "echo ok 2>&1"],
+    ["combined output redirect", "printf ok &> ./out"],
+    ["CRLF quoted content", "printf 'safe\r\nrm -rf ./data'"],
+    ["escaped double quote", String.raw`printf "safe \"rm -rf ./data\""`],
+  ])("%s remains one benign segment", (_name, command) => {
+    expect(classifyDestructiveCommand(command).destructive).toBe(false);
+  });
+
+  it.each([
+    ["unquoted", "cat <<EOF\nrm -rf ./data\nEOF"],
+    ["single-quoted", "cat <<'EOF'\nrm -rf ./data\nEOF"],
+    ["double-quoted", 'cat <<"EOF"\nDROP DATABASE production\nEOF'],
+    ["concatenated quoted word", "cat <<'E'OF\nrm -rf ./data\nEOF"],
+    ["tab-stripped", "cat <<-EOF\n\trm -rf ./data\n\tEOF"],
+  ])(
+    "%s heredoc payload is data, not an executable segment",
+    (_name, command) => {
+      expect(classifyDestructiveCommand(command).destructive).toBe(false);
+    },
+  );
+
+  it("resumes classification after a heredoc terminator", () => {
+    expect(
+      classifyDestructiveCommand(
+        "cat <<EOF\nrm -rf ./data\nEOF\nrm -rf ./cache",
+      ),
+    ).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./cache"],
+    });
+  });
+
+  it.each([
+    ["expansion", "echo $((1 << 2))\nrm -rf ./data"],
+    ["command", "(( flags << 1 ))\nrm -rf ./data"],
+    ["legacy expansion", "echo $[1<<2]\nrm -rf ./data\n2]"],
+    ["indexed assignment", "slots[1<<2]=ready\nrm -rf ./data\n2]=ready"],
+  ])("does not mistake an arithmetic %s for a heredoc", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./data"],
+    });
+  });
+
+  it("resumes after an unquoted heredoc terminator uses line continuation", () => {
+    expect(
+      classifyDestructiveCommand(
+        "cat <<EOF\nsafe payload\nEO\\\nF\nrm -rf ./data\nEOF",
+      ),
+    ).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./data"],
+    });
+  });
+
+  it.each([
+    ["simple", `echo \${value:-<<EOF}\nrm -rf ./data\nEOF`],
+    ["nested", `echo \${value:-\${fallback:-<<EOF}}\nrm -rf ./data\nEOF`],
+    ["continued delimiter", "cat <<EO\\\nF\npayload\nEOF\nrm -rf ./data"],
+    ["continued declaration", "cat <<EOF \\\n; rm -rf ./data\npayload\nEOF"],
+  ])("does not let a %s hide a later executable segment", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./data"],
+    });
+  });
+
+  it.each([
+    ["semicolon", "echo hi;# cat <<EOF\nrm -rf ./data\nEOF"],
+    ["background operator", "echo hi &# cat <<EOF\nrm -rf ./data\nEOF"],
+  ])("ignores a fake heredoc in a comment after a %s", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./data"],
+    });
+  });
+
+  it("does not fold a quoted heredoc body's continued physical lines", () => {
+    expect(
+      classifyDestructiveCommand("cat <<'EOF'\nEO\\\nF\nrm -rf ./data\nEOF")
+        .destructive,
     ).toBe(false);
   });
 });

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -68,9 +68,231 @@ const POWERSHELL_REMOVE_ITEM_BINS = new Set([
 const DESTRUCTIVE_BINS = new Set(["mkfs", "shred", "wipefs"]);
 const DROP_SQL = /\bdrop\s+(database|table|schema)\s+(\S+)/i;
 
+interface HeredocDeclaration {
+  delimiter: string;
+  quoted: boolean;
+  stripTabs: boolean;
+}
+
+interface ParsedHeredocDelimiter {
+  delimiter: string;
+  quoted: boolean;
+}
+
+function hasTrailingLineContinuation(line: string): boolean {
+  let backslashes = 0;
+  for (let i = line.length - 1; i >= 0 && line[i] === "\\"; i -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function parseHeredocDelimiter(
+  line: string,
+  start: number,
+): ParsedHeredocDelimiter | null {
+  let cursor = start;
+  let delimiter = "";
+  let quote: string | null = null;
+  let quoted = false;
+
+  while (cursor < line.length) {
+    const ch = line[cursor] as string;
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        cursor += 1;
+        continue;
+      }
+      if (
+        quote === '"' &&
+        ch === "\\" &&
+        cursor + 1 < line.length &&
+        /[$`"\\]/.test(line[cursor + 1] as string)
+      ) {
+        cursor += 1;
+      }
+      delimiter += line[cursor] as string;
+      cursor += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quoted = true;
+      quote = ch;
+      cursor += 1;
+      continue;
+    }
+    if (ch === "\\" && cursor + 1 < line.length) {
+      quoted = true;
+      cursor += 1;
+      delimiter += line[cursor] as string;
+      cursor += 1;
+      continue;
+    }
+    if (/[\s|;&<>()]/.test(ch)) break;
+    delimiter += ch;
+    cursor += 1;
+  }
+
+  return quote === null && delimiter ? { delimiter, quoted } : null;
+}
+
+function isInsideArrayAssignmentSubscript(
+  line: string,
+  operatorIndex: number,
+): boolean {
+  // Bash evaluates a balanced `name[...]` assignment as arithmetic before it
+  // considers redirections. Be conservative about command position: declining
+  // to mask a lookalike can only add confirmation, while masking one can hide
+  // an executable line.
+  let tokenStart = operatorIndex;
+  while (tokenStart > 0 && !/[\s;|&()]/.test(line[tokenStart - 1] as string)) {
+    tokenStart -= 1;
+  }
+
+  const prefix = line.slice(tokenStart, operatorIndex);
+  const openingBracket = prefix.indexOf("[");
+  if (
+    openingBracket < 1 ||
+    !/^[A-Za-z_][A-Za-z0-9_]*$/.test(prefix.slice(0, openingBracket))
+  ) {
+    return false;
+  }
+
+  let bracketDepth = 0;
+  for (
+    let cursor = tokenStart + openingBracket;
+    cursor < line.length;
+    cursor += 1
+  ) {
+    const ch = line[cursor] as string;
+    if (ch === "[") bracketDepth += 1;
+    else if (ch === "]") {
+      bracketDepth -= 1;
+      if (bracketDepth === 0) {
+        return /^(?:\+?=)/.test(line.slice(cursor + 1));
+      }
+    }
+  }
+  return false;
+}
+
+function heredocDeclarations(line: string): HeredocDeclaration[] {
+  const declarations: HeredocDeclaration[] = [];
+  let arithmeticDepth = 0;
+  let legacyArithmeticDepth = 0;
+  let parameterExpansionDepth = 0;
+  let quote: string | null = null;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i] as string;
+    if (quote) {
+      if (quote === '"' && ch === "\\" && i + 1 < line.length) i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "\\" && i + 1 < line.length) {
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "(" && line[i + 1] === "(") {
+      arithmeticDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (arithmeticDepth > 0 && ch === ")" && line[i + 1] === ")") {
+      arithmeticDepth -= 1;
+      i += 1;
+      continue;
+    }
+    if (arithmeticDepth > 0) continue;
+    if (ch === "$" && line[i + 1] === "[") {
+      legacyArithmeticDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (legacyArithmeticDepth > 0) {
+      if (ch === "[") legacyArithmeticDepth += 1;
+      else if (ch === "]") legacyArithmeticDepth -= 1;
+      continue;
+    }
+    if (ch === "$" && line[i + 1] === "{") {
+      parameterExpansionDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (parameterExpansionDepth > 0) {
+      if (ch === "}") parameterExpansionDepth -= 1;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /[\s;|&()]/.test(line[i - 1] as string)))
+      break;
+    if (ch !== "<" || line[i + 1] !== "<" || line[i + 2] === "<") continue;
+    if (isInsideArrayAssignmentSubscript(line, i)) continue;
+
+    let cursor = i + 2;
+    const stripTabs = line[cursor] === "-";
+    if (stripTabs) cursor += 1;
+    while (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
+
+    const parsed = parseHeredocDelimiter(line, cursor);
+    if (parsed !== null) declarations.push({ ...parsed, stripTabs });
+  }
+  return declarations;
+}
+
+// Heredoc bodies are shell input, not commands. Preserve their newlines so
+// later executable lines remain segment boundaries, but hide payload bytes
+// from both the command and SQL classifiers.
+function maskHeredocBodies(command: string): string {
+  const lines = command.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g) ?? [];
+  const pending: HeredocDeclaration[] = [];
+  let continuedBodyLine = "";
+
+  return lines
+    .map((line) => {
+      const newline = line.endsWith("\r\n")
+        ? "\r\n"
+        : line.endsWith("\n")
+          ? "\n"
+          : line.endsWith("\r")
+            ? "\r"
+            : "";
+      const content = newline ? line.slice(0, -newline.length) : line;
+      const active = pending[0];
+      if (active) {
+        const comparable = active.stripTabs
+          ? content.replace(/^\t+/, "")
+          : content;
+        const joinsNextLine =
+          !active.quoted && hasTrailingLineContinuation(comparable);
+        continuedBodyLine += joinsNextLine
+          ? comparable.slice(0, -1)
+          : comparable;
+        if (!joinsNextLine) {
+          if (continuedBodyLine === active.delimiter) pending.shift();
+          continuedBodyLine = "";
+        }
+        return `${" ".repeat(content.length)}${newline}`;
+      }
+      // A physical newline escaped with a trailing backslash is part of the
+      // declaration's logical command line, not the start of heredoc data.
+      // Decline to mask this uncommon form rather than hide executable text.
+      if (!hasTrailingLineContinuation(content)) {
+        pending.push(...heredocDeclarations(content));
+      }
+      return line;
+    })
+    .join("");
+}
+
 function splitSegments(command: string): string[] {
-  // Chain + pipeline split; quotes are respected coarsely — a metacharacter
-  // inside quotes stays put because we only split on unquoted operators.
+  // Split shell list/pipeline operators while retaining quoted or backslash-
+  // escaped characters in their current segment.
   const segments: string[] = [];
   let current = "";
   let quote: string | null = null;
@@ -78,7 +300,18 @@ function splitSegments(command: string): string[] {
     const ch = command[i] as string;
     if (quote) {
       current += ch;
+      if (quote === '"' && ch === "\\" && i + 1 < command.length) {
+        current += command[i + 1] as string;
+        i += 1;
+        continue;
+      }
       if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "\\" && i + 1 < command.length) {
+      current += ch;
+      current += command[i + 1] as string;
+      i += 1;
       continue;
     }
     if (ch === '"' || ch === "'") {
@@ -86,10 +319,10 @@ function splitSegments(command: string): string[] {
       current += ch;
       continue;
     }
-    if (ch === "|" || ch === ";" || (ch === "&" && command[i + 1] === "&")) {
+    if (ch === "|" || ch === ";" || ch === "&" || ch === "\n" || ch === "\r") {
       segments.push(current);
       current = "";
-      if (ch === "&") i += 1;
+      if (ch === "&" && command[i + 1] === "&") i += 1;
       continue;
     }
     current += ch;
@@ -105,7 +338,8 @@ function tokens(segment: string): string[] {
 export function classifyDestructiveCommand(
   command: string,
 ): DestructiveVerdict {
-  const sql = DROP_SQL.exec(command);
+  const executableCommand = maskHeredocBodies(command);
+  const sql = DROP_SQL.exec(executableCommand);
   if (sql) {
     return {
       destructive: true,
@@ -113,7 +347,7 @@ export function classifyDestructiveCommand(
       targets: [sql[2] ?? ""],
     };
   }
-  for (const segment of splitSegments(command)) {
+  for (const segment of splitSegments(executableCommand)) {
     const argv = tokens(segment);
     // env-var prefixes (FOO=bar cmd …) precede the executable
     let i = 0;


### PR DESCRIPTION
Closes #22810

## Summary

- recognize unquoted LF, CR, and single `&` shell list separators in the destructive-command confirmation classifier
- preserve quoted and backslash-escaped separator content as part of the current command segment
- mask real heredoc bodies without hiding executable text inside parameter expansions, Bash arithmetic contexts, or across continued unquoted heredoc terminators
- prove the real `/bin/bash` parser reaches the guarded lines and the exported `SHELL` action returns `needs_confirmation` before dispatch

Credit to @agent-cortex for the original issue reproduction. The originally announced implementation claim produced no branch or PR during the documented grace window, so this PR is an independent current-develop repair.

## Exact-head verification

Exact head: `a17bf85e5b03a0e7b19492bed36b3d5115de5432`

Base: `fa0a7baf68876cd550d8573cae5876bedd44e54b`

- empty-environment Mode B classifier boundary: 62/62 passed
- empty-environment real Bash/exported `SHELL` boundary: 1/1 test passed across three parser/execution shapes; every action call returned `needs_confirmation` and preserved its disposable target
- load-bearing review: arithmetic shift syntax and unquoted continued terminators are interpreted consistently with Bash, while quoted heredoc continuation remains literal payload data
- `bun run --cwd plugins/plugin-coding-tools typecheck`: passed
- `bun run --cwd plugins/plugin-coding-tools build`: passed (Node and declarations)
- pinned Biome on all three changed files: passed
- `git diff --check`: passed
- full package Vitest: 38 files, 659/659 tests passed

## Evidence Gate

<!-- evidence-head:a17bf85e5b03a0e7b19492bed36b3d5115de5432 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only command classification; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only command classification; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [x] [22848-exact-head.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22848-exact-head.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic command parsing occurs after action selection and requires no model call.
<!-- evidence-row:domain-artifacts -->
- [x] [22848-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22848-domain-artifact.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels changed.

## Risk

Low and fail-safe. The separators mirror Bash command-list boundaries. Quoted and escaped controls preserve benign content. Heredoc masking only suppresses bytes that Bash treats as body data; ambiguous arithmetic or continued forms remain visible to the confirmation classifier. The gate only asks for confirmation; it does not execute or refuse a confirmed operation.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->



