### PR TITLE
fix(plugin-native-agent): time out hung Agent web fallback fetches

### DIFF
--- a/plugins/plugin-native-agent/src/web.test.ts
+++ b/plugins/plugin-native-agent/src/web.test.ts
@@ -1,6 +1,7 @@
 /**
- * Unit tests for the `AgentWeb` HTTP fallback — `window` and `fetch` are
- * fully stubbed; no real API server is involved.
+ * Unit tests for the `AgentWeb` HTTP fallback. `window` and `fetch` are
+ * stubbed; the hang case is a never-settling fetch that rejects when the
+ * production AbortSignal aborts.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -129,6 +130,61 @@ describe("AgentWeb fallback", () => {
           "x-test": "1",
         },
         body: "{}",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("times out a hung Agent.request hop instead of waiting forever", async () => {
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "https://agent.example" },
+    } as Partial<Window>);
+    const fetchMock = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) return;
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal.addEventListener("abort", () => reject(signal.reason));
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const started = performance.now();
+    try {
+      await new AgentWeb().request({ path: "/api/status", timeoutMs: 50 });
+      expect.unreachable("hung request should fail closed");
+    } catch (error) {
+      expect((error as Error).name).toBe("TimeoutError");
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example/api/status",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("attaches AbortSignal to getStatus fetch", async () => {
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "https://agent.example" },
+    } as Partial<Window>);
+    const fetchMock = vi.fn(async () => ({
+      json: async () => ({
+        state: "running",
+        agentName: "eliza",
+        port: 1,
+        startedAt: 1,
+        error: null,
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    await new AgentWeb().getStatus();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example/api/status",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
       }),
     );
   });

--- a/plugins/plugin-native-agent/src/web.ts
+++ b/plugins/plugin-native-agent/src/web.ts
@@ -1,7 +1,8 @@
 /**
  * Web/Electrobun bridge surface for the `Agent` Capacitor plugin: implements
  * `AgentPlugin` over HTTP against the API server, used whenever no native
- * iOS/Android implementation is registered (see `index.ts`).
+ * iOS/Android implementation is registered (see `index.ts`). Every hop uses
+ * AbortSignal.timeout so a hung API TCP accept cannot stall chat/start/status.
  */
 import { WebPlugin } from "@capacitor/core";
 import type {
@@ -69,6 +70,18 @@ function assertRequestPath(path: unknown): string {
     }
   }
   return trimmed;
+}
+
+/** Default bound for start/stop/status/conversation-create/request hops. */
+export const AGENT_WEB_FETCH_TIMEOUT_MS = 30_000;
+/** Chat waits on the agent message loop; still fail closed instead of hanging. */
+export const AGENT_WEB_CHAT_TIMEOUT_MS = 120_000;
+
+function abortSignal(timeoutMs: number): AbortSignal {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return AbortSignal.timeout(AGENT_WEB_FETCH_TIMEOUT_MS);
+  }
+  return AbortSignal.timeout(timeoutMs);
 }
 
 function assertRequestMethod(method: unknown): string {
@@ -140,6 +153,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
         ...this.authHeaders(),
       },
       body: JSON.stringify({ title: "Quick Chat" }),
+      signal: abortSignal(AGENT_WEB_FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       throw new Error(`Failed to create conversation: ${res.status}`);
@@ -170,6 +184,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
           ...this.authHeaders(),
         },
         body: JSON.stringify({ text, channelType: "DM" }),
+        signal: abortSignal(AGENT_WEB_CHAT_TIMEOUT_MS),
       },
     );
 
@@ -254,6 +269,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     const res = await fetch(`${this.apiBase()}/api/agent/start`, {
       method: "POST",
       headers: this.authHeaders(),
+      signal: abortSignal(AGENT_WEB_FETCH_TIMEOUT_MS),
     });
     const data = await res.json();
     return data.status ?? data;
@@ -266,6 +282,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     const res = await fetch(`${this.apiBase()}/api/agent/stop`, {
       method: "POST",
       headers: this.authHeaders(),
+      signal: abortSignal(AGENT_WEB_FETCH_TIMEOUT_MS),
     });
     return res.json();
   }
@@ -282,6 +299,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     }
     const res = await fetch(`${this.apiBase()}/api/status`, {
       headers: this.authHeaders(),
+      signal: abortSignal(AGENT_WEB_FETCH_TIMEOUT_MS),
     });
     return res.json();
   }
@@ -324,6 +342,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
         ...options.headers,
       },
       body: options.body ?? undefined,
+      signal: abortSignal(options.timeoutMs ?? AGENT_WEB_FETCH_TIMEOUT_MS),
     });
     const headers: Record<string, string> = {};
     res.headers.forEach((value, key) => {


### PR DESCRIPTION
Closes #22855

## Problem

`plugins/plugin-native-agent/src/web.ts` is the Capacitor Agent web fallback. All six `fetch` hops had **no `signal`**. `AgentRequestOptions.timeoutMs` was already on the public contract and ignored.

On Node 24.15.0 against an accept-and-hold TCP listener:

| Call | Result |
|---|---|
| origin-shaped `fetch` POST, no signal | still pending at 801.9 ms |
| `AbortSignal.timeout(800)` | TimeoutError 782.2 ms |

Product path: native-agent chat / start / stop / status / `Agent.request` against a hung API. Not leftover-tax. Not native-UI `*-fetch-timeout` (agent runtime HTTP client, not vault/lifeops UI). Not a walk-twin of `#22812` / `#22821` / `#22826` / `#22836`.

## Change

- Every `AgentWeb` fetch uses `AbortSignal.timeout`.
- Default 30s for start/stop/status/conversation-create/`request`.
- Chat messages 120s.
- `Agent.request({ timeoutMs })` honors a finite positive timeout.

## Exact-head evidence

Evidence revision: `6d79cc260eddb077f7b897ed79da74dc6cbd78da`, based on `develop` `a4206025a557`. Owning issue: #22855.

- Pinned Bun 1.3.14 package tests: **16/16 passed** in 69 ms.
- `bun run --cwd plugins/plugin-native-agent typecheck`: pass.
- `bun run --cwd plugins/plugin-native-agent build`: pass.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - Agent web HTTP client; no rendered output.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Agent web HTTP client; no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic hang-boundary receipt is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - Capacitor web fallback has no frontend console/network surface in this unit.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 6d79cc260edd</summary>

```
# domain artifact — native-agent web fallback hung fetch
exact-head: 6d79cc260eddb077f7b897ed79da74dc6cbd78da
based-on: origin/develop a4206025a557
owning-issue: https://github.com/elizaOS/eliza/issues/22855

Pinned Bun 1.3.14 at this exact head:
  bun run --cwd plugins/plugin-native-agent test: 16/16 passed in 69 ms
  bun run --cwd plugins/plugin-native-agent typecheck: pass
  bun run --cwd plugins/plugin-native-agent build: pass

Origin red (Node 24.15.0, accept-and-hold TCP):
  fetch POST no signal: still-pending 801.9 ms
  AbortSignal.timeout(800): TimeoutError 782.2 ms
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

<!-- evidence-head:6d79cc260eddb077f7b897ed79da74dc6cbd78da -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
