### PR TITLE
fix(cloud): make Discord gateway quota atomic

### DIFF
--- a/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
+++ b/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
@@ -91,6 +91,7 @@ interface CreateAgentTestParams {
   userId: string;
   agentName: string;
   dockerImage: string;
+  maxNonTerminalAgents: number;
 }
 
 /** Extract the first argument of the first `createAgent` call, or null. */
@@ -129,6 +130,9 @@ describe("provisioning-agent DEFAULT_DOCKER_IMAGE", () => {
     const call = firstCreateAgentCall();
     expect(call).toBeDefined();
     expect(call!.dockerImage).toBe("ghcr.io/elizaos/eliza:stable");
+    // $10 balance resolves to the existing 100-agent tier. The shared create
+    // authority, not this route's stale preflight, enforces it at insertion.
+    expect(call!.maxNonTerminalAgents).toBe(100);
   });
 
   test("rejects the legacy bare image name (no ghcr.io prefix)", async () => {
@@ -198,6 +202,40 @@ describe("provisioning-agent DEFAULT_DOCKER_IMAGE", () => {
     expect(await res.json()).toMatchObject({ code: "insufficient_credits" });
     // The gate fires BEFORE any dedicated agent is minted/provisioned.
     expect(mockCreateAgent).not.toHaveBeenCalled();
+    expect(mockEnqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("maps an atomic quota refusal to the canonical 429 envelope", async () => {
+    mockListByOrganization.mockResolvedValue([]);
+    mockCreateAgent.mockClear();
+    mockEnqueueAgentProvision.mockClear();
+    mockCheckAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 10,
+      error: undefined,
+    });
+    mockCreateAgent.mockRejectedValueOnce(
+      new elizaSandboxActual.AgentQuotaExceededError(100, 100),
+    );
+
+    const response = await app.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { Authorization: "Bearer valid-session-token" },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect((await response.json()) as unknown).toEqual({
+      success: false,
+      error:
+        "Agent quota exceeded: your organization already has 100 active agents (limit 100). Delete or stop an agent, or add credits to raise the limit.",
+      code: "agent_quota_exceeded",
+      details: {
+        currentAgents: 100,
+        maxAgents: 100,
+      },
+    });
     expect(mockEnqueueAgentProvision).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/route.ts
@@ -12,11 +12,16 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { containersEnv } from "@/lib/config/containers-env";
+import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  AgentQuotaExceededError,
+  elizaSandboxService,
+} from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -122,6 +127,9 @@ app.post("/", async (c) => {
         agentName: DEFAULT_AGENT_NAME,
         dockerImage: DEFAULT_DOCKER_IMAGE,
         reuseExistingNonTerminal: true,
+        maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(
+          creditCheck.balance,
+        ),
       });
 
     // The org-scoped guard reused an in-flight sandbox; its provision job is
@@ -163,6 +171,23 @@ app.post("/", async (c) => {
       data: { status: sandbox.status, agentId: sandbox.id },
     });
   } catch (err) {
+    if (err instanceof AgentQuotaExceededError) {
+      logger.warn(
+        "[eliza-app provisioning-agent] provision blocked: per-org quota exceeded",
+        {
+          orgId: session.organizationId,
+          count: err.count,
+          max: err.max,
+        },
+      );
+      return failureResponse(
+        c,
+        new ApiError(429, "agent_quota_exceeded", err.message, {
+          currentAgents: err.count,
+          maxAgents: err.max,
+        }),
+      );
+    }
     logger.error("[eliza-app provisioning-agent] POST provision error", {
       error: err,
     });

--- a/packages/cloud/api/v1/eliza/discord/gateway-agent/route.test.ts
+++ b/packages/cloud/api/v1/eliza/discord/gateway-agent/route.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pins the managed Discord gateway route's quota boundary: it delegates the
+ * primary-backed atomic admission to the service and translates an at-cap
+ * refusal to the canonical API envelope.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as compatActual from "@/lib/api/compat-envelope";
+import * as authActual from "@/lib/auth/workers-hono-auth";
+import * as managedDiscordActual from "@/lib/services/agent-managed-discord";
+import { AgentQuotaExceededError } from "@/lib/services/eliza-sandbox";
+
+const authSnapshot = { ...authActual };
+const compatSnapshot = { ...compatActual };
+const managedDiscordSnapshot = { ...managedDiscordActual };
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "00000000-0000-4000-8000-000000000002",
+  organization_id: "00000000-0000-4000-8000-000000000001",
+}));
+const ensureGatewayAgent = mock(async () => ({
+  created: false,
+  sandbox: { id: "00000000-0000-4000-8000-000000000003" },
+}));
+const toCompatAgent = mock((sandbox: { id: string }) => ({
+  agent_id: sandbox.id,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...authSnapshot,
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/api/compat-envelope", () => ({
+  ...compatSnapshot,
+  toCompatAgent,
+}));
+mock.module("@/lib/services/agent-managed-discord", () => ({
+  ...managedDiscordSnapshot,
+  managedAgentDiscordService: {
+    ...managedDiscordSnapshot.managedAgentDiscordService,
+    ensureGatewayAgent,
+  },
+}));
+const { default: app } = await import(
+  `./route.ts?test=gateway-quota-${Date.now()}`
+);
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => authSnapshot);
+  mock.module("@/lib/api/compat-envelope", () => compatSnapshot);
+  mock.module(
+    "@/lib/services/agent-managed-discord",
+    () => managedDiscordSnapshot,
+  );
+});
+
+describe("POST /api/v1/eliza/discord/gateway-agent", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    ensureGatewayAgent.mockClear();
+    ensureGatewayAgent.mockResolvedValue({
+      created: false,
+      sandbox: { id: "00000000-0000-4000-8000-000000000003" },
+    });
+    toCompatAgent.mockClear();
+  });
+
+  test("delegates quota admission to the atomic service authority", async () => {
+    const response = await app.request("/", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect(ensureGatewayAgent).toHaveBeenCalledWith({
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+    });
+    expect(await response.json()).toEqual({
+      success: true,
+      data: {
+        agent: { agent_id: "00000000-0000-4000-8000-000000000003" },
+        created: false,
+      },
+    });
+  });
+
+  test("returns the canonical typed quota response when admission is full", async () => {
+    ensureGatewayAgent.mockRejectedValueOnce(
+      new AgentQuotaExceededError(20, 20),
+    );
+
+    const response = await app.request("/", { method: "POST" });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(await response.json()).toEqual({
+      success: false,
+      error:
+        "Agent quota exceeded: your organization already has 20 active agents (limit 20). Delete or stop an agent, or add credits to raise the limit.",
+      code: "agent_quota_exceeded",
+      details: {
+        currentAgents: 20,
+        maxAgents: 20,
+      },
+    });
+    expect(toCompatAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/discord/gateway-agent/route.ts
+++ b/packages/cloud/api/v1/eliza/discord/gateway-agent/route.ts
@@ -6,10 +6,11 @@
  */
 
 import { Hono } from "hono";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { toCompatAgent } from "@/lib/api/compat-envelope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { managedAgentDiscordService } from "@/lib/services/agent-managed-discord";
+import { AgentQuotaExceededError } from "@/lib/services/eliza-sandbox";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -30,6 +31,15 @@ app.post("/", async (c) => {
       },
     });
   } catch (error) {
+    if (error instanceof AgentQuotaExceededError) {
+      return failureResponse(
+        c,
+        new ApiError(429, "agent_quota_exceeded", error.message, {
+          currentAgents: error.count,
+          maxAgents: error.max,
+        }),
+      );
+    }
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
@@ -44,12 +44,14 @@ import { users } from "../../../db/schemas/users";
 
 const PGLITE_TIMEOUT = 60_000;
 const CAP = 3;
+const GATEWAY_CAP = 5;
 let pgliteReady = true;
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
 let AgentQuotaExceededError: typeof import("../eliza-sandbox").AgentQuotaExceededError;
+let ManagedAgentDiscordService: typeof import("../agent-managed-discord").ManagedAgentDiscordService;
 
 let seq = 0;
 function uniq(p: string): string {
@@ -57,10 +59,10 @@ function uniq(p: string): string {
   return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-async function seedOrg(): Promise<string> {
+async function seedOrg(creditBalance = "5.000000"): Promise<string> {
   const [org] = await dbWrite
     .insert(organizations)
-    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .values({ name: "Org", slug: uniq("org"), credit_balance: creditBalance })
     .returning();
   return org.id;
 }
@@ -93,6 +95,7 @@ beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ ElizaSandboxService, AgentQuotaExceededError } = await import("../eliza-sandbox"));
+    ({ ManagedAgentDiscordService } = await import("../agent-managed-discord"));
 
     const schema = { organizations, users, userCharacters, agentSandboxes };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
@@ -274,6 +277,238 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
         }),
       ).rejects.toBeInstanceOf(AgentQuotaExceededError);
       expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("managed Discord gateway — quota-atomic ensure (#23003)", () => {
+  test(
+    "two concurrent first-use ensures converge on one row and one creation winner",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ManagedAgentDiscordService();
+
+      // Both promises are released in the same turn. The real transaction's
+      // org lock serializes marker recheck -> quota -> insert, so the second
+      // call reconstructs the first call's committed logical resource.
+      const outcomes = await Promise.allSettled([
+        svc.ensureGatewayAgent({
+          organizationId: orgId,
+          userId,
+        }),
+        svc.ensureGatewayAgent({
+          organizationId: orgId,
+          userId,
+        }),
+      ]);
+
+      const fulfilled = outcomes.flatMap((outcome) =>
+        outcome.status === "fulfilled" ? [outcome.value] : [],
+      );
+      expect(fulfilled).toHaveLength(2);
+      expect(fulfilled.map((result) => result.sandbox.id)).toEqual([
+        fulfilled[0]?.sandbox.id,
+        fulfilled[0]?.sandbox.id,
+      ]);
+      expect(fulfilled.map((result) => result.created).sort()).toEqual([false, true]);
+      expect(await countOrgRows(orgId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "at capacity a missing gateway inserts nothing and throws the typed quota error",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const orgId = await seedOrg("0.500000");
+      const userId = await seedUser(orgId);
+      const sandboxSvc = new ElizaSandboxService();
+      const gatewaySvc = new ManagedAgentDiscordService();
+
+      for (let i = 0; i < GATEWAY_CAP; i++) {
+        await sandboxSvc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `at-cap-${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: GATEWAY_CAP,
+        });
+      }
+
+      await expect(
+        gatewaySvc.ensureGatewayAgent({
+          organizationId: orgId,
+          userId,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      expect(await countOrgRows(orgId)).toBe(GATEWAY_CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an existing gateway retries successfully at capacity without consuming another slot",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const orgId = await seedOrg("0.500000");
+      const userId = await seedUser(orgId);
+      const sandboxSvc = new ElizaSandboxService();
+      const gatewaySvc = new ManagedAgentDiscordService();
+
+      const first = await gatewaySvc.ensureGatewayAgent({
+        organizationId: orgId,
+        userId,
+      });
+      for (let i = 1; i < GATEWAY_CAP; i++) {
+        await sandboxSvc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `fill-${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: GATEWAY_CAP,
+        });
+      }
+
+      const retry = await gatewaySvc.ensureGatewayAgent({
+        organizationId: orgId,
+        userId,
+      });
+      expect(first.created).toBe(true);
+      expect(retry.created).toBe(false);
+      expect(retry.sandbox.id).toBe(first.sandbox.id);
+      expect(await countOrgRows(orgId)).toBe(GATEWAY_CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "gateway, eliza-app, and standard creates race for the last slot with one fresh admission",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const orgId = await seedOrg("0.500000");
+      const userId = await seedUser(orgId);
+      const sandboxSvc = new ElizaSandboxService();
+      const gatewaySvc = new ManagedAgentDiscordService();
+
+      // Eliza-app uses createAgent's reuse branch. Fill limit-1 with stopped
+      // rows so that branch cannot reuse a live row and must compete for the
+      // same final quota slot as the gateway.
+      for (let i = 0; i < GATEWAY_CAP - 1; i++) {
+        const created = await sandboxSvc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `stopped-${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: GATEWAY_CAP,
+        });
+        await setAgentStatus(created.agent.id, "stopped");
+      }
+
+      const outcomes = await Promise.allSettled([
+        gatewaySvc
+          .ensureGatewayAgent({
+            organizationId: orgId,
+            userId,
+          })
+          .then((result) => ({
+            kind: "gateway" as const,
+            inserted: result.created,
+          })),
+        sandboxSvc
+          .createAgent({
+            organizationId: orgId,
+            userId,
+            agentName: "eliza-app-racer",
+            executionTier: "custom",
+            reuseExistingNonTerminal: true,
+            maxNonTerminalAgents: GATEWAY_CAP,
+          })
+          .then((result) => ({
+            kind: "eliza-app" as const,
+            inserted: !result.idempotent,
+          })),
+        sandboxSvc
+          .createAgent({
+            organizationId: orgId,
+            userId,
+            agentName: "standard-racer",
+            executionTier: "custom",
+            reuseExistingNonTerminal: false,
+            maxNonTerminalAgents: GATEWAY_CAP,
+          })
+          .then((result) => ({
+            kind: "standard" as const,
+            inserted: !result.idempotent,
+          })),
+      ]);
+
+      const fulfilled = outcomes.flatMap((outcome) =>
+        outcome.status === "fulfilled" ? [outcome.value] : [],
+      );
+      const rejected = outcomes.filter(
+        (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+      );
+      // Eliza-app may idempotently reuse whichever live row wins first (the
+      // pre-existing #22553 selection behavior, deliberately not changed
+      // here), so fulfilled CALLS may be 1 or 2. Fresh INSERT admissions must
+      // still have exactly one winner, and every loser is a typed quota error.
+      expect(fulfilled.filter((outcome) => outcome.inserted)).toHaveLength(1);
+      expect(rejected.length).toBeGreaterThanOrEqual(1);
+      for (const rejection of rejected) {
+        expect(rejection.reason).toBeInstanceOf(AgentQuotaExceededError);
+      }
+      expect(await countOrgRows(orgId)).toBe(GATEWAY_CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "organization quota remains isolated under concurrent ensures",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const orgA = await seedOrg("0.500000");
+      const userA = await seedUser(orgA);
+      const orgB = await seedOrg("0.500000");
+      const userB = await seedUser(orgB);
+      const sandboxSvc = new ElizaSandboxService();
+      const gatewaySvc = new ManagedAgentDiscordService();
+
+      // Saturate A first. If the quota count accidentally loses its tenant
+      // predicate, B's concurrent ensure will also be refused.
+      for (let i = 0; i < GATEWAY_CAP; i++) {
+        await sandboxSvc.createAgent({
+          organizationId: orgA,
+          userId: userA,
+          agentName: `org-a-${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: GATEWAY_CAP,
+        });
+      }
+
+      const outcomes = await Promise.allSettled([
+        gatewaySvc.ensureGatewayAgent({
+          organizationId: orgA,
+          userId: userA,
+        }),
+        gatewaySvc.ensureGatewayAgent({
+          organizationId: orgB,
+          userId: userB,
+        }),
+      ]);
+
+      expect(outcomes[0]?.status).toBe("rejected");
+      if (outcomes[0]?.status === "rejected") {
+        expect(outcomes[0].reason).toBeInstanceOf(AgentQuotaExceededError);
+      }
+      expect(outcomes[1]?.status).toBe("fulfilled");
+      if (outcomes[1]?.status === "fulfilled") {
+        expect(outcomes[1].value.created).toBe(true);
+      }
+      expect(await countOrgRows(orgA)).toBe(GATEWAY_CAP);
+      expect(await countOrgRows(orgB)).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Transaction-trace proof for managed Discord gateway admission (#23003).
+ *
+ * PGlite serializes statements and therefore proves the observable quota
+ * result but not the advisory-lock key or ordering. This focused boundary test
+ * captures the real Drizzle SQL emitted by the transaction helper and pins the
+ * sequence: deadlines -> org advisory lock -> primary balance -> scoped marker
+ * recheck -> quota count -> insert.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { DbTransaction } from "../../db/client";
+import { ensureManagedDiscordGatewayInTransaction } from "./agent-managed-discord";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const USER_ID = "22222222-2222-4222-8222-222222222222";
+const AGENT_ID = "33333333-3333-4333-8333-333333333333";
+
+describe("ensureManagedDiscordGatewayInTransaction", () => {
+  test("orders the org lock before primary tier, scoped marker, quota, and insert", async () => {
+    const events: string[] = [];
+    const whereClauses: SQL[] = [];
+    let selectNumber = 0;
+
+    const execute = mock(async (statement: SQL) => {
+      const query = new PgDialect().sqlToQuery(statement);
+      if (query.sql.includes("set_config")) {
+        events.push("deadlines");
+      } else if (query.sql.includes("pg_advisory_xact_lock")) {
+        events.push("org-lock");
+        expect(query.params).toContain(ORG_ID);
+        expect(query.params).toContain("agent-create");
+      }
+      return { rows: [] };
+    });
+
+    const select = mock(() => {
+      selectNumber += 1;
+      const current = selectNumber;
+      const chain = {
+        from: () => chain,
+        where: (clause: SQL) => {
+          whereClauses.push(clause);
+          return chain;
+        },
+        orderBy: () => chain,
+        for: () => chain,
+        limit: async () => {
+          if (current === 1) {
+            events.push("primary-balance");
+            return [{ creditBalance: "0.500000" }];
+          }
+          events.push("gateway-marker");
+          return [];
+        },
+        // biome-ignore lint/suspicious/noThenProperty: Drizzle's quota count is awaited at where().
+        then: (resolve: (rows: Array<{ count: number }>) => unknown) => {
+          events.push("quota-count");
+          return resolve([{ count: 0 }]);
+        },
+      };
+      return chain;
+    });
+
+    const insert = mock(() => ({
+      values: mock(() => ({
+        returning: mock(async () => {
+          events.push("insert");
+          return [
+            {
+              id: AGENT_ID,
+              organization_id: ORG_ID,
+              user_id: USER_ID,
+              agent_config: {
+                __agentManagedDiscordGateway: {
+                  mode: "shared-gateway",
+                  createdAt: "2026-08-20T00:00:00.000Z",
+                },
+              },
+            },
+          ];
+        }),
+      })),
+    }));
+
+    const tx = { execute, select, insert } as unknown as DbTransaction;
+    const result = await ensureManagedDiscordGatewayInTransaction(tx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.sandbox.id).toBe(AGENT_ID);
+    expect(events).toEqual([
+      "deadlines",
+      "org-lock",
+      "primary-balance",
+      "gateway-marker",
+      "quota-count",
+      "insert",
+    ]);
+
+    expect(whereClauses).toHaveLength(3);
+    const marker = new PgDialect().sqlToQuery(whereClauses[1] as SQL);
+    expect(marker.sql).toContain("organization_id");
+    expect(marker.sql).toContain("agent_config");
+    expect(marker.sql).toContain("'shared-gateway'");
+    expect(marker.params).toContain(ORG_ID);
+    expect(marker.params).toContain("__agentManagedDiscordGateway");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
@@ -1,14 +1,26 @@
 // Coordinates cloud service agent managed discord behavior behind route handlers.
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
+import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
+import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { type AgentSandbox, agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { organizations } from "../../db/schemas/organizations";
+import { getMaxNonTerminalAgentsForOrg } from "../constants/agent-sandbox-quota";
 import { logger } from "../utils/logger";
 import {
+  AGENT_MANAGED_DISCORD_GATEWAY_KEY,
   type ManagedAgentDiscordBinding,
   readManagedAgentDiscordBinding,
-  readManagedAgentDiscordGateway,
   withManagedAgentDiscordBinding,
   withManagedAgentDiscordGateway,
   withoutManagedAgentDiscordBinding,
 } from "./eliza-agent-config";
+import {
+  configureElizaLifecycleTransaction,
+  elizaAgentCreateAdvisoryLockSql,
+} from "./eliza-provision-lock";
+import { assertOrgAgentQuota } from "./eliza-sandbox";
 import { provisioningJobService } from "./provisioning-jobs";
 
 const DISCORD_OWNER_USER_IDS_ENV_KEY = "AGENT_DISCORD_OWNER_USER_IDS_JSON";
@@ -131,44 +143,109 @@ function toStatus(
   };
 }
 
-export class ManagedAgentDiscordService {
-  async ensureGatewayAgent(params: { organizationId: string; userId: string }): Promise<{
-    created: boolean;
-    sandbox: Awaited<ReturnType<typeof agentSandboxesRepository.create>>;
-  }> {
-    const sandboxes = await agentSandboxesRepository.listByOrganization(params.organizationId);
-    const existingGateway = sandboxes.find((sandbox) =>
-      readManagedAgentDiscordGateway(
-        (sandbox.agent_config as Record<string, unknown> | null) ?? {},
+/**
+ * Execute the gateway marker recheck and quota admission under one caller-owned
+ * primary transaction. Exported for a transaction-trace test; production
+ * callers should use {@link ManagedAgentDiscordService.ensureGatewayAgent}.
+ */
+export async function ensureManagedDiscordGatewayInTransaction(
+  tx: DbTransaction,
+  params: { organizationId: string; userId: string },
+): Promise<{ created: boolean; sandbox: AgentSandbox }> {
+  await configureElizaLifecycleTransaction(tx);
+  await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
+
+  // Resolve the tier from the primary inside the admission transaction.
+  // Cache/replica reads can lag a balance decrease for minutes and admit a
+  // gateway against a tier the organization no longer owns.
+  const [organization] = await tx
+    .select({ creditBalance: organizations.credit_balance })
+    .from(organizations)
+    .where(eq(organizations.id, params.organizationId))
+    .limit(1);
+  const creditBalance = Number.parseFloat(String(organization?.creditBalance ?? ""));
+  const maxNonTerminalAgents = getMaxNonTerminalAgentsForOrg(creditBalance);
+
+  // This MUST be a primary-DB marker recheck under the org lock. Filter to the
+  // one logical gateway row: locking every sandbox in the organization couples
+  // admission to unrelated lifecycle work and can exhaust the bounded timeout.
+  const [existingGateway] = await tx
+    .select()
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.organization_id, params.organizationId),
+        sql`${agentSandboxes.agent_config} -> ${AGENT_MANAGED_DISCORD_GATEWAY_KEY} ->> 'mode' = 'shared-gateway'`,
       ),
-    );
+    )
+    .orderBy(desc(agentSandboxes.created_at))
+    .for("update")
+    .limit(1);
 
-    if (existingGateway) {
-      return {
-        created: false,
-        sandbox: existingGateway,
-      };
-    }
+  if (existingGateway) {
+    return {
+      created: false,
+      sandbox: existingGateway,
+    };
+  }
 
-    const sandbox = await agentSandboxesRepository.create({
+  await assertOrgAgentQuota(tx, params.organizationId, maxNonTerminalAgents);
+
+  const [sandbox] = await tx
+    .insert(agentSandboxes)
+    .values({
       organization_id: params.organizationId,
       user_id: params.userId,
       agent_name: MANAGED_DISCORD_GATEWAY_AGENT_NAME,
       agent_config: withManagedAgentDiscordGateway({}),
       environment_vars: {},
+      // `pending` + non-pool is intentionally quota-counted. Keep this aligned
+      // with QUOTA_COUNTED_STATUSES and account-limit snapshots.
       status: "pending",
+      pool_status: null,
       database_status: "none",
-    });
+    })
+    .returning();
+  if (!sandbox) {
+    throw new Error("Failed to create managed Discord gateway agent");
+  }
 
-    logger.info("[managed-discord] Created shared Discord gateway agent", {
-      agentId: sandbox.id,
-      organizationId: params.organizationId,
-    });
+  return {
+    created: true,
+    sandbox,
+  };
+}
 
-    return {
-      created: true,
-      sandbox,
-    };
+export class ManagedAgentDiscordService {
+  /**
+   * Return the org's shared Discord gateway, creating it atomically when absent.
+   *
+   * The gateway is deliberately a regular non-pool `pending` sandbox, so it
+   * consumes one slot from the same resource-holding agent quota as every other
+   * user-owned sandbox. The marker recheck, quota count, and insert all run
+   * under the canonical per-org create lock; concurrent gateway retries and
+   * sibling create routes therefore share one admission authority.
+   */
+  async ensureGatewayAgent(params: { organizationId: string; userId: string }): Promise<{
+    created: boolean;
+    sandbox: AgentSandbox;
+  }> {
+    // Preserve the repository create path's compatibility bootstrap before
+    // moving the admission itself into a direct transaction.
+    await ensureAgentSandboxSchema();
+
+    const result = await dbWrite.transaction((tx) =>
+      ensureManagedDiscordGatewayInTransaction(tx, params),
+    );
+
+    if (result.created) {
+      logger.info("[managed-discord] Created shared Discord gateway agent", {
+        agentId: result.sandbox.id,
+        organizationId: params.organizationId,
+      });
+    }
+
+    return result;
   }
 
   async getStatus(params: {

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
@@ -94,6 +94,7 @@ describe("ensureElizaAppProvisioning", () => {
       agentName: "Eliza",
       dockerImage: "ghcr.io/elizaos/eliza:stable",
       reuseExistingNonTerminal: true,
+      maxNonTerminalAgents: 20,
     });
     expect(enqueueAgentProvision).toHaveBeenCalledWith({
       agentId: "agent-1",

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
@@ -4,6 +4,7 @@ import { jobsRepository } from "../../../db/repositories/jobs";
 import type { AgentSandbox, AgentSandboxStatus } from "../../../db/schemas/agent-sandboxes";
 import { ApiError } from "../../api/cloud-worker-errors";
 import { containersEnv } from "../../config/containers-env";
+import { getMaxNonTerminalAgentsForOrg } from "../../constants/agent-sandbox-quota";
 import { logger } from "../../utils/logger";
 import { checkAgentCreditGate } from "../agent-billing-gate";
 import { elizaSandboxService } from "../eliza-sandbox";
@@ -214,6 +215,7 @@ export async function ensureElizaAppProvisioning(params: {
     agentName: DEFAULT_AGENT_NAME,
     dockerImage: DEFAULT_DOCKER_IMAGE,
     reuseExistingNonTerminal: true,
+    maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(creditGate.balance),
   });
 
   // The org-scoped guard reused an in-flight sandbox; its provision job is


### PR DESCRIPTION
Closes #23003.

## What changed

- serialize managed-Discord gateway admission with the canonical organization-scoped creation lock
- read the balance tier, recheck the gateway marker, enforce the shared non-terminal sandbox ceiling, and insert on the primary writer in one transaction
- keep existing-gateway retries idempotent even when the organization is already at capacity
- pass the same balance-derived ceiling through both eliza-app provisioning front doors
- map late atomic quota rejection to the canonical `429 AGENT_QUOTA_EXCEEDED` response

## Verification

- shared trace + real PGlite quota/concurrency tests: 15 passed, 75 assertions
- API gateway/provisioning route tests: 7 passed, 23 assertions
- eliza-app provisioning tests: 15 passed, 34 assertions
- Biome: 9 changed files checked, no findings
- `git diff --check`
- independent review: no P0–P3 findings after the stale-balance, over-broad row-lock, and lock-discrimination follow-ups were resolved

The concurrency suite covers double first-use, at-cap rejection, retry at cap, a gateway/eliza-app/standard-create race for the last slot, and organization isolation. The SQL trace test also verifies the deadline setup, organization-keyed advisory lock, primary balance read, scoped marker recheck, quota count, and insert order.

No quota tier, pricing, provider call, secret, migration, or production configuration is changed.

Generated by OpenAI gpt-5 / Codex.
