### PR TITLE
fix(x): add AbortSignal timeout to broker token fetch

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -145,6 +145,7 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
           Accept: "application/json",
           Authorization: `Bearer ${this.brokerToken()}`,
         },
+        signal: AbortSignal.timeout(15_000),
       },
     );
     if (response.status === 401 || response.status === 403) {


### PR DESCRIPTION
## Problem
`plugins/plugin-x/src/client/auth-providers/broker.ts` `fetchFromBroker` retrieves managed X credentials with `fetch` and **no `signal`**. Every X action that needs a broker token hangs if the cloud token hop never returns.

## Fix
Pass `AbortSignal.timeout(15_000)` into `fetch`. A hung hop now fails closed with `TimeoutError` instead of hanging.

Closes #22860

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza