### PR TITLE
fix(cloud): fail closed on miswired webhook gateway bindings at deploy

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -691,11 +691,36 @@ jobs:
           fi
           echo "Staging session exchange is off before config validation or deploy ($result)."
 
+      # Installed in THIS job (not inherited from migrate-db, a separate
+      # runner instance) so verify_webhook_gateway_binding_candidates below
+      # can fetch the live gateway secret's value from Railway and prove it
+      # still matches the Worker's queued value — closing the "same name,
+      # different value" gap a names-only wrangler inventory cannot see.
+      # Pinned to the exact version migrate-db already proved compatible.
+      - name: Install pinned Railway CLI for webhook gateway value match
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli-deploy-api"
+          archive="$RUNNER_TEMP/railway-v5.38.0-deploy-api.tar.gz"
+          mkdir -p "$cli_root"
+          curl --fail --silent --show-error --location --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
       - name: Prepare Worker secrets for atomic deploy
         id: worker-secrets
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
           HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
@@ -1088,9 +1113,41 @@ jobs:
             fi
             local secret_inventory
             secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
-            printf '%s' "$secret_inventory" | node \
+
+            # Names-only wiring (above/below) proves a binding NAME exists or
+            # is queued; it cannot prove the VALUE still matches the live
+            # gateway's. Fetch that live value from Railway — the same
+            # trusted source deploy-gateway-webhook.yml already reads for its
+            # analogous Blooio value-match — and hand it to the node script
+            # purely through this one subshell's environment. It is never
+            # exported into the step's persistent shell state, assigned to a
+            # variable outside this function, or passed to any command that
+            # could echo it (no `set -x`, no `jq` on the raw value, no
+            # temp file). A failed or empty fetch resolves to an empty
+            # string, and the node script fails closed on that: a missing
+            # gateway-side proof is a mismatch, never a silent pass.
+            local railway_gateway_secret_inventory=""
+            local railway_gateway_secret_value=""
+            if railway_gateway_secret_inventory="$(railway variable list \
+                --project "$RAILWAY_PROJECT_ID" \
+                --environment "$RAILWAY_ENVIRONMENT_ID" \
+                --service "$RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK" \
+                --json 2>/dev/null)"; then
+              railway_gateway_secret_value="$(printf '%s' "$railway_gateway_secret_inventory" | jq -r \
+                'if (.ELIZA_APP_WEBHOOK_GATEWAY_SECRET | type) == "string" then .ELIZA_APP_WEBHOOK_GATEWAY_SECRET else "" end')"
+            else
+              echo "::warning::Could not fetch the live gateway's ELIZA_APP_WEBHOOK_GATEWAY_SECRET from Railway; the value-match half of the webhook gateway check will fail closed"
+            fi
+            railway_gateway_secret_inventory=""
+
+            printf '%s' "$secret_inventory" | env \
+              "WEBHOOK_GATEWAY_RAILWAY_SECRET_VALUE=$railway_gateway_secret_value" \
+              node \
               "$CHECKOUT_DIR/packages/cloud/scripts/verify-webhook-gateway-binding.mjs" \
               "${worker_secret_names[@]}"
+            local status=$?
+            railway_gateway_secret_value=""
+            return $status
           }
 
           # Like queue_secret, but for values that act as ROUTING TOGGLES

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1249,7 +1249,9 @@ jobs:
           # on the honest WEBHOOK_GATEWAY_NOT_CONFIGURED 503 (#18235), but a
           # configured URL must point at THIS environment's canonical gateway
           # and carry the paired forwarder secret, or every provider webhook
-          # would fail as a misleading 401/upstream error instead.
+          # would fail as a misleading 401/upstream error instead. This runs
+          # before the atomic Worker secrets version is written; the
+          # unset-toggle deletions in the queue loop above have already run.
           verify_webhook_gateway_binding_candidates || exit 1
 
           # Wrangler deploy accepts this JSON additively: named values are

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1082,6 +1082,17 @@ jobs:
             ' "${worker_secret_names[@]}"
           }
 
+          verify_webhook_gateway_binding_candidates() {
+            if ! has_nonblank_value "$ELIZA_APP_WEBHOOK_GATEWAY_URL"; then
+              return 0
+            fi
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node \
+              "$CHECKOUT_DIR/packages/cloud/scripts/verify-webhook-gateway-binding.mjs" \
+              "${worker_secret_names[@]}"
+          }
+
           # Like queue_secret, but for values that act as ROUTING TOGGLES
           # (code branches on presence, e.g. `env.WHISPER_STT_URL`). An unset
           # source must DELETE any previously published secret. A plain
@@ -1234,6 +1245,12 @@ jobs:
           # same Worker version. A missing value may never deploy as a healthy
           # but permanently unauthorized embeddings path.
           verify_staging_embeddings_secret_candidate || exit 1
+          # The messaging webhook gateway URL is a routing toggle: unset stays
+          # on the honest WEBHOOK_GATEWAY_NOT_CONFIGURED 503 (#18235), but a
+          # configured URL must point at THIS environment's canonical gateway
+          # and carry the paired forwarder secret, or every provider webhook
+          # would fail as a misleading 401/upstream error instead.
+          verify_webhook_gateway_binding_candidates || exit 1
 
           # Wrangler deploy accepts this JSON additively: named values are
           # committed in the same Worker version as the exact source, while

--- a/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
@@ -13,7 +13,9 @@ import { resolve } from "node:path";
 import {
   CANONICAL_WEBHOOK_GATEWAY_URLS,
   parseSecretInventoryNames,
+  saltedSecretDigest,
   verifyWebhookGatewayBinding,
+  verifyWebhookGatewaySecretMatch,
 } from "../verify-webhook-gateway-binding.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "../../../..");
@@ -21,6 +23,25 @@ const repoRoot = resolve(import.meta.dirname, "../../../..");
 function withSecret(names: string[] = []): Set<string> {
   return new Set(["ELIZA_APP_WEBHOOK_GATEWAY_SECRET", ...names]);
 }
+
+// Built from concatenated, unremarkable fragments (never a literal
+// secret-shaped string) so this fixture can never trip gitleaks' full-history
+// scan, which flags high-entropy/prefixed strings regardless of intent.
+const FIXTURE_WORKER_SECRET = [
+  "fixture",
+  "forwarder",
+  "value",
+  "alpha",
+  "7",
+].join("-");
+const FIXTURE_GATEWAY_SECRET_MATCHING = FIXTURE_WORKER_SECRET;
+const FIXTURE_GATEWAY_SECRET_ROTATED = [
+  "fixture",
+  "forwarder",
+  "value",
+  "beta",
+  "9",
+].join("-");
 
 describe("verifyWebhookGatewayBinding", () => {
   test("blank or whitespace URL is the honest not-configured state", () => {
@@ -156,6 +177,98 @@ describe("parseSecretInventoryNames", () => {
   });
 });
 
+describe("saltedSecretDigest", () => {
+  test("the same value under the same salt digests identically", () => {
+    const salt = Buffer.from("fixture-salt-one");
+    expect(saltedSecretDigest(FIXTURE_WORKER_SECRET, salt)).toEqual(
+      saltedSecretDigest(FIXTURE_WORKER_SECRET, salt),
+    );
+  });
+
+  test("different values under the same salt digest differently", () => {
+    const salt = Buffer.from("fixture-salt-one");
+    expect(saltedSecretDigest(FIXTURE_WORKER_SECRET, salt)).not.toEqual(
+      saltedSecretDigest(FIXTURE_GATEWAY_SECRET_ROTATED, salt),
+    );
+  });
+
+  test("the same value under different salts digests differently", () => {
+    expect(
+      saltedSecretDigest(FIXTURE_WORKER_SECRET, Buffer.from("salt-a")),
+    ).not.toEqual(
+      saltedSecretDigest(FIXTURE_WORKER_SECRET, Buffer.from("salt-b")),
+    );
+  });
+
+  test("the digest never contains the source value as a substring", () => {
+    const digest = saltedSecretDigest(
+      FIXTURE_WORKER_SECRET,
+      Buffer.from("fixture-salt-one"),
+    ).toString("hex");
+    expect(digest).not.toContain(FIXTURE_WORKER_SECRET);
+  });
+});
+
+describe("verifyWebhookGatewaySecretMatch", () => {
+  test("matching Worker and gateway values pass", () => {
+    const result = verifyWebhookGatewaySecretMatch({
+      workerSecretValue: FIXTURE_WORKER_SECRET,
+      gatewaySecretValue: FIXTURE_GATEWAY_SECRET_MATCHING,
+    });
+    expect(result).toEqual({ ok: true, error: null });
+  });
+
+  test("a mismatched gateway value fails and names the binding, not the value", () => {
+    const result = verifyWebhookGatewaySecretMatch({
+      workerSecretValue: FIXTURE_WORKER_SECRET,
+      gatewaySecretValue: FIXTURE_GATEWAY_SECRET_ROTATED,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ELIZA_APP_WEBHOOK_GATEWAY_SECRET");
+    expect(result.error).not.toContain(FIXTURE_WORKER_SECRET);
+    expect(result.error).not.toContain(FIXTURE_GATEWAY_SECRET_ROTATED);
+  });
+
+  test("an unreachable/erroring proof source (blank gateway value) fails closed", () => {
+    for (const gatewaySecretValue of ["", "   ", undefined]) {
+      const result = verifyWebhookGatewaySecretMatch({
+        workerSecretValue: FIXTURE_WORKER_SECRET,
+        gatewaySecretValue,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("unreadable, unreachable, or unset");
+    }
+  });
+
+  test("a missing Worker-side candidate fails closed rather than skipping", () => {
+    for (const workerSecretValue of ["", "   ", undefined]) {
+      const result = verifyWebhookGatewaySecretMatch({
+        workerSecretValue,
+        gatewaySecretValue: FIXTURE_GATEWAY_SECRET_MATCHING,
+      });
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  test("no fixture or error output contains a plaintext secret-shaped literal", () => {
+    const outputs = [
+      verifyWebhookGatewaySecretMatch({
+        workerSecretValue: FIXTURE_WORKER_SECRET,
+        gatewaySecretValue: FIXTURE_GATEWAY_SECRET_ROTATED,
+      }).error,
+      verifyWebhookGatewaySecretMatch({
+        workerSecretValue: FIXTURE_WORKER_SECRET,
+        gatewaySecretValue: undefined,
+      }).error,
+    ];
+    for (const output of outputs) {
+      expect(output).not.toContain(FIXTURE_WORKER_SECRET);
+      expect(output).not.toContain(FIXTURE_GATEWAY_SECRET_MATCHING);
+      expect(output).not.toContain(FIXTURE_GATEWAY_SECRET_ROTATED);
+    }
+  });
+});
+
 describe("deploy workflow contract", () => {
   const releaseWorkflow = readFileSync(
     resolve(repoRoot, ".github/workflows/cloud-cf-release.yml"),
@@ -202,5 +315,44 @@ describe("deploy workflow contract", () => {
     const secretsFile = releaseWorkflow.indexOf("worker-secrets-file.mjs");
     expect(call).toBeGreaterThan(-1);
     expect(secretsFile).toBeGreaterThan(call);
+  });
+
+  // The value-match half (#18235 follow-up): a names-only inventory alone
+  // cannot prove the Worker's queued secret still matches the live gateway's,
+  // so the binding check must also fetch a live Railway value and hand it to
+  // the node script before that same call site.
+  test("cloud-cf-release fetches the live gateway secret from Railway before verifying", () => {
+    const fetchCall = releaseWorkflow.indexOf("railway variable list");
+    const railwayInstall = releaseWorkflow.indexOf(
+      "Install pinned Railway CLI for webhook gateway value match",
+    );
+    const bindingCheckDef = releaseWorkflow.indexOf(
+      "verify_webhook_gateway_binding_candidates() {",
+    );
+    const nodeInvocation = releaseWorkflow.indexOf(
+      "WEBHOOK_GATEWAY_RAILWAY_SECRET_VALUE=$railway_gateway_secret_value",
+    );
+    expect(railwayInstall).toBeGreaterThan(-1);
+    expect(fetchCall).toBeGreaterThan(bindingCheckDef);
+    expect(nodeInvocation).toBeGreaterThan(fetchCall);
+  });
+
+  test("cloud-cf-release wires the RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK scope used by the deploy-gateway-webhook value-match precedent", () => {
+    expect(releaseWorkflow).toContain(
+      "RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}",
+    );
+    expect(gatewayWorkflow).toContain("RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK");
+  });
+
+  test("the fetched Railway value is only ever passed as an env assignment, never echoed", () => {
+    const occurrences = releaseWorkflow
+      .split("\n")
+      .filter((line) => line.includes("railway_gateway_secret_value"));
+    for (const line of occurrences) {
+      expect(line).not.toMatch(/^\s*echo\b.*railway_gateway_secret_value/);
+      expect(line).not.toMatch(/::error::.*\$railway_gateway_secret_value/);
+      expect(line).not.toMatch(/::notice::.*\$railway_gateway_secret_value/);
+    }
+    expect(occurrences.length).toBeGreaterThan(0);
   });
 });

--- a/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Locks the messaging webhook gateway deploy contract (#18235): the pure
+ * validation in verify-webhook-gateway-binding.mjs, its canonical
+ * per-environment gateway origins staying byte-identical to the protected
+ * Railway release workflow, and the cloud-cf-release wiring that runs the
+ * check before any Worker mutation. Deterministic — no network, no wrangler.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  CANONICAL_WEBHOOK_GATEWAY_URLS,
+  parseSecretInventoryNames,
+  verifyWebhookGatewayBinding,
+} from "../verify-webhook-gateway-binding.mjs";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+
+function withSecret(names: string[] = []): Set<string> {
+  return new Set(["ELIZA_APP_WEBHOOK_GATEWAY_SECRET", ...names]);
+}
+
+describe("verifyWebhookGatewayBinding", () => {
+  test("blank or whitespace URL is the honest not-configured state", () => {
+    for (const gatewayUrl of ["", "   ", undefined]) {
+      expect(
+        verifyWebhookGatewayBinding({
+          deployEnvironment: "staging",
+          gatewayUrl,
+          availableSecretNames: new Set(),
+        }),
+      ).toEqual({ ok: true, errors: [] });
+    }
+  });
+
+  test("accepts the canonical staging URL with the paired secret", () => {
+    expect(
+      verifyWebhookGatewayBinding({
+        deployEnvironment: "staging",
+        gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+        availableSecretNames: withSecret(),
+      }),
+    ).toEqual({ ok: true, errors: [] });
+  });
+
+  test("accepts the canonical production URL with the paired secret", () => {
+    expect(
+      verifyWebhookGatewayBinding({
+        deployEnvironment: "production",
+        gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.production,
+        availableSecretNames: withSecret(),
+      }),
+    ).toEqual({ ok: true, errors: [] });
+  });
+
+  test("rejects a cross-environment miswire (prod gateway on staging)", () => {
+    const result = verifyWebhookGatewayBinding({
+      deployEnvironment: "staging",
+      gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.production,
+      availableSecretNames: withSecret(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain(
+      CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+    );
+  });
+
+  test("rejects a configured URL without the paired forwarder secret", () => {
+    const result = verifyWebhookGatewayBinding({
+      deployEnvironment: "staging",
+      gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+      availableSecretNames: new Set(["DATABASE_URL"]),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain(
+      "ELIZA_APP_WEBHOOK_GATEWAY_SECRET",
+    );
+  });
+
+  test("a queued (not yet published) secret name satisfies the pairing", () => {
+    expect(
+      verifyWebhookGatewayBinding({
+        deployEnvironment: "production",
+        gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.production,
+        availableSecretNames: withSecret(["OPENAI_API_KEY"]),
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("rejects an environment with no canonical gateway", () => {
+    const result = verifyWebhookGatewayBinding({
+      deployEnvironment: "preview",
+      gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+      availableSecretNames: withSecret(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("preview");
+  });
+
+  test("collects both failures at once", () => {
+    const result = verifyWebhookGatewayBinding({
+      deployEnvironment: "staging",
+      gatewayUrl: "https://gateway-webhook-attacker.example.com",
+      availableSecretNames: new Set(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+});
+
+describe("parseSecretInventoryNames", () => {
+  test("parses a bare array and a {result} wrapper", () => {
+    const entries = JSON.stringify([{ name: "A" }, { name: "B" }]);
+    expect(parseSecretInventoryNames(entries)).toEqual(new Set(["A", "B"]));
+    expect(
+      parseSecretInventoryNames(JSON.stringify({ result: [{ name: "C" }] })),
+    ).toEqual(new Set(["C"]));
+  });
+
+  test("rejects malformed inventories instead of returning empty", () => {
+    expect(() => parseSecretInventoryNames('{"foo":1}')).toThrow(
+      "not an array",
+    );
+    expect(() => parseSecretInventoryNames('[{"name":""}]')).toThrow(
+      "invalid entry",
+    );
+    expect(() => parseSecretInventoryNames("[null]")).toThrow("invalid entry");
+  });
+});
+
+describe("deploy workflow contract", () => {
+  const releaseWorkflow = readFileSync(
+    resolve(repoRoot, ".github/workflows/cloud-cf-release.yml"),
+    "utf8",
+  );
+  const gatewayWorkflow = readFileSync(
+    resolve(repoRoot, ".github/workflows/deploy-gateway-webhook.yml"),
+    "utf8",
+  );
+
+  test("canonical URLs match the protected gateway release workflow", () => {
+    expect(gatewayWorkflow).toContain(
+      `'${CANONICAL_WEBHOOK_GATEWAY_URLS.production}'`,
+    );
+    expect(gatewayWorkflow).toContain(
+      `'${CANONICAL_WEBHOOK_GATEWAY_URLS.staging}'`,
+    );
+  });
+
+  test("cloud-cf-release runs the binding check before Worker mutation", () => {
+    expect(releaseWorkflow).toContain(
+      "verify_webhook_gateway_binding_candidates() {",
+    );
+    expect(releaseWorkflow).toContain("verify-webhook-gateway-binding.mjs");
+    const call = releaseWorkflow.indexOf(
+      "verify_webhook_gateway_binding_candidates || exit 1",
+    );
+    const secretsFile = releaseWorkflow.indexOf("worker-secrets-file.mjs");
+    expect(call).toBeGreaterThan(-1);
+    expect(secretsFile).toBeGreaterThan(call);
+  });
+});

--- a/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts
@@ -3,7 +3,8 @@
  * validation in verify-webhook-gateway-binding.mjs, its canonical
  * per-environment gateway origins staying byte-identical to the protected
  * Railway release workflow, and the cloud-cf-release wiring that runs the
- * check before any Worker mutation. Deterministic — no network, no wrangler.
+ * check before the atomic Worker secrets version is written. Deterministic —
+ * no network, no wrangler.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -98,6 +99,32 @@ describe("verifyWebhookGatewayBinding", () => {
     expect(result.errors.join(" ")).toContain("preview");
   });
 
+  test("an Object.prototype member name is not a canonical environment", () => {
+    for (const deployEnvironment of ["constructor", "toString", "valueOf"]) {
+      const result = verifyWebhookGatewayBinding({
+        deployEnvironment,
+        gatewayUrl: CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+        availableSecretNames: withSecret(),
+      });
+      expect(result.ok).toBe(false);
+      expect(result.errors.join(" ")).toContain(
+        "has no canonical webhook gateway",
+      );
+    }
+  });
+
+  test("the mismatch error echoes the rejected URL for operator diagnosis", () => {
+    const result = verifyWebhookGatewayBinding({
+      deployEnvironment: "staging",
+      gatewayUrl: `${CANONICAL_WEBHOOK_GATEWAY_URLS.staging}/`,
+      availableSecretNames: withSecret(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain(
+      `"${CANONICAL_WEBHOOK_GATEWAY_URLS.staging}/"`,
+    );
+  });
+
   test("collects both failures at once", () => {
     const result = verifyWebhookGatewayBinding({
       deployEnvironment: "staging",
@@ -139,16 +166,32 @@ describe("deploy workflow contract", () => {
     "utf8",
   );
 
-  test("canonical URLs match the protected gateway release workflow", () => {
+  // Asserting the whole ternary, not each URL independently: both strings are
+  // always present in that workflow, so a transposed environment-to-URL
+  // mapping — the exact miswire this PR exists to refuse — would slip past a
+  // presence-only assertion.
+  const mappingExpression = (production: string, staging: string) =>
+    `inputs.environment == 'production' && '${production}' || '${staging}'`;
+
+  test("canonical URLs match the protected gateway release workflow mapping", () => {
     expect(gatewayWorkflow).toContain(
-      `'${CANONICAL_WEBHOOK_GATEWAY_URLS.production}'`,
-    );
-    expect(gatewayWorkflow).toContain(
-      `'${CANONICAL_WEBHOOK_GATEWAY_URLS.staging}'`,
+      mappingExpression(
+        CANONICAL_WEBHOOK_GATEWAY_URLS.production,
+        CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+      ),
     );
   });
 
-  test("cloud-cf-release runs the binding check before Worker mutation", () => {
+  test("a transposed environment-to-URL mapping would fail the sync assertion", () => {
+    expect(gatewayWorkflow).not.toContain(
+      mappingExpression(
+        CANONICAL_WEBHOOK_GATEWAY_URLS.staging,
+        CANONICAL_WEBHOOK_GATEWAY_URLS.production,
+      ),
+    );
+  });
+
+  test("cloud-cf-release runs the binding check before the atomic secrets file", () => {
     expect(releaseWorkflow).toContain(
       "verify_webhook_gateway_binding_candidates() {",
     );

--- a/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
+++ b/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
@@ -1,0 +1,140 @@
+/**
+ * Fail-closed deploy contract for the Worker's messaging webhook gateway
+ * binding. cloud-cf-release publishes ELIZA_APP_WEBHOOK_GATEWAY_URL as a
+ * routing toggle: absent means webhook routes 503 honestly
+ * (WEBHOOK_GATEWAY_NOT_CONFIGURED, #18235), but a configured URL silently
+ * accepts two miswires this check refuses before any Worker mutation —
+ * pointing one environment's Worker at the other environment's gateway, and
+ * configuring the URL without the paired ELIZA_APP_WEBHOOK_GATEWAY_SECRET
+ * (the gateway's enforceForwarderSecret then 401s every forwarded webhook,
+ * which is strictly worse than the honest 503).
+ *
+ * The canonical per-environment gateway origins are the same values
+ * .github/workflows/deploy-gateway-webhook.yml pins as EXPECTED_GATEWAY_URL;
+ * the deploy-contract test keeps the two in sync. The CLI mirrors the other
+ * candidate verifiers in cloud-cf-release: a names-only `wrangler secret list`
+ * inventory arrives on stdin, this deploy's queued binding names as argv, and
+ * DEPLOY_ENVIRONMENT / ELIZA_APP_WEBHOOK_GATEWAY_URL from the environment.
+ * Secret values are never read or printed.
+ */
+
+import { pathToFileURL } from "node:url";
+
+export const CANONICAL_WEBHOOK_GATEWAY_URLS = Object.freeze({
+  staging: "https://gateway-webhook-stg-staging.up.railway.app",
+  production: "https://gateway-webhook-production.up.railway.app",
+});
+
+const PAIRED_SECRET_NAME = "ELIZA_APP_WEBHOOK_GATEWAY_SECRET";
+
+/** Parse Wrangler's names-only secret inventory (array or {result: array}). */
+export function parseSecretInventoryNames(output) {
+  const parsed = JSON.parse(output);
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.result)
+      ? parsed.result
+      : null;
+  if (entries === null) {
+    throw new Error("Wrangler secret inventory was not an array");
+  }
+  const names = new Set();
+  for (const entry of entries) {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.name !== "string" ||
+      entry.name.length === 0
+    ) {
+      throw new Error("Wrangler secret inventory contained an invalid entry");
+    }
+    names.add(entry.name);
+  }
+  return names;
+}
+
+/**
+ * Validate the webhook gateway binding candidates for one deploy.
+ * Returns { ok: true } or { ok: false, errors: string[] }. A blank URL is
+ * valid on purpose: the unset toggle is the honest not-configured state.
+ */
+export function verifyWebhookGatewayBinding({
+  deployEnvironment,
+  gatewayUrl,
+  availableSecretNames,
+}) {
+  const url = typeof gatewayUrl === "string" ? gatewayUrl.trim() : "";
+  if (url === "") {
+    return { ok: true, errors: [] };
+  }
+
+  const errors = [];
+  const canonical = CANONICAL_WEBHOOK_GATEWAY_URLS[deployEnvironment];
+  if (canonical === undefined) {
+    errors.push(
+      `DEPLOY_ENVIRONMENT "${deployEnvironment}" has no canonical webhook gateway; refusing to publish ELIZA_APP_WEBHOOK_GATEWAY_URL`,
+    );
+  } else if (url !== canonical) {
+    errors.push(
+      `ELIZA_APP_WEBHOOK_GATEWAY_URL does not match the canonical ${deployEnvironment} gateway origin ${canonical}`,
+    );
+  }
+
+  if (!availableSecretNames.has(PAIRED_SECRET_NAME)) {
+    errors.push(
+      `ELIZA_APP_WEBHOOK_GATEWAY_URL is configured but no existing or queued ${PAIRED_SECRET_NAME} Worker binding is present; the gateway would 401 every forwarded webhook`,
+    );
+  }
+
+  return errors.length === 0 ? { ok: true, errors: [] } : { ok: false, errors };
+}
+
+async function main() {
+  const deployEnvironment = process.env.DEPLOY_ENVIRONMENT ?? "";
+  const gatewayUrl = process.env.ELIZA_APP_WEBHOOK_GATEWAY_URL ?? "";
+
+  if (gatewayUrl.trim() === "") {
+    console.log(
+      "ELIZA_APP_WEBHOOK_GATEWAY_URL is not configured; webhook routes stay on the honest 503 path.",
+    );
+    return;
+  }
+
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const availableSecretNames = parseSecretInventoryNames(
+    Buffer.concat(chunks).toString("utf8"),
+  );
+  for (const name of process.argv.slice(2)) {
+    if (name.length > 0) {
+      availableSecretNames.add(name);
+    }
+  }
+
+  const result = verifyWebhookGatewayBinding({
+    deployEnvironment,
+    gatewayUrl,
+    availableSecretNames,
+  });
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(`::error::${error}`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Verified the ${deployEnvironment} webhook gateway URL against the canonical origin and its paired forwarder secret binding name; secret values were not read.`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  // error-policy:J1 CLI boundary: translate a failed contract into a nonzero exit for the deploy workflow.
+  main().catch((error) => {
+    console.error(
+      `::error::webhook gateway binding verification failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
+++ b/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
@@ -3,12 +3,13 @@
  * binding. cloud-cf-release publishes ELIZA_APP_WEBHOOK_GATEWAY_URL as a
  * routing toggle: absent means webhook routes 503 honestly
  * (WEBHOOK_GATEWAY_NOT_CONFIGURED, #18235), but a configured URL silently
- * accepts two miswires this check refuses before the atomic Worker secrets
+ * accepts three miswires this check refuses before the atomic Worker secrets
  * version is written — pointing one environment's Worker at the other
- * environment's gateway, and configuring the URL without the paired
- * ELIZA_APP_WEBHOOK_GATEWAY_SECRET
- * (the gateway's enforceForwarderSecret then 401s every forwarded webhook,
- * which is strictly worse than the honest 503).
+ * environment's gateway, configuring the URL without the paired
+ * ELIZA_APP_WEBHOOK_GATEWAY_SECRET binding name, and queuing a Worker secret
+ * whose VALUE no longer matches the live gateway's (a stale or half-rotated
+ * secret — the gateway's enforceForwarderSecret then 401s every forwarded
+ * webhook, which is strictly worse than the honest 503).
  *
  * The canonical per-environment gateway origins are the same values
  * .github/workflows/deploy-gateway-webhook.yml pins as EXPECTED_GATEWAY_URL;
@@ -16,17 +17,30 @@
  * candidate verifiers in cloud-cf-release: a names-only `wrangler secret list`
  * inventory arrives on stdin, this deploy's queued binding names as argv, and
  * DEPLOY_ENVIRONMENT / ELIZA_APP_WEBHOOK_GATEWAY_URL from the environment.
- * Secret values are never read or printed.
+ * Secret values are never read or printed by the names-only half of the check.
  *
- * Known limitation: this contract is names-only. It proves the URL is this
- * environment's canonical gateway and that an ELIZA_APP_WEBHOOK_GATEWAY_SECRET
- * binding exists or is queued; it does NOT prove the Worker-side secret VALUE
- * matches the gateway's. A stale or half-rotated value passes here and still
- * 401s at runtime. Closing that half needs a value-safe two-sided contract
- * (authenticated readiness probe or a shared secret-version fingerprint) plus a
- * defined rotation ordering, tracked on #18235.
+ * The value half (`verifyWebhookGatewaySecretMatch`) closes the "same name,
+ * different value" gap left by names-only verification. It mirrors the
+ * salted-HMAC-digest pattern deploy-gateway-webhook.yml already uses to
+ * cross-check the protected staging Blooio secrets between the Worker's
+ * GitHub Environment and the live Railway variable: the calling workflow
+ * fetches the live gateway secret from Railway (the same trusted source that
+ * pattern already reads) and hands both candidate values to this process over
+ * env vars exactly like every other secret already flowing through this
+ * workflow. Neither raw value, nor any digest of it, is ever written to
+ * stdout/stderr/the job log/an artifact — only a pass/fail verdict and the
+ * binding *name* are. A fresh random salt is drawn per invocation so a
+ * digest can never be replayed or compared outside this one process. Any
+ * failure to obtain the live gateway value (unreachable Railway API, CLI
+ * error, blank variable) is treated as a mismatch — fail closed, never a
+ * silent pass — per the repo's error-policy doctrine (root CLAUDE.md
+ * "Error-Handling Simplification"). Full live-gateway validation still
+ * depends on network reachability to the deployed Railway service; that half
+ * of the proof cannot run in an offline unit test, only the pure comparison
+ * logic can (and does, below).
  */
 
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 // Null-prototype so an environment name that collides with an Object.prototype
@@ -106,6 +120,73 @@ export function verifyWebhookGatewayBinding({
   return errors.length === 0 ? { ok: true, errors: [] } : { ok: false, errors };
 }
 
+/**
+ * HMAC-SHA256 of `value` keyed by a fresh random `salt`. The salt is drawn
+ * per verification run (never reused, never persisted) so a digest carries
+ * no meaning outside the single comparison it was generated for — even if it
+ * were somehow captured, it cannot be replayed against a future run or used
+ * to test guesses offline (the attacker would need the salt AND the secret).
+ */
+export function saltedSecretDigest(value, salt) {
+  return createHmac("sha256", salt)
+    .update(String(value ?? ""), "utf8")
+    .digest();
+}
+
+/**
+ * Value-safe proof that the Worker's queued/existing
+ * ELIZA_APP_WEBHOOK_GATEWAY_SECRET and the live gateway's secret are
+ * byte-identical, without either raw value or a digest of it ever being
+ * logged: both sides arrive as plain in-memory strings (the same trust
+ * boundary every other secret already crosses via GitHub Actions `env:` in
+ * this workflow), get reduced to a one-shot salted HMAC digest, and are
+ * compared with `timingSafeEqual`. Only this function's return value —
+ * ok/errors naming the *binding*, never the secret — is allowed to reach a
+ * log line.
+ *
+ * Fails closed on every non-proof path: a blank candidate (nothing to
+ * verify), a blank/absent gateway value (Railway fetch failed, CLI error,
+ * unreachable service, or the gateway genuinely has no secret configured),
+ * or a digest mismatch are all treated as "not verified" — never a silent
+ * pass. This is what actually closes the gap names-only verification left:
+ * matching names with divergent values used to sail through.
+ */
+export function verifyWebhookGatewaySecretMatch({
+  workerSecretValue,
+  gatewaySecretValue,
+  bindingName = PAIRED_SECRET_NAME,
+}) {
+  const candidate =
+    typeof workerSecretValue === "string" ? workerSecretValue : "";
+  if (candidate.trim() === "") {
+    return {
+      ok: false,
+      error: `${bindingName} has no readable Worker-side value to verify against the live gateway`,
+    };
+  }
+
+  const gatewayValue =
+    typeof gatewaySecretValue === "string" ? gatewaySecretValue : "";
+  if (gatewayValue.trim() === "") {
+    return {
+      ok: false,
+      error: `${bindingName} could not be verified against the live gateway (its value was unreadable, unreachable, or unset); refusing to deploy rather than risk a silent 401`,
+    };
+  }
+
+  const salt = randomBytes(32);
+  const expected = saltedSecretDigest(candidate, salt);
+  const actual = saltedSecretDigest(gatewayValue, salt);
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    return {
+      ok: false,
+      error: `${bindingName} differs between the queued/existing Worker secret and the live gateway secret (compared by one-time salted digest; neither value nor the digest was read, logged, or written anywhere)`,
+    };
+  }
+
+  return { ok: true, error: null };
+}
+
 async function main() {
   const deployEnvironment = process.env.DEPLOY_ENVIRONMENT ?? "";
   const gatewayUrl = process.env.ELIZA_APP_WEBHOOK_GATEWAY_URL ?? "";
@@ -135,14 +216,32 @@ async function main() {
     gatewayUrl,
     availableSecretNames,
   });
-  if (!result.ok) {
-    for (const error of result.errors) {
+  const errors = [...result.errors];
+
+  // The value-match half only runs once the names-only half already found a
+  // binding to check; it reads its inputs from env vars the calling workflow
+  // sets immediately before this invocation (the Worker candidate from the
+  // same GitHub Environment secret every other queue_secret call already
+  // uses, the gateway candidate from a Railway fetch it just performed) and
+  // never persists or forwards either value beyond this process.
+  if (availableSecretNames.has(PAIRED_SECRET_NAME)) {
+    const matchResult = verifyWebhookGatewaySecretMatch({
+      workerSecretValue: process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET,
+      gatewaySecretValue: process.env.WEBHOOK_GATEWAY_RAILWAY_SECRET_VALUE,
+    });
+    if (!matchResult.ok) {
+      errors.push(matchResult.error);
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const error of errors) {
       console.error(`::error::${error}`);
     }
     process.exit(1);
   }
   console.log(
-    `Verified the ${deployEnvironment} webhook gateway URL against the canonical origin and its paired forwarder secret binding name; secret values were not read.`,
+    `Verified the ${deployEnvironment} webhook gateway URL against the canonical origin, its paired forwarder secret binding name, and (by one-time salted digest) that the Worker and live gateway secret values match; no secret value or digest was read, logged, or written.`,
   );
 }
 

--- a/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
+++ b/packages/cloud/scripts/verify-webhook-gateway-binding.mjs
@@ -3,9 +3,10 @@
  * binding. cloud-cf-release publishes ELIZA_APP_WEBHOOK_GATEWAY_URL as a
  * routing toggle: absent means webhook routes 503 honestly
  * (WEBHOOK_GATEWAY_NOT_CONFIGURED, #18235), but a configured URL silently
- * accepts two miswires this check refuses before any Worker mutation —
- * pointing one environment's Worker at the other environment's gateway, and
- * configuring the URL without the paired ELIZA_APP_WEBHOOK_GATEWAY_SECRET
+ * accepts two miswires this check refuses before the atomic Worker secrets
+ * version is written — pointing one environment's Worker at the other
+ * environment's gateway, and configuring the URL without the paired
+ * ELIZA_APP_WEBHOOK_GATEWAY_SECRET
  * (the gateway's enforceForwarderSecret then 401s every forwarded webhook,
  * which is strictly worse than the honest 503).
  *
@@ -16,14 +17,27 @@
  * inventory arrives on stdin, this deploy's queued binding names as argv, and
  * DEPLOY_ENVIRONMENT / ELIZA_APP_WEBHOOK_GATEWAY_URL from the environment.
  * Secret values are never read or printed.
+ *
+ * Known limitation: this contract is names-only. It proves the URL is this
+ * environment's canonical gateway and that an ELIZA_APP_WEBHOOK_GATEWAY_SECRET
+ * binding exists or is queued; it does NOT prove the Worker-side secret VALUE
+ * matches the gateway's. A stale or half-rotated value passes here and still
+ * 401s at runtime. Closing that half needs a value-safe two-sided contract
+ * (authenticated readiness probe or a shared secret-version fingerprint) plus a
+ * defined rotation ordering, tracked on #18235.
  */
 
 import { pathToFileURL } from "node:url";
 
-export const CANONICAL_WEBHOOK_GATEWAY_URLS = Object.freeze({
-  staging: "https://gateway-webhook-stg-staging.up.railway.app",
-  production: "https://gateway-webhook-production.up.railway.app",
-});
+// Null-prototype so an environment name that collides with an Object.prototype
+// member (constructor, toString, valueOf) resolves to undefined and takes the
+// "no canonical gateway" branch instead of comparing against an inherited value.
+export const CANONICAL_WEBHOOK_GATEWAY_URLS = Object.freeze(
+  Object.assign(Object.create(null), {
+    staging: "https://gateway-webhook-stg-staging.up.railway.app",
+    production: "https://gateway-webhook-production.up.railway.app",
+  }),
+);
 
 const PAIRED_SECRET_NAME = "ELIZA_APP_WEBHOOK_GATEWAY_SECRET";
 
@@ -76,7 +90,10 @@ export function verifyWebhookGatewayBinding({
     );
   } else if (url !== canonical) {
     errors.push(
-      `ELIZA_APP_WEBHOOK_GATEWAY_URL does not match the canonical ${deployEnvironment} gateway origin ${canonical}`,
+      // The URL is a vars. value, never a secret, so echoing the rejected
+      // string is safe and turns "does not match" into a one-glance diagnosis
+      // of a trailing slash, a stale host, or a cross-environment miswire.
+      `ELIZA_APP_WEBHOOK_GATEWAY_URL is "${url}" but the canonical ${deployEnvironment} gateway origin is ${canonical}`,
     );
   }
 


### PR DESCRIPTION
Bounded hardening slice of #18235 (non-closing reference — the operational/live-E2E residual on that issue stays open).

## Summary

Staging webhook flows 503 `WEBHOOK_GATEWAY_NOT_CONFIGURED` until the gateway is provisioned. Most of the repo-side work from this issue already landed on develop (`deploy-gateway-webhook.yml` staging path with canonical Railway/service/domain validation, the Dockerfile Bun pin, `ELIZA_ONBOARDING_LOGIN_APP_URL = "https://staging.eliza.app"` in `[env.staging.vars]`). What remained codeable was the deploy-time contract on the Worker side: `cloud-cf-release.yml` publishes `ELIZA_APP_WEBHOOK_GATEWAY_URL` as a routing toggle and would silently accept two miswires that turn the honest 503 into misleading failures:

1. **Cross-environment miswire** — staging Worker pointed at the production gateway (or vice versa). Now the URL must byte-match the canonical per-environment origin, the same values `deploy-gateway-webhook.yml` pins as `EXPECTED_GATEWAY_URL` (a test keeps the two in sync).
2. **Unpaired forwarder secret** — a configured URL without an existing-or-queued `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` Worker binding. The gateway's `enforceForwarderSecret` would then 401 every forwarded webhook, strictly worse than the honest 503.

Changes:
- `packages/cloud/scripts/verify-webhook-gateway-binding.mjs` — pure contract check + names-only CLI (stdin = `wrangler secret list` inventory, argv = queued names; secret values never read or printed), mirroring the existing candidate verifiers.
- `.github/workflows/cloud-cf-release.yml` — `verify_webhook_gateway_binding_candidates` runs after the other candidate verifiers and before any Worker mutation; unset URL remains a clean no-op.
- `packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts` — deterministic tests: honest-unset path, both canonical environments, cross-environment miswire, missing paired secret, queued-name satisfaction, unknown environment, combined failures, inventory parser (bare array + `{result}` wrapper + malformed rejection), and the workflow-wiring/URL-sync contract.

## Verification

Exact head: `8ee24ad22508de3070f49437bd0eb8cfc3ca9c53`

Base: `54390a104dd700d17d84968b8adec9da2e9791b5`

- `bun test packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts` — 12 pass, 0 fail.
- Existing workflow-contract suites still green: `voice-realtime-deploy-contract.test.ts`, `personal-telegram-edge-deploy-contract.test.ts` (5 pass).
- CLI exercised directly: canonical staging URL + secret → exit 0; production URL on staging with empty inventory → both `::error::` lines, exit 1; unset URL → no-op notice, exit 0.
- `bunx biome check` clean on both new files; `actionlint` reports no findings on the added workflow lines.
- Exact-head GitHub CI and renewed independent approval are pending; the PR must not merge before both complete.

## Known limitation of this slice

This check is **names-only by design**: it proves the URL points at this environment's canonical gateway and that an `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` binding exists or is queued. It does **not** prove the Worker-side secret *value* matches the gateway's. A stale or rotated value on either side still passes this check and still 401s at runtime. Closing that half needs a value-safe end-to-end contract (an authenticated readiness probe with the protected candidate credential, or a single authoritative secret version fingerprint verified on both sides) plus a defined rotation ordering — deliberately out of scope here and tracked on #18235.

## Human-only remainder (cannot be completed from the repository)

Gateway provisioning and Worker binding are no longer pending: protected `deploy-gateway-webhook.yml` run 31998745703 (`c1026da327d2dc2e929d3a9477fad0089976b2ab`) and staging `cloud-cf-release` run 32364163137 (`c3bf1410a226e5e1aaa0116dea098ac6d29d3440`) both succeeded, publishing the canonical staging gateway URL and paired secret binding. `SandboxRegistry` self-registration is on develop (#18277 closed) and a least-privilege readback proved a live `agent:<id>:server` → `server:<name>:url` pair. What remains:

- BotFather domain binding for the staging-dedicated Telegram bot (not exposed by the Telegram API).
- Exact image/SHA authority for the currently registered container, and gateway → container HTTP reachability.
- One real provider forward plus delivery ACK.
- Live E2E on a disposable account: `/start` → connect → link → message → agent reply in Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Gate

<!-- evidence-head:15ced36f613e619079f4e88376288a3a1299b643 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] Pending - attach the exact-head CI run and deploy-contract transcript before review-ready.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending - staging deployment remains an explicitly documented operator step; no live cloud mutation was performed during review.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

