### PR TITLE
fix(auth): sign out hosted cloud sessions

### DIFF
--- a/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
+++ b/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
@@ -16,6 +16,8 @@ const getCloudStatusMock = vi.hoisted(() => vi.fn());
 const getCloudCreditsMock = vi.hoisted(() => vi.fn());
 const cloudDisconnectMock = vi.hoisted(() => vi.fn());
 const signOutFromSsoBridgedHostMock = vi.hoisted(() => vi.fn());
+const isElizaCloudRuntimeLockedMock = vi.hoisted(() => vi.fn());
+const isAppModeHostMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../api", () => ({
   client: {
@@ -30,11 +32,15 @@ vi.mock("../cloud/sso-bridge/sso-bridge", () => ({
   signOutFromSsoBridgedHost: signOutFromSsoBridgedHostMock,
 }));
 
+vi.mock("../cloud/app-mode/app-mode", () => ({
+  isAppModeHost: isAppModeHostMock,
+}));
+
 vi.mock("../first-run/mobile-runtime-mode", async (importOriginal) => ({
   ...(await importOriginal<
     typeof import("../first-run/mobile-runtime-mode")
   >()),
-  isElizaCloudRuntimeLocked: () => true,
+  isElizaCloudRuntimeLocked: isElizaCloudRuntimeLockedMock,
 }));
 
 function makeParams() {
@@ -45,7 +51,7 @@ function makeParams() {
   };
 }
 
-describe("useCloudState — locked Cloud account sign-out", () => {
+describe("useCloudState — Cloud account sign-out", () => {
   beforeEach(() => {
     getCloudStatusMock.mockResolvedValue({
       connected: true,
@@ -59,6 +65,8 @@ describe("useCloudState — locked Cloud account sign-out", () => {
     });
     cloudDisconnectMock.mockResolvedValue(undefined);
     signOutFromSsoBridgedHostMock.mockResolvedValue(undefined);
+    isElizaCloudRuntimeLockedMock.mockReturnValue(true);
+    isAppModeHostMock.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -93,5 +101,28 @@ describe("useCloudState — locked Cloud account sign-out", () => {
 
     await waitFor(() => expect(client.getCloudStatus).toHaveBeenCalled());
     expect(result.current.elizaCloudConnected).toBe(false);
+  });
+
+  it("uses cross-host logout on the hosted Cloud app", async () => {
+    isElizaCloudRuntimeLockedMock.mockReturnValue(false);
+    isAppModeHostMock.mockReturnValue(true);
+    const params = makeParams();
+    const { result } = renderHook(() => useCloudState(params));
+
+    act(() => {
+      result.current.setElizaCloudEnabled(true);
+      result.current.setElizaCloudConnected(true);
+      result.current.setElizaCloudUserId("hosted-user-before-sign-out");
+    });
+
+    await act(async () => {
+      await result.current.handleCloudSignOut();
+    });
+
+    expect(signOutFromSsoBridgedHost).toHaveBeenCalledTimes(1);
+    expect(client.cloudDisconnect).not.toHaveBeenCalled();
+    expect(result.current.elizaCloudConnected).toBe(false);
+    expect(result.current.elizaCloudEnabled).toBe(false);
+    expect(result.current.elizaCloudUserId).toBeNull();
   });
 });

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -35,6 +35,7 @@ import {
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
 } from "../bridge";
+import { isAppModeHost } from "../cloud/app-mode/app-mode";
 import { publishCloudAuthComplete } from "../cloud/auth/cloud-auth-complete-signal";
 import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
@@ -1497,10 +1498,10 @@ export function useCloudState({
     // the backend connected, so a reload or fresh poll would resurface the same
     // account. Delegate to the real disconnect path (which clears the server
     // session) unless the runtime is locked. The account-only clear below is
-    // reserved for the locked mobile runtime, where handleCloudDisconnect
-    // refuses (Cloud is required in cloud mode) and only the account session
-    // can be dropped.
-    if (!(disconnectLocked || isElizaCloudRuntimeLocked())) {
+    // Locked mobile runtimes and hosted Cloud app-mode both require an account
+    // sign-out. A local backend disconnect either refuses (locked mode) or
+    // leaves the browser's SSO session intact (hosted app-mode).
+    if (!(disconnectLocked || isElizaCloudRuntimeLocked() || isAppModeHost())) {
       await handleCloudDisconnect({ skipConfirmation: true });
       return;
     }


### PR DESCRIPTION
## Summary
- route hosted Cloud app-mode sign-out through the hardened cross-host SSO logout flow
- preserve local backend disconnect behavior outside hosted/locked Cloud runtimes
- add regression coverage for both hosted and locked Cloud account sign-out

## Verification
- `bunx vitest run --config ./vitest.config.ts src/state/useCloudState.cloud-sign-out.test.tsx src/state/useCloudState.backend-sign-out.test.tsx` (3 passed)
- `bunx @biomejs/biome check packages/ui/src/state/useCloudState.ts packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bun run build:core` (59/59 tasks successful)

## Live QA context
Google OAuth now reaches the authenticated hosted workspace. Before this patch, Settings → Overview → Sign out showed “Signing out…” but retained the connected account because hosted app-mode used the local backend disconnect path instead of clearing the browser SSO session.