### PR TITLE
fix(cloud): settle container charges earnings-first per the billing policy (#22951)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/container-billing-concurrent-replay.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-billing-concurrent-replay.integration.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Concurrent container-billing replay (#22951 earnings-first settlement).
+ *
+ * Proves the already-billed fence under GENUINELY overlapping settlement
+ * transactions: two `recordSuccessfulDailyBilling` calls released together on
+ * independent pool sessions, both parked behind an external holder session that
+ * owns the container row lock — so both are provably inside their open
+ * transactions at the same instant (asserted via `pg_stat_activity`) before
+ * either can enter the critical section. Exactly one settles earnings-first;
+ * the loser converges on the already-billed receipt instead of surfacing a
+ * unique-constraint or transaction error. PGlite cannot prove this: it is a
+ * single session, so two drizzle transactions cannot contend for the row lock
+ * (same constraint as compute-stop-concurrency.integration.test.ts).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { Client } from "pg";
+import {
+  acquireEphemeralPostgres,
+  type EphemeralPostgres,
+} from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
+
+const SKIP_REASON =
+  "[container billing concurrent replay] SKIPPED - no real PostgreSQL available. " +
+  "Set APPS_TENANT_DB_EPHEMERAL=1 with Docker, or provide APPS_TENANT_DB_TEST_DSN.";
+const ORIGINAL_ENV = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
+};
+
+let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
+let databaseName: string | null = null;
+let isolatedDsn: string | null = null;
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../client").closeDatabaseConnectionsForTests
+  | undefined;
+let dbWrite: typeof import("../../client").dbWrite | undefined;
+let containerBillingRepository:
+  | typeof import("../container-billing").containerBillingRepository
+  | undefined;
+
+function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function createIsolatedDatabase(baseDsn: string): Promise<string> {
+  databaseName = `eliza_billing_replay_${randomUUID().replaceAll("-", "")}`;
+  const admin = new Client({ connectionString: baseDsn });
+  await admin.connect();
+  try {
+    await admin.query(`CREATE DATABASE "${databaseName}"`);
+  } finally {
+    await admin.end();
+  }
+  const url = new URL(baseDsn);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+/**
+ * Block until at least `minWaiters` OTHER sessions in this database are parked
+ * on a lock (cardinality(pg_blocking_pids) > 0). For this suite that means both
+ * settlement transactions are open and contending for the holder's container
+ * row lock — the proof that the two calls genuinely overlap in flight.
+ */
+async function waitUntilBlockedWaiters(observer: Client, minWaiters: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ waiters: number }>(`
+      SELECT count(*)::int AS waiters
+      FROM pg_stat_activity activity
+      WHERE activity.datname = current_database()
+        AND activity.pid <> pg_backend_pid()
+        AND cardinality(pg_blocking_pids(activity.pid)) > 0
+    `);
+    if ((result.rows[0]?.waiters ?? 0) >= minWaiters) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${minWaiters} blocked settlement waiters`);
+}
+
+if (!postgres) {
+  console.warn(SKIP_REASON);
+} else {
+  isolatedDsn = await createIsolatedDatabase(postgres.dsn);
+  process.env.DATABASE_URL = isolatedDsn;
+  process.env.TEST_DATABASE_URL = isolatedDsn;
+  const [clientModule, repositoryModule] = await Promise.all([
+    import("../../client"),
+    import("../container-billing"),
+  ]);
+  closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
+  dbWrite = clientModule.dbWrite;
+  containerBillingRepository = repositoryModule.containerBillingRepository;
+}
+
+beforeAll(async () => {
+  if (!dbWrite) return;
+  // Minimal schema for recordSuccessfulDailyBilling (same column set as the
+  // PGlite idempotency suite, including the 0139 partial unique indexes the
+  // fence must not violate).
+  const ddl = [
+    `CREATE TABLE IF NOT EXISTS redeemable_earnings (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id uuid NOT NULL,
+      total_earned numeric(18,4) NOT NULL DEFAULT '0',
+      total_redeemed numeric(18,4) NOT NULL DEFAULT '0',
+      total_pending numeric(18,4) NOT NULL DEFAULT '0',
+      available_balance numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_miniapps numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_agents numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_mcps numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_affiliates numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_app_owner_shares numeric(18,4) NOT NULL DEFAULT '0',
+      earned_from_creator_shares numeric(18,4) NOT NULL DEFAULT '0',
+      total_converted_to_credits numeric(18,4) NOT NULL DEFAULT '0',
+      last_earning_at timestamp,
+      last_redemption_at timestamp,
+      version numeric(10,0) NOT NULL DEFAULT '0',
+      created_at timestamp NOT NULL DEFAULT now(),
+      updated_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS redeemable_earnings_ledger (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id uuid NOT NULL,
+      entry_type text NOT NULL,
+      amount numeric(18,4) NOT NULL,
+      balance_after numeric(18,4) NOT NULL,
+      earnings_source text,
+      source_id uuid,
+      redemption_id uuid,
+      description text NOT NULL,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      created_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS redeemable_earnings_ledger_conversion_idempotency_idx
+      ON redeemable_earnings_ledger ((metadata ->> 'idempotency_key'))
+      WHERE entry_type = 'credit_conversion' AND (metadata ->> 'idempotency_key') IS NOT NULL`,
+    `CREATE TABLE IF NOT EXISTS organizations (
+      id uuid PRIMARY KEY,
+      credit_balance numeric(20,6) NOT NULL DEFAULT '0',
+      balance_revision bigint NOT NULL DEFAULT 0,
+      updated_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS users (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS credit_transactions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      user_id uuid,
+      amount numeric(16,6) NOT NULL,
+      type text NOT NULL,
+      description text,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      stripe_payment_intent_id text,
+      created_at timestamp NOT NULL DEFAULT now(),
+      settled_at timestamp
+    )`,
+    `CREATE TABLE IF NOT EXISTS containers (
+      id uuid PRIMARY KEY,
+      name text NOT NULL,
+      project_name text NOT NULL,
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      status text NOT NULL,
+      billing_status text NOT NULL,
+      desired_count integer NOT NULL DEFAULT 1,
+      cpu integer NOT NULL DEFAULT 1,
+      memory integer NOT NULL DEFAULT 1024,
+      shutdown_warning_sent_at timestamp,
+      scheduled_shutdown_at timestamp,
+      lifecycle_revision bigint NOT NULL DEFAULT 0,
+      total_billed numeric(18,6) NOT NULL DEFAULT '0',
+      last_billed_at timestamp,
+      next_billing_at timestamp,
+      created_at timestamp NOT NULL DEFAULT now(),
+      updated_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS container_billing_records (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      container_id uuid NOT NULL,
+      organization_id uuid NOT NULL,
+      amount numeric(16,6) NOT NULL,
+      rate_segments jsonb NOT NULL DEFAULT '[]',
+      billing_period_start timestamp NOT NULL,
+      billing_period_end timestamp NOT NULL,
+      status text NOT NULL DEFAULT 'success',
+      credit_transaction_id uuid,
+      error_message text,
+      created_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS container_billing_records_period_unique
+      ON container_billing_records (container_id, billing_period_start)
+      WHERE status = 'success'`,
+    `CREATE TABLE IF NOT EXISTS compute_billing_rate_segments (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      workload_kind text NOT NULL,
+      workload_id uuid NOT NULL,
+      lifecycle_revision bigint NOT NULL,
+      billing_state text NOT NULL,
+      rate_per_hour numeric(16,6) NOT NULL,
+      effective_at timestamp NOT NULL,
+      created_at timestamp NOT NULL DEFAULT now()
+    )`,
+  ];
+  for (const stmt of ddl) {
+    await dbWrite.execute(stmt);
+  }
+}, 30_000);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+  if (postgres && databaseName) {
+    const admin = new Client({ connectionString: postgres.dsn });
+    await admin.connect();
+    try {
+      await admin.query(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+        [databaseName],
+      );
+      await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
+    } finally {
+      await admin.end();
+    }
+  }
+  await postgres?.stop();
+  postgres = null;
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
+  }
+}, 30_000);
+
+const realPostgres = postgres ? describe : describe.skip;
+
+realPostgres("concurrent settlement replay (earnings-first)", () => {
+  test("two overlapping settlements contend on the row lock: one settles, the loser converges on the already-billed fence", async () => {
+    if (!isolatedDsn || !dbWrite || !containerBillingRepository) {
+      throw new Error("harness unavailable");
+    }
+    const organizationId = randomUUID();
+    const userId = randomUUID();
+    const containerId = randomUUID();
+    // Mixed pools (credits 50, earnings 0.3) with a 0.027917/hr rate over
+    // exactly 24h → a 0.670008 charge split earnings-first: 0.3 from
+    // earnings, 0.370008 from credits — same economics as the sequential
+    // PGlite cases, now under genuine transaction overlap.
+    const periodStart = new Date("2026-08-18T05:00:00Z");
+    const now = new Date("2026-08-19T05:00:00Z");
+    const charge = 0.670008;
+
+    await dbWrite.execute(
+      sql`INSERT INTO organizations (id, credit_balance) VALUES (${organizationId}, '50')`,
+    );
+    await dbWrite.execute(
+      sql`INSERT INTO users (id, organization_id) VALUES (${userId}, ${organizationId})`,
+    );
+    await dbWrite.execute(
+      sql`INSERT INTO redeemable_earnings
+          (user_id, total_earned, available_balance, earned_from_creator_shares)
+         VALUES (${userId}, '0.3', '0.3', '0.3')`,
+    );
+    await dbWrite.execute(
+      sql`INSERT INTO containers
+          (id, name, project_name, organization_id, user_id, status, billing_status, total_billed, created_at)
+         VALUES (${containerId}, 'web', 'proj', ${organizationId}, ${userId}, 'running', 'active', '0', ${periodStart})`,
+    );
+    await dbWrite.execute(
+      sql`INSERT INTO compute_billing_rate_segments
+          (organization_id, workload_kind, workload_id, lifecycle_revision, billing_state, rate_per_hour, effective_at)
+         VALUES (${organizationId}, 'container', ${containerId}, 0, 'running', '0.027917', ${periodStart})`,
+    );
+
+    const input = {
+      containerId,
+      organizationId,
+      userId,
+      containerName: "web",
+      dailyRate: 0.67,
+      earningsSourceUserId: userId,
+      payAsYouGoFromEarnings: true,
+      newBalance: 0,
+      now,
+    };
+
+    const holder = new Client({ connectionString: isolatedDsn });
+    const observer = new Client({ connectionString: isolatedDsn });
+    await Promise.all([holder.connect(), observer.connect()]);
+    try {
+      // Barrier: an external session owns the container row lock so NEITHER
+      // settlement can enter its critical section until both are open and
+      // contending — guaranteeing real overlap rather than accidental
+      // serialization by scheduling order.
+      await holder.query("BEGIN");
+      await holder.query("SELECT id FROM containers WHERE id = $1 FOR UPDATE", [containerId]);
+
+      // Released together; each call opens its own pool session/transaction
+      // and parks on the container row lock behind the holder.
+      const inFlight = [
+        containerBillingRepository.recordSuccessfulDailyBilling(input),
+        containerBillingRepository.recordSuccessfulDailyBilling(input),
+      ];
+      // Prove both transactions are open and blocked at the same instant.
+      await waitUntilBlockedWaiters(observer, 2);
+      await holder.query("COMMIT");
+
+      const results = await Promise.allSettled(inFlight);
+      // The loser must converge on the fence — never a unique-constraint or
+      // transaction error — so both calls fulfill.
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+      const values = results.map(
+        (r) =>
+          (
+            r as PromiseFulfilledResult<{
+              alreadyBilled: boolean;
+              transactionId: string | null;
+              insufficient: boolean;
+              fromEarnings: number;
+            }>
+          ).value,
+      );
+
+      const settled = values.filter((v) => !v.alreadyBilled && v.transactionId !== null);
+      const fenced = values.filter((v) => v.alreadyBilled);
+      expect(settled).toHaveLength(1);
+      expect(fenced).toHaveLength(1);
+      expect(fenced[0]!.transactionId).toBeNull();
+      expect(fenced[0]!.insufficient).toBe(false);
+      // The winner's split is still earnings-first under contention.
+      expect(settled[0]!.fromEarnings).toBeCloseTo(0.3, 6);
+
+      // Final committed state (read from an independent session): exactly
+      // one success receipt, one earnings conversion, one debit.
+      const receipts = await observer.query<{ n: number }>(
+        "SELECT count(*)::int AS n FROM container_billing_records WHERE container_id = $1 AND status = 'success'",
+        [containerId],
+      );
+      expect(receipts.rows[0]!.n).toBe(1);
+
+      const conversions = await observer.query<{ n: number }>(
+        "SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE user_id = $1 AND entry_type = 'credit_conversion'",
+        [userId],
+      );
+      expect(conversions.rows[0]!.n).toBe(1);
+
+      const debit = await observer.query<{ n: number }>(
+        "SELECT count(*)::int AS n FROM credit_transactions WHERE organization_id = $1 AND type = 'debit'",
+        [organizationId],
+      );
+      expect(debit.rows[0]!.n).toBe(1);
+
+      const conversionCredit = await observer.query<{ n: number }>(
+        "SELECT count(*)::int AS n FROM credit_transactions WHERE organization_id = $1 AND type = 'credit'",
+        [organizationId],
+      );
+      expect(conversionCredit.rows[0]!.n).toBe(1);
+
+      const earnings = await observer.query<{ available_balance: string }>(
+        "SELECT available_balance FROM redeemable_earnings WHERE user_id = $1",
+        [userId],
+      );
+      expect(Number(earnings.rows[0]!.available_balance)).toBeCloseTo(0, 4);
+
+      const org = await observer.query<{ credit_balance: string }>(
+        "SELECT credit_balance FROM organizations WHERE id = $1",
+        [organizationId],
+      );
+      expect(Number(org.rows[0]!.credit_balance)).toBeCloseTo(50 + 0.3 - charge, 6);
+    } finally {
+      await holder.query("ROLLBACK").catch(() => undefined);
+      await Promise.all([holder.end(), observer.end()]);
+    }
+  }, 30_000);
+});

--- a/packages/cloud/shared/src/db/repositories/container-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/container-billing.ts
@@ -320,8 +320,13 @@ export class ContainerBillingRepository {
       };
     }
 
-    const creditApplied = Decimal.min(creditAvailable, amount);
-    const earningsApplied = amount.minus(creditApplied);
+    // Earnings-first split (#22951): when the pay-as-you-go toggle is on, the
+    // owner's redeemable earnings absorb the charge FIRST and purchased
+    // credits only cover the remainder — the order `computeContainerBillingPlan`
+    // (and every doc, schema comment, and UI string) promises. A credits-first
+    // split here would silently invert the documented survival-economics rule.
+    const earningsApplied = Decimal.min(earningsAvailable, amount);
+    const creditApplied = amount.minus(earningsApplied);
     // Earnings are stored at 4dp while compute debt is authoritative at 6dp.
     // Convert enough earnings to cover the exact debt and leave sub-0.0001
     // change in canonical organization credits; rounding down would attempt

--- a/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -578,3 +578,301 @@ describe("container billing gate + row-lock guard", () => {
 test("pglite schema applied — never a silent skip", () => {
   expect(pgliteReady).toBe(true);
 });
+
+/**
+ * Earnings-first settlement order (#22951).
+ *
+ * `computeContainerBillingPlan` (the policy every doc, schema comment, and UI
+ * string quotes) says: toggle on → earnings absorb the daily charge FIRST,
+ * credits cover the remainder. The settlement transaction must honor that
+ * order under its locks — a credits-first split drains purchased credits
+ * before redeemable earnings, breaking the documented "survival economics"
+ * loop (an earning agent should keep its purchased credits).
+ *
+ * Rate segment 0.027917/hr over exactly 24h settles to 0.670008 (6dp), so
+ * these cases also pin the 4dp-earnings / 6dp-debt conversion boundary.
+ */
+describe("earnings-first settlement order (#22951)", () => {
+  const RATE_PER_HOUR = "0.027917"; // × 24h = 0.670008 exactly
+  const PERIOD_START = "2026-08-18T05:00:00Z";
+  const NOW = new Date("2026-08-19T05:00:00Z");
+  const CHARGE = 0.670008;
+
+  async function seedEarnFirstCase(credits: string, earnings: string): Promise<void> {
+    await dbWrite.execute(`DELETE FROM container_billing_records;`);
+    await dbWrite.execute(`DELETE FROM compute_billing_rate_segments;`);
+    await dbWrite.execute(`DELETE FROM credit_transactions;`);
+    await dbWrite.execute(`DELETE FROM redeemable_earnings_ledger;`);
+    await dbWrite.execute(`DELETE FROM redeemable_earnings;`);
+    await dbWrite.execute(`DELETE FROM containers;`);
+    await dbWrite.execute(`DELETE FROM users;`);
+    await dbWrite.execute(`DELETE FROM organizations;`);
+    await dbWrite.execute(
+      `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '${credits}');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO users (id, organization_id) VALUES ('${USER_ID}', '${ORG_ID}');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO redeemable_earnings
+        (user_id, total_earned, available_balance, earned_from_creator_shares)
+       VALUES ('${USER_ID}', '${earnings}', '${earnings}', '${earnings}');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO containers
+        (id, name, project_name, organization_id, user_id, status, billing_status, total_billed, created_at)
+       VALUES ('${CONTAINER_ID}', 'web', 'proj', '${ORG_ID}', '${USER_ID}', 'running', 'active', '0', '${PERIOD_START}');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO compute_billing_rate_segments
+        (organization_id, workload_kind, workload_id, lifecycle_revision, billing_state, rate_per_hour, effective_at)
+       VALUES ('${ORG_ID}', 'container', '${CONTAINER_ID}', 0, 'running', '${RATE_PER_HOUR}', '${PERIOD_START}');`,
+    );
+  }
+
+  function earnFirstInput(payAsYouGo: boolean) {
+    return {
+      containerId: CONTAINER_ID,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      containerName: "web",
+      dailyRate: 0.67,
+      earningsSourceUserId: USER_ID,
+      payAsYouGoFromEarnings: payAsYouGo,
+      newBalance: 0,
+      now: NOW,
+    };
+  }
+
+  test(
+    "toggle on, mixed pools: earnings absorb first, credits only cover the remainder",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnFirstCase("50", "0.3");
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+
+      expect(result.insufficient).toBe(false);
+      expect(result.fromEarnings).toBeCloseTo(0.3, 6);
+
+      // Earnings drained to zero; purchased credits only paid the remainder.
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(0, 4);
+
+      const org = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect(Number((org.rows[0] as { credit_balance: string }).credit_balance)).toBeCloseTo(
+        50 + 0.3 - CHARGE,
+        6,
+      );
+
+      const txs = await dbWrite.execute(
+        `SELECT amount, type, metadata FROM credit_transactions WHERE organization_id = '${ORG_ID}' ORDER BY created_at;`,
+      );
+      expect(txs.rows).toHaveLength(2);
+      const debit = txs.rows.find((r) => (r as { type: string }).type === "debit") as {
+        amount: string;
+        metadata: {
+          paid_from_earnings: string;
+          paid_from_credits: string;
+          earnings_converted: string;
+        };
+      };
+      expect(Number(debit.amount)).toBeCloseTo(-CHARGE, 6);
+      expect(Number(debit.metadata.paid_from_earnings)).toBeCloseTo(0.3, 6);
+      expect(Number(debit.metadata.paid_from_credits)).toBeCloseTo(CHARGE - 0.3, 6);
+      expect(Number(debit.metadata.earnings_converted)).toBeCloseTo(0.3, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "toggle on, earnings-rich: the whole charge converts from earnings, purchased credits untouched",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnFirstCase("50", "1");
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+
+      expect(result.insufficient).toBe(false);
+      expect(result.fromEarnings).toBeCloseTo(CHARGE, 6);
+
+      // 4dp ROUND_UP conversion: 0.670008 debt converts 0.6701 earnings.
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance, total_converted_to_credits FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      const e = earnings.rows[0] as {
+        available_balance: string;
+        total_converted_to_credits: string;
+      };
+      expect(Number(e.available_balance)).toBeCloseTo(1 - 0.6701, 4);
+      expect(Number(e.total_converted_to_credits)).toBeCloseTo(0.6701, 4);
+
+      // Credits keep the sub-0.0001 conversion change instead of being drained.
+      const org = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect(Number((org.rows[0] as { credit_balance: string }).credit_balance)).toBeCloseTo(
+        50 + 0.6701 - CHARGE,
+        6,
+      );
+
+      const debit = await dbWrite.execute(
+        `SELECT metadata FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'debit';`,
+      );
+      const meta = (debit.rows[0] as { metadata: { paid_from_credits: string } }).metadata;
+      expect(Number(meta.paid_from_credits)).toBeCloseTo(0, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "toggle off: credits only — earnings never locked, converted, or ledgered",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnFirstCase("50", "1");
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(false),
+      );
+
+      expect(result.insufficient).toBe(false);
+      expect(result.fromEarnings ?? 0).toBeCloseTo(0, 6);
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(1, 4);
+
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger;`,
+      );
+      expect((ledger.rows[0] as { n: number }).n).toBe(0);
+
+      const org = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect(Number((org.rows[0] as { credit_balance: string }).credit_balance)).toBeCloseTo(
+        50 - CHARGE,
+        6,
+      );
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "insufficient combined pools: fails closed with no writes to any ledger",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnFirstCase("0.2", "0.1");
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+
+      expect(result.insufficient).toBe(true);
+      expect(result.transactionId).toBeNull();
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(0.1, 4);
+      expect(
+        (await dbWrite.execute(`SELECT count(*)::int AS n FROM credit_transactions;`)).rows[0],
+      ).toMatchObject({ n: 0 });
+      expect(
+        (await dbWrite.execute(`SELECT count(*)::int AS n FROM container_billing_records;`))
+          .rows[0],
+      ).toMatchObject({ n: 0 });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rounding boundary: 4dp earnings exactly covering the applied portion leave an 8e-6 credit remainder",
+    async () => {
+      if (!pgliteReady) return;
+      // earnings 0.6700 (4dp max) vs 0.670008 debt: earningsApplied = 0.67,
+      // conversion = 0.67 (no round-up needed), credits absorb 0.000008.
+      await seedEarnFirstCase("50", "0.67");
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+
+      expect(result.insufficient).toBe(false);
+      expect(result.fromEarnings).toBeCloseTo(0.67, 6);
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(0, 4);
+
+      const org = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect(Number((org.rows[0] as { credit_balance: string }).credit_balance)).toBeCloseTo(
+        50 + 0.67 - CHARGE,
+        6,
+      );
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent replay of the mixed case: already-billed fence, no second conversion or debit",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnFirstCase("50", "0.3");
+
+      const first = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+      expect(first.alreadyBilled).toBe(false);
+
+      const replay = await containerBillingRepository.recordSuccessfulDailyBilling(
+        earnFirstInput(true),
+      );
+      expect(replay.alreadyBilled).toBe(true);
+      expect(replay.transactionId).toBeNull();
+
+      expect(
+        (await dbWrite.execute(`SELECT count(*)::int AS n FROM redeemable_earnings_ledger;`))
+          .rows[0],
+      ).toMatchObject({ n: 1 });
+      expect(
+        (await dbWrite.execute(`SELECT count(*)::int AS n FROM credit_transactions;`)).rows[0],
+      ).toMatchObject({ n: 2 });
+      expect(
+        (
+          await dbWrite.execute(
+            `SELECT count(*)::int AS n FROM container_billing_records WHERE status = 'success';`,
+          )
+        ).rows[0],
+      ).toMatchObject({ n: 1 });
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(0, 4);
+    },
+    PGLITE_TIMEOUT,
+  );
+});


### PR DESCRIPTION
# Relates to

Closes #22951 (follow-up to #22942). Claim comment: https://github.com/elizaOS/eliza/issues/22951#issuecomment-5356410141

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the package verification lanes were run after sync; the
      one unrelated blocker is recorded below with the exact failure signature.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@dd57a68ef1e6c28c93c9974de61d4402492a0f31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (f43d944af3); zero conflicts.
- [x] Focused verification re-run post-sync (25/25 green, exact commands below);
      the repo-wide `bun run verify` was not run in full — the exact pre-existing
      unrelated blocker on pristine develop is documented in **Known gaps**.

# Risks

**Low.** One decimal-arithmetic branch swap inside an already-locked transaction; no schema, route, or API-surface change. The funding-order change is user-visible only in *which pool* gets debited (now matching what docs/UI/policy already promised). Worst case for an org with both pools: purchased credits stop being drained before redeemable earnings — the exact intended behavior change. Idempotency, receipt, ledger, and cursor writes are untouched; the concurrent-replay fence is re-proven below.

# Background

## What does this PR do?

Makes container settlement honor the earnings-first policy atomically, closing the #22951 contradiction:

- **Policy** (`packages/cloud/shared/src/lib/services/container-billing-policy.ts:78-79`): `fromEarnings = min(earningsEligible, dailyCost)` — toggle on → earnings absorb the charge first, credits cover the remainder ("survival economics").
- **Implementation before** (`packages/cloud/shared/src/db/repositories/container-billing.ts:323-324`): `creditApplied = Decimal.min(creditAvailable, amount); earningsApplied = amount.minus(creditApplied)` — inverted: purchased credits were consumed first and earnings only covered the overflow.

The fix swaps the application order inside the existing locked transaction (row locks + advisory lock unchanged): `earningsApplied = Decimal.min(earningsAvailable, amount); creditApplied = amount.minus(earningsApplied)`. Split, earnings conversion (4dp ROUND_UP), both ledger rows, the credit debit, the receipt/idempotency record, and the billing cursor all still commit in that one transaction.

Decimal semantics are preserved exactly: earningsApplied is capped by the live 4dp earnings row, so `ceil4(earningsApplied) ≤ earningsAvailable` still holds; credits keep any sub-0.0001 conversion change; no unbacked debit and no money creation. Toggle-off behavior is unchanged (earnings row is never locked → `earningsAvailable = 0` → credits-only, earnings never ledgered).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. Policy (`container-billing-policy.ts` JSDoc), the `pay_as_you_go_from_earnings` schema comment (`organizations.ts:82-86`), `packages/docs/cloud/earnings.mdx`, `packages/docs/cloud/containers.mdx`, and the UI copy (`pay-as-you-go-card.tsx`: "Earnings will pay container hosting before credits") **already document earnings-first** — the repository was the only surface contradicting them, so this PR aligns implementation to the published contract (the "align policy, schema comment, docs, UI copy, and implementation" AC).

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts` → the new `describe("earnings-first settlement order (#22951)")` block at the bottom: six PGlite-backed cases that execute the real settlement SQL (FOR UPDATE locks, JSONB idempotency lookup, partial unique indexes) against seeded mixed pools.

For the concurrent-replay acceptance criterion specifically: `packages/cloud/shared/src/db/repositories/__tests__/container-billing-concurrent-replay.integration.test.ts` → a real-Postgres integration test (ephemeral container, same harness as `compute-stop-concurrency.integration.test.ts`) proving the fence under two GENUINELY overlapping settlement transactions. PGlite is a single session, so the PGlite suite's replay case can only prove the sequential post-commit retry; the integration test proves the in-flight overlap.

## Detailed testing steps

RED control (fix stashed, pristine repository code):

```
$ git stash push -- packages/cloud/shared/src/db/repositories/container-billing.ts
$ cd packages/cloud/shared && bun test src/lib/services/__tests__/container-billing-idempotency.test.ts
(fail) earnings-first settlement order (#22951) > toggle on, mixed pools: earnings absorb first, credits only cover the remainder
(fail) earnings-first settlement order (#22951) > toggle on, earnings-rich: the whole charge converts from earnings, purchased credits untouched
(fail) earnings-first settlement order (#22951) > rounding boundary: 4dp earnings exactly covering the applied portion leave an 8e-6 credit remainder
(fail) earnings-first settlement order (#22951) > concurrent replay of the mixed case: already-billed fence, no second conversion or debit
(pass) toggle off / insufficient cases  ← order-invariant by construction, expected to pass on both
 13 pass / 4 fail
$ git stash pop
```

GREEN (fix applied, same command):

```
$ bun test src/lib/services/__tests__/container-billing-idempotency.test.ts
 17 pass
 0 fail
 83 expect() calls
Ran 17 tests across 1 file. [1.69s]
```

Focused battery (exact head, post-rebase):

```
$ cd packages/cloud/shared && bun test \
    src/lib/services/__tests__/container-billing-idempotency.test.ts \
    src/db/repositories/__tests__/container-billing-numeric.test.ts
 25 pass / 0 fail

$ cd packages/cloud/api && bun test cron/container-billing/route.test.ts
 5 pass / 0 fail      ← cron route tests are repository-mocked and unaffected

$ bun run --cwd packages/cloud/shared typecheck   # clean
$ bunx @biomejs/biome check <changed files>       # clean
$ bun run --cwd packages/cloud/api typecheck      # clean
```

Concurrent replay — genuinely overlapping transactions on real Postgres (added in response to the review; run at head `f427ab10a2`):

```
$ APPS_TENANT_DB_EPHEMERAL=1 bun test     src/db/repositories/__tests__/container-billing-concurrent-replay.integration.test.ts
(pass) concurrent settlement replay (earnings-first) > two overlapping settlements contend on the row lock: one settles, the loser converges on the already-billed fence [62.35ms]
 1 pass / 0 fail / 12 expect() calls

# Harness: ephemeral postgres:16-alpine via acquireEphemeralPostgres; two
# recordSuccessfulDailyBilling calls released together (Promise.allSettled) on
# independent pool sessions, parked behind an external holder session owning
# the container row lock. Overlap is PROVEN before release: pg_stat_activity
# shows >=2 sessions blocked on the holder's lock (waitUntilBlockedWaiters),
# then the holder COMMITs and both settle.

# Assertions: exactly one call settles earnings-first (fromEarnings=0.3); the
# loser converges on the already-billed fence (alreadyBilled=true, no surfaced
# unique-constraint/transaction error — both promises fulfill); final state
# read from an independent session: 1 success receipt, 1 credit_conversion
# ledger entry, 1 debit + 1 conversion credit, earnings 0, org balance
# 50+0.3-0.670008.

RED control (fence broken — .for("update") removed from the container lock):
(fail) two overlapping settlements contend on the row lock...
        expect(results.every((r) => r.status === "fulfilled")).toBe(true)
        Expected: true / Received: false   ← loser surfaces a unique-constraint rejection
$ git checkout -- packages/cloud/shared/src/db/repositories/container-billing.ts   # restore

Sibling regression control (same harness, real-PG lane):
$ APPS_TENANT_DB_EPHEMERAL=1 bun test     src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
 3 pass / 0 fail
```

The six new cases pin the AC matrix:

| AC | Case | Assertion |
|---|---|---|
| toggle on, earnings-first | mixed pools (credits 50 / earnings 0.3 vs charge 0.670008) | earnings drained to 0; credits pay only 0.370008; receipt metadata `paid_from_earnings=0.3`, `paid_from_credits=0.370008` |
| toggle on, full coverage | earnings-rich (credits 50 / earnings 1) | whole charge converts from earnings (0.6701 @4dp ROUND_UP); purchased credits untouched except keeping the 8e-5 conversion change |
| toggle off | credits only | earnings never locked/converted/ledgered; credits pay the full 0.670008 |
| insufficient | combined < charge | fails closed; zero writes to any ledger, earnings untouched |
| rounding boundary | 4dp earnings vs 6dp debt | earnings 0.6700 covers 0.67; credits absorb exactly 0.000008; no unbacked debit |
| concurrent replay (sequential) | same input twice, post-commit | already-billed fence: exactly 1 earnings conversion, 2 credit transactions (conversion + debit), 1 success receipt; no double charge |
| concurrent replay (overlapping) | two calls released together behind an external row-lock holder on real Postgres | both proven in-flight simultaneously via pg_stat_activity; exactly one settles earnings-first, the loser converges on the fence with no surfaced unique/transaction error; final state has 1 receipt, 1 conversion, 1 debit |

# Evidence Gate

<!-- evidence-head:f427ab10a2911d7d6141e2e5a90d653dc1a4107e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend billing settlement logic; no rendered UI surface in this diff (no .tsx/.css changes).
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend billing settlement logic; no rendered UI surface in this diff (no .tsx/.css changes).
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend billing settlement logic; no rendered UI surface in this diff (no .tsx/.css changes).
<!-- evidence-row:backend-logs -->
- [ ] N/A - structured logs are emitted by the cron route and unchanged by this diff; the code path firing end to end is proven by the PGlite-backed suite executing the real settlement SQL against seeded pools (Testing section).
<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend billing settlement logic; no frontend request path touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic billing arithmetic; no model, prompt, provider, or agent code touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the PGlite result rows are asserted directly in-suite (available_balance, total_converted_to_credits, credit_transactions amounts/metadata, redeemable_earnings_ledger counts, container_billing_records counts) — the DB-row artifacts are the assertions; raw command output pasted in Testing.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic billing arithmetic; no model/prompt/provider/agent changes.

## Backend + frontend logs

N/A - the settlement transaction's writes are proven by the PGlite-backed suite asserting the resulting rows (see Testing). The cron route's structured log lines are unchanged by this diff.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface in this diff.

### Before

### After

### Walkthrough video

## Audio / voice walkthrough

N/A - no voice/transcript/TTS surface in this diff.

## Known gaps / failures

`bun run --cwd packages/cloud/shared test` (the full package lane) currently fails **4 tests in `payment-request-settlement.pglite.test.ts** (e.g. "no-op reconciliation fails closed on a corrupt org balance", "durable payment request settlement > concurrent duplicate delivery grants exactly one bound credit"). **Pre-existing and unrelated**: the identical failure signature (166 pass / 4 fail, same test names) reproduces on pristine `origin/develop`@dd57a68 with my changes stashed, in a suite this diff does not touch. Those tests pass standalone (`bun test ./src/lib/services/__tests__/payment-request-settlement.pglite.test.ts` → all pass), so it is a batch-isolation flake in the runner, not a billing regression. Not a blocker for this PR.

The repo-wide `bun run verify` was not run to completion for the same reason (it would hit the same pre-existing package-lane failures); all focused gates for the touched packages (shared tests, api route tests, both typechecks, Biome) pass at the exact head.

# Database changes

None. No schema or migration change — the fix is a decimal-order swap inside the existing settlement transaction.

# Deployment instructions

None beyond the automated cloud deploy flow. The funding-order change takes effect on the next container-billing cron run after deploy; no data migration or operator action required.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@dd57a68ef1e6c28c93c9974de61d4402492a0f31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@dd57a68ef1e6c28c93c9974de61d4402492a0f31:packages/skills/skills/contribute-to-eliza"} -->


