### PR TITLE
fix(plugins): bound elizacloud and orchestrator fetches with timeouts

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1307,6 +1307,9 @@ async function runCloudCommand(args: {
       ...(body ? { "Content-Type": "application/json" } : {}),
     },
     ...(body ? { body: JSON.stringify(body) } : {}),
+    // Bound the cloud-command hop so a stalled Eliza Cloud API cannot hang
+    // the TASKS action forever.
+    signal: AbortSignal.timeout(30_000),
   });
   const payload = await responsePayload(response);
   const payloadText =

--- a/plugins/plugin-elizacloud/src/cloud/bridge-client.ts
+++ b/plugins/plugin-elizacloud/src/cloud/bridge-client.ts
@@ -304,6 +304,9 @@ export class ElizaCloudClient {
         params: { text, roomId, channelType },
       }),
       redirect: "manual",
+      // Same bound as the non-streaming sendMessage sibling; a stalled cloud
+      // agent must not hang the stream open forever.
+      signal: AbortSignal.timeout(60_000),
     });
 
     if (isRedirectResponse(response)) {


### PR DESCRIPTION
## Problem

Two bare fetches in plugin runtime paths:

1. **bridge-client.ts:297** — `sendMessageStream` had no signal while its non-streaming `sendMessage` sibling uses `AbortSignal.timeout(60_000)` — a clear oversight. A stalled cloud agent hung the stream open forever.
2. **parent-agent-broker.ts:1302** — `runCloudCommand` POST had no signal; a stalled Eliza Cloud API hung the TASKS cloud-command action indefinitely.

## Change

- bridge-client: `AbortSignal.timeout(60_000)`, matching the sibling.
- parent-agent-broker: `AbortSignal.timeout(30_000)`.

## Evidence

- `biome check`: pass (0 errors).
- Verified auth-header bytes unchanged (`Bearer` scheme preserved).
- No UI. Screenshots, video, frontend logs, OCR, and live-model trajectory are N/A.