### PR TITLE
fix(agent): time out hung remote-runner HTTP hops

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -144,6 +144,98 @@ function makeRuntime(
   return runtime as IAgentRuntime;
 }
 
+function bunAbortError(): DOMException {
+  // Bun 1.3.14 fetch rejects this way even when abort(reason) was used.
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  return new URL(
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url,
+  );
+}
+
+function hungFetch(
+  _input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    const abort = () => {
+      reject(bunAbortError());
+    };
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function partialBodyFetch(
+  bodyPrefix: string,
+  status = 200,
+): (_input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+  return async (_input, init) => {
+    const signal = init?.signal;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(bodyPrefix));
+        const abort = () => {
+          controller.error(bunAbortError());
+        };
+        if (signal?.aborted) {
+          abort();
+          return;
+        }
+        signal?.addEventListener("abort", abort, { once: true });
+      },
+    });
+    return new Response(body, { status });
+  };
+}
+
+function healthThenProcessFetch(
+  processImpl: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>,
+): typeof fetch {
+  const originalFetch = globalThis.fetch;
+  return Object.assign(
+    async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => {
+      const url = requestUrl(input);
+      if (url.pathname.endsWith("/v1/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (url.pathname.endsWith("/v1/processes/run")) {
+        return processImpl(input, init);
+      }
+      return jsonResponse(404, { error: "not found" });
+    },
+    { preconnect: originalFetch.preconnect },
+  );
+}
+
+function remoteCommandTimeoutConfig(): E2BRemoteRunnerConfig {
+  return makeConfig({
+    provider: "home",
+    apiKey: undefined,
+    remoteHttpBaseUrl: "https://remote-runner.test",
+    remoteHttpToken: "token",
+    timeoutMs: 50,
+    requestTimeoutMs: 50,
+  });
+}
+
 function startRemoteRunnerHttpServer(): RemoteRunnerHttpServer {
   const calls: RemoteRunnerHttpCall[] = [];
   const originalFetch = globalThis.fetch;
@@ -835,5 +927,73 @@ describe("E2BRemoteCapabilityRouterService", () => {
       capability: "fs",
       method: "sandbox.create",
     });
+  });
+  it("returns timedOut from pty.runCommand when /v1/processes/run hangs before headers", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(healthThenProcessFetch(hungFetch));
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      remoteCommandTimeoutConfig(),
+    );
+    const started = Date.now();
+    try {
+      await expect(
+        service.pty.runCommand({ command: "sleep", args: ["30"] }),
+      ).resolves.toMatchObject({
+        timedOut: true,
+        exitCode: null,
+      });
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("returns timedOut from pty.runCommand when process headers arrive then the body stalls", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(
+      healthThenProcessFetch(partialBodyFetch('{"exitCode":0,"stdout":"')),
+    );
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      remoteCommandTimeoutConfig(),
+    );
+    const started = Date.now();
+    try {
+      await expect(
+        service.pty.runCommand({ command: "sleep", args: ["30"] }),
+      ).resolves.toMatchObject({
+        timedOut: true,
+        exitCode: null,
+      });
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("keeps a genuine pre-timeout AbortError as CapabilityError for pty.runCommand", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(
+      healthThenProcessFetch(async () => {
+        throw bunAbortError();
+      }),
+    );
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      remoteCommandTimeoutConfig(),
+    );
+    try {
+      await expect(
+        service.pty.runCommand({ command: "echo", args: ["hi"] }),
+      ).rejects.toMatchObject({
+        code: "CAPABILITY_REQUEST_FAILED",
+        capability: "pty",
+        method: "pty.command.run",
+        message: "The operation was aborted.",
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
   });
 });

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -357,6 +357,13 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
         stdout,
         stderr: typeof payload.stderr === "string" ? payload.stderr : "",
       };
+    } catch (error) {
+      if (timeout.timedOut()) {
+        throw createTimeoutError(
+          opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
+        );
+      }
+      throw error;
     } finally {
       timeout.dispose();
     }
@@ -1110,16 +1117,49 @@ function remoteEntryType(entry: JsonObject): SandboxEntryInfo["type"] {
   return normalizeSandboxEntryType(value);
 }
 
+function createTimeoutError(ms: number): Error {
+  const error = new Error(`The operation timed out after ${ms}ms.`);
+  error.name = "TimeoutError";
+  return error;
+}
+
+function isTimeoutErrorLike(value: unknown): boolean {
+  if (!(value instanceof Error)) return false;
+  if (
+    value.name === "TimeoutError" ||
+    /timed? out|timeout/i.test(value.message)
+  ) {
+    return true;
+  }
+  return isTimeoutErrorLike((value as Error & { cause?: unknown }).cause);
+}
+
 function timeoutSignal(ms: number | undefined): {
   signal: AbortSignal | undefined;
   dispose(): void;
+  timedOut(): boolean;
 } {
-  if (!ms) return { signal: undefined, dispose: () => {} };
+  if (!ms) {
+    return {
+      signal: undefined,
+      dispose: () => {},
+      timedOut: () => false,
+    };
+  }
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), ms);
+  const reason = createTimeoutError(ms);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(reason);
+  }, ms);
   return {
     signal: controller.signal,
     dispose: () => clearTimeout(timer),
+    timedOut: () =>
+      timedOut ||
+      (controller.signal.aborted &&
+        isTimeoutErrorLike(controller.signal.reason)),
   };
 }
 
@@ -1457,9 +1497,7 @@ function commandResultFromError(error: Error): SandboxCommandResult | null {
 }
 
 function isTimeoutError(error: Error): boolean {
-  return (
-    error.name === "TimeoutError" || /timed? out|timeout/i.test(error.message)
-  );
+  return isTimeoutErrorLike(error);
 }
 
 function normalizeSandboxPath(input: string): string {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22864.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` completed after sync; focused verification passed and unrelated full-package typecheck failures are recorded below.
- [x] A reviewer can confirm the change from the exact-head regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `f19633d775879b8017fda8bd8b8524229e6555a2`; zero conflicts.
- [x] Focused suites, Biome, and diff checks pass post-sync; unrelated package typecheck blockers are documented below.

# Risks

Low. The change only distinguishes internally generated remote-runner deadlines from genuine external `AbortError` failures at the existing terminal capability boundary.

# Background

## What does this PR do?

The original HTTP deadline work is now present on `develop` through #23005, so this branch was rebased down to the remaining behavioral gap. A hung `/v1/processes/run` request now becomes the existing public `TerminalRunResult { timedOut: true, exitCode: null }` state. A genuine immediate `AbortError` remains `CAPABILITY_REQUEST_FAILED`.

Regression coverage exercises both a pre-header hang and headers followed by a stalled response body through the real `E2BRemoteCapabilityRouterService.pty.runCommand` boundary.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this restores the existing terminal timeout contract.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/e2b-capability-router.test.ts`, then the timeout translation in `e2b-capability-router.ts`.

## Detailed testing steps

At exact head `b697d74063e671fd0e633e10097f5000de82f4a8`:

```text
bunx vitest run packages/agent/src/services/e2b-capability-router.test.ts packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts
Test Files  2 passed (2)
Tests       33 passed (33)

bunx biome check packages/agent/src/services/e2b-capability-router.ts packages/agent/src/services/e2b-capability-router.test.ts
Checked 2 files. No fixes applied.

git diff --check
passed
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:b697d74063e671fd0e633e10097f5000de82f4a8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only terminal capability translation; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only terminal capability translation; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused test transcript is included above and recorded by the factory proof ledger.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The two production-boundary timeout regressions are the domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model or prompt behavior changed.

## Backend + frontend logs

Backend proof is the exact-head 33/33 focused suite above. Frontend logs are N/A because this change has no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run --cwd packages/agent typecheck` remains red on unrelated missing optional workspace imports (`plugin-capacitor-bridge`, `plugin-wallet`, `plugin-video`, `plugin-vision`, `plugin-notes`, `plugin-todos`, and `cloud-routing`) plus the pre-existing `cloud-github-token.test.ts` tuple error. No error references either changed file. No hosted checks are currently attached to the fork PR.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cr-22865]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0H10T053JYAKZD2WTT0EH7G","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T02:04:55.685Z","completed_at":"2026-08-21T02:33:20.177Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T02:04:56.720Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"897534dc9189e7edc2f8a288a9b066757b5e28ac4e2e595c320da112460347aa","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9fc7e4ab-0817-4005-98b7-db95ba38bf8e","object_id":"sha256:897534dc9189e7edc2f8a288a9b066757b5e28ac4e2e595c320da112460347aa","sha256":"897534dc9189e7edc2f8a288a9b066757b5e28ac4e2e595c320da112460347aa"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"iwaptBWnQmP_Wu2TuL2nuvrjjFnKXgjFmaMb3IO5b83j_IQfS0IR9V1LH6Y3PSZWC04e_DeMi3VHClgnCy-xDQ"}} -->
