### PR TITLE
fix(shared): unlink voice-cancellation listener on independent abort

### DIFF
--- a/packages/shared/src/voice/voice-cancellation-token.test.ts
+++ b/packages/shared/src/voice/voice-cancellation-token.test.ts
@@ -101,6 +101,20 @@ describe("createVoiceCancellationToken", () => {
     expect(token.aborted).toBe(true);
     expect(token.reason).toBe("external");
   });
+
+  it("detaches from a linked signal when the token aborts independently", () => {
+    const ctrl = new AbortController();
+    const remove = vi.spyOn(ctrl.signal, "removeEventListener");
+    const token = createVoiceCancellationToken({
+      runId: "r",
+      linkSignal: ctrl.signal,
+    });
+
+    token.abort("barge-in");
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(token.aborted).toBe(true);
+  });
 });
 
 describe("createAbortedVoiceCancellationToken", () => {

--- a/packages/shared/src/voice/voice-cancellation-token.ts
+++ b/packages/shared/src/voice/voice-cancellation-token.ts
@@ -107,11 +107,14 @@ export function createVoiceCancellationToken(
   const controller = new AbortController();
   const listeners = new Set<VoiceCancellationListener>();
   const state: InternalState = { aborted: false, reason: null };
+  let unlinkSignal: (() => void) | null = null;
 
   const trip = (reason: VoiceCancellationReason): void => {
     if (state.aborted) return;
     state.aborted = true;
     state.reason = reason;
+    unlinkSignal?.();
+    unlinkSignal = null;
     // Call listeners BEFORE aborting the controller so a listener that
     // itself awaits the signal sees the same reason this token recorded
     // (otherwise listeners that observe `signal.aborted` could race).
@@ -132,6 +135,8 @@ export function createVoiceCancellationToken(
     } else {
       const onLinkAbort = () => trip("external");
       opts.linkSignal.addEventListener("abort", onLinkAbort, { once: true });
+      unlinkSignal = () =>
+        opts.linkSignal?.removeEventListener("abort", onLinkAbort);
     }
   }
 


### PR DESCRIPTION
# Relates to

No linked issue; this is a two-file, behavior-preserving listener-lifetime cleanup found during the authorized small-PR audit.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: OpenAI gpt-5.6-sol; Anthropic claude-sonnet-5
- Agent tooling: Codex; Claude Code; Codex desktop review
- Skill path: N/A - repository review workflow; no contribution skill revision recorded
- Provenance status: self-reported

# Sync with develop

- [x] Targets `develop` with a clean exact-head merge state.
- [x] Focused exact-head verification is green.

# Risks

Low. Cleanup runs only inside the existing one-shot `trip()` guard. It removes the linked abort callback before notifying listeners and aborting the child controller; abort reason, listener order, and external-abort behavior remain unchanged.

# Background

A voice cancellation token linked to a long-lived parent signal retained the parent's abort listener when the token independently tripped through barge-in, EOT, timeout, or user cancellation. Repeated voice turns could accumulate closures on the parent signal. This head stores a one-shot unlink callback and invokes it during `trip()`.

# Testing

Pinned Bun 1.3.14 / Node 24.15.0 exact-head validation:

```text
vitest run packages/shared/src/voice/voice-cancellation-token.test.ts
17 passed, 0 failed
```

The regression spies on the real linked signal and proves independent abort removes exactly one listener. The contributor mutation control removes the fix and reproduces the retained listener.

# Evidence Gate

<!-- evidence-head:463bbac92c9283aba4b884cabb73c8c6d9323dbe -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - headless voice cancellation primitive; no pixels.
<!-- evidence-row:after-screenshots -->
- [x] N/A - headless voice cancellation primitive; no pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head test transcript above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/planner behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Listener removal call count and cancellation state are asserted by the regression.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

No implementation gap is known. Broader shared-package build/type errors reported by the contributor reproduce on the base and are unrelated workspace dependency ordering failures.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - GitHub review workflow; contribution skill not used
Attribution status: self-reported
— [codex-round2-connectors]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - GitHub review workflow; contribution skill not used"} -->