### PR TITLE
fix(cloud,ui): bound gateway reply and pairing fetches with timeouts

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -151,6 +151,9 @@ async function sendBlooioMessage(
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    // Bound the outbound Blooio hop so a stalled provider cannot lose the
+    // fire-and-forget reply (also used by scheduled reminder retries).
+    signal: AbortSignal.timeout(15_000),
   });
   const responseText = await response.text();
   if (!response.ok) {

--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
@@ -240,6 +240,10 @@ export const twilioAdapter: PlatformAdapter = {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: body.toString(),
+      // Bound the outbound SMS hop so a stalled Twilio API cannot lose the
+      // fire-and-forget reply silently (sendReply is awaited in the reply
+      // phase and has no enclosing timeout).
+      signal: AbortSignal.timeout(15_000),
     });
 
     if (!response.ok) {

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
@@ -167,6 +167,9 @@ export const whatsappAdapter: PlatformAdapter = {
         type: "text",
         text: { body: text },
       }),
+      // Bound the outbound WhatsApp hop so a stalled Graph API cannot lose
+      // the fire-and-forget reply silently.
+      signal: AbortSignal.timeout(15_000),
     });
 
     if (!response.ok) {

--- a/packages/ui/src/cloud/instances/lib/open-web-ui.ts
+++ b/packages/ui/src/cloud/instances/lib/open-web-ui.ts
@@ -69,8 +69,11 @@ export async function openWebUIWithPairing(agentId: string): Promise<void> {
 
     const deadline = Date.now() + MAX_PAIRING_WAIT_MS;
     while (Date.now() < deadline) {
+      // Bound each pairing hop so a hung endpoint cannot stall the retry
+      // loop past MAX_PAIRING_WAIT_MS (deadline is only checked at loop top).
       const res = await fetch(`/api/v1/eliza/agents/${agentId}/pairing-token`, {
         method: "POST",
+        signal: AbortSignal.timeout(10_000),
       });
       const data = (await res
         .json()


### PR DESCRIPTION
## Problem

Same hang class as the recent timeout fixes, missed in four spots:

1. **gateway-webhook adapters** — `twilio.ts`, `whatsapp.ts`, `blooio.ts` `sendReply` POSTs have no signal. A stalled provider API (Twilio/WhatsApp Graph/Blooio) never resolves, so the fire-and-forget reply phase loses the user's reply silently — no error, no retry, promise leaked. Blooio is also used by scheduled reminder retries.
2. **open-web-ui.ts** — the pairing-token retry loop only re-checks `Date.now() < deadline` at loop top; a hung fetch stalls the popup past `MAX_PAIRING_WAIT_MS` on "Connecting to your agent…" indefinitely.

## Change

- 3 gateway adapters: `AbortSignal.timeout(15_000)` on outbound `sendReply` fetches.
- `open-web-ui`: `AbortSignal.timeout(10_000)` per pairing hop so the loop can make progress and hit its deadline.

## Evidence

- `biome check`: pass (0 errors, 4 files).
- No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.