### PR TITLE
fix(telegram): reject unrecognized accountId instead of silent bot fallback

### DIFF
--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -162,6 +162,34 @@ describe("Telegram message connector adapter", () => {
     );
   });
 
+  it("rejects sends to an unrecognized accountId instead of falling back to the default bot", async () => {
+    const runtime = createRuntime();
+    const managerA = { sendMessage: vi.fn().mockResolvedValue([]) };
+    const managerB = { sendMessage: vi.fn().mockResolvedValue([]) };
+    const service = createTelegramService({
+      bot: {},
+      messageManager: managerA,
+      defaultAccountId: "acct-a",
+      accountStates: new Map([
+        ["acct-a", { accountId: "acct-a", messageManager: managerA, bot: {} }],
+        ["acct-b", { accountId: "acct-b", messageManager: managerB, bot: {} }],
+      ]),
+    });
+
+    await expect(
+      service.handleSendMessage(
+        runtime,
+        { source: "telegram", accountId: "acct-ghost", channelId: "-100123" },
+        { text: "hello" },
+      ),
+    ).rejects.toThrow(
+      "Telegram account acct-ghost is not configured or active",
+    );
+
+    expect(managerA.sendMessage).not.toHaveBeenCalled();
+    expect(managerB.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects sends without a resolvable Telegram target", async () => {
     const runtime = createRuntime();
     const manager = { sendMessage: vi.fn().mockResolvedValue([]) };

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -506,7 +506,23 @@ export class TelegramService extends Service {
       (target as AccountScopedTargetInfo | null | undefined)?.accountId ??
       fallback?.accountId;
     if (direct) {
-      return normalizeTelegramAccountId(direct);
+      const normalized = normalizeTelegramAccountId(direct);
+      // Only enforce this in real multi-account mode. In legacy single-bot
+      // mode accountStates is empty and getAccountState() always falls back
+      // to the one configured bot regardless of accountId -- there is no
+      // second account an unrecognized id could be confused with, so an
+      // explicit id that isn't the exact defaultAccountId string is not an
+      // error there (existing single-bot callers may pass any identifier).
+      if (
+        this.accountStates instanceof Map &&
+        this.accountStates.size > 0 &&
+        this.getAccountState(normalized) === null
+      ) {
+        throw new Error(
+          `Telegram account ${normalized} is not configured or active`,
+        );
+      }
+      return normalized;
     }
     const roomId = target?.roomId ?? fallback?.roomId;
     if (roomId && typeof runtime.getRoom === "function") {


### PR DESCRIPTION
# Relates to

Closes #23152.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: OpenAI gpt-5.6-sol; Anthropic claude-sonnet-5
- Agent tooling: Codex; Claude Code; Codex desktop review
- Skill path: N/A - repository review workflow; no contribution skill revision recorded
- Provenance status: self-reported

# Sync with develop

- [x] Targets `develop` with a clean merge state at reviewed head `d1d72a8e3c13b6fa230a7a6832bdf170638d4123`.
- [x] The exact focused connector suite passes; broader pre-existing workspace type-resolution failures are documented below.

# Risks

Low and fail-closed. The guard applies only when the service owns a non-empty multi-account map. Legacy single-bot compatibility and omitted-account default routing remain unchanged.

# Background

In Telegram multi-account mode, an explicit unknown `accountId` passed through `resolveAccountIdForTarget()`. Downstream fallback selected the default bot, allowing a stale or spoofed target to send from the wrong account. This head validates explicit IDs against active account state before any send side effect.

# Testing

Reviewer exact-head validation with pinned Bun 1.3.14 and Node 24.15.0:

```text
vitest run plugins/plugin-telegram/src/messageConnector.test.ts
15 passed, 0 failed
```

The regression drives `handleSendMessage`, requests `acct-ghost`, asserts rejection, and verifies neither configured manager sends. The contributor's mutation control reverted only the guard and reproduced the default-manager send.

# Evidence Gate

<!-- evidence-head:d1d72a8e3c13b6fa230a7a6832bdf170638d4123 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector routing; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector routing; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head test transcript above proves the fail-closed boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The adapter regression verifies zero outbound sends for an unknown account and correct explicit rejection.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

Package `tsc --noEmit` has pre-existing unresolved workspace dependency errors reported identically on `develop`; the focused behavioral suite is green. No implementation gap is known.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - GitHub review workflow; contribution skill not used
Attribution status: self-reported
— [codex-round2-connectors]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - GitHub review workflow; contribution skill not used"} -->