### PR TITLE
fix(agent,ui): bound bare fetch hops with AbortSignal timeouts

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts
@@ -116,3 +116,75 @@ describe("E2B remote runner router with the Coding remote runner HTTP runner", (
     ).resolves.toBe("remote-coded");
   });
 });
+
+describe("configured request timeout propagation (#23005 review findings)", () => {
+  /**
+   * A fetch whose responses never settle on their own: the only way out is the
+   * caller's AbortSignal firing. `/v1/health` can respond normally so a
+   * specific later hop is the one under test.
+   */
+  function hangingFetch(healthOk: boolean): typeof fetch {
+    return Object.assign(
+      async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        if (healthOk && url.pathname === "/v1/health") {
+          return new Response("ok", { status: 200 });
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+  }
+
+  function makeService(requestTimeoutMs: number, healthOk: boolean) {
+    replaceGlobalFetch(hangingFetch(healthOk));
+    return new E2BRemoteCapabilityRouterService(makeRuntime(), {
+      enabled: true,
+      provider: "home",
+      remoteHttpBaseUrl: REMOTE_RUNNER_URL,
+      remoteHttpToken: REMOTE_RUNNER_TOKEN,
+      agentRunners: ["codex"],
+      workdir: "/workspace",
+      hostWorkspaceRoot: workspaceRoot,
+      timeoutMs: 30_000,
+      requestTimeoutMs,
+      keepAlive: true,
+      allowInternetAccess: false,
+      envs: {},
+      metadata: {},
+    });
+  }
+
+  it("aborts fs.list at the configured request timeout, not the 60s default", async () => {
+    const service = makeService(100, true);
+    const start = Date.now();
+    await expect(service.fs.list({})).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it("aborts fs.writeText at the configured request timeout, not the 60s default", async () => {
+    const service = makeService(100, true);
+    const start = Date.now();
+    await expect(
+      service.fs.writeText({ path: "/workspace/evidence.txt", text: "hi" }),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it("aborts the remote runner health check at the configured request timeout", async () => {
+    const service = makeService(100, false);
+    const start = Date.now();
+    await expect(service.fs.list({})).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+});

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -172,7 +172,7 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
     }
     const apiBase = config.remoteHttpBaseUrl.replace(/\/+$/, "");
     const headers = authHeaders(config.remoteHttpToken);
-    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    const timeout = timeoutSignal(config.requestTimeoutMs);
     try {
       const response = await fetch(`${apiBase}/v1/health`, {
         headers,
@@ -189,12 +189,16 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
 class RemoteRunnerHttpClient implements E2BSandboxClient {
   readonly workspacePrepared = true;
   readonly files = {
-    list: (path: string) => this.list(path),
+    list: (
+      path: string,
+      opts?: { depth?: number; requestTimeoutMs?: number },
+    ) => this.list(path, opts),
     read: (
       path: string,
       opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
     ) => this.read(path, opts),
-    write: (path: string, data: string) => this.write(path, data),
+    write: (path: string, data: string, opts?: { requestTimeoutMs?: number }) =>
+      this.write(path, data, opts),
   };
   readonly commands = {
     run: (cmd: string, opts?: SandboxCommandRunOptions) =>
@@ -209,10 +213,13 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
 
   async kill(): Promise<void> {}
 
-  private async list(path: string): Promise<SandboxEntryInfo[]> {
+  private async list(
+    path: string,
+    opts?: { depth?: number; requestTimeoutMs?: number },
+  ): Promise<SandboxEntryInfo[]> {
     const url = new URL(`${this.apiBase}/v1/fs/entries`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    const timeout = timeoutSignal(opts?.requestTimeoutMs);
     try {
       const response = await fetch(url, {
         headers: this.headers,
@@ -285,10 +292,11 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   private async write(
     path: string,
     data: string,
+    opts?: { requestTimeoutMs?: number },
   ): Promise<{ path: string; name: string }> {
     const url = new URL(`${this.apiBase}/v1/fs/file`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    const timeout = timeoutSignal(opts?.requestTimeoutMs);
     try {
       const response = await fetch(url, {
         method: "PUT",
@@ -395,7 +403,7 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
     config: E2BRemoteRunnerConfig,
     remoteToken: string,
   ): Promise<CloudCodingContainerSession> {
-    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    const timeout = timeoutSignal(config.requestTimeoutMs);
     try {
       const response = await fetch(
         `${config.cloudApiBaseUrl}/coding-containers`,
@@ -447,7 +455,7 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
     let current = session;
     while (!current.url && Date.now() < deadline) {
       await sleep(5000);
-      const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+      const timeout = timeoutSignal(config.requestTimeoutMs);
       try {
         const response = await fetch(
           `${config.cloudApiBaseUrl}/containers/${encodeURIComponent(current.containerId)}`,

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -172,8 +172,16 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
     }
     const apiBase = config.remoteHttpBaseUrl.replace(/\/+$/, "");
     const headers = authHeaders(config.remoteHttpToken);
-    const response = await fetch(`${apiBase}/v1/health`, { headers });
-    if (!response.ok) throw new Error(await response.text());
+    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(`${apiBase}/v1/health`, {
+        headers,
+        signal: timeout.signal,
+      });
+      if (!response.ok) throw new Error(await response.text());
+    } finally {
+      timeout.dispose();
+    }
     return new RemoteRunnerHttpClient(config.provider, apiBase, headers);
   }
 }
@@ -204,39 +212,47 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   private async list(path: string): Promise<SandboxEntryInfo[]> {
     const url = new URL(`${this.apiBase}/v1/fs/entries`);
     url.searchParams.set("path", path);
-    const response = await fetch(url, { headers: this.headers });
-    if (!response.ok) throw new Error(await response.text());
-    const payload = await response.json();
-    const entries = Array.isArray(payload)
-      ? payload
-      : isObject(payload) && Array.isArray(payload.entries)
-        ? payload.entries
-        : null;
-    if (!entries) {
-      throw new Error("Remote runner fs entries response was not an array.");
+    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        headers: this.headers,
+        signal: timeout.signal,
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const payload = await response.json();
+      const entries = Array.isArray(payload)
+        ? payload
+        : isObject(payload) && Array.isArray(payload.entries)
+          ? payload.entries
+          : null;
+      if (!entries) {
+        throw new Error("Remote runner fs entries response was not an array.");
+      }
+      return entries.map((entry) => {
+        if (!isObject(entry)) {
+          throw new Error("Remote runner fs entry was not an object.");
+        }
+        const pathValue = String(entry.path ?? "");
+        const stat: SandboxEntryInfo = {
+          path: pathValue,
+          name: String(entry.name ?? nodePath.posix.basename(pathValue)),
+          type: remoteEntryType(entry),
+          size: typeof entry.size === "number" ? entry.size : 0,
+        };
+        const modified =
+          typeof entry.modifiedAt === "string"
+            ? entry.modifiedAt
+            : typeof entry.modified === "string"
+              ? entry.modified
+              : null;
+        if (modified) {
+          stat.modifiedTime = new Date(modified);
+        }
+        return stat;
+      });
+    } finally {
+      timeout.dispose();
     }
-    return entries.map((entry) => {
-      if (!isObject(entry)) {
-        throw new Error("Remote runner fs entry was not an object.");
-      }
-      const pathValue = String(entry.path ?? "");
-      const stat: SandboxEntryInfo = {
-        path: pathValue,
-        name: String(entry.name ?? nodePath.posix.basename(pathValue)),
-        type: remoteEntryType(entry),
-        size: typeof entry.size === "number" ? entry.size : 0,
-      };
-      const modified =
-        typeof entry.modifiedAt === "string"
-          ? entry.modifiedAt
-          : typeof entry.modified === "string"
-            ? entry.modified
-            : null;
-      if (modified) {
-        stat.modifiedTime = new Date(modified);
-      }
-      return stat;
-    });
   }
 
   private async read(
@@ -272,16 +288,22 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   ): Promise<{ path: string; name: string }> {
     const url = new URL(`${this.apiBase}/v1/fs/file`);
     url.searchParams.set("path", path);
-    const response = await fetch(url, {
-      method: "PUT",
-      headers: {
-        ...this.headers,
-        "content-type": "text/plain",
-      },
-      body: data,
-    });
-    if (!response.ok) throw new Error(await response.text());
-    return { path, name: nodePath.posix.basename(path) };
+    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          ...this.headers,
+          "content-type": "text/plain",
+        },
+        body: data,
+        signal: timeout.signal,
+      });
+      if (!response.ok) throw new Error(await response.text());
+      return { path, name: nodePath.posix.basename(path) };
+    } finally {
+      timeout.dispose();
+    }
   }
 
   private async runCommand(
@@ -373,44 +395,50 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
     config: E2BRemoteRunnerConfig,
     remoteToken: string,
   ): Promise<CloudCodingContainerSession> {
-    const response = await fetch(
-      `${config.cloudApiBaseUrl}/coding-containers`,
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${config.cloudApiToken}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          agent: toCloudCodingAgent(config.agentRunners[0] ?? "codex"),
-          workspacePath: config.workdir,
-          container: {
-            ...(config.cloudContainerImage
-              ? { image: config.cloudContainerImage }
-              : {}),
-            environmentVars: {
-              HOST: "0.0.0.0",
-              ELIZA_REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
-              REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
-              ELIZA_CODING_WORKSPACE: config.workdir,
-              ELIZA_SANDBOX_AGENT_RUNNERS: config.agentRunners.join(","),
-              ...config.envs,
-            },
+    const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(
+        `${config.cloudApiBaseUrl}/coding-containers`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${config.cloudApiToken}`,
+            "content-type": "application/json",
           },
-          metadata: config.metadata,
-        }),
-      },
-    );
-    const payload = await readCloudEnvelope(response);
-    if (!response.ok) {
-      throw new Error(cloudErrorMessage(payload, response.statusText));
-    }
-    const session = parseCloudCodingContainerSession(payload);
-    return session.url
-      ? session
-      : await this.pollCodingContainer(config, session);
-  }
+          body: JSON.stringify({
+            agent: toCloudCodingAgent(config.agentRunners[0] ?? "codex"),
+            workspacePath: config.workdir,
+            container: {
+              ...(config.cloudContainerImage
+                ? { image: config.cloudContainerImage }
+                : {}),
+              environmentVars: {
+                HOST: "0.0.0.0",
+                ELIZA_REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
+                REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
+                ELIZA_CODING_WORKSPACE: config.workdir,
+                ELIZA_SANDBOX_AGENT_RUNNERS: config.agentRunners.join(","),
+                ...config.envs,
+              },
+            },
+            metadata: config.metadata,
+          }),
+          signal: timeout.signal,
+        },
+      );
+      const payload = await readCloudEnvelope(response);
+      if (!response.ok) {
+        throw new Error(cloudErrorMessage(payload, response.statusText));
+      }
 
+      const session = parseCloudCodingContainerSession(payload);
+      return session.url
+        ? session
+        : await this.pollCodingContainer(config, session);
+    } finally {
+      timeout.dispose();
+    }
+  }
   private async pollCodingContainer(
     config: E2BRemoteRunnerConfig,
     session: CloudCodingContainerSession,
@@ -419,17 +447,23 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
     let current = session;
     while (!current.url && Date.now() < deadline) {
       await sleep(5000);
-      const response = await fetch(
-        `${config.cloudApiBaseUrl}/containers/${encodeURIComponent(current.containerId)}`,
-        {
-          headers: { authorization: `Bearer ${config.cloudApiToken}` },
-        },
-      );
-      const payload = await readCloudEnvelope(response);
-      if (!response.ok) {
-        throw new Error(cloudErrorMessage(payload, response.statusText));
+      const timeout = timeoutSignal(DEFAULT_REQUEST_TIMEOUT_MS);
+      try {
+        const response = await fetch(
+          `${config.cloudApiBaseUrl}/containers/${encodeURIComponent(current.containerId)}`,
+          {
+            headers: { authorization: `Bearer ${config.cloudApiToken}` },
+            signal: timeout.signal,
+          },
+        );
+        const payload = await readCloudEnvelope(response);
+        if (!response.ok) {
+          throw new Error(cloudErrorMessage(payload, response.statusText));
+        }
+        current = parseCloudCodingContainerSession(payload);
+      } finally {
+        timeout.dispose();
       }
-      current = parseCloudCodingContainerSession(payload);
       if (current.status === "failed" || current.status === "stopped") {
         throw new Error(
           `Eliza Cloud coding container ${current.containerId} reached status ${current.status}.`,

--- a/packages/ui/src/cloud/instances/lib/use-job-poller.test.ts
+++ b/packages/ui/src/cloud/instances/lib/use-job-poller.test.ts
@@ -81,4 +81,46 @@ describe("useJobPoller — sleep-wake / backgrounding lifecycle (#9943)", () => 
     });
     expect(fetchMock.mock.calls.length).toBeGreaterThan(beforeBackground);
   });
+
+  it("aborts a hung poll hop at the per-poll timeout instead of pinning the poller", async () => {
+    // A jobs endpoint that never settles on its own: the only way out is the
+    // caller's AbortSignal firing (the per-poll `AbortSignal.timeout(10s)`).
+    // Note: Node's AbortSignal.timeout uses an internal timer that vitest fake
+    // timers cannot drive, so back it with the faked global setTimeout here.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), ms);
+      return controller.signal;
+    });
+    const hungFetch = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            ),
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", hungFetch);
+    const { result } = renderHook(() => useJobPoller({ intervalMs: 60_000 }));
+
+    // Tracking an active job arms the poll effect (immediate poll + interval).
+    await act(async () => {
+      result.current.track("agent-1", "job-1");
+      await Promise.resolve();
+    });
+    expect(hungFetch).toHaveBeenCalledTimes(1);
+    expect(hungFetch.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+
+    // The hung hop aborts after the 10s bound; the in-flight guard resets in
+    // the finally block, so the NEXT interval tick still fires a fresh poll.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_100);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(hungFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/packages/ui/src/cloud/instances/lib/use-job-poller.ts
+++ b/packages/ui/src/cloud/instances/lib/use-job-poller.ts
@@ -138,7 +138,11 @@ export function useJobPoller(options: UseJobPollerOptions = {}) {
           }
 
           try {
-            const res = await fetch(`/api/v1/jobs/${job.jobId}`);
+            // Bound each poll hop so a hung job endpoint cannot pin
+            // pollInFlightRef forever and silently kill the poller.
+            const res = await fetch(`/api/v1/jobs/${job.jobId}`, {
+              signal: AbortSignal.timeout(10_000),
+            });
             if (!res.ok) {
               continue;
             }

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -4,7 +4,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api-client";
-import { useSandboxListPoll } from "./use-sandbox-status-poll";
+import {
+  useSandboxListPoll,
+  useSandboxStatusPoll,
+} from "./use-sandbox-status-poll";
 
 vi.mock("../../lib/api-client", () => ({ api: vi.fn() }));
 
@@ -37,6 +40,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe("useSandboxListPoll", () => {
@@ -112,5 +116,47 @@ describe("useSandboxListPoll", () => {
       await Promise.resolve();
     });
     expect(onDataRefresh).not.toHaveBeenCalled();
+  });
+
+  it("aborts a hung status fetch at the per-poll timeout instead of leaving isLoading pinned", async () => {
+    // An agent-status endpoint that never settles on its own: the only way out
+    // is the caller's AbortSignal firing (the per-poll `AbortSignal.timeout(10s)`).
+    // Note: Node's AbortSignal.timeout uses an internal timer that vitest fake
+    // timers cannot drive, so back it with the faked global setTimeout here.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), ms);
+      return controller.signal;
+    });
+    const hungFetch = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            ),
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", hungFetch);
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useSandboxStatusPoll("agent-1", { intervalMs: 60_000 }),
+    );
+
+    // First poll hop is in flight and pinned as loading.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hungFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
+
+    // The per-poll 10s bound aborts the hung hop; the error path clears
+    // isLoading instead of leaving the progress view stuck forever.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_100);
+    });
+    expect(hungFetch.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
@@ -90,7 +90,11 @@ export function useSandboxStatusPoll(
       setResult((prev) => ({ ...prev, isLoading: true }));
 
       try {
-        const res = await fetch(`/api/v1/eliza/agents/${agentId}`);
+        // Bound each poll hop so a hung status endpoint cannot leave
+        // isLoading pinned forever (the error path only fires on rejection).
+        const res = await fetch(`/api/v1/eliza/agents/${agentId}`, {
+          signal: AbortSignal.timeout(10_000),
+        });
         if (cancelledRef.current) return;
 
         if (!res.ok) {


### PR DESCRIPTION
# Relates to

Relates to #9943.

<!-- evidence-head:4382437cee992b3840b906e933a53abb65ef2454 -->

## Exact-head validation

- Rebased without conflicts onto `develop@b89c5eee9ee22b7aec679a04b63b00bec615b47c`; `git range-diff` reports both commits patch-identical.
- Contributor focused proof on the patch-identical predecessor: agent router **30/30** and UI pollers **6/6**. The added deferred-fetch cases exercise configured timeout propagation, abort rejection, poll recovery, and clearing the loading state.
- Maintainer review: Biome clean on all six changed files and `git diff --check` clean. The current shared test host is saturated by unrelated long-running Vitest processes and stalled before collecting these files; this is not represented as a passing rerun.
- No rendered layout changes; screenshots/video/OCR are N/A. The UI change only bounds existing background HTTP polls and preserves their existing error state.

## Problem

Three files still had bare `fetch()` calls with no signal — the same hang class recently fixed across the repo (broker fetches, SIWE polls, media-server hops), but these were missed:

1. **e2b-capability-router.ts** — 5 bare fetches: remote-runner `/v1/health`, fs `list`/write, and cloud coding-container create + poll. A stalled remote runner or Eliza Cloud API hangs the sandbox session indefinitely (the poll loop's own 120s deadline can't fire because the fetch never resolves).
2. **use-job-poller.ts** — a hung job endpoint never resolves, so `pollInFlightRef` stays `true` forever and every subsequent tick bails — the provisioning poller dies silently.
3. **use-sandbox-status-poll.ts** — a hung status endpoint leaves `isLoading` pinned forever; the error/cleanup path only fires on rejection.

## Change

- e2b-capability-router: route all 5 through the existing `timeoutSignal` helper (`DEFAULT_REQUEST_TIMEOUT_MS`), matching sibling `read`/`runCommand` which already used it.
- Both UI pollers: `AbortSignal.timeout(10_000)` on each poll hop.

## Evidence

- `biome check`: pass (0 errors, formatted).
- `bun run --cwd packages/core test process-attachments` baseline: pass (unaffected).
- No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.
