### PR TITLE
fix(plugin-agent-orchestrator): time out hung model-gateway lease hops

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
@@ -19,7 +19,8 @@
  *   broker whose mint fails) refuses the spawn rather than hand out a static
  *   long-lived token.
  * - HTTP REFERENCE BROKER: drives a real loopback HTTP broker end-to-end
- *   (mint + revoke over the wire, through the SSRF guard).
+ *   (mint + revoke over the wire, through the SSRF guard). Hung mint/revoke
+ *   fail closed instead of waiting forever.
  */
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -126,6 +127,7 @@ vi.mock("node:child_process", () => ({
 import { AcpService } from "../../src/services/acp-service.js";
 import {
   configureModelGatewayLease,
+  HttpModelGatewayLeaseBroker,
   isLeaseExpired,
   type LeaseMintRequest,
   type ModelGatewayLease,
@@ -739,5 +741,63 @@ describe("HTTP reference broker — real loopback mint + revoke over the wire", 
     expect(revoke?.url).toBe("/lease/http-lease-1/revoke");
     expect(revoke?.auth).toBe(`Bearer ${GATEWAY_TOKEN}`);
     await service.stop();
+  });
+});
+
+describe("HTTP reference broker — hung lease URL fail-closed", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    server = createServer((_req, _res) => {
+      // accept-and-hold: never write a response
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}/lease`;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function shortTimeoutSignal(): AbortSignal {
+    const controller = new AbortController();
+    setTimeout(() => {
+      controller.abort(
+        Object.assign(new Error("The operation was aborted due to timeout"), {
+          name: "TimeoutError",
+        }),
+      );
+    }, 50);
+    return controller.signal;
+  }
+
+  it("fails closed on a hung mint instead of waiting forever", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(shortTimeoutSignal);
+    const broker = new HttpModelGatewayLeaseBroker(baseUrl, GATEWAY_TOKEN);
+    const started = Date.now();
+    await expect(
+      broker.mint({
+        sessionId: "session-hung",
+        scope: "model-invoke",
+        ttlMs: 45_000,
+        agentType: "claude",
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("fails closed on a hung revoke instead of waiting forever", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(shortTimeoutSignal);
+    const broker = new HttpModelGatewayLeaseBroker(baseUrl, GATEWAY_TOKEN);
+    const started = Date.now();
+    await expect(broker.revoke("lease-hung")).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(Date.now() - started).toBeLessThan(1_000);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
@@ -20,6 +20,8 @@
  * unchanged: the static gateway token is used (today's E2 behavior), fail-closed
  * ONLY under `ELIZA_MODEL_GATEWAY_STRICT=1`, which refuses to hand out a static
  * long-lived token when a broker is expected but absent.
+ * HTTP mint/revoke hops honor `MODEL_GATEWAY_LEASE_FETCH_TIMEOUT_MS` so a hung
+ * lease URL cannot stall spawn or teardown.
  *
  * @module services/model-gateway-lease
  */
@@ -40,6 +42,8 @@ export const MODEL_GATEWAY_LEASE_URL_KEY = "ELIZA_MODEL_GATEWAY_LEASE_URL";
  * layer). In the orchestrator it means: refuse to hand a sub-agent a static
  * long-lived gateway token — a broker lease is mandatory. */
 export const MODEL_GATEWAY_STRICT_KEY = "ELIZA_MODEL_GATEWAY_STRICT";
+/** Bound for HTTP lease mint/revoke so a hung broker cannot stall spawn. */
+export const MODEL_GATEWAY_LEASE_FETCH_TIMEOUT_MS = 15_000;
 
 /** A minted, scoped, short-lived model-invoke lease. */
 export interface ModelGatewayLease {
@@ -147,6 +151,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
         authorization: `Bearer ${this.authToken}`,
       },
       body: JSON.stringify(request),
+      signal: AbortSignal.timeout(MODEL_GATEWAY_LEASE_FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       // error-policy:J3 best-effort read of untrusted error body for context; failure → empty detail, error still thrown below
@@ -173,6 +178,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
       {
         method: "POST",
         headers: { authorization: `Bearer ${this.authToken}` },
+        signal: AbortSignal.timeout(MODEL_GATEWAY_LEASE_FETCH_TIMEOUT_MS),
       },
     );
     // A 404 means the lease is already gone (expired/revoked) — the desired


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22921.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

Closes #22921.


## Problem

`HttpModelGatewayLeaseBroker` mints and revokes per-spawn model-gateway leases through `safeFetch` with **no `signal`**. A hung lease URL stalls spawn or teardown.

On Node 24.15.0 against an accept-and-hold TCP listener the untimed `fetch` shape stays pending at ~819 ms while `AbortSignal.timeout(800)` rejects TimeoutError.

Product path: model-gateway lease HTTP. Not leftover-tax. Not native-UI `*-fetch-timeout`. Not a timeout spray of `ssrf-guard.ts`. HARD_SKIP is `remote-capability-router.ts`, not this file. Not a twin of `#22857` / `#22915` (native-agent web) or `#22861` / `#22865` / `#22868` / `#22892` / `#22895` / `#22905` / `#22908` / `#22913`.

## Change

- Mint and revoke pass `AbortSignal.timeout(15_000)` into `safeFetch`.
- Hung hop fails closed with `TimeoutError`.
- Honest loopback mint + revoke unchanged.

## Exact-head evidence

Evidence revision: `21d5297a9c0bb15f016cc20037832011174a66d3`, based on `develop` `d0b9685f36fe`.

- Pinned Bun 1.3.14 `model-gateway-lease.test.ts`: **22/22 passed**.

Fork cannot upload `pr-evidence` releases (HTTP 404). Domain receipt is the inline transcript below.

No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.

## Evidence Gate


- [x] N/A - model-gateway lease HTTP client; no rendered output.

- [x] N/A - model-gateway lease HTTP client; no rendered output.

- [x] N/A - no rendered user flow.

- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

- [x] N/A - lease hop has no frontend console/network surface in this unit.

- [x] N/A - no model, prompt, planner, or action behavior changed.

- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 21d5297a9c0b</summary>

```
# domain artifact — model-gateway lease hung HTTP
exact-head: 21d5297a9c0bb15f016cc20037832011174a66d3
based-on: origin/develop d0b9685f36fe

Pinned Bun 1.3.14 at this exact head:
  bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts: 22/22 passed

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~819 ms
  AbortSignal.timeout(800): TimeoutError ~804 ms
```

</details>

- [x] N/A - no rendered pixels.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:21d5297a9c0bb15f016cc20037832011174a66d3 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - model-gateway lease HTTP client; no rendered output.

<!-- evidence-row:after-screenshots -->
- [x] N/A - model-gateway lease HTTP client; no rendered output.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.

<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic hang-boundary receipt is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - lease hop has no frontend console/network surface in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain receipt (inline transcript; fork cannot upload pr-evidence releases)
<details>
<summary>domain receipt at 21d5297a9c0b</summary>

```
# domain artifact — model-gateway lease hung HTTP
exact-head: 21d5297a9c0bb15f016cc20037832011174a66d3
based-on: origin/develop d0b9685f36fe

Pinned Bun 1.3.14 at this exact head:
  bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts: 22/22 passed

Origin red (Node 24.15.0, accept-and-hold TCP, same untimed fetch shape):
  fetch no signal: still-pending ~819 ms
  AbortSignal.timeout(800): TimeoutError ~804 ms
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
