### PR TITLE
fix(homepage): add AbortSignal timeout to SIWS nonce/verify fetches

### DIFF
--- a/packages/homepage/src/lib/api/siws.ts
+++ b/packages/homepage/src/lib/api/siws.ts
@@ -142,6 +142,7 @@ export async function signInWithSolana(): Promise<SiwsVerifyResponse> {
     {
       method: "GET",
       headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
     },
   );
   if (!nonceRes.ok) {
@@ -169,6 +170,7 @@ export async function signInWithSolana(): Promise<SiwsVerifyResponse> {
       message,
       signature: bs58Encode(signatureBytes),
     }),
+    signal: AbortSignal.timeout(15_000),
   });
   if (!verifyRes.ok) {
     const detail = await verifyRes.text().catch(() => "");


### PR DESCRIPTION
## Problem
`packages/homepage/src/lib/api/siws.ts` `signInWithSolana` fetches Cloud SIWS nonce and verify with **no `signal`**. A hung `/api/auth/siws/*` hop stalls homepage Solana login.

## Fix
Pass `AbortSignal.timeout(15_000)` into both `fetch` calls (nonce and verify). A hung hop now fails closed with `TimeoutError` instead of hanging.

Closes #22894

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza