### PR TITLE
fix(ui): restore cloud client import hygiene

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -29,8 +29,6 @@ import {
   normalizeDirectCloudSharedAgentApiBase,
 } from "../utils/cloud-agent-base";
 import { ElizaClient } from "./client-base";
-import { desktopHttpTransportForUrl } from "./desktop-http-transport";
-import { fetchAgentTransport, type AgentRequestTransport } from "./transport";
 import type {
   ApiError,
   CloudApiKeySummary,
@@ -72,6 +70,7 @@ import type {
   SandboxStartResponse,
   SandboxWindowInfo,
 } from "./client-types";
+import { desktopHttpTransportForUrl } from "./desktop-http-transport";
 import {
   DEFAULT_DIRECT_CLOUD_APP_BASE_URL,
   DEFAULT_DIRECT_CLOUD_BASE_URL,
@@ -79,6 +78,7 @@ import {
   resolveDirectCloudAuthApiBase,
   resolveDirectCloudWebBase,
 } from "./direct-cloud-endpoints";
+import { fetchAgentTransport } from "./transport";
 
 // ---------------------------------------------------------------------------
 // Module-level constants


### PR DESCRIPTION
# Relates to

Regression introduced by #22926 and observed in develop CI run https://github.com/elizaOS/eliza/actions/runs/32367290491.

- [x] Targets `develop` and is based on the latest `origin/develop@a83adaa8eba1901b1e9fa99e177b4e0f1d7e8bc7` available at publication time.
- [x] `bun install --frozen-lockfile` ran with Bun 1.3.14; focused verification is recorded below.
- [x] The evidence below lets a reviewer reproduce the exact failure and fix.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a83adaa8eba1901b1e9fa99e177b4e0f1d7e8bc7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch was created from the current `origin/develop`; zero conflicts.
- [x] The owning package lint and typecheck pass after building required workspace artifacts.

# Risks

Low. This only organizes imports and removes an unused type-only import. There is no runtime, UI, API, database, or deployment behavior change.

# Background

## What does this PR do?

Restores Biome import ordering in `packages/ui/src/api/client-cloud.ts` and removes the unused `AgentRequestTransport` type import left by #22926. This unblocks the develop Quality/CI gates failing at `assist/source/organizeImports`.

## What kind of change is this?

Bug fix (non-breaking CI hygiene correction).

# Documentation changes needed?

No documentation change: the runtime contract and user-visible behavior are unchanged.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-cloud.ts` import block.

## Detailed testing steps

```bash
bunx @biomejs/biome@2.5.8 check packages/ui/src/api/client-cloud.ts
bun run --cwd packages/ui lint:check
bun run build:core
bun run --cwd packages/ui typecheck
git diff --check
```

All pass with Bun 1.3.14 and Node 24.15.0. The full package lint reports five pre-existing `noDocumentCookie` warnings but exits 0.

# Evidence Gate

<!-- evidence-head:b719923b67c0de3abc9f76271028304cfd888f8f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - import-only non-rendered TypeScript change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - import-only non-rendered TypeScript change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or rendering changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [x] The exact Biome diagnostic is linked through the develop CI run above; the focused command now exits 0 on this head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior.

## Backend + frontend logs

N/A - no runtime behavior.

## Screenshots (before / after) + video walkthrough

N/A - `.ts` import hygiene only; no JSX, CSS, SVG, or rendered output changes.

## Audio / voice walkthrough

N/A - no audio/voice behavior change.

## Known gaps / failures

No focused failures. Root develop contains unrelated inherited failures documented in the linked CI run; this PR addresses only the newly introduced import-order gate regression.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@a83adaa8eba1901b1e9fa99e177b4e0f1d7e8bc7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-v2-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@a83adaa8eba1901b1e9fa99e177b4e0f1d7e8bc7:packages/skills/skills/contribute-to-eliza"} -->
