### PR TITLE
fix(cloud): reject unbacked reconciliation refunds

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -68,6 +68,10 @@ class MockInsufficientCreditsError extends Error {
   }
 }
 
+class MockUnbackedCreditRefundError extends Error {
+  readonly code = "CREDIT_REFUND_REQUIRES_RESERVATION";
+}
+
 mock.module("../credits", () => ({
   assertCreditRefundWithinReservation: ({
     reservedAmount,
@@ -93,6 +97,7 @@ mock.module("../credits", () => ({
     }
   },
   InsufficientCreditsError: MockInsufficientCreditsError,
+  UnbackedCreditRefundError: MockUnbackedCreditRefundError,
   // Must mirror the real export — app-credits.ts imports it for the $0-estimate
   // floor; a missing export would break the module link under this mock.
   MIN_RESERVATION: 0.000001,
@@ -609,20 +614,38 @@ describe("reconcileCredits — charges/refunds the estimate↔actual delta (#914
     expect(refundCredits).not.toHaveBeenCalled();
   });
 
-  test("refunds the markup'd overcharge to the org when actual is below estimated", async () => {
-    const result = await freshService().reconcileCredits({
+  test("rejects serial and concurrent refunds without an authoritative app hold", async () => {
+    const service = freshService();
+    const args = {
       appId: APP_ID,
       userId: USER_ID,
       estimatedBaseCost: 2,
       actualBaseCost: 1,
       description: "recon",
+    };
+
+    await expect(service.reconcileCredits(args)).rejects.toMatchObject({
+      code: "CREDIT_REFUND_REQUIRES_RESERVATION",
     });
-    expect(result.reconciled).toBe(true);
-    expect(result.action).toBe("refund");
-    expect(result.adjustedAmount).toBeCloseTo(1.1, 10);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits.mock.calls[0][0].organizationId).toBe(ORG_ID);
+    await expect(service.reconcileCredits(args)).rejects.toMatchObject({
+      code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+    });
+    const concurrent = await Promise.allSettled([
+      service.reconcileCredits(args),
+      service.reconcileCredits(args),
+    ]);
+    expect(concurrent).toHaveLength(2);
+    for (const result of concurrent) {
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.reason).toMatchObject({ code: "CREDIT_REFUND_REQUIRES_RESERVATION" });
+      }
+    }
+
+    expect(refundCredits).not.toHaveBeenCalled();
     expect(reserveAndDeductCredits).not.toHaveBeenCalled();
+    expect(reduceEarnings).not.toHaveBeenCalled();
+    expect(applyCreatorMovement).not.toHaveBeenCalled();
   });
 
   test("does not reconcile when the user has no organization", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile-fail-closed.test.ts
@@ -1,17 +1,16 @@
 /**
  * Exercises the fail-closed settlement contract of CreditsService.reconcile.
  *
- * Real PGlite-backed coverage verifies two security-sensitive paths:
+ * Real PGlite-backed coverage verifies three security-sensitive paths:
  *
  *  1. A reconcile call naming a `reservation_transaction_id` that matches no
  *     reservation row used to fall through to the legacy lane and mint a
  *     refund keyed only on the caller-supplied `reservedAmount` — credit with
  *     no corresponding debit. It must now throw ReservationNotFoundError and
  *     write nothing.
- *  2. The legacy (no-reservation-id) lane's retry loop used to swallow a
- *     persistent settlement failure and return a success-shaped result
- *     (`adjustmentType: "none"`), making a lost refund indistinguishable from
- *     a clean settle. It must now surface the failure.
+ *  2. The legacy (no-reservation-id) lane must not mint caller-number-backed
+ *     refunds, including under serial replay or concurrent execution. Its
+ *     charge-only compatibility remains covered.
  *  3. Negative/non-finite settlement costs must fail before any ledger read or
  *     write, so provider sentinel values cannot become unbacked refunds.
  *
@@ -152,7 +151,7 @@ describe("reconcile with a reservation id that matches no row", () => {
   );
 });
 
-describe("legacy-lane persistent settlement failure", () => {
+describe("legacy-lane settlement boundaries", () => {
   test("classifies a refund larger than its backing reservation as a fatal invariant failure", () => {
     let thrown: unknown;
     try {
@@ -207,11 +206,8 @@ describe("legacy-lane persistent settlement failure", () => {
   });
 
   test(
-    "surfaces the failure instead of returning a success-shaped result",
+    "rejects an unbacked refund before looking up the target organization",
     async () => {
-      // No reservation_transaction_id → legacy lane. The org row does not
-      // exist, so refundCredits fails on every retry. The old catch returned
-      // `adjustmentType: "none"` here — a fabricated clean settle.
       await expect(
         creditsService.reconcile({
           organizationId: MISSING_ORG_ID,
@@ -219,23 +215,61 @@ describe("legacy-lane persistent settlement failure", () => {
           actualCost: 5,
           description: "legacy settle against missing org",
         }),
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ code: "CREDIT_REFUND_REQUIRES_RESERVATION" });
       expect(await countTransactions(MISSING_ORG_ID)).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "still settles a healthy legacy refund (regression guard)",
+    "rejects serial and concurrent unbacked refunds without mutating the ledger",
     async () => {
-      const result = await creditsService.reconcile({
+      const args = {
         organizationId: ORG_ID,
         reservedAmount: 10,
         actualCost: 4,
-        description: "legacy refund settle",
+        description: "unbacked legacy refund",
+      };
+
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_REQUIRES_RESERVATION",
       });
-      expect(result.adjustmentType).toBe("refund");
-      expect(await getBalance()).toBe(106);
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+      });
+      const concurrent = await Promise.allSettled([
+        creditsService.reconcile(args),
+        creditsService.reconcile(args),
+      ]);
+      expect(concurrent).toHaveLength(2);
+      for (const result of concurrent) {
+        expect(result.status).toBe("rejected");
+        if (result.status === "rejected") {
+          expect(result.reason).toMatchObject({
+            code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+          });
+        }
+      }
+
+      expect(await getBalance()).toBe(100);
+      expect(await countTransactions(ORG_ID)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "preserves charge-only legacy reconciliation without creating credit",
+    async () => {
+      const result = await creditsService.reconcile({
+        organizationId: ORG_ID,
+        reservedAmount: 4,
+        actualCost: 10,
+        description: "legacy overage settle",
+      });
+
+      expect(result.adjustmentType).toBe("overage");
+      expect(await getBalance()).toBe(94);
+      expect(await countTransactions(ORG_ID)).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -280,13 +280,14 @@ describe("CreditsService.reconcile", () => {
     "refund branch: reserved > actual increases balance by the difference",
     async () => {
       if (!pgliteReady) return;
+      const reservationId = await insertReservation(1.0);
 
       const result = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 1.0,
         actualCost: 0.4,
         description: "reconcile refund case",
-        metadata: { user_id: USER_ID },
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
       });
 
       expect(result.adjustmentType).toBe("refund");
@@ -297,7 +298,7 @@ describe("CreditsService.reconcile", () => {
 
       // Exactly one refund row, whose id is the returned settlement id.
       expect(await countByType("refund")).toBe(1);
-      expect(await countTransactions()).toBe(1);
+      expect(await countTransactions()).toBe(2);
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
@@ -428,6 +429,7 @@ describe("CreditsService.reconcile", () => {
     "refund branch: actualCost 0 refunds the ENTIRE reservation (request-failure path)",
     async () => {
       if (!pgliteReady) return;
+      const reservationId = await insertReservation(1.0);
 
       // The live request-failure path settles a reservation against actualCost 0
       // (reservation.reconcile(0)): the request was reserved but produced no
@@ -441,7 +443,7 @@ describe("CreditsService.reconcile", () => {
         reservedAmount: 1.0,
         actualCost: 0,
         description: "reconcile full-refund case",
-        metadata: { user_id: USER_ID },
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
       });
 
       expect(result.adjustmentType).toBe("refund");
@@ -453,7 +455,7 @@ describe("CreditsService.reconcile", () => {
       // Exactly one refund row, for the FULL reserved amount, and its id is the
       // returned settlement id.
       expect(await countByType("refund")).toBe(1);
-      expect(await countTransactions()).toBe(1);
+      expect(await countTransactions()).toBe(2);
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
@@ -509,47 +511,34 @@ describe("CreditsService.reconcile", () => {
   );
 
   test(
-    "NON-IDEMPOTENT double-settle hazard: settling then a second reconcile(0) refunds AGAIN (the free-generation bug #10278's chargeSettled guard prevents)",
+    "reservation-backed late settlement replay cannot issue a second refund",
     async () => {
       if (!pgliteReady) return;
+      const reservationId = await insertReservation(1.0);
+      const metadata = { user_id: USER_ID, reservation_transaction_id: reservationId };
 
-      // reconcile() is a pure function of (reservedAmount - actualCost); it has NO
-      // settled-guard of its own. The metered media routes (generate-video /
-      // generate-music / generate-image) reserve the full amount up front, then on
-      // success call reconcile(actualCost) to settle. If a *post-settle*, non-critical
-      // step then throws (e.g. generationsService.create), the route's catch arm used
-      // to call reconcile(0) — refunding the FULL reservation a SECOND time and handing
-      // the user a free generation. This test pins that hazard at the money layer so the
-      // route-level `if (reservation && !chargeSettled)` guard can never be silently
-      // removed without a red test.
-
-      // 1) Settle: reserved 1.0, actual 0.4 -> refund the 0.6 over-reservation.
       const settle = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 1.0,
         actualCost: 0.4,
         description: "media settle (charge committed)",
-        metadata: { user_id: USER_ID },
+        metadata,
       });
       expect(settle.adjustmentType).toBe("refund");
       expect(await getBalance()).toBeCloseTo(10.6, 6);
 
-      // 2) The OLD post-settle catch path: reconcile(0) on the same reservation.
-      //    Because reconcile is non-idempotent, this refunds the ENTIRE 1.0 again.
-      const doubleRefund = await creditsService.reconcile({
+      const lateReplay = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 1.0,
         actualCost: 0,
-        description: "media post-settle error -> erroneous second refund",
-        metadata: { user_id: USER_ID },
+        description: "late delivery replay",
+        metadata,
       });
-      expect(doubleRefund.adjustmentType).toBe("refund");
+      expect(lateReplay.adjustmentType).toBe("none");
 
-      // The damage: balance is 10.0 + 0.6 + 1.0 = 11.60 (1.0 of free credit on a
-      // request that only over-reserved by 0.6), and TWO refund rows exist. This is
-      // exactly what skipping reconcile(0) once chargeSettled is true prevents.
-      expect(await getBalance()).toBeCloseTo(11.6, 6);
-      expect(await countByType("refund")).toBe(2);
+      expect(await getBalance()).toBeCloseTo(10.6, 6);
+      expect(await countByType("refund")).toBe(1);
+      expect(await countTransactions()).toBe(2);
     },
     PGLITE_TIMEOUT,
   );
@@ -626,13 +615,10 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
   );
 
   test(
-    "without a reservation id the fix is opt-in — behavior is unchanged (still double-applies)",
+    "without a reservation id replayed refunds fail closed",
     async () => {
       if (!pgliteReady) return;
       await seedOrg("10");
-      // No reservation_transaction_id => no dedupe key => prior non-idempotent
-      // behavior is preserved (this documents that the fix does NOT silently
-      // change any existing caller that lacks a reservation id).
       const args = {
         organizationId: ORG_ID,
         reservedAmount: 1.0,
@@ -641,11 +627,16 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
         metadata: { user_id: USER_ID },
       };
 
-      await creditsService.reconcile(args);
-      await creditsService.reconcile(args);
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+      });
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+      });
 
-      expect(await getBalance()).toBeCloseTo(11.2, 6);
-      expect(await countByType("refund")).toBe(2);
+      expect(await getBalance()).toBeCloseTo(10, 6);
+      expect(await countByType("refund")).toBe(0);
+      expect(await countTransactions()).toBe(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -39,6 +39,7 @@ import {
   creditsService,
   InsufficientCreditsError,
   MIN_RESERVATION,
+  UnbackedCreditRefundError,
 } from "./credits";
 import {
   getAppByIdHydrationGeneration,
@@ -1348,97 +1349,19 @@ export class AppCreditsService {
       });
 
     if (baseCostDifference < 0) {
-      // A creator withdrawal can race settlement. Reverse the cashable creator
-      // amount in full before refunding the consumer; otherwise a failed or
-      // partial clawback would leave both parties holding the same money.
-      const refundAmount = Math.abs(totalCostDifference);
-      const creatorEarningsReduction = Math.abs(creatorMarkupDifference);
-      const maximumRefund = computeInferenceCharge(estimatedBaseCost, {
-        monetizationEnabled: monetizationActive,
-        platformOffsetAmount: app.platform_offset_amount,
-        purchaseSharePercentage: app.purchase_share_percentage,
-        inferenceMarkupPercentage: app.inference_markup_percentage,
-      }).totalCost;
-      assertCreditRefundWithinReservation({
-        reservedAmount: maximumRefund,
-        refundAmount,
-        scope: "AppCreditsService.reconcileCredits",
-      });
-
-      if (monetizationActive && creatorEarningsReduction > 0) {
-        try {
-          await this.reverseCreatorEarnings(
-            appId,
-            userId,
-            creatorEarningsReduction,
-            Math.abs(baseCostDifference),
-            "reconcile_refund",
-            earningsLegMetadata({
-              type: "reconciliation_refund",
-              baseCostDifference,
-              estimatedBaseCost,
-              actualBaseCost,
-              description,
-            }),
-            app,
-          );
-        } catch (reversalError) {
-          // error-policy:J2 a failed clawback must retain the consumer charge;
-          // log the money context and rethrow.
-          logger.error(
-            "[AppCredits] Creator-earnings reversal failed; retaining the consumer charge",
-            {
-              appId,
-              userId,
-              organizationId,
-              refundAmount,
-              creatorEarningsReduction,
-              error: reversalError instanceof Error ? reversalError.message : String(reversalError),
-            },
-          );
-          throw reversalError;
-        }
-      }
-
-      const { newBalance } = await creditsService.refundCredits({
-        organizationId,
-        amount: refundAmount,
-        description: `App reconciliation refund (${app.name ?? appId})`,
-        // Idempotent per reservation (#11512): a re-invoked reconcile must not
-        // credit the org a second refund (2×reserved − actual = minted,
-        // cashable credit).
-        stripePaymentIntentId: chargeKey ? `reconcile-refund:${chargeKey}` : undefined,
-        metadata: {
-          appId,
-          userId,
-          baseCostDifference,
-          estimatedBaseCost,
-          actualBaseCost,
-          markupPercentage,
-          ...settlementMetadata,
-        },
-      });
-
-      logger.info("[AppCredits] Reconciliation: Refunded overcharge to org balance", {
+      // A marked app-chat reservation returns through settleAppReservation
+      // above. Reaching this legacy branch means no immutable hold facts were
+      // verified, even if the caller supplied some unrelated transaction id.
+      const error = new UnbackedCreditRefundError("AppCreditsService.reconcileCredits");
+      logger.error("[AppCredits] Refusing refund without an authoritative reservation", {
         appId,
         userId,
         organizationId,
         estimatedBaseCost,
         actualBaseCost,
-        refundAmount,
-        creatorEarningsReduction,
-        newBalance,
+        code: error.code,
       });
-
-      await markReservationSettled();
-
-      return {
-        reconciled: true,
-        difference: baseCostDifference,
-        action: "refund",
-        adjustedAmount: refundAmount,
-        newBalance,
-      };
+      throw error;
     }
 
     // CHARGE: Actual exceeded estimated — debit the delta from the org balance.

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -158,6 +158,19 @@ export class ReservationNotFoundError extends ElizaError {
   }
 }
 
+/** Refuses a refund that is not tied to an authoritative reservation row. */
+export class UnbackedCreditRefundError extends ElizaError {
+  override readonly name = "UnbackedCreditRefundError";
+
+  constructor(scope: string) {
+    super(`${scope} cannot refund without an authoritative reservation`, {
+      code: "CREDIT_REFUND_REQUIRES_RESERVATION",
+      context: { scope },
+      severity: "fatal",
+    });
+  }
+}
+
 /** Refuses malformed amounts before they can reach a credit-ledger mutation. */
 export class InvalidCreditAmountError extends ElizaError {
   override readonly name = "InvalidCreditAmountError";
@@ -2158,7 +2171,7 @@ export class CreditsService {
           // error-policy:J2 retry the same transaction-scoped settlement, then
           // surface its failure so a durable reservation remains recoverable.
           if (error instanceof ReservationNotFoundError) {
-            // Not transient: the row is absent, not busy. Retrying cannot help.
+            // The row is absent, not busy. Retrying cannot help.
             throw error;
           }
           if (attempt === MAX_RETRIES) {
@@ -2199,46 +2212,22 @@ export class CreditsService {
       actual: actualCost,
     };
 
-    // Stable per-(reservation, phase) idempotency key. Threaded into
-    // refund/deduct as `stripePaymentIntentId` so a retry of an already-committed
-    // reconcile (commit-then-ack-loss) is a no-op instead of a second refund
-    // (platform loss) or a second overage charge (consumer double-charge).
-    // Without a reservation id there is nothing stable to key on, so we keep the
-    // prior non-idempotent behavior. (#10846 finding 2)
-    const reconKey = (phase: "refund" | "overage"): string | undefined =>
-      reservationTxId ? `recon:${reservationTxId}:${phase}` : undefined;
+    // The reservation-backed lane returns above. This legacy lane remains only
+    // for charge-only compatibility and therefore has no authoritative
+    // transaction from which to derive a stable key.
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
         if (difference > 0) {
-          assertCreditRefundWithinReservation({
-            reservedAmount,
-            refundAmount: difference,
-            scope: "CreditsService.reconcile",
-          });
-          const refund = await this.refundCredits({
-            organizationId,
-            amount: difference,
-            description: `${description} (refund)`,
-            metadata: { ...baseMetadata, type: "reconciliation_refund" },
-            stripePaymentIntentId: reconKey("refund"),
-          });
-          logger.info("[Credits] Reconciled - refunded excess", {
+          const error = new UnbackedCreditRefundError("CreditsService.reconcile");
+          logger.error("[Credits] Refusing refund without an authoritative reservation", {
             organizationId,
             reserved: reservedAmount,
             actual: actualCost,
-            refunded: difference,
+            refund: difference,
+            code: error.code,
           });
-          return {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId:
-              typeof metadata?.reservation_transaction_id === "string"
-                ? metadata.reservation_transaction_id
-                : null,
-            settlementTransactionIds: [refund.transaction.id],
-            adjustmentType: "refund",
-          };
+          throw error;
         }
 
         const overage = -difference;
@@ -2247,7 +2236,6 @@ export class CreditsService {
           amount: overage,
           description: `${description} (overage)`,
           metadata: { ...baseMetadata, type: "reconciliation_overage" },
-          stripePaymentIntentId: reconKey("overage"),
         });
         if (!overageResult.success || !overageResult.transaction) {
           logger.warn("[Credits] Reconciled - overage uncollected", {
@@ -2286,6 +2274,10 @@ export class CreditsService {
           adjustmentType: "overage",
         };
       } catch (error) {
+        if (error instanceof UnbackedCreditRefundError) {
+          // Contract failures cannot become backed through a retry.
+          throw error;
+        }
         if (attempt === MAX_RETRIES) {
           logger.error("[Credits] Reconciliation failed after retries", {
             organizationId,


### PR DESCRIPTION
Closes #22850.

## Problem

The exported legacy no-reservation reconciliation lanes trusted caller-supplied `reservedAmount` and `actualCost`. A positive difference could mint a refund without an authoritative debit or reservation row, and serial or concurrent replay could mint it repeatedly. Production callers currently use reservation IDs, but the public server contract remained fail-open.

## Change

- Reject positive reconciliation refunds unless the reservation-backed lane has claimed an authoritative hold.
- Apply the same invariant to `CreditsService` and `AppCreditsService`.
- Preserve charge-only legacy compatibility; no caller-supplied refund is synthesized.
- Fail the typed contract immediately rather than retrying a non-transient invariant error.
- Add real-PGlite serial/concurrent unchanged-balance and unchanged-ledger regressions plus app-credit boundary coverage.

## Exact-head evidence

Evidence revision: `d24a72ad0ce23e202fccd69524eab8f062e77fe2`, based exactly on `develop@7a2207ac2b00192ed828ee7eb72afb842662d7ec`.

- [Exact-head validation receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22919-exact-head-validation.md)
- Real-PGlite fail-closed settlement boundary: **10/10 passed**. Missing holds, invalid costs, and serial/concurrent unbacked refunds leave balance and rows unchanged; charge-only legacy reconciliation remains one debit.
- AppCredits serial/concurrent unbacked-refund boundary: **1/1 passed**.
- Reservation-backed and replay regressions: **4/4 passed**.
- Cloud Shared typecheck, Biome on all five changed files, and diff-check: **passed**.
- Broad-lane disclosure: Bun module mocks leak between these files when combined. The unfiltered app-credit file also retains four unrelated current-base PGlite/fixture-environment failures. This PR does not claim those polluted or unrelated cases are green.

No production balance, payment, or provider mutation occurred. Tests use isolated PGlite state.

## Evidence Gate

<!-- evidence-head:d24a72ad0ce23e202fccd69524eab8f062e77fe2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only credit ledger invariant; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only credit ledger invariant; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] [Exact isolated backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22919-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, planner, prompt, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Real-PGlite ledger invariant artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22919-domain-artifact.md)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-cortex-plugins]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
