### PR TITLE
fix(auth): accept canonical Steward session JWTs

### DIFF
--- a/packages/cloud/shared/src/lib/auth/steward-client.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.test.ts
@@ -174,6 +174,19 @@ describe("verifyStewardTokenCached — token lifecycle claims", () => {
     expect(await verify(userIdOnly)).toBeNull();
   });
 
+  test("accepts canonical Steward session tokens whose protected header omits typ", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const canonicalStewardToken = await new SignJWT({
+      sub: "canonical-steward-user",
+      iat: now,
+      exp: now + 60,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .sign(secretKey());
+
+    expect((await verify(canonicalStewardToken))?.userId).toBe("canonical-steward-user");
+  });
+
   test("revalidates lifetime on distributed cache hits", async () => {
     const now = Math.floor(Date.now() / 1000);
     const signingKeyFingerprint = createHash("sha256")

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -439,9 +439,14 @@ async function verifyStewardTokenWithoutCaches(input: {
     clockTolerance: STEWARD_VERIFY_CLOCK_SKEW_SECONDS,
   });
 
+  // @stwd/auth's canonical HS256 session signer omits `typ`; older Eliza
+  // signers included `typ: "JWT"`. Both are ordinary JWT representations.
+  // Keep every other explicit type fail-closed so a token minted for another
+  // protocol cannot be confused with a Steward browser session.
+  const ordinaryTypeIsValid = protectedHeader.typ === undefined || protectedHeader.typ === "JWT";
   if (
     (input.stagingHeader.isCandidate && protectedHeader.typ !== STAGING_SESSION_TOKEN_TYP) ||
-    (!input.stagingHeader.isCandidate && protectedHeader.typ !== "JWT")
+    (!input.stagingHeader.isCandidate && !ordinaryTypeIsValid)
   ) {
     logger.warn("[StewardClient] Rejected token with an invalid typ header");
     return null;


### PR DESCRIPTION
## Summary
- accept canonical Steward HS256 session tokens whose protected header omits `typ`
- continue accepting legacy `typ: JWT` and reject every other explicit token type
- add regression coverage matching the live Steward signer

## Verification
- `bun test packages/cloud/shared/src/lib/auth/steward-client.test.ts` (15 pass)
- `bun test packages/cloud/api/auth/steward-nonce-exchange/route.test.ts` (4 pass)
- `bun test packages/cloud/api/auth/steward-refresh/route.test.ts` (5 pass)
- `bun run --cwd packages/cloud/shared typecheck`
- Biome check on changed files

## Live evidence
Production Google OAuth reached the nonce exchange successfully, then the API Worker returned `401 {"error":"Invalid token","code":"invalid_token"}`. Cloudflare Worker logs identify the cause as `[StewardClient] Rejected token with an invalid typ header`; Steward’s canonical signer uses `{ alg: HS256 }` without a `typ` header.