### PR TITLE
fix(ui): time out hung Cloud SIWE nonce and verify fetches

### DIFF
--- a/packages/ui/src/state/cloud-siwe-login.test.ts
+++ b/packages/ui/src/state/cloud-siwe-login.test.ts
@@ -689,4 +689,48 @@ describe("SIWE chain binding (#18458)", () => {
     ).rejects.toThrow(/kept switching chains/);
     expect(window.localStorage.getItem("steward_session_token")).toBeNull();
   });
+
+  it("fails closed on a hung SIWE verify hop instead of waiting forever", async () => {
+    window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
+    await installE2eWalletIfRequested();
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+      const controller = new AbortController();
+      setTimeout(() => {
+        controller.abort(
+          Object.assign(new Error("The operation was aborted due to timeout"), {
+            name: "TimeoutError",
+          }),
+        );
+      }, 50);
+      return controller.signal;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/auth/siwe/nonce")) {
+          return new Response(JSON.stringify(NONCE_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) return;
+          const abort = () => reject(signal.reason);
+          if (signal.aborted) {
+            abort();
+            return;
+          }
+          signal.addEventListener("abort", abort, { once: true });
+        });
+      }),
+    );
+    const started = Date.now();
+    await expect(
+      siweLoginWithInjectedWallet("https://api.test/"),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(window.localStorage.getItem("steward_session_token")).toBeNull();
+  });
 });

--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -23,6 +23,8 @@
  * `chainId` to the nonce, and re-read immediately before the signature so a
  * mid-prompt chain switch is detected and the handshake rebuilds or fails
  * closed — never signing a stale mainnet (1) default for a Base/BSC wallet.
+ * Nonce and verify hops honor `SIWE_FETCH_TIMEOUT_MS` so a hung Cloud auth
+ * API cannot stall app SIWE login.
  */
 import { logger } from "@elizaos/logger";
 import { writeStoredStewardToken } from "@elizaos/shared/steward-session-client";
@@ -163,6 +165,8 @@ async function readBody(res: Response): Promise<string> {
 }
 
 /** Bounded pre-signature nonce attempts before surfacing the failure. */
+/** Bound for Cloud SIWE nonce/verify so app login cannot hang forever. */
+export const SIWE_FETCH_TIMEOUT_MS = 15_000;
 const NONCE_MAX_ATTEMPTS = 3;
 /** Backoff between nonce attempts: 500ms then 1000ms (1.5s total worst case). */
 const NONCE_RETRY_BASE_DELAY_MS = 500;
@@ -195,6 +199,7 @@ async function fetchSiweNonce(
     try {
       nonceRes = await fetch(nonceUrl, {
         headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(SIWE_FETCH_TIMEOUT_MS),
       });
     } catch (error) {
       // Transport failure (offline, DNS, TLS, aborted): transient, retry.
@@ -352,6 +357,7 @@ export async function siweLoginWithInjectedWallet(
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ message, signature }),
+    signal: AbortSignal.timeout(SIWE_FETCH_TIMEOUT_MS),
   });
   if (!verifyRes.ok) {
     throw new Error(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22912.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

Closes #22912.


## Problem

App SIWE login fetches Cloud nonce and verify with **no `signal`**. A hung auth API stalls injected-wallet sign-in.

On Node 24.15.0 against an accept-and-hold TCP listener the untimed `fetch` shape stays pending at ~818 ms while `AbortSignal.timeout(800)` rejects TimeoutError.

Product path: app SIWE. Not leftover-tax. Not extra-decode. Not native-UI `*-fetch-timeout`. Not a walk-twin of `#22812` / `#22821` / `#22826` / `#22836`. Not a twin of `#22895` (homepage SIWS) or `#22857` / `#22861` / `#22865` / `#22868` / `#22892` / `#22905` / `#22908`.

## Change

- Nonce and verify use `AbortSignal.timeout(15_000)`.
- Hung verify fails closed with `TimeoutError` and does not store a session.
- Honest recoverable-signature handshake unchanged.

## Exact-head evidence

Evidence revision: `6b4567da8d87e213498f87958f0231a73d5d4f0d`, based on `develop` `e8bfd8830e51b2bfb40bc214e8544c2549553985`.

- Pinned Bun 1.3.14 `packages/ui/src/state/cloud-siwe-login.test.ts`: **29/29 passed**.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate


- [x] N/A - SIWE HTTP client; no rendered output in this unit.

- [x] N/A - SIWE HTTP client; no rendered output in this unit.

- [x] N/A - no rendered user flow.

- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

- [x] N/A - unit uses mocked fetch, not a browser console.

- [x] N/A - no model, prompt, planner, or action behavior changed.

- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 6b4567da8d87</summary>

```
# domain artifact — app SIWE hung nonce/verify
exact-head: 6b4567da8d87e213498f87958f0231a73d5d4f0d
based-on: origin/develop e8bfd8830e51b2bfb40bc214e8544c2549553985

Pinned Bun 1.3.14 at this exact head:
  bunx vitest run packages/ui/src/state/cloud-siwe-login.test.ts: 29/29 passed

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~818 ms
  AbortSignal.timeout(800): TimeoutError ~805 ms
```

</details>

- [x] N/A - no rendered pixels.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:6b4567da8d87e213498f87958f0231a73d5d4f0d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - SIWE HTTP client; no rendered output in this unit.

<!-- evidence-row:after-screenshots -->
- [x] N/A - SIWE HTTP client; no rendered output in this unit.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.

<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - unit uses mocked fetch, not a browser console.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 6b4567da8d87</summary>

```
# domain artifact — app SIWE hung nonce/verify
exact-head: 6b4567da8d87e213498f87958f0231a73d5d4f0d
based-on: origin/develop e8bfd8830e51b2bfb40bc214e8544c2549553985

Pinned Bun 1.3.14 at this exact head:
  bunx vitest run packages/ui/src/state/cloud-siwe-login.test.ts: 29/29 passed

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~818 ms
  AbortSignal.timeout(800): TimeoutError ~805 ms
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
