### PR TITLE
fix(agent): serialize pending-prompts store mutations against a race

### DIFF
--- a/packages/agent/src/services/pending-prompts/service.test.ts
+++ b/packages/agent/src/services/pending-prompts/service.test.ts
@@ -60,6 +60,77 @@ describe("PendingPromptsService", () => {
     await service.stop();
   });
 
+  it("does not drop a concurrent record() under a raced cache read", async () => {
+    const cache = new Map<string, unknown>();
+    let releaseFirstRead: (() => void) | undefined;
+    const firstReadGate = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    let roomReadCount = 0;
+    const runtime = {
+      agentId: "test-agent",
+      async getCache<T>(key: string): Promise<T | null> {
+        if (key.startsWith("eliza:lifeops:pending-prompts:room:")) {
+          roomReadCount += 1;
+          // Snapshot the value now (as a real round-trip would capture it at
+          // request time), then delay only the response -- so a concurrent
+          // write that lands during the delay is invisible to this read.
+          const snapshot = cache.get(key);
+          if (roomReadCount === 1) {
+            await firstReadGate;
+          }
+          return snapshot === undefined ? null : (snapshot as T);
+        }
+        const value = cache.get(key);
+        return value === undefined ? null : (value as T);
+      },
+      async setCache<T>(key: string, value: T): Promise<boolean> {
+        cache.set(key, value);
+        return true;
+      },
+      async deleteCache(key: string): Promise<boolean> {
+        return cache.delete(key);
+      },
+    } as unknown as IAgentRuntime;
+
+    const service = await PendingPromptsService.start(runtime);
+    const store = service.getStore();
+    const roomId = "room-race";
+    const firedAt = new Date().toISOString();
+
+    // Two concurrent record() calls for the same room: the first's room read
+    // is held open (simulating a slow/interleaved cache round-trip) while the
+    // second's own record() call runs to completion, then the first is
+    // released. Without a lock serializing the read-modify-write, the first
+    // call's stale (pre-second-write) snapshot overwrites the second's entry.
+    const first = store.record({
+      taskId: "task-a",
+      roomId,
+      promptSnippet: "first",
+      firedAt,
+    });
+    const second = store.record({
+      taskId: "task-b",
+      roomId,
+      promptSnippet: "second",
+      firedAt,
+    });
+    // Let second's unblocked read-modify-write chain fully drain (a macrotask
+    // boundary flushes every pending microtask) before releasing first's
+    // gated read.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFirstRead?.();
+    await Promise.all([first, second]);
+
+    const stored = await store.list(roomId);
+    expect(stored.map((entry) => entry.taskId).sort()).toEqual([
+      "task-a",
+      "task-b",
+    ]);
+
+    await service.stop();
+  });
+
   it("lists pending prompts across rooms as canonical pending user actions", async () => {
     const runtime = makeRuntime();
     const service = await PendingPromptsService.start(runtime);

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -22,6 +22,51 @@ type RuntimeCacheLike = Pick<
   "getCache" | "setCache" | "deleteCache"
 >;
 
+/**
+ * Serializes mutating store operations per runtime so a concurrent
+ * read-modify-write (two `record()` calls racing on the same room, for
+ * example) can't read a stale snapshot and clobber the other's write.
+ * `createPendingPromptsStore` builds a fresh store object on every call
+ * (see `PendingPromptsService.getStore()`), so the lock must live outside
+ * any single store instance — keyed by the runtime's cache identity — for
+ * concurrent callers to actually share it.
+ */
+const MUTATION_LOCK_KEY = "mutation";
+type LockRunner = <T>(key: string, task: () => Promise<T>) => Promise<T>;
+const lockRunners = new WeakMap<RuntimeCacheLike, LockRunner>();
+
+function createLockRunner(): LockRunner {
+  const tails = new Map<string, Promise<void>>();
+  return async <T>(key: string, task: () => Promise<T>): Promise<T> => {
+    const previous = tails.get(key);
+    const run = async (): Promise<T> => {
+      if (previous) await previous.catch(() => undefined);
+      return task();
+    };
+    const result = run();
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    tails.set(key, tail);
+    try {
+      return await result;
+    } finally {
+      if (tails.get(key) === tail) {
+        tails.delete(key);
+      }
+    }
+  };
+}
+
+function getLockRunner(cache: RuntimeCacheLike): LockRunner {
+  const existing = lockRunners.get(cache);
+  if (existing) return existing;
+  const created = createLockRunner();
+  lockRunners.set(cache, created);
+  return created;
+}
+
 export type ExpectedReplyKind = "any" | "yes_no" | "approval" | "free_form";
 
 export interface PendingPrompt {
@@ -152,6 +197,7 @@ export function createPendingPromptsStore(
   runtime: IAgentRuntime,
 ): PendingPromptsStore {
   const cache: RuntimeCacheLike = runtime;
+  const withLock = getLockRunner(cache);
 
   const store: PendingPromptsStore = {
     async record(
@@ -189,17 +235,19 @@ export function createPendingPromptsStore(
       if (input.expiresAt !== undefined) {
         recorded.expiresAt = input.expiresAt;
       }
-      const existing = await loadRoom(cache, input.roomId);
-      const filtered = existing.filter(
-        (entry) => entry.taskId !== input.taskId,
-      );
-      filtered.push(recorded);
-      // Bound per-room growth: keep newest N entries (FIFO eviction).
-      const trimmed =
-        filtered.length > PER_ROOM_MAX_PROMPTS
-          ? filtered.slice(-PER_ROOM_MAX_PROMPTS)
-          : filtered;
-      await saveRoom(cache, input.roomId, trimmed);
+      await withLock(MUTATION_LOCK_KEY, async () => {
+        const existing = await loadRoom(cache, input.roomId);
+        const filtered = existing.filter(
+          (entry) => entry.taskId !== input.taskId,
+        );
+        filtered.push(recorded);
+        // Bound per-room growth: keep newest N entries (FIFO eviction).
+        const trimmed =
+          filtered.length > PER_ROOM_MAX_PROMPTS
+            ? filtered.slice(-PER_ROOM_MAX_PROMPTS)
+            : filtered;
+        await saveRoom(cache, input.roomId, trimmed);
+      });
       return recorded;
     },
 
@@ -213,20 +261,23 @@ export function createPendingPromptsStore(
           ? now.getTime() - opts.lookbackMinutes * 60_000
           : null;
 
-      const stored = await loadRoom(cache, roomId);
-      let mutated = false;
-      const live: RecordedPendingPrompt[] = [];
-      for (const entry of stored) {
-        const retainMs = Date.parse(entry.retainUntilIso);
-        if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
-          mutated = true;
-          continue;
+      const live = await withLock(MUTATION_LOCK_KEY, async () => {
+        const stored = await loadRoom(cache, roomId);
+        let mutated = false;
+        const kept: RecordedPendingPrompt[] = [];
+        for (const entry of stored) {
+          const retainMs = Date.parse(entry.retainUntilIso);
+          if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
+            mutated = true;
+            continue;
+          }
+          kept.push(entry);
         }
-        live.push(entry);
-      }
-      if (mutated) {
-        await saveRoom(cache, roomId, live);
-      }
+        if (mutated) {
+          await saveRoom(cache, roomId, kept);
+        }
+        return kept;
+      });
 
       const visible = live.filter((entry) => {
         if (lookbackCutoffMs === null) return true;
@@ -269,42 +320,47 @@ export function createPendingPromptsStore(
     },
 
     async resolve(roomId: string, taskId: string): Promise<void> {
-      const existing = await loadRoom(cache, roomId);
-      const next = existing.filter((entry) => entry.taskId !== taskId);
-      if (next.length === existing.length) {
-        return;
-      }
-      await saveRoom(cache, roomId, next);
-    },
-
-    async forgetTask(taskId: string): Promise<void> {
-      const rooms = await listRooms(cache);
-      for (const roomId of rooms) {
+      await withLock(MUTATION_LOCK_KEY, async () => {
         const existing = await loadRoom(cache, roomId);
         const next = existing.filter((entry) => entry.taskId !== taskId);
         if (next.length !== existing.length) {
           await saveRoom(cache, roomId, next);
         }
-      }
+      });
+    },
+
+    async forgetTask(taskId: string): Promise<void> {
+      await withLock(MUTATION_LOCK_KEY, async () => {
+        const rooms = await listRooms(cache);
+        for (const roomId of rooms) {
+          const existing = await loadRoom(cache, roomId);
+          const next = existing.filter((entry) => entry.taskId !== taskId);
+          if (next.length !== existing.length) {
+            await saveRoom(cache, roomId, next);
+          }
+        }
+      });
     },
 
     async clearAll(): Promise<void> {
-      const rooms = await listRooms(cache);
-      for (const roomId of rooms) {
-        if (typeof cache.deleteCache === "function") {
-          await cache.deleteCache(roomCacheKey(roomId));
-        } else {
-          await cache.setCache<RecordedPendingPrompt[]>(
-            roomCacheKey(roomId),
-            [],
-          );
+      await withLock(MUTATION_LOCK_KEY, async () => {
+        const rooms = await listRooms(cache);
+        for (const roomId of rooms) {
+          if (typeof cache.deleteCache === "function") {
+            await cache.deleteCache(roomCacheKey(roomId));
+          } else {
+            await cache.setCache<RecordedPendingPrompt[]>(
+              roomCacheKey(roomId),
+              [],
+            );
+          }
         }
-      }
-      if (typeof cache.deleteCache === "function") {
-        await cache.deleteCache(ROOM_INDEX_KEY);
-      } else {
-        await cache.setCache<string[]>(ROOM_INDEX_KEY, []);
-      }
+        if (typeof cache.deleteCache === "function") {
+          await cache.deleteCache(ROOM_INDEX_KEY);
+        } else {
+          await cache.setCache<string[]>(ROOM_INDEX_KEY, []);
+        }
+      });
     },
   };
   return store;


### PR DESCRIPTION
## What's wrong

Every mutating `PendingPromptsStore` method (`record`, `list`'s expiry cleanup, `resolve`, `forgetTask`, `clearAll`) followed the same read-modify-write shape: load the room's entries from the runtime cache, derive a new array, then write it back — with no atomicity between the read and the write. Two concurrent calls touching the same room (e.g. two scheduled tasks firing into the same room close together, or a `record()` racing `list()`'s cleanup) can both read the same snapshot; whichever call's write lands last overwrites the other's entirely, silently dropping the other prompt.

`PendingPromptsService.getStore()` also builds a brand-new store object on every call (it is not memoized), so a lock scoped to a single store instance would not help — concurrent callers routinely go through different store objects backed by the same runtime cache.

## Fix

A small per-cache mutation lock (`WeakMap<cache, LockRunner>`, keyed by runtime cache identity so it's shared across store instances) serializing every mutating method's read-modify-write span through a single `"mutation"` key. Read-only access (`list()`'s non-mutating visibility filtering) is unaffected.

## Verification

- New test: `does not drop a concurrent record() under a raced cache read` — fires two concurrent `record()` calls for the same room with the first's cache read held open (its response snapshotted at request time, matching how a real round-trip would race, then delayed) until after the second call's full read-modify-write has completed; asserts both entries survive.
- Full suite: 6/6 passing in the pending-prompts package tests.
- **Mutation resistance**: reverted the source fix only, re-ran the new test — failed exactly as predicted (only the first call's entry survived, the second was silently dropped). Reapplied the fix and reconfirmed 6/6 passing.
- `biome check` clean on both changed files.
- `packages/agent` has pre-existing unrelated `tsc` errors (missing optional plugin modules, `@elizaos/cloud-routing`, a duplicate-import in `packages/ui`) confirmed identical on a clean checkout before this change; none reference the changed files.

## Attribution

Bug found by gpt-5.6-sol (via Codex) during an independent `packages/agent` audit for TOCTOU races. The lock's cross-instance sharing design (accounting for `getStore()` building a fresh store per call), regression test, and full verification completed by Claude Code (claude-sonnet-5) after Codex's sandbox could not write to `.git` in this worktree.