### PR TITLE
Fix OAuth callback state consumption from URL fragments

### DIFF
--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
@@ -19,13 +19,10 @@ import {
 } from "./steward-oauth-pkce.js";
 
 const STORAGE_KEY = "steward.oauth.pkce.verifier";
-const COOKIE_KEY = "steward_oauth_pkce_verifier";
 
 afterEach(() => {
   window.sessionStorage.removeItem(STORAGE_KEY);
   window.localStorage.removeItem(STORAGE_KEY);
-  // biome-ignore lint/suspicious/noDocumentCookie: deterministic cleanup for the cookie-fallback test
-  document.cookie = `${COOKIE_KEY}=; Path=/; Max-Age=0`;
 });
 
 describe("steward-oauth-pkce", () => {
@@ -141,42 +138,6 @@ describe("steward-oauth-pkce", () => {
       expect(removed).toBe(false);
       expect(consumeStewardPkceVerifier()).toBe("local-verifier");
       expect(removed).toBe(true);
-    } finally {
-      Object.defineProperty(globalThis, "window", {
-        configurable: true,
-        value: previousWindow,
-      });
-    }
-  });
-
-  it("falls back to a short-lived same-site cookie when Web Storage is unavailable", () => {
-    const previousWindow = globalThis.window;
-    const restrictedWindow = Object.create(previousWindow) as Window;
-    Object.defineProperty(restrictedWindow, "sessionStorage", {
-      configurable: true,
-      get() {
-        throw new DOMException("Access denied", "SecurityError");
-      },
-    });
-    Object.defineProperty(restrictedWindow, "localStorage", {
-      configurable: true,
-      get() {
-        throw new DOMException("Access denied", "SecurityError");
-      },
-    });
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      value: restrictedWindow,
-    });
-
-    try {
-      expect(storeStewardPkceVerifier("cookie-verifier", "cookie-state")).toBe(
-        true,
-      );
-      expect(document.cookie).toContain(`${COOKIE_KEY}=`);
-      expect(peekStewardOAuthState()).toBe("cookie-state");
-      expect(consumeStewardPkceVerifier()).toBe("cookie-verifier");
-      expect(document.cookie).not.toContain(`${COOKIE_KEY}=`);
     } finally {
       Object.defineProperty(globalThis, "window", {
         configurable: true,

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
@@ -15,7 +15,6 @@
 export type StewardOAuthProvider = "google" | "discord" | "github" | "twitter";
 
 const STEWARD_PKCE_VERIFIER_STORAGE_KEY = "steward.oauth.pkce.verifier";
-const STEWARD_PKCE_VERIFIER_COOKIE_KEY = "steward_oauth_pkce_verifier";
 const STEWARD_PKCE_VERIFIER_TTL_MS = 10 * 60 * 1000;
 const PKCE_VERIFIER_BYTES = 48;
 const OAUTH_STATE_BYTES = 32;
@@ -92,19 +91,6 @@ export function storeStewardPkceVerifier(
   } catch {
     // same as above
   }
-  // Some privacy-focused browser profiles discard Web Storage while bouncing
-  // through an external identity provider. Keep the same short-lived record in
-  // a SameSite cookie so the callback can still prove state + PKCE ownership.
-  // It is deleted as soon as the verifier is consumed and never leaves the
-  // first-party Eliza origin.
-  try {
-    // biome-ignore lint/suspicious/noDocumentCookie: broad browser support is required for the Web Storage fallback
-    document.cookie = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=${encodeURIComponent(stored)}; Path=/; Max-Age=${Math.floor(STEWARD_PKCE_VERIFIER_TTL_MS / 1000)}; SameSite=Lax${window.location.protocol === "https:" ? "; Secure" : ""}`;
-    storedAnywhere =
-      readStoredPkceRecordFromCookie() !== null || storedAnywhere;
-  } catch {
-    // cookies disabled
-  }
   return storedAnywhere;
 }
 
@@ -114,8 +100,7 @@ export function consumeStewardPkceVerifier(): string | null {
     () => window.sessionStorage,
   );
   const localVerifier = consumeStoredPkceVerifier(() => window.localStorage);
-  const cookieVerifier = consumeStoredPkceVerifierFromCookie();
-  return sessionVerifier ?? localVerifier ?? cookieVerifier;
+  return sessionVerifier ?? localVerifier;
 }
 
 /**
@@ -128,35 +113,7 @@ export function peekStewardOAuthState(): string | null {
   if (typeof window === "undefined") return null;
   const sessionRecord = readStoredPkceRecord(() => window.sessionStorage);
   const localRecord = readStoredPkceRecord(() => window.localStorage);
-  const cookieRecord = readStoredPkceRecordFromCookie();
-  return (
-    sessionRecord?.state ?? localRecord?.state ?? cookieRecord?.state ?? null
-  );
-}
-
-function readStoredPkceRecordFromCookie(): StoredPkceVerifier | null {
-  try {
-    const prefix = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=`;
-    const value = document.cookie
-      .split(";")
-      .map((part) => part.trim())
-      .find((part) => part.startsWith(prefix))
-      ?.slice(prefix.length);
-    return value ? parseStoredPkceRecord(decodeURIComponent(value)) : null;
-  } catch {
-    return null;
-  }
-}
-
-function consumeStoredPkceVerifierFromCookie(): string | null {
-  const record = readStoredPkceRecordFromCookie();
-  try {
-    // biome-ignore lint/suspicious/noDocumentCookie: delete the compatibility cookie synchronously on consume
-    document.cookie = `${STEWARD_PKCE_VERIFIER_COOKIE_KEY}=; Path=/; Max-Age=0; SameSite=Lax${window.location.protocol === "https:" ? "; Secure" : ""}`;
-  } catch {
-    // cookies disabled
-  }
-  return record?.verifier ?? null;
+  return sessionRecord?.state ?? localRecord?.state ?? null;
 }
 
 function consumeStoredPkceVerifier(getStorage: () => Storage): string | null {
@@ -178,31 +135,27 @@ function readStoredPkceRecord(
     const storage = getStorage();
     const value = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     if (!value) return null;
-    return parseStoredPkceRecord(value);
+    try {
+      const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
+      if (
+        typeof parsed.verifier === "string" &&
+        typeof parsed.expiresAt === "number" &&
+        parsed.expiresAt >= Date.now()
+      ) {
+        return {
+          verifier: parsed.verifier,
+          ...(typeof parsed.state === "string" ? { state: parsed.state } : {}),
+          expiresAt: parsed.expiresAt,
+        };
+      }
+      return null;
+    } catch {
+      // Pre-JSON blobs stored the bare verifier string; they carry no state,
+      // so the callback's required state match fails for them by design.
+      return null;
+    }
   } catch {
     // error-policy:J4 web storage unavailable -> no stored record
-    return null;
-  }
-}
-
-function parseStoredPkceRecord(value: string): StoredPkceVerifier | null {
-  try {
-    const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
-    if (
-      typeof parsed.verifier === "string" &&
-      typeof parsed.expiresAt === "number" &&
-      parsed.expiresAt >= Date.now()
-    ) {
-      return {
-        verifier: parsed.verifier,
-        ...(typeof parsed.state === "string" ? { state: parsed.state } : {}),
-        expiresAt: parsed.expiresAt,
-      };
-    }
-    return null;
-  } catch {
-    // Pre-JSON blobs stored the bare verifier string; they carry no state,
-    // so the callback's required state match fails for them by design.
     return null;
   }
 }

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.hash-strip.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.hash-strip.test.ts
@@ -11,7 +11,11 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { stripLegacyTokenHashFromAddressBar } from "./steward-session";
+import {
+  consumeStewardCodeFromQuery,
+  consumeStewardOAuthStateFromCallback,
+  stripLegacyTokenHashFromAddressBar,
+} from "./steward-session";
 
 const realLocation = window.location;
 
@@ -91,5 +95,34 @@ describe("stripLegacyTokenHashFromAddressBar", () => {
     // The snapshot stands in for an already-rewritten address bar: no second
     // history write against the live location.
     expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("OAuth fragment callback consumption", () => {
+  it("consumes Steward's #code + #state callback without losing the state echo", () => {
+    setUrl({ hash: "#code=nonce-code&state=app-state" });
+    const replaceSpy = vi.spyOn(window.history, "replaceState");
+
+    expect(consumeStewardCodeFromQuery()).toBe("nonce-code");
+    expect(replaceSpy).toHaveBeenLastCalledWith(
+      null,
+      "",
+      "/login#state=app-state",
+    );
+    expect(consumeStewardOAuthStateFromCallback()).toBe("app-state");
+    expect(replaceSpy).toHaveBeenLastCalledWith(null, "", "/login");
+  });
+
+  it("preserves a snapshotted fragment state until the code consumer hands it off", () => {
+    setUrl({ hash: "" });
+    const stewardWindow = window as Window & {
+      __stewardOAuthHash?: string;
+    };
+    stewardWindow.__stewardOAuthHash = "#code=nonce-code&state=app-state";
+
+    expect(consumeStewardCodeFromQuery()).toBe("nonce-code");
+    expect(stewardWindow.__stewardOAuthHash).toBe("#state=app-state");
+    expect(consumeStewardOAuthStateFromCallback()).toBe("app-state");
+    expect(stewardWindow.__stewardOAuthHash).toBeUndefined();
   });
 });

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -192,10 +192,14 @@ export function consumeStewardCodeFromQuery(): string | null {
   const hashCode = hashParams.get("code");
   if (!hashCode) return null;
   hashParams.delete("code");
+  const nextHash = hashParams.toString();
   if (snapshotted) {
-    delete stewardWindow.__stewardOAuthHash;
+    if (nextHash) {
+      stewardWindow.__stewardOAuthHash = `#${nextHash}`;
+    } else {
+      delete stewardWindow.__stewardOAuthHash;
+    }
   } else {
-    const nextHash = hashParams.toString();
     window.history.replaceState(
       null,
       "",
@@ -203,6 +207,55 @@ export function consumeStewardCodeFromQuery(): string | null {
     );
   }
   return hashCode;
+}
+
+/**
+ * Consume the app-owned OAuth `state` echo from either the query string or
+ * fragment. Steward's nonce-exchange callback intentionally returns `code`
+ * and `state` in the fragment, so reading React Router's query params alone
+ * rejects every otherwise-valid provider callback as a state mismatch.
+ */
+export function consumeStewardOAuthStateFromCallback(): string | null {
+  if (typeof window === "undefined") return null;
+
+  const queryParams = new URLSearchParams(window.location.search);
+  const queryState = queryParams.get("state");
+  if (queryState) {
+    queryParams.delete("code");
+    queryParams.delete("state");
+    const query = queryParams.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+    );
+    return queryState;
+  }
+
+  const stewardWindow = window as Window & { __stewardOAuthHash?: string };
+  const snapshotted = stewardWindow.__stewardOAuthHash;
+  const hash = snapshotted || window.location.hash;
+  if (!hash || hash.length < 2) return null;
+  const hashParams = new URLSearchParams(hash.replace(/^#/, ""));
+  const hashState = hashParams.get("state");
+  if (!hashState) return null;
+  hashParams.delete("code");
+  hashParams.delete("state");
+  const nextHash = hashParams.toString();
+  if (snapshotted) {
+    if (nextHash) {
+      stewardWindow.__stewardOAuthHash = `#${nextHash}`;
+    } else {
+      delete stewardWindow.__stewardOAuthHash;
+    }
+  } else {
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}${nextHash ? `#${nextHash}` : ""}`,
+    );
+  }
+  return hashState;
 }
 
 /**

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const callbackState = vi.hoisted(() => ({
   hasCallback: true,
+  returnedState: "state-1" as string | null,
   expectedState: "state-1" as string | null,
   pkceVerifier: "verifier-1" as string | undefined,
   exchangeCalls: 0,
@@ -29,6 +30,7 @@ const callbackState = vi.hoisted(() => ({
 vi.mock("../../lib/steward-session", () => ({
   hasStewardOAuthCallbackInUrl: () => callbackState.hasCallback,
   consumeStewardCodeFromQuery: () => "callback-code",
+  consumeStewardOAuthStateFromCallback: () => callbackState.returnedState,
   stripLegacyTokenHashFromAddressBar: () => false,
   exchangeStewardCodeViaApi: () => {
     callbackState.exchangeCalls += 1;
@@ -117,6 +119,7 @@ function renderSection(initialUrl = "/login?code=callback-code&state=state-1") {
 describe("StewardLoginSection — OAuth callback completion state (#13519)", () => {
   beforeEach(() => {
     callbackState.hasCallback = true;
+    callbackState.returnedState = "state-1";
     callbackState.expectedState = "state-1";
     callbackState.pkceVerifier = "verifier-1";
     callbackState.exchangeCalls = 0;
@@ -200,6 +203,7 @@ describe("StewardLoginSection — OAuth callback completion state (#13519)", () 
   });
 
   it("refuses the exchange when the callback carries no state echo", async () => {
+    callbackState.returnedState = null;
     renderSection("/login?code=callback-code");
 
     await waitFor(() =>

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
@@ -23,6 +23,7 @@ const harness = vi.hoisted(() => ({
 vi.mock("../../lib/steward-session", () => ({
   hasStewardOAuthCallbackInUrl: () => harness.hasCallback,
   consumeStewardCodeFromQuery: () => harness.code,
+  consumeStewardOAuthStateFromCallback: () => "state-1",
   stripLegacyTokenHashFromAddressBar: () => false,
   exchangeStewardCodeViaApi: () => new Promise(() => {}),
   recoverStewardSessionViaCookie: () => Promise.resolve(null),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -37,6 +37,7 @@ const harness = vi.hoisted(() => {
 vi.mock("../../lib/steward-session", () => ({
   hasStewardOAuthCallbackInUrl: () => harness.hasCallback,
   consumeStewardCodeFromQuery: () => harness.code,
+  consumeStewardOAuthStateFromCallback: () => "state-1",
   stripLegacyTokenHashFromAddressBar: () => false,
   exchangeStewardCodeViaApi: () => new Promise(() => {}),
   recoverStewardSessionViaCookie: () => Promise.resolve(null),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -81,6 +81,7 @@ import {
 } from "../../lib/steward-oauth-url";
 import {
   consumeStewardCodeFromQuery,
+  consumeStewardOAuthStateFromCallback,
   exchangeStewardCodeViaApi,
   hasStewardOAuthCallbackInUrl,
   recoverStewardEmailSessionViaCookie,
@@ -705,7 +706,7 @@ export default function StewardLoginSection() {
       // into the attacker's account. The verifier is consumed ONLY when the
       // state matches, so the user's own in-flight flow survives clicking a
       // foreign link.
-      const returnedState = searchParams.get("state");
+      const returnedState = consumeStewardOAuthStateFromCallback();
       const expectedState = peekStewardOAuthState();
       if (!returnedState || !expectedState || returnedState !== expectedState) {
         stripLegacyTokenParamsFromAddressBar();


### PR DESCRIPTION
Steward returns nonce-exchange code and app state in the URL fragment. The hosted login consumed the fragment code but read state only from React Router query params, so valid Google/Discord/GitHub callbacks failed as state mismatches. This consumes state from query or fragment, preserves snapshot handoff, strips callback material, and removes the unnecessary cookie fallback from the prior mitigation.\n\nVerified: 106 focused login/session tests; Biome; @elizaos/ui and @elizaos/shared typechecks; reproduced against live Google OAuth in shaw Chrome before the fix.