### PR TITLE
fix(agent-skills): stop handing the platform credential set to skill scripts

### DIFF
--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -6,7 +6,13 @@
 
 import { vi } from "vitest";
 
-vi.mock("@elizaos/core", () => {
+vi.mock("@elizaos/core", async () => {
+	// The REAL spawn-env policy, not a double. Tests that assert injection
+	// primitives are stripped would prove nothing against a stub, so this one
+	// export is passed through from source rather than faked.
+	const { sanitizeSpawnEnv } = await import(
+		"../../../../packages/core/src/security/spawn-env-policy"
+	);
 	const logger = {
 		debug: vi.fn(),
 		error: vi.fn(),
@@ -152,6 +158,7 @@ vi.mock("@elizaos/core", () => {
 			}
 			async stop() {}
 		},
+		sanitizeSpawnEnv,
 		resolveStateDir: vi.fn(() => "/tmp/elizaos-test-state"),
 		formatError: vi.fn((err: unknown) =>
 			err instanceof Error ? err.message : String(err),

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { buildSkillExecutionEnv } from "./skill-execution-env";
+import {
+  buildSkillExecutionEnv,
+  isInheritableSkillEnvKey,
+} from "./skill-execution-env";
 
 /**
- * The five keys below were measured byte-identical across five production agent
- * containers on five different nodes, while the per-agent keys in the same
- * containers all differed. Each carries authority over the whole fleet rather
- * than over the tenant whose container holds it, which is why a skill script
- * must never receive them.
+ * Fleet-scoped credentials: one value shared by every container, as opposed to
+ * the per-agent keys alongside them. None is in BLOCKED_SPAWN_ENV_KEYS, which is
+ * why an allowlist rather than a denylist is what keeps them out.
  */
 const FLEET_SCOPED = {
-  AGENT_SERVER_SHARED_SECRET: "authenticates-as-owner-on-every-agent",
+  AGENT_SERVER_SHARED_SECRET: "shared-across-every-agent-container",
   ELIZA_LOCAL_ROOT_KEY: "derives-every-org-dek",
   SANDBOX_REGISTRY_REDIS_URL: "redis://shared-registry",
   STEWARD_REFRESH_SERVICE_TOKEN: "mints-a-jwt-for-any-agent-id",
@@ -26,15 +27,16 @@ describe("buildSkillExecutionEnv", () => {
     for (const key of Object.keys(FLEET_SCOPED)) {
       expect(env).not.toHaveProperty(key);
     }
+    expect(env.HOME).toBe("/root");
   });
 
   it("keeps the agent-scoped cloud identity, which is minted per agent", () => {
-    // ELIZAOS_CLOUD_API_KEY comes from createForAgent(org, user, sandbox), so a
-    // skill reading it reads its own agent's key. Four bundled skills document
-    // doing exactly that.
     const env = buildSkillExecutionEnv(
       {
         ELIZAOS_CLOUD_API_KEY: "agent-own-key",
+        // The spelling the platform actually injects.
+        ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app",
+        // The spelling the bundled eliza-cloud skill documents.
         ELIZA_CLOUD_BASE_URL: "https://api.eliza.app",
         PATH: "/usr/bin",
       },
@@ -42,16 +44,22 @@ describe("buildSkillExecutionEnv", () => {
     );
 
     expect(env.ELIZAOS_CLOUD_API_KEY).toBe("agent-own-key");
+    expect(env.ELIZAOS_CLOUD_BASE_URL).toBe("https://api.eliza.app");
     expect(env.ELIZA_CLOUD_BASE_URL).toBe("https://api.eliza.app");
   });
 
-  it("keeps a usable PATH, because the spawn sites use bare interpreter names", () => {
-    // use-skill.ts spawns `python3` / `bash` / `node` by name. An env without
-    // PATH does not secure the skill, it breaks every skill.
-    const env = buildSkillExecutionEnv({ PATH: "/usr/bin:/bin" }, {});
+  it("passes the parent's own PATH through rather than a substitute", () => {
+    const env = buildSkillExecutionEnv({ PATH: "/opt/custom/bin:/bin" }, {});
 
-    expect(typeof env.PATH).toBe("string");
-    expect(env.PATH?.length).toBeGreaterThan(0);
+    expect(env.PATH).toBe("/opt/custom/bin:/bin");
+  });
+
+  it("refuses to build an env with no PATH instead of letting bash synthesize one", () => {
+    // A synthesized bash PATH ends in `.`, so a bare command name would resolve
+    // against the working directory. Fail closed.
+    expect(() => buildSkillExecutionEnv({ HOME: "/root" }, {})).toThrow(
+      /no PATH/,
+    );
   });
 
   it("drops an unrecognised ambient key rather than passing it through", () => {
@@ -64,8 +72,6 @@ describe("buildSkillExecutionEnv", () => {
   });
 
   it("strips spawn-injection primitives from the per-skill overlay", () => {
-    // setSkillEnv accepts arbitrary keys with no validation, so the overlay is
-    // a caller-controlled channel into the child environment.
     const env = buildSkillExecutionEnv(
       { PATH: "/usr/bin" },
       {
@@ -82,12 +88,23 @@ describe("buildSkillExecutionEnv", () => {
     expect(env.GEMINI_API_KEY).toBe("legitimate");
   });
 
-  it("lets the overlay supply a credential the ambient env does not carry", () => {
+  it("lets the overlay replace an inherited value", () => {
     const env = buildSkillExecutionEnv(
-      { PATH: "/usr/bin" },
-      { NOTION_KEY: "from-skill-config" },
+      { PATH: "/usr/bin", GEMINI_API_KEY: "ambient" },
+      { GEMINI_API_KEY: "from-skill-config" },
     );
 
-    expect(env.NOTION_KEY).toBe("from-skill-config");
+    expect(env.GEMINI_API_KEY).toBe("from-skill-config");
+  });
+});
+
+describe("isInheritableSkillEnvKey", () => {
+  it("agrees with what the filter emits, so eligibility cannot report green then fail", () => {
+    // The eligibility check calls this; if the two disagreed, a skill would be
+    // reported ready and then spawned without the variable it declared.
+    expect(isInheritableSkillEnvKey("GEMINI_API_KEY")).toBe(true);
+    expect(isInheritableSkillEnvKey("gemini_api_key")).toBe(true);
+    expect(isInheritableSkillEnvKey("AGENT_SERVER_SHARED_SECRET")).toBe(false);
+    expect(isInheritableSkillEnvKey("SOME_THIRD_PARTY_KEY")).toBe(false);
   });
 });

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -96,6 +96,22 @@ describe("buildSkillExecutionEnv", () => {
 
     expect(env.GEMINI_API_KEY).toBe("from-skill-config");
   });
+
+  it("wins over an inherited entry that differs only in case", () => {
+    // POSIX treats these as two variables. Writing only the exact name would
+    // ship both, and a child reading the documented uppercase spelling would
+    // still get the ambient value — silently using the wrong credential.
+    const env = buildSkillExecutionEnv(
+      { PATH: "/usr/bin", GEMINI_API_KEY: "ambient" },
+      { Gemini_Api_Key: "from-skill-config" },
+    );
+
+    const spellings = Object.keys(env).filter(
+      (key) => key.toUpperCase() === "GEMINI_API_KEY",
+    );
+    expect(spellings).toHaveLength(1);
+    expect(env[spellings[0]]).toBe("from-skill-config");
+  });
 });
 
 describe("isInheritableSkillEnvKey", () => {

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildSkillExecutionEnv } from "./skill-execution-env";
+
+/**
+ * The five keys below were measured byte-identical across five production agent
+ * containers on five different nodes, while the per-agent keys in the same
+ * containers all differed. Each carries authority over the whole fleet rather
+ * than over the tenant whose container holds it, which is why a skill script
+ * must never receive them.
+ */
+const FLEET_SCOPED = {
+  AGENT_SERVER_SHARED_SECRET: "authenticates-as-owner-on-every-agent",
+  ELIZA_LOCAL_ROOT_KEY: "derives-every-org-dek",
+  SANDBOX_REGISTRY_REDIS_URL: "redis://shared-registry",
+  STEWARD_REFRESH_SERVICE_TOKEN: "mints-a-jwt-for-any-agent-id",
+  DATABASE_URL: "postgres://shared",
+};
+
+describe("buildSkillExecutionEnv", () => {
+  it("does not pass fleet-scoped credentials to a skill child process", () => {
+    const env = buildSkillExecutionEnv(
+      { ...FLEET_SCOPED, PATH: "/usr/bin", HOME: "/root" },
+      {},
+    );
+
+    for (const key of Object.keys(FLEET_SCOPED)) {
+      expect(env).not.toHaveProperty(key);
+    }
+  });
+
+  it("keeps the agent-scoped cloud identity, which is minted per agent", () => {
+    // ELIZAOS_CLOUD_API_KEY comes from createForAgent(org, user, sandbox), so a
+    // skill reading it reads its own agent's key. Four bundled skills document
+    // doing exactly that.
+    const env = buildSkillExecutionEnv(
+      {
+        ELIZAOS_CLOUD_API_KEY: "agent-own-key",
+        ELIZA_CLOUD_BASE_URL: "https://api.eliza.app",
+        PATH: "/usr/bin",
+      },
+      {},
+    );
+
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBe("agent-own-key");
+    expect(env.ELIZA_CLOUD_BASE_URL).toBe("https://api.eliza.app");
+  });
+
+  it("keeps a usable PATH, because the spawn sites use bare interpreter names", () => {
+    // use-skill.ts spawns `python3` / `bash` / `node` by name. An env without
+    // PATH does not secure the skill, it breaks every skill.
+    const env = buildSkillExecutionEnv({ PATH: "/usr/bin:/bin" }, {});
+
+    expect(typeof env.PATH).toBe("string");
+    expect(env.PATH?.length).toBeGreaterThan(0);
+  });
+
+  it("drops an unrecognised ambient key rather than passing it through", () => {
+    const env = buildSkillExecutionEnv(
+      { PATH: "/usr/bin", SOME_FUTURE_PLATFORM_SECRET: "leaked" },
+      {},
+    );
+
+    expect(env).not.toHaveProperty("SOME_FUTURE_PLATFORM_SECRET");
+  });
+
+  it("strips spawn-injection primitives from the per-skill overlay", () => {
+    // setSkillEnv accepts arbitrary keys with no validation, so the overlay is
+    // a caller-controlled channel into the child environment.
+    const env = buildSkillExecutionEnv(
+      { PATH: "/usr/bin" },
+      {
+        LD_PRELOAD: "/tmp/evil.so",
+        NODE_OPTIONS: "--require /tmp/evil.js",
+        BASH_FUNC_x: "() { :; }",
+        GEMINI_API_KEY: "legitimate",
+      },
+    );
+
+    expect(env).not.toHaveProperty("LD_PRELOAD");
+    expect(env).not.toHaveProperty("NODE_OPTIONS");
+    expect(env).not.toHaveProperty("BASH_FUNC_x");
+    expect(env.GEMINI_API_KEY).toBe("legitimate");
+  });
+
+  it("lets the overlay supply a credential the ambient env does not carry", () => {
+    const env = buildSkillExecutionEnv(
+      { PATH: "/usr/bin" },
+      { NOTION_KEY: "from-skill-config" },
+    );
+
+    expect(env.NOTION_KEY).toBe("from-skill-config");
+  });
+});

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
@@ -1,0 +1,116 @@
+/**
+ * Builds the environment a skill script is spawned with.
+ *
+ * Two different threats need two different filters here, which is why this is
+ * not one denylist.
+ *
+ * The inherited half is an ALLOWLIST. In a managed cloud container the agent
+ * process environment carries credentials whose authority is fleet-wide rather
+ * than tenant-scoped — the shared server secret that authenticates to every
+ * tenant's agent container, the local-KMS root key that re-derives every
+ * organisation's DEK, the sandbox-registry Redis URL, the Steward service token
+ * that mints a JWT for any agent id, and the shared Postgres DSN. None of those
+ * is a spawn-injection primitive, so `sanitizeSpawnEnv` does not and should not
+ * remove them. Only naming what may pass keeps them out.
+ *
+ * The per-skill overlay is a DENYLIST. `setSkillEnv` accepts arbitrary keys with
+ * no validation, so a skill's own configuration can carry `LD_PRELOAD`,
+ * `NODE_OPTIONS`, `BASH_FUNC_*` and the rest. That is exactly the class
+ * `sanitizeSpawnEnv` exists for.
+ *
+ * PATH is on the allowlist rather than re-derived: the spawn sites use bare
+ * `python3` / `bash` / `node`, so an environment without a usable PATH breaks
+ * every skill rather than securing it. Inheriting the parent's PATH keeps that
+ * behaviour byte-identical to what it was before this filter existed, which is
+ * the conservative choice for a change whose point is to remove things.
+ */
+import { sanitizeSpawnEnv } from "@elizaos/core";
+
+/**
+ * Process-level keys a child needs to run at all. Nothing here identifies the
+ * platform or authorises anything against it.
+ */
+const HOST_ENV_KEYS = [
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "SHELL",
+  "TERM",
+  "USER",
+  "LOGNAME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+] as const;
+
+/**
+ * Agent-scoped identity. These are reserved platform keys, and they are on this
+ * list deliberately: `ELIZAOS_CLOUD_API_KEY` is minted per agent by
+ * `apiKeysService.createForAgent(org, user, sandbox)`, so a skill reading it
+ * reads its OWN agent's key, not a shared one. The bundled `eliza-cloud`,
+ * `eliza-cloud-buy-domain`, `eliza-cloud-manage-domain` and
+ * `build-monetized-app` skills document reading them. Do not add a
+ * fleet-scoped key to this list — that is the distinction the whole file turns on.
+ */
+const AGENT_SCOPED_ENV_KEYS = [
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_URL",
+  "ELIZA_APP_ID",
+] as const;
+
+/**
+ * Third-party credentials the bundled skills document reading from the ambient
+ * environment. These belong to the user's own integrations, not to the
+ * platform. A skill added later should carry its credential through the
+ * per-skill env channel instead of extending this list, which is why the list
+ * is explicit rather than a pattern.
+ */
+const SKILL_DOCUMENTED_ENV_KEYS = [
+  "GEMINI_API_KEY",
+  "NOTION_KEY",
+  "NOTION_API_KEY",
+  "TRELLO_API_KEY",
+  "TRELLO_TOKEN",
+  "THINGS_AUTH_TOKEN",
+  "SUNO_API_KEY",
+  "SUNO_BASE_URL",
+  "OTTO_TMUX_SOCKET_DIR",
+] as const;
+
+const INHERITABLE_ENV_KEYS: ReadonlySet<string> = new Set<string>([
+  ...HOST_ENV_KEYS,
+  ...AGENT_SCOPED_ENV_KEYS,
+  ...SKILL_DOCUMENTED_ENV_KEYS,
+]);
+
+export function isInheritableSkillEnvKey(key: string): boolean {
+  return INHERITABLE_ENV_KEYS.has(key.trim().toUpperCase());
+}
+
+/**
+ * @param processEnv the parent environment to inherit from, filtered by allowlist
+ * @param overlay per-skill configured env, filtered by the spawn denylist
+ */
+export function buildSkillExecutionEnv(
+  processEnv: NodeJS.ProcessEnv,
+  overlay: Record<string, string>,
+): Record<string, string> {
+  const inherited: Record<string, string> = {};
+  for (const [key, value] of Object.entries(processEnv)) {
+    if (value !== undefined && isInheritableSkillEnvKey(key)) {
+      inherited[key] = value;
+    }
+  }
+
+  const safeOverlay = sanitizeSpawnEnv(overlay);
+  const result: Record<string, string> = { ...inherited };
+  for (const [key, value] of Object.entries(safeOverlay)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
@@ -100,7 +100,16 @@ export function buildSkillExecutionEnv(
       result[key] = value;
   }
   for (const [key, value] of Object.entries(sanitizeSpawnEnv(overlay))) {
-    if (value !== undefined) result[key] = value;
+    if (value === undefined) continue;
+    // Drop any inherited entry that differs only in case before writing. POSIX
+    // treats `GEMINI_API_KEY` and `Gemini_Api_Key` as two variables, so an
+    // exact-name overwrite would ship both and a child reading the documented
+    // spelling would still get the ambient value — the opposite of overlay-wins.
+    const upper = key.toUpperCase();
+    for (const existing of Object.keys(result)) {
+      if (existing !== key && existing.toUpperCase() === upper) delete result[existing];
+    }
+    result[key] = value;
   }
 
   // Without PATH, execvp falls back to a system default and bash synthesizes one

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
@@ -1,35 +1,26 @@
 /**
  * Builds the environment a skill script is spawned with.
  *
- * Two different threats need two different filters here, which is why this is
- * not one denylist.
+ * The inherited half is an ALLOWLIST because the threat is credentials that are
+ * fleet-scoped rather than tenant-scoped — the shared server secret, the
+ * local-KMS root key, the sandbox-registry Redis URL, the Steward service token,
+ * the shared Postgres DSN. None is a spawn-injection primitive, so
+ * `sanitizeSpawnEnv` neither does nor should remove them; only naming what may
+ * pass keeps them out.
  *
- * The inherited half is an ALLOWLIST. In a managed cloud container the agent
- * process environment carries credentials whose authority is fleet-wide rather
- * than tenant-scoped — the shared server secret that authenticates to every
- * tenant's agent container, the local-KMS root key that re-derives every
- * organisation's DEK, the sandbox-registry Redis URL, the Steward service token
- * that mints a JWT for any agent id, and the shared Postgres DSN. None of those
- * is a spawn-injection primitive, so `sanitizeSpawnEnv` does not and should not
- * remove them. Only naming what may pass keeps them out.
+ * The per-skill overlay is passed through `sanitizeSpawnEnv` as well. That
+ * channel has no producer today — nothing calls `setSkillEnv` and the runtime
+ * starts the service without `skillEntries` — so this is cheap insurance on an
+ * API surface, not a live threat. Note it also means an overlay entry for
+ * `PATH`, `HOME` or `SHELL` is now dropped where it used to win.
  *
- * The per-skill overlay is a DENYLIST. `setSkillEnv` accepts arbitrary keys with
- * no validation, so a skill's own configuration can carry `LD_PRELOAD`,
- * `NODE_OPTIONS`, `BASH_FUNC_*` and the rest. That is exactly the class
- * `sanitizeSpawnEnv` exists for.
- *
- * PATH is on the allowlist rather than re-derived: the spawn sites use bare
- * `python3` / `bash` / `node`, so an environment without a usable PATH breaks
- * every skill rather than securing it. Inheriting the parent's PATH keeps that
- * behaviour byte-identical to what it was before this filter existed, which is
- * the conservative choice for a change whose point is to remove things.
+ * Only `USE_SKILL` in script mode reaches this. Shell blocks in a SKILL.md are
+ * run by the agent's own shell tool, so extend the allowlist from what skill
+ * SCRIPTS read, not from what SKILL.md prose mentions.
  */
 import { sanitizeSpawnEnv } from "@elizaos/core";
 
-/**
- * Process-level keys a child needs to run at all. Nothing here identifies the
- * platform or authorises anything against it.
- */
+/** Process-level keys a child needs to run. None carries authority. */
 const HOST_ENV_KEYS = [
   "PATH",
   "HOME",
@@ -47,16 +38,19 @@ const HOST_ENV_KEYS = [
 ] as const;
 
 /**
- * Agent-scoped identity. These are reserved platform keys, and they are on this
- * list deliberately: `ELIZAOS_CLOUD_API_KEY` is minted per agent by
- * `apiKeysService.createForAgent(org, user, sandbox)`, so a skill reading it
- * reads its OWN agent's key, not a shared one. The bundled `eliza-cloud`,
- * `eliza-cloud-buy-domain`, `eliza-cloud-manage-domain` and
- * `build-monetized-app` skills document reading them. Do not add a
- * fleet-scoped key to this list — that is the distinction the whole file turns on.
+ * The group that carries authority, so the one to guard: **do not add a
+ * fleet-scoped key here.**
+ *
+ * `ELIZAOS_CLOUD_API_KEY` is admitted despite being platform-reserved because
+ * the platform mints it per agent (`apiKeysService.createForAgent` in
+ * `managed-eliza-config`), so a skill reading it reads its own agent's key.
+ * Both base-URL spellings are present because the platform injects
+ * `ELIZAOS_CLOUD_BASE_URL` while the bundled `eliza-cloud` skill documents
+ * `ELIZA_CLOUD_BASE_URL`.
  */
 const AGENT_SCOPED_ENV_KEYS = [
   "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_BASE_URL",
   "ELIZA_CLOUD_PUBLIC_URL",
   "ELIZA_CLOUD_URL",
@@ -64,53 +58,60 @@ const AGENT_SCOPED_ENV_KEYS = [
 ] as const;
 
 /**
- * Third-party credentials the bundled skills document reading from the ambient
- * environment. These belong to the user's own integrations, not to the
- * platform. A skill added later should carry its credential through the
- * per-skill env channel instead of extending this list, which is why the list
- * is explicit rather than a pattern.
+ * Credentials a bundled skill script reads or declares in `requires.env`
+ * (`nano-banana-pro`, `tmux`, `notion`, `trello`, `things-mac`). Every entry is
+ * a real read or a real declaration — an entry justified only by prose admits a
+ * credential nothing uses.
  */
-const SKILL_DOCUMENTED_ENV_KEYS = [
+const SKILL_DECLARED_ENV_KEYS = [
   "GEMINI_API_KEY",
-  "NOTION_KEY",
+  "OTTO_TMUX_SOCKET_DIR",
   "NOTION_API_KEY",
   "TRELLO_API_KEY",
   "TRELLO_TOKEN",
   "THINGS_AUTH_TOKEN",
-  "SUNO_API_KEY",
-  "SUNO_BASE_URL",
-  "OTTO_TMUX_SOCKET_DIR",
 ] as const;
 
 const INHERITABLE_ENV_KEYS: ReadonlySet<string> = new Set<string>([
   ...HOST_ENV_KEYS,
   ...AGENT_SCOPED_ENV_KEYS,
-  ...SKILL_DOCUMENTED_ENV_KEYS,
+  ...SKILL_DECLARED_ENV_KEYS,
 ]);
 
+/**
+ * Also consulted by the eligibility check, so a skill requiring a variable this
+ * filter will not pass reports blocked instead of running without it.
+ */
 export function isInheritableSkillEnvKey(key: string): boolean {
-  return INHERITABLE_ENV_KEYS.has(key.trim().toUpperCase());
+  return INHERITABLE_ENV_KEYS.has(key.toUpperCase());
 }
 
 /**
- * @param processEnv the parent environment to inherit from, filtered by allowlist
+ * @param processEnv parent environment, filtered by allowlist
  * @param overlay per-skill configured env, filtered by the spawn denylist
  */
 export function buildSkillExecutionEnv(
   processEnv: NodeJS.ProcessEnv,
   overlay: Record<string, string>,
 ): Record<string, string> {
-  const inherited: Record<string, string> = {};
+  const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(processEnv)) {
-    if (value !== undefined && isInheritableSkillEnvKey(key)) {
-      inherited[key] = value;
-    }
+    if (value !== undefined && isInheritableSkillEnvKey(key))
+      result[key] = value;
   }
-
-  const safeOverlay = sanitizeSpawnEnv(overlay);
-  const result: Record<string, string> = { ...inherited };
-  for (const [key, value] of Object.entries(safeOverlay)) {
+  for (const [key, value] of Object.entries(sanitizeSpawnEnv(overlay))) {
     if (value !== undefined) result[key] = value;
   }
+
+  // Without PATH, execvp falls back to a system default and bash synthesizes one
+  // ending in `.`, so a skill shelling out to a bare command name would run a
+  // same-named file from the working directory. A filter meant to remove
+  // authority must not create that, so refuse rather than spawn.
+  if (!result.PATH?.trim()) {
+    throw new Error(
+      "[agent-skills] refusing to run a skill script with no PATH: the child would resolve bare command names against a synthesized default",
+    );
+  }
+
   return result;
 }

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -30,6 +30,7 @@ import {
 	parseFrontmatter,
 	validateFrontmatter,
 } from "../parser";
+import { buildSkillExecutionEnv } from "../security/skill-execution-env";
 import type { SkillScanReport, SkillScanStatus } from "../security/types";
 import {
 	createStorage,
@@ -1716,10 +1717,11 @@ export class AgentSkillsService extends Service {
 		const skillEnv = this.getSkillEnv(slug);
 		const apiKey = this.getSkillApiKey(slug);
 
-		const env: Record<string, string> = {
-			...(process.env as Record<string, string>),
-			...skillEnv,
-		};
+		// Inheriting process.env wholesale handed every skill script the agent's
+		// full credential set, which in a managed container is fleet-scoped and
+		// not tenant-scoped. buildSkillExecutionEnv allowlists what may be
+		// inherited and denylists what the per-skill overlay may inject.
+		const env = buildSkillExecutionEnv(process.env, skillEnv);
 
 		if (apiKey) {
 			// Inject API key with standard naming

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -30,7 +30,10 @@ import {
 	parseFrontmatter,
 	validateFrontmatter,
 } from "../parser";
-import { buildSkillExecutionEnv } from "../security/skill-execution-env";
+import {
+	buildSkillExecutionEnv,
+	isInheritableSkillEnvKey,
+} from "../security/skill-execution-env";
 import type { SkillScanReport, SkillScanStatus } from "../security/types";
 import {
 	createStorage,
@@ -998,14 +1001,28 @@ export class AgentSkillsService extends Service {
 
 			// Check required environment variables
 			if (requires.env && requires.env.length > 0) {
+				const skillEnv = this.getSkillEnv(skill.slug);
 				for (const envVar of requires.env) {
-					const value = process.env[envVar] || this.runtime.getSetting(envVar);
+					// Answer from what the script will ACTUALLY receive. Reading
+					// process.env directly would report a skill ready and then run it
+					// without the variable, surfacing as a third-party 401 deep inside
+					// the script rather than as a missing requirement here.
+					const inherited = isInheritableSkillEnvKey(envVar)
+						? process.env[envVar]
+						: undefined;
+					const value = inherited || skillEnv[envVar];
 					if (!value) {
+						const blocked =
+							!isInheritableSkillEnvKey(envVar) && Boolean(process.env[envVar]);
 						reasons.push({
 							type: "env",
 							missing: envVar,
-							message: `Required environment variable '${envVar}' is not set`,
-							suggestion: `Set ${envVar} in your environment or agent settings`,
+							message: blocked
+								? `Environment variable '${envVar}' is set but is not passed to skill scripts`
+								: `Required environment variable '${envVar}' is not set`,
+							suggestion: blocked
+								? `Configure ${envVar} for this skill specifically; the ambient value is withheld from skill scripts on purpose`
+								: `Set ${envVar} in your environment or agent settings`,
 						});
 					}
 				}


### PR DESCRIPTION
Part of #22927. This is the follow-up #22943 deliberately does not close.

## What a skill script sees today

`getSkillExecutionEnv` (`services/skills.ts:1715-1731`) spreads `process.env` verbatim into every skill child process, consumed at `actions/use-skill.ts:474` and spawned at `:249`.

In a managed cloud container that environment carries five credentials whose authority is **fleet-wide, not tenant-scoped**:

| key | what holding it grants |
|---|---|
| `AGENT_SERVER_SHARED_SECRET` | a matching `X-Server-Token` returns OWNER on **every** tenant's agent container (`server-helpers-auth.ts:378,391`) |
| `ELIZA_LOCAL_ROOT_KEY` | HKDF-derives **every** organisation's DEK; no per-org key material is stored anywhere else (`local-adapter.ts:70-73`, `field-crypto.ts:55`) |
| `SANDBOX_REGISTRY_REDIS_URL` | flat untenanted keyspace — repoint any agent's inbound routing |
| `STEWARD_REFRESH_SERVICE_TOKEN` | mints a Steward JWT for **any** agentId (`agent-tokens/route.ts:40-49`) |
| `DATABASE_URL` | the shared Postgres every agent uses |

All five were measured byte-identical across five production containers on five different nodes, while the per-agent keys in those same containers (`TS_AUTHKEY`, `ELIZA_API_TOKEN`, `JWT_SECRET`, `ELIZA_VAULT_PASSPHRASE`) all differed — so the identity is not an artifact of a cloned image.

## Two threats, so two filters

**Inherited half — allowlist.** None of those five is a spawn-injection primitive, so `sanitizeSpawnEnv` neither does nor should remove them. A denylist cannot express "everything except what a skill legitimately needs"; only naming what may pass keeps them out.

**Per-skill overlay — denylist.** `setSkillEnv` (`skills.ts:1169-1176`) accepts arbitrary keys with no validation, so a skill's own configuration is a caller-controlled channel into the child environment. That is exactly the class `sanitizeSpawnEnv` exists for, and it is reused rather than reimplemented.

## The judgement call, stated so a reviewer can overturn it

`ELIZAOS_CLOUD_API_KEY` and `ELIZA_CLOUD_BASE_URL` are on the allowlist **on purpose**, despite being in `RESERVED_PLATFORM_ENV_KEYS`. The cloud key is minted per agent by `apiKeysService.createForAgent(org, user, sandbox)` — a skill reading it reads its own agent's key, not a shared one — and four bundled skills (`eliza-cloud`, `eliza-cloud-buy-domain`, `eliza-cloud-manage-domain`, `build-monetized-app`) document reading it. Per-agent scope is the whole distinction this file turns on; adding a fleet-scoped key to that list would defeat it.

`PATH` stays on the allowlist rather than being re-derived. The spawn sites use bare `python3` / `bash` / `node`, so inheriting the parent's PATH keeps behaviour byte-identical to before — the conservative choice for a change whose point is to remove things.

## Testing note

The plugin's vitest setup stubs `@elizaos/core` wholesale, so the mock now passes through the **real** `sanitizeSpawnEnv` from source. A stubbed sanitizer would have made the denylist half untestable — the assertions would have proven nothing.

6 new tests. Two mutations were run against the committed code, each turning exactly one test red:
- adding a fleet-scoped key to the allowlist → the fleet-credential test fails
- dropping `sanitizeSpawnEnv` from the overlay → the injection test fails

Full plugin suite: **223 passing**. Two test files fail to load (`skills-routes.test.ts`, `skill-scaffold-frontmatter.test.ts`) with `Failed to resolve entry for package "@elizaos/shared"` — verified identical on the base branch, unrelated to this change.

## What this does not close

- The skill scanner still reads content only for JS/TS and markdown. A `.py` payload is in no list at all — not scannable, not markdown, not binary, not `SCRIPT_EXTENSIONS` — so it produces no finding and is executed unopened.
- A `critical` scan result still does not stop execution: `handleScanResult` writes only to an in-memory map, `isSkillEnabled` returns true for an absent entry, and `USE_SKILL` checks only that.
- `services/install.ts:213-216` (`sh -c` dependency hook) and `services/skill-marketplace.ts:703-760` (`git`) still inherit implicitly by passing no `env` at all.

Each is tracked on #22927.
