### PR TITLE
fix(mcp): detach abort listeners once a marketplace request settles

### DIFF
--- a/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
+++ b/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
@@ -3,6 +3,7 @@
  * bounded reads, cancellation, stable errors, proportional schema validation,
  * search mapping, and the official latest-version detail endpoint.
  */
+import { getEventListeners } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMcpServerDetails,
@@ -149,6 +150,48 @@ describe("MCP marketplace client", () => {
     const abortListener = addListener.mock.calls.find(([type]) => type === "abort")?.[1];
     expect(abortListener).toBeTypeOf("function");
     expect(removeListener).toHaveBeenCalledWith("abort", abortListener);
+  });
+
+  it("keeps a shared caller signal flat across repeated settled searches", async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse(
+        registryList({
+          name: "io.example/files",
+          description: "Files",
+          version: "1.0.0",
+        })
+      )
+    );
+    const caller = new AbortController();
+
+    for (let index = 0; index < 12; index += 1) {
+      await searchMcpMarketplace(undefined, 10, { signal: caller.signal });
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+    }
+  });
+
+  it("detaches the caller abort listener on detail success and handled 404", async () => {
+    const caller = new AbortController();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        server: {
+          name: "io.example/files",
+          description: "Files",
+          version: "1.0.0",
+        },
+      })
+    );
+
+    await expect(
+      getMcpServerDetails("io.example/files", { signal: caller.signal })
+    ).resolves.toMatchObject({ name: "io.example/files" });
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+
+    fetchMock.mockResolvedValueOnce(new Response("missing", { status: 404 }));
+    await expect(
+      getMcpServerDetails("io.example/missing", { signal: caller.signal })
+    ).resolves.toBeNull();
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
   });
 
   it("fails closed on invalid JSON or a consumed field with the wrong type", async () => {

--- a/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
+++ b/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
@@ -130,6 +130,27 @@ describe("MCP marketplace client", () => {
     ]);
   });
 
+  it("detaches the caller abort listener once a request settles on its own", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        registryList({
+          name: "io.example/files",
+          description: "Files",
+          version: "1.0.0",
+        })
+      )
+    );
+    const caller = new AbortController();
+    const addListener = vi.spyOn(caller.signal, "addEventListener");
+    const removeListener = vi.spyOn(caller.signal, "removeEventListener");
+
+    await searchMcpMarketplace(undefined, 10, { signal: caller.signal });
+
+    const abortListener = addListener.mock.calls.find(([type]) => type === "abort")?.[1];
+    expect(abortListener).toBeTypeOf("function");
+    expect(removeListener).toHaveBeenCalledWith("abort", abortListener);
+  });
+
   it("fails closed on invalid JSON or a consumed field with the wrong type", async () => {
     fetchMock.mockResolvedValueOnce(new Response("not json"));
     await expect(searchMcpMarketplace()).rejects.toMatchObject({

--- a/plugins/plugin-mcp/src/mcp-marketplace.ts
+++ b/plugins/plugin-mcp/src/mcp-marketplace.ts
@@ -107,6 +107,8 @@ interface ResolvedRequestOptions {
   signal: AbortSignal;
   abortKind?: "caller" | "timeout";
   remainingResponseBytes: number;
+  /** Detaches the abort listeners resolveRequestOptions() registered. */
+  dispose: () => void;
 }
 
 function invalidResponse(message: string, cause?: unknown): never {
@@ -328,6 +330,7 @@ function resolveRequestOptions(options: McpMarketplaceRequestOptions): ResolvedR
   const resolved: ResolvedRequestOptions = {
     signal: controller.signal,
     remainingResponseBytes: maxResponseBytes,
+    dispose: () => {},
   };
   const abort = (kind: "caller" | "timeout", reason: unknown) => {
     if (!controller.signal.aborted) {
@@ -336,20 +339,22 @@ function resolveRequestOptions(options: McpMarketplaceRequestOptions): ResolvedR
     }
   };
 
+  const onCallerAbort = () => abort("caller", options.signal?.reason);
+  const onTimeoutAbort = () => abort("timeout", timeoutSignal.reason);
   if (options.signal?.aborted) {
     abort("caller", options.signal.reason);
   } else {
-    options.signal?.addEventListener("abort", () => abort("caller", options.signal?.reason), {
-      once: true,
-    });
+    options.signal?.addEventListener("abort", onCallerAbort, { once: true });
   }
   if (timeoutSignal.aborted) {
     abort("timeout", timeoutSignal.reason);
   } else {
-    timeoutSignal.addEventListener("abort", () => abort("timeout", timeoutSignal.reason), {
-      once: true,
-    });
+    timeoutSignal.addEventListener("abort", onTimeoutAbort, { once: true });
   }
+  resolved.dispose = () => {
+    options.signal?.removeEventListener("abort", onCallerAbort);
+    timeoutSignal.removeEventListener("abort", onTimeoutAbort);
+  };
   return resolved;
 }
 
@@ -489,72 +494,76 @@ export async function searchMcpMarketplace(
 ): Promise<{ results: McpMarketplaceSearchItem[] }> {
   const requestedLimit = resolveSearchLimit(limit);
   const resolved = resolveRequestOptions(options);
-  const results: McpMarketplaceSearchItem[] = [];
-  const seenNames = new Set<string>();
-  const normalizedQuery = query?.toLowerCase();
-  // Query searches may need to scan several pages before the local predicate
-  // matches, so use the largest public result bound to minimize round trips.
-  const pageLimit = normalizedQuery ? MAX_MCP_MARKETPLACE_RESULTS : requestedLimit;
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  let pageCount = 0;
+  try {
+    const results: McpMarketplaceSearchItem[] = [];
+    const seenNames = new Set<string>();
+    const normalizedQuery = query?.toLowerCase();
+    // Query searches may need to scan several pages before the local predicate
+    // matches, so use the largest public result bound to minimize round trips.
+    const pageLimit = normalizedQuery ? MAX_MCP_MARKETPLACE_RESULTS : requestedLimit;
+    let cursor: string | undefined;
+    const seenCursors = new Set<string>();
+    let pageCount = 0;
 
-  do {
-    pageCount += 1;
-    if (pageCount > MAX_MCP_MARKETPLACE_PAGES) {
-      invalidResponse(`MCP registry pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`);
-    }
-    const page = await fetchRegistryJson(
-      createSearchUrl(pageLimit, cursor),
-      parseListResponse,
-      resolved
-    );
-    cursor = page.nextCursor;
-    if (cursor && seenCursors.has(cursor)) {
-      invalidResponse("MCP registry response repeated a pagination cursor");
-    }
-    if (cursor) seenCursors.add(cursor);
-    for (const { server, official } of page.entries) {
-      if (!official?.isLatest || seenNames.has(server.name)) continue;
-      seenNames.add(server.name);
-      if (
-        normalizedQuery &&
-        !server.name.toLowerCase().includes(normalizedQuery) &&
-        !server.title?.toLowerCase().includes(normalizedQuery) &&
-        !server.description.toLowerCase().includes(normalizedQuery)
-      ) {
-        continue;
+    do {
+      pageCount += 1;
+      if (pageCount > MAX_MCP_MARKETPLACE_PAGES) {
+        invalidResponse(`MCP registry pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`);
       }
+      const page = await fetchRegistryJson(
+        createSearchUrl(pageLimit, cursor),
+        parseListResponse,
+        resolved
+      );
+      cursor = page.nextCursor;
+      if (cursor && seenCursors.has(cursor)) {
+        invalidResponse("MCP registry response repeated a pagination cursor");
+      }
+      if (cursor) seenCursors.add(cursor);
+      for (const { server, official } of page.entries) {
+        if (!official?.isLatest || seenNames.has(server.name)) continue;
+        seenNames.add(server.name);
+        if (
+          normalizedQuery &&
+          !server.name.toLowerCase().includes(normalizedQuery) &&
+          !server.title?.toLowerCase().includes(normalizedQuery) &&
+          !server.description.toLowerCase().includes(normalizedQuery)
+        ) {
+          continue;
+        }
 
-      const remote = server.remotes?.[0];
-      const pkg = server.packages?.[0];
-      const packageRemote =
-        pkg?.transport && pkg.transport.type !== "stdio" ? pkg.transport.url : undefined;
-      const connectionType = remote || packageRemote ? "remote" : "stdio";
+        const remote = server.remotes?.[0];
+        const pkg = server.packages?.[0];
+        const packageRemote =
+          pkg?.transport && pkg.transport.type !== "stdio" ? pkg.transport.url : undefined;
+        const connectionType = remote || packageRemote ? "remote" : "stdio";
 
-      results.push({
-        id: `${server.name}@${server.version}`,
-        name: server.name,
-        title: server.title || server.name.split("/").pop() || server.name,
-        description: server.description || "No description",
-        version: server.version,
-        connectionType,
-        connectionUrl: remote?.url ?? packageRemote,
-        npmPackage:
-          connectionType === "stdio" && pkg?.registryType === "npm" ? pkg.identifier : undefined,
-        dockerImage:
-          connectionType === "stdio" && pkg?.registryType === "oci" ? pkg.identifier : undefined,
-        repositoryUrl: server.repository?.url,
-        websiteUrl: server.websiteUrl,
-        iconUrl: server.icons?.[0]?.src,
-        publishedAt: official.publishedAt,
-        isLatest: true,
-      });
-      if (results.length >= requestedLimit) break;
-    }
-  } while (cursor && results.length < requestedLimit);
+        results.push({
+          id: `${server.name}@${server.version}`,
+          name: server.name,
+          title: server.title || server.name.split("/").pop() || server.name,
+          description: server.description || "No description",
+          version: server.version,
+          connectionType,
+          connectionUrl: remote?.url ?? packageRemote,
+          npmPackage:
+            connectionType === "stdio" && pkg?.registryType === "npm" ? pkg.identifier : undefined,
+          dockerImage:
+            connectionType === "stdio" && pkg?.registryType === "oci" ? pkg.identifier : undefined,
+          repositoryUrl: server.repository?.url,
+          websiteUrl: server.websiteUrl,
+          iconUrl: server.icons?.[0]?.src,
+          publishedAt: official.publishedAt,
+          isLatest: true,
+        });
+        if (results.length >= requestedLimit) break;
+      }
+    } while (cursor && results.length < requestedLimit);
 
-  return { results };
+    return { results };
+  } finally {
+    resolved.dispose();
+  }
 }
 
 export async function getMcpServerDetails(
@@ -578,5 +587,7 @@ export async function getMcpServerDetails(
       return null;
     }
     throw error;
+  } finally {
+    resolved.dispose();
   }
 }


### PR DESCRIPTION
## What's wrong

`resolveRequestOptions()` registers anonymous `abort` listeners on both the caller-supplied signal and an internal `AbortSignal.timeout()` for every `searchMcpMarketplace()`/`getMcpServerDetails()` call. Neither function removed them once the request settled — on success, on a thrown error, or (for `getMcpServerDetails`) on the handled 404 path. Every call that completes without its own signal aborting first leaks the listener closure on the caller's signal for the rest of that signal's lifetime; a caller reusing a long-lived `AbortSignal` across repeated marketplace calls accumulates one listener per call.

Same shape as #22974 and #22977, found in a different plugin during a follow-up audit for that exact pattern.

## Fix

Capture named abort handlers in `resolveRequestOptions()` and expose a `dispose()` that removes both, then call it from a `finally` block in both call sites so it runs on every completion path (success, thrown error, and the caught-404 branch in `getMcpServerDetails`) without changing either function's existing control flow or error handling.

## Verification

- New test: `detaches the caller abort listener once a request settles on its own` — asserts `removeEventListener("abort", ...)` is called with the exact listener `addEventListener` registered, after a normal successful search.
- Full `plugin-mcp` suite: 118/121 passing. The 3 failures are in `service-resilience.test.ts` (a stale `./providers/openai` module-resolution error) — confirmed pre-existing and unrelated by reproducing identically with this fix fully reverted, before touching anything. `mcp-marketplace.test.ts` itself: 14/14 passing.
- **Mutation resistance**: reverted the source fix only, re-ran the new test — failed exactly as predicted (`removeEventListener` called 0 times). Reapplied the fix and reconfirmed 14/14 passing.
- `biome check` and `tsc --noEmit` clean on both changed files.

## Attribution

Bug found by gpt-5.6-sol (via Codex) during an independent plugin audit for the #22974/#22977 listener-leak pattern. Fix, regression test, and verification (including reconciling this change against an unrelated pagination-guard change that landed upstream since the audit) completed by Claude Code (claude-sonnet-5) after Codex's sandbox could not write to `.git` in this worktree.

## Evidence Gate

<!-- evidence-head:a4929a443ee333c029c4b5356480371210b59b25 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.

<!-- evidence-row:backend-logs -->
- [x] Exact-head owning Vitest lane: `mcp-marketplace.test.ts` 16/16.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Independent mutation/control review reproduced listener growth on develop and flat listener counts on this head.

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.