### PR TITLE
feat(headscale): split tag:eliza-cp from the dual-worn proxy tag — phase 1

### DIFF
--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -134,9 +134,13 @@ used to be hand-run on every CP (and lost on a rebuild — a DR gap):
   `certbot.timer`; a root-owned deploy hook verifies the renewed leaf still has
   both exact SANs and validates nginx before reloading it. Cert issuance is
   idempotent (`certbot certonly`, skipped when a valid cert already exists).
-- the **`cp-<env>-router` tailscale self-enrollment** (`tag:eliza-proxy`, owned
-  by the `tunnel` user) so the daemon on the CP can reach agent `tag:agent`
-  `100.64.x` IPs. Idempotent (skips if already enrolled).
+- the **`cp-<env>-router` tailscale self-enrollment** (`tag:eliza-cp`, owned
+  by the `tunnel` user; split from the dual-worn `tag:eliza-proxy` in #22945)
+  so the daemon on the CP can reach agent `tag:agent` `100.64.x` IPs.
+  Idempotent (skips if already enrolled) — which means an ALREADY-enrolled
+  router keeps its old tag: retag in place with
+  `headscale nodes tag -i <id> -t tag:eliza-cp` plus
+  `tailscale set --advertise-tags=tag:eliza-cp` on the CP.
 
 The matching canonical **DNS record** (`headscale[-staging].eliza.app` → CP
 ipv4, `proxied=false`) is managed by this Terraform module

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -10,7 +10,7 @@
  *     and temporary legacy Headscale names during the eliza.app migration
  *     (TS2021/noise needs a no-http2 vhost with Upgrade/Connection passthrough
  *     + long timeouts — a CF-proxied or h2 origin breaks it)
- *   - enroll the CP itself as a tailscale node (cp-<env>-router, tag:eliza-proxy)
+ *   - enroll the CP itself as a tailscale node (cp-<env>-router, tag:eliza-cp)
  *     against its local Headscale, so the daemon can reach agent 100.64.x IPs
  *   - upsert the daemon env that makes sandbox provisioning require Headscale
  *   - restart Headscale and the provisioning worker, then health-check both
@@ -163,7 +163,7 @@ Optional:
   --headscale-user <user>              User for agent preauth keys (default agent).
   --cp-router-hostname <name>          Tailscale hostname the CP enrolls itself as
                                        (default derived from the public URL, e.g.
-                                       cp-staging-router). tag:eliza-proxy, owned
+                                       cp-staging-router). tag:eliza-cp, owned
                                        by the 'tunnel' headscale user.
   --certbot-email <email>              Email for the Let's Encrypt account / expiry
                                        notices (default ops@elizalabs.ai).
@@ -1120,7 +1120,8 @@ echo "public Headscale overlap is healthy on one exact dual-SAN leaf"
 
 // ── CP self-enrollment as a tailscale node (cp-<env>-router) ─────────────────
 // The CP enrolls ITSELF against its local headscale as cp-<env>-router with
-// tag:eliza-proxy (owned by the 'tunnel' user in acl.hujson). This is what lets
+// tag:eliza-cp (owned by the 'tunnel' user in acl.hujson; split from the
+// dual-worn tag:eliza-proxy in #22945). This is what lets
 // the daemon on the CP reach agent tag:agent 100.64.x IPs. Previously a manual
 // `tailscale up` per CP (the DR gap). Idempotent: skips if a node with this
 // hostname is already enrolled. headscale v0.28's `preauthkeys create -u` takes
@@ -1128,7 +1129,7 @@ echo "public Headscale overlap is healthy on one exact dual-SAN leaf"
 const cpRouterSteps = skipCpRouter
   ? `echo "skip-cp-router set: leaving CP tailscale enrollment untouched"`
   : `
-echo "--- CP self-enrollment: ${cpRouterHostname} (tag:eliza-proxy) ---"
+echo "--- CP self-enrollment: ${cpRouterHostname} (tag:eliza-cp) ---"
 CP_ROUTER_HOST=${shellQuote(cpRouterHostname)}
 LOGIN_SERVER=${shellQuote(publicUrl)}
 
@@ -1146,10 +1147,10 @@ else
     | jq -r '.[] | select(.name == "tunnel") | .id')
   [ -n "$TUNNEL_UID" ] || { echo "tunnel user not found; cannot mint preauth key"; exit 1; }
 
-  # Short-lived, single-use, pre-tagged preauth key. Tagged tag:eliza-proxy so
+  # Short-lived, single-use, pre-tagged preauth key. Tagged tag:eliza-cp so
   # the node lands tagged at join (ownership enforced by acl.hujson tagOwners).
   PREAUTH_KEY=$(sudo headscale preauthkeys create -u "$TUNNEL_UID" \\
-    --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
+    --tags tag:eliza-cp --expiration 1h -o json 2>/dev/null | jq -r '.key')
   [ -n "$PREAUTH_KEY" ] || { echo "failed to mint preauth key for cp-router"; exit 1; }
 
   # This branch already proved the expected router is absent and minted a
@@ -1160,7 +1161,7 @@ else
     --login-server="$LOGIN_SERVER" \\
     --authkey="$PREAUTH_KEY" \\
     --hostname="$CP_ROUTER_HOST" \\
-    --advertise-tags=tag:eliza-proxy \\
+    --advertise-tags=tag:eliza-cp \\
     --accept-routes
   echo "$CP_ROUTER_HOST enrolled"
 fi

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -162,6 +162,17 @@ describe("Headscale control-plane self-enrollment", () => {
     );
   });
 
+  test("enrolls the CP router under tag:eliza-cp, not the dual-worn proxy tag (#22945)", () => {
+    const remote = renderRemoteScript();
+
+    expect(remote).toContain("--tags tag:eliza-cp");
+    expect(remote).toContain("--advertise-tags=tag:eliza-cp");
+    // The tunnel proxy keeps tag:eliza-proxy (its deploy workflow mints it);
+    // the arm script must no longer advertise or mint the shared tag.
+    expect(remote).not.toContain("--tags tag:eliza-proxy");
+    expect(remote).not.toContain("--advertise-tags=tag:eliza-proxy");
+  });
+
   test("does not emit forced reauthentication when router enrollment is skipped", () => {
     const remote = renderRemoteScript(["--skip-cp-router"]);
 
@@ -204,6 +215,23 @@ describe("Headscale ACL policy", () => {
 
     expect(proxyToAgent).toHaveLength(1);
     expect(proxyToAgent[0]?.dst).toEqual([`tag:agent:${AGENT_CONTAINER_PORT}`]);
+  });
+
+  test("grants tag:eliza-cp the agent container port, cloning the proxy rule's dst (#22945 phase 1)", () => {
+    const policy = committedPolicy();
+    const cpToAgent = rulesFrom(policy, "tag:eliza-cp", "tag:agent");
+    const proxyToAgent = rulesFrom(policy, "tag:eliza-proxy", "tag:agent");
+
+    expect(cpToAgent).toHaveLength(1);
+    expect(cpToAgent[0]?.dst).toEqual([`tag:agent:${AGENT_CONTAINER_PORT}`]);
+    // Migration invariant: phase 1 narrows the src only — the two rules'
+    // dst must stay identical until phase 2 removes the proxy rule.
+    expect(cpToAgent[0]?.dst).toEqual(proxyToAgent[0]?.dst);
+    // eliza-cp gets agent reach and NOTHING else (no tunnel/proxy rules).
+    const cpRules = policy.acls.filter((rule) =>
+      rule.src.includes("tag:eliza-cp"),
+    );
+    expect(cpRules).toHaveLength(1);
   });
 
   test("keeps customer tunnels and iMessage gateways off the agent fleet", () => {

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -297,3 +297,5 @@ tailscale ping -c 1 <some agent container's tailnet IP>
 ```
 
 This should fail with "no path". Do not add Tailscale-style `tests` blocks to `acl.hujson`; Headscale v0.28 rejects that field at startup.
+
+After the #22945 phase-2 removal PR lands, additionally verify from the Railway tunnel proxy that no `tag:agent` IP is reachable (the CP router on `tag:eliza-cp` must still reach `tag:agent:2138`). During phase 1 the tunnel proxy retains agent reach by design — do not treat that as a failure.

--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -16,9 +16,11 @@ deploys to `/etc/headscale/acl.hujson`.
 
 | Tag | Used by | Reach |
 |---|---|---|
-| `tag:agent` | Internal agent containers (set in [`headscale-integration.ts`](../../shared/src/lib/services/headscale-integration.ts:57)) | Internal services only — must NOT reach customer tunnels. |
+| `tag:agent` | Internal agent containers (set in [`headscale-integration.ts`](../../shared/src/lib/services/headscale-integration.ts:147)) | Internal services only — must NOT reach customer tunnels. |
 | `tag:eliza-tunnel` | Customer tunnel sessions minted by [`auth-key/route.ts`](../../api/v1/apis/tunnels/tailscale/auth-key/route.ts) | The reverse proxy and the customer's own node. Cross-customer routing is enforced by the proxy lookup layer. |
-| `tag:eliza-proxy` | The public reverse proxy node and the control plane's own `cp-<env>-router` | Customer tunnel HTTPS endpoints, plus the agent fleet on the container port only (`tag:agent:2138`) for bridge and health traffic. |
+| `tag:eliza-proxy` | The public reverse proxy node (Railway tunnel proxy; its deploy workflow mints the key) | Customer tunnel HTTPS endpoints. During the #22945 migration it also keeps `tag:agent:2138` reach until the phase-2 removal PR. |
+| `tag:eliza-cp` | The control plane's own `cp-<env>-router` (arm-script self-enrollment) | The agent fleet on the container port only (`tag:agent:2138`) for bridge and health traffic. Nothing else. |
+| `tag:imessage-gateway` | User-owned Mac/iPhone iMessage bridges (operator-assigned; see `HEADSCALE_IMESSAGE_GATEWAY_TAG` in the messaging-gateway preflight) | The tunnel proxy on 443 only — never agent containers. |
 
 The exact ACL policy lives in `acl.hujson` next to this README. **Edit there, not in the headscale admin UI** — the file is committed and deployed.
 

--- a/packages/cloud/services/headscale/acl.hujson
+++ b/packages/cloud/services/headscale/acl.hujson
@@ -12,6 +12,10 @@
     "tag:eliza-tunnel": ["tunnel@"],
     // The public reverse proxy is itself a tagged service node.
     "tag:eliza-proxy": ["tunnel@"],
+    // The control-plane router (cp-<env>-router). Split from tag:eliza-proxy
+    // so agent reach can be narrowed to the CP alone — the tunnel proxy has
+    // no code path that dials a tag:agent node (#22945).
+    "tag:eliza-cp": ["tunnel@"],
     // User-owned Mac/iPhone iMessage bridges use a dedicated tag so they can
     // reach only the tunnel proxy, never agent containers directly.
     "tag:imessage-gateway": ["tunnel@"]
@@ -37,12 +41,21 @@
     // widening this rule to match. Otherwise default-deny drops the probe with
     // no symptom but a timeout.
     //
-    // Scope: tag:eliza-proxy is carried by BOTH the control plane router and
-    // the internet-facing tunnel proxy, so this also grants the public proxy
-    // reach to agents on 2138. A dedicated tag:eliza-cp would narrow it.
+    // MIGRATION (#22945 phase 1): tag:eliza-proxy is still carried by both
+    // the CP router and the internet-facing tunnel proxy, so during the
+    // coexistence window the tunnel proxy KEEPS agent reach — unchanged risk
+    // vs #22617 alone. Phase 2 deletes this rule once cp-<env>-router wears
+    // tag:eliza-cp on BOTH environments (evidence gate in the removal PR).
     {
       "action": "accept",
       "src": ["tag:eliza-proxy"],
+      "dst": ["tag:agent:2138"]
+    },
+    // The dst clones the rule above verbatim: this migration narrows the SRC
+    // only. Re-verifying live bridge_url ports is the pre-phase-2 ops check.
+    {
+      "action": "accept",
+      "src": ["tag:eliza-cp"],
       "dst": ["tag:agent:2138"]
     },
     // Agents can reach each other on internal ports (existing behavior).

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -335,6 +335,11 @@ CONTAINERS_SSH_KEY=
 # `image` field on POST /api/v1/containers for those).
 # ELIZA_AGENT_IMAGE=ghcr.io/elizaos/eliza:latest
 # ELIZA_AGENT_IMAGE_PLATFORM=linux/amd64
+# Last fallback of the per-sandbox container-port chain:
+#   environmentVars.PORT -> HTTP_PORT -> container.port -> ELIZA_AGENT_PORT.
+# The code default is 3000, but the canonical agent image listens on 2138 and
+# production sets ELIZA_AGENT_PORT=2138 — the headscale ACL's agent rule
+# (acl.hujson, tag:agent:2138) must match what live bridge_urls actually use.
 # ELIZA_AGENT_PORT=3000
 # AGENT_DOCKER_IMAGE=ghcr.io/agent-ai/agent:v2.0.0-steward-5
 


### PR DESCRIPTION
Part of #22945 — phase 1 of 2. Least-privilege follow-up both reviews on #22617 called for.

## Problem

`tag:eliza-proxy` is dual-worn: the control-plane router (arm-script self-enrollment) AND the internet-facing Railway tunnel proxy (deploy-workflow-minted reusable key). #22617's `eliza-proxy → tag:agent:2138` rule therefore also grants the public proxy L3 reach to every agent.

## Phase 1 (this PR) — coexistence

- **acl.hujson**: `tag:eliza-cp` tagOwner + `eliza-cp → tag:agent:2138` BESIDE the proxy rule. The dst **clones the existing rule verbatim** — this migration narrows the `src` only; re-verifying live `bridge_url` ports is the pre-phase-2 ops check, not a reason to touch the dst here. Stated in-file: during phase 1 the tunnel proxy KEEPS agent reach — unchanged risk vs #22617 alone.
- **arm script**: CP self-enrollment mints/advertises `tag:eliza-cp`. Tunnel-proxy side untouched (`deploy-tunnel-proxy.yml` + its test keep `tag:eliza-proxy` — verified still green).
- **arm test**: the CP tag becomes a locked contract (nothing pinned it), plus two phase-1 invariants: `eliza-cp` has exactly one rule, and its dst must equal the proxy rule's dst until phase 2. Mutation-checked: re-advertising the old tag → 1 red; diverging the cloned dst → 1 red.
- **docs**: README tag table (+`eliza-cp`, +the missing `imessage-gateway` row, stale anchor fixed), terraform CP README (retag-in-place procedure), DEPLOY.md (phase-2 isolation check), cloud/shared `.env.example` (the real per-sandbox port chain).

## Ops runbook (staging, then prod — after merge)

Converge orders ACL-install → headscale-restart → health-gate → enrollment by construction, so the tagOwner is live before any advertise:

1. Dispatch `arm-headscale-control-plane.yml` converge (staging from develop; prod from main once promoted).
2. **Retag in place (primary path)** — a plain converge NEVER retags an already-enrolled router (the script skips existing nodes): on the CP, `sudo headscale nodes tag -i <router-node-id> -t tag:eliza-cp` then `sudo tailscale set --advertise-tags=tag:eliza-cp` (syncs persisted prefs). `delete node + re-arm` is the explicit DR fallback only: hard routing outage for ALL dedicated agents until re-enrollment, and the router gets a new tailnet IP (verified unreferenced in-repo).
3. Verify: CP router reaches `tag:agent:2138` (probes/peers healthy); tunnel proxy still reaches `tag:eliza-tunnel:443`. Do NOT check "tunnel proxy cannot reach agents" — it can, by design, until phase 2.
4. Pre-phase-2: enumerate DISTINCT ports across live `bridge_url`s in both envs' DBs; if anything but 2138 shows up, that is an #22617-rule problem to resolve before removal.

## Phase 2 (separate PR)

Removes `eliza-proxy → tag:agent:2138`. Its body must carry a per-env evidence gate: `headscale nodes list` showing `cp-<env>-router` wearing `tag:eliza-cp` (+ updated tailscaled prefs) for staging AND prod. Acceptance: from the Railway tunnel proxy, no path to any `tag:agent` IP; DEPLOY.md checks pass. Any CP re-armed after phase 2 must use a post-phase-1 checkout.

## Testing

Arm suite 10/10 (8 existing + 2 new pins), tunnel-proxy workflow test 5/5 untouched, biome clean. Read-only change until the converge dispatch — merging this alters no live network.
