### PR TITLE
fix(orchestrator): add AbortSignal timeout to parent-agent cloud commands

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1307,6 +1307,7 @@ async function runCloudCommand(args: {
       ...(body ? { "Content-Type": "application/json" } : {}),
     },
     ...(body ? { body: JSON.stringify(body) } : {}),
+    signal: AbortSignal.timeout(15_000),
   });
   const payload = await responsePayload(response);
   const payloadText =


### PR DESCRIPTION
## Problem
`plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts` runs Eliza Cloud commands with `fetch(built.url)` and **no `signal`**. A hung Cloud API stalls `USE_SKILL parent-agent` cloud-command.

## Fix
Pass `AbortSignal.timeout(15_000)` into `fetch`. A hung hop now fails closed with `TimeoutError` instead of hanging.

Closes #22900

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza