### PR TITLE
fix(plugin-form): fail closed on user control.pattern compile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1860,6 +1860,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
         "uuid": "^14.0.0",
       },
       "devDependencies": {

--- a/plugins/plugin-form/package.json
+++ b/plugins/plugin-form/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*",
     "uuid": "^14.0.0"
   },
   "agentConfig": {

--- a/plugins/plugin-form/src/__tests__/pattern-deadline-probe.ts
+++ b/plugins/plugin-form/src/__tests__/pattern-deadline-probe.ts
@@ -1,0 +1,57 @@
+/**
+ * Out-of-process probe for the control-pattern execution boundary.
+ *
+ * `validation.test.ts` spawns this file with a hard spawn deadline and reads
+ * the JSON verdict it prints. Running the production paths here rather than in
+ * the Vitest worker means a matcher regression that reintroduces catastrophic
+ * backtracking kills a throwaway child process instead of hanging the test
+ * runner, and the hang is reported as a failure rather than as a timeout with
+ * no evidence.
+ *
+ * argv[2] is a JSON array of `{ name, pattern, input, expectValid }`.
+ */
+
+import { getBuiltinType } from "../builtins";
+import type { FormControl } from "../types";
+import { validateField } from "../validation";
+
+interface ProbeCase {
+  name: string;
+  pattern: string;
+  input: string;
+  expectValid: boolean;
+}
+
+function control(pattern: string): FormControl {
+  return { key: "code", label: "Code", type: "text", pattern };
+}
+
+const cases = JSON.parse(process.argv[2] ?? "[]") as ProbeCase[];
+const builtinText = getBuiltinType("text");
+if (!builtinText?.validate) {
+  throw new Error("built-in text control type is not registered");
+}
+
+const results = cases.map((probe) => {
+  const fieldStart = performance.now();
+  const fieldResult = validateField(probe.input, control(probe.pattern));
+  const fieldMs = performance.now() - fieldStart;
+
+  const builtinStart = performance.now();
+  const builtinResult = builtinText.validate?.(
+    probe.input,
+    control(probe.pattern),
+  );
+  const builtinMs = performance.now() - builtinStart;
+
+  return {
+    name: probe.name,
+    expectValid: probe.expectValid,
+    validateFieldValid: fieldResult.valid,
+    builtinValid: builtinResult?.valid ?? null,
+    validateFieldMs: Math.round(fieldMs),
+    builtinMs: Math.round(builtinMs),
+  };
+});
+
+process.stdout.write(`${JSON.stringify({ results })}\n`);

--- a/plugins/plugin-form/src/builtins.ts
+++ b/plugins/plugin-form/src/builtins.ts
@@ -128,7 +128,9 @@ const textType: ControlType = {
       };
     }
 
-    // Check pattern if specified
+    // Check pattern if specified. Goes through the shared agent-authored-regex
+    // dialect, never a bare `new RegExp` on caller input; any refusal fails
+    // the field closed.
     if (control.pattern) {
       const checked = testControlPattern(control.pattern, str);
       if (!checked.ok) {

--- a/plugins/plugin-form/src/builtins.ts
+++ b/plugins/plugin-form/src/builtins.ts
@@ -65,6 +65,7 @@
 import type { JsonValue } from "@elizaos/core";
 import { basicEmailValid } from "./email";
 import type { ControlType, FormControl, ValidationResult } from "./types";
+import { testControlPattern } from "./validation";
 
 // ============================================================================
 // VALIDATION HELPERS
@@ -129,8 +130,8 @@ const textType: ControlType = {
 
     // Check pattern if specified
     if (control.pattern) {
-      const regex = new RegExp(control.pattern);
-      if (!regex.test(str)) {
+      const checked = testControlPattern(control.pattern, str);
+      if (!checked.ok) {
         return { valid: false, error: "Invalid format" };
       }
     }

--- a/plugins/plugin-form/src/validation.test.ts
+++ b/plugins/plugin-form/src/validation.test.ts
@@ -1,16 +1,28 @@
 /**
- * Control-pattern compile/test must fail closed. Origin validateText did
- * `new RegExp(control.pattern)` with no try/catch, so "(" throws SyntaxError
- * and `^(a+)+$` against a short non-match hangs the event loop.
+ * Holds the execution boundary for `FormControl.pattern`.
+ *
+ * `control.pattern` is agent- or plugin-authored data that reaches
+ * `validateField` (via `FormService.startSession` / `setField` / `submit`) and
+ * the built-in `text` control type. These tests are responsible for three
+ * things on both of those paths: an untrusted pattern is admitted only if it
+ * belongs to the shared linear-time dialect, every refusal fails the field
+ * closed rather than passing the value, and an adversarial pattern/value pair
+ * completes under a hard out-of-process deadline instead of occupying the
+ * event loop. They also pin the ordinary format patterns a form author is
+ * expected to keep using, so tightening the dialect cannot silently break
+ * honest fields.
  */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { getBuiltinType } from "./builtins";
+import type { FormControl, ValidationResult } from "./types";
 import {
   MAX_CONTROL_PATTERN_INPUT_LENGTH,
   MAX_CONTROL_PATTERN_LENGTH,
   testControlPattern,
   validateField,
 } from "./validation";
-import type { FormControl } from "./types";
 
 function textControl(pattern: string): FormControl {
   return {
@@ -21,8 +33,59 @@ function textControl(pattern: string): FormControl {
   };
 }
 
-describe("testControlPattern", () => {
-  it("matches and rejects valid patterns normally", () => {
+function viaBuiltinText(pattern: string, value: string): ValidationResult {
+  const builtin = getBuiltinType("text");
+  if (!builtin?.validate) throw new Error("built-in text control is missing");
+  return builtin.validate(value, textControl(pattern));
+}
+
+/**
+ * Exponential-backtracking families that a nested-quantifier string scan does
+ * not see. Only the first is a nested quantifier; every other entry is flat,
+ * or alternation-based, or bounded, and each is paired with the near-miss
+ * value that makes a backtracking engine blow up on a few dozen characters.
+ */
+const ADVERSARIAL_PATTERNS: Array<{ name: string; pattern: string }> = [
+  { name: "nested quantifier", pattern: "^(a+)+$" },
+  { name: "nested star", pattern: "^(a*)*$" },
+  { name: "extra grouping layer", pattern: "^((a+))+$" },
+  { name: "overlapping alternation", pattern: "^(a|aa)+$" },
+  { name: "duplicate alternation branch", pattern: "^(a|a)+$" },
+  { name: "quantified optional branch", pattern: "^(a?)+$" },
+  { name: "two overlapping repetitions", pattern: "^a+a+$" },
+  { name: "bounded inner repetition", pattern: "^(a{1,2})+$" },
+  { name: "two bounded choices", pattern: "^a{1,40}a{1,40}$" },
+  { name: "counted overlapping optionals", pattern: "^(a?){40}a{40}$" },
+  { name: "word/space repetition", pattern: "^(\\w+\\s?)*$" },
+  { name: "character-class repetition", pattern: "^([a-zA-Z]+)*$" },
+  { name: "backreference ambiguity", pattern: "^(a+)\\1$" },
+  { name: "lookahead", pattern: "^(?=a+)a+$" },
+];
+
+/** The near-miss value: long enough that a hang would be unmistakable. */
+const NEAR_MISS = `${"a".repeat(4_000)}!`;
+
+/**
+ * Ordinary format patterns a form author writes. Tightening the dialect must
+ * not take these away.
+ */
+const HONEST_PATTERNS: Array<{
+  pattern: string;
+  accepts: string;
+  rejects: string;
+}> = [
+  { pattern: "^\\d+$", accepts: "12345", rejects: "12a" },
+  { pattern: "^[A-Z]{3}-\\d{4}$", accepts: "ABC-1234", rejects: "ABC-123" },
+  { pattern: "^[a-z0-9_-]{1,32}$", accepts: "ok_id", rejects: "NO" },
+  { pattern: "^[A-Z]{2}[0-9]{4}$", accepts: "AB1234", rejects: "AB123" },
+  { pattern: "^a{2,4}$", accepts: "aaa", rejects: "a" },
+  { pattern: "\\S", accepts: "x", rejects: "   " },
+  { pattern: "^[0-9]{3}\\.[0-9]{2}$", accepts: "123.45", rejects: "123,45" },
+  { pattern: "^\\+[0-9]{7,15}$", accepts: "+12345678", rejects: "12345678" },
+];
+
+describe("testControlPattern dialect", () => {
+  it("matches and rejects an admitted pattern normally", () => {
     expect(testControlPattern("^\\d+$", "123")).toEqual({ ok: true });
     expect(testControlPattern("^\\d+$", "abc")).toEqual({
       ok: false,
@@ -30,51 +93,211 @@ describe("testControlPattern", () => {
     });
   });
 
-  it("returns invalid instead of throwing on a broken pattern", () => {
+  it("refuses a pattern that does not compile at all", () => {
     expect(testControlPattern("(", "x")).toEqual({
       ok: false,
-      reason: "invalid",
+      reason: "unsupported",
+    });
+    expect(testControlPattern("[a", "x")).toEqual({
+      ok: false,
+      reason: "unsupported",
+    });
+    expect(testControlPattern("", "x")).toEqual({
+      ok: false,
+      reason: "unsupported",
     });
   });
 
-  it("refuses nested quantifiers without running them", () => {
-    const start = Date.now();
-    const result = testControlPattern("^(a+)+$", `${"a".repeat(28)}!`);
-    expect(Date.now() - start).toBeLessThan(50);
-    expect(result).toEqual({ ok: false, reason: "invalid" });
+  it.each(ADVERSARIAL_PATTERNS)(
+    "refuses the $name family before it can execute",
+    ({ pattern }) => {
+      expect(testControlPattern(pattern, NEAR_MISS)).toEqual({
+        ok: false,
+        reason: "unsupported",
+      });
+    },
+  );
+
+  it("keeps escaped metacharacters as literals", () => {
+    expect(testControlPattern("^a\\+b$", "a+b")).toEqual({ ok: true });
+    expect(testControlPattern("^a\\+b$", "aab")).toEqual({
+      ok: false,
+      reason: "mismatch",
+    });
+    expect(testControlPattern("^\\$[0-9]{2}$", "$40")).toEqual({ ok: true });
+    expect(testControlPattern("^a\\.b$", "axb")).toEqual({
+      ok: false,
+      reason: "mismatch",
+    });
+    // An escaped delimiter is a literal, not an opened group or class.
+    expect(testControlPattern("^\\(x\\)$", "(x)")).toEqual({ ok: true });
+    expect(testControlPattern("^\\[x\\]$", "[x]")).toEqual({ ok: true });
   });
 
-  it("refuses over-long patterns and values before compile", () => {
-    expect(
-      testControlPattern("a".repeat(MAX_CONTROL_PATTERN_LENGTH + 1), "a"),
-    ).toEqual({ ok: false, reason: "too-long" });
-    expect(
-      testControlPattern(
-        "^a+$",
-        "a".repeat(MAX_CONTROL_PATTERN_INPUT_LENGTH + 1),
-      ),
-    ).toEqual({ ok: false, reason: "too-long" });
+  it("handles character classes, including ones holding metacharacters", () => {
+    expect(testControlPattern("^[a-c]{2}$", "ab")).toEqual({ ok: true });
+    expect(testControlPattern("^[a-c]{2}$", "ad")).toEqual({
+      ok: false,
+      reason: "mismatch",
+    });
+    expect(testControlPattern("^[^0-9]{3}$", "abc")).toEqual({ ok: true });
+    expect(testControlPattern("^[()|]{1}$", "|")).toEqual({ ok: true });
+    expect(testControlPattern("^[\\]]$", "]")).toEqual({ ok: true });
   });
+
+  it("holds the exact pattern and input boundaries", () => {
+    const atCap = `^${"a".repeat(MAX_CONTROL_PATTERN_LENGTH - 2)}$`;
+    expect(atCap.length).toBe(MAX_CONTROL_PATTERN_LENGTH);
+    expect(
+      testControlPattern(atCap, "a".repeat(MAX_CONTROL_PATTERN_LENGTH - 2)),
+    ).toEqual({ ok: true });
+    expect(testControlPattern(`a${atCap}`, "a")).toEqual({
+      ok: false,
+      reason: "too-long",
+    });
+
+    const atInputCap = "a".repeat(MAX_CONTROL_PATTERN_INPUT_LENGTH);
+    expect(testControlPattern("^a+$", atInputCap)).toEqual({ ok: true });
+    expect(testControlPattern("^a+$", `${atInputCap}a`)).toEqual({
+      ok: false,
+      reason: "too-long",
+    });
+  });
+
+  it.each(HONEST_PATTERNS)(
+    "still runs the ordinary pattern $pattern",
+    ({ pattern, accepts, rejects }) => {
+      expect(testControlPattern(pattern, accepts)).toEqual({ ok: true });
+      expect(testControlPattern(pattern, rejects)).toEqual({
+        ok: false,
+        reason: "mismatch",
+      });
+    },
+  );
 });
 
 describe("validateField pattern host", () => {
-  it("does not throw on an invalid user pattern", () => {
+  it("does not throw on a pattern that fails to compile", () => {
     expect(validateField("x", textControl("("))).toEqual({
       valid: false,
       error: "Code has invalid format",
     });
   });
 
-  it("does not hang on a nested-quantifier user pattern", () => {
-    const start = Date.now();
-    const result = validateField(`${"a".repeat(28)}!`, textControl("^(a+)+$"));
-    expect(Date.now() - start).toBeLessThan(50);
-    expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/invalid format/);
+  it.each(ADVERSARIAL_PATTERNS)(
+    "fails closed on the $name family",
+    ({ pattern }) => {
+      expect(validateField(NEAR_MISS, textControl(pattern))).toEqual({
+        valid: false,
+        error: "Code has invalid format",
+      });
+    },
+  );
+
+  it.each(HONEST_PATTERNS)(
+    "still validates against the ordinary pattern $pattern",
+    ({ pattern, accepts, rejects }) => {
+      expect(validateField(accepts, textControl(pattern)).valid).toBe(true);
+      expect(validateField(rejects, textControl(pattern)).valid).toBe(false);
+    },
+  );
+});
+
+describe("builtin text control pattern host", () => {
+  it("does not throw on a pattern that fails to compile", () => {
+    expect(viaBuiltinText("(", "x")).toEqual({
+      valid: false,
+      error: "Invalid format",
+    });
   });
 
-  it("still accepts a linear pattern", () => {
-    expect(validateField("12345", textControl("^\\d+$")).valid).toBe(true);
-    expect(validateField("abc", textControl("^\\d+$")).valid).toBe(false);
+  it.each(ADVERSARIAL_PATTERNS)(
+    "fails closed on the $name family",
+    ({ pattern }) => {
+      expect(viaBuiltinText(pattern, NEAR_MISS)).toEqual({
+        valid: false,
+        error: "Invalid format",
+      });
+    },
+  );
+
+  it.each(HONEST_PATTERNS)(
+    "still validates against the ordinary pattern $pattern",
+    ({ pattern, accepts, rejects }) => {
+      expect(viaBuiltinText(pattern, accepts).valid).toBe(true);
+      expect(viaBuiltinText(pattern, rejects).valid).toBe(false);
+    },
+  );
+});
+
+/**
+ * The assertions above prove the *answer*. This one proves the *boundedness*:
+ * it runs the same production paths in a separate process under a hard
+ * deadline, so a regression that reintroduces catastrophic backtracking is
+ * reported as a killed child rather than hanging Vitest.
+ */
+describe("control-pattern execution deadline (out of process)", () => {
+  const PROBE_DEADLINE_MS = 20_000;
+  const PER_CASE_BUDGET_MS = 250;
+
+  it("answers every adversarial pattern inside an out-of-process deadline", {
+    timeout: PROBE_DEADLINE_MS + 20_000,
+  }, () => {
+    const probe = fileURLToPath(
+      new URL("./__tests__/pattern-deadline-probe.ts", import.meta.url),
+    );
+    const cases = [
+      ...ADVERSARIAL_PATTERNS.map(({ name, pattern }) => ({
+        name,
+        pattern,
+        input: NEAR_MISS,
+        expectValid: false,
+      })),
+      ...HONEST_PATTERNS.map(({ pattern, accepts }) => ({
+        name: `honest ${pattern}`,
+        pattern,
+        input: accepts,
+        expectValid: true,
+      })),
+    ];
+
+    const result = spawnSync("bun", [probe, JSON.stringify(cases)], {
+      encoding: "utf8",
+      timeout: PROBE_DEADLINE_MS,
+      killSignal: "SIGKILL",
+    });
+
+    expect(
+      result.error,
+      `could not run the out-of-process probe: ${result.error?.message}`,
+    ).toBeUndefined();
+    expect(
+      result.signal,
+      `the probe was killed after ${PROBE_DEADLINE_MS}ms - a control pattern is no longer bounded on the production path`,
+    ).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+
+    const payload = JSON.parse(
+      result.stdout.trim().split("\n").at(-1) ?? "{}",
+    ) as {
+      results: Array<{
+        name: string;
+        expectValid: boolean;
+        validateFieldValid: boolean;
+        builtinValid: boolean | null;
+        validateFieldMs: number;
+        builtinMs: number;
+      }>;
+    };
+
+    expect(payload.results).toHaveLength(cases.length);
+    for (const entry of payload.results) {
+      expect(entry.validateFieldValid, entry.name).toBe(entry.expectValid);
+      expect(entry.builtinValid, entry.name).toBe(entry.expectValid);
+      expect(entry.validateFieldMs, entry.name).toBeLessThan(
+        PER_CASE_BUDGET_MS,
+      );
+      expect(entry.builtinMs, entry.name).toBeLessThan(PER_CASE_BUDGET_MS);
+    }
   });
 });

--- a/plugins/plugin-form/src/validation.test.ts
+++ b/plugins/plugin-form/src/validation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Control-pattern compile/test must fail closed. Origin validateText did
+ * `new RegExp(control.pattern)` with no try/catch, so "(" throws SyntaxError
+ * and `^(a+)+$` against a short non-match hangs the event loop.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CONTROL_PATTERN_INPUT_LENGTH,
+  MAX_CONTROL_PATTERN_LENGTH,
+  testControlPattern,
+  validateField,
+} from "./validation";
+import type { FormControl } from "./types";
+
+function textControl(pattern: string): FormControl {
+  return {
+    key: "code",
+    label: "Code",
+    type: "text",
+    pattern,
+  };
+}
+
+describe("testControlPattern", () => {
+  it("matches and rejects valid patterns normally", () => {
+    expect(testControlPattern("^\\d+$", "123")).toEqual({ ok: true });
+    expect(testControlPattern("^\\d+$", "abc")).toEqual({
+      ok: false,
+      reason: "mismatch",
+    });
+  });
+
+  it("returns invalid instead of throwing on a broken pattern", () => {
+    expect(testControlPattern("(", "x")).toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+
+  it("refuses nested quantifiers without running them", () => {
+    const start = Date.now();
+    const result = testControlPattern("^(a+)+$", `${"a".repeat(28)}!`);
+    expect(Date.now() - start).toBeLessThan(50);
+    expect(result).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("refuses over-long patterns and values before compile", () => {
+    expect(
+      testControlPattern("a".repeat(MAX_CONTROL_PATTERN_LENGTH + 1), "a"),
+    ).toEqual({ ok: false, reason: "too-long" });
+    expect(
+      testControlPattern(
+        "^a+$",
+        "a".repeat(MAX_CONTROL_PATTERN_INPUT_LENGTH + 1),
+      ),
+    ).toEqual({ ok: false, reason: "too-long" });
+  });
+});
+
+describe("validateField pattern host", () => {
+  it("does not throw on an invalid user pattern", () => {
+    expect(validateField("x", textControl("("))).toEqual({
+      valid: false,
+      error: "Code has invalid format",
+    });
+  });
+
+  it("does not hang on a nested-quantifier user pattern", () => {
+    const start = Date.now();
+    const result = validateField(`${"a".repeat(28)}!`, textControl("^(a+)+$"));
+    expect(Date.now() - start).toBeLessThan(50);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/invalid format/);
+  });
+
+  it("still accepts a linear pattern", () => {
+    expect(validateField("12345", textControl("^\\d+$")).valid).toBe(true);
+    expect(validateField("abc", textControl("^\\d+$")).valid).toBe(false);
+  });
+});

--- a/plugins/plugin-form/src/validation.ts
+++ b/plugins/plugin-form/src/validation.ts
@@ -195,6 +195,50 @@ export function validateField(
   }
 }
 
+export const MAX_CONTROL_PATTERN_LENGTH = 256;
+export const MAX_CONTROL_PATTERN_INPUT_LENGTH = 4_096;
+
+/**
+ * Compile and test a caller-supplied form control pattern without throwing
+ * or running nested-quantifier JavaScript regexes that hang the event loop.
+ */
+export function testControlPattern(
+  pattern: string,
+  value: string,
+): { ok: true } | { ok: false; reason: "invalid" | "mismatch" | "too-long" } {
+  if (typeof pattern !== "string" || pattern.length === 0) {
+    return { ok: false, reason: "invalid" };
+  }
+  if (
+    pattern.length > MAX_CONTROL_PATTERN_LENGTH ||
+    value.length > MAX_CONTROL_PATTERN_INPUT_LENGTH
+  ) {
+    return { ok: false, reason: "too-long" };
+  }
+  if (hasNestedQuantifier(pattern)) {
+    return { ok: false, reason: "invalid" };
+  }
+  try {
+    const regex = new RegExp(pattern);
+    return regex.test(value) ? { ok: true } : { ok: false, reason: "mismatch" };
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+}
+
+function hasNestedQuantifier(pattern: string): boolean {
+  for (let i = 0; i < pattern.length - 1; i += 1) {
+    const ch = pattern[i];
+    if (ch !== "+" && ch !== "*") continue;
+    let j = i + 1;
+    if (pattern[j] === "?") j += 1;
+    if (pattern[j] !== ")") continue;
+    const next = pattern[j + 1];
+    if (next === "+" || next === "*" || next === "{") return true;
+  }
+  return false;
+}
+
 /**
  * Validate text field.
  *
@@ -209,8 +253,8 @@ function validateText(
   // Pattern validation
   // WHY regex: Flexible, powerful, user-defined patterns
   if (control.pattern) {
-    const regex = new RegExp(control.pattern);
-    if (!regex.test(strValue)) {
+    const checked = testControlPattern(control.pattern, strValue);
+    if (!checked.ok) {
       return {
         valid: false,
         error: `${control.label || control.key} has invalid format`,

--- a/plugins/plugin-form/src/validation.ts
+++ b/plugins/plugin-form/src/validation.ts
@@ -46,6 +46,12 @@
  */
 
 import type { JsonValue } from "@elizaos/core";
+import {
+  isSafeUntrustedRegexPattern,
+  MAX_UNTRUSTED_REGEX_INPUT_LENGTH,
+  MAX_UNTRUSTED_REGEX_PATTERN_LENGTH,
+  matchesSafeUntrustedRegexPattern,
+} from "@elizaos/shared/config/config-catalog";
 import { strictEmailValid } from "./email";
 import type { FormControl, TypeHandler } from "./types";
 
@@ -195,19 +201,40 @@ export function validateField(
   }
 }
 
-export const MAX_CONTROL_PATTERN_LENGTH = 256;
-export const MAX_CONTROL_PATTERN_INPUT_LENGTH = 4_096;
+/**
+ * Caps and dialect for `FormControl.pattern` come from the shared
+ * agent-authored-regex policy in `@elizaos/shared`, the same gate the config
+ * and UI renderers use. Re-exported here so form code and its tests have one
+ * name for them and one source of truth for the numbers.
+ */
+export const MAX_CONTROL_PATTERN_LENGTH = MAX_UNTRUSTED_REGEX_PATTERN_LENGTH;
+export const MAX_CONTROL_PATTERN_INPUT_LENGTH =
+  MAX_UNTRUSTED_REGEX_INPUT_LENGTH;
 
 /**
- * Compile and test a caller-supplied form control pattern without throwing
- * or running nested-quantifier JavaScript regexes that hang the event loop.
+ * Test a caller-supplied form control pattern against a value.
+ *
+ * WHY the shared dialect instead of `new RegExp(pattern).test(value)`:
+ * `control.pattern` is agent- or plugin-authored data, and a backtracking
+ * engine lets that data choose its own running time. Neither a try/catch nor a
+ * length cap bounds it - `^(a|aa)+$` is nine characters and takes seconds on a
+ * forty-character near-miss. `isSafeUntrustedRegexPattern` admits only a flat
+ * sequence with at most one variable repetition (no groups, no alternation, no
+ * backreferences, bounded fixed repetitions), so an admitted pattern has no
+ * ambiguity to backtrack through, and everything else is refused before the
+ * engine ever sees it.
+ *
+ * Every non-`ok` result is a validation failure at both call sites, so a
+ * refused pattern fails the field closed rather than passing it unchecked.
  */
 export function testControlPattern(
   pattern: string,
   value: string,
-): { ok: true } | { ok: false; reason: "invalid" | "mismatch" | "too-long" } {
+):
+  | { ok: true }
+  | { ok: false; reason: "unsupported" | "mismatch" | "too-long" } {
   if (typeof pattern !== "string" || pattern.length === 0) {
-    return { ok: false, reason: "invalid" };
+    return { ok: false, reason: "unsupported" };
   }
   if (
     pattern.length > MAX_CONTROL_PATTERN_LENGTH ||
@@ -215,28 +242,12 @@ export function testControlPattern(
   ) {
     return { ok: false, reason: "too-long" };
   }
-  if (hasNestedQuantifier(pattern)) {
-    return { ok: false, reason: "invalid" };
+  if (!isSafeUntrustedRegexPattern(pattern)) {
+    return { ok: false, reason: "unsupported" };
   }
-  try {
-    const regex = new RegExp(pattern);
-    return regex.test(value) ? { ok: true } : { ok: false, reason: "mismatch" };
-  } catch {
-    return { ok: false, reason: "invalid" };
-  }
-}
-
-function hasNestedQuantifier(pattern: string): boolean {
-  for (let i = 0; i < pattern.length - 1; i += 1) {
-    const ch = pattern[i];
-    if (ch !== "+" && ch !== "*") continue;
-    let j = i + 1;
-    if (pattern[j] === "?") j += 1;
-    if (pattern[j] !== ")") continue;
-    const next = pattern[j + 1];
-    if (next === "+" || next === "*" || next === "{") return true;
-  }
-  return false;
+  return matchesSafeUntrustedRegexPattern(pattern, value)
+    ? { ok: true }
+    : { ok: false, reason: "mismatch" };
 }
 
 /**
@@ -250,8 +261,8 @@ function validateText(
 ): ValidationResult {
   const strValue = String(value);
 
-  // Pattern validation
-  // WHY regex: Flexible, powerful, user-defined patterns
+  // Pattern validation. Untrusted pattern text never reaches a bare
+  // `new RegExp(...).test(...)`; see testControlPattern.
   if (control.pattern) {
     const checked = testControlPattern(control.pattern, strValue);
     if (!checked.ok) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23330

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

The superseded head `cd07082e983b` - the nested-quantifier heuristic this
review rejected - was authored with `xai/grok-4.6` via Grok Bot.app. The
current head deletes that heuristic and is authored as declared above.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change removes a bespoke guard and routes `FormControl.pattern`
through `isSafeUntrustedRegexPattern` / `matchesSafeUntrustedRegexPattern` -
the agent-authored-regex policy already merged in `@elizaos/shared` and already
used by the config and UI renderers. No new dialect is invented. The dialect is
narrower than JavaScript's, so a pattern using groups, alternation,
backreferences, lookaround, or more than one variable repetition now fails the
field closed with the ordinary "invalid format" error instead of executing; the
ordinary format patterns form authors write are covered by tests and unchanged.
No schema, API contract, or storage migration.

# Background

## What does this PR do?

# Relates to

#23330 - untrusted `FormControl.pattern` is compiled and executed as an
unbounded `RegExp` in `@elizaos/plugin-form`.

# Evidence Gate

## What

On develop, `validateText` in `validation.ts` and the built-in `text` control in
`builtins.ts` both do `new RegExp(control.pattern)` then `.test(strValue)` with
no try/catch and no bound on execution. `FormService.startSession` / `setField`
/ `submit` reach both through `validateField` (`service.ts` is HARD_SKIP and is
not edited).

The first head of this PR wrapped that in a try/catch, length caps, and a
`hasNestedQuantifier` string scan. Review rejected the scan, correctly: it only
sees `+` or `*` immediately before `)` followed by another quantifier, so every
one of these passed it and still executed:

| family | pattern | nested? |
| --- | --- | --- |
| overlapping alternation | `^(a\|aa)+$` | no |
| duplicate alternation branch | `^(a\|a)+$` | no |
| quantified optional branch | `^(a?)+$` | no |
| two flat overlapping repetitions | `^a+a+$` | no |
| bounded inner repetition | `^(a{1,2})+$` | no |
| two bounded choices | `^a{1,40}a{1,40}$` | no |
| backreference ambiguity | `^(a+)\1$` | no |

A length cap does not bound backtracking work, so no cap repairs that shape.

**This head deletes the heuristic and reuses the policy this repository already
merged for the same problem.** `isSafeUntrustedRegexPattern` /
`matchesSafeUntrustedRegexPattern` in
`packages/shared/src/config/config-catalog.ts` admit only a flat sequence with
at most one variable repetition - no groups, no alternation, no
backreferences, no lookaround, fixed repetitions bounded by the subject ceiling
- and are already the gate for agent-authored config and UI validators. An
admitted pattern has no ambiguity to backtrack through; everything else is
refused before the engine sees it.

`testControlPattern` now delegates to that gate and returns `unsupported`,
`too-long` or `mismatch`. Both hosts treat every non-`ok` result as a
validation failure, so the fail-closed claim holds for arbitrary pattern syntax
rather than for one shape. The caps come from the shared constants
(`MAX_UNTRUSTED_REGEX_PATTERN_LENGTH` / `MAX_UNTRUSTED_REGEX_INPUT_LENGTH`)
instead of a second set of numbers, and no `catch` remains on this path - so
the `error-policy:J3` classification the review asked for has nothing left to
annotate here; the one retained catch lives in the shared helper and already
carries it.

## Scope

- `plugins/plugin-form/src/validation.ts`
- `plugins/plugin-form/src/builtins.ts`
- `plugins/plugin-form/src/validation.test.ts`
- `plugins/plugin-form/src/__tests__/pattern-deadline-probe.ts` (new)
- `plugins/plugin-form/package.json` + `bun.lock` (`@elizaos/shared` workspace
  dependency; the lockfile hunk is exactly that one line)

Does not edit HARD_SKIP `service.ts` / `template.ts` / `form-control-graph.ts`.

## Proof

Executed on this exact head, rebased onto `origin/develop` `3c6a11f121da`:

- `bun run --cwd plugins/plugin-form test` -> **9 files / 128 tests passed**
- `bun run --cwd plugins/plugin-form typecheck` -> pass (`tsc --noEmit`)
- `bun run --cwd plugins/plugin-form lint:check` -> pass (36 files, biome)
- root `bun run verify` -> **red at `check:i18n`**, unrelated pre-existing
  `packages/ui` translation drift; the rest of the same chain was executed
  explicitly, including `turbo run typecheck lint:check` for this package.
  See Known gaps for the exact split and the five upstream reds.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-form/src/validation.test.ts`. It drives fourteen adversarial
families - only the first is a nested quantifier - through **both** hosts,
`validateField` and the built-in `text` control, and asserts each fails the
field closed. Then the last describe block: it re-runs the same production
paths in a **separate process under a hard spawn deadline**
(`src/__tests__/pattern-deadline-probe.ts`), so a regression that reintroduces
catastrophic backtracking is reported as a killed child instead of hanging
Vitest.

## Detailed testing steps

```
bun install
bun run --cwd packages/core build     # plugin-form tests import @elizaos/core
bun run --cwd plugins/plugin-form test
bun run --cwd plugins/plugin-form typecheck
bun run --cwd plugins/plugin-form lint:check
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:116e325d04155602b1adf2c839fe48300bfbdedc -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow; the change is field-validation logic.

<!-- evidence-row:backend-logs -->
- [x] N/A - no server, route, or process boundary in this unit; the change is a
      pure function reached by `validateField`, and the executed test
      transcript below is the proof.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
$ git rev-parse HEAD
116e325d04155602b1adf2c839fe48300bfbdedc
$ git diff --name-only origin/develop...HEAD
bun.lock
plugins/plugin-form/package.json
plugins/plugin-form/src/__tests__/pattern-deadline-probe.ts
plugins/plugin-form/src/builtins.ts
plugins/plugin-form/src/validation.test.ts
plugins/plugin-form/src/validation.ts

$ git diff origin/develop...HEAD -- bun.lock
+        "@elizaos/shared": "workspace:*",      (one line, under plugin-form)

$ bun run --cwd plugins/plugin-form test
 Test Files  9 passed (9)
      Tests  128 passed (128)

$ bun run --cwd plugins/plugin-form typecheck
$ tsc --noEmit -p tsconfig.json          (exit 0, no output)

$ bun run --cwd plugins/plugin-form lint:check
Checked 36 files in 442ms. No fixes applied.   (exit 0)

Test coverage added at this head (all through BOTH hosts, validateField and
the built-in text control):
  adversarial families, each vs a 4,001-char near-miss value
    nested quantifier            ^(a+)+$
    nested star                  ^(a*)*$
    extra grouping layer         ^((a+))+$
    overlapping alternation      ^(a|aa)+$
    duplicate alternation branch ^(a|a)+$
    quantified optional branch   ^(a?)+$
    two overlapping repetitions  ^a+a+$
    bounded inner repetition     ^(a{1,2})+$
    two bounded choices          ^a{1,40}a{1,40}$
    counted overlapping optional ^(a?){40}a{40}$
    word/space repetition        ^(\w+\s?)*$
    character-class repetition   ^([a-zA-Z]+)*$
    backreference ambiguity      ^(a+)\1$
    lookahead                    ^(?=a+)a+$
  escaped metacharacters         ^a\+b$  ^\$[0-9]{2}$  ^\(x\)$  ^\[x\]$
  character classes              ^[a-c]{2}$  ^[^0-9]{3}$  ^[()|]{1}$  ^[\]]$
  exact boundaries               pattern at/over MAX_CONTROL_PATTERN_LENGTH,
                                 value at/over MAX_CONTROL_PATTERN_INPUT_LENGTH
  ordinary patterns preserved    ^\d+$  ^[A-Z]{3}-\d{4}$  ^[a-z0-9_-]{1,32}$
                                 ^[A-Z]{2}[0-9]{4}$  ^a{2,4}$  \S
                                 ^[0-9]{3}\.[0-9]{2}$  ^\+[0-9]{7,15}$
  out-of-process deadline        every case above re-run in a spawned child
                                 with a hard 20s kill deadline and a 250ms
                                 per-case budget; a hang is a killed child,
                                 not a hung Vitest worker
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

**Root `bun run verify` is red on this head, and none of the five blockers is
in this diff.** `git diff --name-only origin/develop...HEAD` touches only
`plugins/plugin-form` plus the one-line lockfile entry, so every other package
on this branch is byte-identical to `origin/develop` `3c6a11f121da`.

1. `check:i18n` - pre-existing `packages/ui` translation-key drift
   (`cloud.agents.detail.sharedAgent`, `cloud.agents.detail.errorWithCount`
   and siblings across es/ja/ko/pt/tl/vi/zh-CN). This is where `verify` stops.
2. `@elizaos/agent#lint:check` - two biome formatting findings in
   `packages/agent/src/api/http-access-context.test.ts`, a file this PR does
   not touch.
3. `@elizaos/cloud-api#typecheck` - two `TS2353` errors in
   `packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts`,
   also untouched here.
4. `@elizaos/container-control-plane#typecheck`.
5. `audit:mock-module-exports` - one baseline violation, a mock in
   `packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts` missing
   the bound export `readPersonalElizaCutover`. `packages/cloud` on this
   branch is byte-identical to `origin/develop`, and the gate reproduces
   standalone (`bun run audit:mock-module-exports`) with the same single
   finding.

Correcting my own earlier summary in the review reply, which said the
`audit:*` gates were all green: gate 5 above is red. Everything else in the
chain was executed explicitly on this head and passed -
`check:agents-claude`, `check:biome-version`, the bun-version and turbo-cache
contracts, `fix-deps:check`, `ensure-plugin-test-conventions:check`,
`audit:alias-read-guard`, `audit:tsconfig-workspace-resolution`,
`turbo run typecheck lint:check --filter=@elizaos/plugin-form`,
`audit:build-model`, `audit:turbo-build-deps`, `audit:tee-secret-leak`,
`audit:hetzner-fleet-routing`, `audit:workflow-triggers`, `audit:scripts`,
`audit:scripts:inventory`, `audit:test-lane-membership`,
`audit:provider-contracts`, `audit:view-bundle-inventory` and
`audit:focused-tests`. The monorepo-wide `turbo run typecheck lint:check`
stops on blockers 2-4, which is why the turbo stage above is reported scoped
to the package this PR changes.

Fork cannot upload `pr-evidence` release assets, so the domain receipt is
inline, and a fork PR gets no hosted checks until a maintainer approves the
workflow run.

**Behavioural narrowing, stated plainly.** The shared dialect is smaller than
JavaScript's: a form definition relying on groups, alternation,
backreferences, lookaround, or more than one variable repetition is now
rejected as an invalid format instead of matched. In-repo exposure is zero -
`git grep -nE "pattern:\s*[\"'\`]" -- plugins/ packages/` returns one hit and
it is a `console.warn` string in plugin-vision, so no shipped form definition
declares a control pattern - and the ordinary format patterns are pinned by
tests. This is the same trade the config and UI renderers already took.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
