### PR TITLE
fix(fish-audio): detach abort listener when synthesis finishes on its own

### DIFF
--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -310,6 +310,29 @@ describe("fishAudioPlugin", () => {
     await expect(result.bytes).rejects.toThrow("Fish Audio TTS aborted");
   });
 
+  test("detaches the abort listener once synthesis finishes on its own", async () => {
+    Object.defineProperty(globalThis, "WebSocket", {
+      value: FakeFishSocket,
+      configurable: true,
+    });
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, "removeEventListener");
+
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "hello", audioStream: true, signal: controller.signal },
+    );
+    if (!("bytes" in result)) throw new Error("Expected streaming result");
+    await result.bytes;
+
+    expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+
   test("buffers bytes when audioStream is false", async () => {
     Object.defineProperty(globalThis, "WebSocket", {
       value: FakeFishSocket,

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -252,11 +252,13 @@ function createFishAudioStream(
   const socket = openSocket(config.apiKey, config.model);
   socket.binaryType = "arraybuffer";
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  let unlistenAbort: (() => void) | undefined;
 
   const finish = () => {
     if (done) return;
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
+    unlistenAbort?.();
     resolveBytes(concatBytes(bufferedChunks, totalBytes));
     while (waiters.length > 0) {
       waiters.shift()?.({ done: true, value: undefined });
@@ -266,6 +268,7 @@ function createFishAudioStream(
     if (done) return;
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
+    unlistenAbort?.();
     failure = error;
     rejectBytes(error);
     while (waiters.length > 0) {
@@ -391,8 +394,9 @@ function createFishAudioStream(
   };
   if (config.signal?.aborted) {
     abort();
-  } else {
-    config.signal?.addEventListener("abort", abort, { once: true });
+  } else if (config.signal) {
+    config.signal.addEventListener("abort", abort, { once: true });
+    unlistenAbort = () => config.signal?.removeEventListener("abort", abort);
   }
 
   const audioStream: AsyncIterable<Uint8Array> = {


### PR DESCRIPTION
# Relates to

No linked issue; this is a two-file listener-lifetime cleanup discovered while auditing the same leak class as #22974 in a separate provider lifecycle.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: OpenAI gpt-5.6-sol; Anthropic claude-sonnet-5
- Agent tooling: Codex; Claude Code; Codex desktop review
- Skill path: N/A - repository review workflow; no contribution skill revision recorded
- Provenance status: self-reported

# Sync with develop

- [x] Targets `develop` with a clean exact-head merge state.
- [x] Focused exact-head verification is green.

# Risks

Low. The existing abort handler is detached only after the one-shot stream reaches `finish()` or `fail()`. Active cancellation remains wired; successful bytes, stream waiter completion, provider failures, and deadline behavior are unchanged.

# Background

`createFishAudioStream()` attached an abort listener to the caller signal but retained it after normal completion or failure. Long-lived caller signals therefore retained the socket, chunks, and waiter closure. This head stores an unlink callback and invokes it from both terminal paths.

# Testing

Pinned Bun 1.3.14 / Node 24.15.0 exact-head validation:

```text
vitest run plugins/plugin-fish-audio/__tests__/streaming.test.ts
15 passed, 0 failed, 1 intentional live-credentials skip
```

The regression completes a real fake-WebSocket synthesis and verifies the exact registered abort handler is removed. Contributor mutation control reproduces the leak when cleanup is removed.

# Evidence Gate

<!-- evidence-head:8c70dd10bfb7a1e36fc5ba48f731d4afa652c5ad -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend audio stream lifecycle; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend audio stream lifecycle; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head test transcript above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/planner behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Fake-WebSocket completion bytes and listener cleanup are asserted by the regression.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

The live Fish Audio credential smoke remains intentionally skipped without provider credentials. The deterministic stream lifecycle is covered; no implementation gap is known.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - GitHub review workflow; contribution skill not used
Attribution status: self-reported
— [codex-round2-connectors]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - GitHub review workflow; contribution skill not used"} -->