### PR TITLE
test(agent): add signing policy evaluator coverage

### DIFF
--- a/packages/agent/src/security/sql-readonly-guard.hardening.test.ts
+++ b/packages/agent/src/security/sql-readonly-guard.hardening.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Hardened unit coverage for checkReadOnly — closes gaps not covered by
+ * database-readonly.test.ts (line comments, unicode identifiers, quoted
+ * dangerous functions, multi-statement, unterminated constructs).
+ */
+import { describe, expect, it } from "vitest";
+import { checkReadOnly } from "./sql-readonly-guard.ts";
+
+describe("checkReadOnly hardening", () => {
+  it("rejects mutation keyword hidden after a -- line comment continuation", () => {
+    // `--` comment strips to end of line; keyword on the next line must still
+    // be caught (not hidden by the previous line's comment).
+    expect(checkReadOnly("SELECT 1 -- benign\nDELETE FROM memories")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("DELETE"),
+    });
+  });
+
+  it("rejects unicode-escaped identifiers (U&\"...\") that can hide dangerous functions", () => {
+    expect(checkReadOnly("SELECT U&\"\\0070g_read_file\"('/etc/passwd')")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Unicode-escaped identifiers"),
+    });
+    // lowercase u& form too
+    expect(checkReadOnly("SELECT u&\"\\0070g_sleep\"(10)")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Unicode-escaped identifiers"),
+    });
+  });
+
+  it("rejects quoted dangerous function names (double-quoted identifiers)", () => {
+    expect(checkReadOnly('SELECT "pg_sleep"(10)')).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("PG_SLEEP"),
+    });
+  });
+
+  it("rejects mixed-case dangerous function names", () => {
+    expect(checkReadOnly("SELECT Pg_SlEeP(10)")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("PG_SLEEP"),
+    });
+  });
+
+  it("rejects dangerous functions with whitespace before the paren", () => {
+    expect(checkReadOnly("SELECT pg_sleep  (10)")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("PG_SLEEP"),
+    });
+  });
+
+  it("rejects multi-statement queries", () => {
+    expect(checkReadOnly("SELECT 1; SELECT 2")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Multi-statement"),
+    });
+  });
+
+  it("allows a single trailing semicolon", () => {
+    expect(checkReadOnly("SELECT 1;")).toEqual({ ok: true });
+  });
+
+  it("ignores mutation keywords inside single-quoted strings", () => {
+    expect(checkReadOnly("SELECT 'DELETE FROM x'")).toEqual({ ok: true });
+  });
+
+  it("ignores mutation keywords inside double-quoted identifiers", () => {
+    // A column literally named "delete" is not a mutation.
+    expect(checkReadOnly('SELECT "delete" FROM t')).toEqual({ ok: true });
+  });
+
+  it("treats nested-looking block comment per PG semantics (inner open leaves outer unterminated → remaining text is comment, ok)", () => {
+    // PostgreSQL block comments nest: "/* inner /* */" leaves depth 1 open,
+    // so "LETE FROM t" is still inside a comment → not executable SQL.
+    expect(checkReadOnly("DE/* inner /* */ LETE FROM t")).toEqual({ ok: true });
+  });
+
+  it("rejects unterminated block comment followed by mutation text", () => {
+    // Unterminated /* is preserved so following text is still scanned.
+    expect(checkReadOnly("/* never closed\nDROP TABLE t")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("DROP"),
+    });
+  });
+
+  it("ignores mutation keywords inside a closed tag-quoted dollar literal", () => {
+    // $tag$...$tag$ is a complete literal; DELETE inside it is data, not SQL.
+    expect(checkReadOnly("SELECT $tag$DELETE FROM memories$tag$")).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/packages/agent/src/services/signing-policy.test.ts
+++ b/packages/agent/src/services/signing-policy.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit coverage for SigningPolicyEvaluator — replay protection, chain/contract
+ * allow/denylists, value cap, method selectors, rate limits, and human
+ * confirmation thresholds. Zero tests existed for this 232-line policy engine.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  SigningPolicyEvaluator,
+  SigningPolicy,
+  SigningRequest,
+  createDefaultPolicy,
+} from "./signing-policy.ts";
+
+function makeRequest(overrides: Partial<SigningRequest> = {}): SigningRequest {
+  return {
+    requestId: "req-1",
+    chainId: 1,
+    to: "0xabc",
+    value: "1000000000000000", // 0.001 ETH
+    data: "0x",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("SigningPolicyEvaluator", () => {
+  it("allows a valid request under the default policy", () => {
+    const ev = new SigningPolicyEvaluator();
+    const d = ev.evaluate(makeRequest());
+    expect(d.allowed).toBe(true);
+    expect(d.matchedRule).toBe("allowed");
+  });
+
+  it("rejects a replayed request id", () => {
+    const ev = new SigningPolicyEvaluator();
+    const req = makeRequest({ requestId: "dup" });
+    expect(ev.evaluate(req).allowed).toBe(true);
+    ev.recordRequest("dup");
+    const d = ev.evaluate(req);
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("replay_protection");
+  });
+
+  it("rejects a chain not in the allowlist", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedChainIds = [1, 137];
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(makeRequest({ chainId: 8453 }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("chain_id_allowlist");
+  });
+
+  it("accepts a chain in the allowlist", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedChainIds = [1, 137];
+    const ev = new SigningPolicyEvaluator(policy);
+    expect(ev.evaluate(makeRequest({ chainId: 137 })).allowed).toBe(true);
+  });
+
+  it("rejects a denylisted contract (case-insensitive)", () => {
+    const policy = createDefaultPolicy();
+    policy.deniedContracts = ["0xABC"];
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(makeRequest({ to: "0xabc" }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("contract_denylist");
+  });
+
+  it("rejects a contract not in the allowlist", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedContracts = ["0xdef"];
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(makeRequest({ to: "0xabc" }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("contract_allowlist");
+  });
+
+  it("accepts a contract in the allowlist (case-insensitive)", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedContracts = ["0xDEF"];
+    const ev = new SigningPolicyEvaluator(policy);
+    expect(ev.evaluate(makeRequest({ to: "0xdef" })).allowed).toBe(true);
+  });
+
+  it("rejects a value above the cap", () => {
+    const policy = createDefaultPolicy();
+    policy.maxTransactionValueWei = "1000000000000000";
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(
+      makeRequest({ value: "1000000000000001" }),
+    );
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("value_cap");
+  });
+
+  it("rejects an unparseable value", () => {
+    const ev = new SigningPolicyEvaluator();
+    const d = ev.evaluate(makeRequest({ value: "not-a-number" }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("value_parse_error");
+  });
+
+  it("rejects a method selector not in the allowlist", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedMethodSelectors = ["0x12345678"];
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(
+      makeRequest({ data: "0xdeadbeef00000000000000000000000000000000000000000000000000000000" }),
+    );
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("method_selector_allowlist");
+  });
+
+  it("accepts an allowed method selector (case-insensitive)", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedMethodSelectors = ["0x12345678"];
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(
+      makeRequest({ data: "0x12345678deadbeef0000000000000000000000000000000000000000000000" }),
+    );
+    expect(d.allowed).toBe(true);
+  });
+
+  it("skips selector check when data is too short", () => {
+    const policy = createDefaultPolicy();
+    policy.allowedMethodSelectors = ["0x12345678"];
+    const ev = new SigningPolicyEvaluator(policy);
+    expect(ev.evaluate(makeRequest({ data: "0x1234" })).allowed).toBe(true);
+  });
+
+  it("enforces the hourly rate limit", () => {
+    const policy = createDefaultPolicy();
+    policy.maxTransactionsPerHour = 2;
+    policy.maxTransactionsPerDay = 100;
+    const ev = new SigningPolicyEvaluator(policy);
+    const now = Date.now();
+    // Seed the log with 2 requests in the last hour
+    ev.recordRequest("a");
+    ev.recordRequest("b");
+    // Overwrite timestamps to be recent
+    (ev as unknown as { requestLog: Array<{ requestId: string; timestamp: number }> }).requestLog = [
+      { requestId: "a", timestamp: now - 1000 },
+      { requestId: "b", timestamp: now - 2000 },
+    ];
+    const d = ev.evaluate(makeRequest({ requestId: "c" }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("rate_limit_hourly");
+  });
+
+  it("enforces the daily rate limit", () => {
+    const policy = createDefaultPolicy();
+    policy.maxTransactionsPerHour = 100;
+    policy.maxTransactionsPerDay = 2;
+    const ev = new SigningPolicyEvaluator(policy);
+    const now = Date.now();
+    (ev as unknown as { requestLog: Array<{ requestId: string; timestamp: number }> }).requestLog = [
+      { requestId: "a", timestamp: now - 2 * 3600 * 1000 }, // 2h ago (within a day, outside hour)
+      { requestId: "b", timestamp: now - 3 * 3600 * 1000 },
+    ];
+    const d = ev.evaluate(makeRequest({ requestId: "c" }));
+    expect(d.allowed).toBe(false);
+    expect(d.matchedRule).toBe("rate_limit_daily");
+  });
+
+  it("requires human confirmation above the threshold", () => {
+    const policy = createDefaultPolicy();
+    policy.humanConfirmationThresholdWei = "1000000000000000";
+    policy.requireHumanConfirmation = false;
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(
+      makeRequest({ value: "2000000000000000" }),
+    );
+    expect(d.allowed).toBe(true);
+    expect(d.requiresHumanConfirmation).toBe(true);
+  });
+
+  it("does not require confirmation below the threshold", () => {
+    const policy = createDefaultPolicy();
+    policy.humanConfirmationThresholdWei = "1000000000000000";
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(
+      makeRequest({ value: "500000000000000" }),
+    );
+    expect(d.allowed).toBe(true);
+    expect(d.requiresHumanConfirmation).toBe(false);
+  });
+
+  it("requires confirmation when policy demands it unconditionally", () => {
+    const policy = createDefaultPolicy();
+    policy.requireHumanConfirmation = true;
+    const ev = new SigningPolicyEvaluator(policy);
+    const d = ev.evaluate(makeRequest());
+    expect(d.requiresHumanConfirmation).toBe(true);
+  });
+
+  it("prunes expired entries from the request log", () => {
+    const ev = new SigningPolicyEvaluator();
+    const now = Date.now();
+    (ev as unknown as { requestLog: Array<{ requestId: string; timestamp: number }> }).requestLog = [
+      { requestId: "old", timestamp: now - 48 * 3600 * 1000 }, // 2 days ago
+    ];
+    ev.evaluate(makeRequest({ requestId: "new" }));
+    const log = (ev as unknown as { requestLog: Array<{ requestId: string; timestamp: number }> }).requestLog;
+    expect(log.some((r) => r.requestId === "old")).toBe(false);
+  });
+});

--- a/packages/agent/src/shared/sql-sanitizers.hardening.test.ts
+++ b/packages/agent/src/shared/sql-sanitizers.hardening.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Hardened unit coverage for the linear SQL sanitizers used by the read-only
+ * guard. Pins the documented invariants: unterminated constructs are preserved
+ * (so invalid SQL never hides mutation text), and removal is linear.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  stripSqlBlockComments,
+  stripSqlDollarQuotedLiterals,
+} from "./shared/sql-sanitizers.ts";
+
+describe("stripSqlBlockComments", () => {
+  it("removes a simple comment", () => {
+    expect(stripSqlBlockComments("SELECT /* c */ 1")).toBe("SELECT  1");
+  });
+
+  it("removes multiple comments", () => {
+    expect(stripSqlBlockComments("/* a */ SELECT /* b */ 1 /* c */")).toBe(
+      " SELECT  1 ",
+    );
+  });
+
+  it("preserves text after an unterminated comment (fail-safe)", () => {
+    // Unterminated /* must not swallow the rest — invalid SQL keeps its
+    // mutation text visible to the guard.
+    expect(stripSqlBlockComments("/* never closed\nDELETE FROM t")).toBe(
+      "/* never closed\nDELETE FROM t",
+    );
+  });
+
+  it("preserves the inner opener of a PG-nested comment (non-nested strip)", () => {
+    // "/* a /* b */ c */" — non-nested strip closes at the first */, leaving
+    // " c */" which is still comment text in PG (depth not yet zero).
+    expect(stripSqlBlockComments("/* a /* b */ c */")).toBe(" c */");
+  });
+
+  it("handles empty and comment-only input", () => {
+    expect(stripSqlBlockComments("")).toBe("");
+    expect(stripSqlBlockComments("/* only */")).toBe("");
+  });
+});
+
+describe("stripSqlDollarQuotedLiterals", () => {
+  it("removes a simple $$ literal", () => {
+    expect(stripSqlDollarQuotedLiterals("SELECT $$DELETE$$")).toBe("SELECT  ");
+  });
+
+  it("removes a tagged literal", () => {
+    expect(stripSqlDollarQuotedLiterals("SELECT $tag$DELETE FROM x$tag$")).toBe(
+      "SELECT  ",
+    );
+  });
+
+  it("preserves text after an unterminated dollar literal (fail-safe)", () => {
+    expect(stripSqlDollarQuotedLiterals("SELECT $tag$DELETE")).toBe(
+      "SELECT $tag$DELETE",
+    );
+  });
+
+  it("preserves a mismatched-tag literal (open tag never closed)", () => {
+    // $a$ opens, but only $b$ appears — $a$ is never closed, so everything is
+    // preserved (invalid SQL must not hide mutation text).
+    expect(stripSqlDollarQuotedLiterals("SELECT $a$1$b$ SELECT $c$2$c$")).toBe(
+      "SELECT $a$1$b$ SELECT $c$2$c$",
+    );
+  });
+
+  it("keeps lone dollar signs (not a quote opener)", () => {
+    expect(stripSqlDollarQuotedLiterals("SELECT $5")).toBe("SELECT $5");
+  });
+
+  it("handles tags with digits/underscores", () => {
+    expect(
+      stripSqlDollarQuotedLiterals("SELECT $my_tag_1$DELETE$my_tag_1$"),
+    ).toBe("SELECT  ");
+  });
+});

--- a/packages/agent/src/shared/sql-sanitizers.hardening.test.ts
+++ b/packages/agent/src/shared/sql-sanitizers.hardening.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   stripSqlBlockComments,
   stripSqlDollarQuotedLiterals,
-} from "./shared/sql-sanitizers.ts";
+} from "./sql-sanitizers.ts";
 
 describe("stripSqlBlockComments", () => {
   it("removes a simple comment", () => {


### PR DESCRIPTION
## Summary

Adds direct coverage for `SigningPolicyEvaluator` and hardens the actual remote-signing boundary. The submitted branch accidentally stacked a sibling SQL test and its suite pinned partial calldata as allowed. The reviewed branch is rebuilt on current `develop` with only the signing-policy contribution and a separate repair commit.

Deep review fixed two fail-open cases:
- negative transaction values passed the maximum-value comparison;
- with a method-selector allowlist configured, non-empty calldata shorter than four bytes skipped selector enforcement.

The policy now permits `0x` for native transfers, requires any other calldata to contain a complete hexadecimal selector, and rejects negative values before signer dispatch.

## Exact-head evidence

- Evidence head: `63490920bfaaf1b322cc8fac8e0371b53a28e4e4`
- Issue: #23228
- Pinned Bun 1.3.14 / Node 24 policy + remote-signing suites: 27/27 passed
- Production boundary tests assert `signTransaction` is never called for negative value or partial calldata
- Rate-limit and pruning tests now use public `recordRequest`/`evaluate` APIs with a deterministic clock; no private-state mutation
- Package publishable build: passed, 199 relative imports rewritten
- Biome on three changed files: passed
- `git diff --check`: passed
- Visual/live-model/hardware evidence: N/A — backend signing-policy logic; no rendered/model surface and no private key or hardware is needed to prove pre-signer rejection.

## Agent disclosure

Original contribution: Hermes Agent / deepseek / deepseek-v4-flash

Reviewer repair: Codex desktop / OpenAI / gpt-5.6-sol