### PR TITLE
fix(orchestrator): add AbortSignal timeout to model-gateway lease mint/revoke

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
@@ -147,6 +147,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
         authorization: `Bearer ${this.authToken}`,
       },
       body: JSON.stringify(request),
+      signal: AbortSignal.timeout(15_000),
     });
     if (!res.ok) {
       // error-policy:J3 best-effort read of untrusted error body for context; failure → empty detail, error still thrown below
@@ -173,6 +174,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
       {
         method: "POST",
         headers: { authorization: `Bearer ${this.authToken}` },
+        signal: AbortSignal.timeout(15_000),
       },
     );
     // A 404 means the lease is already gone (expired/revoked) — the desired


### PR DESCRIPTION
## Problem
`HttpModelGatewayLeaseBroker` in `plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts` calls `safeFetch` for lease mint and revoke with **no `signal`**. A hung `ELIZA_MODEL_GATEWAY_LEASE_URL` stalls spawn (mint) or teardown (revoke) indefinitely.

## Fix
Pass `AbortSignal.timeout(15_000)` into both `safeFetch` calls (mint and revoke). A hung lease URL now fails closed with `TimeoutError` instead of hanging.

## Acceptance criteria
- [x] Mint and revoke pass `AbortSignal.timeout` (15s) into `safeFetch`
- [x] Hung lease URL fails closed (`TimeoutError`) instead of hanging
- [x] Honest loopback mint + revoke still work (verified via signal propagation test)

Closes #22921

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza