### PR TITLE
fix(core): fail closed on cyclic or over-deep connector account JSON

### DIFF
--- a/packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
+++ b/packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
@@ -5,6 +5,10 @@
  */
 import { describe, expect, it } from "vitest";
 import type { IDatabaseAdapter, UUID } from "../types";
+import {
+	CONNECTOR_JSON_UNBOUNDED,
+	MAX_CONNECTOR_JSON_NODES,
+} from "./connector-json";
 import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
 
 const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
@@ -145,5 +149,300 @@ describe("InMemoryDatabaseAdapter connector account storage", () => {
 				credentialType: "oauth.refresh_token",
 			}),
 		).resolves.toBeNull();
+	});
+});
+
+function nest(depth: number): Record<string, unknown> {
+	let value: Record<string, unknown> = { leaf: true };
+	for (let i = 0; i < depth; i += 1) {
+		value = { n: value };
+	}
+	return value;
+}
+
+function expectUnbounded(error: unknown): void {
+	expect(error).toBeInstanceOf(Error);
+	expect(error).not.toBeInstanceOf(TypeError);
+	expect((error as { code?: string }).code).toBe(CONNECTOR_JSON_UNBOUNDED);
+}
+
+async function expectUpsertRejects(
+	adapter: InMemoryDatabaseAdapter,
+	params: Parameters<InMemoryDatabaseAdapter["upsertConnectorAccount"]>[0],
+): Promise<void> {
+	try {
+		await adapter.upsertConnectorAccount(params);
+	} catch (error) {
+		expectUnbounded(error);
+		return;
+	}
+	throw new Error("expected the connector account upsert to reject");
+}
+
+/**
+ * The bounded JSON projection itself is unit-tested in `connector-json.test.ts`.
+ * These cases pin the contract at the adapter boundary: that every connector
+ * write and read actually routes through it, that a typed rejection leaves no
+ * ghost record or bricked lookup key, and that the projection's reflection
+ * bound still holds when a hostile value arrives through the public
+ * `IDatabaseAdapter` surface rather than through a direct helper call.
+ */
+describe("InMemoryDatabaseAdapter connector JSON bounds", () => {
+	it("origin JSON.stringify of a 40000-deep profile RangeErrors", () => {
+		// bun stringify is iterative until ~40k; node already RangeErrors at 8k.
+		expect(() => JSON.parse(JSON.stringify(nest(40_000)))).toThrow(RangeError);
+	});
+
+	it("upserts an honest profile and metadata clone", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const nested = { plan: "free" };
+		const account = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-honest",
+			profile: { login: "octo", extra: nested },
+			metadata: { source: "oauth" },
+		});
+		expect(account.profile).toEqual({ login: "octo", extra: { plan: "free" } });
+		expect(account.metadata).toEqual({ source: "oauth" });
+		// The stored record must not alias caller-owned subtrees.
+		nested.plan = "mutated";
+		const read = await adapter.getConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-honest",
+		});
+		expect(read?.profile).toEqual({ login: "octo", extra: { plan: "free" } });
+	});
+
+	it("fail-closes upsert on a cyclic profile instead of TypeError", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const cyclic: Record<string, unknown> = { login: "octo" };
+		cyclic.self = cyclic;
+		expect(() => JSON.parse(JSON.stringify(cyclic))).toThrow(TypeError);
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-cycle",
+			profile: cyclic,
+		});
+	});
+
+	it("fail-closes upsert on a 40000-deep profile instead of RangeError", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-deep",
+			profile: nest(40_000),
+		});
+	});
+
+	it("leaves no ghost account behind a rejected write", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const cyclic: Record<string, unknown> = { login: "octo" };
+		cyclic.self = cyclic;
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-ghost",
+			profile: cyclic,
+		});
+		await expect(
+			adapter.getConnectorAccount({
+				agentId,
+				provider: "github",
+				accountKey: "github-ghost",
+			}),
+		).resolves.toBeNull();
+		await expect(
+			adapter.listConnectorAccounts({ agentId, provider: "github" }),
+		).resolves.toHaveLength(0);
+	});
+
+	it("keeps the existing record and lookup key when a re-upsert is rejected", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const account = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-reupsert",
+			profile: { login: "octo" },
+		});
+		const cyclic: Record<string, unknown> = { login: "octo" };
+		cyclic.self = cyclic;
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-reupsert",
+			profile: cyclic,
+		});
+		// Key lookup must still resolve the live account, and the next honest
+		// upsert must reuse its id instead of minting a duplicate.
+		await expect(
+			adapter.getConnectorAccount({
+				agentId,
+				provider: "github",
+				accountKey: "github-reupsert",
+			}),
+		).resolves.toMatchObject({ id: account.id, profile: { login: "octo" } });
+		await expect(
+			adapter.upsertConnectorAccount({
+				agentId,
+				provider: "github",
+				accountKey: "github-reupsert",
+				profile: { login: "octo-2" },
+			}),
+		).resolves.toMatchObject({ id: account.id });
+		await expect(
+			adapter.listConnectorAccounts({ agentId, provider: "github" }),
+		).resolves.toHaveLength(1);
+	});
+
+	it("never invokes an own enumerable accessor on the upsert path", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		let calls = 0;
+		const profile: Record<string, unknown> = {};
+		Object.defineProperty(profile, "login", {
+			configurable: true,
+			enumerable: true,
+			get() {
+				calls += 1;
+				return "octo";
+			},
+		});
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-own-accessor",
+			profile,
+		});
+		expect(calls).toBe(0);
+	});
+
+	it("fail-closes a revoked proxy profile without leaking a raw TypeError", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const revoked = Proxy.revocable({ login: "octo" }, {});
+		revoked.revoke();
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-revoked-proxy",
+			profile: { nested: revoked.proxy } as never,
+		});
+	});
+
+	it("stops requesting array index descriptors at the node cap on upsert", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		let indexDescriptorCalls = 0;
+		const dense = new Proxy(
+			Array.from({ length: 100_000 }, () => 1),
+			{
+				getOwnPropertyDescriptor(target, key) {
+					if (key !== "length") indexDescriptorCalls += 1;
+					return Reflect.getOwnPropertyDescriptor(target, key);
+				},
+			},
+		);
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-dense-array",
+			profile: { arr: dense } as never,
+		});
+		// The length cap must short-circuit before any index descriptor is
+		// materialised, so the walk never pays O(elements) to fail closed.
+		expect(indexDescriptorCalls).toBe(0);
+	});
+
+	it("rejects a wide object profile before allocating per-property descriptors", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const keys = Array.from(
+			{ length: MAX_CONNECTOR_JSON_NODES * 4 },
+			(_, index) => `k${index}`,
+		);
+		const target = Object.fromEntries(keys.map((key) => [key, 1]));
+		let descriptorCalls = 0;
+		const wide = new Proxy(target, {
+			getOwnPropertyDescriptor(currentTarget, key) {
+				descriptorCalls += 1;
+				return Reflect.getOwnPropertyDescriptor(currentTarget, key);
+			},
+		});
+		await expectUpsertRejects(adapter, {
+			agentId,
+			provider: "github",
+			accountKey: "github-wide-object",
+			profile: { wide } as never,
+		});
+		expect(descriptorCalls).toBe(0);
+	});
+
+	it("records a bounded audit event for hostile metadata instead of throwing", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const account = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-audit-cycle",
+		});
+		const cyclic: Record<string, unknown> = {
+			safe: "visible",
+			accessToken: "secret",
+		};
+		cyclic.self = cyclic;
+		const audit = await adapter.appendConnectorAccountAuditEvent({
+			accountId: account.id,
+			action: "credential.set",
+			metadata: cyclic,
+		});
+		expect(audit.metadata.safe).toBe("visible");
+		expect(audit.metadata.accessToken).toBe("[REDACTED]");
+		expect(audit.metadata.self).toBe("[BOUNDED]");
+	});
+
+	it("bounds deep non-cyclic audit metadata without dropping the event", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const account = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-audit-deep",
+		});
+		const audit = await adapter.appendConnectorAccountAuditEvent({
+			accountId: account.id,
+			action: "credential.set",
+			metadata: { safe: "visible", deep: nest(40) },
+		});
+		expect(audit.metadata.safe).toBe("visible");
+		expect(JSON.stringify(audit.metadata)).toContain("[BOUNDED]");
+	});
+
+	it("preserves literal [BOUNDED] profile strings across write and read", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const profile = { arr: ["[BOUNDED]", "must-survive", 3] };
+		const account = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "github",
+			accountKey: "github-bounded-literal",
+			profile,
+		});
+		expect(account.profile).toEqual(profile);
+		await expect(
+			adapter.getConnectorAccount({
+				agentId,
+				provider: "github",
+				accountKey: "github-bounded-literal",
+			}),
+		).resolves.toMatchObject({ profile });
 	});
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23287 (owning issue, filed for this head). Context: #23156 landed the
shared bounded connector JSON projection on `develop`; #23029 (closed) tracked the
plugin-sql parity that #23156 resolved.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`84f58095b90b425d81bbaf6ff93914797045a332`) with zero conflicts remaining.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5 (this head); xai/grok-4.6 (superseded heads)
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` @ `84f58095b90b425d81bbaf6ff93914797045a332`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Very low. Test-only change. No production file is touched: after the rebase,
`packages/core/src/database/inMemoryAdapter.ts` is byte-identical to `develop`
(`git diff origin/develop HEAD -- packages/core/src/database/inMemoryAdapter.ts`
is empty). No schema, API contract, or storage migration.

# Background

## What does this PR do?

## What

**Scope changed on this head, and the change is a reduction — please read this
section before re-reviewing.**

This PR originally carried its own bounded connector-JSON walk inside
`InMemoryDatabaseAdapter`. While rebasing onto current `develop` as requested,
that implementation turned out to be fully superseded: #23156 landed
`packages/core/src/database/connector-json.ts`, a shared descriptor-only bounded
projection that both `InMemoryDatabaseAdapter` and the plugin-sql connector-account
store now import. It already implements everything this PR was carrying, including
the exact resource bound raised in the last review — array `length` inspected and
width-rejected before any index descriptor is requested, and an own-key inventory
width-rejected before any per-property descriptor is materialised — and it already
pins both with `Proxy`-counter tests in `connector-json.test.ts`.

Rebasing this branch onto `develop` therefore collapses the whole implementation
diff to nothing. Re-landing a second, divergent copy of that walk inside
`inMemoryAdapter.ts` would be strictly worse than what already ships.

What is left, and what this PR now is: **adapter-boundary regression coverage.**
`connector-json.test.ts` exercises the projection helpers directly;
`inMemoryConnectorAccountStorage.test.ts` had only the storage-surface test. The
integration contract between them was unpinned. This head adds 13 cases driving the
real `InMemoryDatabaseAdapter` through the public `IDatabaseAdapter` surface:

- cyclic and 40000-deep profiles fail closed with `CONNECTOR_JSON_UNBOUNDED`
  instead of a raw `TypeError` / `RangeError`;
- a rejected write leaves **no ghost account** (`getConnectorAccount` resolves
  `null`, `listConnectorAccounts` is empty);
- a rejected **re-upsert** keeps the live record resolvable by key and the next
  honest upsert reuses its id instead of minting a duplicate — the clone-before-
  mutate ordering, which is an adapter-level invariant that cannot be expressed
  against the projection helpers alone;
- an own enumerable accessor is **never invoked** (`calls === 0`) and a revoked
  proxy fails typed on the real upsert path;
- reflection stays bounded *through the adapter*: a 100 000-element dense array
  requests **0** index descriptors and a wide object requests **0** property
  descriptors before the typed rejection;
- hostile (cyclic + secret-bearing) and deep audit metadata is bounded and redacted
  but the event is still **recorded**, not thrown after the push;
- honest values are not aliased to caller-owned subtrees, and literal `"[BOUNDED]"`
  strings survive a write/read round trip.

If you would rather close this PR as superseded by #23156 and land the coverage
separately under #23287, say so and I will not re-push — I have deliberately not
closed or merged anything.

## Proof

Executed at this exact head in the PR worktree (see Evidence Gate for the receipt):

- `bun run --cwd packages/core test src/database` → **62/62 pass, 9 files, 0 fail**
  (the connector-account file itself is 14/14).
- `bun run --cwd packages/core typecheck` (`tsc --noEmit -p ./tsconfig.json`) →
  **0 errors**.
- `bunx @biomejs/biome check packages/core/src/database/inMemoryConnectorAccountStorage.test.ts`
  → clean.
- Supersession, executed rather than asserted:
  `git diff origin/develop HEAD -- packages/core/src/database/inMemoryAdapter.ts`
  produces **no output**, and `git diff --stat origin/develop...HEAD` lists exactly
  one file, the test file.

## What kind of change is this?

Tests (adding missing regression coverage; no production behaviour change)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/database/inMemoryConnectorAccountStorage.test.ts` — it is the
only file in the diff. The two descriptor-counter cases
("stops requesting array index descriptors at the node cap on upsert" and
"rejects a wide object profile before allocating per-property descriptors") are the
ones that answer the last review's resource-boundary question at the adapter level.

## Detailed testing steps

```
git checkout fix/connector-account-json-unbounded
bun run --cwd packages/core test src/database
bun run --cwd packages/core typecheck
bunx @biomejs/biome check packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:8e589319da6e8c281fb58431722a2066b863a899 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only diff; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only diff; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; the focused suite transcript is the artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused suite, typecheck, lint, and the supersession diff at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head: 8e589319da6e8c281fb58431722a2066b863a899
rebase base: 84f58095b90b425d81bbaf6ff93914797045a332 (origin/develop)

$ bun run --cwd packages/core test src/database
 RUN  v4.1.10 .../packages/core
 Test Files  9 passed (9)
      Tests  62 passed (62)
   Duration  5.96s
exit 0

$ bun run --cwd packages/core test src/database/inMemoryConnectorAccountStorage.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
exit 0

$ bun run --cwd packages/core typecheck
node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
Done!  (0 errors)
exit 0

$ bunx @biomejs/biome check packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
Checked 1 file in 784ms. No fixes applied.
exit 0

supersession check (why the implementation diff is gone):
$ git diff origin/develop HEAD -- packages/core/src/database/inMemoryAdapter.ts
(no output - byte-identical to develop)
$ git diff --stat origin/develop...HEAD
 .../inMemoryConnectorAccountStorage.test.ts | 299 +++++++++++++++++++++
 1 file changed, 299 insertions(+)

pre-rebase counter-check (the reviewed head 62b7b21c87c7, before rebase):
the two descriptor-counter assertions were first run against that head's own
walker and reproduced the reported bound exactly -
  dense 100k array   -> 100001 descriptor requests (expected <= 2050)
  wide 100k object   -> 100000 descriptor requests (expected <= 1)
develop's shared projection reports 0 and 0.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; the focused suite is the proof.

## Screenshots (before / after) + video walkthrough

N/A - test-only diff, no rendered UI surface.

### Before

N/A - test-only diff, no rendered UI surface.

### After

N/A - test-only diff, no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` was **not** run on this head. The worktree's `bun install`
  is incomplete on this machine (a partial `node_modules` from an interrupted
  install), so a root-wide verify cannot be trusted to mean anything here. The
  package-scoped suite, typecheck, and lint above were all executed and are the
  proof. This is the one gate the last review asked for that I could not close.
- Hosted CI check-runs: none on this head. Fork branches on this repository do not
  schedule check-runs; this is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is inline.
- Two divergences from `JSON.stringify` remain in `develop`'s shared projection and
  are **not** touched here: array `toJSON` hosts are traversed as elements, and
  redacted audit leaves are not charged against the node budget. Both are bounded,
  pre-existing on `develop`, and out of scope for a test-only diff.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
