### PR TITLE
fix(cloud): close residual numeric grammar and overflow gaps

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
@@ -43,6 +43,41 @@ describe("parseDirectWalletMetadataNumber", () => {
       }),
     ).toBe(0);
   });
+
+  test("refuses alternate numeric syntax and unsafe integer metadata", () => {
+    for (const value of ["0x10", "0b10", "1e2", " 18 ", "+18", "018"]) {
+      expect(() =>
+        parseDirectWalletMetadataNumber({
+          paymentId: "pay-noncanonical",
+          field: "token_decimals",
+          value,
+          integer: true,
+          max: 255,
+        }),
+      ).toThrow("Direct wallet payment has corrupt numeric metadata");
+    }
+
+    for (const value of ["9007199254740993", Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() =>
+        parseDirectWalletMetadataNumber({
+          paymentId: "pay-unsafe",
+          field: "verify_attempts",
+          value,
+          integer: true,
+        }),
+      ).toThrow("Direct wallet payment has corrupt numeric metadata");
+    }
+
+    expect(() =>
+      parseDirectWalletMetadataNumber({
+        paymentId: "pay-increment-overflow",
+        field: "verify_attempts",
+        value: Number.MAX_SAFE_INTEGER,
+        integer: true,
+        max: Number.MAX_SAFE_INTEGER - 1,
+      }),
+    ).toThrow("Direct wallet payment has corrupt numeric metadata");
+  });
 });
 
 describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
@@ -1,7 +1,8 @@
-// Exercises the fail-closed slippage-band boundary for direct wallet native-coin
-// payments. A corrupt/tampered/drifted `slippage_bps` metadata value must be
-// refused (fail closed) instead of silently widening the accepted-payment band
-// on the EVM native verify path (#13415 fallback-slop cloud-shared service layer).
+/**
+ * Exercises the real direct-wallet metadata parsers with deterministic values.
+ * Corrupt stored numerics must fail before token sweep or native-payment-band
+ * verification can consume them.
+ */
 import { describe, expect, test } from "bun:test";
 import {
   CorruptDirectWalletSlippageError,
@@ -45,7 +46,7 @@ describe("parseDirectWalletMetadataNumber", () => {
   });
 
   test("refuses alternate numeric syntax and unsafe integer metadata", () => {
-    for (const value of ["0x10", "0b10", "1e2", " 18 ", "+18", "018"]) {
+    for (const value of ["0x10", "0b10", "1e2", " 18 ", "+18", "018", "18.0", "18.00", "0.0"]) {
       expect(() =>
         parseDirectWalletMetadataNumber({
           paymentId: "pay-noncanonical",
@@ -89,6 +90,12 @@ describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {
   test("accepts the canonical native slippage (200 bps) and 0", () => {
     expect(parseDirectWalletSlippageBps(0)).toBe(0);
     expect(parseDirectWalletSlippageBps(200)).toBe(200);
+  });
+
+  test("refuses alternate integer syntax at the stored slippage boundary", () => {
+    for (const value of ["0x10", "0b10", "1e2", " 18 ", "+18", "018", "18.0", "18.00", "0.0"]) {
+      expect(() => parseDirectWalletSlippageBps(value)).toThrow(CorruptDirectWalletSlippageError);
+    }
   });
 
   test("accepts a stored NUMERIC string that is a clean non-negative integer", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/tts-first-line-cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tts-first-line-cache.test.ts
@@ -14,7 +14,20 @@ describe("parseTtsCacheByteAggregate", () => {
   });
 
   test("refuses corrupt totals instead of evicting every cache entry from NaN", () => {
-    for (const value of [undefined, "garbage", Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5]) {
+    for (const value of [
+      undefined,
+      "garbage",
+      "0x10",
+      "0b10",
+      "1e3",
+      " 4096 ",
+      "+4096",
+      "04096",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -1,
+      1.5,
+    ]) {
       expect(() => parseTtsCacheByteAggregate(value)).toThrow(
         "TTS first-line cache returned a corrupt byte aggregate",
       );

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
@@ -305,6 +305,31 @@ test("settle refuses a zero-amount request instead of settling for nothing", asy
   expect(settle).not.toHaveBeenCalled();
 });
 
+test("settle refuses alternate stored-money syntax before moving funds", async () => {
+  for (const amountUsd of ["0x10", "0b10", "1e2", " 0.05 ", "+0.05", ".05", "00.05"]) {
+    findPaymentById.mockResolvedValue(
+      paymentRecord({
+        metadata: {
+          kind: "x402_payment_request",
+          appId: APP_ID,
+          amountUsd,
+          description: "Noncanonical amount",
+          requirements: { scheme: "exact", network: "eip155:8453", payTo: "0xpayto" },
+        },
+      }),
+    );
+
+    await expect(x402PaymentRequestsService.settle(PAYMENT_ID, validPayload)).rejects.toThrow(
+      /corrupt amountUsd/i,
+    );
+  }
+
+  expect(settle).not.toHaveBeenCalled();
+  expect(markAsConfirmed).not.toHaveBeenCalled();
+  expect(addPurchaseEarnings).not.toHaveBeenCalled();
+  expect(addEarnings).not.toHaveBeenCalled();
+});
+
 test("public projection refuses corrupt stored amount and fee values", () => {
   expect(() =>
     x402PaymentRequestsService.toView(

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
@@ -329,3 +329,36 @@ test("public projection refuses corrupt stored amount and fee values", () => {
     ),
   ).toThrow(/corrupt platformFeeUsd/i);
 });
+
+test("public projection accepts plain decimals and refuses alternate stored-money syntax", () => {
+  const view = x402PaymentRequestsService.toView(
+    paymentRecord({
+      metadata: {
+        kind: "x402_payment_request",
+        amountUsd: "0.05",
+        platformFeeUsd: "0.0005",
+        serviceFeeUsd: "0.01",
+        totalChargedUsd: "0.0605",
+      },
+    }) as never,
+  );
+  expect(view).toMatchObject({
+    amountUsd: 0.05,
+    platformFeeUsd: 0.0005,
+    serviceFeeUsd: 0.01,
+    totalChargedUsd: 0.0605,
+  });
+
+  for (const value of ["0x10", "0b10", "1e2", " 0.05 ", "+0.05", ".05", "00.05"]) {
+    expect(() =>
+      x402PaymentRequestsService.toView(
+        paymentRecord({
+          metadata: {
+            kind: "x402_payment_request",
+            amountUsd: value,
+          },
+        }) as never,
+      ),
+    ).toThrow(/corrupt amountUsd/i);
+  }
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -528,6 +528,37 @@ describe("linkedinAdsProvider", () => {
     expect(result.error).toContain("invalid analytics metric");
   });
 
+  test("fails closed on alternate numeric syntax and cumulative metric overflow", async () => {
+    enqueue({
+      elements: [{ ...ANALYTICS_FIXTURE.elements[0], costInLocalCurrency: "0x10" }],
+    });
+    const alternateSyntax = await linkedinAdsProvider.getCampaignMetrics(
+      credentials,
+      "507404993/603407684/145282384",
+    );
+    expect(alternateSyntax.success).toBe(false);
+    expect(alternateSyntax.metrics).toBeUndefined();
+    expect(alternateSyntax.error).toContain("invalid analytics metric");
+
+    const overflowCases = [
+      [{ costInLocalCurrency: Number.MAX_VALUE }, { costInLocalCurrency: Number.MAX_VALUE }],
+      [{ impressions: Number.MAX_VALUE }, { impressions: Number.MAX_VALUE }],
+      [{ clicks: Number.MAX_VALUE }, { clicks: Number.MAX_VALUE }],
+      [{ externalWebsiteConversions: Number.MAX_VALUE, oneClickLeads: Number.MAX_VALUE }],
+      [{ costInLocalCurrency: Number.MAX_VALUE, impressions: Number.MIN_VALUE }],
+    ];
+    for (const elements of overflowCases) {
+      enqueue({ elements });
+      const result = await linkedinAdsProvider.getCampaignMetrics(
+        credentials,
+        "507404993/603407684/145282384",
+      );
+      expect(result.success).toBe(false);
+      expect(result.metrics).toBeUndefined();
+      expect(result.error).toContain("invalid analytics metric");
+    }
+  });
+
   test("propagates LinkedIn API errors as failed results without partial success", async () => {
     enqueue(
       { message: "Not enough permissions to access: adCampaignGroups.CREATE", status: 403 },

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -338,7 +338,7 @@ function parseAnalyticsMetric(field: string, value: string | number | null | und
   if (value === null || value === undefined) return 0;
   if (
     (typeof value !== "string" && typeof value !== "number") ||
-    (typeof value === "string" && value.trim() === "")
+    (typeof value === "string" && !/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value))
   ) {
     throw new ElizaError("LinkedIn returned an invalid analytics metric", {
       code: "LINKEDIN_ANALYTICS_INVALID_METRIC",
@@ -355,30 +355,70 @@ function parseAnalyticsMetric(field: string, value: string | number | null | und
   return parsed;
 }
 
+function addAnalyticsMetric(total: number, field: string, value: number): number {
+  const next = total + value;
+  if (!Number.isFinite(next)) {
+    throw new ElizaError("LinkedIn returned an invalid analytics metric", {
+      code: "LINKEDIN_ANALYTICS_INVALID_METRIC",
+      context: { field },
+    });
+  }
+  return next;
+}
+
 function sumAnalytics(elements: LinkedInAnalyticsElement[]): CampaignMetrics {
   let spend = 0;
   let impressions = 0;
   let clicks = 0;
   let conversions = 0;
   for (const element of elements) {
-    spend += parseAnalyticsMetric("costInLocalCurrency", element.costInLocalCurrency);
-    impressions += parseAnalyticsMetric("impressions", element.impressions);
-    clicks += parseAnalyticsMetric(
-      element.clicks === null || element.clicks === undefined ? "landingPageClicks" : "clicks",
-      element.clicks ?? element.landingPageClicks,
+    spend = addAnalyticsMetric(
+      spend,
+      "costInLocalCurrency",
+      parseAnalyticsMetric("costInLocalCurrency", element.costInLocalCurrency),
     );
-    conversions +=
-      parseAnalyticsMetric("externalWebsiteConversions", element.externalWebsiteConversions) +
-      parseAnalyticsMetric("oneClickLeads", element.oneClickLeads);
+    impressions = addAnalyticsMetric(
+      impressions,
+      "impressions",
+      parseAnalyticsMetric("impressions", element.impressions),
+    );
+    const clickField =
+      element.clicks === null || element.clicks === undefined ? "landingPageClicks" : "clicks";
+    clicks = addAnalyticsMetric(
+      clicks,
+      clickField,
+      parseAnalyticsMetric(clickField, element.clicks ?? element.landingPageClicks),
+    );
+    conversions = addAnalyticsMetric(
+      conversions,
+      "externalWebsiteConversions",
+      parseAnalyticsMetric("externalWebsiteConversions", element.externalWebsiteConversions),
+    );
+    conversions = addAnalyticsMetric(
+      conversions,
+      "oneClickLeads",
+      parseAnalyticsMetric("oneClickLeads", element.oneClickLeads),
+    );
+  }
+  const ctr = impressions > 0 ? clicks / impressions : 0;
+  const cpc = clicks > 0 ? spend / clicks : 0;
+  const cpm = impressions > 0 ? (spend / impressions) * 1000 : 0;
+  for (const [field, value] of Object.entries({ ctr, cpc, cpm })) {
+    if (!Number.isFinite(value)) {
+      throw new ElizaError("LinkedIn returned an invalid analytics metric", {
+        code: "LINKEDIN_ANALYTICS_INVALID_METRIC",
+        context: { field },
+      });
+    }
   }
   return {
     spend,
     impressions,
     clicks,
     conversions,
-    ctr: impressions > 0 ? clicks / impressions : 0,
-    cpc: clicks > 0 ? spend / clicks : 0,
-    cpm: impressions > 0 ? (spend / impressions) * 1000 : 0,
+    ctr,
+    cpc,
+    cpm,
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -148,6 +148,8 @@ const NATIVE_SLIPPAGE_BPS = 200;
  * pass verification.
  */
 const MAX_DIRECT_SLIPPAGE_BPS = NATIVE_SLIPPAGE_BPS;
+const CANONICAL_NONNEGATIVE_INTEGER_PATTERN = /^(?:0|[1-9]\d*)$/;
+const CANONICAL_NONNEGATIVE_DECIMAL_PATTERN = /^(?:0|[1-9]\d*)(?:\.\d+)?$/;
 
 /**
  * Thrown when a stored `slippage_bps` metadata value cannot be trusted to
@@ -183,7 +185,12 @@ export class CorruptDirectWalletSlippageError extends Error {
  */
 export function parseDirectWalletSlippageBps(rawValue: unknown): number {
   if (rawValue === undefined || rawValue === null) return 0;
-  const numeric = typeof rawValue === "number" ? rawValue : Number(rawValue);
+  const numeric =
+    typeof rawValue === "number"
+      ? rawValue
+      : typeof rawValue === "string" && CANONICAL_NONNEGATIVE_INTEGER_PATTERN.test(rawValue)
+        ? Number(rawValue)
+        : Number.NaN;
   if (
     !Number.isFinite(numeric) ||
     !Number.isInteger(numeric) ||
@@ -595,7 +602,12 @@ export function parseDirectWalletMetadataNumber(params: {
   max?: number;
 }): number {
   const value = params.value ?? params.defaultValue;
-  const canonicalString = typeof value !== "string" || /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value);
+  const canonicalString =
+    typeof value !== "string" ||
+    (params.integer
+      ? CANONICAL_NONNEGATIVE_INTEGER_PATTERN
+      : CANONICAL_NONNEGATIVE_DECIMAL_PATTERN
+    ).test(value);
   const parsed =
     canonicalString && (typeof value === "number" || typeof value === "string")
       ? Number(value)

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -595,14 +595,15 @@ export function parseDirectWalletMetadataNumber(params: {
   max?: number;
 }): number {
   const value = params.value ?? params.defaultValue;
+  const canonicalString = typeof value !== "string" || /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value);
   const parsed =
-    (typeof value === "number" || typeof value === "string") && String(value).trim() !== ""
+    canonicalString && (typeof value === "number" || typeof value === "string")
       ? Number(value)
       : Number.NaN;
   if (
     !Number.isFinite(parsed) ||
     parsed < 0 ||
-    (params.integer && !Number.isInteger(parsed)) ||
+    (params.integer && !Number.isSafeInteger(parsed)) ||
     (params.max !== undefined && parsed > params.max)
   ) {
     throw new ElizaError("Direct wallet payment has corrupt numeric metadata", {
@@ -2421,6 +2422,7 @@ export class DirectWalletPaymentsService {
             value: (metadataOf(payment) as Record<string, unknown>).verify_attempts,
             defaultValue: 0,
             integer: true,
+            max: Number.MAX_SAFE_INTEGER - 1,
           }) + 1;
 
         const bumpVerifyAttempts = () =>

--- a/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
+++ b/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
@@ -64,8 +64,9 @@ const BYPASS_MODELS: ReadonlySet<string> = new Set([
 ]);
 
 export function parseTtsCacheByteAggregate(value: unknown): number {
+  const canonicalString = typeof value !== "string" || /^(?:0|[1-9]\d*)$/.test(value);
   const parsed =
-    (typeof value === "number" || typeof value === "string") && String(value).trim() !== ""
+    canonicalString && (typeof value === "number" || typeof value === "string")
       ? Number(value)
       : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed < 0) {

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -732,25 +732,21 @@ class X402PaymentRequestsService {
       throw new X402PaymentRequestError("Payment request is missing requirements", 500);
     }
 
-    // Validate the USD amount BEFORE the facilitator moves funds on-chain.
-    // create() guarantees a finite positive amountUsd in metadata, so a
-    // non-finite or non-positive value here means the stored request is
-    // corrupt; settling it would take the payer's money and then credit
-    // earnings from NaN (Number(undefined) is NaN, and NaN survives the old
-    // `<= 0` guard because NaN comparisons are false).
-    const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add);
-    if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
-      logger.error("[x402-payment-requests] refusing to settle request with corrupt amount", {
-        paymentRequestId: payment.id,
-        metadataAmountUsd: metadata.amountUsd,
-        creditsToAdd: payment.credits_to_add,
+    // Validate the canonical stored USD amount BEFORE the facilitator moves
+    // funds on-chain. The public projection uses the same boundary, but settle
+    // must not rely on a caller having projected the record first.
+    let amountUsd: number;
+    try {
+      amountUsd = parseStoredPaymentAmount({
+        paymentId: payment.id,
+        field: "amountUsd",
+        value: metadata.amountUsd ?? payment.credits_to_add,
       });
+    } catch (error) {
+      // error-policy:J1 boundary — preserve the typed corrupt-amount failure
+      // after recording the failed payment callback.
       await this.triggerFailureCallback(payment, "corrupt_amount");
-      throw new X402PaymentRequestError(
-        `Payment request ${payment.id} has a corrupt amount and cannot be settled`,
-        500,
-        "corrupt_amount",
-      );
+      throw error;
     }
 
     let paymentPayload: Parameters<typeof x402FacilitatorService.settle>[0];

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -189,9 +189,10 @@ function parseStoredPaymentAmount(params: {
   value: unknown;
   allowZero?: boolean;
 }): number {
+  const canonicalString =
+    typeof params.value !== "string" || /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(params.value);
   const parsed =
-    (typeof params.value === "number" || typeof params.value === "string") &&
-    String(params.value).trim() !== ""
+    canonicalString && (typeof params.value === "number" || typeof params.value === "string")
       ? Number(params.value)
       : Number.NaN;
   if (!Number.isFinite(parsed) || parsed < 0 || (!params.allowZero && parsed === 0)) {


### PR DESCRIPTION
Fixes #22839.

Successor corrective to merged #22830. This closes the numeric grammar and cumulative-overflow cases that remained reachable after that merge.

## Problem

Several persisted-number boundaries still delegated string grammar to JavaScript `Number(...)`. That admitted hexadecimal, binary, exponent, sign, whitespace, and leading-zero forms where the storage contracts are plain decimal. The direct-wallet retry counter also accepted integers outside JavaScript's safe range, and LinkedIn validated each metric without validating cumulative or derived results.

## Change

- Require canonical nonnegative plain-decimal strings at direct-wallet metadata, x402 stored-money, TTS byte-aggregate, and LinkedIn analytics boundaries.
- Require safe integers for direct-wallet integer metadata and reserve increment headroom for `verify_attempts`.
- Fail closed when LinkedIn cumulative totals or derived CTR/CPC/CPM become non-finite, while preserving fractional conversions.
- Add production-path regressions through direct-wallet parsing, TTS eviction accounting, x402 `toView`, and LinkedIn `getCampaignMetrics`; retain the sibling app-analytics pricing contract.

## Exact-head evidence

Evidence revision: `93545ddb882a7baee919d1d45bd08f367d367a01`, based on `develop` `7ddb6b0b4ea971b277af795d20dbe922de15072c`.

- Exact rebased-head focused production suites, each in an isolated Bun process: **60/60 passed** (direct-wallet 16, TTS 10, x402 9, LinkedIn 18, sibling app-analytics 7). The direct-wallet suite covers hexadecimal, binary, exponent, whitespace, sign, leading-zero, and fractional spellings at both stored integer boundaries.
- Exact repaired-head x402 settlement suite: **9/9 passed**. Alternate stored-money syntax is rejected before the facilitator can move funds; the sibling `slippage_bps` and generic integer metadata parsers now reject the same alternate syntax matrix.
- `packages/cloud/shared` typecheck: passed.
- Linked-workspace/core build emitted successful node/browser/edge/testing bundles and declarations; its Turbo wrapper retained a post-completion handle and was interrupted after the success receipt.
- Biome on all eight changed files: passed.
- `git diff --check origin/develop...HEAD`: passed.
- Package-wide isolated runner: dependency-preflight rerun advanced through 11 batches, then stopped in batch 12 on four pre-existing `app-credits-ledger.test.ts` PGlite fixture failures (`credit_transactions` lookup for synthetic IDs). The patch does not touch that service/test/schema path; the same four failures reproduce when that file is run alone. No affected suite failed.

No live credentials, provider calls, payment mutations, TTS eviction, or advertising spend occurred. Tests use bounded synthetic values and mocked provider responses. This PR is draft-held for independent exact-head review before merge.

## Evidence Gate

<!-- evidence-head:93545ddb882a7baee919d1d45bd08f367d367a01 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only numeric validation; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only numeric validation; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production deployment or external provider call; exact deterministic test receipts are listed inline.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external artifact; production-boundary numeric receipts are deterministic tests listed inline.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-cortex-plugins]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


