### PR TITLE
perf(cloud): serve the CLI-session login hot path from a thin shell

### DIFF
--- a/packages/cloud/api/src/cli-session-app.test.ts
+++ b/packages/cloud/api/src/cli-session-app.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Thin CLI-session shell contract (#22948): the mounted routes behave exactly
+ * as they do on the full app — server-minted create, format-gated poll — with
+ * the shell's own no-store default, and without serving the authenticated
+ * complete mutation.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createSessionCalls: string[] = [];
+const activeSessions = new Map<
+  string,
+  { session_id: string; status: string; expires_at: Date }
+>();
+
+mock.module("@/lib/services/cli-auth-sessions", () => ({
+  cliAuthSessionsService: {
+    createSession: async (sessionId: string) => {
+      createSessionCalls.push(sessionId);
+      return {
+        session_id: sessionId,
+        status: "pending",
+        expires_at: new Date("2026-08-20T12:00:00.000Z"),
+      };
+    },
+    getActiveSession: async (sessionId: string) =>
+      activeSessions.get(sessionId) ?? null,
+    getAndClearApiKey: async () => ({
+      status: "unavailable",
+      reason: "consumed",
+    }),
+  },
+  looksLikeCliAuthSessionId: (value: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    ),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const { createCliSessionThinApp } = await import("./cli-session-app");
+
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ENV = {
+  NODE_ENV: "test",
+  ENVIRONMENT: "test",
+  REDIS_RATE_LIMITING: "false",
+  BLOB: {},
+} as unknown as AppEnv["Bindings"];
+const PENDING_ID = "bbbbbbbb-2222-4333-8444-cccccccccccc";
+
+beforeEach(() => {
+  createSessionCalls.length = 0;
+  activeSessions.clear();
+});
+
+describe("createCliSessionThinApp", () => {
+  test("creates a session with a server-minted UUID, ignoring a client id", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      "/api/auth/cli-session",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "attacker-chosen" }),
+      },
+      ENV,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { sessionId: string; status: string };
+    expect(body.status).toBe("pending");
+    expect(body.sessionId).not.toBe("attacker-chosen");
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test("polls a pending session by id", async () => {
+    activeSessions.set(PENDING_ID, {
+      session_id: PENDING_ID,
+      status: "pending",
+      expires_at: new Date("2026-08-20T12:00:00.000Z"),
+    });
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      `/api/auth/cli-session/${PENDING_ID}`,
+      { method: "GET" },
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("pending");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  test("rejects a malformed poll id with 400", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      "/api/auth/cli-session/not-a-uuid",
+      { method: "GET" },
+      ENV,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("polling is not metered by the create's STRICT limiter (12 sequential polls stay 200)", async () => {
+    activeSessions.set(PENDING_ID, {
+      session_id: PENDING_ID,
+      status: "pending",
+      expires_at: new Date("2026-08-20T12:00:00.000Z"),
+    });
+    const app = createCliSessionThinApp();
+    for (let i = 0; i < 12; i++) {
+      const res = await app.request(
+        `/api/auth/cli-session/${PENDING_ID}`,
+        { method: "GET" },
+        ENV,
+      );
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test("rejects a cookie-authenticated cross-origin create (CSRF guard parity with the full app)", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      "https://api.elizacloud.ai/api/auth/cli-session",
+      {
+        method: "POST",
+        headers: {
+          cookie: "steward-token-test=ambient",
+          origin: "https://evil.example",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      },
+      ENV,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("forbidden_origin");
+    expect(createSessionCalls).toHaveLength(0);
+  });
+
+  test("fails closed in production when REDIS_RATE_LIMITING=true without Redis", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      "/api/auth/cli-session",
+      { method: "POST", body: "{}" },
+      {
+        ...(ENV as object),
+        ENVIRONMENT: "production",
+        REDIS_RATE_LIMITING: "true",
+      } as unknown as AppEnv["Bindings"],
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("RATE_LIMIT_UNAVAILABLE");
+    expect(createSessionCalls).toHaveLength(0);
+  });
+
+  test("OPTIONS preflight gets first-party CORS for the app origin", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      "https://api.elizacloud.ai/api/auth/cli-session",
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.elizacloud.ai",
+          "access-control-request-method": "POST",
+        },
+      },
+      ENV,
+    );
+    expect(res.status).toBeLessThan(500);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://app.elizacloud.ai",
+    );
+  });
+
+  test("does not serve the authenticated complete mutation", async () => {
+    const app = createCliSessionThinApp();
+    const res = await app.request(
+      `/api/auth/cli-session/${PENDING_ID}/complete`,
+      { method: "POST" },
+      ENV,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("resource_not_found");
+  });
+});

--- a/packages/cloud/api/src/cli-session-app.ts
+++ b/packages/cloud/api/src/cli-session-app.ts
@@ -1,0 +1,226 @@
+/**
+ * Thin Hono shell for the CLI-session login hot path (#22948).
+ *
+ * The desktop/CLI login flow polls `POST /api/auth/cli-session` +
+ * `GET /api/auth/cli-session/:id` at low frequency from varied colos, so with
+ * Smart Placement it lands on a cold isolate nearly every request and pays the
+ * monolithic bootstrap (677 route modules) as multi-second dispatch time —
+ * invisible in `full_app_module_init` because workerd's clock freezes across
+ * pure CPU. Same mechanism and same remedy as the thin Steward shell
+ * (`steward/thin-app.ts`, #18049) and the thin inference entry.
+ *
+ * The route modules are mounted as-is; the create route carries its own STRICT
+ * Redis limiter. The authenticated `/:sessionId/complete` mutation stays on
+ * the full app (see `cli-session-paths.ts`).
+ *
+ * Deliberately absent from the bootstrap-app stack: the global authMiddleware
+ * — both routes are pre-auth by design and resolve nothing from a session.
+ * The cookie-mutation CSRF guard is NOT optional the same way (the create is
+ * a POST under /api/) and is re-mounted below, like the thin inference entry
+ * does. Note the create limiter's Redis-outage fallback bucket is per-isolate,
+ * which this cold-isolate-heavy path dilutes — the Cloudflare-native 600/min
+ * GLOBAL_RATE_LIMITER backstop below is the enforceable per-IP floor.
+ */
+
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger as honoLogger } from "hono/logger";
+import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
+import { runWithDbCacheAsync } from "@/db/client";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import { hasRedisConfig } from "@/lib/cache/redis-factory";
+import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
+import {
+  getIpKey,
+  getRequestIp,
+  rateLimit,
+  rateLimitConfigVerdict,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
+import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
+import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { runWithRequestContext } from "@/lib/runtime/request-context";
+import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
+import { logger } from "@/lib/utils/logger";
+import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import cliSessionPollRoute from "../auth/cli-session/[sessionId]/route";
+import cliSessionCreateRoute from "../auth/cli-session/route";
+import { cookieMutationGuardMiddleware } from "./middleware/cookie-mutation-guard";
+
+export function createCliSessionThinApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+
+  app.use("*", async (c, next) => {
+    setRuntimeR2Bucket(c.env.BLOB);
+    let canDeferRequestTask = false;
+    try {
+      canDeferRequestTask = typeof c.executionCtx?.waitUntil === "function";
+    } catch {
+      // error-policy:J4 Local/test Hono requests intentionally have no
+      // Worker context; shared services retain their inline-await fallback.
+    }
+    await runWithCloudBindingsAsync(
+      c.env as Record<string, unknown>,
+      async () =>
+        runWithRequestContext(
+          {
+            clientIp: getRequestIp(c),
+            idempotencyKey:
+              c.req.header("idempotency-key") ||
+              c.req.header("x-request-id") ||
+              crypto.randomUUID(),
+            ...(canDeferRequestTask
+              ? {
+                  defer: (task: Promise<unknown>) =>
+                    c.executionCtx.waitUntil(task),
+                }
+              : {}),
+          },
+          async () => runWithDbCacheAsync(async () => next()),
+        ),
+    );
+  });
+
+  app.use("*", requestId());
+  app.use("*", httpTelemetryMiddleware());
+  app.use("*", corsMiddleware);
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      crossOriginResourcePolicy: "cross-origin",
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+
+  // Neither mounted route sets Cache-Control, so this is an unconditional
+  // no-store on the poll's API-key-bearing 200; the has() guard only keeps the
+  // shell drop-in compatible with a route that sets its own policy.
+  app.use("*", async (c, next) => {
+    await next();
+    if (
+      !c.res.headers.has("Cache-Control") &&
+      c.res.headers.get("Content-Type")?.includes("application/json")
+    ) {
+      c.res.headers.set("Cache-Control", "no-store");
+    }
+  });
+
+  app.use("*", honoLogger());
+  app.use("*", async (c, next) => {
+    const reqId = c.get("requestId") ?? crypto.randomUUID();
+    const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
+    c.set("requestId", reqId);
+    c.set("traceId", traceId);
+    return observeCloudRequest(
+      {
+        id: reqId,
+        traceId,
+        method: c.req.method,
+        path: new URL(c.req.url).pathname,
+      },
+      async () => {
+        await next();
+        return {
+          result: undefined,
+          status: c.res.status,
+          userId: null,
+          organizationId: null,
+          authMethod: null,
+        };
+      },
+    );
+  });
+
+  // Same production Redis fail-closed contract as bootstrap-app and the thin
+  // Steward shell (#9853): the create route's STRICT limiter is load-bearing,
+  // so never serve it with rate limiting silently disabled.
+  let rateLimitConfigLogged = false;
+  app.use("*", async (c, next) => {
+    const verdict = rateLimitConfigVerdict({
+      environment: c.env.ENVIRONMENT,
+      redisRateLimiting: c.env.REDIS_RATE_LIMITING,
+      hasRedisClient: hasRedisConfig(c.env),
+    });
+    if (!rateLimitConfigLogged) {
+      rateLimitConfigLogged = true;
+      if (verdict === "fail-closed") {
+        logger.error(
+          "[cli-session-thin-app] FATAL: REDIS_RATE_LIMITING=true in production but no Redis client is reachable (set the REDIS_URL secret). Failing closed.",
+        );
+      } else if (verdict === "warn-disabled") {
+        logger.warn(
+          '[cli-session-thin-app] Rate limiting is DISABLED in production (REDIS_RATE_LIMITING!="true") — limiters fall open.',
+        );
+      }
+    }
+    if (verdict === "fail-closed") {
+      return c.json(
+        {
+          error: "Rate limiting misconfigured",
+          code: "RATE_LIMIT_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+    await next();
+  });
+
+  // Global IP backstop (600/min) — same ceiling/namespace as bootstrap-app so
+  // the thin path is not unmetered.
+  app.use(
+    "*",
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
+  );
+
+  // CSRF guard directly before the routes, like the thin inference entry:
+  // mounted here (after the global limiter and observeCloudRequest) its 403s
+  // stay metered and observed exactly as on the full app.
+  app.use("*", cookieMutationGuardMiddleware);
+
+  // Poll mounts FIRST: the create sub-app registers its STRICT limiter with a
+  // path-less app.use, which Hono merges as /api/auth/cli-session/* — mounted
+  // the other way round it would wrap the 2s-interval poll and 429 every
+  // login ~20s in. Same registration order as the generated full-app router.
+  app.route("/api/auth/cli-session/:sessionId", cliSessionPollRoute);
+  app.route("/api/auth/cli-session", cliSessionCreateRoute);
+
+  app.notFound((c) =>
+    c.json(
+      { success: false, error: "Not found", code: "resource_not_found" },
+      404,
+    ),
+  );
+  app.onError((err, c) => {
+    if (
+      err instanceof ApiError ||
+      (err instanceof HTTPException && err.status < 500)
+    ) {
+      logger.debug("[CliSessionThinApp] Request rejected", {
+        status: err.status,
+        message: err.message,
+      });
+      return failureResponse(c, err);
+    }
+    logger.error("[CliSessionThinApp] Unhandled error", {
+      error: describeUnhandledError(err),
+    });
+    return failureResponse(c, err);
+  });
+
+  return app;
+}

--- a/packages/cloud/api/src/cli-session-dispatch.test.ts
+++ b/packages/cloud/api/src/cli-session-dispatch.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Worker-entry wiring for the thin CLI-session shell (#22948): the create POST
+ * and poll GET must be answered before full-app bootstrap, marked with the
+ * thin-path header. The negative side (complete never matches) is pinned in
+ * cli-session-paths.test.ts, without forcing a full-app import here.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/lib/services/cli-auth-sessions", () => ({
+  cliAuthSessionsService: {
+    createSession: async (sessionId: string) => ({
+      session_id: sessionId,
+      status: "pending",
+      expires_at: new Date("2026-08-20T12:00:00.000Z"),
+    }),
+    getActiveSession: async () => null,
+    getAndClearApiKey: async () => ({
+      status: "unavailable",
+      reason: "consumed",
+    }),
+  },
+  looksLikeCliAuthSessionId: (value: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    ),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const worker = (await import("./index")).default;
+
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const executionCtx = {
+  waitUntil: () => undefined,
+  passThroughOnException: () => undefined,
+} as unknown as ExecutionContext;
+
+const env = {
+  ENVIRONMENT: "test",
+  NODE_ENV: "test",
+  REDIS_RATE_LIMITING: "false",
+  BLOB: {},
+} as unknown as AppEnv["Bindings"];
+
+describe("thin CLI-session dispatch (#22948)", () => {
+  test("answers the create POST on the thin path before full-app bootstrap", async () => {
+    const res = await worker.fetch(
+      new Request("https://api.example.test/api/auth/cli-session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+      env,
+      executionCtx,
+    );
+    expect(res.status).toBe(201);
+    expect(res.headers.get("X-Eliza-Cli-Session-Path")).toBe("thin");
+    expect(res.headers.get("Server-Timing")).toMatch(
+      /entry_dispatch;dur=\d+(?:\.\d+)?/,
+    );
+    expect(res.headers.get("Server-Timing")).toContain(
+      "cli_session_module_init",
+    );
+    expect(res.headers.get("Server-Timing")).not.toContain("full_app_dispatch");
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("pending");
+  });
+
+  test("answers the poll GET on the thin path", async () => {
+    const res = await worker.fetch(
+      new Request(
+        "https://api.example.test/api/auth/cli-session/bbbbbbbb-2222-4333-8444-cccccccccccc",
+      ),
+      env,
+      executionCtx,
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("X-Eliza-Cli-Session-Path")).toBe("thin");
+    expect(res.headers.get("Server-Timing")).not.toContain(
+      "cli_session_module_init",
+    );
+  });
+});

--- a/packages/cloud/api/src/cli-session-paths.test.ts
+++ b/packages/cloud/api/src/cli-session-paths.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Thin CLI-session dispatch predicate: exactly the create POST and the
+ * single-segment poll GET go to the thin shell; the authenticated
+ * `/:sessionId/complete` mutation must always fall through to the full app.
+ */
+import { describe, expect, test } from "bun:test";
+import { isThinCliSessionPath } from "./cli-session-paths";
+
+describe("isThinCliSessionPath", () => {
+  test("routes create POST and its preflight to the thin shell", () => {
+    expect(isThinCliSessionPath("POST", "/api/auth/cli-session")).toBe(true);
+    expect(isThinCliSessionPath("OPTIONS", "/api/auth/cli-session")).toBe(true);
+    expect(isThinCliSessionPath("post", "/api/auth/cli-session/")).toBe(true);
+  });
+
+  test("routes single-segment poll GET/HEAD and preflight to the thin shell", () => {
+    const poll = "/api/auth/cli-session/bbbbbbbb-2222-4333-8444-cccccccccccc";
+    expect(isThinCliSessionPath("GET", poll)).toBe(true);
+    expect(isThinCliSessionPath("HEAD", poll)).toBe(true);
+    expect(isThinCliSessionPath("OPTIONS", poll)).toBe(true);
+  });
+
+  test("never captures the authenticated complete mutation", () => {
+    const complete =
+      "/api/auth/cli-session/bbbbbbbb-2222-4333-8444-cccccccccccc/complete";
+    expect(isThinCliSessionPath("POST", complete)).toBe(false);
+    expect(isThinCliSessionPath("GET", complete)).toBe(false);
+    expect(isThinCliSessionPath("OPTIONS", complete)).toBe(false);
+  });
+
+  test("rejects methods the thin routes do not implement", () => {
+    expect(isThinCliSessionPath("GET", "/api/auth/cli-session")).toBe(false);
+    expect(isThinCliSessionPath("PUT", "/api/auth/cli-session")).toBe(false);
+    expect(isThinCliSessionPath("POST", "/api/auth/cli-session/some-id")).toBe(
+      false,
+    );
+    expect(isThinCliSessionPath("DELETE", "/api/auth/cli-session/x")).toBe(
+      false,
+    );
+  });
+
+  test("leaves unrelated paths to the other dispatchers", () => {
+    expect(isThinCliSessionPath("GET", "/api/auth/cli-sessions")).toBe(false);
+    expect(isThinCliSessionPath("POST", "/api/auth")).toBe(false);
+    expect(isThinCliSessionPath("GET", "/steward/auth/providers")).toBe(false);
+    expect(isThinCliSessionPath("POST", "/api/v1/cli-auth/x/token")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cloud/api/src/cli-session-paths.ts
+++ b/packages/cloud/api/src/cli-session-paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Paths served by the thin CLI-session shell (#22948).
+ *
+ * Only the two login-hot-path endpoints the CLI/desktop flow hammers:
+ * session create (POST) and status poll (GET). OPTIONS preflight is eligible
+ * for both paths; HEAD is eligible for the poll (Hono answers HEAD via the
+ * GET handler). The authenticated `/:sessionId/complete` mutation stays on
+ * the full app — it needs the complete auth middleware stack — and is
+ * excluded here by the single-segment constraint, not by handler-side
+ * dispatch.
+ */
+
+const CLI_SESSION_CREATE_PATH = /^\/api\/auth\/cli-session\/?$/;
+const CLI_SESSION_POLL_PATH = /^\/api\/auth\/cli-session\/[^/]+\/?$/;
+
+export function isThinCliSessionPath(
+  method: string,
+  pathname: string,
+): boolean {
+  const upper = method.toUpperCase();
+  if (CLI_SESSION_CREATE_PATH.test(pathname)) {
+    return upper === "POST" || upper === "OPTIONS";
+  }
+  if (CLI_SESSION_POLL_PATH.test(pathname)) {
+    return upper === "GET" || upper === "HEAD" || upper === "OPTIONS";
+  }
+  return false;
+}

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -267,6 +267,9 @@ test("correlates and times dispatch outside full-app middleware", async () => {
   expect(response.headers.get("server-timing")).toMatch(
     /full_app_module_init;dur=\d+(?:\.\d+)?/,
   );
+  expect(response.headers.get("server-timing")).toContain(
+    'full_app_isolate;dur=0;desc="cold"',
+  );
 
   const warmResponse = await cloudApiWorker.fetch(
     makeRequest(),
@@ -278,6 +281,9 @@ test("correlates and times dispatch outside full-app middleware", async () => {
   );
   expect(warmResponse.headers.get("server-timing")).not.toContain(
     "full_app_module_init",
+  );
+  expect(warmResponse.headers.get("server-timing")).toContain(
+    'full_app_isolate;dur=0;desc="warm"',
   );
 });
 

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -30,11 +30,13 @@ import { shouldDecorateHttpTelemetryStatus } from "@/lib/observability/http-tele
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { isStorageReadCapabilityPath, serveBlobHostRequest } from "./blob-host";
+import { isThinCliSessionPath } from "./cli-session-paths";
 import { isPersonalSharedTelegramEdgeEnabled } from "./personal-shared-telegram-edge";
 import { serveRegistryHostRequest } from "./registry-host";
 import { isThinStewardPublicPath } from "./steward/public-paths";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
+export { isThinCliSessionPath } from "./cli-session-paths";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
 export { InferenceRateLimitV2RollbackFloor } from "./inference-rate-limit-v2-rollback-floor";
 export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
@@ -48,6 +50,8 @@ let appPromise: Promise<Hono<AppEnv>> | undefined;
 const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();
 /** Lazy thin shell for login-critical Steward GETs (#18049). */
 let stewardThinAppPromise: Promise<Hono<AppEnv>> | undefined;
+/** Lazy thin shell for the CLI-session login hot path (#22948). */
+let cliSessionThinAppPromise: Promise<Hono<AppEnv>> | undefined;
 /** Lazy provider-webhook shell that avoids the generated application router. */
 let webhookAppPromise: Promise<Hono<AppEnv>> | undefined;
 /** Lazy authenticated Discord shell that avoids the generated application router. */
@@ -201,6 +205,16 @@ export function decorateFullAppDispatchResponse(
   const responseHeaders = new Headers(response.headers);
   setHttpTelemetryHeaders(responseHeaders, traceId, [
     { name: "full_app_dispatch", durationMs: dispatchMs },
+    // Cold/warm marker on every decorated response: `full_app_module_init`
+    // alone cannot distinguish "warm isolate" from "header stripped", and its
+    // duration under-reports cold bootstrap because workerd freezes the clock
+    // across pure CPU — the cost lands in full_app_dispatch at the first I/O
+    // (#22948).
+    {
+      name: "full_app_isolate",
+      durationMs: 0,
+      description: moduleInitMs === null ? "warm" : "cold",
+    },
     ...(moduleInitMs === null
       ? []
       : [{ name: "full_app_module_init", durationMs: moduleInitMs }]),
@@ -269,6 +283,13 @@ async function getStewardThinApp(): Promise<Hono<AppEnv>> {
     m.createStewardThinApp(),
   );
   return stewardThinAppPromise;
+}
+
+async function getCliSessionThinApp(): Promise<Hono<AppEnv>> {
+  cliSessionThinAppPromise ??= import("./cli-session-app").then((m) =>
+    m.createCliSessionThinApp(),
+  );
+  return cliSessionThinAppPromise;
 }
 
 const ELIZA_APP_WEBHOOK_PATH =
@@ -398,6 +419,40 @@ async function dispatchDiscordGateway(
     status: response.status,
     statusText: response.statusText,
     headers: responseHeaders,
+  });
+}
+
+async function dispatchCliSession(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const pathname = new URL(request.url).pathname;
+  if (!isThinCliSessionPath(request.method, pathname)) return null;
+
+  const dispatchStartedAt = performance.now();
+  const moduleWasInitialized = cliSessionThinAppPromise !== undefined;
+  const app = await getCliSessionThinApp();
+  const moduleInitMs = performance.now() - dispatchStartedAt;
+  const response = await app.fetch(request, env, ctx);
+  const dispatchMs = performance.now() - dispatchStartedAt;
+
+  const headers = new Headers(response.headers);
+  headers.set("X-Eliza-Cli-Session-Path", "thin");
+  headers.append(
+    "Server-Timing",
+    `entry_dispatch;dur=${dispatchMs.toFixed(1)}`,
+  );
+  if (!moduleWasInitialized) {
+    headers.append(
+      "Server-Timing",
+      `cli_session_module_init;dur=${moduleInitMs.toFixed(1)}`,
+    );
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
   });
 }
 
@@ -891,6 +946,12 @@ export default {
         ctx,
       );
       if (discordGatewayResponse) return discordGatewayResponse;
+      const cliSessionThinResponse = await dispatchCliSession(
+        apiRequest,
+        env,
+        ctx,
+      );
+      if (cliSessionThinResponse) return cliSessionThinResponse;
       const stewardThinResponse = await dispatchThinSteward(
         apiRequest,
         env,
@@ -937,6 +998,10 @@ export default {
       ctx,
     );
     if (discordGatewayResponse) return discordGatewayResponse;
+
+    // CLI-session login hot path before full-app bootstrap (#22948).
+    const cliSessionThinResponse = await dispatchCliSession(request, env, ctx);
+    if (cliSessionThinResponse) return cliSessionThinResponse;
 
     // Login-critical Steward GETs before full-app bootstrap (#18049).
     const stewardThinResponse = await dispatchThinSteward(request, env, ctx);


### PR DESCRIPTION
Fixes #22948.

## Root cause — not what the Server-Timing suggests

The issue's benchmarks show `full_app_module_init;dur=0` on every response, which reads as "warm isolate, module init cached". It is the opposite. That metric is only emitted when the isolate was COLD (`moduleWasInitialized === false`), so its presence on every sample means every request was the first dispatch in a fresh isolate. The `dur=0` is a workerd artifact: the clock freezes across pure CPU, so evaluating the generated router — **677 static route imports, 993 handler registrations** — registers as 0ms, and the hidden cost lands in `full_app_dispatch`/`cloud_worker` the moment the route does its first I/O. `placement = { mode = "smart" }` spreads the low-frequency CLI polling across placement colos, so isolates never stay warm for this traffic shape.

Confirming evidence from the code: the GET poll has **no rate limiter and touches no Redis** yet is as slow as the Redis-limited POST — the cost is shared, and the only shared multi-second mechanism is the bootstrap (documented in-repo at `steward/thin-app.ts:1-13`, built for exactly this in #18049). Per-request `pg.Pool` over Hyperdrive and the create's per-request Redis TCP sequence are additive, not dominant.

## Change

Third instance of the established remedy (thin Steward shell #18049, thin inference entry):

- **`cli-session-app.ts`** — dependency-light shell mounting the existing create + poll route modules unchanged, with the full middleware contract: ALS bootstrap, telemetry, CORS, secure headers, no-store default, Redis fail-closed config guard, 600/min `GLOBAL_RATE_LIMITER` backstop, and the cookie-mutation CSRF guard (inference-app parity). **Mount order matters**: the poll mounts before the create, because the create sub-app's path-less STRICT limiter merges as `/api/auth/cli-session/*` — the opposite order meters the 2s-interval poll under the create's 10/min IP budget and 429s every login ~20s in. Pinned by a 12-sequential-polls test; the full app's generated router happens to register in the safe order, the shell now does so deliberately.
- **`cli-session-paths.ts`** — strict predicate: create POST + single-segment poll GET (plus preflight/HEAD). `/:sessionId/complete` structurally cannot match and stays on the full app with its auth stack.
- **`index.ts`** — `dispatchCliSession` before full-app bootstrap in both entry branches; responses carry `X-Eliza-Cli-Session-Path: thin` + `entry_dispatch`/`cli_session_module_init` Server-Timing. Also: `full_app_isolate;dur=0;desc="cold"|"warm"` is now emitted on every decorated full-app response — previously warm was indistinguishable from a stripped header, which is what made the issue's evidence misleading.

## Testing

- 17 tests across 3 new files + 2 assertions added to `index.test.ts`; full `cloud/api` unit suite: **469 files green, 6 failures identical by name on pristine develop** (module-shape errors in credits/browser/models/wallets tests — pre-existing, baselined both sides).
- `tsc --noEmit` clean; `biome check` clean.
- Mutation-checked against committed objects: loosening the poll-path regex → the `/complete`-exclusion test reds; unwiring `dispatchCliSession` → both wiring tests red; unmounting the CSRF guard → its 403 test reds; **remounting create first → the 12-poll test reds** (this is the one a plausible refactor would hit).

## Post-merge verification (staging)

Rerun the issue's protocol: `curl -D-` on create + poll must show `X-Eliza-Cli-Session-Path: thin` with `cloud_worker` well under the 3-5s baseline, and full-app endpoints now report `full_app_isolate;desc=` on every response so cold-rate is finally measurable. I'll post before/after numbers on #22948.

## Noted, deliberately out of scope

- No env kill switch (siblings have `THIN_INFERENCE_ENTRY_ENABLED` only for inference), and the memoized shell promise caches a rejection — both inherited sibling patterns, worth one follow-up across all three shells.
- The create's per-request Redis TCP sequence (connect+AUTH+pipeline+PEXPIRE under a 1s cap, no circuit breaker) and the limiter keys lacking an environment prefix while staging and prod share one Redis — real, measured secondary findings; posting them on #22948 for a follow-up rather than widening this diff.
