### PR TITLE
fix(cloud-api): bound STT and embeddings upstream hops with timeouts

### DIFF
--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -403,6 +403,9 @@ app.post("/", async (c) => {
           ...request,
           model: passthroughUpstream.modelId,
         }),
+        // Bound the billed upstream hop so a stalled provider cannot strand
+        // the credit-settle chain.
+        signal: AbortSignal.timeout(30_000),
       });
       if (!upstreamResponse.ok) {
         // Throw the same error shape the SDK path produces so the route catch

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -700,6 +700,8 @@ async function __hono_POST(c: AppContext) {
       let deepgramResponse: Response;
       try {
         await deepgramReservation.markProviderDispatched?.();
+        // Bound the upstream STT hop so a stalled Deepgram API cannot hang
+        // the request path while the credit reservation is held.
         deepgramResponse = await fetch(deepgramUrl, {
           method: "POST",
           headers: {
@@ -707,6 +709,7 @@ async function __hono_POST(c: AppContext) {
             "Content-Type": finalMimeType,
           },
           body: buffer,
+          signal: AbortSignal.timeout(30_000),
         });
       } catch (error) {
         // error-policy:J1 provider transport failures translate at the route boundary.
@@ -1082,7 +1085,13 @@ async function __hono_POST(c: AppContext) {
       form.append("timestamp_granularities[]", "segment");
       const whisperResponse = await fetch(
         `${whisperBaseUrl.replace(/\/+$/, "")}/v1/audio/transcriptions`,
-        { method: "POST", body: form },
+        {
+          method: "POST",
+          body: form,
+          // Bound the upstream STT hop so a stalled Whisper server cannot
+          // hang the request path.
+          signal: AbortSignal.timeout(30_000),
+        },
       );
       if (!whisperResponse.ok) {
         await whisperResponse.body?.cancel().catch((cancelError) => {


### PR DESCRIPTION
## Problem

Three upstream fetches in cloud API route handlers had no signal:

1. **stt/route.ts:703** — Deepgram batch STT. A stalled provider hangs the request path while the credit reservation is held. The Cartesia branch right below already used `AbortSignal.timeout`; Deepgram was missed.
2. **stt/route.ts:1083** — Whisper fallback, completely bare options.
3. **embeddings/route.ts:396** — OpenAI passthrough; a stalled provider strands the billed credit-settle chain.

## Change

- All three: `AbortSignal.timeout(30_000)`.

## Evidence

- `biome check`: pass (0 errors, 2 files).
- Verified auth-header bytes unchanged (Deepgram keeps `Token` scheme, embeddings keeps `Bearer`).
- No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.