### PR TITLE
fix(lifeops): guard malformed sourceId decode in DELETE money/sources route

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts
@@ -1,0 +1,149 @@
+/**
+ * DELETE /api/lifeops/money/sources/:sourceId encoding.
+ *
+ * Origin decoded the path segment with bare `decodeURIComponent` inside
+ * `runFinancesRoute`. `new URL` accepts `/%`, `/%ZZ`, `/%2`, `/%E0%A4%A`;
+ * `decodeURIComponent` then throws URIError. The finances catch only maps
+ * `FinancesServiceError` and rethrows everything else, and the LifeOps
+ * handler has no outer try/catch — so malformed percent-encoding 500s.
+ * Fail closed through `ctx.decodePathComponent` (400) before the service.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import type { AgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LifeOpsRouteContext } from "./lifeops-routes.js";
+
+const deletePaymentSource = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@elizaos/plugin-calendar/routes/calendar-routes", () => ({
+  handleCalendarRoutes: vi.fn(async () => false),
+}));
+
+vi.mock("@elizaos/plugin-finances/finances-service", () => ({
+  FinancesService: class MockFinancesService {
+    deletePaymentSource = deletePaymentSource;
+  },
+  sanitizePaymentSourceForClient: (source: unknown) => source,
+}));
+
+const { handleLifeOpsRoutes } = await import("./lifeops-routes.js");
+
+interface CapturedResponse {
+  body: string;
+  ended: boolean;
+  statusCode: number;
+}
+
+function buildContext(pathname: string): {
+  ctx: LifeOpsRouteContext;
+  response: CapturedResponse;
+} {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    configurable: true,
+    value: "127.0.0.1",
+  });
+  const req = new IncomingMessage(socket);
+  req.method = "DELETE";
+  req.url = pathname;
+
+  const captured: CapturedResponse = {
+    body: "",
+    ended: false,
+    statusCode: 200,
+  };
+  const res = new ServerResponse(req);
+  res.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    captured.body =
+      chunk === undefined
+        ? ""
+        : Buffer.isBuffer(chunk)
+          ? chunk.toString("utf8")
+          : String(chunk);
+    captured.ended = true;
+    captured.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+
+  const url = new URL(pathname, "http://localhost");
+  const ctx: LifeOpsRouteContext = {
+    req,
+    res,
+    method: "DELETE",
+    pathname: url.pathname,
+    url,
+    state: {
+      adminEntityId: null,
+      runtime: { agentId: "agent-1" } as unknown as AgentRuntime,
+    },
+    json(response, data, status = 200) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(data));
+    },
+    error(response, message, status = 400) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: message }));
+    },
+    async readJsonBody<T extends object>(): Promise<T | null> {
+      return null;
+    },
+    decodePathComponent(raw, response, fieldName) {
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        // error-policy:J3 same contract as server-helpers decodePathComponent.
+        response.statusCode = 400;
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            error: `Invalid ${fieldName}: malformed URL encoding`,
+          }),
+        );
+        return null;
+      }
+    },
+  };
+  return { ctx, response: captured };
+}
+
+describe("DELETE /api/lifeops/money/sources/:sourceId encoding", () => {
+  beforeEach(() => {
+    deletePaymentSource.mockClear();
+  });
+
+  it.each(["%", "%ZZ", "%2", "%E0%A4%A"])(
+    "rejects malformed sourceId %s with 400 before deletePaymentSource",
+    async (segment) => {
+      const { ctx, response } = buildContext(
+        `/api/lifeops/money/sources/${segment}`,
+      );
+      await expect(handleLifeOpsRoutes(ctx)).resolves.toBe(true);
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: "Invalid sourceId: malformed URL encoding",
+      });
+      expect(deletePaymentSource).not.toHaveBeenCalled();
+    },
+  );
+
+  it("deletes a percent-encoded sourceId after a successful decode", async () => {
+    const { ctx, response } = buildContext(
+      "/api/lifeops/money/sources/src%2Fbank-1",
+    );
+    await expect(handleLifeOpsRoutes(ctx)).resolves.toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ ok: true });
+    expect(deletePaymentSource).toHaveBeenCalledWith("src/bank-1");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -2524,8 +2524,10 @@ export async function handleLifeOpsRoutes(
       ctx.error(res, "sourceId required", 400);
       return true;
     }
+    const decodedSourceId = ctx.decodePathComponent(sourceId, res, "sourceId");
+    if (!decodedSourceId) return true;
     return runFinancesRoute(ctx, async (service) => {
-      await service.deletePaymentSource(decodeURIComponent(sourceId));
+      await service.deletePaymentSource(decodedSourceId);
       json(res, { ok: true });
     });
   }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE hang / 500 / auth-bind / input-boundary audit on a live product path. No new issue filed (mission forbids self-directed issue creation).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6+zai/glm-5.2
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app + fx
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

## Summary

`DELETE /api/lifeops/money/sources/:sourceId` sliced the path segment then called `decodeURIComponent(sourceId)` inside `runFinancesRoute`. `new URL` accepts `/%`, `/%ZZ`, `/%2`, `/%E0%A4%A`; `decodeURIComponent` throws `URIError`; the finances catch only maps `FinancesServiceError` and rethrows everything else, and `handleLifeOpsRoutes` has no outer try/catch — so malformed percent-encoding in the `sourceId` path segment produced an unhandled 500 instead of a clean 400.

## Fix

Route the decode through `ctx.decodePathComponent(sourceId, res, "sourceId")` **before** entering `runFinancesRoute`. This returns `400` on malformed encoding (matching the existing contract used by `decodeMatchedPathComponent` and the server-helpers `decodePathComponent`), preventing the `URIError` from ever reaching the service call.

```diff
     const sourceId = pathname.slice("/api/lifeops/money/sources/".length);
     if (!sourceId) {
       ctx.error(res, "sourceId required", 400);
       return true;
     }
+    const decodedSourceId = ctx.decodePathComponent(sourceId, res, "sourceId");
+    if (!decodedSourceId) return true;
     return runFinancesRoute(ctx, async (service) => {
-      await service.deletePaymentSource(decodeURIComponent(sourceId));
+      await service.deletePaymentSource(decodedSourceId);
       json(res, { ok: true });
     });
```

## Root cause

`runFinancesRoute` (lines 906–976) wraps the handler in a try/catch that **only** maps `FinancesServiceError` to an HTTP response and **rethrows** everything else (`throw error` at line 974). `URIError` is not a `FinancesServiceError`, so it propagates out of `handleLifeOpsRoutes`, which has no outer try/catch, and the HTTP layer turns it into a 500.

Same vulnerability class as #22980, different host file — `voice-models-routes.ts` is not touched.

## Verification

```
npx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts \
  plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts

 ✓ plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts (5 tests) 8ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The test covers:
- `%`, `%ZZ`, `%2`, `%E0%A4%A` → 400 `{"error":"Invalid sourceId: malformed URL encoding"}` before `deletePaymentSource` is called
- `src%2Fbank-1` → 200 `{"ok":true}` with `deletePaymentSource("src/bank-1")` (successful decode still works)

# Relates to

# Evidence Gate

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:940945033714ebb1325b0950cc26022d71aeb1c8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
     const sourceId = pathname.slice("/api/lifeops/money/sources/".length);
     if (!sourceId) {
       ctx.error(res, "sourceId required", 400);
       return true;
     }
+    const decodedSourceId = ctx.decodePathComponent(sourceId, res, "sourceId");
+    if (!decodedSourceId) return true;
     return runFinancesRoute(ctx, async (service) => {
-      await service.deletePaymentSource(decodeURIComponent(sourceId));
+      await service.deletePaymentSource(decodedSourceId);
       json(res, { ok: true });
     });


npx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts \
  plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts

 ✓ plugins/plugin-personal-assistant/src/routes/lifeops-money-sources-encoding.test.ts (5 tests) 8ms

 Test Files  1 passed (1)
      Tests  5 passed (5)

```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6+zai/glm-5.2
Client / agent tooling: Grok Bot.app + fx
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6+zai/glm-5.2","client":"Grok Bot.app + fx","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
