### PR TITLE
fix(plugin-x): time out hung broker token fetches

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/broker.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.test.ts
@@ -14,6 +14,7 @@ function runtime(settings: Record<string, string>): IAgentRuntime {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("BrokerAuthProvider", () => {
@@ -46,8 +47,51 @@ describe("BrokerAuthProvider", () => {
         headers: expect.objectContaining({
           Authorization: "Bearer agent-cloud-key",
         }),
+        signal: expect.any(AbortSignal),
       }),
     );
+  });
+
+  it("times out a hung broker token hop instead of waiting forever", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+      const controller = new AbortController();
+      setTimeout(() => {
+        controller.abort(
+          Object.assign(new Error("The operation was aborted due to timeout"), {
+            name: "TimeoutError",
+          }),
+        );
+      }, 50);
+      return controller.signal;
+    });
+    const fetchMock = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) return;
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal.addEventListener("abort", () => reject(signal.reason));
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new BrokerAuthProvider(
+      runtime({ ELIZAOS_CLOUD_API_KEY: "agent-cloud-key" }),
+    );
+    const started = performance.now();
+    try {
+      await provider.getAccessToken();
+      expect.unreachable("hung broker fetch should fail closed");
+    } catch (error) {
+      expect((error as Error).name).toBe("TimeoutError");
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/api/v1/twitter/token?connectionRole=agent",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(performance.now() - started).toBeLessThan(1_000);
   });
 
   it("fails closed when the broker returns an invalid response", async () => {

--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -6,6 +6,8 @@
  * every cached credential is additionally capped at a short TTL so a
  * broker-side rotation (owner reconnect, refresh-token rotate) propagates
  * without a restart. `invalidate()` drops the cache immediately on rejection.
+ * Broker HTTP uses AbortSignal.timeout so a hung cloud token hop cannot stall
+ * every X action that needs credentials.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { getSetting } from "../../utils/settings";
@@ -29,6 +31,7 @@ type BrokerToken = BrokerOAuth1Token | BrokerOAuth2Token;
 
 const BROKER_CACHE_MS = 5 * 60 * 1000;
 const OAUTH2_REFRESH_MARGIN_MS = 60 * 1000;
+export const BROKER_FETCH_TIMEOUT_MS = 30_000;
 
 function isBrokerToken(value: unknown): value is BrokerToken {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -145,6 +148,7 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
           Accept: "application/json",
           Authorization: `Bearer ${this.brokerToken()}`,
         },
+        signal: AbortSignal.timeout(BROKER_FETCH_TIMEOUT_MS),
       },
     );
     if (response.status === 401 || response.status === 403) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22860.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

Closes #22860

## Problem

`BrokerAuthProvider.fetchFromBroker` retrieves managed X credentials with `fetch` and **no `signal`. Every X action that needs a broker token hangs if the cloud token hop never returns.

On Node 24.15.0 against an accept-and-hold TCP listener the untimed `fetch` shape stays pending at ~802 ms while `AbortSignal.timeout(800)` rejects TimeoutError.

Product path: `getAccessToken` / `getBrokerCredentials`. Not leftover-tax. Not native-UI `*-fetch-timeout`. Not a walk-twin of `#22812` / `#22821` / `#22826` / `#22836`. Not a twin of `#22857` (native-agent web fallback). HARD_SKIP is `plugin-x` `connector-account-provider.ts`, not this file.

## Change

- `fetchFromBroker` uses `AbortSignal.timeout(30_000)`.
- Hung broker hop fails closed with `TimeoutError`.
- Honest cached/agent-role/owner-role token vending unchanged.

## Exact-head evidence

Evidence revision: `35c80a9591bd842d88e2459e7381dff29dd055cb`, based on `develop` `e8bfd8830e51b2bfb40bc214e8544c2549553985`. Owning issue: #22860.

- Pinned Bun 1.3.14 focused broker suite: **5/5 passed** in 59 ms.
- `bun run --cwd plugins/plugin-x typecheck`: pass.
- `bun run --cwd plugins/plugin-x build`: pass.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate


- [x] N/A - X broker HTTP client; no rendered output.

- [x] N/A - X broker HTTP client; no rendered output.

- [x] N/A - no rendered user flow.

- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

- [x] N/A - broker token hop has no frontend console/network surface in this unit.

- [x] N/A - no model, prompt, planner, or action behavior changed.

- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 35c80a9591bd</summary>

```
# domain artifact — X broker token hung fetch
exact-head: 35c80a9591bd842d88e2459e7381dff29dd055cb
based-on: origin/develop e8bfd8830e51b2bfb40bc214e8544c2549553985
owning-issue: https://github.com/elizaOS/eliza/issues/22860

Pinned Bun 1.3.14 at this exact head:
  bun run --cwd plugins/plugin-x test src/client/auth-providers/broker.test.ts: 5/5 passed
  bun run --cwd plugins/plugin-x typecheck: pass
  bun run --cwd plugins/plugin-x build: pass

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~802 ms
  AbortSignal.timeout(800): TimeoutError ~782 ms
```

</details>

- [x] N/A - no rendered pixels.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:35c80a9591bd842d88e2459e7381dff29dd055cb -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - X broker HTTP client; no rendered output.

<!-- evidence-row:after-screenshots -->
- [x] N/A - X broker HTTP client; no rendered output.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.

<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - broker token hop has no frontend console/network surface in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 35c80a9591bd</summary>

```
# domain artifact — X broker token hung fetch
exact-head: 35c80a9591bd842d88e2459e7381dff29dd055cb
based-on: origin/develop e8bfd8830e51b2bfb40bc214e8544c2549553985
owning-issue: https://github.com/elizaOS/eliza/issues/22860

Pinned Bun 1.3.14 at this exact head:
  bun run --cwd plugins/plugin-x test src/client/auth-providers/broker.test.ts: 5/5 passed
  bun run --cwd plugins/plugin-x typecheck: pass
  bun run --cwd plugins/plugin-x build: pass

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~802 ms
  AbortSignal.timeout(800): TimeoutError ~782 ms
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
