### PR TITLE
fix(agent): fail closed on cyclic tool-cache redactor walks

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
@@ -180,4 +180,20 @@ describe("wrapActionWithCache", () => {
     const cache = createToolCallCacheFromConfig({ enabled: false });
     expect(cache).toBeNull();
   });
+  it("returns a deep-but-legal ActionResult without rejecting", async () => {
+    const cache = createToolCallCacheFromConfig({ diskRoot: tempRoot });
+    if (!cache) throw new Error("cache must be enabled");
+    let deep: Record<string, unknown> = { v: 1 };
+    for (let i = 0; i < 64; i++) deep = { child: deep };
+    const { action } = makeFakeAction("web_search", () => ({
+      success: true,
+      data: deep,
+    }));
+    const wrapped = wrapActionWithCache(action, cache, { diskRoot: tempRoot });
+    await expect(
+      wrapped.handler({} as never, {} as never, undefined, {
+        parameters: { q: "deep" },
+      }),
+    ).resolves.toEqual({ success: true, data: deep });
+  });
 });

--- a/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import type { Action, ActionResult } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveToolDescriptor } from "./tool-call-cache/registry.ts";
+import type { ToolOutput } from "./tool-call-cache/types.ts";
 import {
   createToolCallCacheFromConfig,
   wrapActionWithCache,
@@ -183,7 +184,7 @@ describe("wrapActionWithCache", () => {
   it("returns a deep-but-legal ActionResult without rejecting", async () => {
     const cache = createToolCallCacheFromConfig({ diskRoot: tempRoot });
     if (!cache) throw new Error("cache must be enabled");
-    let deep: Record<string, unknown> = { v: 1 };
+    let deep: ToolOutput = { v: 1 };
     for (let i = 0; i < 64; i++) deep = { child: deep };
     const { action } = makeFakeAction("web_search", () => ({
       success: true,

--- a/packages/agent/src/runtime/tool-call-cache-wrapper.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.ts
@@ -22,6 +22,7 @@ import {
   type CacheableToolDescriptor,
   defaultPrivacyRedactor,
   isCacheable,
+  isCacheableToolOutput,
   resolveToolDescriptor,
   ToolCallCache,
   type ToolOutput,
@@ -77,33 +78,6 @@ function extractArgs(options: unknown): Record<string, unknown> {
   return {};
 }
 
-function isToolOutput(
-  value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
-): value is ToolOutput {
-  if (
-    typeof value === "string" ||
-    typeof value === "boolean" ||
-    value === null
-  ) {
-    return true;
-  }
-  if (typeof value === "number") return Number.isFinite(value);
-  if (!value || typeof value !== "object") return false;
-
-  if (seen.has(value)) return false;
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.every((entry) => isToolOutput(entry, seen));
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) return false;
-
-  return Object.values(value).every((entry) => isToolOutput(entry, seen));
-}
-
 /**
  * Wrap an Action's handler so cacheable tools route through the cache.
  * Non-cacheable actions are returned unchanged.
@@ -135,7 +109,7 @@ export function wrapActionWithCache(
         !Array.isArray(result) &&
         "success" in result &&
         typeof result.success === "boolean" &&
-        isToolOutput(result),
+        isCacheableToolOutput(result),
     );
   };
 

--- a/packages/agent/src/runtime/tool-call-cache/bounded-walk.ts
+++ b/packages/agent/src/runtime/tool-call-cache/bounded-walk.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared descriptor-safe bounded traversal for the tool-call cache.
+ *
+ * One walker backs all three consumers — output validation
+ * (`isCacheableToolOutput`), cycle detection, and privacy redaction
+ * (`defaultPrivacyRedactor`) — so they cannot drift apart in what they
+ * consider walkable.
+ *
+ * Hostile-input contract:
+ *   - Width is reserved BEFORE any per-entry work. Array length is read from
+ *     the `length` property *descriptor* and object width from
+ *     `Object.getOwnPropertyNames`; both are compared against the remaining
+ *     key budget before a single element/property is touched. Nothing calls
+ *     `Object.values`/`Object.entries`, so a flat million-key result is
+ *     rejected without allocating a values array.
+ *   - Property values are read from data descriptors only. An accessor
+ *     (getter/setter) property is rejected outright, so no user getter and no
+ *     Proxy `get` trap is ever invoked.
+ *   - Every reflection call is guarded. A revoked or throwing Proxy surfaces
+ *     as a `reflection` rejection instead of leaking a raw `TypeError` onto
+ *     the caller's success path.
+ *   - Depth, node count, aggregate key width, per-string length and aggregate
+ *     bytes are all budgeted, and the budget is shared across the whole walk.
+ *   - Cycle detection is path-local (`seen.delete` on container exit) so valid
+ *     DAGs / repeated references are preserved; only true cycles reject.
+ */
+
+export interface BoundedWalkLimits {
+  /** Maximum container nesting. Depth 0 is the root value. */
+  maxDepth: number;
+  /** Maximum values visited across the whole walk. */
+  maxNodes: number;
+  /** Maximum aggregate array length + own-key width reserved across the walk. */
+  maxKeys: number;
+  /** Maximum length of any single string leaf. */
+  maxStringLength: number;
+  /** Maximum aggregate estimated bytes (node overhead + key + string lengths). */
+  maxBytes: number;
+}
+
+/** Default budget. Callers may narrow (never widen) individual limits. */
+export const TOOL_OUTPUT_LIMITS: BoundedWalkLimits = {
+  /** Maximum container nesting. Depth 0 is the root value. */
+  maxDepth: 32,
+  /** Maximum values visited across the whole walk. */
+  maxNodes: 100_000,
+  /** Maximum aggregate array length + own-key width reserved across the walk. */
+  maxKeys: 100_000,
+  /** Maximum length of any single string leaf. */
+  maxStringLength: 4_000_000,
+  /** Maximum aggregate estimated bytes (node overhead + key + string lengths). */
+  maxBytes: 16_000_000,
+};
+
+export type BoundedWalkRejection =
+  /** Property is a getter/setter; reading it would run user code. */
+  | "accessor"
+  /** Aggregate byte budget exhausted. */
+  | "bytes"
+  /** True cycle (the value is already on the current path). */
+  | "cycle"
+  /** Depth budget exhausted. */
+  | "depth"
+  /** Aggregate array-length / own-key width budget exhausted. */
+  | "keys"
+  /** Node budget exhausted. */
+  | "nodes"
+  /** A reflection call threw (revoked/hostile Proxy). */
+  | "reflection"
+  /** A single string leaf exceeded the per-string cap. */
+  | "string-length"
+  /** Not representable as `ToolOutput` (function, symbol, NaN, class instance…). */
+  | "unsupported";
+
+export type BoundedWalkResult =
+  | { ok: true; value: unknown }
+  | { ok: false; reason: BoundedWalkRejection };
+
+export interface BoundedWalkOptions {
+  /** Applied to every string leaf. Identity when omitted. */
+  transformString?: (input: string) => string;
+  /**
+   * When provided the walk never fails: a rejected node is replaced by this
+   * value and traversal continues (still inside the same shared budget).
+   * Used by the redactor, which must always return a value.
+   */
+  substitute?: (reason: BoundedWalkRejection) => unknown;
+  /**
+   * When false, primitives that are not JSON-representable (undefined,
+   * function, symbol, bigint, NaN) pass through unchanged instead of being
+   * rejected. The redactor sets this; validation leaves it on.
+   */
+  strictPrimitives?: boolean;
+  /** Narrowed limits, merged over {@link TOOL_OUTPUT_LIMITS}. */
+  limits?: Partial<BoundedWalkLimits>;
+}
+
+/** Flat per-node overhead charged against the byte budget. */
+const NODE_BYTE_COST = 8;
+
+interface WalkState {
+  limits: BoundedWalkLimits;
+  transformString: ((input: string) => string) | undefined;
+  substitute: ((reason: BoundedWalkRejection) => unknown) | undefined;
+  strictPrimitives: boolean;
+  seen: WeakSet<object>;
+  nodes: number;
+  keys: number;
+  bytes: number;
+}
+
+type ContainerShape =
+  | { kind: "array"; length: number }
+  | { kind: "object"; names: string[] }
+  | { kind: "reject"; reason: BoundedWalkRejection };
+
+/**
+ * Classify a container and report its width without reading any property
+ * value. Every reflection call is guarded so a revoked Proxy rejects rather
+ * than throwing.
+ */
+function describeContainer(value: object): ContainerShape {
+  let isArray: boolean;
+  try {
+    isArray = Array.isArray(value);
+  } catch {
+    return { kind: "reject", reason: "reflection" };
+  }
+
+  if (isArray) {
+    let lengthDescriptor: PropertyDescriptor | undefined;
+    try {
+      lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    } catch {
+      return { kind: "reject", reason: "reflection" };
+    }
+    if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+      return { kind: "reject", reason: "accessor" };
+    }
+    if (typeof lengthDescriptor.value !== "number") {
+      return { kind: "reject", reason: "unsupported" };
+    }
+    return { kind: "array", length: lengthDescriptor.value };
+  }
+
+  let prototype: unknown;
+  try {
+    prototype = Object.getPrototypeOf(value);
+  } catch {
+    return { kind: "reject", reason: "reflection" };
+  }
+  if (prototype !== Object.prototype && prototype !== null) {
+    return { kind: "reject", reason: "unsupported" };
+  }
+
+  let names: string[];
+  try {
+    names = Object.getOwnPropertyNames(value);
+  } catch {
+    return { kind: "reject", reason: "reflection" };
+  }
+  return { kind: "object", names };
+}
+
+/** Read one own property as a data descriptor, never through `[[Get]]`. */
+function readDataProperty(
+  container: object,
+  key: string,
+):
+  | { kind: "value"; value: unknown }
+  | { kind: "absent" }
+  | { kind: "reject"; reason: BoundedWalkRejection } {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(container, key);
+  } catch {
+    return { kind: "reject", reason: "reflection" };
+  }
+  if (!descriptor) return { kind: "absent" };
+  // Accessor properties are rejected before the getter can run.
+  if (!("value" in descriptor)) return { kind: "reject", reason: "accessor" };
+  if (!descriptor.enumerable) return { kind: "absent" };
+  return { kind: "value", value: descriptor.value };
+}
+
+function walkValue(
+  value: unknown,
+  state: WalkState,
+  depth: number,
+): BoundedWalkResult {
+  if (state.nodes >= state.limits.maxNodes) {
+    return { ok: false, reason: "nodes" };
+  }
+  state.nodes += 1;
+  state.bytes += NODE_BYTE_COST;
+  if (state.bytes > state.limits.maxBytes) {
+    return { ok: false, reason: "bytes" };
+  }
+
+  if (value === null) return { ok: true, value: null };
+
+  const type = typeof value;
+  if (type === "string") {
+    const text = value as string;
+    if (text.length > state.limits.maxStringLength) {
+      return { ok: false, reason: "string-length" };
+    }
+    state.bytes += text.length;
+    if (state.bytes > state.limits.maxBytes) {
+      return { ok: false, reason: "bytes" };
+    }
+    return {
+      ok: true,
+      value: state.transformString ? state.transformString(text) : text,
+    };
+  }
+  if (type === "boolean") return { ok: true, value };
+  if (type === "number") {
+    if (Number.isFinite(value)) return { ok: true, value };
+    return state.strictPrimitives
+      ? { ok: false, reason: "unsupported" }
+      : { ok: true, value };
+  }
+  if (type !== "object") {
+    return state.strictPrimitives
+      ? { ok: false, reason: "unsupported" }
+      : { ok: true, value };
+  }
+
+  const container = value as object;
+  if (state.seen.has(container)) return { ok: false, reason: "cycle" };
+  if (depth >= state.limits.maxDepth) return { ok: false, reason: "depth" };
+
+  const shape = describeContainer(container);
+  if (shape.kind === "reject") return { ok: false, reason: shape.reason };
+
+  // Reserve the full width BEFORE touching a single entry, so a hostile flat
+  // object/array is rejected without per-entry allocation or reflection.
+  const width = shape.kind === "array" ? shape.length : shape.names.length;
+  if (!Number.isSafeInteger(width) || width < 0) {
+    return { ok: false, reason: "unsupported" };
+  }
+  if (state.keys + width > state.limits.maxKeys) {
+    return { ok: false, reason: "keys" };
+  }
+  state.keys += width;
+
+  state.seen.add(container);
+  try {
+    if (shape.kind === "array") {
+      const out: unknown[] = [];
+      for (let index = 0; index < shape.length; index += 1) {
+        const read = readDataProperty(container, String(index));
+        if (read.kind === "reject") {
+          if (!state.substitute) return { ok: false, reason: read.reason };
+          out.push(state.substitute(read.reason));
+          continue;
+        }
+        // Array holes serialize as null through JSON; mirror that.
+        if (read.kind === "absent") {
+          out.push(null);
+          continue;
+        }
+        const child = walkValue(read.value, state, depth + 1);
+        if (!child.ok) {
+          if (!state.substitute) return child;
+          out.push(state.substitute(child.reason));
+          continue;
+        }
+        out.push(child.value);
+      }
+      return { ok: true, value: out };
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const name of shape.names) {
+      state.bytes += name.length;
+      if (state.bytes > state.limits.maxBytes) {
+        return { ok: false, reason: "bytes" };
+      }
+      const read = readDataProperty(container, name);
+      if (read.kind === "reject") {
+        if (!state.substitute) return { ok: false, reason: read.reason };
+        out[name] = state.substitute(read.reason);
+        continue;
+      }
+      if (read.kind === "absent") continue;
+      const child = walkValue(read.value, state, depth + 1);
+      if (!child.ok) {
+        if (!state.substitute) return child;
+        out[name] = state.substitute(child.reason);
+        continue;
+      }
+      out[name] = child.value;
+    }
+    return { ok: true, value: out };
+  } finally {
+    state.seen.delete(container);
+  }
+}
+
+/**
+ * Walk `value` under a shared node/key/string/byte budget using
+ * descriptor-safe, path-local traversal. Returns the (optionally transformed)
+ * copy on success, or the first rejection reason. With `substitute` the walk
+ * always succeeds and rejected subtrees are replaced in place.
+ */
+export function boundedWalk(
+  value: unknown,
+  options: BoundedWalkOptions = {},
+): BoundedWalkResult {
+  const state: WalkState = {
+    limits: { ...TOOL_OUTPUT_LIMITS, ...options.limits },
+    transformString: options.transformString,
+    substitute: options.substitute,
+    strictPrimitives: options.strictPrimitives ?? true,
+    seen: new WeakSet<object>(),
+    nodes: 0,
+    keys: 0,
+    bytes: 0,
+  };
+  const result = walkValue(value, state, 0);
+  if (!result.ok && state.substitute) {
+    return { ok: true, value: state.substitute(result.reason) };
+  }
+  return result;
+}

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -18,7 +18,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { ToolCallCache } from "./cache.ts";
+import { isCacheableToolOutput, ToolCallCache } from "./cache.ts";
 import { buildCacheKey, canonicalizeJson } from "./key.ts";
 import {
   defaultPrivacyRedactor,
@@ -574,6 +574,113 @@ describe("ToolCallCache", () => {
       redact: defaultPrivacyRedactor,
     });
     expect(fresh.get(desc, args)).toBeUndefined();
+  });
+
+  /**
+   * Hostile-input regressions. Each fixture must be returned to the caller
+   * untouched and must never enter either tier, on all three write routes:
+   * direct `set()`, the default `run()` predicate, and a lenient custom
+   * `run()` predicate that says "cache everything".
+   */
+  async function expectUncacheableOnEveryRoute(
+    label: string,
+    make: () => unknown,
+  ): Promise<void> {
+    const cache = makeCache();
+    const desc = resolveToolDescriptor("web_search");
+    const lenient = (_output: unknown): _output is ToolOutput => true;
+
+    const viaDefault = make();
+    await expect(
+      cache.run(
+        desc,
+        { q: `${label}-default` },
+        async () => viaDefault as ToolOutput,
+      ),
+    ).resolves.toBe(viaDefault);
+    expect(cache.get(desc, { q: `${label}-default` })).toBeUndefined();
+
+    const viaLenient = make();
+    await expect(
+      cache.run(
+        desc,
+        { q: `${label}-lenient` },
+        async () => viaLenient,
+        lenient,
+      ),
+    ).resolves.toBe(viaLenient);
+    expect(cache.get(desc, { q: `${label}-lenient` })).toBeUndefined();
+
+    const viaSet = make();
+    expect(() =>
+      cache.set(desc, { q: `${label}-set` }, viaSet as ToolOutput),
+    ).not.toThrow();
+    expect(cache.get(desc, { q: `${label}-set` })).toBeUndefined();
+  }
+
+  it("returns a flat-wide result uncached on set, default run and lenient run", async () => {
+    const makeWide = (): Record<string, number> => {
+      const wide: Record<string, number> = {};
+      for (let i = 0; i < 150_000; i += 1) wide[`k${i}`] = i;
+      return wide;
+    };
+    // Width is reserved before any per-entry work, so the verdict is stable.
+    expect(isCacheableToolOutput(makeWide())).toBe(false);
+    expect(isCacheableToolOutput(makeWide())).toBe(false);
+    await expectUncacheableOnEveryRoute("wide", makeWide);
+  });
+
+  it("returns an accessor-bearing result uncached without invoking the getter", async () => {
+    let getterCalls = 0;
+    const makeAccessor = (): Record<string, unknown> => {
+      const value: Record<string, unknown> = { ok: "plain" };
+      Object.defineProperty(value, "leak", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return "secret";
+        },
+      });
+      return value;
+    };
+    expect(isCacheableToolOutput(makeAccessor())).toBe(false);
+    await expectUncacheableOnEveryRoute("accessor", makeAccessor);
+    expect(getterCalls).toBe(0);
+  });
+
+  it("returns a reflection-hostile proxy uncached without running its get trap", async () => {
+    let getTrapCalls = 0;
+    // Wrapped in a plain object: a bare proxy as a resolved promise value
+    // would trip the runtime's own `then` lookup before the cache sees it.
+    const makeHostile = (): unknown => ({
+      ok: "plain",
+      nested: new Proxy(
+        { payload: "value" },
+        {
+          get(target, property, receiver) {
+            getTrapCalls += 1;
+            return Reflect.get(target, property, receiver);
+          },
+          ownKeys() {
+            throw new TypeError("hostile ownKeys trap");
+          },
+        },
+      ),
+    });
+    expect(isCacheableToolOutput(makeHostile())).toBe(false);
+    await expectUncacheableOnEveryRoute("hostile-proxy", makeHostile);
+    expect(getTrapCalls).toBe(0);
+  });
+
+  it("returns a revoked proxy uncached instead of leaking a raw TypeError", async () => {
+    const makeRevoked = (): unknown => {
+      const revocable = Proxy.revocable({ payload: "value" }, {});
+      revocable.revoke();
+      return { ok: "plain", nested: revocable.proxy };
+    };
+    expect(isCacheableToolOutput(makeRevoked())).toBe(false);
+    await expectUncacheableOnEveryRoute("revoked-proxy", makeRevoked);
   });
 
   it("registry includes web_search, web_fetch, file_read, rag_search, knowledge_lookup", () => {

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -456,7 +456,7 @@ describe("ToolCallCache", () => {
       redact: defaultPrivacyRedactor,
     });
     const desc = resolveToolDescriptor("web_search");
-    let deep: Record<string, unknown> = { bottom: "bottom-value" };
+    let deep: ToolOutput = { bottom: "bottom-value" };
     for (let i = 0; i < 12; i++) deep = { child: deep };
 
     const out = await cache.run(desc, { q: "deep" }, async () => deep);
@@ -502,11 +502,78 @@ describe("ToolCallCache", () => {
   it("returns deep-but-legal output through run without rejecting", async () => {
     const cache = makeCache();
     const desc = resolveToolDescriptor("web_search");
-    let deep: Record<string, unknown> = { v: 1 };
+    let deep: ToolOutput = { v: 1 };
     for (let i = 0; i < 64; i++) deep = { child: deep };
     await expect(
       cache.run(desc, { q: "legal-deep" }, async () => deep),
     ).resolves.toEqual(deep);
+  });
+
+  it("never stores cyclic output as a memory-tier hit via run or set", async () => {
+    const cache = makeCache();
+    const desc = resolveToolDescriptor("web_search");
+    const cyclic = { v: 1 } as ToolOutput & { self?: unknown };
+    cyclic.self = cyclic;
+
+    const defaultOut = await cache.run(
+      desc,
+      { q: "cycle-default" },
+      async () => cyclic,
+    );
+    expect(defaultOut).toBe(cyclic);
+    expect(cache.get(desc, { q: "cycle-default" })).toBeUndefined();
+
+    const lenient = (_output: unknown): _output is typeof cyclic => true;
+    let calls = 0;
+    const lenientOut = await cache.run(
+      desc,
+      { q: "cycle-lenient" },
+      async () => {
+        calls += 1;
+        return cyclic;
+      },
+      lenient,
+    );
+    expect(lenientOut).toBe(cyclic);
+    expect(cache.get(desc, { q: "cycle-lenient" })).toBeUndefined();
+    await cache.run(
+      desc,
+      { q: "cycle-lenient" },
+      async () => {
+        calls += 1;
+        return cyclic;
+      },
+      lenient,
+    );
+    expect(calls).toBe(2);
+
+    cache.set(desc, { q: "cycle-set" }, cyclic);
+    expect(cache.get(desc, { q: "cycle-set" })).toBeUndefined();
+  });
+
+  it("evicts a prior successful disk row when a later write is degraded", () => {
+    const cache = new ToolCallCache({
+      diskRoot: tempRoot,
+      redact: defaultPrivacyRedactor,
+    });
+    const desc = resolveToolDescriptor("web_search");
+    const args = { q: "flip" };
+
+    cache.set(desc, args, { ok: "t1" });
+    const key = buildCacheKey(desc.name, args);
+    const file = path.join(tempRoot, key.slice(0, 2), `${key}.json`);
+    expect(existsSync(file)).toBe(true);
+
+    let deep: ToolOutput = { bottom: "t2" };
+    for (let i = 0; i < 12; i++) deep = { child: deep };
+    cache.set(desc, args, deep);
+    expect(existsSync(file)).toBe(false);
+
+    const fresh = new ToolCallCache({
+      diskRoot: tempRoot,
+      redact: defaultPrivacyRedactor,
+    });
+    expect(fresh.get(desc, args)).toBeUndefined();
   });
 
   it("registry includes web_search, web_fetch, file_read, rag_search, knowledge_lookup", () => {

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -6,14 +6,26 @@
  * and privacy redaction.
  */
 
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ToolCallCache } from "./cache.ts";
 import { buildCacheKey, canonicalizeJson } from "./key.ts";
-import { defaultPrivacyRedactor } from "./redact.ts";
+import {
+  defaultPrivacyRedactor,
+  REDACT_BOUNDED_SENTINEL,
+  REDACT_CYCLE_SENTINEL,
+  REDACT_DEPTH_SENTINEL,
+} from "./redact.ts";
 import { CACHEABLE_TOOL_REGISTRY, resolveToolDescriptor } from "./registry.ts";
 import type {
   CacheableToolDescriptor,
@@ -326,7 +338,7 @@ describe("ToolCallCache", () => {
       callback: () => "not serializable",
     } as unknown as ToolOutput;
 
-    expect(() => cache.set(descriptor, args, invalidOutput)).toThrow();
+    expect(() => cache.set(descriptor, args, invalidOutput)).not.toThrow();
     expect(cache.get(descriptor, args)).toBeUndefined();
   });
 
@@ -406,12 +418,12 @@ describe("ToolCallCache", () => {
   it("fail-closes on cyclic tool output instead of stack-overflowing the disk write", () => {
     const cyclic: Record<string, unknown> = { blob: "sk-AAAAAAAAAAAAAAAAAA" };
     cyclic.self = cyclic;
-    let redacted: Record<string, unknown>;
+    let redacted: Record<string, unknown> = {};
     expect(() => {
       redacted = defaultPrivacyRedactor(cyclic) as Record<string, unknown>;
     }).not.toThrow();
-    expect(redacted!.blob).toContain("<REDACTED:openai-key>");
-    expect(redacted!.self).toBe("[REDACTED_BOUNDED]");
+    expect(redacted.blob).toContain("<REDACTED:openai-key>");
+    expect(redacted.self).toBe(REDACT_CYCLE_SENTINEL);
   });
 
   it("fail-closes on a deep nest instead of overflowing", () => {
@@ -422,7 +434,79 @@ describe("ToolCallCache", () => {
       redacted = defaultPrivacyRedactor(deep);
     }).not.toThrow();
     expect(() => JSON.stringify(redacted)).not.toThrow();
-    expect(JSON.stringify(redacted)).toContain("[REDACTED_BOUNDED]");
+    expect(JSON.stringify(redacted)).toContain(REDACT_DEPTH_SENTINEL);
+  });
+
+  it("preserves a shared acyclic subtree instead of destroying the DAG", () => {
+    const shared = { leaf: 1, key: "sk-AAAAAAAAAAAAAAAAAA" };
+    const redacted = defaultPrivacyRedactor({ x: shared, y: shared }) as {
+      x: { leaf: number; key: string };
+      y: { leaf: number; key: string };
+    };
+    expect(redacted.x.leaf).toBe(1);
+    expect(redacted.y.leaf).toBe(1);
+    expect(redacted.x.key).toContain("<REDACTED:openai-key>");
+    expect(redacted.y.key).toContain("<REDACTED:openai-key>");
+    expect(redacted.y).not.toBe(REDACT_CYCLE_SENTINEL);
+  });
+
+  it("does not persist or serve a depth-truncated disk hit", async () => {
+    const cache = new ToolCallCache({
+      diskRoot: tempRoot,
+      redact: defaultPrivacyRedactor,
+    });
+    const desc = resolveToolDescriptor("web_search");
+    let deep: Record<string, unknown> = { bottom: "bottom-value" };
+    for (let i = 0; i < 12; i++) deep = { child: deep };
+
+    const out = await cache.run(desc, { q: "deep" }, async () => deep);
+    expect(out).toEqual(deep);
+
+    const key = buildCacheKey(desc.name, { q: "deep" });
+    const file = path.join(tempRoot, key.slice(0, 2), `${key}.json`);
+    expect(existsSync(file)).toBe(false);
+
+    const fresh = new ToolCallCache({
+      diskRoot: tempRoot,
+      redact: defaultPrivacyRedactor,
+    });
+    expect(fresh.get(desc, { q: "deep" })).toBeUndefined();
+  });
+
+  it("does not serve a prior-head truncated disk row as a successful hit", () => {
+    const cache = new ToolCallCache({
+      diskRoot: tempRoot,
+      redact: defaultPrivacyRedactor,
+    });
+    const desc = resolveToolDescriptor("web_search");
+    const key = buildCacheKey(desc.name, { q: "old" });
+    const dir = path.join(tempRoot, key.slice(0, 2));
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${key}.json`);
+    writeFileSync(
+      file,
+      JSON.stringify({
+        key,
+        toolName: desc.name,
+        toolVersion: desc.version,
+        cachedAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+        output: { child: { child: REDACT_BOUNDED_SENTINEL } },
+      }),
+      "utf8",
+    );
+    expect(cache.get(desc, { q: "old" })).toBeUndefined();
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("returns deep-but-legal output through run without rejecting", async () => {
+    const cache = makeCache();
+    const desc = resolveToolDescriptor("web_search");
+    let deep: Record<string, unknown> = { v: 1 };
+    for (let i = 0; i < 64; i++) deep = { child: deep };
+    await expect(
+      cache.run(desc, { q: "legal-deep" }, async () => deep),
+    ).resolves.toEqual(deep);
   });
 
   it("registry includes web_search, web_fetch, file_read, rag_search, knowledge_lookup", () => {

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -403,6 +403,28 @@ describe("ToolCallCache", () => {
     expect(redacted.key).toContain("<REDACTED:openai-key>");
   });
 
+  it("fail-closes on cyclic tool output instead of stack-overflowing the disk write", () => {
+    const cyclic: Record<string, unknown> = { blob: "sk-AAAAAAAAAAAAAAAAAA" };
+    cyclic.self = cyclic;
+    let redacted: Record<string, unknown>;
+    expect(() => {
+      redacted = defaultPrivacyRedactor(cyclic) as Record<string, unknown>;
+    }).not.toThrow();
+    expect(redacted!.blob).toContain("<REDACTED:openai-key>");
+    expect(redacted!.self).toBe("[REDACTED_BOUNDED]");
+  });
+
+  it("fail-closes on a deep nest instead of overflowing", () => {
+    let deep: unknown = { blob: "Bearer abcdefghijklmnopqr1234" };
+    for (let i = 0; i < 24; i++) deep = { child: deep };
+    let redacted: unknown;
+    expect(() => {
+      redacted = defaultPrivacyRedactor(deep);
+    }).not.toThrow();
+    expect(() => JSON.stringify(redacted)).not.toThrow();
+    expect(JSON.stringify(redacted)).toContain("[REDACTED_BOUNDED]");
+  });
+
   it("registry includes web_search, web_fetch, file_read, rag_search, knowledge_lookup", () => {
     expect(CACHEABLE_TOOL_REGISTRY.web_search?.cacheable).toBe(true);
     expect(CACHEABLE_TOOL_REGISTRY.web_fetch?.cacheable).toBe(true);

--- a/packages/agent/src/runtime/tool-call-cache/cache.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.ts
@@ -18,6 +18,7 @@
 import path from "node:path";
 
 import { resolveStateDir } from "../../config/paths.ts";
+import { boundedWalk } from "./bounded-walk.ts";
 import { DiskStore } from "./disk-store.ts";
 import { buildCacheKey } from "./key.ts";
 import { Lru } from "./lru.ts";
@@ -43,61 +44,18 @@ export interface ToolCallCacheOptions {
 
 type CacheOutputValidator<T> = (output: unknown) => output is T & ToolOutput;
 
-/** Fail-safe bound: deep acyclic tool output must not RangeError the persist path. */
-const MAX_TOOL_OUTPUT_DEPTH = 32;
-const MAX_TOOL_OUTPUT_NODES = 100_000;
-
-export function isCacheableToolOutput(
-  value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
-  depth = 0,
-  ctx: { nodes: number } = { nodes: 0 },
-): value is ToolOutput {
-  if (depth > MAX_TOOL_OUTPUT_DEPTH) return false;
-  ctx.nodes += 1;
-  if (ctx.nodes > MAX_TOOL_OUTPUT_NODES) return false;
-  if (value === null) return true;
-  if (typeof value === "string" || typeof value === "boolean") return true;
-  if (typeof value === "number") return Number.isFinite(value);
-  if (typeof value !== "object") return false;
-  if (seen.has(value)) return false;
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      return value.every((entry) =>
-        isCacheableToolOutput(entry, seen, depth + 1, ctx),
-      );
-    }
-    const prototype = Object.getPrototypeOf(value);
-    return (
-      (prototype === Object.prototype || prototype === null) &&
-      Object.values(value).every((entry) =>
-        isCacheableToolOutput(entry, seen, depth + 1, ctx),
-      )
-    );
-  } finally {
-    seen.delete(value);
-  }
-}
-
-/** Path-scoped cycle walk. structuredClone supports cycles; this does not. */
-function containsCycle(
-  value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
-): boolean {
-  if (!value || typeof value !== "object") return false;
-  if (seen.has(value)) return true;
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      return value.some((item) => containsCycle(item, seen));
-    }
-    return Object.values(value as Record<string, unknown>).some((item) =>
-      containsCycle(item, seen),
-    );
-  } finally {
-    seen.delete(value);
-  }
+/**
+ * Fail-safe bound for anything that may enter either cache tier.
+ *
+ * Delegates to the shared descriptor-safe walker, so validation, cycle
+ * detection and redaction agree on what is walkable and all three reserve
+ * width (array length / own-key count) before per-entry work. A cyclic,
+ * accessor-bearing, reflection-hostile, over-wide, over-deep or oversize
+ * value is rejected without invoking a getter or a Proxy `get` trap and
+ * without allocating a values array.
+ */
+export function isCacheableToolOutput(value: unknown): value is ToolOutput {
+  return boundedWalk(value).ok;
 }
 
 export class ToolCallCache {
@@ -152,6 +110,12 @@ export class ToolCallCache {
    * Record a fresh tool result. Returns immediately when the descriptor is not cacheable.
    * Both tiers are written synchronously; the disk tier runs through the
    * privacy redactor inside DiskStore.write.
+   *
+   * The bound is enforced here, independently of any caller-supplied
+   * `shouldCache` predicate, and BEFORE `structuredClone`: a lenient custom
+   * validator (or a direct `set()` caller) must not be able to push a cyclic,
+   * accessor-bearing, hostile-proxy or million-key value into either tier or
+   * through the clone/redaction work.
    */
   set(
     descriptor: CacheableToolDescriptor,
@@ -159,6 +123,7 @@ export class ToolCallCache {
     output: ToolOutput,
   ): void {
     if (!descriptor.cacheable) return;
+    if (!isCacheableToolOutput(output)) return;
     const key = buildCacheKey(descriptor.name, args);
     const cachedAt = this.now();
     let cloned: ToolOutput;
@@ -168,9 +133,9 @@ export class ToolCallCache {
       // Non-cloneable output (functions, etc.) cannot enter either tier.
       return;
     }
-    // structuredClone supports cyclic graphs. Fail closed so a cycle or an
-    // already-degraded sentinel never becomes a memory-tier hit.
-    if (containsCycle(cloned) || isRedactionDegraded(cloned)) {
+    // An output that already equals a degradation sentinel must not become a
+    // memory-tier hit either — it would be indistinguishable from corruption.
+    if (isRedactionDegraded(cloned)) {
       return;
     }
     const entry: ToolCacheEntry = {

--- a/packages/agent/src/runtime/tool-call-cache/cache.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.ts
@@ -80,6 +80,26 @@ export function isCacheableToolOutput(
   }
 }
 
+/** Path-scoped cycle walk. structuredClone supports cycles; this does not. */
+function containsCycle(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (seen.has(value)) return true;
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.some((item) => containsCycle(item, seen));
+    }
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      containsCycle(item, seen),
+    );
+  } finally {
+    seen.delete(value);
+  }
+}
+
 export class ToolCallCache {
   private readonly memory: Lru<string, ToolCacheEntry>;
   private readonly disk: DiskStore;
@@ -145,7 +165,12 @@ export class ToolCallCache {
     try {
       cloned = structuredClone(output);
     } catch {
-      // Cyclic output cannot be cloned into either tier; return uncached.
+      // Non-cloneable output (functions, etc.) cannot enter either tier.
+      return;
+    }
+    // structuredClone supports cyclic graphs. Fail closed so a cycle or an
+    // already-degraded sentinel never becomes a memory-tier hit.
+    if (containsCycle(cloned) || isRedactionDegraded(cloned)) {
       return;
     }
     const entry: ToolCacheEntry = {

--- a/packages/agent/src/runtime/tool-call-cache/cache.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.ts
@@ -21,6 +21,7 @@ import { resolveStateDir } from "../../config/paths.ts";
 import { DiskStore } from "./disk-store.ts";
 import { buildCacheKey } from "./key.ts";
 import { Lru } from "./lru.ts";
+import { isRedactionDegraded } from "./redact.ts";
 import type {
   CacheableToolDescriptor,
   PrivacyRedactor,
@@ -42,25 +43,41 @@ export interface ToolCallCacheOptions {
 
 type CacheOutputValidator<T> = (output: unknown) => output is T & ToolOutput;
 
-function isToolOutput(
+/** Fail-safe bound: deep acyclic tool output must not RangeError the persist path. */
+const MAX_TOOL_OUTPUT_DEPTH = 32;
+const MAX_TOOL_OUTPUT_NODES = 100_000;
+
+export function isCacheableToolOutput(
   value: unknown,
-  seen = new WeakSet<object>(),
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+  ctx: { nodes: number } = { nodes: 0 },
 ): value is ToolOutput {
+  if (depth > MAX_TOOL_OUTPUT_DEPTH) return false;
+  ctx.nodes += 1;
+  if (ctx.nodes > MAX_TOOL_OUTPUT_NODES) return false;
   if (value === null) return true;
   if (typeof value === "string" || typeof value === "boolean") return true;
   if (typeof value === "number") return Number.isFinite(value);
   if (typeof value !== "object") return false;
   if (seen.has(value)) return false;
   seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.every((entry) => isToolOutput(entry, seen));
+  try {
+    if (Array.isArray(value)) {
+      return value.every((entry) =>
+        isCacheableToolOutput(entry, seen, depth + 1, ctx),
+      );
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return (
+      (prototype === Object.prototype || prototype === null) &&
+      Object.values(value).every((entry) =>
+        isCacheableToolOutput(entry, seen, depth + 1, ctx),
+      )
+    );
+  } finally {
+    seen.delete(value);
   }
-  const prototype = Object.getPrototypeOf(value);
-  return (
-    (prototype === Object.prototype || prototype === null) &&
-    Object.values(value).every((entry) => isToolOutput(entry, seen))
-  );
 }
 
 export class ToolCallCache {
@@ -101,6 +118,11 @@ export class ToolCallCache {
       this.disk.delete(key);
       return undefined;
     }
+    if (isRedactionDegraded(candidate.output)) {
+      this.memory.delete(key);
+      this.disk.delete(key);
+      return undefined;
+    }
 
     if (!fromMemory) this.memory.set(key, candidate);
     return structuredClone(candidate);
@@ -119,13 +141,20 @@ export class ToolCallCache {
     if (!descriptor.cacheable) return;
     const key = buildCacheKey(descriptor.name, args);
     const cachedAt = this.now();
+    let cloned: ToolOutput;
+    try {
+      cloned = structuredClone(output);
+    } catch {
+      // Cyclic output cannot be cloned into either tier; return uncached.
+      return;
+    }
     const entry: ToolCacheEntry = {
       key,
       toolName: descriptor.name,
       toolVersion: descriptor.version,
       cachedAt,
       expiresAt: cachedAt + descriptor.ttlMs,
-      output: structuredClone(output),
+      output: cloned,
     };
     this.memory.set(key, entry);
     this.disk.write(entry);
@@ -181,7 +210,9 @@ export class ToolCallCache {
     descriptor: CacheableToolDescriptor,
     args: ToolArgs,
     execute: () => Promise<unknown>,
-    shouldCache: (output: unknown) => output is ToolOutput = isToolOutput,
+    shouldCache: (
+      output: unknown,
+    ) => output is ToolOutput = isCacheableToolOutput,
   ): Promise<unknown> {
     const hit = this.get(descriptor, args);
     if (hit && shouldCache(hit.output)) return hit.output;

--- a/packages/agent/src/runtime/tool-call-cache/disk-store.ts
+++ b/packages/agent/src/runtime/tool-call-cache/disk-store.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import { isRedactionDegraded } from "./redact.ts";
 import type { PrivacyRedactor, ToolCacheEntry } from "./types.ts";
 
 export class DiskStore {
@@ -45,9 +46,14 @@ export class DiskStore {
     const dir = path.dirname(file);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
+    const output = this.redact(entry.output);
+    // A truncated or cyclic walk must not persist as a successful disk hit.
+    if (isRedactionDegraded(output)) {
+      return;
+    }
     const sanitized: ToolCacheEntry = {
       ...entry,
-      output: this.redact(entry.output) as ToolCacheEntry["output"],
+      output: output as ToolCacheEntry["output"],
     };
     writeFileSync(file, JSON.stringify(sanitized), "utf8");
   }

--- a/packages/agent/src/runtime/tool-call-cache/disk-store.ts
+++ b/packages/agent/src/runtime/tool-call-cache/disk-store.ts
@@ -48,7 +48,10 @@ export class DiskStore {
 
     const output = this.redact(entry.output);
     // A truncated or cyclic walk must not persist as a successful disk hit.
+    // Evict any existing row so a later degraded rewrite cannot leave the
+    // previous successful value to be served by a fresh process.
     if (isRedactionDegraded(output)) {
+      this.delete(entry.key);
       return;
     }
     const sanitized: ToolCacheEntry = {

--- a/packages/agent/src/runtime/tool-call-cache/index.ts
+++ b/packages/agent/src/runtime/tool-call-cache/index.ts
@@ -4,6 +4,12 @@
  * redactor, the cacheable-tool registry (descriptor lookup + isCacheable), and
  * the shared cache types.
  */
+export type {
+  BoundedWalkOptions,
+  BoundedWalkRejection,
+  BoundedWalkResult,
+} from "./bounded-walk.ts";
+export { boundedWalk, TOOL_OUTPUT_LIMITS } from "./bounded-walk.ts";
 export type { ToolCallCacheOptions } from "./cache.ts";
 export { isCacheableToolOutput, ToolCallCache } from "./cache.ts";
 export { buildCacheKey, canonicalizeJson } from "./key.ts";

--- a/packages/agent/src/runtime/tool-call-cache/index.ts
+++ b/packages/agent/src/runtime/tool-call-cache/index.ts
@@ -5,9 +5,12 @@
  * the shared cache types.
  */
 export type { ToolCallCacheOptions } from "./cache.ts";
-export { ToolCallCache } from "./cache.ts";
+export { isCacheableToolOutput, ToolCallCache } from "./cache.ts";
 export { buildCacheKey, canonicalizeJson } from "./key.ts";
-export { defaultPrivacyRedactor } from "./redact.ts";
+export {
+  defaultPrivacyRedactor,
+  isRedactionDegraded,
+} from "./redact.ts";
 export {
   CACHEABLE_TOOL_REGISTRY,
   isCacheable,

--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -3,7 +3,11 @@
  * redaction over the tool-call cache write path.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { defaultPrivacyRedactor } from "./redact.ts";
+import {
+  defaultPrivacyRedactor,
+  isRedactionDegraded,
+  REDACT_BUDGET_SENTINEL,
+} from "./redact.ts";
 
 const ORIG_ENV = { ...process.env };
 
@@ -134,6 +138,52 @@ describe("defaultPrivacyRedactor", () => {
     expect(defaultPrivacyRedactor(true)).toBe(true);
     expect(defaultPrivacyRedactor(null)).toBe(null);
     expect(defaultPrivacyRedactor(undefined)).toBe(undefined);
+  });
+
+  it("bounds a flat-wide object instead of redacting every key", () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 150_000; i += 1) wide[`k${i}`] = i;
+    const out = defaultPrivacyRedactor(wide);
+    expect(out).toBe(REDACT_BUDGET_SENTINEL);
+    expect(isRedactionDegraded(out)).toBe(true);
+  });
+
+  it("marks an accessor property degraded without invoking the getter", () => {
+    let getterCalls = 0;
+    const value: Record<string, unknown> = { ok: "plain" };
+    Object.defineProperty(value, "leak", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return "secret";
+      },
+    });
+    const out = defaultPrivacyRedactor(value) as Record<string, unknown>;
+    expect(getterCalls).toBe(0);
+    expect(out.ok).toBe("plain");
+    expect(out.leak).toBe(REDACT_BUDGET_SENTINEL);
+    expect(isRedactionDegraded(out)).toBe(true);
+  });
+
+  it("marks a revoked proxy degraded instead of throwing", () => {
+    const revocable = Proxy.revocable({ payload: "value" }, {});
+    revocable.revoke();
+    let out: unknown;
+    expect(() => {
+      out = defaultPrivacyRedactor({ nested: revocable.proxy });
+    }).not.toThrow();
+    expect((out as Record<string, unknown>).nested).toBe(
+      REDACT_BUDGET_SENTINEL,
+    );
+    expect(isRedactionDegraded(out)).toBe(true);
+  });
+
+  it("bounds an oversize string leaf", () => {
+    const huge = "a".repeat(4_000_001);
+    expect(defaultPrivacyRedactor({ blob: huge })).toEqual({
+      blob: REDACT_BUDGET_SENTINEL,
+    });
   });
 
   it("does not treat short strings as env secrets", () => {

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -13,6 +13,8 @@
  * subtrees / DAGs are fully redacted. True cycles emit [Circular]; containers
  * past the depth cap emit [MaxDepth]. DiskStore refuses to persist a degraded
  * value so a sentinel can never be served as a successful cross-process hit.
+ * Legitimate tool output that already equals a sentinel string is treated as
+ * degraded and is deliberately uncacheable (safe, re-executed every time).
  */
 
 import type { PrivacyRedactor } from "./types.ts";

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -8,6 +8,11 @@
  *   - common API key shapes (`sk-…`, `Bearer …`, `ghp_…`, `AKIA…`)
  *   - environment-variable values whose key name looks like a secret
  *   - geographic coordinates (matching the Location-plugin patterns)
+ *
+ * Walk is path-scoped (seen.delete on container exit) so shared acyclic
+ * subtrees / DAGs are fully redacted. True cycles emit [Circular]; containers
+ * past the depth cap emit [MaxDepth]. DiskStore refuses to persist a degraded
+ * value so a sentinel can never be served as a successful cross-process hit.
  */
 
 import type { PrivacyRedactor } from "./types.ts";
@@ -183,6 +188,13 @@ function redactCoordsBlocks(input: string): string {
   return matchedAny ? output + input.slice(copiedThrough) : input;
 }
 
+/** Depth cap bounds containers, not string leaves (a string at depth 9 is kept). */
+export const MAX_REDACT_DEPTH = 8;
+export const REDACT_CYCLE_SENTINEL = "[Circular]";
+export const REDACT_DEPTH_SENTINEL = "[MaxDepth]";
+/** Prior-head sentinel; still treated as degraded so old disk rows are not served. */
+export const REDACT_BOUNDED_SENTINEL = "[REDACTED_BOUNDED]";
+
 function snapshotEnvCredentials(): string[] {
   const out: string[] = [];
   for (const [key, value] of Object.entries(process.env)) {
@@ -209,10 +221,6 @@ function redactString(input: string, envValues: string[]): string {
   return out;
 }
 
-/** Fail-closed bound: cyclic or deeply nested tool outputs must not stack-overflow the disk write. */
-const MAX_REDACT_DEPTH = 8;
-const BOUNDED_SENTINEL = "[REDACTED_BOUNDED]";
-
 function walk(
   value: unknown,
   envValues: string[],
@@ -223,21 +231,56 @@ function walk(
     return redactString(value, envValues);
   }
   if (value && typeof value === "object") {
-    if (depth > MAX_REDACT_DEPTH || seen.has(value)) {
-      return BOUNDED_SENTINEL;
+    if (depth > MAX_REDACT_DEPTH) {
+      return REDACT_DEPTH_SENTINEL;
+    }
+    if (seen.has(value)) {
+      return REDACT_CYCLE_SENTINEL;
     }
     seen.add(value);
-    if (Array.isArray(value)) {
-      return value.map((item) => walk(item, envValues, seen, depth + 1));
+    try {
+      if (Array.isArray(value)) {
+        return value.map((item) => walk(item, envValues, seen, depth + 1));
+      }
+      const obj = value as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(obj)) {
+        out[key] = walk(obj[key], envValues, seen, depth + 1);
+      }
+      return out;
+    } finally {
+      seen.delete(value);
     }
-    const obj = value as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(obj)) {
-      out[key] = walk(obj[key], envValues, seen, depth + 1);
-    }
-    return out;
   }
   return value;
+}
+
+export function isRedactionDegraded(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): boolean {
+  if (
+    value === REDACT_CYCLE_SENTINEL ||
+    value === REDACT_DEPTH_SENTINEL ||
+    value === REDACT_BOUNDED_SENTINEL
+  ) {
+    return true;
+  }
+  if (!value || typeof value !== "object") return false;
+  if (depth > 64) return true;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.some((item) => isRedactionDegraded(item, seen, depth + 1));
+    }
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      isRedactionDegraded(item, seen, depth + 1),
+    );
+  } finally {
+    seen.delete(value);
+  }
 }
 
 export const defaultPrivacyRedactor: PrivacyRedactor = (value) => {

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -209,18 +209,31 @@ function redactString(input: string, envValues: string[]): string {
   return out;
 }
 
-function walk(value: unknown, envValues: string[]): unknown {
+/** Fail-closed bound: cyclic or deeply nested tool outputs must not stack-overflow the disk write. */
+const MAX_REDACT_DEPTH = 8;
+const BOUNDED_SENTINEL = "[REDACTED_BOUNDED]";
+
+function walk(
+  value: unknown,
+  envValues: string[],
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
   if (typeof value === "string") {
     return redactString(value, envValues);
   }
-  if (Array.isArray(value)) {
-    return value.map((item) => walk(item, envValues));
-  }
   if (value && typeof value === "object") {
+    if (depth > MAX_REDACT_DEPTH || seen.has(value)) {
+      return BOUNDED_SENTINEL;
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      return value.map((item) => walk(item, envValues, seen, depth + 1));
+    }
     const obj = value as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(obj)) {
-      out[key] = walk(obj[key], envValues);
+      out[key] = walk(obj[key], envValues, seen, depth + 1);
     }
     return out;
   }

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -9,14 +9,21 @@
  *   - environment-variable values whose key name looks like a secret
  *   - geographic coordinates (matching the Location-plugin patterns)
  *
- * Walk is path-scoped (seen.delete on container exit) so shared acyclic
- * subtrees / DAGs are fully redacted. True cycles emit [Circular]; containers
- * past the depth cap emit [MaxDepth]. DiskStore refuses to persist a degraded
- * value so a sentinel can never be served as a successful cross-process hit.
- * Legitimate tool output that already equals a sentinel string is treated as
- * degraded and is deliberately uncacheable (safe, re-executed every time).
+ * The walk is the shared descriptor-safe bounded traversal in
+ * `bounded-walk.ts`: path-scoped cycle detection (so shared acyclic subtrees /
+ * DAGs are fully redacted), width reserved before any per-entry work, data
+ * descriptors only (accessors and reflection failures never run user code),
+ * and a node/key/string/byte budget shared across the whole walk.
+ *
+ * True cycles emit [Circular]; containers past the depth cap emit [MaxDepth];
+ * anything rejected by the work budget or by hostile reflection emits
+ * [Bounded]. DiskStore refuses to persist a degraded value so a sentinel can
+ * never be served as a successful cross-process hit. Legitimate tool output
+ * that already equals a sentinel string is treated as degraded and is
+ * deliberately uncacheable (safe, re-executed every time).
  */
 
+import { type BoundedWalkRejection, boundedWalk } from "./bounded-walk.ts";
 import type { PrivacyRedactor } from "./types.ts";
 
 const CREDENTIAL_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
@@ -194,8 +201,23 @@ function redactCoordsBlocks(input: string): string {
 export const MAX_REDACT_DEPTH = 8;
 export const REDACT_CYCLE_SENTINEL = "[Circular]";
 export const REDACT_DEPTH_SENTINEL = "[MaxDepth]";
+/** Emitted when the work/size budget or hostile reflection stopped the walk. */
+export const REDACT_BUDGET_SENTINEL = "[Bounded]";
 /** Prior-head sentinel; still treated as degraded so old disk rows are not served. */
 export const REDACT_BOUNDED_SENTINEL = "[REDACTED_BOUNDED]";
+
+const DEGRADED_SENTINELS: ReadonlySet<string> = new Set([
+  REDACT_CYCLE_SENTINEL,
+  REDACT_DEPTH_SENTINEL,
+  REDACT_BUDGET_SENTINEL,
+  REDACT_BOUNDED_SENTINEL,
+]);
+
+function sentinelFor(reason: BoundedWalkRejection): string {
+  if (reason === "cycle") return REDACT_CYCLE_SENTINEL;
+  if (reason === "depth") return REDACT_DEPTH_SENTINEL;
+  return REDACT_BUDGET_SENTINEL;
+}
 
 function snapshotEnvCredentials(): string[] {
   const out: string[] = [];
@@ -223,69 +245,31 @@ function redactString(input: string, envValues: string[]): string {
   return out;
 }
 
-function walk(
-  value: unknown,
-  envValues: string[],
-  seen: WeakSet<object> = new WeakSet(),
-  depth = 0,
-): unknown {
-  if (typeof value === "string") {
-    return redactString(value, envValues);
-  }
-  if (value && typeof value === "object") {
-    if (depth > MAX_REDACT_DEPTH) {
-      return REDACT_DEPTH_SENTINEL;
-    }
-    if (seen.has(value)) {
-      return REDACT_CYCLE_SENTINEL;
-    }
-    seen.add(value);
-    try {
-      if (Array.isArray(value)) {
-        return value.map((item) => walk(item, envValues, seen, depth + 1));
-      }
-      const obj = value as Record<string, unknown>;
-      const out: Record<string, unknown> = {};
-      for (const key of Object.keys(obj)) {
-        out[key] = walk(obj[key], envValues, seen, depth + 1);
-      }
-      return out;
-    } finally {
-      seen.delete(value);
-    }
-  }
-  return value;
-}
-
-export function isRedactionDegraded(
-  value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
-  depth = 0,
-): boolean {
-  if (
-    value === REDACT_CYCLE_SENTINEL ||
-    value === REDACT_DEPTH_SENTINEL ||
-    value === REDACT_BOUNDED_SENTINEL
-  ) {
-    return true;
-  }
-  if (!value || typeof value !== "object") return false;
-  if (depth > 64) return true;
-  if (seen.has(value)) return false;
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      return value.some((item) => isRedactionDegraded(item, seen, depth + 1));
-    }
-    return Object.values(value as Record<string, unknown>).some((item) =>
-      isRedactionDegraded(item, seen, depth + 1),
-    );
-  } finally {
-    seen.delete(value);
-  }
+/**
+ * True when a value carries a degradation sentinel, or when the bounded walk
+ * itself refuses it (cycle, budget exhaustion, accessor, hostile reflection).
+ * Such a value must never be persisted or served as a successful hit.
+ */
+export function isRedactionDegraded(value: unknown): boolean {
+  let degraded = false;
+  const result = boundedWalk(value, {
+    strictPrimitives: false,
+    transformString: (input) => {
+      if (DEGRADED_SENTINELS.has(input)) degraded = true;
+      return input;
+    },
+  });
+  return degraded || !result.ok;
 }
 
 export const defaultPrivacyRedactor: PrivacyRedactor = (value) => {
   const envValues = snapshotEnvCredentials();
-  return walk(value, envValues);
+  const result = boundedWalk(value, {
+    limits: { maxDepth: MAX_REDACT_DEPTH },
+    strictPrimitives: false,
+    transformString: (input) => redactString(input, envValues),
+    substitute: sentinelFor,
+  });
+  // `substitute` is set, so the walk always succeeds.
+  return result.ok ? result.value : REDACT_BUDGET_SENTINEL;
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23312 — filed as the owning issue for this hole after maintainer
review. Occupancy-FREE crash / hang / input-boundary on the tool-call cache
persist path: the validation, cycle and redaction walks each traversed a tool
result before bounding the work, allocating a values array and invoking
enumerable getters / Proxy traps before any cap could reject the value, and
`ToolCallCache.set()` trusted an optional caller-supplied predicate instead of
enforcing the bound itself.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6 (original implementation); anthropic/claude-opus-5 (maintainer-review repair)
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app; Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The tool-call cache fails closed on hostile-shaped output instead of doing
unbounded work on it. A result that exceeds the supported bound, carries an
accessor property, or fails reflection is returned to the caller **uncached**
rather than throwing or being partially materialised. Honest cacheable tool
results are unaffected: shared acyclic subtrees (DAGs) are still fully redacted,
deep-but-legal results still return from `run` / `wrapActionWithCache`, and a
truncated redaction still cannot be persisted or replayed as a disk hit. No
schema, API contract, or storage migration.

# Background

## What does this PR do?

Replaces the three independent walkers in the tool-call cache —
`isCacheableToolOutput()`, the `set()` cycle check, and the redactor `walk()` —
with a single shared, descriptor-safe, path-local bounded traversal in the new
`packages/agent/src/runtime/tool-call-cache/bounded-walk.ts`.

- **Width is reserved before per-entry work.** Array width comes from the
  `length` *property descriptor*; object width from
  `Object.getOwnPropertyNames`. Both are charged against the key budget before
  a single entry is read. `Object.values` / `Object.entries` are gone from the
  cache, so nothing allocates a full values array before the cap can reject.
- **No user code runs during traversal.** Property values are read only from
  data descriptors, so an enumerable getter or a Proxy `get` trap is never
  invoked. An accessor-bearing property is rejected outright.
- **Reflection is guarded.** `Array.isArray`, `Object.getPrototypeOf`,
  `Object.getOwnPropertyNames` and `Object.getOwnPropertyDescriptor` are each
  wrapped, so a revoked or hostile Proxy becomes a rejection instead of a raw
  `TypeError` on the already-succeeded tool path.
- **Work is budgeted.** One shared budget across the whole walk: depth 32
  (redactor 8), 100k nodes, 100k aggregate key width, 4,000,000 code units per string leaf, 16,000,000 aggregate estimated bytes.
- **`set()` enforces the bound itself**, before `structuredClone`, so a lenient
  custom `shouldCache` predicate or a direct `set()` caller cannot push an
  unbounded value into either tier.

Earlier rounds (retained and still covered): path-scoped cycle detection so DAGs
survive, `[Circular]` / `[MaxDepth]` / `[Bounded]` sentinels,
`DiskStore.write()` refusing to persist a degraded value and evicting any stale
row, `ToolCallCache.get()` missing and deleting any row carrying a sentinel, and
the bounded validator shared by `run()` and `wrapActionWithCache`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/tool-call-cache/cache.test.ts` — the four
hostile-input cases at the end of the `ToolCallCache` describe. Each runs a
fixture through all three write routes (direct `set()`, default `run()`, lenient
`run()` with an always-true predicate) via one helper and asserts the tool
result is returned uncached, nothing throws, and the getter / `get`-trap call
counters stay at zero. Then
`packages/agent/src/runtime/tool-call-cache/redact.test.ts` for the same shapes
against `defaultPrivacyRedactor`, and
`packages/agent/src/runtime/tool-call-cache-wrapper.test.ts` for the wrapper
path.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:036f6ad68cffa10048466f4b4f97b6fd6dd2073e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; agent cache unit tests only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; agent cache unit tests only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this backend cache change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head 036f6ad68cffa10048466f4b4f97b6fd6dd2073e
base 2b42fc7127b78eb9bd2fef83d404a9d5c86b32a2 (origin/develop tip at rebase)
worktree /Volumes/thescoho_1TB/Developer/worktrees/eliza-fix-22949-cr

$ bun run --cwd packages/agent vitest run src/runtime/tool-call-cache src/runtime/tool-call-cache-wrapper.test.ts
RUN v4.1.10 packages/agent
Test Files  3 passed (3)
Tests  60 passed (60)
Duration  28.30s
[recorded exit 0 at 036f6ad68, 2026-08-21T04:12:58Z]
  flat-wide (150k keys) -> returned uncached on set / default run / lenient run
  accessor-bearing      -> returned uncached; getter call counter 0
  hostile Proxy (throwing ownKeys) -> returned uncached; get-trap counter 0
  revoked Proxy         -> returned uncached; no raw TypeError
  redactor: wide / accessor / revoked / oversize-string -> [Bounded], degraded
  retained: DAG preserved, [MaxDepth] never persisted, deep run/wrapper ok

$ bunx biome check packages/agent/src/runtime/tool-call-cache/ packages/agent/src/runtime/tool-call-cache-wrapper.ts packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
Checked 13 files in 401ms. No fixes applied.  (0 errors, 0 warnings)

$ bun run --cwd packages/agent typecheck   # head vs base control, errors grouped by file
head 036f6ad: 12 src/api/auth-routes.test.ts, 6 src/runtime/operations/cold-strategy.test.ts, 1 src/providers/session-bridge.test.ts
base 2b42fc7: 12 src/api/auth-routes.test.ts, 6 src/runtime/operations/cold-strategy.test.ts, 1 src/providers/session-bridge.test.ts
=> identical sets; zero typecheck errors in any file this PR touches

$ bun run verify   # root gate; run on this change set at the earlier
#                    rebase base 84f58095b9, before the per-string-cap bump.
#                    Not rerun at this exact head (~40min monorepo cost).
Tasks: 224 successful, 226 total
Failed: @elizaos/app-core#typecheck
  ../agent/src/services/e2b-capability-router.ts(363,59): error TS2339:
  Property 'requestTimeoutMs' does not exist on type 'RemoteRunnerHttpClient'
control: same command at detached origin/develop 2f437cef14ad -> same single
error, in a file this PR does not touch. Every other verify step passed,
including alias-read-guard over the six changed guarded source files.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this backend-only change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

Root `bun run verify` does not pass end-to-end, on a pre-existing unrelated
blocker: `@elizaos/app-core#typecheck` fails at
`packages/agent/src/services/e2b-capability-router.ts:363` with
`TS2339: Property 'requestTimeoutMs' does not exist on type 'RemoteRunnerHttpClient'`.
The same command at a detached `origin/develop` (`2f437cef14ad`) fails
identically, so it is not caused by this PR; 224 of 226 verify tasks pass.
`bun run --cwd packages/agent typecheck` likewise has an identical error set at
this head and at the base control (all in `src/api/auth-routes.test.ts`,
`src/runtime/operations/cold-strategy.test.ts`,
`src/providers/session-bridge.test.ts` — none touched here), so this PR adds
zero typecheck errors.

No hosted CI checks run on this PR (fork PR without workflow authorization);
the exact-head local gates above are the substitute.

Fork cannot upload `pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
