### PR TITLE
fix(ci): let the headscale converge skip a broken certificate step

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -24,6 +24,16 @@ on:
         required: false
         type: string
         default: ""
+      skip_nginx_cert:
+        description: >-
+          Skip the nginx vhost + Let's Encrypt step. The certificate covers both
+          the canonical and the legacy hostname, so a conflicting server_name on
+          the box fails the whole run - and that step runs BEFORE the ACL and
+          config are written, so a cert failure leaves the policy unconverged.
+          Set this to reach the ACL when the cert is the thing that is broken.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -42,6 +52,7 @@ jobs:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_OPERATION: ${{ inputs.operation }}
       TARGET_REVIEWED_LEGACY_VHOST_SHA256: ${{ inputs.reviewed_legacy_vhost_sha256 }}
+      TARGET_SKIP_NGINX_CERT: ${{ inputs.skip_nginx_cert }}
       DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
       DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.ELIZA_PROVISIONING_SSH_KNOWN_HOSTS }}
@@ -188,6 +199,15 @@ jobs:
               )
               ;;
           esac
+          if [ "$TARGET_SKIP_NGINX_CERT" = "true" ]; then
+            # The script rejects this combination itself; fail here with the
+            # reason rather than after SSH has already run.
+            if [ "$TARGET_OPERATION" = "retire-legacy-vhost-and-converge" ]; then
+              echo "::error::skip_nginx_cert cannot be combined with legacy vhost retirement"
+              exit 1
+            fi
+            args+=(--skip-nginx-cert)
+          fi
           "${args[@]}"
 
       - name: Verify dual-SAN public identity and health

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -42,6 +42,7 @@ interface HeadscaleWorkflow {
       inputs: {
         environment: { options: string[] };
         operation: { options: string[] };
+        skip_nginx_cert: { type: string; default: boolean };
       };
     };
   };
@@ -261,6 +262,28 @@ describe("Headscale protected workflow contract", () => {
     ).run;
     expect(sourceGuard).toContain('production) expected_ref="refs/heads/main"');
     expect(sourceGuard).toContain('if [ "$GITHUB_REF" != "$expected_ref" ]');
+  });
+
+  test("can reach the ACL when the certificate step is the broken thing", () => {
+    // The remote script runs the nginx + Let's Encrypt block BEFORE it writes
+    // acl.hujson and the headscale policy config, so a cert failure aborts the
+    // run with the policy left unconverged. That is exactly what happened on
+    // 2026-08-18: both production runs died at certbot and the corrected ACL
+    // never reached the box. This input is the escape hatch.
+    const inputs = workflow.on.workflow_dispatch.inputs;
+    expect(inputs.skip_nginx_cert.type).toBe("boolean");
+    expect(inputs.skip_nginx_cert.default).toBe(false);
+
+    const converge = namedStep(
+      workflow,
+      "Inspect or converge Headscale control plane",
+    ).run;
+    expect(converge).toContain("args+=(--skip-nginx-cert)");
+    // The script refuses this pairing itself; the workflow must refuse it
+    // before SSH rather than after.
+    expect(converge).toContain(
+      "skip_nginx_cert cannot be combined with legacy vhost retirement",
+    );
   });
 
   test("invokes the reviewed script without exposing a force-reauth input", () => {


### PR DESCRIPTION
## Why production is still down

The corrected `tag:eliza-proxy → tag:agent:2138` rule has been on `main` since #22664 merged. Production dedicated agents are still unreachable, and re-dispatching the converge as-is will not change that.

The remote script runs the nginx vhost + Let's Encrypt block at `arm-headscale-control-plane.mjs:737-847`. It writes `acl.hujson` at `:1235` and the headscale `policy:` config at `:1239-1300`. **The certificate step runs first**, so a certificate failure aborts the run before the ACL is ever installed — and the run reports a generic `remote Headscale arm failed (exit 1)` rather than "the policy was not applied".

That is what happened. Both production runs on 2026-08-18:

- `32088029805` (01:23) failed at *Install deploy SSH identity* — never connected.
- `32088750679` (01:35) failed at *Inspect or converge* — reached certbot and died there:

```
01:39:21  conflicting server name "headscale.elizacloud.ai" on 0.0.0.0:80, ignored
01:39:22  Requesting a certificate for headscale.eliza.app and headscale.elizacloud.ai
01:39:37  error: remote Headscale arm failed (exit 1)
```

Neither reached `:1235`. The certificate covers both the canonical and the legacy hostname, and the legacy vhost has a conflicting `server_name` on the box, so the request fails and takes the whole converge with it.

## The change

`--skip-nginx-cert` already exists in the script (`:77`, `:176`, `:225`). The workflow simply never passed it. This exposes it as a boolean input, default `false`, so the certificate problem can be worked around to get the ACL onto the box while the vhost conflict is fixed separately.

It also refuses the one combination the script itself refuses — legacy vhost retirement — but does so *before* SSH rather than after, so the failure names the reason.

## What this does not do

It does not fix the vhost conflict, and it does not renew the certificate. Skipping the step leaves whatever certificate is currently installed in place. This is an escape hatch for the case where the certificate is the broken thing, not a way to stop managing certificates — hence `default: false`.

## Tests

9 pass in `arm-headscale-control-plane.test.ts`. The new case pins the input type and default, that the converge step passes the flag, and that the retirement combination is refused — with a comment recording the 2026-08-18 incident as the reason the escape hatch exists.

Part of #22508
