### PR TITLE
test(agent): add terminal run limits coverage

### DIFF
--- a/packages/agent/src/api/terminal-run-limits.test.ts
+++ b/packages/agent/src/api/terminal-run-limits.test.ts
@@ -2,24 +2,9 @@
  * Unit coverage for resolveTerminalRunLimits — env-driven concurrency and
  * duration guardrails with clamping to defaults and hard caps.
  */
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const ORIG_ENV = { ...process.env };
-
-// Mock @elizaos/shared's parseClampedInteger: fallback for unset, clamp to
-// [min, max], throw/fallback on non-integer. Mirror the real contract.
-vi.mock("@elizaos/shared", () => {
-  const parseClampedInteger = (
-    raw: string | undefined,
-    opts: { fallback: number; min: number; max: number },
-  ): number => {
-    if (raw === undefined || raw.trim() === "") return opts.fallback;
-    const n = Number(raw);
-    if (!Number.isFinite(n) || !Number.isInteger(n)) return opts.fallback;
-    return Math.min(opts.max, Math.max(opts.min, n));
-  };
-  return { parseClampedInteger };
-});
 
 import { resolveTerminalRunLimits } from "./terminal-run-limits.ts";
 
@@ -48,6 +33,15 @@ describe("resolveTerminalRunLimits", () => {
     expect(r.maxDurationMs).toBe(600000);
   });
 
+  it("uses the shared parser's canonical whitespace and sign handling", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = " +4 ";
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = " 600000 ";
+    expect(resolveTerminalRunLimits()).toEqual({
+      maxConcurrent: 4,
+      maxDurationMs: 600000,
+    });
+  });
+
   it("clamps concurrency to the hard cap", () => {
     process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "999";
     expect(resolveTerminalRunLimits().maxConcurrent).toBe(16);
@@ -74,6 +68,17 @@ describe("resolveTerminalRunLimits", () => {
     const r = resolveTerminalRunLimits();
     expect(r.maxConcurrent).toBe(2);
     expect(r.maxDurationMs).toBe(5 * 60 * 1000);
+  });
+
+  it("rejects non-canonical numeric forms and unsafe integers", () => {
+    for (const value of ["1.5", "1e2", "0x10", "9007199254740993"]) {
+      process.env.ELIZA_TERMINAL_MAX_CONCURRENT = value;
+      process.env.ELIZA_TERMINAL_MAX_DURATION_MS = value;
+      expect(resolveTerminalRunLimits()).toEqual({
+        maxConcurrent: 2,
+        maxDurationMs: 5 * 60 * 1000,
+      });
+    }
   });
 
   it("falls back to defaults on empty string input", () => {

--- a/packages/agent/src/api/terminal-run-limits.test.ts
+++ b/packages/agent/src/api/terminal-run-limits.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit coverage for resolveTerminalRunLimits — env-driven concurrency and
+ * duration guardrails with clamping to defaults and hard caps.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const ORIG_ENV = { ...process.env };
+
+// Mock @elizaos/shared's parseClampedInteger: fallback for unset, clamp to
+// [min, max], throw/fallback on non-integer. Mirror the real contract.
+vi.mock("@elizaos/shared", () => {
+  const parseClampedInteger = (
+    raw: string | undefined,
+    opts: { fallback: number; min: number; max: number },
+  ): number => {
+    if (raw === undefined || raw.trim() === "") return opts.fallback;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) return opts.fallback;
+    return Math.min(opts.max, Math.max(opts.min, n));
+  };
+  return { parseClampedInteger };
+});
+
+import { resolveTerminalRunLimits } from "./terminal-run-limits.ts";
+
+describe("resolveTerminalRunLimits", () => {
+  beforeEach(() => {
+    process.env = { ...ORIG_ENV };
+    delete process.env.ELIZA_TERMINAL_MAX_CONCURRENT;
+    delete process.env.ELIZA_TERMINAL_MAX_DURATION_MS;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  it("returns defaults when env vars are unset", () => {
+    const r = resolveTerminalRunLimits();
+    expect(r.maxConcurrent).toBe(2);
+    expect(r.maxDurationMs).toBe(5 * 60 * 1000);
+  });
+
+  it("respects explicit values within range", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "4";
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = "600000";
+    const r = resolveTerminalRunLimits();
+    expect(r.maxConcurrent).toBe(4);
+    expect(r.maxDurationMs).toBe(600000);
+  });
+
+  it("clamps concurrency to the hard cap", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "999";
+    expect(resolveTerminalRunLimits().maxConcurrent).toBe(16);
+  });
+
+  it("clamps concurrency to the minimum", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "0";
+    expect(resolveTerminalRunLimits().maxConcurrent).toBe(1);
+  });
+
+  it("clamps duration to the hard cap", () => {
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = "999999999";
+    expect(resolveTerminalRunLimits().maxDurationMs).toBe(60 * 60 * 1000);
+  });
+
+  it("clamps duration to the minimum", () => {
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = "100";
+    expect(resolveTerminalRunLimits().maxDurationMs).toBe(1000);
+  });
+
+  it("falls back to defaults on non-numeric input", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "abc";
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = "not-a-number";
+    const r = resolveTerminalRunLimits();
+    expect(r.maxConcurrent).toBe(2);
+    expect(r.maxDurationMs).toBe(5 * 60 * 1000);
+  });
+
+  it("falls back to defaults on empty string input", () => {
+    process.env.ELIZA_TERMINAL_MAX_CONCURRENT = "";
+    process.env.ELIZA_TERMINAL_MAX_DURATION_MS = "";
+    const r = resolveTerminalRunLimits();
+    expect(r.maxConcurrent).toBe(2);
+    expect(r.maxDurationMs).toBe(5 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for `resolveTerminalRunLimits`, the production helper used by the terminal-run route for concurrency and wall-clock guardrails.

The submitted branch accidentally stacked sibling test PRs and mocked `@elizaos/shared` with a local parser reimplementation. The reviewed branch is rebuilt on current `develop` with only the intended test, and now executes the real shared `parseClampedInteger` contract.

## Coverage (10 cases)

- Defaults when environment values are absent or empty
- Valid explicit concurrency/duration
- Exact min/max clamping
- Real shared-parser whitespace and leading-sign behavior
- Rejection of text, decimal, exponent, hexadecimal, and unsafe-integer forms

## Exact-head evidence

- Evidence head: `0f773192b195c31bab41fa725da0165ec2d7cf71`
- Pinned Bun 1.3.14 / Node 24 focused Vitest: 10/10 passed
- Changed-file Biome: passed
- `git diff --check`: passed
- Production caller trace: `misc-routes.ts` calls `resolveTerminalRunLimits()` immediately before enforcing active-run concurrency and creating the wall-clock timeout.
- Visual/live-model/hardware evidence: N/A — test-only backend configuration coverage.

## Agent disclosure

Original contribution: Hermes Agent / deepseek / deepseek-v4-flash

Reviewer repair: Codex desktop / OpenAI / gpt-5.6-sol