### PR TITLE
fix(cloud): operator reconciler for legacy malformed container-delete jobs

### DIFF
--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -29,6 +29,7 @@
     "check:tenant-scope": "bun scripts/check-tenant-scope.ts",
     "check:tenant-scope:self-test": "bun test scripts/check-tenant-scope.test.ts",
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",
+    "reconcile:container-delete-jobs": "bun scripts/reconcile-container-delete-jobs.ts",
     "test": "node scripts/run-bun-tests.mjs",
     "test:vitest": "vitest run",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",

--- a/packages/cloud/shared/scripts/reconcile-container-delete-jobs.ts
+++ b/packages/cloud/shared/scripts/reconcile-container-delete-jobs.ts
@@ -1,0 +1,31 @@
+/**
+ * Operator CLI for the legacy CONTAINER_DELETE queue reconciliation (#15821).
+ * Connects through the package's normal database resolution (point
+ * `DATABASE_URL` at staging or production), prints a sanitized JSON inventory
+ * of every CONTAINER_DELETE job row, and applies the safe status-guarded
+ * transitions only when `--apply` is passed. Dry-run is the default; run it
+ * first and attach the report to the issue before applying.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... bun scripts/reconcile-container-delete-jobs.ts [--apply]
+ */
+
+import process from "node:process";
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const unknown = process.argv.slice(2).filter((arg) => arg !== "--apply");
+  if (unknown.length > 0) {
+    process.stderr.write(`Unknown arguments: ${unknown.join(" ")}\nUsage: [--apply]\n`);
+    process.exit(2);
+  }
+  const { dbWrite, closeDatabaseConnectionsForTests } = await import("../src/db/client");
+  const { reconcileContainerDeleteJobs } = await import(
+    "../src/lib/services/container-delete-job-reconciler"
+  );
+  const report = await reconcileContainerDeleteJobs(dbWrite, { apply });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  await closeDatabaseConnectionsForTests();
+}
+
+await main();

--- a/packages/cloud/shared/src/lib/services/__tests__/container-delete-job-reconciler.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-delete-job-reconciler.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Exercises the legacy CONTAINER_DELETE reconciler against real in-process
+ * Postgres semantics (PGlite): classification of persisted payloads, dry-run
+ * write-freedom, the two status-guarded apply transitions, idempotent
+ * re-application, and concurrent double-apply safety. Integration-backed; no
+ * mocks stand in for the system under test.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const ORG_A = "00000000-0000-4000-8000-000000015821";
+const ORG_B = "00000000-0000-4000-8000-000000025821";
+const CONTAINER_A = "00000000-0000-4000-8000-000000115821";
+const CONTAINER_B = "00000000-0000-4000-8000-000000215821";
+const JOB_VALID = "00000000-0000-4000-8000-000000315821";
+const JOB_ORG_ONLY_FAILED = "00000000-0000-4000-8000-000000415821";
+const JOB_ORG_ONLY_NO_ROWS = "00000000-0000-4000-8000-000000515821";
+const JOB_UNRECOVERABLE_PENDING = "00000000-0000-4000-8000-000000615821";
+const JOB_UNRECOVERABLE_FAILED = "00000000-0000-4000-8000-000000715821";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let reconcileContainerDeleteJobs: typeof import("../container-delete-job-reconciler").reconcileContainerDeleteJobs;
+let UNRECOVERABLE_DELETE_JOB_ERROR: string;
+let databaseReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ reconcileContainerDeleteJobs, UNRECOVERABLE_DELETE_JOB_ERROR } = await import(
+      "../container-delete-job-reconciler"
+    ));
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS containers (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        status text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS jobs (
+        id uuid PRIMARY KEY,
+        type text NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        data jsonb NOT NULL,
+        error text,
+        attempts integer NOT NULL DEFAULT 0,
+        max_attempts integer NOT NULL DEFAULT 3,
+        organization_id uuid NOT NULL,
+        scheduled_for timestamp NOT NULL DEFAULT now(),
+        completed_at timestamp,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+  } catch (error) {
+    databaseReady = false;
+    console.warn("[container-delete-job-reconciler-test] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+async function seed(): Promise<void> {
+  await dbWrite.execute("DELETE FROM jobs");
+  await dbWrite.execute("DELETE FROM containers");
+  await dbWrite.execute(`
+    INSERT INTO containers (id, organization_id, status, metadata) VALUES
+      ('${CONTAINER_A}', '${ORG_A}', 'deleting', '{"hostContainerId":"abc123"}'::jsonb),
+      ('${CONTAINER_B}', '${ORG_A}', 'running', '{}'::jsonb)
+  `);
+  await dbWrite.execute(`
+    INSERT INTO jobs (id, type, status, data, attempts, organization_id, error) VALUES
+      ('${JOB_VALID}', 'container_delete', 'pending',
+       '{"containerId":"${CONTAINER_A}","organizationId":"${ORG_A}"}'::jsonb, 0, '${ORG_A}', NULL),
+      ('${JOB_ORG_ONLY_FAILED}', 'container_delete', 'failed',
+       '{"organizationId":"${ORG_A}"}'::jsonb, 3, '${ORG_A}', 'Invalid container delete job data'),
+      ('${JOB_ORG_ONLY_NO_ROWS}', 'container_delete', 'failed',
+       '{"organizationId":"${ORG_B}"}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data'),
+      ('${JOB_UNRECOVERABLE_PENDING}', 'container_delete', 'pending',
+       '{"containerId":""}'::jsonb, 0, '${ORG_B}', NULL),
+      ('${JOB_UNRECOVERABLE_FAILED}', 'container_delete', 'failed',
+       '{}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data')
+  `);
+}
+
+async function jobRow(id: string): Promise<{ status: string; error: string | null }> {
+  const result = await dbWrite.execute(`SELECT status, error FROM jobs WHERE id = '${id}'`);
+  const rows = (result as { rows: Array<{ status: string; error: string | null }> }).rows;
+  expect(rows.length).toBe(1);
+  return rows[0];
+}
+
+describe("container-delete job reconciler (PGlite integration)", () => {
+  beforeEach(async () => {
+    if (!databaseReady) return;
+    await seed();
+  });
+
+  test(
+    "dry run classifies every row and writes nothing",
+    async () => {
+      if (!databaseReady) return;
+      const report = await reconcileContainerDeleteJobs(dbWrite);
+      expect(report.dryRun).toBe(true);
+      expect(report.scannedJobs).toBe(5);
+      expect(report.validJobs).toBe(1);
+      expect(report.recoverableJobs).toBe(2);
+      expect(report.unrecoverableJobs).toBe(2);
+      expect(report.requeuedJobs).toBe(0);
+      expect(report.markedFailedJobs).toBe(0);
+
+      const byId = new Map(report.entries.map((entry) => [entry.jobId, entry]));
+      expect(byId.get(JOB_VALID)?.plannedAction).toBe("none");
+      expect(byId.get(JOB_ORG_ONLY_FAILED)?.plannedAction).toBe("requeue");
+      expect(byId.get(JOB_ORG_ONLY_FAILED)?.deletingContainerIds).toEqual([CONTAINER_A]);
+      expect(byId.get(JOB_ORG_ONLY_FAILED)?.deletingContainersWithHostId).toBe(1);
+      expect(byId.get(JOB_ORG_ONLY_NO_ROWS)?.plannedAction).toBe("none");
+      expect(byId.get(JOB_UNRECOVERABLE_PENDING)?.plannedAction).toBe("mark-failed");
+      expect(byId.get(JOB_UNRECOVERABLE_FAILED)?.plannedAction).toBe("none");
+      for (const entry of report.entries) expect(entry.applied).toBe(false);
+
+      expect((await jobRow(JOB_ORG_ONLY_FAILED)).status).toBe("failed");
+      expect((await jobRow(JOB_UNRECOVERABLE_PENDING)).status).toBe("pending");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "apply performs only the two guarded transitions and is idempotent",
+    async () => {
+      if (!databaseReady) return;
+      const first = await reconcileContainerDeleteJobs(dbWrite, { apply: true });
+      expect(first.requeuedJobs).toBe(1);
+      expect(first.markedFailedJobs).toBe(1);
+
+      const requeued = await jobRow(JOB_ORG_ONLY_FAILED);
+      expect(requeued.status).toBe("pending");
+      expect(requeued.error).toBeNull();
+      const failed = await jobRow(JOB_UNRECOVERABLE_PENDING);
+      expect(failed.status).toBe("failed");
+      expect(failed.error).toBe(UNRECOVERABLE_DELETE_JOB_ERROR);
+      expect((await jobRow(JOB_VALID)).status).toBe("pending");
+      expect((await jobRow(JOB_ORG_ONLY_NO_ROWS)).status).toBe("failed");
+
+      const second = await reconcileContainerDeleteJobs(dbWrite, { apply: true });
+      expect(second.requeuedJobs).toBe(0);
+      // The previously stamped unrecoverable row is failed now; a re-run
+      // reports it without touching it again.
+      expect(second.markedFailedJobs).toBe(0);
+      expect((await jobRow(JOB_ORG_ONLY_FAILED)).status).toBe("pending");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "concurrent apply runs never double-transition a row",
+    async () => {
+      if (!databaseReady) return;
+      const [a, b] = await Promise.all([
+        reconcileContainerDeleteJobs(dbWrite, { apply: true }),
+        reconcileContainerDeleteJobs(dbWrite, { apply: true }),
+      ]);
+      expect(a.requeuedJobs + b.requeuedJobs).toBe(1);
+      expect(a.markedFailedJobs + b.markedFailedJobs).toBe(1);
+      expect((await jobRow(JOB_ORG_ONLY_FAILED)).status).toBe("pending");
+      expect((await jobRow(JOB_UNRECOVERABLE_PENDING)).status).toBe("failed");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "requeued organization-only row satisfies the executor's recovery contract",
+    async () => {
+      if (!databaseReady) return;
+      await reconcileContainerDeleteJobs(dbWrite, { apply: true });
+      const { isContainerDeleteJobData } = await import("../container-jobs-data");
+      const result = await dbWrite.execute(
+        `SELECT data FROM jobs WHERE id = '${JOB_ORG_ONLY_FAILED}'`,
+      );
+      const data = (result as { rows: Array<{ data: unknown }> }).rows[0].data;
+      // Still organization-only (the reconciler never fabricates a containerId),
+      // which is exactly the shape the executor's recovery branch handles.
+      expect(isContainerDeleteJobData(data)).toBe(false);
+      const organizationId = Reflect.get(data as object, "organizationId");
+      expect(organizationId).toBe(ORG_A);
+    },
+    TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/container-delete-job-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/container-delete-job-reconciler.ts
@@ -1,0 +1,282 @@
+/**
+ * Operator reconciliation for legacy malformed CONTAINER_DELETE queue rows
+ * (#15821). Producers now serialize through the canonical codec, but rows
+ * enqueued before that fix may still sit in the queue with payloads the
+ * executor cannot fully trust. This module inventories those rows, classifies
+ * each one through the same codec the executor uses, and — only in apply
+ * mode — performs the two safe transitions: requeue a failed
+ * organization-only row that still has `deleting` container rows to consume,
+ * and terminally fail a pending row whose payload can never identify an owner.
+ *
+ * Every mutation is guarded on the status the classification observed, so
+ * concurrent daemons or a second reconciler run cannot double-apply a
+ * transition; the report counts only rows this run actually changed. The
+ * inventory carries ids and counts only (no names, env vars, or hostnames) so
+ * it is safe to paste into an issue as operator evidence.
+ */
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { dbWrite } from "../../db/client";
+import { containers } from "../../db/schemas/containers";
+import { jobs } from "../../db/schemas/jobs";
+import { isContainerDeleteJobData } from "./container-jobs-data";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+/** Drizzle surface the reconciler needs; the real `dbWrite` is assignable. */
+export type ReconcilerDatabase = Pick<typeof dbWrite, "select" | "update">;
+
+export type ContainerDeleteJobClassification =
+  | "valid"
+  | "recoverable-organization-only"
+  | "unrecoverable";
+
+export type ContainerDeleteJobPlannedAction = "none" | "requeue" | "mark-failed";
+
+/** Sanitized per-job inventory row: ids, states, and counts only. */
+export interface ContainerDeleteJobInventoryEntry {
+  jobId: string;
+  status: string;
+  attempts: number;
+  maxAttempts: number;
+  createdAt: string;
+  classification: ContainerDeleteJobClassification;
+  /** Present when the payload carried a usable owning organization. */
+  organizationId: string | null;
+  /** Present only when the payload passed the canonical codec. */
+  containerId: string | null;
+  /** For organization-only rows: ids of that org's `deleting` container rows. */
+  deletingContainerIds: string[];
+  /** How many of those deleting rows persisted an immutable host Docker id. */
+  deletingContainersWithHostId: number;
+  plannedAction: ContainerDeleteJobPlannedAction;
+  /** Why the planned action was chosen (operator-facing, deterministic). */
+  reason: string;
+  /** True when apply mode performed the planned action on this row. */
+  applied: boolean;
+}
+
+export interface ContainerDeleteJobReconciliationReport {
+  dryRun: boolean;
+  scannedJobs: number;
+  validJobs: number;
+  recoverableJobs: number;
+  unrecoverableJobs: number;
+  requeuedJobs: number;
+  markedFailedJobs: number;
+  entries: ContainerDeleteJobInventoryEntry[];
+}
+
+/** Error text stamped on rows terminally failed by the reconciler. */
+export const UNRECOVERABLE_DELETE_JOB_ERROR =
+  "CONTAINER_DELETE_PAYLOAD_UNRECOVERABLE: legacy job payload has no valid " +
+  "containerId or organizationId; terminally failed by the container-delete " +
+  "reconciler (#15821). Any live container is swept by the orphan reconciler " +
+  "using its immutable host id.";
+
+/** Statuses that are already settled and must never be touched. */
+const TERMINAL_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+function readOrganizationId(data: unknown): string | null {
+  if (typeof data !== "object" || data === null) return null;
+  const organizationId = Reflect.get(data, "organizationId");
+  return typeof organizationId === "string" && organizationId.trim().length > 0
+    ? organizationId
+    : null;
+}
+
+/** Classify one persisted payload through the executor's own codec. */
+export function classifyContainerDeleteJobData(data: unknown): ContainerDeleteJobClassification {
+  if (isContainerDeleteJobData(data)) return "valid";
+  return readOrganizationId(data) === null ? "unrecoverable" : "recoverable-organization-only";
+}
+
+interface ScannedJobRow {
+  id: string;
+  status: string;
+  data: unknown;
+  attempts: number;
+  max_attempts: number;
+  created_at: Date;
+  organization_id: string;
+}
+
+interface PlannedEntry {
+  entry: ContainerDeleteJobInventoryEntry;
+  guardStatus: string | null;
+}
+
+function planEntry(
+  row: ScannedJobRow,
+  deletingRows: Array<{ id: string; hasHostId: boolean }>,
+): PlannedEntry {
+  const classification = classifyContainerDeleteJobData(row.data);
+  const payloadOrganizationId = readOrganizationId(row.data);
+  const base: ContainerDeleteJobInventoryEntry = {
+    jobId: row.id,
+    status: row.status,
+    attempts: row.attempts,
+    maxAttempts: row.max_attempts,
+    createdAt: row.created_at.toISOString(),
+    classification,
+    organizationId: payloadOrganizationId,
+    containerId:
+      classification === "valid" &&
+      typeof row.data === "object" &&
+      row.data !== null &&
+      typeof Reflect.get(row.data, "containerId") === "string"
+        ? (Reflect.get(row.data, "containerId") as string)
+        : null,
+    deletingContainerIds: deletingRows.map((r) => r.id),
+    deletingContainersWithHostId: deletingRows.filter((r) => r.hasHostId).length,
+    plannedAction: "none",
+    reason: "",
+    applied: false,
+  };
+
+  if (classification === "valid") {
+    base.reason = "payload passes the canonical codec; normal worker path owns it";
+    return { entry: base, guardStatus: null };
+  }
+  if (TERMINAL_JOB_STATUSES.has(row.status) && row.status !== "failed") {
+    base.reason = `terminal status ${row.status}; no reconciliation applies`;
+    return { entry: base, guardStatus: null };
+  }
+  if (classification === "recoverable-organization-only") {
+    if (row.status === "failed" && deletingRows.length > 0) {
+      base.plannedAction = "requeue";
+      base.reason =
+        "failed organization-only payload with live deleting rows; requeue so the " +
+        "executor's bounded recovery branch consumes them";
+      return { entry: base, guardStatus: "failed" };
+    }
+    base.reason =
+      row.status === "failed"
+        ? "failed organization-only payload but no deleting rows remain; nothing stranded"
+        : `status ${row.status}; the executor's recovery branch already owns this row`;
+    return { entry: base, guardStatus: null };
+  }
+  // unrecoverable
+  if (row.status === "pending") {
+    base.plannedAction = "mark-failed";
+    base.reason = "pending payload identifies no owner; terminally fail with operator context";
+    return { entry: base, guardStatus: "pending" };
+  }
+  base.reason =
+    row.status === "failed"
+      ? "already failed with no usable payload; escalate to an operator"
+      : `status ${row.status}; left untouched — a live worker may hold it`;
+  return { entry: base, guardStatus: null };
+}
+
+/**
+ * Inventory (and in apply mode reconcile) every CONTAINER_DELETE job row.
+ * Dry-run performs no writes; apply mode performs only status-guarded
+ * single-row transitions, so it is idempotent and safe under concurrency.
+ */
+export async function reconcileContainerDeleteJobs(
+  db: ReconcilerDatabase,
+  options: { apply?: boolean } = {},
+): Promise<ContainerDeleteJobReconciliationReport> {
+  const apply = options.apply === true;
+  const rows = (await db
+    .select({
+      id: jobs.id,
+      status: jobs.status,
+      data: jobs.data,
+      attempts: jobs.attempts,
+      max_attempts: jobs.max_attempts,
+      created_at: jobs.created_at,
+      organization_id: jobs.organization_id,
+    })
+    .from(jobs)
+    .where(eq(jobs.type, JOB_TYPES.CONTAINER_DELETE))
+    .orderBy(jobs.created_at)) as ScannedJobRow[];
+
+  const organizationIds = new Set<string>();
+  for (const row of rows) {
+    if (classifyContainerDeleteJobData(row.data) === "recoverable-organization-only") {
+      const organizationId = readOrganizationId(row.data);
+      if (organizationId) organizationIds.add(organizationId);
+    }
+  }
+
+  const deletingByOrganization = new Map<string, Array<{ id: string; hasHostId: boolean }>>();
+  if (organizationIds.size > 0) {
+    const deletingRows = await db
+      .select({
+        id: containers.id,
+        organization_id: containers.organization_id,
+        hasHostId: sql<boolean>`jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'hostContainerId')`,
+      })
+      .from(containers)
+      .where(
+        and(
+          eq(containers.status, "deleting"),
+          inArray(containers.organization_id, [...organizationIds]),
+        ),
+      );
+    for (const row of deletingRows) {
+      const list = deletingByOrganization.get(row.organization_id) ?? [];
+      list.push({ id: row.id, hasHostId: row.hasHostId === true });
+      deletingByOrganization.set(row.organization_id, list);
+    }
+  }
+
+  const report: ContainerDeleteJobReconciliationReport = {
+    dryRun: !apply,
+    scannedJobs: rows.length,
+    validJobs: 0,
+    recoverableJobs: 0,
+    unrecoverableJobs: 0,
+    requeuedJobs: 0,
+    markedFailedJobs: 0,
+    entries: [],
+  };
+
+  for (const row of rows) {
+    const organizationId = readOrganizationId(row.data);
+    const deletingRows = organizationId ? (deletingByOrganization.get(organizationId) ?? []) : [];
+    const { entry, guardStatus } = planEntry(row, deletingRows);
+    if (entry.classification === "valid") report.validJobs += 1;
+    else if (entry.classification === "recoverable-organization-only") report.recoverableJobs += 1;
+    else report.unrecoverableJobs += 1;
+
+    if (apply && guardStatus !== null && entry.plannedAction !== "none") {
+      const changed = await applyTransition(db, row.id, entry.plannedAction, guardStatus);
+      entry.applied = changed;
+      if (changed && entry.plannedAction === "requeue") report.requeuedJobs += 1;
+      if (changed && entry.plannedAction === "mark-failed") report.markedFailedJobs += 1;
+    }
+    report.entries.push(entry);
+  }
+  return report;
+}
+
+async function applyTransition(
+  db: ReconcilerDatabase,
+  jobId: string,
+  action: Exclude<ContainerDeleteJobPlannedAction, "none">,
+  guardStatus: string,
+): Promise<boolean> {
+  const values =
+    action === "requeue"
+      ? {
+          status: "pending" as const,
+          scheduled_for: new Date(),
+          error: null,
+          completed_at: null,
+          updated_at: new Date(),
+        }
+      : {
+          status: "failed" as const,
+          error: UNRECOVERABLE_DELETE_JOB_ERROR,
+          completed_at: new Date(),
+          updated_at: new Date(),
+        };
+  const updated = await db
+    .update(jobs)
+    .set(values)
+    .where(and(eq(jobs.id, jobId), eq(jobs.status, guardStatus)))
+    .returning({ id: jobs.id });
+  return updated.length === 1;
+}


### PR DESCRIPTION
Fixes #15821

## What

The preventative slices for this issue are already on `develop` (#15792 codec validation + bounded recovery, #15869 immutable-ID delete, #20432 producer codec). What remained was the operator reconciliation of legacy malformed `CONTAINER_DELETE` queue rows, with no tooling to do it safely. This PR adds that tooling:

- **`packages/cloud/shared/src/lib/services/container-delete-job-reconciler.ts`** — inventories every `CONTAINER_DELETE` job row, classifies each persisted payload through the executor's own canonical codec (`isContainerDeleteJobData`) into `valid` / `recoverable-organization-only` / `unrecoverable`, and in apply mode performs only the two safe transitions:
  - **requeue** a `failed` organization-only row that still has `deleting` container rows for its org (the executor's bounded recovery branch then consumes them by immutable host ID — never by reusable name);
  - **mark-failed** a `pending` row whose payload can never identify an owner, stamping an operator-visible `CONTAINER_DELETE_PAYLOAD_UNRECOVERABLE` error.
  Everything else (valid rows, in-progress rows, already-terminal rows, orgs with nothing left to delete) is reported but never touched. Every mutation is a single-row status-guarded `UPDATE ... WHERE status = <observed>` with `RETURNING`, so concurrent daemons or double runs cannot double-apply, and the run counts only rows it actually changed.
- **`packages/cloud/shared/scripts/reconcile-container-delete-jobs.ts`** (+ `reconcile:container-delete-jobs` package script) — operator CLI over the package's normal `DATABASE_URL` resolution. Dry-run by default; `--apply` performs the guarded transitions. Output is a sanitized JSON report (IDs, statuses, attempts, counts, per-row reason — no names, env vars, or hostnames) suitable to paste into the issue as the required inventory evidence.

## Verification

- New PGlite integration suite `container-delete-job-reconciler.integration.test.ts` (real in-process Postgres, no mocks): 4/4 pass — dry-run classification with zero writes; apply performs exactly the two guarded transitions and is idempotent on re-run; two concurrent apply runs never double-transition a row; a requeued row keeps its organization-only shape (the reconciler never fabricates a `containerId`) so it exactly matches the executor recovery contract.
- Neighboring suites re-run green: `container-job-executors`, `container-job-service`, `container-jobs-data`, `container-retirement.integration` — 50/50 pass.
- CLI smoke against a real file-backed PGlite store: seeded a failed org-only job + deleting container row + unrecoverable pending job; dry-run printed the full classified inventory with `plannedAction`/`reason` and wrote nothing; `--apply` reported `requeuedJobs: 1`, `markedFailedJobs: 1`, both rows verified transitioned; second apply reported 0/0.
- `biome check` clean on all new files; `tsc --noEmit` reports no errors in the touched files.

## Remaining human steps (operator-gated, unchanged from triage)

1. Run `DATABASE_URL=<staging> bun run --cwd packages/cloud/shared reconcile:container-delete-jobs` and attach the sanitized dry-run report to #15821; repeat for production.
2. Review the planned actions, then re-run with `--apply`.
3. Confirm requeued jobs reach terminal state via the daemon logs and provider-side container/route artifacts, per the issue's acceptance list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
