### PR TITLE
fix(agent): add AbortSignal timeout to TERMINAL_SHELL loopback fetch

### DIFF
--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -475,6 +475,7 @@ export const terminalAction: Action = {
           captureOutput: true,
           ...(terminalToken ? { terminalToken } : {}),
         }),
+        signal: AbortSignal.timeout(15_000),
       },
     );
 


### PR DESCRIPTION
## Problem
`packages/agent/src/actions/terminal.ts` `TERMINAL_SHELL` POSTs to loopback `/api/terminal/run` with `fetch` and **no `signal`**. If the local API accepts and holds, the action never returns.

## Fix
Pass `AbortSignal.timeout(15_000)` into `fetch`. A hung loopback hop now fails closed with `TimeoutError` instead of hanging.

Closes #22891

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza