### PR TITLE
test(agent): add privacy redactor coverage

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for defaultPrivacyRedactor — credential, geo, and env-secret
  * redaction over the tool-call cache write path.
  */
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { defaultPrivacyRedactor } from "./redact.ts";
 
 const ORIG_ENV = { ...process.env };
@@ -32,7 +32,7 @@ describe("defaultPrivacyRedactor", () => {
       "auth sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456",
     ) as string;
     expect(out).not.toContain("sk-ant-api03");
-    expect(out).toMatch(/<REDACTED:[a-z-]+>/);
+    expect(out).toContain("<REDACTED:anthropic-key>");
   });
 
   it("redacts a Bearer token", () => {
@@ -70,6 +70,8 @@ describe("defaultPrivacyRedactor", () => {
       '{"latitude": 48.8566, "longitude": 2.3522}',
     ) as string;
     expect(out).toContain("[REDACTED_GEO]");
+    expect(out).not.toContain("48.8566");
+    expect(out).not.toContain("2.3522");
   });
 
   it("redacts env secret values by name", () => {

--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit coverage for defaultPrivacyRedactor — credential, geo, and env-secret
+ * redaction over the tool-call cache write path.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { defaultPrivacyRedactor } from "./tool-call-cache/redact.ts";
+
+const ORIG_ENV = { ...process.env };
+
+describe("defaultPrivacyRedactor", () => {
+  beforeEach(() => {
+    process.env = { ...ORIG_ENV };
+    delete process.env.MY_API_KEY;
+    delete process.env.MY_TOKEN;
+    delete process.env.ELIZA_API_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  it("redacts an OpenAI-style key", () => {
+    const out = defaultPrivacyRedactor(
+      "using key sk-abcdefghijklmnop1234567890",
+    ) as string;
+    expect(out).toContain("<REDACTED:openai-key>");
+    expect(out).not.toContain("sk-abcdefghijklmnop");
+  });
+
+  it("redacts an Anthropic-style key", () => {
+    const out = defaultPrivacyRedactor(
+      "auth sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456",
+    ) as string;
+    expect(out).not.toContain("sk-ant-api03");
+    expect(out).toMatch(/<REDACTED:[a-z-]+>/);
+  });
+
+  it("redacts a Bearer token", () => {
+    const out = defaultPrivacyRedactor(
+      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+    ) as string;
+    expect(out).not.toContain("Bearer abcdefghijklmnopqrstuvwxyz123456");
+    expect(out).toContain("<REDACTED:bearer>");
+  });
+
+  it("redacts a GitHub token", () => {
+    const out = defaultPrivacyRedactor(
+      "token ghp_1234567890abcdefghijklmnopqrst",
+    ) as string;
+    expect(out).not.toContain("ghp_1234567890");
+    expect(out).toContain("<REDACTED:github-token>");
+  });
+
+  it("redacts an AWS access key", () => {
+    const out = defaultPrivacyRedactor("key AKIAIOSFODNN7EXAMPLE") as string;
+    expect(out).not.toContain("AKIAIOSFODNN7");
+    expect(out).toContain("<REDACTED:aws-access-key>");
+  });
+
+  it("redacts geographic coordinates (JSON coords object)", () => {
+    const out = defaultPrivacyRedactor(
+      '{"coords":{"latitude":37.7749,"longitude":-122.4194}}',
+    ) as string;
+    expect(out).toContain("[REDACTED_GEO]");
+    expect(out).not.toContain("37.7749");
+  });
+
+  it("redacts lat/lng pair", () => {
+    const out = defaultPrivacyRedactor(
+      '{"latitude": 48.8566, "longitude": 2.3522}',
+    ) as string;
+    expect(out).toContain("[REDACTED_GEO]");
+  });
+
+  it("redacts env secret values by name", () => {
+    process.env.MY_API_KEY = "super-secret-value-12345";
+    const out = defaultPrivacyRedactor(
+      "the value is super-secret-value-12345",
+    ) as string;
+    expect(out).toContain("<REDACTED:env-secret>");
+    expect(out).not.toContain("super-secret-value-12345");
+  });
+
+  it("recurses into nested objects and arrays", () => {
+    const out = defaultPrivacyRedactor({
+      a: { b: ["plain", "key sk-abcdefghijklmnop1234567890"] },
+      c: { d: "lat 37.7749, -122.4194" },
+    }) as Record<string, unknown>;
+    expect(JSON.stringify(out)).not.toContain("sk-abcdefghijklmnop");
+    expect(JSON.stringify(out)).toContain("[REDACTED_GEO]");
+  });
+
+  it("leaves plain values untouched", () => {
+    const out = defaultPrivacyRedactor(
+      "hello world, no secrets here",
+    ) as string;
+    expect(out).toBe("hello world, no secrets here");
+  });
+
+  it("handles non-string primitives", () => {
+    expect(defaultPrivacyRedactor(42)).toBe(42);
+    expect(defaultPrivacyRedactor(true)).toBe(true);
+    expect(defaultPrivacyRedactor(null)).toBe(null);
+    expect(defaultPrivacyRedactor(undefined)).toBe(undefined);
+  });
+
+  it("does not treat short strings as env secrets", () => {
+    process.env.MY_API_KEY = "short";
+    const out = defaultPrivacyRedactor("the value is short") as string;
+    expect(out).toBe("the value is short");
+  });
+});

--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -3,7 +3,7 @@
  * redaction over the tool-call cache write path.
  */
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { defaultPrivacyRedactor } from "./tool-call-cache/redact.ts";
+import { defaultPrivacyRedactor } from "./redact.ts";
 
 const ORIG_ENV = { ...process.env };
 

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -13,8 +13,10 @@
 import type { PrivacyRedactor } from "./types.ts";
 
 const CREDENTIAL_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "openai-key", pattern: /\bsk-[A-Za-z0-9_-]{16,}\b/g },
+  // The generic sk- shape also accepts hyphens, so the provider-specific
+  // prefix must be classified first.
   { label: "anthropic-key", pattern: /\bsk-ant-[A-Za-z0-9_-]{16,}\b/g },
+  { label: "openai-key", pattern: /\bsk-[A-Za-z0-9_-]{16,}\b/g },
   { label: "bearer", pattern: /\bBearer\s+[A-Za-z0-9._-]{16,}\b/g },
   { label: "github-token", pattern: /\bghp_[A-Za-z0-9]{20,}\b/g },
   { label: "aws-access-key", pattern: /\bAKIA[0-9A-Z]{16}\b/g },


### PR DESCRIPTION
## Summary

Expands coverage for `defaultPrivacyRedactor`, which is wired through `ToolCallCache` into every `DiskStore.write`. The submitted stacked branch was rebuilt on current `develop` with only the intended privacy-redactor commits and a separate reviewer repair.

Deep review found that the generic `sk-` matcher ran before the Anthropic-specific matcher, so Anthropic credentials were redacted but mislabeled as OpenAI credentials. The provider-specific matcher now runs first and the regression requires the exact label.

## Coverage (12 cases)

- Exact OpenAI and Anthropic labels
- Bearer, GitHub, and AWS credential shapes
- Geographic coordinate patterns with raw-value absence checks
- Environment-secret redaction by secret-named key
- Nested object/array recursion, primitive passthrough, and short-value guard

## Exact-head evidence

- Evidence head: `4c035687d1eb7743dd164d5fba1da494fd379937`
- Pinned Bun 1.3.14 / Node 24 focused Vitest: 12/12 passed
- Independent pre-rebase exact audit: combined redactor + full cache seam 32/32, 72 assertions
- Independent real `ToolCallCache -> DiskStore` temp-root write/read: Anthropic label persisted, original credential absent
- The final freshness rebase preserved byte-identical changed source/test blobs; focused 12/12, Biome, and diff-check reran green
- Visual/live-model/hardware evidence: N/A — backend cache redaction with no rendered, model, connector, or device surface.

## Agent disclosure

Original contribution: Hermes Agent / deepseek / deepseek-v4-flash

Reviewer repair and independent review: Codex desktop / OpenAI / gpt-5.6-sol