### PR TITLE
fix(desktop): route cloud HTTPS API requests through desktop bridge to bypass WKWebView CORS

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-http-request.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-http-request.ts
@@ -1,5 +1,10 @@
 /** Implements Electrobun desktop desktop http request ts behavior for app-core shell integration. */
-import { isLoopbackBindHost, isWildcardBindHost } from "@elizaos/shared";
+import {
+  isElizaCloudControlPlaneHostname,
+  isElizaDedicatedAgentHostname,
+  isLoopbackBindHost,
+  isWildcardBindHost,
+} from "@elizaos/shared";
 import { resolveExternalApiBase } from "./api-base";
 
 function isExternalPlainHttpUrl(parsed: URL): boolean {
@@ -16,6 +21,21 @@ function isConfiguredExternalApiBaseUrl(parsed: URL): boolean {
     process.env as Record<string, string | undefined>,
   ).base;
   return Boolean(configured && parsed.origin === configured);
+}
+
+/**
+ * Trusted Eliza Cloud HTTPS origins whose CORS policy does not allowlist
+ * loopback renderer origins (e.g. http://127.0.0.1:5174). The desktop main
+ * process (bun) can reach these directly, so the renderer proxies through
+ * desktopHttpRequest to bypass the WKWebView CORS block.
+ */
+function isTrustedElizaCloudHttpsUrl(parsed: URL): boolean {
+  if (parsed.protocol !== "https:") return false;
+  const hostname = parsed.hostname.toLowerCase();
+  return (
+    isElizaCloudControlPlaneHostname(hostname) ||
+    isElizaDedicatedAgentHostname(hostname)
+  );
 }
 
 export function normalizeDesktopHttpRequest(params: unknown): {
@@ -35,10 +55,11 @@ export function normalizeDesktopHttpRequest(params: unknown): {
   const parsed = new URL(record.url);
   if (
     !isExternalPlainHttpUrl(parsed) &&
-    !isConfiguredExternalApiBaseUrl(parsed)
+    !isConfiguredExternalApiBaseUrl(parsed) &&
+    !isTrustedElizaCloudHttpsUrl(parsed)
   ) {
     throw new Error(
-      "desktopHttpRequest supports only external or configured desktop API plain HTTP URLs.",
+      "desktopHttpRequest supports only external or configured desktop API plain HTTP URLs, or trusted Eliza Cloud HTTPS URLs.",
     );
   }
   const method = typeof record.method === "string" ? record.method : "GET";

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -29,6 +29,8 @@ import {
   normalizeDirectCloudSharedAgentApiBase,
 } from "../utils/cloud-agent-base";
 import { ElizaClient } from "./client-base";
+import { desktopHttpTransportForUrl } from "./desktop-http-transport";
+import { fetchAgentTransport, type AgentRequestTransport } from "./transport";
 import type {
   ApiError,
   CloudApiKeySummary,
@@ -520,6 +522,22 @@ function resolveBrowserCloudApiRequestUrl(url: string): string {
 }
 
 /**
+ * Fetch a direct Cloud API URL through the Electrobun desktop HTTP bridge when
+ * available, bypassing the WKWebView CORS block on loopback renderer origins.
+ * Falls back to a regular fetch() on web/native platforms.
+ */
+async function directCloudFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const transport = desktopHttpTransportForUrl(url);
+  if (transport) {
+    return transport.request(url, init ?? {}, undefined);
+  }
+  return fetchAgentTransport.request(url, init ?? {}, undefined);
+}
+
+/**
  * The browser-navigable Eliza Cloud WEB base for a configured cloud base URL
  * (API hosts map to their site host; www maps to the apex). Every URL handed
  * to a browser window/tab must be built on this — never on the raw configured
@@ -849,7 +867,7 @@ async function fetchDirectCloudWithTimeout(
   }, DIRECT_CLOUD_HTTP_TIMEOUT_MS);
 
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    return await directCloudFetch(url, { ...init, signal: controller.signal });
   } catch (err) {
     if (timedOut) {
       throw new Error(
@@ -3246,7 +3264,7 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       };
     }
 
-    const res = await fetch(
+    const res = await directCloudFetch(
       resolveBrowserCloudApiRequestUrl(`${authApiBase}/api/auth/cli-session`),
       {
         method: "POST",
@@ -3308,7 +3326,7 @@ ElizaClient.prototype.cloudLoginPollDirect = async function (
       return parseCloudLoginPollData(parseDirectCloudJsonSafe(res.data));
     }
 
-    const res = await fetch(
+    const res = await directCloudFetch(
       resolveBrowserCloudApiRequestUrl(
         `${authApiBase}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
       ),
@@ -4563,7 +4581,7 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
   // dedicated container subdomain). Both accept the cloud session token —
   // the dedicated-agent proxy swaps it for the container's own token.
   const authedFetch: AuthedAgentFetch = async (base, path, init) => {
-    const res = await fetch(`${base}${path}`, {
+    const res = await directCloudFetch(`${base}${path}`, {
       method: init?.method ?? "GET",
       headers: {
         Accept: "application/json",
@@ -4741,7 +4759,7 @@ ElizaClient.prototype.deleteSharedBridgeAgent = async function (
           )
         ).status
       : (
-          await fetch(resolveBrowserCloudApiRequestUrl(url), {
+          await directCloudFetch(resolveBrowserCloudApiRequestUrl(url), {
             method: "DELETE",
             headers,
             signal: AbortSignal.timeout(20_000),

--- a/packages/ui/src/api/desktop-http-transport.ts
+++ b/packages/ui/src/api/desktop-http-transport.ts
@@ -3,7 +3,12 @@
  * renderer RPC (bypassing CORS/bind-host limits) when running under Electrobun,
  * falling back to fetch otherwise.
  */
-import { isLoopbackBindHost, isWildcardBindHost } from "@elizaos/shared";
+import {
+  isElizaCloudControlPlaneHostname,
+  isElizaDedicatedAgentHostname,
+  isLoopbackBindHost,
+  isWildcardBindHost,
+} from "@elizaos/shared";
 import { getElectrobunRendererRpc } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { isDesktopExternalHttpApiBaseUrl } from "./desktop-external-api-base";
@@ -33,6 +38,25 @@ function isExternalPlainHttpUrl(url: string): boolean {
   } catch {
     // error-policy:J3 unparseable URL is not routed through the privileged
     // desktop HTTP bridge (fail-closed).
+    return false;
+  }
+}
+
+/**
+ * Trusted Eliza Cloud HTTPS origins whose CORS policy does not allowlist
+ * loopback renderer origins. The desktop main process proxies these through
+ * desktopHttpRequest to bypass the WKWebView CORS block.
+ */
+function isTrustedElizaCloudHttpsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    const hostname = parsed.hostname.toLowerCase();
+    return (
+      isElizaCloudControlPlaneHostname(hostname) ||
+      isElizaDedicatedAgentHostname(hostname)
+    );
+  } catch {
     return false;
   }
 }
@@ -75,7 +99,9 @@ export function desktopHttpTransportForUrl(
   url: string,
 ): AgentRequestTransport | null {
   return isElectrobunRuntime() &&
-    (isExternalPlainHttpUrl(url) || isDesktopExternalHttpApiBaseUrl(url))
+    (isExternalPlainHttpUrl(url) ||
+      isDesktopExternalHttpApiBaseUrl(url) ||
+      isTrustedElizaCloudHttpsUrl(url))
     ? desktopHttpTransport
     : null;
 }


### PR DESCRIPTION
## Summary

- The Electrobun renderer (WKWebView served from `http://127.0.0.1:5174`) could not reach `https://api.eliza.app` directly — the Cloud API's CORS policy does not allowlist loopback origins, so every cloud login/auth request failed with `TypeError: Load failed`
- The main Bun process can reach the same endpoints fine, but the existing `desktopHttpRequest` RPC explicitly rejected HTTPS URLs (only plain HTTP was allowed)
- This PR extends the desktop HTTP bridge to accept trusted Eliza Cloud HTTPS origins (production/staging control-plane and dedicated-agent hostnames via `isElizaCloudControlPlaneHostname` / `isElizaDedicatedAgentHostname`) and routes cloud login, poll, authed agent fetch, and shared-bridge delete calls through it via a new `directCloudFetch` helper
- Non-Eliza HTTPS remains rejected — the allowlist is narrow and fail-closed

## Changes

- **`packages/app-core/platforms/electrobun/src/desktop-http-request.ts`**: Added `isTrustedElizaCloudHttpsUrl()` check to allow HTTPS URLs on trusted Eliza Cloud hostnames through the main-process `desktopHttpRequest` RPC
- **`packages/ui/src/api/desktop-http-transport.ts`**: Added matching `isTrustedElizaCloudHttpsUrl()` so the renderer transport selects the desktop bridge for trusted Cloud HTTPS URLs
- **`packages/ui/src/api/client-cloud.ts`**: Added `directCloudFetch()` helper that uses `desktopHttpTransportForUrl` when available, falling back to `fetchAgentTransport`. Replaced raw `fetch()` calls in `cloudLoginDirect`, `cloudLoginPollDirect`, `fetchDirectCloudWithTimeout`, `authedFetch` (cloud agent handoff), and `deleteSharedBridgeAgent` with `directCloudFetch`

#### Test plan

- [x] `packages/ui` typecheck passes
- [x] `packages/ui/src/api/desktop-http-transport.test.ts` — 3 tests pass
- [x] `packages/app-core/platforms/electrobun` full test suite — 581 tests pass
- [x] `packages/app-core/platforms/electrobun/src/desktop-http-request.test.ts` — 4 tests pass
- [x] Built cloud-only canary macOS app, installed, and verified sign-in flow opens browser with login URL (no more `TypeError: Load failed` for `api.eliza.app/api/auth/cli-session`)
- [ ] CI green

Generated with [Devin](https://devin.ai)
