### PR TITLE
feat(browser): consolidate cross-browser bridge security and packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,8 @@ with `ELIZA_DEV_SERVER_REGISTRY`. See
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
-| `bun run test:browser-bridge` | retired with the removed `packages/browser-extension` workspace; no replacement |
-| `bun run test:browser-bridge:safari` | retired with the removed `packages/browser-extension` workspace; no replacement |
+| `bun run test:browser-bridge` | `bun run --cwd packages/browser-bridge-extension test:smoke:installed` (requires installed browsers) |
+| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-bridge-extension test:smoke:safari` (requires installed Safari) |
 | `bun run voice:latency-report` | `bun run --cwd packages/app-core voice:latency-report` |
 | `bun run voice:interactive` | `bun run --cwd packages/app-core voice:interactive` |
 | `bun run voice:duet` | `bun run --cwd packages/app-core voice:duet` |
@@ -159,6 +159,7 @@ packages/
   logger/           structured logging package
   vault/            secrets and configuration storage adapters
   skills/           bundled runtime skills and loading utilities
+  browser-bridge-extension/ Chrome MV3, Firefox, and Safari companion browser extension
   registry/         first-party and community plugin registry data and validation
   scenario-runner/  real-runtime scenario execution and report generation
   test/             repository-wide scenarios and test corpus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ with `ELIZA_DEV_SERVER_REGISTRY`. See
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
-| `bun run test:browser-bridge` | retired with the removed `packages/browser-extension` workspace; no replacement |
-| `bun run test:browser-bridge:safari` | retired with the removed `packages/browser-extension` workspace; no replacement |
+| `bun run test:browser-bridge` | `bun run --cwd packages/browser-bridge-extension test:smoke:installed` (requires installed browsers) |
+| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-bridge-extension test:smoke:safari` (requires installed Safari) |
 | `bun run voice:latency-report` | `bun run --cwd packages/app-core voice:latency-report` |
 | `bun run voice:interactive` | `bun run --cwd packages/app-core voice:interactive` |
 | `bun run voice:duet` | `bun run --cwd packages/app-core voice:duet` |
@@ -159,6 +159,7 @@ packages/
   logger/           structured logging package
   vault/            secrets and configuration storage adapters
   skills/           bundled runtime skills and loading utilities
+  browser-bridge-extension/ Chrome MV3, Firefox, and Safari companion browser extension
   registry/         first-party and community plugin registry data and validation
   scenario-runner/  real-runtime scenario execution and report generation
   test/             repository-wide scenarios and test corpus

--- a/bun.lock
+++ b/bun.lock
@@ -459,6 +459,22 @@
         "vitest": "^4.1.10",
       },
     },
+    "packages/browser-bridge-extension": {
+      "name": "@elizaos/browser-extension",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "fflate": "^0.8.3",
+      },
+      "devDependencies": {
+        "@types/jsdom": "^27.0.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "jsdom": "^29.1.1",
+        "puppeteer-core": "^24.43.1",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.17",
+        "web-ext": "^10.6.0",
+      },
+    },
     "packages/cloud/api": {
       "name": "@elizaos/cloud-api",
       "version": "2.0.3-beta.0",
@@ -3942,6 +3958,12 @@
 
     "@derhuerst/http-basic": ["@derhuerst/http-basic@8.2.4", "", { "dependencies": { "caseless": "^0.12.0", "concat-stream": "^2.0.0", "http-response-object": "^3.0.1", "parse-cache-control": "^1.0.1" } }, "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw=="],
 
+    "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.9", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-AYxk5G/b2BPEfubcuxVEZEOpsLf0isqrPNJnnwAlUjZAiLdFg/uvLNRDuBhsC/Ar62X+rUhVlvlL+tKp9HCjfQ=="],
+
+    "@devicefarmer/adbkit-logcat": ["@devicefarmer/adbkit-logcat@2.1.3", "", {}, "sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw=="],
+
+    "@devicefarmer/adbkit-monkey": ["@devicefarmer/adbkit-monkey@1.2.1", "", {}, "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="],
+
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
@@ -4009,6 +4031,8 @@
     "@elizaos/app-core": ["@elizaos/app-core@workspace:packages/app-core"],
 
     "@elizaos/auth": ["@elizaos/auth@workspace:packages/auth"],
+
+    "@elizaos/browser-extension": ["@elizaos/browser-extension@workspace:packages/browser-bridge-extension"],
 
     "@elizaos/bun-ios-runtime": ["@elizaos/bun-ios-runtime@workspace:packages/native/bun-runtime"],
 
@@ -4374,6 +4398,10 @@
 
     "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
 
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
@@ -4446,7 +4474,11 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
+    "@fluent/syntax": ["@fluent/syntax@0.19.0", "", {}, "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ=="],
+
     "@fontsource/poppins": ["@fontsource/poppins@5.3.0", "", {}, "sha512-cms1nM7U6SN8epIV1WMVOV8VsA645aSm3wHfzIQnkk188U341ThbJGSl2Sv54V29gnDbT2arMPfLzvVIIVCceQ=="],
+
+    "@fregante/relaxed-json": ["@fregante/relaxed-json@2.0.0", "", {}, "sha512-PyUXQWB42s4jBli435TDiYuVsadwRHnMc27YaLouINktvTWsL3FcKrRMGawTayFk46X+n5bE23RjUTWQwrukWw=="],
 
     "@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
 
@@ -4775,6 +4807,8 @@
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
 
     "@matrix-org/matrix-sdk-crypto-wasm": ["@matrix-org/matrix-sdk-crypto-wasm@18.5.0", "", {}, "sha512-E826Hy1rG26LanPjtSsOiVRcVoHfSgPgj2r2Xsb5RPScpaKi9XJADQ0u3dNjRCitZPX4oyLNl1FDd5AfDlmIwQ=="],
+
+    "@mdn/browser-compat-data": ["@mdn/browser-compat-data@8.0.8", "", {}, "sha512-Rutrrc3FYOc+um4/QC4WFETNk2fV8NKWoqQl3tQfcVTQ1WFaoJRbsJBasSF34ltitmnYYD6ZsKW1cOQtSj1jbQ=="],
 
     "@mdx-js/esbuild": ["@mdx-js/esbuild@3.1.1", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/unist": "^3.0.0", "source-map": "^0.7.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" }, "peerDependencies": { "esbuild": ">=0.14.0" } }, "sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ=="],
 
@@ -5281,6 +5315,12 @@
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
+
+    "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
+
+    "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
+
+    "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.3", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -6248,6 +6288,8 @@
 
     "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 
+    "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
+
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
@@ -6640,6 +6682,12 @@
 
     "adapter-types": ["adapter-types@0.2.1", "", {}, "sha512-IdA9om1M/GGHGB08RHd68sq+BDwgVdThA3ZoewzoGGOQjHgq1KNZNUQk7eVGqw+qtMA/ceYy9GjXLo++7IoReA=="],
 
+    "addons-linter": ["addons-linter@10.10.0", "", { "dependencies": { "@fluent/syntax": "0.19.0", "@fregante/relaxed-json": "2.0.0", "@mdn/browser-compat-data": "8.0.8", "addons-moz-compare": "1.3.0", "addons-scanner-utils": "15.4.0", "ajv": "8.20.0", "cheerio": "1.2.0", "columnify": "1.6.0", "common-tags": "1.8.2", "css-tree": "3.2.1", "deepmerge": "4.3.1", "eslint": "9.39.4", "eslint-plugin-no-unsanitized": "4.1.5", "eslint-visitor-keys": "5.0.1", "espree": "11.2.0", "esprima": "4.0.1", "fast-json-patch": "3.1.1", "image-size": "2.0.2", "json-merge-patch": "1.0.2", "pino": "10.3.1", "semver": "7.8.5", "source-map-support": "0.5.21", "upath": "3.0.8", "yargs": "17.7.2", "yauzl": "3.4.0" }, "bin": { "addons-linter": "bin/addons-linter" } }, "sha512-1n5Xvn4DyHMsulchNDl4ucWnXXQhHwLif6eK80KjieI9KIK3xD+3OYXk5ZcA6a2J8y+Nrlvq9/vq6w7KOqT2MQ=="],
+
+    "addons-moz-compare": ["addons-moz-compare@1.3.0", "", {}, "sha512-/rXpQeaY0nOKhNx00pmZXdk5Mu+KhVlL3/pSBuAYwrxRrNiTvI/9xfQI8Lmm7DMMl+PDhtfAHY/0ibTpdeoQQQ=="],
+
+    "addons-scanner-utils": ["addons-scanner-utils@15.4.0", "", { "dependencies": { "common-tags": "1.8.2", "first-chunk-stream": "3.0.0", "jsonwebtoken": "^9.0.3", "strip-bom-stream": "4.0.0", "upath": "3.0.7", "yauzl": "3.4.0" }, "peerDependencies": { "express": "5.2.1", "safe-compare": "1.1.4" }, "optionalPeers": ["express", "safe-compare"] }, "sha512-i3PnJx9YLZi96o4t4JWArP6JimC01949YVAcMJKHfyQ5qmUBaH21qNS8f12/RsloejW8IcCEljhh3Fq3gxFNsg=="],
+
     "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "adze": ["adze@2.3.0", "", { "dependencies": { "@ungap/structured-clone": "1.2.0", "picocolors": "1.1.1" } }, "sha512-c5I7uXn5jZ075LbW0lhkmllq4OLQsLHbEV63MbykOQr/VPIOdTgbxGH4QoXHqakAUO3rUSEmURd5eM9GgpJB6g=="],
@@ -6698,9 +6746,11 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
+    "array-differ": ["array-differ@4.0.0", "", {}, "sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw=="],
+
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
-    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+    "array-union": ["array-union@3.0.1", "", {}, "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
@@ -6731,6 +6781,8 @@
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
@@ -6828,11 +6880,13 @@
 
     "bonjour-service": ["bonjour-service@1.4.2", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "multicast-dns": "^7.2.5" } }, "sha512-lMskhnsW70yWHr4PhPeh2rvaIkLSaDpp+nmtbXBZaNKTXwxL73QOkW6HhbzqTImXjevn9TreGT4GACGBCGP9nQ=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "boxen": ["boxen@5.1.2", "", { "dependencies": { "ansi-align": "^3.0.0", "camelcase": "^6.2.0", "chalk": "^4.1.0", "cli-boxes": "^2.2.1", "string-width": "^4.2.2", "type-fest": "^0.20.2", "widest-line": "^3.1.0", "wrap-ansi": "^7.0.0" } }, "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ=="],
+    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
     "bplist-creator": ["bplist-creator@0.1.0", "", { "dependencies": { "stream-buffers": "2.2.x" } }, "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg=="],
 
@@ -6926,7 +6980,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
@@ -6960,11 +7014,15 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
-    "chrome-launcher": ["chrome-launcher@0.15.2", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0" }, "bin": { "print-chrome-path": "bin/print-chrome-path.js" } }, "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ=="],
+    "chrome-launcher": ["chrome-launcher@1.2.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q=="],
 
     "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
 
@@ -6984,7 +7042,7 @@
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
-    "cli-boxes": ["cli-boxes@2.2.1", "", {}, "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="],
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
     "cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
@@ -7038,6 +7096,8 @@
 
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
+    "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
+
     "compress-commons": ["compress-commons@4.1.2", "", { "dependencies": { "buffer-crc32": "^0.2.13", "crc32-stream": "^4.0.2", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg=="],
 
     "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
@@ -7049,6 +7109,10 @@
     "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
+
+    "configstore": ["configstore@7.1.0", "", { "dependencies": { "atomically": "^2.0.3", "dot-prop": "^9.0.0", "graceful-fs": "^4.2.11", "xdg-basedir": "^5.1.0" } }, "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg=="],
 
     "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
 
@@ -7117,6 +7181,8 @@
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -7222,11 +7288,13 @@
 
     "dayjs": ["dayjs@1.11.22", "", {}, "sha512-1YRnxzt/AabP3GHxnaB9/b+ZScCKu5TeF+co+BWG+lnWVIwEcTFc1FVE0WLNmNO3sA6GGXL40i5qkHfbLzpwrg=="],
 
+    "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "debug-logfmt": ["debug-logfmt@1.4.15", "", { "dependencies": { "@kikobeats/time-span": "~1.0.5", "null-prototype-object": "~1.2.2", "pretty-ms": "~7.0.1" }, "peerDependencies": { "debug": "*" } }, "sha512-tMgdJRAlvf0sv3We8KpVlAnv0V9hnOoB3QqmvkXSGYnYMUJvJTGawqipROgh5WaPKXyt79cdPYx30jSu9aO7Rg=="],
 
-    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+    "decamelize": ["decamelize@6.0.1", "", {}, "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -7241,6 +7309,8 @@
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -7316,7 +7386,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
 
@@ -7327,6 +7397,8 @@
     "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
+
+    "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
@@ -7390,6 +7462,8 @@
 
     "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "engine.io-client": ["engine.io-client@6.6.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q=="],
@@ -7428,6 +7502,8 @@
 
     "es5-ext": ["es5-ext@0.10.64", "", { "dependencies": { "es6-iterator": "^2.0.3", "es6-symbol": "^3.1.3", "esniff": "^2.0.1", "next-tick": "^1.1.0" } }, "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg=="],
 
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
     "es6-iterator": ["es6-iterator@2.0.3", "", { "dependencies": { "d": "1", "es5-ext": "^0.10.35", "es6-symbol": "^3.1.1" } }, "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g=="],
 
     "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
@@ -7444,6 +7520,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-goat": ["escape-goat@4.0.0", "", {}, "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -7451,6 +7529,8 @@
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "eslint": ["eslint@10.8.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.7.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ=="],
+
+    "eslint-plugin-no-unsanitized": ["eslint-plugin-no-unsanitized@4.1.5", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -7638,6 +7718,10 @@
 
     "find-versions": ["find-versions@6.0.0", "", { "dependencies": { "semver-regex": "^4.0.5", "super-regex": "^1.0.0" } }, "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA=="],
 
+    "firefox-profile": ["firefox-profile@4.7.1", "", { "dependencies": { "adm-zip": "~0.6.x", "fs-extra": "^11.2.0", "ini": "^4.1.3", "minimist": "^1.2.8", "xml2js": "^0.6.2" }, "bin": { "firefox-profile": "lib/cli.js" } }, "sha512-rUFGvJzXxhhOltBxf1aML9jTVismzgC3w00v2dG4Bxu5Xr6o9/D9QUT4do1ZUE9NHzmRFyQ6Bz+HBWnxZMO65w=="],
+
+    "first-chunk-stream": ["first-chunk-stream@3.0.0", "", {}, "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
@@ -7696,6 +7780,8 @@
 
     "fuse.js": ["fuse.js@7.3.0", "", {}, "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w=="],
 
+    "fx-runner": ["fx-runner@1.6.0", "", { "dependencies": { "commander": "^12.1.0", "shell-quote": "1.10.0", "which": "^4.0.0", "winreg": "0.0.12" }, "bin": { "fx-runner": "bin/fx-runner" } }, "sha512-PEEUfnQJw0/io6SspBbR4EIeXFL/qe/sugesCyfr9M3llgyxNaOH8stvO6KJOKRjeUAvEB6oSZKS3lgjSEOsXg=="],
+
     "gauge": ["gauge@3.0.2", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.2", "console-control-strings": "^1.0.0", "has-unicode": "^2.0.1", "object-assign": "^4.1.1", "signal-exit": "^3.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.2" } }, "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q=="],
 
     "gaussian": ["gaussian@1.3.0", "", {}, "sha512-rYQ0ESfB+z0t7G95nHH80Zh7Pgg9A0FUYoZqV0yPec5WJZWKIHV2MPYpiJNy8oZAeVqyKwC10WXKSCnUQ5iDVg=="],
@@ -7745,6 +7831,8 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
+
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "globals": ["globals@17.9.0", "", {}, "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg=="],
 
@@ -7888,7 +7976,7 @@
 
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
-    "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
+    "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
@@ -7907,6 +7995,8 @@
     "incur": ["incur@0.4.26", "", { "dependencies": { "@cfworker/json-schema": "^4.1.1", "@modelcontextprotocol/server": "2.0.0-alpha.4", "@scalar/openapi-types": "^0.8.0", "@toon-format/toon": "^2.1.0", "tokenx": "^1.3.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "bin": { "incur": "dist/bin.js", "incur.src": "src/bin.ts" } }, "sha512-63lwOc8+o1VeFkIW3sWWMrDSP5Dd1NsvucUWyxLUk+DoNRiNl7cj481nlLdlboXkq+tqYPBSlV/7XbylS2S4BA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
@@ -7976,9 +8066,13 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
+
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
 
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
@@ -7986,9 +8080,11 @@
 
     "is-network-error": ["is-network-error@1.3.2", "", {}, "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA=="],
 
+    "is-npm": ["is-npm@6.1.0", "", {}, "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -8015,6 +8111,8 @@
     "is-unix": ["is-unix@2.0.14", "", {}, "sha512-ZE+Iq0h1pxZu/IGsBKobH5PZ0L3ylv7WHEmKiRG8kEzue6f+w0i3ckwnDY7Ckej2jjq1c7NDYljEkNqOxv4w9A=="],
 
     "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
+
+    "is-utf8": ["is-utf8@0.2.1", "", {}, "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="],
 
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
@@ -8087,6 +8185,8 @@
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-merge-patch": ["json-merge-patch@1.0.2", "", { "dependencies": { "fast-deep-equal": "^3.1.3" } }, "sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
 
@@ -8164,6 +8264,10 @@
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
+    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
+
+    "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
+
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
@@ -8188,7 +8292,7 @@
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
-    "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
+    "lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
 
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
@@ -8276,6 +8380,8 @@
 
     "lodash.isundefined": ["lodash.isundefined@3.0.1", "", {}, "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="],
 
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
@@ -8325,6 +8431,8 @@
     "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
     "make-fetch-happen": ["make-fetch-happen@15.0.2", "", { "dependencies": { "@npmcli/agent": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ=="],
 
@@ -8600,6 +8708,8 @@
 
     "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
+    "multimatch": ["multimatch@6.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.5", "array-differ": "^4.0.0", "array-union": "^3.0.1", "minimatch": "^3.0.4" } }, "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ=="],
+
     "music-metadata": ["music-metadata@11.14.0", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^2.0.0", "debug": "^4.4.3", "file-type": "^21.3.4", "media-typer": "^2.0.0", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
@@ -8679,6 +8789,8 @@
     "npmlog": ["npmlog@5.0.1", "", { "dependencies": { "are-we-there-yet": "^2.0.0", "console-control-strings": "^1.1.0", "gauge": "^3.0.0", "set-blocking": "^2.0.0" } }, "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw=="],
 
     "nprogress": ["nprogress@0.2.0", "", {}, "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "null-prototype-object": ["null-prototype-object@1.2.7", "", {}, "sha512-pSZWCUew0zed2gxCerA4zdXRGg8ezLiWwvE8RvncezTcROXL0uz3PjSZXl5NsI04Egz0Uu46o1wyX6qr3u/ZWA=="],
 
@@ -8776,6 +8888,8 @@
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
+    "package-json": ["package-json@10.0.1", "", { "dependencies": { "ky": "^1.2.0", "registry-auth-token": "^5.0.2", "registry-url": "^6.0.1", "semver": "^7.6.0" } }, "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
@@ -8802,7 +8916,7 @@
 
     "parse-headers": ["parse-headers@2.0.6", "", {}, "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="],
 
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
@@ -8811,6 +8925,10 @@
     "parse-url": ["parse-url@8.1.0", "", { "dependencies": { "parse-path": "^7.0.0" } }, "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -8968,6 +9086,8 @@
 
     "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
+    "promise-toolbox": ["promise-toolbox@0.21.0", "", { "dependencies": { "make-error": "^1.3.2" } }, "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "promzard": ["promzard@2.0.0", "", { "dependencies": { "read": "^4.0.0" } }, "sha512-Ncd0vyS2eXGOjchIRg6PVCYKetJYrW1BSbbIo+bKdig61TB6nH2RQNF2uP+qMpsI73L/jURLWojcw8JNIKZ3gg=="],
@@ -9008,6 +9128,8 @@
 
     "prosemirror-virtual-cursor": ["prosemirror-virtual-cursor@0.4.2", "", { "peerDependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" }, "optionalPeers": ["prosemirror-model", "prosemirror-state", "prosemirror-view"] }, "sha512-pUMKnIuOhhnMcgIJUjhIQTVJruBEGxfMBVQSrK0g2qhGPDm1i12KdsVaFw15dYk+29tZcxjMeR7P5VDKwmbwJg=="],
 
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
+
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "protocols": ["protocols@2.0.2", "", {}, "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ=="],
@@ -9027,6 +9149,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "pupa": ["pupa@3.3.0", "", { "dependencies": { "escape-goat": "^4.0.0" } }, "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA=="],
 
     "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
 
@@ -9069,6 +9193,8 @@
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "rcedit": ["rcedit@5.0.2", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-dgysxaeXZ4snLpPjn8aVtHvZDCx+aRcvZbaWBgl1poU6OPustMvOkj9a9ZqASQ6i5Y5szJ13LSvglEOwrmgUxA=="],
 
@@ -9165,6 +9291,10 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "registry-auth-token": ["registry-auth-token@5.1.1", "", { "dependencies": { "@pnpm/npm-conf": "^3.0.2" } }, "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q=="],
+
+    "registry-url": ["registry-url@6.0.1", "", { "dependencies": { "rc": "1.2.8" } }, "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q=="],
 
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
 
@@ -9382,6 +9512,8 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
+    "split": ["split@1.0.1", "", { "dependencies": { "through": "2" } }, "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg=="],
+
     "split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
@@ -9440,7 +9572,11 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
+    "strip-bom": ["strip-bom@5.0.0", "", {}, "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A=="],
+
+    "strip-bom-buf": ["strip-bom-buf@2.0.0", "", { "dependencies": { "is-utf8": "^0.2.1" } }, "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ=="],
+
+    "strip-bom-stream": ["strip-bom-stream@4.0.0", "", { "dependencies": { "first-chunk-stream": "^3.0.0", "strip-bom-buf": "^2.0.0" } }, "sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
@@ -9457,6 +9593,10 @@
     "stripe": ["stripe@22.5.0", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ=="],
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
+
+    "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
@@ -9728,7 +9868,11 @@
 
     "unzipper": ["unzipper@0.10.14", "", { "dependencies": { "big-integer": "^1.6.17", "binary": "~0.3.0", "bluebird": "~3.4.1", "buffer-indexof-polyfill": "~1.0.0", "duplexer2": "~0.1.4", "fstream": "^1.0.12", "graceful-fs": "^4.2.2", "listenercount": "~1.0.1", "readable-stream": "~2.3.6", "setimmediate": "~1.0.4" } }, "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g=="],
 
+    "upath": ["upath@3.0.8", "", {}, "sha512-YAsrLMIlhfSCm9rga5TZsJ1mXgahs7N0qOTokzU8mFz35hUrYMvVkaEPefI3rEb/vkAWAOj1Km/qdije9RC1kQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
+    "update-notifier": ["update-notifier@7.3.1", "", { "dependencies": { "boxen": "^8.0.1", "chalk": "^5.3.0", "configstore": "^7.0.0", "is-in-ci": "^1.0.0", "is-installed-globally": "^1.0.0", "is-npm": "^6.0.0", "latest-version": "^9.0.0", "pupa": "^3.1.0", "semver": "^7.6.3", "xdg-basedir": "^5.1.0" } }, "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -9810,7 +9954,11 @@
 
     "wasm-feature-detect": ["wasm-feature-detect@1.9.0", "", {}, "sha512-zonE+xlIIYtxPy++L24ow0hAD8CICb4+FgPyROd3buyXIqsJvUEDkBgfCCoXOd1Hu3DUr0GOfnPIdcGV+YpNaA=="],
 
+    "watchpack": ["watchpack@2.5.2", "", { "dependencies": { "graceful-fs": "^4.1.2" } }, "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg=="],
+
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "web-ext": ["web-ext@10.6.0", "", { "dependencies": { "@babel/runtime": "8.0.0", "@devicefarmer/adbkit": "3.3.9", "addons-linter": "10.10.0", "camelcase": "8.0.0", "chrome-launcher": "1.2.0", "debounce": "1.2.1", "decamelize": "6.0.1", "es6-error": "4.1.1", "firefox-profile": "4.7.1", "fx-runner": "1.6.0", "https-proxy-agent": "^7.0.0", "jose": "5.9.6", "jszip": "3.10.1", "multimatch": "6.0.0", "open": "11.0.0", "parse-json": "8.3.0", "pino": "10.3.1", "promise-toolbox": "0.21.0", "source-map-support": "0.5.21", "strip-bom": "5.0.0", "strip-json-comments": "5.0.3", "tmp": "0.2.7", "update-notifier": "7.3.1", "watchpack": "2.5.2", "yargs": "17.7.2", "zip-dir": "2.0.0" }, "bin": { "web-ext": "bin/web-ext.js" } }, "sha512-r1MfSwVy5wRQw3UgTUCw9CDViFIoDPri1Wq8qh/mRjC8T+K0TfuxKz68bzYTEP3rbAW6Wn8y7v/jXzBYd3LLGA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -9830,11 +9978,15 @@
 
     "whatsapp-rust-bridge": ["whatsapp-rust-bridge@0.5.4", "", {}, "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A=="],
 
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -9846,9 +9998,11 @@
 
     "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
-    "widest-line": ["widest-line@3.1.0", "", { "dependencies": { "string-width": "^4.0.0" } }, "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg=="],
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
+
+    "winreg": ["winreg@0.0.12", "", {}, "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -9873,6 +10027,8 @@
     "wsl-utils": ["wsl-utils@1.0.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA=="],
 
     "xcode": ["xcode@3.0.1", "", { "dependencies": { "simple-plist": "^1.1.0", "uuid": "^7.0.3" } }, "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA=="],
+
+    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xhr": ["xhr@2.6.0", "", { "dependencies": { "global": "~4.4.0", "is-function": "^1.0.1", "parse-headers": "^2.0.0", "xtend": "^4.0.0" } }, "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA=="],
 
@@ -9915,6 +10071,8 @@
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "youtube-dl-exec": ["youtube-dl-exec@3.1.12", "", { "dependencies": { "binary-version-check": "~6.1.0", "dargs": "~7.0.0", "debug-logfmt": "~1.4.0", "is-unix": "~2.0.10", "tinyspawn": "~1.5.0" } }, "sha512-S7YwBZ1Kka7TYA/t0eOnHfI2QQMGFxJXp8UFQYOEwqg8sp+OH8MJ5c1c0RgJfoqewP/PGS5j8EtmcXg5E2HM4Q=="],
+
+    "zip-dir": ["zip-dir@2.0.0", "", { "dependencies": { "async": "^3.2.0", "jszip": "^3.2.2" } }, "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg=="],
 
     "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
 
@@ -9998,6 +10156,8 @@
 
     "@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
+    "@coral-xyz/anchor/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "@coral-xyz/anchor/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "@coral-xyz/anchor/pako": ["pako@2.2.0", "", {}, "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w=="],
@@ -10009,6 +10169,12 @@
     "@cypress/request/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@cypress/request/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "@devicefarmer/adbkit/bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
+
+    "@devicefarmer/adbkit/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "@devicefarmer/adbkit/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
     "@discordjs/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
@@ -10023,6 +10189,8 @@
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@elizaos/app/@capacitor/core": ["@capacitor/core@8.5.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ=="],
+
+    "@elizaos/browser-extension/@types/jsdom": ["@types/jsdom@27.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw=="],
 
     "@elizaos/capacitor-agent/@capacitor/core": ["@capacitor/core@8.5.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ=="],
 
@@ -10117,6 +10285,16 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "@eslint/eslintrc/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "@eslint/eslintrc/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "@ethersproject/abi/@ethersproject/keccak256": ["@ethersproject/keccak256@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "js-sha3": "0.8.0" } }, "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng=="],
 
@@ -10442,6 +10620,8 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
 
+    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
+
     "@poppinss/dumper/@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
@@ -10451,6 +10631,8 @@
     "@raydium-io/raydium-sdk/@solana/spl-token": ["@solana/spl-token@0.3.11", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.88.0" } }, "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ=="],
 
     "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "@react-native/dev-middleware/chrome-launcher": ["chrome-launcher@0.15.2", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0" }, "bin": { "print-chrome-path": "bin/print-chrome-path.js" } }, "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ=="],
 
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
@@ -10728,6 +10910,14 @@
 
     "@zkochan/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "addons-linter/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "addons-linter/yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
+
+    "addons-scanner-utils/upath": ["upath@3.0.7", "", {}, "sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g=="],
+
+    "addons-scanner-utils/yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
+
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.15", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q=="],
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.46", "", { "dependencies": { "@ai-sdk/provider": "3.0.15", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8", "undici": "^6.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tEtld97plCFiYevsJuOkGkeuhQndeMWFBVrJS4AjnbD5AqrNSXRCe0p+BZ3Cju/sxDeeZ9ym3q9YUV8fASA7aQ=="],
@@ -10770,9 +10960,13 @@
 
     "borsh/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
-    "boxen/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "boxen/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "boxen/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "boxen/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "bplist-creator/stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
 
@@ -10800,6 +10994,22 @@
 
     "cbw-sdk/preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
 
+    "cheerio/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "cheerio/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "cheerio/htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "cheerio/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "cheerio-select/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "cheerio-select/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "chrome-launcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "chrome-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -10809,6 +11019,8 @@
     "chromium-edge-launcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "chromium-edge-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "chromium-edge-launcher/lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
     "clipboardy/execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
 
@@ -10832,9 +11044,15 @@
 
     "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
+    "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
     "crc32-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "cross-spawn-windows-exe/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "css-select/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "css-select/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -10854,7 +11072,11 @@
 
     "discord.js/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
-    "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+    "dom-serializer/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
+
+    "dot-prop/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "dotenv-expand/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
@@ -10877,6 +11099,8 @@
     "elysia/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "eslint/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -10940,6 +11164,8 @@
 
     "figlet/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "firefox-profile/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
+
     "flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "fluent-ffmpeg/async": ["async@0.2.10", "", {}, "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="],
@@ -10951,6 +11177,10 @@
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "fstream/mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
+
+    "fx-runner/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "fx-runner/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -10966,6 +11196,10 @@
 
     "glob/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
+    "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "globby/array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
     "googleapis-common/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
 
     "googleapis-common/google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
@@ -10979,6 +11213,8 @@
     "gunzip-maybe/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
 
     "hardhat/@ethereumjs/util": ["@ethereumjs/util@9.1.0", "", { "dependencies": { "@ethereumjs/rlp": "^5.0.2", "ethereum-cryptography": "^2.2.1" } }, "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog=="],
+
+    "hardhat/boxen": ["boxen@5.1.2", "", { "dependencies": { "ansi-align": "^3.0.0", "camelcase": "^6.2.0", "chalk": "^4.1.0", "cli-boxes": "^2.2.1", "string-width": "^4.2.2", "type-fest": "^0.20.2", "widest-line": "^3.1.0", "wrap-ansi": "^7.0.0" } }, "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ=="],
 
     "hardhat/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -11032,6 +11268,8 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-validate/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
@@ -11066,9 +11304,11 @@
 
     "lerna/tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 
-    "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
     "load-bmfont/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "load-json-file/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "load-json-file/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "localforage/lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
 
@@ -11107,6 +11347,8 @@
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+
+    "metro/image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -11156,6 +11398,8 @@
 
     "mocha/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "mocha/is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
     "mocha/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "mocha/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
@@ -11163,6 +11407,8 @@
     "mocha/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "mocha/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "multimatch/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "music-metadata/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
@@ -11266,11 +11512,15 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
-
-    "parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+    "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "parse5-htmlparser2-tree-adapter/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "peek-stream/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
 
@@ -11317,6 +11567,8 @@
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "quicktype-core/readable-stream": ["readable-stream@4.5.2", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g=="],
+
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
@@ -11430,6 +11682,8 @@
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
+    "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "valtio/use-sync-external-store": ["use-sync-external-store@1.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="],
 
     "varuint-bitcoin/uint8array-tools": ["uint8array-tools@0.0.8", "", {}, "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g=="],
@@ -11460,7 +11714,17 @@
 
     "wagmi/use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
+    "web-ext/@babel/runtime": ["@babel/runtime@8.0.0", "", {}, "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw=="],
+
+    "web-ext/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
+
+    "web-ext/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
     "websocket/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
@@ -11473,6 +11737,8 @@
     "xcode/uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yargs-unparser/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "yargs-unparser/decamelize": ["decamelize@4.0.0", "", {}, "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="],
 
@@ -11514,9 +11780,13 @@
 
     "@cypress/request/tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
+    "@devicefarmer/adbkit/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
+
     "@discordjs/node-pre-gyp/make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@discordjs/node-pre-gyp/nopt/abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
+    "@elizaos/browser-extension/@types/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "@elizaos/operator/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -11676,6 +11946,10 @@
 
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@eslint/eslintrc/espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
     "@jimp/custom/@jimp/core/@jimp/utils": ["@jimp/utils@0.22.12", "", { "dependencies": { "regenerator-runtime": "^0.13.3" } }, "sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q=="],
 
     "@jimp/custom/@jimp/core/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -11775,6 +12049,8 @@
     "@meteora-ag/dlmm/@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@meteora-ag/dlmm/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@meteora-ag/dlmm/@coral-xyz/anchor/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "@meteora-ag/dlmm/@coral-xyz/anchor/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
@@ -11897,6 +12173,12 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@raydium-io/raydium-sdk/@solana/spl-token/@solana/buffer-layout-utils": ["@solana/buffer-layout-utils@0.2.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/web3.js": "^1.32.0", "bigint-buffer": "^1.1.5", "bignumber.js": "^9.0.1" } }, "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g=="],
+
+    "@react-native/dev-middleware/chrome-launcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "@react-native/dev-middleware/chrome-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "@react-native/dev-middleware/chrome-launcher/lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
     "@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
@@ -12114,6 +12396,28 @@
 
     "@whiskeysockets/baileys/pino/thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
+    "addons-linter/eslint/@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "addons-linter/eslint/@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "addons-linter/eslint/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "addons-linter/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "addons-linter/eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "addons-linter/eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "addons-linter/eslint/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "addons-linter/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "addons-linter/eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "addons-linter/eslint/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "addons-linter/eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 
     "ai/@ai-sdk/provider-utils/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
@@ -12144,13 +12448,27 @@
 
     "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
+    "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "boxen/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "boxen/wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
     "cacache/glob/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "cacheable-request/get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
+    "cheerio/htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "chrome-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "chromium-edge-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "chromium-edge-launcher/lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "clipboardy/execa/cross-spawn": ["cross-spawn@6.0.6", "", { "dependencies": { "nice-try": "^1.0.4", "path-key": "^2.0.1", "semver": "^5.5.0", "shebang-command": "^1.2.0", "which": "^1.2.9" } }, "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw=="],
 
@@ -12186,6 +12504,10 @@
 
     "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
+    "cosmiconfig/parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "cosmiconfig/parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
     "crc32-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "cross-spawn-windows-exe/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
@@ -12195,6 +12517,8 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -12266,6 +12590,8 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "fx-runner/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
     "git-workspace-service/@octokit/rest/@octokit/core": ["@octokit/core@5.2.2", "", { "dependencies": { "@octokit/auth-token": "^4.0.0", "@octokit/graphql": "^7.1.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.0.0", "before-after-hook": "^2.2.0", "universal-user-agent": "^6.0.0" } }, "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg=="],
 
     "git-workspace-service/@octokit/rest/@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@11.4.4-cjs.2", "", { "dependencies": { "@octokit/types": "^13.7.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw=="],
@@ -12293,6 +12619,16 @@
     "hardhat/@ethereumjs/util/@ethereumjs/rlp": ["@ethereumjs/rlp@5.0.2", "", { "bin": { "rlp": "bin/rlp.cjs" } }, "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA=="],
 
     "hardhat/@ethereumjs/util/ethereum-cryptography": ["ethereum-cryptography@2.2.1", "", { "dependencies": { "@noble/curves": "1.4.2", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0" } }, "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg=="],
+
+    "hardhat/boxen/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "hardhat/boxen/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "hardhat/boxen/cli-boxes": ["cli-boxes@2.2.1", "", {}, "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="],
+
+    "hardhat/boxen/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "hardhat/boxen/widest-line": ["widest-line@3.1.0", "", { "dependencies": { "string-width": "^4.0.0" } }, "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg=="],
 
     "hardhat/ethereum-cryptography/@noble/hashes": ["@noble/hashes@1.2.0", "", {}, "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="],
 
@@ -12332,7 +12668,9 @@
 
     "lerna/@octokit/rest/@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1", "", { "dependencies": { "@octokit/types": "^13.8.0" }, "peerDependencies": { "@octokit/core": "^5" } }, "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ=="],
 
-    "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+    "load-json-file/parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "load-json-file/parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "mcp-handler/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
 
@@ -12444,6 +12782,10 @@
 
     "parse-bmfont-xml/xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
+    "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "parse5-parser-stream/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "pepr/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
     "pepr/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
@@ -12457,6 +12799,8 @@
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -12539,6 +12883,8 @@
     "storybook/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
 
     "storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "swiftlint/cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "tar-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -12662,7 +13008,17 @@
 
     "viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
+    "web-ext/open/default-browser": ["default-browser@5.5.1", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw=="],
+
+    "web-ext/open/powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "web-ext/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
     "websocket/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -12721,6 +13077,8 @@
     "zip-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "@cypress/request/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "@elizaos/browser-extension/@types/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@elizaos/plugin-wallet/@solana/spl-token/@solana/buffer-layout-utils/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -12784,6 +13142,10 @@
 
     "@raydium-io/raydium-sdk/@solana/spl-token/@solana/buffer-layout-utils/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "@react-native/dev-middleware/chrome-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "@react-native/dev-middleware/chrome-launcher/lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
@@ -12801,6 +13163,8 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "@reown/appkit-ui/qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -12888,11 +13252,21 @@
 
     "@walletconnect/logger/pino/pino-abstract-transport/duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
 
+    "addons-linter/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "addons-linter/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "binary-version/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "binary-version/execa/onetime/mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
 
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
+    "boxen/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
     "cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "chromium-edge-launcher/lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "clipboardy/execa/cross-spawn/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
@@ -13078,6 +13452,10 @@
 
     "storybook/open/wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
+    "swiftlint/cosmiconfig/parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "swiftlint/cosmiconfig/parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
     "tuf-js/make-fetch-happen/minipass-fetch/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
 
     "verdaccio-audit/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -13116,6 +13494,12 @@
 
     "verdaccio/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "web-ext/open/default-browser/default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "web-ext/open/wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -13127,6 +13511,8 @@
     "@meteora-ag/dlmm/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "@meteora-ag/dlmm/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@react-native/dev-middleware/chrome-launcher/lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -460,7 +460,7 @@
       },
     },
     "packages/browser-bridge-extension": {
-      "name": "@elizaos/browser-extension",
+      "name": "@elizaos/browser-bridge-extension",
       "version": "2.0.3-beta.7",
       "dependencies": {
         "fflate": "^0.8.3",
@@ -4032,7 +4032,7 @@
 
     "@elizaos/auth": ["@elizaos/auth@workspace:packages/auth"],
 
-    "@elizaos/browser-extension": ["@elizaos/browser-extension@workspace:packages/browser-bridge-extension"],
+    "@elizaos/browser-bridge-extension": ["@elizaos/browser-bridge-extension@workspace:packages/browser-bridge-extension"],
 
     "@elizaos/bun-ios-runtime": ["@elizaos/bun-ios-runtime@workspace:packages/native/bun-runtime"],
 
@@ -10190,7 +10190,7 @@
 
     "@elizaos/app/@capacitor/core": ["@capacitor/core@8.5.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ=="],
 
-    "@elizaos/browser-extension/@types/jsdom": ["@types/jsdom@27.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw=="],
+    "@elizaos/browser-bridge-extension/@types/jsdom": ["@types/jsdom@27.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw=="],
 
     "@elizaos/capacitor-agent/@capacitor/core": ["@capacitor/core@8.5.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ=="],
 
@@ -11786,7 +11786,7 @@
 
     "@discordjs/node-pre-gyp/nopt/abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
 
-    "@elizaos/browser-extension/@types/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "@elizaos/browser-bridge-extension/@types/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "@elizaos/operator/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -13078,7 +13078,7 @@
 
     "@cypress/request/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
-    "@elizaos/browser-extension/@types/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "@elizaos/browser-bridge-extension/@types/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@elizaos/plugin-wallet/@solana/spl-token/@solana/buffer-layout-utils/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -137,6 +137,8 @@ const EMPTY_BROWSER_BRIDGE_PACKAGE_STATUS = {
   extensionPath: null,
   chromeBuildPath: null,
   chromePackagePath: null,
+  firefoxBuildPath: null,
+  firefoxPackagePath: null,
   safariWebExtensionPath: null,
   safariAppPath: null,
   safariPackagePath: null,

--- a/packages/browser-bridge-extension/AGENTS.md
+++ b/packages/browser-bridge-extension/AGENTS.md
@@ -96,8 +96,9 @@ bun run --cwd packages/browser-bridge-extension package:firefox
 bun run --cwd packages/browser-bridge-extension package:safari
 bun run --cwd packages/browser-bridge-extension package:stores
 bun run --cwd packages/browser-bridge-extension package:release
-bun run --cwd packages/browser-bridge-extension test
+bun run --cwd packages/browser-bridge-extension test               # test:unit only; CI-safe
 bun run --cwd packages/browser-bridge-extension test:unit
+bun run --cwd packages/browser-bridge-extension test:smoke:installed
 bun run --cwd packages/browser-bridge-extension test:smoke
 bun run --cwd packages/browser-bridge-extension test:smoke:site-access
 bun run --cwd packages/browser-bridge-extension test:smoke:firefox
@@ -109,7 +110,7 @@ Output lands in `dist/chrome/`, `dist/firefox/`, or `dist/safari/`. Load the Chr
 
 The extension opens its pairing guide once on a fresh browser profile so the owner can import credentials without relying on a background-page debug target. The Chrome and Firefox smokes install the unpacked build into the system browser and exercise authenticated manual pairing, explicit website access, sync, a real DOM action, progress, completion, and website-block redirect. Set `FIREFOX_EXECUTABLE_PATH` when Firefox is not installed in a standard platform location.
 
-Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
+Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). The default `test` script runs `test:unit` only, because the `client` repository test lane must pass on machines without an installed browser; `test:smoke:installed` chains the Chrome and Firefox installed-browser smokes and is an explicit opt-in. `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
 
 ## Agent API endpoints the extension calls
 
@@ -118,8 +119,10 @@ All calls use `Authorization: Bearer <pairingToken>` and `X-Browser-Bridge-Compa
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/api/browser-bridge/companions/auto-pair` | Retired compatibility endpoint; returns `410 Gone` without minting credentials |
+| `POST` | `/api/browser-bridge/companions/preflight` | Authenticated companion/settings-version staleness check before a sync heartbeat |
 | `POST` | `/api/browser-bridge/companions/sync` | Heartbeat: posts tab snapshot + page context; receives settings + optional session |
-| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/actions/begin` | Claims the durable, exact action-attempt lease that must precede any side effect |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step, bound to the claimed attempt |
 | `POST` | `/api/browser-bridge/companions/sessions/:id/complete` | Marks session done or failed |
 | `GET` | `/api/website-blocker` | Fetches active blocked/allowed site lists for declarativeNetRequest rules |
 | `GET` | `/api/status` | Used by auto-discovery to confirm a loopback address is a live agent |

--- a/packages/browser-bridge-extension/AGENTS.md
+++ b/packages/browser-bridge-extension/AGENTS.md
@@ -1,0 +1,213 @@
+# @elizaos/browser-bridge-extension
+
+Browser extension for Chrome-family browsers, Firefox, and Safari that pairs a user's browser profile with an Eliza agent so the agent can read open tabs and execute owner-approved browser actions.
+
+## Purpose / role
+
+This is a standalone browser extension — it is not a Node/Bun package imported by other packages. It exposes no npm exports. It communicates with the elizaOS agent API server (default `http://127.0.0.1:31337`) over HTTP using a companion pairing token. The corresponding `/api/browser-bridge/*` server-side routes live in `plugins/plugin-browser/src/routes/bridge.ts`; the `/api/website-blocker` route is served by `plugins/plugin-native-websiteblocker`. Extension-local wire types mirror the owning plugin contracts so this standalone workspace does not depend on runtime packages.
+
+## Layout
+
+```
+packages/browser-bridge-extension/
+  entrypoints/
+    background.ts     Service worker: sync loop, session execution, website blocker
+    content.ts        Content script injected into allowlisted pages: page capture + DOM actions
+    popup.ts          Extension popup UI controller
+    blocked.ts        Redirect target page shown when a site is blocked
+  src/
+    protocol.ts               Internal message types (PopupRequest/Response, ContentScriptMessage, BackgroundState, etc.)
+    browser-bridge-contracts.ts  Public data contracts: BrowserBridgeSettings, BrowserBridgeAction, SyncBrowserBridgeStateRequest, etc.
+    api-client.ts             BrowserBridgeRelayClient — typed HTTP client for companion sync/session endpoints
+    storage.ts                chrome.storage.local wrappers; companion config persistence; agent API auto-discovery
+    tab-cache.ts              Tab merge/filter logic; selectTabsForSync; findFocusedTab
+    page-extract.ts           capturePageContext() — collects title, text, headings, links, forms from the live DOM
+    dom-actions.ts            runDomAction() — executes click/type/submit/history_back/history_forward in page
+    popup-model.ts            derivePopupStatusModel() — pure status model for popup rendering
+    webextension.ts           Thin promise wrapper over chrome.* / browser.* APIs (storage, tabs, windows, alarms, scripting, permissions, declarativeNetRequest)
+    url.ts                    normalizeHttpBaseUrl, normalizeHttpOrigin helpers
+  scripts/
+    build.mjs                 Bun build script; produces IIFE bundles + manifest.json in dist/<chrome|firefox|safari>/
+    package-webextension.mjs  Deterministic ZIP/XPI packager shared by Chrome and Firefox
+    package-chrome.mjs        Packages dist/chrome into a .zip for Chrome Web Store
+    package-firefox.mjs       Packages dist/firefox into reproducible .zip and .xpi artifacts
+    package-safari.mjs        Invokes xcrun to wrap dist/safari into a Safari Web Extension
+    package-store-assets.mjs  Packages store asset screenshots/descriptions
+    package-release.mjs       Orchestrates all packaging steps
+    extension-smoke.mjs       Installed Chrome smoke plus reusable local agent harness
+    extension-smoke-firefox.mjs Firefox artifact and installed-browser WebDriver BiDi smoke
+    extension-smoke-safari.mjs  Node smoke test for Safari build artifacts
+    release-version.mjs       Version helpers (semver → Chrome 4-part version)
+    script-utils.mjs          Shared build script utilities
+  public/
+    popup.html / popup.css    Extension popup page
+    blocked.html              Website-blocker redirect page
+    icons/                    Optional development overrides; release icons come from packages/shared assets
+  safari/                     Xcode project wrapper for Safari Web Extension packaging
+  vitest.extension.config.ts  Vitest config for src/ unit tests
+  dist/                       Build output (gitignored); dist/chrome/, dist/safari/
+```
+
+## Key internal modules
+
+| Module | Role |
+|---|---|
+| `src/protocol.ts` | All runtime message types between extension contexts (popup ↔ background, background ↔ content) |
+| `src/browser-bridge-contracts.ts` | Data types shared between extension and the agent API (`BrowserBridgeSettings`, `BrowserBridgeAction`, sync request/response shapes) |
+| `src/api-client.ts` | `BrowserBridgeRelayClient` — calls `/api/browser-bridge/companions/sync`, `/progress`, `/complete` with Bearer pairing token |
+| `src/storage.ts` | Config persistence in `chrome.storage.local`; loopback discovery of agent API (`http://127.0.0.1:31337` default) |
+| `src/webextension.ts` | Normalizes `chrome.*` / `browser.*` API differences; all extension API calls go through here |
+
+## Build constants
+
+The build script (`scripts/build.mjs`) injects one define constant into each bundle:
+
+- `__BROWSER_BRIDGE_KIND__`: `"chrome"`, `"firefox"`, or `"safari"` (selected by the corresponding build script)
+
+## Extension entrypoints and manifest
+
+`scripts/build.mjs` produces `dist/<kind>/manifest.json` at build time. Key manifest fields:
+
+- `permissions`: `tabs`, `storage`, `scripting`, `alarms`, `activeTab`, `declarativeNetRequestWithHostAccess`
+- `host_permissions` (default install): `http://127.0.0.1/*` and `http://localhost/*` for background-owned local-agent discovery
+- `optional_host_permissions`: `https://*/*`, `http://*/*` — requested only from the popup's browser-managed **Grant Website Access** action
+- `content_security_policy`: `script-src 'self'; object-src 'self'` — no inline scripts, no `unsafe-eval`
+- Background entrypoint: MV3 service worker on Chrome/Safari and a background script on Firefox
+- Content scripts at `document_idle`: `content.js` (page capture + DOM actions), injected only on allowlisted hosts
+- No wallet shim is emitted. A future wallet injection path requires a
+  separately reviewed, explicit top-frame origin grant before any signing code
+  may enter the store artifact.
+
+## Commands
+
+All scripts are run from the package directory:
+
+```bash
+bun run --cwd packages/browser-bridge-extension build             # Chrome (default)
+bun run --cwd packages/browser-bridge-extension build:chrome
+bun run --cwd packages/browser-bridge-extension build:firefox
+bun run --cwd packages/browser-bridge-extension build:safari-webextension
+bun run --cwd packages/browser-bridge-extension clean             # remove dist/
+bun run --cwd packages/browser-bridge-extension typecheck
+bun run --cwd packages/browser-bridge-extension lint:check
+bun run --cwd packages/browser-bridge-extension format:check
+bun run --cwd packages/browser-bridge-extension package:chrome
+bun run --cwd packages/browser-bridge-extension package:firefox
+bun run --cwd packages/browser-bridge-extension package:safari
+bun run --cwd packages/browser-bridge-extension package:stores
+bun run --cwd packages/browser-bridge-extension package:release
+bun run --cwd packages/browser-bridge-extension test
+bun run --cwd packages/browser-bridge-extension test:unit
+bun run --cwd packages/browser-bridge-extension test:smoke
+bun run --cwd packages/browser-bridge-extension test:smoke:site-access
+bun run --cwd packages/browser-bridge-extension test:smoke:firefox
+bun run --cwd packages/browser-bridge-extension lint:firefox
+bun run --cwd packages/browser-bridge-extension test:smoke:safari
+```
+
+Output lands in `dist/chrome/`, `dist/firefox/`, or `dist/safari/`. Load the Chrome directory from `chrome://extensions`; load the Firefox directory temporarily from `about:debugging#/runtime/this-firefox`.
+
+The extension opens its pairing guide once on a fresh browser profile so the owner can import credentials without relying on a background-page debug target. The Chrome and Firefox smokes install the unpacked build into the system browser and exercise authenticated manual pairing, explicit website access, sync, a real DOM action, progress, completion, and website-block redirect. Set `FIREFOX_EXECUTABLE_PATH` when Firefox is not installed in a standard platform location.
+
+Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
+
+## Agent API endpoints the extension calls
+
+All calls use `Authorization: Bearer <pairingToken>` and `X-Browser-Bridge-Companion-Id: <companionId>`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/browser-bridge/companions/auto-pair` | Retired compatibility endpoint; returns `410 Gone` without minting credentials |
+| `POST` | `/api/browser-bridge/companions/sync` | Heartbeat: posts tab snapshot + page context; receives settings + optional session |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/complete` | Marks session done or failed |
+| `GET` | `/api/website-blocker` | Fetches active blocked/allowed site lists for declarativeNetRequest rules |
+| `GET` | `/api/status` | Used by auto-discovery to confirm a loopback address is a live agent |
+
+## Browser actions the extension can execute
+
+Triggered by `BrowserBridgeAction` objects delivered in the sync response's `session.actions` array:
+
+`open`, `navigate`, `focus_tab`, `back`, `forward`, `reload` — handled in the service worker via `chrome.tabs.*`
+
+`click`, `type`, `submit`, `history_back`, `history_forward` — handled by `runDomAction()` in the content script via `browser-bridge:execute-dom-action` message
+
+`read_page`, `extract_links`, `extract_forms` — handled by `capturePageContext()` in the content script via `browser-bridge:capture-page` message
+
+## Config / env
+
+No environment variables. Configuration is stored in `chrome.storage.local` under two keys:
+
+- `browserBridgeCompanionConfig` — `CompanionConfig` (apiBaseUrl, companionId, pairingToken, browser, profileId, profileLabel, label)
+- `browserBridgeBackgroundState` — `BackgroundState` (persisted across service worker restarts)
+
+Default `apiBaseUrl` is `http://127.0.0.1:31337`. Auto-discovery also probes `http://127.0.0.1:2138`, `http://localhost:2138`, `http://localhost:31337`.
+
+## How to extend
+
+**Add a new DOM action kind:**
+1. Add the kind to `DomActionRequest["kind"]` union in `src/protocol.ts`.
+2. Add a case in `runDomAction()` in `src/dom-actions.ts`.
+3. Add the same kind to `BrowserBridgeActionKind` in `src/browser-bridge-contracts.ts`.
+4. Handle it in `executeAction()` in `entrypoints/background.ts` if it requires tab-level orchestration rather than in-page execution.
+
+**Add a new popup message type:**
+1. Add to the `PopupRequest` union in `src/protocol.ts`.
+2. Add a case in `handlePopupMessage()` in `entrypoints/background.ts`.
+3. Wire the button/handler in `entrypoints/popup.ts`.
+
+**Expand the host allowlist at build time:**
+Edit `BROWSER_BRIDGE_HOST_ALLOWLIST` in `scripts/build.mjs`. The array is mirrored into `host_permissions` and `content_scripts.matches` in the generated manifest.
+
+## Conventions / gotchas
+
+- The extension has no npm exports and is `"private": true`. Nothing imports from it via package resolution.
+- `src/webextension.ts` normalizes `chrome.*` / `browser.*` differences. All extension API calls must go through this module — never call `chrome.*` or `browser.*` directly from other src files.
+- Do not add dormant injected-script bundles to store artifacts. Wallet
+  injection requires a separately reviewed explicit top-frame origin grant and
+  a reachable, tested activation path.
+- Sync runs on a 30-second alarm (`SYNC_INTERVAL_MINUTES = 0.5`) and is debounced 750ms after tab events. Do not remove the debounce — rapid tab events would otherwise flood the agent API.
+- `isCompanionAuthError()` in the background detects expired/revoked pairing tokens and clears stored config so the popup can require a newly authenticated manual pairing.
+- Unit tests in `src/storage.test.ts` use `jsdom` via `vitest.extension.config.ts`. Do not run `bun test` from the repo root for this package — it uses its own vitest config.
+
+<!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->
+## ⛔ NON-NEGOTIABLE — evidence, trajectories & real end-to-end tests
+
+> The binding, repo-wide standard is **[AGENTS.md](../../AGENTS.md)**. Read it.
+> Nothing in this package is *done* until it is *proven* done — a reviewer must confirm it
+> works **without reading the code**, from the artifacts you attach. This applies to **every**
+> feature, fix, refactor, and chore here. "Tests pass" is not proof; "CI is green" is not proof.
+
+- **Record AND read model trajectories.** Capture the *actual* inputs and outputs of the model
+  from a **live** LLM — not the deterministic proxy, not a mock: the prompt, the
+  providers/context, the raw model output, every tool/action call, and the result. Then **open
+  the trajectory and review it by hand.** A captured-but-unread trajectory is not evidence
+  (`packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out>`).
+- **Real, full-featured E2E — no larp.** Every feature ships detailed end-to-end tests that
+  drive the *real* path end to end. Not the happy "front door" only: cover error paths,
+  edge/empty/invalid input, concurrency, roles/permissions, and adversarial input. A test that
+  asserts against a mock/stub/fixture standing in for the thing under test **does not count**.
+  If the real model/device/chain/connector/account is hard to reach, **make it reachable — that
+  is the work**, not an excuse to mock. If the existing tests here are shallow or mocked, fixing
+  them is part of your change.
+- **Screenshots + logs at every phase**, plus a **complete walkthrough video/run-through** of
+  the entire feature or view, start to finish (`bun run test:e2e:record`).
+- **Manually review every artifact the change touches** — never just the green check: client
+  logs (console + network), server logs (`[ClassName] …`), the model trajectories in and out,
+  before/after full-page screenshots, **and the domain artifacts listed below for this package.**
+- **No residuals. No shortcuts.** The goal is not "done" — it is *everything* done. Clear every
+  blocker by the **hard path**: build the real architecture, stand up the real
+  model/device/service, actually test it. Never leave a TODO, a stub, a stepping-stone, or a
+  "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
+  highest-effort, production-ready version. Keep going until every possibility is exhausted.
+
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
+explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
+behavior, **re-capture** evidence; stale proof is worse than none.
+
+**Capture & manually review for this package — CLI / tooling:**
+- The real command/flow invocation transcript (args in, stdout/stderr, exit code) and the artifacts it generated (files, scaffolds, manifests, screenshots/recordings).
+- Failure paths: bad args, missing deps, partial state, permission/network errors.
+- A recording/log of the actual run end to end — not a unit test of one helper.
+- Any model interaction captured as a live trajectory and reviewed.
+<!-- END: evidence-and-e2e-mandate -->

--- a/packages/browser-bridge-extension/AGENTS.md
+++ b/packages/browser-bridge-extension/AGENTS.md
@@ -42,7 +42,7 @@ packages/browser-bridge-extension/
   public/
     popup.html / popup.css    Extension popup page
     blocked.html              Website-blocker redirect page
-    icons/                    Optional development overrides; release icons come from packages/shared assets
+    icons                     Release icons copied from packages/shared assets
   safari/                     Xcode project wrapper for Safari Web Extension packaging
   vitest.extension.config.ts  Vitest config for src/ unit tests
   dist/                       Build output (gitignored); dist/chrome/, dist/safari/

--- a/packages/browser-bridge-extension/CLAUDE.md
+++ b/packages/browser-bridge-extension/CLAUDE.md
@@ -96,8 +96,9 @@ bun run --cwd packages/browser-bridge-extension package:firefox
 bun run --cwd packages/browser-bridge-extension package:safari
 bun run --cwd packages/browser-bridge-extension package:stores
 bun run --cwd packages/browser-bridge-extension package:release
-bun run --cwd packages/browser-bridge-extension test
+bun run --cwd packages/browser-bridge-extension test               # test:unit only; CI-safe
 bun run --cwd packages/browser-bridge-extension test:unit
+bun run --cwd packages/browser-bridge-extension test:smoke:installed
 bun run --cwd packages/browser-bridge-extension test:smoke
 bun run --cwd packages/browser-bridge-extension test:smoke:site-access
 bun run --cwd packages/browser-bridge-extension test:smoke:firefox
@@ -109,7 +110,7 @@ Output lands in `dist/chrome/`, `dist/firefox/`, or `dist/safari/`. Load the Chr
 
 The extension opens its pairing guide once on a fresh browser profile so the owner can import credentials without relying on a background-page debug target. The Chrome and Firefox smokes install the unpacked build into the system browser and exercise authenticated manual pairing, explicit website access, sync, a real DOM action, progress, completion, and website-block redirect. Set `FIREFOX_EXECUTABLE_PATH` when Firefox is not installed in a standard platform location.
 
-Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
+Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). The default `test` script runs `test:unit` only, because the `client` repository test lane must pass on machines without an installed browser; `test:smoke:installed` chains the Chrome and Firefox installed-browser smokes and is an explicit opt-in. `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
 
 ## Agent API endpoints the extension calls
 
@@ -118,8 +119,10 @@ All calls use `Authorization: Bearer <pairingToken>` and `X-Browser-Bridge-Compa
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/api/browser-bridge/companions/auto-pair` | Retired compatibility endpoint; returns `410 Gone` without minting credentials |
+| `POST` | `/api/browser-bridge/companions/preflight` | Authenticated companion/settings-version staleness check before a sync heartbeat |
 | `POST` | `/api/browser-bridge/companions/sync` | Heartbeat: posts tab snapshot + page context; receives settings + optional session |
-| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/actions/begin` | Claims the durable, exact action-attempt lease that must precede any side effect |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step, bound to the claimed attempt |
 | `POST` | `/api/browser-bridge/companions/sessions/:id/complete` | Marks session done or failed |
 | `GET` | `/api/website-blocker` | Fetches active blocked/allowed site lists for declarativeNetRequest rules |
 | `GET` | `/api/status` | Used by auto-discovery to confirm a loopback address is a live agent |

--- a/packages/browser-bridge-extension/CLAUDE.md
+++ b/packages/browser-bridge-extension/CLAUDE.md
@@ -1,0 +1,213 @@
+# @elizaos/browser-bridge-extension
+
+Browser extension for Chrome-family browsers, Firefox, and Safari that pairs a user's browser profile with an Eliza agent so the agent can read open tabs and execute owner-approved browser actions.
+
+## Purpose / role
+
+This is a standalone browser extension — it is not a Node/Bun package imported by other packages. It exposes no npm exports. It communicates with the elizaOS agent API server (default `http://127.0.0.1:31337`) over HTTP using a companion pairing token. The corresponding `/api/browser-bridge/*` server-side routes live in `plugins/plugin-browser/src/routes/bridge.ts`; the `/api/website-blocker` route is served by `plugins/plugin-native-websiteblocker`. Extension-local wire types mirror the owning plugin contracts so this standalone workspace does not depend on runtime packages.
+
+## Layout
+
+```
+packages/browser-bridge-extension/
+  entrypoints/
+    background.ts     Service worker: sync loop, session execution, website blocker
+    content.ts        Content script injected into allowlisted pages: page capture + DOM actions
+    popup.ts          Extension popup UI controller
+    blocked.ts        Redirect target page shown when a site is blocked
+  src/
+    protocol.ts               Internal message types (PopupRequest/Response, ContentScriptMessage, BackgroundState, etc.)
+    browser-bridge-contracts.ts  Public data contracts: BrowserBridgeSettings, BrowserBridgeAction, SyncBrowserBridgeStateRequest, etc.
+    api-client.ts             BrowserBridgeRelayClient — typed HTTP client for companion sync/session endpoints
+    storage.ts                chrome.storage.local wrappers; companion config persistence; agent API auto-discovery
+    tab-cache.ts              Tab merge/filter logic; selectTabsForSync; findFocusedTab
+    page-extract.ts           capturePageContext() — collects title, text, headings, links, forms from the live DOM
+    dom-actions.ts            runDomAction() — executes click/type/submit/history_back/history_forward in page
+    popup-model.ts            derivePopupStatusModel() — pure status model for popup rendering
+    webextension.ts           Thin promise wrapper over chrome.* / browser.* APIs (storage, tabs, windows, alarms, scripting, permissions, declarativeNetRequest)
+    url.ts                    normalizeHttpBaseUrl, normalizeHttpOrigin helpers
+  scripts/
+    build.mjs                 Bun build script; produces IIFE bundles + manifest.json in dist/<chrome|firefox|safari>/
+    package-webextension.mjs  Deterministic ZIP/XPI packager shared by Chrome and Firefox
+    package-chrome.mjs        Packages dist/chrome into a .zip for Chrome Web Store
+    package-firefox.mjs       Packages dist/firefox into reproducible .zip and .xpi artifacts
+    package-safari.mjs        Invokes xcrun to wrap dist/safari into a Safari Web Extension
+    package-store-assets.mjs  Packages store asset screenshots/descriptions
+    package-release.mjs       Orchestrates all packaging steps
+    extension-smoke.mjs       Installed Chrome smoke plus reusable local agent harness
+    extension-smoke-firefox.mjs Firefox artifact and installed-browser WebDriver BiDi smoke
+    extension-smoke-safari.mjs  Node smoke test for Safari build artifacts
+    release-version.mjs       Version helpers (semver → Chrome 4-part version)
+    script-utils.mjs          Shared build script utilities
+  public/
+    popup.html / popup.css    Extension popup page
+    blocked.html              Website-blocker redirect page
+    icons/                    Optional development overrides; release icons come from packages/shared assets
+  safari/                     Xcode project wrapper for Safari Web Extension packaging
+  vitest.extension.config.ts  Vitest config for src/ unit tests
+  dist/                       Build output (gitignored); dist/chrome/, dist/safari/
+```
+
+## Key internal modules
+
+| Module | Role |
+|---|---|
+| `src/protocol.ts` | All runtime message types between extension contexts (popup ↔ background, background ↔ content) |
+| `src/browser-bridge-contracts.ts` | Data types shared between extension and the agent API (`BrowserBridgeSettings`, `BrowserBridgeAction`, sync request/response shapes) |
+| `src/api-client.ts` | `BrowserBridgeRelayClient` — calls `/api/browser-bridge/companions/sync`, `/progress`, `/complete` with Bearer pairing token |
+| `src/storage.ts` | Config persistence in `chrome.storage.local`; loopback discovery of agent API (`http://127.0.0.1:31337` default) |
+| `src/webextension.ts` | Normalizes `chrome.*` / `browser.*` API differences; all extension API calls go through here |
+
+## Build constants
+
+The build script (`scripts/build.mjs`) injects one define constant into each bundle:
+
+- `__BROWSER_BRIDGE_KIND__`: `"chrome"`, `"firefox"`, or `"safari"` (selected by the corresponding build script)
+
+## Extension entrypoints and manifest
+
+`scripts/build.mjs` produces `dist/<kind>/manifest.json` at build time. Key manifest fields:
+
+- `permissions`: `tabs`, `storage`, `scripting`, `alarms`, `activeTab`, `declarativeNetRequestWithHostAccess`
+- `host_permissions` (default install): `http://127.0.0.1/*` and `http://localhost/*` for background-owned local-agent discovery
+- `optional_host_permissions`: `https://*/*`, `http://*/*` — requested only from the popup's browser-managed **Grant Website Access** action
+- `content_security_policy`: `script-src 'self'; object-src 'self'` — no inline scripts, no `unsafe-eval`
+- Background entrypoint: MV3 service worker on Chrome/Safari and a background script on Firefox
+- Content scripts at `document_idle`: `content.js` (page capture + DOM actions), injected only on allowlisted hosts
+- No wallet shim is emitted. A future wallet injection path requires a
+  separately reviewed, explicit top-frame origin grant before any signing code
+  may enter the store artifact.
+
+## Commands
+
+All scripts are run from the package directory:
+
+```bash
+bun run --cwd packages/browser-bridge-extension build             # Chrome (default)
+bun run --cwd packages/browser-bridge-extension build:chrome
+bun run --cwd packages/browser-bridge-extension build:firefox
+bun run --cwd packages/browser-bridge-extension build:safari-webextension
+bun run --cwd packages/browser-bridge-extension clean             # remove dist/
+bun run --cwd packages/browser-bridge-extension typecheck
+bun run --cwd packages/browser-bridge-extension lint:check
+bun run --cwd packages/browser-bridge-extension format:check
+bun run --cwd packages/browser-bridge-extension package:chrome
+bun run --cwd packages/browser-bridge-extension package:firefox
+bun run --cwd packages/browser-bridge-extension package:safari
+bun run --cwd packages/browser-bridge-extension package:stores
+bun run --cwd packages/browser-bridge-extension package:release
+bun run --cwd packages/browser-bridge-extension test
+bun run --cwd packages/browser-bridge-extension test:unit
+bun run --cwd packages/browser-bridge-extension test:smoke
+bun run --cwd packages/browser-bridge-extension test:smoke:site-access
+bun run --cwd packages/browser-bridge-extension test:smoke:firefox
+bun run --cwd packages/browser-bridge-extension lint:firefox
+bun run --cwd packages/browser-bridge-extension test:smoke:safari
+```
+
+Output lands in `dist/chrome/`, `dist/firefox/`, or `dist/safari/`. Load the Chrome directory from `chrome://extensions`; load the Firefox directory temporarily from `about:debugging#/runtime/this-firefox`.
+
+The extension opens its pairing guide once on a fresh browser profile so the owner can import credentials without relying on a background-page debug target. The Chrome and Firefox smokes install the unpacked build into the system browser and exercise authenticated manual pairing, explicit website access, sync, a real DOM action, progress, completion, and website-block redirect. Set `FIREFOX_EXECUTABLE_PATH` when Firefox is not installed in a standard platform location.
+
+Chrome 137 and later reject `--load-extension` in the branded browser. Chrome smokes therefore require an official Chrome for Testing executable through `CHROME_FOR_TESTING_EXECUTABLE_PATH` (or the standard `/Applications/Google Chrome for Testing.app` path on macOS). `test:smoke` runs the loopback pairing/action contract headlessly. `test:smoke:site-access` runs headed and waits up to two minutes for the browser-managed optional-permission decision before proving the website-block redirect; it is the installed-browser acceptance lane and cannot be replaced by a headless result.
+
+## Agent API endpoints the extension calls
+
+All calls use `Authorization: Bearer <pairingToken>` and `X-Browser-Bridge-Companion-Id: <companionId>`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/browser-bridge/companions/auto-pair` | Retired compatibility endpoint; returns `410 Gone` without minting credentials |
+| `POST` | `/api/browser-bridge/companions/sync` | Heartbeat: posts tab snapshot + page context; receives settings + optional session |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/progress` | Reports completed action step |
+| `POST` | `/api/browser-bridge/companions/sessions/:id/complete` | Marks session done or failed |
+| `GET` | `/api/website-blocker` | Fetches active blocked/allowed site lists for declarativeNetRequest rules |
+| `GET` | `/api/status` | Used by auto-discovery to confirm a loopback address is a live agent |
+
+## Browser actions the extension can execute
+
+Triggered by `BrowserBridgeAction` objects delivered in the sync response's `session.actions` array:
+
+`open`, `navigate`, `focus_tab`, `back`, `forward`, `reload` — handled in the service worker via `chrome.tabs.*`
+
+`click`, `type`, `submit`, `history_back`, `history_forward` — handled by `runDomAction()` in the content script via `browser-bridge:execute-dom-action` message
+
+`read_page`, `extract_links`, `extract_forms` — handled by `capturePageContext()` in the content script via `browser-bridge:capture-page` message
+
+## Config / env
+
+No environment variables. Configuration is stored in `chrome.storage.local` under two keys:
+
+- `browserBridgeCompanionConfig` — `CompanionConfig` (apiBaseUrl, companionId, pairingToken, browser, profileId, profileLabel, label)
+- `browserBridgeBackgroundState` — `BackgroundState` (persisted across service worker restarts)
+
+Default `apiBaseUrl` is `http://127.0.0.1:31337`. Auto-discovery also probes `http://127.0.0.1:2138`, `http://localhost:2138`, `http://localhost:31337`.
+
+## How to extend
+
+**Add a new DOM action kind:**
+1. Add the kind to `DomActionRequest["kind"]` union in `src/protocol.ts`.
+2. Add a case in `runDomAction()` in `src/dom-actions.ts`.
+3. Add the same kind to `BrowserBridgeActionKind` in `src/browser-bridge-contracts.ts`.
+4. Handle it in `executeAction()` in `entrypoints/background.ts` if it requires tab-level orchestration rather than in-page execution.
+
+**Add a new popup message type:**
+1. Add to the `PopupRequest` union in `src/protocol.ts`.
+2. Add a case in `handlePopupMessage()` in `entrypoints/background.ts`.
+3. Wire the button/handler in `entrypoints/popup.ts`.
+
+**Expand the host allowlist at build time:**
+Edit `BROWSER_BRIDGE_HOST_ALLOWLIST` in `scripts/build.mjs`. The array is mirrored into `host_permissions` and `content_scripts.matches` in the generated manifest.
+
+## Conventions / gotchas
+
+- The extension has no npm exports and is `"private": true`. Nothing imports from it via package resolution.
+- `src/webextension.ts` normalizes `chrome.*` / `browser.*` differences. All extension API calls must go through this module — never call `chrome.*` or `browser.*` directly from other src files.
+- Do not add dormant injected-script bundles to store artifacts. Wallet
+  injection requires a separately reviewed explicit top-frame origin grant and
+  a reachable, tested activation path.
+- Sync runs on a 30-second alarm (`SYNC_INTERVAL_MINUTES = 0.5`) and is debounced 750ms after tab events. Do not remove the debounce — rapid tab events would otherwise flood the agent API.
+- `isCompanionAuthError()` in the background detects expired/revoked pairing tokens and clears stored config so the popup can require a newly authenticated manual pairing.
+- Unit tests in `src/storage.test.ts` use `jsdom` via `vitest.extension.config.ts`. Do not run `bun test` from the repo root for this package — it uses its own vitest config.
+
+<!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->
+## ⛔ NON-NEGOTIABLE — evidence, trajectories & real end-to-end tests
+
+> The binding, repo-wide standard is **[AGENTS.md](../../AGENTS.md)**. Read it.
+> Nothing in this package is *done* until it is *proven* done — a reviewer must confirm it
+> works **without reading the code**, from the artifacts you attach. This applies to **every**
+> feature, fix, refactor, and chore here. "Tests pass" is not proof; "CI is green" is not proof.
+
+- **Record AND read model trajectories.** Capture the *actual* inputs and outputs of the model
+  from a **live** LLM — not the deterministic proxy, not a mock: the prompt, the
+  providers/context, the raw model output, every tool/action call, and the result. Then **open
+  the trajectory and review it by hand.** A captured-but-unread trajectory is not evidence
+  (`packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out>`).
+- **Real, full-featured E2E — no larp.** Every feature ships detailed end-to-end tests that
+  drive the *real* path end to end. Not the happy "front door" only: cover error paths,
+  edge/empty/invalid input, concurrency, roles/permissions, and adversarial input. A test that
+  asserts against a mock/stub/fixture standing in for the thing under test **does not count**.
+  If the real model/device/chain/connector/account is hard to reach, **make it reachable — that
+  is the work**, not an excuse to mock. If the existing tests here are shallow or mocked, fixing
+  them is part of your change.
+- **Screenshots + logs at every phase**, plus a **complete walkthrough video/run-through** of
+  the entire feature or view, start to finish (`bun run test:e2e:record`).
+- **Manually review every artifact the change touches** — never just the green check: client
+  logs (console + network), server logs (`[ClassName] …`), the model trajectories in and out,
+  before/after full-page screenshots, **and the domain artifacts listed below for this package.**
+- **No residuals. No shortcuts.** The goal is not "done" — it is *everything* done. Clear every
+  blocker by the **hard path**: build the real architecture, stand up the real
+  model/device/service, actually test it. Never leave a TODO, a stub, a stepping-stone, or a
+  "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
+  highest-effort, production-ready version. Keep going until every possibility is exhausted.
+
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
+explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
+behavior, **re-capture** evidence; stale proof is worse than none.
+
+**Capture & manually review for this package — CLI / tooling:**
+- The real command/flow invocation transcript (args in, stdout/stderr, exit code) and the artifacts it generated (files, scaffolds, manifests, screenshots/recordings).
+- Failure paths: bad args, missing deps, partial state, permission/network errors.
+- A recording/log of the actual run end to end — not a unit test of one helper.
+- Any model interaction captured as a live trajectory and reviewed.
+<!-- END: evidence-and-e2e-mandate -->

--- a/packages/browser-bridge-extension/CLAUDE.md
+++ b/packages/browser-bridge-extension/CLAUDE.md
@@ -42,7 +42,7 @@ packages/browser-bridge-extension/
   public/
     popup.html / popup.css    Extension popup page
     blocked.html              Website-blocker redirect page
-    icons/                    Optional development overrides; release icons come from packages/shared assets
+    icons                     Release icons copied from packages/shared assets
   safari/                     Xcode project wrapper for Safari Web Extension packaging
   vitest.extension.config.ts  Vitest config for src/ unit tests
   dist/                       Build output (gitignored); dist/chrome/, dist/safari/

--- a/packages/browser-bridge-extension/README.md
+++ b/packages/browser-bridge-extension/README.md
@@ -1,0 +1,99 @@
+# `@elizaos/browser-bridge-extension`
+
+The browser bridge extension pairs a user's personal browser profile with an
+Eliza agent so the agent can read the current page and run owner-approved
+browser actions.
+
+## What it does
+
+Once installed and paired, the extension:
+
+- Syncs open tabs and the current page's text/links/forms to the Eliza agent every 30 seconds and on every tab change.
+- Executes agent-directed browser actions: open a URL, navigate, click an element, type into a field, submit a form, scroll history, or focus a tab.
+- Enforces an agent-configured website blocklist using the browser's `declarativeNetRequest` API.
+
+## Supported browsers
+
+| Browser | Build target |
+|---|---|
+| Chrome / Chromium / Edge | `bun run build:chrome` → `dist/chrome/` |
+| Firefox | `bun run build:firefox` → `dist/firefox/` |
+| Safari (macOS / iOS) | `bun run build:safari-webextension` → `dist/safari/`, then packaged with Xcode |
+
+## Security model
+
+**Host allowlist (default install)**
+
+The extension ships with a scoped host allowlist instead of a blanket `<all_urls>` grant. The default-install hosts are:
+
+- `http://127.0.0.1/*` and `http://localhost/*` for the local agent API
+- `https://eliza.how/*` and subdomains
+- `https://eliza.dev/*` and subdomains
+
+The page-capture content script auto-injects only on these origins. No wallet
+shim ships in the store artifact: a signing token must never be injected into
+every allowlisted origin or child frame. Wallet injection remains out of scope
+until an explicit top-frame origin grant is wired and reviewed end to end.
+
+**Optional hosts**
+
+If a user wants the agent to read or act on an additional site, the extension
+uses the browser's extension site-access controls to grant the exact origin.
+The sync and action paths independently check the browser's effective grants
+before sharing tab metadata or executing a browser action.
+
+**Content Security Policy**
+
+`script-src 'self'; object-src 'self'` is enforced on extension pages. Inline
+scripts are forbidden; only first-party bundle code may execute. No
+`unsafe-eval` and no `wasm-unsafe-eval`.
+
+**Threat model boundaries**
+
+- Out of scope: keylogging, password harvesting, generic content extraction beyond allowlisted hosts.
+- In scope: agent-directed `click`, `type`, `submit`, `history_back`, and `history_forward` actions on allowlisted pages.
+
+## Pairing
+
+The extension connects to a running Eliza agent API server (default `http://127.0.0.1:31337`).
+
+**Authenticated pair:** On a fresh profile the extension opens its pairing guide once. Create a browser companion pairing from authenticated Eliza Browser settings, copy the resulting pairing JSON, paste it into **Pairing and Advanced Tools**, and click **Import Pairing JSON**.
+
+The retired `/api/browser-bridge/companions/auto-pair` compatibility endpoint returns `410 Gone` and never mints credentials. Loopback reachability and an extension `Origin` are not proof of owner authorization.
+
+## Development
+
+```bash
+# Install dependencies
+bun install --cwd packages/browser-bridge-extension
+
+# Build Chrome extension
+bun run --cwd packages/browser-bridge-extension build:chrome
+
+# Build Firefox extension
+bun run --cwd packages/browser-bridge-extension build:firefox
+
+# Load in Chrome: chrome://extensions → Developer mode → Load unpacked → select dist/chrome/
+
+# Run unit tests plus installed Chrome and Firefox smokes
+bun run --cwd packages/browser-bridge-extension test
+
+# Smoke-check an installed Chrome-family extension
+bun run --cwd packages/browser-bridge-extension test:smoke
+
+# Package, install, and exercise the extension in Firefox over WebDriver BiDi
+bun run --cwd packages/browser-bridge-extension test:smoke:firefox
+```
+
+The Firefox smoke uses the system Firefox application. Set
+`FIREFOX_EXECUTABLE_PATH` when Firefox is not installed in its standard macOS,
+Linux, or Windows location.
+
+## Packaging for distribution
+
+```bash
+bun run --cwd packages/browser-bridge-extension package:chrome   # → ZIP for Chrome Web Store
+bun run --cwd packages/browser-bridge-extension package:firefox  # → deterministic ZIP + XPI for AMO/self-hosting
+bun run --cwd packages/browser-bridge-extension package:safari   # → xcrun Safari Web Extension
+bun run --cwd packages/browser-bridge-extension package:release  # → all formats
+```

--- a/packages/browser-bridge-extension/README.md
+++ b/packages/browser-bridge-extension/README.md
@@ -27,13 +27,15 @@ Once installed and paired, the extension:
 The extension ships with a scoped host allowlist instead of a blanket `<all_urls>` grant. The default-install hosts are:
 
 - `http://127.0.0.1/*` and `http://localhost/*` for the local agent API
-- `https://eliza.how/*` and subdomains
-- `https://eliza.dev/*` and subdomains
 
 The page-capture content script auto-injects only on these origins. No wallet
 shim ships in the store artifact: a signing token must never be injected into
 every allowlisted origin or child frame. Wallet injection remains out of scope
 until an explicit top-frame origin grant is wired and reviewed end to end.
+
+Blocked-site entries are host-scoped: blocking a host also blocks its
+subdomains across HTTP(S) schemes and ports. Website grants remain exact
+origins and still require the browser's own effective host permission.
 
 **Optional hosts**
 
@@ -75,8 +77,11 @@ bun run --cwd packages/browser-bridge-extension build:firefox
 
 # Load in Chrome: chrome://extensions → Developer mode → Load unpacked → select dist/chrome/
 
-# Run unit tests plus installed Chrome and Firefox smokes
+# Run CI-safe unit tests
 bun run --cwd packages/browser-bridge-extension test
+
+# Explicitly run the installed Chrome and Firefox acceptance lanes
+bun run --cwd packages/browser-bridge-extension test:smoke:installed
 
 # Smoke-check an installed Chrome-family extension
 bun run --cwd packages/browser-bridge-extension test:smoke

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -1,0 +1,993 @@
+/**
+ * Extension service worker — the always-on coordinator. Runs the periodic sync
+ * loop, pulls agent-directed browser sessions
+ * and executes them via the content script, and enforces the website blocklist
+ * through declarativeNetRequest. Bridges popup requests and content-script
+ * responses to the BrowserBridgeRelayClient.
+ *
+ * Under MV3 the worker can be evicted between events, so durable state lives in
+ * chrome.storage.local via src/storage.ts rather than in module scope.
+ */
+import { browserActionAuthorizationError } from "../src/action-authorization";
+import { resolveBrowserActionTarget } from "../src/action-target";
+import { BrowserBridgeRelayClient, RelayApiError } from "../src/api-client";
+import type {
+  BrowserBridgeAction,
+  BrowserBridgeSettings,
+  LifeOpsBrowserSession,
+} from "../src/browser-bridge-contracts";
+import { sendWithContentScriptRecovery } from "../src/content-script-messaging";
+import type {
+  BackgroundState,
+  CompanionConfig,
+  CompanionPreflightRequest,
+  CompanionSession,
+  CompanionSyncRequest,
+  ContentScriptResponse,
+  DomActionRequest,
+  PopupRequest,
+  PopupResponse,
+} from "../src/protocol";
+import { withBrowserBridgeRequestTimeout } from "../src/request-timeout";
+import {
+  clearCompanionConfig,
+  isValidApiBaseUrl,
+  loadBackgroundState,
+  loadCompanionConfig,
+  normalizeCompanionConfig,
+  saveBackgroundState,
+  saveCompanionConfig,
+} from "../src/storage";
+import {
+  findFocusedTab,
+  type RememberedTab,
+  selectTabsForSync,
+} from "../src/tab-cache";
+import {
+  addAlarmListener,
+  addInstalledListener,
+  addRuntimeMessageListener,
+  addStartupListener,
+  addTabsActivatedListener,
+  addTabsRemovedListener,
+  addTabsUpdatedListener,
+  addWindowFocusListener,
+  createAlarm,
+  createTab,
+  executeContentScriptFiles,
+  focusWindow,
+  getAllWindows,
+  getDynamicRules,
+  getExtensionUrl,
+  getGrantedOrigins,
+  getManifestVersion,
+  hasAllUrlHostPermission,
+  hasManifestPermission,
+  isIncognitoAccessAllowed,
+  queryTabs,
+  reloadTab,
+  sendTabMessage,
+  storageGet,
+  storageSet,
+  updateDynamicRules,
+  updateTab,
+} from "../src/webextension";
+
+declare const __BROWSER_BRIDGE_KIND__: "chrome" | "firefox" | "safari";
+
+const SYNC_ALARM = "browser-bridge-sync";
+const SYNC_INTERVAL_MINUTES = 0.5;
+const SYNC_DEBOUNCE_MS = 750;
+const MAX_REMEMBERED_TABS = 10;
+
+let backgroundState: BackgroundState = {
+  config: null,
+  settings: null,
+  syncing: false,
+  lastSyncAt: null,
+  lastError: null,
+  lastSessionStatus: null,
+  activeSessionId: null,
+  rememberedTabCount: 0,
+  settingsSummary: null,
+};
+let rememberedTabs: RememberedTab[] = [];
+let syncScheduled = false;
+let syncInFlight = false;
+let activeSessionId: string | null = null;
+
+function canSyncUrl(url: string | undefined): url is string {
+  return typeof url === "string" && /^https?:\/\//i.test(url);
+}
+
+function parseNumericId(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isCompanionAuthError(error: unknown): error is RelayApiError {
+  if (!(error instanceof RelayApiError) || error.status !== 401) {
+    return false;
+  }
+  return (
+    error.code === null ||
+    error.code === "browser_bridge_companion_pairing_invalid" ||
+    error.code === "browser_bridge_companion_token_expired" ||
+    error.code === "browser_bridge_companion_token_revoked"
+  );
+}
+
+function companionAuthErrorMessage(error: RelayApiError): string {
+  if (error.code === "browser_bridge_companion_token_revoked") {
+    return "Pairing was revoked. Create a new pairing in Eliza and import its pairing JSON.";
+  }
+  if (error.code === "browser_bridge_companion_token_expired") {
+    return "Pairing expired. Create a new pairing in Eliza and import its pairing JSON.";
+  }
+  return "Pairing is no longer valid. Create a new pairing in Eliza and import its pairing JSON.";
+}
+
+async function saveState(): Promise<void> {
+  backgroundState = {
+    ...backgroundState,
+    rememberedTabCount: rememberedTabs.length,
+    activeSessionId,
+  };
+  await saveBackgroundState(backgroundState);
+}
+
+async function setState(next: Partial<BackgroundState>): Promise<void> {
+  backgroundState = {
+    ...backgroundState,
+    ...next,
+  };
+  await saveState();
+}
+
+async function readConfig(): Promise<CompanionConfig | null> {
+  const config = await loadCompanionConfig();
+  backgroundState.config = config;
+  return config;
+}
+
+async function describePermissionState(): Promise<{
+  tabs: boolean;
+  scripting: boolean;
+  activeTab: boolean;
+  allOrigins: boolean;
+  grantedOrigins: string[];
+  incognitoEnabled: boolean;
+}> {
+  return {
+    tabs: true,
+    scripting: true,
+    activeTab: hasManifestPermission("activeTab"),
+    allOrigins: await hasAllUrlHostPermission(),
+    grantedOrigins: await getGrantedOrigins(),
+    incognitoEnabled: await isIncognitoAccessAllowed(),
+  };
+}
+
+async function collectSnapshotTabs(
+  config: CompanionConfig,
+  settings: BrowserBridgeSettings | null,
+): Promise<RememberedTab[]> {
+  const windows = await getAllWindows();
+  const snapshot: RememberedTab[] = [];
+  const nowIso = new Date().toISOString();
+  for (const windowInfo of windows) {
+    for (const tab of windowInfo.tabs ?? []) {
+      if (!canSyncUrl(tab.url)) {
+        continue;
+      }
+      if (typeof tab.id !== "number" || typeof tab.windowId !== "number") {
+        continue;
+      }
+      snapshot.push({
+        browser: config.browser,
+        profileId: config.profileId,
+        windowId: String(tab.windowId),
+        tabId: String(tab.id),
+        url: tab.url,
+        title: tab.title?.trim() || tab.url,
+        activeInWindow: tab.active === true,
+        focusedWindow: windowInfo.focused === true,
+        focusedActive: tab.active === true && windowInfo.focused === true,
+        incognito: tab.incognito === true,
+        faviconUrl: tab.favIconUrl ?? null,
+        lastSeenAt: nowIso,
+        lastFocusedAt: tab.active === true ? nowIso : null,
+        metadata: {},
+      });
+    }
+  }
+  rememberedTabs = selectTabsForSync({
+    previous: rememberedTabs,
+    snapshot,
+    settings,
+    grantedOrigins: await getGrantedOrigins(),
+    fallbackMaxRememberedTabs: MAX_REMEMBERED_TABS,
+  });
+  await saveState();
+  return rememberedTabs;
+}
+
+async function captureFocusedPageContext(
+  tabs: readonly RememberedTab[],
+): Promise<CompanionSyncRequest["pageContexts"]> {
+  const focused = findFocusedTab(tabs);
+  if (!focused) {
+    return [];
+  }
+  const tabId = parseNumericId(focused.tabId);
+  if (tabId === null) {
+    return [];
+  }
+  try {
+    const response = await sendContentScriptMessage(tabId, {
+      type: "browser-bridge:capture-page",
+      expectedUrl: focused.url,
+    });
+    if (!response.ok || !response.page) {
+      return [];
+    }
+    return [
+      {
+        browser: focused.browser,
+        profileId: focused.profileId,
+        windowId: focused.windowId,
+        tabId: focused.tabId,
+        url: response.page.url,
+        title: response.page.title,
+        selectionText: response.page.selectionText,
+        mainText: response.page.mainText,
+        headings: response.page.headings,
+        links: response.page.links,
+        forms: response.page.forms,
+        capturedAt: response.page.capturedAt,
+      },
+    ];
+  } catch {
+    // error-policy:J4 Page capture failure omits that tab's optional context;
+    // the tab remains visible and no synthetic page contents are emitted.
+    return [];
+  }
+}
+
+async function sendContentScriptMessage(
+  tabId: number,
+  message: unknown,
+): Promise<ContentScriptResponse> {
+  return await sendWithContentScriptRecovery({
+    send: () => sendTabMessage<ContentScriptResponse>(tabId, message),
+    inject: () => executeContentScriptFiles(tabId, ["content.js"]),
+  });
+}
+
+async function buildSyncRequest(
+  config: CompanionConfig,
+  settings: BrowserBridgeSettings,
+  settingsVersion: string,
+): Promise<CompanionSyncRequest> {
+  const tabs = await collectSnapshotTabs(config, settings);
+  return {
+    settingsVersion,
+    companion: {
+      browser: config.browser,
+      profileId: config.profileId,
+      profileLabel: config.profileLabel,
+      label: config.label,
+      extensionVersion: getManifestVersion(),
+      connectionState: "connected",
+      permissions: await describePermissionState(),
+      lastSeenAt: new Date().toISOString(),
+    },
+    tabs,
+    pageContexts: await captureFocusedPageContext(tabs),
+  };
+}
+
+async function buildPreflightRequest(
+  config: CompanionConfig,
+): Promise<CompanionPreflightRequest> {
+  return {
+    companion: {
+      browser: config.browser,
+      profileId: config.profileId,
+      profileLabel: config.profileLabel,
+      label: config.label,
+      extensionVersion: getManifestVersion(),
+      connectionState: "connected",
+      permissions: await describePermissionState(),
+      lastSeenAt: new Date().toISOString(),
+    },
+  };
+}
+
+async function preflightAndSync(
+  client: BrowserBridgeRelayClient,
+  config: CompanionConfig,
+) {
+  const preflight = await client.preflight(await buildPreflightRequest(config));
+  backgroundState.settings = preflight.settings;
+  return await client.sync(
+    await buildSyncRequest(
+      config,
+      preflight.settings,
+      preflight.settingsVersion,
+    ),
+  );
+}
+
+async function runContentAction(
+  tabId: number,
+  expectedUrl: string,
+  action: DomActionRequest,
+): Promise<Record<string, unknown>> {
+  const response = await sendContentScriptMessage(tabId, {
+    type: "browser-bridge:execute-dom-action",
+    expectedUrl,
+    action,
+  });
+  if (response.ok === false) {
+    throw new Error(response.error);
+  }
+  return response.actionResult ?? {};
+}
+
+async function executeAction(
+  client: BrowserBridgeRelayClient,
+  config: CompanionConfig,
+  session: CompanionSession,
+  action: BrowserBridgeAction,
+  currentTabId: number | null,
+  expectedActionIndex: number,
+  attemptId: string,
+): Promise<{ currentTabId: number | null; result: Record<string, unknown> }> {
+  const freshSync = await preflightAndSync(client, config);
+  backgroundState.settings = freshSync.settings;
+  if (
+    freshSync.session?.id !== session.id ||
+    freshSync.session.currentActionIndex !== expectedActionIndex
+  ) {
+    throw new Error(
+      "The browser session checkpoint changed before action execution.",
+    );
+  }
+  const freshAction = freshSync.session.actions[expectedActionIndex];
+  if (!freshAction || freshAction.id !== action.id) {
+    throw new Error(
+      "The browser session action changed before action execution.",
+    );
+  }
+  const leasedSession = await client.beginSessionAction(session.id, {
+    currentActionIndex: expectedActionIndex,
+    actionId: freshAction.id,
+    attemptId,
+  });
+  const executableAction = leasedSession.actions[expectedActionIndex];
+  if (
+    leasedSession.currentActionIndex !== expectedActionIndex ||
+    !executableAction ||
+    executableAction.id !== freshAction.id
+  ) {
+    throw new Error("The browser action lease does not match its checkpoint.");
+  }
+  const openTabs = await queryTabs({});
+  const openWindows = await getAllWindows();
+  const focusedTab =
+    (await queryTabs({ active: true, lastFocusedWindow: true }))[0] ?? null;
+  const target = resolveBrowserActionTarget({
+    actionKind: executableAction.kind,
+    actionTabId: executableAction.tabId,
+    sessionTabId: session.tabId,
+    currentTabId,
+    actionWindowId: executableAction.windowId,
+    sessionWindowId: session.windowId,
+    tabs: openTabs,
+    windows: openWindows,
+    focusedTab,
+  });
+  const resolvedTabId = target.tabId;
+  const existingTarget =
+    resolvedTabId === null
+      ? null
+      : (openTabs.find((tab) => tab.id === resolvedTabId) ?? null);
+  const targetUrl =
+    executableAction.kind === "open" || executableAction.kind === "navigate"
+      ? executableAction.url
+      : existingTarget?.url;
+  if (!targetUrl) {
+    throw new Error(
+      `${executableAction.kind} requires an authorized target URL`,
+    );
+  }
+  const authorizationError = browserActionAuthorizationError({
+    settings: freshSync.settings,
+    target: {
+      url: targetUrl,
+      incognito: target.incognito,
+      focusedActive: target.focusedActive,
+    },
+    grantedOrigins: await getGrantedOrigins(),
+    currentFocusedUrl: focusedTab?.url ?? null,
+  });
+  if (authorizationError) {
+    throw new Error(authorizationError);
+  }
+  switch (executableAction.kind) {
+    case "open": {
+      if (!executableAction.url) {
+        throw new Error("open requires url");
+      }
+      const tab = await createTab({
+        url: executableAction.url,
+        active: true,
+        ...(target.windowId === null ? {} : { windowId: target.windowId }),
+      });
+      return {
+        currentTabId: typeof tab.id === "number" ? tab.id : null,
+        result: {
+          openedUrl: executableAction.url,
+          tabId: tab.id ?? null,
+          windowId: tab.windowId ?? null,
+        },
+      };
+    }
+    case "navigate": {
+      if (!executableAction.url) {
+        throw new Error("navigate requires url");
+      }
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        const tab = await createTab({
+          url: executableAction.url,
+          active: true,
+          ...(target.windowId === null ? {} : { windowId: target.windowId }),
+        });
+        return {
+          currentTabId: typeof tab.id === "number" ? tab.id : null,
+          result: {
+            navigatedUrl: executableAction.url,
+            tabId: tab.id ?? null,
+            createdTab: true,
+          },
+        };
+      }
+      const tab = await updateTab(tabId, {
+        url: executableAction.url,
+        active: true,
+      });
+      if (typeof tab.windowId === "number") {
+        await focusWindow(tab.windowId);
+      }
+      return {
+        currentTabId: tabId,
+        result: {
+          navigatedUrl: executableAction.url,
+          tabId,
+        },
+      };
+    }
+    case "focus_tab": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error("focus_tab requires a target tab");
+      }
+      const tab = await updateTab(tabId, { active: true });
+      if (typeof tab.windowId === "number") {
+        await focusWindow(tab.windowId);
+      }
+      return {
+        currentTabId: tabId,
+        result: {
+          focusedTabId: tabId,
+        },
+      };
+    }
+    case "reload": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error("reload requires a target tab");
+      }
+      await reloadTab(tabId);
+      return {
+        currentTabId: tabId,
+        result: {
+          reloadedTabId: tabId,
+        },
+      };
+    }
+    case "back": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error("back requires a target tab");
+      }
+      return {
+        currentTabId: tabId,
+        result: await runContentAction(tabId, targetUrl, {
+          kind: "history_back",
+        }),
+      };
+    }
+    case "forward": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error("forward requires a target tab");
+      }
+      return {
+        currentTabId: tabId,
+        result: await runContentAction(tabId, targetUrl, {
+          kind: "history_forward",
+        }),
+      };
+    }
+    case "click":
+    case "type":
+    case "submit": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error(`${executableAction.kind} requires a target tab`);
+      }
+      return {
+        currentTabId: tabId,
+        result: await runContentAction(tabId, targetUrl, {
+          kind: executableAction.kind,
+          selector: executableAction.selector ?? null,
+          text: executableAction.text ?? null,
+        }),
+      };
+    }
+    case "read_page":
+    case "extract_links":
+    case "extract_forms": {
+      const tabId = resolvedTabId;
+      if (tabId === null) {
+        throw new Error(`${executableAction.kind} requires a target tab`);
+      }
+      const response = await sendContentScriptMessage(tabId, {
+        type: "browser-bridge:capture-page",
+        expectedUrl: targetUrl,
+      });
+      if (response.ok === false || !response.page) {
+        throw new Error(
+          "error" in response ? response.error : "page capture failed",
+        );
+      }
+      const result =
+        executableAction.kind === "read_page"
+          ? {
+              title: response.page.title,
+              url: response.page.url,
+              selectionText: response.page.selectionText,
+              mainText: response.page.mainText,
+            }
+          : executableAction.kind === "extract_links"
+            ? { links: response.page.links }
+            : { forms: response.page.forms };
+      return {
+        currentTabId: tabId,
+        result,
+      };
+    }
+    default:
+      throw new Error(`Unsupported action kind ${executableAction.kind}`);
+  }
+}
+
+async function executeSession(
+  client: BrowserBridgeRelayClient,
+  session: LifeOpsBrowserSession,
+): Promise<void> {
+  if (activeSessionId === session.id) {
+    return;
+  }
+  activeSessionId = session.id;
+  await setState({
+    activeSessionId,
+    lastSessionStatus: `running ${session.title}`,
+    lastError: null,
+  });
+
+  const actionResults: Record<string, unknown> = {};
+  let currentTabId = parseNumericId(session.tabId);
+
+  try {
+    for (
+      let index = session.currentActionIndex;
+      index < session.actions.length;
+      index += 1
+    ) {
+      const action = session.actions[index];
+      const config = await readConfig();
+      if (!config) {
+        throw new Error("Browser companion configuration is unavailable.");
+      }
+      const attemptId = crypto.randomUUID();
+      const outcome = await executeAction(
+        client,
+        config,
+        session,
+        action,
+        currentTabId,
+        index,
+        attemptId,
+      );
+      currentTabId = outcome.currentTabId;
+      actionResults[action.id] = outcome.result;
+      await client.updateSessionProgress(session.id, {
+        completedActionId: action.id,
+        attemptId,
+        currentActionIndex: index + 1,
+        result: {
+          [action.id]: outcome.result,
+        },
+        metadata: {
+          lastActionId: action.id,
+          lastActionKind: action.kind,
+        },
+      });
+    }
+    await client.completeSession(session.id, {
+      status: "done",
+      result: {
+        actionResults,
+      },
+    });
+    await setState({
+      lastSessionStatus: `completed ${session.title}`,
+    });
+  } catch (error) {
+    const conflict = error instanceof RelayApiError && error.status === 409;
+    if (!conflict) {
+      // error-policy:J1 Session execution owns the terminal failure transition.
+      await client.completeSession(session.id, {
+        status: "failed",
+        result: {
+          actionResults,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+    await setState({
+      lastError: error instanceof Error ? error.message : String(error),
+      lastSessionStatus: `${conflict ? "conflicted" : "failed"} ${session.title}`,
+    });
+  } finally {
+    activeSessionId = null;
+    await saveState();
+  }
+}
+
+const BLOCKING_RULE_ID_OFFSET = 10_001;
+const ALLOWLIST_RULE_ID_OFFSET = 20_001;
+
+async function syncBlockingRules(apiBase: string): Promise<void> {
+  const data = await withBrowserBridgeRequestTimeout(
+    "Website blocker policy sync",
+    async (signal) => {
+      const resp = await fetch(`${apiBase}/api/website-blocker`, { signal });
+      if (!resp.ok) {
+        throw new Error(
+          `website blocker sync failed: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      return (await resp.json()) as {
+        active?: boolean;
+        blockedWebsites?: string[];
+        allowedWebsites?: string[];
+        websites?: string[];
+      };
+    },
+  );
+
+  const existingRules = await getDynamicRules();
+  const blockingRuleIds = existingRules
+    .filter(
+      (rule) =>
+        rule.id >= BLOCKING_RULE_ID_OFFSET &&
+        rule.id < BLOCKING_RULE_ID_OFFSET + 5_000,
+    )
+    .map((rule) => rule.id);
+  const allowRuleIds = existingRules
+    .filter(
+      (rule) =>
+        rule.id >= ALLOWLIST_RULE_ID_OFFSET &&
+        rule.id < ALLOWLIST_RULE_ID_OFFSET + 5_000,
+    )
+    .map((rule) => rule.id);
+
+  if (
+    !data.active ||
+    !Array.isArray(data.blockedWebsites ?? data.websites) ||
+    (data.blockedWebsites ?? data.websites)?.length === 0
+  ) {
+    const ruleIdsToRemove = [...blockingRuleIds, ...allowRuleIds];
+    if (ruleIdsToRemove.length > 0) {
+      await updateDynamicRules({ removeRuleIds: ruleIdsToRemove });
+    }
+    return;
+  }
+
+  const extensionBlockedPage = getExtensionUrl("blocked.html");
+  const blockedWebsites = (data.blockedWebsites ?? data.websites ?? []).filter(
+    (website): website is string => typeof website === "string",
+  );
+  if (!(await hasAllUrlHostPermission())) {
+    throw new Error(
+      "Grant Website Access in the extension popup before enabling LifeOps website blocking.",
+    );
+  }
+  const allowedWebsites = (data.allowedWebsites ?? []).filter(
+    (website): website is string => typeof website === "string",
+  );
+  const blockedRules = blockedWebsites.map((host, index) => ({
+    id: BLOCKING_RULE_ID_OFFSET + index,
+    priority: 1,
+    action: {
+      type: "redirect" as const,
+      redirect: {
+        url: `${extensionBlockedPage}?host=${encodeURIComponent(host)}&url=${encodeURIComponent(`https://${host}`)}&api=${encodeURIComponent(apiBase)}`,
+      },
+    },
+    condition: {
+      urlFilter: `||${host}^`,
+      resourceTypes: ["main_frame" as const],
+    },
+  }));
+  const allowRules = allowedWebsites.map((host, index) => ({
+    id: ALLOWLIST_RULE_ID_OFFSET + index,
+    priority: 2,
+    action: {
+      type: "allow" as const,
+    },
+    condition: {
+      urlFilter: `||${host}^`,
+      resourceTypes: ["main_frame" as const],
+    },
+  }));
+
+  await updateDynamicRules({
+    removeRuleIds: [...blockingRuleIds, ...allowRuleIds],
+    addRules: [...allowRules, ...blockedRules],
+  });
+}
+
+async function syncNow(reason: string): Promise<BackgroundState> {
+  const config = await readConfig();
+  if (!config) {
+    await setState({
+      syncing: false,
+      lastError:
+        backgroundState.lastError ??
+        "Agent Browser Bridge is not paired. Create an authenticated pairing in Eliza and import its pairing JSON.",
+      settingsSummary: null,
+      lastSessionStatus: null,
+    });
+    return backgroundState;
+  }
+  if (syncInFlight) {
+    syncScheduled = true;
+    return backgroundState;
+  }
+  syncInFlight = true;
+  await setState({
+    syncing: true,
+    config,
+    lastError: null,
+  });
+
+  try {
+    const client = new BrowserBridgeRelayClient(config);
+    const response = await preflightAndSync(client, config);
+    await setState({
+      syncing: false,
+      lastSyncAt: new Date().toISOString(),
+      settings: response.settings,
+      settingsSummary: `${response.settings.enabled ? response.settings.trackingMode : "off"} / control ${response.settings.allowBrowserControl ? "on" : "off"}`,
+      lastError: null,
+      rememberedTabCount: response.tabs.length,
+    });
+    if (response.session) {
+      await executeSession(client, response.session);
+    }
+    try {
+      await syncBlockingRules(config.apiBaseUrl);
+    } catch (error) {
+      // error-policy:J4 Blocking-policy failure is shown in extension state
+      // without fabricating successful rule synchronization.
+      await setState({
+        lastError: `website blocker sync failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  } catch (error) {
+    // error-policy:J1 The sync-loop boundary translates failures into durable
+    // extension state and revokes invalid local pairing state.
+    const isPairingInvalid = isCompanionAuthError(error);
+    if (isPairingInvalid) {
+      syncScheduled = false;
+      await clearCompanionConfig();
+    }
+    await setState({
+      syncing: false,
+      ...(isPairingInvalid && { config: null, settingsSummary: null }),
+      lastError: isPairingInvalid
+        ? companionAuthErrorMessage(error)
+        : `${reason}: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  } finally {
+    syncInFlight = false;
+    if (syncScheduled) {
+      syncScheduled = false;
+      setTimeout(() => {
+        void syncNow("queued");
+      }, SYNC_DEBOUNCE_MS);
+    }
+  }
+  return backgroundState;
+}
+
+function scheduleSync(reason: string): void {
+  if (syncScheduled) {
+    return;
+  }
+  syncScheduled = true;
+  setTimeout(() => {
+    syncScheduled = false;
+    void syncNow(reason);
+  }, SYNC_DEBOUNCE_MS);
+}
+
+async function handlePopupMessage(
+  message: PopupRequest,
+): Promise<PopupResponse> {
+  try {
+    switch (message.type) {
+      case "browser-bridge:get-state": {
+        const config = await readConfig();
+        const persistedState = await loadBackgroundState();
+        backgroundState = persistedState ?? backgroundState;
+        backgroundState.config = config;
+        return { ok: true, state: backgroundState };
+      }
+      case "browser-bridge:auto-pair": {
+        await setState({
+          lastError:
+            "Automatic pairing is disabled. Create an authenticated pairing in Eliza and import its pairing JSON.",
+        });
+        return { ok: true, state: backgroundState };
+      }
+      case "browser-bridge:save-config": {
+        if (
+          typeof message.config?.apiBaseUrl === "string" &&
+          message.config.apiBaseUrl.trim().length > 0 &&
+          !isValidApiBaseUrl(message.config.apiBaseUrl)
+        ) {
+          throw new Error("apiBaseUrl must be an http:// or https:// URL");
+        }
+        const nextConfig = normalizeCompanionConfig({
+          ...(await readConfig()),
+          ...(message.config ?? {}),
+          browser: __BROWSER_BRIDGE_KIND__,
+        });
+        if (!nextConfig) {
+          throw new Error("companionId and pairingToken are required");
+        }
+        await saveCompanionConfig(nextConfig);
+        await setState({
+          config: nextConfig,
+          settings: backgroundState.settings,
+          lastError: null,
+        });
+        createAlarm(SYNC_ALARM, SYNC_INTERVAL_MINUTES);
+        scheduleSync("config");
+        return { ok: true, state: backgroundState };
+      }
+      case "browser-bridge:clear-config": {
+        await clearCompanionConfig();
+        rememberedTabs = [];
+        activeSessionId = null;
+        await setState({
+          config: null,
+          settings: null,
+          lastError: "Agent Browser Bridge companion pairing cleared.",
+          lastSessionStatus: null,
+          lastSyncAt: null,
+          rememberedTabCount: 0,
+          settingsSummary: null,
+        });
+        return { ok: true, state: backgroundState };
+      }
+      case "browser-bridge:sync-now": {
+        return { ok: true, state: await syncNow("popup") };
+      }
+      default:
+        throw new Error("Unsupported popup request");
+    }
+  } catch (error) {
+    // error-policy:J1 Popup requests return a structured failure response.
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      state: backgroundState,
+    };
+  }
+}
+
+addRuntimeMessageListener((message, _sender, sendResponse) => {
+  const request = message as PopupRequest | undefined;
+  if (!request || typeof request !== "object" || !("type" in request)) {
+    return false;
+  }
+  void handlePopupMessage(request).then((response) => {
+    sendResponse(response);
+  });
+  return true;
+});
+
+addInstalledListener(() => {
+  createAlarm(SYNC_ALARM, SYNC_INTERVAL_MINUTES);
+  scheduleSync("install");
+});
+
+addStartupListener(() => {
+  createAlarm(SYNC_ALARM, SYNC_INTERVAL_MINUTES);
+  scheduleSync("startup");
+});
+
+addAlarmListener((alarm) => {
+  if (alarm.name === SYNC_ALARM) {
+    void syncNow("alarm");
+  }
+});
+
+addTabsActivatedListener(() => {
+  scheduleSync("tab-activated");
+});
+
+addTabsUpdatedListener((_tabId, changeInfo) => {
+  const record = changeInfo as {
+    status?: string;
+    url?: string;
+    title?: string;
+  };
+  if (record.status === "complete" || record.url || record.title) {
+    scheduleSync("tab-updated");
+  }
+});
+
+addTabsRemovedListener(() => {
+  scheduleSync("tab-removed");
+});
+
+addWindowFocusListener(() => {
+  scheduleSync("window-focus");
+});
+
+void (async () => {
+  const persistedState = await loadBackgroundState();
+  if (persistedState) {
+    backgroundState = persistedState;
+  }
+  const config = await readConfig();
+  if (
+    !config &&
+    !(await storageGet<boolean>("browserBridgePairingGuideSeen"))
+  ) {
+    await storageSet({ browserBridgePairingGuideSeen: true });
+    try {
+      await createTab({ url: getExtensionUrl("popup.html") });
+    } catch (error) {
+      // error-policy:J4 Failure to open the first-run pairing guide is visible
+      // in extension state while the toolbar popup remains available.
+      await setState({
+        lastError: `Could not open the pairing guide: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+  createAlarm(SYNC_ALARM, SYNC_INTERVAL_MINUTES);
+  scheduleSync("startup-bootstrap");
+})();

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -64,6 +64,7 @@ import {
   hasAllUrlHostPermission,
   hasManifestPermission,
   isIncognitoAccessAllowed,
+  isPrivilegedExtensionSender,
   queryTabs,
   reloadTab,
   sendTabMessage,
@@ -917,7 +918,14 @@ async function handlePopupMessage(
   }
 }
 
-addRuntimeMessageListener((message, _sender, sendResponse) => {
+addRuntimeMessageListener((message, sender, sendResponse) => {
+  // This channel writes the pairing credential (`browser-bridge:save-config`),
+  // so it accepts messages only from the extension's own privileged contexts.
+  // Content scripts share `runtime.onMessage`, and ours run on every localhost
+  // port.
+  if (!isPrivilegedExtensionSender(sender)) {
+    return false;
+  }
   const request = message as PopupRequest | undefined;
   if (!request || typeof request !== "object" || !("type" in request)) {
     return false;

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -595,6 +595,26 @@ async function executeSession(
 
   const actionResults: Record<string, unknown> = {};
   let currentTabId = parseNumericId(session.tabId);
+  const priorReceipt = session.metadata.browserActionReceipt;
+  let completionActionId =
+    priorReceipt &&
+    typeof priorReceipt === "object" &&
+    !Array.isArray(priorReceipt) &&
+    typeof (priorReceipt as Record<string, unknown>).actionId === "string"
+      ? ((priorReceipt as Record<string, unknown>).actionId as string)
+      : null;
+  let completionAttemptId =
+    priorReceipt &&
+    typeof priorReceipt === "object" &&
+    !Array.isArray(priorReceipt) &&
+    typeof (priorReceipt as Record<string, unknown>).attemptId === "string"
+      ? ((priorReceipt as Record<string, unknown>).attemptId as string)
+      : null;
+  let activeAttempt: {
+    actionId: string;
+    actionIndex: number;
+    attemptId: string;
+  } | null = null;
 
   try {
     for (
@@ -608,6 +628,11 @@ async function executeSession(
         throw new Error("Browser companion configuration is unavailable.");
       }
       const attemptId = crypto.randomUUID();
+      activeAttempt = {
+        actionId: action.id,
+        actionIndex: index,
+        attemptId,
+      };
       const outcome = await executeAction(
         client,
         config,
@@ -631,9 +656,15 @@ async function executeSession(
           lastActionKind: action.kind,
         },
       });
+      completionActionId = action.id;
+      completionAttemptId = attemptId;
+      activeAttempt = null;
     }
     await client.completeSession(session.id, {
       status: "done",
+      currentActionIndex: session.actions.length,
+      completedActionId: completionActionId,
+      attemptId: completionAttemptId,
       result: {
         actionResults,
       },
@@ -642,16 +673,32 @@ async function executeSession(
       lastSessionStatus: `completed ${session.title}`,
     });
   } catch (error) {
-    const conflict = error instanceof RelayApiError && error.status === 409;
-    if (!conflict) {
-      // error-policy:J1 Session execution owns the terminal failure transition.
-      await client.completeSession(session.id, {
-        status: "failed",
-        result: {
-          actionResults,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      });
+    let conflict =
+      (error instanceof RelayApiError && error.status === 409) ||
+      activeAttempt === null;
+    if (!conflict && activeAttempt) {
+      try {
+        // error-policy:J1 Session execution owns the terminal failure transition.
+        await client.completeSession(session.id, {
+          status: "failed",
+          currentActionIndex: activeAttempt.actionIndex,
+          completedActionId: activeAttempt.actionId,
+          attemptId: activeAttempt.attemptId,
+          result: {
+            actionResults,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+      } catch (completionError) {
+        if (
+          completionError instanceof RelayApiError &&
+          completionError.status === 409
+        ) {
+          conflict = true;
+        } else {
+          throw completionError;
+        }
+      }
     }
     await setState({
       lastError: error instanceof Error ? error.message : String(error),

--- a/packages/browser-bridge-extension/entrypoints/blocked.ts
+++ b/packages/browser-bridge-extension/entrypoints/blocked.ts
@@ -1,0 +1,134 @@
+/**
+ * Controller for the block interstitial (blocked.html) shown when
+ * declarativeNetRequest redirects a blocked site. Reads the blocked URL/host
+ * and agent base from the query string, then polls the agent for the group's
+ * required tasks and links back to LifeOps so the user can clear the block.
+ */
+import {
+  loadCompanionConfig,
+  resolveTrustedBlockedPageApiBase,
+} from "../src/storage";
+import {
+  normalizeHostForComparison,
+  normalizeNavigableUrlForHost,
+} from "../src/url";
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface RequiredTask {
+  id?: string;
+  title: string;
+  completed: boolean;
+}
+
+interface BlockedHostResponse {
+  blocked: boolean;
+  host: string;
+  groupKey: string | null;
+  requiredTasks: RequiredTask[];
+  websites: string[];
+}
+
+const params = new URLSearchParams(window.location.search);
+const blockedUrl = params.get("url");
+const blockedHost =
+  normalizeHostForComparison(params.get("host")) ??
+  normalizeHostForComparison(blockedUrl) ??
+  "Unknown site";
+const requestedApiBase = params.get("api");
+let apiBase: string | null = null;
+
+const blockedSiteEl = document.getElementById("blockedSite");
+const taskListEl = document.getElementById("taskList");
+const openLifeOpsEl = document.getElementById("openLifeOps");
+
+if (blockedSiteEl) {
+  blockedSiteEl.textContent = blockedHost;
+}
+
+openLifeOpsEl?.removeAttribute("href");
+
+function appendTask(title: string, completed = false): void {
+  if (!taskListEl) return;
+  const item = document.createElement("li");
+  const status = document.createElement("span");
+  status.className = completed ? "status-dot completed" : "status-dot";
+  item.append(status, document.createTextNode(title));
+  taskListEl.append(item);
+}
+
+function renderTasks(tasks: RequiredTask[]): void {
+  if (!taskListEl) {
+    return;
+  }
+  taskListEl.replaceChildren();
+  if (tasks.length === 0) {
+    appendTask("Site is blocked by LifeOps policy");
+    return;
+  }
+  for (const task of tasks) {
+    appendTask(task.title, task.completed);
+  }
+}
+
+function renderFallback(): void {
+  if (!taskListEl) {
+    return;
+  }
+  taskListEl.replaceChildren();
+  appendTask("Complete your LifeOps tasks to unblock");
+}
+
+async function fetchBlockingReason(): Promise<BlockedHostResponse | null> {
+  if (!apiBase) {
+    return null;
+  }
+  try {
+    const resp = await fetch(
+      `${apiBase}/api/website-blocker?host=${encodeURIComponent(blockedHost)}`,
+    );
+    if (!resp.ok) {
+      return null;
+    }
+    return (await resp.json()) as BlockedHostResponse;
+  } catch {
+    // error-policy:J4 A failed policy lookup keeps the interstitial visibly
+    // degraded and does not navigate or claim that the site is unblocked.
+    return null;
+  }
+}
+
+async function loadBlockingReason(): Promise<void> {
+  const data = await fetchBlockingReason();
+  if (data?.requiredTasks) {
+    renderTasks(data.requiredTasks);
+  } else {
+    renderFallback();
+  }
+}
+
+async function pollForUnblock(): Promise<void> {
+  const data = await fetchBlockingReason();
+  if (data && !data.blocked) {
+    const target = normalizeNavigableUrlForHost(blockedUrl, blockedHost);
+    if (target) {
+      window.location.href = target;
+    }
+  }
+}
+
+async function initializeBlockedPage(): Promise<void> {
+  const pairedConfig = await loadCompanionConfig();
+  apiBase = resolveTrustedBlockedPageApiBase(requestedApiBase, pairedConfig);
+  if (apiBase && openLifeOpsEl) {
+    openLifeOpsEl.setAttribute("href", apiBase.replace(/:\d+$/, ":2138"));
+  }
+  await loadBlockingReason();
+  if (apiBase) {
+    setInterval(() => {
+      void pollForUnblock();
+    }, POLL_INTERVAL_MS);
+  }
+}
+
+void initializeBlockedPage();

--- a/packages/browser-bridge-extension/entrypoints/content.ts
+++ b/packages/browser-bridge-extension/entrypoints/content.ts
@@ -1,0 +1,60 @@
+/**
+ * Content script injected into allowlisted or owner-granted pages: routes
+ * capture-page and DOM-action messages from the background worker to
+ * page-extract / dom-actions and returns the result. Thin adapter — all logic
+ * lives in src/.
+ */
+
+import { assertContentScriptPageUrl } from "../src/content-script-messaging";
+import { runDomAction } from "../src/dom-actions";
+import { capturePageContext } from "../src/page-extract";
+import type {
+  ContentScriptMessage,
+  ContentScriptResponse,
+} from "../src/protocol";
+import { addRuntimeMessageListener } from "../src/webextension";
+
+const contentGlobal = globalThis as typeof globalThis & {
+  __elizaBrowserBridgeContentRegistered?: boolean;
+};
+
+if (!contentGlobal.__elizaBrowserBridgeContentRegistered) {
+  contentGlobal.__elizaBrowserBridgeContentRegistered = true;
+  addRuntimeMessageListener((message, _sender, sendResponse) => {
+    const request = message as ContentScriptMessage | undefined;
+    if (!request || typeof request !== "object" || !("type" in request)) {
+      return false;
+    }
+
+    try {
+      if (request.type === "browser-bridge:capture-page") {
+        assertContentScriptPageUrl(request.expectedUrl, window.location.href);
+        const response: ContentScriptResponse = {
+          ok: true,
+          page: capturePageContext(),
+        };
+        sendResponse(response);
+        return false;
+      }
+
+      if (request.type === "browser-bridge:execute-dom-action") {
+        assertContentScriptPageUrl(request.expectedUrl, window.location.href);
+        const response: ContentScriptResponse = {
+          ok: true,
+          actionResult: runDomAction(request.action),
+        };
+        sendResponse(response);
+        return false;
+      }
+    } catch (error) {
+      // error-policy:J1 Translate page extraction/action errors into the extension message protocol.
+      sendResponse({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      } satisfies ContentScriptResponse);
+      return false;
+    }
+
+    return false;
+  });
+}

--- a/packages/browser-bridge-extension/entrypoints/popup.ts
+++ b/packages/browser-bridge-extension/entrypoints/popup.ts
@@ -1,47 +1,36 @@
 /**
- * Popup UI controller: renders the status model from derivePopupStatusModel,
- * drives the settings form (agent API URL, companion id, tracking mode), and
- * imports authenticated manual pairing or triggers sync through the background worker.
+ * Renders the extension's compact connection status and exposes only
+ * contextual recovery, permission, and disconnect controls.
  */
-import { derivePopupStatusModel } from "../src/popup-model";
+import {
+  derivePopupStatusModel,
+  type PopupContextualAction,
+} from "../src/popup-model";
 import type {
   BackgroundState,
   CompanionConfig,
   PopupRequest,
   PopupResponse,
 } from "../src/protocol";
-import {
-  DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
-  discoverAgentApiBaseUrl,
-} from "../src/storage";
+import { discoverAgentApiBaseUrl } from "../src/storage";
 import {
   hasAllUrlHostPermission,
   requestAllWebsiteAccess,
   sendRuntimeMessage,
 } from "../src/webextension";
 
-type FormRefs = {
-  apiBaseUrl: HTMLInputElement;
-  autoPairButton: HTMLButtonElement;
-  browser: HTMLSelectElement;
-  companionId: HTMLInputElement;
-  pairingToken: HTMLInputElement;
-  profileId: HTMLInputElement;
-  profileLabel: HTMLInputElement;
-  label: HTMLInputElement;
-  pairingJson: HTMLTextAreaElement;
-  advancedTools: HTMLDetailsElement;
-  statusBadge: HTMLElement;
+type PopupRefs = {
   statusTitle: HTMLElement;
-  statusDetail: HTMLElement;
-  statusChecklist: HTMLUListElement;
-  summary: HTMLElement;
-  saveButton: HTMLButtonElement;
-  importButton: HTMLButtonElement;
-  syncButton: HTMLButtonElement;
-  clearButton: HTMLButtonElement;
-  siteAccessButton: HTMLButtonElement;
-  siteAccessStatus: HTMLElement;
+  primaryAction: HTMLButtonElement;
+  details: HTMLDetailsElement;
+  recovery: HTMLDetailsElement;
+  pairingJson: HTMLTextAreaElement;
+  importPairingButton: HTMLButtonElement;
+  appValue: HTMLElement;
+  lastSyncValue: HTMLElement;
+  modeValue: HTMLElement;
+  tabCountValue: HTMLElement;
+  disconnectButton: HTMLButtonElement;
 };
 
 type ElementConstructor<T extends HTMLElement> = { new (): T };
@@ -57,29 +46,19 @@ function requireElement<T extends HTMLElement>(
   return element;
 }
 
-function getFormRefs(): FormRefs {
+function getPopupRefs(): PopupRefs {
   return {
-    apiBaseUrl: requireElement("#apiBaseUrl", HTMLInputElement),
-    autoPairButton: requireElement("#autoPair", HTMLButtonElement),
-    browser: requireElement("#browser", HTMLSelectElement),
-    companionId: requireElement("#companionId", HTMLInputElement),
-    pairingToken: requireElement("#pairingToken", HTMLInputElement),
-    profileId: requireElement("#profileId", HTMLInputElement),
-    profileLabel: requireElement("#profileLabel", HTMLInputElement),
-    label: requireElement("#label", HTMLInputElement),
-    pairingJson: requireElement("#pairingJson", HTMLTextAreaElement),
-    advancedTools: requireElement("#advancedTools", HTMLDetailsElement),
-    statusBadge: requireElement("#statusBadge", HTMLElement),
     statusTitle: requireElement("#statusTitle", HTMLElement),
-    statusDetail: requireElement("#statusDetail", HTMLElement),
-    statusChecklist: requireElement("#statusChecklist", HTMLUListElement),
-    summary: requireElement("#summary", HTMLElement),
-    saveButton: requireElement("#save", HTMLButtonElement),
-    importButton: requireElement("#import", HTMLButtonElement),
-    syncButton: requireElement("#sync", HTMLButtonElement),
-    clearButton: requireElement("#clear", HTMLButtonElement),
-    siteAccessButton: requireElement("#siteAccess", HTMLButtonElement),
-    siteAccessStatus: requireElement("#siteAccessStatus", HTMLElement),
+    primaryAction: requireElement("#primaryAction", HTMLButtonElement),
+    details: requireElement("#details", HTMLDetailsElement),
+    recovery: requireElement("#recovery", HTMLDetailsElement),
+    pairingJson: requireElement("#pairingJson", HTMLTextAreaElement),
+    importPairingButton: requireElement("#importPairing", HTMLButtonElement),
+    appValue: requireElement("#appValue", HTMLElement),
+    lastSyncValue: requireElement("#lastSyncValue", HTMLElement),
+    modeValue: requireElement("#modeValue", HTMLElement),
+    tabCountValue: requireElement("#tabCountValue", HTMLElement),
+    disconnectButton: requireElement("#disconnect", HTMLButtonElement),
   };
 }
 
@@ -89,129 +68,22 @@ function popupResponseError(response: PopupResponse): string {
     : "The browser bridge returned an incomplete success response.";
 }
 
-function renderChecklist(
-  listElement: HTMLUListElement,
-  entries: string[],
-): void {
-  listElement.innerHTML = "";
-  for (const entry of entries) {
-    const item = document.createElement("li");
-    item.textContent = entry;
-    listElement.appendChild(item);
-  }
-}
-
-function renderSummary(refs: FormRefs, entries: string[]): void {
-  refs.summary.replaceChildren();
-  for (const entry of entries) {
-    const pill = document.createElement("span");
-    pill.className = "summary-pill";
-    pill.textContent = entry;
-    refs.summary.appendChild(pill);
-  }
-}
-
-function renderState(
-  refs: FormRefs,
-  state: BackgroundState,
-  discoveredApiBaseUrl: string | null,
-): void {
-  const config = state.config;
-  refs.apiBaseUrl.value =
-    config?.apiBaseUrl ?? DEFAULT_BROWSER_BRIDGE_API_BASE_URL;
-  refs.browser.value = config?.browser ?? "chrome";
-  refs.companionId.value = config?.companionId ?? "";
-  refs.pairingToken.value = config?.pairingToken ?? "";
-  refs.profileId.value = config?.profileId ?? "default";
-  refs.profileLabel.value = config?.profileLabel ?? "default";
-  refs.label.value = config?.label ?? "";
-  const model = derivePopupStatusModel({
-    state,
-    discoveredApiBaseUrl,
-  });
-  refs.statusBadge.textContent = model.badge;
-  refs.statusBadge.dataset.kind = model.kind;
-  refs.statusTitle.textContent = model.title;
-  refs.statusDetail.textContent = model.detail;
-  renderChecklist(refs.statusChecklist, model.checklist);
-  renderSummary(
-    refs,
-    state.activeSessionId
-      ? [...model.summary, `Session: ${state.activeSessionId}`]
-      : model.summary,
-  );
-  refs.autoPairButton.textContent = model.primaryLabel;
-  refs.autoPairButton.disabled = state.syncing;
-  refs.syncButton.hidden = !model.showSync || model.primaryAction === "sync";
-  refs.syncButton.disabled = state.syncing;
-}
-
-function applyDiscoveredApiBaseUrl(
-  refs: FormRefs,
-  state: BackgroundState,
-  discovered: string | null,
-): void {
-  const configured = state.config?.apiBaseUrl?.trim() ?? "";
-  if (
-    configured.length > 0 &&
-    configured.replace(/\/+$/, "") !== DEFAULT_BROWSER_BRIDGE_API_BASE_URL
-  ) {
-    return;
-  }
-  if (!discovered) {
-    return;
-  }
-  refs.apiBaseUrl.value = discovered;
-}
-
-async function renderResolvedState(
-  refs: FormRefs,
-  state: BackgroundState,
-): Promise<void> {
-  const discoveredApiBaseUrl = await discoverAgentApiBaseUrl();
-  renderState(refs, state, discoveredApiBaseUrl);
-  applyDiscoveredApiBaseUrl(refs, state, discoveredApiBaseUrl);
-  const allWebsiteAccess = await hasAllUrlHostPermission();
-  refs.siteAccessButton.disabled = allWebsiteAccess;
-  refs.siteAccessButton.textContent = allWebsiteAccess
-    ? "Website Access Granted"
-    : "Grant Website Access";
-  refs.siteAccessStatus.textContent = allWebsiteAccess
-    ? "Eliza may use the HTTP and HTTPS sites allowed by your Browser settings."
-    : "Required for cross-site control and LifeOps website blocking. Your browser will show a permission prompt.";
-}
-
 async function sendMessage<T extends PopupRequest>(
   request: T,
 ): Promise<PopupResponse> {
   return await sendRuntimeMessage<PopupResponse>(request);
 }
 
-function readConfig(refs: FormRefs): Partial<CompanionConfig> {
-  return {
-    apiBaseUrl: refs.apiBaseUrl.value,
-    browser:
-      refs.browser.value === "safari" || refs.browser.value === "firefox"
-        ? refs.browser.value
-        : "chrome",
-    companionId: refs.companionId.value,
-    pairingToken: refs.pairingToken.value,
-    profileId: refs.profileId.value,
-    profileLabel: refs.profileLabel.value,
-    label: refs.label.value,
-  };
-}
+let currentAction: PopupContextualAction | null = null;
 
-function parsePairingJson(jsonValue: string): Partial<CompanionConfig> {
-  const trimmed = jsonValue.trim();
-  if (!trimmed) {
-    throw new Error("Paste the pairing JSON before importing it");
-  }
+function parsePairingJson(value: string): Partial<CompanionConfig> {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Paste pairing JSON from Eliza first");
   let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
   } catch {
-    // error-policy:J3 Manual pairing input remains an explicit validation error.
+    // error-policy:J3 Manual recovery input remains an explicit validation error.
     throw new Error("Pairing JSON must be valid JSON");
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -222,7 +94,7 @@ function parsePairingJson(jsonValue: string): Partial<CompanionConfig> {
     apiBaseUrl:
       typeof record.apiBaseUrl === "string" ? record.apiBaseUrl : undefined,
     browser:
-      record.browser === "safari" || record.browser === "firefox"
+      record.browser === "firefox" || record.browser === "safari"
         ? record.browser
         : "chrome",
     companionId:
@@ -240,133 +112,164 @@ function parsePairingJson(jsonValue: string): Partial<CompanionConfig> {
   };
 }
 
-async function refresh(refs: FormRefs): Promise<void> {
+function renderError(refs: PopupRefs, label: string): void {
+  currentAction = null;
+  refs.statusTitle.dataset.kind = "error";
+  refs.statusTitle.textContent = label;
+  refs.primaryAction.hidden = true;
+  refs.primaryAction.disabled = false;
+}
+
+async function renderState(
+  refs: PopupRefs,
+  state: BackgroundState,
+  discoveredApiBaseUrl: string | null,
+): Promise<void> {
+  const hasAllWebsiteAccess = await hasAllUrlHostPermission();
+  const view = derivePopupStatusModel({
+    state,
+    discoveredApiBaseUrl,
+    hasAllWebsiteAccess,
+  });
+  currentAction = view.action?.kind ?? null;
+  refs.statusTitle.dataset.kind = view.kind;
+  refs.statusTitle.textContent = view.label;
+  refs.primaryAction.hidden = view.action === null;
+  refs.primaryAction.disabled = false;
+  refs.primaryAction.textContent = view.action?.label ?? "";
+  refs.appValue.textContent = view.diagnostics.app;
+  refs.lastSyncValue.textContent = view.diagnostics.lastSync;
+  refs.modeValue.textContent = view.diagnostics.mode;
+  refs.tabCountValue.textContent = view.diagnostics.tabCount;
+  refs.disconnectButton.hidden = !view.showDisconnect;
+}
+
+async function loadState(): Promise<{
+  state: BackgroundState;
+  discoveredApiBaseUrl: string | null;
+} | null> {
   const response = await sendMessage({ type: "browser-bridge:get-state" });
-  if (!response.ok || !response.state) {
-    refs.statusTitle.textContent = "Agent Browser Bridge could not load";
-    refs.statusDetail.textContent = popupResponseError(response);
+  if (!response.ok || !response.state) return null;
+  return {
+    state: response.state,
+    discoveredApiBaseUrl: await discoverAgentApiBaseUrl(),
+  };
+}
+
+async function refresh(refs: PopupRefs): Promise<void> {
+  const loaded = await loadState();
+  if (!loaded) {
+    renderError(refs, "Couldn’t read the browser connection");
     return;
   }
-  await renderResolvedState(refs, response.state);
+  await renderState(refs, loaded.state, loaded.discoveredApiBaseUrl);
+}
+
+async function runContextualAction(refs: PopupRefs): Promise<void> {
+  const action = currentAction;
+  if (!action) return;
+  if (action === "show_recovery") {
+    refs.details.open = true;
+    refs.recovery.open = true;
+    refs.pairingJson.focus();
+    return;
+  }
+  refs.primaryAction.disabled = true;
+  refs.statusTitle.dataset.kind = "syncing";
+  refs.statusTitle.textContent =
+    action === "grant_website_access"
+      ? "Waiting for browser permission…"
+      : "Connecting to Eliza…";
+
+  if (action === "grant_website_access") {
+    try {
+      if (!(await requestAllWebsiteAccess())) {
+        renderError(refs, "Website access wasn’t granted");
+        currentAction = "grant_website_access";
+        refs.primaryAction.textContent = "Try again";
+        refs.primaryAction.hidden = false;
+        return;
+      }
+    } catch {
+      // error-policy:J4 Permission failure remains a visible recoverable state.
+      renderError(refs, "Website access wasn’t granted");
+      currentAction = "grant_website_access";
+      refs.primaryAction.textContent = "Try again";
+      refs.primaryAction.hidden = false;
+      return;
+    }
+  }
+
+  const response = await sendMessage({ type: "browser-bridge:sync-now" });
+  if (!response.ok || !response.state) {
+    renderError(refs, "Couldn’t connect to Eliza");
+    currentAction = action;
+    refs.primaryAction.textContent = "Retry connection";
+    refs.primaryAction.hidden = false;
+    return;
+  }
+  await renderState(refs, response.state, await discoverAgentApiBaseUrl());
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const refs = getFormRefs();
-
+  const refs = getPopupRefs();
   void refresh(refs);
 
-  refs.autoPairButton.addEventListener("click", async () => {
-    const currentResponse = await sendMessage({
-      type: "browser-bridge:get-state",
-    });
-    const currentState = currentResponse.ok ? currentResponse.state : null;
-    const discoveredApiBaseUrl = await discoverAgentApiBaseUrl();
-    const model = currentState
-      ? derivePopupStatusModel({
-          state: currentState,
-          discoveredApiBaseUrl,
-        })
-      : null;
-    refs.statusDetail.textContent =
-      model?.primaryAction === "sync"
-        ? "Syncing this browser with Eliza…"
-        : "Paste pairing JSON copied from authenticated Eliza Browser settings.";
-    if (model?.primaryAction !== "sync") {
-      refs.advancedTools.open = true;
-      refs.pairingJson.focus();
-      return;
-    }
-    const response = await sendMessage({ type: "browser-bridge:sync-now" });
-    if (!response.ok || !response.state) {
-      refs.statusDetail.textContent = popupResponseError(response);
-      return;
-    }
-    await renderResolvedState(refs, response.state);
+  refs.primaryAction.addEventListener("click", () => {
+    void runContextualAction(refs);
   });
 
-  refs.saveButton.addEventListener("click", async () => {
-    refs.statusDetail.textContent = "Saving manual pairing…";
-    const response = await sendMessage({
-      type: "browser-bridge:save-config",
-      config: readConfig(refs),
-    });
+  refs.disconnectButton.addEventListener("click", async () => {
+    if (!globalThis.confirm("Disconnect this browser from Eliza?")) return;
+    refs.disconnectButton.disabled = true;
+    const response = await sendMessage({ type: "browser-bridge:clear-config" });
+    refs.disconnectButton.disabled = false;
     if (!response.ok || !response.state) {
-      refs.statusDetail.textContent = popupResponseError(response);
+      renderError(refs, popupResponseError(response));
       return;
     }
-    await renderResolvedState(refs, response.state);
+    refs.details.open = false;
+    await renderState(refs, response.state, await discoverAgentApiBaseUrl());
   });
 
-  refs.importButton.addEventListener("click", async () => {
-    refs.statusDetail.textContent = "Importing manual pairing JSON…";
+  refs.importPairingButton.addEventListener("click", async () => {
     let config: Partial<CompanionConfig>;
     try {
       config = parsePairingJson(refs.pairingJson.value);
     } catch (error) {
-      // error-policy:J4 Invalid manual pairing input is shown in the popup and
-      // never reaches extension storage or the agent.
-      refs.statusDetail.textContent =
-        error instanceof Error ? error.message : String(error);
+      // error-policy:J4 Invalid recovery input stays visible without storage.
+      renderError(
+        refs,
+        error instanceof Error ? error.message : "Pairing JSON is invalid",
+      );
       return;
     }
+    refs.importPairingButton.disabled = true;
+    refs.statusTitle.dataset.kind = "syncing";
+    refs.statusTitle.textContent = "Importing pairing…";
     const response = await sendMessage({
       type: "browser-bridge:save-config",
       config,
     });
+    refs.importPairingButton.disabled = false;
     if (!response.ok || !response.state) {
-      refs.statusDetail.textContent = popupResponseError(response);
+      renderError(refs, "Couldn’t import pairing");
       return;
     }
     refs.pairingJson.value = "";
-    await renderResolvedState(refs, response.state);
-  });
-
-  refs.syncButton.addEventListener("click", async () => {
-    refs.statusDetail.textContent = "Syncing this browser with Eliza…";
-    const response = await sendMessage({ type: "browser-bridge:sync-now" });
-    if (!response.ok || !response.state) {
-      refs.statusDetail.textContent = popupResponseError(response);
-      return;
-    }
-    await renderResolvedState(refs, response.state);
-  });
-
-  refs.clearButton.addEventListener("click", async () => {
-    const response = await sendMessage({
-      type: "browser-bridge:clear-config",
+    refs.recovery.open = false;
+    refs.details.open = false;
+    const syncResponse = await sendMessage({
+      type: "browser-bridge:sync-now",
     });
-    if (!response.ok || !response.state) {
-      refs.statusDetail.textContent = popupResponseError(response);
+    if (!syncResponse.ok || !syncResponse.state) {
+      renderError(refs, "Pairing saved · Couldn’t connect to Eliza");
       return;
     }
-    await renderResolvedState(refs, response.state);
-  });
-
-  refs.siteAccessButton.addEventListener("click", async () => {
-    refs.siteAccessStatus.textContent =
-      "Waiting for the browser permission decision…";
-    try {
-      const granted = await requestAllWebsiteAccess();
-      if (!granted) {
-        refs.siteAccessStatus.textContent =
-          "Website access was not granted. Loopback pairing remains available.";
-        return;
-      }
-      refs.siteAccessButton.disabled = true;
-      refs.siteAccessButton.textContent = "Website Access Granted";
-      refs.siteAccessStatus.textContent =
-        "Website access granted. Syncing permissions and blocking rules with Eliza…";
-      const response = await sendMessage({ type: "browser-bridge:sync-now" });
-      if (!response.ok || !response.state) {
-        refs.siteAccessStatus.textContent = popupResponseError(response);
-        return;
-      }
-      await renderResolvedState(refs, response.state);
-    } catch (error) {
-      // error-policy:J4 Browser permission failures remain visible and do not
-      // claim that website access was granted.
-      refs.siteAccessStatus.textContent =
-        error instanceof Error ? error.message : String(error);
-    }
+    await renderState(
+      refs,
+      syncResponse.state,
+      await discoverAgentApiBaseUrl(),
+    );
   });
 });

--- a/packages/browser-bridge-extension/entrypoints/popup.ts
+++ b/packages/browser-bridge-extension/entrypoints/popup.ts
@@ -1,0 +1,372 @@
+/**
+ * Popup UI controller: renders the status model from derivePopupStatusModel,
+ * drives the settings form (agent API URL, companion id, tracking mode), and
+ * imports authenticated manual pairing or triggers sync through the background worker.
+ */
+import { derivePopupStatusModel } from "../src/popup-model";
+import type {
+  BackgroundState,
+  CompanionConfig,
+  PopupRequest,
+  PopupResponse,
+} from "../src/protocol";
+import {
+  DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
+  discoverAgentApiBaseUrl,
+} from "../src/storage";
+import {
+  hasAllUrlHostPermission,
+  requestAllWebsiteAccess,
+  sendRuntimeMessage,
+} from "../src/webextension";
+
+type FormRefs = {
+  apiBaseUrl: HTMLInputElement;
+  autoPairButton: HTMLButtonElement;
+  browser: HTMLSelectElement;
+  companionId: HTMLInputElement;
+  pairingToken: HTMLInputElement;
+  profileId: HTMLInputElement;
+  profileLabel: HTMLInputElement;
+  label: HTMLInputElement;
+  pairingJson: HTMLTextAreaElement;
+  advancedTools: HTMLDetailsElement;
+  statusBadge: HTMLElement;
+  statusTitle: HTMLElement;
+  statusDetail: HTMLElement;
+  statusChecklist: HTMLUListElement;
+  summary: HTMLElement;
+  saveButton: HTMLButtonElement;
+  importButton: HTMLButtonElement;
+  syncButton: HTMLButtonElement;
+  clearButton: HTMLButtonElement;
+  siteAccessButton: HTMLButtonElement;
+  siteAccessStatus: HTMLElement;
+};
+
+type ElementConstructor<T extends HTMLElement> = { new (): T };
+
+function requireElement<T extends HTMLElement>(
+  selector: string,
+  elementConstructor: ElementConstructor<T>,
+): T {
+  const element = document.querySelector(selector);
+  if (!(element instanceof elementConstructor)) {
+    throw new Error(`Missing element ${selector}`);
+  }
+  return element;
+}
+
+function getFormRefs(): FormRefs {
+  return {
+    apiBaseUrl: requireElement("#apiBaseUrl", HTMLInputElement),
+    autoPairButton: requireElement("#autoPair", HTMLButtonElement),
+    browser: requireElement("#browser", HTMLSelectElement),
+    companionId: requireElement("#companionId", HTMLInputElement),
+    pairingToken: requireElement("#pairingToken", HTMLInputElement),
+    profileId: requireElement("#profileId", HTMLInputElement),
+    profileLabel: requireElement("#profileLabel", HTMLInputElement),
+    label: requireElement("#label", HTMLInputElement),
+    pairingJson: requireElement("#pairingJson", HTMLTextAreaElement),
+    advancedTools: requireElement("#advancedTools", HTMLDetailsElement),
+    statusBadge: requireElement("#statusBadge", HTMLElement),
+    statusTitle: requireElement("#statusTitle", HTMLElement),
+    statusDetail: requireElement("#statusDetail", HTMLElement),
+    statusChecklist: requireElement("#statusChecklist", HTMLUListElement),
+    summary: requireElement("#summary", HTMLElement),
+    saveButton: requireElement("#save", HTMLButtonElement),
+    importButton: requireElement("#import", HTMLButtonElement),
+    syncButton: requireElement("#sync", HTMLButtonElement),
+    clearButton: requireElement("#clear", HTMLButtonElement),
+    siteAccessButton: requireElement("#siteAccess", HTMLButtonElement),
+    siteAccessStatus: requireElement("#siteAccessStatus", HTMLElement),
+  };
+}
+
+function popupResponseError(response: PopupResponse): string {
+  return "error" in response
+    ? response.error
+    : "The browser bridge returned an incomplete success response.";
+}
+
+function renderChecklist(
+  listElement: HTMLUListElement,
+  entries: string[],
+): void {
+  listElement.innerHTML = "";
+  for (const entry of entries) {
+    const item = document.createElement("li");
+    item.textContent = entry;
+    listElement.appendChild(item);
+  }
+}
+
+function renderSummary(refs: FormRefs, entries: string[]): void {
+  refs.summary.replaceChildren();
+  for (const entry of entries) {
+    const pill = document.createElement("span");
+    pill.className = "summary-pill";
+    pill.textContent = entry;
+    refs.summary.appendChild(pill);
+  }
+}
+
+function renderState(
+  refs: FormRefs,
+  state: BackgroundState,
+  discoveredApiBaseUrl: string | null,
+): void {
+  const config = state.config;
+  refs.apiBaseUrl.value =
+    config?.apiBaseUrl ?? DEFAULT_BROWSER_BRIDGE_API_BASE_URL;
+  refs.browser.value = config?.browser ?? "chrome";
+  refs.companionId.value = config?.companionId ?? "";
+  refs.pairingToken.value = config?.pairingToken ?? "";
+  refs.profileId.value = config?.profileId ?? "default";
+  refs.profileLabel.value = config?.profileLabel ?? "default";
+  refs.label.value = config?.label ?? "";
+  const model = derivePopupStatusModel({
+    state,
+    discoveredApiBaseUrl,
+  });
+  refs.statusBadge.textContent = model.badge;
+  refs.statusBadge.dataset.kind = model.kind;
+  refs.statusTitle.textContent = model.title;
+  refs.statusDetail.textContent = model.detail;
+  renderChecklist(refs.statusChecklist, model.checklist);
+  renderSummary(
+    refs,
+    state.activeSessionId
+      ? [...model.summary, `Session: ${state.activeSessionId}`]
+      : model.summary,
+  );
+  refs.autoPairButton.textContent = model.primaryLabel;
+  refs.autoPairButton.disabled = state.syncing;
+  refs.syncButton.hidden = !model.showSync || model.primaryAction === "sync";
+  refs.syncButton.disabled = state.syncing;
+}
+
+function applyDiscoveredApiBaseUrl(
+  refs: FormRefs,
+  state: BackgroundState,
+  discovered: string | null,
+): void {
+  const configured = state.config?.apiBaseUrl?.trim() ?? "";
+  if (
+    configured.length > 0 &&
+    configured.replace(/\/+$/, "") !== DEFAULT_BROWSER_BRIDGE_API_BASE_URL
+  ) {
+    return;
+  }
+  if (!discovered) {
+    return;
+  }
+  refs.apiBaseUrl.value = discovered;
+}
+
+async function renderResolvedState(
+  refs: FormRefs,
+  state: BackgroundState,
+): Promise<void> {
+  const discoveredApiBaseUrl = await discoverAgentApiBaseUrl();
+  renderState(refs, state, discoveredApiBaseUrl);
+  applyDiscoveredApiBaseUrl(refs, state, discoveredApiBaseUrl);
+  const allWebsiteAccess = await hasAllUrlHostPermission();
+  refs.siteAccessButton.disabled = allWebsiteAccess;
+  refs.siteAccessButton.textContent = allWebsiteAccess
+    ? "Website Access Granted"
+    : "Grant Website Access";
+  refs.siteAccessStatus.textContent = allWebsiteAccess
+    ? "Eliza may use the HTTP and HTTPS sites allowed by your Browser settings."
+    : "Required for cross-site control and LifeOps website blocking. Your browser will show a permission prompt.";
+}
+
+async function sendMessage<T extends PopupRequest>(
+  request: T,
+): Promise<PopupResponse> {
+  return await sendRuntimeMessage<PopupResponse>(request);
+}
+
+function readConfig(refs: FormRefs): Partial<CompanionConfig> {
+  return {
+    apiBaseUrl: refs.apiBaseUrl.value,
+    browser:
+      refs.browser.value === "safari" || refs.browser.value === "firefox"
+        ? refs.browser.value
+        : "chrome",
+    companionId: refs.companionId.value,
+    pairingToken: refs.pairingToken.value,
+    profileId: refs.profileId.value,
+    profileLabel: refs.profileLabel.value,
+    label: refs.label.value,
+  };
+}
+
+function parsePairingJson(jsonValue: string): Partial<CompanionConfig> {
+  const trimmed = jsonValue.trim();
+  if (!trimmed) {
+    throw new Error("Paste the pairing JSON before importing it");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // error-policy:J3 Manual pairing input remains an explicit validation error.
+    throw new Error("Pairing JSON must be valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Pairing JSON must be a JSON object");
+  }
+  const record = parsed as Record<string, unknown>;
+  return {
+    apiBaseUrl:
+      typeof record.apiBaseUrl === "string" ? record.apiBaseUrl : undefined,
+    browser:
+      record.browser === "safari" || record.browser === "firefox"
+        ? record.browser
+        : "chrome",
+    companionId:
+      typeof record.companionId === "string" ? record.companionId : "",
+    pairingToken:
+      typeof record.pairingToken === "string" ? record.pairingToken : "",
+    pairingTokenExpiresAt:
+      typeof record.pairingTokenExpiresAt === "string"
+        ? record.pairingTokenExpiresAt
+        : null,
+    profileId: typeof record.profileId === "string" ? record.profileId : "",
+    profileLabel:
+      typeof record.profileLabel === "string" ? record.profileLabel : "",
+    label: typeof record.label === "string" ? record.label : "",
+  };
+}
+
+async function refresh(refs: FormRefs): Promise<void> {
+  const response = await sendMessage({ type: "browser-bridge:get-state" });
+  if (!response.ok || !response.state) {
+    refs.statusTitle.textContent = "Agent Browser Bridge could not load";
+    refs.statusDetail.textContent = popupResponseError(response);
+    return;
+  }
+  await renderResolvedState(refs, response.state);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const refs = getFormRefs();
+
+  void refresh(refs);
+
+  refs.autoPairButton.addEventListener("click", async () => {
+    const currentResponse = await sendMessage({
+      type: "browser-bridge:get-state",
+    });
+    const currentState = currentResponse.ok ? currentResponse.state : null;
+    const discoveredApiBaseUrl = await discoverAgentApiBaseUrl();
+    const model = currentState
+      ? derivePopupStatusModel({
+          state: currentState,
+          discoveredApiBaseUrl,
+        })
+      : null;
+    refs.statusDetail.textContent =
+      model?.primaryAction === "sync"
+        ? "Syncing this browser with Eliza…"
+        : "Paste pairing JSON copied from authenticated Eliza Browser settings.";
+    if (model?.primaryAction !== "sync") {
+      refs.advancedTools.open = true;
+      refs.pairingJson.focus();
+      return;
+    }
+    const response = await sendMessage({ type: "browser-bridge:sync-now" });
+    if (!response.ok || !response.state) {
+      refs.statusDetail.textContent = popupResponseError(response);
+      return;
+    }
+    await renderResolvedState(refs, response.state);
+  });
+
+  refs.saveButton.addEventListener("click", async () => {
+    refs.statusDetail.textContent = "Saving manual pairing…";
+    const response = await sendMessage({
+      type: "browser-bridge:save-config",
+      config: readConfig(refs),
+    });
+    if (!response.ok || !response.state) {
+      refs.statusDetail.textContent = popupResponseError(response);
+      return;
+    }
+    await renderResolvedState(refs, response.state);
+  });
+
+  refs.importButton.addEventListener("click", async () => {
+    refs.statusDetail.textContent = "Importing manual pairing JSON…";
+    let config: Partial<CompanionConfig>;
+    try {
+      config = parsePairingJson(refs.pairingJson.value);
+    } catch (error) {
+      // error-policy:J4 Invalid manual pairing input is shown in the popup and
+      // never reaches extension storage or the agent.
+      refs.statusDetail.textContent =
+        error instanceof Error ? error.message : String(error);
+      return;
+    }
+    const response = await sendMessage({
+      type: "browser-bridge:save-config",
+      config,
+    });
+    if (!response.ok || !response.state) {
+      refs.statusDetail.textContent = popupResponseError(response);
+      return;
+    }
+    refs.pairingJson.value = "";
+    await renderResolvedState(refs, response.state);
+  });
+
+  refs.syncButton.addEventListener("click", async () => {
+    refs.statusDetail.textContent = "Syncing this browser with Eliza…";
+    const response = await sendMessage({ type: "browser-bridge:sync-now" });
+    if (!response.ok || !response.state) {
+      refs.statusDetail.textContent = popupResponseError(response);
+      return;
+    }
+    await renderResolvedState(refs, response.state);
+  });
+
+  refs.clearButton.addEventListener("click", async () => {
+    const response = await sendMessage({
+      type: "browser-bridge:clear-config",
+    });
+    if (!response.ok || !response.state) {
+      refs.statusDetail.textContent = popupResponseError(response);
+      return;
+    }
+    await renderResolvedState(refs, response.state);
+  });
+
+  refs.siteAccessButton.addEventListener("click", async () => {
+    refs.siteAccessStatus.textContent =
+      "Waiting for the browser permission decision…";
+    try {
+      const granted = await requestAllWebsiteAccess();
+      if (!granted) {
+        refs.siteAccessStatus.textContent =
+          "Website access was not granted. Loopback pairing remains available.";
+        return;
+      }
+      refs.siteAccessButton.disabled = true;
+      refs.siteAccessButton.textContent = "Website Access Granted";
+      refs.siteAccessStatus.textContent =
+        "Website access granted. Syncing permissions and blocking rules with Eliza…";
+      const response = await sendMessage({ type: "browser-bridge:sync-now" });
+      if (!response.ok || !response.state) {
+        refs.siteAccessStatus.textContent = popupResponseError(response);
+        return;
+      }
+      await renderResolvedState(refs, response.state);
+    } catch (error) {
+      // error-policy:J4 Browser permission failures remain visible and do not
+      // claim that website access was granted.
+      refs.siteAccessStatus.textContent =
+        error instanceof Error ? error.message : String(error);
+    }
+  });
+});

--- a/packages/browser-bridge-extension/package.json
+++ b/packages/browser-bridge-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@elizaos/browser-extension",
+  "name": "@elizaos/browser-bridge-extension",
   "version": "2.0.3-beta.7",
   "type": "module",
   "scripts": {
@@ -12,7 +12,8 @@
     "package:safari": "bun scripts/package-safari.mjs",
     "package:stores": "bun scripts/package-store-assets.mjs",
     "package:release": "bun scripts/package-release.mjs",
-    "test": "bun run test:unit && bun run test:smoke && bun run test:smoke:firefox",
+    "test": "bun run test:unit",
+    "test:smoke:installed": "bun run test:smoke && bun run test:smoke:firefox",
     "test:unit": "bunx vitest run --config ./vitest.extension.config.ts",
     "test:smoke": "node scripts/extension-smoke.mjs",
     "test:smoke:site-access": "BROWSER_BRIDGE_SMOKE_SITE_ACCESS=1 node scripts/extension-smoke.mjs",

--- a/packages/browser-bridge-extension/package.json
+++ b/packages/browser-bridge-extension/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@elizaos/browser-extension",
+  "version": "2.0.3-beta.7",
+  "type": "module",
+  "scripts": {
+    "build": "bun scripts/build.mjs chrome",
+    "build:chrome": "bun scripts/build.mjs chrome",
+    "build:firefox": "bun scripts/build.mjs firefox",
+    "build:safari-webextension": "bun scripts/build.mjs safari",
+    "package:chrome": "bun scripts/package-chrome.mjs",
+    "package:firefox": "bun scripts/package-firefox.mjs",
+    "package:safari": "bun scripts/package-safari.mjs",
+    "package:stores": "bun scripts/package-store-assets.mjs",
+    "package:release": "bun scripts/package-release.mjs",
+    "test": "bun run test:unit && bun run test:smoke && bun run test:smoke:firefox",
+    "test:unit": "bunx vitest run --config ./vitest.extension.config.ts",
+    "test:smoke": "node scripts/extension-smoke.mjs",
+    "test:smoke:site-access": "BROWSER_BRIDGE_SMOKE_SITE_ACCESS=1 node scripts/extension-smoke.mjs",
+    "test:smoke:firefox": "node scripts/extension-smoke-firefox.mjs",
+    "lint:firefox": "web-ext lint --source-dir dist/firefox --self-hosted",
+    "test:smoke:safari": "node scripts/extension-smoke-safari.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "clean": "node ../scripts/rm-path-recursive.mjs dist",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
+  },
+  "dependencies": {
+    "fflate": "^0.8.3"
+  },
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "jsdom": "^29.1.1",
+    "@types/jsdom": "^27.0.0",
+    "puppeteer-core": "^24.43.1",
+    "typescript": "^6.0.3",
+    "web-ext": "^10.6.0",
+    "vitest": "^4.0.17"
+  },
+  "elizaos": {
+    "scripts": {
+      "testLanes": [
+        "client"
+      ]
+    }
+  },
+  "private": true
+}

--- a/packages/browser-bridge-extension/public/blocked.html
+++ b/packages/browser-bridge-extension/public/blocked.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Site Blocked by LifeOps</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #1a1a2e;
+        color: #e0e0e0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        padding: 2rem;
+      }
+      .container {
+        max-width: 480px;
+        text-align: center;
+      }
+      h1 { font-size: 1.5rem; margin-bottom: 1rem; color: #fff; }
+      .blocked-site {
+        font-size: 1.1rem;
+        color: #ff6b6b;
+        margin-bottom: 1.5rem;
+        word-break: break-all;
+      }
+      .reason {
+        background: rgba(255,255,255,0.05);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+      }
+      .reason h2 { font-size: 1rem; margin-bottom: 0.75rem; color: #a0a0ff; }
+      .task-list { list-style: none; padding: 0; }
+      .task-list li {
+        padding: 0.5rem 0;
+        border-bottom: 1px solid rgba(255,255,255,0.05);
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .task-list li:last-child { border-bottom: none; }
+      .status-dot {
+        width: 8px; height: 8px; border-radius: 50%;
+        background: #ff6b6b;
+        flex-shrink: 0;
+      }
+      .status-dot.completed { background: #51cf66; }
+      .message {
+        color: #aaa;
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+      .open-lifeops {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.75rem 2rem;
+        background: #a0a0ff;
+        color: #1a1a2e;
+        border: none;
+        border-radius: 8px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      .open-lifeops:hover { background: #8080ff; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>This site is blocked</h1>
+      <div class="blocked-site" id="blockedSite"></div>
+      <div class="reason">
+        <h2>Complete these to unblock:</h2>
+        <ul class="task-list" id="taskList">
+          <li><span class="status-dot"></span> Loading...</li>
+        </ul>
+      </div>
+      <p class="message" id="message">Complete the tasks above, then this site will automatically unblock.</p>
+      <a class="open-lifeops" id="openLifeOps" href="#">Open LifeOps</a>
+    </div>
+    <script src="./blocked.js"></script>
+  </body>
+</html>

--- a/packages/browser-bridge-extension/public/popup.css
+++ b/packages/browser-bridge-extension/public/popup.css
@@ -1,265 +1,223 @@
 :root {
-  color-scheme: light;
-  font-family: "Poppins", "Inter", system-ui, sans-serif;
-  background:
-    radial-gradient(
-      circle at top left,
-      rgba(246, 210, 157, 0.48),
-      transparent 36%
-    ),
-    radial-gradient(
-      circle at bottom right,
-      rgba(156, 212, 190, 0.35),
-      transparent 34%
-    ),
-    linear-gradient(180deg, #fbf6ea 0%, #efe6d6 100%);
-  color: #1f2920;
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: CanvasText;
+  background: Canvas;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  min-width: 380px;
+  min-width: 280px;
+  max-width: 360px;
 }
 
 .panel {
-  padding: 18px;
+  width: 100%;
+  padding: 16px;
 }
 
-.panel-header h1 {
+h1 {
   margin: 0;
-  font-size: 24px;
-  line-height: 1.08;
+  font-size: 14px;
+  line-height: 1.4;
+  font-weight: 650;
 }
 
-.eyebrow {
-  margin: 0 0 4px;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #536453;
-}
-
-.lede {
-  margin: 8px 0 0;
-  font-size: 13px;
-  line-height: 1.5;
-  color: #48564a;
-}
-
-.status-hero,
-.auto-card,
-.advanced-card,
-.import-card {
-  margin-top: 16px;
-  border: 1px solid rgba(34, 54, 38, 0.12);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.76);
-  backdrop-filter: blur(10px);
-}
-
-.status-hero {
+.connection {
+  margin-top: 12px;
   padding: 14px;
+  border: 1px solid color-mix(in srgb, CanvasText 16%, transparent);
+  border-radius: 12px;
 }
 
-.status-topline {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+.status {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.45;
+  font-weight: 600;
 }
 
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 10px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  background: rgba(45, 98, 67, 0.12);
-  color: #215438;
+.status[data-kind="connected"] {
+  color: #167046;
 }
 
-.status-badge[data-kind="connected"] {
-  background: rgba(36, 118, 73, 0.14);
-  color: #1d6b47;
-}
-
-.status-badge[data-kind="needs_app"],
-.status-badge[data-kind="needs_pairing"] {
-  background: rgba(188, 122, 22, 0.14);
+.status[data-kind="needs_app"],
+.status[data-kind="needs_settings"],
+.status[data-kind="needs_permission"] {
   color: #8a4f09;
 }
 
-.status-badge[data-kind="needs_settings"],
-.status-badge[data-kind="error"] {
-  background: rgba(160, 66, 26, 0.12);
-  color: #8a3c16;
-}
-
-.status-title {
-  margin: 10px 0 0;
-  font-size: 18px;
-  line-height: 1.2;
-}
-
-.status-detail {
-  margin: 8px 0 0;
-  font-size: 13px;
-  line-height: 1.5;
-  color: #4d5b4f;
-}
-
-.status-checklist {
-  margin: 12px 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 8px;
-}
-
-.status-checklist li {
-  border-radius: 14px;
-  background: rgba(243, 239, 229, 0.9);
-  padding: 10px 12px;
-  font-size: 12px;
-  line-height: 1.45;
-  color: #334336;
-}
-
-.summary-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.summary-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 28px;
-  padding: 0 11px;
-  border-radius: 999px;
-  background: rgba(238, 234, 223, 0.95);
-  font-size: 11px;
-  line-height: 1.35;
-  color: #526053;
-}
-
-.auto-card,
-.advanced-card {
-  padding: 14px;
-}
-
-.import-copy h2 {
-  margin: 0;
-  font-size: 14px;
-}
-
-.import-copy p {
-  margin: 4px 0 0;
-  font-size: 12px;
-  line-height: 1.45;
-  color: #5c695e;
-}
-
-.actions,
-.advanced-actions {
-  display: grid;
-  gap: 8px;
-}
-
-.actions {
-  margin-top: 12px;
-  grid-template-columns: 1.5fr 1fr;
-}
-
-.actions.single-action {
-  grid-template-columns: 1fr;
-}
-
-.advanced-actions {
-  margin-top: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.advanced-card summary {
-  cursor: pointer;
-  list-style: none;
-  font-size: 14px;
-  font-weight: 700;
-  color: #213022;
-}
-
-.advanced-card summary::-webkit-details-marker {
-  display: none;
-}
-
-.form-grid {
-  display: grid;
-  gap: 10px;
-  margin-top: 14px;
-}
-
-label {
-  display: grid;
-  gap: 4px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #314235;
-}
-
-input,
-select {
-  height: 38px;
-  border: 1px solid rgba(40, 68, 49, 0.16);
-  border-radius: 10px;
-  padding: 0 12px;
-  background: rgba(255, 255, 255, 0.9);
-  color: #1f2a1f;
-}
-
-textarea {
-  border: 1px solid rgba(40, 68, 49, 0.16);
-  border-radius: 12px;
-  padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.9);
-  color: #1f2a1f;
-  resize: vertical;
-  font: inherit;
-}
-
-.import-card {
-  padding: 14px;
-  background: rgba(252, 249, 241, 0.88);
+.status[data-kind="error"] {
+  color: #a33b22;
 }
 
 button {
-  height: 40px;
-  border: none;
-  border-radius: 999px;
-  background: #dde5da;
-  color: #1d281f;
-  font-weight: 700;
+  min-height: 40px;
+  width: 100%;
+  margin-top: 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
 }
 
 button.primary {
-  background: #1e6d49;
-  color: #f6fff9;
+  background: #b94c0e;
+  color: #fff;
+}
+
+button.primary:hover {
+  background: #a9430e;
+}
+
+button.disconnect {
+  border-color: color-mix(in srgb, CanvasText 20%, transparent);
+  background: Canvas;
+  color: CanvasText;
 }
 
 button.secondary {
-  background: #dce6df;
-  color: #223025;
-}
-
-button.danger {
-  background: #ead6cd;
-  color: #7b2d12;
+  border-color: color-mix(in srgb, CanvasText 20%, transparent);
+  background: Canvas;
+  color: CanvasText;
 }
 
 button:disabled {
+  cursor: wait;
   opacity: 0.65;
+}
+
+button:focus-visible,
+summary:focus-visible {
+  outline: 3px solid #e87524;
+  outline-offset: 3px;
+}
+
+.details {
+  margin-top: 10px;
+  padding: 2px 4px;
+}
+
+.details summary {
+  min-height: 36px;
+  padding: 8px 4px;
+  font-size: 12px;
+  line-height: 20px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.recovery {
+  margin-top: 10px;
+  border-top: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+}
+
+.recovery label {
+  display: block;
+  margin-top: 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.recovery textarea {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  border: 1px solid color-mix(in srgb, CanvasText 20%, transparent);
+  border-radius: 8px;
+  padding: 8px;
+  resize: vertical;
+  background: Canvas;
+  color: CanvasText;
+  font: 11px/1.4 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+dl {
+  display: grid;
+  gap: 10px;
+  margin: 8px 0 0;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+  border-radius: 10px;
+}
+
+dl div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.7fr);
+  gap: 8px;
+}
+
+dt,
+dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+dt {
+  color: color-mix(in srgb, CanvasText 66%, transparent);
+}
+
+dd {
+  text-align: right;
+}
+
+@media (prefers-color-scheme: dark) {
+  .status[data-kind="connected"] {
+    color: #65d69e;
+  }
+
+  .status[data-kind="needs_app"],
+  .status[data-kind="needs_settings"],
+  .status[data-kind="needs_permission"] {
+    color: #f4a950;
+  }
+
+  .status[data-kind="error"] {
+    color: #ff967a;
+  }
+}
+
+@media (forced-colors: active) {
+  .connection,
+  dl,
+  button {
+    border-color: ButtonText;
+  }
+
+  .recovery,
+  .recovery textarea {
+    border-color: ButtonText;
+  }
+
+  .status,
+  .status[data-kind] {
+    color: CanvasText;
+  }
+
+  button.primary {
+    background: ButtonFace;
+    color: ButtonText;
+  }
+}
+
+@media (max-width: 300px) {
+  .panel {
+    padding: 12px;
+  }
+
+  dl div {
+    grid-template-columns: 1fr;
+  }
+
+  dd {
+    text-align: left;
+  }
 }

--- a/packages/browser-bridge-extension/public/popup.css
+++ b/packages/browser-bridge-extension/public/popup.css
@@ -1,0 +1,265 @@
+:root {
+  color-scheme: light;
+  font-family: "Poppins", "Inter", system-ui, sans-serif;
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(246, 210, 157, 0.48),
+      transparent 36%
+    ),
+    radial-gradient(
+      circle at bottom right,
+      rgba(156, 212, 190, 0.35),
+      transparent 34%
+    ),
+    linear-gradient(180deg, #fbf6ea 0%, #efe6d6 100%);
+  color: #1f2920;
+}
+
+body {
+  margin: 0;
+  min-width: 380px;
+}
+
+.panel {
+  padding: 18px;
+}
+
+.panel-header h1 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.08;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #536453;
+}
+
+.lede {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #48564a;
+}
+
+.status-hero,
+.auto-card,
+.advanced-card,
+.import-card {
+  margin-top: 16px;
+  border: 1px solid rgba(34, 54, 38, 0.12);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.76);
+  backdrop-filter: blur(10px);
+}
+
+.status-hero {
+  padding: 14px;
+}
+
+.status-topline {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(45, 98, 67, 0.12);
+  color: #215438;
+}
+
+.status-badge[data-kind="connected"] {
+  background: rgba(36, 118, 73, 0.14);
+  color: #1d6b47;
+}
+
+.status-badge[data-kind="needs_app"],
+.status-badge[data-kind="needs_pairing"] {
+  background: rgba(188, 122, 22, 0.14);
+  color: #8a4f09;
+}
+
+.status-badge[data-kind="needs_settings"],
+.status-badge[data-kind="error"] {
+  background: rgba(160, 66, 26, 0.12);
+  color: #8a3c16;
+}
+
+.status-title {
+  margin: 10px 0 0;
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.status-detail {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #4d5b4f;
+}
+
+.status-checklist {
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.status-checklist li {
+  border-radius: 14px;
+  background: rgba(243, 239, 229, 0.9);
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #334336;
+}
+
+.summary-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.summary-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 11px;
+  border-radius: 999px;
+  background: rgba(238, 234, 223, 0.95);
+  font-size: 11px;
+  line-height: 1.35;
+  color: #526053;
+}
+
+.auto-card,
+.advanced-card {
+  padding: 14px;
+}
+
+.import-copy h2 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.import-copy p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #5c695e;
+}
+
+.actions,
+.advanced-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.actions {
+  margin-top: 12px;
+  grid-template-columns: 1.5fr 1fr;
+}
+
+.actions.single-action {
+  grid-template-columns: 1fr;
+}
+
+.advanced-actions {
+  margin-top: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.advanced-card summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 14px;
+  font-weight: 700;
+  color: #213022;
+}
+
+.advanced-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.form-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+label {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #314235;
+}
+
+input,
+select {
+  height: 38px;
+  border: 1px solid rgba(40, 68, 49, 0.16);
+  border-radius: 10px;
+  padding: 0 12px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2a1f;
+}
+
+textarea {
+  border: 1px solid rgba(40, 68, 49, 0.16);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2a1f;
+  resize: vertical;
+  font: inherit;
+}
+
+.import-card {
+  padding: 14px;
+  background: rgba(252, 249, 241, 0.88);
+}
+
+button {
+  height: 40px;
+  border: none;
+  border-radius: 999px;
+  background: #dde5da;
+  color: #1d281f;
+  font-weight: 700;
+}
+
+button.primary {
+  background: #1e6d49;
+  color: #f6fff9;
+}
+
+button.secondary {
+  background: #dce6df;
+  color: #223025;
+}
+
+button.danger {
+  background: #ead6cd;
+  color: #7b2d12;
+}
+
+button:disabled {
+  opacity: 0.65;
+}

--- a/packages/browser-bridge-extension/public/popup.html
+++ b/packages/browser-bridge-extension/public/popup.html
@@ -3,103 +3,67 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Agent Browser Bridge</title>
+    <title>Eliza Browser</title>
     <link rel="stylesheet" href="./popup.css" />
   </head>
   <body>
     <main class="panel">
-      <header class="panel-header">
-        <p class="eyebrow">Agent Browser Bridge</p>
-        <h1>Connect Your Browser</h1>
-        <p class="lede">Use the exact browser profile that contains your real accounts. Pairing credentials must be created in authenticated Eliza settings.</p>
-      </header>
+      <h1>Eliza Browser</h1>
 
-      <section class="status-hero">
-        <div class="status-topline">
-          <span id="statusBadge" class="status-badge" data-kind="syncing">Loading</span>
-        </div>
-        <h2 id="statusTitle" class="status-title">Loading extension state…</h2>
-        <p id="statusDetail" class="status-detail"></p>
-        <ul id="statusChecklist" class="status-checklist"></ul>
-        <div id="summary" class="summary-grid"></div>
+      <section class="connection" aria-label="Browser connection">
+        <p
+          id="statusTitle"
+          class="status"
+          data-kind="syncing"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          Connecting to Eliza…
+        </p>
+        <button id="primaryAction" class="primary" type="button" hidden></button>
       </section>
 
-      <section class="auto-card">
-        <div class="import-copy">
-          <h2>Authenticated Pairing</h2>
-          <p>Create a browser companion pairing in Eliza's Browser settings, copy its pairing JSON, then import it below.</p>
-        </div>
-        <div class="actions">
-          <button id="autoPair" class="primary" type="button">Import Pairing JSON</button>
-          <button id="sync" type="button">Sync This Browser</button>
-        </div>
-      </section>
-
-      <section class="auto-card">
-        <div class="import-copy">
-          <h2>Website Access</h2>
-          <p id="siteAccessStatus">Checking browser-managed website permissions…</p>
-        </div>
-        <div class="actions single-action">
-          <button id="siteAccess" class="secondary" type="button">Grant Website Access</button>
-        </div>
-      </section>
-
-      <details id="advancedTools" class="advanced-card">
-        <summary>Pairing and Advanced Tools</summary>
-
-        <section class="form-grid">
-          <label>
-            <span>API Base URL</span>
-            <input id="apiBaseUrl" type="url" placeholder="http://127.0.0.1:31337" />
-          </label>
-          <label>
-            <span>Browser</span>
-            <select id="browser" disabled>
-              <option value="chrome">Chrome</option>
-              <option value="safari">Safari</option>
-            </select>
-          </label>
-          <label>
-            <span>Companion ID</span>
-            <input id="companionId" type="text" placeholder="UUID from Eliza pairing" />
-          </label>
-          <label>
-            <span>Pairing Token</span>
-            <input id="pairingToken" type="password" placeholder="lobr_…" />
-          </label>
-          <label>
-            <span>Profile ID</span>
-            <input id="profileId" type="text" placeholder="default" />
-          </label>
-          <label>
-            <span>Profile Label</span>
-            <input id="profileLabel" type="text" placeholder="Default" />
-          </label>
-          <label>
-            <span>Companion Label</span>
-            <input id="label" type="text" placeholder="Agent Browser Bridge chrome Default" />
-          </label>
-        </section>
-
-        <section class="import-card">
-          <div class="import-copy">
-            <h2>Manual Pairing JSON</h2>
-            <p>Paste pairing JSON copied from authenticated Eliza Browser settings, then import it here.</p>
+      <details id="details" class="details">
+        <summary>Details</summary>
+        <dl>
+          <div>
+            <dt>App</dt>
+            <dd id="appValue">Looking for Eliza…</dd>
           </div>
+          <div>
+            <dt>Last connected</dt>
+            <dd id="lastSyncValue">Not yet</dd>
+          </div>
+          <div>
+            <dt>Browser mode</dt>
+            <dd id="modeValue">Not available</dd>
+          </div>
+          <div>
+            <dt>Shared tabs</dt>
+            <dd id="tabCountValue">0</dd>
+          </div>
+        </dl>
+        <button id="disconnect" class="disconnect" type="button" hidden>
+          Disconnect this browser
+        </button>
+
+        <details id="recovery" class="recovery">
+          <summary>Advanced recovery</summary>
+          <label for="pairingJson">Pairing JSON from Eliza</label>
           <textarea
             id="pairingJson"
-            rows="7"
-            placeholder='{"apiBaseUrl":"http://127.0.0.1:31337","companionId":"...","pairingToken":"...","browser":"chrome"}'
+            rows="5"
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck="false"
           ></textarea>
-          <div class="advanced-actions">
-            <button id="import" class="secondary" type="button">Import Pairing JSON</button>
-            <button id="save" class="secondary" type="button">Save Manual Pairing</button>
-            <button id="clear" class="danger" type="button">Clear</button>
-          </div>
-        </section>
+          <button id="importPairing" class="secondary" type="button">
+            Import pairing
+          </button>
+        </details>
       </details>
     </main>
     <script src="./popup.js"></script>
   </body>
-  </html>
+</html>

--- a/packages/browser-bridge-extension/public/popup.html
+++ b/packages/browser-bridge-extension/public/popup.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Browser Bridge</title>
+    <link rel="stylesheet" href="./popup.css" />
+  </head>
+  <body>
+    <main class="panel">
+      <header class="panel-header">
+        <p class="eyebrow">Agent Browser Bridge</p>
+        <h1>Connect Your Browser</h1>
+        <p class="lede">Use the exact browser profile that contains your real accounts. Pairing credentials must be created in authenticated Eliza settings.</p>
+      </header>
+
+      <section class="status-hero">
+        <div class="status-topline">
+          <span id="statusBadge" class="status-badge" data-kind="syncing">Loading</span>
+        </div>
+        <h2 id="statusTitle" class="status-title">Loading extension state…</h2>
+        <p id="statusDetail" class="status-detail"></p>
+        <ul id="statusChecklist" class="status-checklist"></ul>
+        <div id="summary" class="summary-grid"></div>
+      </section>
+
+      <section class="auto-card">
+        <div class="import-copy">
+          <h2>Authenticated Pairing</h2>
+          <p>Create a browser companion pairing in Eliza's Browser settings, copy its pairing JSON, then import it below.</p>
+        </div>
+        <div class="actions">
+          <button id="autoPair" class="primary" type="button">Import Pairing JSON</button>
+          <button id="sync" type="button">Sync This Browser</button>
+        </div>
+      </section>
+
+      <section class="auto-card">
+        <div class="import-copy">
+          <h2>Website Access</h2>
+          <p id="siteAccessStatus">Checking browser-managed website permissions…</p>
+        </div>
+        <div class="actions single-action">
+          <button id="siteAccess" class="secondary" type="button">Grant Website Access</button>
+        </div>
+      </section>
+
+      <details id="advancedTools" class="advanced-card">
+        <summary>Pairing and Advanced Tools</summary>
+
+        <section class="form-grid">
+          <label>
+            <span>API Base URL</span>
+            <input id="apiBaseUrl" type="url" placeholder="http://127.0.0.1:31337" />
+          </label>
+          <label>
+            <span>Browser</span>
+            <select id="browser" disabled>
+              <option value="chrome">Chrome</option>
+              <option value="safari">Safari</option>
+            </select>
+          </label>
+          <label>
+            <span>Companion ID</span>
+            <input id="companionId" type="text" placeholder="UUID from Eliza pairing" />
+          </label>
+          <label>
+            <span>Pairing Token</span>
+            <input id="pairingToken" type="password" placeholder="lobr_…" />
+          </label>
+          <label>
+            <span>Profile ID</span>
+            <input id="profileId" type="text" placeholder="default" />
+          </label>
+          <label>
+            <span>Profile Label</span>
+            <input id="profileLabel" type="text" placeholder="Default" />
+          </label>
+          <label>
+            <span>Companion Label</span>
+            <input id="label" type="text" placeholder="Agent Browser Bridge chrome Default" />
+          </label>
+        </section>
+
+        <section class="import-card">
+          <div class="import-copy">
+            <h2>Manual Pairing JSON</h2>
+            <p>Paste pairing JSON copied from authenticated Eliza Browser settings, then import it here.</p>
+          </div>
+          <textarea
+            id="pairingJson"
+            rows="7"
+            placeholder='{"apiBaseUrl":"http://127.0.0.1:31337","companionId":"...","pairingToken":"...","browser":"chrome"}'
+          ></textarea>
+          <div class="advanced-actions">
+            <button id="import" class="secondary" type="button">Import Pairing JSON</button>
+            <button id="save" class="secondary" type="button">Save Manual Pairing</button>
+            <button id="clear" class="danger" type="button">Clear</button>
+          </div>
+        </section>
+      </details>
+    </main>
+    <script src="./popup.js"></script>
+  </body>
+  </html>

--- a/packages/browser-bridge-extension/safari/.gitignore
+++ b/packages/browser-bridge-extension/safari/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/packages/browser-bridge-extension/scripts/build.mjs
+++ b/packages/browser-bridge-extension/scripts/build.mjs
@@ -83,7 +83,9 @@ export async function buildBrowserBridgeExtension(kind = browserKind) {
     outdir: outputDir,
     target: "browser",
     format: "iife",
-    sourcemap: "external",
+    // Store archives ship executable bundles only. External maps are not
+    // referenced by the manifest and unnecessarily expose source paths.
+    sourcemap: "none",
     minify: false,
     naming: "[name].js",
     define,
@@ -161,9 +163,9 @@ export async function buildBrowserBridgeExtension(kind = browserKind) {
         matches: ["http://*/*", "https://*/*"],
         // Without this the interstitial has a stable chrome-extension://<id>/
         // URL that every page on the web can probe, which makes the extension
-        // trivially fingerprintable. Chrome 106+ rotates the token per session;
-        // Firefox ignores the key rather than rejecting the manifest.
-        use_dynamic_url: true,
+        // trivially fingerprintable. Chrome 106+ rotates the token per session.
+        // Safari's converter warns on this Chrome-only manifest key.
+        ...(kind === "chrome" ? { use_dynamic_url: true } : {}),
       },
     ],
     icons: {

--- a/packages/browser-bridge-extension/scripts/build.mjs
+++ b/packages/browser-bridge-extension/scripts/build.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * Bun build for the extension: bundles the entrypoints to IIFE, stamps the
+ * versioned manifest.json, and emits per-browser output under
+ * dist/<chrome|firefox|safari>/. Exports BROWSER_BRIDGE_HOST_ALLOWLIST — the
+ * SOC2-scoped default host grant baked into the manifest and checked by the
+ * smoke tests.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildChromeExtensionVersion,
+  resolveBrowserBridgeReleaseVersion,
+} from "./release-version.mjs";
+import { run } from "./script-utils.mjs";
+
+// SOC2 L-4: explicit host allowlist instead of a blanket `<all_urls>` grant.
+// Documented in README.md. Hosts beyond this list require an explicit grant
+// through the browser's extension site-access controls.
+export const BROWSER_BRIDGE_HOST_ALLOWLIST = [
+  // Local Eliza agent API. Chrome match patterns do not encode the port,
+  // so these cover 127.0.0.1:31337 plus smoke-test/random dev ports.
+  "http://127.0.0.1/*",
+  "http://localhost/*",
+];
+
+export const BROWSER_BRIDGE_BUILD_KINDS = ["chrome", "firefox", "safari"];
+
+export function parseBrowserBridgeBuildKind(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!BROWSER_BRIDGE_BUILD_KINDS.includes(normalized)) {
+    throw new Error(
+      `Unsupported browser extension build target "${value ?? ""}". Expected chrome, firefox, or safari.`,
+    );
+  }
+  return normalized;
+}
+
+const browserKind = import.meta.main
+  ? parseBrowserBridgeBuildKind(process.argv[2] ?? "chrome")
+  : "chrome";
+const extensionRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const publicDir = path.join(extensionRoot, "public");
+const cleanupHelper = path.resolve(
+  extensionRoot,
+  "..",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
+const release = resolveBrowserBridgeReleaseVersion();
+const extensionVersion = buildChromeExtensionVersion(release);
+
+export function resolveBrowserBridgeIconSources(root = extensionRoot) {
+  const iconDir = path.resolve(root, "..", "shared", "assets", "favicons");
+  return [
+    ["icon16.png", path.join(iconDir, "favicon-16x16.png")],
+    ["icon32.png", path.join(iconDir, "favicon-32x32.png")],
+    ["icon192.png", path.join(iconDir, "android-chrome-192x192.png")],
+  ];
+}
+
+export async function buildBrowserBridgeExtension(kind = browserKind) {
+  const outputDir = path.join(extensionRoot, "dist", kind);
+
+  await run("node", [cleanupHelper, outputDir], { cwd: extensionRoot });
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const define = {
+    __BROWSER_BRIDGE_KIND__: JSON.stringify(kind),
+  };
+
+  const buildResult = await Bun.build({
+    entrypoints: [
+      path.join(extensionRoot, "entrypoints", "background.ts"),
+      path.join(extensionRoot, "entrypoints", "content.ts"),
+      path.join(extensionRoot, "entrypoints", "popup.ts"),
+      path.join(extensionRoot, "entrypoints", "blocked.ts"),
+    ],
+    outdir: outputDir,
+    target: "browser",
+    format: "iife",
+    sourcemap: "external",
+    minify: false,
+    naming: "[name].js",
+    define,
+  });
+
+  if (!buildResult.success) {
+    const messages = buildResult.logs.map((log) => log.message).join("\n");
+    throw new Error(`Extension build failed:\n${messages}`);
+  }
+
+  await fs.copyFile(
+    path.join(publicDir, "popup.html"),
+    path.join(outputDir, "popup.html"),
+  );
+  await fs.copyFile(
+    path.join(publicDir, "popup.css"),
+    path.join(outputDir, "popup.css"),
+  );
+  await fs.copyFile(
+    path.join(publicDir, "blocked.html"),
+    path.join(outputDir, "blocked.html"),
+  );
+
+  for (const [fileName, sourcePath] of resolveBrowserBridgeIconSources()) {
+    await fs.copyFile(sourcePath, path.join(outputDir, fileName));
+  }
+
+  const manifest = {
+    manifest_version: 3,
+    name: "Agent Browser Bridge",
+    version: extensionVersion,
+    version_name: release.raw,
+    description:
+      "Agent Browser Bridge pairs your personal browser profile with an Eliza agent so the agent can read the current page and run owner-approved browser actions.",
+    permissions: [
+      "tabs",
+      "storage",
+      "scripting",
+      "alarms",
+      "activeTab",
+      "declarativeNetRequestWithHostAccess",
+    ],
+    // SOC2 L-4: scoped host permissions. The default-install allowlist is
+    // the minimum set the extension needs to function with first-party
+    // Eliza surfaces. Additional hosts require an explicit browser-managed
+    // site-access grant and are rechecked before data sharing or action use.
+    host_permissions: BROWSER_BRIDGE_HOST_ALLOWLIST,
+    optional_host_permissions: ["https://*/*", "http://*/*"],
+    background:
+      kind === "firefox"
+        ? { scripts: ["background.js"] }
+        : { service_worker: "background.js" },
+    // SOC2 L-4: strict CSP. Disallow inline scripts; only first-party
+    // bundle code may execute.
+    content_security_policy: {
+      extension_pages: "script-src 'self'; object-src 'self'",
+    },
+    action: {
+      default_title: "Agent Browser Bridge",
+      default_popup: "popup.html",
+    },
+    content_scripts: [
+      {
+        matches: BROWSER_BRIDGE_HOST_ALLOWLIST,
+        js: ["content.js"],
+        run_at: "document_idle",
+      },
+    ],
+    // DNR redirects originate on arbitrary user-granted sites. Only the
+    // interstitial and its first-party bundle are exposed; blocked.ts binds
+    // its API access back to the stored companion origin before fetching.
+    web_accessible_resources: [
+      {
+        resources: ["blocked.html", "blocked.js"],
+        matches: ["http://*/*", "https://*/*"],
+      },
+    ],
+    icons: {
+      16: "icon16.png",
+      32: "icon32.png",
+      192: "icon192.png",
+    },
+    browser_specific_settings:
+      kind === "firefox"
+        ? {
+            gecko: {
+              id: "browser-bridge@elizaos.ai",
+              strict_min_version: "142.0",
+              data_collection_permissions: {
+                required: ["none"],
+              },
+            },
+          }
+        : kind === "safari"
+          ? {
+              safari: {
+                strict_min_version: "17.0",
+              },
+            }
+          : undefined,
+  };
+
+  await fs.writeFile(
+    path.join(outputDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  console.log(
+    `Built Agent Browser Bridge extension ${release.raw} (${extensionVersion}) to ${outputDir}`,
+  );
+}
+
+if (import.meta.main) {
+  await buildBrowserBridgeExtension();
+}

--- a/packages/browser-bridge-extension/scripts/build.mjs
+++ b/packages/browser-bridge-extension/scripts/build.mjs
@@ -159,6 +159,11 @@ export async function buildBrowserBridgeExtension(kind = browserKind) {
       {
         resources: ["blocked.html", "blocked.js"],
         matches: ["http://*/*", "https://*/*"],
+        // Without this the interstitial has a stable chrome-extension://<id>/
+        // URL that every page on the web can probe, which makes the extension
+        // trivially fingerprintable. Chrome 106+ rotates the token per session;
+        // Firefox ignores the key rather than rejecting the manifest.
+        use_dynamic_url: true,
       },
     ],
     icons: {

--- a/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
@@ -141,7 +141,9 @@ async function runInstalledFirefoxSmoke() {
     // about:blank even though its extension document is loaded. Identify the
     // installed guide by its real DOM rather than a stale protocol URL.
     const popupPage = await waitForInstalledPairingGuide(browser);
-    await popupPage.click("#autoPair");
+    // Firefox BiDi can report no clickable geometry for an installed
+    // extension page whose protocol URL is stale even though its DOM is live.
+    await popupPage.$eval("#autoPair", (element) => element.click());
     const pairingJson = JSON.stringify({
       apiBaseUrl: mockServer.origin,
       companionId: "companion-smoke-test",
@@ -159,7 +161,7 @@ async function runInstalledFirefoxSmoke() {
       },
       pairingJson,
     );
-    await popupPage.click("#import");
+    await popupPage.$eval("#import", (element) => element.click());
     try {
       await popupPage.waitForFunction(
         () =>

--- a/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Validates Firefox's deterministic XPI-ready artifacts, then installs the
+ * unpacked extension into the real Firefox application over WebDriver BiDi and
+ * proves authenticated manual pairing, tab sync, DOM action execution, and completion callbacks.
+ */
+
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { unzipSync } from "fflate";
+import puppeteer from "puppeteer-core";
+import { startMockAgentServer } from "./extension-smoke.mjs";
+import { run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const firefoxDist = path.join(extensionRoot, "dist", "firefox");
+const artifactsDir = path.join(extensionRoot, "dist", "artifacts");
+const resultsDir = path.join(extensionRoot, "dist", "test-results");
+
+function resolveFirefoxExecutable() {
+  const configured = process.env.FIREFOX_EXECUTABLE_PATH?.trim();
+  const candidates = [
+    configured,
+    process.platform === "darwin"
+      ? "/Applications/Firefox.app/Contents/MacOS/firefox"
+      : null,
+    process.platform === "linux" ? "/usr/bin/firefox" : null,
+    process.platform === "linux" ? "/usr/local/bin/firefox" : null,
+    process.platform === "win32" && process.env.PROGRAMFILES
+      ? path.join(process.env.PROGRAMFILES, "Mozilla Firefox", "firefox.exe")
+      : null,
+    process.platform === "win32" && process.env["PROGRAMFILES(X86)"]
+      ? path.join(
+          process.env["PROGRAMFILES(X86)"],
+          "Mozilla Firefox",
+          "firefox.exe",
+        )
+      : null,
+  ].filter(
+    (candidate) => typeof candidate === "string" && candidate.length > 0,
+  );
+  const executable = candidates.find((candidate) =>
+    fsSync.existsSync(candidate),
+  );
+  if (!executable) {
+    throw new Error(
+      "Firefox is not installed in a standard location. Install Firefox or set FIREFOX_EXECUTABLE_PATH to the Firefox executable.",
+    );
+  }
+  return executable;
+}
+
+async function waitForFirefoxAction(page, requests, timeout = 30_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const clicked = await page.evaluate(
+      () => document.querySelector("#smoke-action")?.dataset.clicked === "yes",
+    );
+    const completed = requests.some((request) =>
+      request.path.endsWith("/session-smoke-test/complete"),
+    );
+    if (clicked && completed) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    "Firefox did not execute the DOM click and report session completion within 30 seconds.",
+  );
+}
+
+async function saveFailureScreenshot(page) {
+  await fs.mkdir(resultsDir, { recursive: true });
+  try {
+    await page.screenshot({
+      path: path.join(resultsDir, "firefox-manual-pair-and-sync.png"),
+      fullPage: true,
+    });
+  } catch (error) {
+    // error-policy:J6 Failure capture must not replace the owning smoke error.
+    console.warn(
+      `Could not save Firefox smoke failure screenshot: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function waitForInstalledPairingGuide(browser, timeout = 20_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const page of await browser.pages()) {
+      try {
+        if (
+          (await page.title()) === "Agent Browser Bridge" &&
+          (await page.$("#pairingJson"))
+        ) {
+          return page;
+        }
+      } catch {
+        // error-policy:J4 A page that disappears during discovery is simply
+        // not the installed pairing guide; the timeout remains visible.
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    "Firefox did not open the installed extension pairing guide within 20 seconds",
+  );
+}
+
+async function runInstalledFirefoxSmoke() {
+  const mockServer = await startMockAgentServer();
+  let browser = null;
+  let appPage = null;
+  try {
+    browser = await puppeteer.launch({
+      browser: "firefox",
+      executablePath: resolveFirefoxExecutable(),
+      headless: true,
+      protocol: "webDriverBiDi",
+      timeout: 45_000,
+    });
+    const version = await browser.version();
+    if (!version.toLowerCase().startsWith("firefox/")) {
+      throw new Error(`Expected Firefox, but launched ${version}`);
+    }
+    appPage = (await browser.pages())[0] ?? (await browser.newPage());
+    await appPage.goto(`${mockServer.origin}/chat`, {
+      waitUntil: "domcontentloaded",
+    });
+    const extensionId = await browser.installExtension(firefoxDist);
+    if (extensionId !== "browser-bridge@elizaos.ai") {
+      throw new Error(
+        `Firefox installed unexpected extension ID ${extensionId}`,
+      );
+    }
+    // Firefox 153's BiDi implementation reports an extension-created tab as
+    // about:blank even though its extension document is loaded. Identify the
+    // installed guide by its real DOM rather than a stale protocol URL.
+    const popupPage = await waitForInstalledPairingGuide(browser);
+    await popupPage.click("#autoPair");
+    const pairingJson = JSON.stringify({
+      apiBaseUrl: mockServer.origin,
+      companionId: "companion-smoke-test",
+      pairingToken: "lobr_smoke_pairing_token",
+      browser: "firefox",
+      profileId: "default",
+      profileLabel: "Default",
+      label: "Agent Browser Bridge Firefox smoke",
+    });
+    await popupPage.$eval(
+      "#pairingJson",
+      (element, value) => {
+        element.value = value;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+      },
+      pairingJson,
+    );
+    await popupPage.click("#import");
+    try {
+      await popupPage.waitForFunction(
+        () =>
+          document
+            .querySelector("#autoPair")
+            ?.textContent?.includes("Sync This Browser"),
+        { timeout: 20_000 },
+      );
+    } catch (error) {
+      const popupState = await popupPage.evaluate(() => ({
+        action: document.querySelector("#autoPair")?.textContent,
+        detail: document.querySelector("#statusDetail")?.textContent,
+        pairingJson: document.querySelector("#pairingJson")?.value,
+        title: document.querySelector("#statusTitle")?.textContent,
+      }));
+      throw new Error(
+        `Firefox pairing import did not settle: ${JSON.stringify(popupState)}`,
+        { cause: error },
+      );
+    }
+    await popupPage.close();
+    await waitForFirefoxAction(appPage, mockServer.requests);
+
+    const autoPair = mockServer.requests.find(
+      (request) => request.path === "/api/browser-bridge/companions/auto-pair",
+    );
+    const preflight = mockServer.requests.find(
+      (request) =>
+        request.method === "POST" &&
+        request.path === "/api/browser-bridge/companions/preflight",
+    );
+    const sync = mockServer.requests.find(
+      (request) =>
+        request.method === "POST" &&
+        request.path === "/api/browser-bridge/companions/sync",
+    );
+    const progress = mockServer.requests.find(
+      (request) =>
+        request.path.endsWith("/session-smoke-test/progress") &&
+        request.body?.completedActionId === "action-smoke-click" &&
+        request.body?.result?.["action-smoke-click"]?.tagName === "button",
+    );
+    const begin = mockServer.requests.find((request) =>
+      request.path.endsWith("/session-smoke-test/actions/begin"),
+    );
+    const complete = mockServer.requests.find((request) =>
+      request.path.endsWith("/session-smoke-test/complete"),
+    );
+    if (
+      autoPair ||
+      !preflight ||
+      sync?.body?.settingsVersion !== "settings-smoke-v1" ||
+      sync?.authorization !== "Bearer lobr_smoke_pairing_token" ||
+      sync?.companionId !== "companion-smoke-test" ||
+      !begin ||
+      !progress ||
+      begin.body?.attemptId !== progress.body?.attemptId ||
+      !complete
+    ) {
+      throw new Error(
+        "Firefox smoke did not observe imported-auth preflight, version-bound sync, action progress, and completion without auto-pair.",
+      );
+    }
+    return version;
+  } catch (error) {
+    if (appPage) {
+      await saveFailureScreenshot(appPage);
+    }
+    throw error;
+  } finally {
+    if (browser) {
+      try {
+        await browser.close();
+      } catch (error) {
+        // error-policy:J6 Browser teardown must not hide the smoke result.
+        console.warn(
+          `Could not close Firefox after smoke: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    await mockServer.close();
+  }
+}
+
+await run("bun", [path.join(scriptDir, "package-firefox.mjs")], {
+  cwd: extensionRoot,
+});
+
+const manifest = JSON.parse(
+  await fs.readFile(path.join(firefoxDist, "manifest.json"), "utf8"),
+);
+if (manifest.manifest_version !== 3) {
+  throw new Error("Firefox manifest must use Manifest V3");
+}
+if (manifest.background?.scripts?.[0] !== "background.js") {
+  throw new Error(
+    "Firefox manifest must use a persistent WebExtension background script declaration",
+  );
+}
+if (manifest.background?.service_worker) {
+  throw new Error(
+    "Firefox build must not depend on Chromium service_worker semantics",
+  );
+}
+if (
+  manifest.browser_specific_settings?.gecko?.id !== "browser-bridge@elizaos.ai"
+) {
+  throw new Error("Firefox manifest is missing the stable Gecko extension ID");
+}
+if (
+  manifest.optional_host_permissions?.join(",") !== "https://*/*,http://*/*"
+) {
+  throw new Error("Firefox optional host permissions drifted");
+}
+if (manifest.content_security_policy?.extension_pages.includes("unsafe-eval")) {
+  throw new Error("Firefox extension CSP must not permit eval");
+}
+
+const zipPath = path.join(artifactsDir, "browser-bridge-firefox.zip");
+const xpiPath = path.join(artifactsDir, "browser-bridge-firefox.xpi");
+const [zipBytes, xpiBytes] = await Promise.all([
+  fs.readFile(zipPath),
+  fs.readFile(xpiPath),
+]);
+if (!zipBytes.equals(xpiBytes)) {
+  throw new Error("Firefox ZIP and XPI-ready artifacts must be byte-identical");
+}
+const entries = unzipSync(new Uint8Array(zipBytes));
+if (!entries["manifest.json"] || !entries["background.js"]) {
+  throw new Error(
+    "Firefox archive must contain manifest.json and background.js at its root",
+  );
+}
+if (entries["firefox/manifest.json"]) {
+  throw new Error(
+    "Firefox archive must not nest the extension under a firefox directory",
+  );
+}
+const firstHash = createHash("sha256").update(zipBytes).digest("hex");
+await run("bun", [path.join(scriptDir, "package-firefox.mjs")], {
+  cwd: extensionRoot,
+});
+const secondHash = createHash("sha256")
+  .update(await fs.readFile(zipPath))
+  .digest("hex");
+if (firstHash !== secondHash) {
+  throw new Error("Firefox package is not byte-reproducible");
+}
+const firefoxVersion = await runInstalledFirefoxSmoke();
+console.log(
+  `Firefox extension smoke passed (${firefoxVersion}, sha256 ${secondHash})`,
+);

--- a/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-firefox.mjs
@@ -94,7 +94,7 @@ async function waitForInstalledPairingGuide(browser, timeout = 20_000) {
     for (const page of await browser.pages()) {
       try {
         if (
-          (await page.title()) === "Agent Browser Bridge" &&
+          (await page.title()) === "Eliza Browser" &&
           (await page.$("#pairingJson"))
         ) {
           return page;
@@ -143,7 +143,7 @@ async function runInstalledFirefoxSmoke() {
     const popupPage = await waitForInstalledPairingGuide(browser);
     // Firefox BiDi can report no clickable geometry for an installed
     // extension page whose protocol URL is stale even though its DOM is live.
-    await popupPage.$eval("#autoPair", (element) => element.click());
+    await popupPage.$eval("#primaryAction", (element) => element.click());
     const pairingJson = JSON.stringify({
       apiBaseUrl: mockServer.origin,
       companionId: "companion-smoke-test",
@@ -161,19 +161,18 @@ async function runInstalledFirefoxSmoke() {
       },
       pairingJson,
     );
-    await popupPage.$eval("#import", (element) => element.click());
+    await popupPage.$eval("#importPairing", (element) => element.click());
     try {
       await popupPage.waitForFunction(
         () =>
           document
-            .querySelector("#autoPair")
-            ?.textContent?.includes("Sync This Browser"),
+            .querySelector("#statusTitle")
+            ?.textContent?.includes("Connected"),
         { timeout: 20_000 },
       );
     } catch (error) {
       const popupState = await popupPage.evaluate(() => ({
-        action: document.querySelector("#autoPair")?.textContent,
-        detail: document.querySelector("#statusDetail")?.textContent,
+        action: document.querySelector("#primaryAction")?.textContent,
         pairingJson: document.querySelector("#pairingJson")?.value,
         title: document.querySelector("#statusTitle")?.textContent,
       }));

--- a/packages/browser-bridge-extension/scripts/extension-smoke-safari.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-safari.mjs
@@ -1,0 +1,591 @@
+#!/usr/bin/env node
+/**
+ * Installed-Safari smoke: creates a development-signed container app, verifies
+ * that Safari registers its extension while unsigned extensions remain off,
+ * and exercises pairing/sync through the real installed popup. The plist and
+ * UI checks require a real macOS/Safari host and a local Apple Development
+ * signing identity.
+ */
+import { spawn } from "node:child_process";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const signedSafariAppPath = path.join(
+  extensionRoot,
+  "dist",
+  "artifacts",
+  "Agent Browser Bridge.app",
+);
+const safariExtensionsPlist = path.join(
+  os.homedir(),
+  "Library/Containers/com.apple.Safari/Data/Library/Safari/WebExtensions/Extensions.plist",
+);
+const safariDeveloperWindowName = "Developer";
+const safariExtensionsWindowName = "Extensions";
+const safariAppName = "Safari";
+const safariAppDisplayName = "Agent Browser Bridge";
+const safariBundleIdentifierPrefix = "ai.elizaos.browserbridge";
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const timeoutMs = options.timeoutMs ?? null;
+    const child = spawn(command, args, {
+      stdio: "pipe",
+      ...options,
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout =
+      typeof timeoutMs === "number" && timeoutMs > 0
+        ? setTimeout(() => {
+            child.kill("SIGTERM");
+            reject(
+              new Error(
+                `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+              ),
+            );
+          }, timeoutMs)
+        : null;
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} exited with code ${code ?? "unknown"}\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+function assertMacOs() {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "Safari smoke tests only run on macOS because they depend on Safari, safaridriver, and AppleScript UI scripting.",
+    );
+  }
+}
+
+async function runAppleScript(source, options = {}) {
+  const { stdout } = await run("osascript", ["-e", source], {
+    cwd: extensionRoot,
+    timeoutMs: options.timeoutMs ?? 20_000,
+  });
+  return stdout.trim();
+}
+
+async function resolveSafariSigningIdentity() {
+  const { stdout } = await run(
+    "security",
+    ["find-identity", "-v", "-p", "codesigning"],
+    { cwd: extensionRoot },
+  );
+  const match = stdout.match(
+    /^\s*\d+\)\s+([0-9A-F]{40})\s+"Apple Development:.*\(([A-Z0-9]{10})\)"/m,
+  );
+  if (!match) {
+    throw new Error(
+      "Installed Safari smoke requires an Apple Development signing identity in the login keychain.",
+    );
+  }
+  return { identity: match[1], team: match[2] };
+}
+
+async function buildSignedSafariWebExtension() {
+  const signing = await resolveSafariSigningIdentity();
+  await run("bun", [path.join(scriptDir, "package-safari.mjs")], {
+    cwd: extensionRoot,
+    env: {
+      ...process.env,
+      ELIZA_SAFARI_SIGNING_IDENTITY: signing.identity,
+      ELIZA_SAFARI_SIGNING_TEAM: signing.team,
+    },
+    timeoutMs: 180_000,
+  });
+}
+
+async function ensureSafariDevelopMenu() {
+  const present = await runAppleScript(`
+    tell application "${safariAppName}" to activate
+    tell application "System Events"
+      tell process "${safariAppName}"
+        return exists menu "Develop" of menu bar 1
+      end tell
+    end tell
+  `);
+  if (present !== "true") {
+    throw new Error(
+      "Safari's Develop menu is disabled. Enable it manually before running installed Safari acceptance.",
+    );
+  }
+}
+
+async function openSafariDeveloperSettings() {
+  await runAppleScript(`
+    tell application "${safariAppName}" to activate
+    delay 1
+    tell application "System Events"
+      tell process "${safariAppName}"
+        set frontmost to true
+        if not (exists window "${safariDeveloperWindowName}") then
+          click menu item "Developer Settings…" of menu "Develop" of menu bar 1
+          delay 1
+        end if
+      end tell
+    end tell
+  `);
+}
+
+async function readSafariDeveloperFlags() {
+  const raw = await runAppleScript(`
+    tell application "System Events"
+      tell process "${safariAppName}"
+        tell window "${safariDeveloperWindowName}"
+          tell group 1 of group 1
+            set remoteAutomation to value of checkbox "Allow remote automation"
+            set unsignedExtensions to value of checkbox "Allow unsigned extensions"
+            set jsFromAppleEvents to value of checkbox "Allow JavaScript from Apple Events"
+          end tell
+          set authPromptVisible to exists sheet 1
+          return (remoteAutomation as string) & "," & (unsignedExtensions as string) & "," & (jsFromAppleEvents as string) & "," & (authPromptVisible as string)
+        end tell
+      end tell
+    end tell
+  `);
+  const [
+    remoteAutomation,
+    unsignedExtensions,
+    jsFromAppleEvents,
+    authPromptVisible,
+  ] = raw.split(",");
+  return {
+    remoteAutomation: remoteAutomation === "1",
+    unsignedExtensions: unsignedExtensions === "1",
+    jsFromAppleEvents: jsFromAppleEvents === "1",
+    authPromptVisible: authPromptVisible === "true",
+  };
+}
+
+async function ensureSafariDeveloperPrerequisites() {
+  await openSafariDeveloperSettings();
+  const flags = await readSafariDeveloperFlags();
+  if (!flags.remoteAutomation) {
+    throw new Error(
+      'Safari remote automation is disabled. Enable "Allow remote automation" manually before running installed Safari acceptance.',
+    );
+  }
+  if (!flags.jsFromAppleEvents) {
+    throw new Error(
+      'Safari has "Allow JavaScript from Apple Events" turned off. Enable it manually before running installed Safari acceptance.',
+    );
+  }
+  if (flags.unsignedExtensions || flags.authPromptVisible) {
+    throw new Error(
+      'Installed Safari acceptance requires "Allow unsigned extensions" to remain OFF and no authentication sheet to be pending.',
+    );
+  }
+}
+
+export function parseSafariWebExtensionsPlist(stdout) {
+  const entries = new Map();
+  let currentEntry = null;
+  for (const line of stdout.split("\n")) {
+    const entryMatch = line.match(/^ {2}"([^"]+)" => \{$/);
+    if (entryMatch) {
+      currentEntry = entryMatch[1];
+      entries.set(currentEntry, { removed: false });
+      continue;
+    }
+    if (currentEntry && /^ {4}"RemovedDate" => /.test(line)) {
+      entries.get(currentEntry).removed = true;
+    }
+  }
+  return entries;
+}
+
+async function readSafariWebExtensionsPlist() {
+  try {
+    const { stdout } = await run("plutil", ["-p", safariExtensionsPlist], {
+      cwd: extensionRoot,
+    });
+    return parseSafariWebExtensionsPlist(stdout);
+  } catch {
+    return new Map();
+  }
+}
+
+export function normalizeSafariExtensionKey(key) {
+  return key.replace(/\s+\([^)]*\)$/, "").trim();
+}
+
+export function browserBridgeSafariPopupCandidates(extensionKeys) {
+  const baseIds = extensionKeys.map(normalizeSafariExtensionKey);
+  return [
+    ...new Set(
+      baseIds.flatMap((baseId) => [
+        `safari-web-extension://${baseId}/popup.html`,
+        `safari-web-extension://${baseId}/dist/safari/popup.html`,
+      ]),
+    ),
+  ];
+}
+
+async function installSignedSafariExtension() {
+  await run("open", ["-n", signedSafariAppPath], {
+    cwd: extensionRoot,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  const installed = await readSafariWebExtensionsPlist();
+  return [...installed]
+    .flatMap(([key, state]) =>
+      !state.removed &&
+      (/browserbridge/i.test(key) ||
+        key.startsWith(safariBundleIdentifierPrefix))
+        ? [key]
+        : [],
+    )
+    .filter(
+      (key) =>
+        /browserbridge/i.test(key) ||
+        key.startsWith(safariBundleIdentifierPrefix),
+    );
+}
+
+async function openSafariExtensionsPreferences() {
+  await runAppleScript(`
+    tell application "${safariAppName}" to activate
+    delay 1
+    tell application "System Events"
+      tell process "${safariAppName}"
+        set frontmost to true
+        click menu item "Settings…" of menu "Safari" of menu bar 1
+        delay 1
+        click button "Extensions" of toolbar 1 of window 1
+        delay 1
+      end tell
+    end tell
+  `);
+}
+
+async function enableBrowserBridgeExtensionInSafari() {
+  await openSafariExtensionsPreferences();
+  const rowName = await runAppleScript(`
+    tell application "System Events"
+      tell process "${safariAppName}"
+        tell window "${safariExtensionsWindowName}"
+          tell table 1 of scroll area 1 of group 2 of group 1 of group 1
+            repeat with currentRow in rows
+              try
+                set rowElement to UI element 1 of currentRow
+                set rowLabel to name of rowElement
+                if rowLabel contains "Agent Browser Bridge" then
+                  if value of checkbox 1 of rowElement is 0 then click checkbox 1 of rowElement
+                  return rowLabel
+                end if
+              end try
+            end repeat
+          end tell
+        end tell
+      end tell
+    end tell
+  `);
+  if (!rowName) {
+    throw new Error(
+      "Safari did not show an Agent Browser Bridge extension row after launching the signed container app.",
+    );
+  }
+  return rowName;
+}
+
+async function openSafariUrl(url, inNewTab = false) {
+  const escapedUrl = url.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  await runAppleScript(`
+    tell application "${safariAppName}"
+      activate
+      if not (exists front window) then
+        make new document
+      end if
+      tell front window
+        if ${inNewTab ? "true" : "false"} then
+          set current tab to (make new tab with properties {URL:"${escapedUrl}"})
+        else
+          set URL of current tab to "${escapedUrl}"
+        end if
+      end tell
+    end tell
+  `);
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+}
+
+async function readSafariFrontTabState() {
+  const raw = await runAppleScript(`
+    tell application "${safariAppName}"
+      set payload to do JavaScript "JSON.stringify({ title: document.querySelector('#statusTitle')?.textContent ?? document.title ?? '', detail: document.querySelector('#statusDetail')?.textContent ?? '', badge: document.querySelector('#statusBadge')?.textContent ?? '', button: document.querySelector('#autoPair')?.textContent ?? '', summary: document.querySelector('#summary')?.textContent ?? '' })" in current tab of front window
+      return payload
+    end tell
+  `);
+  return JSON.parse(raw || "{}");
+}
+
+async function clickSafariPopupPrimaryButton() {
+  await runAppleScript(`
+    tell application "${safariAppName}"
+      do JavaScript "document.querySelector('#autoPair')?.click();" in current tab of front window
+    end tell
+  `);
+}
+
+async function importSafariPairing(config) {
+  const encodedConfig = Buffer.from(JSON.stringify(config), "utf8").toString(
+    "base64",
+  );
+  const javascript = `document.querySelector('#advancedTools').open = true; document.querySelector('#pairingJson').value = atob('${encodedConfig}'); document.querySelector('#import').click();`;
+  const escapedJavascript = javascript
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  await runAppleScript(`
+    tell application "${safariAppName}"
+      do JavaScript "${escapedJavascript}" in current tab of front window
+    end tell
+  `);
+}
+
+async function waitForSafariPopup(predicate, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    let state = null;
+    try {
+      state = await readSafariFrontTabState();
+    } catch {
+      // error-policy:J4 Transient unreadable popup state remains visibly
+      // pending and becomes a timeout failure at this polling boundary.
+      state = null;
+    }
+    if (state && predicate(state)) {
+      return state;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error("Timed out waiting for Safari popup state.");
+}
+
+async function startMockAgentServer() {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    let body = "";
+    for await (const chunk of req) {
+      body += String(chunk);
+    }
+    requests.push({
+      path: url.pathname,
+      authorization: req.headers.authorization ?? null,
+      companionId: req.headers["x-browser-bridge-companion-id"] ?? null,
+      body: body.trim() ? JSON.parse(body) : null,
+    });
+    const now = new Date().toISOString();
+
+    if (url.pathname === "/chat") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end("<!doctype html><title>Eliza</title><h1>Eliza</h1>");
+      return;
+    }
+    if (url.pathname === "/api/status") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ state: "running" }));
+      return;
+    }
+    if (
+      req.method === "POST" &&
+      url.pathname === "/api/browser-bridge/companions/auto-pair"
+    ) {
+      res.writeHead(410, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "Automatic browser pairing is disabled. Import pairing JSON.",
+        }),
+      );
+      return;
+    }
+    if (
+      req.method === "POST" &&
+      url.pathname === "/api/browser-bridge/companions/sync"
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          companion: {
+            id: "browser-bridge-safari-smoke",
+            agentId: "agent-safari-smoke",
+            browser: "safari",
+            profileId: "default",
+            profileLabel: "Default",
+            label: "Agent Browser Bridge Safari smoke",
+            extensionVersion: "0.1.0",
+            connectionState: "connected",
+            permissions: {
+              tabs: true,
+              scripting: true,
+              activeTab: true,
+              allOrigins: true,
+              grantedOrigins: ["<all_urls>"],
+              incognitoEnabled: false,
+            },
+            lastSeenAt: now,
+            pairedAt: now,
+            metadata: {},
+            createdAt: now,
+            updatedAt: now,
+          },
+          tabs: [],
+          currentPage: null,
+          settings: {
+            enabled: true,
+            trackingMode: "active_tabs",
+            allowBrowserControl: true,
+            requireConfirmationForAccountAffecting: true,
+            incognitoEnabled: false,
+            siteAccessMode: "all_sites",
+            grantedOrigins: [],
+            blockedOrigins: [],
+            maxRememberedTabs: 10,
+            pauseUntil: null,
+            metadata: {},
+            updatedAt: now,
+          },
+          session: null,
+        }),
+      );
+      return;
+    }
+    if (url.pathname === "/api/website-blocker") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ active: false, websites: [] }));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    requests,
+    async close() {
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+}
+
+async function resolveSafariPopupUrl(extensionKeys) {
+  const candidates = browserBridgeSafariPopupCandidates(extensionKeys);
+  for (const candidate of candidates) {
+    await openSafariUrl(candidate, true);
+    let state = null;
+    try {
+      state = await readSafariFrontTabState();
+    } catch {
+      // error-policy:J3 An unreadable candidate is rejected rather than
+      // treated as a working Safari extension origin.
+      state = null;
+    }
+    if (
+      state &&
+      typeof state.title === "string" &&
+      state.title.trim().length > 0
+    ) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Could not resolve a working Safari popup URL for ${safariAppDisplayName}. Tried: ${candidates.join(", ")}`,
+  );
+}
+
+export async function main() {
+  assertMacOs();
+  await buildSignedSafariWebExtension();
+  await ensureSafariDevelopMenu();
+  await ensureSafariDeveloperPrerequisites();
+  const extensionKeys = await installSignedSafariExtension();
+  if (extensionKeys.length === 0) {
+    throw new Error(
+      `Safari did not register the signed ${safariAppDisplayName} extension after launching its container app.`,
+    );
+  }
+  await enableBrowserBridgeExtensionInSafari();
+  const mockServer = await startMockAgentServer();
+  try {
+    await openSafariUrl(`${mockServer.origin}/chat`);
+    const popupUrl = await resolveSafariPopupUrl(extensionKeys);
+    await openSafariUrl(popupUrl, true);
+    await waitForSafariPopup(
+      (state) => state.title && state.title !== "Loading extension state…",
+      20_000,
+    );
+    await importSafariPairing({
+      apiBaseUrl: mockServer.origin,
+      companionId: "browser-bridge-safari-smoke",
+      pairingToken: "lobr_safari_smoke_token",
+      browser: "safari",
+      profileId: "default",
+      profileLabel: "Default",
+      label: "Agent Browser Bridge Safari smoke",
+    });
+    await waitForSafariPopup(
+      (state) => String(state.button ?? "").includes("Sync This Browser"),
+      20_000,
+    );
+    await clickSafariPopupPrimaryButton();
+    await waitForSafariPopup(
+      (state) => String(state.title ?? "").includes("connected to Eliza"),
+      20_000,
+    );
+    if (
+      mockServer.requests.some(
+        (request) =>
+          request.path === "/api/browser-bridge/companions/auto-pair",
+      )
+    ) {
+      throw new Error("Safari smoke observed a forbidden auto-pair request.");
+    }
+    const syncRequest = mockServer.requests.find(
+      (request) => request.path === "/api/browser-bridge/companions/sync",
+    );
+    if (
+      syncRequest?.authorization !== "Bearer lobr_safari_smoke_token" ||
+      syncRequest?.companionId !== "browser-bridge-safari-smoke"
+    ) {
+      throw new Error(
+        "Safari smoke sync did not use imported pairing credentials.",
+      );
+    }
+    console.log(`${safariAppDisplayName} Safari smoke checks passed.`);
+  } finally {
+    await mockServer.close();
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/packages/browser-bridge-extension/scripts/extension-smoke-safari.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-safari.mjs
@@ -336,7 +336,7 @@ async function openSafariUrl(url, inNewTab = false) {
 async function readSafariFrontTabState() {
   const raw = await runAppleScript(`
     tell application "${safariAppName}"
-      set payload to do JavaScript "JSON.stringify({ title: document.querySelector('#statusTitle')?.textContent ?? document.title ?? '', detail: document.querySelector('#statusDetail')?.textContent ?? '', badge: document.querySelector('#statusBadge')?.textContent ?? '', button: document.querySelector('#autoPair')?.textContent ?? '', summary: document.querySelector('#summary')?.textContent ?? '' })" in current tab of front window
+      set payload to do JavaScript "JSON.stringify({ title: document.querySelector('#statusTitle')?.textContent ?? document.title ?? '', button: document.querySelector('#primaryAction')?.textContent ?? '', app: document.querySelector('#appValue')?.textContent ?? '' })" in current tab of front window
       return payload
     end tell
   `);
@@ -346,7 +346,7 @@ async function readSafariFrontTabState() {
 async function clickSafariPopupPrimaryButton() {
   await runAppleScript(`
     tell application "${safariAppName}"
-      do JavaScript "document.querySelector('#autoPair')?.click();" in current tab of front window
+      do JavaScript "document.querySelector('#primaryAction')?.click();" in current tab of front window
     end tell
   `);
 }
@@ -355,7 +355,7 @@ async function importSafariPairing(config) {
   const encodedConfig = Buffer.from(JSON.stringify(config), "utf8").toString(
     "base64",
   );
-  const javascript = `document.querySelector('#advancedTools').open = true; document.querySelector('#pairingJson').value = atob('${encodedConfig}'); document.querySelector('#import').click();`;
+  const javascript = `document.querySelector('#details').open = true; document.querySelector('#recovery').open = true; document.querySelector('#pairingJson').value = atob('${encodedConfig}'); document.querySelector('#importPairing').click();`;
   const escapedJavascript = javascript
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"');

--- a/packages/browser-bridge-extension/scripts/extension-smoke-safari.test.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke-safari.test.mjs
@@ -1,0 +1,30 @@
+/**
+ * Deterministic coverage for Safari's human-readable extension-plist parser.
+ */
+import { describe, expect, it } from "vitest";
+import { parseSafariWebExtensionsPlist } from "./extension-smoke-safari.mjs";
+
+describe("parseSafariWebExtensionsPlist", () => {
+  it("distinguishes active and removed extension records", () => {
+    const records = parseSafariWebExtensionsPlist(`{
+  "com.apple.Safari.UnpackedExtensions.ACTIVE (UNSIGNED)" => {
+    "Enabled" => true
+  }
+  "com.apple.Safari.UnpackedExtensions.REMOVED (UNSIGNED)" => {
+    "Enabled" => false
+    "RemovedDate" => 2026-08-18 19:55:59 +0000
+  }
+}`);
+
+    expect([...records]).toEqual([
+      [
+        "com.apple.Safari.UnpackedExtensions.ACTIVE (UNSIGNED)",
+        { removed: false },
+      ],
+      [
+        "com.apple.Safari.UnpackedExtensions.REMOVED (UNSIGNED)",
+        { removed: true },
+      ],
+    ]);
+  });
+});

--- a/packages/browser-bridge-extension/scripts/extension-smoke.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke.mjs
@@ -1,0 +1,769 @@
+#!/usr/bin/env node
+/**
+ * Installed Chrome for Testing smoke: verifies the dist/chrome artifacts and
+ * exercises optional website access, pairing, sync, a real DOM click, and a
+ * website-block redirect against a deterministic local agent HTTP harness.
+ * The browser, extension, page, and transport are real; only the agent business
+ * service is isolated. Branded Chrome 137+ rejects command-line extension loads.
+ */
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(extensionRoot, "..", "..");
+const chromeDistDir = path.join(extensionRoot, "dist", "chrome");
+const resultsDir = path.join(extensionRoot, "dist", "test-results");
+const exerciseSiteAccess = process.env.BROWSER_BRIDGE_SMOKE_SITE_ACCESS === "1";
+const removePathRecursiveScript = path.join(
+  repoRoot,
+  "packages",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
+
+function resolveBunCommand() {
+  const bunFromEnv = process.env.BUN?.trim();
+  if (bunFromEnv && fs.existsSync(bunFromEnv)) {
+    return bunFromEnv;
+  }
+  if (
+    typeof process.versions.bun === "string" &&
+    typeof process.execPath === "string" &&
+    process.execPath.length > 0 &&
+    fs.existsSync(process.execPath)
+  ) {
+    return process.execPath;
+  }
+  const homeBun = path.join(
+    os.homedir(),
+    ".bun",
+    "bin",
+    process.platform === "win32" ? "bun.exe" : "bun",
+  );
+  if (fs.existsSync(homeBun)) {
+    return homeBun;
+  }
+  return process.platform === "win32" ? "bun.exe" : "bun";
+}
+
+function resolvePlaywrightModulePath() {
+  const candidates = [
+    path.join(repoRoot, "node_modules", "@playwright", "test", "index.mjs"),
+    path.join(
+      repoRoot,
+      "packages",
+      "app",
+      "node_modules",
+      "@playwright",
+      "test",
+      "index.mjs",
+    ),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "Could not resolve @playwright/test. Install app dependencies before running Agent Browser Bridge smoke tests.",
+  );
+}
+
+async function ensureChromeBuild() {
+  await run(
+    resolveBunCommand(),
+    [path.join(scriptDir, "build.mjs"), "chrome"],
+    {
+      cwd: extensionRoot,
+    },
+  );
+}
+
+async function loadPlaywright() {
+  const modulePath = resolvePlaywrightModulePath();
+  const playwright = await import(pathToFileURL(modulePath).href);
+  if (!playwright.chromium) {
+    throw new Error("Resolved @playwright/test but chromium is unavailable");
+  }
+  return playwright;
+}
+
+async function createTempDir(prefix) {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+function resolveChromeForTestingExecutable() {
+  const configured = process.env.CHROME_FOR_TESTING_EXECUTABLE_PATH?.trim();
+  const candidates = [
+    configured,
+    process.platform === "darwin"
+      ? "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+      : undefined,
+  ].filter((candidate) => typeof candidate === "string");
+  const executable = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!executable) {
+    throw new Error(
+      "Chrome for Testing is required because branded Chrome 137+ disables --load-extension. Set CHROME_FOR_TESTING_EXECUTABLE_PATH to an installed official Chrome for Testing executable.",
+    );
+  }
+  return executable;
+}
+
+async function removePathRecursive(targetPath) {
+  await run(process.execPath, [removePathRecursiveScript, targetPath], {
+    cwd: repoRoot,
+  });
+}
+
+async function waitForServiceWorker(context) {
+  return (
+    context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"))
+  );
+}
+
+async function launchExtensionContext(chromium) {
+  const userDataDir = await createTempDir("browser-bridge-smoke-");
+  try {
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      executablePath: resolveChromeForTestingExecutable(),
+      headless:
+        process.env.BROWSER_BRIDGE_SMOKE_HEADLESS === "1" ||
+        !exerciseSiteAccess,
+      args: [
+        `--disable-extensions-except=${chromeDistDir}`,
+        `--load-extension=${chromeDistDir}`,
+      ],
+    });
+    const serviceWorker = await waitForServiceWorker(context);
+    const extensionId = new URL(serviceWorker.url()).host;
+    return {
+      context,
+      extensionId,
+      async close() {
+        await context.close();
+        await removePathRecursive(userDataDir);
+      },
+    };
+  } catch (error) {
+    // error-policy:J2 Preserve the launch failure after removing its isolated
+    // temporary profile.
+    await removePathRecursive(userDataDir);
+    throw error;
+  }
+}
+
+async function saveScreenshot(page, name) {
+  await fsp.mkdir(resultsDir, { recursive: true });
+  const screenshotPath = path.join(resultsDir, `${name}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+}
+
+async function saveFailureScreenshot(page, name) {
+  try {
+    await saveScreenshot(page, name);
+  } catch (error) {
+    // error-policy:J6 Failure capture must not replace the owning smoke error.
+    console.warn(
+      `Could not save Chrome smoke failure screenshot: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function openPopup(context, extensionId) {
+  const popupPage = await context.newPage();
+  await popupPage.goto(`chrome-extension://${extensionId}/popup.html`);
+  await popupPage.waitForLoadState("domcontentloaded");
+  return popupPage;
+}
+
+async function waitForPopupText(page, selector, expected, timeout = 20_000) {
+  await page.waitForFunction(
+    ([query, value]) => {
+      const element = document.querySelector(query);
+      return Boolean(element?.textContent?.includes(value));
+    },
+    [selector, expected],
+    {
+      timeout,
+    },
+  );
+}
+
+async function waitForPopupSettled(page) {
+  await page.waitForFunction(() => {
+    const title = document.querySelector("#statusTitle")?.textContent ?? "";
+    const badge = document.querySelector("#statusBadge")?.textContent ?? "";
+    const primary = document.querySelector("#autoPair");
+    const primaryLabel = primary?.textContent?.trim() ?? "";
+    return (
+      title.trim().length > 0 &&
+      title !== "Loading extension state…" &&
+      title !== "Looking for Eliza in this browser" &&
+      badge !== "Loading" &&
+      primaryLabel.length > 0 &&
+      primary instanceof HTMLButtonElement &&
+      !primary.disabled
+    );
+  });
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createMockCompanion(origin, requestBody) {
+  const profileId =
+    typeof requestBody?.profileId === "string" && requestBody.profileId.trim()
+      ? requestBody.profileId
+      : "default";
+  const profileLabel =
+    typeof requestBody?.profileLabel === "string" &&
+    requestBody.profileLabel.trim()
+      ? requestBody.profileLabel
+      : "Default";
+  const browser = ["chrome", "firefox", "safari"].includes(requestBody?.browser)
+    ? requestBody.browser
+    : "chrome";
+  return {
+    id: "companion-smoke-test",
+    agentId: "agent-smoke-test",
+    browser,
+    profileId,
+    profileLabel,
+    label: "Agent Browser Bridge smoke",
+    extensionVersion: "0.1.0",
+    connectionState: "connected",
+    permissions: {
+      tabs: true,
+      scripting: true,
+      activeTab: true,
+      allOrigins: true,
+      grantedOrigins: ["<all_urls>"],
+      incognitoEnabled: false,
+    },
+    lastSeenAt: nowIso(),
+    pairedAt: nowIso(),
+    metadata: {
+      smokeTest: true,
+      origin,
+    },
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+}
+
+export async function startMockAgentServer() {
+  const requests = [];
+  let sessionCompleted = false;
+  let activeSession = null;
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    let body = "";
+    for await (const chunk of req) {
+      body += String(chunk);
+    }
+    const jsonBody = body.trim() ? JSON.parse(body) : null;
+    requests.push({
+      method: req.method ?? "GET",
+      path: url.pathname,
+      body: jsonBody,
+      authorization: req.headers.authorization ?? null,
+      companionId: req.headers["x-browser-bridge-companion-id"] ?? null,
+    });
+    if (process.env.BROWSER_BRIDGE_SMOKE_LOG_REQUESTS === "1") {
+      console.log(`${req.method ?? "GET"} ${url.pathname}`);
+    }
+
+    if (url.pathname === "/chat") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(
+        '<!doctype html><html><head><title>Eliza</title></head><body><h1>Eliza</h1><p>Mock app page for extension smoke tests.</p><button id="smoke-action" onclick="this.dataset.clicked=\'yes\'">Run smoke action</button></body></html>',
+      );
+      return;
+    }
+
+    if (url.pathname === "/api/status") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ state: "running" }));
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname === "/api/browser-bridge/companions/auto-pair"
+    ) {
+      res.writeHead(410, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "Automatic browser pairing is disabled. Import pairing JSON.",
+        }),
+      );
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname === "/api/browser-bridge/companions/preflight"
+    ) {
+      const origin = `http://127.0.0.1:${server.address().port}`;
+      const companion = createMockCompanion(origin, jsonBody?.companion);
+      const responsePayload = {
+        companion,
+        settings: {
+          enabled: true,
+          trackingMode: "active_tabs",
+          allowBrowserControl: true,
+          requireConfirmationForAccountAffecting: true,
+          incognitoEnabled: false,
+          siteAccessMode: "all_sites",
+          grantedOrigins: [],
+          blockedOrigins: [],
+          maxRememberedTabs: 10,
+          pauseUntil: null,
+          metadata: {},
+          updatedAt: nowIso(),
+        },
+        settingsVersion: "settings-smoke-v1",
+      };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(responsePayload));
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname ===
+        "/api/browser-bridge/companions/sessions/session-smoke-test/actions/begin"
+    ) {
+      if (
+        !activeSession ||
+        jsonBody?.currentActionIndex !== activeSession.currentActionIndex ||
+        jsonBody?.actionId !==
+          activeSession.actions[activeSession.currentActionIndex]?.id ||
+        typeof jsonBody?.attemptId !== "string" ||
+        !jsonBody.attemptId
+      ) {
+        res.writeHead(409, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Action checkpoint mismatch" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ session: activeSession }));
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname === "/api/browser-bridge/companions/sync"
+    ) {
+      const origin = `http://127.0.0.1:${server.address().port}`;
+      const companion = createMockCompanion(origin, jsonBody?.companion);
+      const firstTab = Array.isArray(jsonBody?.tabs) ? jsonBody.tabs[0] : null;
+      const responsePayload = {
+        companion,
+        tabs: Array.isArray(jsonBody?.tabs)
+          ? jsonBody.tabs.map((tab, index) => ({
+              id: `tab-${index + 1}`,
+              agentId: companion.agentId,
+              companionId: companion.id,
+              browser: companion.browser,
+              profileId: tab.profileId,
+              windowId: tab.windowId,
+              tabId: tab.tabId,
+              url: tab.url,
+              title: tab.title,
+              activeInWindow: tab.activeInWindow,
+              focusedWindow: tab.focusedWindow,
+              focusedActive: tab.focusedActive,
+              incognito: Boolean(tab.incognito),
+              faviconUrl: tab.faviconUrl ?? null,
+              lastSeenAt: tab.lastSeenAt ?? nowIso(),
+              lastFocusedAt: tab.lastFocusedAt ?? null,
+              metadata: tab.metadata ?? {},
+              createdAt: nowIso(),
+              updatedAt: nowIso(),
+            }))
+          : [],
+        currentPage: firstTab
+          ? {
+              id: "page-smoke-test",
+              agentId: companion.agentId,
+              browser: companion.browser,
+              profileId: firstTab.profileId,
+              windowId: firstTab.windowId,
+              tabId: firstTab.tabId,
+              url: firstTab.url,
+              title: firstTab.title,
+              selectionText: null,
+              mainText: "Mock agent page",
+              headings: ["Eliza"],
+              links: [],
+              forms: [],
+              capturedAt: nowIso(),
+              metadata: {},
+            }
+          : null,
+        settings: {
+          enabled: true,
+          trackingMode: "active_tabs",
+          allowBrowserControl: true,
+          requireConfirmationForAccountAffecting: true,
+          incognitoEnabled: false,
+          siteAccessMode: "all_sites",
+          grantedOrigins: [],
+          blockedOrigins: [],
+          maxRememberedTabs: 10,
+          pauseUntil: null,
+          metadata: {},
+          updatedAt: nowIso(),
+        },
+        settingsVersion: "settings-smoke-v1",
+        session:
+          firstTab && !sessionCompleted
+            ? {
+                id: "session-smoke-test",
+                agentId: companion.agentId,
+                domain: "browser",
+                subjectType: "smoke",
+                subjectId: "smoke",
+                visibilityScope: "private",
+                contextPolicy: "private",
+                workflowId: null,
+                browser: companion.browser,
+                companionId: companion.id,
+                profileId: companion.profileId,
+                windowId: firstTab.windowId,
+                tabId: firstTab.tabId,
+                title: "Chrome action smoke",
+                status: "running",
+                actions: [
+                  {
+                    id: "action-smoke-click",
+                    kind: "click",
+                    label: "Click the smoke button",
+                    browser: companion.browser,
+                    windowId: firstTab.windowId,
+                    tabId: firstTab.tabId,
+                    url: firstTab.url,
+                    selector: "#smoke-action",
+                    text: null,
+                    accountAffecting: false,
+                    requiresConfirmation: false,
+                    metadata: {},
+                  },
+                ],
+                currentActionIndex: 0,
+                awaitingConfirmationForActionId: null,
+                result: {},
+                metadata: {},
+                createdAt: nowIso(),
+                updatedAt: nowIso(),
+                finishedAt: null,
+              }
+            : null,
+      };
+      activeSession = responsePayload.session;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(responsePayload));
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname ===
+        "/api/browser-bridge/companions/sessions/session-smoke-test/progress"
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname ===
+        "/api/browser-bridge/companions/sessions/session-smoke-test/complete"
+    ) {
+      sessionCompleted = true;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    if (url.pathname === "/api/website-blocker") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify(
+          exerciseSiteAccess && url.searchParams.get("host")
+            ? {
+                active: true,
+                blocked: true,
+                host: url.searchParams.get("host"),
+                groupKey: "smoke",
+                requiredTasks: [
+                  {
+                    id: "task-smoke",
+                    title: "Complete the installed-browser smoke task",
+                    completed: false,
+                  },
+                ],
+                websites: ["localhost"],
+              }
+            : exerciseSiteAccess
+              ? {
+                  active: true,
+                  blockedWebsites: ["localhost"],
+                  allowedWebsites: [],
+                }
+              : { active: false, blockedWebsites: [], allowedWebsites: [] },
+        ),
+      );
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  });
+
+  const configuredPort = Number.parseInt(
+    process.env.BROWSER_BRIDGE_SMOKE_PORT ?? "0",
+    10,
+  );
+  if (!Number.isInteger(configuredPort) || configuredPort < 0) {
+    throw new Error(
+      "BROWSER_BRIDGE_SMOKE_PORT must be a non-negative integer.",
+    );
+  }
+  await new Promise((resolve) => {
+    server.listen(configuredPort, "127.0.0.1", resolve);
+  });
+
+  const port = server.address().port;
+  const origin = `http://127.0.0.1:${port}`;
+  return {
+    origin,
+    requests,
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function runPopupBootScenario(chromium) {
+  const session = await launchExtensionContext(chromium);
+  const popupPage = await openPopup(session.context, session.extensionId);
+  try {
+    await waitForPopupSettled(popupPage);
+  } catch (error) {
+    await saveFailureScreenshot(popupPage, "popup-boot-failure");
+    throw error;
+  } finally {
+    await session.close();
+  }
+}
+
+async function runManualPairAndSyncScenario(chromium) {
+  const mockServer = await startMockAgentServer();
+  const session = await launchExtensionContext(chromium);
+  const appPage = await session.context.newPage();
+  await appPage.goto(`${mockServer.origin}/chat`);
+  await appPage.waitForLoadState("domcontentloaded");
+  const popupPage = await openPopup(session.context, session.extensionId);
+
+  try {
+    await waitForPopupSettled(popupPage);
+    if (exerciseSiteAccess) {
+      await popupPage.click("#siteAccess");
+      await waitForPopupText(
+        popupPage,
+        "#siteAccess",
+        "Website Access Granted",
+        120_000,
+      );
+      await saveScreenshot(popupPage, "chrome-website-access-granted");
+    }
+    await popupPage.click("#autoPair");
+    await popupPage.waitForFunction(
+      () => document.querySelector("#advancedTools")?.open === true,
+    );
+    await popupPage.fill(
+      "#pairingJson",
+      JSON.stringify({
+        apiBaseUrl: mockServer.origin,
+        companionId: "companion-smoke-test",
+        pairingToken: "lobr_smoke_pairing_token",
+        browser: "chrome",
+        profileId: "default",
+        profileLabel: "Default",
+        label: "Agent Browser Bridge smoke",
+      }),
+    );
+    await popupPage.click("#import");
+    await waitForPopupText(popupPage, "#autoPair", "Sync This Browser", 20_000);
+
+    await popupPage.click("#autoPair");
+    await waitForPopupText(
+      popupPage,
+      "#statusTitle",
+      "This browser is connected to Eliza",
+      20_000,
+    );
+    await waitForPopupText(
+      popupPage,
+      "#summary",
+      `App: ${mockServer.origin}`,
+      10_000,
+    );
+
+    const syncRequests = mockServer.requests.filter(
+      (request) =>
+        request.method === "POST" &&
+        request.path === "/api/browser-bridge/companions/sync",
+    );
+    if (
+      mockServer.requests.some(
+        (request) =>
+          request.path === "/api/browser-bridge/companions/auto-pair",
+      )
+    ) {
+      throw new Error("Chrome smoke observed a forbidden auto-pair request.");
+    }
+    if (
+      syncRequests.some(
+        (request) =>
+          request.authorization !== "Bearer lobr_smoke_pairing_token" ||
+          request.companionId !== "companion-smoke-test",
+      )
+    ) {
+      throw new Error(
+        "Chrome smoke sync did not use imported pairing credentials.",
+      );
+    }
+    const preflightRequests = mockServer.requests.filter(
+      (request) =>
+        request.method === "POST" &&
+        request.path === "/api/browser-bridge/companions/preflight",
+    );
+    if (preflightRequests.length === 0) {
+      throw new Error(
+        "Expected the smoke test to preflight companion settings before sync.",
+      );
+    }
+    if (syncRequests.length === 0) {
+      throw new Error(
+        "Expected the smoke test to hit the companion sync route at least once.",
+      );
+    }
+    if (
+      syncRequests.some(
+        (request) => request.body?.settingsVersion !== "settings-smoke-v1",
+      )
+    ) {
+      throw new Error(
+        "Expected every smoke sync request to bind the preflight settings version.",
+      );
+    }
+    await appPage.waitForFunction(
+      () => document.querySelector("#smoke-action")?.dataset.clicked === "yes",
+      undefined,
+      { timeout: 20_000 },
+    );
+    await appPage.waitForTimeout(250);
+    const progressRequest = mockServer.requests.find(
+      (request) =>
+        request.path.endsWith("/session-smoke-test/progress") &&
+        request.body?.result?.["action-smoke-click"]?.tagName === "button",
+    );
+    const beginRequest = mockServer.requests.find((request) =>
+      request.path.endsWith("/session-smoke-test/actions/begin"),
+    );
+    const completionRequest = mockServer.requests.find((request) =>
+      request.path.endsWith("/session-smoke-test/complete"),
+    );
+    if (
+      !beginRequest ||
+      !progressRequest ||
+      beginRequest.body?.attemptId !== progressRequest.body?.attemptId ||
+      !completionRequest
+    ) {
+      throw new Error(
+        "Expected an action lease, matching attempt-bound DOM result, and session completion callback.",
+      );
+    }
+
+    if (exerciseSiteAccess) {
+      const blockedTarget = `${mockServer.origin.replace("127.0.0.1", "localhost")}/blocked-target`;
+      await appPage.goto(blockedTarget);
+      await appPage.waitForURL(
+        (url) =>
+          url.protocol === "chrome-extension:" &&
+          url.pathname.endsWith("/blocked.html"),
+        { timeout: 20_000 },
+      );
+      await waitForPopupText(
+        appPage,
+        "#taskList",
+        "Complete the installed-browser smoke task",
+        20_000,
+      );
+      const redirectedUrl = new URL(appPage.url());
+      if (
+        redirectedUrl.searchParams.get("api") !== mockServer.origin ||
+        redirectedUrl.searchParams.get("host") !== "localhost"
+      ) {
+        throw new Error(
+          `Blocked-page redirect did not bind to the paired agent and blocked host: ${redirectedUrl}`,
+        );
+      }
+      await saveScreenshot(appPage, "chrome-blocked-page-success");
+    }
+  } catch (error) {
+    await saveFailureScreenshot(popupPage, "manual-pair-and-sync-failure");
+    throw error;
+  } finally {
+    try {
+      await popupPage.close();
+      await appPage.close();
+    } catch (error) {
+      // error-policy:J6 Page teardown must not hide the smoke result.
+      console.warn(
+        `Could not close Chrome smoke pages: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    await session.close();
+    await mockServer.close();
+  }
+}
+
+async function main() {
+  await ensureChromeBuild();
+  const { chromium } = await loadPlaywright();
+  await runPopupBootScenario(chromium);
+  await runManualPairAndSyncScenario(chromium);
+  console.log("Agent Browser Bridge extension smoke checks passed.");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv.includes("--server-only")) {
+    const mockServer = await startMockAgentServer();
+    console.log(
+      `Browser bridge smoke server listening at ${mockServer.origin}`,
+    );
+    await new Promise(() => {});
+  } else {
+    await main();
+  }
+}

--- a/packages/browser-bridge-extension/scripts/extension-smoke.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke.mjs
@@ -198,17 +198,13 @@ async function waitForPopupText(page, selector, expected, timeout = 20_000) {
 async function waitForPopupSettled(page) {
   await page.waitForFunction(() => {
     const title = document.querySelector("#statusTitle")?.textContent ?? "";
-    const badge = document.querySelector("#statusBadge")?.textContent ?? "";
-    const primary = document.querySelector("#autoPair");
-    const primaryLabel = primary?.textContent?.trim() ?? "";
+    const primary = document.querySelector("#primaryAction");
     return (
       title.trim().length > 0 &&
-      title !== "Loading extension state…" &&
-      title !== "Looking for Eliza in this browser" &&
-      badge !== "Loading" &&
-      primaryLabel.length > 0 &&
-      primary instanceof HTMLButtonElement &&
-      !primary.disabled
+      title !== "Connecting to Eliza…" &&
+      (!(primary instanceof HTMLButtonElement) ||
+        primary.hidden ||
+        !primary.disabled)
     );
   });
 }
@@ -585,19 +581,11 @@ async function runManualPairAndSyncScenario(chromium) {
 
   try {
     await waitForPopupSettled(popupPage);
-    if (exerciseSiteAccess) {
-      await popupPage.click("#siteAccess");
-      await waitForPopupText(
-        popupPage,
-        "#siteAccess",
-        "Website Access Granted",
-        120_000,
-      );
-      await saveScreenshot(popupPage, "chrome-website-access-granted");
-    }
-    await popupPage.click("#autoPair");
+    await popupPage.click("#primaryAction");
     await popupPage.waitForFunction(
-      () => document.querySelector("#advancedTools")?.open === true,
+      () =>
+        document.querySelector("#details")?.open === true &&
+        document.querySelector("#recovery")?.open === true,
     );
     await popupPage.fill(
       "#pairingJson",
@@ -611,22 +599,25 @@ async function runManualPairAndSyncScenario(chromium) {
         label: "Agent Browser Bridge smoke",
       }),
     );
-    await popupPage.click("#import");
-    await waitForPopupText(popupPage, "#autoPair", "Sync This Browser", 20_000);
-
-    await popupPage.click("#autoPair");
-    await waitForPopupText(
-      popupPage,
-      "#statusTitle",
-      "This browser is connected to Eliza",
-      20_000,
-    );
-    await waitForPopupText(
-      popupPage,
-      "#summary",
-      `App: ${mockServer.origin}`,
-      10_000,
-    );
+    await popupPage.click("#importPairing");
+    await waitForPopupText(popupPage, "#statusTitle", "Connected", 20_000);
+    if (exerciseSiteAccess) {
+      await waitForPopupText(
+        popupPage,
+        "#primaryAction",
+        "Grant website access",
+        20_000,
+      );
+      await popupPage.click("#primaryAction");
+      await waitForPopupText(
+        popupPage,
+        "#statusTitle",
+        "Connected to Eliza",
+        120_000,
+      );
+      await saveScreenshot(popupPage, "chrome-website-access-granted");
+    }
+    await waitForPopupText(popupPage, "#appValue", mockServer.origin, 10_000);
 
     const syncRequests = mockServer.requests.filter(
       (request) =>

--- a/packages/browser-bridge-extension/scripts/package-chrome.mjs
+++ b/packages/browser-bridge-extension/scripts/package-chrome.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+/**
+ * Packages dist/chrome into a versioned .zip for Chrome Web Store upload.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDeterministicWebExtensionArchive } from "./package-webextension.mjs";
+import {
+  buildBrowserBridgeReleaseMetadata,
+  resolveBrowserBridgeReleaseVersion,
+  versionedArtifactName,
+} from "./release-version.mjs";
+import { run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const distDir = path.join(extensionRoot, "dist");
+const chromeDistDir = path.join(distDir, "chrome");
+const artifactsDir = path.join(distDir, "artifacts");
+const artifactPath = path.join(artifactsDir, "browser-bridge-chrome.zip");
+const release = resolveBrowserBridgeReleaseVersion();
+const metadata = buildBrowserBridgeReleaseMetadata(release);
+const versionedArtifactPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-chrome", "zip", release),
+);
+
+await run("bun", [path.join(scriptDir, "build.mjs"), "chrome"], {
+  cwd: extensionRoot,
+});
+
+await fs.mkdir(artifactsDir, { recursive: true });
+await fs.access(path.join(chromeDistDir, "manifest.json"));
+const result = await createDeterministicWebExtensionArchive({
+  sourceDir: chromeDistDir,
+  outputPath: artifactPath,
+});
+await fs.copyFile(artifactPath, versionedArtifactPath);
+
+console.log(
+  `Packaged Chrome extension ${metadata.chromeVersionName} (${result.files.length} files, sha256 ${result.sha256}) at ${artifactPath} and ${versionedArtifactPath}`,
+);

--- a/packages/browser-bridge-extension/scripts/package-firefox.mjs
+++ b/packages/browser-bridge-extension/scripts/package-firefox.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+/**
+ * Builds and packages the Firefox WebExtension as deterministic ZIP and XPI artifacts.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDeterministicWebExtensionArchive } from "./package-webextension.mjs";
+import {
+  resolveBrowserBridgeReleaseVersion,
+  versionedArtifactName,
+} from "./release-version.mjs";
+import { run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const firefoxDistDir = path.join(extensionRoot, "dist", "firefox");
+const artifactsDir = path.join(extensionRoot, "dist", "artifacts");
+const release = resolveBrowserBridgeReleaseVersion();
+const zipPath = path.join(artifactsDir, "browser-bridge-firefox.zip");
+const xpiPath = path.join(artifactsDir, "browser-bridge-firefox.xpi");
+const versionedZipPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-firefox", "zip", release),
+);
+const versionedXpiPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-firefox", "xpi", release),
+);
+
+await run("bun", [path.join(scriptDir, "build.mjs"), "firefox"], {
+  cwd: extensionRoot,
+});
+const result = await createDeterministicWebExtensionArchive({
+  sourceDir: firefoxDistDir,
+  outputPath: zipPath,
+});
+await Promise.all([
+  fs.copyFile(zipPath, xpiPath),
+  fs.copyFile(zipPath, versionedZipPath),
+  fs.copyFile(zipPath, versionedXpiPath),
+]);
+console.log(
+  `Packaged Firefox extension (${result.files.length} files, sha256 ${result.sha256}) at ${zipPath}`,
+);

--- a/packages/browser-bridge-extension/scripts/package-release.mjs
+++ b/packages/browser-bridge-extension/scripts/package-release.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+import { createHash } from "node:crypto";
+/**
+ * Orchestrates a full extension release: builds, packages the Chrome and Safari
+ * artifacts and store assets, and emits release metadata (GitHub release URLs
+ * and versioned artifact names) for the publish step.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildBrowserBridgeReleaseMetadata,
+  buildGitHubReleaseAssetDownloadUrl,
+  buildGitHubReleasePageUrl,
+  resolveBrowserBridgeReleaseRepository,
+  resolveBrowserBridgeReleaseVersion,
+  resolveBrowserBridgeStoreUrls,
+  resolveSourceDateIso,
+  versionedArtifactName,
+} from "./release-version.mjs";
+import { run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const artifactsDir = path.join(extensionRoot, "dist", "artifacts");
+const release = resolveBrowserBridgeReleaseVersion();
+const repository = resolveBrowserBridgeReleaseRepository();
+const storeUrls = resolveBrowserBridgeStoreUrls();
+const metadata = buildBrowserBridgeReleaseMetadata(release);
+const chromeAssetName = versionedArtifactName(
+  "browser-bridge-chrome",
+  "zip",
+  release,
+);
+const safariAssetName = versionedArtifactName(
+  "browser-bridge-safari",
+  "zip",
+  release,
+);
+const firefoxAssetName = versionedArtifactName(
+  "browser-bridge-firefox",
+  "xpi",
+  release,
+);
+
+await run("bun", [path.join(scriptDir, "package-chrome.mjs")], {
+  cwd: extensionRoot,
+});
+await run("bun", [path.join(scriptDir, "package-firefox.mjs")], {
+  cwd: extensionRoot,
+});
+await run("bun", [path.join(scriptDir, "package-safari.mjs")], {
+  cwd: extensionRoot,
+});
+await run("bun", [path.join(scriptDir, "package-store-assets.mjs")], {
+  cwd: extensionRoot,
+});
+
+await fs.mkdir(artifactsDir, { recursive: true });
+
+async function sha256For(fileName) {
+  return createHash("sha256")
+    .update(await fs.readFile(path.join(artifactsDir, fileName)))
+    .digest("hex");
+}
+
+const generatedAt = resolveSourceDateIso();
+
+const manifest = {
+  ...metadata,
+  schema: "browser_bridge_release_v2",
+  repository,
+  releasePageUrl: buildGitHubReleasePageUrl(repository, release),
+  generatedAt,
+  chrome: {
+    installKind: storeUrls.chromeWebStoreUrl
+      ? "chrome_web_store"
+      : "github_release",
+    installUrl:
+      storeUrls.chromeWebStoreUrl ??
+      buildGitHubReleaseAssetDownloadUrl(repository, release, chromeAssetName),
+    storeListingUrl: storeUrls.chromeWebStoreUrl,
+    asset: {
+      fileName: chromeAssetName,
+      downloadUrl: buildGitHubReleaseAssetDownloadUrl(
+        repository,
+        release,
+        chromeAssetName,
+      ),
+      sha256: await sha256For(chromeAssetName),
+    },
+  },
+  firefox: {
+    installKind: storeUrls.firefoxAddonsUrl
+      ? "firefox_addons"
+      : "github_release",
+    installUrl:
+      storeUrls.firefoxAddonsUrl ??
+      buildGitHubReleaseAssetDownloadUrl(repository, release, firefoxAssetName),
+    storeListingUrl: storeUrls.firefoxAddonsUrl,
+    asset: {
+      fileName: firefoxAssetName,
+      downloadUrl: buildGitHubReleaseAssetDownloadUrl(
+        repository,
+        release,
+        firefoxAssetName,
+      ),
+      sha256: await sha256For(firefoxAssetName),
+    },
+  },
+  safari: {
+    installKind: storeUrls.safariAppStoreUrl
+      ? "apple_app_store"
+      : "github_release",
+    installUrl:
+      storeUrls.safariAppStoreUrl ??
+      buildGitHubReleaseAssetDownloadUrl(repository, release, safariAssetName),
+    storeListingUrl: storeUrls.safariAppStoreUrl,
+    asset: {
+      fileName: safariAssetName,
+      downloadUrl: buildGitHubReleaseAssetDownloadUrl(
+        repository,
+        release,
+        safariAssetName,
+      ),
+      sha256: await sha256For(safariAssetName),
+    },
+  },
+};
+
+const manifestPath = path.join(
+  artifactsDir,
+  "browser-bridge-release-manifest.json",
+);
+const versionedManifestPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-release-manifest", "json", release),
+);
+await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+await fs.writeFile(
+  versionedManifestPath,
+  `${JSON.stringify(manifest, null, 2)}\n`,
+);
+
+console.log(`Wrote release manifest at ${manifestPath}`);
+console.log(`Wrote versioned release manifest at ${versionedManifestPath}`);

--- a/packages/browser-bridge-extension/scripts/package-safari.mjs
+++ b/packages/browser-bridge-extension/scripts/package-safari.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env bun
 /**
  * Wraps dist/safari into a Safari Web Extension via xcrun, producing the
- * versioned app bundle for the Safari release. Release/source packaging is
- * unsigned and reproducible by default; the installed-browser smoke supplies
- * an exact Apple Development identity and team for a trusted local build.
+ * versioned app bundle for the Safari release. Release/source archives are
+ * unsigned and deterministic for a fixed converter/build output; the
+ * installed-browser smoke supplies an exact Apple Development identity and
+ * team for a trusted local build.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createDeterministicDirectoryArchive } from "./package-webextension.mjs";
 import {
   buildBrowserBridgeReleaseMetadata,
   buildSafariExtensionVersions,
@@ -64,6 +66,11 @@ async function patchGeneratedSafariProjectVersions(projectPath) {
     /PRODUCT_BUNDLE_IDENTIFIER = "ai\.elizaos\.browserbridge\.Agent-Browser-Bridge\.Extension";/g,
     `PRODUCT_BUNDLE_IDENTIFIER = ${bundleIdentifier}.Extension;`,
   );
+  const projectIds = [...new Set(source.match(/\b[A-F0-9]{24}\b/g) ?? [])];
+  for (const [index, projectId] of projectIds.entries()) {
+    const deterministicId = index.toString(16).toUpperCase().padStart(24, "0");
+    source = source.replaceAll(projectId, deterministicId);
+  }
   await fs.writeFile(projectFile, source);
 }
 
@@ -160,21 +167,17 @@ await fs.rm(versionedArtifactZipPath, { force: true });
 await fs.rm(versionedProjectZipPath, { force: true });
 await fs.cp(builtAppPath, artifactAppPath, { recursive: true });
 
-await run("ditto", [
-  "-c",
-  "-k",
-  "--keepParent",
-  artifactAppPath,
-  artifactZipPath,
-]);
+await createDeterministicDirectoryArchive({
+  sourceDir: artifactAppPath,
+  outputPath: artifactZipPath,
+  rootName: path.basename(artifactAppPath),
+});
 await fs.copyFile(artifactZipPath, versionedArtifactZipPath);
-await run("ditto", [
-  "-c",
-  "-k",
-  "--keepParent",
-  generatedProjectDir,
-  versionedProjectZipPath,
-]);
+await createDeterministicDirectoryArchive({
+  sourceDir: generatedProjectDir,
+  outputPath: versionedProjectZipPath,
+  rootName: path.basename(generatedProjectDir),
+});
 
 console.log(
   `Packaged Safari app ${metadata.releaseVersion} at ${artifactAppPath}`,

--- a/packages/browser-bridge-extension/scripts/package-safari.mjs
+++ b/packages/browser-bridge-extension/scripts/package-safari.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env bun
+/**
+ * Wraps dist/safari into a Safari Web Extension via xcrun, producing the
+ * versioned app bundle for the Safari release. Release/source packaging is
+ * unsigned and reproducible by default; the installed-browser smoke supplies
+ * an exact Apple Development identity and team for a trusted local build.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildBrowserBridgeReleaseMetadata,
+  buildSafariExtensionVersions,
+  resolveBrowserBridgeReleaseVersion,
+  versionedArtifactName,
+} from "./release-version.mjs";
+import { findFileWithExtension, run } from "./script-utils.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const distDir = path.join(extensionRoot, "dist");
+const safariDistDir = path.join(distDir, "safari");
+const safariWorkDir = path.join(extensionRoot, "safari");
+const generatedProjectDir = path.join(safariWorkDir, "generated");
+const derivedDataDir = path.join(distDir, "safari-derived-data");
+const artifactsDir = path.join(distDir, "artifacts");
+const cleanupHelper = path.resolve(
+  extensionRoot,
+  "..",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
+const appName = "Agent Browser Bridge";
+const bundleIdentifier = "ai.elizaos.browserbridge.app";
+const release = resolveBrowserBridgeReleaseVersion();
+const metadata = buildBrowserBridgeReleaseMetadata(release);
+const safariVersions = buildSafariExtensionVersions(release);
+const signingTeam = process.env.ELIZA_SAFARI_SIGNING_TEAM?.trim() || null;
+const signingIdentity =
+  process.env.ELIZA_SAFARI_SIGNING_IDENTITY?.trim() || null;
+
+if (Boolean(signingTeam) !== Boolean(signingIdentity)) {
+  throw new Error(
+    "ELIZA_SAFARI_SIGNING_TEAM and ELIZA_SAFARI_SIGNING_IDENTITY must be supplied together.",
+  );
+}
+
+async function patchGeneratedSafariProjectVersions(projectPath) {
+  const projectFile = path.join(projectPath, "project.pbxproj");
+  let source = await fs.readFile(projectFile, "utf8");
+  source = source.replace(
+    /MARKETING_VERSION = [^;]+;/g,
+    `MARKETING_VERSION = ${safariVersions.marketingVersion};`,
+  );
+  source = source.replace(
+    /CURRENT_PROJECT_VERSION = [^;]+;/g,
+    `CURRENT_PROJECT_VERSION = ${safariVersions.buildVersion};`,
+  );
+  source = source.replace(
+    /PRODUCT_BUNDLE_IDENTIFIER = "ai\.elizaos\.browserbridge\.Agent-Browser-Bridge";/g,
+    `PRODUCT_BUNDLE_IDENTIFIER = ${bundleIdentifier};`,
+  );
+  source = source.replace(
+    /PRODUCT_BUNDLE_IDENTIFIER = "ai\.elizaos\.browserbridge\.Agent-Browser-Bridge\.Extension";/g,
+    `PRODUCT_BUNDLE_IDENTIFIER = ${bundleIdentifier}.Extension;`,
+  );
+  await fs.writeFile(projectFile, source);
+}
+
+await run("bun", [path.join(scriptDir, "build.mjs"), "safari"], {
+  cwd: extensionRoot,
+});
+
+await fs.mkdir(safariWorkDir, { recursive: true });
+await run("node", [cleanupHelper, generatedProjectDir, derivedDataDir], {
+  cwd: extensionRoot,
+});
+await fs.mkdir(artifactsDir, { recursive: true });
+
+await run("xcrun", [
+  "safari-web-extension-converter",
+  safariDistDir,
+  "--project-location",
+  generatedProjectDir,
+  "--app-name",
+  appName,
+  "--bundle-identifier",
+  bundleIdentifier,
+  "--swift",
+  "--macos-only",
+  "--copy-resources",
+  "--no-open",
+  "--no-prompt",
+  "--force",
+]);
+
+const projectPath = await findFileWithExtension(
+  generatedProjectDir,
+  ".xcodeproj",
+);
+if (!projectPath) {
+  throw new Error("Failed to locate generated Safari Xcode project");
+}
+await patchGeneratedSafariProjectVersions(projectPath);
+
+const signingArgs =
+  signingTeam && signingIdentity
+    ? [
+        "CODE_SIGNING_ALLOWED=YES",
+        "CODE_SIGNING_REQUIRED=YES",
+        "CODE_SIGN_STYLE=Manual",
+        `CODE_SIGN_IDENTITY=${signingIdentity}`,
+        `DEVELOPMENT_TEAM=${signingTeam}`,
+      ]
+    : [
+        "CODE_SIGNING_ALLOWED=NO",
+        "CODE_SIGNING_REQUIRED=NO",
+        "CODE_SIGN_IDENTITY=",
+      ];
+
+await run("xcodebuild", [
+  "-project",
+  projectPath,
+  "-scheme",
+  appName,
+  "-configuration",
+  "Release",
+  "-destination",
+  "platform=macOS",
+  "-derivedDataPath",
+  derivedDataDir,
+  ...signingArgs,
+  "build",
+]);
+
+const builtAppPath = await findFileWithExtension(
+  path.join(derivedDataDir, "Build", "Products"),
+  ".app",
+);
+if (!builtAppPath) {
+  throw new Error("Failed to locate built Safari app bundle");
+}
+if (signingTeam && signingIdentity) {
+  await run("codesign", ["--verify", "--deep", "--strict", builtAppPath]);
+}
+
+const artifactAppPath = path.join(artifactsDir, `${appName}.app`);
+const artifactZipPath = path.join(artifactsDir, "browser-bridge-safari.zip");
+const versionedArtifactZipPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-safari", "zip", release),
+);
+const versionedProjectZipPath = path.join(
+  artifactsDir,
+  versionedArtifactName("browser-bridge-safari-project", "zip", release),
+);
+await run("node", [cleanupHelper, artifactAppPath], { cwd: extensionRoot });
+await fs.rm(artifactZipPath, { force: true });
+await fs.rm(versionedArtifactZipPath, { force: true });
+await fs.rm(versionedProjectZipPath, { force: true });
+await fs.cp(builtAppPath, artifactAppPath, { recursive: true });
+
+await run("ditto", [
+  "-c",
+  "-k",
+  "--keepParent",
+  artifactAppPath,
+  artifactZipPath,
+]);
+await fs.copyFile(artifactZipPath, versionedArtifactZipPath);
+await run("ditto", [
+  "-c",
+  "-k",
+  "--keepParent",
+  generatedProjectDir,
+  versionedProjectZipPath,
+]);
+
+console.log(
+  `Packaged Safari app ${metadata.releaseVersion} at ${artifactAppPath}`,
+);
+console.log(`Packaged Safari zip at ${artifactZipPath}`);
+console.log(`Packaged Safari release zip at ${versionedArtifactZipPath}`);
+console.log(`Packaged Safari project zip at ${versionedProjectZipPath}`);

--- a/packages/browser-bridge-extension/scripts/package-store-assets.mjs
+++ b/packages/browser-bridge-extension/scripts/package-store-assets.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env bun
+/**
+ * Assembles the store-listing bundle — screenshots, descriptions, and
+ * release-metadata JSON — for the Chrome, Firefox, and Safari store submissions.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildBrowserBridgeReleaseMetadata,
+  buildGitHubReleasePageUrl,
+  resolveBrowserBridgeReleaseRepository,
+  resolveBrowserBridgeReleaseVersion,
+  resolveBrowserBridgeStoreUrls,
+  resolveSourceDateIso,
+  versionedArtifactName,
+} from "./release-version.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDir, "..");
+const artifactsDir = path.join(extensionRoot, "dist", "artifacts");
+const release = resolveBrowserBridgeReleaseVersion();
+const repository = resolveBrowserBridgeReleaseRepository();
+const metadata = buildBrowserBridgeReleaseMetadata(release);
+const storeUrls = resolveBrowserBridgeStoreUrls();
+
+function envValue(name) {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+const marketingUrl =
+  envValue("ELIZA_BROWSER_BRIDGE_MARKETING_URL") ??
+  (repository ? `https://github.com/${repository}` : null);
+const supportUrl =
+  envValue("ELIZA_BROWSER_BRIDGE_SUPPORT_URL") ??
+  (repository ? `https://github.com/${repository}/issues` : null);
+const privacyPolicyUrl =
+  envValue("ELIZA_BROWSER_BRIDGE_PRIVACY_POLICY_URL") ?? null;
+
+const chromePackageFile = versionedArtifactName(
+  "browser-bridge-chrome",
+  "zip",
+  release,
+);
+const firefoxPackageFile = versionedArtifactName(
+  "browser-bridge-firefox",
+  "xpi",
+  release,
+);
+const safariPackageFile = versionedArtifactName(
+  "browser-bridge-safari",
+  "zip",
+  release,
+);
+const safariProjectFile = versionedArtifactName(
+  "browser-bridge-safari-project",
+  "zip",
+  release,
+);
+
+const sharedSubmissionData = {
+  schema: "browser_bridge_store_submission_v1",
+  releaseTag: release.tag,
+  releaseVersion: release.raw,
+  releasePageUrl: buildGitHubReleasePageUrl(repository, release),
+  repository,
+  marketingUrl,
+  supportUrl,
+  privacyPolicyUrl,
+  generatedAt: resolveSourceDateIso(),
+};
+
+const chromeSubmission = {
+  ...sharedSubmissionData,
+  browser: "chrome",
+  title: "Agent Browser Bridge",
+  category: "Productivity",
+  shortDescription:
+    "Connect your real browser to your Eliza agent so it can read the page you are on and carry out owner-approved actions.",
+  description:
+    "Agent Browser Bridge pairs your personal Chrome profile with an Eliza agent. It keeps the current page available to the agent and can execute owner-approved browser actions such as opening tabs, navigating, clicking, typing, and reading page content. Pairing credentials are created only from authenticated Eliza Browser settings and imported into the extension.",
+  packageFileName: chromePackageFile,
+  version: metadata.chromeVersion,
+  versionName: metadata.chromeVersionName,
+  storeListingUrl: storeUrls.chromeWebStoreUrl,
+  permissions: [
+    {
+      name: "tabs",
+      justification:
+        "The agent needs tab URLs, titles, focus state, and window information so it can reflect the active browser context back to the user.",
+    },
+    {
+      name: "storage",
+      justification:
+        "The extension stores the companion pairing, sync status, and local settings between browser restarts.",
+    },
+    {
+      name: "scripting",
+      justification:
+        "The extension performs DOM reads and owner-approved DOM actions on the active page when the user explicitly enables browser control.",
+    },
+    {
+      name: "alarms",
+      justification:
+        "The extension uses periodic alarms to keep browser state synced even when the popup is closed.",
+    },
+    {
+      name: "activeTab",
+      justification:
+        "The agent uses active-tab access to inspect or act on the page the user is currently focused on.",
+    },
+    {
+      name: "declarativeNetRequestWithHostAccess",
+      justification:
+        "After the user grants website access, the extension uses host-level redirect rules for sites selected by the LifeOps website blocker.",
+    },
+    {
+      name: "<all_urls>",
+      justification:
+        "This is optional at install and requested only from the popup's Grant Website Access button. It enables cross-site control and website blocking while the app still applies its own site-access settings.",
+    },
+  ],
+  reviewerNotes: [
+    "Pairing credentials must be created from authenticated Eliza Browser settings and imported as pairing JSON.",
+    "Browser control is disabled by default unless the user enables it in agent settings.",
+    "The retired zero-config auto-pair endpoint returns 410 and never mints credentials from loopback reachability or an extension Origin.",
+  ],
+};
+
+const safariSubmission = {
+  ...sharedSubmissionData,
+  browser: "safari",
+  appName: "Agent Browser Bridge",
+  bundleIdentifier: "ai.elizaos.browserbridge.app",
+  category: "Productivity",
+  subtitle: "Owner-approved browser relay for Eliza agents",
+  description:
+    "Agent Browser Bridge pairs your Safari profile with an Eliza agent so the agent can reflect the page you are on and, when you explicitly allow it, carry out owner-approved browser actions. The packaged Safari release includes both the signed app bundle target and the generated Xcode project archive required for App Store submission.",
+  packageFileName: safariPackageFile,
+  xcodeProjectArchiveFileName: safariProjectFile,
+  marketingVersion: metadata.safariMarketingVersion,
+  buildVersion: metadata.safariBuildVersion,
+  storeListingUrl: storeUrls.safariAppStoreUrl,
+  capabilities: [
+    "Safari Web Extension",
+    "Authenticated pairing JSON import for local or cloud agent apps",
+    "Optional browser control for owner-approved sessions",
+  ],
+  reviewerNotes: [
+    "The app bundle is generated from the same extension source as Chrome and is intended for App Store signing/export downstream.",
+    "Privacy policy URL is required before submission if it is still null in this artifact.",
+    "Reviewers should create a pairing in authenticated Eliza Browser settings and import its JSON in the Safari extension popup.",
+  ],
+};
+
+const firefoxSubmission = {
+  ...sharedSubmissionData,
+  browser: "firefox",
+  title: "Agent Browser Bridge",
+  category: "productivity",
+  summary:
+    "Connect Firefox to an Eliza agent for owner-approved page reading and browser actions.",
+  description:
+    "Agent Browser Bridge pairs a Firefox profile with an Eliza agent. It syncs the current browser context and can run owner-approved actions including navigation, clicking, typing, and structured page extraction. Broad site access remains optional and is requested at runtime.",
+  packageFileName: firefoxPackageFile,
+  version: metadata.chromeVersion,
+  storeListingUrl: storeUrls.firefoxAddonsUrl,
+  permissions: chromeSubmission.permissions,
+  dataCollectionPermissions: { required: ["none"] },
+  reviewerNotes: [
+    "The package declares a stable Gecko extension ID and supports Firefox 142 or later.",
+    "Pairing credentials must be created in authenticated Eliza Browser settings and imported in this Firefox profile.",
+    "The package passes web-ext lint in self-hosted mode with no errors, warnings, or notices.",
+  ],
+};
+
+const checklistLines = [
+  "# Agent Browser Bridge Store Submission Checklist",
+  "",
+  `Release: ${release.tag}`,
+  "",
+  "## Chrome Web Store",
+  "",
+  `- Upload package: \`${chromePackageFile}\``,
+  `- Version: \`${metadata.chromeVersion}\` (\`${metadata.chromeVersionName}\`)`,
+  `- Support URL: ${supportUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_SUPPORT_URL"}`,
+  `- Privacy policy URL: ${privacyPolicyUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_PRIVACY_POLICY_URL"}`,
+  `- Marketing URL: ${marketingUrl ?? "Optional"}`,
+  `- Store listing URL: ${storeUrls.chromeWebStoreUrl ?? "Not configured yet"}`,
+  "",
+  "## Safari App Store",
+  "",
+  `- Upload signed app derived from: \`${safariPackageFile}\``,
+  `- Generated Xcode project archive: \`${safariProjectFile}\``,
+  `- Marketing version: \`${metadata.safariMarketingVersion}\``,
+  `- Build version: \`${metadata.safariBuildVersion}\``,
+  `- Bundle identifier: \`ai.elizaos.browserbridge.app\``,
+  `- Support URL: ${supportUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_SUPPORT_URL"}`,
+  `- Privacy policy URL: ${privacyPolicyUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_PRIVACY_POLICY_URL"}`,
+  `- App Store URL: ${storeUrls.safariAppStoreUrl ?? "Not configured yet"}`,
+  "",
+  "## Firefox Add-ons",
+  "",
+  `- Upload package: \`${firefoxPackageFile}\``,
+  `- Version: \`${metadata.chromeVersion}\` (\`${release.raw}\`)`,
+  `- Support URL: ${supportUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_SUPPORT_URL"}`,
+  `- Privacy policy URL: ${privacyPolicyUrl ?? "REQUIRED: set ELIZA_BROWSER_BRIDGE_PRIVACY_POLICY_URL"}`,
+  `- Add-ons listing URL: ${storeUrls.firefoxAddonsUrl ?? "Not configured yet"}`,
+  "",
+  "## Notes",
+  "",
+  "- Authenticated pairing JSON import is the only credential setup flow; zero-config auto-pair is disabled.",
+  "- Re-sign the Safari app bundle and export through App Store Connect before submission.",
+  "- Review the JSON metadata files in this artifacts directory for permission text and reviewer notes.",
+  "",
+];
+
+await fs.mkdir(artifactsDir, { recursive: true });
+
+const outputs = [
+  {
+    fileName: "browser-bridge-chrome-store-metadata.json",
+    contents: `${JSON.stringify(chromeSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: versionedArtifactName(
+      "browser-bridge-chrome-store-metadata",
+      "json",
+      release,
+    ),
+    contents: `${JSON.stringify(chromeSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: "browser-bridge-firefox-store-metadata.json",
+    contents: `${JSON.stringify(firefoxSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: versionedArtifactName(
+      "browser-bridge-firefox-store-metadata",
+      "json",
+      release,
+    ),
+    contents: `${JSON.stringify(firefoxSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: "browser-bridge-safari-store-metadata.json",
+    contents: `${JSON.stringify(safariSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: versionedArtifactName(
+      "browser-bridge-safari-store-metadata",
+      "json",
+      release,
+    ),
+    contents: `${JSON.stringify(safariSubmission, null, 2)}\n`,
+  },
+  {
+    fileName: "browser-bridge-store-checklist.md",
+    contents: checklistLines.join("\n"),
+  },
+  {
+    fileName: versionedArtifactName(
+      "browser-bridge-store-checklist",
+      "md",
+      release,
+    ),
+    contents: checklistLines.join("\n"),
+  },
+];
+
+for (const output of outputs) {
+  await fs.writeFile(path.join(artifactsDir, output.fileName), output.contents);
+}
+
+console.log(
+  `Wrote Agent Browser Bridge store metadata and checklist artifacts to ${artifactsDir}`,
+);

--- a/packages/browser-bridge-extension/scripts/package-webextension.mjs
+++ b/packages/browser-bridge-extension/scripts/package-webextension.mjs
@@ -27,6 +27,9 @@ async function collectFiles(root, current = root) {
         `Refusing to package non-regular extension path: ${absolute}`,
       );
     }
+    if (entry.name.endsWith(".map")) {
+      continue;
+    }
     files.push({
       absolute,
       relative: path.relative(root, absolute).split(path.sep).join("/"),

--- a/packages/browser-bridge-extension/scripts/package-webextension.mjs
+++ b/packages/browser-bridge-extension/scripts/package-webextension.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Creates byte-reproducible WebExtension archives from a built browser tree.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { zipSync } from "fflate";
+
+// DOS ZIP timestamps are local-time encoded and cannot precede 1980. Use the
+// second UTC day so negative-offset hosts remain within the representable range.
+const ZIP_EPOCH = new Date("1980-01-02T00:00:00.000Z");
+
+async function collectFiles(root, current = root) {
+  const entries = await fs.readdir(current, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  const files = [];
+  for (const entry of entries) {
+    const absolute = path.join(current, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(root, absolute)));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(
+        `Refusing to package non-regular extension path: ${absolute}`,
+      );
+    }
+    files.push({
+      absolute,
+      relative: path.relative(root, absolute).split(path.sep).join("/"),
+    });
+  }
+  return files;
+}
+
+export async function createDeterministicWebExtensionArchive({
+  sourceDir,
+  outputPath,
+}) {
+  const manifestPath = path.join(sourceDir, "manifest.json");
+  await fs.access(manifestPath);
+  const files = await collectFiles(sourceDir);
+  const input = {};
+  for (const file of files) {
+    input[file.relative] = [
+      new Uint8Array(await fs.readFile(file.absolute)),
+      {
+        mtime: ZIP_EPOCH,
+      },
+    ];
+  }
+  const archive = zipSync(input, { level: 9 });
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, archive);
+  return {
+    path: outputPath,
+    bytes: archive.byteLength,
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    files: files.map((file) => file.relative),
+  };
+}

--- a/packages/browser-bridge-extension/scripts/package-webextension.mjs
+++ b/packages/browser-bridge-extension/scripts/package-webextension.mjs
@@ -33,24 +33,29 @@ async function collectFiles(root, current = root) {
     files.push({
       absolute,
       relative: path.relative(root, absolute).split(path.sep).join("/"),
+      mode: (await fs.stat(absolute)).mode & 0o777,
     });
   }
   return files;
 }
 
-export async function createDeterministicWebExtensionArchive({
+export async function createDeterministicDirectoryArchive({
   sourceDir,
   outputPath,
+  rootName,
 }) {
-  const manifestPath = path.join(sourceDir, "manifest.json");
-  await fs.access(manifestPath);
   const files = await collectFiles(sourceDir);
   const input = {};
   for (const file of files) {
-    input[file.relative] = [
+    const archivePath = rootName
+      ? `${rootName.replace(/\/$/, "")}/${file.relative}`
+      : file.relative;
+    input[archivePath] = [
       new Uint8Array(await fs.readFile(file.absolute)),
       {
+        attrs: file.mode << 16,
         mtime: ZIP_EPOCH,
+        os: 3,
       },
     ];
   }
@@ -63,4 +68,13 @@ export async function createDeterministicWebExtensionArchive({
     sha256: createHash("sha256").update(archive).digest("hex"),
     files: files.map((file) => file.relative),
   };
+}
+
+export async function createDeterministicWebExtensionArchive({
+  sourceDir,
+  outputPath,
+}) {
+  const manifestPath = path.join(sourceDir, "manifest.json");
+  await fs.access(manifestPath);
+  return createDeterministicDirectoryArchive({ sourceDir, outputPath });
 }

--- a/packages/browser-bridge-extension/scripts/release-version.mjs
+++ b/packages/browser-bridge-extension/scripts/release-version.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * Version resolution for the release pipeline: derives the release version from
+ * package.json (with a nightly-epoch fallback), converts semver to Chrome's
+ * 4-part scheme and Safari's build versions, and builds GitHub release and
+ * store URLs. Shared by every packaging script.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const extensionRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const extensionPackageJsonPath = path.join(extensionRoot, "package.json");
+const NIGHTLY_EPOCH_UTC_MS = Date.UTC(2020, 0, 1);
+const DEFAULT_REPOSITORY = "elizaos/eliza";
+
+function readExtensionPackageVersion() {
+  const packageJson = JSON.parse(
+    fs.readFileSync(extensionPackageJsonPath, "utf8"),
+  );
+  return typeof packageJson.version === "string" && packageJson.version.trim()
+    ? packageJson.version.trim()
+    : "0.1.0";
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function normalizeReleaseVersionCandidate(raw) {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+}
+
+export function parseReleaseVersion(raw) {
+  const normalized = normalizeReleaseVersionCandidate(raw);
+  if (!normalized) {
+    throw new Error("Release version is required");
+  }
+  const match = normalized.match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc|nightly)\.([0-9A-Za-z.-]+))?$/,
+  );
+  if (!match) {
+    throw new Error(
+      `Unsupported Agent Browser Bridge release version "${raw}". Expected 1.2.3 or 1.2.3-alpha.0 style semver.`,
+    );
+  }
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  const patch = Number.parseInt(match[3], 10);
+  const prereleaseLabel = match[4] ?? null;
+  const prereleaseValue = match[5] ?? null;
+
+  return {
+    raw: normalized,
+    tag: `v${normalized}`,
+    major,
+    minor,
+    patch,
+    prereleaseLabel,
+    prereleaseValue,
+    baseVersion: `${major}.${minor}.${patch}`,
+    hasPrerelease: prereleaseLabel !== null,
+  };
+}
+
+export function resolveBrowserBridgeReleaseVersion(env = process.env) {
+  const candidate =
+    normalizeReleaseVersionCandidate(env.ELIZA_RELEASE_TAG) ??
+    normalizeReleaseVersionCandidate(env.RELEASE_VERSION) ??
+    normalizeReleaseVersionCandidate(env.npm_package_version) ??
+    readExtensionPackageVersion();
+  return parseReleaseVersion(candidate);
+}
+
+export function resolveBrowserBridgeReleaseRepository(env = process.env) {
+  const raw =
+    typeof env.GITHUB_REPOSITORY === "string"
+      ? env.GITHUB_REPOSITORY.trim()
+      : "";
+  return raw || DEFAULT_REPOSITORY;
+}
+
+function parseNumericPrereleaseValue(value) {
+  if (!value) {
+    return 0;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function deriveNightlyOrdinal(value) {
+  if (typeof value === "string" && /^\d{8}$/.test(value)) {
+    const year = Number.parseInt(value.slice(0, 4), 10);
+    const month = Number.parseInt(value.slice(4, 6), 10);
+    const day = Number.parseInt(value.slice(6, 8), 10);
+    const utcMs = Date.UTC(year, month - 1, day);
+    if (Number.isFinite(utcMs)) {
+      return clamp(
+        Math.floor((utcMs - NIGHTLY_EPOCH_UTC_MS) / 86_400_000) + 1,
+        1,
+        9999,
+      );
+    }
+  }
+
+  const parsed = parseNumericPrereleaseValue(value);
+  if (parsed > 0) {
+    return clamp(parsed, 1, 9999);
+  }
+
+  let hash = 0;
+  for (const character of String(value ?? "")) {
+    hash = (hash * 33 + character.charCodeAt(0)) % 9999;
+  }
+  return clamp(hash, 1, 9999);
+}
+
+function derivePrereleaseOrdinal(release) {
+  if (!release.hasPrerelease || !release.prereleaseLabel) {
+    return 0;
+  }
+  if (release.prereleaseLabel === "nightly") {
+    return deriveNightlyOrdinal(release.prereleaseValue);
+  }
+  return clamp(parseNumericPrereleaseValue(release.prereleaseValue), 0, 9999);
+}
+
+function deriveChromeBuildSegment(release) {
+  if (!release.hasPrerelease || !release.prereleaseLabel) {
+    return 60000;
+  }
+
+  const ordinal = derivePrereleaseOrdinal(release);
+  switch (release.prereleaseLabel) {
+    case "rc":
+      return 50000 + ordinal;
+    case "beta":
+      return 40000 + ordinal;
+    case "nightly":
+      return 10000 + ordinal;
+    default:
+      return 20000 + ordinal;
+  }
+}
+
+export function buildChromeExtensionVersion(release) {
+  return [
+    release.major,
+    release.minor,
+    release.patch,
+    deriveChromeBuildSegment(release),
+  ].join(".");
+}
+
+export function buildSafariExtensionVersions(release) {
+  const ordinal = derivePrereleaseOrdinal(release);
+  const suffix =
+    !release.hasPrerelease || !release.prereleaseLabel
+      ? 9000
+      : release.prereleaseLabel === "rc"
+        ? 8000 + ordinal
+        : release.prereleaseLabel === "beta"
+          ? 7000 + ordinal
+          : 5000 + ordinal;
+
+  const buildVersion =
+    release.major * 100_000_000 +
+    release.minor * 1_000_000 +
+    release.patch * 10_000 +
+    suffix;
+
+  return {
+    marketingVersion: release.baseVersion,
+    buildVersion: String(buildVersion),
+  };
+}
+
+export function buildBrowserBridgeReleaseMetadata(release) {
+  const chromeVersion = buildChromeExtensionVersion(release);
+  const safari = buildSafariExtensionVersions(release);
+  return {
+    schema: "browser_bridge_release_v2",
+    releaseTag: release.tag,
+    releaseVersion: release.raw,
+    chromeVersion,
+    chromeVersionName: release.raw,
+    safariMarketingVersion: safari.marketingVersion,
+    safariBuildVersion: safari.buildVersion,
+  };
+}
+
+export function versionedArtifactName(prefix, extension, release) {
+  return `${prefix}-${release.tag}.${extension.replace(/^\./, "")}`;
+}
+
+export function buildGitHubReleasePageUrl(repository, release) {
+  if (!repository) {
+    return null;
+  }
+  return `https://github.com/${repository}/releases/tag/${release.tag}`;
+}
+
+export function buildGitHubReleaseAssetDownloadUrl(
+  repository,
+  release,
+  assetName,
+) {
+  if (!repository || !assetName) {
+    return null;
+  }
+  return `https://github.com/${repository}/releases/download/${release.tag}/${assetName}`;
+}
+
+export function resolveBrowserBridgeStoreUrls(env = process.env) {
+  const chromeWebStoreUrl =
+    typeof env.ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL === "string" &&
+    env.ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL.trim()
+      ? env.ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL.trim()
+      : null;
+  const safariAppStoreUrl =
+    typeof env.ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL === "string" &&
+    env.ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL.trim()
+      ? env.ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL.trim()
+      : null;
+  const firefoxAddonsUrl =
+    typeof env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL === "string" &&
+    env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL.trim()
+      ? env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL.trim()
+      : null;
+  return {
+    chromeWebStoreUrl,
+    firefoxAddonsUrl,
+    safariAppStoreUrl,
+  };
+}
+
+export function resolveSourceDateIso(env = process.env) {
+  const raw = env.SOURCE_DATE_EPOCH ?? "0";
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `Invalid SOURCE_DATE_EPOCH "${raw}". Expected a non-negative integer number of seconds.`,
+    );
+  }
+  const milliseconds = Number(raw) * 1000;
+  if (!Number.isSafeInteger(milliseconds)) {
+    throw new Error(
+      `SOURCE_DATE_EPOCH "${raw}" is outside the safe date range.`,
+    );
+  }
+  return new Date(milliseconds).toISOString();
+}

--- a/packages/browser-bridge-extension/scripts/script-utils.mjs
+++ b/packages/browser-bridge-extension/scripts/script-utils.mjs
@@ -1,0 +1,45 @@
+/**
+ * Shared helpers for the extension build/packaging scripts: a promisified
+ * child-process `run` and small fs utilities.
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      ...options,
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} exited with code ${code ?? "unknown"}`,
+        ),
+      );
+    });
+  });
+}
+
+export async function findFileWithExtension(directory, extension) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.name.endsWith(extension)) {
+      return fullPath;
+    }
+    if (entry.isDirectory()) {
+      const nested = await findFileWithExtension(fullPath, extension);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/browser-bridge-extension/src/action-authorization.test.ts
+++ b/packages/browser-bridge-extension/src/action-authorization.test.ts
@@ -78,6 +78,24 @@ describe("browserActionAuthorizationError", () => {
     );
   });
 
+  it("matches the visible host block across schemes, ports, and subdomains", () => {
+    expect(authorize({ blockedOrigins: ["allowed.example"] })).toMatch(
+      /blocked/i,
+    );
+    expect(
+      browserActionAuthorizationError({
+        settings: { ...settings, blockedOrigins: ["https://example"] },
+        target: {
+          url: "http://pay.example:8443/account",
+          incognito: false,
+          focusedActive: true,
+        },
+        grantedOrigins: ["<all_urls>"],
+        currentFocusedUrl: "http://pay.example:8443/account",
+      }),
+    ).toMatch(/blocked/i);
+  });
+
   it("does not let current-site mode navigate the focused tab cross-origin", () => {
     expect(
       browserActionAuthorizationError({

--- a/packages/browser-bridge-extension/src/action-authorization.test.ts
+++ b/packages/browser-bridge-extension/src/action-authorization.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Adversarial tests for the last-moment browser action authorization gate.
+ */
+import { describe, expect, it } from "vitest";
+import { browserActionAuthorizationError } from "./action-authorization";
+import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
+
+const settings: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "all_sites",
+  grantedOrigins: [],
+  blockedOrigins: [],
+  maxRememberedTabs: 10,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: null,
+};
+
+function authorize(overrides: Partial<BrowserBridgeSettings> = {}) {
+  return browserActionAuthorizationError({
+    settings: { ...settings, ...overrides },
+    target: {
+      url: "https://allowed.example/account",
+      incognito: false,
+      focusedActive: true,
+    },
+    grantedOrigins: ["https://allowed.example/*"],
+    currentFocusedUrl: "https://allowed.example/home",
+    now: new Date("2026-08-17T12:00:00.000Z"),
+  });
+}
+
+describe("browserActionAuthorizationError", () => {
+  it("fails closed when control is revoked or the bridge becomes paused", () => {
+    expect(authorize({ enabled: false })).toMatch(/disabled/i);
+    expect(authorize({ trackingMode: "off" })).toMatch(/disabled/i);
+    expect(authorize({ allowBrowserControl: false })).toMatch(/disabled/i);
+    expect(authorize({ pauseUntil: "2026-08-17T12:01:00.000Z" })).toMatch(
+      /paused/i,
+    );
+  });
+
+  it("requires both the browser's effective grant and the server site grant", () => {
+    const target = {
+      url: "https://allowed.example/account",
+      incognito: false,
+      focusedActive: true,
+    };
+    expect(
+      browserActionAuthorizationError({
+        settings: { ...settings, siteAccessMode: "granted_sites" },
+        target,
+        grantedOrigins: ["https://allowed.example/*"],
+        currentFocusedUrl: target.url,
+      }),
+    ).toMatch(/grant list/i);
+    expect(
+      browserActionAuthorizationError({
+        settings: {
+          ...settings,
+          siteAccessMode: "granted_sites",
+          grantedOrigins: ["https://allowed.example"],
+        },
+        target,
+        grantedOrigins: [],
+        currentFocusedUrl: target.url,
+      }),
+    ).toMatch(/browser has not granted/i);
+  });
+
+  it("rejects a site blocked after a session was claimed", () => {
+    expect(authorize({ blockedOrigins: ["https://allowed.example/"] })).toMatch(
+      /blocked/i,
+    );
+  });
+
+  it("does not let current-site mode navigate the focused tab cross-origin", () => {
+    expect(
+      browserActionAuthorizationError({
+        settings: { ...settings, siteAccessMode: "current_site_only" },
+        target: {
+          url: "https://other.example/",
+          incognito: false,
+          focusedActive: true,
+        },
+        grantedOrigins: ["https://other.example/*"],
+        currentFocusedUrl: "https://allowed.example/",
+      }),
+    ).toMatch(/currently focused site/i);
+  });
+
+  it("rejects incognito actions unless both browser and server allow them", () => {
+    expect(
+      browserActionAuthorizationError({
+        settings,
+        target: {
+          url: "https://allowed.example/",
+          incognito: true,
+          focusedActive: true,
+        },
+        grantedOrigins: ["https://allowed.example/*"],
+        currentFocusedUrl: "https://allowed.example/",
+      }),
+    ).toMatch(/incognito/i);
+  });
+});

--- a/packages/browser-bridge-extension/src/action-authorization.ts
+++ b/packages/browser-bridge-extension/src/action-authorization.ts
@@ -4,7 +4,10 @@
  * browser's current effective host grants immediately before every action.
  */
 import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
-import { urlMatchesGrantedOrigins } from "./tab-cache";
+import {
+  urlMatchesBlockedOrigins,
+  urlMatchesGrantedOrigins,
+} from "./tab-cache";
 
 export interface ActionAuthorizationTarget {
   url: string;
@@ -58,7 +61,7 @@ export function browserActionAuthorizationError(args: {
   if (!targetOrigin || !urlMatchesGrantedOrigins(target.url, grantedOrigins)) {
     return "The browser has not granted access to the target site.";
   }
-  if (new Set(settings.blockedOrigins.map(normalizeOrigin)).has(targetOrigin)) {
+  if (urlMatchesBlockedOrigins(target.url, settings.blockedOrigins)) {
     return "The target site is blocked by browser bridge settings.";
   }
   if (settings.siteAccessMode === "granted_sites") {

--- a/packages/browser-bridge-extension/src/action-authorization.ts
+++ b/packages/browser-bridge-extension/src/action-authorization.ts
@@ -1,0 +1,81 @@
+/**
+ * Fail-closed authorization for companion-directed browser actions. The
+ * service worker calls this with freshly fetched server settings and the
+ * browser's current effective host grants immediately before every action.
+ */
+import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
+import { urlMatchesGrantedOrigins } from "./tab-cache";
+
+export interface ActionAuthorizationTarget {
+  url: string;
+  incognito: boolean;
+  focusedActive: boolean;
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.replace(/\/+$/, "").toLowerCase();
+  } catch {
+    // error-policy:J3 Invalid action URLs have no authorized origin.
+    return null;
+  }
+}
+
+function isPaused(settings: BrowserBridgeSettings, now: Date): boolean {
+  return (
+    typeof settings.pauseUntil === "string" &&
+    Date.parse(settings.pauseUntil) > now.getTime()
+  );
+}
+
+export function browserActionAuthorizationError(args: {
+  settings: BrowserBridgeSettings;
+  target: ActionAuthorizationTarget;
+  grantedOrigins: readonly string[];
+  currentFocusedUrl: string | null;
+  now?: Date;
+}): string | null {
+  const {
+    settings,
+    target,
+    grantedOrigins,
+    currentFocusedUrl,
+    now = new Date(),
+  } = args;
+  if (!settings.enabled || settings.trackingMode === "off") {
+    return "Browser bridge is disabled.";
+  }
+  if (!settings.allowBrowserControl) {
+    return "Browser control is disabled.";
+  }
+  if (isPaused(settings, now)) {
+    return "Browser bridge is paused.";
+  }
+  if (target.incognito && !settings.incognitoEnabled) {
+    return "Browser control is not allowed in incognito windows.";
+  }
+  const targetOrigin = normalizeOrigin(target.url);
+  if (!targetOrigin || !urlMatchesGrantedOrigins(target.url, grantedOrigins)) {
+    return "The browser has not granted access to the target site.";
+  }
+  if (new Set(settings.blockedOrigins.map(normalizeOrigin)).has(targetOrigin)) {
+    return "The target site is blocked by browser bridge settings.";
+  }
+  if (settings.siteAccessMode === "granted_sites") {
+    const settingsGrants = new Set(
+      settings.grantedOrigins.map(normalizeOrigin),
+    );
+    if (!settingsGrants.has(targetOrigin)) {
+      return "The target site is not in the browser bridge site grant list.";
+    }
+  }
+  if (settings.siteAccessMode === "current_site_only") {
+    const focusedOrigin = currentFocusedUrl
+      ? normalizeOrigin(currentFocusedUrl)
+      : null;
+    if (!target.focusedActive || focusedOrigin !== targetOrigin) {
+      return "Browser control is limited to the currently focused site.";
+    }
+  }
+  return null;
+}

--- a/packages/browser-bridge-extension/src/action-target.test.ts
+++ b/packages/browser-bridge-extension/src/action-target.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Adversarial tests ensure browser action authorization remains bound to the
+ * exact tab and window later used by the extension API.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveBrowserActionTarget } from "./action-target";
+import type { ExtensionTab, ExtensionWindow } from "./webextension";
+
+const tabs: ExtensionTab[] = [
+  { id: 11, windowId: 1, active: true, incognito: false },
+  { id: 22, windowId: 2, active: true, incognito: true },
+];
+const windows: ExtensionWindow[] = [
+  { id: 1, focused: true, incognito: false },
+  { id: 2, focused: false, incognito: true },
+];
+
+function resolve(
+  overrides: Partial<Parameters<typeof resolveBrowserActionTarget>[0]> = {},
+) {
+  return resolveBrowserActionTarget({
+    actionKind: "open",
+    currentTabId: null,
+    tabs,
+    windows,
+    focusedTab: tabs[0] ?? null,
+    ...overrides,
+  });
+}
+
+describe("resolveBrowserActionTarget", () => {
+  it("binds an open action to its explicit incognito destination window", () => {
+    expect(resolve({ actionWindowId: "2" })).toEqual({
+      tabId: null,
+      windowId: 2,
+      incognito: true,
+      focusedActive: false,
+    });
+  });
+
+  it("authorizes a same-window open against the currently focused site", () => {
+    expect(resolve()).toMatchObject({
+      windowId: 1,
+      incognito: false,
+      focusedActive: true,
+    });
+  });
+
+  it("rejects a tab and window identity from different windows", () => {
+    expect(() => resolve({ actionTabId: "11", actionWindowId: "2" })).toThrow(
+      /does not belong to window 2/i,
+    );
+  });
+
+  it("fails closed for malformed and stale browser identifiers", () => {
+    expect(() => resolve({ actionWindowId: "2x" })).toThrow(
+      /positive integer/i,
+    );
+    expect(() => resolve({ actionTabId: "999" })).toThrow(
+      /no longer available/i,
+    );
+  });
+
+  it("selects the active tab in an explicit window for non-open actions", () => {
+    expect(resolve({ actionKind: "navigate", actionWindowId: "2" })).toEqual({
+      tabId: 22,
+      windowId: 2,
+      incognito: true,
+      focusedActive: false,
+    });
+  });
+
+  it("does not fall back across windows when the destination has no tab", () => {
+    expect(
+      resolve({
+        actionKind: "navigate",
+        actionWindowId: "2",
+        tabs: [tabs[0] as ExtensionTab],
+      }),
+    ).toMatchObject({ tabId: null, windowId: 2, incognito: true });
+  });
+});

--- a/packages/browser-bridge-extension/src/action-target.ts
+++ b/packages/browser-bridge-extension/src/action-target.ts
@@ -1,0 +1,124 @@
+/**
+ * Resolves the exact browser tab and window an agent action will affect so the
+ * authorization decision and extension API call cannot disagree about the
+ * destination, including across incognito and multi-window sessions.
+ */
+import type { BrowserBridgeActionKind } from "./browser-bridge-contracts";
+import type { ExtensionTab, ExtensionWindow } from "./webextension";
+
+export interface BrowserActionTarget {
+  tabId: number | null;
+  windowId: number | null;
+  incognito: boolean;
+  focusedActive: boolean;
+}
+
+function parseBrowserId(
+  label: string,
+  value: string | null | undefined,
+): number | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(`${label} must be a positive integer browser identifier.`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${label} exceeds the safe browser identifier range.`);
+  }
+  return parsed;
+}
+
+function firstDefined<T>(...values: Array<T | null>): T | null {
+  return values.find((value): value is T => value !== null) ?? null;
+}
+
+export function resolveBrowserActionTarget(args: {
+  actionKind: BrowserBridgeActionKind;
+  actionTabId?: string | null;
+  sessionTabId?: string | null;
+  currentTabId: number | null;
+  actionWindowId?: string | null;
+  sessionWindowId?: string | null;
+  tabs: readonly ExtensionTab[];
+  windows: readonly ExtensionWindow[];
+  focusedTab: ExtensionTab | null;
+}): BrowserActionTarget {
+  const requestedTabId = firstDefined(
+    parseBrowserId("action.tabId", args.actionTabId),
+    parseBrowserId("session.tabId", args.sessionTabId),
+    args.currentTabId,
+  );
+  const requestedWindowId = firstDefined(
+    parseBrowserId("action.windowId", args.actionWindowId),
+    parseBrowserId("session.windowId", args.sessionWindowId),
+  );
+
+  let targetTab =
+    requestedTabId === null
+      ? null
+      : (args.tabs.find((tab) => tab.id === requestedTabId) ?? null);
+  if (requestedTabId !== null && !targetTab) {
+    throw new Error(`Browser tab ${requestedTabId} is no longer available.`);
+  }
+  if (
+    targetTab &&
+    requestedWindowId !== null &&
+    targetTab.windowId !== requestedWindowId
+  ) {
+    throw new Error(
+      `Browser tab ${requestedTabId} does not belong to window ${requestedWindowId}.`,
+    );
+  }
+
+  const destinationWindowId = firstDefined(
+    requestedWindowId,
+    targetTab?.windowId ?? null,
+    args.focusedTab?.windowId ?? null,
+  );
+  if (requestedWindowId !== null) {
+    const windowExists =
+      args.windows.some((window) => window.id === requestedWindowId) ||
+      args.tabs.some((tab) => tab.windowId === requestedWindowId);
+    if (!windowExists) {
+      throw new Error(
+        `Browser window ${requestedWindowId} is no longer available.`,
+      );
+    }
+  }
+
+  if (!targetTab && args.actionKind !== "open") {
+    targetTab =
+      args.tabs.find(
+        (tab) => tab.windowId === destinationWindowId && tab.active === true,
+      ) ??
+      (destinationWindowId === null ||
+      args.focusedTab?.windowId === destinationWindowId
+        ? args.focusedTab
+        : null);
+  }
+
+  const destinationWindow = args.windows.find(
+    (window) => window.id === destinationWindowId,
+  );
+  const destinationIncognito =
+    destinationWindow?.incognito ??
+    targetTab?.incognito ??
+    args.tabs.find((tab) => tab.windowId === destinationWindowId)?.incognito ??
+    false;
+
+  return {
+    tabId: targetTab?.id ?? null,
+    windowId: destinationWindowId,
+    incognito: destinationIncognito,
+    focusedActive:
+      args.actionKind === "open"
+        ? destinationWindowId !== null &&
+          destinationWindowId === args.focusedTab?.windowId &&
+          args.focusedTab.active === true
+        : targetTab !== null &&
+          targetTab.id === args.focusedTab?.id &&
+          targetTab.active === true,
+  };
+}

--- a/packages/browser-bridge-extension/src/api-client.test.ts
+++ b/packages/browser-bridge-extension/src/api-client.test.ts
@@ -290,6 +290,9 @@ describe("BrowserBridgeRelayClient", () => {
     };
     const completion: CompanionSessionCompleteRequest = {
       status: "done",
+      currentActionIndex: 1,
+      completedActionId: "action-0",
+      attemptId: "attempt-0",
       result: { ok: true },
     };
 

--- a/packages/browser-bridge-extension/src/api-client.test.ts
+++ b/packages/browser-bridge-extension/src/api-client.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Unit tests for BrowserBridgeRelayClient: URL joining, Bearer auth, and
+ * RelayApiError mapping, driven against a mocked fetch.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BrowserBridgeRelayClient, type RelayApiError } from "./api-client";
+import type {
+  CompanionConfig,
+  CompanionSessionBeginRequest,
+  CompanionSessionCompleteRequest,
+  CompanionSessionProgressRequest,
+  CompanionSyncRequest,
+} from "./protocol";
+
+const config: CompanionConfig = {
+  apiBaseUrl: "https://agent.example.com/root/",
+  companionId: "companion-1",
+  pairingToken: "pairing-token",
+  pairingTokenExpiresAt: null,
+  browser: "chrome",
+  profileId: "default",
+  profileLabel: "Default",
+  label: "Agent Browser Bridge chrome Default",
+};
+
+function jsonResponse(payload: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+    ...init,
+  });
+}
+
+function syncResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    companion: {
+      id: config.companionId,
+      browser: config.browser,
+      profileId: config.profileId,
+    },
+    tabs: [],
+    currentPage: null,
+    settings: {
+      enabled: true,
+      trackingMode: "active_tabs",
+      allowBrowserControl: true,
+      requireConfirmationForAccountAffecting: true,
+      incognitoEnabled: false,
+      siteAccessMode: "all_sites",
+      grantedOrigins: [],
+      blockedOrigins: [],
+      maxRememberedTabs: 10,
+      pauseUntil: null,
+      metadata: {},
+      updatedAt: null,
+    },
+    session: null,
+    settingsVersion: "settings-v1",
+    ...overrides,
+  };
+}
+
+describe("BrowserBridgeRelayClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends sync requests with pairing headers and normalized endpoint URLs", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(syncResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request: CompanionSyncRequest = {
+      settingsVersion: "settings-v1",
+      companion: {
+        browser: "chrome",
+        profileId: "default",
+        profileLabel: "Default",
+        label: "Agent Browser Bridge chrome Default",
+      },
+      tabs: [],
+      pageContexts: [],
+    };
+
+    const client = new BrowserBridgeRelayClient(config);
+    await expect(client.sync(request)).resolves.toMatchObject({
+      settings: { enabled: true },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example.com/root/api/browser-bridge/companions/sync",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(request),
+        headers: expect.objectContaining({
+          Authorization: "Bearer pairing-token",
+          "Content-Type": "application/json",
+          "X-Browser-Bridge-Companion-Id": "companion-1",
+        }),
+      }),
+    );
+  });
+
+  it("preflights without browser data and rejects a data-bearing response", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          companion: syncResponse().companion,
+          settings: syncResponse().settings,
+          settingsVersion: "settings-v1",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          companion: syncResponse().companion,
+          settings: syncResponse().settings,
+          settingsVersion: "settings-v1",
+          tabs: [],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new BrowserBridgeRelayClient(config);
+    const request = {
+      companion: {
+        browser: "chrome" as const,
+        profileId: "default",
+        label: config.label,
+      },
+    };
+    await expect(client.preflight(request)).resolves.toMatchObject({
+      settingsVersion: "settings-v1",
+    });
+    expect(
+      JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)),
+    ).not.toHaveProperty("tabs");
+    await expect(client.preflight(request)).rejects.toThrow("forbidden tabs");
+  });
+
+  it("rejects successful responses for a different companion", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          syncResponse({
+            companion: {
+              id: "attacker-companion",
+              browser: config.browser,
+              profileId: config.profileId,
+            },
+          }),
+        ),
+      ),
+    );
+
+    await expect(
+      new BrowserBridgeRelayClient(config).sync({
+        settingsVersion: "settings-v1",
+      } as CompanionSyncRequest),
+    ).rejects.toMatchObject({
+      status: 502,
+      code: "browser_bridge_response_invalid",
+    });
+  });
+
+  it("rejects malformed actions before the service worker can execute them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          syncResponse({
+            session: {
+              id: "session-1",
+              companionId: config.companionId,
+              browser: config.browser,
+              profileId: config.profileId,
+              currentActionIndex: 0,
+              actions: [{ id: "action-1", kind: "run_javascript" }],
+            },
+          }),
+        ),
+      ),
+    );
+
+    await expect(
+      new BrowserBridgeRelayClient(config).sync({
+        settingsVersion: "settings-v1",
+      } as CompanionSyncRequest),
+    ).rejects.toThrow("malformed action");
+  });
+
+  it("rejects cross-profile tabs, pages, stale versions, and malformed action controls", async () => {
+    const client = new BrowserBridgeRelayClient(config);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        syncResponse({ tabs: [{ browser: "chrome", profileId: "other" }] }),
+      ),
+    );
+    await expect(
+      client.sync({ settingsVersion: "settings-v1" } as CompanionSyncRequest),
+    ).rejects.toThrow("tab identity");
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        syncResponse({
+          currentPage: { browser: "firefox", profileId: "default" },
+        }),
+      ),
+    );
+    await expect(
+      client.sync({ settingsVersion: "settings-v1" } as CompanionSyncRequest),
+    ).rejects.toThrow("currentPage identity");
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(syncResponse({ settingsVersion: "settings-v2" })),
+    );
+    await expect(
+      client.sync({ settingsVersion: "settings-v1" } as CompanionSyncRequest),
+    ).rejects.toThrow("settingsVersion does not match");
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        syncResponse({
+          session: {
+            id: "session-1",
+            companionId: config.companionId,
+            browser: config.browser,
+            profileId: config.profileId,
+            currentActionIndex: 0,
+            actions: [
+              {
+                id: "action-1",
+                kind: "click",
+                label: "Click",
+                browser: "firefox",
+                windowId: null,
+                tabId: null,
+                url: null,
+                selector: "button",
+                text: null,
+                accountAffecting: false,
+                requiresConfirmation: false,
+                metadata: {},
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    await expect(
+      client.sync({ settingsVersion: "settings-v1" } as CompanionSyncRequest),
+    ).rejects.toThrow("malformed action");
+  });
+
+  it("encodes session ids for progress and completion endpoints", async () => {
+    const leasedSession = {
+      id: "session/one two",
+      companionId: config.companionId,
+      browser: config.browser,
+      profileId: config.profileId,
+      currentActionIndex: 0,
+      actions: [
+        {
+          id: "action-0",
+          kind: "click",
+          label: "Click",
+          url: "https://allowed.example/",
+          selector: "button",
+          text: null,
+          accountAffecting: false,
+          requiresConfirmation: false,
+          metadata: {},
+        },
+      ],
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ session: leasedSession }))
+      .mockResolvedValue(jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new BrowserBridgeRelayClient(config);
+    const begin: CompanionSessionBeginRequest = {
+      actionId: "action-0",
+      currentActionIndex: 0,
+      attemptId: "attempt-0",
+    };
+    const progress: CompanionSessionProgressRequest = {
+      completedActionId: "action-0",
+      attemptId: "attempt-0",
+      currentActionIndex: 1,
+      result: { "action-0": { ok: true } },
+    };
+    const completion: CompanionSessionCompleteRequest = {
+      status: "done",
+      result: { ok: true },
+    };
+
+    await expect(
+      client.beginSessionAction("session/one two", begin),
+    ).resolves.toMatchObject({ id: "session/one two" });
+    await client.updateSessionProgress("session/one two", progress);
+    await client.completeSession("session/one two", completion);
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://agent.example.com/root/api/browser-bridge/companions/sessions/session%2Fone%20two/actions/begin",
+      "https://agent.example.com/root/api/browser-bridge/companions/sessions/session%2Fone%20two/progress",
+      "https://agent.example.com/root/api/browser-bridge/companions/sessions/session%2Fone%20two/complete",
+    ]);
+  });
+
+  it("throws structured relay errors from error, message, and non-json responses", async () => {
+    const client = new BrowserBridgeRelayClient(config);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { code: "PAIRING_EXPIRED", error: "Pairing expired" },
+        { status: 401, statusText: "Unauthorized" },
+      ),
+    );
+    await expect(
+      client.sync({ settingsVersion: "settings-v1" } as CompanionSyncRequest),
+    ).rejects.toMatchObject({
+      name: "RelayApiError",
+      message: "Pairing expired",
+      status: 401,
+      code: "PAIRING_EXPIRED",
+    } satisfies Partial<RelayApiError>);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { message: "Session missing" },
+        { status: 404, statusText: "Not Found" },
+      ),
+    );
+    await expect(
+      client.updateSessionProgress(
+        "missing",
+        {} as CompanionSessionProgressRequest,
+      ),
+    ).rejects.toThrow("Session missing");
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("not json", { status: 500, statusText: "Server Error" }),
+    );
+    await expect(
+      client.completeSession("broken", {} as CompanionSessionCompleteRequest),
+    ).rejects.toMatchObject({
+      status: 500,
+      code: null,
+      message: "500 Server Error",
+    });
+  });
+});

--- a/packages/browser-bridge-extension/src/api-client.ts
+++ b/packages/browser-bridge-extension/src/api-client.ts
@@ -1,0 +1,391 @@
+/**
+ * BrowserBridgeRelayClient — typed HTTP client for the companion endpoints on
+ * the agent API (`/companions/sync`, `/progress`, `/complete`), authenticated
+ * with the Bearer pairing token from the companion config. Non-2xx responses
+ * are wrapped in RelayApiError carrying the HTTP status and server error code.
+ */
+import type {
+  BrowserBridgeCompanionPreflightResponse,
+  BrowserBridgeCompanionSyncResponse,
+  BrowserBridgeSettings,
+  LifeOpsBrowserSession,
+} from "./browser-bridge-contracts";
+import type {
+  CompanionConfig,
+  CompanionPreflightRequest,
+  CompanionSessionBeginRequest,
+  CompanionSessionCompleteRequest,
+  CompanionSessionProgressRequest,
+  CompanionSyncRequest,
+} from "./protocol";
+import { withBrowserBridgeRequestTimeout } from "./request-timeout";
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+export class RelayApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string | null = null,
+  ) {
+    super(message);
+    this.name = "RelayApiError";
+  }
+}
+
+async function throwApiError(response: Response): Promise<never> {
+  let message: string;
+  let code: string | null = null;
+  try {
+    const payload = (await response.json()) as {
+      code?: string;
+      error?: string;
+      message?: string;
+    };
+    code = typeof payload.code === "string" ? payload.code : null;
+    message =
+      payload.error ??
+      payload.message ??
+      `${response.status} ${response.statusText}`;
+  } catch {
+    // error-policy:J1 The HTTP boundary preserves status even when the remote
+    // error body is not valid JSON.
+    message = `${response.status} ${response.statusText}`;
+  }
+  throw new RelayApiError(message, response.status, code);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function invalidSyncResponse(message: string): never {
+  throw new RelayApiError(
+    `Invalid browser companion sync response: ${message}`,
+    502,
+    "browser_bridge_response_invalid",
+  );
+}
+
+function readSettings(value: unknown): BrowserBridgeSettings {
+  const settings = value;
+  if (
+    !isRecord(settings) ||
+    typeof settings.enabled !== "boolean" ||
+    !["off", "current_tab", "active_tabs"].includes(
+      String(settings.trackingMode),
+    ) ||
+    typeof settings.allowBrowserControl !== "boolean" ||
+    typeof settings.requireConfirmationForAccountAffecting !== "boolean" ||
+    typeof settings.incognitoEnabled !== "boolean" ||
+    !["current_site_only", "granted_sites", "all_sites"].includes(
+      String(settings.siteAccessMode),
+    ) ||
+    !Array.isArray(settings.grantedOrigins) ||
+    !settings.grantedOrigins.every((entry) => typeof entry === "string") ||
+    !Array.isArray(settings.blockedOrigins) ||
+    !settings.blockedOrigins.every((entry) => typeof entry === "string") ||
+    typeof settings.maxRememberedTabs !== "number" ||
+    !Number.isInteger(settings.maxRememberedTabs) ||
+    settings.maxRememberedTabs < 1 ||
+    (settings.pauseUntil !== null && typeof settings.pauseUntil !== "string") ||
+    !isRecord(settings.metadata) ||
+    (settings.updatedAt !== null && typeof settings.updatedAt !== "string")
+  )
+    invalidSyncResponse("settings are malformed");
+  return settings as unknown as BrowserBridgeSettings;
+}
+
+function readSettingsVersion(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    invalidSyncResponse("settingsVersion is missing");
+  }
+  return value;
+}
+
+function readCompanion(
+  payload: Record<string, unknown>,
+  config: CompanionConfig,
+): void {
+  const companion = payload.companion;
+  if (!isRecord(companion)) invalidSyncResponse("companion is missing");
+  if (
+    companion.id !== config.companionId ||
+    companion.browser !== config.browser ||
+    companion.profileId !== config.profileId
+  ) {
+    invalidSyncResponse("companion identity does not match the pairing");
+  }
+}
+
+function readPreflightResponse(
+  payload: unknown,
+  config: CompanionConfig,
+): BrowserBridgeCompanionPreflightResponse {
+  if (!isRecord(payload)) invalidSyncResponse("payload is not an object");
+  readCompanion(payload, config);
+  for (const forbidden of ["session", "tabs", "currentPage"]) {
+    if (Object.hasOwn(payload, forbidden))
+      invalidSyncResponse(`preflight contains forbidden ${forbidden} data`);
+  }
+  return {
+    companion:
+      payload.companion as BrowserBridgeCompanionPreflightResponse["companion"],
+    settings: readSettings(payload.settings),
+    settingsVersion: readSettingsVersion(payload.settingsVersion),
+  };
+}
+
+const ACTION_KINDS = new Set([
+  "open",
+  "navigate",
+  "focus_tab",
+  "back",
+  "forward",
+  "reload",
+  "click",
+  "type",
+  "submit",
+  "read_page",
+  "extract_links",
+  "extract_forms",
+]);
+
+function readSession(
+  value: unknown,
+  config: CompanionConfig,
+): LifeOpsBrowserSession | null {
+  if (value === null) return null;
+  if (!isRecord(value)) invalidSyncResponse("session is malformed");
+  if (
+    typeof value.id !== "string" ||
+    value.id.length === 0 ||
+    value.companionId !== config.companionId ||
+    value.browser !== config.browser ||
+    value.profileId !== config.profileId ||
+    !Array.isArray(value.actions) ||
+    !Number.isInteger(value.currentActionIndex) ||
+    Number(value.currentActionIndex) < 0 ||
+    Number(value.currentActionIndex) > value.actions.length
+  ) {
+    invalidSyncResponse("session identity or checkpoint is invalid");
+  }
+  for (const action of value.actions) {
+    if (
+      !isRecord(action) ||
+      typeof action.id !== "string" ||
+      action.id.length === 0 ||
+      typeof action.kind !== "string" ||
+      !ACTION_KINDS.has(action.kind) ||
+      typeof action.label !== "string" ||
+      (action.browser !== null &&
+        action.browser !== undefined &&
+        action.browser !== config.browser) ||
+      (action.windowId !== null &&
+        action.windowId !== undefined &&
+        typeof action.windowId !== "string") ||
+      (action.tabId !== null &&
+        action.tabId !== undefined &&
+        typeof action.tabId !== "string") ||
+      (action.url !== null && typeof action.url !== "string") ||
+      (action.selector !== null && typeof action.selector !== "string") ||
+      (action.text !== null && typeof action.text !== "string") ||
+      typeof action.accountAffecting !== "boolean" ||
+      typeof action.requiresConfirmation !== "boolean" ||
+      !isRecord(action.metadata)
+    ) {
+      invalidSyncResponse("session contains a malformed action");
+    }
+  }
+  return value as unknown as LifeOpsBrowserSession;
+}
+
+function readSyncResponse(
+  payload: unknown,
+  config: CompanionConfig,
+  requestSettingsVersion: string,
+): BrowserBridgeCompanionSyncResponse {
+  if (!isRecord(payload)) invalidSyncResponse("payload is not an object");
+  readCompanion(payload, config);
+  readSettings(payload.settings);
+  const settingsVersion = readSettingsVersion(payload.settingsVersion);
+
+  readSession(payload.session, config);
+  if (!Array.isArray(payload.tabs)) invalidSyncResponse("tabs are malformed");
+  for (const tab of payload.tabs) {
+    if (
+      !isRecord(tab) ||
+      tab.browser !== config.browser ||
+      tab.profileId !== config.profileId ||
+      tab.companionId !== config.companionId
+    ) {
+      invalidSyncResponse("tab identity does not match the pairing");
+    }
+  }
+  if (payload.currentPage !== null && !isRecord(payload.currentPage)) {
+    invalidSyncResponse("currentPage is malformed");
+  }
+  if (
+    isRecord(payload.currentPage) &&
+    (payload.currentPage.browser !== config.browser ||
+      payload.currentPage.profileId !== config.profileId ||
+      (Object.hasOwn(payload.currentPage, "companionId") &&
+        payload.currentPage.companionId !== config.companionId))
+  ) {
+    invalidSyncResponse("currentPage identity does not match the pairing");
+  }
+  if (settingsVersion !== requestSettingsVersion)
+    invalidSyncResponse("settingsVersion does not match the request");
+  return payload as unknown as BrowserBridgeCompanionSyncResponse;
+}
+
+export class BrowserBridgeRelayClient {
+  constructor(private readonly config: CompanionConfig) {}
+
+  private headers(): HeadersInit {
+    return {
+      Authorization: `Bearer ${this.config.pairingToken}`,
+      "Content-Type": "application/json",
+      "X-Browser-Bridge-Companion-Id": this.config.companionId,
+    };
+  }
+
+  async preflight(
+    request: CompanionPreflightRequest,
+  ): Promise<BrowserBridgeCompanionPreflightResponse> {
+    return withBrowserBridgeRequestTimeout(
+      "Browser companion preflight",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            "/api/browser-bridge/companions/preflight",
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify(request),
+            signal,
+          },
+        );
+        if (!response.ok) await throwApiError(response);
+        return readPreflightResponse(await response.json(), this.config);
+      },
+    );
+  }
+
+  async sync(
+    request: CompanionSyncRequest,
+  ): Promise<BrowserBridgeCompanionSyncResponse> {
+    return withBrowserBridgeRequestTimeout(
+      "Browser companion sync",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            "/api/browser-bridge/companions/sync",
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify(request),
+            signal,
+          },
+        );
+        if (!response.ok) {
+          await throwApiError(response);
+        }
+        return readSyncResponse(
+          await response.json(),
+          this.config,
+          request.settingsVersion,
+        );
+      },
+    );
+  }
+
+  async updateSessionProgress(
+    sessionId: string,
+    request: CompanionSessionProgressRequest,
+  ): Promise<void> {
+    await withBrowserBridgeRequestTimeout(
+      "Browser session progress",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            `/api/browser-bridge/companions/sessions/${encodeURIComponent(sessionId)}/progress`,
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify(request),
+            signal,
+          },
+        );
+        if (!response.ok) {
+          await throwApiError(response);
+        }
+      },
+    );
+  }
+
+  async beginSessionAction(
+    sessionId: string,
+    request: CompanionSessionBeginRequest,
+  ): Promise<LifeOpsBrowserSession> {
+    return withBrowserBridgeRequestTimeout(
+      "Browser session action begin",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            `/api/browser-bridge/companions/sessions/${encodeURIComponent(sessionId)}/actions/begin`,
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify(request),
+            signal,
+          },
+        );
+        if (!response.ok) {
+          await throwApiError(response);
+        }
+        const payload = (await response.json()) as unknown;
+        if (!isRecord(payload)) invalidSyncResponse("payload is not an object");
+        const session = readSession(payload.session, this.config);
+        if (!session) invalidSyncResponse("session is missing");
+        return session;
+      },
+    );
+  }
+
+  async completeSession(
+    sessionId: string,
+    request: CompanionSessionCompleteRequest,
+  ): Promise<void> {
+    await withBrowserBridgeRequestTimeout(
+      "Browser session completion",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            `/api/browser-bridge/companions/sessions/${encodeURIComponent(sessionId)}/complete`,
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify(request),
+            signal,
+          },
+        );
+        if (!response.ok) {
+          await throwApiError(response);
+        }
+      },
+    );
+  }
+}

--- a/packages/browser-bridge-extension/src/browser-bridge-contracts.ts
+++ b/packages/browser-bridge-extension/src/browser-bridge-contracts.ts
@@ -1,0 +1,243 @@
+/**
+ * Data contracts shared between the extension and the agent's
+ * `/api/browser-bridge/*` routes: bridge settings, action kinds, and the sync
+ * request/response shapes. Both sides depend on these types to agree on the
+ * wire format; type-only, no runtime code.
+ */
+export type BrowserBridgeKind = "chrome" | "firefox" | "safari";
+
+export type BrowserBridgeTrackingMode = "off" | "current_tab" | "active_tabs";
+
+export type BrowserBridgeSiteAccessMode =
+  | "current_site_only"
+  | "granted_sites"
+  | "all_sites";
+
+export type BrowserBridgeCompanionConnectionState =
+  | "disconnected"
+  | "connected"
+  | "paused"
+  | "permission_blocked";
+
+export type BrowserBridgeActionKind =
+  | "open"
+  | "navigate"
+  | "focus_tab"
+  | "back"
+  | "forward"
+  | "reload"
+  | "click"
+  | "type"
+  | "submit"
+  | "read_page"
+  | "extract_links"
+  | "extract_forms";
+
+export interface BrowserBridgeAction {
+  id: string;
+  kind: BrowserBridgeActionKind;
+  label: string;
+  browser?: BrowserBridgeKind | null;
+  windowId?: string | null;
+  tabId?: string | null;
+  url: string | null;
+  selector: string | null;
+  text: string | null;
+  accountAffecting: boolean;
+  requiresConfirmation: boolean;
+  metadata: Record<string, unknown>;
+}
+
+export interface BrowserBridgePermissionState {
+  tabs: boolean;
+  scripting: boolean;
+  activeTab: boolean;
+  allOrigins: boolean;
+  grantedOrigins: string[];
+  incognitoEnabled: boolean;
+}
+
+export interface BrowserBridgeSettings {
+  enabled: boolean;
+  trackingMode: BrowserBridgeTrackingMode;
+  allowBrowserControl: boolean;
+  requireConfirmationForAccountAffecting: boolean;
+  incognitoEnabled: boolean;
+  siteAccessMode: BrowserBridgeSiteAccessMode;
+  grantedOrigins: string[];
+  blockedOrigins: string[];
+  maxRememberedTabs: number;
+  pauseUntil: string | null;
+  metadata: Record<string, unknown>;
+  updatedAt: string | null;
+}
+
+export interface BrowserBridgeCompanionStatus {
+  id: string;
+  agentId: string;
+  browser: BrowserBridgeKind;
+  profileId: string;
+  profileLabel: string;
+  label: string;
+  extensionVersion: string | null;
+  connectionState: BrowserBridgeCompanionConnectionState;
+  permissions: BrowserBridgePermissionState;
+  lastSeenAt: string | null;
+  pairedAt: string | null;
+  pairingTokenExpiresAt?: string | null;
+  pairingTokenRevokedAt?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SyncBrowserBridgeStateRequest {
+  companion: {
+    browser: BrowserBridgeKind;
+    profileId: string;
+    profileLabel?: string | null;
+    label: string;
+    extensionVersion?: string | null;
+    connectionState?: BrowserBridgeCompanionConnectionState;
+    permissions?: Partial<BrowserBridgePermissionState>;
+    lastSeenAt?: string | null;
+    metadata?: Record<string, unknown>;
+  };
+  tabs: Array<{
+    browser: BrowserBridgeKind;
+    profileId: string;
+    windowId: string;
+    tabId: string;
+    url: string;
+    title: string;
+    activeInWindow: boolean;
+    focusedWindow: boolean;
+    focusedActive: boolean;
+    incognito?: boolean;
+    faviconUrl?: string | null;
+    lastSeenAt?: string;
+    lastFocusedAt?: string | null;
+    metadata?: Record<string, unknown>;
+  }>;
+  pageContexts?: Array<{
+    browser: BrowserBridgeKind;
+    profileId: string;
+    windowId: string;
+    tabId: string;
+    url: string;
+    title: string;
+    selectionText?: string | null;
+    mainText?: string | null;
+    headings?: string[];
+    links?: Array<{ text: string; href: string }>;
+    forms?: Array<{ action: string | null; fields: string[] }>;
+    capturedAt?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+}
+
+export interface BrowserBridgeCompanionPreflightRequest {
+  companion: SyncBrowserBridgeStateRequest["companion"];
+}
+
+export interface BrowserBridgeCompanionSyncRequest
+  extends SyncBrowserBridgeStateRequest {
+  settingsVersion: string;
+}
+
+export interface BrowserBridgeCompanionPreflightResponse {
+  companion: BrowserBridgeCompanionStatus;
+  settings: BrowserBridgeSettings;
+  settingsVersion: string;
+}
+
+export interface BrowserBridgeCompanionConfig {
+  apiBaseUrl: string;
+  companionId: string;
+  pairingToken: string;
+  pairingTokenExpiresAt?: string | null;
+  browser: BrowserBridgeKind;
+  profileId: string;
+  profileLabel: string;
+  label: string;
+}
+
+export interface CreateBrowserBridgeCompanionAutoPairRequest {
+  browser: BrowserBridgeKind;
+  profileId?: string | null;
+  profileLabel?: string | null;
+  label?: string | null;
+  extensionVersion?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BrowserBridgeCompanionAutoPairResponse {
+  companion: BrowserBridgeCompanionStatus;
+  config: BrowserBridgeCompanionConfig;
+}
+
+export interface UpdateBrowserBridgeSessionProgressRequest {
+  currentActionIndex?: number;
+  result?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BrowserBridgeCompanionSessionProgressRequest
+  extends UpdateBrowserBridgeSessionProgressRequest {
+  completedActionId: string;
+  attemptId: string;
+}
+
+export interface BrowserBridgeCompanionSessionBeginRequest {
+  currentActionIndex: number;
+  actionId: string;
+  attemptId: string;
+}
+
+export type LifeOpsBrowserSessionStatus =
+  | "awaiting_confirmation"
+  | "queued"
+  | "running"
+  | "done"
+  | "cancelled"
+  | "failed";
+
+export interface LifeOpsBrowserSession {
+  id: string;
+  agentId: string;
+  domain: string;
+  subjectType: string;
+  subjectId: string;
+  visibilityScope: string;
+  contextPolicy: string;
+  workflowId: string | null;
+  browser: BrowserBridgeKind | null;
+  companionId: string | null;
+  profileId: string | null;
+  windowId: string | null;
+  tabId: string | null;
+  title: string;
+  status: LifeOpsBrowserSessionStatus;
+  actions: BrowserBridgeAction[];
+  currentActionIndex: number;
+  awaitingConfirmationForActionId: string | null;
+  result: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+}
+
+export interface CompleteLifeOpsBrowserSessionRequest {
+  status?: Extract<LifeOpsBrowserSessionStatus, "done" | "failed">;
+  result?: Record<string, unknown>;
+}
+
+export interface BrowserBridgeCompanionSyncResponse {
+  companion: BrowserBridgeCompanionStatus;
+  tabs: Array<Record<string, unknown>>;
+  currentPage: Record<string, unknown> | null;
+  settings: BrowserBridgeSettings;
+  settingsVersion: string;
+  session: LifeOpsBrowserSession | null;
+}

--- a/packages/browser-bridge-extension/src/browser-bridge-contracts.ts
+++ b/packages/browser-bridge-extension/src/browser-bridge-contracts.ts
@@ -231,6 +231,9 @@ export interface LifeOpsBrowserSession {
 export interface CompleteLifeOpsBrowserSessionRequest {
   status?: Extract<LifeOpsBrowserSessionStatus, "done" | "failed">;
   result?: Record<string, unknown>;
+  currentActionIndex?: number;
+  completedActionId?: string | null;
+  attemptId?: string | null;
 }
 
 export interface BrowserBridgeCompanionSyncResponse {

--- a/packages/browser-bridge-extension/src/build-package.test.ts
+++ b/packages/browser-bridge-extension/src/build-package.test.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { unzipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { parseBrowserBridgeBuildKind } from "../scripts/build.mjs";
 import { createDeterministicWebExtensionArchive } from "../scripts/package-webextension.mjs";
@@ -26,6 +27,7 @@ type BuiltManifest = {
   web_accessible_resources: Array<{
     resources: string[];
     matches: string[];
+    use_dynamic_url?: boolean;
   }>;
   content_security_policy: { extension_pages: string };
   background: { service_worker?: string; scripts?: string[] };
@@ -106,6 +108,7 @@ describe("cross-browser extension build", () => {
         {
           resources: ["blocked.html", "blocked.js"],
           matches: ["http://*/*", "https://*/*"],
+          use_dynamic_url: true,
         },
       ]);
     }
@@ -138,5 +141,10 @@ describe("cross-browser extension build", () => {
     expect(createHash("sha256").update(first).digest("hex")).toBe(
       createHash("sha256").update(second).digest("hex"),
     );
+    expect(
+      Object.keys(unzipSync(new Uint8Array(first))).some((name) =>
+        name.endsWith(".map"),
+      ),
+    ).toBe(false);
   }, 30_000);
 });

--- a/packages/browser-bridge-extension/src/build-package.test.ts
+++ b/packages/browser-bridge-extension/src/build-package.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Exercises real cross-browser build output and reproducible archive generation.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseBrowserBridgeBuildKind } from "../scripts/build.mjs";
+import { createDeterministicWebExtensionArchive } from "../scripts/package-webextension.mjs";
+import { resolveSourceDateIso } from "../scripts/release-version.mjs";
+import { run } from "../scripts/script-utils.mjs";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+type BuiltManifest = {
+  manifest_version: number;
+  permissions: string[];
+  host_permissions: string[];
+  optional_host_permissions: string[];
+  content_scripts: Array<{ js: string[]; all_frames?: boolean }>;
+  web_accessible_resources: Array<{
+    resources: string[];
+    matches: string[];
+  }>;
+  content_security_policy: { extension_pages: string };
+  background: { service_worker?: string; scripts?: string[] };
+  browser_specific_settings?: {
+    gecko?: { id?: string };
+  };
+};
+
+async function readManifest(kind: string): Promise<BuiltManifest> {
+  return JSON.parse(
+    await fs.readFile(
+      path.join(packageRoot, "dist", kind, "manifest.json"),
+      "utf8",
+    ),
+  ) as BuiltManifest;
+}
+
+async function buildExtension(kind: string): Promise<void> {
+  await run("bun", [path.join(packageRoot, "scripts", "build.mjs"), kind], {
+    cwd: packageRoot,
+    stdio: "pipe",
+  });
+}
+
+describe("cross-browser extension build", () => {
+  it("uses a validated reproducible timestamp for release metadata", () => {
+    expect(resolveSourceDateIso({ SOURCE_DATE_EPOCH: "0" })).toBe(
+      "1970-01-01T00:00:00.000Z",
+    );
+    expect(resolveSourceDateIso({ SOURCE_DATE_EPOCH: "172800" })).toBe(
+      "1970-01-03T00:00:00.000Z",
+    );
+    expect(() =>
+      resolveSourceDateIso({ SOURCE_DATE_EPOCH: "not-a-number" }),
+    ).toThrow(/Invalid SOURCE_DATE_EPOCH/);
+  });
+
+  it("rejects unknown build targets instead of silently producing Chrome", () => {
+    expect(() => parseBrowserBridgeBuildKind("netscape")).toThrow(
+      /Expected chrome, firefox, or safari/,
+    );
+  });
+
+  it("emits least-privilege Chrome and Firefox manifests from shared code", async () => {
+    await buildExtension("chrome");
+    await buildExtension("firefox");
+    const chrome = await readManifest("chrome");
+    const firefox = await readManifest("firefox");
+
+    for (const manifest of [chrome, firefox]) {
+      expect(manifest.manifest_version).toBe(3);
+      expect(manifest.host_permissions).not.toContain("<all_urls>");
+      expect(manifest.host_permissions).toEqual([
+        "http://127.0.0.1/*",
+        "http://localhost/*",
+      ]);
+      expect(manifest.optional_host_permissions).toEqual([
+        "https://*/*",
+        "http://*/*",
+      ]);
+      expect(manifest.permissions).toContain(
+        "declarativeNetRequestWithHostAccess",
+      );
+      expect(manifest.permissions).not.toContain("declarativeNetRequest");
+      expect(manifest.content_security_policy.extension_pages).toBe(
+        "script-src 'self'; object-src 'self'",
+      );
+      expect(manifest.content_security_policy.extension_pages).not.toContain(
+        "unsafe-eval",
+      );
+      expect(manifest.content_scripts).toEqual([
+        expect.objectContaining({ js: ["content.js"] }),
+      ]);
+      expect(
+        manifest.content_scripts.flatMap((entry) => entry.js),
+      ).not.toContain("wallet-shim.js");
+      expect(manifest.web_accessible_resources).toEqual([
+        {
+          resources: ["blocked.html", "blocked.js"],
+          matches: ["http://*/*", "https://*/*"],
+        },
+      ]);
+    }
+
+    expect(chrome.background).toEqual({ service_worker: "background.js" });
+    expect(chrome.browser_specific_settings).toBeUndefined();
+    expect(firefox.background).toEqual({ scripts: ["background.js"] });
+    expect(firefox.browser_specific_settings?.gecko?.id).toBe(
+      "browser-bridge@elizaos.ai",
+    );
+  }, 30_000);
+
+  it("creates byte-identical root-layout archives on repeated packaging", async () => {
+    await buildExtension("firefox");
+    const sourceDir = path.join(packageRoot, "dist", "firefox");
+    const firstPath = path.join(packageRoot, "dist", "test-firefox-1.xpi");
+    const secondPath = path.join(packageRoot, "dist", "test-firefox-2.xpi");
+    await createDeterministicWebExtensionArchive({
+      sourceDir,
+      outputPath: firstPath,
+    });
+    await createDeterministicWebExtensionArchive({
+      sourceDir,
+      outputPath: secondPath,
+    });
+    const [first, second] = await Promise.all([
+      fs.readFile(firstPath),
+      fs.readFile(secondPath),
+    ]);
+    expect(createHash("sha256").update(first).digest("hex")).toBe(
+      createHash("sha256").update(second).digest("hex"),
+    );
+  }, 30_000);
+});

--- a/packages/browser-bridge-extension/src/build-package.test.ts
+++ b/packages/browser-bridge-extension/src/build-package.test.ts
@@ -9,7 +9,10 @@ import { fileURLToPath } from "node:url";
 import { unzipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { parseBrowserBridgeBuildKind } from "../scripts/build.mjs";
-import { createDeterministicWebExtensionArchive } from "../scripts/package-webextension.mjs";
+import {
+  createDeterministicDirectoryArchive,
+  createDeterministicWebExtensionArchive,
+} from "../scripts/package-webextension.mjs";
 import { resolveSourceDateIso } from "../scripts/release-version.mjs";
 import { run } from "../scripts/script-utils.mjs";
 
@@ -77,7 +80,10 @@ describe("cross-browser extension build", () => {
     const chrome = await readManifest("chrome");
     const firefox = await readManifest("firefox");
 
-    for (const manifest of [chrome, firefox]) {
+    for (const [kind, manifest] of [
+      ["chrome", chrome],
+      ["firefox", firefox],
+    ] as const) {
       expect(manifest.manifest_version).toBe(3);
       expect(manifest.host_permissions).not.toContain("<all_urls>");
       expect(manifest.host_permissions).toEqual([
@@ -108,7 +114,7 @@ describe("cross-browser extension build", () => {
         {
           resources: ["blocked.html", "blocked.js"],
           matches: ["http://*/*", "https://*/*"],
-          use_dynamic_url: true,
+          ...(kind === "chrome" ? { use_dynamic_url: true } : {}),
         },
       ]);
     }
@@ -147,4 +153,22 @@ describe("cross-browser extension build", () => {
       ),
     ).toBe(false);
   }, 30_000);
+
+  it("preserves executable modes in deterministic directory archives", async () => {
+    const sourceDir = path.join(packageRoot, "dist", "test-app");
+    const executablePath = path.join(sourceDir, "Contents", "MacOS", "bridge");
+    await fs.mkdir(path.dirname(executablePath), { recursive: true });
+    await fs.writeFile(executablePath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    const first = await createDeterministicDirectoryArchive({
+      sourceDir,
+      outputPath: path.join(packageRoot, "dist", "test-app-1.zip"),
+      rootName: "Test.app",
+    });
+    const second = await createDeterministicDirectoryArchive({
+      sourceDir,
+      outputPath: path.join(packageRoot, "dist", "test-app-2.zip"),
+      rootName: "Test.app",
+    });
+    expect(first.sha256).toBe(second.sha256);
+  });
 });

--- a/packages/browser-bridge-extension/src/content-script-messaging.test.ts
+++ b/packages/browser-bridge-extension/src/content-script-messaging.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Deterministic tests for one-shot content-script transport recovery and
+ * duplicate-listener prevention on healthy pages.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertContentScriptPageUrl,
+  sendWithContentScriptRecovery,
+} from "./content-script-messaging";
+
+describe("assertContentScriptPageUrl", () => {
+  it("binds page access to the exact URL authorized by the service worker", () => {
+    expect(() =>
+      assertContentScriptPageUrl(
+        "https://allowed.example/form",
+        "https://allowed.example/form",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertContentScriptPageUrl(
+        "https://allowed.example/form",
+        "https://other.example/redirect",
+      ),
+    ).toThrow("page navigated after browser action authorization");
+  });
+});
+
+describe("sendWithContentScriptRecovery", () => {
+  it("does not reinject when the existing listener responds", async () => {
+    const send = vi.fn().mockResolvedValue({ ok: true });
+    const inject = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      sendWithContentScriptRecovery({ send, inject }),
+    ).resolves.toEqual({ ok: true });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("injects once after a missing receiver and retries the original message", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Receiving end does not exist"))
+      .mockResolvedValueOnce({ ok: true });
+    const inject = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      sendWithContentScriptRecovery({ send, inject }),
+    ).resolves.toEqual({ ok: true });
+    expect(inject).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the retry failure without an injection loop", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("blocked page"));
+    const inject = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      sendWithContentScriptRecovery({ send, inject }),
+    ).rejects.toThrow("blocked page");
+    expect(inject).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/browser-bridge-extension/src/content-script-messaging.ts
+++ b/packages/browser-bridge-extension/src/content-script-messaging.ts
@@ -1,0 +1,27 @@
+/**
+ * Recovers extension-to-page messaging after navigation or content-script
+ * eviction without reinjecting into healthy pages and duplicating listeners.
+ */
+export async function sendWithContentScriptRecovery<T>(args: {
+  send: () => Promise<T>;
+  inject: () => Promise<void>;
+}): Promise<T> {
+  try {
+    return await args.send();
+  } catch {
+    // error-policy:J1 Recover a missing content-script transport once, then surface retry failure.
+    await args.inject();
+    return await args.send();
+  }
+}
+
+export function assertContentScriptPageUrl(
+  expectedUrl: string,
+  currentUrl: string,
+): void {
+  if (currentUrl !== expectedUrl) {
+    throw new Error(
+      "The page navigated after browser action authorization; refusing to use the new page.",
+    );
+  }
+}

--- a/packages/browser-bridge-extension/src/dom-actions.test.ts
+++ b/packages/browser-bridge-extension/src/dom-actions.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for runDomAction over a jsdom DOM (test-dom-setup): click / type /
+ * submit behavior and handling of hostile input and invalid targets.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "./test-dom-setup";
+import { runDomAction } from "./dom-actions";
+
+describe("runDomAction", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("types into inputs and dispatches input/change events for hostile text literally", () => {
+    document.body.innerHTML = `<textarea id="target" name="message"></textarea>`;
+    const input = document.querySelector("#target") as HTMLTextAreaElement;
+    const events: string[] = [];
+    input.addEventListener("input", () => events.push("input"));
+    input.addEventListener("change", () => events.push("change"));
+
+    const text = `<img src=x onerror=alert(1)>\nhello`;
+    expect(runDomAction({ kind: "type", selector: "#target", text })).toEqual({
+      selector: "message",
+      valueLength: text.length,
+    });
+
+    expect(input.value).toBe(text);
+    expect(events).toEqual(["input", "change"]);
+  });
+
+  it("types into contenteditable elements without interpreting markup", () => {
+    document.body.innerHTML = `<div id="editor" contenteditable="true"></div>`;
+    const editor = document.querySelector("#editor") as HTMLElement;
+    Object.defineProperty(editor, "isContentEditable", {
+      configurable: true,
+      value: true,
+    });
+
+    runDomAction({
+      kind: "type",
+      selector: "#editor",
+      text: "<script>alert(1)</script>",
+    });
+
+    expect(editor.textContent).toBe("<script>alert(1)</script>");
+    expect(editor.innerHTML).not.toContain("<script>");
+  });
+
+  it("clicks enabled elements after scrolling them into view", () => {
+    document.body.innerHTML = `<button id="target" type="button">Run</button>`;
+    const button = document.querySelector("#target") as HTMLButtonElement;
+    Object.defineProperty(button, "scrollIntoView", {
+      configurable: true,
+      value: () => undefined,
+    });
+    const scrollIntoView = vi
+      .spyOn(button, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    const clicks: string[] = [];
+    button.addEventListener("click", () => clicks.push("clicked"));
+
+    expect(runDomAction({ kind: "click", selector: "#target" })).toEqual({
+      selector: "#target",
+      tagName: "button",
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "center",
+      inline: "center",
+    });
+    expect(clicks).toEqual(["clicked"]);
+  });
+
+  it("rejects invalid selectors, disabled controls, readonly inputs, and unsupported targets", () => {
+    document.body.innerHTML = [
+      `<button id="disabled" disabled>Disabled</button>`,
+      `<input id="readonly" readonly />`,
+      `<section id="plain"></section>`,
+    ].join("");
+
+    expect(() => runDomAction({ kind: "click", selector: "[" })).toThrow(
+      /Invalid selector/,
+    );
+    expect(() =>
+      runDomAction({ kind: "click", selector: "#disabled" }),
+    ).toThrow(/disabled/);
+    expect(() =>
+      runDomAction({ kind: "type", selector: "#readonly", text: "nope" }),
+    ).toThrow(/read-only/);
+    expect(() =>
+      runDomAction({ kind: "type", selector: "#plain", text: "nope" }),
+    ).toThrow(/does not support typing/);
+  });
+
+  it("submits the nearest form and reports the action URL", () => {
+    document.body.innerHTML = `
+      <form id="form" action="/submit">
+        <input id="field" name="field" />
+      </form>
+    `;
+    const form = document.querySelector("#form") as HTMLFormElement;
+    const requestSubmit = vi
+      .spyOn(form, "requestSubmit")
+      .mockImplementation(() => undefined);
+
+    expect(runDomAction({ kind: "submit", selector: "#field" })).toEqual({
+      action: "https://unit-test.local/submit",
+    });
+    expect(requestSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("routes history actions to browser history primitives", () => {
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const forward = vi
+      .spyOn(window.history, "forward")
+      .mockImplementation(() => {});
+
+    expect(runDomAction({ kind: "history_back" })).toEqual({
+      direction: "back",
+    });
+    expect(runDomAction({ kind: "history_forward" })).toEqual({
+      direction: "forward",
+    });
+    expect(back).toHaveBeenCalledOnce();
+    expect(forward).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/browser-bridge-extension/src/dom-actions.ts
+++ b/packages/browser-bridge-extension/src/dom-actions.ts
@@ -1,0 +1,126 @@
+/**
+ * Executes agent-directed DOM actions — click, type, submit, history
+ * back/forward — inside a page's content-script context. Because it acts on
+ * live untrusted pages, it validates selectors and refuses missing, non-element,
+ * or disabled targets before mutating anything.
+ */
+import type { DomActionRequest } from "./protocol";
+
+function requireElement(selector?: string | null): HTMLElement {
+  if (!selector) {
+    throw new Error("selector is required");
+  }
+  let element: Element | null;
+  try {
+    element = document.querySelector(selector);
+  } catch (error) {
+    // error-policy:J2 Preserve selector context when the DOM parser rejects it.
+    throw new Error(
+      `Invalid selector ${selector}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`No HTMLElement found for selector ${selector}`);
+  }
+  if (
+    (element instanceof HTMLButtonElement ||
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement ||
+      element instanceof HTMLTextAreaElement) &&
+    element.disabled
+  ) {
+    throw new Error(`Target element is disabled for selector ${selector}`);
+  }
+  if (typeof element.scrollIntoView === "function") {
+    element.scrollIntoView({ block: "center", inline: "center" });
+  }
+  return element;
+}
+
+function setElementText(
+  element: HTMLElement,
+  text: string,
+): Record<string, unknown> {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    if (element.readOnly) {
+      throw new Error("Target element is read-only");
+    }
+    element.focus();
+    element.value = text;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+    return {
+      selector: element.name || element.id || element.tagName.toLowerCase(),
+      valueLength: text.length,
+    };
+  }
+  if (element.isContentEditable) {
+    element.focus();
+    element.textContent = text;
+    element.dispatchEvent(
+      new InputEvent("input", { bubbles: true, data: text }),
+    );
+    return {
+      selector: element.id || element.tagName.toLowerCase(),
+      valueLength: text.length,
+    };
+  }
+  throw new Error("Target element does not support typing");
+}
+
+function submitElement(selector?: string | null): Record<string, unknown> {
+  const target = selector ? requireElement(selector) : null;
+  const form =
+    (target instanceof HTMLFormElement ? target : target?.closest("form")) ??
+    document.forms[0] ??
+    null;
+  if (!form) {
+    throw new Error("No form available to submit");
+  }
+  if (typeof form.requestSubmit === "function") {
+    form.requestSubmit();
+  } else {
+    form.submit();
+  }
+  return {
+    action: form.action || null,
+  };
+}
+
+export function runDomAction(
+  action: DomActionRequest,
+): Record<string, unknown> {
+  switch (action.kind) {
+    case "click": {
+      const element = requireElement(action.selector);
+      element.click();
+      return {
+        selector: action.selector ?? null,
+        tagName: element.tagName.toLowerCase(),
+      };
+    }
+    case "type": {
+      if (typeof action.text !== "string") {
+        throw new Error("text is required");
+      }
+      const element = requireElement(action.selector);
+      return setElementText(element, action.text);
+    }
+    case "submit":
+      return submitElement(action.selector);
+    case "history_back":
+      window.history.back();
+      return { direction: "back" };
+    case "history_forward":
+      window.history.forward();
+      return { direction: "forward" };
+    default:
+      throw new Error(
+        `Unsupported DOM action ${(action as { kind: string }).kind}`,
+      );
+  }
+}

--- a/packages/browser-bridge-extension/src/page-extract.test.ts
+++ b/packages/browser-bridge-extension/src/page-extract.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for capturePageContext over a jsdom DOM (test-dom-setup): field
+ * extraction, visibility filtering, and length caps.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./test-dom-setup";
+import { capturePageContext } from "./page-extract";
+
+describe("capturePageContext", () => {
+  beforeEach(() => {
+    document.title = "Unit page";
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("captures visible page context while excluding hidden/password fields", () => {
+    document.body.innerHTML = `
+      <main>
+        <h1>Account Settings</h1>
+        <p>Visible text   with spacing.</p>
+        <p style="display: none">Hidden text should not leak.</p>
+        <a href="/next">Next page</a>
+        <form action="/save">
+          <input name="email" />
+          <input type="password" name="password" />
+          <input type="hidden" name="csrf" />
+          <textarea aria-label="Notes"></textarea>
+        </form>
+      </main>
+    `;
+
+    const snapshot = capturePageContext();
+
+    expect(snapshot).toMatchObject({
+      url: "https://unit-test.local/",
+      title: "Unit page",
+      headings: ["Account Settings"],
+      links: [{ text: "Next page", href: "https://unit-test.local/next" }],
+      forms: [
+        {
+          action: "https://unit-test.local/save",
+          fields: ["email", "Notes"],
+        },
+      ],
+      capturedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(snapshot.mainText).toContain("Visible text with spacing.");
+    expect(snapshot.mainText).not.toContain("Hidden text");
+  });
+
+  it("normalizes script-like text as text without executing or exposing hidden fields", () => {
+    document.body.innerHTML = `
+      <h2>Search</h2>
+      <p>&lt;script&gt;alert(1)&lt;/script&gt;</p>
+      <form>
+        <input id="visible-query" />
+        <input type="hidden" id="internal-token" />
+      </form>
+    `;
+
+    const snapshot = capturePageContext();
+
+    expect(snapshot.mainText).toContain("<script>alert(1)</script>");
+    expect(snapshot.forms[0]?.fields).toEqual(["visible-query"]);
+  });
+
+  it("does not leak text or field names hidden by an ancestor", () => {
+    document.body.innerHTML = `
+      <section>
+        <p>Visible account copy.</p>
+        <div style="display: none">
+          <p>Nested hidden recovery code.</p>
+          <form action="/hidden">
+            <input name="hidden-email" />
+          </form>
+        </div>
+        <form action="/visible">
+          <div style="visibility: hidden">
+            <input name="shadow-token" />
+          </div>
+          <input name="visible-email" />
+        </form>
+      </section>
+    `;
+
+    const snapshot = capturePageContext();
+
+    expect(snapshot.mainText).toContain("Visible account copy.");
+    expect(snapshot.mainText).not.toContain("Nested hidden recovery code");
+    expect(snapshot.forms).toContainEqual({
+      action: "https://unit-test.local/visible",
+      fields: ["visible-email"],
+    });
+    expect(JSON.stringify(snapshot.forms)).not.toContain("hidden-email");
+    expect(JSON.stringify(snapshot.forms)).not.toContain("shadow-token");
+  });
+
+  it("bounds large text, heading, link, and form collections", () => {
+    document.body.innerHTML = [
+      ...Array.from({ length: 20 }, (_, index) => `<h1>Heading ${index}</h1>`),
+      ...Array.from(
+        { length: 50 },
+        (_, index) => `<a href="/${index}">Link ${index}</a>`,
+      ),
+      ...Array.from(
+        { length: 15 },
+        (_, index) =>
+          `<form action="/${index}"><input name="field-${index}" /></form>`,
+      ),
+      `<p>${"x".repeat(13_000)}</p>`,
+    ].join("");
+
+    const snapshot = capturePageContext();
+
+    expect(snapshot.headings).toHaveLength(12);
+    expect(snapshot.links).toHaveLength(40);
+    expect(snapshot.forms).toHaveLength(10);
+    expect(snapshot.mainText?.length).toBeLessThanOrEqual(12_000);
+  });
+});

--- a/packages/browser-bridge-extension/src/page-extract.ts
+++ b/packages/browser-bridge-extension/src/page-extract.ts
@@ -1,0 +1,133 @@
+/**
+ * capturePageContext() — snapshots the live DOM (title, visible text, headings,
+ * links, forms) so the agent can read the current page. Runs in the
+ * content-script context; every field is whitespace-normalized and length-capped
+ * so a large page cannot bloat the sync payload.
+ */
+import type { PageContextSnapshot } from "./protocol";
+
+function normalizeText(
+  value: string | null | undefined,
+  maxLength: number,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  return normalized.slice(0, maxLength);
+}
+
+function isVisible(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  let current: HTMLElement | null = element;
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.opacity === "0"
+    ) {
+      return false;
+    }
+    current = current.parentElement;
+  }
+  return true;
+}
+
+function collectVisibleText(maxLength: number): string | null {
+  if (!document.body) {
+    return null;
+  }
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const parts: string[] = [];
+  let currentLength = 0;
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode;
+    const parent = textNode.parentElement;
+    if (!parent || !isVisible(parent)) {
+      continue;
+    }
+    const nextText = normalizeText(textNode.textContent, 500);
+    if (!nextText) {
+      continue;
+    }
+    parts.push(nextText);
+    currentLength += nextText.length + 1;
+    if (currentLength >= maxLength) {
+      break;
+    }
+  }
+  return normalizeText(parts.join(" "), maxLength);
+}
+
+function collectHeadings(): string[] {
+  return Array.from(document.querySelectorAll("h1, h2, h3"))
+    .map((heading) => normalizeText(heading.textContent, 200))
+    .filter((value): value is string => Boolean(value))
+    .slice(0, 12);
+}
+
+function collectLinks(): Array<{ text: string; href: string }> {
+  return Array.from(document.querySelectorAll("a[href]"))
+    .map((link) => ({
+      text: normalizeText(link.textContent, 160) ?? "",
+      href: link instanceof HTMLAnchorElement ? link.href : "",
+    }))
+    .filter((link) => link.href.length > 0)
+    .slice(0, 40);
+}
+
+function collectForms(): Array<{ action: string | null; fields: string[] }> {
+  return Array.from(document.forms)
+    .map((form) => {
+      const fields = Array.from(form.elements)
+        .map((element) => {
+          if (
+            !(
+              element instanceof HTMLInputElement ||
+              element instanceof HTMLTextAreaElement ||
+              element instanceof HTMLSelectElement
+            )
+          ) {
+            return null;
+          }
+          if (!isVisible(element)) {
+            return null;
+          }
+          if (
+            element instanceof HTMLInputElement &&
+            (element.type === "password" || element.type === "hidden")
+          ) {
+            return null;
+          }
+          return normalizeText(
+            element.name || element.id || element.getAttribute("aria-label"),
+            120,
+          );
+        })
+        .filter((value): value is string => Boolean(value));
+      return {
+        action: normalizeText(form.action, 500),
+        fields: fields.slice(0, 20),
+      };
+    })
+    .slice(0, 10);
+}
+
+export function capturePageContext(): PageContextSnapshot {
+  return {
+    url: window.location.href,
+    title: document.title || window.location.href,
+    selectionText: normalizeText(window.getSelection?.()?.toString(), 2000),
+    mainText: collectVisibleText(12000),
+    headings: collectHeadings(),
+    links: collectLinks(),
+    forms: collectForms(),
+    capturedAt: new Date().toISOString(),
+  };
+}

--- a/packages/browser-bridge-extension/src/popup-markup.test.ts
+++ b/packages/browser-bridge-extension/src/popup-markup.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Static DOM contract for the minimal default surface and transient, collapsed
+ * pairing recovery path; stored credentials have no field or value to render.
+ */
+import { readFile } from "node:fs/promises";
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+async function loadPopupDocument(): Promise<Document> {
+  const html = await readFile(
+    new URL("../public/popup.html", import.meta.url),
+    "utf8",
+  );
+  return new JSDOM(html).window.document;
+}
+
+describe("popup markup", () => {
+  it("has one hidden default action and collapsed native details", async () => {
+    const document = await loadPopupDocument();
+    const actions = [...document.querySelectorAll("#primaryAction")];
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.hasAttribute("hidden")).toBe(true);
+    expect(document.querySelector("#details")?.tagName).toBe("DETAILS");
+    expect(document.querySelector("#details")?.hasAttribute("open")).toBe(
+      false,
+    );
+    expect(document.querySelector("#recovery")?.hasAttribute("open")).toBe(
+      false,
+    );
+  });
+
+  it("contains no stored-secret fields or prepopulated recovery value", async () => {
+    const document = await loadPopupDocument();
+    expect(document.querySelector("input[type='password']")).toBeNull();
+    expect(document.querySelector("#pairingToken")).toBeNull();
+    expect(document.querySelector("#companionId")).toBeNull();
+    expect(document.querySelector("#apiBaseUrl")).toBeNull();
+    const recovery =
+      document.querySelector<HTMLTextAreaElement>("#pairingJson");
+    expect(recovery?.value).toBe("");
+    expect(recovery?.closest("details")?.hasAttribute("open")).toBe(false);
+  });
+
+  it("announces the atomic one-line status", async () => {
+    const status = (await loadPopupDocument()).querySelector("#statusTitle");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.getAttribute("aria-atomic")).toBe("true");
+  });
+});

--- a/packages/browser-bridge-extension/src/popup-model.test.ts
+++ b/packages/browser-bridge-extension/src/popup-model.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for derivePopupStatusModel across the connection states; pure
+ * model, no browser environment.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { derivePopupStatusModel } from "./popup-model";
+import type { BackgroundState } from "./protocol";
+
+function baseState(overrides: Partial<BackgroundState> = {}): BackgroundState {
+  return {
+    config: null,
+    settings: null,
+    syncing: false,
+    lastSyncAt: null,
+    lastError: null,
+    lastSessionStatus: null,
+    activeSessionId: null,
+    rememberedTabCount: 0,
+    settingsSummary: null,
+    ...overrides,
+  };
+}
+
+const config = {
+  apiBaseUrl: "https://agent.example.com",
+  companionId: "companion-1",
+  pairingToken: "pairing-token",
+  pairingTokenExpiresAt: null,
+  browser: "chrome" as const,
+  profileId: "default",
+  profileLabel: "Default",
+  label: "Agent Browser Bridge chrome Default",
+};
+
+const enabledSettings = {
+  enabled: true,
+  trackingMode: "active_tabs" as const,
+  allowBrowserControl: true,
+  pauseUntil: null,
+};
+
+describe("derivePopupStatusModel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prioritizes syncing and error states over connection details", () => {
+    expect(
+      derivePopupStatusModel({
+        state: baseState({ config, settings: enabledSettings, syncing: true }),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({
+      kind: "syncing",
+      primaryAction: "sync",
+      showSync: true,
+    });
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState({
+          config,
+          settings: enabledSettings,
+          lastError: "Pairing expired",
+        }),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({
+      kind: "error",
+      detail: "Pairing expired",
+      primaryAction: "sync",
+      showSync: true,
+    });
+  });
+
+  it("classifies connected, control-off, disabled, paused, pairing, and missing-app states", () => {
+    expect(
+      derivePopupStatusModel({
+        state: baseState({ config, settings: enabledSettings }),
+        discoveredApiBaseUrl: null,
+      }).kind,
+    ).toBe("connected");
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState({
+          config,
+          settings: { ...enabledSettings, allowBrowserControl: false },
+        }),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({ kind: "needs_settings", badge: "Control Off" });
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState({
+          config,
+          settings: { ...enabledSettings, enabled: false },
+        }),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({ kind: "needs_settings", badge: "Access Off" });
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState({
+          config,
+          settings: {
+            ...enabledSettings,
+            pauseUntil: "2026-01-01T13:00:00.000Z",
+          },
+        }),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({ kind: "needs_settings", badge: "Paused" });
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState(),
+        discoveredApiBaseUrl: "http://127.0.0.1:2138",
+      }),
+    ).toMatchObject({
+      kind: "needs_pairing",
+      primaryAction: "manual_pair",
+      primaryLabel: "Import Pairing JSON",
+      showSync: false,
+    });
+
+    expect(
+      derivePopupStatusModel({
+        state: baseState(),
+        discoveredApiBaseUrl: null,
+      }),
+    ).toMatchObject({
+      kind: "needs_app",
+      primaryAction: "manual_pair",
+      primaryLabel: "Import Pairing JSON",
+      showSync: false,
+    });
+  });
+
+  it("summarizes configured or discovered app, sync time, tab count, and mode", () => {
+    const model = derivePopupStatusModel({
+      state: baseState({
+        config,
+        settings: enabledSettings,
+        lastSyncAt: "2026-01-01T11:59:00.000Z",
+        rememberedTabCount: 3,
+        settingsSummary: "Active tabs",
+      }),
+      discoveredApiBaseUrl: "http://127.0.0.1:2138",
+    });
+
+    expect(model.summary).toEqual(
+      expect.arrayContaining([
+        "App: https://agent.example.com",
+        "Remembered tabs: 3",
+        "Mode: Active tabs",
+      ]),
+    );
+    expect(model.summary.some((entry) => entry.startsWith("Last sync: "))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/browser-bridge-extension/src/popup-model.test.ts
+++ b/packages/browser-bridge-extension/src/popup-model.test.ts
@@ -1,8 +1,9 @@
 /**
- * Unit tests for derivePopupStatusModel across the connection states; pure
- * model, no browser environment.
+ * Unit coverage for every compact popup state, including the invariant that
+ * the default surface exposes no more than one contextual action.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
 import { derivePopupStatusModel } from "./popup-model";
 import type { BackgroundState } from "./protocol";
 
@@ -24,20 +25,42 @@ function baseState(overrides: Partial<BackgroundState> = {}): BackgroundState {
 const config = {
   apiBaseUrl: "https://agent.example.com",
   companionId: "companion-1",
-  pairingToken: "pairing-token",
+  pairingToken: "pairing-token-must-not-render",
   pairingTokenExpiresAt: null,
   browser: "chrome" as const,
   profileId: "default",
   profileLabel: "Default",
-  label: "Agent Browser Bridge chrome Default",
+  label: "Eliza Browser chrome Default",
 };
 
-const enabledSettings = {
+const enabledSettings: BrowserBridgeSettings = {
   enabled: true,
-  trackingMode: "active_tabs" as const,
+  trackingMode: "active_tabs",
   allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "granted_sites",
+  grantedOrigins: [],
+  blockedOrigins: [],
+  maxRememberedTabs: 10,
   pauseUntil: null,
+  metadata: {},
+  updatedAt: null,
 };
+
+function derive(
+  state: BackgroundState,
+  options: {
+    discoveredApiBaseUrl?: string | null;
+    hasAllWebsiteAccess?: boolean;
+  } = {},
+) {
+  return derivePopupStatusModel({
+    state,
+    discoveredApiBaseUrl: options.discoveredApiBaseUrl ?? null,
+    hasAllWebsiteAccess: options.hasAllWebsiteAccess ?? false,
+  });
+}
 
 describe("derivePopupStatusModel", () => {
   beforeEach(() => {
@@ -45,126 +68,104 @@ describe("derivePopupStatusModel", () => {
     vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps every default state to zero or one contextual action", () => {
+    const views = [
+      derive(baseState({ syncing: true })),
+      derive(baseState()),
+      derive(baseState(), { discoveredApiBaseUrl: "http://127.0.0.1:2138" }),
+      derive(baseState({ config, lastError: "Pairing expired" })),
+      derive(baseState({ config })),
+      derive(baseState({ config, settings: enabledSettings })),
+      derive(
+        baseState({
+          config,
+          settings: { ...enabledSettings, siteAccessMode: "all_sites" },
+        }),
+      ),
+    ];
+    for (const view of views) {
+      expect(view.action === null ? 0 : 1).toBeLessThanOrEqual(1);
+    }
   });
 
-  it("prioritizes syncing and error states over connection details", () => {
-    expect(
-      derivePopupStatusModel({
-        state: baseState({ config, settings: enabledSettings, syncing: true }),
-        discoveredApiBaseUrl: null,
-      }),
-    ).toMatchObject({
-      kind: "syncing",
-      primaryAction: "sync",
-      showSync: true,
+  it("uses pairing recovery only when configuration is missing", () => {
+    expect(derive(baseState())).toMatchObject({
+      kind: "needs_app",
+      action: { kind: "show_recovery", label: "Pair this browser" },
     });
-
     expect(
-      derivePopupStatusModel({
-        state: baseState({
-          config,
-          settings: enabledSettings,
-          lastError: "Pairing expired",
-        }),
-        discoveredApiBaseUrl: null,
-      }),
+      derive(baseState(), { discoveredApiBaseUrl: "http://127.0.0.1:2138" }),
+    ).toMatchObject({
+      kind: "needs_settings",
+      action: { kind: "show_recovery", label: "Pair this browser" },
+    });
+    expect(
+      derive(baseState({ config, settings: enabledSettings })).action,
+    ).toBeNull();
+  });
+
+  it("shows website access only when all-sites mode needs it", () => {
+    const state = baseState({
+      config,
+      settings: { ...enabledSettings, siteAccessMode: "all_sites" },
+    });
+    expect(derive(state)).toMatchObject({
+      kind: "needs_permission",
+      action: { kind: "grant_website_access" },
+    });
+    expect(derive(state, { hasAllWebsiteAccess: true })).toMatchObject({
+      kind: "connected",
+      action: null,
+    });
+    expect(
+      derive(baseState({ config, settings: enabledSettings })).action,
+    ).toBeNull();
+  });
+
+  it("renders paused, disabled, control-off, retry, and connected states", () => {
+    for (const settings of [
+      { ...enabledSettings, pauseUntil: "2026-01-01T13:00:00.000Z" },
+      { ...enabledSettings, enabled: false },
+      { ...enabledSettings, allowBrowserControl: false },
+    ]) {
+      expect(derive(baseState({ config, settings }))).toMatchObject({
+        kind: "needs_settings",
+        action: null,
+      });
+    }
+    expect(
+      derive(baseState({ config, lastError: "Pairing expired" })),
     ).toMatchObject({
       kind: "error",
-      detail: "Pairing expired",
-      primaryAction: "sync",
-      showSync: true,
+      action: { kind: "sync", label: "Retry connection" },
+    });
+    expect(
+      derive(baseState({ config, settings: enabledSettings })),
+    ).toMatchObject({
+      kind: "connected",
+      label: "Connected to Eliza",
+      action: null,
     });
   });
 
-  it("classifies connected, control-off, disabled, paused, pairing, and missing-app states", () => {
-    expect(
-      derivePopupStatusModel({
-        state: baseState({ config, settings: enabledSettings }),
-        discoveredApiBaseUrl: null,
-      }).kind,
-    ).toBe("connected");
-
-    expect(
-      derivePopupStatusModel({
-        state: baseState({
-          config,
-          settings: { ...enabledSettings, allowBrowserControl: false },
-        }),
-        discoveredApiBaseUrl: null,
-      }),
-    ).toMatchObject({ kind: "needs_settings", badge: "Control Off" });
-
-    expect(
-      derivePopupStatusModel({
-        state: baseState({
-          config,
-          settings: { ...enabledSettings, enabled: false },
-        }),
-        discoveredApiBaseUrl: null,
-      }),
-    ).toMatchObject({ kind: "needs_settings", badge: "Access Off" });
-
-    expect(
-      derivePopupStatusModel({
-        state: baseState({
-          config,
-          settings: {
-            ...enabledSettings,
-            pauseUntil: "2026-01-01T13:00:00.000Z",
-          },
-        }),
-        discoveredApiBaseUrl: null,
-      }),
-    ).toMatchObject({ kind: "needs_settings", badge: "Paused" });
-
-    expect(
-      derivePopupStatusModel({
-        state: baseState(),
-        discoveredApiBaseUrl: "http://127.0.0.1:2138",
-      }),
-    ).toMatchObject({
-      kind: "needs_pairing",
-      primaryAction: "manual_pair",
-      primaryLabel: "Import Pairing JSON",
-      showSync: false,
-    });
-
-    expect(
-      derivePopupStatusModel({
-        state: baseState(),
-        discoveredApiBaseUrl: null,
-      }),
-    ).toMatchObject({
-      kind: "needs_app",
-      primaryAction: "manual_pair",
-      primaryLabel: "Import Pairing JSON",
-      showSync: false,
-    });
-  });
-
-  it("summarizes configured or discovered app, sync time, tab count, and mode", () => {
-    const model = derivePopupStatusModel({
-      state: baseState({
+  it("never copies pairing credentials into diagnostics", () => {
+    const view = derive(
+      baseState({
         config,
         settings: enabledSettings,
         lastSyncAt: "2026-01-01T11:59:00.000Z",
         rememberedTabCount: 3,
         settingsSummary: "Active tabs",
       }),
-      discoveredApiBaseUrl: "http://127.0.0.1:2138",
+    );
+    expect(view.diagnostics).toMatchObject({
+      app: "https://agent.example.com",
+      mode: "Active tabs",
+      tabCount: "3",
     });
-
-    expect(model.summary).toEqual(
-      expect.arrayContaining([
-        "App: https://agent.example.com",
-        "Remembered tabs: 3",
-        "Mode: Active tabs",
-      ]),
-    );
-    expect(model.summary.some((entry) => entry.startsWith("Last sync: "))).toBe(
-      true,
-    );
+    expect(JSON.stringify(view)).not.toContain(config.pairingToken);
+    expect(JSON.stringify(view)).not.toContain(config.companionId);
   });
 });

--- a/packages/browser-bridge-extension/src/popup-model.ts
+++ b/packages/browser-bridge-extension/src/popup-model.ts
@@ -1,0 +1,224 @@
+/**
+ * Pure derivation of the popup's status model from BackgroundState — badge,
+ * title, checklist, and which primary action (manual pairing vs sync) to offer for
+ * each connection state. Keeps popup.ts free of branching and makes the
+ * connected / needs-pairing / error states unit-testable in isolation.
+ */
+import type { BackgroundState } from "./protocol";
+
+export type PopupStatusKind =
+  | "connected"
+  | "needs_app"
+  | "needs_pairing"
+  | "needs_settings"
+  | "syncing"
+  | "error";
+
+export interface PopupStatusModel {
+  kind: PopupStatusKind;
+  badge: string;
+  title: string;
+  detail: string;
+  checklist: string[];
+  primaryAction: "manual_pair" | "sync";
+  primaryLabel: string;
+  showSync: boolean;
+  summary: string[];
+}
+
+function isFutureIso(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && parsed > Date.now();
+}
+
+function formatClock(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return new Date(parsed).toLocaleTimeString();
+}
+
+export function derivePopupStatusModel(args: {
+  state: BackgroundState;
+  discoveredApiBaseUrl: string | null;
+}): PopupStatusModel {
+  const { state, discoveredApiBaseUrl } = args;
+  const settings = state.settings;
+  const hasConfig = Boolean(state.config);
+  const browserEnabled = Boolean(settings?.enabled);
+  const trackingEnabled = settings ? settings.trackingMode !== "off" : false;
+  const paused = isFutureIso(settings?.pauseUntil ?? null);
+  const controlEnabled = Boolean(settings?.allowBrowserControl);
+  const lastSync = formatClock(state.lastSyncAt);
+  const summary = [
+    state.config?.apiBaseUrl
+      ? `App: ${state.config.apiBaseUrl}`
+      : discoveredApiBaseUrl
+        ? `App: ${discoveredApiBaseUrl}`
+        : "App: not found yet",
+    lastSync ? `Last sync: ${lastSync}` : null,
+    `Remembered tabs: ${state.rememberedTabCount}`,
+    state.settingsSummary ? `Mode: ${state.settingsSummary}` : null,
+  ].filter((entry): entry is string => Boolean(entry));
+
+  if (state.syncing) {
+    return {
+      kind: "syncing",
+      badge: "Syncing",
+      title: "Checking this browser",
+      detail:
+        "Agent Browser Bridge is syncing tabs and permissions so Eliza can see the latest browser state.",
+      checklist: [
+        "Keep this browser open.",
+        "If you are pairing for the first time, leave Eliza open in this same profile.",
+      ],
+      primaryAction: "sync",
+      primaryLabel: "Syncing…",
+      showSync: true,
+      summary,
+    };
+  }
+
+  if (state.lastError) {
+    return {
+      kind: "error",
+      badge: "Attention",
+      title: "This browser needs attention",
+      detail: state.lastError,
+      checklist: [
+        "Try syncing this browser again.",
+        "If pairing expired, create a new pairing in Eliza and import its pairing JSON.",
+      ],
+      primaryAction: hasConfig ? "sync" : "manual_pair",
+      primaryLabel: hasConfig ? "Sync This Browser" : "Import Pairing JSON",
+      showSync: hasConfig,
+      summary,
+    };
+  }
+
+  if (hasConfig && settings && browserEnabled && trackingEnabled && !paused) {
+    if (!controlEnabled) {
+      return {
+        kind: "needs_settings",
+        badge: "Control Off",
+        title: "This browser is connected, but browser control is off",
+        detail:
+          "Eliza can see this browser profile, but it cannot open sites or focus tabs for you until Browser control is enabled.",
+        checklist: [
+          "Turn on Browser control in Browser setup if you want automatic site opening.",
+          "Keep it off only if you are willing to open and focus the target tab manually.",
+        ],
+        primaryAction: "sync",
+        primaryLabel: "Sync This Browser",
+        showSync: true,
+        summary,
+      };
+    }
+
+    return {
+      kind: "connected",
+      badge: "Connected",
+      title: "This browser is connected to Eliza",
+      detail:
+        "Eliza can read and control the tabs allowed by your Browser settings in this profile.",
+      checklist: [
+        "Open an account-backed site in this same profile.",
+        "Use Browser settings in Eliza to verify what this browser is sharing right now.",
+      ],
+      primaryAction: "sync",
+      primaryLabel: "Sync This Browser",
+      showSync: true,
+      summary,
+    };
+  }
+
+  if (
+    hasConfig &&
+    settings &&
+    (!browserEnabled || !trackingEnabled || paused)
+  ) {
+    return {
+      kind: "needs_settings",
+      badge: paused ? "Paused" : "Access Off",
+      title: paused
+        ? "Browser access is paused"
+        : "This browser is paired, but Agent Browser Bridge access is off",
+      detail: paused
+        ? "Eliza is paired to this browser, but Browser access is paused right now."
+        : "Turn Browser access back on in Eliza so enabled connectors can see this profile again.",
+      checklist: paused
+        ? [
+            "Clear Pause until in Browser setup, or wait for it to expire.",
+            "Then sync this browser again.",
+          ]
+        : [
+            "Turn on Enabled and choose Current tab or Active tabs in Browser setup.",
+            "Then sync this browser again.",
+          ],
+      primaryAction: "sync",
+      primaryLabel: "Sync This Browser",
+      showSync: true,
+      summary,
+    };
+  }
+
+  if (!hasConfig && discoveredApiBaseUrl) {
+    return {
+      kind: "needs_pairing",
+      badge: "Ready",
+      title: "Eliza is open in this browser profile",
+      detail:
+        "This browser found a live Eliza app. Create an authenticated pairing in Eliza, then import its pairing JSON here.",
+      checklist: [
+        "Create a browser companion pairing in Eliza's Browser settings.",
+        "Copy its pairing JSON, then import it in this extension.",
+      ],
+      primaryAction: "manual_pair",
+      primaryLabel: "Import Pairing JSON",
+      showSync: false,
+      summary,
+    };
+  }
+
+  if (!hasConfig) {
+    return {
+      kind: "needs_app",
+      badge: "Waiting",
+      title: "Open Eliza in this browser profile",
+      detail:
+        "Open Eliza, create an authenticated browser companion pairing, then import its pairing JSON in this extension.",
+      checklist: [
+        "Open Eliza in this browser profile.",
+        "Create and copy a pairing JSON object from Browser settings.",
+        "Return here and import it.",
+      ],
+      primaryAction: "manual_pair",
+      primaryLabel: "Import Pairing JSON",
+      showSync: false,
+      summary,
+    };
+  }
+
+  return {
+    kind: "error",
+    badge: "Attention",
+    title: "This browser needs attention",
+    detail:
+      "The browser is paired, but Agent Browser Bridge could not confirm a healthy connection yet.",
+    checklist: [
+      "Try syncing this browser again.",
+      "If pairing expired, create a new pairing in Eliza and import its pairing JSON.",
+    ],
+    primaryAction: "sync",
+    primaryLabel: "Sync This Browser",
+    showSync: true,
+    summary,
+  };
+}

--- a/packages/browser-bridge-extension/src/popup-model.ts
+++ b/packages/browser-bridge-extension/src/popup-model.ts
@@ -1,224 +1,126 @@
 /**
- * Pure derivation of the popup's status model from BackgroundState — badge,
- * title, checklist, and which primary action (manual pairing vs sync) to offer for
- * each connection state. Keeps popup.ts free of branching and makes the
- * connected / needs-pairing / error states unit-testable in isolation.
+ * Derives the compact popup status and its sole contextual action from the
+ * background connection state. Diagnostics are intentionally non-secret and
+ * remain separate from the default one-line status surface.
  */
 import type { BackgroundState } from "./protocol";
 
 export type PopupStatusKind =
   | "connected"
   | "needs_app"
-  | "needs_pairing"
   | "needs_settings"
+  | "needs_permission"
   | "syncing"
   | "error";
 
+export type PopupContextualAction =
+  | "show_recovery"
+  | "sync"
+  | "grant_website_access";
+
 export interface PopupStatusModel {
   kind: PopupStatusKind;
-  badge: string;
-  title: string;
-  detail: string;
-  checklist: string[];
-  primaryAction: "manual_pair" | "sync";
-  primaryLabel: string;
-  showSync: boolean;
-  summary: string[];
+  label: string;
+  action: { kind: PopupContextualAction; label: string } | null;
+  diagnostics: {
+    app: string;
+    lastSync: string;
+    mode: string;
+    tabCount: string;
+  };
+  showDisconnect: boolean;
 }
 
 function isFutureIso(value: string | null | undefined): boolean {
-  if (!value) {
-    return false;
-  }
+  if (!value) return false;
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) && parsed > Date.now();
 }
 
-function formatClock(value: string | null): string | null {
-  if (!value) {
-    return null;
-  }
+function formatClock(value: string | null): string {
+  if (!value) return "Not yet";
   const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) {
-    return null;
-  }
-  return new Date(parsed).toLocaleTimeString();
+  return Number.isFinite(parsed)
+    ? new Date(parsed).toLocaleTimeString()
+    : "Not available";
 }
 
 export function derivePopupStatusModel(args: {
   state: BackgroundState;
   discoveredApiBaseUrl: string | null;
+  hasAllWebsiteAccess: boolean;
 }): PopupStatusModel {
-  const { state, discoveredApiBaseUrl } = args;
+  const { state, discoveredApiBaseUrl, hasAllWebsiteAccess } = args;
   const settings = state.settings;
   const hasConfig = Boolean(state.config);
-  const browserEnabled = Boolean(settings?.enabled);
-  const trackingEnabled = settings ? settings.trackingMode !== "off" : false;
-  const paused = isFutureIso(settings?.pauseUntil ?? null);
-  const controlEnabled = Boolean(settings?.allowBrowserControl);
-  const lastSync = formatClock(state.lastSyncAt);
-  const summary = [
-    state.config?.apiBaseUrl
-      ? `App: ${state.config.apiBaseUrl}`
-      : discoveredApiBaseUrl
-        ? `App: ${discoveredApiBaseUrl}`
-        : "App: not found yet",
-    lastSync ? `Last sync: ${lastSync}` : null,
-    `Remembered tabs: ${state.rememberedTabCount}`,
-    state.settingsSummary ? `Mode: ${state.settingsSummary}` : null,
-  ].filter((entry): entry is string => Boolean(entry));
+  const diagnostics = {
+    app: state.config?.apiBaseUrl ?? discoveredApiBaseUrl ?? "Not found",
+    lastSync: formatClock(state.lastSyncAt),
+    mode: state.settingsSummary ?? "Not available",
+    tabCount: String(state.rememberedTabCount),
+  };
+  const model = (
+    kind: PopupStatusKind,
+    label: string,
+    action: PopupStatusModel["action"] = null,
+  ): PopupStatusModel => ({
+    kind,
+    label,
+    action,
+    diagnostics,
+    showDisconnect: hasConfig,
+  });
 
   if (state.syncing) {
-    return {
-      kind: "syncing",
-      badge: "Syncing",
-      title: "Checking this browser",
-      detail:
-        "Agent Browser Bridge is syncing tabs and permissions so Eliza can see the latest browser state.",
-      checklist: [
-        "Keep this browser open.",
-        "If you are pairing for the first time, leave Eliza open in this same profile.",
-      ],
-      primaryAction: "sync",
-      primaryLabel: "Syncing…",
-      showSync: true,
-      summary,
-    };
-  }
-
-  if (state.lastError) {
-    return {
-      kind: "error",
-      badge: "Attention",
-      title: "This browser needs attention",
-      detail: state.lastError,
-      checklist: [
-        "Try syncing this browser again.",
-        "If pairing expired, create a new pairing in Eliza and import its pairing JSON.",
-      ],
-      primaryAction: hasConfig ? "sync" : "manual_pair",
-      primaryLabel: hasConfig ? "Sync This Browser" : "Import Pairing JSON",
-      showSync: hasConfig,
-      summary,
-    };
-  }
-
-  if (hasConfig && settings && browserEnabled && trackingEnabled && !paused) {
-    if (!controlEnabled) {
-      return {
-        kind: "needs_settings",
-        badge: "Control Off",
-        title: "This browser is connected, but browser control is off",
-        detail:
-          "Eliza can see this browser profile, but it cannot open sites or focus tabs for you until Browser control is enabled.",
-        checklist: [
-          "Turn on Browser control in Browser setup if you want automatic site opening.",
-          "Keep it off only if you are willing to open and focus the target tab manually.",
-        ],
-        primaryAction: "sync",
-        primaryLabel: "Sync This Browser",
-        showSync: true,
-        summary,
-      };
-    }
-
-    return {
-      kind: "connected",
-      badge: "Connected",
-      title: "This browser is connected to Eliza",
-      detail:
-        "Eliza can read and control the tabs allowed by your Browser settings in this profile.",
-      checklist: [
-        "Open an account-backed site in this same profile.",
-        "Use Browser settings in Eliza to verify what this browser is sharing right now.",
-      ],
-      primaryAction: "sync",
-      primaryLabel: "Sync This Browser",
-      showSync: true,
-      summary,
-    };
-  }
-
-  if (
-    hasConfig &&
-    settings &&
-    (!browserEnabled || !trackingEnabled || paused)
-  ) {
-    return {
-      kind: "needs_settings",
-      badge: paused ? "Paused" : "Access Off",
-      title: paused
-        ? "Browser access is paused"
-        : "This browser is paired, but Agent Browser Bridge access is off",
-      detail: paused
-        ? "Eliza is paired to this browser, but Browser access is paused right now."
-        : "Turn Browser access back on in Eliza so enabled connectors can see this profile again.",
-      checklist: paused
-        ? [
-            "Clear Pause until in Browser setup, or wait for it to expire.",
-            "Then sync this browser again.",
-          ]
-        : [
-            "Turn on Enabled and choose Current tab or Active tabs in Browser setup.",
-            "Then sync this browser again.",
-          ],
-      primaryAction: "sync",
-      primaryLabel: "Sync This Browser",
-      showSync: true,
-      summary,
-    };
-  }
-
-  if (!hasConfig && discoveredApiBaseUrl) {
-    return {
-      kind: "needs_pairing",
-      badge: "Ready",
-      title: "Eliza is open in this browser profile",
-      detail:
-        "This browser found a live Eliza app. Create an authenticated pairing in Eliza, then import its pairing JSON here.",
-      checklist: [
-        "Create a browser companion pairing in Eliza's Browser settings.",
-        "Copy its pairing JSON, then import it in this extension.",
-      ],
-      primaryAction: "manual_pair",
-      primaryLabel: "Import Pairing JSON",
-      showSync: false,
-      summary,
-    };
+    return model("syncing", "Connecting to Eliza…");
   }
 
   if (!hasConfig) {
-    return {
-      kind: "needs_app",
-      badge: "Waiting",
-      title: "Open Eliza in this browser profile",
-      detail:
-        "Open Eliza, create an authenticated browser companion pairing, then import its pairing JSON in this extension.",
-      checklist: [
-        "Open Eliza in this browser profile.",
-        "Create and copy a pairing JSON object from Browser settings.",
-        "Return here and import it.",
-      ],
-      primaryAction: "manual_pair",
-      primaryLabel: "Import Pairing JSON",
-      showSync: false,
-      summary,
-    };
+    if (discoveredApiBaseUrl) {
+      return model(
+        state.lastError ? "error" : "needs_settings",
+        state.lastError ? "Pairing needs attention" : "Eliza is ready to pair",
+        { kind: "show_recovery", label: "Pair this browser" },
+      );
+    }
+    return model("needs_app", "Open Eliza, then pair this browser", {
+      kind: "show_recovery",
+      label: "Pair this browser",
+    });
   }
 
-  return {
-    kind: "error",
-    badge: "Attention",
-    title: "This browser needs attention",
-    detail:
-      "The browser is paired, but Agent Browser Bridge could not confirm a healthy connection yet.",
-    checklist: [
-      "Try syncing this browser again.",
-      "If pairing expired, create a new pairing in Eliza and import its pairing JSON.",
-    ],
-    primaryAction: "sync",
-    primaryLabel: "Sync This Browser",
-    showSync: true,
-    summary,
-  };
+  if (state.lastError) {
+    return model("error", "Connection needs attention", {
+      kind: "sync",
+      label: "Retry connection",
+    });
+  }
+
+  if (!settings) {
+    return model("syncing", "Finishing connection to Eliza…", {
+      kind: "sync",
+      label: "Retry connection",
+    });
+  }
+
+  if (isFutureIso(settings.pauseUntil)) {
+    return model("needs_settings", "Connected · Browser access is paused");
+  }
+
+  if (!settings.enabled || settings.trackingMode === "off") {
+    return model("needs_settings", "Connected · Browser access is off");
+  }
+
+  if (!settings.allowBrowserControl) {
+    return model("needs_settings", "Connected · Browser control is off");
+  }
+
+  if (settings.siteAccessMode === "all_sites" && !hasAllWebsiteAccess) {
+    return model("needs_permission", "Connected · Website access needed", {
+      kind: "grant_website_access",
+      label: "Grant website access",
+    });
+  }
+
+  return model("connected", "Connected to Eliza");
 }

--- a/packages/browser-bridge-extension/src/privileged-sender.test.ts
+++ b/packages/browser-bridge-extension/src/privileged-sender.test.ts
@@ -14,7 +14,11 @@ const EXTENSION_ID = "abcdefghijklmnopqrstuvwxyzabcdef";
 
 function stubExtensionId(id: string | undefined): void {
   vi.stubGlobal("chrome", {
-    runtime: { id, sendMessage: () => undefined },
+    runtime: {
+      id,
+      getURL: (path: string) => `chrome-extension://${id}/${path}`,
+      sendMessage: () => undefined,
+    },
   });
 }
 
@@ -29,11 +33,42 @@ describe("isPrivilegedExtensionSender", () => {
     expect(isPrivilegedExtensionSender({ id: EXTENSION_ID })).toBe(true);
   });
 
-  it("rejects a content script, which carries a tab", () => {
+  it("accepts the extension's installed guide when hosted in a tab", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(
+      isPrivilegedExtensionSender({
+        id: EXTENSION_ID,
+        tab: { id: 7 },
+        url: `chrome-extension://${EXTENSION_ID}/popup.html`,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a content script even though it carries this extension's id", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(
+      isPrivilegedExtensionSender({
+        id: EXTENSION_ID,
+        tab: { id: 7 },
+        url: "http://localhost:5173/chat",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects tab senders without a valid URL", () => {
     stubExtensionId(EXTENSION_ID);
 
     expect(
       isPrivilegedExtensionSender({ id: EXTENSION_ID, tab: { id: 7 } }),
+    ).toBe(false);
+    expect(
+      isPrivilegedExtensionSender({
+        id: EXTENSION_ID,
+        tab: { id: 7 },
+        url: "not a URL",
+      }),
     ).toBe(false);
   });
 

--- a/packages/browser-bridge-extension/src/privileged-sender.test.ts
+++ b/packages/browser-bridge-extension/src/privileged-sender.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The background's runtime.onMessage channel dispatches credential writes
+ * (`browser-bridge:save-config`). Content scripts share that channel and this
+ * extension's run on `http://localhost/*` at any port — i.e. any local dev
+ * server the user happens to be running — so the sender has to be checked
+ * before the message is dispatched.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isPrivilegedExtensionSender } from "./webextension.ts";
+
+const EXTENSION_ID = "abcdefghijklmnopqrstuvwxyzabcdef";
+
+function stubExtensionId(id: string | undefined): void {
+  vi.stubGlobal("chrome", {
+    runtime: { id, sendMessage: () => undefined },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isPrivilegedExtensionSender", () => {
+  it("accepts the extension's own popup", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(isPrivilegedExtensionSender({ id: EXTENSION_ID })).toBe(true);
+  });
+
+  it("rejects a content script, which carries a tab", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(
+      isPrivilegedExtensionSender({ id: EXTENSION_ID, tab: { id: 7 } }),
+    ).toBe(false);
+  });
+
+  it("rejects another extension", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(isPrivilegedExtensionSender({ id: "some-other-extension" })).toBe(
+      false,
+    );
+  });
+
+  // Fail closed: if the runtime cannot tell us our own id, we cannot prove the
+  // sender is privileged, so nothing is privileged.
+  it("rejects everything when the extension id is unavailable", () => {
+    stubExtensionId(undefined);
+
+    expect(isPrivilegedExtensionSender({ id: EXTENSION_ID })).toBe(false);
+  });
+
+  it("rejects malformed senders", () => {
+    stubExtensionId(EXTENSION_ID);
+
+    expect(isPrivilegedExtensionSender(undefined)).toBe(false);
+    expect(isPrivilegedExtensionSender("popup")).toBe(false);
+    expect(isPrivilegedExtensionSender({})).toBe(false);
+  });
+});

--- a/packages/browser-bridge-extension/src/protocol.ts
+++ b/packages/browser-bridge-extension/src/protocol.ts
@@ -1,0 +1,96 @@
+/**
+ * Runtime message contracts exchanged between the extension's contexts —
+ * popup UI, background service worker, and content script — plus the
+ * companion-sync aliases from the local browser-bridge wire contracts.
+ * Type-only; no runtime code.
+ */
+import type {
+  BrowserBridgeCompanionAutoPairResponse,
+  BrowserBridgeCompanionConfig,
+  BrowserBridgeCompanionPreflightRequest,
+  BrowserBridgeCompanionSessionBeginRequest,
+  BrowserBridgeCompanionSessionProgressRequest,
+  BrowserBridgeCompanionSyncRequest,
+  BrowserBridgeSettings,
+  CompleteLifeOpsBrowserSessionRequest,
+  CreateBrowserBridgeCompanionAutoPairRequest,
+  LifeOpsBrowserSession,
+} from "./browser-bridge-contracts";
+
+export type CompanionPreflightRequest = BrowserBridgeCompanionPreflightRequest;
+export type CompanionSyncRequest = BrowserBridgeCompanionSyncRequest;
+export type CompanionSession = LifeOpsBrowserSession;
+export type CompanionSessionBeginRequest =
+  BrowserBridgeCompanionSessionBeginRequest;
+export type CompanionSessionProgressRequest =
+  BrowserBridgeCompanionSessionProgressRequest;
+export type CompanionSessionCompleteRequest =
+  CompleteLifeOpsBrowserSessionRequest;
+export type CompanionConfig = BrowserBridgeCompanionConfig;
+export type CompanionAutoPairRequest =
+  CreateBrowserBridgeCompanionAutoPairRequest;
+export type CompanionAutoPairResponse = BrowserBridgeCompanionAutoPairResponse;
+
+export type BackgroundState = {
+  config: CompanionConfig | null;
+  settings: BrowserBridgeSettings | null;
+  syncing: boolean;
+  lastSyncAt: string | null;
+  lastError: string | null;
+  lastSessionStatus: string | null;
+  activeSessionId: string | null;
+  rememberedTabCount: number;
+  settingsSummary: string | null;
+};
+
+export type PopupRequest =
+  | { type: "browser-bridge:get-state" }
+  | { type: "browser-bridge:sync-now" }
+  | { type: "browser-bridge:auto-pair" }
+  | {
+      type: "browser-bridge:save-config";
+      config: Partial<CompanionConfig>;
+    }
+  | { type: "browser-bridge:clear-config" };
+
+export type PopupResponse =
+  | { ok: true; state: BackgroundState }
+  | { ok: false; error: string; state?: BackgroundState };
+
+export type CapturePageMessage = {
+  type: "browser-bridge:capture-page";
+  expectedUrl: string;
+};
+
+export type PageContextSnapshot = {
+  url: string;
+  title: string;
+  selectionText: string | null;
+  mainText: string | null;
+  headings: string[];
+  links: Array<{ text: string; href: string }>;
+  forms: Array<{ action: string | null; fields: string[] }>;
+  capturedAt: string;
+};
+
+export type DomActionRequest = {
+  kind: "click" | "type" | "submit" | "history_back" | "history_forward";
+  selector?: string | null;
+  text?: string | null;
+};
+
+export type ExecuteDomActionMessage = {
+  type: "browser-bridge:execute-dom-action";
+  expectedUrl: string;
+  action: DomActionRequest;
+};
+
+export type ContentScriptMessage = CapturePageMessage | ExecuteDomActionMessage;
+
+export type ContentScriptResponse =
+  | {
+      ok: true;
+      page?: PageContextSnapshot;
+      actionResult?: Record<string, unknown>;
+    }
+  | { ok: false; error: string };

--- a/packages/browser-bridge-extension/src/protocol.ts
+++ b/packages/browser-bridge-extension/src/protocol.ts
@@ -5,7 +5,6 @@
  * Type-only; no runtime code.
  */
 import type {
-  BrowserBridgeCompanionAutoPairResponse,
   BrowserBridgeCompanionConfig,
   BrowserBridgeCompanionPreflightRequest,
   BrowserBridgeCompanionSessionBeginRequest,
@@ -13,7 +12,6 @@ import type {
   BrowserBridgeCompanionSyncRequest,
   BrowserBridgeSettings,
   CompleteLifeOpsBrowserSessionRequest,
-  CreateBrowserBridgeCompanionAutoPairRequest,
   LifeOpsBrowserSession,
 } from "./browser-bridge-contracts";
 
@@ -27,9 +25,6 @@ export type CompanionSessionProgressRequest =
 export type CompanionSessionCompleteRequest =
   CompleteLifeOpsBrowserSessionRequest;
 export type CompanionConfig = BrowserBridgeCompanionConfig;
-export type CompanionAutoPairRequest =
-  CreateBrowserBridgeCompanionAutoPairRequest;
-export type CompanionAutoPairResponse = BrowserBridgeCompanionAutoPairResponse;
 
 export type BackgroundState = {
   config: CompanionConfig | null;

--- a/packages/browser-bridge-extension/src/request-timeout.test.ts
+++ b/packages/browser-bridge-extension/src/request-timeout.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Deterministic coverage for the browser-bridge request deadline, including a
+ * transport that ignores AbortSignal so background sync cannot remain wedged.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withBrowserBridgeRequestTimeout } from "./request-timeout";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withBrowserBridgeRequestTimeout", () => {
+  it("returns successful operations and clears their deadline", async () => {
+    vi.useFakeTimers();
+    await expect(
+      withBrowserBridgeRequestTimeout(
+        "relay sync",
+        async (signal) => {
+          expect(signal.aborted).toBe(false);
+          return "ok";
+        },
+        25,
+      ),
+    ).resolves.toBe("ok");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts and rejects when a transport ignores cancellation", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | null = null;
+    const request = withBrowserBridgeRequestTimeout(
+      "relay sync",
+      async (signal) => {
+        observedSignal = signal;
+        return new Promise<never>(() => undefined);
+      },
+      25,
+    );
+    const rejection = expect(request).rejects.toThrow(
+      "relay sync timed out after 25 ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+    expect(observedSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves an operation failure before the deadline", async () => {
+    vi.useFakeTimers();
+    const failure = new Error("relay rejected the pairing");
+    await expect(
+      withBrowserBridgeRequestTimeout(
+        "relay sync",
+        async () => {
+          throw failure;
+        },
+        25,
+      ),
+    ).rejects.toBe(failure);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects invalid timeout configuration", async () => {
+    await expect(
+      withBrowserBridgeRequestTimeout("relay sync", async () => "ok", 0),
+    ).rejects.toThrow("positive finite number");
+  });
+});

--- a/packages/browser-bridge-extension/src/request-timeout.ts
+++ b/packages/browser-bridge-extension/src/request-timeout.ts
@@ -1,0 +1,36 @@
+/**
+ * Bounds browser-bridge network operations across both header and body reads.
+ * The timeout rejects independently of AbortSignal support so a stalled relay
+ * cannot wedge the extension's singleton background sync loop indefinitely.
+ */
+
+export const BROWSER_BRIDGE_REQUEST_TIMEOUT_MS = 15_000;
+
+export async function withBrowserBridgeRequestTimeout<T>(
+  label: string,
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs = BROWSER_BRIDGE_REQUEST_TIMEOUT_MS,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      "Browser bridge request timeout must be a positive finite number.",
+    );
+  }
+
+  const controller = new AbortController();
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${timeoutMs} ms.`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    if (timeoutHandle !== null) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/packages/browser-bridge-extension/src/storage.test.ts
+++ b/packages/browser-bridge-extension/src/storage.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for config normalization and trusted API-discovery candidate
+ * ordering; pure functions, no chrome.storage.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  candidateApiBaseUrlsFromTabs,
+  DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
+  getOrCreateExtensionProfileId,
+  isValidApiBaseUrl,
+  normalizeAutoPairCompanionConfig,
+  normalizeCompanionConfig,
+  resolveTrustedBlockedPageApiBase,
+} from "./storage";
+
+describe("candidateApiBaseUrlsFromTabs", () => {
+  it("deduplicates loopback origins and excludes remote app tabs", () => {
+    expect(
+      candidateApiBaseUrlsFromTabs([
+        { title: "Eliza", url: "https://eliza.dev" },
+        { title: "LifeOps", url: "https://eliza.dev/settings" },
+        { title: "Other", url: "http://127.0.0.1:31337" },
+      ]),
+    ).toEqual(["http://127.0.0.1:31337"]);
+  });
+
+  it("rejects title-spoofed remote, plaintext remote, credentialed, and subdomain candidates", () => {
+    expect(
+      candidateApiBaseUrlsFromTabs([
+        { title: "Eliza", url: "javascript:alert(1)" },
+        { title: "Eliza", url: "https://user:pass@example.com/app" },
+        { title: "Eliza LifeOps", url: "https://attacker.example/app" },
+        { title: "Eliza", url: "http://eliza.dev/app" },
+        { title: "Eliza", url: "https://app.eliza.dev/app" },
+        { title: "Eliza", url: "http://127.0.0.1.attacker.example/app" },
+        { title: "Other", url: "http://[::1]:2138/settings" },
+        { title: "Other", url: "file:///tmp/index.html" },
+      ]),
+    ).toEqual(["http://[::1]:2138"]);
+  });
+});
+
+describe("getOrCreateExtensionProfileId", () => {
+  function emptyStore() {
+    let value: string | null = null;
+    return {
+      get: async () => value,
+      set: async (next: string) => {
+        value = next;
+      },
+    };
+  }
+
+  it("is stable across reloads and unique for separate extension profiles", async () => {
+    const firstStore = emptyStore();
+    const secondStore = emptyStore();
+    const first = await getOrCreateExtensionProfileId(firstStore);
+    expect(await getOrCreateExtensionProfileId(firstStore)).toBe(first);
+    expect(await getOrCreateExtensionProfileId(secondStore)).not.toBe(first);
+  });
+});
+
+describe("normalizeCompanionConfig", () => {
+  const baseConfig = {
+    apiBaseUrl: "https://agent.example.com/api?debug=true#section",
+    companionId: " companion-1 ",
+    pairingToken: " token-1 ",
+    browser: "chrome",
+    profileId: " profile ",
+    profileLabel: " Work ",
+  };
+
+  it("normalizes safe config fields and strips URL query/fragment", () => {
+    expect(normalizeCompanionConfig(baseConfig)).toMatchObject({
+      apiBaseUrl: "https://agent.example.com/api",
+      companionId: "companion-1",
+      pairingToken: "token-1",
+      browser: "chrome",
+      profileId: "profile",
+      profileLabel: "Work",
+    });
+  });
+
+  it("rejects hostile API bases and invalid browser names", () => {
+    for (const apiBaseUrl of [
+      "javascript:alert(1)",
+      "file:///tmp/socket",
+      "https://user:pass@agent.example.com",
+      "http://agent.example.com",
+      "http://127.0.0.1.attacker.example",
+      "not a url",
+    ]) {
+      expect(
+        normalizeCompanionConfig({ ...baseConfig, apiBaseUrl }),
+      ).toBeNull();
+      expect(isValidApiBaseUrl(apiBaseUrl)).toBe(false);
+    }
+
+    expect(
+      normalizeCompanionConfig({ ...baseConfig, browser: "firefox" }),
+    ).toMatchObject({ browser: "firefox" });
+    expect(
+      normalizeCompanionConfig({ ...baseConfig, browser: "netscape" }),
+    ).toBeNull();
+  });
+
+  it("uses the loopback default for blank API base URLs", () => {
+    expect(
+      normalizeCompanionConfig({ ...baseConfig, apiBaseUrl: "   " })
+        ?.apiBaseUrl,
+    ).toBe(DEFAULT_BROWSER_BRIDGE_API_BASE_URL);
+  });
+});
+
+describe("normalizeAutoPairCompanionConfig", () => {
+  const config = {
+    apiBaseUrl: "https://agent.example.com",
+    companionId: "companion-1",
+    pairingToken: "token-1",
+    browser: "chrome" as const,
+    profileId: "default",
+    profileLabel: "Default",
+  };
+  const expected = {
+    apiBaseUrl: "https://agent.example.com",
+    companionId: "companion-1",
+    browser: "chrome" as const,
+  };
+
+  it("accepts a response bound to the request API, browser, and companion", () => {
+    expect(normalizeAutoPairCompanionConfig(config, expected)).toMatchObject(
+      expected,
+    );
+  });
+
+  it("accepts the server-owned spelling of the same loopback endpoint", () => {
+    expect(
+      normalizeAutoPairCompanionConfig(
+        { ...config, apiBaseUrl: "http://127.0.0.1:31337" },
+        { ...expected, apiBaseUrl: "http://localhost:31337" },
+      ),
+    ).toMatchObject({ apiBaseUrl: "http://127.0.0.1:31337" });
+    expect(
+      normalizeAutoPairCompanionConfig(
+        { ...config, apiBaseUrl: "http://127.0.0.1:31338" },
+        { ...expected, apiBaseUrl: "http://localhost:31337" },
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a response that redirects credentials across trust boundaries", () => {
+    expect(
+      normalizeAutoPairCompanionConfig(
+        { ...config, apiBaseUrl: "https://attacker.example" },
+        expected,
+      ),
+    ).toBeNull();
+    expect(
+      normalizeAutoPairCompanionConfig(
+        { ...config, browser: "firefox" },
+        expected,
+      ),
+    ).toBeNull();
+    expect(
+      normalizeAutoPairCompanionConfig(
+        { ...config, companionId: "companion-attacker" },
+        expected,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("resolveTrustedBlockedPageApiBase", () => {
+  const paired = normalizeCompanionConfig({
+    apiBaseUrl: "http://127.0.0.1:31337",
+    companionId: "companion-1",
+    pairingToken: "token-1",
+    browser: "chrome",
+    profileId: "default",
+    profileLabel: "Default",
+  });
+
+  it("accepts only the exact persisted companion origin", () => {
+    expect(
+      resolveTrustedBlockedPageApiBase("http://127.0.0.1:31337", paired),
+    ).toBe("http://127.0.0.1:31337");
+    expect(
+      resolveTrustedBlockedPageApiBase("https://attacker.example", paired),
+    ).toBeNull();
+    expect(
+      resolveTrustedBlockedPageApiBase("http://localhost:31337", paired),
+    ).toBeNull();
+    expect(
+      resolveTrustedBlockedPageApiBase("http://127.0.0.1:31337", null),
+    ).toBeNull();
+  });
+});

--- a/packages/browser-bridge-extension/src/storage.test.ts
+++ b/packages/browser-bridge-extension/src/storage.test.ts
@@ -8,7 +8,6 @@ import {
   DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
   getOrCreateExtensionProfileId,
   isValidApiBaseUrl,
-  normalizeAutoPairCompanionConfig,
   normalizeCompanionConfig,
   resolveTrustedBlockedPageApiBase,
 } from "./storage";
@@ -109,64 +108,6 @@ describe("normalizeCompanionConfig", () => {
       normalizeCompanionConfig({ ...baseConfig, apiBaseUrl: "   " })
         ?.apiBaseUrl,
     ).toBe(DEFAULT_BROWSER_BRIDGE_API_BASE_URL);
-  });
-});
-
-describe("normalizeAutoPairCompanionConfig", () => {
-  const config = {
-    apiBaseUrl: "https://agent.example.com",
-    companionId: "companion-1",
-    pairingToken: "token-1",
-    browser: "chrome" as const,
-    profileId: "default",
-    profileLabel: "Default",
-  };
-  const expected = {
-    apiBaseUrl: "https://agent.example.com",
-    companionId: "companion-1",
-    browser: "chrome" as const,
-  };
-
-  it("accepts a response bound to the request API, browser, and companion", () => {
-    expect(normalizeAutoPairCompanionConfig(config, expected)).toMatchObject(
-      expected,
-    );
-  });
-
-  it("accepts the server-owned spelling of the same loopback endpoint", () => {
-    expect(
-      normalizeAutoPairCompanionConfig(
-        { ...config, apiBaseUrl: "http://127.0.0.1:31337" },
-        { ...expected, apiBaseUrl: "http://localhost:31337" },
-      ),
-    ).toMatchObject({ apiBaseUrl: "http://127.0.0.1:31337" });
-    expect(
-      normalizeAutoPairCompanionConfig(
-        { ...config, apiBaseUrl: "http://127.0.0.1:31338" },
-        { ...expected, apiBaseUrl: "http://localhost:31337" },
-      ),
-    ).toBeNull();
-  });
-
-  it("rejects a response that redirects credentials across trust boundaries", () => {
-    expect(
-      normalizeAutoPairCompanionConfig(
-        { ...config, apiBaseUrl: "https://attacker.example" },
-        expected,
-      ),
-    ).toBeNull();
-    expect(
-      normalizeAutoPairCompanionConfig(
-        { ...config, browser: "firefox" },
-        expected,
-      ),
-    ).toBeNull();
-    expect(
-      normalizeAutoPairCompanionConfig(
-        { ...config, companionId: "companion-attacker" },
-        expected,
-      ),
-    ).toBeNull();
   });
 });
 

--- a/packages/browser-bridge-extension/src/storage.ts
+++ b/packages/browser-bridge-extension/src/storage.ts
@@ -266,28 +266,6 @@ export function normalizeCompanionConfig(
   };
 }
 
-export function normalizeAutoPairCompanionConfig(
-  input: Partial<CompanionConfig> | null | undefined,
-  expected: {
-    apiBaseUrl: string;
-    browser: CompanionConfig["browser"];
-    companionId: string;
-  },
-): CompanionConfig | null {
-  const config = normalizeCompanionConfig(input);
-  const expectedApiBaseUrl = normalizeApiBaseUrl(expected.apiBaseUrl);
-  if (
-    !config ||
-    !expectedApiBaseUrl ||
-    !areEquivalentApiBaseUrls(config.apiBaseUrl, expectedApiBaseUrl) ||
-    config.browser !== expected.browser ||
-    config.companionId !== expected.companionId
-  ) {
-    return null;
-  }
-  return config;
-}
-
 /** Binds a DNR interstitial's request target to the persisted pairing. */
 export function resolveTrustedBlockedPageApiBase(
   requested: unknown,
@@ -296,27 +274,6 @@ export function resolveTrustedBlockedPageApiBase(
   if (!pairedConfig) return null;
   const normalized = normalizeApiBaseUrl(requested);
   return normalized === pairedConfig.apiBaseUrl ? normalized : null;
-}
-
-function areEquivalentApiBaseUrls(left: string, right: string): boolean {
-  if (left === right) return true;
-  try {
-    const leftUrl = new URL(left);
-    const rightUrl = new URL(right);
-    if (
-      !isLoopbackHost(leftUrl.hostname) ||
-      !isLoopbackHost(rightUrl.hostname)
-    ) {
-      return false;
-    }
-    const endpointKey = (url: URL) =>
-      `${url.protocol}//loopback:${url.port || (url.protocol === "https:" ? "443" : "80")}${url.pathname.replace(/\/+$/, "")}`;
-    return endpointKey(leftUrl) === endpointKey(rightUrl);
-  } catch {
-    // error-policy:J3 Config normalization should already have rejected these
-    // values; the comparison still fails closed if that invariant changes.
-    return false;
-  }
 }
 
 export async function loadCompanionConfig(): Promise<CompanionConfig | null> {

--- a/packages/browser-bridge-extension/src/storage.ts
+++ b/packages/browser-bridge-extension/src/storage.ts
@@ -1,0 +1,385 @@
+/**
+ * Persistence and agent-API discovery over chrome.storage.local. Loads and
+ * normalizes the companion pairing config and cached background state, and
+ * probes loopback candidates to locate a local agent API (default
+ * http://127.0.0.1:31337). Remote relay origins require explicit manual
+ * pairing and never participate in trust-on-first-use discovery.
+ */
+import type { BackgroundState, CompanionConfig } from "./protocol";
+import {
+  type ExtensionTab,
+  queryTabs,
+  storageGet,
+  storageRemove,
+  storageSet,
+} from "./webextension";
+
+const CONFIG_KEY = "browserBridgeCompanionConfig";
+const STATE_KEY = "browserBridgeBackgroundState";
+const PROFILE_ID_KEY = "browserBridgeExtensionProfileId";
+export const DEFAULT_BROWSER_BRIDGE_API_BASE_URL = "http://127.0.0.1:31337";
+const LOOPBACK_DISCOVERY_CANDIDATES = [
+  "http://127.0.0.1:2138",
+  DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
+  "http://localhost:2138",
+  "http://localhost:31337",
+] as const;
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeApiBaseUrl(value: unknown): string | null {
+  const trimmed = normalizeString(value).replace(/\/+$/, "");
+  if (!trimmed) {
+    return DEFAULT_BROWSER_BRIDGE_API_BASE_URL;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
+      return null;
+    }
+    if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+      return null;
+    }
+    parsed.hash = "";
+    parsed.search = "";
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    // error-policy:J3 Invalid untrusted config URLs are rejected explicitly.
+    return null;
+  }
+}
+
+export function isValidApiBaseUrl(value: unknown): value is string {
+  return normalizeApiBaseUrl(value) !== null;
+}
+
+function shouldAutofillApiBaseUrl(value: unknown): boolean {
+  const trimmed = normalizeString(value).replace(/\/+$/, "");
+  return (
+    trimmed.length === 0 || trimmed === DEFAULT_BROWSER_BRIDGE_API_BASE_URL
+  );
+}
+
+function normalizeOriginCandidate(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
+      return null;
+    }
+    const origin = parsed.origin.replace(/\/+$/, "");
+    if (!isLoopbackHost(parsed.hostname)) {
+      return null;
+    }
+    return origin;
+  } catch {
+    // error-policy:J3 Invalid tab and discovery URLs are excluded.
+    return null;
+  }
+}
+
+function normalizeIsoString(value: unknown): string | null {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+  const parsed = Date.parse(normalized);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "[::1]"
+  );
+}
+
+export function isLoopbackApiBaseUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      !parsed.username &&
+      !parsed.password &&
+      isLoopbackHost(parsed.hostname)
+    );
+  } catch {
+    // error-policy:J3 Invalid candidates are not loopback endpoints.
+    return false;
+  }
+}
+
+export function candidateApiBaseUrlsFromTabs(
+  tabs: readonly ExtensionTab[],
+): string[] {
+  const loopback = new Set<string>();
+
+  for (const tab of tabs) {
+    const url = normalizeString(tab.url);
+    if (!url) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      // error-policy:J3 Invalid tab URLs cannot become discovery candidates.
+      continue;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      continue;
+    }
+    if (parsed.username || parsed.password) continue;
+    const origin = normalizeOriginCandidate(url);
+    if (!origin) continue;
+    loopback.add(origin);
+  }
+
+  return [...loopback];
+}
+
+async function isReachableAgentApiBaseUrl(baseUrl: string): Promise<boolean> {
+  const normalized = normalizeOriginCandidate(baseUrl);
+  if (!normalized || typeof fetch !== "function") {
+    return false;
+  }
+
+  const controller =
+    typeof AbortController === "function" ? new AbortController() : null;
+  const timeout = controller
+    ? globalThis.setTimeout(() => controller.abort(), 1500)
+    : null;
+  try {
+    const response = await fetch(`${normalized}/api/status`, {
+      method: "GET",
+      cache: "no-store",
+      signal: controller?.signal,
+    });
+    if (!response.ok) {
+      return false;
+    }
+    let payload: Record<string, unknown> | null;
+    try {
+      payload = (await response.json()) as Record<string, unknown>;
+    } catch {
+      // error-policy:J3 A non-JSON status response is not a valid agent probe.
+      return false;
+    }
+    if (!payload || typeof payload !== "object") {
+      return false;
+    }
+    return (
+      typeof payload.state === "string" ||
+      typeof payload.startedAt === "number" ||
+      typeof payload.uptime === "number" ||
+      typeof payload.pendingRestart === "boolean"
+    );
+  } catch {
+    // error-policy:J4 An unreachable candidate is visibly absent from the
+    // discovery result; no pairing success is fabricated.
+    return false;
+  } finally {
+    if (timeout !== null) {
+      globalThis.clearTimeout(timeout);
+    }
+  }
+}
+
+export async function discoverReachableAgentApiBaseUrls(): Promise<string[]> {
+  const tabs = await queryTabs({});
+  const candidates = [
+    ...candidateApiBaseUrlsFromTabs(tabs),
+    ...LOOPBACK_DISCOVERY_CANDIDATES,
+  ];
+  const seen = new Set<string>();
+  const reachable: string[] = [];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeOriginCandidate(candidate);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    if (await isReachableAgentApiBaseUrl(normalized)) {
+      reachable.push(normalized);
+    }
+  }
+
+  return reachable;
+}
+
+export async function discoverAgentApiBaseUrl(): Promise<string | null> {
+  const reachable = await discoverReachableAgentApiBaseUrls();
+  return reachable[0] ?? null;
+}
+
+export function normalizeCompanionConfig(
+  input: Partial<CompanionConfig> | null | undefined,
+): CompanionConfig | null {
+  if (!input) {
+    return null;
+  }
+  const apiBaseUrl = normalizeApiBaseUrl(input.apiBaseUrl);
+  if (!apiBaseUrl) {
+    return null;
+  }
+  const companionId = normalizeString(input.companionId);
+  const pairingToken = normalizeString(input.pairingToken);
+  const browserInput = normalizeString(input.browser);
+  const browser =
+    browserInput.length === 0
+      ? "chrome"
+      : browserInput === "safari" ||
+          browserInput === "firefox" ||
+          browserInput === "chrome"
+        ? browserInput
+        : null;
+  if (!browser) {
+    return null;
+  }
+  const profileId = normalizeString(input.profileId) || "default";
+  const profileLabel = normalizeString(input.profileLabel) || profileId;
+  const label =
+    normalizeString(input.label) ||
+    `Agent Browser Bridge ${browser} ${profileLabel}`;
+  if (!companionId || !pairingToken) {
+    return null;
+  }
+  return {
+    apiBaseUrl,
+    companionId,
+    pairingToken,
+    pairingTokenExpiresAt: normalizeIsoString(input.pairingTokenExpiresAt),
+    browser,
+    profileId,
+    profileLabel,
+    label,
+  };
+}
+
+export function normalizeAutoPairCompanionConfig(
+  input: Partial<CompanionConfig> | null | undefined,
+  expected: {
+    apiBaseUrl: string;
+    browser: CompanionConfig["browser"];
+    companionId: string;
+  },
+): CompanionConfig | null {
+  const config = normalizeCompanionConfig(input);
+  const expectedApiBaseUrl = normalizeApiBaseUrl(expected.apiBaseUrl);
+  if (
+    !config ||
+    !expectedApiBaseUrl ||
+    !areEquivalentApiBaseUrls(config.apiBaseUrl, expectedApiBaseUrl) ||
+    config.browser !== expected.browser ||
+    config.companionId !== expected.companionId
+  ) {
+    return null;
+  }
+  return config;
+}
+
+/** Binds a DNR interstitial's request target to the persisted pairing. */
+export function resolveTrustedBlockedPageApiBase(
+  requested: unknown,
+  pairedConfig: CompanionConfig | null,
+): string | null {
+  if (!pairedConfig) return null;
+  const normalized = normalizeApiBaseUrl(requested);
+  return normalized === pairedConfig.apiBaseUrl ? normalized : null;
+}
+
+function areEquivalentApiBaseUrls(left: string, right: string): boolean {
+  if (left === right) return true;
+  try {
+    const leftUrl = new URL(left);
+    const rightUrl = new URL(right);
+    if (
+      !isLoopbackHost(leftUrl.hostname) ||
+      !isLoopbackHost(rightUrl.hostname)
+    ) {
+      return false;
+    }
+    const endpointKey = (url: URL) =>
+      `${url.protocol}//loopback:${url.port || (url.protocol === "https:" ? "443" : "80")}${url.pathname.replace(/\/+$/, "")}`;
+    return endpointKey(leftUrl) === endpointKey(rightUrl);
+  } catch {
+    // error-policy:J3 Config normalization should already have rejected these
+    // values; the comparison still fails closed if that invariant changes.
+    return false;
+  }
+}
+
+export async function loadCompanionConfig(): Promise<CompanionConfig | null> {
+  const stored = await storageGet<Partial<CompanionConfig>>(CONFIG_KEY);
+  return normalizeCompanionConfig(stored);
+}
+
+type ProfileIdStore = {
+  get: () => Promise<unknown>;
+  set: (value: string) => Promise<void>;
+};
+
+export async function getOrCreateExtensionProfileId(
+  store: ProfileIdStore = {
+    get: () => storageGet<string>(PROFILE_ID_KEY),
+    set: (value) => storageSet({ [PROFILE_ID_KEY]: value }),
+  },
+): Promise<string> {
+  const existing = normalizeString(await store.get());
+  if (existing) return existing;
+  const generated = `extension-profile-${crypto.randomUUID()}`;
+  await store.set(generated);
+  return generated;
+}
+
+export async function saveCompanionConfig(
+  nextConfig: Partial<CompanionConfig>,
+): Promise<CompanionConfig | null> {
+  const current = await loadCompanionConfig();
+  const merged = {
+    ...(current ?? {
+      apiBaseUrl: DEFAULT_BROWSER_BRIDGE_API_BASE_URL,
+      browser: "chrome",
+      profileId: "default",
+      profileLabel: "default",
+      label: "",
+    }),
+    ...nextConfig,
+  };
+  const discoveredApiBaseUrl = shouldAutofillApiBaseUrl(merged.apiBaseUrl)
+    ? await discoverAgentApiBaseUrl()
+    : null;
+  const normalized = normalizeCompanionConfig({
+    ...merged,
+    apiBaseUrl: discoveredApiBaseUrl ?? merged.apiBaseUrl,
+  });
+  if (!normalized) {
+    return null;
+  }
+  await storageSet({ [CONFIG_KEY]: normalized });
+  return normalized;
+}
+
+export async function clearCompanionConfig(): Promise<void> {
+  await storageRemove(CONFIG_KEY);
+}
+
+export async function loadBackgroundState(): Promise<BackgroundState | null> {
+  return await storageGet<BackgroundState>(STATE_KEY);
+}
+
+export async function saveBackgroundState(
+  state: BackgroundState,
+): Promise<void> {
+  await storageSet({ [STATE_KEY]: state });
+}

--- a/packages/browser-bridge-extension/src/tab-cache.test.ts
+++ b/packages/browser-bridge-extension/src/tab-cache.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Verifies that tab synchronization cannot expose URL/title metadata outside
+ * the browser's actual host grants, even when agent settings request all sites.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
+import {
+  type RememberedTab,
+  selectTabsForSync,
+  urlMatchesGrantedOrigins,
+} from "./tab-cache";
+
+const settings: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "all_sites",
+  grantedOrigins: [],
+  blockedOrigins: [],
+  maxRememberedTabs: 10,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: null,
+};
+
+function tab(url: string): RememberedTab {
+  return {
+    browser: "firefox",
+    profileId: "default",
+    windowId: "1",
+    tabId: url,
+    url,
+    title: url,
+    activeInWindow: true,
+    focusedWindow: true,
+    focusedActive: true,
+    incognito: false,
+    faviconUrl: null,
+    lastSeenAt: "2026-08-18T00:00:00.000Z",
+    lastFocusedAt: "2026-08-18T00:00:00.000Z",
+    metadata: {},
+  };
+}
+
+describe("browser host grant enforcement", () => {
+  it("matches exact, wildcard-subdomain, and all-URL grants", () => {
+    expect(
+      urlMatchesGrantedOrigins("https://eliza.dev/chat", [
+        "https://eliza.dev/*",
+      ]),
+    ).toBe(true);
+    expect(
+      urlMatchesGrantedOrigins("https://app.eliza.dev/chat", [
+        "https://*.eliza.dev/*",
+      ]),
+    ).toBe(true);
+    expect(
+      urlMatchesGrantedOrigins("http://127.0.0.1:31337/chat", [
+        "http://127.0.0.1/*",
+      ]),
+    ).toBe(true);
+    expect(
+      urlMatchesGrantedOrigins("https://private.example/chat", ["<all_urls>"]),
+    ).toBe(true);
+  });
+
+  it("does not sync ungranted tab metadata under all-sites settings", () => {
+    const allowed = tab("https://eliza.dev/chat");
+    const privateTab = tab("https://private.example/account");
+    expect(
+      selectTabsForSync({
+        previous: [],
+        snapshot: [allowed, privateTab],
+        settings,
+        grantedOrigins: ["https://eliza.dev/*"],
+        fallbackMaxRememberedTabs: 10,
+      }).map((candidate) => candidate.url),
+    ).toEqual([allowed.url]);
+  });
+});

--- a/packages/browser-bridge-extension/src/tab-cache.test.ts
+++ b/packages/browser-bridge-extension/src/tab-cache.test.ts
@@ -8,6 +8,7 @@ import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
 import {
   type RememberedTab,
   selectTabsForSync,
+  urlMatchesBlockedOrigins,
   urlMatchesGrantedOrigins,
 } from "./tab-cache";
 
@@ -79,5 +80,32 @@ describe("browser host grant enforcement", () => {
         fallbackMaxRememberedTabs: 10,
       }).map((candidate) => candidate.url),
     ).toEqual([allowed.url]);
+  });
+
+  it("applies host-scoped blocks across schemes, ports, and subdomains", () => {
+    const blocked = ["https://example.com"];
+    expect(urlMatchesBlockedOrigins("http://example.com/path", blocked)).toBe(
+      true,
+    );
+    expect(
+      urlMatchesBlockedOrigins("https://pay.example.com:8443/", blocked),
+    ).toBe(true);
+    expect(urlMatchesBlockedOrigins("https://evil-example.com/", blocked)).toBe(
+      false,
+    );
+
+    const visible = selectTabsForSync({
+      previous: [],
+      snapshot: [
+        tab("https://pay.example.com/account"),
+        tab("https://allowed.example/account"),
+      ],
+      settings: { ...settings, blockedOrigins: blocked },
+      grantedOrigins: ["<all_urls>"],
+      fallbackMaxRememberedTabs: 10,
+    });
+    expect(visible.map((candidate) => candidate.url)).toEqual([
+      "https://allowed.example/account",
+    ]);
   });
 });

--- a/packages/browser-bridge-extension/src/tab-cache.ts
+++ b/packages/browser-bridge-extension/src/tab-cache.ts
@@ -1,0 +1,222 @@
+/**
+ * Tab bookkeeping for the background sync loop: merges freshly queried tabs
+ * into the remembered set, ranks them by focus then recency, and selects the
+ * subset to sync according to the tracking mode (current tab vs active tabs).
+ * Pure functions over RememberedTab — no browser API calls.
+ */
+import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
+import type { CompanionSyncRequest } from "./protocol";
+
+export type RememberedTab = CompanionSyncRequest["tabs"][number];
+
+function identityKey(
+  tab: Pick<RememberedTab, "browser" | "profileId" | "windowId" | "tabId">,
+): string {
+  return `${tab.browser}:${tab.profileId}:${tab.windowId}:${tab.tabId}`;
+}
+
+function sortTabs(tabs: readonly RememberedTab[]): RememberedTab[] {
+  return [...tabs].sort((left, right) => {
+    const leftRank = left.focusedActive ? 3 : left.activeInWindow ? 2 : 1;
+    const rightRank = right.focusedActive ? 3 : right.activeInWindow ? 2 : 1;
+    if (leftRank !== rightRank) {
+      return rightRank - leftRank;
+    }
+    const leftAnchor = Date.parse(left.lastFocusedAt ?? left.lastSeenAt ?? "");
+    const rightAnchor = Date.parse(
+      right.lastFocusedAt ?? right.lastSeenAt ?? "",
+    );
+    if (
+      Number.isFinite(leftAnchor) &&
+      Number.isFinite(rightAnchor) &&
+      leftAnchor !== rightAnchor
+    ) {
+      return rightAnchor - leftAnchor;
+    }
+    return left.title.localeCompare(right.title);
+  });
+}
+
+function normalizeOrigin(origin: string): string {
+  return origin.trim().replace(/\/+$/, "").toLowerCase();
+}
+
+function tabOrigin(tab: Pick<RememberedTab, "url">): string | null {
+  try {
+    return normalizeOrigin(new URL(tab.url).origin);
+  } catch {
+    // error-policy:J3 Invalid tab URLs have no shareable origin.
+    return null;
+  }
+}
+
+export function urlMatchesGrantedOrigins(
+  url: string,
+  grantedOrigins: readonly string[],
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 Invalid target URLs never match a browser grant.
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  return grantedOrigins.some((rawPattern) => {
+    const pattern = rawPattern.trim().toLowerCase();
+    if (pattern === "<all_urls>" || pattern === "*://*/*") {
+      return true;
+    }
+    const match = /^(\*|https?):\/\/([^/]+)\/\*$/.exec(pattern);
+    if (!match) {
+      return false;
+    }
+    const [, scheme, hostPattern] = match;
+    if (scheme !== "*" && `${scheme}:` !== parsed.protocol) {
+      return false;
+    }
+    if (hostPattern === "*") {
+      return true;
+    }
+    if (hostPattern.startsWith("*.")) {
+      const domain = hostPattern.slice(2);
+      return hostname === domain || hostname.endsWith(`.${domain}`);
+    }
+    return hostname === hostPattern;
+  });
+}
+
+function isTrackingPaused(settings: BrowserBridgeSettings, now: Date): boolean {
+  return (
+    typeof settings.pauseUntil === "string" &&
+    settings.pauseUntil.length > 0 &&
+    Date.parse(settings.pauseUntil) > now.getTime()
+  );
+}
+
+function isAllowedBySiteAccess(
+  tab: RememberedTab,
+  settings: BrowserBridgeSettings,
+  grantedOrigins: readonly string[],
+): boolean {
+  if (tab.incognito && !settings.incognitoEnabled) {
+    return false;
+  }
+  const origin = tabOrigin(tab);
+  if (!origin) {
+    return false;
+  }
+  if (!urlMatchesGrantedOrigins(tab.url, grantedOrigins)) {
+    return false;
+  }
+  const blockedOrigins = new Set(settings.blockedOrigins.map(normalizeOrigin));
+  if (blockedOrigins.has(origin)) {
+    return false;
+  }
+  switch (settings.siteAccessMode) {
+    case "current_site_only":
+      return tab.focusedActive;
+    case "granted_sites": {
+      const grantedOrigins = new Set(
+        settings.grantedOrigins.map(normalizeOrigin),
+      );
+      return grantedOrigins.has(origin);
+    }
+    default:
+      return true;
+  }
+}
+
+export function mergeRememberedTabs(
+  previous: readonly RememberedTab[],
+  snapshot: readonly RememberedTab[],
+  maxRememberedTabs: number,
+): RememberedTab[] {
+  const byKey = new Map(previous.map((tab) => [identityKey(tab), tab]));
+  for (const tab of snapshot) {
+    const key = identityKey(tab);
+    const prior = byKey.get(key);
+    byKey.set(key, {
+      ...tab,
+      lastFocusedAt:
+        tab.lastFocusedAt ??
+        prior?.lastFocusedAt ??
+        (tab.focusedActive || tab.activeInWindow ? tab.lastSeenAt : null),
+    });
+  }
+  const openKeys = new Set(snapshot.map((tab) => identityKey(tab)));
+  const merged = [...byKey.values()].map((tab) => {
+    if (openKeys.has(identityKey(tab))) {
+      return tab;
+    }
+    return {
+      ...tab,
+      activeInWindow: false,
+      focusedWindow: false,
+      focusedActive: false,
+    };
+  });
+  return sortTabs(merged).slice(0, Math.max(1, maxRememberedTabs));
+}
+
+export function findFocusedTab(
+  tabs: readonly RememberedTab[],
+): RememberedTab | null {
+  return (
+    tabs.find((tab) => tab.focusedActive) ??
+    tabs.find((tab) => tab.activeInWindow) ??
+    tabs[0] ??
+    null
+  );
+}
+
+export function selectTabsForSync(args: {
+  previous: readonly RememberedTab[];
+  snapshot: readonly RememberedTab[];
+  settings: BrowserBridgeSettings | null;
+  fallbackMaxRememberedTabs: number;
+  grantedOrigins: readonly string[];
+  now?: Date;
+}): RememberedTab[] {
+  const {
+    previous,
+    snapshot,
+    settings,
+    fallbackMaxRememberedTabs,
+    grantedOrigins,
+    now = new Date(),
+  } = args;
+  if (
+    !settings?.enabled ||
+    settings.trackingMode === "off" ||
+    isTrackingPaused(settings, now)
+  ) {
+    return [];
+  }
+
+  const filteredPrevious = previous.filter((tab) =>
+    isAllowedBySiteAccess(tab, settings, grantedOrigins),
+  );
+  const filteredSnapshot = snapshot.filter((tab) =>
+    isAllowedBySiteAccess(tab, settings, grantedOrigins),
+  );
+
+  if (settings.trackingMode === "current_tab") {
+    const focused = findFocusedTab(filteredSnapshot);
+    return focused ? [focused] : [];
+  }
+
+  const maxRememberedTabs =
+    Number.isFinite(settings.maxRememberedTabs) &&
+    settings.maxRememberedTabs > 0
+      ? settings.maxRememberedTabs
+      : fallbackMaxRememberedTabs;
+  return mergeRememberedTabs(
+    filteredPrevious,
+    filteredSnapshot,
+    maxRememberedTabs,
+  );
+}

--- a/packages/browser-bridge-extension/src/tab-cache.ts
+++ b/packages/browser-bridge-extension/src/tab-cache.ts
@@ -41,6 +41,25 @@ function normalizeOrigin(origin: string): string {
   return origin.trim().replace(/\/+$/, "").toLowerCase();
 }
 
+function normalizeBlockedHost(value: string): string | null {
+  const candidate = value.trim().toLowerCase();
+  if (!candidate) return null;
+  try {
+    const parsed = new URL(
+      /^[a-z][a-z0-9+.-]*:\/\//.test(candidate)
+        ? candidate
+        : `https://${candidate.replace(/^\*\./, "")}`,
+    );
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.hostname.toLowerCase().replace(/\.+$/, "") || null;
+  } catch {
+    // error-policy:J3 Invalid block entries cannot match a tab.
+    return null;
+  }
+}
+
 function tabOrigin(tab: Pick<RememberedTab, "url">): string | null {
   try {
     return normalizeOrigin(new URL(tab.url).origin);
@@ -89,6 +108,34 @@ export function urlMatchesGrantedOrigins(
   });
 }
 
+/**
+ * Applies the host-scoped block policy shown by the app: a stored host or URL
+ * blocks that host and its subdomains regardless of scheme or port.
+ */
+export function urlMatchesBlockedOrigins(
+  url: string,
+  blockedOrigins: readonly string[],
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 Invalid target URLs never match a block entry.
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  const hostname = parsed.hostname.toLowerCase().replace(/\.+$/, "");
+  return blockedOrigins.some((entry) => {
+    const blockedHost = normalizeBlockedHost(entry);
+    return (
+      blockedHost !== null &&
+      (hostname === blockedHost || hostname.endsWith(`.${blockedHost}`))
+    );
+  });
+}
+
 function isTrackingPaused(settings: BrowserBridgeSettings, now: Date): boolean {
   return (
     typeof settings.pauseUntil === "string" &&
@@ -112,8 +159,7 @@ function isAllowedBySiteAccess(
   if (!urlMatchesGrantedOrigins(tab.url, grantedOrigins)) {
     return false;
   }
-  const blockedOrigins = new Set(settings.blockedOrigins.map(normalizeOrigin));
-  if (blockedOrigins.has(origin)) {
+  if (urlMatchesBlockedOrigins(tab.url, settings.blockedOrigins)) {
     return false;
   }
   switch (settings.siteAccessMode) {

--- a/packages/browser-bridge-extension/src/test-dom-setup.ts
+++ b/packages/browser-bridge-extension/src/test-dom-setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Bun test preload that installs a minimal jsdom browser surface on globalThis.
+ */
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM(
+  "<!doctype html><html><head></head><body></body></html>",
+  {
+    url: "https://unit-test.local/",
+    pretendToBeVisual: true,
+  },
+);
+
+const globals: Record<string, unknown> = {
+  window: dom.window,
+  document: dom.window.document,
+  navigator: dom.window.navigator,
+  HTMLElement: dom.window.HTMLElement,
+  HTMLButtonElement: dom.window.HTMLButtonElement,
+  HTMLInputElement: dom.window.HTMLInputElement,
+  HTMLTextAreaElement: dom.window.HTMLTextAreaElement,
+  HTMLSelectElement: dom.window.HTMLSelectElement,
+  HTMLAnchorElement: dom.window.HTMLAnchorElement,
+  HTMLFormElement: dom.window.HTMLFormElement,
+  Node: dom.window.Node,
+  NodeFilter: dom.window.NodeFilter,
+  Event: dom.window.Event,
+  InputEvent: dom.window.InputEvent,
+  getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+};
+
+for (const [key, value] of Object.entries(globals)) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}

--- a/packages/browser-bridge-extension/src/url.test.ts
+++ b/packages/browser-bridge-extension/src/url.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the URL normalization helpers, including rejection of unsafe
+ * URL forms (credentials, non-http schemes).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  normalizeHostForComparison,
+  normalizeHttpBaseUrl,
+  normalizeHttpOrigin,
+  normalizeNavigableUrl,
+  normalizeNavigableUrlForHost,
+} from "./url";
+
+describe("normalizeHttpBaseUrl", () => {
+  it("normalizes http URLs by trimming, stripping query/fragment, and removing trailing slashes", () => {
+    expect(
+      normalizeHttpBaseUrl(" https://agent.example.com/api///?debug=1#top "),
+    ).toBe("https://agent.example.com/api");
+  });
+
+  it("uses the provided default for blank input and rejects unsafe URL forms", () => {
+    expect(normalizeHttpBaseUrl("   ", "http://127.0.0.1:31337")).toBe(
+      "http://127.0.0.1:31337",
+    );
+    for (const value of [
+      "javascript:alert(1)",
+      "file:///tmp/socket",
+      "https://user:pass@agent.example.com",
+      "not a url",
+    ]) {
+      expect(normalizeHttpBaseUrl(value)).toBeNull();
+    }
+  });
+});
+
+describe("normalizeHttpOrigin", () => {
+  it("keeps only the safe origin for http URLs", () => {
+    expect(normalizeHttpOrigin("http://localhost:2138/path?debug=1#top")).toBe(
+      "http://localhost:2138",
+    );
+    expect(normalizeHttpOrigin("https://agent.example.com/app")).toBe(
+      "https://agent.example.com",
+    );
+  });
+
+  it("rejects missing, credentialed, non-http, and malformed origins", () => {
+    for (const value of [
+      null,
+      undefined,
+      "ftp://agent.example.com",
+      "https://user:pass@agent.example.com",
+      "not a url",
+    ]) {
+      expect(normalizeHttpOrigin(value)).toBeNull();
+    }
+  });
+});
+
+describe("normalizeNavigableUrl", () => {
+  it("keeps a full http(s) blocked-site URL, preserving path and query", () => {
+    expect(normalizeNavigableUrl("https://example.com/read?id=7")).toBe(
+      "https://example.com/read?id=7",
+    );
+    expect(normalizeNavigableUrl("http://intra.example/page")).toBe(
+      "http://intra.example/page",
+    );
+  });
+
+  it("upgrades a scheme-less host to https", () => {
+    expect(normalizeNavigableUrl("example.com")).toBe("https://example.com/");
+    expect(normalizeNavigableUrl("  news.example.com/top  ")).toBe(
+      "https://news.example.com/top",
+    );
+    expect(normalizeNavigableUrl("example.com:443/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(normalizeNavigableUrl("localhost:3000/path")).toBe(
+      "https://localhost:3000/path",
+    );
+  });
+
+  it("returns null for explicit non-http schemes so they never reach location.href", () => {
+    // The block interstitial's `?url=` query param is attacker-controllable;
+    // explicit schemes must not be force-prefixed into navigable https URLs.
+    for (const value of [
+      "javascript:alert(document.cookie)",
+      "JavaScript:alert(1)",
+      "javascript:foo@evil.example",
+      "data:text/html,<script>alert(1)</script>",
+      "mailto:foo@example.com",
+      "file://evil.example/path",
+      "vbscript:msgbox(1)",
+      "httpx://not-really-http.example",
+      "//evil.example.com",
+    ]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+
+  it("returns null for credentialed URLs", () => {
+    for (const value of [
+      "https://user:pass@example.com/path",
+      "http://user@example.com/path",
+      "user:pass@example.com/path",
+    ]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+
+  it("returns null for empty or blank input", () => {
+    for (const value of [null, undefined, "", "   "]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+
+  it("never yields a non-http(s) scheme for any hostile input (the security invariant)", () => {
+    // The one property the navigation sink relies on: the result is always
+    // either null or an http/https URL. A `file:`/`javascript:`/`data:` scheme
+    // can never survive to be assigned to `window.location.href`.
+    for (const value of [
+      "javascript:alert(1)",
+      "data:text/html,x",
+      "file:///etc/passwd",
+      "vbscript:msgbox(1)",
+      "httpx://not-really-http.example",
+      "//evil.example.com",
+      "\tjavascript:alert(1)",
+    ]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+});
+
+describe("normalizeNavigableUrlForHost", () => {
+  it("allows redirects only when the normalized URL host matches the polled host", () => {
+    expect(
+      normalizeNavigableUrlForHost(
+        "https://blocked.example/read",
+        "blocked.example",
+      ),
+    ).toBe("https://blocked.example/read");
+    expect(
+      normalizeNavigableUrlForHost(
+        "blocked.example:443/read",
+        "https://blocked.example",
+      ),
+    ).toBe("https://blocked.example/read");
+  });
+
+  it("rejects host/url mismatches from attacker-controlled blocked-page query params", () => {
+    expect(
+      normalizeNavigableUrlForHost("https://evil.example", "blocked.example"),
+    ).toBeNull();
+    expect(
+      normalizeNavigableUrlForHost(
+        "https://blocked.example.evil.example",
+        "blocked.example",
+      ),
+    ).toBeNull();
+  });
+
+  it("normalizes hosts to lowercase hostnames for comparison", () => {
+    expect(normalizeHostForComparison("HTTPS://Example.COM:443/path")).toBe(
+      "example.com",
+    );
+  });
+});

--- a/packages/browser-bridge-extension/src/url.ts
+++ b/packages/browser-bridge-extension/src/url.ts
@@ -1,0 +1,128 @@
+/**
+ * URL normalization helpers shared across the extension: coerce a user-entered
+ * agent API URL, a page origin, or a blocked-site navigation target to a
+ * canonical, safe http(s) form. Rejects non-http(s) schemes and
+ * credentials-in-URL so downstream code can trust the result. Pure functions
+ * with no browser dependencies.
+ */
+export function normalizeHttpBaseUrl(
+  value: unknown,
+  defaultValue: string | null = null,
+): string | null {
+  const trimmed =
+    typeof value === "string" ? value.trim().replace(/\/+$/, "") : "";
+  if (!trimmed) {
+    return defaultValue;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
+      return null;
+    }
+    parsed.hash = "";
+    parsed.search = "";
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    // error-policy:J3 Invalid untrusted base URLs are rejected explicitly.
+    return null;
+  }
+}
+
+export function normalizeHttpOrigin(
+  value: string | null | undefined,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
+      return null;
+    }
+    return parsed.origin.replace(/\/+$/, "");
+  } catch {
+    // error-policy:J3 Invalid untrusted origins are rejected explicitly.
+    return null;
+  }
+}
+
+/**
+ * Coerce a blocked-site URL — which arrives from the block interstitial's own
+ * `?url=` query param and may be scheme-less (e.g. `example.com`) — to a
+ * canonical http(s) URL safe to assign to `window.location.href`. Returns null
+ * for anything that does not resolve to an http/https URL, so a crafted
+ * `javascript:`/`data:` value can never reach the navigation sink (a
+ * `startsWith("http")` string check does not stop a `javascript:` scheme from
+ * being force-prefixed, nor does it validate the URL is well-formed). Pure; no
+ * browser dependencies.
+ */
+export function normalizeNavigableUrl(
+  value: string | null | undefined,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("//")) {
+    return null;
+  }
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+  const scheme = schemeMatch?.[1]?.toLowerCase();
+  const afterSchemeColon = schemeMatch
+    ? trimmed.slice(schemeMatch[0].length)
+    : "";
+  const hostPortLike =
+    scheme !== undefined &&
+    (scheme.includes(".") || scheme === "localhost") &&
+    /^\d+(?:[/?#]|$)/.test(afterSchemeColon);
+  if (scheme && scheme !== "http" && scheme !== "https" && !hostPortLike) {
+    return null;
+  }
+  const candidate =
+    scheme === "http" || scheme === "https" ? trimmed : `https://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    // error-policy:J3 untrusted query-string input resolves to an explicit invalid navigation target.
+    return null;
+  }
+}
+
+export function normalizeHostForComparison(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeNavigableUrl(value);
+  if (!normalized) {
+    return null;
+  }
+  return new URL(normalized).hostname.toLowerCase();
+}
+
+export function normalizeNavigableUrlForHost(
+  value: string | null | undefined,
+  expectedHost: string | null | undefined,
+): string | null {
+  const target = normalizeNavigableUrl(value);
+  const host = normalizeHostForComparison(expectedHost);
+  if (!target || !host) {
+    return null;
+  }
+  const targetHost = new URL(target).hostname.toLowerCase();
+  return targetHost === host ? target : null;
+}

--- a/packages/browser-bridge-extension/src/webextension.test.ts
+++ b/packages/browser-bridge-extension/src/webextension.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Adversarial tests for the browser API facade using callback- and
+ * promise-style shims that never settle, matching extension-runtime hangs.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BROWSER_BRIDGE_REQUEST_TIMEOUT_MS } from "./request-timeout";
+import { queryTabs, sendTabMessage } from "./webextension";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("browser extension operation deadlines", () => {
+  it("rejects a content-script message when its callback never runs", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("chrome", {
+      runtime: {},
+      tabs: {
+        sendMessage: vi.fn(() => undefined),
+      },
+    });
+
+    const request = sendTabMessage(42, {
+      type: "browser-bridge:capture-page",
+    });
+    const rejection = expect(request).rejects.toThrow(
+      `tabs.sendMessage timed out after ${BROWSER_BRIDGE_REQUEST_TIMEOUT_MS} ms`,
+    );
+
+    await vi.advanceTimersByTimeAsync(BROWSER_BRIDGE_REQUEST_TIMEOUT_MS);
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects a browser API promise that never settles", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("chrome", {
+      runtime: {},
+      tabs: {
+        query: vi.fn(() => new Promise<never>(() => undefined)),
+      },
+    });
+
+    const request = queryTabs({});
+    const rejection = expect(request).rejects.toThrow(
+      `tabs.query timed out after ${BROWSER_BRIDGE_REQUEST_TIMEOUT_MS} ms`,
+    );
+
+    await vi.advanceTimersByTimeAsync(BROWSER_BRIDGE_REQUEST_TIMEOUT_MS);
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the deadline after a callback-style operation succeeds", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("chrome", {
+      runtime: {},
+      tabs: {
+        query: vi.fn(
+          (
+            _query: Record<string, unknown>,
+            callback: (tabs: unknown[]) => void,
+          ) => callback([{ id: 7 }]),
+        ),
+      },
+    });
+
+    await expect(queryTabs({})).resolves.toEqual([{ id: 7 }]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/browser-bridge-extension/src/webextension.ts
+++ b/packages/browser-bridge-extension/src/webextension.ts
@@ -1,0 +1,612 @@
+/**
+ * Promise-based facade over the raw `chrome.*` / `browser.*` extension APIs
+ * (runtime messaging, storage, tabs, windows, alarms, scripting, permissions,
+ * declarativeNetRequest). Every extension-API call in the package routes through
+ * here so Chrome, Firefox, and Safari differences and callback-vs-promise quirks are
+ * normalized in one place.
+ */
+import { withBrowserBridgeRequestTimeout } from "./request-timeout";
+
+type Callback<T> = (value: T) => void;
+
+type RawRuntime = {
+  lastError?: { message?: string };
+  getManifest?: () => { version?: string; permissions?: string[] };
+  onInstalled?: {
+    addListener: (listener: (details: { reason?: string }) => void) => void;
+  };
+  onStartup?: { addListener: (listener: () => void) => void };
+  onMessage?: {
+    addListener: (
+      listener: (
+        message: unknown,
+        sender: unknown,
+        sendResponse: (response: unknown) => void,
+      ) => boolean | undefined,
+    ) => void;
+  };
+  sendMessage?: (
+    message: unknown,
+    callback?: Callback<unknown>,
+  ) => Promise<unknown> | undefined;
+};
+
+type RawStorageArea = {
+  get?: (
+    keys: string | string[] | Record<string, unknown> | null,
+    callback?: Callback<Record<string, unknown>>,
+  ) => Promise<Record<string, unknown>> | undefined;
+  set?: (
+    values: Record<string, unknown>,
+    callback?: Callback<void>,
+  ) => Promise<void> | void;
+  remove?: (
+    keys: string | string[],
+    callback?: Callback<void>,
+  ) => Promise<void> | void;
+};
+
+type RawTabs = {
+  query?: (
+    queryInfo: Record<string, unknown>,
+    callback?: Callback<unknown[]>,
+  ) => Promise<unknown[]> | undefined;
+  update?: (
+    tabId: number,
+    updateProperties: Record<string, unknown>,
+    callback?: Callback<unknown>,
+  ) => Promise<unknown> | undefined;
+  create?: (
+    createProperties: Record<string, unknown>,
+    callback?: Callback<unknown>,
+  ) => Promise<unknown> | undefined;
+  reload?: (
+    tabId: number,
+    reloadProperties?: Record<string, unknown>,
+    callback?: Callback<void>,
+  ) => Promise<void> | void;
+  sendMessage?: (
+    tabId: number,
+    message: unknown,
+    options?: Record<string, unknown>,
+    callback?: Callback<unknown>,
+  ) => Promise<unknown> | undefined;
+  onActivated?: {
+    addListener: (listener: (info: unknown) => void) => void;
+  };
+  onUpdated?: {
+    addListener: (
+      listener: (tabId: number, changeInfo: unknown) => void,
+    ) => void;
+  };
+  onRemoved?: {
+    addListener: (listener: (tabId: number) => void) => void;
+  };
+};
+
+type RawWindows = {
+  getAll?: (
+    getInfo: Record<string, unknown>,
+    callback?: Callback<unknown[]>,
+  ) => Promise<unknown[]> | undefined;
+  update?: (
+    windowId: number,
+    updateInfo: Record<string, unknown>,
+    callback?: Callback<unknown>,
+  ) => Promise<unknown> | undefined;
+  onFocusChanged?: {
+    addListener: (listener: (windowId: number) => void) => void;
+  };
+};
+
+type RawAlarms = {
+  create?: (name: string, alarmInfo?: Record<string, unknown>) => void;
+  clear?: (
+    name: string,
+    callback?: Callback<boolean>,
+  ) => Promise<boolean> | undefined;
+  onAlarm?: {
+    addListener: (listener: (alarm: { name?: string }) => void) => void;
+  };
+};
+
+type RawExtension = {
+  isAllowedIncognitoAccess?: (
+    callback?: Callback<boolean>,
+  ) => Promise<boolean> | undefined;
+};
+
+type RawPermissions = {
+  contains?: (
+    permissions: Record<string, unknown>,
+    callback?: Callback<boolean>,
+  ) => Promise<boolean> | undefined;
+  getAll?: (
+    callback?: Callback<{
+      permissions?: string[];
+      origins?: string[];
+    }>,
+  ) =>
+    | Promise<{
+        permissions?: string[];
+        origins?: string[];
+      }>
+    | undefined;
+  request?: (
+    permissions: Record<string, unknown>,
+    callback?: Callback<boolean>,
+  ) => Promise<boolean> | undefined;
+};
+
+type RawScriptingExecutionResult = {
+  result?: unknown;
+};
+
+type RawScripting = {
+  executeScript?: (
+    injection:
+      | {
+          target: { tabId: number };
+          world?: "ISOLATED" | "MAIN";
+          func: (...args: unknown[]) => unknown;
+          args?: unknown[];
+        }
+      | {
+          target: { tabId: number };
+          world?: "ISOLATED";
+          files: string[];
+        },
+    callback?: Callback<RawScriptingExecutionResult[]>,
+  ) => Promise<RawScriptingExecutionResult[]> | undefined;
+};
+
+type RawDeclarativeNetRequestRule = {
+  id: number;
+  priority: number;
+  action: {
+    type: string;
+    redirect?: { url: string };
+  };
+  condition: {
+    urlFilter?: string;
+    resourceTypes?: string[];
+  };
+};
+
+type RawDeclarativeNetRequest = {
+  getDynamicRules?: (
+    callback?: Callback<RawDeclarativeNetRequestRule[]>,
+  ) => Promise<RawDeclarativeNetRequestRule[]> | undefined;
+  updateDynamicRules?: (
+    options: {
+      removeRuleIds?: number[];
+      addRules?: RawDeclarativeNetRequestRule[];
+    },
+    callback?: Callback<void>,
+  ) => Promise<void> | void;
+};
+
+type RawApi = {
+  runtime?: RawRuntime & {
+    getURL?: (path: string) => string;
+  };
+  storage?: { local?: RawStorageArea };
+  scripting?: RawScripting;
+  tabs?: RawTabs;
+  windows?: RawWindows;
+  alarms?: RawAlarms;
+  extension?: RawExtension;
+  permissions?: RawPermissions;
+  declarativeNetRequest?: RawDeclarativeNetRequest;
+};
+
+export type ExtensionTab = {
+  id?: number;
+  windowId?: number;
+  url?: string;
+  title?: string;
+  active?: boolean;
+  incognito?: boolean;
+  favIconUrl?: string;
+};
+
+export type ExtensionWindow = {
+  id?: number;
+  focused?: boolean;
+  incognito?: boolean;
+  tabs?: ExtensionTab[];
+};
+
+function getRawApi(): RawApi {
+  const globalWithApi = globalThis as typeof globalThis & {
+    browser?: RawApi;
+    chrome?: RawApi;
+  };
+  const candidates = [globalWithApi.chrome, globalWithApi.browser].filter(
+    (candidate): candidate is RawApi => Boolean(candidate),
+  );
+  const api =
+    candidates.find(
+      (candidate) =>
+        Boolean(candidate.runtime?.sendMessage) ||
+        Boolean(candidate.tabs?.query) ||
+        Boolean(candidate.storage?.local?.get),
+    ) ?? candidates[0];
+  if (!api) {
+    throw new Error("Browser extension API is unavailable.");
+  }
+  return api;
+}
+
+function getLastError(): string | null {
+  const api = getRawApi();
+  return api.runtime?.lastError?.message?.trim() ?? null;
+}
+
+function invokeAsync<T>(
+  operation: string,
+  call: (callback: Callback<T>) => Promise<T> | T | undefined | undefined,
+): Promise<T> {
+  return withBrowserBridgeRequestTimeout(operation, async () => {
+    return await new Promise<T>((resolve, reject) => {
+      try {
+        const maybePromise = call((value) => {
+          const errorMessage = getLastError();
+          if (errorMessage) {
+            reject(new Error(errorMessage));
+            return;
+          }
+          resolve(value);
+        });
+        if (
+          maybePromise &&
+          typeof (maybePromise as Promise<T>).then === "function"
+        ) {
+          (maybePromise as Promise<T>).then(resolve, reject);
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+export function getManifestVersion(): string {
+  return getRawApi().runtime?.getManifest?.().version ?? "0.0.0";
+}
+
+export function hasManifestPermission(permission: string): boolean {
+  const permissions = getRawApi().runtime?.getManifest?.().permissions;
+  return Array.isArray(permissions) && permissions.includes(permission);
+}
+
+export async function storageGet<T>(key: string): Promise<T | null> {
+  const area = getRawApi().storage?.local;
+  if (!area?.get) {
+    throw new Error("storage.local.get is unavailable");
+  }
+  const values = await invokeAsync<Record<string, unknown>>(
+    "storage.local.get",
+    (callback) => area.get?.(key, callback),
+  );
+  return (values[key] as T | undefined) ?? null;
+}
+
+export async function storageSet(
+  values: Record<string, unknown>,
+): Promise<void> {
+  const area = getRawApi().storage?.local;
+  if (!area?.set) {
+    throw new Error("storage.local.set is unavailable");
+  }
+  await invokeAsync<void>("storage.local.set", (callback) =>
+    area.set?.(values, callback),
+  );
+}
+
+export async function storageRemove(key: string): Promise<void> {
+  const area = getRawApi().storage?.local;
+  if (!area?.remove) {
+    throw new Error("storage.local.remove is unavailable");
+  }
+  await invokeAsync<void>("storage.local.remove", (callback) =>
+    area.remove?.(key, callback),
+  );
+}
+
+export async function queryTabs(
+  queryInfo: Record<string, unknown>,
+): Promise<ExtensionTab[]> {
+  const tabs = getRawApi().tabs;
+  if (!tabs?.query) {
+    return [];
+  }
+  const results = await invokeAsync<unknown[]>("tabs.query", (callback) =>
+    tabs.query?.(queryInfo, callback),
+  );
+  return results as ExtensionTab[];
+}
+
+export async function getAllWindows(): Promise<ExtensionWindow[]> {
+  const windows = getRawApi().windows;
+  if (!windows?.getAll) {
+    return [];
+  }
+  const results = await invokeAsync<unknown[]>("windows.getAll", (callback) =>
+    windows.getAll?.({ populate: true }, callback),
+  );
+  return results as ExtensionWindow[];
+}
+
+export async function updateTab(
+  tabId: number,
+  updateProperties: Record<string, unknown>,
+): Promise<ExtensionTab> {
+  const tabs = getRawApi().tabs;
+  if (!tabs?.update) {
+    throw new Error("tabs.update is unavailable");
+  }
+  const result = await invokeAsync<unknown>("tabs.update", (callback) =>
+    tabs.update?.(tabId, updateProperties, callback),
+  );
+  return result as ExtensionTab;
+}
+
+export async function createTab(
+  createProperties: Record<string, unknown>,
+): Promise<ExtensionTab> {
+  const tabs = getRawApi().tabs;
+  if (!tabs?.create) {
+    throw new Error("tabs.create is unavailable");
+  }
+  const result = await invokeAsync<unknown>("tabs.create", (callback) =>
+    tabs.create?.(createProperties, callback),
+  );
+  return result as ExtensionTab;
+}
+
+export async function reloadTab(tabId: number): Promise<void> {
+  const tabs = getRawApi().tabs;
+  if (!tabs?.reload) {
+    return;
+  }
+  await invokeAsync<void>("tabs.reload", (callback) =>
+    tabs.reload?.(tabId, {}, callback),
+  );
+}
+
+export async function sendTabMessage<T>(
+  tabId: number,
+  message: unknown,
+): Promise<T> {
+  const tabs = getRawApi().tabs;
+  if (!tabs?.sendMessage) {
+    throw new Error("tabs.sendMessage is unavailable");
+  }
+  const result = await invokeAsync<unknown>("tabs.sendMessage", (callback) =>
+    tabs.sendMessage?.(tabId, message, {}, callback),
+  );
+  return result as T;
+}
+
+export async function sendRuntimeMessage<T>(message: unknown): Promise<T> {
+  const runtime = getRawApi().runtime;
+  if (!runtime?.sendMessage) {
+    throw new Error("runtime.sendMessage is unavailable");
+  }
+  const result = await invokeAsync<unknown>("runtime.sendMessage", (callback) =>
+    runtime.sendMessage?.(message, callback),
+  );
+  return result as T;
+}
+
+export async function executeScriptInMainWorld<T>(
+  tabId: number,
+  func: (...args: unknown[]) => T | Promise<T>,
+  args: unknown[] = [],
+): Promise<T> {
+  const scripting = getRawApi().scripting;
+  if (!scripting?.executeScript) {
+    throw new Error("scripting.executeScript is unavailable");
+  }
+  const results = await invokeAsync<RawScriptingExecutionResult[]>(
+    "scripting.executeScript",
+    (callback) =>
+      scripting.executeScript?.(
+        {
+          target: { tabId },
+          world: "MAIN",
+          func,
+          args,
+        },
+        callback,
+      ),
+  );
+  return results[0]?.result as T | undefined as T;
+}
+
+export async function executeContentScriptFiles(
+  tabId: number,
+  files: string[],
+): Promise<void> {
+  const scripting = getRawApi().scripting;
+  if (!scripting?.executeScript) {
+    throw new Error("scripting.executeScript is unavailable");
+  }
+  await invokeAsync<RawScriptingExecutionResult[]>(
+    "scripting.executeScript",
+    (callback) =>
+      scripting.executeScript?.(
+        {
+          target: { tabId },
+          world: "ISOLATED",
+          files,
+        },
+        callback,
+      ),
+  );
+}
+
+export function addRuntimeMessageListener(
+  listener: (
+    message: unknown,
+    sender: unknown,
+    sendResponse: (response: unknown) => void,
+  ) => boolean | undefined,
+): void {
+  getRawApi().runtime?.onMessage?.addListener(listener);
+}
+
+export function addInstalledListener(
+  listener: (details: { reason?: string }) => void,
+): void {
+  getRawApi().runtime?.onInstalled?.addListener(listener);
+}
+
+export function addStartupListener(listener: () => void): void {
+  getRawApi().runtime?.onStartup?.addListener(listener);
+}
+
+export function addTabsActivatedListener(
+  listener: (info: unknown) => void,
+): void {
+  getRawApi().tabs?.onActivated?.addListener(listener);
+}
+
+export function addTabsUpdatedListener(
+  listener: (tabId: number, changeInfo: unknown) => void,
+): void {
+  getRawApi().tabs?.onUpdated?.addListener(listener);
+}
+
+export function addTabsRemovedListener(
+  listener: (tabId: number) => void,
+): void {
+  getRawApi().tabs?.onRemoved?.addListener(listener);
+}
+
+export function addWindowFocusListener(
+  listener: (windowId: number) => void,
+): void {
+  getRawApi().windows?.onFocusChanged?.addListener(listener);
+}
+
+export function createAlarm(name: string, periodInMinutes: number): void {
+  getRawApi().alarms?.create?.(name, { periodInMinutes });
+}
+
+export function clearAlarm(name: string): void {
+  getRawApi().alarms?.clear?.(name);
+}
+
+export function addAlarmListener(
+  listener: (alarm: { name?: string }) => void,
+): void {
+  getRawApi().alarms?.onAlarm?.addListener(listener);
+}
+
+export async function isIncognitoAccessAllowed(): Promise<boolean> {
+  const extension = getRawApi().extension;
+  if (!extension?.isAllowedIncognitoAccess) {
+    return false;
+  }
+  return await invokeAsync<boolean>(
+    "extension.isAllowedIncognitoAccess",
+    (callback) => extension.isAllowedIncognitoAccess?.(callback),
+  );
+}
+
+export async function hasAllUrlHostPermission(): Promise<boolean> {
+  const permissions = getRawApi().permissions;
+  if (!permissions?.contains) {
+    return false;
+  }
+  return await invokeAsync<boolean>("permissions.contains", (callback) =>
+    permissions.contains?.(
+      { origins: ["https://*/*", "http://*/*"] },
+      callback,
+    ),
+  );
+}
+
+/**
+ * Requests persistent access to normal HTTP(S) pages from a popup click.
+ * Callers must invoke this directly inside a user-gesture handler; routing the
+ * request through the background worker would lose the browser gesture token.
+ */
+export async function requestAllWebsiteAccess(): Promise<boolean> {
+  const permissions = getRawApi().permissions;
+  if (!permissions?.request) {
+    throw new Error("permissions.request is unavailable");
+  }
+  return await invokeAsync<boolean>("permissions.request", (callback) =>
+    permissions.request?.({ origins: ["https://*/*", "http://*/*"] }, callback),
+  );
+}
+
+export async function getGrantedOrigins(): Promise<string[]> {
+  const permissions = getRawApi().permissions;
+  if (!permissions?.getAll) {
+    return [];
+  }
+  const granted = await invokeAsync<{
+    permissions?: string[];
+    origins?: string[];
+  }>("permissions.getAll", (callback) => permissions.getAll?.(callback));
+  return Array.isArray(granted.origins)
+    ? granted.origins
+        .filter(
+          (candidate): candidate is string => typeof candidate === "string",
+        )
+        .map((candidate) => candidate.trim())
+        .filter((candidate) => candidate.length > 0)
+        .sort((left, right) => left.localeCompare(right))
+    : [];
+}
+
+export async function focusWindow(windowId: number): Promise<void> {
+  const windows = getRawApi().windows;
+  if (!windows?.update) {
+    return;
+  }
+  await invokeAsync<unknown>("windows.update", (callback) =>
+    windows.update?.(windowId, { focused: true }, callback),
+  );
+}
+
+export function getExtensionUrl(path: string): string {
+  const runtime = getRawApi().runtime;
+  if (!runtime?.getURL) {
+    return path;
+  }
+  return runtime.getURL(path);
+}
+
+export type DeclarativeNetRequestRule = RawDeclarativeNetRequestRule;
+
+export async function getDynamicRules(): Promise<
+  RawDeclarativeNetRequestRule[]
+> {
+  const dnr = getRawApi().declarativeNetRequest;
+  if (!dnr?.getDynamicRules) {
+    return [];
+  }
+  return await invokeAsync<RawDeclarativeNetRequestRule[]>(
+    "declarativeNetRequest.getDynamicRules",
+    (callback) => dnr.getDynamicRules?.(callback),
+  );
+}
+
+export async function updateDynamicRules(options: {
+  removeRuleIds?: number[];
+  addRules?: RawDeclarativeNetRequestRule[];
+}): Promise<void> {
+  const dnr = getRawApi().declarativeNetRequest;
+  if (!dnr?.updateDynamicRules) {
+    return;
+  }
+  await invokeAsync<void>(
+    "declarativeNetRequest.updateDynamicRules",
+    (callback) => dnr.updateDynamicRules?.(options, callback),
+  );
+}

--- a/packages/browser-bridge-extension/src/webextension.ts
+++ b/packages/browser-bridge-extension/src/webextension.ts
@@ -452,19 +452,28 @@ export async function executeContentScriptFiles(
 }
 
 /**
- * True only for a message sent from this extension's own privileged contexts
- * (the popup or options page). Content scripts carry a `tab`, and anything
- * from another extension carries a different `id`. The popup channel dispatches
- * credential writes, so a content script on any granted origin must not reach
- * it — content scripts here run on `http://localhost/*` at any port, i.e. any
- * local dev server the user happens to be running.
+ * True only for a message sent from this extension's own privileged pages.
+ * Browsers may host an installed guide or popup in a tab, so `tab` alone does
+ * not distinguish it from a content script. A tab sender is privileged only
+ * when its URL has this extension's origin; content scripts here run on
+ * `http://localhost/*` at any port and therefore fail that check.
  */
 export function isPrivilegedExtensionSender(sender: unknown): boolean {
   const extensionId = getRawApi().runtime?.id;
   if (!extensionId) return false;
   if (!sender || typeof sender !== "object") return false;
-  const candidate = sender as { id?: unknown; tab?: unknown };
-  return candidate.id === extensionId && candidate.tab === undefined;
+  const candidate = sender as { id?: unknown; tab?: unknown; url?: unknown };
+  if (candidate.id !== extensionId) return false;
+  if (candidate.tab === undefined) return true;
+  if (typeof candidate.url !== "string") return false;
+  const extensionUrl = getRawApi().runtime?.getURL?.("");
+  if (!extensionUrl) return false;
+  try {
+    return new URL(candidate.url).origin === new URL(extensionUrl).origin;
+  } catch {
+    // error-policy:J3 A malformed sender URL is untrusted input.
+    return false;
+  }
 }
 
 export function addRuntimeMessageListener(

--- a/packages/browser-bridge-extension/src/webextension.ts
+++ b/packages/browser-bridge-extension/src/webextension.ts
@@ -10,6 +10,7 @@ import { withBrowserBridgeRequestTimeout } from "./request-timeout";
 type Callback<T> = (value: T) => void;
 
 type RawRuntime = {
+  id?: string;
   lastError?: { message?: string };
   getManifest?: () => { version?: string; permissions?: string[] };
   onInstalled?: {
@@ -265,6 +266,9 @@ function invokeAsync<T>(
           (maybePromise as Promise<T>).then(resolve, reject);
         }
       } catch (error) {
+        // error-policy:J2 rethrow across the callback/promise shim boundary —
+        // a synchronous throw from the browser API becomes the rejection the
+        // awaiting caller already handles, with the original error intact.
         reject(error);
       }
     });
@@ -445,6 +449,22 @@ export async function executeContentScriptFiles(
         callback,
       ),
   );
+}
+
+/**
+ * True only for a message sent from this extension's own privileged contexts
+ * (the popup or options page). Content scripts carry a `tab`, and anything
+ * from another extension carries a different `id`. The popup channel dispatches
+ * credential writes, so a content script on any granted origin must not reach
+ * it — content scripts here run on `http://localhost/*` at any port, i.e. any
+ * local dev server the user happens to be running.
+ */
+export function isPrivilegedExtensionSender(sender: unknown): boolean {
+  const extensionId = getRawApi().runtime?.id;
+  if (!extensionId) return false;
+  if (!sender || typeof sender !== "object") return false;
+  const candidate = sender as { id?: unknown; tab?: unknown };
+  return candidate.id === extensionId && candidate.tab === undefined;
 }
 
 export function addRuntimeMessageListener(

--- a/packages/browser-bridge-extension/tsconfig.json
+++ b/packages/browser-bridge-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun-types", "vitest/globals"]
+  },
+  "include": ["entrypoints/**/*.ts", "src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/test-dom-setup.ts"]
+}

--- a/packages/browser-bridge-extension/vitest.extension.config.ts
+++ b/packages/browser-bridge-extension/vitest.extension.config.ts
@@ -1,0 +1,11 @@
+/**
+ * Vitest config for the extension's src/ unit tests; loads the jsdom DOM shim
+ * (test-dom-setup) so DOM-dependent modules run under Node.
+ */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./src/test-dom-setup.ts"],
+  },
+});

--- a/packages/shared/src/contracts/personal-assistant.test.ts
+++ b/packages/shared/src/contracts/personal-assistant.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   capabilitiesForSide,
+  LIFEOPS_BROWSER_KINDS,
   LIFEOPS_CONNECTOR_DEGRADATION_AXES,
   LIFEOPS_DISCORD_CAPABILITIES,
   LIFEOPS_GOOGLE_CAPABILITIES,
@@ -19,6 +20,10 @@ import {
 } from "./personal-assistant";
 
 describe("LifeOps shared contracts", () => {
+  it("supports every shipped browser-bridge companion", () => {
+    expect(LIFEOPS_BROWSER_KINDS).toEqual(["chrome", "firefox", "safari"]);
+  });
+
   it("keeps owner-side capabilities read-only", () => {
     expect(capabilitiesForSide(LIFEOPS_GOOGLE_CAPABILITIES, "owner")).toEqual([
       "google.calendar.read",

--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -3752,6 +3752,9 @@ export interface UpdateLifeOpsBrowserSessionProgressRequest {
 export interface CompleteLifeOpsBrowserSessionRequest {
   status?: Extract<LifeOpsBrowserSessionStatus, "done" | "failed">;
   result?: Record<string, unknown>;
+  currentActionIndex?: number;
+  completedActionId?: string | null;
+  attemptId?: string | null;
 }
 
 // ── Settings card prop contracts ─────────────────────────────────────────────

--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -1042,7 +1042,7 @@ export interface LifeOpsWorkflowPermissionPolicy {
 // `LifeOpsBrowserKind`, `LIFEOPS_BROWSER_ACTION_KINDS`,
 // `LifeOpsBrowserActionKind`, and `LifeOpsBrowserAction` remain here
 // because workflow-linked session shapes below still reference them.
-export const LIFEOPS_BROWSER_KINDS = ["chrome", "safari"] as const;
+export const LIFEOPS_BROWSER_KINDS = ["chrome", "firefox", "safari"] as const;
 export type LifeOpsBrowserKind = (typeof LIFEOPS_BROWSER_KINDS)[number];
 
 export const LIFEOPS_BROWSER_ACTION_KINDS = [

--- a/packages/ui/src/api/browser-contracts.ts
+++ b/packages/ui/src/api/browser-contracts.ts
@@ -1,9 +1,9 @@
 /**
- * Wire types for the browser-companion bridge (Chrome/Safari): tracking mode,
+ * Wire types for the Chrome, Firefox, and Safari browser-companion bridge: tracking mode,
  * site-access mode, connection state, and workspace tab shapes shared by the
  * client and the desktop bridge.
  */
-export type BrowserBridgeKind = "chrome" | "safari";
+export type BrowserBridgeKind = "chrome" | "firefox" | "safari";
 
 export type BrowserBridgeTrackingMode = "off" | "current_tab" | "active_tabs";
 
@@ -163,11 +163,13 @@ export interface SyncBrowserBridgeStateRequest {
 export interface BrowserBridgeCompanionReleaseAsset {
   fileName: string;
   downloadUrl: string | null;
+  sha256: string | null;
 }
 
 export interface BrowserBridgeCompanionReleaseTarget {
   installKind:
     | "chrome_web_store"
+    | "firefox_addons"
     | "apple_app_store"
     | "github_release"
     | "local_download";
@@ -184,9 +186,11 @@ export interface BrowserBridgeCompanionReleaseManifest {
   releasePageUrl: string | null;
   chromeVersion: string;
   chromeVersionName: string;
+  firefoxVersion: string;
   safariMarketingVersion: string;
   safariBuildVersion: string;
   chrome: BrowserBridgeCompanionReleaseTarget;
+  firefox: BrowserBridgeCompanionReleaseTarget;
   safari: BrowserBridgeCompanionReleaseTarget;
   generatedAt: string;
 }
@@ -195,6 +199,8 @@ export interface BrowserBridgeCompanionPackageStatus {
   extensionPath: string | null;
   chromeBuildPath: string | null;
   chromePackagePath: string | null;
+  firefoxBuildPath: string | null;
+  firefoxPackagePath: string | null;
   safariWebExtensionPath: string | null;
   safariAppPath: string | null;
   safariPackagePath: string | null;

--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -4,14 +4,14 @@ Adds browser automation and companion bridge management to an Eliza agent.
 
 ## Purpose / role
 
-Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile) and the Chrome/Safari Agent Browser Bridge companion extension surface. Loaded by the elizaOS runtime via the `browserPlugin` export. Auto-enabled when `config.features.browser` is truthy (checked by `auto-enable.ts`); disabled by default unless that config key is set.
+Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile) and the Chrome, Firefox, and Safari Agent Browser Bridge companion extension surface. Loaded by the elizaOS runtime via the `browserPlugin` export. Auto-enabled when `config.features.browser` is truthy (checked by `auto-enable.ts`); disabled by default unless that config key is set.
 
 ## Plugin surface
 
 ### Actions
 
 - **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `fill`, `clear`, `press`, `scroll`, `scroll_into`, `hover`, `drag`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `wait_for_url`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only. `wait_for_url` (pure predicate + poll loop in `src/actions/wait-for-url*.ts`) optionally opens a `url`, then polls the current tab URL against a `pattern` (substring, or a `/regex/` literal — invalid regex falls back to substring), streaming a `HandlerCallback` status each poll and resolving with a typed match/timeout result (never throws on timeout). Tunables: `timeoutMs` (default 300000) and `pollIntervalMs` (default 2000).
-- **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome/Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
+- **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome, Firefox, and Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
 
 ### Providers
 
@@ -30,7 +30,7 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 All under `/api/browser-bridge/` — defined in `src/plugin.ts` and handled by `src/routes/bridge.ts`:
 
-Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, `POST /companions/auto-pair`, `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
+Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
 
 Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
 
@@ -79,7 +79,7 @@ src/
     browser-matrix.ts              Machine-checkable BROWSER action parity matrix (#9476)
     index.ts                       Parity tooling barrel
   targets/
-    bridge-target.ts               `bridge` BrowserTarget — dispatches to Chrome/Safari companion
+    bridge-target.ts               `bridge` BrowserTarget — dispatches to paired browser companions
     stagehand-target.ts            `stagehand` BrowserTarget — Playwright/Stagehand fallback
   workspace/
     browser-workspace.ts           Public API surface and main command router (executeBrowserWorkspaceCommand)
@@ -134,6 +134,7 @@ bun run --cwd plugins/plugin-browser test                            # run packa
 | `ELIZA_MOBILE_PLATFORM` / `ELIZA_PLATFORM` / `CAPACITOR_PLATFORM` | no | Platform hint (`ios`/`android`/`mobile`) — changes target scoring |
 | `ELIZA_BROWSER_BRIDGE_COMPANION_TOKEN_TTL_MS` | no | Overrides the default companion pairing token TTL (milliseconds) |
 | `ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL` | no | Custom Chrome Web Store URL for the companion extension |
+| `ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL` | no | Custom Firefox Add-ons listing URL for the companion extension |
 | `ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL` | no | Custom Safari App Store URL for the companion extension |
 
 Autofill-login vault keys (set by user via Settings → Vault → Logins, not env vars):

--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -30,9 +30,11 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 All under `/api/browser-bridge/` — defined in `src/plugin.ts` and handled by `src/routes/bridge.ts`:
 
-Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
+Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/preflight` (public), `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
 
-Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
+Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/actions/begin` (public), `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
+
+The public companion callbacks authenticate on the companion id plus pairing token rather than the local gate. `POST /companions/sessions/:id/actions/begin` claims the durable action-attempt lease that every side effect must hold; `POST /companions/preflight` reports companion and settings-version staleness before a sync heartbeat.
 
 Workspace setup routes: `src/routes/workspace-setup.ts` + `src/routes/workspace.ts`.
 

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -4,14 +4,14 @@ Adds browser automation and companion bridge management to an Eliza agent.
 
 ## Purpose / role
 
-Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile) and the Chrome/Safari Agent Browser Bridge companion extension surface. Loaded by the elizaOS runtime via the `browserPlugin` export. Auto-enabled when `config.features.browser` is truthy (checked by `auto-enable.ts`); disabled by default unless that config key is set.
+Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile) and the Chrome, Firefox, and Safari Agent Browser Bridge companion extension surface. Loaded by the elizaOS runtime via the `browserPlugin` export. Auto-enabled when `config.features.browser` is truthy (checked by `auto-enable.ts`); disabled by default unless that config key is set.
 
 ## Plugin surface
 
 ### Actions
 
 - **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `fill`, `clear`, `press`, `scroll`, `scroll_into`, `hover`, `drag`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `wait_for_url`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only. `wait_for_url` (pure predicate + poll loop in `src/actions/wait-for-url*.ts`) optionally opens a `url`, then polls the current tab URL against a `pattern` (substring, or a `/regex/` literal — invalid regex falls back to substring), streaming a `HandlerCallback` status each poll and resolving with a typed match/timeout result (never throws on timeout). Tunables: `timeoutMs` (default 300000) and `pollIntervalMs` (default 2000).
-- **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome/Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
+- **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome, Firefox, and Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
 
 ### Providers
 
@@ -30,7 +30,7 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 All under `/api/browser-bridge/` — defined in `src/plugin.ts` and handled by `src/routes/bridge.ts`:
 
-Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, `POST /companions/auto-pair`, `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
+Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
 
 Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
 
@@ -79,7 +79,7 @@ src/
     browser-matrix.ts              Machine-checkable BROWSER action parity matrix (#9476)
     index.ts                       Parity tooling barrel
   targets/
-    bridge-target.ts               `bridge` BrowserTarget — dispatches to Chrome/Safari companion
+    bridge-target.ts               `bridge` BrowserTarget — dispatches to paired browser companions
     stagehand-target.ts            `stagehand` BrowserTarget — Playwright/Stagehand fallback
   workspace/
     browser-workspace.ts           Public API surface and main command router (executeBrowserWorkspaceCommand)
@@ -134,6 +134,7 @@ bun run --cwd plugins/plugin-browser test                            # run packa
 | `ELIZA_MOBILE_PLATFORM` / `ELIZA_PLATFORM` / `CAPACITOR_PLATFORM` | no | Platform hint (`ios`/`android`/`mobile`) — changes target scoring |
 | `ELIZA_BROWSER_BRIDGE_COMPANION_TOKEN_TTL_MS` | no | Overrides the default companion pairing token TTL (milliseconds) |
 | `ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL` | no | Custom Chrome Web Store URL for the companion extension |
+| `ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL` | no | Custom Firefox Add-ons listing URL for the companion extension |
 | `ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL` | no | Custom Safari App Store URL for the companion extension |
 
 Autofill-login vault keys (set by user via Settings → Vault → Logins, not env vars):

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -30,9 +30,11 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 All under `/api/browser-bridge/` — defined in `src/plugin.ts` and handled by `src/routes/bridge.ts`:
 
-Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
+Static: `GET /sessions`, `GET /settings`, `POST /settings`, `POST /companions/pair`, retired `POST /companions/auto-pair` (`410 Gone`), `GET /companions`, `POST /companions/revoke` (public), `GET /packages`, `POST /packages/open-path`, `POST /companions/preflight` (public), `POST /companions/sync` (public), `GET /tabs`, `GET /current-page`, `POST /sync`, `POST /sessions`.
 
-Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
+Dynamic: `GET /sessions/:id`, `POST /sessions/:id/confirm`, `POST /sessions/:id/progress`, `POST /sessions/:id/complete`, `POST /companions/:id/revoke`, `POST /companions/sessions/:id/actions/begin` (public), `POST /companions/sessions/:id/progress` (public), `POST /companions/sessions/:id/complete` (public), `GET|POST /packages/:browser/build|open-manager|download`.
+
+The public companion callbacks authenticate on the companion id plus pairing token rather than the local gate. `POST /companions/sessions/:id/actions/begin` claims the durable action-attempt lease that every side effect must hold; `POST /companions/preflight` reports companion and settings-version staleness before a sync heartbeat.
 
 Workspace setup routes: `src/routes/workspace-setup.ts` + `src/routes/workspace.ts`.
 

--- a/plugins/plugin-browser/README.md
+++ b/plugins/plugin-browser/README.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-browser
 
-Browser automation and companion bridge plugin for elizaOS. Adds the `BROWSER` action and `MANAGE_BROWSER_BRIDGE` action to any Eliza agent, owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile), and manages the Chrome/Safari Agent Browser Bridge companion extension.
+Browser automation and companion bridge plugin for elizaOS. Adds the `BROWSER` action and `MANAGE_BROWSER_BRIDGE` action to any Eliza agent, owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, JSDOM fallback on web/mobile), and manages the Chrome, Firefox, and Safari Agent Browser Bridge companion extension.
 
 ## What this plugin provides
 
@@ -37,7 +37,7 @@ Browser automation and companion bridge plugin for elizaOS. Adds the `BROWSER` a
 | `cursor_hide` | Hide the cursor overlay |
 | `autofill_login` | Fill saved credentials into a browser tab (vault-gated; requires `domain`) |
 
-**MANAGE_BROWSER_BRIDGE** — Manages the Chrome/Safari companion extension. Subactions: `install` (build + reveal + open manager), `reveal_folder` (open the build folder in Finder/Explorer), `open_manager` (`chrome://extensions`), `refresh` (report paired companions and settings). Owner-only.
+**MANAGE_BROWSER_BRIDGE** — Manages the Chrome, Firefox, and Safari companion extension. Subactions: `install` (build + reveal + open manager), `reveal_folder` (open the build folder in Finder/Explorer), `open_manager` (the selected browser's extension manager), `refresh` (report paired companions and settings). Owner-only.
 
 ### Browser targets
 
@@ -46,7 +46,7 @@ The plugin uses a pluggable target registry in `BrowserService`. Targets are sel
 | Target ID | Backend | When available |
 |---|---|---|
 | `workspace` | Electrobun `BrowserView` (desktop) or JSDOM (web) | Always |
-| `bridge` | Paired Chrome/Safari via companion extension | At least one companion paired |
+| `bridge` | Paired Chrome, Firefox, or Safari via companion extension | At least one companion paired |
 | `stagehand` | Playwright/Stagehand via HTTP endpoint | `ELIZA_BROWSER_STAGEHAND_COMMAND_URL` or `STAGEHAND_SERVER_URL` set |
 
 External plugins can register additional targets by calling `BrowserService.registerTarget(target)`.
@@ -100,6 +100,9 @@ The plugin is opt-in. It activates when `config.features.browser` is truthy in t
 | `ELIZA_BROWSER_STAGEHAND_AUTO_SETUP` | Set `false` to disable automatic stagehand-server install/build |
 | `ELIZA_BROWSER_ALLOW_STAGEHAND_ON_MOBILE` | Set `true` to allow stagehand target on mobile |
 | `ELIZA_MOBILE_PLATFORM` / `ELIZA_PLATFORM` / `CAPACITOR_PLATFORM` | Platform hint for target scoring (`ios`/`android`/`mobile`) |
+| `ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL` | Chrome Web Store listing override |
+| `ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL` | Firefox Add-ons listing override |
+| `ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL` | Safari App Store listing override |
 
 ### Vault keys (set by the user, not env vars)
 

--- a/plugins/plugin-browser/package.json
+++ b/plugins/plugin-browser/package.json
@@ -2,7 +2,7 @@
   "name": "@elizaos/plugin-browser",
   "version": "2.0.3-beta.7",
   "type": "module",
-  "description": "Browser plugin: BROWSER action and MANAGE_BROWSER_BRIDGE management action. Owns the workspace browser (electrobun-embedded + jsdom fallback) and the Chrome/Safari companion bridge. Targets are registered with the BrowserService; the agent uses what is available.",
+  "description": "Browser plugin: BROWSER action and MANAGE_BROWSER_BRIDGE management action. Owns the workspace browser (electrobun-embedded + jsdom fallback) and the Chrome, Firefox, and Safari companion bridge. Targets are registered with the BrowserService; the agent uses what is available.",
   "main": "./dist/index.js",
   "exports": {
     "./package.json": "./package.json",

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -34,7 +34,7 @@ import {
 /**
  * Targets are the registered browser backends. The agent uses what is
  * available; specifying a target overrides automatic routing. `workspace`
- * is the app-owned browser surface, `bridge` is the paired Chrome/Safari
+ * is the app-owned browser surface, `bridge` is the paired Chrome, Firefox, or Safari
  * companion, `stagehand` is the Playwright/Stagehand fallback, and other
  * plugins may register additional target ids.
  */
@@ -799,7 +799,7 @@ export const browserAction: Action = {
     "SIGN_IN_TO_SITE",
   ],
   description:
-    "BROWSER action. Control registered browser target: app workspace, bridge Chrome/Safari companion, computeruse Chromium, or Stagehand fallback. BrowserService picks target if omitted. Interaction: click, type (append), fill (replace), clear, press, scroll (direction/pixels, optional selector), hover, drag (selector -> targetSelector). action=autofill_login + domain vault-gated autofills open workspace tab. action=wait_for_url + pattern opens an optional url then watches the tab and resumes when its URL matches (OAuth callback, deploy/CI done), streaming progress.",
+    "BROWSER action. Control registered browser target: app workspace, bridge Chrome/Firefox/Safari companion, computeruse Chromium, or Stagehand fallback. BrowserService picks target if omitted. Interaction: click, type (append), fill (replace), clear, press, scroll (direction/pixels, optional selector), hover, drag (selector -> targetSelector). action=autofill_login + domain vault-gated autofills open workspace tab. action=wait_for_url + pattern opens an optional url then watches the tab and resumes when its URL matches (OAuth callback, deploy/CI done), streaming progress.",
   descriptionCompressed:
     "Browser open|navigate|click|type|fill|clear|scroll|hover|drag|screenshot|state|autofill_login|wait_for_url; bridge status elsewhere",
   routingHint:

--- a/plugins/plugin-browser/src/actions/manage-browser-bridge.ts
+++ b/plugins/plugin-browser/src/actions/manage-browser-bridge.ts
@@ -357,7 +357,7 @@ export const manageBrowserBridgeAction: Action = {
     "BROWSER_BRIDGE_REFRESH",
   ],
   description:
-    "Owner-only Agent Browser Bridge management for Chrome/Safari. Actions: refresh status/settings/connection, install build+reveal setup, reveal_folder open build folder, open_manager chrome://extensions only on explicit ask. Infer action if omitted.",
+    "Owner-only Agent Browser Bridge management for Chrome, Firefox, and Safari. Actions: refresh status/settings/connection, install build+reveal setup, reveal_folder open build folder, open_manager browser extension settings only on explicit ask. Infer action if omitted.",
   descriptionCompressed:
     "Browser Bridge: refresh|install|reveal_folder|open_manager chrome://extensions",
   validate: async (

--- a/plugins/plugin-browser/src/contracts.ts
+++ b/plugins/plugin-browser/src/contracts.ts
@@ -8,7 +8,7 @@
 
 import type { LifeOpsBrowserSession } from "./lifeops-session-contracts.js";
 
-export const BROWSER_BRIDGE_KINDS = ["chrome", "safari"] as const;
+export const BROWSER_BRIDGE_KINDS = ["chrome", "firefox", "safari"] as const;
 export type BrowserBridgeKind = (typeof BROWSER_BRIDGE_KINDS)[number];
 
 export const BROWSER_BRIDGE_TRACKING_MODES = [
@@ -271,11 +271,27 @@ export interface BrowserBridgeCompanionRevokeResponse {
   revokedAt: string;
 }
 
+export interface BrowserBridgeCompanionPreflightRequest {
+  companion: UpsertBrowserBridgeCompanionRequest;
+}
+
+export interface BrowserBridgeCompanionSyncRequest
+  extends SyncBrowserBridgeStateRequest {
+  settingsVersion: string;
+}
+
+export interface BrowserBridgeCompanionPreflightResponse {
+  companion: BrowserBridgeCompanionStatus;
+  settings: BrowserBridgeSettings;
+  settingsVersion: string;
+}
+
 export interface BrowserBridgeCompanionSyncResponse {
   companion: BrowserBridgeCompanionStatus;
   tabs: BrowserBridgeTabSummary[];
   currentPage: BrowserBridgePageContext | null;
   settings: BrowserBridgeSettings;
+  settingsVersion: string;
   session: LifeOpsBrowserSession | null;
 }
 
@@ -285,10 +301,24 @@ export interface UpdateBrowserBridgeSessionProgressRequest {
   metadata?: Record<string, unknown>;
 }
 
+export interface BrowserBridgeCompanionSessionProgressRequest
+  extends UpdateBrowserBridgeSessionProgressRequest {
+  completedActionId: string;
+  attemptId: string;
+}
+
+export interface BrowserBridgeCompanionSessionBeginRequest {
+  currentActionIndex: number;
+  actionId: string;
+  attemptId: string;
+}
+
 export const BROWSER_BRIDGE_PACKAGE_PATH_TARGETS = [
   "extension_root",
   "chrome_build",
   "chrome_package",
+  "firefox_build",
+  "firefox_package",
   "safari_web_extension",
   "safari_app",
   "safari_package",
@@ -300,6 +330,8 @@ export interface BrowserBridgeCompanionPackageStatus {
   extensionPath: string | null;
   chromeBuildPath: string | null;
   chromePackagePath: string | null;
+  firefoxBuildPath: string | null;
+  firefoxPackagePath: string | null;
   safariWebExtensionPath: string | null;
   safariAppPath: string | null;
   safariPackagePath: string | null;
@@ -309,11 +341,13 @@ export interface BrowserBridgeCompanionPackageStatus {
 export interface BrowserBridgeCompanionReleaseAsset {
   fileName: string;
   downloadUrl: string | null;
+  sha256: string | null;
 }
 
 export interface BrowserBridgeCompanionReleaseTarget {
   installKind:
     | "chrome_web_store"
+    | "firefox_addons"
     | "apple_app_store"
     | "github_release"
     | "local_download";
@@ -330,9 +364,11 @@ export interface BrowserBridgeCompanionReleaseManifest {
   releasePageUrl: string | null;
   chromeVersion: string;
   chromeVersionName: string;
+  firefoxVersion: string;
   safariMarketingVersion: string;
   safariBuildVersion: string;
   chrome: BrowserBridgeCompanionReleaseTarget;
+  firefox: BrowserBridgeCompanionReleaseTarget;
   safari: BrowserBridgeCompanionReleaseTarget;
   generatedAt: string;
 }

--- a/plugins/plugin-browser/src/dispatch-types.ts
+++ b/plugins/plugin-browser/src/dispatch-types.ts
@@ -18,7 +18,7 @@
  *
  * Replay is forbidden for ALL subactions once execution begins — even
  * read-only ones. Registered targets are distinct browser sessions (the
- * embedded workspace vs. the user's real Chrome/Safari via the bridge), so
+ * embedded workspace vs. the user's real Chrome, Firefox, or Safari via the bridge), so
  * retrying a failed read against a different target would silently answer
  * from a different browser. The classification only controls error shape: a
  * failed read rethrows its original cause, while an opaquely failed mutation

--- a/plugins/plugin-browser/src/lifeops-session-contracts.ts
+++ b/plugins/plugin-browser/src/lifeops-session-contracts.ts
@@ -57,4 +57,7 @@ export interface ConfirmLifeOpsBrowserSessionRequest {
 export interface CompleteLifeOpsBrowserSessionRequest {
   status?: Extract<LifeOpsBrowserSessionStatus, "done" | "failed">;
   result?: Record<string, unknown>;
+  currentActionIndex?: number;
+  completedActionId?: string | null;
+  attemptId?: string | null;
 }

--- a/plugins/plugin-browser/src/packaging.test.ts
+++ b/plugins/plugin-browser/src/packaging.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Verifies Firefox-aware package discovery, release metadata, and path routing.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { BrowserBridgeCompanionPackageStatus } from "./contracts.js";
+import {
+  browserBridgePackageContentType,
+  buildBrowserBridgeReleaseManifestForVersion,
+  resolveBrowserBridgeCompanionPackagePath,
+} from "./packaging.js";
+
+describe("browser bridge packaging", () => {
+  it("publishes install metadata for Chrome, Firefox, and Safari", () => {
+    const manifest = buildBrowserBridgeReleaseManifestForVersion(
+      "2.0.3-beta.7",
+      {
+        GITHUB_REPOSITORY: "elizaOS/eliza",
+        ELIZA_BROWSER_BRIDGE_CHROME_STORE_URL:
+          "https://chromewebstore.google.com/detail/eliza/test",
+        ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL:
+          "https://addons.mozilla.org/firefox/addon/eliza/",
+        ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL:
+          "https://apps.apple.com/app/eliza/id1",
+      },
+    );
+
+    expect(manifest).toMatchObject({
+      releaseTag: "v2.0.3-beta.7",
+      firefoxVersion: "2.0.3-beta.7",
+      firefox: {
+        installKind: "firefox_addons",
+        installUrl: "https://addons.mozilla.org/firefox/addon/eliza/",
+        asset: {
+          fileName: "browser-bridge-firefox-v2.0.3-beta.7.xpi",
+          sha256: null,
+        },
+      },
+    });
+  });
+
+  it("routes Firefox build and package targets without Chrome fallback", () => {
+    const status = {
+      extensionPath: "/extension",
+      chromeBuildPath: "/extension/dist/chrome",
+      chromePackagePath: "/extension/dist/artifacts/chrome.zip",
+      firefoxBuildPath: "/extension/dist/firefox",
+      firefoxPackagePath: "/extension/dist/artifacts/firefox.xpi",
+      safariWebExtensionPath: "/extension/dist/safari",
+      safariAppPath: "/extension/dist/artifacts/safari.app",
+      safariPackagePath: "/extension/dist/artifacts/safari.zip",
+      releaseManifest: null,
+    } satisfies BrowserBridgeCompanionPackageStatus;
+
+    expect(
+      resolveBrowserBridgeCompanionPackagePath(status, "firefox_build"),
+    ).toBe("/extension/dist/firefox");
+    expect(
+      resolveBrowserBridgeCompanionPackagePath(status, "firefox_package"),
+    ).toBe("/extension/dist/artifacts/firefox.xpi");
+    expect(browserBridgePackageContentType("firefox")).toBe(
+      "application/x-xpinstall",
+    );
+    expect(browserBridgePackageContentType("chrome")).toBe("application/zip");
+  });
+});

--- a/plugins/plugin-browser/src/packaging.ts
+++ b/plugins/plugin-browser/src/packaging.ts
@@ -356,6 +356,7 @@ function buildGitHubReleaseAssetDownloadUrl(
 
 function resolveBrowserBridgeStoreUrls(env = process.env): {
   chromeWebStoreUrl: string | null;
+  firefoxAddonsUrl: string | null;
   safariAppStoreUrl: string | null;
 } {
   const chromeWebStoreUrl =
@@ -368,8 +369,14 @@ function resolveBrowserBridgeStoreUrls(env = process.env): {
     env.ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL.trim()
       ? env.ELIZA_BROWSER_BRIDGE_SAFARI_STORE_URL.trim()
       : null;
+  const firefoxAddonsUrl =
+    typeof env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL === "string" &&
+    env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL.trim()
+      ? env.ELIZA_BROWSER_BRIDGE_FIREFOX_ADDONS_URL.trim()
+      : null;
   return {
     chromeWebStoreUrl,
+    firefoxAddonsUrl,
     safariAppStoreUrl,
   };
 }
@@ -394,6 +401,11 @@ export function buildBrowserBridgeReleaseManifestForVersion(
     "zip",
     release,
   );
+  const firefoxAssetName = versionedArtifactName(
+    "browser-bridge-firefox",
+    "xpi",
+    release,
+  );
   const safariVersions = buildSafariExtensionVersions(release);
   return {
     schema: "browser_bridge_release_v2",
@@ -403,6 +415,7 @@ export function buildBrowserBridgeReleaseManifestForVersion(
     releasePageUrl: buildGitHubReleasePageUrl(repository, release),
     chromeVersion: buildChromeExtensionVersion(release),
     chromeVersionName: release.raw,
+    firefoxVersion: release.raw,
     safariMarketingVersion: safariVersions.marketingVersion,
     safariBuildVersion: safariVersions.buildVersion,
     chrome: {
@@ -424,6 +437,29 @@ export function buildBrowserBridgeReleaseManifestForVersion(
           release,
           chromeAssetName,
         ),
+        sha256: null,
+      },
+    },
+    firefox: {
+      installKind: storeUrls.firefoxAddonsUrl
+        ? "firefox_addons"
+        : "github_release",
+      installUrl:
+        storeUrls.firefoxAddonsUrl ??
+        buildGitHubReleaseAssetDownloadUrl(
+          repository,
+          release,
+          firefoxAssetName,
+        ),
+      storeListingUrl: storeUrls.firefoxAddonsUrl,
+      asset: {
+        fileName: firefoxAssetName,
+        downloadUrl: buildGitHubReleaseAssetDownloadUrl(
+          repository,
+          release,
+          firefoxAssetName,
+        ),
+        sha256: null,
       },
     },
     safari: {
@@ -445,6 +481,7 @@ export function buildBrowserBridgeReleaseManifestForVersion(
           release,
           safariAssetName,
         ),
+        sha256: null,
       },
     },
     generatedAt: new Date().toISOString(),
@@ -498,7 +535,14 @@ function resolveBrowserBridgeExtensionRoot(): string | null {
 }
 
 function packageScriptName(browser: BrowserBridgeKind): string {
-  return browser === "safari" ? "package-safari.mjs" : "package-chrome.mjs";
+  switch (browser) {
+    case "chrome":
+      return "package-chrome.mjs";
+    case "firefox":
+      return "package-firefox.mjs";
+    case "safari":
+      return "package-safari.mjs";
+  }
 }
 
 function runCommand(
@@ -547,6 +591,10 @@ export function resolveBrowserBridgeCompanionPackagePath(
       return status.chromeBuildPath;
     case "chrome_package":
       return status.chromePackagePath;
+    case "firefox_build":
+      return status.firefoxBuildPath;
+    case "firefox_package":
+      return status.firefoxPackagePath;
     case "safari_web_extension":
       return status.safariWebExtensionPath;
     case "safari_app":
@@ -625,6 +673,26 @@ async function openChromeExtensionsManager(): Promise<void> {
   }
 }
 
+async function openFirefoxExtensionsManager(): Promise<void> {
+  const managerUrl = "about:debugging#/runtime/this-firefox";
+  const cwd = outerRepoRoot;
+  switch (process.platform) {
+    case "darwin":
+      await runCommand("open", ["-a", "Firefox", managerUrl], cwd);
+      return;
+    case "win32":
+      await runCommand("cmd", ["/c", "start", "", "firefox", managerUrl], cwd);
+      return;
+    case "linux":
+      await runCommand("firefox", [managerUrl], cwd);
+      return;
+    default:
+      throw new Error(
+        `Opening the Firefox extensions manager is not supported on ${process.platform}`,
+      );
+  }
+}
+
 export function getBrowserBridgeCompanionPackageStatus(): BrowserBridgeCompanionPackageStatus {
   const resolvedExtensionPath = resolveBrowserBridgeExtensionPath();
   if (!resolvedExtensionPath) {
@@ -632,6 +700,8 @@ export function getBrowserBridgeCompanionPackageStatus(): BrowserBridgeCompanion
       extensionPath: null,
       chromeBuildPath: null,
       chromePackagePath: null,
+      firefoxBuildPath: null,
+      firefoxPackagePath: null,
       safariWebExtensionPath: null,
       safariAppPath: null,
       safariPackagePath: null,
@@ -649,6 +719,10 @@ export function getBrowserBridgeCompanionPackageStatus(): BrowserBridgeCompanion
     chromeBuildPath: existingPath(path.join(distDir, "chrome")),
     chromePackagePath: existingPath(
       path.join(artifactsDir, "browser-bridge-chrome.zip"),
+    ),
+    firefoxBuildPath: existingPath(path.join(distDir, "firefox")),
+    firefoxPackagePath: existingPath(
+      path.join(artifactsDir, "browser-bridge-firefox.xpi"),
     ),
     safariWebExtensionPath: existingPath(path.join(distDir, "safari")),
     safariAppPath: existingPath(
@@ -668,17 +742,27 @@ export function getBrowserBridgeCompanionDownloadFile(
 ): { path: string; filename: string; contentType: string } {
   const status = getBrowserBridgeCompanionPackageStatus();
   const filePath =
-    browser === "safari" ? status.safariPackagePath : status.chromePackagePath;
+    browser === "safari"
+      ? status.safariPackagePath
+      : browser === "firefox"
+        ? status.firefoxPackagePath
+        : status.chromePackagePath;
   if (!filePath) {
     throw new Error(
-      `${browser === "safari" ? "Safari" : "Chrome"} package has not been built yet`,
+      `${browser[0]?.toUpperCase()}${browser.slice(1)} package has not been built yet`,
     );
   }
   return {
     path: filePath,
     filename: path.basename(filePath),
-    contentType: "application/zip",
+    contentType: browserBridgePackageContentType(browser),
   };
+}
+
+export function browserBridgePackageContentType(
+  browser: BrowserBridgeKind,
+): "application/zip" | "application/x-xpinstall" {
+  return browser === "firefox" ? "application/x-xpinstall" : "application/zip";
 }
 
 export async function openBrowserBridgeCompanionPackagePath(
@@ -706,13 +790,17 @@ export async function openBrowserBridgeCompanionPackagePath(
 export async function openBrowserBridgeCompanionManager(
   browser: BrowserBridgeKind,
 ): Promise<{ browser: BrowserBridgeKind }> {
-  if (browser !== "chrome") {
-    throw new Error(
-      "Only Chrome exposes a local extensions manager for unpacked install",
-    );
+  if (browser === "chrome") {
+    await openChromeExtensionsManager();
+    return { browser };
   }
-  await openChromeExtensionsManager();
-  return { browser };
+  if (browser === "firefox") {
+    await openFirefoxExtensionsManager();
+    return { browser };
+  }
+  throw new Error(
+    "Safari extensions are managed through the containing app and Safari Settings",
+  );
 }
 
 export async function buildBrowserBridgeCompanionPackage(

--- a/plugins/plugin-browser/src/plugin.ts
+++ b/plugins/plugin-browser/src/plugin.ts
@@ -145,6 +145,13 @@ const DYNAMIC_ROUTES: Array<{
   { type: "POST", path: "/api/browser-bridge/companions/:id/revoke" },
   {
     type: "POST",
+    path: "/api/browser-bridge/companions/sessions/:id/actions/begin",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
+  },
+  {
+    type: "POST",
     path: "/api/browser-bridge/companions/sessions/:id/progress",
     public: true,
     publicReason: COMPANION_ROUTE_REASON,

--- a/plugins/plugin-browser/src/plugin.ts
+++ b/plugins/plugin-browser/src/plugin.ts
@@ -7,7 +7,6 @@
  */
 
 import type http from "node:http";
-import { TLSSocket } from "node:tls";
 import type {
   AgentRuntime,
   LegacyRouteHandler,
@@ -56,31 +55,6 @@ function httpDecodePathComponent(
   }
 }
 
-function firstHeaderValue(value: string | string[] | undefined): string | null {
-  if (Array.isArray(value)) {
-    return firstHeaderValue(value[0]);
-  }
-  if (typeof value !== "string") {
-    return null;
-  }
-  const normalized = value.split(",")[0]?.trim();
-  return normalized ? normalized : null;
-}
-
-function requestBaseUrl(req: http.IncomingMessage): string {
-  const headers = req.headers ?? {};
-  const protocol =
-    firstHeaderValue(headers["x-forwarded-proto"]) ??
-    (req.socket instanceof TLSSocket && req.socket.encrypted
-      ? "https"
-      : "http");
-  const host =
-    firstHeaderValue(headers["x-forwarded-host"]) ??
-    firstHeaderValue(headers.host) ??
-    "localhost";
-  return `${protocol}://${host}`;
-}
-
 function routeOwnerEntityId(runtime: AgentRuntime | null): UUID | null {
   const ownerId = runtime ? resolveCanonicalOwnerId(runtime) : null;
   return typeof ownerId === "string" ? (ownerId as UUID) : null;
@@ -92,7 +66,7 @@ function buildRouteContext(
   runtime: AgentRuntime | null,
 ): BrowserBridgeRouteContext {
   const method = (req.method ?? "GET").toUpperCase();
-  const url = new URL(req.url ?? "/", requestBaseUrl(req));
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
   return {
     req,
     res,
@@ -137,6 +111,13 @@ const STATIC_ROUTES: Array<{
   },
   { type: "GET", path: "/api/browser-bridge/packages" },
   { type: "POST", path: "/api/browser-bridge/packages/open-path" },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/companions/preflight",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
+  },
   {
     type: "POST",
     path: "/api/browser-bridge/companions/sync",
@@ -239,7 +220,7 @@ const browserBridgePluginRoutes: Route[] = [
 export const browserPlugin: Plugin = {
   name: "@elizaos/plugin-browser",
   description:
-    "Browser plugin: BROWSER (including action=autofill_login) + MANAGE_BROWSER_BRIDGE; workspace browser command router (electrobun-embedded BrowserView + JSDOM fallback) and Chrome/Safari companion bridge (settings, pairing, tab + page-context sync, packaging artifacts).",
+    "Browser plugin: BROWSER (including action=autofill_login) + MANAGE_BROWSER_BRIDGE; workspace browser command router (electrobun-embedded BrowserView + JSDOM fallback) and Chrome/Firefox/Safari companion bridge (settings, pairing, tab + page-context sync, packaging artifacts).",
   schema: browserBridgeSchema,
   routes: [...browserBridgePluginRoutes, ...browserWorkspaceRoutes],
   services: [BrowserService as ServiceClass],

--- a/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
@@ -76,6 +76,116 @@ function createContext(args: {
 }
 
 describe("Browser Bridge companion revoke route", () => {
+  it("binds action-begin requests to authenticated companion credentials", async () => {
+    const beginBrowserSessionActionFromCompanion = vi.fn(async () => ({
+      id: "session-1",
+      currentActionIndex: 0,
+    }));
+    const ctx = createContext({
+      method: "POST",
+      pathname:
+        "/api/browser-bridge/companions/sessions/session-1/actions/begin",
+      headers: {
+        authorization: "Bearer pairing-token-1",
+        "x-browser-bridge-companion-id": "companion-1",
+      },
+      body: {
+        currentActionIndex: 0,
+        actionId: "action-1",
+        attemptId: "attempt-1",
+      },
+      service: { beginBrowserSessionActionFromCompanion },
+    });
+    const { handleBrowserBridgeRoutes } = await import("../bridge.js");
+
+    const handled = await handleBrowserBridgeRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(beginBrowserSessionActionFromCompanion).toHaveBeenCalledWith(
+      "companion-1",
+      "pairing-token-1",
+      "session-1",
+      {
+        currentActionIndex: 0,
+        actionId: "action-1",
+        attemptId: "attempt-1",
+      },
+      "owner-1",
+    );
+    expect(ctx.res.statusCode).toBe(200);
+  });
+
+  it("rejects action-begin requests without companion authentication", async () => {
+    const beginBrowserSessionActionFromCompanion = vi.fn();
+    const ctx = createContext({
+      method: "POST",
+      pathname:
+        "/api/browser-bridge/companions/sessions/session-1/actions/begin",
+      body: {
+        currentActionIndex: 0,
+        actionId: "action-1",
+        attemptId: "attempt-1",
+      },
+      service: { beginBrowserSessionActionFromCompanion },
+    });
+    const { handleBrowserBridgeRoutes } = await import("../bridge.js");
+
+    const handled = await handleBrowserBridgeRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(beginBrowserSessionActionFromCompanion).not.toHaveBeenCalled();
+    expect(ctx.res.statusCode).toBe(401);
+  });
+
+  it("fails closed instead of minting credentials for a loopback extension", async () => {
+    const request = {
+      browser: "chrome" as const,
+      profileId: "default",
+    };
+    const getService = vi.fn();
+    const ctx = createContext({
+      method: "POST",
+      pathname: "/api/browser-bridge/companions/auto-pair",
+      headers: { origin: "chrome-extension://installed-extension" },
+      body: request,
+      runtime: {
+        agentId: "agent-1",
+        getService,
+      } as AgentRuntime,
+    });
+    const { handleBrowserBridgeRoutes } = await import("../bridge.js");
+
+    const handled = await handleBrowserBridgeRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(getService).not.toHaveBeenCalled();
+    expect(ctx.res.statusCode).toBe(410);
+    expect(ctx.res.body).toEqual({
+      error:
+        "Automatic browser pairing is disabled. Create an authenticated pairing in Eliza and import its pairing JSON in the extension.",
+    });
+  });
+
+  it("fails closed before parsing attacker-controlled auto-pair payloads", async () => {
+    const readJsonBody = vi.fn(async () => ({ browser: "chrome" }));
+    const ctx = createContext({
+      method: "POST",
+      pathname: "/api/browser-bridge/companions/auto-pair",
+      headers: { origin: "chrome-extension://installed-extension" },
+      body: { browser: "chrome" },
+      remoteAddress: "192.0.2.10",
+      service: {},
+    });
+    ctx.readJsonBody = readJsonBody;
+    const { handleBrowserBridgeRoutes } = await import("../bridge.js");
+
+    const handled = await handleBrowserBridgeRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(readJsonBody).not.toHaveBeenCalled();
+    expect(ctx.res.statusCode).toBe(410);
+  });
+
   it("revokes a companion token by companion id", async () => {
     const revokedAt = "2026-05-08T12:00:00.000Z";
     const service = {
@@ -187,6 +297,42 @@ describe("Browser Bridge companion revoke route", () => {
     });
     expect(syncBrowserCompanion).not.toHaveBeenCalled();
     expect(readJsonBody).not.toHaveBeenCalled();
+  });
+
+  it("authenticates preflight before reading its body and returns no browser data", async () => {
+    const readJsonBody = vi.fn(async () => ({ companion: {} }));
+    const unauthenticated = createContext({
+      method: "POST",
+      pathname: "/api/browser-bridge/companions/preflight",
+      service: { preflightBrowserCompanion: vi.fn() },
+    });
+    unauthenticated.readJsonBody = readJsonBody;
+    const { handleBrowserBridgeRoutes } = await import("../bridge.js");
+    await handleBrowserBridgeRoutes(unauthenticated);
+    expect(unauthenticated.res.statusCode).toBe(401);
+    expect(readJsonBody).not.toHaveBeenCalled();
+
+    const response = {
+      companion: { id: "companion-1" },
+      settings: { enabled: false },
+      settingsVersion: "bbsv1_hash",
+    };
+    const preflightBrowserCompanion = vi.fn(async () => response as never);
+    const authenticated = createContext({
+      method: "POST",
+      pathname: "/api/browser-bridge/companions/preflight",
+      headers: {
+        "x-browser-bridge-companion-id": "companion-1",
+        authorization: "Bearer token",
+      },
+      body: { companion: { browser: "chrome", profileId: "profile-1" } },
+      service: { preflightBrowserCompanion },
+    });
+    await handleBrowserBridgeRoutes(authenticated);
+    expect(authenticated.res.body).toEqual(response);
+    expect(authenticated.res.body).not.toHaveProperty("session");
+    expect(authenticated.res.body).not.toHaveProperty("tabs");
+    expect(authenticated.res.body).not.toHaveProperty("currentPage");
   });
 
   it("rejects malformed JSON bodies before service mutation", async () => {

--- a/plugins/plugin-browser/src/routes/__tests__/browser-bridge-route-registration.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/browser-bridge-route-registration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Registration parity for the `/api/browser-bridge/*` surface: every path the
+ * plugin advertises to the HTTP host must be reachable by the shared handler,
+ * and every companion-callback path must carry the public flags the extension
+ * relies on when it talks to the agent without a session cookie. A handler
+ * added to `bridge.ts` without a matching entry in `plugin.ts` answers 404 in
+ * production, which unit tests of the handler alone cannot detect. The runtime
+ * is deliberately absent so each route resolves to the 503 runtime-unavailable
+ * branch — the assertion is that the handler claims the path at all.
+ */
+
+import type http from "node:http";
+import type { Route } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { browserPlugin } from "../../plugin.js";
+import {
+  type BrowserBridgeRouteContext,
+  handleBrowserBridgeRoutes,
+} from "../bridge.js";
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@elizaos/agent", () => ({
+  checkRateLimit: vi.fn(() => ({ allowed: true, retryAfterMs: 0 })),
+  createIntegrationTelemetrySpan: vi.fn(() => ({
+    failure: vi.fn(),
+    success: vi.fn(),
+  })),
+}));
+
+/** Replaces route-template parameters with concrete, decodable components. */
+function materializePath(template: string): string {
+  return template
+    .replace("/:browser/", "/chrome/")
+    .replace("/:id/", "/session-1/")
+    .replace(/\/:id$/, "/session-1");
+}
+
+function createContext(
+  method: string,
+  pathname: string,
+): BrowserBridgeRouteContext & {
+  res: http.ServerResponse & { body?: unknown };
+} {
+  const res = { statusCode: 200 } as http.ServerResponse & { body?: unknown };
+  return {
+    req: {
+      headers: {},
+      socket: { remoteAddress: "127.0.0.1" },
+    } as http.IncomingMessage,
+    res,
+    method,
+    pathname,
+    url: new URL(`http://127.0.0.1${pathname}`),
+    state: { runtime: null, adminEntityId: null },
+    json: (target, data, status = 200) => {
+      target.statusCode = status;
+      (target as typeof res).body = data;
+    },
+    error: (target, message, status = 400) => {
+      target.statusCode = status;
+      (target as typeof res).body = { error: message };
+    },
+    readJsonBody: vi.fn(async () => ({}) as never),
+    decodePathComponent: (raw: string) => decodeURIComponent(raw),
+  };
+}
+
+function bridgeRoutes(): Route[] {
+  return (browserPlugin.routes ?? []).filter((route) =>
+    route.path.startsWith("/api/browser-bridge/"),
+  );
+}
+
+describe("browser bridge route registration", () => {
+  it("registers the companion action-lease begin callback as a public write", () => {
+    const route = bridgeRoutes().find(
+      (candidate) =>
+        candidate.path ===
+        "/api/browser-bridge/companions/sessions/:id/actions/begin",
+    );
+    expect(route).toBeDefined();
+    expect(route?.type).toBe("POST");
+    expect((route as { public?: boolean }).public).toBe(true);
+    expect((route as { publicWrite?: string }).publicWrite).toBeTruthy();
+  });
+
+  it("registers the authenticated companion preflight callback as a public write", () => {
+    const route = bridgeRoutes().find(
+      (candidate) =>
+        candidate.path === "/api/browser-bridge/companions/preflight",
+    );
+    expect(route).toBeDefined();
+    expect(route?.type).toBe("POST");
+    expect((route as { public?: boolean }).public).toBe(true);
+    expect((route as { publicWrite?: string }).publicWrite).toBeTruthy();
+  });
+
+  it("resolves every advertised bridge path to a handler branch", async () => {
+    const unhandled: string[] = [];
+    // The `/packages/*` family runs stateless handlers that shell out to the
+    // host OS (opening a browser's extension manager, revealing a directory),
+    // so it cannot be swept without real side effects; its registration is
+    // covered by the packaging tests instead.
+    const sweepable = bridgeRoutes().filter(
+      (route) => !route.path.startsWith("/api/browser-bridge/packages"),
+    );
+    expect(sweepable.length).toBeGreaterThan(0);
+    for (const route of sweepable) {
+      const pathname = materializePath(route.path);
+      const ctx = createContext(route.type, pathname);
+      const handled = await handleBrowserBridgeRoutes(ctx);
+      if (!handled) {
+        unhandled.push(`${route.type} ${pathname}`);
+      }
+    }
+    expect(unhandled).toEqual([]);
+  });
+
+  it("does not claim paths outside the advertised bridge surface", async () => {
+    const ctx = createContext(
+      "POST",
+      "/api/browser-bridge/companions/sessions/session-1/actions/finish",
+    );
+    await expect(handleBrowserBridgeRoutes(ctx)).resolves.toBe(false);
+  });
+});

--- a/plugins/plugin-browser/src/routes/bridge.ts
+++ b/plugins/plugin-browser/src/routes/bridge.ts
@@ -8,7 +8,7 @@
  * call into the LifeOps route service because that app owns workflow-scoped
  * browser sessions.
  *
- * Companion/auto-pair/sync authentication uses the
+ * Companion sync authentication uses the
  * `X-Browser-Bridge-Companion-Id` header paired with a bearer pairing
  * token. The old `X-LifeOps-Browser-Companion-Id` and legacy
  * `x-eliza-browser-companion-id` aliases were deliberately removed.
@@ -19,9 +19,14 @@ import type http from "node:http";
 import type { ReadJsonBodyOptions } from "@elizaos/core";
 import { type AgentRuntime, logger, type UUID } from "@elizaos/core";
 import {
+  BROWSER_BRIDGE_KINDS,
   BROWSER_BRIDGE_PACKAGE_PATH_TARGETS,
   type BrowserBridgeCompanionAuthErrorCode,
-  type CreateBrowserBridgeCompanionAutoPairRequest,
+  type BrowserBridgeCompanionPreflightRequest,
+  type BrowserBridgeCompanionSessionBeginRequest,
+  type BrowserBridgeCompanionSessionProgressRequest,
+  type BrowserBridgeCompanionSyncRequest,
+  type BrowserBridgeKind,
   type CreateBrowserBridgeCompanionPairingRequest,
   type SyncBrowserBridgeStateRequest,
   type UpdateBrowserBridgeSessionProgressRequest,
@@ -43,6 +48,10 @@ import {
   BROWSER_BRIDGE_ROUTE_SERVICE_TYPE,
   type BrowserBridgeRouteService,
 } from "../service.js";
+
+function isBrowserBridgeKind(value: string): value is BrowserBridgeKind {
+  return BROWSER_BRIDGE_KINDS.some((kind) => kind === value);
+}
 
 export interface BrowserBridgeRouteContext {
   req: http.IncomingMessage;
@@ -119,23 +128,6 @@ function getBrowserCompanionAuth(
     companionId,
     pairingToken,
   };
-}
-
-function browserAutoPairOriginAllowed(ctx: BrowserBridgeRouteContext): boolean {
-  const originHeader =
-    typeof ctx.req.headers.origin === "string"
-      ? ctx.req.headers.origin.trim()
-      : "";
-  if (!originHeader) {
-    return requestIsLoopback(ctx);
-  }
-  if (originHeader === ctx.url.origin) {
-    return true;
-  }
-  return (
-    originHeader.startsWith("chrome-extension://") ||
-    originHeader.startsWith("safari-web-extension://")
-  );
 }
 
 function requestIsLoopback(ctx: BrowserBridgeRouteContext): boolean {
@@ -564,34 +556,12 @@ export async function handleBrowserBridgeRoutes(
     method === "POST" &&
     pathname === "/api/browser-bridge/companions/auto-pair"
   ) {
-    if (rateLimitRequest(ctx, "companions:auto-pair")) {
-      return true;
-    }
-    if (!browserAutoPairOriginAllowed(ctx)) {
-      ctx.error(
-        res,
-        "browser auto-pair must come from the agent app or a browser extension",
-        403,
-      );
-      return true;
-    }
-    const body =
-      await readJsonBody<CreateBrowserBridgeCompanionAutoPairRequest>(req, res);
-    if (!body) return true;
-    if (!isBrowserBridgeRouteBodyObject(body)) {
-      return rejectMalformedBrowserBridgePayload(ctx);
-    }
-    return runRoute(ctx, async (service) => {
-      json(
-        res,
-        await service.autoPairBrowserCompanion(
-          body,
-          ctx.url.origin,
-          ctx.state.adminEntityId,
-        ),
-        201,
-      );
-    });
+    ctx.error(
+      res,
+      "Automatic browser pairing is disabled. Create an authenticated pairing in Eliza and import its pairing JSON in the extension.",
+      410,
+    );
+    return true;
   }
 
   if (method === "GET" && pathname === "/api/browser-bridge/companions") {
@@ -701,6 +671,35 @@ export async function handleBrowserBridgeRoutes(
     });
   }
 
+  if (
+    method === "POST" &&
+    pathname === "/api/browser-bridge/companions/preflight"
+  ) {
+    if (rateLimitRequest(ctx, "companions:preflight")) return true;
+    return runRoute(ctx, async (service) => {
+      const auth = getBrowserCompanionAuth(ctx);
+      if (!auth) return;
+      const body = await readJsonBody<BrowserBridgeCompanionPreflightRequest>(
+        req,
+        res,
+      );
+      if (!body) return;
+      if (!isBrowserBridgeRouteBodyObject(body)) {
+        rejectMalformedBrowserBridgePayload(ctx);
+        return;
+      }
+      json(
+        res,
+        await service.preflightBrowserCompanion(
+          auth.companionId,
+          auth.pairingToken,
+          body,
+          ctx.state.adminEntityId,
+        ),
+      );
+    });
+  }
+
   if (method === "POST" && pathname === "/api/browser-bridge/companions/sync") {
     if (rateLimitRequest(ctx, "companions:sync")) {
       return true;
@@ -710,7 +709,10 @@ export async function handleBrowserBridgeRoutes(
       if (!auth) {
         return;
       }
-      const body = await readJsonBody<SyncBrowserBridgeStateRequest>(req, res);
+      const body = await readJsonBody<BrowserBridgeCompanionSyncRequest>(
+        req,
+        res,
+      );
       if (!body) return;
       if (!isBrowserBridgeRouteBodyObject(body)) {
         rejectMalformedBrowserBridgePayload(ctx);
@@ -748,8 +750,12 @@ export async function handleBrowserBridgeRoutes(
       "browser package target",
     );
     if (!browser) return true;
-    if (browser !== "chrome" && browser !== "safari") {
-      ctx.error(res, "browser must be chrome or safari", 400);
+    if (!isBrowserBridgeKind(browser)) {
+      ctx.error(
+        res,
+        `browser must be one of: ${BROWSER_BRIDGE_KINDS.join(", ")}`,
+        400,
+      );
       return true;
     }
     return runStatelessRoute(ctx, async () => {
@@ -779,8 +785,12 @@ export async function handleBrowserBridgeRoutes(
       "browser package target",
     );
     if (!browser) return true;
-    if (browser !== "chrome" && browser !== "safari") {
-      ctx.error(res, "browser must be chrome or safari", 400);
+    if (!isBrowserBridgeKind(browser)) {
+      ctx.error(
+        res,
+        `browser must be one of: ${BROWSER_BRIDGE_KINDS.join(", ")}`,
+        400,
+      );
       return true;
     }
     return runStatelessRoute(ctx, async () => {
@@ -800,8 +810,12 @@ export async function handleBrowserBridgeRoutes(
       "browser package target",
     );
     if (!browser) return true;
-    if (browser !== "chrome" && browser !== "safari") {
-      ctx.error(res, "browser must be chrome or safari", 400);
+    if (!isBrowserBridgeKind(browser)) {
+      ctx.error(
+        res,
+        `browser must be one of: ${BROWSER_BRIDGE_KINDS.join(", ")}`,
+        400,
+      );
       return true;
     }
     return runStatelessRoute(ctx, async () => {
@@ -981,6 +995,43 @@ export async function handleBrowserBridgeRoutes(
     });
   }
 
+  const browserCompanionBeginMatch = pathname.match(
+    /^\/api\/browser-bridge\/companions\/sessions\/([^/]+)\/actions\/begin$/,
+  );
+  if (method === "POST" && browserCompanionBeginMatch) {
+    if (rateLimitRequest(ctx, "companions:session-action-begin")) {
+      return true;
+    }
+    const sessionId = decodeMatchedPathComponent(
+      ctx,
+      browserCompanionBeginMatch,
+      1,
+      res,
+      "browser session id",
+    );
+    if (!sessionId) return true;
+    return runRoute(ctx, async (service) => {
+      const auth = getBrowserCompanionAuth(ctx);
+      if (!auth) return;
+      const body =
+        await readJsonBody<BrowserBridgeCompanionSessionBeginRequest>(req, res);
+      if (!body) return;
+      if (!isBrowserBridgeRouteBodyObject(body)) {
+        rejectMalformedBrowserBridgePayload(ctx);
+        return;
+      }
+      json(res, {
+        session: await service.beginBrowserSessionActionFromCompanion(
+          auth.companionId,
+          auth.pairingToken,
+          sessionId,
+          body,
+          ctx.state.adminEntityId,
+        ),
+      });
+    });
+  }
+
   const browserCompanionProgressMatch = pathname.match(
     /^\/api\/browser-bridge\/companions\/sessions\/([^/]+)\/progress$/,
   );
@@ -1002,7 +1053,10 @@ export async function handleBrowserBridgeRoutes(
         return;
       }
       const body =
-        await readJsonBody<UpdateBrowserBridgeSessionProgressRequest>(req, res);
+        await readJsonBody<BrowserBridgeCompanionSessionProgressRequest>(
+          req,
+          res,
+        );
       if (!body) return;
       if (!isBrowserBridgeRouteBodyObject(body)) {
         rejectMalformedBrowserBridgePayload(ctx);

--- a/plugins/plugin-browser/src/service.ts
+++ b/plugins/plugin-browser/src/service.ts
@@ -4,15 +4,18 @@
 
 import type { Service, UUID } from "@elizaos/core";
 import type {
-  BrowserBridgeCompanionAutoPairResponse,
   BrowserBridgeCompanionPairingResponse,
+  BrowserBridgeCompanionPreflightRequest,
+  BrowserBridgeCompanionPreflightResponse,
   BrowserBridgeCompanionRevokeResponse,
+  BrowserBridgeCompanionSessionBeginRequest,
+  BrowserBridgeCompanionSessionProgressRequest,
   BrowserBridgeCompanionStatus,
+  BrowserBridgeCompanionSyncRequest,
   BrowserBridgeCompanionSyncResponse,
   BrowserBridgePageContext,
   BrowserBridgeSettings,
   BrowserBridgeTabSummary,
-  CreateBrowserBridgeCompanionAutoPairRequest,
   CreateBrowserBridgeCompanionPairingRequest,
   SyncBrowserBridgeStateRequest,
   UpdateBrowserBridgeSessionProgressRequest,
@@ -56,11 +59,6 @@ export interface BrowserBridgeRouteService extends Service {
     request: CreateBrowserBridgeCompanionPairingRequest,
     ownerEntityId?: UUID | null,
   ): Promise<BrowserBridgeCompanionPairingResponse>;
-  autoPairBrowserCompanion(
-    request: CreateBrowserBridgeCompanionAutoPairRequest,
-    apiBaseUrl: string,
-    ownerEntityId?: UUID | null,
-  ): Promise<BrowserBridgeCompanionAutoPairResponse>;
   revokeBrowserCompanion(
     companionId: string,
     ownerEntityId?: UUID | null,
@@ -73,9 +71,15 @@ export interface BrowserBridgeRouteService extends Service {
   syncBrowserCompanion(
     companionId: string,
     pairingToken: string,
-    request: SyncBrowserBridgeStateRequest,
+    request: BrowserBridgeCompanionSyncRequest,
     ownerEntityId?: UUID | null,
   ): Promise<BrowserBridgeCompanionSyncResponse>;
+  preflightBrowserCompanion(
+    companionId: string,
+    pairingToken: string,
+    request: BrowserBridgeCompanionPreflightRequest,
+    ownerEntityId?: UUID | null,
+  ): Promise<BrowserBridgeCompanionPreflightResponse>;
   listBrowserSessions(
     ownerEntityId?: UUID | null,
   ): Promise<LifeOpsBrowserSession[]>;
@@ -106,7 +110,14 @@ export interface BrowserBridgeRouteService extends Service {
     companionId: string,
     pairingToken: string,
     sessionId: string,
-    request: UpdateBrowserBridgeSessionProgressRequest,
+    request: BrowserBridgeCompanionSessionProgressRequest,
+    ownerEntityId?: UUID | null,
+  ): Promise<LifeOpsBrowserSession>;
+  beginBrowserSessionActionFromCompanion(
+    companionId: string,
+    pairingToken: string,
+    sessionId: string,
+    request: BrowserBridgeCompanionSessionBeginRequest,
     ownerEntityId?: UUID | null,
   ): Promise<LifeOpsBrowserSession>;
   completeBrowserSessionFromCompanion(

--- a/plugins/plugin-health/src/contracts/lifeops.ts
+++ b/plugins/plugin-health/src/contracts/lifeops.ts
@@ -916,7 +916,7 @@ export interface LifeOpsWorkflowPermissionPolicy {
 // `LifeOpsBrowserKind`, `LIFEOPS_BROWSER_ACTION_KINDS`,
 // `LifeOpsBrowserActionKind`, and `LifeOpsBrowserAction` remain here
 // because workflow-linked session shapes below still reference them.
-export const LIFEOPS_BROWSER_KINDS = ["chrome", "safari"] as const;
+export const LIFEOPS_BROWSER_KINDS = ["chrome", "firefox", "safari"] as const;
 export type LifeOpsBrowserKind = (typeof LIFEOPS_BROWSER_KINDS)[number];
 
 export const LIFEOPS_BROWSER_ACTION_KINDS = [

--- a/plugins/plugin-personal-assistant/src/actions/connector.ts
+++ b/plugins/plugin-personal-assistant/src/actions/connector.ts
@@ -72,7 +72,7 @@ type ConnectorActionParams = {
   recentLimit?: number;
   query?: string;
   channelId?: string;
-  browser?: "chrome" | "safari";
+  browser?: "chrome" | "firefox" | "safari";
   profileId?: string;
   profileLabel?: string;
   redirectUrl?: string;
@@ -1806,11 +1806,11 @@ export const connectorAction: Action & {
     },
     {
       name: "browser",
-      description: "browser_bridge connect only: chrome | safari.",
+      description: "browser_bridge connect only: chrome | firefox | safari.",
       required: false,
       schema: {
         type: "string" as const,
-        enum: ["chrome", "safari"],
+        enum: ["chrome", "firefox", "safari"],
       },
     },
     {

--- a/plugins/plugin-personal-assistant/src/lifeops/browser-extension-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/browser-extension-store.ts
@@ -17,7 +17,7 @@ export interface BrowserSessionRegistration {
   readonly deviceId: string;
   readonly userAgent: string;
   readonly extensionVersion: string;
-  readonly browserVendor: "chrome" | "safari" | "unknown";
+  readonly browserVendor: "chrome" | "firefox" | "safari" | "unknown";
   readonly registeredAt: string;
 }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
@@ -14,6 +14,7 @@ import {
   BrowserDomain,
   type BrowserDomainDeps,
   browserSessionActionsDigest,
+  MAX_BROWSER_SESSION_APPROVAL_AGE_MS,
 } from "./browser-service.js";
 
 const companion = {
@@ -165,7 +166,7 @@ describe("BrowserDomain action begin", () => {
       sessionMetadata: {
         browserApproval: {
           actionsDigest: browserSessionActionsDigest([action]),
-          confirmedAt: "2026-08-20T00:01:00.000Z",
+          confirmedAt: new Date().toISOString(),
         },
       },
     });
@@ -178,6 +179,39 @@ describe("BrowserDomain action begin", () => {
       ),
     ).resolves.toMatchObject({ id: "session-1" });
     expect(begin).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [
+      "expired",
+      new Date(
+        Date.now() - MAX_BROWSER_SESSION_APPROVAL_AGE_MS - 1,
+      ).toISOString(),
+    ],
+    ["malformed", "not-a-timestamp"],
+    ["future", new Date(Date.now() + 60_000).toISOString()],
+  ])("rejects a %s owner approval", async (_label, confirmedAt) => {
+    const action = browserAction();
+    const { begin, domain, requireConfirmation } = harness({
+      action,
+      sessionMetadata: {
+        browserApproval: {
+          actionsDigest: browserSessionActionsDigest([action]),
+          confirmedAt,
+        },
+      },
+    });
+
+    await expect(
+      domain.beginBrowserSessionActionFromCompanion(
+        companion.id,
+        "token",
+        "session-1",
+        beginRequest,
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(requireConfirmation).toHaveBeenCalledOnce();
+    expect(begin).not.toHaveBeenCalled();
   });
 
   it("still requires explicit action confirmation when account policy is off", async () => {
@@ -222,5 +256,47 @@ describe("BrowserDomain action begin", () => {
       expect.objectContaining({ companionId: companion.id }),
       expect.objectContaining({ requiresOwnerRelease: true }),
     );
+  });
+});
+
+describe("BrowserDomain companion completion", () => {
+  it("rejects a runtime status outside done or failed before persistence", async () => {
+    const action = browserAction({ accountAffecting: false });
+    const session = browserSession(action, {
+      browserActionAttempt: {
+        actionId: action.id,
+        actionIndex: 0,
+        attemptId: "attempt-1",
+      },
+    });
+    const complete = vi.fn();
+    const context = {
+      agentId: () => "agent-1",
+      repository: {
+        completeBrowserSessionFromCompanion: complete,
+      },
+    } as unknown as LifeOpsContext;
+    const domain = new BrowserDomain(context, {
+      recordBrowserAudit: vi.fn(),
+    } as unknown as BrowserDomainDeps);
+    vi.spyOn(domain, "requireBrowserCompanion").mockResolvedValue(companion);
+    vi.spyOn(domain, "requireBrowserSessionForCompanion").mockResolvedValue(
+      session,
+    );
+
+    await expect(
+      domain.completeBrowserSessionFromCompanion(
+        companion.id,
+        "token",
+        session.id,
+        {
+          status: "cancelled",
+          currentActionIndex: 0,
+          completedActionId: action.id,
+          attemptId: "attempt-1",
+        } as never,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(complete).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Browser action-begin tests exercise the last server-side confirmation and
+ * action-lease boundary before a companion may perform a browser side effect.
+ */
+import type {
+  BrowserBridgeAction,
+  BrowserBridgeCompanionStatus,
+  BrowserBridgeSettings,
+} from "@elizaos/plugin-browser";
+import { describe, expect, it, vi } from "vitest";
+import type { LifeOpsBrowserSession } from "../../contracts/index.js";
+import type { LifeOpsContext } from "../lifeops-context.js";
+import {
+  BrowserDomain,
+  type BrowserDomainDeps,
+  browserSessionActionsDigest,
+} from "./browser-service.js";
+
+const companion = {
+  id: "companion-1",
+  browser: "chrome",
+  profileId: "profile-1",
+} as BrowserBridgeCompanionStatus;
+
+const settings: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "all_sites",
+  grantedOrigins: [],
+  blockedOrigins: [],
+  maxRememberedTabs: 10,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: null,
+};
+
+function browserAction(
+  overrides: Partial<BrowserBridgeAction> = {},
+): BrowserBridgeAction {
+  return {
+    id: "action-1",
+    kind: "click",
+    label: "Submit account change",
+    url: "https://allowed.example/account",
+    selector: "button",
+    text: null,
+    accountAffecting: true,
+    requiresConfirmation: false,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function browserSession(
+  action: BrowserBridgeAction,
+  metadata: Record<string, unknown> = {},
+): LifeOpsBrowserSession {
+  return {
+    id: "session-1",
+    agentId: "agent-1",
+    domain: "browser",
+    subjectType: "owner",
+    subjectId: "owner",
+    visibilityScope: "owner",
+    contextPolicy: "owner_private",
+    workflowId: null,
+    browser: "chrome",
+    companionId: companion.id,
+    profileId: companion.profileId,
+    windowId: null,
+    tabId: null,
+    title: "Account update",
+    status: "running",
+    actions: [action],
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {},
+    metadata,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    updatedAt: "2026-08-20T00:00:00.000Z",
+    finishedAt: null,
+  };
+}
+
+function harness(args: {
+  action?: BrowserBridgeAction;
+  sessionMetadata?: Record<string, unknown>;
+  settings?: BrowserBridgeSettings;
+}) {
+  const action = args.action ?? browserAction();
+  const session = browserSession(action, args.sessionMetadata);
+  const requireConfirmation = vi.fn(async () => ({
+    ...session,
+    status: "awaiting_confirmation" as const,
+    awaitingConfirmationForActionId: action.id,
+  }));
+  const begin = vi.fn(async () => ({
+    ...session,
+    metadata: {
+      ...session.metadata,
+      browserActionAttempt: { actionId: action.id },
+    },
+  }));
+  const context = {
+    agentId: () => "agent-1",
+    repository: {
+      requireBrowserSessionActionConfirmation: requireConfirmation,
+      beginBrowserSessionActionFromCompanion: begin,
+    },
+  } as unknown as LifeOpsContext;
+  const deps = {
+    requireBrowserAvailableForActions: vi.fn(
+      async () => args.settings ?? settings,
+    ),
+  } as unknown as BrowserDomainDeps;
+  const domain = new BrowserDomain(context, deps);
+  vi.spyOn(domain, "requireBrowserCompanion").mockResolvedValue(companion);
+  vi.spyOn(domain, "requireBrowserSessionForCompanion").mockResolvedValue(
+    session,
+  );
+  return { action, begin, domain, requireConfirmation, session };
+}
+
+const beginRequest = {
+  currentActionIndex: 0,
+  actionId: "action-1",
+  attemptId: "attempt-1",
+};
+
+describe("BrowserDomain action begin", () => {
+  it("re-gates a previously queued account action under current settings", async () => {
+    const { begin, domain, requireConfirmation } = harness({});
+    await expect(
+      domain.beginBrowserSessionActionFromCompanion(
+        companion.id,
+        "token",
+        "session-1",
+        beginRequest,
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(requireConfirmation).toHaveBeenCalledOnce();
+    expect(begin).not.toHaveBeenCalled();
+  });
+
+  it("accepts an approval bound to the exact immutable action set", async () => {
+    const action = browserAction();
+    const { begin, domain } = harness({
+      action,
+      sessionMetadata: {
+        browserApproval: {
+          actionsDigest: browserSessionActionsDigest([action]),
+          confirmedAt: "2026-08-20T00:01:00.000Z",
+        },
+      },
+    });
+    await expect(
+      domain.beginBrowserSessionActionFromCompanion(
+        companion.id,
+        "token",
+        "session-1",
+        beginRequest,
+      ),
+    ).resolves.toMatchObject({ id: "session-1" });
+    expect(begin).toHaveBeenCalledOnce();
+  });
+
+  it("still requires explicit action confirmation when account policy is off", async () => {
+    const action = browserAction({
+      accountAffecting: false,
+      requiresConfirmation: true,
+    });
+    const { begin, domain, requireConfirmation } = harness({
+      action,
+      settings: {
+        ...settings,
+        requireConfirmationForAccountAffecting: false,
+      },
+    });
+    await expect(
+      domain.beginBrowserSessionActionFromCompanion(
+        companion.id,
+        "token",
+        "session-1",
+        beginRequest,
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(requireConfirmation).toHaveBeenCalledOnce();
+    expect(begin).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.action-begin.test.ts
@@ -87,6 +87,7 @@ function browserSession(
 
 function harness(args: {
   action?: BrowserBridgeAction;
+  beginResult?: "leased" | "blocked";
   sessionMetadata?: Record<string, unknown>;
   settings?: BrowserBridgeSettings;
 }) {
@@ -97,13 +98,17 @@ function harness(args: {
     status: "awaiting_confirmation" as const,
     awaitingConfirmationForActionId: action.id,
   }));
-  const begin = vi.fn(async () => ({
-    ...session,
-    metadata: {
-      ...session.metadata,
-      browserActionAttempt: { actionId: action.id },
-    },
-  }));
+  const begin = vi.fn(async () =>
+    args.beginResult === "blocked"
+      ? null
+      : {
+          ...session,
+          metadata: {
+            ...session.metadata,
+            browserActionAttempt: { actionId: action.id },
+          },
+        },
+  );
   const context = {
     agentId: () => "agent-1",
     repository: {
@@ -112,6 +117,7 @@ function harness(args: {
     },
   } as unknown as LifeOpsContext;
   const deps = {
+    recordBrowserAudit: vi.fn(async () => undefined),
     requireBrowserAvailableForActions: vi.fn(
       async () => args.settings ?? settings,
     ),
@@ -121,7 +127,14 @@ function harness(args: {
   vi.spyOn(domain, "requireBrowserSessionForCompanion").mockResolvedValue(
     session,
   );
-  return { action, begin, domain, requireConfirmation, session };
+  return {
+    action,
+    audit: deps.recordBrowserAudit,
+    begin,
+    domain,
+    requireConfirmation,
+    session,
+  };
 }
 
 const beginRequest = {
@@ -189,5 +202,25 @@ describe("BrowserDomain action begin", () => {
     ).rejects.toMatchObject({ status: 409 });
     expect(requireConfirmation).toHaveBeenCalledOnce();
     expect(begin).not.toHaveBeenCalled();
+  });
+
+  it("records the authenticated companion when an action lease is blocked", async () => {
+    const action = browserAction({ accountAffecting: false });
+    const { audit, domain } = harness({ action, beginResult: "blocked" });
+    await expect(
+      domain.beginBrowserSessionActionFromCompanion(
+        companion.id,
+        "token",
+        "session-1",
+        beginRequest,
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(audit).toHaveBeenCalledWith(
+      "browser_session_updated",
+      "session-1",
+      expect.any(String),
+      expect.objectContaining({ companionId: companion.id }),
+      expect.objectContaining({ requiresOwnerRelease: true }),
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.preflight.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.preflight.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Browser companion preflight tests verify settings-version binding without
+ * reading or persisting browser state before authorization succeeds.
+ */
+
+import type { BrowserBridgeSettings } from "@elizaos/plugin-browser";
+import { describe, expect, it, vi } from "vitest";
+import {
+  BrowserDomain,
+  browserBridgeSettingsVersion,
+} from "./browser-service.js";
+
+const settings: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: false,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "all_sites",
+  grantedOrigins: [],
+  blockedOrigins: [],
+  maxRememberedTabs: 20,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: null,
+};
+
+function harness() {
+  const companion = {
+    id: "companion-1",
+    browser: "chrome",
+    profileId: "profile-1",
+  } as const;
+  const domain = new BrowserDomain(
+    {} as ConstructorParameters<typeof BrowserDomain>[0],
+    {
+      getBrowserSettingsInternal: vi.fn(async () => settings),
+      isBrowserPaused: vi.fn(() => false),
+    } as unknown as ConstructorParameters<typeof BrowserDomain>[1],
+  );
+  vi.spyOn(domain, "requireBrowserCompanion").mockResolvedValue(
+    companion as Awaited<ReturnType<typeof domain.requireBrowserCompanion>>,
+  );
+  const syncBrowserState = vi
+    .spyOn(domain, "syncBrowserState")
+    .mockResolvedValue({ companion, tabs: [], currentPage: null } as never);
+  return { companion, domain, syncBrowserState };
+}
+
+const companionRequest = {
+  companion: {
+    browser: "chrome" as const,
+    profileId: "profile-1",
+    label: "Chrome profile",
+  },
+};
+
+describe("BrowserDomain companion preflight", () => {
+  it("returns only identity, effective settings, and a nonempty version", async () => {
+    const { domain, syncBrowserState } = harness();
+    const response = await domain.preflightBrowserCompanion(
+      "companion-1",
+      "token",
+      companionRequest,
+    );
+    expect(Object.keys(response).sort()).toEqual([
+      "companion",
+      "settings",
+      "settingsVersion",
+    ]);
+    expect(response.settingsVersion).toBe(
+      browserBridgeSettingsVersion(settings),
+    );
+    expect(response.settingsVersion.length).toBeGreaterThan(20);
+    expect(syncBrowserState).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale version before state persistence and accepts a fresh version", async () => {
+    const { domain, syncBrowserState } = harness();
+    const request = { ...companionRequest, tabs: [], pageContexts: [] };
+    await expect(
+      domain.syncBrowserCompanion("companion-1", "token", {
+        ...request,
+        settingsVersion: "stale",
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "browser_bridge_settings_stale",
+    });
+    expect(syncBrowserState).not.toHaveBeenCalled();
+
+    await expect(
+      domain.syncBrowserCompanion("companion-1", "token", {
+        ...request,
+        settingsVersion: browserBridgeSettingsVersion(settings),
+      }),
+    ).resolves.toMatchObject({
+      tabs: [],
+      settingsVersion: browserBridgeSettingsVersion(settings),
+    });
+    expect(syncBrowserState).toHaveBeenCalledOnce();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -1416,6 +1416,28 @@ export class BrowserDomain {
         startedAt: new Date().toISOString(),
       });
     if (!leased) {
+      // Failing closed on an uncertain side effect is right — we cannot know
+      // whether the previous attempt already clicked something. But the caller
+      // does not transition the session to `failed` on a 409, so without an
+      // audit record this wedges in `running` and silently re-loops on every
+      // sync with no owner-visible signal. An unrecoverable state has to be
+      // observable, not just safe.
+      await this.deps.recordBrowserAudit(
+        "browser_session_updated",
+        session.id,
+        "browser action lease blocked by an unresolved execution attempt",
+        {
+          sessionId: session.id,
+          companionId: companion.companionId,
+          currentActionIndex,
+          actionId,
+        },
+        {
+          outcome: "blocked",
+          reason: "uncertain_or_concurrent_attempt",
+          requiresOwnerRelease: true,
+        },
+      );
       fail(
         409,
         "browser action already has an uncertain or concurrent execution attempt",

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -1428,7 +1428,7 @@ export class BrowserDomain {
         "browser action lease blocked by an unresolved execution attempt",
         {
           sessionId: session.id,
-          companionId: companion.companionId,
+          companionId: companion.id,
           currentActionIndex,
           actionId,
         },

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -146,16 +146,29 @@ function browserActionNeedsApproval(
   );
 }
 
+export const MAX_BROWSER_SESSION_APPROVAL_AGE_MS = 2 * 60 * 1000;
+
 function hasCurrentBrowserSessionApproval(
   session: LifeOpsBrowserSession,
+  nowMs = Date.now(),
 ): boolean {
   const approval = session.metadata.browserApproval;
+  const confirmedAt =
+    approval !== null &&
+    typeof approval === "object" &&
+    !Array.isArray(approval) &&
+    typeof (approval as Record<string, unknown>).confirmedAt === "string"
+      ? Date.parse((approval as Record<string, unknown>).confirmedAt as string)
+      : Number.NaN;
   return (
     approval !== null &&
     typeof approval === "object" &&
     !Array.isArray(approval) &&
     (approval as Record<string, unknown>).actionsDigest ===
-      browserSessionActionsDigest(session.actions)
+      browserSessionActionsDigest(session.actions) &&
+    Number.isFinite(confirmedAt) &&
+    confirmedAt <= nowMs &&
+    nowMs - confirmedAt <= MAX_BROWSER_SESSION_APPROVAL_AGE_MS
   );
 }
 
@@ -1206,7 +1219,15 @@ export class BrowserDomain {
           }
         : lifecycle.metadata,
     };
-    await this.ctx.repository.updateBrowserSession(finalizedSession);
+    const persisted =
+      await this.ctx.repository.updateBrowserSessionIfAwaitingConfirmation({
+        session: finalizedSession,
+        expectedActionId: session.awaitingConfirmationForActionId,
+        expectedUpdatedAt: session.updatedAt,
+      });
+    if (!persisted) {
+      fail(409, "browser session confirmation lost a concurrent update");
+    }
     await this.deps.recordBrowserAudit(
       "browser_session_updated",
       finalizedSession.id,
@@ -1600,9 +1621,13 @@ export class BrowserDomain {
       request.result === undefined
         ? undefined
         : requireRecord(request.result, "result");
+    const status = normalizeEnumValue(request.status ?? "done", "status", [
+      "done",
+      "failed",
+    ] as const);
     if (session.status !== "running") {
       if (
-        session.status === (request.status ?? "done") &&
+        session.status === status &&
         recordPatchMatches(session.result, requestedResult)
       ) {
         return session;
@@ -1613,7 +1638,23 @@ export class BrowserDomain {
       );
     }
     const updatedAt = new Date().toISOString();
-    const status = request.status ?? "done";
+    const currentActionIndex = normalizeBrowserSessionActionIndex(
+      request.currentActionIndex,
+      session.actions.length,
+    );
+    if (currentActionIndex !== session.currentActionIndex) {
+      fail(409, "browser session completion checkpoint is stale");
+    }
+    const completedActionId = normalizeOptionalString(
+      request.completedActionId,
+    );
+    const attemptId = normalizeOptionalString(request.attemptId);
+    if ((completedActionId?.length ?? 0) > 128) {
+      fail(400, "completedActionId must be at most 128 characters");
+    }
+    if ((attemptId?.length ?? 0) > 128) {
+      fail(400, "attemptId must be at most 128 characters");
+    }
     if (
       status === "done" &&
       session.currentActionIndex !== session.actions.length
@@ -1622,6 +1663,29 @@ export class BrowserDomain {
         409,
         "browser session cannot complete before every action is acknowledged",
       );
+    }
+    if (status === "done" && session.actions.length > 0) {
+      const lastAction = session.actions[session.actions.length - 1];
+      if (
+        !completedActionId ||
+        completedActionId !== lastAction?.id ||
+        !attemptId
+      ) {
+        fail(
+          409,
+          "browser session completion does not match its final receipt",
+        );
+      }
+    }
+    if (status === "failed") {
+      const activeAction = session.actions[session.currentActionIndex];
+      if (
+        !completedActionId ||
+        completedActionId !== activeAction?.id ||
+        !attemptId
+      ) {
+        fail(409, "browser session failure does not match its active attempt");
+      }
     }
     const lifecycle = mergeBrowserTaskLifecycle({
       session,
@@ -1635,6 +1699,9 @@ export class BrowserDomain {
         sessionId,
         companion,
         status,
+        expectedActionIndex: currentActionIndex,
+        completedActionId,
+        attemptId,
         resultPatch: lifecycle.result,
         updatedAt,
       });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -10,18 +10,20 @@ import {
   authenticateBrowserBridgeCompanionCredential,
   BROWSER_BRIDGE_KINDS,
   type BrowserBridgeAction,
-  type BrowserBridgeCompanionAutoPairResponse,
-  type BrowserBridgeCompanionConfig,
   type BrowserBridgeCompanionPairingResponse,
+  type BrowserBridgeCompanionPreflightRequest,
+  type BrowserBridgeCompanionPreflightResponse,
   type BrowserBridgeCompanionRevokeResponse,
+  type BrowserBridgeCompanionSessionBeginRequest,
+  type BrowserBridgeCompanionSessionProgressRequest,
   type BrowserBridgeCompanionStatus,
+  type BrowserBridgeCompanionSyncRequest,
   type BrowserBridgeCompanionSyncResponse,
   type BrowserBridgeKind,
   type BrowserBridgePageContext,
   type BrowserBridgeSettings,
   type BrowserBridgeTabSummary,
   browserBridgeDomainFromUrl,
-  type CreateBrowserBridgeCompanionAutoPairRequest,
   type CreateBrowserBridgeCompanionPairingRequest,
   createBrowserBridgePageContext,
   createBrowserBridgeTabSummary,
@@ -88,6 +90,74 @@ type BrowserScreenTimeEvent = {
   durationSeconds?: number;
   metadata?: Record<string, unknown>;
 };
+
+function canonicalizeSettingsValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeSettingsValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalizeSettingsValue(entry)]),
+    );
+  }
+  return value;
+}
+
+function sameCanonicalValue(left: unknown, right: unknown): boolean {
+  return (
+    JSON.stringify(canonicalizeSettingsValue(left)) ===
+    JSON.stringify(canonicalizeSettingsValue(right))
+  );
+}
+
+function recordPatchMatches(
+  current: Record<string, unknown>,
+  patch: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    patch === undefined ||
+    Object.entries(patch).every(([key, value]) =>
+      sameCanonicalValue(current[key], value),
+    )
+  );
+}
+
+export function browserBridgeSettingsVersion(
+  settings: BrowserBridgeSettings,
+): string {
+  const canonical = JSON.stringify(canonicalizeSettingsValue(settings));
+  return `bbsv1_${crypto.createHash("sha256").update(canonical).digest("base64url")}`;
+}
+
+export function browserSessionActionsDigest(
+  actions: readonly BrowserBridgeAction[],
+): string {
+  const canonical = JSON.stringify(canonicalizeSettingsValue(actions));
+  return `bbad1_${crypto.createHash("sha256").update(canonical).digest("base64url")}`;
+}
+
+function browserActionNeedsApproval(
+  action: BrowserBridgeAction,
+  settings: BrowserBridgeSettings,
+): boolean {
+  return (
+    action.requiresConfirmation ||
+    (settings.requireConfirmationForAccountAffecting && action.accountAffecting)
+  );
+}
+
+function hasCurrentBrowserSessionApproval(
+  session: LifeOpsBrowserSession,
+): boolean {
+  const approval = session.metadata.browserApproval;
+  return (
+    approval !== null &&
+    typeof approval === "object" &&
+    !Array.isArray(approval) &&
+    (approval as Record<string, unknown>).actionsDigest ===
+      browserSessionActionsDigest(session.actions)
+  );
+}
 
 /**
  * Base browser helpers and the cross-domain screen-time recorder the browser
@@ -202,8 +272,11 @@ export class BrowserDomain {
         normalizeBrowserActionInput(action, `actions[${index}]`),
       ),
     );
-    await this.deps.requireBrowserAvailableForActions(actions);
-    const awaitingActionId = resolveAwaitingBrowserActionId(actions);
+    const settings = await this.deps.requireBrowserAvailableForActions(actions);
+    const awaitingActionId = resolveAwaitingBrowserActionId(
+      actions,
+      settings.requireConfirmationForAccountAffecting,
+    );
     const session = createLifeOpsBrowserSession({
       agentId: this.ctx.agentId(),
       ...ownership,
@@ -316,41 +389,18 @@ export class BrowserDomain {
   public async claimQueuedBrowserSession(
     companion: BrowserBridgeCompanionStatus,
   ): Promise<LifeOpsBrowserSession | null> {
-    const claimable = (await this.listBrowserSessions())
-      .filter(
-        (session) =>
-          session.status === "queued" &&
-          browserSessionMatchesCompanion(session, companion),
-      )
-      .sort((left, right) => {
-        const leftMs = Date.parse(left.createdAt);
-        const rightMs = Date.parse(right.createdAt);
-        if (
-          Number.isFinite(leftMs) &&
-          Number.isFinite(rightMs) &&
-          leftMs !== rightMs
-        ) {
-          return leftMs - rightMs;
-        }
-        return left.createdAt.localeCompare(right.createdAt);
-      })[0];
-    if (!claimable) {
+    const nowIso = new Date().toISOString();
+    const claimed = await this.ctx.repository.claimBrowserSession(
+      this.ctx.agentId(),
+      companion,
+      nowIso,
+    );
+    if (!claimed) {
       return null;
     }
-    const nowIso = new Date().toISOString();
-    const nextSession: LifeOpsBrowserSession = {
-      ...claimable,
-      status: "running",
-      metadata: mergeMetadata(claimable.metadata, {
-        claimedAt: nowIso,
-        claimedByCompanionId: companion.id,
-      }),
-      updatedAt: nowIso,
-    };
-    await this.ctx.repository.updateBrowserSession(nextSession);
     await this.deps.recordBrowserAudit(
       "browser_session_updated",
-      nextSession.id,
+      claimed.id,
       "browser session claimed by companion",
       {
         companionId: companion.id,
@@ -358,10 +408,10 @@ export class BrowserDomain {
         profileId: companion.profileId,
       },
       {
-        status: nextSession.status,
+        status: claimed.status,
       },
     );
-    return nextSession;
+    return claimed;
   }
 
   public async requireBrowserSessionForCompanion(
@@ -498,8 +548,14 @@ export class BrowserDomain {
         companionInput.lastSeenAt,
         "companion.lastSeenAt",
       ) ?? new Date().toISOString();
-    const existingTabs = await this.ctx.repository.listBrowserTabs(
+    const allExistingTabs = await this.ctx.repository.listBrowserTabs(
       this.ctx.agentId(),
+    );
+    const existingTabs = allExistingTabs.filter(
+      (tab) =>
+        tab.companionId === companion.id &&
+        tab.browser === browser &&
+        tab.profileId === profileId,
     );
     const currentSyncMs = Date.parse(nowIso);
     const previouslyFocusedTab =
@@ -664,20 +720,29 @@ export class BrowserDomain {
     const allTabs = await this.ctx.repository.listBrowserTabs(
       this.ctx.agentId(),
     );
-    const keptTabs = selectRememberedBrowserTabs(
-      allTabs.filter((tab) => browserUrlAllowedBySettings(tab.url, settings)),
+    const currentCompanionTabs = allTabs.filter(
+      (tab) =>
+        tab.companionId === companion.id &&
+        tab.browser === browser &&
+        tab.profileId === profileId,
+    );
+    const companionTabs = selectRememberedBrowserTabs(
+      currentCompanionTabs.filter((tab) =>
+        browserUrlAllowedBySettings(tab.url, settings),
+      ),
       settings.maxRememberedTabs,
     );
-    const keptTabIds = new Set(keptTabs.map((tab) => tab.id));
+    const keptTabIds = new Set(companionTabs.map((tab) => tab.id));
     await this.ctx.repository.deleteBrowserTabsByIds(
       this.ctx.agentId(),
-      allTabs.filter((tab) => !keptTabIds.has(tab.id)).map((tab) => tab.id),
+      currentCompanionTabs
+        .filter((tab) => !keptTabIds.has(tab.id))
+        .map((tab) => tab.id),
     );
-
     const focusedTab =
-      keptTabs.find((tab) => tab.focusedActive) ??
-      keptTabs.find((tab) => tab.activeInWindow) ??
-      keptTabs[0] ??
+      companionTabs.find((tab) => tab.focusedActive) ??
+      companionTabs.find((tab) => tab.activeInWindow) ??
+      companionTabs[0] ??
       null;
     const focusedKey = focusedTab ? browserTabIdentityKey(focusedTab) : null;
     const existingContexts = await this.ctx.repository.listBrowserPageContexts(
@@ -805,21 +870,21 @@ export class BrowserDomain {
       syncedContextIds.add(nextContext.id);
     }
 
-    const keptKeys = new Set(keptTabs.map((tab) => browserTabIdentityKey(tab)));
+    const keptKeys = new Set(
+      companionTabs.map((tab) => browserTabIdentityKey(tab)),
+    );
     await this.ctx.repository.deleteBrowserPageContextsByIds(
       this.ctx.agentId(),
       existingContexts
         .filter((context) => {
+          if (context.browser !== browser || context.profileId !== profileId) {
+            return false;
+          }
           const key = browserPageContextIdentityKey(context);
           if (!keptKeys.has(key)) {
             return true;
           }
-          if (
-            context.browser === browser &&
-            context.profileId === profileId &&
-            !syncedContextIds.has(context.id) &&
-            key !== focusedKey
-          ) {
+          if (!syncedContextIds.has(context.id) && key !== focusedKey) {
             return true;
           }
           return false;
@@ -827,10 +892,20 @@ export class BrowserDomain {
         .map((context) => context.id),
     );
 
-    const currentPage = await this.getCurrentBrowserPage();
+    const currentPage = focusedKey
+      ? ((
+          await this.ctx.repository.listBrowserPageContexts(this.ctx.agentId())
+        ).find(
+          (context) =>
+            context.browser === browser &&
+            context.profileId === profileId &&
+            browserPageContextIdentityKey(context) === focusedKey &&
+            browserUrlAllowedBySettings(context.url, settings),
+        ) ?? null)
+      : null;
     return {
       companion,
-      tabs: await this.listBrowserTabs(),
+      tabs: companionTabs,
       currentPage,
     };
   }
@@ -942,42 +1017,6 @@ export class BrowserDomain {
     };
   }
 
-  async autoPairBrowserCompanion(
-    request: CreateBrowserBridgeCompanionAutoPairRequest,
-    apiBaseUrl: string,
-  ): Promise<BrowserBridgeCompanionAutoPairResponse> {
-    const profileId = normalizeOptionalString(request.profileId) ?? "default";
-    const profileLabel =
-      normalizeOptionalString(request.profileLabel) ?? "Default";
-    const label =
-      normalizeOptionalString(request.label) ??
-      `Agent Browser Bridge ${normalizeEnumValue(request.browser, "browser", BROWSER_BRIDGE_KINDS)} ${profileLabel}`;
-    const pairing = await this.createBrowserCompanionPairing({
-      browser: request.browser,
-      profileId,
-      profileLabel,
-      label,
-      extensionVersion: request.extensionVersion ?? null,
-      metadata: request.metadata,
-    });
-    const config: BrowserBridgeCompanionConfig = {
-      apiBaseUrl: requireNonEmptyString(apiBaseUrl, "apiBaseUrl")
-        .slice(0, 2048)
-        .replace(/\/{1,256}$/, ""),
-      companionId: pairing.companion.id,
-      pairingToken: pairing.pairingToken,
-      pairingTokenExpiresAt: pairing.pairingTokenExpiresAt,
-      browser: pairing.companion.browser,
-      profileId: pairing.companion.profileId,
-      profileLabel: pairing.companion.profileLabel,
-      label: pairing.companion.label,
-    };
-    return {
-      companion: pairing.companion,
-      config,
-    };
-  }
-
   async revokeBrowserCompanion(
     companionId: string,
   ): Promise<BrowserBridgeCompanionRevokeResponse> {
@@ -1023,7 +1062,7 @@ export class BrowserDomain {
   async syncBrowserCompanion(
     companionId: string,
     pairingToken: string,
-    request: SyncBrowserBridgeStateRequest,
+    request: BrowserBridgeCompanionSyncRequest,
   ): Promise<BrowserBridgeCompanionSyncResponse> {
     const companion = await this.requireBrowserCompanion(
       companionId,
@@ -1042,8 +1081,19 @@ export class BrowserDomain {
     if (browser !== companion.browser || profileId !== companion.profileId) {
       fail(403, "browser companion payload does not match the paired profile");
     }
-    const state = await this.syncBrowserState(request);
     const settings = await this.getBrowserSettings();
+    const settingsVersion = browserBridgeSettingsVersion(settings);
+    if (
+      typeof request.settingsVersion !== "string" ||
+      request.settingsVersion !== settingsVersion
+    ) {
+      fail(
+        409,
+        "browser companion settings changed; preflight again",
+        "browser_bridge_settings_stale",
+      );
+    }
+    const state = await this.syncBrowserState(request);
     const session =
       settings.enabled &&
       settings.trackingMode !== "off" &&
@@ -1054,7 +1104,38 @@ export class BrowserDomain {
     return {
       ...state,
       settings,
+      settingsVersion,
       session,
+    };
+  }
+
+  async preflightBrowserCompanion(
+    companionId: string,
+    pairingToken: string,
+    request: BrowserBridgeCompanionPreflightRequest,
+  ): Promise<BrowserBridgeCompanionPreflightResponse> {
+    const companion = await this.requireBrowserCompanion(
+      companionId,
+      pairingToken,
+    );
+    const companionInput = requireRecord(request.companion, "companion");
+    const browser = normalizeEnumValue(
+      companionInput.browser,
+      "companion.browser",
+      BROWSER_BRIDGE_KINDS,
+    );
+    const profileId = requireNonEmptyString(
+      companionInput.profileId,
+      "companion.profileId",
+    );
+    if (browser !== companion.browser || profileId !== companion.profileId) {
+      fail(403, "browser companion payload does not match the paired profile");
+    }
+    const settings = await this.getBrowserSettings();
+    return {
+      companion,
+      settings,
+      settingsVersion: browserBridgeSettingsVersion(settings),
     };
   }
 
@@ -1115,7 +1196,15 @@ export class BrowserDomain {
     const finalizedSession: LifeOpsBrowserSession = {
       ...nextSession,
       result: lifecycle.result,
-      metadata: lifecycle.metadata,
+      metadata: confirmed
+        ? {
+            ...lifecycle.metadata,
+            browserApproval: {
+              actionsDigest: browserSessionActionsDigest(session.actions),
+              confirmedAt: nextSession.updatedAt,
+            },
+          }
+        : lifecycle.metadata,
     };
     await this.ctx.repository.updateBrowserSession(finalizedSession);
     await this.deps.recordBrowserAudit(
@@ -1236,7 +1325,7 @@ export class BrowserDomain {
               "done",
               "failed",
             ] as const),
-      currentActionIndex: Math.max(0, session.actions.length - 1),
+      currentActionIndex: session.actions.length,
       result: lifecycle.result,
       metadata: lifecycle.metadata,
       finishedAt: new Date().toISOString(),
@@ -1259,11 +1348,11 @@ export class BrowserDomain {
     return nextSession;
   }
 
-  async updateBrowserSessionProgressFromCompanion(
+  async beginBrowserSessionActionFromCompanion(
     companionId: string,
     pairingToken: string,
     sessionId: string,
-    request: UpdateLifeOpsBrowserSessionProgressRequest,
+    request: BrowserBridgeCompanionSessionBeginRequest,
   ): Promise<LifeOpsBrowserSession> {
     const companion = await this.requireBrowserCompanion(
       companionId,
@@ -1273,17 +1362,202 @@ export class BrowserDomain {
       companion,
       sessionId,
     );
+    if (session.status !== "running") {
+      fail(
+        409,
+        `browser session cannot begin an action from status ${session.status}`,
+      );
+    }
+    const currentActionIndex = normalizeBrowserSessionActionIndex(
+      request.currentActionIndex,
+      session.actions.length,
+    );
+    if (currentActionIndex !== session.currentActionIndex) {
+      fail(409, "browser action checkpoint is stale");
+    }
+    const actionId = requireNonEmptyString(request.actionId, "actionId");
+    const attemptId = requireNonEmptyString(request.attemptId, "attemptId");
+    if (attemptId.length > 128) {
+      fail(400, "attemptId must be at most 128 characters");
+    }
+    const action = session.actions[currentActionIndex];
+    if (!action || action.id !== actionId) {
+      fail(409, "browser action does not match the current checkpoint");
+    }
+    const settings = await this.deps.requireBrowserAvailableForActions([
+      action,
+    ]);
     if (
-      session.status !== "queued" &&
-      session.status !== "running" &&
-      session.status !== "awaiting_confirmation"
+      browserActionNeedsApproval(action, settings) &&
+      !hasCurrentBrowserSessionApproval(session)
     ) {
+      const awaiting =
+        await this.ctx.repository.requireBrowserSessionActionConfirmation({
+          agentId: this.ctx.agentId(),
+          sessionId: session.id,
+          companion,
+          currentActionIndex,
+          actionId,
+          updatedAt: new Date().toISOString(),
+        });
+      if (!awaiting) {
+        fail(409, "browser action confirmation lost a concurrent update");
+      }
+      fail(409, "Browser action requires current owner confirmation.");
+    }
+    const leased =
+      await this.ctx.repository.beginBrowserSessionActionFromCompanion({
+        agentId: this.ctx.agentId(),
+        sessionId: session.id,
+        companion,
+        currentActionIndex,
+        actionId,
+        attemptId,
+        startedAt: new Date().toISOString(),
+      });
+    if (!leased) {
+      fail(
+        409,
+        "browser action already has an uncertain or concurrent execution attempt",
+      );
+    }
+    return leased;
+  }
+
+  async updateBrowserSessionProgressFromCompanion(
+    companionId: string,
+    pairingToken: string,
+    sessionId: string,
+    request: BrowserBridgeCompanionSessionProgressRequest,
+  ): Promise<LifeOpsBrowserSession> {
+    const companion = await this.requireBrowserCompanion(
+      companionId,
+      pairingToken,
+    );
+    const session = await this.requireBrowserSessionForCompanion(
+      companion,
+      sessionId,
+    );
+    if (session.status !== "running") {
       fail(
         409,
         `browser session cannot update progress from status ${session.status}`,
       );
     }
-    return this.updateBrowserSessionProgress(session.id, request);
+    const currentActionIndex =
+      request.currentActionIndex === undefined
+        ? session.currentActionIndex
+        : normalizeBrowserSessionActionIndex(
+            request.currentActionIndex,
+            session.actions.length,
+          );
+    const completedActionId = requireNonEmptyString(
+      request.completedActionId,
+      "completedActionId",
+    );
+    const attemptId = requireNonEmptyString(request.attemptId, "attemptId");
+    if (attemptId.length > 128) {
+      fail(400, "attemptId must be at most 128 characters");
+    }
+    if (currentActionIndex < session.currentActionIndex) {
+      fail(409, "browser session checkpoint cannot move backwards");
+    }
+    const resultPatch =
+      request.result === undefined
+        ? undefined
+        : requireRecord(request.result, "result");
+    const metadataPatch =
+      request.metadata === undefined
+        ? undefined
+        : requireRecord(request.metadata, "metadata");
+    if (
+      metadataPatch &&
+      ("browserActionAttempt" in metadataPatch ||
+        "browserActionReceipt" in metadataPatch)
+    ) {
+      fail(400, "metadata contains reserved browser action receipt fields");
+    }
+    if (currentActionIndex === session.currentActionIndex) {
+      const completedAction = session.actions[currentActionIndex - 1];
+      if (!completedAction || completedAction.id !== completedActionId) {
+        fail(
+          409,
+          "browser session checkpoint action does not match its receipt",
+        );
+      }
+      const receipt = session.metadata.browserActionReceipt;
+      const receiptMatches =
+        receipt !== null &&
+        typeof receipt === "object" &&
+        !Array.isArray(receipt) &&
+        (receipt as Record<string, unknown>).actionId === completedActionId &&
+        (receipt as Record<string, unknown>).attemptId === attemptId &&
+        (receipt as Record<string, unknown>).actionIndex ===
+          currentActionIndex - 1;
+      if (
+        receiptMatches &&
+        recordPatchMatches(session.result, resultPatch) &&
+        recordPatchMatches(session.metadata, metadataPatch)
+      ) {
+        return session;
+      }
+      fail(409, "browser session checkpoint replay conflicts with its receipt");
+    }
+    if (currentActionIndex !== session.currentActionIndex + 1) {
+      fail(409, "browser session checkpoint must advance exactly one action");
+    }
+    const expectedAction = session.actions[session.currentActionIndex];
+    if (!expectedAction || expectedAction.id !== completedActionId) {
+      fail(
+        409,
+        "browser session checkpoint action does not match the queued action",
+      );
+    }
+    const updatedAt = new Date().toISOString();
+    const lifecycle = mergeBrowserTaskLifecycle({
+      session,
+      resultPatch,
+      metadataPatch,
+      now: updatedAt,
+    });
+    const metadataWithoutAttempt = { ...lifecycle.metadata };
+    delete metadataWithoutAttempt.browserActionAttempt;
+    const receiptMetadata = {
+      ...metadataWithoutAttempt,
+      browserActionReceipt: {
+        actionId: completedActionId,
+        actionIndex: session.currentActionIndex,
+        attemptId,
+        completedAt: updatedAt,
+      },
+    };
+    const updated =
+      await this.ctx.repository.updateBrowserSessionProgressFromCompanion({
+        agentId: this.ctx.agentId(),
+        sessionId: session.id,
+        companion,
+        expectedActionIndex: session.currentActionIndex,
+        completedActionId,
+        attemptId,
+        currentActionIndex,
+        resultPatch: lifecycle.result,
+        metadataPatch: receiptMetadata,
+        updatedAt,
+      });
+    if (!updated) {
+      fail(409, "browser session checkpoint lost a concurrent update");
+    }
+    await this.deps.recordBrowserAudit(
+      "browser_session_updated",
+      updated.id,
+      "browser session progress updated",
+      {
+        currentActionIndex: updated.currentActionIndex,
+        browserTask: summarizeBrowserTaskLifecycle(updated),
+      },
+      { status: updated.status },
+    );
+    return updated;
   }
 
   async completeBrowserSessionFromCompanion(
@@ -1296,7 +1570,73 @@ export class BrowserDomain {
       companionId,
       pairingToken,
     );
-    await this.requireBrowserSessionForCompanion(companion, sessionId);
-    return this.completeBrowserSession(sessionId, request);
+    const session = await this.requireBrowserSessionForCompanion(
+      companion,
+      sessionId,
+    );
+    const requestedResult =
+      request.result === undefined
+        ? undefined
+        : requireRecord(request.result, "result");
+    if (session.status !== "running") {
+      if (
+        session.status === (request.status ?? "done") &&
+        recordPatchMatches(session.result, requestedResult)
+      ) {
+        return session;
+      }
+      fail(
+        409,
+        `browser session cannot complete from status ${session.status}`,
+      );
+    }
+    const updatedAt = new Date().toISOString();
+    const status = request.status ?? "done";
+    if (
+      status === "done" &&
+      session.currentActionIndex !== session.actions.length
+    ) {
+      fail(
+        409,
+        "browser session cannot complete before every action is acknowledged",
+      );
+    }
+    const lifecycle = mergeBrowserTaskLifecycle({
+      session,
+      resultPatch: requestedResult,
+      now: updatedAt,
+      completed: status === "done",
+    });
+    const completed =
+      await this.ctx.repository.completeBrowserSessionFromCompanion({
+        agentId: this.ctx.agentId(),
+        sessionId,
+        companion,
+        status,
+        resultPatch: lifecycle.result,
+        updatedAt,
+      });
+    if (!completed) {
+      const latest = await this.getBrowserSession(sessionId);
+      if (
+        latest.status === status &&
+        latest.companionId === companion.id &&
+        latest.browser === companion.browser &&
+        latest.profileId === companion.profileId
+      ) {
+        return latest;
+      }
+      fail(409, "browser session completion lost a concurrent update");
+    }
+    await this.deps.recordBrowserAudit(
+      "browser_session_updated",
+      completed.id,
+      status === "failed"
+        ? "browser session failed"
+        : "browser session completed",
+      { result: request.result ?? null },
+      { status: completed.status },
+    );
+    return completed;
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -7169,6 +7169,194 @@ export class LifeOpsRepository {
     );
   }
 
+  /** Atomically claims the oldest eligible session for one exact companion. */
+  async claimBrowserSession(
+    agentId: string,
+    companion: BrowserBridgeCompanionStatus,
+    claimedAt: string,
+  ): Promise<LifeOpsBrowserSession | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `WITH candidate AS (
+         SELECT id
+           FROM app_lifeops.life_workflow_browser_sessions
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND (browser IS NULL OR browser = ${sqlQuote(companion.browser)})
+            AND (profile_id IS NULL OR profile_id = ${sqlQuote(companion.profileId)})
+            AND (companion_id IS NULL OR companion_id = ${sqlQuote(companion.id)})
+            AND (
+              status = 'queued'
+              OR (
+                status = 'running'
+                AND metadata_json::jsonb ->> 'claimedByCompanionId' = ${sqlQuote(companion.id)}
+              )
+            )
+          ORDER BY
+            CASE WHEN status = 'running' THEN 0 ELSE 1 END,
+            created_at ASC,
+            id ASC
+          LIMIT 1
+          FOR UPDATE SKIP LOCKED
+       )
+       UPDATE app_lifeops.life_workflow_browser_sessions AS session
+          SET status = 'running',
+              browser = COALESCE(session.browser, ${sqlQuote(companion.browser)}),
+              companion_id = ${sqlQuote(companion.id)},
+              profile_id = COALESCE(session.profile_id, ${sqlQuote(companion.profileId)}),
+              metadata_json = (session.metadata_json::jsonb || ${sqlJson({
+                claimedAt,
+                claimedByCompanionId: companion.id,
+                claimedBrowser: companion.browser,
+                claimedProfileId: companion.profileId,
+              })}::jsonb)::text,
+              updated_at = ${sqlQuote(claimedAt)}
+         FROM candidate
+        WHERE session.id = candidate.id
+          AND session.agent_id = ${sqlQuote(agentId)}
+        RETURNING session.*`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
+  /** Atomically leases one exact action before any browser side effect. */
+  async beginBrowserSessionActionFromCompanion(args: {
+    agentId: string;
+    sessionId: string;
+    companion: BrowserBridgeCompanionStatus;
+    currentActionIndex: number;
+    actionId: string;
+    attemptId: string;
+    startedAt: string;
+  }): Promise<LifeOpsBrowserSession | null> {
+    const attempt = {
+      actionId: args.actionId,
+      actionIndex: args.currentActionIndex,
+      attemptId: args.attemptId,
+      startedAt: args.startedAt,
+    };
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_lifeops.life_workflow_browser_sessions
+          SET metadata_json = (metadata_json::jsonb || ${sqlJson({
+            browserActionAttempt: attempt,
+          })}::jsonb)::text,
+              updated_at = ${sqlQuote(args.startedAt)}
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND id = ${sqlQuote(args.sessionId)}
+          AND status = 'running'
+          AND companion_id = ${sqlQuote(args.companion.id)}
+          AND browser = ${sqlQuote(args.companion.browser)}
+          AND profile_id = ${sqlQuote(args.companion.profileId)}
+          AND current_action_index = ${sqlInteger(args.currentActionIndex)}
+          AND (actions_json::jsonb -> ${sqlInteger(args.currentActionIndex)} ->> 'id') = ${sqlQuote(args.actionId)}
+          AND NOT (metadata_json::jsonb ? 'browserActionAttempt')
+        RETURNING *`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
+  /** Moves a currently targeted action back behind owner confirmation. */
+  async requireBrowserSessionActionConfirmation(args: {
+    agentId: string;
+    sessionId: string;
+    companion: BrowserBridgeCompanionStatus;
+    currentActionIndex: number;
+    actionId: string;
+    updatedAt: string;
+  }): Promise<LifeOpsBrowserSession | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_lifeops.life_workflow_browser_sessions
+          SET status = 'awaiting_confirmation',
+              awaiting_confirmation_for_action_id = ${sqlQuote(args.actionId)},
+              metadata_json = (metadata_json::jsonb - 'browserActionAttempt')::text,
+              updated_at = ${sqlQuote(args.updatedAt)}
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND id = ${sqlQuote(args.sessionId)}
+          AND status = 'running'
+          AND companion_id = ${sqlQuote(args.companion.id)}
+          AND browser = ${sqlQuote(args.companion.browser)}
+          AND profile_id = ${sqlQuote(args.companion.profileId)}
+          AND current_action_index = ${sqlInteger(args.currentActionIndex)}
+          AND (actions_json::jsonb -> ${sqlInteger(args.currentActionIndex)} ->> 'id') = ${sqlQuote(args.actionId)}
+          AND NOT (metadata_json::jsonb ? 'browserActionAttempt')
+        RETURNING *`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
+  /** Applies a monotonic companion checkpoint without a read/write race. */
+  async updateBrowserSessionProgressFromCompanion(args: {
+    agentId: string;
+    sessionId: string;
+    companion: BrowserBridgeCompanionStatus;
+    expectedActionIndex: number;
+    completedActionId: string;
+    attemptId: string;
+    currentActionIndex: number;
+    resultPatch: Record<string, unknown>;
+    metadataPatch: Record<string, unknown>;
+    updatedAt: string;
+  }): Promise<LifeOpsBrowserSession | null> {
+    if (args.currentActionIndex !== args.expectedActionIndex + 1) {
+      return null;
+    }
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_lifeops.life_workflow_browser_sessions
+          SET current_action_index = ${sqlInteger(args.currentActionIndex)},
+              result_json = ${sqlJson(args.resultPatch)},
+              metadata_json = ${sqlJson(args.metadataPatch)},
+              updated_at = ${sqlQuote(args.updatedAt)}
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND id = ${sqlQuote(args.sessionId)}
+          AND status = 'running'
+          AND companion_id = ${sqlQuote(args.companion.id)}
+          AND browser = ${sqlQuote(args.companion.browser)}
+          AND profile_id = ${sqlQuote(args.companion.profileId)}
+          AND current_action_index = ${sqlInteger(args.expectedActionIndex)}
+          AND (actions_json::jsonb -> ${sqlInteger(args.expectedActionIndex)} ->> 'id') = ${sqlQuote(args.completedActionId)}
+          AND metadata_json::jsonb -> 'browserActionAttempt' ->> 'actionId' = ${sqlQuote(args.completedActionId)}
+          AND (metadata_json::jsonb -> 'browserActionAttempt' ->> 'actionIndex')::integer = ${sqlInteger(args.expectedActionIndex)}
+          AND metadata_json::jsonb -> 'browserActionAttempt' ->> 'attemptId' = ${sqlQuote(args.attemptId)}
+          AND ${sqlInteger(args.currentActionIndex)} <= jsonb_array_length(actions_json::jsonb)
+        RETURNING *`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
+  /** Completes only a running session owned by the exact companion identity. */
+  async completeBrowserSessionFromCompanion(args: {
+    agentId: string;
+    sessionId: string;
+    companion: BrowserBridgeCompanionStatus;
+    status: Extract<LifeOpsBrowserSession["status"], "done" | "failed">;
+    resultPatch: Record<string, unknown>;
+    updatedAt: string;
+  }): Promise<LifeOpsBrowserSession | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_lifeops.life_workflow_browser_sessions
+          SET status = ${sqlQuote(args.status)},
+              current_action_index = jsonb_array_length(actions_json::jsonb),
+              result_json = (result_json::jsonb || ${sqlJson(args.resultPatch)}::jsonb)::text,
+              updated_at = ${sqlQuote(args.updatedAt)},
+              finished_at = ${sqlQuote(args.updatedAt)}
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND id = ${sqlQuote(args.sessionId)}
+          AND status = 'running'
+          AND companion_id = ${sqlQuote(args.companion.id)}
+          AND browser = ${sqlQuote(args.companion.browser)}
+          AND profile_id = ${sqlQuote(args.companion.profileId)}
+          AND (
+            ${sqlQuote(args.status)} = 'failed'
+            OR current_action_index = jsonb_array_length(actions_json::jsonb)
+          )
+        RETURNING *`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
   async getBrowserSession(
     agentId: string,
     sessionId: string,

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -7169,6 +7169,34 @@ export class LifeOpsRepository {
     );
   }
 
+  /** Atomically settles one still-current owner confirmation decision. */
+  async updateBrowserSessionIfAwaitingConfirmation(args: {
+    session: LifeOpsBrowserSession;
+    expectedActionId: string;
+    expectedUpdatedAt: string;
+  }): Promise<LifeOpsBrowserSession | null> {
+    const { session } = args;
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_lifeops.life_workflow_browser_sessions
+          SET status = ${sqlQuote(session.status)},
+              current_action_index = ${sqlInteger(session.currentActionIndex)},
+              awaiting_confirmation_for_action_id = ${sqlText(session.awaitingConfirmationForActionId)},
+              result_json = ${sqlJson(session.result)},
+              metadata_json = ${sqlJson(session.metadata)},
+              updated_at = ${sqlQuote(session.updatedAt)},
+              finished_at = ${sqlText(session.finishedAt)}
+        WHERE id = ${sqlQuote(session.id)}
+          AND agent_id = ${sqlQuote(session.agentId)}
+          AND status = 'awaiting_confirmation'
+          AND awaiting_confirmation_for_action_id = ${sqlQuote(args.expectedActionId)}
+          AND updated_at = ${sqlQuote(args.expectedUpdatedAt)}
+          AND actions_json = ${sqlJson(session.actions)}
+        RETURNING *`,
+    );
+    return rows[0] ? parseBrowserSession(rows[0]) : null;
+  }
+
   /** Atomically claims the oldest eligible session for one exact companion. */
   async claimBrowserSession(
     agentId: string,
@@ -7331,9 +7359,29 @@ export class LifeOpsRepository {
     sessionId: string;
     companion: BrowserBridgeCompanionStatus;
     status: Extract<LifeOpsBrowserSession["status"], "done" | "failed">;
+    expectedActionIndex: number;
+    completedActionId: string | null;
+    attemptId: string | null;
     resultPatch: Record<string, unknown>;
     updatedAt: string;
   }): Promise<LifeOpsBrowserSession | null> {
+    const executionFence =
+      args.status === "failed"
+        ? `AND current_action_index = ${sqlInteger(args.expectedActionIndex)}
+           AND (actions_json::jsonb -> ${sqlInteger(args.expectedActionIndex)} ->> 'id') = ${sqlQuote(args.completedActionId ?? "")}
+           AND metadata_json::jsonb -> 'browserActionAttempt' ->> 'actionId' = ${sqlQuote(args.completedActionId ?? "")}
+           AND (metadata_json::jsonb -> 'browserActionAttempt' ->> 'actionIndex')::integer = ${sqlInteger(args.expectedActionIndex)}
+           AND metadata_json::jsonb -> 'browserActionAttempt' ->> 'attemptId' = ${sqlQuote(args.attemptId ?? "")}`
+        : args.expectedActionIndex === 0
+          ? `AND current_action_index = 0
+             AND jsonb_array_length(actions_json::jsonb) = 0
+             AND NOT (metadata_json::jsonb ? 'browserActionAttempt')`
+          : `AND current_action_index = ${sqlInteger(args.expectedActionIndex)}
+             AND current_action_index = jsonb_array_length(actions_json::jsonb)
+             AND metadata_json::jsonb -> 'browserActionReceipt' ->> 'actionId' = ${sqlQuote(args.completedActionId ?? "")}
+             AND (metadata_json::jsonb -> 'browserActionReceipt' ->> 'actionIndex')::integer = ${sqlInteger(args.expectedActionIndex - 1)}
+             AND metadata_json::jsonb -> 'browserActionReceipt' ->> 'attemptId' = ${sqlQuote(args.attemptId ?? "")}
+             AND NOT (metadata_json::jsonb ? 'browserActionAttempt')`;
     const rows = await executeRawSql(
       this.runtime,
       `UPDATE app_lifeops.life_workflow_browser_sessions
@@ -7348,6 +7396,7 @@ export class LifeOpsRepository {
           AND companion_id = ${sqlQuote(args.companion.id)}
           AND browser = ${sqlQuote(args.companion.browser)}
           AND profile_id = ${sqlQuote(args.companion.profileId)}
+          ${executionFence}
           AND (
             ${sqlQuote(args.status)} = 'failed'
             OR current_action_index = jsonb_array_length(actions_json::jsonb)

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Browser service helper tests cover confirmation policy at the session
+ * creation boundary without replacing the domain object under test.
+ */
+import type { BrowserBridgeAction } from "@elizaos/plugin-browser";
+import { describe, expect, it } from "vitest";
+import { resolveAwaitingBrowserActionId } from "./service-helpers-browser.js";
+
+function action(
+  id: string,
+  overrides: Partial<BrowserBridgeAction>,
+): BrowserBridgeAction {
+  return {
+    id,
+    kind: "click",
+    label: id,
+    url: "https://allowed.example/",
+    selector: "button",
+    text: null,
+    accountAffecting: false,
+    requiresConfirmation: false,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("resolveAwaitingBrowserActionId", () => {
+  it("honors the account-affecting confirmation setting", () => {
+    const actions = [action("account", { accountAffecting: true })];
+    expect(resolveAwaitingBrowserActionId(actions, true)).toBe("account");
+    expect(resolveAwaitingBrowserActionId(actions, false)).toBeNull();
+  });
+
+  it("never bypasses an action's explicit confirmation requirement", () => {
+    const actions = [action("explicit", { requiresConfirmation: true })];
+    expect(resolveAwaitingBrowserActionId(actions, false)).toBe("explicit");
+  });
+
+  it("selects the first action requiring confirmation under the policy", () => {
+    const actions = [
+      action("safe", {}),
+      action("account", { accountAffecting: true }),
+      action("explicit", { requiresConfirmation: true }),
+    ];
+    expect(resolveAwaitingBrowserActionId(actions, true)).toBe("account");
+    expect(resolveAwaitingBrowserActionId(actions, false)).toBe("explicit");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.ts
@@ -152,17 +152,20 @@ export function normalizeBrowserSessionActionIndex(
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     fail(400, "currentActionIndex must be a non-negative integer");
   }
-  if (maxActions <= 0) {
-    return 0;
+  if (value > maxActions) {
+    fail(400, "currentActionIndex cannot exceed the action count");
   }
-  return Math.min(value, maxActions - 1);
+  return value;
 }
 
 export function resolveAwaitingBrowserActionId(
   actions: BrowserBridgeAction[],
+  requireConfirmationForAccountAffecting = true,
 ): string | null {
   const next = actions.find(
-    (action) => action.accountAffecting || action.requiresConfirmation,
+    (action) =>
+      action.requiresConfirmation ||
+      (requireConfirmationForAccountAffecting && action.accountAffecting),
   );
   return next?.id ?? null;
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-browser.ts
@@ -264,17 +264,46 @@ export function browserOriginFromUrl(url: string): string | null {
   }
 }
 
+function browserUrlMatchesBlockedEntry(url: URL, entry: string): boolean {
+  const candidate = entry.trim().toLowerCase();
+  if (!candidate) return false;
+  try {
+    const parsed = new URL(
+      /^[a-z][a-z0-9+.-]*:\/\//.test(candidate)
+        ? candidate
+        : `https://${candidate.replace(/^\*\./, "")}`,
+    );
+    const blockedHost = parsed.hostname.toLowerCase().replace(/\.+$/, "");
+    const targetHost = url.hostname.toLowerCase().replace(/\.+$/, "");
+    return (
+      blockedHost.length > 0 &&
+      (targetHost === blockedHost || targetHost.endsWith(`.${blockedHost}`))
+    );
+  } catch {
+    // error-policy:J3 Invalid persisted block entries do not match a URL.
+    return false;
+  }
+}
+
 export function browserUrlAllowedBySettings(
   url: string,
   settings: BrowserBridgeSettings,
 ): boolean {
-  const origin = browserOriginFromUrl(url);
-  if (!origin) {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 Invalid browser URLs are not allowed by policy.
     return false;
   }
-  if (settings.blockedOrigins.includes(origin)) {
+  if (
+    settings.blockedOrigins.some((entry) =>
+      browserUrlMatchesBlockedEntry(parsed, entry),
+    )
+  ) {
     return false;
   }
+  const origin = parsed.origin;
   if (settings.siteAccessMode === "granted_sites") {
     return settings.grantedOrigins.includes(origin);
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/service-mixin-browser.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-mixin-browser.ts
@@ -4,15 +4,18 @@
  * settings, tab-context, and session methods onto the LifeOpsService base.
  */
 import type {
-  BrowserBridgeCompanionAutoPairResponse,
   BrowserBridgeCompanionPairingResponse,
+  BrowserBridgeCompanionPreflightRequest,
+  BrowserBridgeCompanionPreflightResponse,
   BrowserBridgeCompanionRevokeResponse,
+  BrowserBridgeCompanionSessionBeginRequest,
+  BrowserBridgeCompanionSessionProgressRequest,
   BrowserBridgeCompanionStatus,
+  BrowserBridgeCompanionSyncRequest,
   BrowserBridgeCompanionSyncResponse,
   BrowserBridgePageContext,
   BrowserBridgeSettings,
   BrowserBridgeTabSummary,
-  CreateBrowserBridgeCompanionAutoPairRequest,
   CreateBrowserBridgeCompanionPairingRequest,
   SyncBrowserBridgeStateRequest,
   UpdateBrowserBridgeSettingsRequest,
@@ -44,8 +47,13 @@ export interface BrowserBridgeService {
   syncBrowserCompanion(
     companionId: string,
     pairingToken: string,
-    request: SyncBrowserBridgeStateRequest,
+    request: BrowserBridgeCompanionSyncRequest,
   ): Promise<BrowserBridgeCompanionSyncResponse>;
+  preflightBrowserCompanion(
+    companionId: string,
+    pairingToken: string,
+    request: BrowserBridgeCompanionPreflightRequest,
+  ): Promise<BrowserBridgeCompanionPreflightResponse>;
   listBrowserSessions(): Promise<LifeOpsBrowserSession[]>;
   getBrowserSession(sessionId: string): Promise<LifeOpsBrowserSession>;
   createBrowserSession(
@@ -63,7 +71,13 @@ export interface BrowserBridgeService {
     companionId: string,
     pairingToken: string,
     sessionId: string,
-    request: UpdateLifeOpsBrowserSessionProgressRequest,
+    request: BrowserBridgeCompanionSessionProgressRequest,
+  ): Promise<LifeOpsBrowserSession>;
+  beginBrowserSessionActionFromCompanion(
+    companionId: string,
+    pairingToken: string,
+    sessionId: string,
+    request: BrowserBridgeCompanionSessionBeginRequest,
   ): Promise<LifeOpsBrowserSession>;
   completeBrowserSessionFromCompanion(
     companionId: string,
@@ -71,10 +85,6 @@ export interface BrowserBridgeService {
     sessionId: string,
     request: CompleteLifeOpsBrowserSessionRequest,
   ): Promise<LifeOpsBrowserSession>;
-  autoPairBrowserCompanion(
-    request: CreateBrowserBridgeCompanionAutoPairRequest,
-    apiBaseUrl: string,
-  ): Promise<BrowserBridgeCompanionAutoPairResponse>;
   revokeBrowserCompanion(
     companionId: string,
   ): Promise<BrowserBridgeCompanionRevokeResponse>;

--- a/plugins/plugin-personal-assistant/src/lifeops/service-normalize-connector.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-normalize-connector.ts
@@ -799,6 +799,42 @@ export function normalizeOriginList(value: unknown, field: string): string[] {
   );
 }
 
+export function normalizeBlockedOriginList(
+  value: unknown,
+  field: string,
+): string[] {
+  if (!Array.isArray(value)) {
+    fail(400, `${field} must be an array`);
+  }
+  return normalizedStringSet(
+    value.map((candidate, index) => {
+      const entryField = `${field}[${index}]`;
+      const text = requireNonEmptyString(candidate, entryField).toLowerCase();
+      try {
+        const parsed = new URL(
+          /^[a-z][a-z0-9+.-]*:\/\//.test(text)
+            ? text
+            : `https://${text.replace(/^\*\./, "")}`,
+        );
+        if (
+          (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+          !parsed.hostname
+        ) {
+          fail(400, `${entryField} must be a valid HTTP(S) origin or hostname`);
+        }
+        return parsed.hostname.toLowerCase().replace(/\.+$/, "");
+      } catch (error) {
+        // error-policy:J3 Block entries are normalized to explicit hosts.
+        if (error instanceof LifeOpsServiceError) throw error;
+        return fail(
+          400,
+          `${entryField} must be a valid HTTP(S) origin or hostname`,
+        );
+      }
+    }),
+  );
+}
+
 export function normalizeBrowserSettingsUpdate(
   request: UpdateBrowserBridgeSettingsRequest,
   current: BrowserBridgeSettings,
@@ -842,7 +878,7 @@ export function normalizeBrowserSettingsUpdate(
     blockedOrigins:
       request.blockedOrigins === undefined
         ? [...current.blockedOrigins]
-        : normalizeOriginList(request.blockedOrigins, "blockedOrigins"),
+        : normalizeBlockedOriginList(request.blockedOrigins, "blockedOrigins"),
     maxRememberedTabs:
       request.maxRememberedTabs === undefined
         ? current.maxRememberedTabs

--- a/plugins/plugin-personal-assistant/src/lifeops/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service.ts
@@ -13,15 +13,18 @@ export {
 } from "./service-types.js";
 
 import type {
-  BrowserBridgeCompanionAutoPairResponse,
   BrowserBridgeCompanionPairingResponse,
+  BrowserBridgeCompanionPreflightRequest,
+  BrowserBridgeCompanionPreflightResponse,
   BrowserBridgeCompanionRevokeResponse,
+  BrowserBridgeCompanionSessionBeginRequest,
+  BrowserBridgeCompanionSessionProgressRequest,
   BrowserBridgeCompanionStatus,
+  BrowserBridgeCompanionSyncRequest,
   BrowserBridgeCompanionSyncResponse,
   BrowserBridgePageContext,
   BrowserBridgeSettings,
   BrowserBridgeTabSummary,
-  CreateBrowserBridgeCompanionAutoPairRequest,
   CreateBrowserBridgeCompanionPairingRequest,
   SyncBrowserBridgeStateRequest,
   UpdateBrowserBridgeSettingsRequest,
@@ -1457,9 +1460,21 @@ export class LifeOpsService extends LifeOpsServiceBase {
   syncBrowserCompanion(
     companionId: string,
     pairingToken: string,
-    request: SyncBrowserBridgeStateRequest,
+    request: BrowserBridgeCompanionSyncRequest,
   ): Promise<BrowserBridgeCompanionSyncResponse> {
     return this.browserDomain.syncBrowserCompanion(
+      companionId,
+      pairingToken,
+      request,
+    );
+  }
+
+  preflightBrowserCompanion(
+    companionId: string,
+    pairingToken: string,
+    request: BrowserBridgeCompanionPreflightRequest,
+  ): Promise<BrowserBridgeCompanionPreflightResponse> {
+    return this.browserDomain.preflightBrowserCompanion(
       companionId,
       pairingToken,
       request,
@@ -1505,9 +1520,23 @@ export class LifeOpsService extends LifeOpsServiceBase {
     companionId: string,
     pairingToken: string,
     sessionId: string,
-    request: UpdateLifeOpsBrowserSessionProgressRequest,
+    request: BrowserBridgeCompanionSessionProgressRequest,
   ): Promise<LifeOpsBrowserSession> {
     return this.browserDomain.updateBrowserSessionProgressFromCompanion(
+      companionId,
+      pairingToken,
+      sessionId,
+      request,
+    );
+  }
+
+  beginBrowserSessionActionFromCompanion(
+    companionId: string,
+    pairingToken: string,
+    sessionId: string,
+    request: BrowserBridgeCompanionSessionBeginRequest,
+  ): Promise<LifeOpsBrowserSession> {
+    return this.browserDomain.beginBrowserSessionActionFromCompanion(
       companionId,
       pairingToken,
       sessionId,
@@ -1527,13 +1556,6 @@ export class LifeOpsService extends LifeOpsServiceBase {
       sessionId,
       request,
     );
-  }
-
-  autoPairBrowserCompanion(
-    request: CreateBrowserBridgeCompanionAutoPairRequest,
-    apiBaseUrl: string,
-  ): Promise<BrowserBridgeCompanionAutoPairResponse> {
-    return this.browserDomain.autoPairBrowserCompanion(request, apiBaseUrl);
   }
 
   revokeBrowserCompanion(

--- a/plugins/plugin-personal-assistant/src/service.ts
+++ b/plugins/plugin-personal-assistant/src/service.ts
@@ -7,16 +7,19 @@
 import { type IAgentRuntime, Service, type UUID } from "@elizaos/core";
 import {
   BROWSER_BRIDGE_ROUTE_SERVICE_TYPE,
-  type BrowserBridgeCompanionAutoPairResponse,
   type BrowserBridgeCompanionPairingResponse,
+  type BrowserBridgeCompanionPreflightRequest,
+  type BrowserBridgeCompanionPreflightResponse,
   type BrowserBridgeCompanionRevokeResponse,
+  type BrowserBridgeCompanionSessionBeginRequest,
+  type BrowserBridgeCompanionSessionProgressRequest,
   type BrowserBridgeCompanionStatus,
+  type BrowserBridgeCompanionSyncRequest,
   type BrowserBridgeCompanionSyncResponse,
   type BrowserBridgePageContext,
   type BrowserBridgeRouteService,
   type BrowserBridgeSettings,
   type BrowserBridgeTabSummary,
-  type CreateBrowserBridgeCompanionAutoPairRequest,
   type CreateBrowserBridgeCompanionPairingRequest,
   type SyncBrowserBridgeStateRequest,
   type UpdateBrowserBridgeSessionProgressRequest,
@@ -100,17 +103,6 @@ export class BrowserBridgePluginService
     return this.lifeOps(ownerEntityId).createBrowserCompanionPairing(request);
   }
 
-  async autoPairBrowserCompanion(
-    request: CreateBrowserBridgeCompanionAutoPairRequest,
-    apiBaseUrl: string,
-    ownerEntityId?: UUID | null,
-  ): Promise<BrowserBridgeCompanionAutoPairResponse> {
-    return this.lifeOps(ownerEntityId).autoPairBrowserCompanion(
-      request,
-      apiBaseUrl,
-    );
-  }
-
   async revokeBrowserCompanion(
     companionId: string,
     ownerEntityId?: UUID | null,
@@ -132,10 +124,23 @@ export class BrowserBridgePluginService
   async syncBrowserCompanion(
     companionId: string,
     pairingToken: string,
-    request: SyncBrowserBridgeStateRequest,
+    request: BrowserBridgeCompanionSyncRequest,
     ownerEntityId?: UUID | null,
   ): Promise<BrowserBridgeCompanionSyncResponse> {
     return this.lifeOps(ownerEntityId).syncBrowserCompanion(
+      companionId,
+      pairingToken,
+      request,
+    );
+  }
+
+  async preflightBrowserCompanion(
+    companionId: string,
+    pairingToken: string,
+    request: BrowserBridgeCompanionPreflightRequest,
+    ownerEntityId?: UUID | null,
+  ): Promise<BrowserBridgeCompanionPreflightResponse> {
+    return this.lifeOps(ownerEntityId).preflightBrowserCompanion(
       companionId,
       pairingToken,
       request,
@@ -199,12 +204,27 @@ export class BrowserBridgePluginService
     companionId: string,
     pairingToken: string,
     sessionId: string,
-    request: UpdateBrowserBridgeSessionProgressRequest,
+    request: BrowserBridgeCompanionSessionProgressRequest,
     ownerEntityId?: UUID | null,
   ): Promise<LifeOpsBrowserSession> {
     return this.lifeOps(
       ownerEntityId,
     ).updateBrowserSessionProgressFromCompanion(
+      companionId,
+      pairingToken,
+      sessionId,
+      request,
+    );
+  }
+
+  async beginBrowserSessionActionFromCompanion(
+    companionId: string,
+    pairingToken: string,
+    sessionId: string,
+    request: BrowserBridgeCompanionSessionBeginRequest,
+    ownerEntityId?: UUID | null,
+  ): Promise<LifeOpsBrowserSession> {
+    return this.lifeOps(ownerEntityId).beginBrowserSessionActionFromCompanion(
       companionId,
       pairingToken,
       sessionId,

--- a/plugins/plugin-personal-assistant/test/browser-helpers-security.test.ts
+++ b/plugins/plugin-personal-assistant/test/browser-helpers-security.test.ts
@@ -84,6 +84,18 @@ describe("browserOriginFromUrl / browserUrlAllowedBySettings", () => {
         settings({ blockedOrigins: ["https://bad.com"] }),
       ),
     ).toBe(false);
+    expect(
+      browserUrlAllowedBySettings(
+        "http://pay.bad.com:8443/",
+        settings({ blockedOrigins: ["https://bad.com"] }),
+      ),
+    ).toBe(false);
+    expect(
+      browserUrlAllowedBySettings(
+        "https://evil-bad.com/",
+        settings({ blockedOrigins: ["bad.com"] }),
+      ),
+    ).toBe(true);
     // granted_sites mode: only listed origins pass.
     expect(
       browserUrlAllowedBySettings(

--- a/plugins/plugin-personal-assistant/test/browser-session-companion-atomic.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/browser-session-companion-atomic.pglite.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Exercises browser-companion claims and checkpoints against the real PGlite
+ * repository so concurrent workers cannot share or rewind durable sessions.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import type { BrowserBridgeCompanionStatus } from "@elizaos/plugin-browser";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { LifeOpsBrowserSession } from "../src/contracts/index.js";
+import {
+  BrowserDomain,
+  type BrowserDomainDeps,
+} from "../src/lifeops/domains/browser-service.js";
+import type { LifeOpsContext } from "../src/lifeops/lifeops-context.js";
+import {
+  createLifeOpsBrowserSession,
+  LifeOpsRepository,
+} from "../src/lifeops/repository.js";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "./helpers/runtime.js";
+
+let runtimeResult: RealTestRuntimeResult | null = null;
+let runtime: AgentRuntime;
+let repository: LifeOpsRepository;
+
+function browserDomain(): BrowserDomain {
+  const context = {
+    runtime,
+    repository,
+    agentId: () => runtime.agentId,
+  } as unknown as LifeOpsContext;
+  const deps = {
+    recordBrowserAudit: async () => {},
+  } as unknown as BrowserDomainDeps;
+  return new BrowserDomain(context, deps);
+}
+
+function companion(
+  id: string,
+  profileId: string,
+): BrowserBridgeCompanionStatus {
+  const now = new Date().toISOString();
+  return {
+    id,
+    agentId: runtime.agentId,
+    browser: "chrome",
+    profileId,
+    profileLabel: profileId,
+    label: id,
+    extensionVersion: "test",
+    connectionState: "connected",
+    permissions: {
+      tabs: true,
+      scripting: true,
+      activeTab: true,
+      allOrigins: false,
+      grantedOrigins: [],
+      incognitoEnabled: false,
+    },
+    lastSeenAt: now,
+    pairedAt: now,
+    metadata: {},
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function queuedSession(): LifeOpsBrowserSession {
+  return createLifeOpsBrowserSession({
+    agentId: runtime.agentId,
+    domain: "browser",
+    subjectType: "owner",
+    subjectId: "owner",
+    visibilityScope: "owner",
+    contextPolicy: "owner_private",
+    workflowId: null,
+    browser: "chrome",
+    companionId: null,
+    profileId: null,
+    windowId: null,
+    tabId: null,
+    title: "atomic companion session",
+    status: "queued",
+    actions: [0, 1].map((index) => ({
+      id: `action-${index}`,
+      kind: "read_page" as const,
+      label: `Read ${index}`,
+      url: null,
+      selector: null,
+      text: null,
+      accountAffecting: false,
+      requiresConfirmation: false,
+      metadata: {},
+    })),
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {},
+    metadata: {},
+    finishedAt: null,
+  });
+}
+
+beforeAll(async () => {
+  runtimeResult = await createLifeOpsTestRuntime();
+  runtime = runtimeResult.runtime;
+  repository = new LifeOpsRepository(runtime);
+}, 180_000);
+
+afterAll(async () => {
+  await runtimeResult?.cleanup();
+  runtimeResult = null;
+});
+
+describe("browser companion atomic persistence", () => {
+  it("allows exactly one competing companion to claim queued work", async () => {
+    const session = queuedSession();
+    await repository.createBrowserSession(session);
+    const first = companion("companion-claim-a", "profile-a");
+    const second = companion("companion-claim-b", "profile-b");
+    const firstDomain = browserDomain();
+    const secondDomain = browserDomain();
+
+    const claims = await Promise.all([
+      firstDomain.claimQueuedBrowserSession(first),
+      secondDomain.claimQueuedBrowserSession(second),
+    ]);
+
+    expect(claims.filter(Boolean)).toHaveLength(1);
+    const persisted = await repository.getBrowserSession(
+      runtime.agentId,
+      session.id,
+    );
+    expect(persisted?.status).toBe("running");
+    expect(persisted?.companionId).toBe(claims.find(Boolean)?.companionId);
+    expect(persisted?.profileId).toBe(claims.find(Boolean)?.profileId);
+  });
+
+  it("accepts the terminal checkpoint idempotently and rejects rewinds or foreign updates", async () => {
+    const session = queuedSession();
+    await repository.createBrowserSession(session);
+    const owner = companion("companion-progress-owner", "profile-owner");
+    const foreign = companion("companion-progress-foreign", "profile-foreign");
+    const claimed = await repository.claimBrowserSession(
+      runtime.agentId,
+      owner,
+      new Date().toISOString(),
+    );
+    expect(claimed?.id).toBe(session.id);
+
+    const competingAttempts = await Promise.all(
+      ["attempt-first-a", "attempt-first-b"].map((attemptId) =>
+        repository.beginBrowserSessionActionFromCompanion({
+          agentId: runtime.agentId,
+          sessionId: session.id,
+          companion: owner,
+          currentActionIndex: 0,
+          actionId: session.actions[0].id,
+          attemptId,
+          startedAt: new Date().toISOString(),
+        }),
+      ),
+    );
+    expect(competingAttempts.filter(Boolean)).toHaveLength(1);
+    const firstAttemptId = competingAttempts[0]
+      ? "attempt-first-a"
+      : "attempt-first-b";
+    const duplicateLease =
+      await repository.beginBrowserSessionActionFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        currentActionIndex: 0,
+        actionId: session.actions[0].id,
+        attemptId: firstAttemptId,
+        startedAt: new Date().toISOString(),
+      });
+    expect(duplicateLease).toBeNull();
+
+    const mismatchedAction =
+      await repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        expectedActionIndex: 0,
+        completedActionId: session.actions[1].id,
+        attemptId: firstAttemptId,
+        currentActionIndex: 1,
+        resultPatch: { wrongAction: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      });
+    expect(mismatchedAction).toBeNull();
+
+    const firstStep =
+      await repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        expectedActionIndex: 0,
+        completedActionId: session.actions[0].id,
+        attemptId: firstAttemptId,
+        currentActionIndex: 1,
+        resultPatch: { first: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      });
+    expect(firstStep?.currentActionIndex).toBe(1);
+
+    const secondAttemptId = "attempt-second";
+    await expect(
+      repository.beginBrowserSessionActionFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        currentActionIndex: 1,
+        actionId: session.actions[1].id,
+        attemptId: secondAttemptId,
+        startedAt: new Date().toISOString(),
+      }),
+    ).resolves.toMatchObject({ currentActionIndex: 1 });
+
+    const terminal = await repository.updateBrowserSessionProgressFromCompanion(
+      {
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        expectedActionIndex: 1,
+        completedActionId: session.actions[1].id,
+        attemptId: secondAttemptId,
+        currentActionIndex: session.actions.length,
+        resultPatch: { terminal: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      },
+    );
+    expect(terminal?.currentActionIndex).toBe(session.actions.length);
+
+    const [retry, rewind, intrusion] = await Promise.all([
+      repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        expectedActionIndex: session.actions.length,
+        completedActionId: session.actions[1].id,
+        attemptId: secondAttemptId,
+        currentActionIndex: session.actions.length,
+        resultPatch: { retried: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      }),
+      repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        expectedActionIndex: session.actions.length,
+        completedActionId: session.actions[1].id,
+        attemptId: secondAttemptId,
+        currentActionIndex: 1,
+        resultPatch: { rewound: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      }),
+      repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: foreign,
+        expectedActionIndex: session.actions.length,
+        completedActionId: session.actions[1].id,
+        attemptId: secondAttemptId,
+        currentActionIndex: session.actions.length,
+        resultPatch: { stolen: true },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      }),
+    ]);
+    expect(retry).toBeNull();
+    expect(rewind).toBeNull();
+    expect(intrusion).toBeNull();
+
+    const foreignCompletion =
+      await repository.completeBrowserSessionFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: foreign,
+        status: "done",
+        resultPatch: { stolen: true },
+        updatedAt: new Date().toISOString(),
+      });
+    expect(foreignCompletion).toBeNull();
+  });
+
+  it("settles competing terminal outcomes once", async () => {
+    const session = queuedSession();
+    await repository.createBrowserSession(session);
+    const owner = companion("companion-complete-owner", "profile-complete");
+    await repository.claimBrowserSession(
+      runtime.agentId,
+      owner,
+      new Date().toISOString(),
+    );
+
+    const results = await Promise.all([
+      repository.completeBrowserSessionFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        status: "done",
+        resultPatch: { winner: "done" },
+        updatedAt: new Date().toISOString(),
+      }),
+      repository.completeBrowserSessionFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: owner,
+        status: "failed",
+        resultPatch: { winner: "failed" },
+        updatedAt: new Date().toISOString(),
+      }),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    const persisted = await repository.getBrowserSession(
+      runtime.agentId,
+      session.id,
+    );
+    expect(["done", "failed"]).toContain(persisted?.status);
+    expect(persisted?.currentActionIndex).toBe(session.actions.length);
+  });
+});

--- a/plugins/plugin-personal-assistant/test/browser-session-companion-atomic.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/browser-session-companion-atomic.pglite.test.ts
@@ -284,13 +284,67 @@ describe("browser companion atomic persistence", () => {
         sessionId: session.id,
         companion: foreign,
         status: "done",
+        expectedActionIndex: session.actions.length,
+        completedActionId: session.actions[1].id,
+        attemptId: secondAttemptId,
         resultPatch: { stolen: true },
         updatedAt: new Date().toISOString(),
       });
     expect(foreignCompletion).toBeNull();
   });
 
-  it("settles competing terminal outcomes once", async () => {
+  it("atomically settles only one concurrent owner confirmation", async () => {
+    const base = queuedSession();
+    const expectedUpdatedAt = new Date().toISOString();
+    const awaiting: LifeOpsBrowserSession = {
+      ...base,
+      status: "awaiting_confirmation",
+      awaitingConfirmationForActionId: base.actions[0].id,
+      updatedAt: expectedUpdatedAt,
+    };
+    await repository.createBrowserSession(awaiting);
+
+    const approved: LifeOpsBrowserSession = {
+      ...awaiting,
+      status: "queued",
+      awaitingConfirmationForActionId: null,
+      metadata: { browserApproval: { confirmedAt: new Date().toISOString() } },
+      updatedAt: new Date(Date.now() + 1).toISOString(),
+    };
+    const denied: LifeOpsBrowserSession = {
+      ...awaiting,
+      status: "cancelled",
+      awaitingConfirmationForActionId: null,
+      finishedAt: new Date().toISOString(),
+      updatedAt: new Date(Date.now() + 2).toISOString(),
+    };
+    const results = await Promise.all(
+      [approved, denied].map((candidate) =>
+        repository.updateBrowserSessionIfAwaitingConfirmation({
+          session: candidate,
+          expectedActionId: awaiting.actions[0].id,
+          expectedUpdatedAt,
+        }),
+      ),
+    );
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    const persisted = await repository.getBrowserSession(
+      runtime.agentId,
+      awaiting.id,
+    );
+    expect(["queued", "cancelled"]).toContain(persisted?.status);
+    if (persisted?.status === "queued") {
+      await repository.updateBrowserSession({
+        ...persisted,
+        status: "cancelled",
+        finishedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+  });
+
+  it("rejects a stale failed completion after its progress receipt committed", async () => {
     const session = queuedSession();
     await repository.createBrowserSession(session);
     const owner = companion("companion-complete-owner", "profile-complete");
@@ -299,32 +353,55 @@ describe("browser companion atomic persistence", () => {
       owner,
       new Date().toISOString(),
     );
-
-    const results = await Promise.all([
-      repository.completeBrowserSessionFromCompanion({
+    const firstAction = session.actions[0];
+    const attemptId = "attempt-before-lost-progress-response";
+    await repository.beginBrowserSessionActionFromCompanion({
+      agentId: runtime.agentId,
+      sessionId: session.id,
+      companion: owner,
+      currentActionIndex: 0,
+      actionId: firstAction.id,
+      attemptId,
+      startedAt: new Date().toISOString(),
+    });
+    const progressed =
+      await repository.updateBrowserSessionProgressFromCompanion({
         agentId: runtime.agentId,
         sessionId: session.id,
         companion: owner,
-        status: "done",
-        resultPatch: { winner: "done" },
+        expectedActionIndex: 0,
+        completedActionId: firstAction.id,
+        attemptId,
+        currentActionIndex: 1,
+        resultPatch: { first: true },
+        metadataPatch: {
+          browserActionReceipt: {
+            actionId: firstAction.id,
+            actionIndex: 0,
+            attemptId,
+          },
+        },
         updatedAt: new Date().toISOString(),
-      }),
-      repository.completeBrowserSessionFromCompanion({
-        agentId: runtime.agentId,
-        sessionId: session.id,
-        companion: owner,
-        status: "failed",
-        resultPatch: { winner: "failed" },
-        updatedAt: new Date().toISOString(),
-      }),
-    ]);
+      });
+    expect(progressed?.currentActionIndex).toBe(1);
 
-    expect(results.filter(Boolean)).toHaveLength(1);
+    const staleFailure = await repository.completeBrowserSessionFromCompanion({
+      agentId: runtime.agentId,
+      sessionId: session.id,
+      companion: owner,
+      status: "failed",
+      expectedActionIndex: 0,
+      completedActionId: firstAction.id,
+      attemptId,
+      resultPatch: { staleFailure: true },
+      updatedAt: new Date().toISOString(),
+    });
+    expect(staleFailure).toBeNull();
     const persisted = await repository.getBrowserSession(
       runtime.agentId,
       session.id,
     );
-    expect(["done", "failed"]).toContain(persisted?.status);
-    expect(persisted?.currentActionIndex).toBe(session.actions.length);
+    expect(persisted?.status).toBe("running");
+    expect(persisted?.currentActionIndex).toBe(1);
   });
 });

--- a/plugins/plugin-personal-assistant/test/connector-normalize-origins.test.ts
+++ b/plugins/plugin-personal-assistant/test/connector-normalize-origins.test.ts
@@ -1,6 +1,7 @@
 // Exercises LifeOps owner workflows, connector boundaries, and scheduled-task behavior.
 import { describe, expect, it } from "vitest";
 import {
+  normalizeBlockedOriginList,
   normalizeBrowserPermissionGrant,
   normalizeBrowserPermissionGrantList,
   normalizeOrigin,
@@ -71,5 +72,17 @@ describe("list normalizers", () => {
       normalizeOriginList(["https://a.com/1", "https://a.com/2"], "o"),
     ).toEqual(["https://a.com"]);
     expect(() => normalizeOriginList({}, "o")).toThrow();
+  });
+
+  it("normalizes block entries to host-scoped policy values", () => {
+    expect(
+      normalizeBlockedOriginList(
+        ["https://Example.com/path", "example.com", "*.sub.example.com"],
+        "blockedOrigins",
+      ),
+    ).toEqual(["example.com", "sub.example.com"]);
+    expect(() =>
+      normalizeBlockedOriginList(["file:///tmp/secret"], "blockedOrigins"),
+    ).toThrow();
   });
 });

--- a/plugins/plugin-personal-assistant/test/scenario-support/lifeops-seeds.ts
+++ b/plugins/plugin-personal-assistant/test/scenario-support/lifeops-seeds.ts
@@ -40,14 +40,14 @@ type BrowserTelemetryWindow = {
 
 type BrowserTelemetrySeed = {
   deviceId: string;
-  browserVendor?: "chrome" | "safari" | "unknown";
+  browserVendor?: "chrome" | "firefox" | "safari" | "unknown";
   extensionVersion?: string;
   userAgent?: string;
   windows: BrowserTelemetryWindow[];
 };
 
 type BrowserPageContextSeed = {
-  browser: "chrome" | "safari";
+  browser: "chrome" | "firefox" | "safari";
   profileId: string;
   windowId: string;
   tabId: string;


### PR DESCRIPTION
<!-- evidence-head:ec951ba76f7097a6f01e39608186834aac9b1947 -->

## Summary

Consolidates the authenticated Chrome, Firefox, and Safari browser bridge on current `develop`, removes unauthenticated loopback auto-pair credential minting, fences privileged action execution and terminal lifecycle transitions, validates exact browser/tab/window targets and host grants, and packages deterministic cross-browser release artifacts.

The popup is now a one-line health surface with at most one contextual action. Diagnostics are collapsed; stored credentials are never copied into the DOM. The only remaining manual recovery is a collapsed pairing-JSON import until secure native enrollment lands in #23898. Browser-managed website access remains just-in-time because browsers require an owner gesture.

Closes #21412. Follow-up: #23898.

## Security invariants

- no public/loopback-origin auto-pair token minting
- popup messages require a privileged extension sender
- live policy and browser host grants are rechecked before sync/action
- action begin/progress/complete are fenced by action, checkpoint, attempt, and receipt
- owner approval is digest-bound, atomically settled, and expires after two minutes
- terminal status is strictly `done` or `failed`
- stale workers cannot fail or complete another attempt
- explicit browser/profile/tab/window/incognito targeting
- bounded operation deadlines and deterministic packaging

## Exact-head verification

Head `ec951ba76f7097a6f01e39608186834aac9b1947`, rebased on `develop` `378192acf6d22f1545ea0b046374d3f170aec582`.

- plugin-computeruse: 99 files passed / 1 skipped; 902 tests passed / 17 skipped; typecheck; Biome: pass\n- extension: 16 files / 84 tests; typecheck; Biome: pass
- plugin-browser: 34 files / 284 tests; typecheck; Biome: pass
- personal-assistant lifecycle/PGlite: 2 files / 12 tests: pass
- changed personal-assistant files Biome: pass
- installed Chrome for Testing manual pair -> authenticated sync -> real DOM action -> progress/complete: pass
- installed Firefox 153.0.4 same flow: pass; package SHA-256 `ad8fd03da92bbdb5cca04717be340b55e9576a9ff6ccb6a2646b2b9007ea0337`
- Safari WebExtension conversion + unsigned Xcode Release wrapper: `BUILD SUCCEEDED`
- compact popup visually inspected in fresh Chrome profile; no secret fields/default credential values

`bun run verify` reaches the monorepo Turbo lane but current `develop` has an unrelated app-core Biome import-order failure in `packages/app-core/src/runtime/agent-host-bridge-cookie-cors.test.ts`; package-scoped gates above are green. Personal-assistant full typecheck also requires the normal Turbo-built workspace declarations; the focused real PGlite lifecycle lane is green.

## Merge holds

- signed and enabled installed-Safari pair/sync/action acceptance still requires an Apple Development identity/team and owner-controlled Safari extension enablement
- independent approval must be refreshed for this exact head; the prior approval explicitly excluded merge-readiness and predates the lifecycle/UI commits
- hosted exact-head CI must complete

The PR remains draft until those holds are satisfied.
