### PR TITLE
fix(plugin-zai): fail closed on unbounded providerOptions graphs

### DIFF
--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -227,4 +227,35 @@ describe("z.ai text parameter resolution", () => {
       })
     );
   });
+
+  it("handles valid providerOptions and rejects cyclic providerOptions with ZAI_PROVIDER_OPTIONS_UNBOUNDED", async () => {
+    const runtime = {
+      character: {},
+      getSetting(key: string) {
+        if (key === "ZAI_API_KEY") return "test-key";
+        return undefined;
+      },
+    };
+
+    const { handleTextSmall } = await import("../models/text");
+
+    await expect(
+      handleTextSmall(runtime as never, {
+        prompt: "hello",
+        providerOptions: { agentName: "test-agent", extra: { foo: "bar" } },
+      })
+    ).resolves.toBe("ok");
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    await expect(
+      handleTextSmall(runtime as never, {
+        prompt: "hello",
+        providerOptions: cyclic as never,
+      })
+    ).rejects.toMatchObject({
+      code: "ZAI_PROVIDER_OPTIONS_UNBOUNDED",
+    });
+  });
 });

--- a/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
+++ b/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Deterministic tests for the z.ai providerOptions walk. No live model:
+ * the walker is the production readProviderOptions used on generate-text
+ * params.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ZAI_PROVIDER_OPTIONS_DEPTH,
+  MAX_ZAI_PROVIDER_OPTIONS_NODES,
+  readProviderOptions,
+  ZAI_PROVIDER_OPTIONS_UNBOUNDED,
+} from "../models/zai-provider-options";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("readProviderOptions", () => {
+  it("preserves root and nested __proto__ keys as inert own data", () => {
+    const nested = Object.fromEntries([["__proto__", { nested: true }]]);
+    const input = Object.fromEntries([
+      ["__proto__", { root: true }],
+      ["zai", nested],
+    ]);
+
+    const copied = readProviderOptions(input);
+
+    expect(Object.getPrototypeOf(copied)).toBe(Object.prototype);
+    expect(Object.hasOwn(copied ?? {}, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copied, "__proto__")?.value).toEqual({ root: true });
+    const copiedNested = copied?.zai as Record<string, unknown>;
+    expect(Object.getPrototypeOf(copiedNested)).toBe(Object.prototype);
+    expect(Object.hasOwn(copiedNested, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copiedNested, "__proto__")?.value).toEqual({
+      nested: true,
+    });
+  });
+
+  it("preserves honest scalars, lists, and nested records", () => {
+    expect(
+      readProviderOptions({
+        agentName: "eliza",
+        zai: { effort: "high", tags: ["a", { b: true }] },
+      })
+    ).toEqual({
+      agentName: "eliza",
+      zai: { effort: "high", tags: ["a", { b: true }] },
+    });
+    expect(readProviderOptions(null)).toBeUndefined();
+    expect(readProviderOptions(["not", "a", "record"])).toBeUndefined();
+    expect(readProviderOptions({ bad: () => "fn" })).toBeUndefined();
+  });
+
+  it(`accepts a ${MAX_ZAI_PROVIDER_OPTIONS_DEPTH}-deep nest under payload`, () => {
+    // Root options object is depth 0, so payload may nest MAX-1 arrays.
+    const accepted = nestArray(MAX_ZAI_PROVIDER_OPTIONS_DEPTH - 1);
+    expect(readProviderOptions({ payload: accepted })).toEqual({ payload: accepted });
+  });
+
+  it(`throws ${ZAI_PROVIDER_OPTIONS_UNBOUNDED} one past depth ${MAX_ZAI_PROVIDER_OPTIONS_DEPTH}`, () => {
+    try {
+      readProviderOptions({
+        payload: nestArray(MAX_ZAI_PROVIDER_OPTIONS_DEPTH),
+      });
+      expect.unreachable("parse should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${ZAI_PROVIDER_OPTIONS_UNBOUNDED} past ${MAX_ZAI_PROVIDER_OPTIONS_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_ZAI_PROVIDER_OPTIONS_NODES] = "x";
+    try {
+      readProviderOptions({ payload: sparse });
+      expect.unreachable("parse should fail closed on over-budget sparse length");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("preserves within-budget sparse holes and length", () => {
+    const payload: unknown[] = [];
+    payload[2] = "x";
+    const result = readProviderOptions({ payload })?.payload as unknown[];
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    try {
+      readProviderOptions(cyclic);
+      expect.unreachable("parse should fail closed on cyclic input");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("fails closed on accessor properties", () => {
+    const hostile = {};
+    Object.defineProperty(hostile, "trap", {
+      get() {
+        throw new Error("getter side effect");
+      },
+      enumerable: true,
+    });
+
+    try {
+      readProviderOptions(hostile);
+      expect.unreachable("parse should fail closed on accessor descriptor");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+});

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -13,7 +13,7 @@ import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
 import { ElizaError, logger, ModelType } from "@elizaos/core";
 import { generateText } from "ai";
 import { createZaiClient, type ZaiFetch } from "../providers";
-import { createModelName, type ModelName, type ModelSize, type ProviderOptions } from "../types";
+import { createModelName, type ModelName, type ModelSize } from "../types";
 import {
   getApiKey,
   getExperimentalTelemetry,
@@ -24,6 +24,7 @@ import {
   type ZaiThinkingConfig,
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
+import { type ProviderOptions, readProviderOptions } from "./zai-provider-options";
 
 interface ResolvedTextParams {
   readonly prompt: string;
@@ -62,10 +63,9 @@ function resolveTextParams(
   const defaultMaxTokens = modelName.includes("air") || modelName.includes("flash") ? 4096 : 8192;
   const maxTokens = params.omitMaxTokens ? undefined : (params.maxTokens ?? defaultMaxTokens);
 
-  const rawProviderOptions = rawParams.providerOptions as ProviderOptions | undefined;
-  const providerOptions: ProviderOptions = rawProviderOptions
-    ? JSON.parse(JSON.stringify(rawProviderOptions))
-    : {};
+  const rawProviderOptions = rawParams.providerOptions;
+  const providerOptions: ProviderOptions =
+    (rawProviderOptions ? readProviderOptions(rawProviderOptions) : undefined) ?? {};
 
   return {
     prompt,

--- a/plugins/plugin-zai/models/zai-provider-options.ts
+++ b/plugins/plugin-zai/models/zai-provider-options.ts
@@ -1,0 +1,188 @@
+/**
+ * Bounds the nested provider-options walk used when z.ai text handlers
+ * accept `GenerateTextParams.providerOptions`. Hostile nests RangeError'd
+ * or threw TypeError on JSON.stringify. Depth, node, and cycle limits
+ * are all load-bearing. Descriptor-only reads so a getter cannot hang
+ * the z.ai generate path.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_ZAI_PROVIDER_OPTIONS_DEPTH = 32;
+export const MAX_ZAI_PROVIDER_OPTIONS_NODES = 2_048;
+export const ZAI_PROVIDER_OPTIONS_UNBOUNDED = "ZAI_PROVIDER_OPTIONS_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+type ProviderOptionValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ProviderOptionValue[]
+  | { [key: string]: ProviderOptionValue | undefined };
+
+export type ProviderOptions = {
+  [key: string]: ProviderOptionValue | undefined;
+  agentName?: string;
+};
+
+function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
+  throw new ElizaError("z.ai providerOptions JSON exceeds the parse walk budget", {
+    code: ZAI_PROVIDER_OPTIONS_UNBOUNDED,
+    context,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_ZAI_PROVIDER_OPTIONS_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_ZAI_PROVIDER_OPTIONS_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Preserve reflection failures while adding the failed operation.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(value: object, key: PropertyKey): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key)
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+function newWalkContext(): WalkContext {
+  return {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  };
+}
+
+/**
+ * Production z.ai boundary: descriptor-only validation/copy of
+ * `providerOptions` with one shared node/cycle budget.
+ */
+export function readProviderOptions(value: unknown): ProviderOptions | undefined {
+  if (typeof value !== "object" || value === null || isArrayRecord(value)) {
+    return undefined;
+  }
+  const copied = readProviderOptionValue(value, 0, newWalkContext());
+  if (
+    copied === undefined ||
+    copied === null ||
+    typeof copied !== "object" ||
+    Array.isArray(copied)
+  ) {
+    return undefined;
+  }
+  return copied as ProviderOptions;
+}
+
+function readProviderOptionValue(
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): ProviderOptionValue | undefined {
+  if (depth > MAX_ZAI_PROVIDER_OPTIONS_DEPTH) {
+    failUnbounded({ depth, max: MAX_ZAI_PROVIDER_OPTIONS_DEPTH });
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return value;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      const out = new Array<ProviderOptionValue>(length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+        if (nested === undefined) {
+          return undefined;
+        }
+        out[index] = nested;
+      }
+      return out;
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    const record: { [key: string]: ProviderOptionValue | undefined } = {};
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      if (descriptor.value === undefined) {
+        Object.defineProperty(record, key, {
+          value: undefined,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+        continue;
+      }
+      const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+      if (nested === undefined) {
+        return undefined;
+      }
+      Object.defineProperty(record, key, {
+        value: nested,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return record;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- skill_revision: elizaOS/eliza@3775f57b4e:packages/skills/skills/contribute-to-eliza -->
<!-- evidence-head:3a2841fb16b856ace599dd89ff64822d1eb6c7c6 -->

## Summary
- Replaces unsafe `JSON.parse(JSON.stringify(rawProviderOptions))` in `plugins/plugin-zai/models/text.ts` with bounded `readProviderOptions` walker (`plugins/plugin-zai/models/zai-provider-options.ts`, 188 lines).
- Enforces `MAX_ZAI_PROVIDER_OPTIONS_DEPTH = 32`, `MAX_ZAI_PROVIDER_OPTIONS_NODES = 2_048`, WeakSet cycle detection, descriptor-only reads (`Object.getOwnPropertyDescriptor` + `Reflect.ownKeys` + `enumerable` check) to prevent getter execution, and `Object.defineProperty` preservation of `__proto__` as inert own data (no `Object.prototype` pollution).
- Fail-closed to typed `ElizaError` code `ZAI_PROVIDER_OPTIONS_UNBOUNDED` with `severity:"fatal"` via `failUnbounded`; preserves `cause` via `inspectRecord` J2 wrapper.
- Valid nested payloads deep-copy correctly; hostile depth>32 / nodes>2048 / cyclic / accessor payloads throw typed error instead of `RangeError`/`TypeError` or stack overflow.

## Changes
| File | Change |
|------|--------|
| `plugins/plugin-zai/models/zai-provider-options.ts` | **New** — descriptor-only walker, depth/nodes/cycle guards, `readProviderOptions` + `readProviderOptionValue`, `reserve`/`failUnbounded` (188 lines) |
| `plugins/plugin-zai/models/text.ts` | Replace `JSON.parse(JSON.stringify(...))` with `readProviderOptions` import and `rawProviderOptions ? readProviderOptions(...) : undefined) ?? {}` in `resolveTextParams` |
| `plugins/plugin-zai/__tests__/zai-provider-options.test.ts` | **New** — 8 deterministic tests: honest scalars/lists/nested, `__proto__` inert (root+nested), depth 32 accept / 33 throw, nodes 2048 sparse-hole throw / within-budget holes preserved, cyclic throw, accessor throw (129 lines) |
| `plugins/plugin-zai/__tests__/text-params.test.ts` | +1 integration test: `handleTextSmall` with valid `providerOptions {agentName, extra}` resolves `ok`, cyclic `self` rejects `ZAI_PROVIDER_OPTIONS_UNBOUNDED` via `resolveTextParams` path (+31) |

## Verification
- Rebased on `origin/develop@3775f57b4e` (`test(agent): add audit log coverage (#23014)`) — `git rebase origin/develop` clean, 1 commit `3a2841fb16`.
- `bun run --cwd plugins/plugin-zai typecheck` → `tsc --noEmit` pass (0 errors).
- `bun run --cwd plugins/plugin-zai test` → 7 files, **43 passed** (`zai-provider-options.test.ts` 8 + `text-params.test.ts` 8 + 5 other suites 27).
- `bunx biome check` on 4 changed files → `Checked 4 files in 6ms. No fixes applied.`
- `git diff --stat origin/develop..HEAD` → `4 files changed, 353 insertions(+), 5 deletions(-)` (proportional — walker complexity).

## Evidence
| Check | Result |
|-------|--------|
| typecheck | `bun run --cwd plugins/plugin-zai typecheck` — PASS |
| tests | `bun run --cwd plugins/plugin-zai test` — 7 files 43 passed |
| biome | `bunx biome check` 4 files — PASS |
| diff | `4 files 353+ 5-` |
| rebase | `origin/develop@3775f57b4e` → `3a2841fb16` clean |
| mergeable | `MERGEABLE:CLEAN` `mergeStateStatus:CLEAN` |
| atomic | Single concern: bound `providerOptions` graphs (S-tier, walker + wiring + tests) |
