### PR TITLE
fix(core): multilingual completed-side-effect claim tiers (#17027 AC7)

### DIFF
--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -1261,3 +1261,131 @@ describe("subjectless past-participle openers (Discord group-surface fabrication
 		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
 	});
 });
+
+describe("multilingual completed-side-effect claim tiers (#17027 AC7)", () => {
+	// Fabricated confirmations per locale MUST fire: a reply asserting a
+	// finished save/schedule with zero tool calls is the exact invariant the
+	// receipt gate protects, regardless of language.
+	it.each([
+		// es — perfective, preterite, state, opener
+		"He guardado tu recordatorio para mañana a las 9.",
+		"Ya he creado la tarea de entrenamiento.",
+		"Acabo de programar el recordatorio.",
+		"Guardé la nota en tu calendario.",
+		"Tu recordatorio está programado para las 9.",
+		"Listo — tu recordatorio queda guardado.",
+		// pt — preterite, acabei de, state, opener
+		"Criei o lembrete para amanhã às 9.",
+		"Já salvei a sua tarefa.",
+		"Acabei de agendar o lembrete.",
+		"Seu lembrete está salvo.",
+		"Pronto — o lembrete foi criado.",
+		// ko — past, passive, headline
+		"알림을 설정했어요.",
+		"리마인더를 저장했습니다.",
+		"일정이 등록되었습니다.",
+		"메모 저장 완료!",
+		"알림을 예약해 뒀어요.",
+		// tl — completed aspect
+		"Naitakda ko na ang paalala mo para bukas.",
+		"Nai-save ko na ang tala.",
+		"Nakatakda na ang paalala mo.",
+		"Idinagdag ko na sa iskedyul mo.",
+		// vi — perfective đã / xong, incl. the "nhắc nhở" noun the ASCII \b
+		// boundary silently killed in the first attempt (#19824)
+		"Mình đã đặt lời nhắc lúc 9 giờ sáng.",
+		"Đã lưu nhắc nhở của bạn.",
+		"Nhắc nhở đã được lưu.",
+		"Mình đã giúp bạn tạo nhắc nhở tập luyện.",
+		"Lưu xong rồi, ghi chú của bạn đã có trong lịch.",
+		// zh-CN — 了 perfective, 已 perfective, passive
+		"我已经把提醒设置好了。",
+		"提醒已保存。",
+		"我帮你把任务添加了。",
+		"好了，提醒已经安排在明天早上九点。",
+	])("flags %p as a fabricated completion claim", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
+	});
+
+	// Denials, negations, and not-yet statements must NOT fire.
+	it.each([
+		"No he guardado el recordatorio todavía.",
+		"Todavía no lo he programado.",
+		"Não salvei o lembrete ainda.",
+		"Ainda não criei a tarefa.",
+		"알림을 저장 안 했어요.",
+		"알림을 설정하지 않았어요.",
+		"Hindi ko pa nai-save ang paalala.",
+		"Mình chưa đặt lời nhắc.",
+		"Mình chưa lưu xong ghi chú.",
+		"我还没设置提醒。",
+		"我没有把任务保存下来。",
+	])("passes denial/negation %p through", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	// Offers and questions — including full-width terminators and
+	// particle-final questions with no question mark — must NOT fire.
+	it.each([
+		"¿Quieres que guarde el recordatorio?",
+		"¿Guardé bien tu recordatorio?",
+		"Quer que eu salve o lembrete?",
+		"알림을 설정했어요?",
+		"알림을 저장할까요?",
+		"Gusto mo bang i-save ko ang paalala?",
+		"Naitakda ko ba ang paalala?",
+		"Bạn có muốn mình đặt lời nhắc không?",
+		"Bạn đã lưu lời nhắc chưa?",
+		// zh noun-plus-question-particle offers, the second #19824 killer:
+		// no ？ at all, question is carried by the particle alone
+		"要我把提醒设置好吗",
+		"需要我帮你把任务添加了吗",
+		"我把提醒设置好了吗？",
+		"提醒设置好了吧？",
+	])("passes offer/question %p through", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	// Future intent, conditionals, and instructions are plans, not reports.
+	it.each([
+		"Cuando haya guardado el recordatorio te aviso.",
+		"Si guardo la nota, te lo confirmo.",
+		"Se você quiser, eu salvo o lembrete.",
+		"알림을 저장할게요.",
+		"지금 알림을 설정하겠습니다.",
+		"Ise-save ko ang paalala mamaya.",
+		"Kung gusto mo, itatakda ko ang paalala.",
+		"Mình sẽ đặt lời nhắc ngay bây giờ.",
+		"Nếu bạn muốn, mình đặt lời nhắc lúc 9 giờ.",
+		"如果你想，我可以把提醒设置好。",
+		"我会帮你把任务安排好的。",
+	])("passes future/conditional %p through", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	// Descriptions of the USER's own actions or of existing state are not
+	// agent completion claims.
+	it.each([
+		"Bạn đã đặt lời nhắc lúc 9 giờ rồi mà.",
+		"你已经把提醒设置好了，不用再设一次。",
+		"Na-save mo na ang paalala kahapon.",
+		"Tus recordatorios están en la aplicación.",
+		"Os lembretes ficam na agenda do aplicativo.",
+		"알림은 설정에서 변경할 수 있어요.",
+		"你可以在日历里保存任务。",
+	])("passes second-person/state description %p through", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	// Ordinary uses of save/set vocabulary with no tracked-work noun in the
+	// claiming sentence must pass (noun gate).
+	it.each([
+		"He guardado un buen recuerdo de ese viaje.",
+		"Salvei o melhor para o final.",
+		"저는 그 말을 기억했어요.",
+		"我把话说完了。",
+		"Đã lưu ý đến điều đó.",
+	])("passes tracked-noun-free sentence %p through", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+});

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -208,8 +208,10 @@ const LOCALE_SIDE_EFFECT_CLAIM_SHAPES: readonly LocaleSideEffectClaimShapes[] =
 				/(?<![\p{L}])acab(?:o|amos)\s+de\s+(?:crear|guardar|programar|añadir|agregar|configurar|actualizar|eliminar|borrar|cancelar|apuntar|anotar|registrar|agendar)/giu,
 				// First-person preterite is unambiguous by conjugation: "guardé", "programé"
 				/(?<![\p{L}])(?:guardé|creé|programé|agregué|añadí|configuré|actualicé|eliminé|borré|cancelé|anoté|registré|agendé|apunté)(?![\p{L}])/giu,
-				// "tu recordatorio está programado", "queda guardado", "está listo"
-				/(?<![\p{L}])(?:est[áa]n?|queda(?:n|ron)?|qued[óo])\s+(?:ya\s+)?(?:guardad|programad|cread|configurad|agendad|anotad|registrad|list)[oa]s?(?![\p{L}])/giu,
+				// "tu recordatorio está programado", "queda guardado". Vague
+				// readiness ("quedó listo", like English "is ready") is left to
+				// the model's semantic replyEffectStatus classification.
+				/(?<![\p{L}])(?:est[áa]n?|queda(?:n|ron)?|qued[óo])\s+(?:ya\s+)?(?:guardad|programad|cread|configurad|agendad|anotad|registrad)[oa]s?(?![\p{L}])/giu,
 				// Participle-first openers: "Listo —", "Guardado."
 				/(?:^|[.!?。！？\n]\s*)(?:listo|hecho|guardado|creado|agendado|programado|añadido|agregado)\s*[.!…—–:-]/giu,
 			],

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -12,6 +12,17 @@
  * fire; consent-seeking offers, questions, and conditionals must pass
  * through untouched (a rewritten offer forces an unwanted planner run — the
  * user asked a question and got an action).
+ *
+ * Coverage is tiered by locale: the English shapes below, plus per-locale
+ * claim tiers for the shipped keyword locales (es, ko, pt, tl, vi, zh-CN).
+ * Each locale tier gates on that locale's tracked-work nouns inside the
+ * containing sentence, matches only perfective/completed verb shapes, and
+ * excludes negation/subordination leads, second-person descriptions, and
+ * question sentences — including full-width terminators and particle-final
+ * questions (吗/吧/呢, -까요, …không) that carry no question mark. None of
+ * these patterns use `\b`, which is ASCII-only and silently dead against
+ * letters like the Vietnamese "nhắc nhở" — boundaries are Unicode
+ * lookarounds instead (#17027 AC7).
  */
 
 // Perfective first-person claims ("I've set…", "I have scheduled…", "I just
@@ -163,10 +174,193 @@ const SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN =
 const NOUN_FIRST_SIDE_EFFECT_CLAIM_PATTERN =
 	/(?:^|[.!?]\s+)(?:todos?|to[- ]dos?|notes?|reminders?|alarms?|tasks?|events?|appointments?|goals?|habits?)\s+(?:added|created|saved|scheduled|booked|logged|deleted|removed|renamed|cancell?ed|set|updated)\s*(?::|[.!…]|$)/gi;
 
+/**
+ * One locale's fabricated-completion claim tier. `claims` are the
+ * perfective/completed assertion shapes (global regexes); a match counts only
+ * when the containing sentence also names a `subjectNoun`, is not a question
+ * (terminator, embedded `? ？ ¿`, or `questionTail` particle), and the
+ * sentence prefix before the match does not end in a `nonAssertiveLead`
+ * (negation, subordination, second-person subject, or offer scaffolding).
+ */
+interface LocaleSideEffectClaimShapes {
+	readonly locale: string;
+	readonly subjectNoun: RegExp;
+	readonly claims: readonly RegExp[];
+	readonly nonAssertiveLead: RegExp;
+	readonly questionTail?: RegExp;
+}
+
+// Sentence terminators across the shipped locales: ASCII plus the full-width
+// CJK set. Commas (including 、，) deliberately do NOT split — the noun gate
+// should see the whole clause chain ("好了，提醒已保存。").
+const MULTILINGUAL_SENTENCE_TERMINATOR = /[.!?。！？\n]/u;
+
+const LOCALE_SIDE_EFFECT_CLAIM_SHAPES: readonly LocaleSideEffectClaimShapes[] =
+	[
+		{
+			locale: "es",
+			subjectNoun:
+				/(?<![\p{L}])(?:recordatorios?|alarmas?|tareas?|citas?|calendario|rutinas?|h[áa]bitos?|metas?|objetivos?|notas?|apuntes?|pendientes?|seguimientos?|agenda|eventos?)(?![\p{L}])/iu,
+			claims: [
+				// "he guardado", "ya he creado", "te he programado"
+				/(?<![\p{L}])(?:ya\s+)?(?:he|hemos)\s+(?:cread|guardad|programad|añadid|agregad|configurad|actualizad|eliminad|borrad|cancelad|apuntad|anotad|registrad|agendad)o/giu,
+				// "acabo de crear un recordatorio"
+				/(?<![\p{L}])acab(?:o|amos)\s+de\s+(?:crear|guardar|programar|añadir|agregar|configurar|actualizar|eliminar|borrar|cancelar|apuntar|anotar|registrar|agendar)/giu,
+				// First-person preterite is unambiguous by conjugation: "guardé", "programé"
+				/(?<![\p{L}])(?:guardé|creé|programé|agregué|añadí|configuré|actualicé|eliminé|borré|cancelé|anoté|registré|agendé|apunté)(?![\p{L}])/giu,
+				// "tu recordatorio está programado", "queda guardado", "está listo"
+				/(?<![\p{L}])(?:est[áa]n?|queda(?:n|ron)?|qued[óo])\s+(?:ya\s+)?(?:guardad|programad|cread|configurad|agendad|anotad|registrad|list)[oa]s?(?![\p{L}])/giu,
+				// Participle-first openers: "Listo —", "Guardado."
+				/(?:^|[.!?。！？\n]\s*)(?:listo|hecho|guardado|creado|agendado|programado|añadido|agregado)\s*[.!…—–:-]/giu,
+			],
+			nonAssertiveLead:
+				/(?:(?<![\p{L}])(?:no|nunca|jamás|todav[íi]a\s+no|a[úu]n\s+no)\s+(?:(?:lo|la|los|las|le|les|te|me|se)\s+)?|(?:^|[,;—–-]\s*)(?:si|cuando|una\s+vez\s+que|en\s+cuanto|apenas|antes\s+de\s+que|mientras)\s+[^.!?\n]*)$/iu,
+		},
+		{
+			locale: "pt",
+			subjectNoun:
+				/(?<![\p{L}])(?:lembretes?|alarmes?|tarefas?|compromissos?|agenda|calend[áa]rio|rotinas?|h[áa]bitos?|metas?|objetivos?|notas?|anota[çc](?:[ãa]o|[õo]es)|pend[êe]ncias?|eventos?)(?![\p{L}])/iu,
+			claims: [
+				// First-person preterite: "criei", "já salvei", "agendei"
+				/(?<![\p{L}])(?:j[áa]\s+)?(?:criei|salvei|guardei|agendei|adicionei|configurei|atualizei|apaguei|removi|cancelei|registrei|anotei|marquei)(?![\p{L}])/giu,
+				// "acabei de criar o lembrete"
+				/(?<![\p{L}])acabei\s+de\s+(?:criar|salvar|guardar|agendar|adicionar|configurar|atualizar|apagar|remover|cancelar|registrar|anotar|marcar)/giu,
+				// "seu lembrete está salvo", "ficou agendado", "foi criado"
+				/(?<![\p{L}])(?:est[áa]|est[ãa]o|ficou|ficaram|foi|foram)\s+(?:j[áa]\s+)?(?:salv|guardad|agendad|criad|configurad|registrad|anotad|marcad|atualizad)[oa]s?(?![\p{L}])/giu,
+				// "Pronto —", "Feito.", "Salvo!"
+				/(?:^|[.!?。！？\n]\s*)(?:pronto|feito|salvo|criado|agendado|adicionado)\s*[.!…—–:-]/giu,
+			],
+			nonAssertiveLead:
+				/(?:(?<![\p{L}])(?:n[ãa]o|nunca|jamais|ainda\s+n[ãa]o)\s+(?:(?:o|a|os|as|lhe|lhes|te|me|se)\s+)?|(?:^|[,;—–-]\s*)(?:se|quando|assim\s+que|antes\s+de|depois\s+que|caso)\s+[^.!?\n]*)$/iu,
+		},
+		{
+			locale: "ko",
+			subjectNoun:
+				/(?:알림|리마인더|일정|할\s?일|습관|목표|메모|노트|루틴|캘린더|미리\s?알림|예약|과제|체크인)/u,
+			claims: [
+				// "저장했어요", "알림을 설정했습니다", "등록해 뒀어요", "저장되었습니다".
+				// Adjacency is the negation guard: "저장 안 했어요" and future
+				// volitionals ("저장할게요") never form 저장했/저장됐.
+				/(?:저장|설정|추가|등록|예약|생성|기록|변경|수정|삭제|취소)(?:을|를)?\s*(?:완료했|했|해\s?두었|해\s?뒀|해\s?놓았|해\s?놨|되었|됐)/gu,
+				// Headline noun form: "저장 완료!"
+				/(?:저장|설정|추가|등록|예약|생성|기록)\s*완료/gu,
+			],
+			nonAssertiveLead: /(?:안|못)\s*$/u,
+			questionTail: /(?:까요|나요|가요|을까)$/u,
+		},
+		{
+			locale: "tl",
+			subjectNoun:
+				/(?<![\p{L}])(?:paalala|alarma|gawain|iskedyul|tala|layunin|rutina|kalendaryo|appointment|tasks?|reminders?|notes?|habits?|goals?|todos?)(?![\p{L}])/iu,
+			claims: [
+				// Completed-aspect verb forms: "Naitakda ko na", "Nai-save",
+				// "nakatakda na ang paalala". A following second-person/third-person
+				// pronoun ("Na-save mo…") describes the USER's action, not the
+				// agent's, and is excluded. Contemplated-aspect forms (reduplicated
+				// "Ise-save", "Itatakda") are deliberately absent.
+				/(?<![\p{L}-])(?:naitakda|naidagdag|nailagay|naitala|itinakda|idinagdag|inilagay|kinansela|tinanggal|inalis|nai-?saved?|na-?saved?|na-?set|naka-?set|nakatakda|na-?i?-?scheduled?|in-?updated?)(?![\p{L}])(?!\s+(?:mo|niya|nila|ninyo)(?![\p{L}]))/giu,
+				/(?<![\p{L}])ginawa\s+ko\s+na(?![\p{L}])/giu,
+			],
+			nonAssertiveLead:
+				/(?:(?<![\p{L}])(?:hindi|di)(?:\s+ko)?(?:\s+pa)?\s+|(?:^|[,;]\s*)(?:kung|kapag|bago|pagkatapos|para)\s+[^.!?\n]*)$/iu,
+			questionTail: /\sba$/iu,
+		},
+		{
+			locale: "vi",
+			subjectNoun:
+				/(?:lời\s+nhắc|nhắc\s+nhở|báo\s+thức|công\s+việc|lịch\s+hẹn|lịch|ghi\s+chú|thói\s+quen|mục\s+tiêu|việc\s+cần\s+làm|nhiệm\s+vụ|sự\s+kiện|cuộc\s+hẹn)/iu,
+			claims: [
+				// Perfective "đã/vừa" + verb: "Mình đã đặt lời nhắc", "đã được lưu",
+				// "đã giúp bạn tạo nhắc nhở"
+				/(?:đã|vừa(?:\s+mới)?)\s+(?:được\s+|giúp\s+bạn\s+)?(?:đặt|lưu|tạo|thêm|lên\s+lịch|đặt\s+lịch|ghi(?:\s+lại)?|xóa|xoá|hủy|huỷ|cập\s+nhật|sửa|chỉnh)/giu,
+				// verb + "xong (rồi)": "lưu xong rồi"
+				/(?:đặt|lưu|tạo|thêm|ghi|xóa|xoá|hủy|huỷ|cập\s+nhật)\s+xong(?:\s+rồi)?/giu,
+				// "Xong rồi —" opener (noun gate still applies to the sentence)
+				/(?:^|[.!?。！？\n]\s*)(?:xong\s+rồi|đã\s+xong)\s*[.!…—–,:-]/giu,
+			],
+			// "chưa/không" negate; "sẽ/định/sắp" are future intent; a directly
+			// preceding second-person pronoun describes the user's own action.
+			nonAssertiveLead:
+				/(?:(?:chưa|không|sẽ|định|sắp|muốn|nên|hãy|bạn|anh|chị|em|cậu)\s+|(?:^|[,;]\s*)(?:nếu|khi|trước\s+khi|giả\s+sử)\s+[^.!?\n]*)$/iu,
+			questionTail: /(?:không|chưa|hả|à|phải\s+không)$/iu,
+		},
+		{
+			locale: "zh-CN",
+			subjectNoun:
+				/(?:提醒|闹钟|任务|日程|待办|备忘|笔记|习惯|目标|日历|打卡|事项|清单|例行)/u,
+			claims: [
+				// Perfective 了: "设置好了", "保存了", "已经…添加完了"
+				/(?:设置|设定|保存|创建|添加|新建|安排|预约|记录|删除|取消|更新|修改)(?:好|完)?了/gu,
+				// Perfective 已/已经 (covers passives: "提醒已保存")
+				/已经?(?:为你|帮你|给你|被)?(?:设置|设定|保存|创建|添加|新建|安排|预约|记录|删除|取消|更新|修改)/gu,
+			],
+			// Negation/modality directly before the verb phrase; a sentence whose
+			// subject is 你/您 with no 我 describes the USER's action ("你已经把提醒
+			// 设置好了"), not the agent's — the tempered [^我] scan keeps "你好，我已
+			// 经…" assertive.
+			nonAssertiveLead:
+				/(?:(?:没|没有|还没|尚未|未|不会|无法|不能|别|不用|无需)\s*|^(?:你|您)(?:(?!我)[^。！？!?\n])*|(?:^|[，,；;]\s*)(?:如果|要是|假如|万一|一旦)(?:(?!。)[^。！？!?\n])*)$/u,
+			questionTail: /(?:吗|吧|呢|么)$/u,
+		},
+	];
+
+function localeClauseAround(
+	text: string,
+	index: number,
+): { sentence: string; start: number; terminator: string } {
+	let start = index;
+	while (
+		start > 0 &&
+		!MULTILINGUAL_SENTENCE_TERMINATOR.test(text[start - 1] ?? "")
+	) {
+		start -= 1;
+	}
+	let end = index;
+	while (
+		end < text.length &&
+		!MULTILINGUAL_SENTENCE_TERMINATOR.test(text[end] ?? "")
+	) {
+		end += 1;
+	}
+	return {
+		sentence: text.slice(start, end),
+		start,
+		terminator: text[end] ?? "",
+	};
+}
+
+function localeReplyClaimsCompletedSideEffect(text: string): boolean {
+	for (const shapes of LOCALE_SIDE_EFFECT_CLAIM_SHAPES) {
+		if (!shapes.subjectNoun.test(text)) continue;
+		for (const claim of shapes.claims) {
+			for (const match of text.matchAll(claim)) {
+				const firstWordOffset = match[0].search(/[\p{L}\p{N}]/u);
+				const claimIndex =
+					(match.index ?? 0) + (firstWordOffset >= 0 ? firstWordOffset : 0);
+				const { sentence, start, terminator } = localeClauseAround(
+					text,
+					claimIndex,
+				);
+				if (!shapes.subjectNoun.test(sentence)) continue;
+				if (terminator === "?" || terminator === "？") continue;
+				if (/[?？¿]/u.test(sentence)) continue;
+				if (shapes.questionTail?.test(sentence.trim())) continue;
+				if (shapes.nonAssertiveLead.test(text.slice(start, claimIndex))) {
+					continue;
+				}
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	const text = reply.trim();
 	if (!text) return false;
-	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) return false;
+	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) {
+		return localeReplyClaimsCompletedSideEffect(text);
+	}
 	if (stateSideEffectClaimHasLocalSubject(text)) return true;
 	for (const match of text.matchAll(
 		SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN,
@@ -191,7 +385,9 @@ export function replyClaimsCompletedSideEffect(reply: string): boolean {
 		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
 		return true;
 	}
-	return false;
+	// English nouns can co-occur with non-English claim grammar (loanword
+	// nouns in Tagalog, code-switched replies) — always try the locale tiers.
+	return localeReplyClaimsCompletedSideEffect(text);
 }
 
 // Read-side twin of the completed-side-effect patterns above: assertions that


### PR DESCRIPTION
Fixes #17027

## Summary

The receipt-based structural core of #17027 (EffectReceipt contract, planner-final REPLY gate, send-boundary receipt binding, PA lifeops receipts) and the AC6 per-kind failure classification are already on `develop`. The remaining codeable residual was **AC7 multilingual claim coverage**: `replyClaimsCompletedSideEffect` — the defense-in-depth wording detector consumed by the Stage-1 evaluator, the planner REPLY gate, and the planned-reply egress guard — only understood English, so a fabricated "저장했어요." / "提醒已保存。" / "Đã lưu nhắc nhở của bạn." confirmation never tripped the wording tier. The prior attempt (#19824) was closed for concrete defects: a dead Vietnamese `nhắc nhở` noun gate and misclassified Chinese noun-plus-question-particle offers.

This PR adds per-locale claim tiers for the shipped keyword locales (**es, ko, pt, tl, vi, zh-CN**) in `packages/core/src/services/message/side-effect-claims.ts`:

- **Noun gating per sentence** — a claim only counts when its containing sentence (multilingual terminators `。！？` included) names a tracked-work noun in that locale.
- **Perfective-only verb shapes** — Spanish/Portuguese perfect + unambiguous first-person preterite + state participles + participle-first openers; Korean 했/됐/되었/해 뒀/완료 adjacency (future volitionals `-할게요`, `-하겠습니다` and detached negation `안 했` structurally cannot match); Tagalog completed-aspect forms only (contemplated `Ise-save`/`Itatakda` excluded); Vietnamese `đã/vừa` + verb and verb + `xong`; Chinese perfective `了`/`已(经)` (bare `设置好` without `了` never matches).
- **Negation/subordination leads** — `no/não/todavía no`, `chưa/không`, `hindi ko pa`, `没/还没/尚未`, conditional leads (`si/se/cuando/nếu/kung/如果…`).
- **Second-person exclusions** — `Bạn đã đặt…`, `你已经把提醒设置好了`, `Na-save mo…` describe the user's own action, not agent work (tempered `你…$` scan keeps `你好，我已经…` assertive; `帮你/给你/为你` still fire).
- **Question gating without a question mark** — full-width `？`, inverted `¿`, and particle-final questions: zh `吗/吧/呢/么`, ko `-까요/-나요`, vi `…không/chưa/hả`, tl sentence-final `ba`. This fixes the #19824 Chinese misclassification (`要我把提醒设置好吗` and `需要我帮你把任务添加了吗` pass through).
- **No ASCII `\b` anywhere** — boundaries are Unicode lookarounds (`(?<![\p{L}])`), fixing the #19824 dead `nhắc nhở` gate (`\b` after a Vietnamese diacritic letter never matches).

English behavior is unchanged except that replies whose only English content is a loanword noun now fall through to the locale tiers instead of returning early.

## Tests

`packages/core/src/services/message.side-effect-claim.test.ts` gains a `multilingual completed-side-effect claim tiers (#17027 AC7)` block: 76 cases — 29 fabricated confirmations across all six locales that must fire (including the two #19824 killer shapes), and 47 pass-through cases covering denials/negations, offers/questions (particle-final, no `?`), future/conditional intent, second-person and existing-state descriptions, and tracked-noun-free ordinary vocabulary.

- Direct execution of all 76 cases against the leaf module: **ALL OK**
- `bun run --cwd packages/core typecheck`: green
- `bunx biome check` on both touched files: green
- Full `message.side-effect-claim.test.ts` vitest suite run in progress in the worktree (fresh worktree needed `bun install` + keyword codegen); CI will run the same lane.

## Remaining human-only residual

The live-LLM transcript evidence rows (AC8 / Definition of Done) require live-model trajectories on the claimed lane (`claimed:shaw-codex`) and are documented on the issue; they are not codeable in this deterministic lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
