### PR TITLE
fix(core): count archived tool calls toward the maxToolCalls budget

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-tool-call-budget.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-tool-call-budget.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `maxToolCalls` must bound the whole turn, not the portion of it that happens
+ * to still be live. Compaction moves settled steps from `trajectory.steps` into
+ * `trajectory.archivedSteps`; counting only the live half restarted the budget
+ * every time compaction ran, so a turn could execute unboundedly many
+ * side-effecting tool calls under a cap the operator had set.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { TrajectoryLimitExceeded } from "../limits";
+import { runPlannerLoop } from "../planner-loop";
+
+describe("tool-call budget across compaction", () => {
+	it("counts archived tool calls toward maxToolCalls", async () => {
+		const MAX = 3;
+		// Bounds the test if the budget fails to fire; without it the loop runs
+		// until the worker dies, which is the pre-fix behaviour.
+		const HARD_STOP = 10;
+		const longPayload = `result: ${"x".repeat(20_000)}`;
+		let plannerCall = 0;
+		const runtime = {
+			redactSecrets: (text: string) => text,
+			useModel: vi.fn(async () => {
+				plannerCall += 1;
+				if (plannerCall > HARD_STOP) {
+					return {
+						text: "",
+						toolCalls: [
+							{ id: "final", name: "REPLY", arguments: { text: "done" } },
+						],
+					};
+				}
+				return {
+					text: "",
+					toolCalls: [
+						{
+							id: `call-${plannerCall}`,
+							name: "GENERATE",
+							arguments: { n: plannerCall },
+						},
+					],
+				};
+			}),
+			logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: longPayload,
+		}));
+
+		let thrown: unknown;
+		try {
+			await runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: {
+					maxToolCalls: MAX,
+					// Isolate the budget under test from the repeat guards.
+					maxRepeatedToolCalls: 50,
+					maxRepeatedFailures: 50,
+					maxTerminalOnlyContinuations: 50,
+					// Force compaction every round: tiny window, keep nothing.
+					contextWindowTokens: 2_000,
+					compactionReserveTokens: 500,
+					compactionKeepSteps: 0,
+				},
+				executeToolCall,
+				evaluate: vi.fn(async () => ({
+					success: true,
+					decision: "CONTINUE" as const,
+					thought: "keep going",
+				})),
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(executeToolCall.mock.calls.length).toBe(MAX);
+		expect(thrown).toBeInstanceOf(TrajectoryLimitExceeded);
+		expect((thrown as TrajectoryLimitExceeded).kind).toBe("tool_calls");
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3178,8 +3178,13 @@ async function executeQueuedToolCall(params: {
 	assertTrajectoryLimit({
 		kind: "tool_calls",
 		max: params.config.maxToolCalls,
+		// Compaction moves settled steps out of `steps` into `archivedSteps`,
+		// so counting only the live half restarts the budget mid-turn. Every
+		// other trajectory-wide read in this file spans both halves.
 		observed:
-			params.trajectory.steps.filter((step) => step.toolCall).length + 1,
+			[...params.trajectory.archivedSteps, ...params.trajectory.steps].filter(
+				(step) => step.toolCall,
+			).length + 1,
 	});
 
 	const streamingContext = getStreamingContext();


### PR DESCRIPTION
# Relates to

`maxToolCalls` stops bounding a turn as soon as compaction runs.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off the current `origin/develop` tip.
- [x] Focused package tests pass on the exact head; the root gate has one pre-existing unrelated failure, documented in the evidence row below rather than claimed green.
- [x] A reviewer can confirm the fix from the failing-before / passing-after test without reading the diff.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5` (diagnosis, fix, tests, verification)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off `origin/develop` at `f43d944af3`; zero conflicts.

# Risks

Low, and in the safe direction: the budget starts being enforced where it previously stopped being enforced. A turn that today runs past `maxToolCalls` because compaction cleared the counter will now terminate at the cap with the same `TrajectoryLimitExceeded(tool_calls)` it would have raised had compaction not run. No other limit, counter or trajectory read changes. `maxToolCalls` defaults to 16 (`runtime/limits.ts:114`), and the loop's other guards are untouched.

# Background

## What does this PR do?

`executeQueuedToolCall` checks the tool-call budget like this (`planner-loop.ts:3180`):

```ts
assertTrajectoryLimit({
	kind: "tool_calls",
	max: params.config.maxToolCalls,
	observed:
		params.trajectory.steps.filter((step) => step.toolCall).length + 1,
});
```

It counts `trajectory.steps` only. But compaction **moves** settled steps out of that array (`planner-loop.ts:2517`):

```ts
args.trajectory.archivedSteps.push(...compactedSteps);
args.trajectory.steps = keptSteps;
```

So every compaction pass shrinks the number the budget is measured against, and the allowance restarts mid-turn. With `compactionKeepSteps: 0` the counter returns to zero each round and the cap never fires at all.

This is the only trajectory-wide read in the file that looks at one half. The other three all span both:

- `planner-loop.ts:3792` — `for (const step of [...trajectory.archivedSteps, ...trajectory.steps])`
- `planner-loop.ts:3843` — `const steps = [...trajectory.archivedSteps, ...trajectory.steps];`
- `planner-loop.ts:3925` — `const steps = [...trajectory.archivedSteps, ...trajectory.steps];`

The file is already explicit that steps move and that state must survive the move — `planner-loop.ts:4063`: *"to `archivedSteps`, and a settled call must stay settled across that move."* The budget is the one place that does not survive it.

The fix makes the count span both halves, matching the three siblings.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Testing

New test: `packages/core/src/runtime/__tests__/planner-loop-tool-call-budget.test.ts`. It drives the real `runPlannerLoop` with `maxToolCalls: 3` and a compaction-forcing config (`contextWindowTokens: 2_000`, `compactionReserveTokens: 500`, `compactionKeepSteps: 0`) plus a 20k-character tool payload, and isolates the budget from the repeat guards so only the limit under test can end the turn.

**Failing before, passing after**, by reverting only the `observed:` expression:

```
# before (develop)
AssertionError: expected 10 to be 3 // Object.is equality
  Tests  1 failed (1)

# after
  Tests  1 passed (1)
```

The `10` is the test's own hard stop, not a natural end: the loop terminated normally with no limit raised. Without that hard stop the run does not terminate — my first attempt at this test killed the vitest worker outright, which is the pre-fix behaviour on an unbounded tool-calling turn.

With the fix, `executeToolCall` is invoked exactly 3 times and the loop ends on `TrajectoryLimitExceeded(tool_calls)`.

Regression suites at this head:

- `bun run --cwd packages/core test src/runtime/limits.test.ts` → **14 passed**
- `bun run --cwd packages/core test src/runtime/__tests__/planner-loop.test.ts` → **127 passed**
- `bun run --cwd packages/core test src/runtime/__tests__/planner-loop-multistep-advance.test.ts` → **3 passed**
- Root `bun run verify` → see the evidence row below.

# Evidence

<!-- evidence-head:51f6773fdff0e73daf71a97a8ec6ca30922b397b -->

<!-- evidence-row:before-screenshots -->
N/A - runtime planner accounting; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
N/A - runtime planner accounting; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI change; the behaviour is proven by the failing-before / passing-after test above.

<!-- evidence-row:backend-logs -->
Focused suite at this head:

```
RESULT maxToolCalls=3 executeToolCall=3 terminatedBy=TrajectoryLimitExceeded(tool_calls)
 ✓ src/runtime/__tests__/planner-loop-tool-call-budget.test.ts (1 test)
      Tests  1 passed (1)
```

Same test with only the `observed:` expression reverted to `params.trajectory.steps`:

```
RESULT maxToolCalls=3 executeToolCall=10 terminatedBy=undefined
AssertionError: expected 10 to be 3 // Object.is equality
      Tests  1 failed (1)
```

Root `bun run verify` at this exact head: **137 successful, 139 total**, one failure — and it is **not this change**:

```
Failed:    @elizaos/ui#lint:check
  @elizaos/ui:lint:check: Found 3 errors.   (duplicate `ApiError` declaration, packages/ui)
```

I checked rather than assuming: stashing this branch's two files and running
`bun run --cwd packages/ui lint:check` on clean `develop@f43d944af3` exits **1** with the identical
`ApiError` redeclaration. It reproduces with zero changes from me, in a package this PR does not
touch. Everything else in the run is green, including every `@elizaos/core` task.

Flagging it rather than ticking the gate as clean. Happy to rebase once that lands if you would
rather see a fully green run first.

# Documentation changes needed?

No. `maxToolCalls` already means what this makes it do.
