### PR TITLE
fix(agent-orchestrator): scope admin-stop suppression to fresh stamps

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-marker.test.ts
@@ -1,18 +1,24 @@
 /**
  * Deterministic tests for the administrative-stop marker: the stamp merges the
- * ONE canonical key via updateSessionMetadata, tolerates services without the
- * method, and never throws when the stamp fails (fail-open toward the
- * never-silent-terminal invariant — the stop must proceed regardless).
+ * canonical reason and stamped-at keys via updateSessionMetadata, tolerates
+ * services without the method, never throws when the stamp fails (fail-open
+ * toward the never-silent-terminal invariant — the stop must proceed
+ * regardless), and the freshness predicate treats missing, unparseable, and
+ * beyond-TTL timestamps as stale.
  */
 import { describe, expect, test } from "vitest";
 import {
+  ADMIN_STOP_MARKER_TTL_MS,
   ADMIN_STOP_META_KEY,
+  ADMIN_STOP_STAMPED_AT_META_KEY,
+  isAdminStopMarkerCurrent,
   markSessionAdministrativelyStopped,
 } from "../services/admin-stop-marker";
 
 describe("markSessionAdministrativelyStopped", () => {
-  test("stamps the canonical key with the reason", async () => {
+  test("stamps the reason and a parseable stamped-at instant together", async () => {
     const patches: Array<[string, Record<string, unknown>]> = [];
+    const before = Date.now();
     await markSessionAdministrativelyStopped(
       {
         updateSessionMetadata: async (id, patch) => {
@@ -22,9 +28,14 @@ describe("markSessionAdministrativelyStopped", () => {
       "sess-1",
       "user_stop",
     );
-    expect(patches).toEqual([
-      ["sess-1", { [ADMIN_STOP_META_KEY]: "user_stop" }],
-    ]);
+    const after = Date.now();
+    expect(patches.length).toBe(1);
+    const [id, patch] = patches[0] as [string, Record<string, unknown>];
+    expect(id).toBe("sess-1");
+    expect(patch[ADMIN_STOP_META_KEY]).toBe("user_stop");
+    const stampedMs = Date.parse(String(patch[ADMIN_STOP_STAMPED_AT_META_KEY]));
+    expect(stampedMs).toBeGreaterThanOrEqual(before);
+    expect(stampedMs).toBeLessThanOrEqual(after);
   });
 
   test("is a no-op for services without updateSessionMetadata", async () => {
@@ -46,5 +57,35 @@ describe("markSessionAdministrativelyStopped", () => {
     expect(logged.length).toBe(1);
     expect(logged[0]).toContain("sess-3");
     expect(logged[0]).toContain("store gone");
+  });
+});
+
+describe("isAdminStopMarkerCurrent", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+
+  test("honors a stamp inside the freshness window, including the boundary", () => {
+    expect(
+      isAdminStopMarkerCurrent(new Date(now - 1_000).toISOString(), now),
+    ).toBe(true);
+    expect(
+      isAdminStopMarkerCurrent(
+        new Date(now - ADMIN_STOP_MARKER_TTL_MS).toISOString(),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  test("treats a stamp past the window as stale", () => {
+    expect(
+      isAdminStopMarkerCurrent(
+        new Date(now - ADMIN_STOP_MARKER_TTL_MS - 1).toISOString(),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("treats missing and unparseable timestamps as stale (pre-#22981 stamps)", () => {
+    expect(isAdminStopMarkerCurrent(undefined, now)).toBe(false);
+    expect(isAdminStopMarkerCurrent("not-a-date", now)).toBe(false);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-suppression.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-suppression.test.ts
@@ -1,15 +1,24 @@
 /**
  * Exercises the swarm coordinator's administrative-stop suppression against
  * the real service (deterministic ACP double, no subprocess): a `stopped`
- * carrying `adminStopReason` is lifecycle plumbing and must not synthesize —
- * and must NOT claim the synthesis dedupe slot, so a later genuine lineage
- * completion still posts. An UNMARKED stop still synthesizes (the #11689
- * never-silent-terminal invariant this suppression must not erode).
+ * carrying a FRESH `adminStopReason` stamp is lifecycle plumbing and must not
+ * synthesize — without claiming the synthesis dedupe slot, so a later genuine
+ * lineage completion still posts, and repeatedly, so duplicate teardown
+ * `stopped` events from one admin action stay quiet. A STALE stamp (past the
+ * freshness TTL, or timestamp-less as pre-#22981 stamps are) belongs to an
+ * administrative stop that failed to tear the session down; its survivor's
+ * genuine crash must synthesize and the marker must be cleared (#22981). An
+ * UNMARKED stop still synthesizes (the #11689 never-silent-terminal invariant
+ * this suppression must not erode).
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { AcpService } from "../services/acp-service.js";
-import { ADMIN_STOP_META_KEY } from "../services/admin-stop-marker.js";
+import {
+  ADMIN_STOP_MARKER_TTL_MS,
+  ADMIN_STOP_META_KEY,
+  ADMIN_STOP_STAMPED_AT_META_KEY,
+} from "../services/admin-stop-marker.js";
 import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
 
 type MetadataPatch = Record<string, unknown>;
@@ -31,14 +40,41 @@ function storedSession(
   };
 }
 
+function freshStamp(reason: string): Record<string, unknown> {
+  return {
+    [ADMIN_STOP_META_KEY]: reason,
+    [ADMIN_STOP_STAMPED_AT_META_KEY]: new Date().toISOString(),
+  };
+}
+
+function staleStamp(reason: string): Record<string, unknown> {
+  return {
+    [ADMIN_STOP_META_KEY]: reason,
+    [ADMIN_STOP_STAMPED_AT_META_KEY]: new Date(
+      Date.now() - ADMIN_STOP_MARKER_TTL_MS - 60_000,
+    ).toISOString(),
+  };
+}
+
 function makeCoordinatorHarness(sessions: Map<string, unknown>): {
   service: SwarmCoordinatorService;
   emit: (sessionId: string, event: string, data: unknown) => void;
   completions: Array<{ status: string; sessionId: string }>;
+  updateSessionMetadata: ReturnType<typeof vi.fn>;
 } {
   const handlers: Array<
     (sessionId: string, event: string, data: unknown) => void
   > = [];
+  const updateSessionMetadata = vi.fn(
+    async (sessionId: string, patch: MetadataPatch) => {
+      const session = sessions.get(sessionId) as
+        | { metadata?: Record<string, unknown> }
+        | undefined;
+      if (session) {
+        session.metadata = { ...session.metadata, ...patch };
+      }
+    },
+  );
   const acp = {
     onSessionEvent(
       handler: (sessionId: string, event: string, data: unknown) => void,
@@ -47,16 +83,7 @@ function makeCoordinatorHarness(sessions: Map<string, unknown>): {
       return () => {};
     },
     getSession: async (sessionId: string) => sessions.get(sessionId),
-    updateSessionMetadata: vi.fn(
-      async (sessionId: string, patch: MetadataPatch) => {
-        const session = sessions.get(sessionId) as
-          | { metadata?: Record<string, unknown> }
-          | undefined;
-        if (session) {
-          session.metadata = { ...session.metadata, ...patch };
-        }
-      },
-    ),
+    updateSessionMetadata,
   };
   const runtime = {
     getService: (type: string) =>
@@ -77,16 +104,14 @@ function makeCoordinatorHarness(sessions: Map<string, unknown>): {
       for (const h of [...handlers]) h(sessionId, event, data);
     },
     completions,
+    updateSessionMetadata,
   };
 }
 
 describe("administrative-stop suppression", () => {
-  it("suppresses a marked stop and does NOT claim the dedupe slot — a later lineage completion still posts", async () => {
+  it("suppresses a freshly marked stop and does NOT claim the dedupe slot — a later lineage completion still posts", async () => {
     const sessions = new Map<string, unknown>([
-      [
-        "sess-admin",
-        storedSession("sess-admin", { [ADMIN_STOP_META_KEY]: "user_stop" }),
-      ],
+      ["sess-admin", storedSession("sess-admin", freshStamp("user_stop"))],
     ]);
     const { emit, completions } = makeCoordinatorHarness(sessions);
 
@@ -98,6 +123,62 @@ describe("administrative-stop suppression", () => {
     await flushMicrotasks();
     expect(completions).toEqual([
       { status: "completed", sessionId: "sess-admin" },
+    ]);
+  });
+
+  it("keeps suppressing duplicate teardown stopped events while the stamp is fresh", async () => {
+    const sessions = new Map<string, unknown>([
+      ["sess-dup", storedSession("sess-dup", freshStamp("task_lifecycle"))],
+    ]);
+    const { emit, completions, updateSessionMetadata } =
+      makeCoordinatorHarness(sessions);
+
+    emit("sess-dup", "stopped", {});
+    await flushMicrotasks();
+    emit("sess-dup", "stopped", {});
+    await flushMicrotasks();
+
+    expect(completions).toEqual([]);
+    // A fresh marker is left in place for the duplicate; nothing cleared it.
+    expect(updateSessionMetadata).not.toHaveBeenCalled();
+  });
+
+  it("a STALE stamp does not silence the survivor's genuine crash — it synthesizes and the marker is cleared", async () => {
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-survivor",
+        storedSession("sess-survivor", staleStamp("user_stop")),
+      ],
+    ]);
+    const { emit, completions, updateSessionMetadata } =
+      makeCoordinatorHarness(sessions);
+
+    emit("sess-survivor", "stopped", {});
+    await flushMicrotasks();
+
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-survivor" },
+    ]);
+    expect(updateSessionMetadata).toHaveBeenCalledWith("sess-survivor", {
+      [ADMIN_STOP_META_KEY]: null,
+      [ADMIN_STOP_STAMPED_AT_META_KEY]: null,
+    });
+  });
+
+  it("a timestamp-less (pre-#22981) stamp is stale — the stop synthesizes", async () => {
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-legacy",
+        storedSession("sess-legacy", { [ADMIN_STOP_META_KEY]: "user_stop" }),
+      ],
+    ]);
+    const { emit, completions } = makeCoordinatorHarness(sessions);
+
+    emit("sess-legacy", "stopped", {});
+    await flushMicrotasks();
+
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-legacy" },
     ]);
   });
 

--- a/plugins/plugin-agent-orchestrator/src/services/admin-stop-marker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/admin-stop-marker.ts
@@ -5,22 +5,60 @@
  * archive/delete/pause, user stop, API stop) rather than the session dying on
  * its own, downstream consumers must be able to tell the two apart: the swarm
  * coordinator suppresses its "stopped before completion" synthesis for marked
- * stops (the stop is plumbing the user already caused), and the mid-task
- * forwarder drops marked sessions as a belt against stop-failure races. An
- * UNMARKED stop (crash, subprocess death, genuine user-visible failure) must
- * keep synthesizing — the #11689 never-silent-terminal invariant.
+ * stops (the stop is plumbing the user already caused). An UNMARKED stop
+ * (crash, subprocess death, genuine user-visible failure) must keep
+ * synthesizing — the #11689 never-silent-terminal invariant.
  *
- * ONE definition of the key lives here; do not add per-file literal copies.
+ * The marker is freshness-scoped (#22981): the stamp records when it was
+ * written, and suppression honors it only within {@link ADMIN_STOP_MARKER_TTL_MS}
+ * of that instant. Stop→`stopped` latency is seconds, so a marker old enough
+ * to breach the window belongs to an administrative stop that failed to tear
+ * the session down; honoring it would silence the survivor's later genuine
+ * crash. A marker without a parseable timestamp is treated as stale for the
+ * same reason — fail toward never-silent. Duplicate `stopped` events from one
+ * teardown (the one-shot runner pattern) all land well inside the window and
+ * stay suppressed.
+ *
+ * ONE definition of the keys lives here; do not add per-file literal copies.
  */
 
 export const ADMIN_STOP_META_KEY = "adminStopReason";
 
+/** ISO-8601 instant the admin-stop marker was stamped; pairs with the reason. */
+export const ADMIN_STOP_STAMPED_AT_META_KEY = "adminStopStampedAt";
+
 /**
- * Best-effort stamp of {@link ADMIN_STOP_META_KEY} onto the session's
- * metadata via `AcpService.updateSessionMetadata` (which merges the patch
- * into the store snapshot the coordinator's fresh-metadata re-read observes).
- * Never throws and never blocks the stop that follows it: a failed stamp only
- * costs the suppression (the stop still synthesizes — fail-open toward the
+ * Freshness window for honoring a stamp. Teardown `stopped` events follow the
+ * stop within seconds; ten minutes is generous headroom for a wedged subprocess
+ * while still bounding how long a stamped-but-failed stop can shadow a
+ * surviving session's genuine terminal.
+ */
+export const ADMIN_STOP_MARKER_TTL_MS = 10 * 60_000;
+
+/**
+ * Whether a stamp taken at `stampedAt` (ISO-8601, from the session metadata)
+ * still authorizes suppression at `nowMs`. Missing or unparseable timestamps
+ * are stale: pre-#22981 stamps carry no timestamp, and the only such sessions
+ * still alive to emit `stopped` are exactly the failed-stop survivors whose
+ * terminals must synthesize.
+ */
+export function isAdminStopMarkerCurrent(
+  stampedAt: string | undefined,
+  nowMs: number,
+): boolean {
+  if (!stampedAt) return false;
+  const stampedMs = Date.parse(stampedAt);
+  if (Number.isNaN(stampedMs)) return false;
+  return nowMs - stampedMs <= ADMIN_STOP_MARKER_TTL_MS;
+}
+
+/**
+ * Best-effort stamp of {@link ADMIN_STOP_META_KEY} (and its
+ * {@link ADMIN_STOP_STAMPED_AT_META_KEY} instant) onto the session's metadata
+ * via `AcpService.updateSessionMetadata` (which merges the patch into the
+ * store snapshot the coordinator's fresh-metadata re-read observes). Never
+ * throws and never blocks the stop that follows it: a failed stamp only costs
+ * the suppression (the stop still synthesizes — fail-open toward the
  * never-silent invariant).
  */
 export async function markSessionAdministrativelyStopped(
@@ -38,6 +76,7 @@ export async function markSessionAdministrativelyStopped(
   try {
     await service.updateSessionMetadata(sessionId, {
       [ADMIN_STOP_META_KEY]: reason,
+      [ADMIN_STOP_STAMPED_AT_META_KEY]: new Date().toISOString(),
     });
   } catch (err) {
     // error-policy:J6 best-effort teardown stamp on a session already being

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -99,7 +99,11 @@ const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 // the handoff's generation token, honored only while handoff-pending.ts
 // still registers it in-flight; a stale marker is ignored AND cleared so the
 // stop synthesizes exactly as if the marker had never leaked.
-import { ADMIN_STOP_META_KEY } from "./admin-stop-marker.js";
+import {
+  ADMIN_STOP_META_KEY,
+  ADMIN_STOP_STAMPED_AT_META_KEY,
+  isAdminStopMarkerCurrent,
+} from "./admin-stop-marker.js";
 
 const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 
@@ -1008,12 +1012,31 @@ export class SwarmCoordinatorService
       // later genuine lineage completion still posts. An UNMARKED stop
       // (crash, subprocess death) still synthesizes — the #11689
       // never-silent-terminal invariant is the regression line.
+      //
+      // The stamp only authorizes suppression while fresh (#22981): a stamped
+      // stopSession that THREW leaves a surviving session wearing the marker,
+      // and honoring it later would silence that survivor's genuine crash —
+      // forever, since nothing clears it. Freshness keeps every duplicate
+      // teardown `stopped` from one admin action suppressed (they land within
+      // seconds) while a marker past the TTL — or one without a timestamp —
+      // is cleared and the stop synthesizes.
       const adminStop = readString(fresh, ADMIN_STOP_META_KEY);
       if (adminStop) {
-        logger.debug(
-          `[SwarmCoordinatorService] suppressed administrative stop (sessionId=${sessionId}, reason=${adminStop})`,
+        if (
+          isAdminStopMarkerCurrent(
+            readString(fresh, ADMIN_STOP_STAMPED_AT_META_KEY),
+            Date.now(),
+          )
+        ) {
+          logger.debug(
+            `[SwarmCoordinatorService] suppressed administrative stop (sessionId=${sessionId}, reason=${adminStop})`,
+          );
+          return;
+        }
+        logger.warn(
+          `[SwarmCoordinatorService] stale administrative-stop marker cleared; synthesizing stop (sessionId=${sessionId}, reason=${adminStop})`,
         );
-        return;
+        await this.clearStaleAdminStopMarker(sessionId);
       }
       // Handoff decided but successor spawn not yet settled: the stop is
       // teardown plumbing racing ahead of the successor stamp. Same semantics
@@ -1397,6 +1420,23 @@ export class SwarmCoordinatorService
    * future terminal for this session; the calling stop still synthesizes this
    * turn regardless of whether the clear lands.
    */
+  private async clearStaleAdminStopMarker(sessionId: string): Promise<void> {
+    const acp = this.acp();
+    if (typeof acp?.updateSessionMetadata !== "function") return;
+    try {
+      await acp.updateSessionMetadata(sessionId, {
+        [ADMIN_STOP_META_KEY]: null,
+        [ADMIN_STOP_STAMPED_AT_META_KEY]: null,
+      });
+      this.enrichmentMetadataCache.delete(sessionId);
+    } catch {
+      // error-policy:J6 best-effort marker cleanup while the stop already
+      // synthesizes; a missed clear re-runs on the session's next stopped and
+      // never suppresses a terminal (staleness is decided by the timestamp,
+      // not the marker's presence).
+    }
+  }
+
   private async clearStalePendingHandoffMarker(
     sessionId: string,
   ): Promise<void> {


### PR DESCRIPTION
# Relates to

Closes #22981. Hardens the administrative-stop marker introduced in #22852 (flagged in my review there; the PR merged before the review landed).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `f43d944af3` (zero conflicts); exact head `02aaba94d484cc96f944ffa0e81b32bbb372fa66`.

# Risks

Low. The change narrows when an existing suppression fires; it never widens it. Every path that previously synthesized still synthesizes. The only behavior change for markers stamped by current develop (timestamp-less) is that their `stopped` synthesizes — which is exactly the pre-#22852, never-silent behavior, and the only such sessions still alive to emit `stopped` are the failed-stop survivors this fix exists for.

# Background

## What does this PR do?

#22852's `adminStopReason` stamp is never cleared and the coordinator honors it unconditionally, so the stamp outlives the administrative action it was written for. The reachable bad timeline: stamp succeeds → `acp.stopSession` **throws** (the `user_stop` catch even marks the session `stop_failed`) → the session survives wearing the marker → its later **genuine crash** emits `stopped` → the fresh-metadata read still sees the marker → the crash is silently swallowed, forever. That violates the #11689 never-silent-terminal invariant that the suppression's own comment names as its regression line. The adjacent `HANDOFF_PENDING_META_KEY` already solves the analogous staleness ("a stale marker is ignored AND cleared"); the admin-stop marker had no staleness handling.

The fix scopes suppression to fresh stamps:

- `markSessionAdministrativelyStopped` now stamps `adminStopStampedAt` (ISO-8601) alongside the reason; still best-effort, fail-open, never blocking the stop.
- The coordinator honors the marker only within `ADMIN_STOP_MARKER_TTL_MS` (10 minutes — teardown `stopped` events follow the stop within seconds; the window is generous headroom for a wedged subprocess while bounding how long a failed stop can shadow a survivor). Duplicate teardown `stopped` events from one admin action (the one-shot runner pattern documented in the coordinator) all land inside the window and stay suppressed, without clearing the marker.
- A stale stamp — or a timestamp-less pre-fix stamp — is cleared best-effort (`clearStaleAdminStopMarker`, mirroring `clearStalePendingHandoffMarker`: null-patch + enrichment-cache eviction + `error-policy:J6`) and the stop synthesizes, failing toward never-silent.
- The module header's claim that "the mid-task forwarder drops marked sessions" is corrected — nothing reads the marker in the forwarder (also flagged in the #22852 review).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change. The marker module's header documents the freshness contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/src/__tests__/admin-stop-suppression.test.ts` — the stale-stamp and timestamp-less cases are the regression line; the harness drives the real `SwarmCoordinatorService` via `bindToAcp` (same harness #22852 shipped).

## Detailed testing steps

1. Check out exact head `02aaba94d484cc96f944ffa0e81b32bbb372fa66`.
2. `bun x vitest run src/__tests__/admin-stop-suppression.test.ts src/__tests__/admin-stop-marker.test.ts` from `plugins/plugin-agent-orchestrator` → **11/11**: fresh stamp suppresses without claiming the dedupe slot; duplicate `stopped` events stay suppressed with the marker intact; a stale stamp synthesizes AND clears both keys; a timestamp-less stamp synthesizes; an unmarked stop synthesizes; the stamp writes reason + parseable instant; fail-open and method-absent tolerance hold; the freshness predicate pins the TTL boundary, missing, and unparseable timestamps.
3. Counterfactual: revert only `src/services/` to `origin/develop` and re-run — exactly the six new pins fail (the stale and timestamp-less stops are silently suppressed; the stamp writes only one key), while the five preserved-behavior cases still pass. Restore.
4. Neighborhood: `verify-retry-stop-race` 9/9 and `verify-retry-busy-session` 6/6 with the change (26/26 across the four suites).
5. `tsc6 --noEmit -p tsconfig.json` in the plugin: clean. Biome on the four changed files: clean. `git diff --check`: clean.

<!-- evidence-head:02aaba94d484cc96f944ffa0e81b32bbb372fa66 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — backend coordinator behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — backend coordinator behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — deterministic unit/regression proof below stands alone.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Counterfactual + head suite runs (vitest)</summary>

```
# head 02aaba94d484cc96f944ffa0e81b32bbb372fa66
admin-stop-suppression.test.ts + admin-stop-marker.test.ts
 Test Files  2 passed (2)
      Tests  11 passed (11)

# src/services reverted to origin/develop (unfixed), same tests
 × stamps the reason and a parseable stamped-at instant together
 × honors a stamp inside the freshness window, including the boundary
 × treats a stamp past the window as stale
 × treats missing and unparseable timestamps as stale (pre-#22981 stamps)
 × a STALE stamp does not silence the survivor's genuine crash — it synthesizes and the marker is cleared
 × a timestamp-less (pre-#22981) stamp is stale — the stop synthesizes
      Tests  6 failed | 5 passed (11)

# head, full neighborhood
admin-stop-suppression + admin-stop-marker + verify-retry-stop-race + verify-retry-busy-session
 Test Files  4 passed (4)
      Tests  26 passed (26)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — no agent-behavior change; deterministic coordinator plumbing.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates at exact head (tsc6, Biome, whitespace)</summary>

```
$ tsc6 --noEmit -p tsconfig.json        # plugins/plugin-agent-orchestrator
(clean, exit 0)

$ biome check src/services/admin-stop-marker.ts \
    src/services/swarm-coordinator-service.ts \
    src/__tests__/admin-stop-marker.test.ts \
    src/__tests__/admin-stop-suppression.test.ts
Checked 4 files in 42ms. No fixes applied.

$ git diff --check
(clean)
```

</details>
<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.
