### PR TITLE
fix(core): bound action result diagnostics

### DIFF
--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -1333,6 +1333,101 @@ describe("executePlannedToolCall", () => {
 		);
 	});
 
+	it("bounds cyclic and deep handler results before completion diagnostics", async () => {
+		const cyclic: Record<string, unknown> = { label: "loop" };
+		cyclic.self = cyclic;
+		const cyclicDate = new Date("2026-08-20T00:00:00.000Z") as Date & {
+			apiKey?: string;
+			self?: unknown;
+		};
+		Object.defineProperties(cyclicDate, {
+			apiKey: { enumerable: true, value: "short-secret" },
+			self: { enumerable: true, value: cyclicDate },
+		});
+		const fallbackCanary = "sk-0123456789abcdefghij";
+		const fallbackValue = Symbol(fallbackCanary);
+		let deep: Record<string, unknown> = { leaf: "must-be-bounded" };
+		for (let depth = 0; depth < 12; depth += 1) {
+			deep = { child: deep };
+		}
+		const emitted: Array<{ type: EventType; payload: unknown }> = [];
+		const streamed: unknown[] = [];
+		let settledResult: unknown;
+		const action = makeAction({
+			name: "RETURN_DATA",
+			handler: async () => ({
+				success: true,
+				data: {
+					actionName: "RETURN_DATA",
+					cyclic,
+					cyclicDate,
+					deep,
+					fallbackValue,
+				},
+			}),
+		});
+		const runtime = makeRuntime([action], {
+			emitEvent: async (type, payload) => {
+				emitted.push({ type, payload });
+			},
+		});
+
+		const result = await runWithStreamingContext(
+			{
+				onStreamChunk: () => {},
+				onToolResult: (payload) => {
+					streamed.push(payload);
+				},
+			},
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{ message: makeMessage() },
+					{ name: "RETURN_DATA", params: {} },
+					{
+						onSettledResult: (settled) => {
+							settledResult = settled;
+						},
+					},
+				),
+		);
+
+		expect(result.success).toBe(true);
+		const rawCyclic = result.data?.cyclic;
+		expect(rawCyclic).toBe(cyclic);
+		expect((rawCyclic as Record<string, unknown>).self).toBe(cyclic);
+		expect(result.data?.cyclicDate).toBe(cyclicDate);
+		expect(cyclicDate.self).toBe(cyclicDate);
+		expect(result.data?.deep).toBe(deep);
+		expect(result.data?.fallbackValue).toBe(fallbackValue);
+		expect(settledResult).toBe(result);
+		const completedEvents = emitted.filter(
+			(entry) => entry.type === EventType.ACTION_COMPLETED,
+		);
+		expect(completedEvents).toHaveLength(1);
+		expect(streamed).toHaveLength(1);
+		const eventPayload = completedEvents[0]?.payload as
+			| { content?: { actionResult?: unknown } }
+			| undefined;
+		const eventActionResult = eventPayload?.content?.actionResult;
+		const streamedActionResult = (streamed[0] as { result?: unknown }).result;
+		for (const diagnosticSurface of [eventActionResult, streamedActionResult]) {
+			const diagnosticData = (
+				diagnosticSurface as { data?: Record<string, unknown> } | undefined
+			)?.data;
+			expect(diagnosticData?.cyclicDate).toEqual({
+				apiKey: "[REDACTED]",
+				self: "[REDACTED]",
+			});
+			const serialized = JSON.stringify(diagnosticSurface);
+			expect(serialized).toContain('"self":"[REDACTED]"');
+			expect(serialized).toContain('"deep":');
+			expect(serialized).toContain('"fallbackValue":');
+			expect(serialized).not.toContain("must-be-bounded");
+			expect(serialized).not.toContain(fallbackCanary);
+		}
+	});
+
 	it("suppresses sensitive action result data in ACTION_COMPLETED events", async () => {
 		const emitEvent = vi.fn(async () => {});
 		const onToolResult = vi.fn();

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -1428,6 +1428,210 @@ describe("executePlannedToolCall", () => {
 		}
 	});
 
+	it("masks callable diagnostics without changing or rejecting the settled result", async () => {
+		let settledResult: unknown;
+		let callableTraps = 0;
+		const callable = new Proxy(() => undefined, {
+			get() {
+				callableTraps += 1;
+				throw new Error("callable diagnostic trap escaped");
+			},
+		});
+		const action = makeAction({
+			name: "RETURN_HOSTILE_DATA",
+			handler: async () => ({
+				success: true,
+				data: { payload: callable },
+			}),
+		});
+		const emitted: unknown[] = [];
+		const streamed: unknown[] = [];
+		const runtime = makeRuntime([action], {
+			emitEvent: async (_type, payload) => emitted.push(payload),
+		});
+
+		const result = await runWithStreamingContext(
+			{
+				onStreamChunk: () => {},
+				onToolResult: (payload) => streamed.push(payload),
+			},
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{ message: makeMessage() },
+					{ name: "RETURN_HOSTILE_DATA", params: {} },
+					{
+						onSettledResult: (result) => {
+							settledResult = result;
+						},
+					},
+				),
+		);
+		expect(result).toBe(settledResult);
+		expect(result.data?.payload).toBe(callable);
+		expect(callableTraps).toBe(0);
+		expect(JSON.stringify(emitted)).toContain('"payload":"[REDACTED]"');
+		expect(JSON.stringify(streamed)).toContain('"payload":"[REDACTED]"');
+	});
+
+	it("does not invoke accessors and bounds shallow diagnostic outputs", async () => {
+		let accessorCalls = 0;
+		const payload: Record<string, unknown> = {};
+		Object.defineProperty(payload, "value", {
+			enumerable: true,
+			get() {
+				accessorCalls += 1;
+				return "safe";
+			},
+		});
+		const wide = Array.from({ length: 10_000 }, () => "😀".repeat(100));
+		const emitted: unknown[] = [];
+		const streamed: unknown[] = [];
+		const action = makeAction({
+			name: "RETURN_WIDE_DATA",
+			handler: async () => ({ success: true, data: { payload, wide } }),
+		});
+		const runtime = makeRuntime([action], {
+			emitEvent: async (_type, eventPayload) => {
+				emitted.push(eventPayload);
+			},
+		});
+
+		const result = await runWithStreamingContext(
+			{
+				onStreamChunk: () => {},
+				onToolResult: (value) => streamed.push(value),
+			},
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{ message: makeMessage() },
+					{ name: "RETURN_WIDE_DATA", params: {} },
+				),
+		);
+		expect(result.data?.payload).toBe(payload);
+		expect(result.data?.wide).toBe(wide);
+		expect(accessorCalls).toBe(0);
+		for (const diagnostic of [emitted, streamed]) {
+			const serialized = JSON.stringify(diagnostic);
+			expect(serialized).toContain('"value":"[REDACTED]"');
+			expect(serialized).toContain('"wide":"[REDACTED]"');
+			expect(new TextEncoder().encode(serialized).byteLength).toBeLessThan(
+				64 * 1_024,
+			);
+		}
+	});
+
+	it("masks revoked proxies after settlement without rejecting execution", async () => {
+		let settled = false;
+		const { proxy, revoke } = Proxy.revocable({}, {});
+		revoke();
+		const action = makeAction({
+			name: "RETURN_REVOKED_DATA",
+			handler: async () => ({ success: true, data: { proxy } }),
+		});
+		const runtime = makeRuntime([action], { emitEvent: async () => {} });
+
+		const result = await executePlannedToolCall(
+			runtime,
+			{ message: makeMessage() },
+			{ name: "RETURN_REVOKED_DATA", params: {} },
+			{ onSettledResult: () => (settled = true) },
+		);
+		expect(result.data?.proxy).toBe(proxy);
+		expect(settled).toBe(true);
+	});
+
+	it("bounds UTF-8 strings and sparse arrays without coercion or prototype mutation", async () => {
+		let coercionCalls = 0;
+		const coercible = {
+			[Symbol.toPrimitive]() {
+				coercionCalls += 1;
+				return "must-not-coerce";
+			},
+			toString() {
+				coercionCalls += 1;
+				return "must-not-stringify";
+			},
+		};
+		const protoPayload: Record<string, unknown> = {};
+		Object.defineProperty(protoPayload, "__proto__", {
+			enumerable: true,
+			value: { polluted: "diagnostic-only" },
+		});
+		const sparse: unknown[] = [];
+		sparse.length = 10_000_000;
+		sparse[9_999_999] = "tail";
+		const emitted: unknown[] = [];
+		const action = makeAction({
+			name: "RETURN_BOUNDED_DATA",
+			handler: async () => ({
+				success: true,
+				data: {
+					coercible,
+					huge: "😀".repeat(100_000),
+					multibyte: "😀".repeat(3_000),
+					protoPayload,
+					sparse,
+				},
+			}),
+		});
+		const runtime = makeRuntime([action], {
+			emitEvent: async (_type, payload) => emitted.push(payload),
+		});
+
+		const result = await executePlannedToolCall(
+			runtime,
+			{ message: makeMessage() },
+			{ name: "RETURN_BOUNDED_DATA", params: {} },
+		);
+		expect(result.data?.coercible).toBe(coercible);
+		expect(result.data?.sparse).toBe(sparse);
+		expect(coercionCalls).toBe(0);
+
+		const completed = emitted.find(
+			(value) =>
+				(value as { content?: { actionResult?: unknown } }).content
+					?.actionResult !== undefined,
+		) as {
+			content?: {
+				actionResult?: {
+					data?: Record<string, unknown>;
+				};
+			};
+		};
+		const diagnosticData = completed.content?.actionResult?.data;
+		expect(diagnosticData?.sparse).toBe("[REDACTED]");
+		expect(diagnosticData?.coercible).toEqual({
+			toString: "[REDACTED]",
+		});
+		const projectedPrototype = diagnosticData?.protoPayload as Record<
+			string,
+			unknown
+		>;
+		expect(Object.getPrototypeOf(projectedPrototype)).toBe(Object.prototype);
+		expect(Object.hasOwn(projectedPrototype, "__proto__")).toBe(true);
+		expect(
+			Object.getOwnPropertyDescriptor(projectedPrototype, "__proto__")?.value,
+		).toEqual({
+			polluted: "diagnostic-only",
+		});
+		expect(
+			(Object.prototype as { polluted?: unknown }).polluted,
+		).toBeUndefined();
+		const projectedHuge = diagnosticData?.huge;
+		expect(projectedHuge).toBe("[REDACTED]");
+		const projectedMultibyte = diagnosticData?.multibyte as string;
+		expect(projectedMultibyte.endsWith("…")).toBe(true);
+		expect(projectedMultibyte).not.toContain("�");
+		expect(
+			new TextEncoder().encode(projectedMultibyte).byteLength,
+		).toBeLessThanOrEqual(8 * 1_024);
+		expect(
+			new TextEncoder().encode(JSON.stringify(diagnosticData)).byteLength,
+		).toBeLessThan(64 * 1_024);
+	});
+
 	it("suppresses sensitive action result data in ACTION_COMPLETED events", async () => {
 		const emitEvent = vi.fn(async () => {});
 		const onToolResult = vi.fn();

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -13,7 +13,6 @@ import { isSensitiveKeyName } from "../security/redact";
 import {
 	composeToolDiagnosticRedactor,
 	projectToolDiagnosticArgs,
-	projectToolDiagnosticValue,
 	TOOL_DIAGNOSTIC_MASK,
 	type ToolDiagnosticTextRedactor,
 } from "../security/tool-diagnostics";
@@ -90,55 +89,218 @@ function isContentRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-const MAX_CONTENT_VALUE_DEPTH = 8;
+const MAX_ACTION_RESULT_DIAGNOSTIC_DEPTH = 8;
+const MAX_ACTION_RESULT_DIAGNOSTIC_NODES = 1_024;
+const MAX_ACTION_RESULT_DIAGNOSTIC_STRING_BYTES = 8 * 1_024;
+const MAX_ACTION_RESULT_DIAGNOSTIC_TOTAL_STRING_BYTES = 16 * 1_024;
 
-function toContentValue(
+interface ActionResultDiagnosticBudget {
+	nodes: number;
+	stringBytes: number;
+}
+
+function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+	if (maxBytes <= 0) return TOOL_DIAGNOSTIC_MASK;
+	const suffix = "…";
+	const suffixBytes = utf8ByteLength(suffix);
+	if (maxBytes < suffixBytes) return "";
+	const characters: Array<{ bytes: number; value: string }> = [];
+	let bytes = 0;
+	for (const character of value) {
+		const characterBytes = utf8ByteLength(character);
+		if (bytes + characterBytes > maxBytes) {
+			while (characters.length > 0 && bytes + suffixBytes > maxBytes) {
+				bytes -= characters.pop()?.bytes ?? 0;
+			}
+			return `${characters.map((entry) => entry.value).join("")}${suffix}`;
+		}
+		characters.push({ bytes: characterBytes, value: character });
+		bytes += characterBytes;
+	}
+	return characters.map((entry) => entry.value).join("");
+}
+
+function boundedDiagnosticString(
+	value: string,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
+	budget: ActionResultDiagnosticBudget,
+): ContentValue {
+	if (value.length > MAX_ACTION_RESULT_DIAGNOSTIC_STRING_BYTES) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	const remaining =
+		MAX_ACTION_RESULT_DIAGNOSTIC_TOTAL_STRING_BYTES - budget.stringBytes;
+	let redacted: string;
+	try {
+		redacted = redactDiagnosticText(value);
+	} catch {
+		// error-policy:J4 A broken redactor becomes an explicit diagnostic mask.
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	const bounded = truncateUtf8(
+		redacted,
+		Math.min(MAX_ACTION_RESULT_DIAGNOSTIC_STRING_BYTES, remaining),
+	);
+	budget.stringBytes += utf8ByteLength(bounded);
+	return bounded;
+}
+
+function defineDiagnosticProperty(
+	record: Record<string, ContentValue>,
+	key: string,
+	value: ContentValue,
+): void {
+	Object.defineProperty(record, key, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
+}
+
+function projectActionResultDiagnosticValue(
 	value: unknown,
 	redactDiagnosticText: ToolDiagnosticTextRedactor,
 	seen: WeakSet<object>,
 	depth: number,
+	budget: ActionResultDiagnosticBudget,
+	suppressKeys?: ReadonlySet<string>,
 ): ContentValue {
-	if (
-		value === undefined ||
-		value === null ||
-		typeof value === "number" ||
-		typeof value === "boolean"
-	) {
+	budget.nodes += 1;
+	if (budget.nodes > MAX_ACTION_RESULT_DIAGNOSTIC_NODES) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	if (value === undefined || value === null || typeof value === "boolean") {
 		return value as ContentValue;
 	}
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : TOOL_DIAGNOSTIC_MASK;
+	}
 	if (typeof value === "string") {
-		return redactDiagnosticText(value);
+		return boundedDiagnosticString(value, redactDiagnosticText, budget);
 	}
-	if (typeof value !== "object") {
-		return redactDiagnosticText(String(value));
+	if (typeof value !== "object" || value === null) {
+		return TOOL_DIAGNOSTIC_MASK;
 	}
-	if (depth >= MAX_CONTENT_VALUE_DEPTH || seen.has(value)) {
+	if (depth >= MAX_ACTION_RESULT_DIAGNOSTIC_DEPTH || seen.has(value)) {
 		return TOOL_DIAGNOSTIC_MASK;
 	}
 	seen.add(value);
 	try {
-		if (Array.isArray(value)) {
-			return value.map((entry) =>
-				toContentValue(entry, redactDiagnosticText, seen, depth + 1),
-			);
+		let isArray: boolean;
+		try {
+			isArray = Array.isArray(value);
+		} catch {
+			// error-policy:J4 Revoked proxies degrade to an explicit diagnostic mask.
+			return TOOL_DIAGNOSTIC_MASK;
 		}
-		if (isContentRecord(value)) {
-			const record: Record<string, ContentValue> = {};
-			for (const [key, entry] of Object.entries(value)) {
-				if (isSensitiveKeyName(key)) {
-					record[key] = TOOL_DIAGNOSTIC_MASK;
-					continue;
+		if (isArray) {
+			let lengthDescriptor: PropertyDescriptor | undefined;
+			try {
+				lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+			} catch {
+				// error-policy:J4 Hostile proxy traps degrade to a diagnostic mask.
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			const length = lengthDescriptor?.value;
+			if (
+				typeof length !== "number" ||
+				!Number.isSafeInteger(length) ||
+				length < 0 ||
+				length > MAX_ACTION_RESULT_DIAGNOSTIC_NODES - budget.nodes
+			) {
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			const projected: ContentValue[] = new Array(length);
+			for (let index = 0; index < length; index += 1) {
+				let descriptor: PropertyDescriptor | undefined;
+				try {
+					descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+				} catch {
+					// error-policy:J4 Hostile proxy traps degrade to a diagnostic mask.
+					return TOOL_DIAGNOSTIC_MASK;
 				}
-				record[key] = toContentValue(
-					entry,
+				budget.nodes += 1;
+				if (budget.nodes > MAX_ACTION_RESULT_DIAGNOSTIC_NODES) {
+					return TOOL_DIAGNOSTIC_MASK;
+				}
+				if (!descriptor) continue;
+				projected[index] =
+					"value" in descriptor
+						? projectActionResultDiagnosticValue(
+								descriptor.value,
+								redactDiagnosticText,
+								seen,
+								depth + 1,
+								budget,
+							)
+						: TOOL_DIAGNOSTIC_MASK;
+			}
+			return projected;
+		}
+
+		let keys: PropertyKey[];
+		try {
+			keys = Reflect.ownKeys(value);
+		} catch {
+			// error-policy:J4 Revoked or hostile proxies degrade to a diagnostic mask.
+			return TOOL_DIAGNOSTIC_MASK;
+		}
+		if (keys.length > MAX_ACTION_RESULT_DIAGNOSTIC_NODES - budget.nodes) {
+			return TOOL_DIAGNOSTIC_MASK;
+		}
+		const record: Record<string, ContentValue> = {};
+		for (const key of keys) {
+			if (typeof key !== "string") continue;
+			let descriptor: PropertyDescriptor | undefined;
+			try {
+				descriptor = Object.getOwnPropertyDescriptor(value, key);
+			} catch {
+				// error-policy:J4 Hostile proxy traps degrade to a diagnostic mask.
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			if (!descriptor?.enumerable) continue;
+			budget.nodes += 1;
+			if (budget.nodes > MAX_ACTION_RESULT_DIAGNOSTIC_NODES) {
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			if (key.length > MAX_ACTION_RESULT_DIAGNOSTIC_STRING_BYTES) {
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			const keyBytes = utf8ByteLength(key);
+			if (
+				keyBytes > MAX_ACTION_RESULT_DIAGNOSTIC_STRING_BYTES ||
+				keyBytes >
+					MAX_ACTION_RESULT_DIAGNOSTIC_TOTAL_STRING_BYTES - budget.stringBytes
+			) {
+				return TOOL_DIAGNOSTIC_MASK;
+			}
+			budget.stringBytes += keyBytes;
+			let projected: ContentValue;
+			if (suppressKeys?.has(key)) {
+				projected = sensitiveActionResultMarker(
+					"value" in descriptor ? descriptor.value : undefined,
+					redactDiagnosticText,
+					budget,
+				);
+			} else if (isSensitiveKeyName(key) || !("value" in descriptor)) {
+				projected = TOOL_DIAGNOSTIC_MASK;
+			} else {
+				projected = projectActionResultDiagnosticValue(
+					descriptor.value,
 					redactDiagnosticText,
 					seen,
 					depth + 1,
+					budget,
 				);
 			}
-			return record;
+			defineDiagnosticProperty(record, key, projected);
 		}
-		return redactDiagnosticText(String(value));
+		return record;
 	} finally {
 		seen.delete(value);
 	}
@@ -149,33 +311,45 @@ function actionResultToContentRecord(
 	redactDiagnosticText: ToolDiagnosticTextRedactor,
 	options: { suppressData?: boolean } = {},
 ): Record<string, ContentValue> {
-	const diagnosticResult: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(result)) {
-		if (options.suppressData && (key === "data" || key === "values")) {
-			diagnosticResult[key] = sensitiveActionResultMarker(value);
-			continue;
-		}
-		diagnosticResult[key] = value;
-	}
-	const projectedResult = projectToolDiagnosticValue(
-		diagnosticResult,
+	const projectedResult = projectActionResultDiagnosticValue(
+		result,
 		redactDiagnosticText,
-	) as Record<string, unknown>;
-	const record: Record<string, ContentValue> = {};
-	const seen = new WeakSet<object>();
-	for (const [key, value] of Object.entries(projectedResult)) {
-		record[key] = toContentValue(value, redactDiagnosticText, seen, 0);
-	}
-	return record;
+		new WeakSet<object>(),
+		0,
+		{ nodes: 0, stringBytes: 0 },
+		options.suppressData ? new Set(["data", "values"]) : undefined,
+	);
+	return isContentRecord(projectedResult) ? projectedResult : {};
 }
 
 function sensitiveActionResultMarker(
 	value: unknown,
+	redactDiagnosticText?: ToolDiagnosticTextRedactor,
+	budget?: ActionResultDiagnosticBudget,
 ): Record<string, ContentValue> {
-	const actionName =
-		isContentRecord(value) && typeof value.actionName === "string"
-			? value.actionName
-			: undefined;
+	let actionName: string | undefined;
+	if (value !== null && typeof value === "object") {
+		try {
+			const descriptor = Object.getOwnPropertyDescriptor(value, "actionName");
+			if (
+				descriptor &&
+				"value" in descriptor &&
+				typeof descriptor.value === "string"
+			) {
+				actionName =
+					redactDiagnosticText && budget
+						? (boundedDiagnosticString(
+								descriptor.value,
+								redactDiagnosticText,
+								budget,
+							) as string)
+						: descriptor.value;
+			}
+		} catch {
+			// error-policy:J4 A hostile result degrades to the privacy marker without
+			// allowing diagnostics to fail the settled action.
+		}
+	}
 	return {
 		...(actionName ? { actionName } : {}),
 		suppressed: true,

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -9,10 +9,12 @@ import { validateToolArgs } from "../actions/validate-tool-args";
 import { evaluateConnectorAccountPolicies } from "../connectors/account-manager";
 import { ElizaError } from "../errors";
 import { checkSenderRole } from "../roles";
+import { isSensitiveKeyName } from "../security/redact";
 import {
 	composeToolDiagnosticRedactor,
 	projectToolDiagnosticArgs,
 	projectToolDiagnosticValue,
+	TOOL_DIAGNOSTIC_MASK,
 	type ToolDiagnosticTextRedactor,
 } from "../security/tool-diagnostics";
 import {
@@ -88,40 +90,81 @@ function isContentRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function toContentValue(value: unknown): ContentValue {
+const MAX_CONTENT_VALUE_DEPTH = 8;
+
+function toContentValue(
+	value: unknown,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
+	seen: WeakSet<object>,
+	depth: number,
+): ContentValue {
 	if (
 		value === undefined ||
 		value === null ||
-		typeof value === "string" ||
 		typeof value === "number" ||
 		typeof value === "boolean"
 	) {
 		return value as ContentValue;
 	}
-	if (Array.isArray(value)) {
-		return value.map(toContentValue);
+	if (typeof value === "string") {
+		return redactDiagnosticText(value);
 	}
-	if (isContentRecord(value)) {
-		const record: Record<string, ContentValue> = {};
-		for (const [key, entry] of Object.entries(value)) {
-			record[key] = toContentValue(entry);
+	if (typeof value !== "object") {
+		return redactDiagnosticText(String(value));
+	}
+	if (depth >= MAX_CONTENT_VALUE_DEPTH || seen.has(value)) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	seen.add(value);
+	try {
+		if (Array.isArray(value)) {
+			return value.map((entry) =>
+				toContentValue(entry, redactDiagnosticText, seen, depth + 1),
+			);
 		}
-		return record;
+		if (isContentRecord(value)) {
+			const record: Record<string, ContentValue> = {};
+			for (const [key, entry] of Object.entries(value)) {
+				if (isSensitiveKeyName(key)) {
+					record[key] = TOOL_DIAGNOSTIC_MASK;
+					continue;
+				}
+				record[key] = toContentValue(
+					entry,
+					redactDiagnosticText,
+					seen,
+					depth + 1,
+				);
+			}
+			return record;
+		}
+		return redactDiagnosticText(String(value));
+	} finally {
+		seen.delete(value);
 	}
-	return String(value);
 }
 
 function actionResultToContentRecord(
 	result: ActionResult,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
 	options: { suppressData?: boolean } = {},
 ): Record<string, ContentValue> {
-	const record: Record<string, ContentValue> = {};
+	const diagnosticResult: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(result)) {
 		if (options.suppressData && (key === "data" || key === "values")) {
-			record[key] = sensitiveActionResultMarker(value);
+			diagnosticResult[key] = sensitiveActionResultMarker(value);
 			continue;
 		}
-		record[key] = toContentValue(value);
+		diagnosticResult[key] = value;
+	}
+	const projectedResult = projectToolDiagnosticValue(
+		diagnosticResult,
+		redactDiagnosticText,
+	) as Record<string, unknown>;
+	const record: Record<string, ContentValue> = {};
+	const seen = new WeakSet<object>();
+	for (const [key, value] of Object.entries(projectedResult)) {
+		record[key] = toContentValue(value, redactDiagnosticText, seen, 0);
 	}
 	return record;
 }
@@ -758,12 +801,13 @@ export async function executePlannedToolCall(
 					),
 					actions: [action.name],
 					actionStatus: resultForEvent.success ? "completed" : "failed",
-					actionResult: projectToolDiagnosticValue(
-						actionResultToContentRecord(resultForEvent, {
-							suppressData: suppressActionResult,
-						}),
+					actionResult: actionResultToContentRecord(
+						resultForEvent,
 						redactDiagnosticText,
-					) as Record<string, ContentValue>,
+						{
+							suppressData: suppressActionResult,
+						},
+					),
 					source: executorCtx.message.content.source,
 					error:
 						typeof resultForEvent.error === "string"
@@ -819,10 +863,11 @@ async function emitToolResult(
 		status,
 		redactDiagnosticText,
 	);
-	streamingToolCall.result = projectToolDiagnosticValue(
-		actionResultToStreamingResult(result, options),
+	streamingToolCall.result = actionResultToStreamingResult(
+		result,
 		redactDiagnosticText,
-	) as ToolCall["result"];
+		options,
+	);
 	await emitStreamingHook(streamingContext, "onToolResult", {
 		toolCall: streamingToolCall,
 		toolCallId: streamingToolCall.id,
@@ -904,6 +949,7 @@ function plannedToolCallToStreamingToolCall(
 
 function actionResultToStreamingResult(
 	result: ActionResult,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
 	options: { suppressData?: boolean } = {},
 ): ToolCall["result"] {
 	const streamingResult: ActionResult = {
@@ -925,7 +971,7 @@ function actionResultToStreamingResult(
 		modelReplyRequired: result.modelReplyRequired,
 		continueChain: result.continueChain,
 	};
-	return actionResultToContentRecord(streamingResult);
+	return actionResultToContentRecord(streamingResult, redactDiagnosticText);
 }
 
 export const _resetActionRolePolicyCacheForTests = _resetCacheForTests;


### PR DESCRIPTION
# Relates to

Closes #22819.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

Action handlers can return cyclic, deep, wide, accessor-bearing, callable, proxy,
or otherwise non-JSON data. The raw settled `ActionResult` must remain intact for
runtime consumers, but its `ACTION_COMPLETED` and streaming copies are diagnostic
egress and must never strand an already-settled tool call.

This head replaces the prior built-in/coercion approach with one descriptor-only
projection at the real `executePlannedToolCall` boundary:

- bounds depth, node count, per-string UTF-8 bytes, and cumulative string bytes;
- masks cycles, accessors, callables, symbols, bigint, non-finite numbers, sparse
  or oversized arrays, revoked proxies, and hostile descriptor operations;
- uses `Object.defineProperty` so an enumerable `__proto__` remains data and
  cannot mutate the diagnostic object's prototype;
- never calls arbitrary getters, `toJSON`, `toString`, `Symbol.toPrimitive`, or
  other user code while projecting values;
- preserves the original settled result and nested values by identity.

Diagnostics are deliberately lossy. Unsupported built-ins are represented only
by safe enumerable data or a mask; useful values never justify executing a
handler-owned conversion hook after settlement.

# Sync and exact-head verification

- Base: `origin/develop@48e247e498a3f648dd62938eb947d1e269f30d7d`
- Exact head: `809b849f753ccc7721f1b3a55dffa3bc98d82cf1`
- Rebase: zero conflicts
- Mode B focused suites: 2 files, 77/77 tests passed
- Core typecheck: passed
- Core multi-target build: Node/browser/edge/testing/declarations/packed-edge passed
- Changed-file Biome and `git diff --check`: passed
- Exact-head receipt: https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22853-exact-head-809b849.log

The aggregate core test lane was interrupted after more than six minutes without
progress after reporting unrelated existing failures in `message-runtime-stage1`
and `action-retrieval` plus a timed-out `message.side-effect-claim` file. Root
`bun run verify` stopped at 95/139 tasks because `node-swiftlint` is absent from
the shared dependency tree; `@elizaos/capacitor-gateway` exited 127 before the
core task completed. Neither aggregate gate is represented as green. A fresh
`bun install` was not run because the data volume had only 164 MiB free.

# Reviewer start

```sh
git fetch origin pull/22853/head
git checkout --detach 809b849f753ccc7721f1b3a55dffa3bc98d82cf1
sandbox-exec -p '(version 1) (allow default) (deny network*)' bun x vitest run packages/core/src/security/tool-diagnostics.test.ts packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts --coverage.enabled=false
bun run --cwd packages/core typecheck
sandbox-exec -p '(version 1) (allow default) (deny network*)' bun run --cwd packages/core build
bun x biome check packages/core/src/runtime/execute-planned-tool-call.ts packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
git diff --check
```

# Evidence Gate

<!-- evidence-head:809b849f753ccc7721f1b3a55dffa3bc98d82cf1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI or interactive user flow changed
<!-- evidence-row:backend-logs -->
- [x] [22853-exact-head-809b849.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22853-exact-head-809b849.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the changed path runs after handler settlement and does not change model input, selection, or output
<!-- evidence-row:domain-artifacts -->
- [x] [22853-domain-artifact-809b849.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22853-domain-artifact-809b849.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->


