### PR TITLE
fix(cloud): warm-pool replenish yields to live tenant demand (starvation guard)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -7,7 +7,12 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
 import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { apiKeys } from "../../schemas/api-keys";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import { generations } from "../../schemas/generations";
+import { jobs } from "../../schemas/jobs";
 import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
 
@@ -42,10 +47,33 @@ beforeAll(async () => {
   const repositoryModule = await import("../agent-sandboxes");
   repository = new repositoryModule.AgentSandboxesRepository();
 
-  const schema = { organizations, users, userCharacters, agentSandboxes };
+  const schema = {
+    organizations,
+    users,
+    userCharacters,
+    agentSandboxes,
+    dockerNodes,
+    apiKeys,
+    usageRecords,
+    generations,
+    jobs,
+  };
   const { apply } = await pushSchema(schema as never, dbWrite as never);
   await apply();
   await repository.countAllPoolEntries({ image: IMAGE });
+
+  // Replenish reads the tenant-starvation guard inputs (queued tenant jobs +
+  // placeable-node slack). Seed one open node with ample free capacity so the
+  // guard observes real rows instead of an empty cluster clipping every fill.
+  await dbWrite.insert(dockerNodes).values({
+    node_id: "node-1",
+    hostname: "127.0.0.1",
+    capacity: 16,
+    allocated_count: 0,
+    enabled: true,
+    placement_state: "open",
+    status: "healthy",
+  });
 
   await dbWrite.insert(organizations).values({
     id: USER_ORG_ID,

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
@@ -100,6 +100,13 @@ export interface WarmPoolPolicy {
   /** Max pool entries created in a single replenish tick. */
   replenishBurstLimit: number;
   /**
+   * Node slots kept free for tenants on top of the queued tenant backlog.
+   * Replenish never dips schedulable cluster slack below
+   * `pendingTenantJobs + tenantReserveSlots`, so warm fill cannot starve a
+   * live tenant arrival of placement capacity between daemon polls.
+   */
+  tenantReserveSlots: number;
+  /**
    * Health probes per ready entry per sweep before it is declared dead. The
    * probe crosses the headscale mesh, which routinely has >5s transient
    * hiccups — the creator's own birth-polling observes several consecutive
@@ -121,6 +128,7 @@ export const DEFAULT_WARM_POOL_POLICY: WarmPoolPolicy = {
   stuckProvisioningMs: 10 * 60 * 1000,
   replenishCooldownMs: 60 * 1000,
   replenishBurstLimit: 3,
+  tenantReserveSlots: 2,
   // Retries run concurrently across failing rows, so the sweep's worst-case
   // extra time is (attempts - 1) × (delay + 5s probe timeout) = 18s — well
   // inside the provisioning worker's 60s phase budget.

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
@@ -207,6 +207,34 @@ describe("replenish yields to live tenant demand (starvation guard)", () => {
     // deficit 1 (min floor), 5 free - reserve 2 grants it.
     expect(create).toHaveBeenCalledTimes(1);
   });
+
+  test("a tenant queued mid-burst aborts the remaining creates", async () => {
+    const { WarmPoolManager } = await load();
+    // Deficit 3 with abundant slack: the initial decision grants all three.
+    repo.countUserProvisionsByHour.mockResolvedValue([10, 10, 10, 10, 10, 10]);
+    nodesRepo.findPlaceable.mockResolvedValue([{ capacity: 8, allocated_count: 4 }]);
+    jobsRepo.countInFlightByType.mockResolvedValue(0);
+
+    // The first create "runs long"; while it is in flight the cluster fills up
+    // with tenant demand, exactly the arrival the one-shot snapshot missed.
+    const create = mock(async () => {
+      jobsRepo.countInFlightByType.mockResolvedValue(4);
+      return { id: "new", nodeId: "node-1" };
+    });
+    const { creator } = fakeCreator({ createPoolContainer: create });
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.replenish("img:tag");
+
+    expect(result.decision.toCreate).toBe(2); // 4 free - reserve 2
+    // Without revalidation both planned creates would land; the guard stops
+    // after the first because the refreshed reading grants nothing.
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(result.created).toHaveLength(1);
+    expect(result.contention.pendingTenantJobs).toBe(4);
+    // Revalidation re-read the live contention inputs for the second create.
+    expect(jobsRepo.countInFlightByType).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("replenish never throws — a create failure is captured, not propagated", () => {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
@@ -30,8 +30,22 @@ const repo = {
   countUserProvisionsByHour: mock(async () => [] as number[]),
 };
 
+const jobsRepo = {
+  countInFlightByType: mock(async () => 0),
+};
+
+const nodesRepo = {
+  findPlaceable: mock(async () => [{ capacity: 100, allocated_count: 0 }]),
+};
+
 let warmPoolEnabled = true;
 
+mock.module("../../../db/repositories/jobs", () => ({
+  jobsRepository: jobsRepo,
+}));
+mock.module("../../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: nodesRepo,
+}));
 mock.module("../../utils/logger", () => ({
   logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
 }));
@@ -76,6 +90,10 @@ beforeEach(() => {
   repo.countAllPoolEntries.mockResolvedValue({ ready: 0, provisioning: 0 });
   repo.countUserProvisionsByHour.mockReset();
   repo.countUserProvisionsByHour.mockResolvedValue([]);
+  jobsRepo.countInFlightByType.mockReset();
+  jobsRepo.countInFlightByType.mockResolvedValue(0);
+  nodesRepo.findPlaceable.mockReset();
+  nodesRepo.findPlaceable.mockResolvedValue([{ capacity: 100, allocated_count: 0 }]);
 });
 
 afterEach(() => {
@@ -143,9 +161,51 @@ describe("replenish honors the disabled no-op", () => {
     expect(repo.countAllPoolEntries).not.toHaveBeenCalled();
     expect(repo.listClaimablePool).not.toHaveBeenCalled();
     expect(repo.listWarmPoolReconciliationCandidates).not.toHaveBeenCalled();
+    expect(jobsRepo.countInFlightByType).not.toHaveBeenCalled();
+    expect(nodesRepo.findPlaceable).not.toHaveBeenCalled();
     expect(result.created).toEqual([]);
     expect(result.decision.toCreate).toBe(0);
     expect(result.decision.reason).toContain("WARM_POOL_ENABLED=false");
+  });
+});
+
+describe("replenish yields to live tenant demand (starvation guard)", () => {
+  test("a queued tenant backlog on a tight cluster clips the fill burst", async () => {
+    const { WarmPoolManager } = await load();
+    // Demand history pushes the target well above the burst limit.
+    repo.countUserProvisionsByHour.mockResolvedValue([10, 10, 10, 10, 10, 10]);
+    // 4 free slots, 3 queued tenant jobs + default reserve 2 => grant 0.
+    nodesRepo.findPlaceable.mockResolvedValue([{ capacity: 8, allocated_count: 4 }]);
+    jobsRepo.countInFlightByType.mockResolvedValue(3);
+
+    const { creator, create } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.replenish("img:tag");
+
+    expect(jobsRepo.countInFlightByType).toHaveBeenCalledWith("agent_provision");
+    expect(create).not.toHaveBeenCalled();
+    expect(result.created).toEqual([]);
+    expect(result.decision.reason).toContain("tenant starvation guard");
+    expect(result.contention).toEqual({ pendingTenantJobs: 3, clusterFreeCapacity: 4 });
+  });
+
+  test("an over-allocated node contributes zero slack, never negative", async () => {
+    const { WarmPoolManager } = await load();
+    // One node over-allocated (frees -2 must clamp to 0), one with 5 free.
+    nodesRepo.findPlaceable.mockResolvedValue([
+      { capacity: 8, allocated_count: 10 },
+      { capacity: 8, allocated_count: 3 },
+    ]);
+
+    const { creator, create } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.replenish("img:tag");
+
+    expect(result.contention.clusterFreeCapacity).toBe(5);
+    // deficit 1 (min floor), 5 free - reserve 2 grants it.
+    expect(create).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.test.ts
@@ -17,6 +17,7 @@ import {
   envWarmPoolPolicy,
   immutableImageReference,
   type PoolStateSnapshot,
+  type TenantContentionSnapshot,
 } from "./agent-warm-pool";
 import {
   computeForecast,
@@ -26,6 +27,11 @@ import {
 
 function policy(overrides: Partial<WarmPoolPolicy> = {}): WarmPoolPolicy {
   return { ...DEFAULT_WARM_POOL_POLICY, ...overrides };
+}
+
+/** Abundant slack + no backlog: the starvation guard never binds. */
+function uncontended(overrides: Partial<TenantContentionSnapshot> = {}): TenantContentionSnapshot {
+  return { pendingTenantJobs: 0, clusterFreeCapacity: 1000, ...overrides };
 }
 
 function state(overrides: Partial<PoolStateSnapshot> = {}): PoolStateSnapshot {
@@ -66,6 +72,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 2, targetPoolSize: 5 }),
       policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(3);
     expect(d.reason).toContain("creating 3");
@@ -76,6 +83,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 1, targetPoolSize: 8 }),
       policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(3);
     expect(d.reason).toContain("burst limit 3");
@@ -85,6 +93,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 1, provisioningCount: 2, targetPoolSize: 3 }),
       policy({ maxPoolSize: 10, replenishBurstLimit: 5 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(0);
     expect(d.reason).toMatch(/steady/);
@@ -94,6 +103,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 8, targetPoolSize: 10 }),
       policy({ maxPoolSize: 9, replenishBurstLimit: 3 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(1); // headroom = 9 - 8
   });
@@ -102,6 +112,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 10, targetPoolSize: 12 }),
       policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(0);
     expect(d.reason).toContain("at maxPoolSize 10");
@@ -111,6 +122,7 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 3, targetPoolSize: 3 }),
       policy({ maxPoolSize: 10 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(0);
     expect(d.reason).toMatch(/steady/);
@@ -120,8 +132,74 @@ describe("decideReplenish", () => {
     const d = decideReplenish(
       state({ readyCount: 6, targetPoolSize: 2 }),
       policy({ maxPoolSize: 10 }),
+      uncontended(),
     );
     expect(d.toCreate).toBe(0);
+  });
+});
+
+describe("decideReplenish tenant starvation guard", () => {
+  test("a queued tenant backlog clips the fill burst to the leftover slack", () => {
+    // Wants 3; cluster has 7 free, 3 queued tenants + reserve 2 leaves 2.
+    const d = decideReplenish(
+      state({ readyCount: 2, targetPoolSize: 5 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: 3, clusterFreeCapacity: 7 }),
+    );
+    expect(d.toCreate).toBe(2);
+    expect(d.reason).toContain("tenant starvation guard");
+    expect(d.reason).toContain("creating 2 (wanted 3)");
+  });
+
+  test("the reserve alone binds on a nearly-full cluster with no backlog", () => {
+    // Wants 3; 3 free minus reserve 2 grants 1 even with zero queued tenants.
+    const d = decideReplenish(
+      state({ readyCount: 2, targetPoolSize: 5 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: 0, clusterFreeCapacity: 3 }),
+    );
+    expect(d.toCreate).toBe(1);
+    expect(d.reason).toContain("tenant starvation guard");
+  });
+
+  test("clips to zero when the backlog consumes every free slot", () => {
+    const d = decideReplenish(
+      state({ readyCount: 0, targetPoolSize: 3 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: 5, clusterFreeCapacity: 4 }),
+    );
+    expect(d.toCreate).toBe(0);
+    expect(d.reason).toContain("tenant starvation guard");
+    expect(d.reason).toContain("creating 0 (wanted 3)");
+  });
+
+  test("an empty cluster (no placeable slack) never warm-fills", () => {
+    const d = decideReplenish(
+      state({ readyCount: 0, targetPoolSize: 3 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: 0, clusterFreeCapacity: 0 }),
+    );
+    expect(d.toCreate).toBe(0);
+    expect(d.reason).toContain("tenant starvation guard");
+  });
+
+  test("abundant slack leaves the uncontended decision and reason untouched", () => {
+    const d = decideReplenish(
+      state({ readyCount: 2, targetPoolSize: 5 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: 1, clusterFreeCapacity: 50 }),
+    );
+    expect(d.toCreate).toBe(3);
+    expect(d.reason).not.toContain("starvation");
+  });
+
+  test("a negative pending-jobs reading is treated as zero, never extra slack", () => {
+    const d = decideReplenish(
+      state({ readyCount: 2, targetPoolSize: 5 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3, tenantReserveSlots: 2 }),
+      uncontended({ pendingTenantJobs: -10, clusterFreeCapacity: 4 }),
+    );
+    expect(d.toCreate).toBe(2); // 4 free - reserve 2
   });
 });
 
@@ -365,7 +443,11 @@ describe("envWarmPoolPolicy", () => {
       maxPoolSize: p.maxPoolSize,
     });
     expect(forecast.targetPoolSize).toBe(4);
-    const d = decideReplenish(state({ readyCount: 0, targetPoolSize: forecast.targetPoolSize }), p);
+    const d = decideReplenish(
+      state({ readyCount: 0, targetPoolSize: forecast.targetPoolSize }),
+      p,
+      uncontended(),
+    );
     expect(d.toCreate).toBe(3); // deficit 4, capped by default burst limit 3
     expect(d.reason).toContain("burst limit 3");
   });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -73,6 +73,20 @@ export interface TenantContentionSnapshot {
   clusterFreeCapacity: number;
 }
 
+/**
+ * Warm-pool slots the cluster may grant without dipping tenant-schedulable
+ * slack below `pendingTenantJobs + tenantReserveSlots`. Shared by the burst
+ * decision and by the per-create revalidation inside `replenish()`, so both
+ * apply the identical floor to whatever contention reading they hold.
+ */
+export function grantableWarmSlots(
+  contention: TenantContentionSnapshot,
+  policy: WarmPoolPolicy,
+): number {
+  const reservedForTenants = Math.max(0, contention.pendingTenantJobs) + policy.tenantReserveSlots;
+  return Math.max(0, contention.clusterFreeCapacity - reservedForTenants);
+}
+
 export function decideReplenish(
   state: PoolStateSnapshot,
   policy: WarmPoolPolicy,
@@ -86,8 +100,7 @@ export function decideReplenish(
   // Starvation guard: every queued tenant job needs a slot before the pool
   // may take one, and `tenantReserveSlots` stays free on top of that so an
   // arrival between two daemon polls never cold-queues behind warm fill.
-  const reservedForTenants = Math.max(0, contention.pendingTenantJobs) + policy.tenantReserveSlots;
-  const grantableSlots = Math.max(0, contention.clusterFreeCapacity - reservedForTenants);
+  const grantableSlots = grantableWarmSlots(contention, policy);
   const toCreate = Math.min(uncontended, grantableSlots);
 
   let reason: string;
@@ -301,6 +314,7 @@ export interface PoolContainerCreator {
 export interface ReplenishResult {
   decision: ReplenishDecision;
   state: PoolStateSnapshot;
+  /** The last contention reading the burst acted on, not the opening one. */
   contention: TenantContentionSnapshot;
   reconciliation: WarmPoolReconciliationResult;
   created: Array<{ id: string; nodeId: string | null }>;
@@ -422,7 +436,27 @@ export class WarmPoolManager {
     const failed: Array<{ error: string }> = [];
     if (targetDigest) immutableImageReference(image, targetDigest);
 
+    // A single pool create takes tens of seconds, so a burst decided from one
+    // snapshot would stay blind to tenant jobs queued mid-burst for minutes.
+    // Re-read contention before every create after the first and abandon the
+    // remainder the moment the tenant floor stops granting a slot. This
+    // narrows — but does not close — the window: placement itself is still
+    // non-transactional (see `docker-sandbox-provider` create path), so a warm
+    // and a tenant create can still select the same last slot concurrently.
+    let observedContention = contention;
     for (let i = 0; i < decision.toCreate; i++) {
+      if (i > 0) {
+        observedContention = await this.tenantContention();
+        if (grantableWarmSlots(observedContention, this.policy) < 1) {
+          logger.info("[warm-pool] replenish burst yielded to tenant demand mid-flight", {
+            createdSoFar: created.length,
+            plannedCreates: decision.toCreate,
+            pendingTenantJobs: observedContention.pendingTenantJobs,
+            clusterFreeCapacity: observedContention.clusterFreeCapacity,
+          });
+          break;
+        }
+      }
       try {
         const result = targetDigest
           ? await this.creator.createPoolContainer(image, targetDigest)
@@ -446,8 +480,8 @@ export class WarmPoolManager {
       ready: state.readyCount,
       provisioning: state.provisioningCount,
       target: state.targetPoolSize,
-      pendingTenantJobs: contention.pendingTenantJobs,
-      clusterFreeCapacity: contention.clusterFreeCapacity,
+      pendingTenantJobs: observedContention.pendingTenantJobs,
+      clusterFreeCapacity: observedContention.clusterFreeCapacity,
       created: created.length,
       failed: failed.length,
       reconciled: {
@@ -457,7 +491,7 @@ export class WarmPoolManager {
         failed: reconciliation.failed.length,
       },
     });
-    return { decision, state, contention, reconciliation, created, failed };
+    return { decision, state, contention: observedContention, reconciliation, created, failed };
   }
 
   async drainIdle(image: string): Promise<DrainResult> {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -18,9 +18,12 @@
 
 import { ElizaError } from "@elizaos/core";
 import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
+import { dockerNodesRepository } from "../../../db/repositories/docker-nodes";
+import { jobsRepository } from "../../../db/repositories/jobs";
 import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
 import { containersEnv } from "../../config/containers-env";
 import { logger } from "../../utils/logger";
+import { JOB_TYPES } from "../provisioning-job-types";
 import {
   computeForecast,
   DEFAULT_WARM_POOL_POLICY,
@@ -52,17 +55,48 @@ export interface ReplenishDecision {
   reason: string;
 }
 
+/**
+ * Live-tenant contention observed at replenish time. Warm fill is strictly
+ * lower priority than tenant provisioning: pool creates ride the same node
+ * capacity and the same daemon, so a fill burst launched while tenant work is
+ * queued (or while the cluster is nearly full) would starve paying tenants of
+ * the exact slots the pool exists to serve. See #16961's activation checklist.
+ */
+export interface TenantContentionSnapshot {
+  /** In-flight (pending/in_progress) tenant `agent_provision` jobs. */
+  pendingTenantJobs: number;
+  /**
+   * Sum of `capacity - allocated_count` across currently placeable nodes.
+   * Allocation counters already include in-flight pool creates, so this is
+   * the schedulable slack the pool and tenants compete over.
+   */
+  clusterFreeCapacity: number;
+}
+
 export function decideReplenish(
   state: PoolStateSnapshot,
   policy: WarmPoolPolicy,
+  contention: TenantContentionSnapshot,
 ): ReplenishDecision {
   const total = state.readyCount + state.provisioningCount;
   const headroom = Math.max(0, policy.maxPoolSize - total);
   const deficit = Math.max(0, state.targetPoolSize - total);
-  const toCreate = Math.max(0, Math.min(deficit, policy.replenishBurstLimit, headroom));
+  const uncontended = Math.max(0, Math.min(deficit, policy.replenishBurstLimit, headroom));
+
+  // Starvation guard: every queued tenant job needs a slot before the pool
+  // may take one, and `tenantReserveSlots` stays free on top of that so an
+  // arrival between two daemon polls never cold-queues behind warm fill.
+  const reservedForTenants = Math.max(0, contention.pendingTenantJobs) + policy.tenantReserveSlots;
+  const grantableSlots = Math.max(0, contention.clusterFreeCapacity - reservedForTenants);
+  const toCreate = Math.min(uncontended, grantableSlots);
 
   let reason: string;
-  if (toCreate > 0) {
+  if (uncontended > 0 && toCreate < uncontended) {
+    reason =
+      `tenant starvation guard: free ${contention.clusterFreeCapacity}, ` +
+      `pending tenant jobs ${contention.pendingTenantJobs}, reserve ${policy.tenantReserveSlots}; ` +
+      `creating ${toCreate} (wanted ${uncontended})`;
+  } else if (toCreate > 0) {
     const burstLimited = deficit > policy.replenishBurstLimit;
     reason = burstLimited
       ? `total ${total} < target ${state.targetPoolSize}; creating ${toCreate} (burst limit ${policy.replenishBurstLimit})`
@@ -267,6 +301,7 @@ export interface PoolContainerCreator {
 export interface ReplenishResult {
   decision: ReplenishDecision;
   state: PoolStateSnapshot;
+  contention: TenantContentionSnapshot;
   reconciliation: WarmPoolReconciliationResult;
   created: Array<{ id: string; nodeId: string | null }>;
   failed: Array<{ error: string }>;
@@ -346,11 +381,30 @@ export class WarmPoolManager {
     };
   }
 
+  /**
+   * Read the live-tenant contention inputs for the starvation guard: the
+   * queued tenant provision backlog and the schedulable slack across
+   * placeable nodes. Both reads are cheap aggregates against state the
+   * daemon already maintains; neither mutates anything.
+   */
+  private async tenantContention(): Promise<TenantContentionSnapshot> {
+    const [pendingTenantJobs, placeableNodes] = await Promise.all([
+      jobsRepository.countInFlightByType(JOB_TYPES.AGENT_PROVISION),
+      dockerNodesRepository.findPlaceable(),
+    ]);
+    const clusterFreeCapacity = placeableNodes.reduce(
+      (sum, node) => sum + Math.max(0, node.capacity - node.allocated_count),
+      0,
+    );
+    return { pendingTenantJobs, clusterFreeCapacity };
+  }
+
   async replenish(image: string, targetDigest?: string): Promise<ReplenishResult> {
     if (!containersEnv.warmPoolEnabled()) {
       return {
         decision: { toCreate: 0, reason: "WARM_POOL_ENABLED=false (no-op)" },
         state: emptyState(),
+        contention: { pendingTenantJobs: 0, clusterFreeCapacity: 0 },
         reconciliation: emptyReconciliation(),
         created: [],
         failed: [],
@@ -362,7 +416,8 @@ export class WarmPoolManager {
     // before the capacity snapshot decides whether to create a replacement.
     const reconciliation = await this.reconcileUnclaimable();
     const state = await this.snapshot(image, targetDigest);
-    const decision = decideReplenish(state, this.policy);
+    const contention = await this.tenantContention();
+    const decision = decideReplenish(state, this.policy, contention);
     const created: Array<{ id: string; nodeId: string | null }> = [];
     const failed: Array<{ error: string }> = [];
     if (targetDigest) immutableImageReference(image, targetDigest);
@@ -391,6 +446,8 @@ export class WarmPoolManager {
       ready: state.readyCount,
       provisioning: state.provisioningCount,
       target: state.targetPoolSize,
+      pendingTenantJobs: contention.pendingTenantJobs,
+      clusterFreeCapacity: contention.clusterFreeCapacity,
       created: created.length,
       failed: failed.length,
       reconciled: {
@@ -400,7 +457,7 @@ export class WarmPoolManager {
         failed: reconciliation.failed.length,
       },
     });
-    return { decision, state, reconciliation, created, failed };
+    return { decision, state, contention, reconciliation, created, failed };
   }
 
   async drainIdle(image: string): Promise<DrainResult> {


### PR DESCRIPTION
Refs #16961 (code scope: the starvation-guard checklist row; production activation remains ops-gated, see below).

## What

The warm-pool activation checklist on #16961 requires a **starvation guard**: "warm pool cannot consume slots needed by live tenants; replenish backs off when pending tenant jobs or low free nodes exist." Until now `decideReplenish` looked only at pool state (deficit, burst limit, pool-size headroom) — it was blind to tenant demand and cluster slack, so an enabled pool could burst-fill the last placeable slots ahead of queued tenant provisions.

- `decideReplenish` now takes a `TenantContentionSnapshot` (`pendingTenantJobs`, `clusterFreeCapacity`) and clips its burst so `pendingTenantJobs + tenantReserveSlots` slots stay grantable to tenants. The clip is explained in the decision `reason` (`tenant starvation guard: free N, pending tenant jobs M, reserve R; creating X (wanted Y)`).
- New `WarmPoolPolicy.tenantReserveSlots` (default 2) keeps slack free for tenant arrivals between daemon polls even with an empty backlog.
- `WarmPoolManager.replenish()` reads the contention inputs from state the daemon already maintains: `jobsRepository.countInFlightByType("agent_provision")` and `dockerNodesRepository.findPlaceable()` (sum of max(0, capacity - allocated_count); allocation counters already include in-flight pool creates). The disabled no-op path touches neither repository. Contention is carried on `ReplenishResult` and in the structured replenish log line for the activation-evidence journal.
- Side benefit: an empty or fully-committed cluster now defers warm fill cleanly instead of creating pool rows that fail placement into `error` state.

## Why this shape

Deferring entirely whenever any tenant job is queued would starve the pool under steady traffic; instead every queued tenant job reserves one slot and the pool takes only the leftovers. Capacity is measured as committed-ceiling slack from the placement authority (`findPlaceable`), the same accounting `admitsRequiredMemory`/`deriveNodeCapacity` feed, not free-memory sampling.

## Verification

- `packages/cloud/shared`: `bun test` on `agent-warm-pool.test.ts`, `agent-warm-pool.replenish.test.ts`, `agent-warm-pool.error-policy.test.ts`, `agent-warm-pool-forecast.test.ts` — **66 pass / 0 fail**. New pure-matrix cases: backlog clip, reserve-only bind on a tight cluster, clip-to-zero, empty-cluster defer, abundant-slack no-op, negative-reading clamp. New manager I/O cases: backlog+tight-cluster clips to zero with contention surfaced on the result; over-allocated node contributes zero (never negative) slack; disabled path reads neither jobs nor nodes repo.
- Real-DB integration: `src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts` (isolated PGlite + live HTTP health endpoint) — **14 pass / 0 fail**. The suite now pushes the `docker_nodes`/`jobs` schemas (plus their FK closure) and seeds a placeable node, so replenish exercises the guard against real rows.
- Daemon contract suites `packages/cloud/scripts/admin/daemons/provisioning-worker.{replenish,pool-health,image-rollout}.test.ts` — **13 pass / 0 fail**.
- Follow-up commit `b9a1c9dbb29e` adds per-create contention revalidation; warm-pool suites re-run at that head: **67 pass / 0 fail** (the new mid-burst-tenant case fails when the revalidation branch is disabled, so it discriminates). Biome clean, no `tsc` diagnostics in the touched files.
- `bun run --cwd packages/cloud/shared typecheck` exits 0 with no diagnostics in touched files (remaining output is the documented transitive-plugin noise); Biome check clean on all five changed files.

## Remaining human/ops steps (unchanged by this PR)

Production activation stays gated on the #16961 checklist: set the protected `WARM_POOL_ENABLED` GitHub environment variable and flip the committed `wrangler.toml` value (both wired by #19726), redeploy daemon + Worker, staging soak with claim/identity/billing receipts, then promote from `main`. `WARM_POOL_ENABLED` remains `false` everywhere in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Gate

<!-- evidence-head:b9a1c9dbb29ef0e631e56c4e11b3a92b53ef37b1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, Cloud policy, or warm-pool scheduling change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, Cloud policy, or warm-pool scheduling change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused package, real-database, static, and boundary validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend runtime surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and fail-closed behavior are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->
