### PR TITLE
fix(cloud-apps): scope cloud inventory routing and single-deliver handled failures

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1178,11 +1178,102 @@ describe("cloud-apps surface request inference", () => {
 		}
 	});
 
-	it("falls back to local APP when no cloud-apps action is registered", () => {
+	it("never degrades a cloud-qualified ask to local APP when no cloud-apps action is registered (#17363)", () => {
 		expect(
 			inferDirectCurrentRequestCandidateActions(
 				[viewsAction, appAction],
 				"list my cloud apps",
+			),
+		).toEqual(["VIEWS"]);
+	});
+
+	it("keeps cloud lifecycle/mutation asks off the deterministic cloud candidate (#17363)", () => {
+		for (const message of [
+			"launch my cloud app",
+			"delete my cloud app",
+			"open the settings for my cloud app",
+			"create a cloud app for my portfolio",
+			"deploy my cloud app",
+			"withdraw earnings from my cloud app",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateActions(
+					[viewsAction, appAction, cloudAppsAction],
+					message,
+				),
+			).toEqual([]);
+		}
+	});
+
+	// The candidate array must be EXACTLY empty, not merely free of the cloud
+	// action: narrowing the turn to [VIEWS] alone still dropped the ranked
+	// WEB_SEARCH/SEND_EMAIL candidates the other clauses asked for (#17363).
+	it("yields no deterministic candidate for compound/multi-tool cloud turns (#17363)", () => {
+		for (const message of [
+			"list my cloud apps and then deploy the first one",
+			"list my cloud apps; delete the oldest one",
+			"show my cloud apps. Then launch acme.",
+			"list my cloud apps and also check the deploy status",
+			// Verbs absent from any denylist: the structural clause split, not an
+			// enumerated downstream verb, is what keeps these with the planner.
+			"list my cloud apps and search the web for reviews",
+			"list my cloud apps and search the web for reviews and email me the results",
+			"list my cloud apps and archive the oldest one",
+			"list my cloud apps and compare their traffic",
+			"list my cloud apps and export them to a spreadsheet",
+			"list my cloud apps, summarize their uptime",
+			"list my cloud apps plus tell me what they cost",
+			"show my deployed apps and draft a tweet about them",
+			"what apps do I have on eliza cloud and who visited them",
+			"show my hosted apps then message the team",
+			"list my cloud apps as well as my calendar for today",
+			"list my cloud apps while you check my email",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateActions(
+					[viewsAction, appAction, cloudAppsAction],
+					message,
+				),
+			).toEqual([]);
+		}
+	});
+
+	// The conservative split must not swallow single-intent phrasing whose
+	// conjunction joins another hosted-inventory noun phrase or a politeness
+	// tail — those still deserve the deterministic cloud read.
+	it("still claims single-intent cloud reads that carry a noun-phrase or politeness tail (#17363)", () => {
+		for (const message of [
+			"list my cloud apps and sites",
+			"show me my cloud apps and my deployed sites",
+			"list my cloud apps, please",
+			"what apps do I have deployed on eliza cloud?",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateActions(
+					[viewsAction, appAction, cloudAppsAction],
+					message,
+				),
+			).toEqual(["VIEWS", "LIST_CLOUD_APPS"]);
+		}
+	});
+
+	// A compound cloud turn must yield nothing even when no cloud-apps action is
+	// registered: falling through to [VIEWS] is the same narrowing bug.
+	it("yields no candidate for a compound cloud turn with no cloud action registered (#17363)", () => {
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				[viewsAction, appAction],
+				"list my cloud apps and search the web for reviews",
+			),
+		).toEqual([]);
+	});
+
+	// Non-cloud app turns are untouched by the cloud short-circuit.
+	it("leaves compound local installed-app turns on their existing path", () => {
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				[viewsAction, appAction, cloudAppsAction],
+				"show me the apps",
 			),
 		).toEqual(["VIEWS", "APP"]);
 	});

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1161,6 +1161,12 @@ export function inferDirectCurrentRequestCandidateInference(
 			return { names: [settingsAction], kind: "settings-write" };
 		}
 	}
+	// Ordered before the view-shell fallback: a compound or lifecycle cloud-app
+	// turn must not be narrowed to VIEWS (+ the cloud read) while the tools its
+	// other clauses asked for are dropped by candidate narrowing (#17363).
+	if (shouldDeferCloudAppTurnToPlanner(messageText)) {
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
 	const viewShellAction = findViewShellActionName(actions, messageText);
 	if (viewShellAction) {
 		// A request that names the application surface itself ("show me the
@@ -1585,13 +1591,140 @@ const CLOUD_APP_QUALIFIER_TOKENS: ReadonlySet<string> = new Set<string>([
 	"HOSTED",
 ]);
 
+// Lifecycle/mutation vocabulary that disqualifies the cloud-apps INVENTORY
+// candidate: launch/open, delete, create/deploy, settings, and money/domain
+// operations belong to their own gated actions and must go through the full
+// planner, never a deterministic read hint (#17363). Singular-normalized.
+const CLOUD_APP_LIFECYCLE_TOKENS: ReadonlySet<string> = new Set<string>([
+	"LAUNCH",
+	"OPEN",
+	"START",
+	"RUN",
+	"RESTART",
+	"STOP",
+	"CLOSE",
+	"QUIT",
+	"KILL",
+	"DELETE",
+	"REMOVE",
+	"UNINSTALL",
+	"DESTROY",
+	"CREATE",
+	"BUILD",
+	"MAKE",
+	"DEPLOY",
+	"REDEPLOY",
+	"PUBLISH",
+	"UPDATE",
+	"EDIT",
+	"RENAME",
+	"CONFIGURE",
+	"CONFIG",
+	"SETTING",
+	"ROLLBACK",
+	"WITHDRAW",
+	"REGENERATE",
+	"ROTATE",
+	"MONETIZE",
+	"MONETIZATION",
+	"DOMAIN",
+	"BACKUP",
+]);
+
+// Structural clause separators. The compound test is closed over PUNCTUATION
+// AND CONJUNCTIONS rather than over the verbs that may follow one, because a
+// downstream verb list can never be complete: "search", "archive", "compare"
+// and "export" are all ordinary second clauses that an enumerated verb denylist
+// silently admitted, letting the deterministic hint narrow a genuine multi-tool
+// turn (#17363). Splitting here means an unrecognized continuation counts as a
+// second clause and the full planner keeps the turn.
+const CLOUD_APP_CLAUSE_SEPARATOR_PATTERN =
+	/\s*(?:[;:,!?&]+|\.(?:\s|$)|\bafter\s+that\b|\bas\s+well\s+as\b|\band\b|\balso\b|\bplus\b|\bthen\b|\bnext\b|\bafterwards?\b|\bmeanwhile\b|\bwhile\b)\s*/giu;
+
+// The only continuations a single-intent inventory read may carry: another bare
+// hosted-inventory noun phrase ("... and my deployed sites") or a politeness
+// tail. This is an allowlist, so anything it does not recognize — a pronoun, a
+// verb, a new object — is treated as a second clause.
+const CLOUD_APP_INVENTORY_CONTINUATION_PATTERN =
+	/^(?:(?:please|pls|thanks|thank\s+you|thx)|(?:(?:the|my|our|their|any|all|of)\s+)*(?:(?:eliza\s+)?(?:cloud|deployed|hosted|live|published|web)\s+)*(?:app|application|site|website|project|deployment|page)s?)$/iu;
+
+/**
+ * True when the message carries a structural second clause, so the turn may be
+ * multi-tool and must stay with the full planner.
+ */
+function isCompoundCloudAppTurn(messageText: string): boolean {
+	const trimmed = messageText
+		.trim()
+		.replace(/[.!?]+$/u, "")
+		.trim();
+	const segments = trimmed
+		.split(CLOUD_APP_CLAUSE_SEPARATOR_PATTERN)
+		.map((segment) => segment.trim())
+		.filter((segment) => segment.length > 0);
+	if (segments.length <= 1) return false;
+	return segments
+		.slice(1)
+		.some((segment) => !CLOUD_APP_INVENTORY_CONTINUATION_PATTERN.test(segment));
+}
+
+// Read-shaped inventory phrasing: the request asks WHAT hosted apps exist, not
+// to do anything to one of them.
+const CLOUD_APP_INVENTORY_READ_PATTERN =
+	/\b(?:list|show|see|view|enumerate|check|get|give\s+me|tell\s+me|what|which|how\s+many|do\s+i\s+have|have\s+i\s+got)\b/iu;
+
+/**
+ * True only for a single-clause, explicitly cloud-qualified inventory read
+ * ("list my cloud apps", "what apps do I have deployed on eliza cloud").
+ * Lifecycle/mutation verbs and compound turns disqualify the message so the
+ * full planner keeps arbitration (#17363: "delete my cloud app" and "list my
+ * cloud apps and deploy the first one" were hijacked into LIST_CLOUD_APPS).
+ */
+function looksLikeCloudAppInventoryRequest(messageText: string): boolean {
+	const trimmed = messageText.trim().replace(/[.!?]+\s*$/u, "");
+	if (isCompoundCloudAppTurn(trimmed)) return false;
+	if (!CLOUD_APP_INVENTORY_READ_PATTERN.test(trimmed)) return false;
+	const tokens = tokenizeActionMetadata(trimmed).map(normalizeSingularToken);
+	return !tokens.some((token) => CLOUD_APP_LIFECYCLE_TOKENS.has(token));
+}
+
+/**
+ * True when the message names the application surface AND pins it to the user's
+ * hosted Eliza Cloud apps. Used to decide ownership of the turn before any
+ * deterministic candidate is offered.
+ */
+function looksLikeCloudQualifiedAppRequest(messageText: string): boolean {
+	const tokens = tokenizeActionMetadata(messageText).map(
+		normalizeSingularToken,
+	);
+	if (!tokens.some((token) => token === "APP" || token === "APPLICATION")) {
+		return false;
+	}
+	return tokens.some((token) => CLOUD_APP_QUALIFIER_TOKENS.has(token));
+}
+
+/**
+ * A cloud-qualified app message that is not a single-clause inventory read is
+ * full-planner territory: it may be a lifecycle mutation or a multi-tool turn
+ * whose other tools (WEB_SEARCH, SEND_EMAIL, …) must stay on the candidate
+ * surface. Answering it with the view-shell fallback narrowed the catalog to
+ * VIEWS and dropped the requested second tool, so this yields NO deterministic
+ * candidate at all (#17363).
+ */
+export function shouldDeferCloudAppTurnToPlanner(messageText: string): boolean {
+	if (!looksLikeCloudQualifiedAppRequest(messageText)) return false;
+	return !looksLikeCloudAppInventoryRequest(messageText);
+}
+
 // Resolve the app action an app-shaped message targets. A cloud qualifier next
 // to the APP token pins the ask to the user's hosted Eliza Cloud apps, where
 // the local app-control action is wrong by its own routing contract — without
 // this the cloud-apps action is never on the planner surface and the local APP
-// action wins by forfeit. Falls back to the local app-control surface when no
-// cloud-apps action is registered, so those runtimes keep their previous
-// candidates.
+// action wins by forfeit. The cloud candidate is offered only for a
+// single-clause inventory read; cloud lifecycle/mutation and compound turns
+// yield NO app candidate so the full planner arbitrates. A cloud-qualified
+// message never degrades to the local-device APP action — with no cloud-apps
+// action registered the correct answer is an honest capability gap, not the
+// installed-app list (#17363).
 function findAppActionNameForAppRequest(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 	messageText: string,
@@ -1603,11 +1736,8 @@ function findAppActionNameForAppRequest(
 		return undefined;
 	}
 	if (tokens.some((token) => CLOUD_APP_QUALIFIER_TOKENS.has(token))) {
-		const cloudAppsAction = findAvailableActionName(
-			actions,
-			CLOUD_APPS_ACTION_NAMES,
-		);
-		if (cloudAppsAction) return cloudAppsAction;
+		if (!looksLikeCloudAppInventoryRequest(messageText)) return undefined;
+		return findAvailableActionName(actions, CLOUD_APPS_ACTION_NAMES);
 	}
 	return findAvailableActionName(actions, APP_CONTROL_ACTION_NAMES);
 }

--- a/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
@@ -1,5 +1,5 @@
 /**
- * Live-lane scenario: a real LLM answers "what apps do I have?" against the
+ * Live-lane scenario: a real LLM answers "what apps do I have on eliza cloud?" against the
  * Eliza Cloud Apps read surface. Needs live model credentials (live-only lane).
  */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
@@ -43,7 +43,7 @@ function expectCloudAppsListResult(ctx: ScenarioContext): string | undefined {
  * Live trajectory for the Eliza Cloud Apps read-core (#10218).
  *
  * FOLLOW-UP EVIDENCE — lane: "live-only". This needs BOTH a live model (to route
- * "what apps do I have?" to LIST_CLOUD_APPS) AND a real `ELIZAOS_CLOUD_API_KEY`
+ * "what apps do I have on eliza cloud?" to LIST_CLOUD_APPS) AND a real `ELIZAOS_CLOUD_API_KEY`
  * (so `client.listApps()` reaches Eliza Cloud). It is intentionally excluded
  * from the keyless `pr-deterministic` lane: LIST_CLOUD_APPS calls the Cloud API,
  * which cannot be satisfied by a proxy fixture. Run it manually with a key:
@@ -58,7 +58,7 @@ function expectCloudAppsListResult(ctx: ScenarioContext): string | undefined {
 export default scenario({
   id: "cloud-apps-read-core",
   lane: "live-only",
-  title: "Eliza Cloud Apps read-core: what apps do I have?",
+  title: "Eliza Cloud Apps read-core: what apps do I have on eliza cloud?",
   domain: "cloud-apps",
   status: "active",
   requires: {
@@ -68,7 +68,7 @@ export default scenario({
     {
       kind: "message",
       name: "user asks for their cloud apps",
-      text: "what apps do I have?",
+      text: "what apps do I have on eliza cloud?",
     },
   ],
   finalChecks: [

--- a/plugins/plugin-cloud-apps/AGENTS.md
+++ b/plugins/plugin-cloud-apps/AGENTS.md
@@ -16,9 +16,10 @@ is specific to the plugin.
 
 Reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`, defaults to
 `https://api.eliza.app/api/v1`) via `runtime.getSetting` — the same
-credentials `plugin-elizacloud` uses. With no key, `validate` returns false,
-every action degrades gracefully with a "no key" message, and the provider
-stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
+credentials `plugin-elizacloud` uses. With no key, `validate` returns false for
+every action except `LIST_CLOUD_APPS` (which stays reachable so its handler can
+own the truthful capability failure), each handler degrades gracefully with a
+"no key" message, and the provider stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
 
 ## Layout
 
@@ -134,9 +135,14 @@ bun run --cwd plugins/plugin-cloud-apps build       # bun build.ts
   writes that change `apps` rows must evict `appsService` caches too (the app row
   is cached ~5 min via `getById`; a missed eviction was a real payment-gate
   staleness bug — #11213).
-- **`validate` is only the API-key check.** All real validation lives in the
-  handler; every exit calls `callback` AND returns an `ActionResult` with
-  `userFacingText` (and `verifiedUserFacing: true` on truthful outcomes).
+- **`validate` is only the API-key check — except `LIST_CLOUD_APPS`.** All real
+  validation lives in the handler; every exit calls `callback` AND returns an
+  `ActionResult` with `userFacingText` (and `verifiedUserFacing: true` on
+  truthful outcomes). `LIST_CLOUD_APPS` validates unconditionally: it is the
+  read a cloud-qualified ask lands on, and key-gating it removed the action from
+  the catalog so the truthful "no Cloud API key is configured" reply was
+  unreachable and the turn degraded to the local installed-app answer (#17363).
+  Its handler owns that capability failure and delivers it once.
 - **Deploy "done" ≠ 202-accepted.** It is READY status + a live reachability
   probe of the authoritative `production_url` (`deploy-gate.ts`).
 - **Tests fake ONLY the SDK.** `__tests__/helpers.ts` provides `FakeElizaCloudClient`

--- a/plugins/plugin-cloud-apps/CLAUDE.md
+++ b/plugins/plugin-cloud-apps/CLAUDE.md
@@ -16,9 +16,10 @@ is specific to the plugin.
 
 Reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`, defaults to
 `https://api.eliza.app/api/v1`) via `runtime.getSetting` — the same
-credentials `plugin-elizacloud` uses. With no key, `validate` returns false,
-every action degrades gracefully with a "no key" message, and the provider
-stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
+credentials `plugin-elizacloud` uses. With no key, `validate` returns false for
+every action except `LIST_CLOUD_APPS` (which stays reachable so its handler can
+own the truthful capability failure), each handler degrades gracefully with a
+"no key" message, and the provider stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
 
 ## Layout
 
@@ -134,9 +135,14 @@ bun run --cwd plugins/plugin-cloud-apps build       # bun build.ts
   writes that change `apps` rows must evict `appsService` caches too (the app row
   is cached ~5 min via `getById`; a missed eviction was a real payment-gate
   staleness bug — #11213).
-- **`validate` is only the API-key check.** All real validation lives in the
-  handler; every exit calls `callback` AND returns an `ActionResult` with
-  `userFacingText` (and `verifiedUserFacing: true` on truthful outcomes).
+- **`validate` is only the API-key check — except `LIST_CLOUD_APPS`.** All real
+  validation lives in the handler; every exit calls `callback` AND returns an
+  `ActionResult` with `userFacingText` (and `verifiedUserFacing: true` on
+  truthful outcomes). `LIST_CLOUD_APPS` validates unconditionally: it is the
+  read a cloud-qualified ask lands on, and key-gating it removed the action from
+  the catalog so the truthful "no Cloud API key is configured" reply was
+  unreachable and the turn degraded to the local installed-app answer (#17363).
+  Its handler owns that capability failure and delivers it once.
 - **Deploy "done" ≠ 202-accepted.** It is READY status + a live reachability
   probe of the authoritative `production_url` (`deploy-gate.ts`).
 - **Tests fake ONLY the SDK.** `__tests__/helpers.ts` provides `FakeElizaCloudClient`

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.integration.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.integration.test.ts
@@ -7,36 +7,47 @@ import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+// Spawning a second runtime to transpile and boot the fixture routinely costs
+// more than bun's 5s default, which failed the suite as a timeout rather than
+// as a real defect.
+const FIXTURE_TIMEOUT_MS = 60_000;
+
 describe("LIST_CLOUD_APPS integration", () => {
-  it("propagates delivery failure after one real SDK request and one callback", () => {
-    const fixturePath = fileURLToPath(
-      new URL(
-        "../test/fixtures/list-cloud-apps-callback-boundary.ts",
-        import.meta.url,
-      ),
-    );
-    const result = spawnSync(process.execPath, [fixturePath], {
-      encoding: "utf8",
-      env: process.env,
-    });
-    expect(result.status, result.stderr).toBe(0);
-    const evidence = JSON.parse(result.stdout) as {
-      requests: Array<{
-        path: string;
-        authorization: string | null;
-        apiKey: string | null;
-      }>;
-      delivered: string[];
-    };
-    expect(evidence.requests).toEqual([
-      {
-        path: "/api/v1/apps",
-        authorization: "Bearer eliza_loopback_key",
-        apiKey: "eliza_loopback_key",
-      },
-    ]);
-    expect(evidence.delivered).toHaveLength(1);
-    expect(evidence.delivered[0]).toContain("Delivered Once");
-    expect(evidence.delivered[0]).not.toContain("Cloud API returned an error");
-  });
+  it(
+    "propagates delivery failure after one real SDK request and one callback",
+    () => {
+      const fixturePath = fileURLToPath(
+        new URL(
+          "../test/fixtures/list-cloud-apps-callback-boundary.ts",
+          import.meta.url,
+        ),
+      );
+      const result = spawnSync(process.execPath, [fixturePath], {
+        encoding: "utf8",
+        env: process.env,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const evidence = JSON.parse(result.stdout) as {
+        requests: Array<{
+          path: string;
+          authorization: string | null;
+          apiKey: string | null;
+        }>;
+        delivered: string[];
+      };
+      expect(evidence.requests).toEqual([
+        {
+          path: "/api/v1/apps",
+          authorization: "Bearer eliza_loopback_key",
+          apiKey: "eliza_loopback_key",
+        },
+      ]);
+      expect(evidence.delivered).toHaveLength(1);
+      expect(evidence.delivered[0]).toContain("Delivered Once");
+      expect(evidence.delivered[0]).not.toContain(
+        "Cloud API returned an error",
+      );
+    },
+    FIXTURE_TIMEOUT_MS,
+  );
 });

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
@@ -22,6 +22,7 @@ mock.module("@elizaos/cloud-sdk", () => ({
 const { listCloudAppsAction } = await import(
   "../src/actions/list-cloud-apps.ts"
 );
+const { cloudAppsPlugin } = await import("../src/index.ts");
 
 describe("LIST_CLOUD_APPS", () => {
   beforeEach(() => {
@@ -35,10 +36,55 @@ describe("LIST_CLOUD_APPS", () => {
       ).toBe(true);
     });
 
-    it("returns false when no Cloud API key is configured", async () => {
+    // #17363: gating this read on the key made the canonical no-key reply
+    // unreachable — catalog construction and the executor both drop an action
+    // whose validate() is false, so the handler never ran and the user got the
+    // local installed-app answer or a generic refusal instead of the truthful
+    // "no Cloud API key is configured". The action stays reachable and the
+    // handler owns the capability failure.
+    it("stays reachable with no Cloud API key so the handler owns the failure (#17363)", async () => {
       expect(
         await listCloudAppsAction.validate(unkeyedRuntime(), makeMessage("x")),
-      ).toBe(false);
+      ).toBe(true);
+    });
+
+    it("survives the public validate() gate that builds the action surface (#17363)", async () => {
+      const runtime = unkeyedRuntime();
+      const message = makeMessage("list my cloud apps");
+      // The same filter the runtime applies when constructing the catalog.
+      const reachable: string[] = [];
+      for (const action of cloudAppsPlugin.actions ?? []) {
+        if (await action.validate(runtime, message))
+          reachable.push(action.name);
+      }
+      expect(reachable).toContain("LIST_CLOUD_APPS");
+    });
+
+    it("delivers exactly one canonical no-key reply once past that gate (#17363)", async () => {
+      const runtime = unkeyedRuntime();
+      const message = makeMessage("list my cloud apps");
+      const action = requireDefined(
+        (cloudAppsPlugin.actions ?? []).find(
+          (candidate) => candidate.name === "LIST_CLOUD_APPS",
+        ),
+        "LIST_CLOUD_APPS registration",
+      );
+      expect(await action.validate(runtime, message)).toBe(true);
+
+      const cb = captureCallback();
+      const result = await action.handler(
+        runtime,
+        message,
+        undefined,
+        undefined,
+        cb.fn,
+      );
+      expect(cb.calls).toHaveLength(1);
+      expect(cb.calls[0]?.text).toContain("no Cloud API key");
+      expect(result?.success).toBe(false);
+      expect(result?.userFacingText).toBe(cb.calls[0]?.text ?? "");
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
   });
 
@@ -140,9 +186,27 @@ describe("LIST_CLOUD_APPS", () => {
           .count,
       ).toBe(0);
       expect(cb.calls[0]?.text).toContain("haven't created any apps");
-      // The canned empty message is not a verified terminal answer — the
-      // evaluator still runs and may add guidance (e.g. how to create one).
-      expect(result?.turnComplete).toBeUndefined();
+      // The verified empty inventory IS the complete answer: the terminal
+      // stamp keeps the evaluator from paraphrasing it into a second reply
+      // (#17363).
+      expect(result?.userFacingText).toBe(cb.calls[0]?.text ?? "");
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
+    });
+
+    it("delivers exactly one canonical reply without a callback (userFacingText carries it)", async () => {
+      setListApps(() => Promise.resolve({ success: true, apps: [] }));
+      const result = await listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("list my cloud apps"),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result?.success).toBe(true);
+      expect(result?.userFacingText).toContain("haven't created any apps");
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
 
     it("degrades gracefully when no Cloud API key is configured", async () => {
@@ -161,6 +225,11 @@ describe("LIST_CLOUD_APPS", () => {
           .reason,
       ).toBe("no_key");
       expect(cb.calls[0]?.text).toContain("no Cloud API key");
+      // Verified terminal FAILURE: one canonical reply, success stays false,
+      // and the core failure gate may end the turn (#17363).
+      expect(result?.userFacingText).toBe(cb.calls[0]?.text ?? "");
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
 
     it("handles a Cloud API error without throwing", async () => {
@@ -181,6 +250,17 @@ describe("LIST_CLOUD_APPS", () => {
           .reason,
       ).toBe("error");
       expect(cb.calls[0]?.text).toContain("couldn't fetch");
+      expect(result?.userFacingText).toBe(cb.calls[0]?.text ?? "");
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
+    });
+
+    it("claims only cloud-qualified aliases, leaving generic installed-app language to APP (#17363)", () => {
+      const similes = listCloudAppsAction.similes ?? [];
+      expect(similes.length).toBeGreaterThan(0);
+      for (const simile of similes) {
+        expect(simile).toMatch(/CLOUD|DEPLOYED|HOSTED/);
+      }
     });
 
     it("does not translate a callback failure into an API error", async () => {

--- a/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
@@ -15,11 +15,7 @@ import type {
   State,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
-import {
-  formatAppLine,
-  getCloudClient,
-  resolveCloudApiKey,
-} from "../client.js";
+import { formatAppLine, getCloudClient } from "../client.js";
 
 const NO_KEY_MESSAGE =
   "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY (from cloud.eliza.app → dashboard → API keys) and I can list your apps.";
@@ -32,23 +28,23 @@ export const listCloudAppsAction: Action = {
   name: "LIST_CLOUD_APPS",
   // "LIST_APPS" is deliberately NOT claimed: plugin-app-control's APP action
   // owns it for device-installed apps, and a simile claimed by two parents is
-  // dropped from routing as ambiguous (#16561).
+  // dropped from routing as ambiguous (#16561). Generic aliases (MY_APPS,
+  // GET_APPS, WHAT_APPS_DO_I_HAVE) are likewise NOT claimed (#17363): generic
+  // installed-app language belongs to the local APP action, and every alias
+  // here must carry an explicit cloud/deployed/hosted qualifier.
   similes: [
-    "MY_APPS",
-    "GET_APPS",
-    "WHAT_APPS_DO_I_HAVE",
     "MY_CLOUD_APPS",
     "CLOUD_APPS",
     "LIST_ELIZA_CLOUD_APPS",
     "MY_DEPLOYED_APPS",
-    "MY_SITES",
+    "MY_HOSTED_APPS",
   ],
   description:
-    "List the Eliza Cloud apps the user owns — the hosted apps and sites they created or deployed on Eliza Cloud (name, URL, deployment status, and credits/earnings when present). Use when the user asks what apps they have, to see their apps, their cloud apps, or the sites/apps they've made or deployed. Not for apps installed or running on this device.",
+    "List the Eliza Cloud apps the user owns — the hosted apps and sites they created or deployed on Eliza Cloud (name, URL, deployment status, and credits/earnings when present). Use when the user explicitly asks about their cloud, hosted, or deployed apps/sites. Not for apps installed or running on this device — a generic 'what apps do I have' is the local installed-app inventory.",
   descriptionCompressed:
     "List the user's Eliza Cloud apps (name/url/status); not locally installed apps.",
   routingHint:
-    "The user's own Eliza Cloud apps -> LIST_CLOUD_APPS. 'List my apps', 'my cloud apps', 'what apps do I have on eliza cloud', 'sites/apps I've made or deployed' is LIST_CLOUD_APPS; apps installed or running on this device are APP (NOT this action).",
+    "The user's own Eliza Cloud apps -> LIST_CLOUD_APPS. 'List my cloud apps', 'what apps do I have on eliza cloud', 'my deployed/hosted apps or sites' is LIST_CLOUD_APPS; generic app asks and apps installed or running on this device are APP (NOT this action).",
   // Read-only inventory lookup; safe on any user turn. "general" mirrors the
   // APP action's rationale (#9950): Stage-1 routinely classifies unambiguous
   // app asks ("list my cloud apps") as general context; without it this
@@ -57,9 +53,13 @@ export const listCloudAppsAction: Action = {
   contexts: ["settings", "finance", "apps", "general"],
   contextGate: { anyOf: ["settings", "finance", "apps", "general"] },
 
-  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
-    return resolveCloudApiKey(runtime) !== null;
-  },
+  // Deliberately unconditional. Gating on the Cloud key removed this read from
+  // the action catalog whenever the key was missing, so a cloud-qualified ask
+  // fell through to the local installed-app action or to a generic "I can't do
+  // that" — the user never learned WHY. Keeping the action reachable lets the
+  // handler below own the truthful configured-capability failure and deliver it
+  // once, which is the outcome #17363 requires on the public planner path.
+  validate: async (): Promise<boolean> => true,
 
   handler: async (
     runtime: IAgentRuntime,
@@ -71,10 +71,15 @@ export const listCloudAppsAction: Action = {
     const client = getCloudClient(runtime);
     if (!client) {
       await callback?.({ text: NO_KEY_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
+      // Verified terminal failure: the message above IS the complete honest
+      // outcome, so the evaluator must not paraphrase it into a second reply
+      // (#17363). success stays false.
       return {
         success: false,
         text: "No Eliza Cloud API key configured.",
         userFacingText: NO_KEY_MESSAGE,
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { reason: "no_key" },
       };
     }
@@ -91,6 +96,10 @@ export const listCloudAppsAction: Action = {
         success: false,
         text: "Failed to list Eliza Cloud apps.",
         userFacingText: ERROR_MESSAGE,
+        // Verified terminal failure — one canonical reply, success stays false
+        // (#17363).
+        verifiedUserFacing: true,
+        turnComplete: true,
         error: err instanceof Error ? err : new Error(String(err)),
         data: { reason: "error" },
       };
@@ -103,6 +112,11 @@ export const listCloudAppsAction: Action = {
         success: true,
         text: "User has no Eliza Cloud apps.",
         userFacingText: EMPTY_MESSAGE,
+        // The verified empty inventory IS the complete answer; without the
+        // terminal stamp the evaluator paraphrased it into a second bubble
+        // (#17363).
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { count: 0, apps: [] },
       };
     }
@@ -138,7 +152,10 @@ export const listCloudAppsAction: Action = {
 
   examples: [
     [
-      { name: "{{user}}", content: { text: "what apps do I have?" } },
+      {
+        name: "{{user}}",
+        content: { text: "what apps do I have on eliza cloud?" },
+      },
       {
         name: "{{agent}}",
         content: {

--- a/plugins/plugin-cloud-apps/test/fixtures/list-cloud-apps-callback-boundary.ts
+++ b/plugins/plugin-cloud-apps/test/fixtures/list-cloud-apps-callback-boundary.ts
@@ -62,3 +62,9 @@ try {
 } finally {
   server.stop(true);
 }
+
+// The loopback listener and the SDK's keep-alive sockets can outlive
+// `server.stop`, leaving the child alive long enough for the parent's
+// spawnSync to look like a hang. The evidence is already flushed, so exit
+// explicitly rather than waiting for the event loop to drain.
+process.exit(0);


### PR DESCRIPTION
Fixes #17363

## Summary

Focused repair of the cloud-app inventory routing and delivery contract introduced by #17330:

- **Routing (core `direct-action-heuristics.ts`)** — the deterministic `LIST_CLOUD_APPS` candidate is now offered only for a **single-clause, explicitly cloud-qualified inventory read**. Lifecycle/mutation vocabulary (launch/open/start/stop, delete/remove, create/build/deploy, settings/configure, rollback/withdraw/regenerate/rotate/monetize/domain/backup) and compound/multi-tool turns (`;`, `.`, `then`, `and also <verb>` …) yield **no** app candidate, keeping arbitration with the full planner.
- **No silent degrade** — a cloud-qualified ask never falls back to the local-device `APP` action when no cloud-apps action is registered (previously "list my cloud apps" answered with the installed-app list).
- **Alias ownership (`plugin-cloud-apps`)** — removed the generic `MY_APPS`, `GET_APPS`, `WHAT_APPS_DO_I_HAVE`, `MY_SITES` similes; every remaining alias carries an explicit cloud/deployed/hosted qualifier. Description/routingHint updated so generic "what apps do I have" stays local-device inventory.
- **Single canonical delivery** — the no-key, API-error, and empty-inventory exits now stamp `verifiedUserFacing: true` + `turnComplete: true` (alongside the existing populated path), so with a callback the core gated evaluator suppresses the paraphrased second reply, and without a callback `userFacingText` carries the one canonical message. `success: false` is preserved on the handled failures; the core terminal-failure gate (`tryGateVerifiedFailure` in `planner-loop.ts`, already on develop) ends the turn while keeping the failure truthful, and its single-tool/drained-queue preconditions mean queued or multi-tool turns are never truncated.
- **Scenario** — `cloud-apps-read-core` now asks the unambiguous "what apps do I have on eliza cloud?" so the ambiguous phrase remains local-device inventory after the ownership split.

Note: the acceptance criterion "a sole complete/verified handled failure may terminal-gate while preserving `success: false`" was already implemented on develop in core (`tryGateVerifiedFailure` with multi-tool truncation guards and regression coverage); this PR wires the cloud-apps action into that contract rather than re-implementing it.

## Verification

- `packages/core`: `direct-action-heuristics.test.ts` — 89 pass (new fences: lifecycle/mutation exclusion, compound-turn exclusion, no-degrade-to-local), typecheck clean.
- `plugins/plugin-cloud-apps`: full suite 364 pass, typecheck clean (new assertions: verified-terminal stamps on empty/no-key/error, no-callback delivery via `userFacingText`, cloud-qualified-only similes).
- Biome clean on all touched files.

## Live trajectory

A live model + real Cloud inventory trajectory requires a live `ELIZAOS_CLOUD_API_KEY`, which this environment does not have. Run the documented scenario with a key and attach the report before merge if required:

```
ELIZAOS_CLOUD_API_KEY=eliza_... bun packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios --scenario cloud-apps-read-core --report /tmp/cloud-apps.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)