### PR TITLE
fix(voice): measure real ERLE and native TTS cancel in the workbench

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.test.ts
@@ -1,7 +1,7 @@
 /**
  * Deterministic coverage for the real workbench measurement adapters: stream
  * diarization, streaming ASR selection, ERLE echo replay, and the barge-in
- * playback-stop probe. Native pyannote/WeSpeaker/Kokoro calls are injected so
+ * native-TTS cancellation probe. Native pyannote/WeSpeaker/Kokoro calls are injected so
  * window coverage, stream offsets, blind clustering, canceller replay, and
  * cancel-latency semantics are exercised without model artifacts.
  */
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { fakeFfi } from "./__test-helpers__/fake-ffi";
 import {
 	diarizeVoiceWorkbenchStream,
-	measureBargeInPlaybackStopMs,
+	measureBargeInTtsCancelMs,
 	measureEchoTurnErle,
 	transcribeVoiceWorkbenchStream,
 } from "./workbench-real-services";
@@ -221,9 +221,9 @@ describe("measureEchoTurnErle", () => {
 	});
 });
 
-describe("measureBargeInPlaybackStopMs", () => {
+describe("measureBargeInTtsCancelMs", () => {
 	it("reports the latency from cancel request to stream return", async () => {
-		const cancelMs = await measureBargeInPlaybackStopMs(
+		const cancelMs = await measureBargeInTtsCancelMs(
 			async ({ cancelSignal, onChunk }) => {
 				for (let i = 0; i < 100; i++) {
 					if (cancelSignal.cancelled) return { cancelled: true };
@@ -240,7 +240,7 @@ describe("measureBargeInPlaybackStopMs", () => {
 
 	it("fails fast when the stream produces no audio to cancel", async () => {
 		await expect(
-			measureBargeInPlaybackStopMs(async ({ onChunk }) => {
+			measureBargeInTtsCancelMs(async ({ onChunk }) => {
 				onChunk({ pcm: new Float32Array(0), isFinal: true });
 				return { cancelled: false };
 			}),
@@ -249,7 +249,7 @@ describe("measureBargeInPlaybackStopMs", () => {
 
 	it("fails fast when the engine ignores the cancel signal", async () => {
 		await expect(
-			measureBargeInPlaybackStopMs(async ({ onChunk }) => {
+			measureBargeInTtsCancelMs(async ({ onChunk }) => {
 				for (let i = 0; i < 3; i++) {
 					onChunk({ pcm: new Float32Array(320).fill(0.1), isFinal: false });
 				}

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.test.ts
@@ -1,14 +1,17 @@
 /**
- * Deterministic coverage for the real workbench stream diarization adapter.
- * Native pyannote and WeSpeaker calls are injected so window coverage, stream
- * offsets, final-window clipping, overlap, and blind clustering are exercised
- * without model artifacts.
+ * Deterministic coverage for the real workbench measurement adapters: stream
+ * diarization, streaming ASR selection, ERLE echo replay, and the barge-in
+ * playback-stop probe. Native pyannote/WeSpeaker/Kokoro calls are injected so
+ * window coverage, stream offsets, blind clustering, canceller replay, and
+ * cancel-latency semantics are exercised without model artifacts.
  */
 
 import { describe, expect, it } from "vitest";
 import { fakeFfi } from "./__test-helpers__/fake-ffi";
 import {
 	diarizeVoiceWorkbenchStream,
+	measureBargeInPlaybackStopMs,
+	measureEchoTurnErle,
 	transcribeVoiceWorkbenchStream,
 } from "./workbench-real-services";
 
@@ -151,5 +154,108 @@ describe("transcribeVoiceWorkbenchStream", () => {
 		expect(streamFeeds).toBe(5);
 		expect(result.transcript).toBe("hello from streaming");
 		expect(result.partials).toContain("hello from streaming");
+	});
+});
+
+describe("measureEchoTurnErle", () => {
+	function noiseSignal(samples: number, seed: number): Float32Array {
+		const out = new Float32Array(samples);
+		let state = seed >>> 0;
+		for (let i = 0; i < samples; i++) {
+			state = (state * 1664525 + 1013904223) >>> 0;
+			out[i] = (state / 0xffffffff) * 0.6 - 0.3;
+		}
+		return out;
+	}
+
+	it("cancels a pure linear echo well above the 18 dB floor", () => {
+		const far = noiseSignal(SAMPLE_RATE * 2, 7);
+		const near = new Float32Array(far.length);
+		for (let i = 0; i < far.length; i++) near[i] = far[i] * 0.5;
+		const erleDb = measureEchoTurnErle({ near, farReference: far });
+		expect(erleDb).not.toBeNull();
+		expect(erleDb as number).toBeGreaterThan(18);
+	});
+
+	it("still measures when the near end carries environmental noise", () => {
+		const far = noiseSignal(SAMPLE_RATE * 2, 7);
+		const hiss = noiseSignal(far.length, 99);
+		const near = new Float32Array(far.length);
+		for (let i = 0; i < far.length; i++) {
+			near[i] = far[i] * 0.5 + hiss[i] * 0.01;
+		}
+		const erleDb = measureEchoTurnErle({ near, farReference: far });
+		expect(erleDb).not.toBeNull();
+		expect(Number.isFinite(erleDb as number)).toBe(true);
+		expect(erleDb as number).toBeGreaterThan(6);
+	});
+
+	it("pads a shorter far-end reference instead of truncating the near end", () => {
+		const far = noiseSignal(SAMPLE_RATE, 7);
+		const near = new Float32Array(SAMPLE_RATE * 2);
+		for (let i = 0; i < far.length; i++) near[i] = far[i] * 0.5;
+		const erleDb = measureEchoTurnErle({ near, farReference: far });
+		expect(erleDb).not.toBeNull();
+	});
+
+	it("returns null for an empty or silent window instead of fabricating dB", () => {
+		expect(
+			measureEchoTurnErle({
+				near: new Float32Array(0),
+				farReference: new Float32Array(SAMPLE_RATE),
+			}),
+		).toBeNull();
+		expect(
+			measureEchoTurnErle({
+				near: new Float32Array(SAMPLE_RATE),
+				farReference: new Float32Array(0),
+			}),
+		).toBeNull();
+		// A silent far end has no far-active block — no echo, no measurement.
+		expect(
+			measureEchoTurnErle({
+				near: new Float32Array(SAMPLE_RATE).fill(0.1),
+				farReference: new Float32Array(SAMPLE_RATE),
+			}),
+		).toBeNull();
+	});
+});
+
+describe("measureBargeInPlaybackStopMs", () => {
+	it("reports the latency from cancel request to stream return", async () => {
+		const cancelMs = await measureBargeInPlaybackStopMs(
+			async ({ cancelSignal, onChunk }) => {
+				for (let i = 0; i < 100; i++) {
+					if (cancelSignal.cancelled) return { cancelled: true };
+					onChunk({ pcm: new Float32Array(320).fill(0.1), isFinal: false });
+					await Promise.resolve();
+				}
+				onChunk({ pcm: new Float32Array(0), isFinal: true });
+				return { cancelled: false };
+			},
+		);
+		expect(cancelMs).toBeGreaterThanOrEqual(0);
+		expect(Number.isFinite(cancelMs)).toBe(true);
+	});
+
+	it("fails fast when the stream produces no audio to cancel", async () => {
+		await expect(
+			measureBargeInPlaybackStopMs(async ({ onChunk }) => {
+				onChunk({ pcm: new Float32Array(0), isFinal: true });
+				return { cancelled: false };
+			}),
+		).rejects.toThrow(/produced no audio/);
+	});
+
+	it("fails fast when the engine ignores the cancel signal", async () => {
+		await expect(
+			measureBargeInPlaybackStopMs(async ({ onChunk }) => {
+				for (let i = 0; i < 3; i++) {
+					onChunk({ pcm: new Float32Array(320).fill(0.1), isFinal: false });
+				}
+				onChunk({ pcm: new Float32Array(0), isFinal: true });
+				return { cancelled: false };
+			}),
+		).rejects.toThrow(/ignored the barge-in cancel/);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -13,6 +13,7 @@
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { NlmsEchoCanceller } from "@elizaos/shared/voice/aec";
 import {
 	type OwnerObservation,
 	resolveOwnerCandidate,
@@ -29,6 +30,7 @@ import type {
 	CorpusTtsSynthesizer,
 	GeneratedVoiceCorpus,
 } from "./corpus-generator";
+import { computeFarActiveErle } from "./echo-metrics";
 import { createKokoroTtsBackend } from "./engine-bridge";
 import {
 	type ElizaInferenceContextHandle,
@@ -74,6 +76,9 @@ const MAX_AGENT_TTS_SECONDS = 12;
 const STREAMING_ASR_FRAME_SAMPLES = SAMPLE_RATE / 5;
 const SPEAKER_ENROLLMENT_PHRASE =
 	"This is my voice enrollment sample for reliable speaker recognition.";
+const BARGE_IN_PROBE_REPLY =
+	"The week ahead is mostly sunny with occasional clouds and a light breeze in the evening hours across the entire region.";
+const ECHO_FAR_END_CACHE_LIMIT = 64;
 
 const ELEVENLABS_MODEL_ID = "eleven_turbo_v2_5";
 const ELEVENLABS_VOICE_IDS = [
@@ -371,6 +376,78 @@ export async function diarizeVoiceWorkbenchStream(
 	return observations;
 }
 
+/**
+ * Replay an agent-echo turn through the production `NlmsEchoCanceller` and
+ * report the far-active ERLE. `near` is the observed mic-side turn (the echo
+ * plus any environmental degradation the corpus applied); `farReference` is
+ * the clean agent TTS that produced it, aligned at the turn's start. Returns
+ * null when either side carries no energy — an unmeasurable window must stay
+ * unmeasured rather than fabricate a healthy dB figure.
+ */
+export function measureEchoTurnErle(args: {
+	near: Float32Array;
+	farReference: Float32Array;
+}): number | null {
+	if (args.near.length === 0 || args.farReference.length === 0) return null;
+	const far = new Float32Array(args.near.length);
+	far.set(
+		args.farReference.subarray(
+			0,
+			Math.min(args.farReference.length, args.near.length),
+		),
+	);
+	const canceller = new NlmsEchoCanceller();
+	const residual = canceller.process(args.near, far);
+	return computeFarActiveErle(args.near, residual, far).erleDb;
+}
+
+/** The minimal streaming-synthesis surface the playback-stop probe drives. */
+export type BargeInPlaybackStopStream = (args: {
+	cancelSignal: { cancelled: boolean };
+	onChunk: (chunk: { pcm: Float32Array; isFinal: boolean }) => undefined;
+}) => Promise<{ cancelled: boolean }>;
+
+/**
+ * Measure the real playback-stop latency of a cancellable TTS stream: start
+ * the synthesis, flip the shared cancel signal the moment the first audible
+ * chunk arrives (the engine honours it at chunk boundaries), and report the
+ * milliseconds from the cancel request until the stream actually returned.
+ * A stream that never produced audio or ignored the cancel is a harness
+ * failure, not a null sample — fail fast so the lane cannot silently report
+ * zero coverage.
+ */
+export async function measureBargeInPlaybackStopMs(
+	synthesizeReply: BargeInPlaybackStopStream,
+): Promise<number> {
+	const cancelSignal = { cancelled: false };
+	let cancelRequestedAtMs: number | null = null;
+	const result = await synthesizeReply({
+		cancelSignal,
+		onChunk: (chunk) => {
+			if (
+				!chunk.isFinal &&
+				chunk.pcm.length > 0 &&
+				cancelRequestedAtMs === null
+			) {
+				cancelRequestedAtMs = performance.now();
+				cancelSignal.cancelled = true;
+			}
+			return undefined;
+		},
+	});
+	if (cancelRequestedAtMs === null) {
+		throw new Error(
+			"[voice:workbench --real] barge-in probe synthesis produced no audio to cancel",
+		);
+	}
+	if (!result.cancelled) {
+		throw new Error(
+			"[voice:workbench --real] TTS engine ignored the barge-in cancel signal",
+		);
+	}
+	return performance.now() - cancelRequestedAtMs;
+}
+
 function pcm16ToFloat32(bytes: Uint8Array): Float32Array {
 	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 	const samples = Math.floor(bytes.byteLength / 2);
@@ -454,6 +531,13 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 	private readonly ownerThreshold: number;
 	private readonly voiceMap: Record<string, string>;
 	private readonly profiles = new Map<string, SpeakerProfile>();
+	/**
+	 * Clean agent-TTS far-end references keyed by normalized turn text. Corpus
+	 * generation runs for the whole matrix before any scenario is scored, so the
+	 * cache is keyed by content (identical text ⇒ identical deterministic Kokoro
+	 * output), bounded, and never cleared per scenario.
+	 */
+	private readonly echoFarEndByText = new Map<string, Float32Array>();
 	private readonly selfVoiceEmbeddings: Float32Array[] = [];
 	private ownerObservations: OwnerObservation[] = [];
 	private scenarioId: string | null = null;
@@ -652,7 +736,11 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 			...(this.lastAgentReply
 				? { recentAgentReply: this.lastAgentReply, replyAgeMs: 500 }
 				: {}),
-			agentSpeaking: args.label.isAgentEcho === true,
+			// A barge-in turn happens WHILE the agent's reply is streaming, so the
+			// gate is evaluated with the echo/self-voice guards armed exactly as
+			// the live pipeline arms them mid-reply.
+			agentSpeaking:
+				args.label.isAgentEcho === true || args.label.bargeIn === true,
 			// WeSpeaker-embedding scale: the agent-specific threshold travels with
 			// the measurement (self ~0.37 vs human ~0.15 — never the 0.7 MFCC bar).
 			...(typeof selfVoiceSimilarity === "number"
@@ -694,6 +782,27 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 			}
 		}
 
+		// ERLE — replay the observed mic-side echo against the clean agent TTS
+		// through the production canceller (#16972: real far-end capture, not an
+		// absent feed).
+		let erleDb: number | undefined;
+		if (args.label.isAgentEcho) {
+			const farReference = await this.echoFarEndFor(
+				args.label.referenceTranscript,
+			);
+			const measured = measureEchoTurnErle({ near: audio16, farReference });
+			if (measured !== null) erleDb = measured;
+		}
+
+		// Barge-in playback stop — when the live gate says an addressed speaker
+		// interrupted, hard-stop a real in-flight Kokoro stream and time it; when
+		// the gate holds (echo / bystander), report an explicit non-cancel.
+		let bargeInCancelMs: number | null | undefined;
+		if (args.label.bargeIn) {
+			const shouldCancel = hasSpeech && signal.agentShouldSpeak;
+			bargeInCancelMs = shouldCancel ? await this.measureBargeInCancel() : null;
+		}
+
 		return {
 			hypothesisTranscript: transcript,
 			predictedSpeakerLabel: speakerMatch?.profile.label ?? null,
@@ -702,6 +811,8 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 			inferredEntities,
 			matchedEntityId,
 			...(firstAudioMs !== undefined ? { firstAudioMs } : {}),
+			...(erleDb !== undefined ? { erleDb } : {}),
+			...(bargeInCancelMs !== undefined ? { bargeInCancelMs } : {}),
 			predictedOwner,
 			...(streamingResult
 				? { partialTranscripts: streamingResult.partials }
@@ -729,11 +840,9 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 		sampleRate: number;
 	}): Promise<Float32Array> {
 		if (args.isAgentEcho) {
-			return ensureSampleRate(
-				await this.synthesizeAgent(args.text),
-				SAMPLE_RATE,
-				args.sampleRate,
-			);
+			const pcm = await this.synthesizeAgent(args.text);
+			this.rememberEchoFarEnd(args.text, pcm);
+			return ensureSampleRate(pcm, SAMPLE_RATE, args.sampleRate);
 		}
 		if (this.apiKey) {
 			const voiceId = this.resolveElevenLabsVoiceId(
@@ -835,6 +944,52 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 
 	private async synthesizeAgent(text: string): Promise<Float32Array> {
 		return this.synthesizeKokoro(text, KOKORO_AGENT_VOICE);
+	}
+
+	private rememberEchoFarEnd(text: string, pcm: Float32Array): void {
+		const key = text.trim().toLowerCase();
+		if (!key) return;
+		if (this.echoFarEndByText.size >= ECHO_FAR_END_CACHE_LIMIT) {
+			const oldest = this.echoFarEndByText.keys().next().value;
+			if (oldest !== undefined) this.echoFarEndByText.delete(oldest);
+		}
+		this.echoFarEndByText.set(key, pcm);
+	}
+
+	/**
+	 * The clean far-end reference for an echo turn: the exact PCM this adapter
+	 * synthesized into the corpus when available, otherwise a fresh (Kokoro is
+	 * deterministic per text/voice) agent synthesis of the reference transcript.
+	 */
+	private async echoFarEndFor(
+		referenceTranscript: string,
+	): Promise<Float32Array> {
+		const cached = this.echoFarEndByText.get(
+			referenceTranscript.trim().toLowerCase(),
+		);
+		return cached ?? this.synthesizeAgent(referenceTranscript);
+	}
+
+	private async measureBargeInCancel(): Promise<number> {
+		const replyText = this.lastAgentReply ?? BARGE_IN_PROBE_REPLY;
+		return measureBargeInPlaybackStopMs(({ cancelSignal, onChunk }) =>
+			this.kokoroBackend.synthesizeStream({
+				phrase: {
+					id: 1,
+					text: replyText,
+					fromIndex: 0,
+					toIndex: replyText.length,
+					terminator: "punctuation",
+				},
+				preset: {
+					voiceId: KOKORO_AGENT_VOICE,
+					embedding: new Float32Array(0),
+					bytes: new Uint8Array(0),
+				},
+				cancelSignal,
+				onChunk: (chunk) => onChunk({ pcm: chunk.pcm, isFinal: chunk.isFinal }),
+			}),
+		);
 	}
 
 	private async observeAgentReply(text: string): Promise<number> {

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -401,14 +401,14 @@ export function measureEchoTurnErle(args: {
 	return computeFarActiveErle(args.near, residual, far).erleDb;
 }
 
-/** The minimal streaming-synthesis surface the playback-stop probe drives. */
-export type BargeInPlaybackStopStream = (args: {
+/** The minimal streaming-synthesis surface the native-TTS cancel probe drives. */
+export type BargeInTtsCancelStream = (args: {
 	cancelSignal: { cancelled: boolean };
 	onChunk: (chunk: { pcm: Float32Array; isFinal: boolean }) => undefined;
 }) => Promise<{ cancelled: boolean }>;
 
 /**
- * Measure the real playback-stop latency of a cancellable TTS stream: start
+ * Measure the native synthesis-stop latency of a cancellable TTS stream: start
  * the synthesis, flip the shared cancel signal the moment the first audible
  * chunk arrives (the engine honours it at chunk boundaries), and report the
  * milliseconds from the cancel request until the stream actually returned.
@@ -416,8 +416,8 @@ export type BargeInPlaybackStopStream = (args: {
  * failure, not a null sample — fail fast so the lane cannot silently report
  * zero coverage.
  */
-export async function measureBargeInPlaybackStopMs(
-	synthesizeReply: BargeInPlaybackStopStream,
+export async function measureBargeInTtsCancelMs(
+	synthesizeReply: BargeInTtsCancelStream,
 ): Promise<number> {
 	const cancelSignal = { cancelled: false };
 	let cancelRequestedAtMs: number | null = null;
@@ -794,7 +794,7 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 			if (measured !== null) erleDb = measured;
 		}
 
-		// Barge-in playback stop — when the live gate says an addressed speaker
+		// Barge-in native-TTS cancellation — when the live gate says an addressed speaker
 		// interrupted, hard-stop a real in-flight Kokoro stream and time it; when
 		// the gate holds (echo / bystander), report an explicit non-cancel.
 		let bargeInCancelMs: number | null | undefined;
@@ -972,7 +972,7 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 
 	private async measureBargeInCancel(): Promise<number> {
 		const replyText = this.lastAgentReply ?? BARGE_IN_PROBE_REPLY;
-		return measureBargeInPlaybackStopMs(({ cancelSignal, onChunk }) =>
+		return measureBargeInTtsCancelMs(({ cancelSignal, onChunk }) =>
 			this.kokoroBackend.synthesizeStream({
 				phrase: {
 					id: 1,


### PR DESCRIPTION
Refs #16972. This PR closes two workbench measurement gaps - ERLE and native TTS cancellation - but does not prove audio-sink playback stop or the remaining product gates.

## What changed

The repaired `voice:workbench --real` harness (already on `develop`) still reported two defining signals with **zero samples**, so `desktop-aec-echo` and `speaker-gated-barge-in` failed on coverage instead of measuring the product:

1. **ERLE (echo turns)** — the real adapter now replays every agent-echo turn through the production `NlmsEchoCanceller` (`@elizaos/shared/voice/aec`): near-end = the observed mic-side turn slice (including any corpus environmental degradation), far-end = the exact clean fused-Kokoro TTS PCM the adapter synthesized into the corpus (content-keyed cache, deterministic resynthesis fallback). The reported number is the far-active-masked ERLE; an unmeasurable window (silent near/far) stays unmeasured instead of fabricating a healthy dB figure.
2. **Barge-in native TTS cancellation** — barge-in turns are now gated with `agentSpeaking: true` (they occur mid-reply; scoring them as if the agent were silent was exactly the measurement-topology class the issue flags), and when the live respond gate says an addressed speaker interrupted, the adapter starts a real in-flight fused-Kokoro stream and measures the wall-clock latency from flipping the shared cancel signal to the engine actually stopping. Gate-held turns (agent echo, bystander) report an explicit non-cancel (`null`), and a stream that produces no audio or ignores the cancel fails the run loudly.

Both signals flow through the existing `scoreErle` / `scoreBargeInGating` scorers and the strict fail-closed coverage counters — no thresholds were touched, no gates weakened.

## Verification

- New deterministic suites in `workbench-real-services.test.ts`: canceller replay clears the 18 dB floor on a pure linear echo, survives environmental noise, pads short far-ends, returns null (never a fabricated dB) on empty/silent windows; the native-TTS cancellation probe reports finite latency and fails fast on no-audio / ignored-cancel streams.
- Exact rebased head `7461afd79d9f7`: focused workbench real-services + headless-runner Vitest **26 passed, 0 failed**.
- Package typecheck: pass. Biome on touched files: clean.
- Full package lane: **2,857 passed, 18 skipped**; it then stopped on two untouched baseline failures (`speaker-name-inference.test.ts` assertion and a `bun:test` suite loaded by Vitest).

## Human-only remainder (tracked on #16972)

Product quality (real audio-sink playback stop, endpoint latency, DER/identity/owner accuracy), the pushed-workflow after bundle, the independent real-human holdout calibration, and three consecutive scheduled greens of `voice-live-e2e.yml` require the M4 hardware lane and cannot be closed from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


