### PR TITLE
fix(native-agent): bound web fallback requests

### DIFF
--- a/plugins/plugin-native-agent/src/web.test.ts
+++ b/plugins/plugin-native-agent/src/web.test.ts
@@ -1,7 +1,8 @@
 /**
- * Unit tests for the `AgentWeb` HTTP fallback — `window` and `fetch` are
- * fully stubbed; no real API server is involved.
+ * Contract tests for the `AgentWeb` HTTP fallback, including a real loopback
+ * response whose body stalls until the request deadline aborts it.
  */
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AgentWeb } from "./web";
@@ -131,6 +132,176 @@ describe("AgentWeb fallback", () => {
         body: "{}",
       }),
     );
+  });
+
+  it("applies the owning deadline to every web fallback HTTP hop", async () => {
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "https://agent.example" },
+    } as Partial<Window>);
+    const timeoutCalls: number[] = [];
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((milliseconds) => {
+      timeoutCalls.push(milliseconds);
+      return new AbortController().signal;
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/conversations")) {
+        return {
+          ok: true,
+          json: async () => ({ conversation: { id: "conversation-1" } }),
+        };
+      }
+      if (url.endsWith("/messages")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ text: "reply", agentName: "Eliza" }),
+        };
+      }
+      if (url.endsWith("/api/agent/start")) {
+        return { json: async () => ({ status: { state: "running" } }) };
+      }
+      if (url.endsWith("/api/agent/stop")) {
+        return { json: async () => ({ ok: true }) };
+      }
+      if (url.endsWith("/api/status")) {
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: new Headers(),
+          json: async () => ({ state: "running" }),
+          text: async () => "status",
+        };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const agent = new AgentWeb();
+    await agent.chat({ text: "hello" });
+    await agent.start();
+    await agent.stop();
+    await agent.getStatus();
+    await agent.request({ path: "/api/status" });
+    await agent.request({ path: "/api/status", timeoutMs: 1_234.2 });
+    await agent.request({ path: "/api/status", timeoutMs: 0.01 });
+    await agent.request({ path: "/api/status", timeoutMs: Number.MAX_VALUE });
+
+    expect(timeoutCalls).toEqual([
+      30_000, 120_000, 30_000, 30_000, 30_000, 30_000, 1_235, 1, 2_147_483_647,
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+  });
+
+  it("retries a missing chat conversation only once with fresh deadlines", async () => {
+    let storedConversationId: string | null = "stale-conversation";
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "https://agent.example" },
+      sessionStorage: {
+        getItem: vi.fn(() => storedConversationId),
+        setItem: vi.fn((_key: string, value: string) => {
+          storedConversationId = value;
+        }),
+        removeItem: vi.fn(() => {
+          storedConversationId = null;
+        }),
+      } as unknown as Storage,
+    } as Partial<Window>);
+    const timeoutCalls: number[] = [];
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((milliseconds) => {
+      timeoutCalls.push(milliseconds);
+      return new AbortController().signal;
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/conversations")) {
+        return {
+          ok: true,
+          json: async () => ({ conversation: { id: "fresh-conversation" } }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(new AgentWeb().chat({ text: "hello" })).rejects.toThrow(
+      "Chat request failed: 404",
+    );
+    expect(timeoutCalls).toEqual([120_000, 30_000, 120_000]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid request timeout %s before fetch",
+    async (timeoutMs) => {
+      setWindow({
+        __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "https://agent.example" },
+      } as Partial<Window>);
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        new AgentWeb().request({ path: "/api/status", timeoutMs }),
+      ).rejects.toThrow("timeoutMs must be a finite positive number");
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the request deadline active while the response body stalls", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.write("partial");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Loopback server did not expose a TCP address");
+    }
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: {
+        apiBase: `http://127.0.0.1:${address.port}`,
+      },
+    } as Partial<Window>);
+
+    try {
+      await expect(
+        new AgentWeb().request({ path: "/stall", timeoutMs: 50 }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("aborts when a connected server never sends response headers", async () => {
+    const server = createServer(() => {
+      // Deliberately accept the socket without sending a response head.
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Loopback server did not expose a TCP address");
+    }
+    setWindow({
+      __ELIZAOS_APP_BOOT_CONFIG__: {
+        apiBase: `http://127.0.0.1:${address.port}`,
+      },
+    } as Partial<Window>);
+
+    try {
+      await expect(
+        new AgentWeb().request({ path: "/stall", timeoutMs: 50 }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("fails closed for local-agent IPC base in the web fallback", async () => {

--- a/plugins/plugin-native-agent/src/web.ts
+++ b/plugins/plugin-native-agent/src/web.ts
@@ -26,6 +26,22 @@ interface ElizaWindow extends Window {
   __ELIZA_API_TOKEN__?: string;
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const CHAT_REQUEST_TIMEOUT_MS = 120_000;
+const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
+
+function requestTimeoutMs(timeoutMs: unknown): number {
+  if (timeoutMs === undefined) return DEFAULT_REQUEST_TIMEOUT_MS;
+  if (
+    typeof timeoutMs !== "number" ||
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0
+  ) {
+    throw new Error("Agent.request timeoutMs must be a finite positive number");
+  }
+  return Math.min(Math.ceil(timeoutMs), MAX_TIMER_TIMEOUT_MS);
+}
+
 function readConfiguredApiBase(): string | undefined {
   if (typeof window === "undefined") return undefined;
   const base = (window as ElizaWindow).__ELIZAOS_APP_BOOT_CONFIG__?.apiBase;
@@ -135,6 +151,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
 
     const res = await fetch(`${this.apiBase()}/api/conversations`, {
       method: "POST",
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
       headers: {
         "Content-Type": "application/json",
         ...this.authHeaders(),
@@ -165,6 +182,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
       `${this.apiBase()}/api/conversations/${encodeURIComponent(conversationId)}/messages`,
       {
         method: "POST",
+        signal: AbortSignal.timeout(CHAT_REQUEST_TIMEOUT_MS),
         headers: {
           "Content-Type": "application/json",
           ...this.authHeaders(),
@@ -253,6 +271,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     }
     const res = await fetch(`${this.apiBase()}/api/agent/start`, {
       method: "POST",
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
       headers: this.authHeaders(),
     });
     const data = await res.json();
@@ -265,6 +284,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     }
     const res = await fetch(`${this.apiBase()}/api/agent/stop`, {
       method: "POST",
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
       headers: this.authHeaders(),
     });
     return res.json();
@@ -281,6 +301,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
       };
     }
     const res = await fetch(`${this.apiBase()}/api/status`, {
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
       headers: this.authHeaders(),
     });
     return res.json();
@@ -305,6 +326,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
   async request(options: AgentRequestOptions): Promise<AgentRequestResult> {
     const path = assertRequestPath(options.path);
     const method = assertRequestMethod(options.method);
+    const timeoutMs = requestTimeoutMs(options.timeoutMs);
     if (this.isLocalAgentIpcBase()) {
       return {
         status: 503,
@@ -319,6 +341,7 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     }
     const res = await fetch(`${this.apiBase()}${path}`, {
       method,
+      signal: AbortSignal.timeout(timeoutMs),
       headers: {
         ...this.authHeaders(),
         ...options.headers,


### PR DESCRIPTION
Closes #22855

## Summary

- add a fresh 30-second deadline to conversation creation, lifecycle, status, and default generic web fallback requests
- keep chat message delivery on a fresh 120-second deadline, including the one bounded missing-conversation retry
- honor finite positive `Agent.request.timeoutMs`, rounding sub-millisecond values up and clamping values above the JavaScript timer range
- prove both accepted-socket/no-response-head and response-body stalls reject with `TimeoutError`

## Exact-head verification

Exact head: `787fe46c387601179d3c2e8a27332c40bfa5610a`

Base: `a61d938a9e48d437c4a92570bdb028330ff49eaf`

- full package suite: 22/22 passed in an empty environment
- real loopback header stall: `TimeoutError`
- real loopback partial-body stall: `TimeoutError`
- all six HTTP hops receive the owning deadline; stale chat conversation retry is exactly bounded once
- `bun run --cwd plugins/plugin-native-agent typecheck`: passed
- `bun run --cwd plugins/plugin-native-agent build`: passed (TypeScript, ESM, declarations, IIFE, and CJS)
- pinned Biome on both changed files: passed
- `git diff --check`: passed
- the patch was previously approved at its byte-identical pre-rebase head; a fresh exact-head approval is requested for this current-develop rebase

## Evidence Gate

<!-- evidence-head:787fe46c387601179d3c2e8a27332c40bfa5610a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - transport-only deadline behavior; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - transport-only deadline behavior; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [x] [22915-native-agent-exact-787fe46.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22915-native-agent-exact-787fe46.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend rendering or browser console contract changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic HTTP transport deadlines require no model call.
<!-- evidence-row:domain-artifacts -->
- [x] [22915-22855-native-agent-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22915-22855-native-agent-domain.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

## Risk

Low and fail-closed. The deadline remains attached to the fetch response while JSON or text bodies are consumed, so header and body stalls cannot escape it. Native iOS and Android implementations are unchanged.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->

