### PR TITLE
fix(cloud): enforce fail-closed MONEY rate-limit policy

### DIFF
--- a/packages/cloud/api/__tests__/auto-top-up-cutover-routes.test.ts
+++ b/packages/cloud/api/__tests__/auto-top-up-cutover-routes.test.ts
@@ -115,6 +115,14 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
     rateLimitConfigs.push(config);
     return async (_context: unknown, next: () => Promise<void>) => next();
   },
+  moneyRateLimit: (config: Record<string, unknown>) => {
+    rateLimitConfigs.push({
+      ...config,
+      failClosed: true,
+      localLease: false,
+    });
+    return async (_context: unknown, next: () => Promise<void>) => next();
+  },
 }));
 
 const executeAutoTopUpForOrganization = mock(
@@ -263,11 +271,12 @@ beforeEach(() => {
 });
 
 describe("manual durable auto-top-up route", () => {
-  test("uses STRICT fail-closed limiting", () => {
+  test("uses STRICT fail-closed MONEY limiting", () => {
     expect(rateLimitConfigs).toHaveLength(1);
     expect(rateLimitConfigs[0]).toMatchObject({
       ...STRICT_RATE_LIMIT,
       failClosed: true,
+      localLease: false,
     });
   });
 

--- a/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
+++ b/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
@@ -119,6 +119,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 const { default: balanceApp } = await import("../v1/credits/balance/route");

--- a/packages/cloud/api/__tests__/crypto-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/crypto-webhook-route.test.ts
@@ -33,6 +33,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 mock.module("@/lib/services/crypto-payments", () => ({

--- a/packages/cloud/api/__tests__/money-rate-limit-inventory.test.ts
+++ b/packages/cloud/api/__tests__/money-rate-limit-inventory.test.ts
@@ -39,6 +39,9 @@ const MONEY_MUTATION_ROUTES = [
   "v1/earnings/payout/stripe-connect/transfer/route.ts",
   "v1/earnings/payout/stripe-connect/webhook/route.ts",
   "v1/oxapay/webhook/route.ts",
+  "v1/payment-requests/[id]/cancel/route.ts",
+  "v1/payment-requests/[id]/expire/route.ts",
+  "v1/payment-requests/route.ts",
   "v1/redemptions/route.ts",
   "v1/stripe/checkout/route.ts",
   "v1/stripe/webhook/route.ts",
@@ -73,9 +76,17 @@ const MONEY_PATH_MARKERS = [
   `${path.sep}credits${path.sep}checkout${path.sep}`,
   `${path.sep}credits${path.sep}verify${path.sep}`,
   `${path.sep}app-credits${path.sep}`,
+  `${path.sep}payment-requests${path.sep}`,
 ];
 
-const SKIP_DIRS = new Set(["node_modules", "dist", "coverage", ".turbo"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "coverage",
+  ".turbo",
+  "test",
+  ".wrangler-dry-run",
+]);
 
 function walkRouteFiles(dir: string): string[] {
   const out: string[] = [];
@@ -126,4 +137,19 @@ describe("money mutation rate-limit inventory (#22982)", () => {
       expect(listed.has(relative), relative).toBe(true);
     }
   });
+
+  test("payment-request mutations cannot stay unmarked or fall-open", () => {
+    const listed = new Set<string>(MONEY_MUTATION_ROUTES);
+
+    for (const file of walkRouteFiles(apiRoot)) {
+      const relative = posixFromApi(file);
+      if (relative === "cron" || relative.startsWith("cron/")) continue;
+      const source = readFileSync(file, "utf8");
+      if (!source.includes("getPaymentRequestsService")) continue;
+      const mutates = /\.(post|put|patch|delete)\(/.test(source);
+      if (!mutates) continue;
+      expect(listed.has(relative), relative).toBe(true);
+      expect(source, relative).toContain("moneyRateLimit(");
+    }
+  }, 30_000);
 });

--- a/packages/cloud/api/__tests__/money-rate-limit-inventory.test.ts
+++ b/packages/cloud/api/__tests__/money-rate-limit-inventory.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Checked-in inventory so a new money mutation cannot silently use a bare
+ * RateLimitPresets helper (#22982).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const apiRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const MONEY_MUTATION_ROUTES = [
+  "admin/redemptions/route.ts",
+  "auto-top-up/trigger/route.ts",
+  "billing/checkout/verify/route.ts",
+  "crypto/direct-payments/[id]/attach-tx/route.ts",
+  "crypto/direct-payments/[id]/confirm/route.ts",
+  "crypto/direct-payments/route.ts",
+  "crypto/payments/[id]/confirm/route.ts",
+  "crypto/payments/route.ts",
+  "crypto/webhook/route.ts",
+  "stripe/create-checkout-session/route.ts",
+  "stripe/webhook/route.ts",
+  "v1/app-credits/checkout/route.ts",
+  "v1/app-credits/verify/route.ts",
+  "v1/apps/[id]/charges/[chargeId]/checkout/route.ts",
+  "v1/apps/[id]/charges/route.ts",
+  "v1/apps/[id]/domains/buy/route.ts",
+  "v1/apps/[id]/earnings/withdraw/route.ts",
+  "v1/billing/resources/[id]/cancel/route.ts",
+  "v1/billing/settings/route.ts",
+  "v1/credits/checkout/route.ts",
+  "v1/credits/verify/route.ts",
+  "v1/earnings/payout/stripe-connect/onboard/route.ts",
+  "v1/earnings/payout/stripe-connect/transfer/route.ts",
+  "v1/earnings/payout/stripe-connect/webhook/route.ts",
+  "v1/oxapay/webhook/route.ts",
+  "v1/redemptions/route.ts",
+  "v1/stripe/checkout/route.ts",
+  "v1/stripe/webhook/route.ts",
+  "v1/topup/10/route.ts",
+  "v1/topup/50/route.ts",
+  "v1/topup/100/route.ts",
+  "v1/x402/requests/[id]/settle/route.ts",
+  "v1/x402/requests/route.ts",
+  "v1/x402/settle/route.ts",
+  "v1/x402/verify/route.ts",
+] as const;
+
+const MONEY_PATH_MARKERS = [
+  `${path.sep}auto-top-up${path.sep}`,
+  `${path.sep}oxapay${path.sep}webhook${path.sep}`,
+  `${path.sep}stripe${path.sep}webhook${path.sep}`,
+  `${path.sep}stripe${path.sep}create-checkout-session${path.sep}`,
+  `${path.sep}stripe${path.sep}checkout${path.sep}`,
+  `${path.sep}crypto${path.sep}webhook${path.sep}`,
+  `${path.sep}crypto${path.sep}payments${path.sep}`,
+  `${path.sep}crypto${path.sep}direct-payments${path.sep}`,
+  `${path.sep}x402${path.sep}`,
+  `${path.sep}topup${path.sep}`,
+  `${path.sep}redemptions${path.sep}`,
+  `${path.sep}checkout${path.sep}`,
+  `${path.sep}charges${path.sep}`,
+  `${path.sep}withdraw${path.sep}`,
+  `${path.sep}payout${path.sep}`,
+  `${path.sep}domains${path.sep}buy${path.sep}`,
+  `${path.sep}billing${path.sep}settings${path.sep}`,
+  `${path.sep}billing${path.sep}resources${path.sep}`,
+  `${path.sep}credits${path.sep}checkout${path.sep}`,
+  `${path.sep}credits${path.sep}verify${path.sep}`,
+  `${path.sep}app-credits${path.sep}`,
+];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "coverage", ".turbo"]);
+
+function walkRouteFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) out.push(...walkRouteFiles(full));
+    else if (entry === "route.ts") out.push(full);
+  }
+  return out;
+}
+
+function posixFromApi(file: string): string {
+  return path.relative(apiRoot, file).split(path.sep).join("/");
+}
+
+describe("money mutation rate-limit inventory (#22982)", () => {
+  test("every inventoried money mutation mounts moneyRateLimit", () => {
+    expect(new Set(MONEY_MUTATION_ROUTES).size).toBe(
+      MONEY_MUTATION_ROUTES.length,
+    );
+
+    for (const relative of MONEY_MUTATION_ROUTES) {
+      const source = readFileSync(path.join(apiRoot, relative), "utf8");
+      expect(source, relative).toContain("moneyRateLimit(");
+      expect(source, relative).not.toContain("redisUnavailableFallback");
+    }
+  });
+
+  test("money-path mutation routes cannot silently use a bare preset", () => {
+    const listed = new Set<string>(MONEY_MUTATION_ROUTES);
+    const discovered: string[] = [];
+
+    for (const file of walkRouteFiles(apiRoot)) {
+      const relative = posixFromApi(file);
+      const marked = MONEY_PATH_MARKERS.some((marker) => file.includes(marker));
+      if (!marked) continue;
+      if (relative === "cron" || relative.startsWith("cron/")) continue;
+      const source = readFileSync(file, "utf8");
+      const mutates = /\.(post|put|patch|delete)\(/.test(source);
+      if (!mutates) continue;
+      discovered.push(relative);
+      expect(source, relative).toContain("moneyRateLimit(");
+    }
+
+    for (const relative of discovered) {
+      expect(listed.has(relative), relative).toBe(true);
+    }
+  });
+});

--- a/packages/cloud/api/__tests__/oxapay-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/oxapay-webhook-route.test.ts
@@ -97,6 +97,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 const { createOxaPayWebhookApp } = await import("../v1/oxapay/webhook/route");

--- a/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
+++ b/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
@@ -20,6 +20,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 mock.module("@/lib/services/payout-status", () => ({

--- a/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
@@ -52,6 +52,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { CRITICAL: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 const getBalance = mock();

--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -57,6 +57,12 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: {} },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+
 const { default: app } = await import(
   "../v1/earnings/payout/stripe-connect/webhook/route"
 );

--- a/packages/cloud/api/__tests__/stripe-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-webhook-route.test.ts
@@ -45,6 +45,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 mock.module("@/lib/queue/redis-queue", () => ({

--- a/packages/cloud/api/admin/redemptions/route.json.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.json.test.ts
@@ -17,6 +17,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {}, STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 mock.module("@/lib/services/token-redemption-secure", () => ({
   secureTokenRedemptionService: { approveRedemption },

--- a/packages/cloud/api/admin/redemptions/route.network.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.network.test.ts
@@ -67,6 +67,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {}, STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>

--- a/packages/cloud/api/admin/redemptions/route.status.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.status.test.ts
@@ -23,6 +23,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {}, STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -13,6 +13,7 @@ import {
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAdmin } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -210,7 +211,7 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   }
 });
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const { user: adminUser } = await requireAdmin(c);
     const decodedBody = await decodeRequestJson(c.req);

--- a/packages/cloud/api/auto-top-up/trigger/route.ts
+++ b/packages/cloud/api/auto-top-up/trigger/route.ts
@@ -7,8 +7,8 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { autoTopUpService } from "@/lib/services/auto-top-up";
 import { logger } from "@/lib/utils/logger";
@@ -16,13 +16,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use(
-  "*",
-  rateLimit({
-    ...RateLimitPresets.STRICT,
-    failClosed: true,
-  }),
-);
+app.use("*", moneyRateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
@@ -95,6 +95,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: {

--- a/packages/cloud/api/billing/checkout/verify/route.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.test.ts
@@ -156,6 +156,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 const { default: app } = await import("./route");

--- a/packages/cloud/api/billing/checkout/verify/route.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.ts
@@ -22,8 +22,8 @@ import {
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { safeFetch } from "@/lib/security/safe-fetch";
 import { invoicesService } from "@/lib/services/invoices";
@@ -43,7 +43,7 @@ const VerifyBody = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/crypto/direct-payments/[id]/attach-tx/route.ts
+++ b/packages/cloud/api/crypto/direct-payments/[id]/attach-tx/route.ts
@@ -16,8 +16,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { directWalletPaymentsService } from "@/lib/services/direct-wallet-payments";
 import { logger, redact } from "@/lib/utils/logger";
@@ -39,7 +39,7 @@ const bodySchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const id = c.req.param("id") ?? "";

--- a/packages/cloud/api/crypto/direct-payments/[id]/confirm/route.ts
+++ b/packages/cloud/api/crypto/direct-payments/[id]/confirm/route.ts
@@ -10,8 +10,8 @@ import { cryptoPaymentsRepository } from "@/db/repositories/crypto-payments";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { directWalletPaymentsService } from "@/lib/services/direct-wallet-payments";
 import { logger, redact } from "@/lib/utils/logger";
@@ -27,7 +27,7 @@ const confirmSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const id = c.req.param("id") ?? "";

--- a/packages/cloud/api/crypto/direct-payments/route.ts
+++ b/packages/cloud/api/crypto/direct-payments/route.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -36,7 +37,7 @@ app.get("/config", rateLimit(RateLimitPresets.STANDARD), (c) => {
   return c.json(directWalletPaymentsService.getConfig(c.env));
 });
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     // Wallet is NOT required on the account — OAuth-only users (Google /

--- a/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
+++ b/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
@@ -13,8 +13,8 @@ import { cryptoPaymentsRepository } from "@/db/repositories/crypto-payments";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { cryptoPaymentsService } from "@/lib/services/crypto-payments";
 import { logger, redact } from "@/lib/utils/logger";
@@ -49,7 +49,7 @@ const confirmSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   const ip =
     c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
     c.req.header("x-real-ip") ||

--- a/packages/cloud/api/crypto/payments/route.ts
+++ b/packages/cloud/api/crypto/payments/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/auth/workers-hono-auth";
 import { SUPPORTED_PAY_CURRENCIES } from "@/lib/config/crypto";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -40,7 +41,7 @@ const createPaymentSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserWithOrg(c);
 

--- a/packages/cloud/api/crypto/webhook/route.ts
+++ b/packages/cloud/api/crypto/webhook/route.ts
@@ -17,8 +17,8 @@ import {
   validateWebhookTimestamp,
 } from "@/lib/config/crypto";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { cryptoPaymentsService } from "@/lib/services/crypto-payments";
 import { isOxaPayConfigured } from "@/lib/services/oxapay";
@@ -117,7 +117,7 @@ async function rollbackClaimedWebhookEvent(eventId: string): Promise<void> {
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
   const ip = getClientIp(c);
   const allowedIps = getWebhookAllowedIps(c.env);
 

--- a/packages/cloud/api/stripe/create-checkout-session/route.test.ts
+++ b/packages/cloud/api/stripe/create-checkout-session/route.test.ts
@@ -62,6 +62,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 mock.module("@/lib/services/credits", () => ({
   creditsService: { getCreditPackById },

--- a/packages/cloud/api/stripe/create-checkout-session/route.ts
+++ b/packages/cloud/api/stripe/create-checkout-session/route.ts
@@ -12,8 +12,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { creditsService } from "@/lib/services/credits";
 import { stripeCheckoutOrdersService } from "@/lib/services/stripe-checkout-orders";
@@ -49,7 +49,7 @@ const checkoutRequestSchema = z
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserWithOrg(c);
 

--- a/packages/cloud/api/stripe/webhook/route.ts
+++ b/packages/cloud/api/stripe/webhook/route.ts
@@ -5,8 +5,8 @@ import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleto
 import type { StripeEventMessage } from "@/api-queue/types";
 import { webhookEventsRepository } from "@/db/repositories/webhook-events";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { enqueue } from "@/lib/queue/redis-queue";
 import { isStripeConfigured, requireStripe } from "@/lib/stripe";
@@ -202,7 +202,7 @@ async function handleStripeWebhook(c: AppContext): Promise<Response> {
 }
 
 const app = new Hono<AppEnv>();
-app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), (c) =>
+app.post("/", moneyRateLimit(RateLimitPresets.AGGRESSIVE), (c) =>
   handleStripeWebhook(c),
 );
 export default app;

--- a/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
+++ b/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
@@ -37,6 +37,12 @@ mock.module("@/lib/security/redirect-validation", () => ({
   assertAllowedAbsoluteRedirectUrl: (url: string) => new URL(url),
 }));
 
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+
 mock.module("@/lib/utils/logger", () => ({
   logger: { info: () => undefined, error: () => undefined },
 }));

--- a/packages/cloud/api/v1/app-credits/checkout/route.ts
+++ b/packages/cloud/api/v1/app-credits/checkout/route.ts
@@ -10,6 +10,10 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
+  RateLimitPresets,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import {
   assertAllowedAbsoluteRedirectUrl,
   getDefaultPlatformRedirectOrigins,
 } from "@/lib/security/redirect-validation";
@@ -28,7 +32,7 @@ const CheckoutSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 

--- a/packages/cloud/api/v1/app-credits/verify/route.ts
+++ b/packages/cloud/api/v1/app-credits/verify/route.ts
@@ -10,12 +10,18 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import {
+  moneyRateLimit,
+  RateLimitPresets,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { requireStripe } from "@/lib/stripe";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/checkout/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/checkout/route.ts
@@ -9,8 +9,8 @@ import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { SUPPORTED_PAY_CURRENCIES } from "@/lib/config/crypto";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { appChargeRequestsService } from "@/lib/services/app-charge-requests";
 import { logger } from "@/lib/utils/logger";
@@ -29,7 +29,7 @@ const CheckoutSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use("*", moneyRateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/apps/[id]/charges/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/route.ts
@@ -12,6 +12,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -44,9 +45,7 @@ const CreateChargeSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
-
-app.post("/", async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
@@ -94,7 +93,7 @@ app.post("/", async (c) => {
   }
 });
 
-app.get("/", async (c) => {
+app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.json.test.ts
@@ -50,6 +50,8 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
     CRITICAL: {},
   },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 mock.module("@/lib/auth/app-key-scope", () => ({

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -17,8 +17,8 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
@@ -54,11 +54,7 @@ const app = new Hono<AppEnv>();
 // A domain registration spends credits and commits an external purchase. If
 // the shared limiter is unavailable, reject before route authentication and
 // before any idempotency, ledger, registrar, persistence, or DNS side effect.
-const domainBuyRateLimit = rateLimit({
-  ...RateLimitPresets.CRITICAL,
-  failClosed: true,
-  localLease: false,
-});
+const domainBuyRateLimit = moneyRateLimit(RateLimitPresets.CRITICAL);
 
 app.post("/", domainBuyRateLimit, async (c) => {
   try {

--- a/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
@@ -10,8 +10,8 @@ import {
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { appEarningsService } from "@/lib/services/app-earnings";
 import { appsService } from "@/lib/services/apps";
@@ -203,7 +203,7 @@ async function handlePOST(
 
 const ROUTE_PARAM_SPEC = [{ name: "id", splat: false }] as const;
 const honoRouter = new Hono<AppEnv>();
-honoRouter.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
+honoRouter.post("/", moneyRateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     return await handlePOST(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {

--- a/packages/cloud/api/v1/billing/resources/[id]/cancel/route.ts
+++ b/packages/cloud/api/v1/billing/resources/[id]/cancel/route.ts
@@ -8,8 +8,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   activeBillingService,
@@ -25,7 +25,7 @@ const CancelSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/billing/settings/route.json.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.json.test.ts
@@ -40,6 +40,8 @@ mock.module("@/lib/services/auto-top-up", () => ({
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: { windowMs: 60_000, maxRequests: 100 } },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/billing/settings/route.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.test.ts
@@ -60,6 +60,14 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
     rateLimitConfigs.push(config);
     return async (_context: unknown, next: () => Promise<void>) => next();
   },
+  moneyRateLimit: (config: Record<string, unknown>) => {
+    rateLimitConfigs.push({
+      ...config,
+      failClosed: true,
+      localLease: false,
+    });
+    return async (_context: unknown, next: () => Promise<void>) => next();
+  },
 }));
 
 mock.module("@/lib/utils/logger", () => ({
@@ -93,10 +101,10 @@ beforeEach(() => {
 });
 
 describe("billing settings cutover safety", () => {
-  test("keeps GET standard and makes PUT standard fail-closed", () => {
+  test("keeps GET standard and makes PUT the shared MONEY fail-closed policy", () => {
     expect(rateLimitConfigs).toEqual([
       STANDARD_RATE_LIMIT,
-      { ...STANDARD_RATE_LIMIT, failClosed: true },
+      { ...STANDARD_RATE_LIMIT, failClosed: true, localLease: false },
     ]);
   });
 

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -15,6 +15,7 @@ import { organizationsRepository } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -81,117 +82,113 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   }
 });
 
-app.put(
-  "/",
-  rateLimit({ ...RateLimitPresets.STANDARD, failClosed: true }),
-  async (c) => {
-    try {
-      const user = await requireUserOrApiKeyWithOrg(c);
+app.put("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
+  try {
+    const user = await requireUserOrApiKeyWithOrg(c);
 
-      const decodedBody = await decodeRequestJson(c.req);
-      if (!decodedBody.ok) {
-        // error-policy:J3 malformed JSON is an explicit invalid request.
-        return c.json({ error: "Invalid JSON body" }, 400);
-      }
-      const body = decodedBody.value;
-      const validation = UpdateSettingsSchema.safeParse(body);
-
-      if (!validation.success) {
-        return c.json(
-          {
-            success: false,
-            error: "Invalid request data",
-            details: validation.error.format(),
-          },
-          400,
-        );
-      }
-
-      const { autoTopUp, payAsYouGoFromEarnings } = validation.data;
-
-      if (autoTopUp) {
-        try {
-          await autoTopUpService.updateSettings(user.organization_id, {
-            enabled: autoTopUp.enabled,
-            amount: autoTopUp.amount,
-            threshold: autoTopUp.threshold,
-          });
-        } catch (err) {
-          if (err instanceof AutoTopUpSettingsValidationError) {
-            return c.json(
-              {
-                success: false,
-                error:
-                  "Valid auto top-up values are required to replace corrupt settings.",
-                code: "validation_error" as const,
-              },
-              400,
-            );
-          }
-          // Allow domain-specific validation messages through (e.g. "Cannot
-          // enable auto-top-up without a payment method") — they don't leak
-          // internals.
-          const message = err instanceof Error ? err.message : "";
-          const isValidationError =
-            message.includes("Cannot enable") ||
-            message.includes("must be") ||
-            message.includes("cannot exceed");
-          if (isValidationError) {
-            return c.json(
-              {
-                success: false,
-                error: message,
-                code: "validation_error" as const,
-              },
-              400,
-            );
-          }
-          throw err;
-        }
-
-        logger.info("[Billing Settings API] Updated auto-top-up settings", {
-          organizationId: user.organization_id,
-          userId: user.id,
-          settings: autoTopUp,
-        });
-      }
-
-      if (payAsYouGoFromEarnings !== undefined) {
-        await organizationsRepository.update(user.organization_id, {
-          pay_as_you_go_from_earnings: payAsYouGoFromEarnings,
-          updated_at: new Date(),
-        });
-
-        logger.info("[Billing Settings API] Updated pay-as-you-go toggle", {
-          organizationId: user.organization_id,
-          userId: user.id,
-          enabled: payAsYouGoFromEarnings,
-        });
-      }
-
-      const [updatedSettings, org] = await Promise.all([
-        autoTopUpService.getSettings(user.organization_id),
-        organizationsRepository.findById(user.organization_id),
-      ]);
-
-      return c.json({
-        success: true,
-        message: "Billing settings updated successfully",
-        settings: {
-          autoTopUp: {
-            enabled: updatedSettings.enabled,
-            amount: updatedSettings.amount,
-            threshold: updatedSettings.threshold,
-            hasPaymentMethod: updatedSettings.hasPaymentMethod,
-          },
-          payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
-        },
-      });
-    } catch (error) {
-      logger.error("[Billing Settings API] Error updating settings:", error);
-      return failureResponse(c, error);
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is an explicit invalid request.
+      return c.json({ error: "Invalid JSON body" }, 400);
     }
-  },
-);
+    const body = decodedBody.value;
+    const validation = UpdateSettingsSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json(
+        {
+          success: false,
+          error: "Invalid request data",
+          details: validation.error.format(),
+        },
+        400,
+      );
+    }
+
+    const { autoTopUp, payAsYouGoFromEarnings } = validation.data;
+
+    if (autoTopUp) {
+      try {
+        await autoTopUpService.updateSettings(user.organization_id, {
+          enabled: autoTopUp.enabled,
+          amount: autoTopUp.amount,
+          threshold: autoTopUp.threshold,
+        });
+      } catch (err) {
+        if (err instanceof AutoTopUpSettingsValidationError) {
+          return c.json(
+            {
+              success: false,
+              error:
+                "Valid auto top-up values are required to replace corrupt settings.",
+              code: "validation_error" as const,
+            },
+            400,
+          );
+        }
+        // Allow domain-specific validation messages through (e.g. "Cannot
+        // enable auto-top-up without a payment method") — they don't leak
+        // internals.
+        const message = err instanceof Error ? err.message : "";
+        const isValidationError =
+          message.includes("Cannot enable") ||
+          message.includes("must be") ||
+          message.includes("cannot exceed");
+        if (isValidationError) {
+          return c.json(
+            {
+              success: false,
+              error: message,
+              code: "validation_error" as const,
+            },
+            400,
+          );
+        }
+        throw err;
+      }
+
+      logger.info("[Billing Settings API] Updated auto-top-up settings", {
+        organizationId: user.organization_id,
+        userId: user.id,
+        settings: autoTopUp,
+      });
+    }
+
+    if (payAsYouGoFromEarnings !== undefined) {
+      await organizationsRepository.update(user.organization_id, {
+        pay_as_you_go_from_earnings: payAsYouGoFromEarnings,
+        updated_at: new Date(),
+      });
+
+      logger.info("[Billing Settings API] Updated pay-as-you-go toggle", {
+        organizationId: user.organization_id,
+        userId: user.id,
+        enabled: payAsYouGoFromEarnings,
+      });
+    }
+
+    const [updatedSettings, org] = await Promise.all([
+      autoTopUpService.getSettings(user.organization_id),
+      organizationsRepository.findById(user.organization_id),
+    ]);
+
+    return c.json({
+      success: true,
+      message: "Billing settings updated successfully",
+      settings: {
+        autoTopUp: {
+          enabled: updatedSettings.enabled,
+          amount: updatedSettings.amount,
+          threshold: updatedSettings.threshold,
+          hasPaymentMethod: updatedSettings.hasPaymentMethod,
+        },
+        payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
+      },
+    });
+  } catch (error) {
+    logger.error("[Billing Settings API] Error updating settings:", error);
+    return failureResponse(c, error);
+  }
+});
 
 export default app;

--- a/packages/cloud/api/v1/credits/checkout/route.json.test.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.json.test.ts
@@ -51,6 +51,8 @@ mock.module("@/lib/stripe", () => ({
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/credits/checkout/route.test.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.test.ts
@@ -152,6 +152,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 const { default: app } = await import("./route");

--- a/packages/cloud/api/v1/credits/checkout/route.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.ts
@@ -17,8 +17,8 @@ import {
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   assertAllowedAbsoluteRedirectUrl,
@@ -41,7 +41,7 @@ const CheckoutSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/credits/verify/route.test.ts
+++ b/packages/cloud/api/v1/credits/verify/route.test.ts
@@ -38,6 +38,8 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 mock.module("@/lib/services/stripe-checkout-orders", () => ({
   StripeCheckoutAuthorityError: class extends Error {

--- a/packages/cloud/api/v1/credits/verify/route.ts
+++ b/packages/cloud/api/v1/credits/verify/route.ts
@@ -8,8 +8,8 @@ import type Stripe from "stripe";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   StripeCheckoutAuthorityError,
@@ -21,7 +21,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/onboard/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/onboard/route.ts
@@ -7,8 +7,8 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { nextJsonFromCaughtError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { requireStripe } from "@/lib/stripe";
 import { logger } from "@/lib/utils/logger";
@@ -85,7 +85,7 @@ async function handlePOST(request: Request) {
 }
 
 const honoRouter = new Hono<AppEnv>();
-honoRouter.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
+honoRouter.post("/", moneyRateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     return await handlePOST(c.req.raw);
   } catch (error) {

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
@@ -6,8 +6,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAdmin } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { redeemableEarningsService } from "@/lib/services/redeemable-earnings";
 import { requireStripe } from "@/lib/stripe";
@@ -234,7 +234,7 @@ async function handleTransfer(c: AppContext) {
 }
 
 const honoRouter = new Hono<AppEnv>();
-honoRouter.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
+honoRouter.post("/", moneyRateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     return await handleTransfer(c);
   } catch (error) {

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
@@ -66,6 +66,12 @@ mock.module("@elizaos/cloud-shared/lib/services/stripe-connect-payout", () => ({
 mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
   getAuditDispatcher: () => ({ emit: async () => undefined }),
 }));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: {} },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: mock(() => undefined),

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -6,6 +6,10 @@ import { Hono } from "hono";
 import type Stripe from "stripe";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import {
+  moneyRateLimit,
+  RateLimitPresets,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { isStripeConfigured, requireStripe } from "@/lib/stripe";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -169,7 +173,7 @@ async function handlePOST(c: AppContext): Promise<Response> {
 }
 
 const honoRouter = new Hono<AppEnv>();
-honoRouter.post("/", async (c) => {
+honoRouter.post("/", moneyRateLimit(RateLimitPresets.AGGRESSIVE), async (c) => {
   try {
     return await handlePOST(c);
   } catch (error) {

--- a/packages/cloud/api/v1/oxapay/webhook/route.ts
+++ b/packages/cloud/api/v1/oxapay/webhook/route.ts
@@ -17,8 +17,8 @@
 
 import { Hono } from "hono";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { OxaPayApiError } from "@/lib/services/oxapay";
 import { createOxaPayPaymentAdapter } from "@/lib/services/payment-adapters/oxapay";
@@ -71,7 +71,7 @@ export function createOxaPayWebhookApp(
 ): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
-  app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), async (c) => {
+  app.post("/", moneyRateLimit(RateLimitPresets.AGGRESSIVE), async (c) => {
     const ip = getClientIp(c);
     const allowedIps = getWebhookAllowedIps(c.env);
     if (allowedIps.length > 0 && !allowedIps.includes(ip)) {

--- a/packages/cloud/api/v1/payment-requests/[id]/cancel/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/cancel/route.ts
@@ -9,8 +9,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
@@ -22,7 +22,7 @@ const CancelSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
@@ -13,8 +13,8 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
@@ -22,7 +22,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", moneyRateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/payment-requests/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.test.ts
@@ -35,6 +35,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
     await next();
   },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/payment-requests/route.ts
+++ b/packages/cloud/api/v1/payment-requests/route.ts
@@ -17,6 +17,7 @@ import { MAX_PAYMENT_REQUEST_LEDGER_CENTS } from "@/db/schemas/payment-requests"
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -77,8 +78,6 @@ const ListQuerySchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
-
 function paymentContext(value: z.infer<typeof PaymentContextSchema>) {
   return { kind: value } as const;
 }
@@ -97,7 +96,7 @@ function paymentMetadata(input: z.infer<typeof CreatePaymentRequestSchema>) {
   };
 }
 
-app.post("/", async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
@@ -155,7 +154,7 @@ app.post("/", async (c) => {
   }
 });
 
-app.get("/", async (c) => {
+app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 

--- a/packages/cloud/api/v1/redemptions/route.ts
+++ b/packages/cloud/api/v1/redemptions/route.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -68,7 +69,7 @@ app.options(
     }),
 );
 
-app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     if (c.env.REDEMPTION_EMERGENCY_PAUSE === "true") {
       logger.warn(

--- a/packages/cloud/api/v1/stripe/checkout/route.ts
+++ b/packages/cloud/api/v1/stripe/checkout/route.ts
@@ -15,8 +15,8 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { stripePaymentAdapter } from "@/lib/services/payment-adapters/stripe";
 import type { PaymentRequestRow } from "@/lib/services/payment-requests";
@@ -32,7 +32,7 @@ const CheckoutSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use("*", moneyRateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/stripe/webhook/route.ts
+++ b/packages/cloud/api/v1/stripe/webhook/route.ts
@@ -12,8 +12,8 @@
 
 import { Hono } from "hono";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { stripePaymentAdapter } from "@/lib/services/payment-adapters/stripe";
 import { paymentCallbackBus } from "@/lib/services/payment-callback-bus";
@@ -28,7 +28,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.AGGRESSIVE), async (c) => {
   const rawBody = await c.req.text();
   const signature = c.req.header("stripe-signature") ?? null;
 

--- a/packages/cloud/api/v1/topup/10/route.ts
+++ b/packages/cloud/api/v1/topup/10/route.ts
@@ -9,8 +9,8 @@ import { Hono } from "hono";
 
 import {
   getIpKey,
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -26,10 +26,9 @@ const topup = createTopupHandler({
 // Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
 // even during a Redis blip (M11).
 app.use(
-  rateLimit({
+  moneyRateLimit({
     ...RateLimitPresets.STRICT,
     keyGenerator: getIpKey,
-    failClosed: true,
   }),
 );
 

--- a/packages/cloud/api/v1/topup/100/route.ts
+++ b/packages/cloud/api/v1/topup/100/route.ts
@@ -9,8 +9,8 @@ import { Hono } from "hono";
 
 import {
   getIpKey,
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -26,10 +26,9 @@ const topup = createTopupHandler({
 // Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
 // even during a Redis blip (M11).
 app.use(
-  rateLimit({
+  moneyRateLimit({
     ...RateLimitPresets.STRICT,
     keyGenerator: getIpKey,
-    failClosed: true,
   }),
 );
 

--- a/packages/cloud/api/v1/topup/50/route.ts
+++ b/packages/cloud/api/v1/topup/50/route.ts
@@ -9,8 +9,8 @@ import { Hono } from "hono";
 
 import {
   getIpKey,
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -26,10 +26,9 @@ const topup = createTopupHandler({
 // Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
 // even during a Redis blip (M11).
 app.use(
-  rateLimit({
+  moneyRateLimit({
     ...RateLimitPresets.STRICT,
     keyGenerator: getIpKey,
-    failClosed: true,
   }),
 );
 

--- a/packages/cloud/api/v1/topup/topup-rate-limit.test.ts
+++ b/packages/cloud/api/v1/topup/topup-rate-limit.test.ts
@@ -1,7 +1,7 @@
 /**
  * Top-up money routes are rate-limited and fail CLOSED on a Redis outage
- * (#12227 M11). Proves the `rateLimit({ failClosed: true })` middleware is
- * actually mounted on `/v1/topup/10` by driving a request through the real
+ * (#12227 M11 / #22982). Proves `moneyRateLimit` is actually mounted on
+ * `/v1/topup/10` by driving a request through the real
  * route with a throwing Redis dependency: the request must be rejected (503)
  * BEFORE the top-up handler runs.
  */

--- a/packages/cloud/api/v1/x402/requests/[id]/settle/route.ts
+++ b/packages/cloud/api/v1/x402/requests/[id]/settle/route.ts
@@ -7,8 +7,8 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   X402PaymentRequestError,
@@ -19,7 +19,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const id = c.req.param("id");
     if (!id) {

--- a/packages/cloud/api/v1/x402/requests/route.ts
+++ b/packages/cloud/api/v1/x402/requests/route.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
+  moneyRateLimit,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -35,7 +36,7 @@ const CreatePaymentRequestSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
+app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const body = await c.req.json();

--- a/packages/cloud/api/v1/x402/settle/route.test.ts
+++ b/packages/cloud/api/v1/x402/settle/route.test.ts
@@ -22,6 +22,8 @@ const errorLog = mock((..._args: unknown[]) => undefined);
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 mock.module("@/lib/services/x402-facilitator", () => ({

--- a/packages/cloud/api/v1/x402/settle/route.ts
+++ b/packages/cloud/api/v1/x402/settle/route.ts
@@ -5,8 +5,8 @@
 
 import { Hono } from "hono";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { x402FacilitatorService } from "@/lib/services/x402-facilitator";
 import { logger } from "@/lib/utils/logger";
@@ -14,7 +14,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use("*", moneyRateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   let body: Record<string, unknown>;

--- a/packages/cloud/api/v1/x402/verify/route.test.ts
+++ b/packages/cloud/api/v1/x402/verify/route.test.ts
@@ -18,6 +18,8 @@ const errorLog = mock((..._args: unknown[]) => undefined);
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
 }));
 
 mock.module("@/lib/services/x402-facilitator", () => ({

--- a/packages/cloud/api/v1/x402/verify/route.ts
+++ b/packages/cloud/api/v1/x402/verify/route.ts
@@ -6,8 +6,8 @@
 
 import { Hono } from "hono";
 import {
+  moneyRateLimit,
   RateLimitPresets,
-  rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { x402FacilitatorService } from "@/lib/services/x402-facilitator";
 import { logger } from "@/lib/utils/logger";
@@ -15,7 +15,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use("*", moneyRateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   let body: Record<string, unknown>;

--- a/packages/cloud/shared/src/lib/middleware/money-rate-limit-policy.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/money-rate-limit-policy.test.ts
@@ -1,0 +1,262 @@
+/**
+ * MONEY limiter policy (#22982): caller options cannot weaken fail-closed
+ * shared-Redis enforcement, and mixed middleware cannot overwrite the
+ * money response.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import * as loggerActual from "../utils/logger";
+
+class FakeRedis {
+  counts = new Map<string, number>();
+  throwNext = false;
+
+  async incr(key = "default"): Promise<number> {
+    if (this.throwNext) throw new Error("ECONNREFUSED: redis down");
+    const next = (this.counts.get(key) ?? 0) + 1;
+    this.counts.set(key, next);
+    return next;
+  }
+
+  async pttl(): Promise<number> {
+    if (this.throwNext) throw new Error("ECONNREFUSED: redis down");
+    return 60_000;
+  }
+
+  async pexpire(): Promise<number> {
+    if (this.throwNext) throw new Error("ECONNREFUSED: redis down");
+    return 1;
+  }
+
+  pipeline() {
+    const operations: Array<{ op: "incr" | "pttl"; key: string }> = [];
+    const pipeline = {
+      incr: (key = "default") => {
+        operations.push({ op: "incr", key });
+        return pipeline;
+      },
+      pttl: (key = "default") => {
+        operations.push({ op: "pttl", key });
+        return pipeline;
+      },
+      exec: async () => {
+        const results: number[] = [];
+        for (const operation of operations) {
+          results.push(
+            operation.op === "incr" ? await this.incr(operation.key) : await this.pttl(),
+          );
+        }
+        return results;
+      },
+    };
+    return pipeline;
+  }
+}
+
+const redis = new FakeRedis();
+const handler = mock(async (c: { json: (body: unknown) => Response }) => c.json({ ok: true }));
+
+mock.module("../utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const {
+  RateLimitPresets,
+  moneyRateLimit,
+  moneyRateLimitConfig,
+  rateLimit,
+  _resetHonoRateLimitLeases,
+} = await import("./rate-limit-hono-cloudflare");
+
+afterAll(() => {
+  mock.module("../utils/logger", () => loggerActual);
+});
+
+const ENV = {
+  NODE_ENV: "production",
+  REDIS_RATE_LIMITING: "true",
+  REDIS_URL: "redis://mock:6379",
+  INFERENCE_HOT_PATH_CACHES: "true",
+};
+
+function req() {
+  return new Request("https://api.example.test/pay", {
+    method: "POST",
+    headers: { "cf-connecting-ip": "203.0.113.9" },
+  });
+}
+
+describe("moneyRateLimitConfig (#22982)", () => {
+  test("preserves window and key while forcing fail-closed no-lease flags", () => {
+    const keyGenerator = () => "org:1";
+    const config = moneyRateLimitConfig({
+      ...RateLimitPresets.CRITICAL,
+      keyGenerator,
+      failClosed: false,
+      localLease: true,
+      redisUnavailableFallback: { namespace: "must-not-survive" },
+    });
+
+    expect(config.windowMs).toBe(RateLimitPresets.CRITICAL.windowMs);
+    expect(config.maxRequests).toBe(RateLimitPresets.CRITICAL.maxRequests);
+    expect(config.keyGenerator).toBe(keyGenerator);
+    expect(config.failClosed).toBe(true);
+    expect(config.localLease).toBe(false);
+    expect(config.redisUnavailableFallback).toBeUndefined();
+  });
+});
+
+describe("moneyRateLimit runtime contract (#22982)", () => {
+  beforeEach(() => {
+    redis.counts.clear();
+    redis.throwNext = false;
+    handler.mockClear();
+    _resetHonoRateLimitLeases();
+  });
+
+  test("missing Redis client returns 503 with Retry-After and skips the handler", async () => {
+    const app = new Hono();
+    app.post(
+      "/pay",
+      moneyRateLimit(RateLimitPresets.STRICT, undefined, {
+        buildRedisClient: () => null,
+      }),
+      (c) => handler(c),
+    );
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    await expect(res.json()).resolves.toMatchObject({
+      code: "rate_limit_unavailable",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("Redis constructor failure returns 503 and skips the handler", async () => {
+    const app = new Hono();
+    app.post(
+      "/pay",
+      moneyRateLimit(RateLimitPresets.STRICT, undefined, {
+        buildRedisClient: () => {
+          throw new Error("invalid Redis URL");
+        },
+      }),
+      (c) => handler(c),
+    );
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("runtime Redis exception returns 503 and skips the handler", async () => {
+    redis.throwNext = true;
+    const app = new Hono();
+    app.post(
+      "/pay",
+      moneyRateLimit(RateLimitPresets.STRICT, undefined, {
+        buildRedisClient: () => redis,
+      }),
+      (c) => handler(c),
+    );
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("healthy Redis is consulted every request and exhausted windows return 429", async () => {
+    const app = new Hono();
+    app.post(
+      "/pay",
+      moneyRateLimit({ windowMs: 60_000, maxRequests: 1 }, undefined, {
+        buildRedisClient: () => redis,
+      }),
+      (c) => handler(c),
+    );
+
+    const first = await app.fetch(req(), ENV);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-RateLimit-Policy")).toBe("redis");
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    const second = await app.fetch(req(), ENV);
+    expect(second.status).toBe(429);
+    expect(second.headers.get("Retry-After")).toBeTruthy();
+    await expect(second.json()).resolves.toMatchObject({
+      code: "rate_limit_exceeded",
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect([...redis.counts.values()].reduce((sum, n) => sum + n, 0)).toBe(2);
+  });
+
+  test("hot-path caches cannot serve a stale allow after Redis dies", async () => {
+    const app = new Hono();
+    app.post(
+      "/pay",
+      moneyRateLimit({ windowMs: 60_000, maxRequests: 20 }, undefined, {
+        buildRedisClient: () => redis,
+      }),
+      (c) => handler(c),
+    );
+
+    const first = await app.fetch(req(), ENV);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-RateLimit-Policy")).toBe("redis");
+
+    redis.throwNext = true;
+    const second = await app.fetch(req(), ENV);
+    expect(second.status).toBe(503);
+    expect(second.headers.get("X-RateLimit-Policy")).not.toBe("redis-lease");
+    expect(second.headers.get("Retry-After")).toBe("30");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("an outer fall-open limiter cannot overwrite MONEY 429 status or Retry-After", async () => {
+    const app = new Hono();
+    app.use(
+      "*",
+      rateLimit(
+        {
+          ...RateLimitPresets.RELAXED,
+          maxRequests: 200,
+          keyGenerator: () => "outer",
+        },
+        undefined,
+        { buildRedisClient: () => redis },
+      ),
+    );
+    app.post(
+      "/pay",
+      moneyRateLimit(
+        {
+          windowMs: 60_000,
+          maxRequests: 1,
+          keyGenerator: () => "inner",
+        },
+        undefined,
+        { buildRedisClient: () => redis },
+      ),
+      (c) => handler(c),
+    );
+
+    expect((await app.fetch(req(), ENV)).status).toBe(200);
+    const denied = await app.fetch(req(), ENV);
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("Retry-After")).toBeTruthy();
+    expect(denied.headers.get("X-RateLimit-Limit")).toBe("1");
+    await expect(denied.json()).resolves.toMatchObject({
+      code: "rate_limit_exceeded",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -730,6 +730,31 @@ export const RateLimitPresets = {
   AGGRESSIVE: { windowMs: 60_000, maxRequests: 100, keyGenerator: getIpKey },
 } as const;
 
+/**
+ * Authoritative limiter policy for state-changing money routes (#22982).
+ *
+ * Preserves the caller's window, max, and key generator, then forces
+ * fail-closed shared-Redis checks. Caller options cannot weaken these flags:
+ * a Redis outage must 503, and a healthy allow must not be served from the
+ * per-isolate lease.
+ */
+export function moneyRateLimitConfig(base: RateLimitConfig): RateLimitConfig {
+  return {
+    ...base,
+    failClosed: true,
+    localLease: false,
+    redisUnavailableFallback: undefined,
+  };
+}
+
+export function moneyRateLimit(
+  base: RateLimitConfig,
+  cloudflare?: CloudflareRateLimitOptions,
+  dependencies?: RateLimitDependencies,
+): MiddlewareHandler<AppEnv> {
+  return rateLimit(moneyRateLimitConfig(base), cloudflare, dependencies);
+}
+
 export { getDefaultKey, getIpKey, getRequestIp };
 export const _multiplier = multiplier;
 export const _resetRedisUnavailableFallbackBuckets = () => redisUnavailableFallbackBuckets.clear();


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #22982

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `Grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ead81e8725bd11878434ee54c33a331d22ddb995:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Medium. Money mutation routes now fail closed when Redis is missing, cannot be constructed, or throws at request time. A Redis outage will 503 those endpoints (with `Retry-After: 30`) instead of falling open. GET billing/payment-request reads, auth, provisioning, inference Durable Object admission, and cron auto-top-up are unchanged.

# Background

## What does this PR do?

Adds one shared `moneyRateLimit` helper that forces `failClosed: true`, `localLease: false`, and no `redisUnavailableFallback`. Wires it onto state-changing money mutations including payment-request create/cancel/expire. GET reads stay on ordinary `rateLimit`. Inventory requires listed mutations to mount the helper, walks money-path markers, and fails if a mutating `getPaymentRequestsService` route is unmarked. Cron auto-top-up stays excluded (#20717). `#22999` overlap is the outer POST wrapper plus the `moneyRateLimit` mock export only.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `money-rate-limit-policy.test.ts` — flags cannot be weakened; Redis miss/ctor/runtime → 503; 429 exhaust; no stale lease; mixed-order headers.
2. `money-rate-limit-inventory.test.ts` — listed mounts; marker discovery; payment-request service mutations cannot stay unmarked.
3. Domain-buy and topup fail-closed tests — 503 before handler/side effects.

## Detailed testing steps

Head `984234711ad17f6258e162c1ffb9935a5463595e` on `elizaOS/develop` `ff380c7577e7722ca5fa3494ecc0ca8a3de7c230`. Zero conflicts. The two rebased commits are patch-identical to the reviewed pre-rebase commits. Redemption overlap still `app.post("/", moneyRateLimit(RateLimitPresets.CRITICAL), ...)` plus the mock export.

```
bun test packages/cloud/shared/src/lib/middleware/money-rate-limit-policy.test.ts
# 7 pass

bun test packages/cloud/api/__tests__/money-rate-limit-inventory.test.ts
# 3 pass, 157 expect() calls

bun test packages/cloud/api/v1/payment-requests/route.test.ts
# 3 pass

bun test packages/cloud/api/v1/topup/topup-rate-limit.test.ts
# 1 pass

bun test packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts
# 5 pass

bun test packages/cloud/api/v1/billing/settings/route.test.ts
# 5 pass

bunx tsc --noEmit   # packages/cloud/api, pass
bun run --cwd packages/cloud/shared typecheck   # pass
bun run --cwd packages/cloud/api lint:check     # pass
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:984234711ad17f6258e162c1ffb9935a5463595e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI; Worker middleware and route wiring only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI; Worker middleware and route wiring only.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; limiter policy change with hermetic tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - issue forbids live Redis/Stripe/provider calls; focused hermetic 503/429 tests are the path.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface in this diff.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no ledger, wallet, or on-chain mutation; policy-only limiter wiring.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - issue #22982 forbids live payment, Stripe/OxaPay/crypto/provider calls, production Redis changes, and deploys.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- Maintainer exact-head validation on the patch-identical rebased commits ending at `984234711ad17f6258e162c1ffb9935a5463595e`: policy 7/7, inventory 3/3 (157 expectations), payment requests 3/3, top-up 1/1, domain buy 5/5, billing settings 5/5, and Biome clean on all 67 changed files.
- Package-wide cloud typechecks were attempted after the current-develop rebase, but the partial isolated checkout reports unrelated current-tree/sparse-dependency failures outside this diff (including cloud backup integration fixtures, Telegram edge callback typing, plugin-sql/plugin-scheduling sparse paths, and transitive core document dependencies). No error names a changed file in this PR.
- The earlier full `bun run verify` failed at unrelated `@elizaos/ui#lint:check` CRLF formatting in files outside this diff.
- `check:worker-bundle` previously failed with `Could not resolve "@elizaos/core/edge"` (`dist/edge` not built locally).
- No live Redis/Stripe/OxaPay/production rate-limit activation, as required by the issue non-scope.

AI provider/model: xai / grok-4.6
Client / agent tooling: Grok
Contribution skill revision: elizaOS/eliza@ead81e8725bd11878434ee54c33a331d22ddb995:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [raynord22]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok","skill_revision":"elizaOS/eliza@ead81e8725bd11878434ee54c33a331d22ddb995:packages/skills/skills/contribute-to-eliza"} -->
