### PR TITLE
fix(homepage): fail closed on hung Eliza Cloud hops in elizacloudFetch

### DIFF
--- a/packages/homepage/src/lib/api/client.ts
+++ b/packages/homepage/src/lib/api/client.ts
@@ -32,6 +32,9 @@ function buildUrl(path: string, params?: Record<string, string>): string {
   return url.toString();
 }
 
+/** Fail closed instead of hanging when an Eliza Cloud hop never responds. */
+const ELIZACLOUD_FETCH_TIMEOUT_MS = 15_000;
+
 export async function elizacloudFetch<T = unknown>(
   path: string,
   init?: ApiRequestInit,
@@ -40,6 +43,7 @@ export async function elizacloudFetch<T = unknown>(
   const url = buildUrl(path, params);
   const res = await fetch(url, {
     ...reqInit,
+    signal: reqInit.signal ?? AbortSignal.timeout(ELIZACLOUD_FETCH_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/json",
       ...reqInit.headers,

--- a/packages/homepage/tests/elizacloud-fetch-timeout.test.ts
+++ b/packages/homepage/tests/elizacloud-fetch-timeout.test.ts
@@ -1,0 +1,100 @@
+/**
+ * elizacloudFetch AbortSignal contract (#22907): default timeout signal,
+ * caller signal passthrough, fail-closed on a hung Cloud hop, and honest
+ * JSON success.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import net from "node:net";
+import { elizacloudAuthFetch, elizacloudFetch } from "../src/lib/api/client";
+
+const servers: net.Server[] = [];
+
+async function listenHold(): Promise<string> {
+  // Accept-and-hold: connection opens, response never comes.
+  const server = net.createServer(() => {});
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as net.AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+async function listenJson(body: string): Promise<string> {
+  const server = net.createServer((socket) => {
+    socket.on("data", () => {
+      socket.end(
+        "HTTP/1.1 200 OK\r\n" +
+          "Content-Type: application/json\r\n" +
+          `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+          "Connection: close\r\n\r\n" +
+          body,
+      );
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as net.AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+afterAll(() => {
+  for (const server of servers) server.close();
+});
+
+describe("elizacloudFetch abort signal (#22907)", () => {
+  test("applies a default AbortSignal when the caller passes none", async () => {
+    const realFetch = globalThis.fetch;
+    let captured: RequestInit | undefined;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      captured = init;
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch;
+    try {
+      await elizacloudFetch("/api/agents");
+      expect(captured?.signal).toBeInstanceOf(AbortSignal);
+      expect(captured?.signal?.aborted).toBe(false);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("caller-passed signal is used unchanged, not replaced", async () => {
+    const realFetch = globalThis.fetch;
+    let captured: RequestInit | undefined;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      captured = init;
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch;
+    try {
+      const controller = new AbortController();
+      await elizacloudFetch("/api/agents", { signal: controller.signal });
+      expect(captured?.signal).toBe(controller.signal);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("hung Cloud hop fails closed with TimeoutError", async () => {
+    process.env.VITE_ELIZACLOUD_API_URL = await listenHold();
+    expect(
+      elizacloudFetch("/api/agents", { signal: AbortSignal.timeout(250) }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  test("honest JSON success still returns", async () => {
+    process.env.VITE_ELIZACLOUD_API_URL = await listenJson(
+      JSON.stringify({ ok: true, source: "hold-free" }),
+    );
+    const result = await elizacloudFetch<{ ok: boolean; source: string }>(
+      "/api/agents",
+    );
+    expect(result).toEqual({ ok: true, source: "hold-free" });
+  });
+
+  test("elizacloudAuthFetch inherits the timeout via the shared helper", async () => {
+    process.env.VITE_ELIZACLOUD_API_URL = await listenHold();
+    expect(
+      elizacloudAuthFetch("/api/agents", { signal: AbortSignal.timeout(250) }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #22907

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from frozen `origin/develop` SHA `b73d8ea66c546fbc6f6f64ff6ac704b336e691c4`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. (Not run — see Known gaps; focused tests + scoped typecheck + real-browser harness evidence below.)
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`b73d8ea66c546fbc6f6f64ff6ac704b336e691c4`); zero conflicts.
- [ ] `bun run verify` was **not** run in this measured lane — the exact scope of what was and was not verified is recorded in **Known gaps / failures**.

# Risks

Low. One shared helper (`elizacloudFetch`) gains a default `AbortSignal.timeout(15_000)`; any caller that already passes `signal` keeps its own signal unchanged (identity-tested). Grepped every in-repo browser consumer of the helper (`use-eliza-app-provisioning-chat.ts`, `auth-context.tsx`, `get-started.tsx`) — none pass `signal` today, so the only behavior change is that a Cloud hop that never responds now rejects with `TimeoutError` after 15s instead of hanging the page forever. Requests that complete normally are unaffected (JSON success path exercised against a real local HTTP listener).

# Background

## What does this PR do?

`packages/homepage/src/lib/api/client.ts` `elizacloudFetch` spread caller init into `fetch` with no `signal`, so an Eliza Cloud hop that accepts the TCP connection and never responds hung homepage marketing/auth pages indefinitely (`/profile/edit` spins on "Opening payout profile…" forever — see Before capture). This PR defaults the request to `signal: reqInit.signal ?? AbortSignal.timeout(15_000)` — a hung hop now fails closed with `TimeoutError`, callers that pass their own `signal` are untouched, and `elizacloudAuthFetch` inherits the guard because it routes through the shared helper. The browser consumer is the real production path: `AuthProvider.initAuth` → `fetchUserInfo` → `elizacloudFetch("/api/eliza-app/user/me")` fires on every page load that has a stored session token.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/homepage/src/lib/api/client.ts` (one-line default signal in `elizacloudFetch`)
- `packages/homepage/tests/elizacloud-fetch-timeout.test.ts` (5 focused tests)

## Detailed testing steps

Exact head: `dd9cb6da218e0e8406006017ac98ce00fa41f494`.

1. Reproduced the hang on the frozen base SHA (`b73d8ea6`) with an accept-and-hold TCP listener, Node v24.17.0 — the current `elizacloudFetch` fetch shape (no signal) stays pending at ~818 ms while the same fetch with `AbortSignal.timeout(800)` rejects `TimeoutError` (transcript in Backend logs row).
2. Ran 5 focused bun tests on this head (`bun --conditions=eliza-source test tests/elizacloud-fetch-timeout.test.ts` from `packages/homepage`): 5 pass / 0 fail. Covered: default `AbortSignal` applied when caller passes none; caller-passed `signal` used unchanged (identity-checked); hung accept-and-hold hop rejects `TimeoutError` (real `net` listener, real fetch); honest JSON success still returns the parsed body; `elizacloudAuthFetch` inherits the timeout through the shared helper.
3. Real-browser proof through the package's isolated source harness (`packages/homepage` Vite + Playwright Chromium, `VITE_ELIZACLOUD_API_URL` pointed at the hold listener, session token seeded in `localStorage`): on base, `/profile/edit` spins forever; on this head, the default 15s timeout fires (`TimeoutError: signal timed out` at t≈15s in console, request `net::ERR_ABORTED`), auth fails closed, and the page redirects to sign-in. Desktop + mobile captures and video in the Evidence Gate rows.
4. Scoped typecheck of the two touched files (`bunx tsc --ignoreConfig --noEmit --strict …`) exits 0.

Tests edited: yes — one new file, `packages/homepage/tests/elizacloud-fetch-timeout.test.ts`. No existing test files modified.

# Evidence Gate

Evidence artifacts live on the fork evidence branch `Uuriko/eliza@evidence/22907-elizacloud-fetch-timeout` (fork CLI tooling cannot mint GitHub-hosted upload links, #17600).
<!-- evidence-head:dd9cb6da218e0e8406006017ac98ce00fa41f494 -->


| Evidence row | Artifact |
| --- | --- |
| before-screenshots | ![before desktop](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/before-desktop.jpg) ![before mobile](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/before-mobile.jpg) |
| after-screenshots | ![after desktop](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-desktop.jpg) ![after mobile](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-mobile.jpg) |
| walkthrough-video | https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-walkthrough.mp4 |
| backend-logs | repro + focused bun test transcripts, inline in the row below |
| frontend-logs | browser console + network trace (TimeoutError, net::ERR_ABORTED, fail-closed redirect), inline in the row below |
| ocr-review | rendered DOM text asserted verbatim in the harness logs (stronger than OCR; no OCR tool on this runner) |

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - fork CLI tooling cannot mint GitHub-hosted upload links (#17600); the real pre-fix captures (base `b73d8ea6`, hung Cloud hop, `/profile/edit` still stuck on the loading spinner at t=20s, desktop and mobile) are rendered directly below this row.
![before desktop — /profile/edit stuck on "Opening payout profile…" spinner at t=20s](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/before-desktop.jpg)
![before mobile — same hung spinner at t=20s on 390x844](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - fork CLI tooling cannot mint GitHub-hosted upload links (#17600); the real post-fix captures (head `dd9cb6da`, same hung hop, 15s default timeout fires, auth fails closed and by t=20s the page has redirected to sign-in at `/get-started?returnTo=%2Fprofile%2Fedit`, desktop and mobile) are rendered directly below this row.
![after desktop — failed closed and redirected to sign-in by t=20s](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-desktop.jpg)
![after mobile — same fail-closed redirect on 390x844](https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - fork CLI tooling cannot mint GitHub-hosted upload links (#17600); the real MP4 walkthrough (1440x900, complete after-fix flow: page load with seeded session token, 15s hung hop, TimeoutError, fail-closed redirect to sign-in) is linked directly below this row.
https://raw.githubusercontent.com/Uuriko/eliza/evidence/22907-elizacloud-fetch-timeout/after-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] Terminal transcripts of the repro (base SHA) and the focused test run (head SHA) attached inline:
<details><summary>backend logs / terminal output: hang repro on base b73d8ea6 + focused bun test run on head dd9cb6da</summary>

```text
$ node --version
v24.17.0
$ node /tmp/repro-22907.mjs        # accept-and-hold TCP listener; shape A = current elizacloudFetch options
A untimed fetch after ~818ms: still-pending
B AbortSignal.timeout(800) fetch: rejected:TimeoutError after 805ms

$ cd packages/homepage && bun --conditions=eliza-source test tests/elizacloud-fetch-timeout.test.ts
bun test v1.3.14 (0d9b296a)
 5 pass
 0 fail
 6 expect() calls
Ran 5 tests across 1 file. [569.00ms]
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Browser console + network trace from the Playwright harness runs (full files: `before-logs.txt` / `after-logs.txt` on the evidence branch):
<details><summary>frontend console + network logs: before (hangs) vs after (TimeoutError, request aborted, fail-closed redirect)</summary>

```text
# BEFORE (base b73d8ea6) — request to hung hop never settles, page never leaves the spinner
2026-08-20T17:06:57.959Z [network:mobile] -> GET http://127.0.0.1:47331/api/eliza-app/user/me
2026-08-20T17:07:17.612Z [flow:mobile] t=20619ms url=http://localhost:5199/profile/edit
2026-08-20T17:07:17.667Z [flow:mobile] visible text: Opening payout profile…Sign in is required. We'll bring you back here afterward.

# AFTER (head dd9cb6da) — default 15s AbortSignal.timeout fires, fetch aborts, auth fails closed
2026-08-20T17:07:56.451Z [network:mobile] -> GET http://127.0.0.1:47331/api/eliza-app/user/me
2026-08-20T17:08:11.445Z [console:mobile] error [Auth] Failed to fetch user info: TimeoutError: signal timed out
2026-08-20T17:08:11.451Z [network:mobile] FAILED http://127.0.0.1:47331/api/eliza-app/user/me :: net::ERR_ABORTED
2026-08-20T17:08:16.086Z [flow:mobile] t=20637ms url=http://localhost:5199/get-started?returnTo=%2Fprofile%2Fedit
2026-08-20T17:08:16.126Z [flow:mobile] visible text: HomeAnywhere you want her to be.Pick where you want to talk to Eliza.
```

</details>
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; static homepage fetch helper.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, tasks, wallet, or generated files involved; the network-level artifacts are the logs and captures above.`
<!-- evidence-row:ocr-review -->
- [x] The rendered text of each captured state is asserted verbatim in the harness logs above (`visible text: Opening payout profile…` before vs the sign-in page text after) — exact string capture of the rendered DOM, strictly stronger than OCR output; no OCR tool is installed on this runner.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; static homepage fetch helper.`

## Screenshots (before / after) + video walkthrough

Rendered inline in the Evidence Gate rows above; source files on `Uuriko/eliza@evidence/22907-elizacloud-fetch-timeout`. Captured through the package's isolated source harness (`packages/homepage` Vite + Playwright), which is this package's supported visual-evidence surface; `packages/app` remains the only deploy host and was not rebuilt for this diff.

## Audio / voice walkthrough

`N/A - no voice/TTS/STT surface touched.`

## Known gaps / failures

- **Not run:** `bun run verify` and full `bun install` (focused-test contract for this measured lane). Focused tests, scoped typecheck, and the real-browser harness runs above were run instead.
- **Not run:** full `packages/homepage` `tsc -b` typecheck — blocked in this environment by a pre-existing missing `lucide-react` type resolution in the local `packages/ui` node_modules (unrelated to this diff; the two touched files typecheck clean standalone with `--strict`).
- **Residual (left open on purpose):** an automated test at the literal 15s default would sleep 15s, so the default duration is exercised in the real-browser harness capture (TimeoutError at t≈15s in the after logs/video) rather than in the bun test suite; the suite proves the default signal is installed and that the signal wiring fails closed against a real hung TCP listener with a short `AbortSignal.timeout`. This is why the PR says **Relates to** rather than Fixes — the issue can close once a maintainer accepts this coverage as meeting the acceptance lines.
- Rollback / previous-green: base SHA `b73d8ea66c546fbc6f6f64ff6ac704b336e691c4` (frozen `origin/develop` at branch time).

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-22907]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0G1JGVXVGRRS5FASK7Q49M0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-20T16:55:21.725Z","completed_at":"2026-08-20T16:59:13.456Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"lgNcNhy0Gy9yFun62LvDGypl_nZgEVXWDBwu7u4c2eniTnsDbq96vCLdruWa4L1QOdonbxjkeCOIAwp8g-adDw"}} -->
