### PR TITLE
fix(x): bound broker token fetch with timeout

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/broker.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.test.ts
@@ -1,10 +1,10 @@
 /**
  * Exercises managed X broker authentication with deterministic HTTP responses,
- * including the agent-role route and credential caching contract.
+ * including the agent-role route, request timeout, and credential caching contract.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { BrokerAuthProvider } from "./broker";
+import { BROKER_REQUEST_TIMEOUT_MS, BrokerAuthProvider } from "./broker";
 
 function runtime(settings: Record<string, string>): IAgentRuntime {
   return {
@@ -17,6 +17,10 @@ afterEach(() => {
 });
 
 describe("BrokerAuthProvider", () => {
+  it("exports BROKER_REQUEST_TIMEOUT_MS with 15-second bound", () => {
+    expect(BROKER_REQUEST_TIMEOUT_MS).toBe(15_000);
+  });
+
   it("vends and caches the connected agent-role OAuth2 token", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({
@@ -46,6 +50,7 @@ describe("BrokerAuthProvider", () => {
         headers: expect.objectContaining({
           Authorization: "Bearer agent-cloud-key",
         }),
+        signal: expect.any(AbortSignal),
       }),
     );
   });
@@ -82,7 +87,9 @@ describe("BrokerAuthProvider", () => {
     await expect(provider.getAccessToken()).resolves.toBe("owner-oauth-token");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cloud.eliza.app/api/v1/twitter/token?connectionRole=owner",
-      expect.any(Object),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 

--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -29,6 +29,7 @@ type BrokerToken = BrokerOAuth1Token | BrokerOAuth2Token;
 
 const BROKER_CACHE_MS = 5 * 60 * 1000;
 const OAUTH2_REFRESH_MARGIN_MS = 60 * 1000;
+export const BROKER_REQUEST_TIMEOUT_MS = 15_000;
 
 function isBrokerToken(value: unknown): value is BrokerToken {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -145,6 +146,7 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
           Accept: "application/json",
           Authorization: `Bearer ${this.brokerToken()}`,
         },
+        signal: AbortSignal.timeout(BROKER_REQUEST_TIMEOUT_MS),
       },
     );
     if (response.status === 401 || response.status === 403) {


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- skill_revision: elizaOS/eliza@c3bf1410a226e5e1aaa0116dea098ac6d29d3440:packages/skills/skills/contribute-to-eliza -->
<!-- evidence-head:2890b278c7fec54e4cb60f3098effc2157952412 -->

## Summary

Bounds `BrokerAuthProvider.fetchFromBroker` (`plugins/plugin-x/src/client/auth-providers/broker.ts`) with a 15-second request timeout to prevent a hanging broker from stalling the agent authentication loop.

- Adds `export const BROKER_REQUEST_TIMEOUT_MS = 15_000` beside `BROKER_CACHE_MS`/`OAUTH2_REFRESH_MARGIN_MS` as a single-source timeout (`15_000` numeric separator matches repo canon for token fetches: `X_OAUTH_TOKEN_TIMEOUT_MS`, `GOOGLE_OAUTH_FETCH_TIMEOUT_MS`, `HEALTH_CONNECTOR_TIMEOUT_MS`).
- Passes `signal: AbortSignal.timeout(BROKER_REQUEST_TIMEOUT_MS)` in the single `fetch()` inside `fetchFromBroker` (after `headers`/`Accept`/`Authorization`). Both `getAccessToken()` and `getBrokerCredentials()` funnel through `fetchToken() → fetchFromBroker()`, so no bypass path remains.
- Preserves fail-closed cache semantics: `fetchToken` only populates `this.cached` on success (`cacheCap` + `OAUTH2_REFRESH_MARGIN_MS`); timeout rejects before the `.then` handler so cache is untouched, `inflight` dedup is cleared in `finally`, and concurrent callers share the same rejection. `401`/`403` still invalidate; timeout does not.
- `AbortSignal.timeout` (Node 18+/Bun 1.3.14 native) creates a per-request ephemeral signal; `fetch` rejects with `DOMException` `TimeoutError` which bubbles through `inflight` to `TwitterAuth.resolveCredentials()` and maps to `ElizaError` `X_AUTH_INITIALIZATION_FAILED` / `isLoggedIn() → false` — no unhandled rejection, no stale fallback.

## Changes

- `plugins/plugin-x/src/client/auth-providers/broker.ts` `+2` — `BROKER_REQUEST_TIMEOUT_MS = 15_000` and `signal: AbortSignal.timeout(BROKER_REQUEST_TIMEOUT_MS)` in `fetchFromBroker`.
- `plugins/plugin-x/src/client/auth-providers/broker.test.ts` `+10 -3` — `BROKER_REQUEST_TIMEOUT_MS` value test (`toBe(15_000)`), `signal: expect.any(AbortSignal)` assertions on agent and owner routes, header updated to include request timeout.

## Verification

- Exact head: `2890b278c7fec54e4cb60f3098effc2157952412` rebased on `c3bf1410a226e5e1aaa0116dea098ac6d29d3440` (`origin/develop`, `fix(orchestrator): port administrative-stop marker #22852`).
- `bun run --cwd plugins/plugin-x typecheck` — clean (0 errors).
- `bun run --cwd plugins/plugin-x test -- --run src/client/auth-providers/broker.test.ts` — **5/5 passed** (1 new `exports BROKER_REQUEST_TIMEOUT_MS`, 4 existing).
- `bunx biome check` on 2 changed files — clean, no fixes.
- `git diff --check` — clean.
- Diff: `2 files +12 -3`, single concern (fetch bound).

## Evidence

| Check | Result |
|---|---|
| `typecheck` | `clean (0)` |
| `test:broker` | `5/5` |
| `biome` | `clean` |
| `diff --check` | `clean` |
| `mergeable` | `CLEAN` (0 behind) |
| `atomic` | `2 files +12 -3` single concern |
| `rebase` | `2890b278c7` onto `c3bf1410a2` |

Skill path: `elizaOS/eliza@c3bf1410a226e5e1aaa0116dea098ac6d29d3440:packages/skills/skills/contribute-to-eliza` • Exact head: `2890b278c7fec54e4cb60f3098effc2157952412`
