### PR TITLE
fix(ui): add AbortSignal timeout to cloud SIWE nonce/verify fetches

### DIFF
--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -195,6 +195,7 @@ async function fetchSiweNonce(
     try {
       nonceRes = await fetch(nonceUrl, {
         headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
       });
     } catch (error) {
       // Transport failure (offline, DNS, TLS, aborted): transient, retry.
@@ -352,6 +353,7 @@ export async function siweLoginWithInjectedWallet(
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ message, signature }),
+    signal: AbortSignal.timeout(15_000),
   });
   if (!verifyRes.ok) {
     throw new Error(


### PR DESCRIPTION
## Problem
`packages/ui/src/state/cloud-siwe-login.ts` fetches Cloud SIWE nonce and verify with **no `signal`**. A hung `/api/auth/siwe/*` hop stalls injected-wallet app login.

## Fix
Pass `AbortSignal.timeout(15_000)` into both `fetch` calls (nonce and verify). A hung hop now fails closed with `TimeoutError` instead of hanging.

## Acceptance criteria
- [x] Nonce and verify pass `AbortSignal.timeout` (15s)
- [x] Hung SIWE hop fails closed instead of hanging

Closes #22912

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza