### PR TITLE
fix(agent): cap per-agent push-token registry before cache overflow

### DIFF
--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -28,9 +28,10 @@ import {
   NOTIFICATION_PUSH_SERVICE_TYPE,
   NotificationPushService,
 } from "../services/push/notification-push-service.ts";
-import type {
-  PushPlatform,
-  PushTokenRegistry,
+import {
+  MAX_PUSH_TOKEN_LENGTH,
+  type PushPlatform,
+  type PushTokenRegistry,
 } from "../services/push/push-token-registry.ts";
 
 export interface PushTokenRouteState {
@@ -91,6 +92,10 @@ export async function handlePushTokenRoute(
     const token = typeof body.token === "string" ? body.token.trim() : "";
     if (!token) {
       helpers.error(res, "token is required", 400);
+      return true;
+    }
+    if (token.length > MAX_PUSH_TOKEN_LENGTH) {
+      helpers.error(res, "token exceeds the length cap", 400);
       return true;
     }
     await registry.register(platform, token);

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -10,6 +10,8 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  MAX_PUSH_TOKEN_LENGTH,
+  MAX_PUSH_TOKENS_PER_AGENT,
   type PushTokenRecord,
   PushTokenRegistry,
 } from "./push-token-registry.ts";
@@ -185,5 +187,63 @@ describe("PushTokenRegistry", () => {
       "android-token",
       "ios-token",
     ]);
+  });
+
+  it("evicts the oldest unique token once the per-agent cap is exceeded", async () => {
+    for (let i = 0; i < MAX_PUSH_TOKENS_PER_AGENT; i++) {
+      await registry.register("ios", `tok-${i}`);
+    }
+    expect(await registry.count()).toBe(MAX_PUSH_TOKENS_PER_AGENT);
+
+    await registry.register("android", "tok-newest");
+    const list = await registry.list();
+    expect(list).toHaveLength(MAX_PUSH_TOKENS_PER_AGENT);
+    expect(list.map((r) => r.token)).toContain("tok-newest");
+    expect(list.map((r) => r.token)).not.toContain("tok-0");
+    expect(list.map((r) => r.token)).toContain("tok-1");
+
+    const persisted = ctx.cache.get(
+      "push-tokens:00000000-0000-0000-0000-0000000000aa",
+    ) as PushTokenRecord[];
+    expect(persisted).toHaveLength(MAX_PUSH_TOKENS_PER_AGENT);
+    expect(persisted.map((r) => r.token)).not.toContain("tok-0");
+  });
+
+  it("does not grow the registry when an existing token is re-registered at the cap", async () => {
+    for (let i = 0; i < MAX_PUSH_TOKENS_PER_AGENT; i++) {
+      await registry.register("ios", `tok-${i}`);
+    }
+    await registry.register("android", "tok-0");
+    const list = await registry.list();
+    expect(list).toHaveLength(MAX_PUSH_TOKENS_PER_AGENT);
+    expect(list.find((r) => r.token === "tok-0")?.platform).toBe("android");
+  });
+
+  it("hydrates only the newest capped records from an oversized cache dump", async () => {
+    const dumped: PushTokenRecord[] = [];
+    for (let i = 0; i < MAX_PUSH_TOKENS_PER_AGENT + 40; i++) {
+      dumped.push({
+        token: `old-${i}`,
+        platform: "ios",
+        createdAt: i + 1,
+      });
+    }
+    ctx.cache.set(
+      "push-tokens:00000000-0000-0000-0000-0000000000aa",
+      dumped,
+    );
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    const list = await fresh.list();
+    expect(list).toHaveLength(MAX_PUSH_TOKENS_PER_AGENT);
+    expect(list.map((r) => r.token)).toContain(
+      `old-${MAX_PUSH_TOKENS_PER_AGENT + 39}`,
+    );
+    expect(list.map((r) => r.token)).not.toContain("old-0");
+  });
+
+  it("rejects a token longer than the length cap", async () => {
+    const huge = "x".repeat(MAX_PUSH_TOKEN_LENGTH + 1);
+    await expect(registry.register("ios", huge)).rejects.toThrow(/length cap/);
+    expect(await registry.count()).toBe(0);
   });
 });

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -30,6 +30,20 @@ export interface PushTokenRecord {
 /** Stable cache key the registry persists under (scoped per agent). */
 const cacheKeyFor = (agentId: string): string => `push-tokens:${agentId}`;
 
+/**
+ * Hard cap on distinct tokens stored per agent. A device re-register is an
+ * upsert; unique tokens are unbounded on origin and `persist()` writes the
+ * entire Map to the durable runtime cache. Oldest `createdAt` is evicted first.
+ */
+export const MAX_PUSH_TOKENS_PER_AGENT = 64;
+
+/**
+ * Hard cap on a single token string. The HTTP body reader already stops at
+ * 8 KiB; this keeps a direct `register()` caller from planting a huge Map key
+ * and a huge cache row.
+ */
+export const MAX_PUSH_TOKEN_LENGTH = 4096;
+
 export class PushTokenRegistry {
   private tokens = new Map<string, PushTokenRecord>();
   private hydrated = false;
@@ -65,9 +79,7 @@ export class PushTokenRegistry {
     );
     if (Array.isArray(stored)) {
       this.tokens = new Map(
-        stored
-          .filter(isPushTokenRecord)
-          .map((record) => [record.token, record]),
+        newestPushTokenRecords(stored).map((record) => [record.token, record]),
       );
     }
     this.hydrated = true;
@@ -97,6 +109,9 @@ export class PushTokenRegistry {
     if (!trimmed) {
       throw new Error("[PushTokenRegistry] token is required");
     }
+    if (trimmed.length > MAX_PUSH_TOKEN_LENGTH) {
+      throw new Error("[PushTokenRegistry] token exceeds the length cap");
+    }
     await this.enqueueMutation(async () => {
       await this.hydrate();
       this.tokens.set(trimmed, {
@@ -104,6 +119,7 @@ export class PushTokenRegistry {
         platform,
         createdAt: Date.now(),
       });
+      evictOldestPushTokens(this.tokens);
       await this.persist();
     });
   }
@@ -136,6 +152,34 @@ export class PushTokenRegistry {
   async count(): Promise<number> {
     await this.hydrate();
     return this.tokens.size;
+  }
+}
+
+function newestPushTokenRecords(stored: unknown[]): PushTokenRecord[] {
+  const valid = stored.filter(isPushTokenRecord);
+  if (valid.length <= MAX_PUSH_TOKENS_PER_AGENT) {
+    return valid;
+  }
+  return valid
+    .slice()
+    .sort((left, right) => right.createdAt - left.createdAt)
+    .slice(0, MAX_PUSH_TOKENS_PER_AGENT);
+}
+
+function evictOldestPushTokens(tokens: Map<string, PushTokenRecord>): void {
+  while (tokens.size > MAX_PUSH_TOKENS_PER_AGENT) {
+    let oldestKey: string | null = null;
+    let oldestAt = Number.POSITIVE_INFINITY;
+    for (const [key, record] of tokens) {
+      if (record.createdAt < oldestAt) {
+        oldestAt = record.createdAt;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey === null) {
+      break;
+    }
+    tokens.delete(oldestKey);
   }
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE hang / 500 / auth-bind / input-boundary audit on a live product path. No new issue filed (mission forbids self-directed issue creation).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

## What

`PushTokenRegistry.register` on origin/develop does `this.tokens.set(trimmed, …)` with no cap, then `persist()` writes the entire Map to the durable runtime cache key `push-tokens:${agentId}`. POST `/api/notifications/push-tokens` already caps the **request body** at 8 KiB; unique `{platform, token}` values still grow memory and the cache without bound. GET materializes the full list.

This head caps the registry at 64 distinct tokens per agent (oldest `createdAt` evicted first), rejects a token over 4096 chars (400 on the route, throw on direct `register()`), and hydrates only the newest 64 records from an oversized cache dump. Same-token re-register remains an upsert and does not grow the set.

## Proof

- Origin `register()` (inlined from `origin/develop` `f43d944af31d`) of N unique tokens → Map + cache size N, no evict.
- Overlay `bun test packages/agent/src/services/push/push-token-registry.test.ts packages/agent/src/api/push-token-routes.test.ts` → **25/25**: origin behavior plus cap evict, upsert-at-cap, hydrate-from-oversized-dump, length-cap reject.

Occupancy-FREE hosts `packages/agent/src/services/push/push-token-registry.ts` and `packages/agent/src/api/push-token-routes.ts`. Not leftover-tax. Not a body-cap / decode / timeout / stringify twin. Not HARD_SKIP.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:69628e1047386bc1a49b17b24eedbf9aa6d896d8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
## What
`PushTokenRegistry.register` on origin/develop does `this.tokens.set(trimmed, …)` with no cap, then `persist()` writes the entire Map to the durable runtime cache key `push-tokens:${agentId}`. POST `/api/notifications/push-tokens` already caps the **request body** at 8 KiB; unique `{platform, token}` values still grow memory and the cache without bound. GET materializes the full list.
This head caps the registry at 64 distinct tokens per agent (oldest `createdAt` evicted first), rejects a token over 4096 chars (400 on the route, throw on direct `register()`), and hydrates only the newest 64 records from an oversized cache dump. Same-token re-register remains an upsert and does not grow the set.
## Proof
- Origin `register()` (inlined from `origin/develop` `f43d944af31d`) of N unique tokens → Map + cache size N, no evict.
- Overlay `bun test packages/agent/src/services/push/push-token-registry.test.ts packages/agent/src/api/push-token-routes.test.ts` → **25/25**: origin behavior plus cap evict, upsert-at-cap, hydrate-from-oversized-dump, length-cap reject.
Occupancy-FREE hosts `packages/agent/src/services/push/push-token-registry.ts` and `packages/agent/src/api/push-token-routes.ts`. Not leftover-tax. Not a body-cap / decode / timeout / stringify twin. Not HARD_SKIP.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
