### PR TITLE
fix(cloud): require authoritative backing for reconciliation refunds

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
@@ -1057,20 +1057,24 @@ describe("deduct + reconcile legs under ONE request key (#10847 follow-up)", () 
   test("reconcile-refund replay reverses the creator exactly once (balance + counter)", async () => {
     if (!pgliteReady) return;
     const { appId, payerUserId, creatorUserId } = await seed();
+    let reservationTransactionId: string | undefined;
 
     await runWithRequestContext({ idempotencyKey: "settle-refund" }, async () => {
-      await appCreditsService.deductCredits({
+      const deduction = await appCreditsService.deductCredits({
         appId,
         userId: payerUserId,
         baseCost: 0.03,
         description: "inference (estimate)",
       });
+      reservationTransactionId = deduction.transactionId;
+      expect(reservationTransactionId).toBeTruthy();
       await appCreditsService.reconcileCredits({
         appId,
         userId: payerUserId,
         estimatedBaseCost: 0.03,
         actualBaseCost: 0.01,
         description: "inference (reconcile refund)",
+        reservationTransactionId,
       });
     });
     // +0.03 (deduct leg) − 0.02 (refund leg) at 100% markup.
@@ -1087,6 +1091,7 @@ describe("deduct + reconcile legs under ONE request key (#10847 follow-up)", () 
         estimatedBaseCost: 0.03,
         actualBaseCost: 0.01,
         description: "inference (reconcile refund retry)",
+        reservationTransactionId,
       }),
     );
     expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -574,6 +574,22 @@ describe("reconcileCredits — charges/refunds the estimate↔actual delta (#914
     });
   });
 
+  test("keeps an unkeyed sub-threshold refund-shaped delta as a no-op", async () => {
+    const result = await freshService().reconcileCredits({
+      appId: APP_ID,
+      userId: USER_ID,
+      estimatedBaseCost: 1,
+      actualBaseCost: 0.9999995,
+      description: "sub-threshold recon",
+    });
+
+    expect(result.reconciled).toBe(false);
+    expect(result.action).toBe("none");
+    expect(refundCredits).not.toHaveBeenCalled();
+    expect(reserveAndDeductCredits).not.toHaveBeenCalled();
+    expect(markReservationSettled).not.toHaveBeenCalled();
+  });
+
   test("no-op reconciliation fails closed on a corrupt org balance", async () => {
     findOrgById.mockResolvedValue({ id: ORG_ID, credit_balance: "42.50oops" });
 
@@ -609,19 +625,20 @@ describe("reconcileCredits — charges/refunds the estimate↔actual delta (#914
     expect(refundCredits).not.toHaveBeenCalled();
   });
 
-  test("refunds the markup'd overcharge to the org when actual is below estimated", async () => {
-    const result = await freshService().reconcileCredits({
-      appId: APP_ID,
-      userId: USER_ID,
-      estimatedBaseCost: 2,
-      actualBaseCost: 1,
-      description: "recon",
-    });
-    expect(result.reconciled).toBe(true);
-    expect(result.action).toBe("refund");
-    expect(result.adjustedAmount).toBeCloseTo(1.1, 10);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits.mock.calls[0][0].organizationId).toBe(ORG_ID);
+  test("rejects an unbacked refund before any app or ledger mutation", async () => {
+    await expect(
+      freshService().reconcileCredits({
+        appId: APP_ID,
+        userId: USER_ID,
+        estimatedBaseCost: 2,
+        actualBaseCost: 1,
+        description: "recon",
+      }),
+    ).rejects.toMatchObject({ code: "CREDIT_REFUND_RESERVATION_REQUIRED" });
+
+    expect(findAppById).not.toHaveBeenCalled();
+    expect(findUserById).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
     expect(reserveAndDeductCredits).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
@@ -149,6 +149,14 @@ async function orgTransactions(
     .where(and(eq(creditTransactions.organization_id, orgId), eq(creditTransactions.type, type)));
 }
 
+async function orgTransactionCount(orgId: string): Promise<number> {
+  const rows = await dbWrite
+    .select({ id: creditTransactions.id })
+    .from(creditTransactions)
+    .where(eq(creditTransactions.organization_id, orgId));
+  return rows.length;
+}
+
 /**
  * Make the NEXT `reduceEarnings` call throw (the post-refund write blip that
  * strands reconcile mid-flight); later calls run the real implementation.
@@ -353,15 +361,10 @@ describe("reconcile refund-then-throw + settler re-invoke (#11512)", () => {
     expect(refunds[0]?.stripe_payment_intent_id).toBe(`reconcile-refund:${reservationTxId}`);
   });
 
-  test("client-controlled keys (metadata.idempotencyKey / ALS request key) never become the dedup key", async () => {
+  test("serial and concurrent unkeyed refunds reject before any money or creator mutation", async () => {
     if (!pgliteReady) return;
-    const { appId, payerUserId, payerOrgId } = await seed();
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
 
-    // A reconcile that carries ONLY client-controlled identifiers — the
-    // Idempotency-Key echoed into metadata AND the request-ALS key — must not
-    // mint a synthetic stripe_payment_intent_id from either of them: that
-    // unique index is GLOBAL, so a client key would collide across orgs
-    // (see the cross-tenant tests below for the resulting money loss).
     await runWithRequestContext({ idempotencyKey: "client-chosen-key" }, async () => {
       await appCreditsService.deductCredits({
         appId,
@@ -370,20 +373,153 @@ describe("reconcile refund-then-throw + settler re-invoke (#11512)", () => {
         description: "inference (estimate)",
         metadata: { idempotencyKey: "client-chosen-key" },
       });
-      await appCreditsService.reconcileCredits({
-        appId,
-        userId: payerUserId,
-        estimatedBaseCost: 0.03,
-        actualBaseCost: 0.01,
-        description: "inference (reconcile refund)",
-        metadata: { idempotencyKey: "client-chosen-key" },
-      });
     });
 
-    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
-    const refunds = await orgTransactions(payerOrgId, "refund");
-    expect(refunds).toHaveLength(1);
-    expect(refunds[0]?.stripe_payment_intent_id).toBeNull();
+    const balanceBefore = await orgBalance(payerOrgId);
+    const creatorBefore = await creatorBalance(creatorUserId);
+    const transactionsBefore = await orgTransactionCount(payerOrgId);
+    const attempt = () =>
+      runWithRequestContext({ idempotencyKey: "client-chosen-key" }, () =>
+        appCreditsService.reconcileCredits({
+          appId,
+          userId: payerUserId,
+          estimatedBaseCost: 0.03,
+          actualBaseCost: 0.01,
+          description: "unbacked app reconcile refund",
+          metadata: { idempotencyKey: "client-chosen-key" },
+        }),
+      );
+
+    await expect(attempt()).rejects.toMatchObject({
+      code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+    });
+    await expect(attempt()).rejects.toMatchObject({
+      code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+    });
+
+    const concurrent = await Promise.allSettled([attempt(), attempt(), attempt(), attempt()]);
+    expect(concurrent).toHaveLength(4);
+    for (const result of concurrent) {
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.reason).toMatchObject({
+          code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+        });
+      }
+    }
+
+    expect(await orgBalance(payerOrgId)).toBe(balanceBefore);
+    expect(await creatorBalance(creatorUserId)).toBe(creatorBefore);
+    expect(await orgTransactionCount(payerOrgId)).toBe(transactionsBefore);
+    expect(await orgTransactions(payerOrgId, "refund")).toHaveLength(0);
+  });
+
+  test("a real app debit cannot back a refund into another organization", async () => {
+    if (!pgliteReady) return;
+    const owner = await seed();
+    const other = await seed();
+    const deduction = await appCreditsService.deductCredits({
+      appId: owner.appId,
+      userId: owner.payerUserId,
+      baseCost: 0.03,
+      description: "authoritative app debit",
+    });
+    expect(deduction.transactionId).toBeTruthy();
+
+    const ownerBalanceBefore = await orgBalance(owner.payerOrgId);
+    const otherBalanceBefore = await orgBalance(other.payerOrgId);
+    const creatorBefore = await creatorBalance(owner.creatorUserId);
+    const ownerTransactionsBefore = await orgTransactionCount(owner.payerOrgId);
+
+    await expect(
+      appCreditsService.reconcileCredits({
+        appId: owner.appId,
+        userId: owner.payerUserId,
+        organizationId: other.payerOrgId,
+        estimatedBaseCost: 0.03,
+        actualBaseCost: 0.01,
+        description: "cross-organization refund attempt",
+        reservationTransactionId: deduction.transactionId,
+      }),
+    ).rejects.toMatchObject({ code: "CREDIT_REFUND_RESERVATION_MISMATCH" });
+
+    expect(await orgBalance(owner.payerOrgId)).toBe(ownerBalanceBefore);
+    expect(await orgBalance(other.payerOrgId)).toBe(otherBalanceBefore);
+    expect(await creatorBalance(owner.creatorUserId)).toBe(creatorBefore);
+    expect(await orgTransactionCount(owner.payerOrgId)).toBe(ownerTransactionsBefore);
+    expect(await orgTransactions(owner.payerOrgId, "refund")).toHaveLength(0);
+    expect(await orgTransactions(other.payerOrgId, "refund")).toHaveLength(0);
+  });
+
+  test("a backed refund exactly at the reconciliation threshold settles", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+    const deduction = await appCreditsService.deductCredits({
+      appId,
+      userId: payerUserId,
+      baseCost: 0.000001,
+      description: "exact-threshold app debit",
+    });
+    expect(deduction.transactionId).toBeTruthy();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.999998, 6);
+    // Creator earnings persist at four decimal places, so this microscopic
+    // markup remains zero even though it is part of the six-decimal org debit.
+    expect(await creatorBalance(creatorUserId)).toBe(0);
+
+    const result = await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      organizationId: payerOrgId,
+      estimatedBaseCost: 0.000001,
+      actualBaseCost: 0,
+      description: "exact-threshold backed refund",
+      reservationTransactionId: deduction.transactionId,
+    });
+
+    expect(result.action).toBe("refund");
+    expect(result.adjustedAmount).toBeCloseTo(0.000002, 6);
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(100, 6);
+    expect(await creatorBalance(creatorUserId)).toBe(0);
+    expect(await orgTransactions(payerOrgId, "refund")).toHaveLength(1);
+  });
+
+  test("refund uses the debit's immutable creator and markup despite supplied app drift", async () => {
+    if (!pgliteReady) return;
+    const owner = await seed();
+    const other = await seed();
+    const deduction = await appCreditsService.deductCredits({
+      appId: owner.appId,
+      userId: owner.payerUserId,
+      baseCost: 0.03,
+      description: "immutable accounting debit",
+    });
+    expect(deduction.transactionId).toBeTruthy();
+    expect(await orgBalance(owner.payerOrgId)).toBeCloseTo(99.94, 6);
+    expect(await creatorBalance(owner.creatorUserId)).toBeCloseTo(0.03, 6);
+
+    const result = await appCreditsService.reconcileCredits({
+      appId: owner.appId,
+      userId: owner.payerUserId,
+      organizationId: owner.payerOrgId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.01,
+      description: "refund against drifted app projection",
+      reservationTransactionId: deduction.transactionId,
+      app: {
+        name: "Drifted App",
+        created_by_user_id: other.creatorUserId,
+        monetization_enabled: false,
+        review_status: "rejected",
+        inference_markup_percentage: 0,
+      },
+    });
+
+    expect(result.action).toBe("refund");
+    expect(result.adjustedAmount).toBeCloseTo(0.04, 6);
+    expect(await orgBalance(owner.payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await creatorBalance(owner.creatorUserId)).toBeCloseTo(0.01, 6);
+    expect(await creatorBalance(other.creatorUserId)).toBe(0);
+    expect(await orgTransactions(owner.payerOrgId, "refund")).toHaveLength(1);
   });
 
   test("overage-charge replay debits the org exactly once (symmetric key)", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile-fail-closed.test.ts
@@ -8,11 +8,12 @@
  *     refund keyed only on the caller-supplied `reservedAmount` — credit with
  *     no corresponding debit. It must now throw ReservationNotFoundError and
  *     write nothing.
- *  2. The legacy (no-reservation-id) lane's retry loop used to swallow a
- *     persistent settlement failure and return a success-shaped result
- *     (`adjustmentType: "none"`), making a lost refund indistinguishable from
- *     a clean settle. It must now surface the failure.
- *  3. Negative/non-finite settlement costs must fail before any ledger read or
+ *  2. A positive refund without any reservation id used to trust the caller's
+ *     `reservedAmount`, so serial replays and concurrent calls could mint
+ *     arbitrary credit. Every attempt must now reject before ledger mutation.
+ *  3. Exact/no-op and charge-only legacy reconciliation remain compatible;
+ *     the latter can debit credit but must never create it.
+ *  4. Negative/non-finite settlement costs must fail before any ledger read or
  *     write, so provider sentinel values cannot become unbacked refunds.
  *
  * The actual reconcile/refund/deduct SQL runs against an
@@ -30,12 +31,13 @@ process.env.CREDIT_COST_BUFFER = "1.5";
 const PGLITE_TIMEOUT = 60000;
 
 const ORG_ID = "00000000-0000-0000-0000-0000000000f6";
-const MISSING_ORG_ID = "00000000-0000-0000-0000-0000000000f7";
+const OTHER_ORG_ID = "00000000-0000-0000-0000-0000000000f7";
 const MISSING_RESERVATION_ID = "00000000-0000-0000-0000-0000000000f9";
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let creditsService: typeof import("../credits").creditsService;
+let EPSILON: typeof import("../credits").EPSILON;
 let ReservationNotFoundError: typeof import("../credits").ReservationNotFoundError;
 let assertCreditRefundWithinReservation: typeof import("../credits").assertCreditRefundWithinReservation;
 let pgliteReady = true;
@@ -55,8 +57,10 @@ async function countTransactions(orgId: string): Promise<number> {
 }
 
 async function seedOrg(balance: string): Promise<void> {
-  await dbWrite.execute(`DELETE FROM credit_transactions WHERE organization_id = '${ORG_ID}';`);
-  await dbWrite.execute(`DELETE FROM organizations WHERE id = '${ORG_ID}';`);
+  await dbWrite.execute(
+    `DELETE FROM credit_transactions WHERE organization_id IN ('${ORG_ID}', '${OTHER_ORG_ID}');`,
+  );
+  await dbWrite.execute(`DELETE FROM organizations WHERE id IN ('${ORG_ID}', '${OTHER_ORG_ID}');`);
   await dbWrite.execute(
     `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '${balance}');`,
   );
@@ -67,6 +71,7 @@ beforeAll(async () => {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     const credits = await import("../credits");
     creditsService = credits.creditsService;
+    EPSILON = credits.EPSILON;
     ReservationNotFoundError = credits.ReservationNotFoundError;
     assertCreditRefundWithinReservation = credits.assertCreditRefundWithinReservation;
 
@@ -150,9 +155,49 @@ describe("reconcile with a reservation id that matches no row", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "treats another organization's real reservation as unbacked",
+    async () => {
+      await dbWrite.execute(
+        `INSERT INTO organizations (id, credit_balance) VALUES ('${OTHER_ORG_ID}', '50.00');`,
+      );
+      const inserted = await dbWrite.execute(
+        `INSERT INTO credit_transactions (
+          organization_id,
+          amount,
+          type,
+          description,
+          metadata
+        ) VALUES (
+          '${OTHER_ORG_ID}',
+          '-10.00',
+          'debit',
+          'other organization reservation',
+          '{"type":"reservation"}'::jsonb
+        ) RETURNING id;`,
+      );
+      const reservationTransactionId = (inserted.rows[0] as { id: string }).id;
+
+      await expect(
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 10,
+          actualCost: 4,
+          description: "cross-organization refund attempt",
+          metadata: { reservation_transaction_id: reservationTransactionId },
+        }),
+      ).rejects.toBeInstanceOf(ReservationNotFoundError);
+
+      expect(await getBalance()).toBe(100);
+      expect(await countTransactions(ORG_ID)).toBe(0);
+      expect(await countTransactions(OTHER_ORG_ID)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
 });
 
-describe("legacy-lane persistent settlement failure", () => {
+describe("legacy reconciliation without authoritative reservation backing", () => {
   test("classifies a refund larger than its backing reservation as a fatal invariant failure", () => {
     let thrown: unknown;
     try {
@@ -207,35 +252,88 @@ describe("legacy-lane persistent settlement failure", () => {
   });
 
   test(
-    "surfaces the failure instead of returning a success-shaped result",
+    "rejects serial replays and concurrent unbacked refunds without mutation",
     async () => {
-      // No reservation_transaction_id → legacy lane. The org row does not
-      // exist, so refundCredits fails on every retry. The old catch returned
-      // `adjustmentType: "none"` here — a fabricated clean settle.
-      await expect(
+      const attempt = () =>
         creditsService.reconcile({
-          organizationId: MISSING_ORG_ID,
-          reservedAmount: 25,
-          actualCost: 5,
-          description: "legacy settle against missing org",
-        }),
-      ).rejects.toThrow();
-      expect(await countTransactions(MISSING_ORG_ID)).toBe(0);
+          organizationId: ORG_ID,
+          reservedAmount: 10,
+          actualCost: 4,
+          description: "unbacked legacy refund",
+        });
+
+      await expect(attempt()).rejects.toMatchObject({
+        code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+      });
+      await expect(attempt()).rejects.toMatchObject({
+        code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+      });
+
+      const concurrent = await Promise.allSettled([attempt(), attempt(), attempt(), attempt()]);
+      expect(concurrent).toHaveLength(4);
+      for (const result of concurrent) {
+        expect(result.status).toBe("rejected");
+        if (result.status === "rejected") {
+          expect(result.reason).toMatchObject({
+            code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+          });
+        }
+      }
+
+      expect(await getBalance()).toBe(100);
+      expect(await countTransactions(ORG_ID)).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "still settles a healthy legacy refund (regression guard)",
+    "rejects an unbacked refund exactly at the reconciliation threshold",
+    async () => {
+      await expect(
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: EPSILON,
+          actualCost: 0,
+          description: "exact-threshold unbacked refund",
+        }),
+      ).rejects.toMatchObject({ code: "CREDIT_REFUND_RESERVATION_REQUIRED" });
+
+      expect(await getBalance()).toBe(100);
+      expect(await countTransactions(ORG_ID)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "keeps an exact no-op compatible without creating a ledger row",
     async () => {
       const result = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 10,
-        actualCost: 4,
-        description: "legacy refund settle",
+        actualCost: 10,
+        description: "legacy exact settle",
       });
-      expect(result.adjustmentType).toBe("refund");
-      expect(await getBalance()).toBe(106);
+
+      expect(result.adjustmentType).toBe("none");
+      expect(await getBalance()).toBe(100);
+      expect(await countTransactions(ORG_ID)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "keeps charge-only legacy reconciliation compatible without creating credit",
+    async () => {
+      const result = await creditsService.reconcile({
+        organizationId: ORG_ID,
+        reservedAmount: 4,
+        actualCost: 10,
+        description: "legacy overage settle",
+      });
+
+      expect(result.adjustmentType).toBe("overage");
+      expect(await getBalance()).toBe(94);
+      expect(await countTransactions(ORG_ID)).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -280,13 +280,14 @@ describe("CreditsService.reconcile", () => {
     "refund branch: reserved > actual increases balance by the difference",
     async () => {
       if (!pgliteReady) return;
+      const reservationId = await insertReservation(1.0);
 
       const result = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 1.0,
         actualCost: 0.4,
         description: "reconcile refund case",
-        metadata: { user_id: USER_ID },
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
       });
 
       expect(result.adjustmentType).toBe("refund");
@@ -297,7 +298,7 @@ describe("CreditsService.reconcile", () => {
 
       // Exactly one refund row, whose id is the returned settlement id.
       expect(await countByType("refund")).toBe(1);
-      expect(await countTransactions()).toBe(1);
+      expect(await countTransactions()).toBe(2);
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
@@ -428,6 +429,7 @@ describe("CreditsService.reconcile", () => {
     "refund branch: actualCost 0 refunds the ENTIRE reservation (request-failure path)",
     async () => {
       if (!pgliteReady) return;
+      const reservationId = await insertReservation(1.0);
 
       // The live request-failure path settles a reservation against actualCost 0
       // (reservation.reconcile(0)): the request was reserved but produced no
@@ -441,7 +443,7 @@ describe("CreditsService.reconcile", () => {
         reservedAmount: 1.0,
         actualCost: 0,
         description: "reconcile full-refund case",
-        metadata: { user_id: USER_ID },
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
       });
 
       expect(result.adjustmentType).toBe("refund");
@@ -453,7 +455,7 @@ describe("CreditsService.reconcile", () => {
       // Exactly one refund row, for the FULL reserved amount, and its id is the
       // returned settlement id.
       expect(await countByType("refund")).toBe(1);
-      expect(await countTransactions()).toBe(1);
+      expect(await countTransactions()).toBe(2);
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
@@ -509,19 +511,10 @@ describe("CreditsService.reconcile", () => {
   );
 
   test(
-    "NON-IDEMPOTENT double-settle hazard: settling then a second reconcile(0) refunds AGAIN (the free-generation bug #10278's chargeSettled guard prevents)",
+    "a post-settle reconcile(0) without reservation authority cannot issue a second refund",
     async () => {
       if (!pgliteReady) return;
-
-      // reconcile() is a pure function of (reservedAmount - actualCost); it has NO
-      // settled-guard of its own. The metered media routes (generate-video /
-      // generate-music / generate-image) reserve the full amount up front, then on
-      // success call reconcile(actualCost) to settle. If a *post-settle*, non-critical
-      // step then throws (e.g. generationsService.create), the route's catch arm used
-      // to call reconcile(0) — refunding the FULL reservation a SECOND time and handing
-      // the user a free generation. This test pins that hazard at the money layer so the
-      // route-level `if (reservation && !chargeSettled)` guard can never be silently
-      // removed without a red test.
+      const reservationId = await insertReservation(1.0);
 
       // 1) Settle: reserved 1.0, actual 0.4 -> refund the 0.6 over-reservation.
       const settle = await creditsService.reconcile({
@@ -529,27 +522,25 @@ describe("CreditsService.reconcile", () => {
         reservedAmount: 1.0,
         actualCost: 0.4,
         description: "media settle (charge committed)",
-        metadata: { user_id: USER_ID },
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
       });
       expect(settle.adjustmentType).toBe("refund");
       expect(await getBalance()).toBeCloseTo(10.6, 6);
 
-      // 2) The OLD post-settle catch path: reconcile(0) on the same reservation.
-      //    Because reconcile is non-idempotent, this refunds the ENTIRE 1.0 again.
-      const doubleRefund = await creditsService.reconcile({
-        organizationId: ORG_ID,
-        reservedAmount: 1.0,
-        actualCost: 0,
-        description: "media post-settle error -> erroneous second refund",
-        metadata: { user_id: USER_ID },
-      });
-      expect(doubleRefund.adjustmentType).toBe("refund");
+      // 2) The old post-settle catch shape omitted the reservation id. It must
+      // now fail before the full-reservation refund can be written.
+      await expect(
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0,
+          description: "media post-settle error -> erroneous second refund",
+          metadata: { user_id: USER_ID },
+        }),
+      ).rejects.toMatchObject({ code: "CREDIT_REFUND_RESERVATION_REQUIRED" });
 
-      // The damage: balance is 10.0 + 0.6 + 1.0 = 11.60 (1.0 of free credit on a
-      // request that only over-reserved by 0.6), and TWO refund rows exist. This is
-      // exactly what skipping reconcile(0) once chargeSettled is true prevents.
-      expect(await getBalance()).toBeCloseTo(11.6, 6);
-      expect(await countByType("refund")).toBe(2);
+      expect(await getBalance()).toBeCloseTo(10.6, 6);
+      expect(await countByType("refund")).toBe(1);
     },
     PGLITE_TIMEOUT,
   );
@@ -626,13 +617,10 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
   );
 
   test(
-    "without a reservation id the fix is opt-in — behavior is unchanged (still double-applies)",
+    "without a reservation id repeated refund attempts fail closed",
     async () => {
       if (!pgliteReady) return;
       await seedOrg("10");
-      // No reservation_transaction_id => no dedupe key => prior non-idempotent
-      // behavior is preserved (this documents that the fix does NOT silently
-      // change any existing caller that lacks a reservation id).
       const args = {
         organizationId: ORG_ID,
         reservedAmount: 1.0,
@@ -641,11 +629,16 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
         metadata: { user_id: USER_ID },
       };
 
-      await creditsService.reconcile(args);
-      await creditsService.reconcile(args);
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+      });
+      await expect(creditsService.reconcile(args)).rejects.toMatchObject({
+        code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+      });
 
-      expect(await getBalance()).toBeCloseTo(11.2, 6);
-      expect(await countByType("refund")).toBe(2);
+      expect(await getBalance()).toBeCloseTo(10, 6);
+      expect(await countByType("refund")).toBe(0);
+      expect(await countTransactions()).toBe(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -2,6 +2,7 @@
  * Service for managing app-specific credit balances and purchases.
  */
 
+import { ElizaError } from "@elizaos/core";
 import Decimal from "decimal.js";
 import { and, eq, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
@@ -30,6 +31,7 @@ import {
   parseAppMonetizationNumber,
 } from "./app-credit-math";
 import { APP_USAGE_PROJECTION_VERSION } from "./app-usage-projections";
+import { assertCreditRefundReservationPresent } from "./credit-reconciliation-invariants";
 import {
   APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
   assertCreditRefundWithinReservation,
@@ -225,6 +227,17 @@ function normalizeUuidIdentity(value: unknown): string | null {
     return null;
   }
   return value.toLowerCase();
+}
+
+function appRefundReservationMismatch(
+  reason: string,
+  context: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(`App credit refund reservation ${reason}`, {
+    code: "CREDIT_REFUND_RESERVATION_MISMATCH",
+    context: { scope: "AppCreditsService.reconcileCredits", ...context },
+    severity: "fatal",
+  });
 }
 
 /**
@@ -459,6 +472,8 @@ export interface AppCreditReconciliationParams {
    * twice (#11512). MUST never be a client-supplied value: that unique index
    * is global (not org-scoped), so a client-controlled key would let one
    * org's settle dedupe away another org's refund or overage charge.
+   * Positive refunds require this id; exact/no-op and charge-only legacy
+   * reconciliation may omit it because neither path can create credit.
    */
   reservationTransactionId?: string | null;
 }
@@ -1202,15 +1217,39 @@ export class AppCreditsService {
       scope: "AppCreditsService.reconcileCredits",
     });
 
+    const baseCostDifference = actualBaseCost - estimatedBaseCost;
+    const isMaterialRefund = -baseCostDifference >= RECONCILIATION_THRESHOLD;
+    assertCreditRefundReservationPresent({
+      reservationTransactionId,
+      refundAmount: -baseCostDifference,
+      refundTolerance: RECONCILIATION_THRESHOLD,
+      scope: "AppCreditsService.reconcileCredits",
+    });
+
     // Validate metadata size and depth
     const metadata = validateMetadata(rawMetadata, "reconcileCredits");
+    let refundReservation:
+      | {
+          organizationId: string;
+          totalCost: number;
+          accountingApp: AppCreditAccountingApp;
+        }
+      | undefined;
     if (reservationTransactionId) {
       const [candidate] = await dbWrite
-        .select({ metadata: creditTransactions.metadata })
+        .select({
+          organizationId: creditTransactions.organization_id,
+          amount: creditTransactions.amount,
+          type: creditTransactions.type,
+          metadata: creditTransactions.metadata,
+        })
         .from(creditTransactions)
         .where(eq(creditTransactions.id, reservationTransactionId))
         .limit(1);
       if (!candidate) {
+        if (isMaterialRefund) {
+          throw appRefundReservationMismatch("does not exist", { reservationTransactionId });
+        }
         throw new Error("App reconciliation reservation does not exist");
       }
       if (
@@ -1227,6 +1266,66 @@ export class AppCreditsService {
           metadata,
           reservationTransactionId,
         });
+      }
+
+      if (isMaterialRefund) {
+        const facts = candidate.metadata;
+        const reservedBaseCost = Number(facts.baseCost);
+        const reservedTotalCost = Math.abs(Number(candidate.amount));
+        const factTotalCost = Number(facts.totalCost);
+        const creatorMarkup = Number(facts.creatorMarkup);
+        const markupPercentage = Number(facts.markupPercentage);
+        const monetizationActive = facts.monetizationActive;
+        const creatorUserId = typeof facts.creatorUserId === "string" ? facts.creatorUserId : null;
+        const appName =
+          typeof facts.appName === "string" || facts.appName === null ? facts.appName : null;
+        const expectedCreatorMarkup = new Decimal(reservedBaseCost)
+          .mul(markupPercentage)
+          .div(100)
+          .toDecimalPlaces(6);
+        const expectedTotalCost = new Decimal(reservedBaseCost)
+          .plus(creatorMarkup)
+          .toDecimalPlaces(6);
+        if (
+          candidate.type !== "debit" ||
+          facts.appId !== appId ||
+          facts.userId !== userId ||
+          !Number.isFinite(reservedBaseCost) ||
+          reservedBaseCost < 0 ||
+          Math.abs(reservedBaseCost - estimatedBaseCost) > RECONCILIATION_THRESHOLD ||
+          !Number.isFinite(reservedTotalCost) ||
+          !Number.isFinite(factTotalCost) ||
+          Math.abs(factTotalCost - reservedTotalCost) > RECONCILIATION_THRESHOLD ||
+          !Number.isFinite(creatorMarkup) ||
+          creatorMarkup < 0 ||
+          !Number.isFinite(markupPercentage) ||
+          markupPercentage < 0 ||
+          markupPercentage > 1000 ||
+          typeof monetizationActive !== "boolean" ||
+          !new Decimal(creatorMarkup).toDecimalPlaces(6).equals(expectedCreatorMarkup) ||
+          !new Decimal(factTotalCost).toDecimalPlaces(6).equals(expectedTotalCost) ||
+          (!monetizationActive && (markupPercentage !== 0 || creatorMarkup !== 0)) ||
+          (creatorMarkup > 0 && !creatorUserId)
+        ) {
+          throw appRefundReservationMismatch("facts do not match the refund", {
+            reservationTransactionId,
+            appId,
+            userId,
+          });
+        }
+        refundReservation = {
+          organizationId: candidate.organizationId,
+          totalCost: reservedTotalCost,
+          accountingApp: {
+            name: appName,
+            created_by_user_id: creatorUserId,
+            monetization_enabled: monetizationActive,
+            review_status: monetizationActive ? "approved" : "rejected",
+            platform_offset_amount: 0,
+            purchase_share_percentage: 0,
+            inference_markup_percentage: markupPercentage,
+          },
+        };
       }
     }
     const settlementMetadata = reservationTransactionId
@@ -1254,11 +1353,9 @@ export class AppCreditsService {
     // `recon:<txid>:<phase>` keys (#10846). The `reconcile-refund:` /
     // `reconcile-charge:` prefixes keep the synthetic keys disjoint from
     // real Stripe intent ids (`pi_…`) and those `recon:` keys. When no
-    // reservation transaction id is available (the apps/[id]/chat
-    // direct-reconcile paths), we pass NO key — the prior non-idempotent
-    // behavior, backstopped by those routes' settle-started flags and the
-    // settler's first-call-wins guard (createCreditReservationSettler) — and
-    // NEVER fall back to a client-supplied value.
+    // reservation transaction id is available, only exact/no-op and
+    // charge-only legacy reconciliation may continue. Those paths pass NO key
+    // and NEVER fall back to a client-supplied value.
     const chargeKey = reservationTransactionId || null;
 
     // #11683: the creator-earnings legs below must dedupe across ALL writers
@@ -1271,14 +1368,12 @@ export class AppCreditsService {
     // transaction id (threaded as metadata.idempotencyKey, which
     // recordCreatorEarnings/reverseCreatorEarnings prefer over the ALS key);
     // the movement leg still disambiguates reconcile_refund vs
-    // reconcile_charge. Unkeyed callers keep the prior request-scoped dedup.
+    // reconcile_charge. Unkeyed charge callers keep request-scoped dedup.
     const earningsLegMetadata = (extra: Record<string, unknown>): Record<string, unknown> => ({
       ...extra,
       ...settlementMetadata,
       ...(chargeKey && { idempotencyKey: `reconcile:${chargeKey}` }),
     });
-
-    const baseCostDifference = actualBaseCost - estimatedBaseCost;
 
     // Resolve the org once — every branch below charges or refunds against the
     // org credit balance, not a per-app pool. Stale-settlement callers pass the
@@ -1298,6 +1393,13 @@ export class AppCreditsService {
         adjustedAmount: 0,
         newBalance: 0,
       };
+    }
+    if (refundReservation && refundReservation.organizationId !== organizationId) {
+      throw appRefundReservationMismatch("belongs to a different organization", {
+        reservationTransactionId,
+        organizationId,
+        reservationOrganizationId: refundReservation.organizationId,
+      });
     }
 
     const markReservationSettled = async (): Promise<void> => {
@@ -1334,17 +1436,19 @@ export class AppCreditsService {
       };
     }
 
-    // Calculate the total cost difference including markup. Math in
-    // app-credit-math.ts. Uses the same effective flag as deductCredits so a
-    // review-rejected app's reconcile never mints/reverses markup its deduct
-    // leg didn't charge.
-    const monetizationActive = isAppMonetizationActive(app);
+    // Positive refunds must use the debit row's immutable creator and markup
+    // contract. Current/provided app state remains suitable for no-op and
+    // charge-only paths, but cannot redirect a clawback or change a refund.
+    const settlementApp: AppCreditAccountingApp = refundReservation
+      ? { ...app, ...refundReservation.accountingApp }
+      : app;
+    const monetizationActive = isAppMonetizationActive(settlementApp);
     const { markupPercentage, totalCostDifference, creatorMarkupDifference } =
       computeReconciliation(baseCostDifference, {
         monetizationEnabled: monetizationActive,
-        platformOffsetAmount: app.platform_offset_amount,
-        purchaseSharePercentage: app.purchase_share_percentage,
-        inferenceMarkupPercentage: app.inference_markup_percentage,
+        platformOffsetAmount: settlementApp.platform_offset_amount,
+        purchaseSharePercentage: settlementApp.purchase_share_percentage,
+        inferenceMarkupPercentage: settlementApp.inference_markup_percentage,
       });
 
     if (baseCostDifference < 0) {
@@ -1353,14 +1457,16 @@ export class AppCreditsService {
       // partial clawback would leave both parties holding the same money.
       const refundAmount = Math.abs(totalCostDifference);
       const creatorEarningsReduction = Math.abs(creatorMarkupDifference);
-      const maximumRefund = computeInferenceCharge(estimatedBaseCost, {
-        monetizationEnabled: monetizationActive,
-        platformOffsetAmount: app.platform_offset_amount,
-        purchaseSharePercentage: app.purchase_share_percentage,
-        inferenceMarkupPercentage: app.inference_markup_percentage,
-      }).totalCost;
+      if (!refundReservation) {
+        throw appRefundReservationMismatch("was not verified before mutation", {
+          reservationTransactionId,
+          organizationId,
+          appId,
+          userId,
+        });
+      }
       assertCreditRefundWithinReservation({
-        reservedAmount: maximumRefund,
+        reservedAmount: refundReservation.totalCost,
         refundAmount,
         scope: "AppCreditsService.reconcileCredits",
       });
@@ -1380,7 +1486,7 @@ export class AppCreditsService {
               actualBaseCost,
               description,
             }),
-            app,
+            settlementApp,
           );
         } catch (reversalError) {
           // error-policy:J2 a failed clawback must retain the consumer charge;
@@ -1403,7 +1509,7 @@ export class AppCreditsService {
       const { newBalance } = await creditsService.refundCredits({
         organizationId,
         amount: refundAmount,
-        description: `App reconciliation refund (${app.name ?? appId})`,
+        description: `App reconciliation refund (${settlementApp.name ?? appId})`,
         // Idempotent per reservation (#11512): a re-invoked reconcile must not
         // credit the org a second refund (2×reserved − actual = minted,
         // cashable credit).

--- a/packages/cloud/shared/src/lib/services/credit-reconciliation-invariants.ts
+++ b/packages/cloud/shared/src/lib/services/credit-reconciliation-invariants.ts
@@ -1,0 +1,38 @@
+/**
+ * Enforces fail-closed credit reconciliation invariants shared by organization
+ * and application settlement boundaries before either can mutate a ledger.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+/** Refuses a positive refund whose caller did not identify its backing debit. */
+export class CreditRefundReservationRequiredError extends ElizaError {
+  override readonly name = "CreditRefundReservationRequiredError";
+
+  constructor(scope: string, refundAmount: number) {
+    super(`${scope} requires an authoritative reservation for a positive refund`, {
+      code: "CREDIT_REFUND_RESERVATION_REQUIRED",
+      context: { scope, refundAmount },
+      severity: "fatal",
+    });
+  }
+}
+
+/**
+ * A caller-provided estimate is a ceiling claim, not proof that money was
+ * previously debited. Positive reconciliation therefore requires the stable
+ * server-generated id that the owning settlement path verifies before moving
+ * credit. Exact/no-op and charge-only legacy calls remain compatible.
+ */
+export function assertCreditRefundReservationPresent(params: {
+  reservationTransactionId: string | null | undefined;
+  refundAmount: number;
+  refundTolerance: number;
+  scope: string;
+}): void {
+  const { reservationTransactionId, refundAmount, refundTolerance, scope } = params;
+  if (refundAmount < refundTolerance || reservationTransactionId) {
+    return;
+  }
+  throw new CreditRefundReservationRequiredError(scope, refundAmount);
+}

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -27,6 +27,7 @@ import { getRouteTimeoutMs } from "../utils/request-timeout";
 import type { AffiliateBillingAttribution } from "./affiliate-billing-attribution";
 import { enqueueCollectedAffiliatePayout } from "./affiliate-payout-outbox";
 import type { PricingBillingSource } from "./ai-pricing-definitions";
+import { assertCreditRefundReservationPresent } from "./credit-reconciliation-invariants";
 import { resolveCostBuffer } from "./credits-config";
 import { emailService } from "./email";
 import { organizationsService } from "./organizations";
@@ -2193,6 +2194,13 @@ export class CreditsService {
       };
     }
 
+    assertCreditRefundReservationPresent({
+      reservationTransactionId: reservationTxId,
+      refundAmount: difference,
+      refundTolerance: EPSILON,
+      scope: "CreditsService.reconcile",
+    });
+
     const baseMetadata = {
       ...metadata,
       reserved: reservedAmount,
@@ -2203,8 +2211,9 @@ export class CreditsService {
     // refund/deduct as `stripePaymentIntentId` so a retry of an already-committed
     // reconcile (commit-then-ack-loss) is a no-op instead of a second refund
     // (platform loss) or a second overage charge (consumer double-charge).
-    // Without a reservation id there is nothing stable to key on, so we keep the
-    // prior non-idempotent behavior. (#10846 finding 2)
+    // Without a reservation id there is nothing stable to key on. Only the
+    // charge-only legacy lane can reach that shape; positive refunds fail
+    // closed above. (#10846 finding 2)
     const reconKey = (phase: "refund" | "overage"): string | undefined =>
       reservationTxId ? `recon:${reservationTxId}:${phase}` : undefined;
 


### PR DESCRIPTION
# Relates to

Fixes #22850.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the real PGlite ledger receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c3bf1410a226e5e1aaa0116dea098ac6d29d3440:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c3bf1410a226e5e1aaa0116dea098ac6d29d3440`; zero conflicts.
- [x] `bun run verify` passes post-sync: 360/360 Turbo tasks plus all follow-on repository audits.

# Risks

Medium. This changes money-moving reconciliation boundaries. A legitimate positive refund now requires the server-generated debit/reservation transaction ID and immutable debit facts. Exact/no-op and charge-only legacy paths remain compatible. The primary compatibility risk is an undiscovered refund caller that does not thread its authoritative transaction ID; production callers were audited and the known refund paths already carry it.

# Background

## What does this PR do?

- Rejects positive organization and app reconciliation refunds before any balance, creator-earnings, or ledger mutation when no authoritative backing transaction is identified.
- Verifies app backing belongs to the same organization, app, and user and matches the reserved base/total/markup facts.
- Derives refund and creator-clawback accounting from the debit's immutable metadata, so app ownership or monetization drift cannot redirect or resize settlement.
- Preserves exact/no-op reconciliation, charge-only legacy reconciliation, and idempotent reservation-backed refunds.

## What kind of change is this?

Bug fix (non-breaking fail-closed correction for unbacked credit refunds).

# Documentation changes needed?

No user-facing documentation change is required; this enforces the existing server-generated reservation contract at the money boundary.

# Testing

## Where should a reviewer start?

Start with `credit-reconciliation-invariants.ts`, then the guards in `CreditsService.reconcile` and `AppCreditsService.reconcileCredits`. The real-database acceptance receipts are below.

## Detailed testing steps

All focused suites were run with macOS network access denied on exact head `2cdeeb7300db658c3a5a78d4ff8928e04f708015`:

- organization fail-closed PGlite suite: 12 passed, 0 failed, 41 assertions;
- app reconciliation PGlite suite: 11 passed, 0 failed, 89 assertions;
- app idempotency PGlite suite: 19 passed, 0 failed, 97 assertions;
- selected app boundary regressions: 2 passed, 0 failed, 10 assertions;
- Cloud Shared typecheck and Biome check: passed;
- root `bun run verify`: 360/360 Turbo tasks and every follow-on audit passed;
- independent exact-range static review: 0 Critical, 0 Important, 0 Minor findings.

# Evidence Gate

<!-- evidence-head:2cdeeb7300db658c3a5a78d4ff8928e04f708015 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only credit ledger change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only credit ledger change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive user flow changed in this service boundary.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed HTTP service was exercised; deterministic database receipts are pasted in the domain row.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite ledger and balance receipts from the exact head are pasted inline.
<details>
<summary>Database output and reconciliation receipts</summary>

```text
Organization boundary: serial replay plus four concurrent unbacked refunds all rejected; balance stayed 100.000000 and refund row count stayed 0.
Organization compatibility: exact no-op wrote no row; charge-only legacy settle moved balance 100.000000 to 94.000000 with one debit and no refund.
App boundary: serial replay plus four concurrent unbacked refunds all rejected; payer balance, creator balance, transaction count, and refund rows were unchanged.
Cross-owner backing: a real debit from another organization was rejected before either organization or creator ledger changed.
Immutable accounting: a caller-supplied drifted app could not redirect the clawback; payer ended 99.980000, original creator 0.010000, alternate creator 0, one refund row.
Exact-threshold backing: a 0.000001 backed base refund settled on the real app path and returned the payer to 100.000000 with exactly one refund row.
Network-denied results: organization 12/12; app reconciliation 11/11; app idempotency 19/19; selected app boundary regressions 2/2.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - backend-only change has no rendered text or visual surface to review.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

N/A - this is a deterministic service/ledger boundary; exact-head PGlite state receipts are inline above. No deployed backend or frontend was exercised.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

The broader `credits-reconcile.test.ts` file remains at one unrelated pre-existing failure (`sweep settles app-chat holds through the app lane`) with 36 passing tests. The same failure reproduces on clean `develop`: its existing test data uses the non-UUID identifier `app-chat-test`, which the existing `normalizeUuidIdentity` contract rejects. This PR's real PGlite acceptance suite and all repository verification gates pass.

No live credits, provider calls, deployment, or funds were used.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c3bf1410a226e5e1aaa0116dea098ac6d29d3440:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [rndrntwrk-authoritative-refunds]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@c3bf1410a226e5e1aaa0116dea098ac6d29d3440:packages/skills/skills/contribute-to-eliza"} -->
