### PR TITLE
fix(shared): make SandboxRegistry.unregister() delete atomically

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -79,6 +79,14 @@ function installFetch(): void {
         json: async () => ({ result: cmd.length - 1 }),
       } as unknown as Response;
     }
+    if (cmd[0] === "EVAL") {
+      // Simulates the registry's compare-and-delete script: EVAL, script,
+      // numkeys, key1, key2, expected1, expected2.
+      const [, , , key1, key2, expected1, expected2] = cmd;
+      if (store.get(key1) === expected1) store.delete(key1);
+      if (store.get(key2) === expected2) store.delete(key2);
+      return { ok: true, json: async () => ({ result: 1 }) } as Response;
+    }
     return { ok: true, json: async () => ({ result: null }) } as Response;
   }) as unknown as typeof fetch;
 }
@@ -146,6 +154,31 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     store.set("agent:char-123:server", "sandbox-other");
     store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
     await reg.unregister();
+    expect(store.get("agent:char-123:server")).toBe("sandbox-other");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://9.9.9.9:1/api");
+  });
+
+  it("unregister() does not delete keys another sandbox claims in the same instant it decides to delete", async () => {
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    // Wrap fetch so a concurrent register() from another sandbox lands right
+    // as this unregister() call reaches the command that actually decides
+    // what to delete (the old two-step implementation's DEL, or the atomic
+    // implementation's EVAL) -- the exact TOCTOU window a read-then-delete
+    // race would fall into.
+    const realFetch = global.fetch as unknown as typeof fetch;
+    global.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      const verb = Array.isArray(body) ? body[0] : undefined;
+      if (verb === "DEL" || verb === "EVAL") {
+        store.set("agent:char-123:server", "sandbox-other");
+        store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
+      }
+      return realFetch(input, init);
+    }) as unknown as typeof fetch;
+
+    await reg.unregister();
+
     expect(store.get("agent:char-123:server")).toBe("sandbox-other");
     expect(store.get("server:sandbox-abc:url")).toBe("http://9.9.9.9:1/api");
   });
@@ -364,6 +397,13 @@ async function startFakeRedis(opts?: {
           let n = 0;
           for (const k of cmd.slice(1)) if (store.delete(k)) n++;
           send(`:${n}\r\n`);
+        } else if (verb === "EVAL") {
+          // Simulates the registry's compare-and-delete script: EVAL, script,
+          // numkeys, key1, key2, expected1, expected2.
+          const [, , , key1, key2, expected1, expected2] = cmd;
+          if (store.get(key1) === expected1) store.delete(key1);
+          if (store.get(key2) === expected2) store.delete(key2);
+          send(":1\r\n");
         } else {
           send("-ERR unknown command\r\n");
         }

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -101,16 +101,22 @@ export class SandboxRegistry {
     const { serverName, serverUrl, agentId } = this.config;
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
-    const [registeredUrl, registeredServer] = await Promise.all([
-      this.get(serverUrlKey),
-      this.get(agentServerKey),
+    // Compare-and-delete inside a single Lua script so the ownership check and
+    // the delete are one atomic Redis operation. A read-then-delete over two
+    // round-trips leaves a window where another sandbox's register()/refresh()
+    // can write a new owner's value in between, and this call would then
+    // delete that fresh registration instead of its own stale one.
+    await this.command([
+      "EVAL",
+      "if redis.call('GET',KEYS[1])==ARGV[1] then redis.call('DEL',KEYS[1]) end " +
+        "if redis.call('GET',KEYS[2])==ARGV[2] then redis.call('DEL',KEYS[2]) end " +
+        "return 1",
+      "2",
+      serverUrlKey,
+      agentServerKey,
+      serverUrl,
+      serverName,
     ]);
-    const keysToDelete: string[] = [];
-    if (registeredUrl === serverUrl) keysToDelete.push(serverUrlKey);
-    if (registeredServer === serverName) keysToDelete.push(agentServerKey);
-    if (keysToDelete.length > 0) {
-      await this.command(["DEL", ...keysToDelete]);
-    }
     logger.info(
       `[sandbox-registry] Unregistered ${serverName} (agent ${agentId})`,
     );
@@ -155,11 +161,6 @@ export class SandboxRegistry {
       ["SET", `server:${serverName}:url`, serverUrl, "EX", ttl],
       ["SET", `agent:${agentId}:server`, serverName, "EX", ttl],
     ]);
-  }
-
-  private async get(key: string): Promise<string | null> {
-    const result = await this.command(["GET", key]);
-    return typeof result === "string" ? result : null;
   }
 
   private async command(args: string[]): Promise<unknown> {


### PR DESCRIPTION
## What's wrong

`unregister()` read both ownership keys (`server:<name>:url`, `agent:<agentId>:server`), awaited those two round-trips, then issued a separate `DEL` for whichever keys still matched this sandbox's own identity. Between the reads and the `DEL`, another sandbox's `register()`/`refresh()` can write a fresh value into either key — the current owner's registration — and this stale `unregister()` call would then delete it, since `DEL` only checks the key name, not its current value.

Concretely: sandbox A is shutting down and calls `unregister()`. Its two `GET`s correctly see A's own values. Before A's `DEL` fires, sandbox B starts up and registers under the same `serverName`/`agentId` (a fast restart, or a redeploy reusing the slot). A's `DEL` then removes B's brand-new registration, and the gateway loses routing to a live container.

## Fix

Replace the read-then-delete with a single Redis `EVAL` running a compare-and-delete Lua script, so the ownership check and the delete happen as one atomic server-side operation with no client-visible gap for a concurrent write to land in. Works unchanged across both transports (TCP and Upstash REST) since `EVAL` is dispatched through the same generic `command()` path `DEL` already used. Removed the now-unused `get()` helper.

## Verification

- New test: `unregister() does not delete keys another sandbox claims in the same instant it decides to delete` — wraps `fetch`/the fake RESP server to inject a concurrent overwrite right as the command that decides what to delete (`DEL` for the old code, `EVAL` for the fixed code) is dispatched, then asserts the new owner's keys survive.
- Extended both test doubles (mocked Upstash `fetch`, in-process fake RESP/TCP server) to simulate `EVAL`'s compare-and-delete semantics so the existing REST and TCP `unregister()` coverage continues to exercise the real code path.
- Full suite: 20/20 passing in `sandbox-registry.test.ts`.
- **Mutation resistance**: reverted the source fix only, re-ran the new test — failed exactly as predicted (the race-injected keys were deleted instead of surviving). Reapplied the fix and reconfirmed 20/20 passing.
- `biome check` clean on both changed files.

## Attribution

Bug found by gpt-5.6-sol (via Codex) during an independent `packages/shared` audit for race conditions across `await` boundaries. Fix, regression tests (including extending both transport test doubles for `EVAL`), and verification completed by Claude Code (claude-sonnet-5) after Codex's sandbox could not write to `.git` in this worktree.