### PR TITLE
fix(orchestrator): port administrative-stop marker so lifecycle stops stop narrating as failures

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
@@ -4,7 +4,7 @@
  * method, and never throws when the stamp fails (fail-open toward the
  * never-silent-terminal invariant — the stop must proceed regardless).
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 import {
   ADMIN_STOP_META_KEY,
   markSessionAdministrativelyStopped,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Deterministic tests for the administrative-stop marker: the stamp merges the
+ * ONE canonical key via updateSessionMetadata, tolerates services without the
+ * method, and never throws when the stamp fails (fail-open toward the
+ * never-silent-terminal invariant — the stop must proceed regardless).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  ADMIN_STOP_META_KEY,
+  markSessionAdministrativelyStopped,
+} from "../services/admin-stop-marker";
+
+describe("markSessionAdministrativelyStopped", () => {
+  test("stamps the canonical key with the reason", async () => {
+    const patches: Array<[string, Record<string, unknown>]> = [];
+    await markSessionAdministrativelyStopped(
+      {
+        updateSessionMetadata: async (id, patch) => {
+          patches.push([id, patch]);
+        },
+      },
+      "sess-1",
+      "user_stop",
+    );
+    expect(patches).toEqual([
+      ["sess-1", { [ADMIN_STOP_META_KEY]: "user_stop" }],
+    ]);
+  });
+
+  test("is a no-op for services without updateSessionMetadata", async () => {
+    await markSessionAdministrativelyStopped({}, "sess-2", "task_lifecycle");
+  });
+
+  test("never throws when the stamp fails, and reports through the logger", async () => {
+    const logged: string[] = [];
+    await markSessionAdministrativelyStopped(
+      {
+        updateSessionMetadata: async () => {
+          throw new Error("store gone");
+        },
+      },
+      "sess-3",
+      "idle_reclaim",
+      (msg) => logged.push(msg),
+    );
+    expect(logged.length).toBe(1);
+    expect(logged[0]).toContain("sess-3");
+    expect(logged[0]).toContain("store gone");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-suppression.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-suppression.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Exercises the swarm coordinator's administrative-stop suppression against
+ * the real service (deterministic ACP double, no subprocess): a `stopped`
+ * carrying `adminStopReason` is lifecycle plumbing and must not synthesize —
+ * and must NOT claim the synthesis dedupe slot, so a later genuine lineage
+ * completion still posts. An UNMARKED stop still synthesizes (the #11689
+ * never-silent-terminal invariant this suppression must not erode).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { ADMIN_STOP_META_KEY } from "../services/admin-stop-marker.js";
+import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
+
+type MetadataPatch = Record<string, unknown>;
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function storedSession(
+  id: string,
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    id,
+    agentType: "codex",
+    workdir: "/tmp/orchestrator-admin-stop-test",
+    status: "stopped",
+    metadata,
+  };
+}
+
+function makeCoordinatorHarness(sessions: Map<string, unknown>): {
+  service: SwarmCoordinatorService;
+  emit: (sessionId: string, event: string, data: unknown) => void;
+  completions: Array<{ status: string; sessionId: string }>;
+} {
+  const handlers: Array<
+    (sessionId: string, event: string, data: unknown) => void
+  > = [];
+  const acp = {
+    onSessionEvent(
+      handler: (sessionId: string, event: string, data: unknown) => void,
+    ) {
+      handlers.push(handler);
+      return () => {};
+    },
+    getSession: async (sessionId: string) => sessions.get(sessionId),
+    updateSessionMetadata: vi.fn(
+      async (sessionId: string, patch: MetadataPatch) => {
+        const session = sessions.get(sessionId) as
+          | { metadata?: Record<string, unknown> }
+          | undefined;
+        if (session) {
+          session.metadata = { ...session.metadata, ...patch };
+        }
+      },
+    ),
+  };
+  const runtime = {
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : null,
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+  const service = new SwarmCoordinatorService(runtime);
+  (service as unknown as { bindToAcp: () => void }).bindToAcp();
+  const completions: Array<{ status: string; sessionId: string }> = [];
+  service.setSwarmCompleteCallback(async (payload) => {
+    for (const task of payload.tasks) {
+      completions.push({ status: task.status, sessionId: task.sessionId });
+    }
+  });
+  return {
+    service,
+    emit: (sessionId, event, data) => {
+      for (const h of [...handlers]) h(sessionId, event, data);
+    },
+    completions,
+  };
+}
+
+describe("administrative-stop suppression", () => {
+  it("suppresses a marked stop and does NOT claim the dedupe slot — a later lineage completion still posts", async () => {
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-admin",
+        storedSession("sess-admin", { [ADMIN_STOP_META_KEY]: "user_stop" }),
+      ],
+    ]);
+    const { emit, completions } = makeCoordinatorHarness(sessions);
+
+    emit("sess-admin", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([]);
+
+    emit("sess-admin", "task_complete", { response: "done for real" });
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "completed", sessionId: "sess-admin" },
+    ]);
+  });
+
+  it("an UNMARKED stop still synthesizes — never-silent-terminal holds", async () => {
+    const sessions = new Map<string, unknown>([
+      ["sess-crash", storedSession("sess-crash", {})],
+    ]);
+    const { emit, completions } = makeCoordinatorHarness(sessions);
+
+    emit("sess-crash", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-crash" },
+    ]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -214,7 +214,7 @@ export function createActiveSessionForwardHandler(
               acp,
               active.id,
               "user_interrupt",
-            ).catch(() => undefined);
+            );
             // error-policy:J6 best-effort session cancel on interrupt; warn only
             await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
               runtime.logger?.warn?.(

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -14,6 +14,7 @@ import {
   type Memory,
 } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
+import { markSessionAdministrativelyStopped } from "./admin-stop-marker.js";
 import { decideInterruptionWithModel } from "./interruption-decider.js";
 import { sessionBoundRoomIds } from "./session-room-binding.js";
 import type { SubAgentInbox } from "./sub-agent-inbox.js";
@@ -206,6 +207,14 @@ export function createActiveSessionForwardHandler(
             // planner pipeline runs on this same MESSAGE_RECEIVED and routes
             // the user's redirect; we do not re-deliver to the dead session.
             subAgentInbox.clear(active.id);
+            // Stamp FIRST: the coordinator's stopped/cancelled synthesis reads
+            // this so a user-initiated interrupt never narrates as a task
+            // failure ("stopped before completion") or gets auto-retried.
+            await markSessionAdministrativelyStopped(
+              acp,
+              active.id,
+              "user_interrupt",
+            ).catch(() => undefined);
             // error-policy:J6 best-effort session cancel on interrupt; warn only
             await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
               runtime.logger?.warn?.(

--- a/plugins/plugin-agent-orchestrator/src/services/admin-stop-marker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/admin-stop-marker.ts
@@ -1,0 +1,52 @@
+/**
+ * Administrative-stop marker for ACP sessions.
+ *
+ * When the orchestrator tears a session down for lifecycle reasons (task
+ * archive/delete/pause, user stop, API stop) rather than the session dying on
+ * its own, downstream consumers must be able to tell the two apart: the swarm
+ * coordinator suppresses its "stopped before completion" synthesis for marked
+ * stops (the stop is plumbing the user already caused), and the mid-task
+ * forwarder drops marked sessions as a belt against stop-failure races. An
+ * UNMARKED stop (crash, subprocess death, genuine user-visible failure) must
+ * keep synthesizing — the #11689 never-silent-terminal invariant.
+ *
+ * ONE definition of the key lives here; do not add per-file literal copies.
+ */
+
+export const ADMIN_STOP_META_KEY = "adminStopReason";
+
+/**
+ * Best-effort stamp of {@link ADMIN_STOP_META_KEY} onto the session's
+ * metadata via `AcpService.updateSessionMetadata` (which merges the patch
+ * into the store snapshot the coordinator's fresh-metadata re-read observes).
+ * Never throws and never blocks the stop that follows it: a failed stamp only
+ * costs the suppression (the stop still synthesizes — fail-open toward the
+ * never-silent invariant).
+ */
+export async function markSessionAdministrativelyStopped(
+  service: {
+    updateSessionMetadata?: (
+      id: string,
+      patch: Record<string, unknown>,
+    ) => Promise<void>;
+  },
+  sessionId: string,
+  reason: string,
+  log?: (msg: string) => void,
+): Promise<void> {
+  if (typeof service.updateSessionMetadata !== "function") return;
+  try {
+    await service.updateSessionMetadata(sessionId, {
+      [ADMIN_STOP_META_KEY]: reason,
+    });
+  } catch (err) {
+    // error-policy:J6 best-effort teardown stamp on a session already being
+    // stopped; a missed stamp degrades to today's synthesized stop notice and
+    // must never block the stop itself.
+    log?.(
+      `admin-stop stamp failed for session ${sessionId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -50,6 +50,7 @@ import {
   shouldRequireGoalContract,
 } from "./acceptance-criteria.js";
 import { ACP_METADATA_ISOLATED_WORKDIR, AcpService } from "./acp-service.js";
+import { markSessionAdministrativelyStopped } from "./admin-stop-marker.js";
 import {
   type AdmissionRecord,
   orderQueue,
@@ -1462,6 +1463,13 @@ export class OrchestratorTaskService extends Service {
       await this.syncSmithersRunCopies(acp, completed, prepared.sessionId);
       if (!link.keepAliveAfterComplete) {
         try {
+          // Mark the stop administrative BEFORE stopping so the swarm
+          // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
+          await markSessionAdministrativelyStopped(
+            acp,
+            prepared.sessionId,
+            "smithers_recovery",
+          );
           await acp.stopSession(prepared.sessionId);
         } catch (err) {
           // error-policy:J6 the graph and both durable links are already
@@ -4597,6 +4605,13 @@ export class OrchestratorTaskService extends Service {
     } finally {
       unsubscribe?.();
       try {
+        // Mark the stop administrative BEFORE stopping so the swarm
+        // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
+        await markSessionAdministrativelyStopped(
+          acp,
+          verifierSessionId,
+          "verifier_teardown",
+        );
         await acp.stopSession(verifierSessionId);
       } catch (stopErr) {
         // error-policy:J6 best-effort teardown of the ephemeral verifier session;
@@ -5745,6 +5760,9 @@ export class OrchestratorTaskService extends Service {
       throw new Error("ACP service unavailable; cannot stop active session");
     }
     try {
+      // Mark the stop administrative BEFORE stopping so the swarm
+      // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
+      await markSessionAdministrativelyStopped(acp, sessionId, "user_stop");
       await acp.stopSession(sessionId);
     } catch (err) {
       // error-policy:J2 mark the session stop_failed for observability, then
@@ -6004,6 +6022,13 @@ export class OrchestratorTaskService extends Service {
     await Promise.all(
       active.map(async (session) => {
         try {
+          // Mark the stop administrative BEFORE stopping so the swarm
+          // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
+          await markSessionAdministrativelyStopped(
+            acp,
+            session.sessionId,
+            "task_lifecycle",
+          );
           await acp.stopSession(session.sessionId);
         } catch (err) {
           // error-policy:J1 collect per-session stop failures; the loop throws a
@@ -6561,6 +6586,9 @@ export class OrchestratorTaskService extends Service {
     const victim = candidates[0];
     if (!victim) return false;
     try {
+      // Mark the stop administrative BEFORE stopping so the swarm
+      // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
+      await markSessionAdministrativelyStopped(acp, victim.id, "idle_reclaim");
       await acp.stopSession(victim.id);
       this.log("info", "reclaimed idle keepAlive session for queued task", {
         sessionId: victim.id,

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -85,6 +85,7 @@ const ROUTER_OWNED_TERMINAL_EVENTS = new Set(["task_complete", "error"]);
 // synthesis must not post the old one (#11711). Matching local literal (no
 // import from sub-agent-router — see the ROUTER_ORIGIN_UUID_RE note).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+
 // Pending-handoff marker (matching local key literal — see
 // sub-agent-router.ts): the router stamps it on the ORIGINAL session at the
 // moment it decides on a verify-retry / respawn, BEFORE the successor spawn
@@ -98,6 +99,8 @@ const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 // the handoff's generation token, honored only while handoff-pending.ts
 // still registers it in-flight; a stale marker is ignored AND cleared so the
 // stop synthesizes exactly as if the marker had never leaked.
+import { ADMIN_STOP_META_KEY } from "./admin-stop-marker.js";
+
 const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
@@ -995,6 +998,21 @@ export class SwarmCoordinatorService
       // also refreshes the enrichment cache for downstream reads this turn).
       const fresh = await this.getFreshSessionMetadata(sessionId);
       if (readString(fresh, HANDED_OFF_SUCCESSOR_META_KEY)) {
+        return;
+      }
+      // Administrative stop (task archive/delete/pause, user stop, verifier
+      // teardown, idle reclaim): the lifecycle itself caused this teardown,
+      // so "stopped before completion" is noise the user already knows
+      // about. Suppress WITHOUT claiming the synthesizedCompletionSessions
+      // slot (same no-slot-claim contract as the handoff skip above) so a
+      // later genuine lineage completion still posts. An UNMARKED stop
+      // (crash, subprocess death) still synthesizes — the #11689
+      // never-silent-terminal invariant is the regression line.
+      const adminStop = readString(fresh, ADMIN_STOP_META_KEY);
+      if (adminStop) {
+        logger.debug(
+          `[SwarmCoordinatorService] suppressed administrative stop (sessionId=${sessionId}, reason=${adminStop})`,
+        );
         return;
       }
       // Handoff decided but successor spawn not yet settled: the stop is


### PR DESCRIPTION
# What changed

Ports the administrative-stop marker (live-branch proven) to develop's orchestrator — my retained lane. One canonical `adminStopReason` metadata key, stamped best-effort BEFORE every administrative `stopSession`:

- `recoverOneSmithersRun` → `smithers_recovery`
- `spawnReadOnlyVerifier` teardown → `verifier_teardown`
- `stopTaskAgent` (user/API stop) → `user_stop`
- `stopActiveSessions` (archive/delete/pause/update flows) → `task_lifecycle`
- `reclaimIdleSession` → `idle_reclaim`
- active-session-forward user-interrupt cancel → `user_interrupt`

The swarm coordinator's `stopped` synthesis suppresses marked stops **without claiming the dedupe slot** (same no-slot-claim contract as the handoff skip), so a later genuine lineage completion still posts. Unmarked stops (crash, subprocess death) synthesize unchanged — the #11689 never-silent-terminal invariant is the regression line. Stamps are fail-open: a failed stamp costs only the suppression, never blocks the stop.

Closes the long-standing leak where app-control/API-initiated stops posted spurious "stopped before completion" nags into origin rooms.

# Evidence

- New `admin-stop-marker.test.ts`: 3/3 (stamp shape, method-absent tolerance, fail-open with logger report).
- Synthesis-region regressions: `verify-retry-stop-race` 12/12 green with the change. The two failures in `verify-retry-busy-session` are **pre-existing on develop** — verified by stash baseline (identical 2-fail with the change removed); untouched here.
- Plugin typecheck 0 errors, biome clean.
- PR CI remains starved repo-wide — local receipts above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
