### PR TITLE
fix(homepage): add AbortSignal timeout to elizacloudFetch

### DIFF
--- a/packages/homepage/src/lib/api/client.ts
+++ b/packages/homepage/src/lib/api/client.ts
@@ -44,6 +44,7 @@ export async function elizacloudFetch<T = unknown>(
       "Content-Type": "application/json",
       ...reqInit.headers,
     },
+    signal: reqInit.signal ?? AbortSignal.timeout(15_000),
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Problem
`packages/homepage/src/lib/api/client.ts` `elizacloudFetch` calls Eliza Cloud with **no `signal`**. A hung Cloud hop stalls homepage marketing/auth pages. `elizacloudAuthFetch` reuses this helper.

## Fix
Pass `AbortSignal.timeout(15_000)` (or caller-provided signal) into `fetch`. A hung hop now fails closed with `TimeoutError` instead of hanging.

Closes #22907

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza