### PR TITLE
feat(cloud): add dormant restore target authority

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -76,6 +76,14 @@ describe("dormant restore API boundary", () => {
         occurrences.every((path) => path.includes("/db/repositories/")),
         `${symbol} must remain inside the dormant repository layer`,
       ).toBe(true);
+      const invocationLikeOccurrences = production.match(
+        new RegExp(`\\b${symbol}(?:<[^>]+>)?\\s*\\(`, "g"),
+      );
+      const expectedInvocationLikeOccurrences = symbol === "loadAgentBackupRestoreSourceV3" ? 2 : 1;
+      expect(
+        invocationLikeOccurrences ?? [],
+        `${symbol} gained a production call site`,
+      ).toHaveLength(expectedInvocationLikeOccurrences);
     }
     expect(readFileSync(join(import.meta.dir, "index.ts"), "utf8")).not.toMatch(
       /agent-backup-restore|agent-vault-key-authority/,
@@ -104,6 +112,26 @@ describe("dormant restore API boundary", () => {
       "Restore operation cannot leave target reservation without complete target authority",
     );
 
+    const openOperation = operationSource.slice(
+      operationSource.indexOf("export async function openAgentBackupRestoreOperation"),
+      operationSource.indexOf("export async function claimAgentBackupRestoreOperation"),
+    );
+    const transactionalOpen = openOperation.slice(
+      openOperation.indexOf("return await dbWrite.transaction"),
+    );
+    const openLockAnchors = [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(tx)",
+    ];
+    for (let index = 1; index < openLockAnchors.length; index += 1) {
+      expect(transactionalOpen.indexOf(openLockAnchors[index - 1] as string)).toBeLessThan(
+        transactionalOpen.indexOf(openLockAnchors[index] as string),
+      );
+    }
+
     const reserveSource = operationSource.slice(
       operationSource.indexOf("export async function reserveAgentBackupRestoreTarget"),
       operationSource.indexOf("export async function advanceAgentBackupRestoreOperation"),
@@ -113,10 +141,11 @@ describe("dormant restore API boundary", () => {
     );
     const lockAnchors = [
       ".from(agentSandboxBackups)",
-      "lockAgentBackupCatalogAuthority(",
       ".from(agentBackupRestoreOperations)",
       ".from(agentBackupRestoreLeases)",
       ".from(dockerNodes)",
+      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(tx)",
     ];
     for (let index = 1; index < lockAnchors.length; index += 1) {
@@ -144,6 +173,58 @@ describe("dormant restore API boundary", () => {
       expect(restoreVaultAuthority).toContain(requiredAuthorityField);
     }
 
+    const targetProof = restoreVaultAuthority.slice(
+      restoreVaultAuthority.indexOf("async function proveAgentBackupRestoreVaultTargetAuthority"),
+      restoreVaultAuthority.indexOf("export async function withAgentBackupRestoreVaultPassphrase"),
+    );
+    const vaultLockAnchors = [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      ".from(dockerNodes)",
+      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(tx)",
+    ];
+    for (let index = 1; index < vaultLockAnchors.length; index += 1) {
+      expect(targetProof.indexOf(vaultLockAnchors[index - 1] as string)).toBeLessThan(
+        targetProof.indexOf(vaultLockAnchors[index] as string),
+      );
+    }
+    const finalClock = targetProof.indexOf("readPostLockDatabaseNow(tx)");
+    const lockedHandoff = targetProof.indexOf(
+      "runBoundedAgentBackupRestoreVaultTargetHandoff(",
+      finalClock,
+    );
+    const postHandoffClock = targetProof.indexOf(
+      "const afterHandoffDatabaseNow = await readPostLockDatabaseNow(tx)",
+      lockedHandoff,
+    );
+    expect(finalClock).toBeGreaterThanOrEqual(0);
+    expect(lockedHandoff).toBeGreaterThan(finalClock);
+    expect(postHandoffClock).toBeGreaterThan(lockedHandoff);
+    expect(targetProof.indexOf("return await dbWrite.transaction")).toBeGreaterThanOrEqual(0);
+    expect(vaultSource).toContain("MAX_RESTORE_VAULT_HANDOFF_TIMEOUT_MS = 60_000");
+    expect(vaultSource).toContain("RESTORE_VAULT_HANDOFF_AUTHORITY_MARGIN_MS = 1_000");
+    expect(vaultSource).toContain("return await Promise.race([");
+    expect(vaultSource).toContain("controller.abort(timeoutError)");
+
+    const historySource = readFileSync(
+      join(import.meta.dir, "repositories/agent-backup-restore-history.ts"),
+      "utf8",
+    );
+    const incarnationProof = historySource.slice(
+      historySource.indexOf(
+        "export async function proveUnambiguousAgentNodeIncarnationForLockedNode",
+      ),
+      historySource.indexOf("async function lockCurrentNodeHistory"),
+    );
+    expect(incarnationProof).toContain(
+      "ne(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation)",
+    );
+    expect(incarnationProof).toContain("node.created_at > history.attested_at");
+    expect(incarnationProof).not.toMatch(/\bxmin\b|\bage\s*\(|\bgte\s*\(/);
+
     const vaultCallback = restoreVaultAuthority.slice(
       restoreVaultAuthority.indexOf("export async function withAgentBackupRestoreVaultPassphrase"),
     );
@@ -163,13 +244,44 @@ describe("dormant restore API boundary", () => {
       "await proveAgentBackupRestoreVaultTargetAuthority(",
       preKmsTargetProof + 1,
     );
-    const secretUse = vaultCallback.indexOf("secret.withPassphrase(use)", postKmsTargetProof);
+    const secretUse = vaultCallback.indexOf("secret.withPassphrase(", postKmsTargetProof);
     expect(preKmsSource).toBeGreaterThanOrEqual(0);
     expect(preKmsTargetProof).toBeGreaterThan(preKmsSource);
     expect(kmsDecrypt).toBeGreaterThan(preKmsTargetProof);
     expect(postKmsSource).toBeGreaterThan(kmsDecrypt);
     expect(postKmsTargetProof).toBeGreaterThan(postKmsSource);
     expect(secretUse).toBeGreaterThan(postKmsTargetProof);
+    expect(vaultCallback.slice(preKmsTargetProof, kmsDecrypt)).not.toContain(
+      "secret.withPassphrase",
+    );
+    expect(vaultCallback.slice(postKmsTargetProof, secretUse + 90)).toContain(
+      "secret.withPassphrase((passphrase) => use(passphrase, signal), signal)",
+    );
+  });
+
+  test("keeps cross-backup attempt mismatches out of the blocking lease lock", () => {
+    const leaseSource = readFileSync(
+      join(import.meta.dir, "repositories/agent-backup-restore-lease.ts"),
+      "utf8",
+    );
+    const acquireSource = leaseSource.slice(
+      leaseSource.indexOf("export async function acquireAgentBackupRestoreLease"),
+      leaseSource.indexOf("export async function renewAgentBackupRestoreLease"),
+    );
+    const attemptLock = acquireSource.slice(
+      acquireSource.indexOf("const [existingAttempt]"),
+      acquireSource.indexOf("const [unreleased]"),
+    );
+    const blockingLookup = attemptLock.slice(0, attemptLock.indexOf("if (!existingAttempt)"));
+    expect(blockingLookup).toContain("eq(agentBackupRestoreLeases.backup_id, params.backupId)");
+    expect(blockingLookup).toContain('.for("update")');
+
+    const divergentLookup = attemptLock.slice(attemptLock.indexOf("const [divergentAttempt]"));
+    expect(divergentLookup).toContain(
+      "eq(agentBackupRestoreLeases.restore_attempt_id, params.restoreAttemptId)",
+    );
+    expect(divergentLookup).not.toContain('.for("update")');
+    expect(divergentLookup).toContain("Restore attempt replay authority mismatch");
   });
 
   test("contains no coordinator, capacity, billing, or probe migration in the dormant range", () => {

--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -55,6 +55,11 @@ describe("dormant restore API boundary", () => {
       "createOrRotateAgentVaultKeyGeneration",
       "loadCurrentAgentVaultKeyAuthority",
       "bindAgentBackupVaultKeyGeneration",
+      "withAgentBackupRestoreVaultPassphrase",
+      "openAgentBackupRestoreOperation",
+      "claimAgentBackupRestoreOperation",
+      "reserveAgentBackupRestoreTarget",
+      "advanceAgentBackupRestoreOperation",
       "recordAgentActivationPublication",
       "authorizeAgentActivationDispatch",
       "recordAgentVaultKeySeedReceipt",
@@ -63,12 +68,72 @@ describe("dormant restore API boundary", () => {
       const occurrences = sources.flatMap(({ path, source }) =>
         source.includes(symbol) ? [path] : [],
       );
-      expect(occurrences, `${symbol} must remain definition-only`).toEqual([
-        expect.stringContaining("/db/repositories/"),
-      ]);
+      const expectedOccurrences = symbol === "loadAgentBackupRestoreSourceV3" ? 2 : 1;
+      expect(occurrences, `${symbol} must remain definition-only`).toHaveLength(
+        expectedOccurrences,
+      );
+      expect(
+        occurrences.every((path) => path.includes("/db/repositories/")),
+        `${symbol} must remain inside the dormant repository layer`,
+      ).toBe(true);
     }
     expect(readFileSync(join(import.meta.dir, "index.ts"), "utf8")).not.toMatch(
       /agent-backup-restore|agent-vault-key-authority/,
+    );
+  });
+
+  test("keeps target reservation free of remote effects and generic identity bypasses", () => {
+    const operationSource = readFileSync(
+      join(import.meta.dir, "repositories/agent-backup-restore-operations.ts"),
+      "utf8",
+    );
+    expect(operationSource).not.toMatch(
+      /DockerNodeManager|getAvailableNode|nodeAutoscaler|parseDockerNodes|process\.env|ensureVolumeVaultPassphrase/,
+    );
+    const genericAdvance = operationSource.slice(
+      operationSource.indexOf("export async function advanceAgentBackupRestoreOperation"),
+      operationSource.indexOf("export async function heartbeatAgentBackupRestoreOperation"),
+    );
+    const advanceMutationStart = genericAdvance.indexOf(".set({");
+    const advanceMutation = genericAdvance.slice(
+      advanceMutationStart,
+      genericAdvance.indexOf(".where(", advanceMutationStart),
+    );
+    expect(advanceMutation).not.toMatch(/expected_node_|expected_image_digest/);
+    expect(genericAdvance).toContain(
+      "Restore operation cannot leave target reservation without complete target authority",
+    );
+
+    const reserveSource = operationSource.slice(
+      operationSource.indexOf("export async function reserveAgentBackupRestoreTarget"),
+      operationSource.indexOf("export async function advanceAgentBackupRestoreOperation"),
+    );
+    const transactionalReserve = reserveSource.slice(
+      reserveSource.indexOf("return await dbWrite.transaction"),
+    );
+    const lockAnchors = [
+      ".from(agentSandboxBackups)",
+      "lockAgentBackupCatalogAuthority(",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      ".from(dockerNodes)",
+      "readPostLockDatabaseNow(tx)",
+    ];
+    for (let index = 1; index < lockAnchors.length; index += 1) {
+      expect(transactionalReserve.indexOf(lockAnchors[index - 1] as string)).toBeLessThan(
+        transactionalReserve.indexOf(lockAnchors[index] as string),
+      );
+    }
+
+    const vaultSource = readFileSync(
+      join(import.meta.dir, "repositories/agent-vault-key-authority.ts"),
+      "utf8",
+    );
+    const restoreVaultAuthority = vaultSource.slice(
+      vaultSource.indexOf("async function loadAgentBackupRestoreVaultGeneration"),
+    );
+    expect(restoreVaultAuthority).not.toMatch(
+      /agentVaultKeyAuthorities|ensureVolumeVaultPassphrase|buildVolumeVaultPassphraseCommand/,
     );
   });
 

--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -135,6 +135,41 @@ describe("dormant restore API boundary", () => {
     expect(restoreVaultAuthority).not.toMatch(
       /agentVaultKeyAuthorities|ensureVolumeVaultPassphrase|buildVolumeVaultPassphraseCommand/,
     );
+    for (const requiredAuthorityField of [
+      "restoreOperationId",
+      "restoreClaimGeneration",
+      "targetNodeRecordId",
+      "targetNodeIncarnation",
+    ]) {
+      expect(restoreVaultAuthority).toContain(requiredAuthorityField);
+    }
+
+    const vaultCallback = restoreVaultAuthority.slice(
+      restoreVaultAuthority.indexOf("export async function withAgentBackupRestoreVaultPassphrase"),
+    );
+    const preKmsSource = vaultCallback.indexOf(
+      "const beforeKms = await loadAgentBackupRestoreVaultGeneration(input)",
+    );
+    const preKmsTargetProof = vaultCallback.indexOf(
+      "await proveAgentBackupRestoreVaultTargetAuthority(",
+      preKmsSource,
+    );
+    const kmsDecrypt = vaultCallback.indexOf("await decryptGeneration(", preKmsTargetProof);
+    const postKmsSource = vaultCallback.indexOf(
+      "const afterKms = await loadAgentBackupRestoreVaultGeneration(input)",
+      kmsDecrypt,
+    );
+    const postKmsTargetProof = vaultCallback.indexOf(
+      "await proveAgentBackupRestoreVaultTargetAuthority(",
+      preKmsTargetProof + 1,
+    );
+    const secretUse = vaultCallback.indexOf("secret.withPassphrase(use)", postKmsTargetProof);
+    expect(preKmsSource).toBeGreaterThanOrEqual(0);
+    expect(preKmsTargetProof).toBeGreaterThan(preKmsSource);
+    expect(kmsDecrypt).toBeGreaterThan(preKmsTargetProof);
+    expect(postKmsSource).toBeGreaterThan(kmsDecrypt);
+    expect(postKmsTargetProof).toBeGreaterThan(postKmsSource);
+    expect(secretUse).toBeGreaterThan(postKmsTargetProof);
   });
 
   test("contains no coordinator, capacity, billing, or probe migration in the dormant range", () => {

--- a/packages/cloud/shared/src/db/agent-backup-restore-foundation-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-foundation-migration.test.ts
@@ -425,8 +425,14 @@ describe("0237-0245 restore and vault foundation migrations", () => {
       expect(inserted.rows[0]!.expires_at.getTime() - inserted.rows[0]!.created_at.getTime()).toBe(
         10 * 60 * 1_000,
       );
+      // error-policy:J6 rollback is teardown for a failed transaction proof.
     } catch (error) {
-      await database.exec("ROLLBACK").catch(() => undefined);
+      try {
+        await database.exec("ROLLBACK");
+        // error-policy:J6 rollback failure is reported without replacing the test failure.
+      } catch (rollbackError) {
+        console.warn("[restore migration test] rollback teardown failed", rollbackError);
+      }
       throw error;
     } finally {
       await database.close();

--- a/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
@@ -5,6 +5,18 @@ import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  AGENT_BACKUP_MANIFEST_FORMAT,
+  AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  type AgentBackupManifestV3Draft,
+  canonicalizeAgentBackupManifestV3,
+  computeAgentBackupChunkAadDigest,
+  createAgentBackupManifestV3,
+} from "@elizaos/shared";
 import { pushSchema } from "drizzle-kit/api";
 import { eq, inArray, sql } from "drizzle-orm";
 import { Client } from "pg";
@@ -16,6 +28,7 @@ import {
   agentBackupCatalogAuthorities,
   agentBackupObjects,
   agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
 } from "./schemas/agent-backup-catalog";
 import {
   agentActivationPublications,
@@ -96,6 +109,21 @@ const WRITER_VAULT_GENERATION = "00000000-0000-4000-8000-00000000b30a";
 const WRITER_RESERVE_ONE = "00000000-0000-4000-8000-00000000b30b";
 const WRITER_RESERVE_TWO = "00000000-0000-4000-8000-00000000b30c";
 
+const LOCK_BACKUP_ONE = "00000000-0000-4000-8000-00000000b401";
+const LOCK_BACKUP_TWO = "00000000-0000-4000-8000-00000000b402";
+const LOCK_OPERATION_ONE = "00000000-0000-4000-8000-00000000b403";
+const LOCK_OPERATION_TWO = "00000000-0000-4000-8000-00000000b404";
+const LOCK_ATTEMPT_ID = "00000000-0000-4000-8000-00000000b405";
+const LOCK_LEASE_ID = "00000000-0000-4000-8000-00000000b406";
+const LOCK_FENCE = "00000000-0000-4000-8000-00000000b407";
+const LOCK_VAULT_GENERATION = "00000000-0000-4000-8000-00000000b408";
+const LOCK_KEY_BUNDLE_GENERATION = "00000000-0000-4000-8000-00000000b409";
+const LOCK_TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000b40a";
+const LOCK_TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000b40b";
+const LOCK_OWNER_ID = "restore-lock-order-owner";
+const LOCK_KEY_BUNDLE = Buffer.alloc(AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes, 0x55);
+const LOCK_KEY_BUNDLE_SHA = createHash("sha256").update(LOCK_KEY_BUNDLE).digest("hex");
+
 let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
 let isolatedDatabaseName: string | null = null;
 let isolatedDsn: string | null = null;
@@ -129,6 +157,15 @@ let recordAgentVaultKeySeedReceipt:
   | undefined;
 let commitAgentBackupRestore:
   | typeof import("./repositories/agent-backup-restore-history").commitAgentBackupRestore
+  | undefined;
+let openAgentBackupRestoreOperation:
+  | typeof import("./repositories/agent-backup-restore-operations").openAgentBackupRestoreOperation
+  | undefined;
+let claimAgentBackupRestoreOperation:
+  | typeof import("./repositories/agent-backup-restore-operations").claimAgentBackupRestoreOperation
+  | undefined;
+let reserveAgentBackupRestoreTarget:
+  | typeof import("./repositories/agent-backup-restore-operations").reserveAgentBackupRestoreTarget
   | undefined;
 
 function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
@@ -209,6 +246,348 @@ async function waitUntilDatabaseTime(observer: Client, threshold: Date): Promise
   throw new Error("Timed out waiting for the primary database clock");
 }
 
+function postgresErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+async function buildLockManifest(operationId: string): Promise<{
+  canonicalDraft: string;
+  digest: string;
+}> {
+  const emptyComponent = (name: "character" | "media" | "state-files" | "vault") =>
+    ({
+      name,
+      format: "raw-v1",
+      compression: "none" as const,
+      payloadContentHmacSha256: SHA,
+      state: { kind: "full" as const, resultContentHmacSha256: SHA },
+      totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+      chunks: [],
+    }) as const;
+  const plainBytes = 4;
+  const encryptedBytes = 32;
+  const aadSha256 = await computeAgentBackupChunkAadDigest({
+    identity: {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      lifecycleRevision: "0",
+    },
+    operationId,
+    component: { name: "database", format: "raw-v1", compression: "none" },
+    chunk: {
+      index: 0,
+      offsetBytes: 0,
+      plainBytes,
+      compressedBytes: plainBytes,
+      contentHmacSha256: SHA,
+    },
+  });
+  const draft: AgentBackupManifestV3Draft = {
+    format: AGENT_BACKUP_MANIFEST_FORMAT,
+    schemaVersion: 3,
+    operationId,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    identity: {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      lifecycleRevision: "0",
+    },
+    source: {
+      kind: "robot",
+      provider: "hetzner",
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-lock",
+      containerId: SOURCE_CONTAINER_ID,
+    },
+    runtime: {
+      imageDigest: `sha256:${SHA}`,
+      agentSchemaVersion: "2.0.0",
+      databaseSchemaVersion: "1",
+      plugins: [],
+    },
+    chain: { kind: "full", baseOperationId: null, parentOperationId: null, depth: 0 },
+    components: [
+      emptyComponent("character"),
+      {
+        name: "database",
+        format: "raw-v1",
+        compression: "none",
+        payloadContentHmacSha256: SHA,
+        state: { kind: "full", resultContentHmacSha256: SHA },
+        totals: {
+          plainBytes,
+          compressedBytes: plainBytes,
+          encryptedBytes,
+          chunkCount: 1,
+        },
+        chunks: [
+          {
+            index: 0,
+            offsetBytes: 0,
+            plainBytes,
+            compressedBytes: plainBytes,
+            encryptedBytes,
+            contentHmacSha256: SHA,
+            aadSha256,
+            sha256: SHA,
+          },
+        ],
+      },
+      emptyComponent("media"),
+      emptyComponent("state-files"),
+      emptyComponent("vault"),
+    ],
+    watermarks: [{ namespace: "database.lsn", value: "0/1" }],
+    totals: {
+      plainBytes,
+      compressedBytes: plainBytes,
+      encryptedBytes,
+      chunkCount: 1,
+    },
+    vaultKeyAuthority: {
+      format: "kms-aead-vault-passphrase-v1",
+      generationId: LOCK_VAULT_GENERATION,
+      receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1",
+      receiptDigest: RECEIPT_SHA,
+    },
+    encryption: {
+      algorithm: "AES-256-GCM",
+      chunkEnvelope: "aes-256-gcm-v1",
+      nonceBytes: 12,
+      tagBytes: 16,
+      noncePlacement: "prefix",
+      tagPlacement: "suffix",
+      aad: { version: 1, derivation: "elizaos.agent-backup.chunk-aad.v1" },
+      kms: { provider: "steward", keyId: `org:${ORG_ID}/dek/v1`, keyVersion: 1 },
+      operationKeyBundle: {
+        format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        generationId: LOCK_KEY_BUNDLE_GENERATION,
+        plaintextBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.plaintextBytes,
+        dek: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek,
+        contentHmac: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac,
+        wrapped: {
+          ref: `backup-key-bundle:${operationId}`,
+          bytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes,
+          sha256: LOCK_KEY_BUNDLE_SHA,
+          localReceiptDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+          localReceiptDigest: SHA,
+          contextDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+        },
+      },
+    },
+    integrity: {
+      framedContentHmacSha256: SHA,
+      contentAddressing: {
+        algorithm: "HMAC-SHA-256",
+        scope: "operation",
+        derivation: AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+        keyBundleFormat: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        keyOffsetBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.offsetBytes,
+        keyBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes,
+      },
+    },
+  };
+  const manifest = await createAgentBackupManifestV3(draft);
+  return {
+    canonicalDraft: canonicalizeAgentBackupManifestV3(draft),
+    digest: manifest.integrity.manifestSha256,
+  };
+}
+
+async function seedLockBackup(input: {
+  backupId: string;
+  operationId: string;
+  manifest: Awaited<ReturnType<typeof buildLockManifest>>;
+  catalogRevision: bigint;
+  objectInventoryDigest: string;
+}): Promise<void> {
+  if (!dbWrite) throw new Error("real PostgreSQL harness was not initialized");
+  await dbWrite.insert(agentSandboxBackups).values({
+    id: input.backupId,
+    sandbox_record_id: null,
+    snapshot_type: "auto",
+    state_data: { memories: [], config: {}, workspaceFiles: {} },
+    state_data_storage: "inline",
+    size_bytes: LOCK_KEY_BUNDLE.byteLength,
+    backup_kind: "full",
+    backup_operation_id: input.operationId,
+    catalog_version: 2,
+    catalog_state: "protected",
+    catalog_payload_digest: SHA,
+    catalog_revision: input.catalogRevision,
+    catalog_organization_id: ORG_ID,
+    catalog_agent_id: AGENT_ID,
+    lifecycle_generation: ACTIVATION_GENERATION,
+    lifecycle_revision: 0n,
+    source_provider: "operator-onboarded",
+    source_node_record_id: NODE_RECORD_ID,
+    source_node_id: "robot-node-lock",
+    source_node_incarnation: NODE_INCARNATION,
+    source_provider_server_id: null,
+    source_provider_handle: "container-generation-lock",
+    source_container_id: SOURCE_CONTAINER_ID,
+    retention_reason: "schedule",
+    retention_until: new Date(Date.now() + 86_400_000),
+    manifest_format: AGENT_BACKUP_MANIFEST_FORMAT,
+    manifest_version: 3,
+    manifest_digest: input.manifest.digest,
+    manifest_canonical_draft: input.manifest.canonicalDraft,
+    manifest_object_count: 1,
+    object_inventory_digest: input.objectInventoryDigest,
+    image_digest: `sha256:${SHA}`,
+    database_schema_version: "1",
+    plugin_set_digest: SHA,
+    watermark_digest: SHA,
+    raw_size_bytes: 4,
+    compressed_size_bytes: 4,
+    encrypted_size_bytes: 32,
+    kms_key_id: `org:${ORG_ID}/backup/v1`,
+    kms_key_version: 1,
+    operation_key_bundle_generation_id: LOCK_KEY_BUNDLE_GENERATION,
+    operation_key_bundle_format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+    operation_key_bundle_ref: `backup-key-bundle:${input.operationId}`,
+    operation_key_bundle_ciphertext_base64: LOCK_KEY_BUNDLE.toString("base64"),
+    operation_key_bundle_sha256: LOCK_KEY_BUNDLE_SHA,
+    operation_key_bundle_size_bytes: LOCK_KEY_BUNDLE.byteLength,
+    operation_key_bundle_context: "{}",
+    operation_key_bundle_context_derivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+    operation_key_bundle_local_receipt_derivation:
+      AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+    operation_key_bundle_local_receipt_digest: SHA,
+    vault_key_generation_id: LOCK_VAULT_GENERATION,
+    vault_key_authority_receipt_digest: RECEIPT_SHA,
+  });
+  await dbWrite.insert(agentVaultKeyBackupBindings).values({
+    organization_id: ORG_ID,
+    agent_id: AGENT_ID,
+    backup_id: input.backupId,
+    operation_id: input.operationId,
+    source_activation_generation: ACTIVATION_GENERATION,
+    source_lifecycle_revision: 0n,
+    manifest_sha256: input.manifest.digest,
+    vault_key_generation_id: LOCK_VAULT_GENERATION,
+    vault_key_authority_receipt_digest: RECEIPT_SHA,
+  });
+}
+
+async function seedRestoreOperationLockFixture(includeSecondBackup = false): Promise<{
+  operationId: string;
+  authority: {
+    organizationId: string;
+    agentId: string;
+    backupId: string;
+    operationId: string;
+    sourceActivationGeneration: string;
+    sourceLifecycleRevision: string;
+    expectedManifestSha256: string;
+    restoreAttemptId: string;
+    leaseId: string;
+    ownerId: string;
+    fencingToken: string;
+    catalogEpoch: string;
+    copyRole: "primary";
+  };
+}> {
+  const open = openAgentBackupRestoreOperation;
+  const inventoryDigest = agentBackupObjectInventoryDigest;
+  if (!dbWrite || !open || !inventoryDigest) {
+    throw new Error("real PostgreSQL harness was not initialized");
+  }
+  await dbWrite
+    .insert(agentBackupCatalogAuthorities)
+    .values({ organization_id: ORG_ID, agent_id: AGENT_ID })
+    .onConflictDoNothing();
+  const [catalog] = await dbWrite
+    .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
+    .from(agentBackupCatalogAuthorities)
+    .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+  if (!catalog) throw new Error("restore lock fixture catalogue authority is missing");
+  await dbWrite
+    .insert(agentVaultKeyGenerations)
+    .values({
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      generation_id: LOCK_VAULT_GENERATION,
+      source_activation_generation: ACTIVATION_GENERATION,
+      supersedes_generation_id: null,
+      format: "kms-aead-vault-passphrase-v1",
+      kms_key_id: `org:${ORG_ID}/lock-order/dek/v1`,
+      kms_key_version: 1n,
+      kms_context: "{}",
+      kms_context_derivation: "elizaos.agent-vault-key.kms-context.v1",
+      wrapped_ciphertext_base64: Buffer.alloc(32, 0x11).toString("base64"),
+      wrapped_nonce_base64: Buffer.alloc(12, 0x22).toString("base64"),
+      wrapped_auth_tag_base64: Buffer.alloc(16, 0x33).toString("base64"),
+      wrapped_envelope_sha256: SHA,
+      authority_receipt_derivation: "elizaos.agent-vault-key.authority-receipt.v1",
+      authority_receipt_digest: RECEIPT_SHA,
+    })
+    .onConflictDoNothing();
+  const firstManifest = await buildLockManifest(LOCK_OPERATION_ONE);
+  const exactObjectInventoryDigest = await inventoryDigest([
+    {
+      component: "database",
+      chunkIndex: 0,
+      contentHmacSha256: SHA,
+      ciphertextSha256: SHA,
+      sizeBytes: 32,
+    },
+  ]);
+  await seedLockBackup({
+    backupId: LOCK_BACKUP_ONE,
+    operationId: LOCK_OPERATION_ONE,
+    manifest: firstManifest,
+    catalogRevision: catalog.revision,
+    objectInventoryDigest: exactObjectInventoryDigest,
+  });
+  if (includeSecondBackup) {
+    await seedLockBackup({
+      backupId: LOCK_BACKUP_TWO,
+      operationId: LOCK_OPERATION_TWO,
+      manifest: await buildLockManifest(LOCK_OPERATION_TWO),
+      catalogRevision: catalog.revision,
+      objectInventoryDigest: exactObjectInventoryDigest,
+    });
+  }
+  await dbWrite.insert(agentBackupRestoreLeases).values({
+    id: LOCK_LEASE_ID,
+    organization_id: ORG_ID,
+    agent_id: AGENT_ID,
+    backup_id: LOCK_BACKUP_ONE,
+    operation_id: LOCK_OPERATION_ONE,
+    activation_generation: ACTIVATION_GENERATION,
+    lifecycle_revision: 0n,
+    expected_manifest_sha256: firstManifest.digest,
+    copy_role: "primary",
+    restore_attempt_id: LOCK_ATTEMPT_ID,
+    owner_id: LOCK_OWNER_ID,
+    generation: LOCK_FENCE,
+    catalog_epoch: catalog.revision,
+    expires_at: new Date(Date.now() + 300_000),
+  });
+  const authority = {
+    organizationId: ORG_ID,
+    agentId: AGENT_ID,
+    backupId: LOCK_BACKUP_ONE,
+    operationId: LOCK_OPERATION_ONE,
+    sourceActivationGeneration: ACTIVATION_GENERATION,
+    sourceLifecycleRevision: "0",
+    expectedManifestSha256: firstManifest.digest,
+    restoreAttemptId: LOCK_ATTEMPT_ID,
+    leaseId: LOCK_LEASE_ID,
+    ownerId: LOCK_OWNER_ID,
+    fencingToken: LOCK_FENCE,
+    catalogEpoch: catalog.revision.toString(),
+    copyRole: "primary" as const,
+  };
+  const opened = await open({ authority, leaseId: LOCK_LEASE_ID });
+  return { operationId: opened.operation.id, authority };
+}
+
 if (!postgres) {
   console.warn(SKIP_REASON);
 } else {
@@ -219,12 +598,14 @@ if (!postgres) {
   process.env.TEST_DATABASE_URL = isolated.dsn;
   process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
   process.env.MOCK_REDIS = "1";
-  const [clientModule, repositoryModule, leaseModule, restoreHistoryModule] = await Promise.all([
-    import("./client"),
-    import("./repositories/agent-backup-catalog"),
-    import("./repositories/agent-backup-restore-lease"),
-    import("./repositories/agent-backup-restore-history"),
-  ]);
+  const [clientModule, repositoryModule, leaseModule, restoreHistoryModule, operationsModule] =
+    await Promise.all([
+      import("./client"),
+      import("./repositories/agent-backup-catalog"),
+      import("./repositories/agent-backup-restore-lease"),
+      import("./repositories/agent-backup-restore-history"),
+      import("./repositories/agent-backup-restore-operations"),
+    ]);
   closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
   dbWrite = clientModule.dbWrite;
   reserveAgentBackupOperation = repositoryModule.reserveAgentBackupOperation;
@@ -237,6 +618,9 @@ if (!postgres) {
   recordAgentActivationPublication = restoreHistoryModule.recordAgentActivationPublication;
   recordAgentVaultKeySeedReceipt = restoreHistoryModule.recordAgentVaultKeySeedReceipt;
   commitAgentBackupRestore = restoreHistoryModule.commitAgentBackupRestore;
+  openAgentBackupRestoreOperation = operationsModule.openAgentBackupRestoreOperation;
+  claimAgentBackupRestoreOperation = operationsModule.claimAgentBackupRestoreOperation;
+  reserveAgentBackupRestoreTarget = operationsModule.reserveAgentBackupRestoreTarget;
 }
 
 afterAll(async () => {
@@ -267,6 +651,7 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         agentSandboxBackups,
         agentBackupObjects,
         agentBackupRestoreLeases,
+        agentBackupRestoreOperations,
         agentNodeIncarnationHistories,
         agentActivationPublications,
         agentVaultKeySeedReceipts,
@@ -351,6 +736,9 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
   afterEach(async () => {
     if (!dbWrite) return;
     await dbWrite
+      .delete(agentBackupRestoreOperations)
+      .where(eq(agentBackupRestoreOperations.restore_attempt_id, LOCK_ATTEMPT_ID));
+    await dbWrite
       .update(agentSandboxes)
       .set({
         activation_generation: ACTIVATION_GENERATION,
@@ -378,10 +766,16 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       .where(eq(agentActivationPublications.id, WRITER_PUBLICATION_ID));
     await dbWrite
       .delete(agentBackupRestoreLeases)
-      .where(eq(agentBackupRestoreLeases.id, WRITER_LEASE_ID));
+      .where(inArray(agentBackupRestoreLeases.id, [WRITER_LEASE_ID, LOCK_LEASE_ID]));
     await dbWrite
       .delete(agentVaultKeyBackupBindings)
-      .where(eq(agentVaultKeyBackupBindings.backup_id, WRITER_BACKUP_ID));
+      .where(
+        inArray(agentVaultKeyBackupBindings.backup_id, [
+          WRITER_BACKUP_ID,
+          LOCK_BACKUP_ONE,
+          LOCK_BACKUP_TWO,
+        ]),
+      );
     await dbWrite
       .delete(agentSandboxBackups)
       .where(
@@ -389,6 +783,8 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
           WRITER_OPERATION_ID,
           WRITER_RESERVE_ONE,
           WRITER_RESERVE_TWO,
+          LOCK_OPERATION_ONE,
+          LOCK_OPERATION_TWO,
         ]),
       );
     await dbWrite
@@ -396,10 +792,16 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       .where(eq(agentVaultKeyAuthorities.current_generation_id, WRITER_VAULT_GENERATION));
     await dbWrite
       .delete(agentVaultKeyGenerations)
-      .where(eq(agentVaultKeyGenerations.generation_id, WRITER_VAULT_GENERATION));
+      .where(
+        inArray(agentVaultKeyGenerations.generation_id, [
+          WRITER_VAULT_GENERATION,
+          LOCK_VAULT_GENERATION,
+        ]),
+      );
     await dbWrite
       .delete(agentNodeIncarnationHistories)
       .where(eq(agentNodeIncarnationHistories.docker_node_record_id, NODE_RECORD_ID));
+    await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, LOCK_TARGET_NODE_RECORD_ID));
   });
 
   test("reservation replay and actual restore acquisition share backup-before-authority order", async () => {
@@ -555,6 +957,282 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       await capture.query("ROLLBACK");
       if (scheduler) await scheduler;
       await Promise.allSettled([capture.end(), observer.end()]);
+    }
+  }, 30_000);
+
+  test("operation replay waits on its lease while a claimant waits on the operation", async () => {
+    const open = openAgentBackupRestoreOperation;
+    const claim = claimAgentBackupRestoreOperation;
+    if (!isolatedDsn || !open || !claim) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const fixture = await seedRestoreOperationLockFixture();
+    const blocker = new Client({ connectionString: isolatedDsn });
+    const observer = new Client({ connectionString: isolatedDsn });
+    await Promise.all([blocker.connect(), observer.connect()]);
+    let replayResult: Awaited<ReturnType<typeof open>> | undefined;
+    let replayError: unknown;
+    let replay: Promise<void> | undefined;
+    let claimResult: Awaited<ReturnType<typeof claim>> | undefined;
+    let claimError: unknown;
+    let claiming: Promise<void> | undefined;
+    try {
+      await blocker.query("BEGIN");
+      const blockerPid = await blocker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid");
+      await blocker.query("SELECT id FROM agent_backup_restore_leases WHERE id = $1 FOR UPDATE", [
+        LOCK_LEASE_ID,
+      ]);
+
+      // New order: backup -> operation -> lease -> catalogue. The replay owns
+      // O before it queues for L, so a claimant cannot own O and close the old
+      // C/L/O cycle when the lease holder is released.
+      replay = open({ authority: fixture.authority, leaseId: LOCK_LEASE_ID }).then(
+        (result) => {
+          replayResult = result;
+        },
+        (error: unknown) => {
+          replayError = error;
+        },
+      );
+      const replayPid = await waitUntilBlockedBy(observer, blockerPid.rows[0]!.pid);
+      claiming = claim({
+        operationId: fixture.operationId,
+        ownerId: LOCK_OWNER_ID,
+        claimMs: 60_000,
+      }).then(
+        (result) => {
+          claimResult = result;
+        },
+        (error: unknown) => {
+          claimError = error;
+        },
+      );
+      const claimPid = await waitUntilBlockedBy(observer, replayPid);
+      expect(claimPid).not.toBe(replayPid);
+
+      await blocker.query("COMMIT");
+      await Promise.all([replay, claiming]);
+
+      expect(postgresErrorCode(replayError)).not.toBe("40P01");
+      expect(postgresErrorCode(claimError)).not.toBe("40P01");
+      if (replayError) throw replayError;
+      if (claimError) throw claimError;
+      expect(replayResult?.replayed).toBe(true);
+      expect(replayResult?.operation.id).toBe(fixture.operationId);
+      expect(claimResult?.operation.id).toBe(fixture.operationId);
+      expect(claimResult?.operation.claim_owner).toBe(LOCK_OWNER_ID);
+      expect(claimResult?.operation.claim_generation).toBe(claimResult?.claimGeneration);
+    } finally {
+      await blocker.query("ROLLBACK");
+      if (replay) await replay;
+      if (claiming) await claiming;
+      await Promise.allSettled([blocker.end(), observer.end()]);
+    }
+  }, 30_000);
+
+  test("divergent restore-attempt replay reaches catalogue without waiting on another backup lease", async () => {
+    const open = openAgentBackupRestoreOperation;
+    const acquire = acquireAgentBackupRestoreLease;
+    if (!isolatedDsn || !open || !acquire) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const fixture = await seedRestoreOperationLockFixture(true);
+    const secondManifest = await buildLockManifest(LOCK_OPERATION_TWO);
+    const blocker = new Client({ connectionString: isolatedDsn });
+    const observer = new Client({ connectionString: isolatedDsn });
+    await Promise.all([blocker.connect(), observer.connect()]);
+    let acquisitionResult: Awaited<ReturnType<typeof acquire>> | undefined;
+    let acquisitionError: unknown;
+    let acquisition: Promise<void> | undefined;
+    let replayResult: Awaited<ReturnType<typeof open>> | undefined;
+    let replayError: unknown;
+    let replay: Promise<void> | undefined;
+    try {
+      await blocker.query("BEGIN");
+      const blockerPid = await blocker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid");
+      await blocker.query(
+        "SELECT organization_id FROM agent_backup_catalog_authorities " +
+          "WHERE organization_id = $1 AND agent_id = $2 FOR UPDATE",
+        [ORG_ID, AGENT_ID],
+      );
+
+      // Queue the divergent B2 acquisition on C first. It must not subsequently
+      // wait on L1, which belongs to B1 despite sharing the restore-attempt id.
+      acquisition = acquire({
+        organizationId: ORG_ID,
+        backupId: LOCK_BACKUP_TWO,
+        operationId: LOCK_OPERATION_TWO,
+        sourceActivationGeneration: ACTIVATION_GENERATION,
+        sourceLifecycleRevision: "0",
+        expectedManifestSha256: secondManifest.digest,
+        copyRole: "primary",
+        restoreAttemptId: LOCK_ATTEMPT_ID,
+        ownerId: LOCK_OWNER_ID,
+        fencingToken: LOCK_FENCE,
+        leaseMs: 60_000,
+      }).then(
+        (result) => {
+          acquisitionResult = result;
+        },
+        (error: unknown) => {
+          acquisitionError = error;
+        },
+      );
+      const acquisitionPid = await waitUntilBlockedBy(observer, blockerPid.rows[0]!.pid);
+
+      // The B1 replay owns L1 before it joins the C queue behind B2. With the
+      // old org+attempt FOR UPDATE, B2 then waited on L1 and closed C <-> L1.
+      replay = open({ authority: fixture.authority, leaseId: LOCK_LEASE_ID }).then(
+        (result) => {
+          replayResult = result;
+        },
+        (error: unknown) => {
+          replayError = error;
+        },
+      );
+      // PostgreSQL reports the earlier catalogue waiter as the replay's soft
+      // blocker, rather than reporting the row holder twice. This exact queue
+      // is the old cycle's first half: replay already owns L1, then waits on C
+      // behind the divergent acquisition.
+      const replayPid = await waitUntilBlockedBy(observer, acquisitionPid);
+      expect(replayPid).not.toBe(acquisitionPid);
+
+      await blocker.query("COMMIT");
+      await Promise.all([acquisition, replay]);
+
+      expect(postgresErrorCode(acquisitionError)).not.toBe("40P01");
+      expect(postgresErrorCode(replayError)).not.toBe("40P01");
+      expect(acquisitionResult).toBeUndefined();
+      expect(String(acquisitionError)).toContain("Restore attempt replay authority mismatch");
+      if (replayError) throw replayError;
+      expect(replayResult?.replayed).toBe(true);
+      expect(replayResult?.operation.id).toBe(fixture.operationId);
+    } finally {
+      await blocker.query("ROLLBACK");
+      if (acquisition) await acquisition;
+      if (replay) await replay;
+      await Promise.allSettled([blocker.end(), observer.end()]);
+    }
+  }, 30_000);
+
+  test("target reservation reaches catalogue only after its exact node lock", async () => {
+    const claim = claimAgentBackupRestoreOperation;
+    const reserveTarget = reserveAgentBackupRestoreTarget;
+    if (!isolatedDsn || !dbWrite || !claim || !reserveTarget) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const fixture = await seedRestoreOperationLockFixture(true);
+    await dbWrite.insert(dockerNodes).values({
+      id: LOCK_TARGET_NODE_RECORD_ID,
+      node_id: "restore-lock-target",
+      hostname: "restore-lock-target.example.test",
+      capacity: 2,
+      allocated_count: 0,
+      enabled: true,
+      status: "healthy",
+      placement_state: "open",
+      host_key_fingerprint: "SHA256:restore-lock-target-host-key",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      node_incarnation: LOCK_TARGET_NODE_INCARNATION,
+      metadata: {},
+    });
+    await dbWrite.insert(agentNodeIncarnationHistories).values({
+      docker_node_record_id: LOCK_TARGET_NODE_RECORD_ID,
+      node_id: "restore-lock-target",
+      node_incarnation: LOCK_TARGET_NODE_INCARNATION,
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      host_key_fingerprint: "SHA256:restore-lock-target-host-key",
+    });
+    const claimed = await claim({
+      operationId: fixture.operationId,
+      ownerId: LOCK_OWNER_ID,
+      claimMs: 60_000,
+    });
+    const blocker = new Client({ connectionString: isolatedDsn });
+    const observer = new Client({ connectionString: isolatedDsn });
+    await Promise.all([blocker.connect(), observer.connect()]);
+    let reservationResult: Awaited<ReturnType<typeof reserveTarget>> | undefined;
+    let reservationError: unknown;
+    let reservation: Promise<void> | undefined;
+    let blockerError: unknown;
+    let blockerBackupId: string | undefined;
+    let blockerCatalogRevision: string | undefined;
+    try {
+      await blocker.query("BEGIN");
+      const blockerPid = await blocker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid");
+      await blocker.query("SELECT id FROM docker_nodes WHERE id = $1 FOR UPDATE", [
+        LOCK_TARGET_NODE_RECORD_ID,
+      ]);
+
+      reservation = reserveTarget({
+        operationId: fixture.operationId,
+        ownerId: LOCK_OWNER_ID,
+        claimGeneration: claimed.claimGeneration,
+        targetNodeRecordId: LOCK_TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: LOCK_TARGET_NODE_INCARNATION,
+      }).then(
+        (result) => {
+          reservationResult = result;
+        },
+        (error: unknown) => {
+          reservationError = error;
+        },
+      );
+      await waitUntilBlockedBy(observer, blockerPid.rows[0]!.pid);
+
+      // This independent B2 writer deliberately owns N before it follows
+      // B2 -> C. A reserve implementation that owns C while waiting for N
+      // creates the exact C/N cycle this proof guards against.
+      try {
+        const backup = await blocker.query<{ id: string }>(
+          "SELECT id FROM agent_sandbox_backups WHERE id = $1 FOR UPDATE",
+          [LOCK_BACKUP_TWO],
+        );
+        blockerBackupId = backup.rows[0]?.id;
+        const catalog = await blocker.query<{ catalog_revision: string }>(
+          "SELECT catalog_revision FROM agent_backup_catalog_authorities " +
+            "WHERE organization_id = $1 AND agent_id = $2 FOR UPDATE",
+          [ORG_ID, AGENT_ID],
+        );
+        blockerCatalogRevision = catalog.rows[0]?.catalog_revision;
+      } catch (error) {
+        blockerError = error;
+      }
+      await blocker.query("COMMIT");
+      await reservation;
+
+      expect(postgresErrorCode(blockerError)).not.toBe("40P01");
+      expect(postgresErrorCode(reservationError)).not.toBe("40P01");
+      if (blockerError) throw blockerError;
+      if (reservationError) throw reservationError;
+      expect(blockerBackupId).toBe(LOCK_BACKUP_TWO);
+      expect(blockerCatalogRevision).toBe(fixture.authority.catalogEpoch);
+      expect(reservationResult?.replayed).toBe(false);
+      expect(reservationResult?.operation.id).toBe(fixture.operationId);
+      expect(reservationResult?.target).toEqual({
+        nodeRecordId: LOCK_TARGET_NODE_RECORD_ID,
+        nodeId: "restore-lock-target",
+        nodeIncarnation: LOCK_TARGET_NODE_INCARNATION,
+        imageDigest: `sha256:${SHA}`,
+      });
+      expect(reservationResult?.operation.expected_node_record_id).toBe(LOCK_TARGET_NODE_RECORD_ID);
+      expect(reservationResult?.operation.expected_node_incarnation).toBe(
+        LOCK_TARGET_NODE_INCARNATION,
+      );
+      expect(reservationResult?.operation.expected_image_digest).toBe(`sha256:${SHA}`);
+      const [targetNode] = await dbWrite
+        .select({ allocatedCount: dockerNodes.allocated_count })
+        .from(dockerNodes)
+        .where(eq(dockerNodes.id, LOCK_TARGET_NODE_RECORD_ID));
+      expect(targetNode?.allocatedCount).toBe(1);
+    } finally {
+      await blocker.query("ROLLBACK");
+      if (reservation) await reservation;
+      await Promise.allSettled([blocker.end(), observer.end()]);
     }
   }, 30_000);
 
@@ -863,7 +1541,10 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       sourceProviderHandle: "container-generation-lock",
       sourceContainerId: SOURCE_CONTAINER_ID,
       retentionReason: "schedule" as const,
-      retentionUntil: new Date("2020-01-01T00:00:00.000Z"),
+      // The sanity acquisition below must start from a genuinely protected,
+      // non-expired backup. The race installs its short database-clock
+      // retention window explicitly after releasing that sanity lease.
+      retentionUntil: new Date("2100-01-01T00:00:00.000Z"),
     };
     const backup = await reserve(input);
     const objectAuthority = {
@@ -941,7 +1622,6 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
           operation_key_bundle_local_receipt_digest: RECEIPT_SHA,
           vault_key_generation_id: EXPIRATION_VAULT_GENERATION_ID,
           vault_key_authority_receipt_digest: RECEIPT_SHA,
-          retention_until: sql`clock_timestamp() + INTERVAL '1 hour'`,
         })
         .where(eq(agentSandboxBackups.id, backup.id));
       await tx.insert(agentVaultKeyBackupBindings).values({

--- a/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
@@ -1804,7 +1804,14 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
           lifecycle_generation uuid NOT NULL, lifecycle_revision numeric(20, 0) NOT NULL,
           manifest_digest text NOT NULL, manifest_version integer, catalog_state text,
           vault_key_generation_id uuid, vault_key_authority_receipt_digest text,
-          UNIQUE (id, catalog_organization_id, catalog_agent_id)
+          CONSTRAINT agent_sandbox_backups_catalog_chain_identity_unique
+            UNIQUE (id, catalog_organization_id, catalog_agent_id)
+        );
+        CREATE TABLE agent_sandboxes (
+          id uuid PRIMARY KEY,
+          organization_id uuid NOT NULL REFERENCES organizations(id),
+          activation_backup_id uuid,
+          activation_consent_head_backup_id uuid
         );
         INSERT INTO organizations VALUES ('${CLOCK_ORG_ID}');
         INSERT INTO agent_backup_catalog_authorities

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -3,6 +3,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { MemoryKmsAdapter } from "@elizaos/core/security/kms";
 import {
   AGENT_BACKUP_MANIFEST_FORMAT,
@@ -79,6 +81,7 @@ import {
   loadCurrentAgentVaultKeyAuthority,
   withAgentBackupRestoreVaultPassphrase,
 } from "../agent-vault-key-authority";
+import { dockerNodesRepository } from "../docker-nodes";
 
 const TIMEOUT = 60_000;
 const ORG_ID = "00000000-0000-4000-8000-00000000d001";
@@ -93,6 +96,9 @@ const USER_ID = "00000000-0000-4000-8000-00000000d032";
 const TARGET_ACTIVATION_GENERATION = "00000000-0000-4000-8000-00000000d042";
 const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000d043";
 const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000d044";
+const REARMED_TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000d065";
+const TARGET_NODE_CREATED_AT = new Date("2026-08-19T23:59:59.000Z");
+const TARGET_NODE_ATTESTED_AT = new Date("2026-08-20T00:00:00.000Z");
 const ACTIVATION_PUBLICATION_ID = "00000000-0000-4000-8000-00000000d045";
 const SEED_RECEIPT_ID = "00000000-0000-4000-8000-00000000d046";
 const FINAL_RECEIPT_ID = "00000000-0000-4000-8000-00000000d047";
@@ -107,6 +113,15 @@ let schemaFailure = "";
 
 function isZeroized(value: Uint8Array | null): boolean {
   return value !== null && value.every((byte) => byte === 0);
+}
+
+function expectTokensInOrder(source: string, tokens: readonly string[]): void {
+  let previous = -1;
+  for (const token of tokens) {
+    const index = source.indexOf(token);
+    expect(index).toBeGreaterThan(previous);
+    previous = index;
+  }
 }
 
 function captureVaultRawKeyAtRelease(): {
@@ -658,6 +673,17 @@ async function acquireVaultPassphraseFixture(
     provider_server_id: null,
     node_incarnation: TARGET_NODE_INCARNATION,
     metadata: {},
+    created_at: TARGET_NODE_CREATED_AT,
+  });
+  await dbWrite.insert(agentNodeIncarnationHistories).values({
+    docker_node_record_id: TARGET_NODE_RECORD_ID,
+    node_id: "vault-restore-target-node",
+    node_incarnation: TARGET_NODE_INCARNATION,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    host_key_fingerprint: `SHA256:${SHA}`,
+    attested_at: TARGET_NODE_ATTESTED_AT,
   });
   if (options.reserveTarget !== false) {
     await reserveAgentBackupRestoreTarget({
@@ -682,6 +708,37 @@ async function acquireVaultPassphraseFixture(
       vaultKeyAuthorityReceiptDigest: generation.authority.receiptDigest,
     },
   } as const;
+}
+
+async function rearmVaultTargetNodeThroughIncarnation(
+  nextIncarnation: string,
+  timing: "later" | "backdated" = "later",
+): Promise<void> {
+  const [originalHistory] = await dbWrite
+    .select()
+    .from(agentNodeIncarnationHistories)
+    .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
+  if (!originalHistory) throw new Error("vault target history fixture is missing");
+  await dbWrite
+    .update(dockerNodes)
+    .set({ node_incarnation: nextIncarnation })
+    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+  await dbWrite.insert(agentNodeIncarnationHistories).values({
+    docker_node_record_id: TARGET_NODE_RECORD_ID,
+    node_id: originalHistory.node_id,
+    node_incarnation: nextIncarnation,
+    fleet_kind: originalHistory.fleet_kind,
+    infrastructure_provider: originalHistory.infrastructure_provider,
+    provider_server_id: originalHistory.provider_server_id,
+    host_key_fingerprint: originalHistory.host_key_fingerprint,
+    attested_at: new Date(
+      originalHistory.attested_at.getTime() + (timing === "backdated" ? -1_000 : 1_000),
+    ),
+  });
+  await dbWrite
+    .update(dockerNodes)
+    .set({ node_incarnation: TARGET_NODE_INCARNATION })
+    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
 }
 
 beforeAll(async () => {
@@ -1126,7 +1183,7 @@ describe("strict restore catalogue authority", () => {
     expect(releaseReplay.released_at).toEqual(released.released_at);
   });
 
-  test("replays one immutable seed-to-activation receipt chain and fences boot ABA", async () => {
+  test("replays one immutable seed-to-activation receipt chain and fences current boot drift", async () => {
     const kms = new MemoryKmsAdapter({ seed: () => new Uint8Array(32).fill(0x94) });
     const generation = await createOrRotateAgentVaultKeyGeneration(
       {
@@ -1240,6 +1297,8 @@ describe("strict restore catalogue authority", () => {
       .update(dockerNodes)
       .set({ node_incarnation: TARGET_NODE_INCARNATION })
       .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+    // This direct mutation did not publish a B history. Journaled A -> B -> A
+    // is covered separately and remains rejected after the mutable row rewinds.
 
     const acquired = await acquireAgentBackupRestoreLease({
       organizationId: ORG_ID,
@@ -1479,6 +1538,26 @@ describe("strict restore catalogue authority", () => {
     }
   }, 10_000);
 
+  test("locks vault target authority in backup-to-catalogue order before the DB clock", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "..", "agent-vault-key-authority.ts"),
+      "utf8",
+    );
+    const proof = source.slice(
+      source.indexOf("async function proveAgentBackupRestoreVaultTargetAuthority"),
+      source.indexOf("export async function withAgentBackupRestoreVaultPassphrase"),
+    );
+    expectTokensInOrder(proof, [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      ".from(dockerNodes)",
+      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(",
+    ]);
+  });
+
   test("unwraps the manifest-retained vault generation after current authority rotates", async () => {
     const fixture = await acquireVaultPassphraseFixture(0x47);
     const rotated = await createOrRotateAgentVaultKeyGeneration(
@@ -1574,6 +1653,93 @@ describe("strict restore catalogue authority", () => {
 
       expect(decryptSpy).toHaveBeenCalledTimes(0);
       expect(useCalls).toBe(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("rejects an invalid remote handoff bound before source proof or KMS", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    try {
+      for (const handoffTimeoutMs of [0, 60_001, 1.5, Number.NaN]) {
+        await expect(
+          withAgentBackupRestoreVaultPassphrase(fixture.input, () => undefined, {
+            kmsClient: fixture.kms,
+            handoffTimeoutMs,
+          }),
+        ).rejects.toMatchObject({ code: "AGENT_VAULT_KEY_INPUT_INVALID" });
+      }
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("rejects a backdated target B history before KMS", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    await rearmVaultTargetNodeThroughIncarnation(REARMED_TARGET_NODE_INCARNATION, "backdated");
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("ambiguous multi-incarnation history");
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("fails while incarnation is NULL and resumes after exact host-key CAS re-attestation", async () => {
+    const fixture = await acquireVaultPassphraseFixture(0x4a);
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    try {
+      await dockerNodesRepository.invalidateNodeIncarnation({
+        id: fixture.input.targetNodeRecordId,
+        nodeId: "vault-restore-target-node",
+        expectedIncarnation: TARGET_NODE_INCARNATION,
+        expectedHostKeyFingerprint: `SHA256:${SHA}`,
+      });
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("target node record or incarnation was lost");
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
+
+      const reattested = await dockerNodesRepository.attestNodeIncarnation({
+        id: fixture.input.targetNodeRecordId,
+        nodeId: "vault-restore-target-node",
+        expectedIncarnation: null,
+        expectedHostKeyFingerprint: `SHA256:${SHA}`,
+        observedIncarnation: TARGET_NODE_INCARNATION,
+      });
+      expect(reattested.id).toBe(TARGET_NODE_RECORD_ID);
+      const result = await withAgentBackupRestoreVaultPassphrase(
+        fixture.input,
+        (passphrase) => {
+          useCalls += 1;
+          return Buffer.from(passphrase).toString("ascii");
+        },
+        { kmsClient: fixture.kms },
+      );
+      expect(result).toBe("4a".repeat(32));
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+      expect(useCalls).toBe(1);
     } finally {
       decryptSpy.mockRestore();
     }
@@ -1686,6 +1852,104 @@ describe("strict restore catalogue authority", () => {
       expect(isZeroized(secretRelease.rawKey)).toBe(true);
     } finally {
       decryptSpy.mockRestore();
+      secretRelease.restore();
+    }
+  });
+
+  test("revalidates after KMS and zeroizes plaintext after a backdated B history", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const secretRelease = captureVaultRawKeyAtRelease();
+    const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
+    let borrowedPlaintext: Uint8Array | null = null;
+    let useCalls = 0;
+    const decryptSpy = spyOn(fixture.kms, "decrypt").mockImplementation(
+      async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
+        const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
+        borrowedPlaintext = plaintext;
+        await rearmVaultTargetNodeThroughIncarnation(REARMED_TARGET_NODE_INCARNATION, "backdated");
+        return plaintext;
+      },
+    );
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("ambiguous multi-incarnation history");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+      expect(useCalls).toBe(0);
+      expect(isZeroized(borrowedPlaintext)).toBe(true);
+      expect(isZeroized(secretRelease.rawKey)).toBe(true);
+    } finally {
+      decryptSpy.mockRestore();
+      secretRelease.restore();
+    }
+  });
+
+  test("requires lease and claim authority to cover the configured remote handoff bound", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    const shortAuthorityExpiry = new Date(Date.now() + 5_000);
+    await dbWrite
+      .update(agentBackupRestoreLeases)
+      .set({ expires_at: shortAuthorityExpiry })
+      .where(eq(agentBackupRestoreLeases.id, fixture.input.leaseId));
+    await dbWrite
+      .update(agentBackupRestoreOperations)
+      .set({ claim_expires_at: shortAuthorityExpiry })
+      .where(eq(agentBackupRestoreOperations.id, fixture.input.restoreOperationId));
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms, handoffTimeoutMs: 10_000 },
+        ),
+      ).rejects.toThrow("do not cover the bounded remote handoff plus authority margin");
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("aborts a timed-out remote handoff and zeroizes borrowed secret material", async () => {
+    const fixture = await acquireVaultPassphraseFixture(0x4b);
+    const secretRelease = captureVaultRawKeyAtRelease();
+    let borrowedPassphrase: Uint8Array | null = null;
+    let handoffSignal: AbortSignal | null = null;
+    const callbackFinished = Promise.withResolvers<void>();
+    const startedAt = Date.now();
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          async (passphrase, signal) => {
+            borrowedPassphrase = passphrase;
+            handoffSignal = signal;
+            await new Promise<void>((resolve) => {
+              signal.addEventListener("abort", () => resolve(), { once: true });
+            });
+            await Bun.sleep(1);
+            callbackFinished.resolve();
+          },
+          { kmsClient: fixture.kms, handoffTimeoutMs: 10 },
+        ),
+      ).rejects.toMatchObject({ code: "AGENT_VAULT_KEY_HANDOFF_TIMEOUT" });
+      await callbackFinished.promise;
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      expect(handoffSignal?.aborted).toBe(true);
+      expect(isZeroized(borrowedPassphrase)).toBe(true);
+      expect(isZeroized(secretRelease.rawKey)).toBe(true);
+    } finally {
       secretRelease.restore();
     }
   });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -5,6 +5,7 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ElizaError } from "@elizaos/core";
 import { MemoryKmsAdapter } from "@elizaos/core/security/kms";
 import {
   AGENT_BACKUP_MANIFEST_FORMAT,
@@ -766,6 +767,7 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    // error-policy:J1 setup failure is retained for the test boundary assertion.
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
   }
@@ -903,27 +905,66 @@ describe("strict restore catalogue authority", () => {
       throw new Error("simulated KMS failure");
     });
     try {
-      await expect(
-        createOrRotateAgentVaultKeyGeneration(
-          {
-            organizationId: ORG_ID,
-            agentId: AGENT_ID,
-            generationId: VAULT_GENERATION,
-            sourceActivationGeneration: ACTIVATION_GENERATION,
-            expectedCurrentGenerationId: null,
-          },
-          {
-            kmsClient: kms,
-            randomBytes: (size) => new Uint8Array(size).fill(0x45),
-          },
-        ),
-      ).rejects.toMatchObject({ code: "AGENT_VAULT_KEY_CREATE_FAILED" });
+      const attempt = createOrRotateAgentVaultKeyGeneration(
+        {
+          organizationId: ORG_ID,
+          agentId: AGENT_ID,
+          generationId: VAULT_GENERATION,
+          sourceActivationGeneration: ACTIVATION_GENERATION,
+          expectedCurrentGenerationId: null,
+        },
+        {
+          kmsClient: kms,
+          randomBytes: (size) => new Uint8Array(size).fill(0x45),
+        },
+      );
+      await expect(attempt).rejects.toBeInstanceOf(ElizaError);
+      await expect(attempt).rejects.toMatchObject({
+        code: "AGENT_VAULT_KEY_CREATE_FAILED",
+        cause: expect.any(Error),
+      });
       expect(borrowedPlaintext).not.toBeNull();
       expect(isZeroized(borrowedPlaintext)).toBe(true);
       expect(await dbWrite.select().from(agentVaultKeyGenerations)).toHaveLength(0);
     } finally {
       encryptSpy.mockRestore();
     }
+  });
+
+  test("rejects non-canonical restore authority inputs with typed field context", async () => {
+    const input = {
+      organizationId: ORG_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      sourceActivationGeneration: ACTIVATION_GENERATION,
+      sourceLifecycleRevision: "7",
+      expectedManifestSha256: SHA,
+      copyRole: "primary" as const,
+      restoreAttemptId: "00000000-0000-4000-8000-00000000d010",
+      ownerId: "restore-worker",
+      leaseMs: 60_000,
+    };
+    const uppercaseTenant = acquireAgentBackupRestoreLease({
+      ...input,
+      organizationId: ORG_ID.toUpperCase(),
+    });
+    await expect(uppercaseTenant).rejects.toBeInstanceOf(ElizaError);
+    await expect(uppercaseTenant).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      context: { field: "organizationId" },
+    });
+    await expect(
+      acquireAgentBackupRestoreLease({ ...input, expectedManifestSha256: SHA.toUpperCase() }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      context: { field: "expectedManifestSha256" },
+    });
+    await expect(
+      acquireAgentBackupRestoreLease({ ...input, ownerId: "x".repeat(256) }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      context: { field: "ownerId" },
+    });
   });
 
   for (const state of ["primary_verified", "secondary_pending"] as const) {

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -70,6 +70,7 @@ import {
   bindAgentBackupVaultKeyGeneration,
   createOrRotateAgentVaultKeyGeneration,
   loadCurrentAgentVaultKeyAuthority,
+  withAgentBackupRestoreVaultPassphrase,
 } from "../agent-vault-key-authority";
 
 const TIMEOUT = 60_000;
@@ -572,6 +573,46 @@ async function insertExactProtectedSource(vaultAuthority: {
     },
   ]);
   return { exact, binding };
+}
+
+async function acquireVaultPassphraseFixture(entropyByte = 0x43) {
+  const kms = new MemoryKmsAdapter({ seed: () => new Uint8Array(32).fill(0x93) });
+  const generation = await createOrRotateAgentVaultKeyGeneration(
+    {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      generationId: VAULT_GENERATION,
+      sourceActivationGeneration: ACTIVATION_GENERATION,
+      expectedCurrentGenerationId: null,
+    },
+    {
+      kmsClient: kms,
+      randomBytes: (size) => new Uint8Array(size).fill(entropyByte),
+    },
+  );
+  generation.secret.release();
+  const { exact } = await insertExactProtectedSource(generation.authority);
+  const acquired = await acquireAgentBackupRestoreLease({
+    organizationId: ORG_ID,
+    backupId: BACKUP_ID,
+    operationId: OPERATION_ID,
+    sourceActivationGeneration: ACTIVATION_GENERATION,
+    sourceLifecycleRevision: "7",
+    expectedManifestSha256: exact.manifest.integrity.manifestSha256,
+    copyRole: "primary",
+    restoreAttemptId: RESTORE_ATTEMPT_ID,
+    ownerId: "vault-restore-worker",
+    leaseMs: 60_000,
+  });
+  return {
+    kms,
+    generation,
+    input: {
+      ...acquired.authority,
+      vaultKeyGenerationId: generation.authority.generationId,
+      vaultKeyAuthorityReceiptDigest: generation.authority.receiptDigest,
+    },
+  } as const;
 }
 
 beforeAll(async () => {
@@ -1366,4 +1407,138 @@ describe("strict restore catalogue authority", () => {
       digestSpy.mockRestore();
     }
   }, 10_000);
+
+  test("unwraps the manifest-retained vault generation after current authority rotates", async () => {
+    const fixture = await acquireVaultPassphraseFixture(0x47);
+    const rotated = await createOrRotateAgentVaultKeyGeneration(
+      {
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        generationId: ROTATED_VAULT_GENERATION,
+        sourceActivationGeneration: ACTIVATION_GENERATION,
+        expectedCurrentGenerationId: VAULT_GENERATION,
+      },
+      {
+        kmsClient: fixture.kms,
+        randomBytes: (size) => new Uint8Array(size).fill(0x48),
+      },
+    );
+    rotated.secret.release();
+    let borrowedPassphrase: Uint8Array | null = null;
+
+    const passphraseText = await withAgentBackupRestoreVaultPassphrase(
+      fixture.input,
+      (passphrase) => {
+        borrowedPassphrase = passphrase;
+        return Buffer.from(passphrase).toString("ascii");
+      },
+      { kmsClient: fixture.kms },
+    );
+
+    expect(passphraseText).toBe("47".repeat(32));
+    expect(isZeroized(borrowedPassphrase)).toBe(true);
+    expect(
+      await loadCurrentAgentVaultKeyAuthority({ organizationId: ORG_ID, agentId: AGENT_ID }),
+    ).toEqual(rotated.authority);
+  });
+
+  test("rejects mismatched source, vault, fence, and released-lease authority before KMS or use", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    const use = () => {
+      useCalls += 1;
+      return undefined;
+    };
+    const mismatches = [
+      { ...fixture.input, expectedManifestSha256: "f".repeat(64) },
+      { ...fixture.input, vaultKeyGenerationId: ROTATED_VAULT_GENERATION },
+      { ...fixture.input, vaultKeyAuthorityReceiptDigest: "f".repeat(64) },
+      { ...fixture.input, fencingToken: STALE_VAULT_GENERATION },
+    ] as const;
+    try {
+      for (const input of mismatches) {
+        await expect(
+          withAgentBackupRestoreVaultPassphrase(input, use, { kmsClient: fixture.kms }),
+        ).rejects.toBeInstanceOf(Error);
+      }
+      await releaseAgentBackupRestoreLease(fixture.input);
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(fixture.input, use, { kmsClient: fixture.kms }),
+      ).rejects.toThrow("expired, released, or fenced");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("revalidates after KMS and zeroizes plaintext when the lease is lost during decrypt", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
+    let borrowedPlaintext: Uint8Array | null = null;
+    let useCalls = 0;
+    const decryptSpy = spyOn(fixture.kms, "decrypt").mockImplementation(
+      async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
+        const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
+        borrowedPlaintext = plaintext;
+        await releaseAgentBackupRestoreLease(fixture.input);
+        return plaintext;
+      },
+    );
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("expired, released, or fenced");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+      expect(useCalls).toBe(0);
+      expect(isZeroized(borrowedPlaintext)).toBe(true);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("zeroizes callback passphrases on success and throw while preserving the callback error", async () => {
+    const fixture = await acquireVaultPassphraseFixture(0x49);
+    let successfulPassphrase: Uint8Array | null = null;
+
+    const result = await withAgentBackupRestoreVaultPassphrase(
+      fixture.input,
+      (passphrase) => {
+        successfulPassphrase = passphrase;
+        return Buffer.from(passphrase).toString("ascii");
+      },
+      { kmsClient: fixture.kms },
+    );
+
+    expect(result).toBe("49".repeat(32));
+    expect(isZeroized(successfulPassphrase)).toBe(true);
+
+    const callbackError = new Error("vault restore callback failed");
+    let failedPassphrase: Uint8Array | null = null;
+    let thrown: unknown;
+    try {
+      await withAgentBackupRestoreVaultPassphrase(
+        fixture.input,
+        (passphrase) => {
+          failedPassphrase = passphrase;
+          throw callbackError;
+        },
+        { kmsClient: fixture.kms },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBe(callbackError);
+    expect(isZeroized(failedPassphrase)).toBe(true);
+  });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -1967,13 +1967,14 @@ describe("strict restore catalogue authority", () => {
     const secretRelease = captureVaultRawKeyAtRelease();
     let borrowedPassphrase: Uint8Array | null = null;
     let handoffSignal: AbortSignal | null = null;
+    let handoffStartedAt: number | null = null;
     const callbackFinished = Promise.withResolvers<void>();
-    const startedAt = Date.now();
     try {
       await expect(
         withAgentBackupRestoreVaultPassphrase(
           fixture.input,
           async (passphrase, signal) => {
+            handoffStartedAt = Date.now();
             borrowedPassphrase = passphrase;
             handoffSignal = signal;
             await new Promise<void>((resolve) => {
@@ -1986,7 +1987,8 @@ describe("strict restore catalogue authority", () => {
         ),
       ).rejects.toMatchObject({ code: "AGENT_VAULT_KEY_HANDOFF_TIMEOUT" });
       await callbackFinished.promise;
-      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      expect(handoffStartedAt).not.toBeNull();
+      expect(Date.now() - (handoffStartedAt ?? 0)).toBeLessThan(1_000);
       expect(handoffSignal?.aborted).toBe(true);
       expect(isZeroized(borrowedPassphrase)).toBe(true);
       expect(isZeroized(secretRelease.rawKey)).toBe(true);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -30,6 +30,7 @@ import {
   agentBackupCatalogAuthorities,
   agentBackupObjects,
   agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
 } from "../../schemas/agent-backup-catalog";
 import {
   agentActivationPublications,
@@ -67,6 +68,12 @@ import {
   renewAgentBackupRestoreLease,
 } from "../agent-backup-restore-lease";
 import {
+  claimAgentBackupRestoreOperation,
+  openAgentBackupRestoreOperation,
+  reserveAgentBackupRestoreTarget,
+} from "../agent-backup-restore-operations";
+import {
+  AgentVaultKeySecretHandle,
   bindAgentBackupVaultKeyGeneration,
   createOrRotateAgentVaultKeyGeneration,
   loadCurrentAgentVaultKeyAuthority,
@@ -100,6 +107,27 @@ let schemaFailure = "";
 
 function isZeroized(value: Uint8Array | null): boolean {
   return value !== null && value.every((byte) => byte === 0);
+}
+
+function captureVaultRawKeyAtRelease(): {
+  readonly rawKey: Uint8Array | null;
+  restore: () => void;
+} {
+  const originalRelease = AgentVaultKeySecretHandle.prototype.release;
+  let capturedRawKey: Uint8Array | null = null;
+  const releaseSpy = spyOn(AgentVaultKeySecretHandle.prototype, "release").mockImplementation(
+    function (this: AgentVaultKeySecretHandle) {
+      const rawKey = Reflect.get(this, "rawKey");
+      capturedRawKey = rawKey instanceof Uint8Array ? rawKey : null;
+      originalRelease.call(this);
+    },
+  );
+  return {
+    get rawKey() {
+      return capturedRawKey;
+    },
+    restore: () => releaseSpy.mockRestore(),
+  };
 }
 
 function sha256Hex(value: Uint8Array | string): string {
@@ -575,7 +603,10 @@ async function insertExactProtectedSource(vaultAuthority: {
   return { exact, binding };
 }
 
-async function acquireVaultPassphraseFixture(entropyByte = 0x43) {
+async function acquireVaultPassphraseFixture(
+  entropyByte = 0x43,
+  options: Readonly<{ reserveTarget?: boolean }> = {},
+) {
   const kms = new MemoryKmsAdapter({ seed: () => new Uint8Array(32).fill(0x93) });
   const generation = await createOrRotateAgentVaultKeyGeneration(
     {
@@ -604,11 +635,49 @@ async function acquireVaultPassphraseFixture(entropyByte = 0x43) {
     ownerId: "vault-restore-worker",
     leaseMs: 60_000,
   });
+  const opened = await openAgentBackupRestoreOperation({
+    authority: acquired.authority,
+    leaseId: acquired.authority.leaseId,
+  });
+  const claimed = await claimAgentBackupRestoreOperation({
+    operationId: opened.operation.id,
+    ownerId: acquired.authority.ownerId,
+    claimMs: 60_000,
+  });
+  await dbWrite.insert(dockerNodes).values({
+    id: TARGET_NODE_RECORD_ID,
+    node_id: "vault-restore-target-node",
+    hostname: "vault-restore-target-node.internal",
+    capacity: 2,
+    enabled: true,
+    placement_state: "open",
+    status: "healthy",
+    host_key_fingerprint: `SHA256:${SHA}`,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: TARGET_NODE_INCARNATION,
+    metadata: {},
+  });
+  if (options.reserveTarget !== false) {
+    await reserveAgentBackupRestoreTarget({
+      operationId: opened.operation.id,
+      ownerId: acquired.authority.ownerId,
+      claimGeneration: claimed.claimGeneration,
+      targetNodeRecordId: TARGET_NODE_RECORD_ID,
+      targetNodeIncarnation: TARGET_NODE_INCARNATION,
+    });
+  }
   return {
     kms,
     generation,
+    operation: claimed.operation,
     input: {
       ...acquired.authority,
+      restoreOperationId: opened.operation.id,
+      restoreClaimGeneration: claimed.claimGeneration,
+      targetNodeRecordId: TARGET_NODE_RECORD_ID,
+      targetNodeIncarnation: TARGET_NODE_INCARNATION,
       vaultKeyGenerationId: generation.authority.generationId,
       vaultKeyAuthorityReceiptDigest: generation.authority.receiptDigest,
     },
@@ -627,6 +696,7 @@ beforeAll(async () => {
         agentBackupCatalogAuthorities,
         agentBackupObjects,
         agentBackupRestoreLeases,
+        agentBackupRestoreOperations,
         dockerNodes,
         agentNodeIncarnationHistories,
         agentActivationPublications,
@@ -651,6 +721,7 @@ beforeEach(async () => {
   await dbWrite.delete(agentActivationPublications);
   await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(agentVaultKeyBackupBindings);
+  await dbWrite.delete(agentBackupRestoreOperations);
   await dbWrite.delete(agentBackupRestoreLeases);
   await dbWrite.delete(agentBackupObjects);
   await dbWrite.delete(agentSandboxBackups);
@@ -1442,7 +1513,7 @@ describe("strict restore catalogue authority", () => {
     ).toEqual(rotated.authority);
   });
 
-  test("rejects mismatched source, vault, fence, and released-lease authority before KMS or use", async () => {
+  test("rejects mismatched source, vault, claim, target, fence, and lease authority before KMS or use", async () => {
     const fixture = await acquireVaultPassphraseFixture();
     const decryptSpy = spyOn(fixture.kms, "decrypt");
     let useCalls = 0;
@@ -1455,6 +1526,10 @@ describe("strict restore catalogue authority", () => {
       { ...fixture.input, vaultKeyGenerationId: ROTATED_VAULT_GENERATION },
       { ...fixture.input, vaultKeyAuthorityReceiptDigest: "f".repeat(64) },
       { ...fixture.input, fencingToken: STALE_VAULT_GENERATION },
+      { ...fixture.input, restoreOperationId: "00000000-0000-4000-8000-00000000d060" },
+      { ...fixture.input, restoreClaimGeneration: "00000000-0000-4000-8000-00000000d061" },
+      { ...fixture.input, targetNodeRecordId: "00000000-0000-4000-8000-00000000d062" },
+      { ...fixture.input, targetNodeIncarnation: "00000000-0000-4000-8000-00000000d063" },
     ] as const;
     try {
       for (const input of mismatches) {
@@ -1474,8 +1549,39 @@ describe("strict restore catalogue authority", () => {
     }
   });
 
+  test("does not call KMS without the exact restore operation and persisted target", async () => {
+    const fixture = await acquireVaultPassphraseFixture(0x43, { reserveTarget: false });
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    const use = () => {
+      useCalls += 1;
+    };
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          {
+            ...fixture.input,
+            restoreOperationId: "00000000-0000-4000-8000-00000000d064",
+          },
+          use,
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("operation is missing");
+
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(fixture.input, use, { kmsClient: fixture.kms }),
+      ).rejects.toThrow("lacks its exact complete target authority");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
   test("revalidates after KMS and zeroizes plaintext when the lease is lost during decrypt", async () => {
     const fixture = await acquireVaultPassphraseFixture();
+    const secretRelease = captureVaultRawKeyAtRelease();
     const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
     let borrowedPlaintext: Uint8Array | null = null;
     let useCalls = 0;
@@ -1501,8 +1607,86 @@ describe("strict restore catalogue authority", () => {
       expect(decryptSpy).toHaveBeenCalledTimes(1);
       expect(useCalls).toBe(0);
       expect(isZeroized(borrowedPlaintext)).toBe(true);
+      expect(isZeroized(secretRelease.rawKey)).toBe(true);
     } finally {
       decryptSpy.mockRestore();
+      secretRelease.restore();
+    }
+  });
+
+  test("revalidates after KMS and zeroizes plaintext when the restore claim is lost", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const secretRelease = captureVaultRawKeyAtRelease();
+    const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
+    let borrowedPlaintext: Uint8Array | null = null;
+    let useCalls = 0;
+    const decryptSpy = spyOn(fixture.kms, "decrypt").mockImplementation(
+      async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
+        const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
+        borrowedPlaintext = plaintext;
+        await dbWrite
+          .update(agentBackupRestoreOperations)
+          .set({ claim_owner: null, claim_generation: null, claim_expires_at: null })
+          .where(eq(agentBackupRestoreOperations.id, fixture.input.restoreOperationId));
+        return plaintext;
+      },
+    );
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("claim is not live");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+      expect(useCalls).toBe(0);
+      expect(isZeroized(borrowedPlaintext)).toBe(true);
+      expect(isZeroized(secretRelease.rawKey)).toBe(true);
+    } finally {
+      decryptSpy.mockRestore();
+      secretRelease.restore();
+    }
+  });
+
+  test("revalidates after KMS and zeroizes plaintext when the target incarnation is lost", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const secretRelease = captureVaultRawKeyAtRelease();
+    const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
+    let borrowedPlaintext: Uint8Array | null = null;
+    let useCalls = 0;
+    const decryptSpy = spyOn(fixture.kms, "decrypt").mockImplementation(
+      async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
+        const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
+        borrowedPlaintext = plaintext;
+        await dbWrite
+          .update(dockerNodes)
+          .set({ node_incarnation: "00000000-0000-4000-8000-00000000d065" })
+          .where(eq(dockerNodes.id, fixture.input.targetNodeRecordId));
+        return plaintext;
+      },
+    );
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("target node record or incarnation was lost");
+
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+      expect(useCalls).toBe(0);
+      expect(isZeroized(borrowedPlaintext)).toBe(true);
+      expect(isZeroized(secretRelease.rawKey)).toBe(true);
+    } finally {
+      decryptSpy.mockRestore();
+      secretRelease.restore();
     }
   });
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
@@ -7,6 +7,8 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   AGENT_BACKUP_MANIFEST_FORMAT,
   AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
@@ -33,6 +35,7 @@ import {
   agentBackupRestoreLeases,
   agentBackupRestoreOperations,
 } from "../../schemas/agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-backup-restore-history";
 import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
 import {
   AGENT_VAULT_KEY_AUTHORITY_FORMAT,
@@ -53,6 +56,7 @@ import {
   openAgentBackupRestoreOperation,
   reserveAgentBackupRestoreTarget,
 } from "../agent-backup-restore-operations";
+import { dockerNodesRepository } from "../docker-nodes";
 
 const TIMEOUT = 60_000;
 const ORG_ID = "00000000-0000-4000-8000-00000000f001";
@@ -74,8 +78,19 @@ const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f010";
 const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f011";
 const OTHER_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f012";
 const OTHER_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f013";
+const TARGET_NODE_CREATED_AT = new Date("2026-08-19T23:59:59.000Z");
+const TARGET_NODE_ATTESTED_AT = new Date("2026-08-20T00:00:00.000Z");
 let schemaFailure = "";
 let manifestFixture: Readonly<{ canonicalDraft: string; digest: string }>;
+
+function expectTokensInOrder(source: string, tokens: readonly string[]): void {
+  let previous = -1;
+  for (const token of tokens) {
+    const index = source.indexOf(token);
+    expect(index).toBeGreaterThan(previous);
+    previous = index;
+  }
+}
 
 async function buildManifestFixture(): Promise<typeof manifestFixture> {
   const emptyComponent = (name: "character" | "database" | "media" | "state-files" | "vault") => ({
@@ -222,24 +237,70 @@ async function seedTargetNode(
     status?: "healthy" | "degraded" | "offline" | "unknown";
     placementState?: "open" | "cordoned" | "evacuating" | "drained";
     capacityProvisional?: boolean;
+    createdAt?: Date;
+    recordHistory?: boolean;
   } = {},
 ): Promise<void> {
-  await dbWrite.insert(dockerNodes).values({
-    id: input.id ?? TARGET_NODE_RECORD_ID,
-    node_id: input.nodeId ?? "restore-target-a",
-    hostname: "restore-target.invalid",
-    capacity: input.capacity ?? 2,
-    allocated_count: input.allocatedCount ?? 0,
-    enabled: input.enabled ?? true,
-    status: input.status ?? "healthy",
-    placement_state: input.placementState ?? "open",
-    host_key_fingerprint: "SHA256:test-only-host-key",
-    fleet_kind: "robot",
-    infrastructure_provider: "hetzner",
-    provider_server_id: null,
-    node_incarnation: input.incarnation === undefined ? TARGET_NODE_INCARNATION : input.incarnation,
-    metadata: input.capacityProvisional ? { capacityProvisional: true } : {},
+  const [node] = await dbWrite
+    .insert(dockerNodes)
+    .values({
+      id: input.id ?? TARGET_NODE_RECORD_ID,
+      node_id: input.nodeId ?? "restore-target-a",
+      hostname: "restore-target.invalid",
+      capacity: input.capacity ?? 2,
+      allocated_count: input.allocatedCount ?? 0,
+      enabled: input.enabled ?? true,
+      status: input.status ?? "healthy",
+      placement_state: input.placementState ?? "open",
+      host_key_fingerprint: "SHA256:test-only-host-key",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      node_incarnation:
+        input.incarnation === undefined ? TARGET_NODE_INCARNATION : input.incarnation,
+      metadata: input.capacityProvisional ? { capacityProvisional: true } : {},
+      created_at: input.createdAt ?? TARGET_NODE_CREATED_AT,
+    })
+    .returning();
+  if (!node) throw new Error("restore target fixture was not inserted");
+  if (node.node_incarnation && input.recordHistory !== false) {
+    await dbWrite.insert(agentNodeIncarnationHistories).values({
+      docker_node_record_id: node.id,
+      node_id: node.node_id,
+      node_incarnation: node.node_incarnation,
+      fleet_kind: node.fleet_kind ?? "robot",
+      infrastructure_provider: node.infrastructure_provider ?? "hetzner",
+      provider_server_id: node.provider_server_id,
+      host_key_fingerprint: node.host_key_fingerprint ?? "SHA256:test-only-host-key",
+      attested_at: TARGET_NODE_ATTESTED_AT,
+    });
+  }
+}
+
+async function rearmTargetNodeThroughIncarnation(nextIncarnation: string): Promise<void> {
+  const [originalHistory] = await dbWrite
+    .select()
+    .from(agentNodeIncarnationHistories)
+    .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
+  if (!originalHistory) throw new Error("restore target history fixture is missing");
+  await dbWrite
+    .update(dockerNodes)
+    .set({ node_incarnation: nextIncarnation })
+    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+  await dbWrite.insert(agentNodeIncarnationHistories).values({
+    docker_node_record_id: TARGET_NODE_RECORD_ID,
+    node_id: originalHistory.node_id,
+    node_incarnation: nextIncarnation,
+    fleet_kind: originalHistory.fleet_kind,
+    infrastructure_provider: originalHistory.infrastructure_provider,
+    provider_server_id: originalHistory.provider_server_id,
+    host_key_fingerprint: originalHistory.host_key_fingerprint,
+    attested_at: new Date(originalHistory.attested_at.getTime() + 1_000),
   });
+  await dbWrite
+    .update(dockerNodes)
+    .set({ node_incarnation: TARGET_NODE_INCARNATION })
+    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
 }
 
 async function openAndClaim(): Promise<{
@@ -317,6 +378,7 @@ beforeAll(async () => {
         agentBackupRestoreOperations,
         agentVaultKeyGenerations,
         dockerNodes,
+        agentNodeIncarnationHistories,
       } as never,
       dbWrite as never,
     );
@@ -330,6 +392,7 @@ beforeEach(async () => {
   expect(schemaFailure).toBe("");
   await dbWrite.delete(agentBackupRestoreOperations);
   await dbWrite.delete(agentBackupRestoreLeases);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(dockerNodes);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentVaultKeyGenerations);
@@ -553,7 +616,7 @@ describe("restore operation spine", () => {
   );
 
   test(
-    "makes divergent replay and node-incarnation ABA conflicts without reselection",
+    "makes divergent replay and current incarnation drift conflicts without reselection",
     async () => {
       await seedTargetNode();
       await seedTargetNode({
@@ -594,6 +657,170 @@ describe("restore operation spine", () => {
       const nodes = await dbWrite.select().from(dockerNodes);
       expect(nodes.find((node) => node.id === TARGET_NODE_RECORD_ID)?.allocated_count).toBe(1);
       expect(nodes.find((node) => node.id === OTHER_NODE_RECORD_ID)?.allocated_count).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a target rearmed A-to-B-to-A before reservation without consuming capacity",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await rearmTargetNodeThroughIncarnation("00000000-0000-4000-8000-00000000f014");
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("ambiguous multi-incarnation history");
+
+      const [node] = await dbWrite
+        .select()
+        .from(dockerNodes)
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      const [operation] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, authority.operationId));
+      expect(node?.allocated_count).toBe(0);
+      expect(operation?.expected_node_record_id).toBeNull();
+      expect(operation?.expected_node_incarnation).toBeNull();
+      expect(operation?.expected_image_digest).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a B inserted after A even when B is backdated before reservation",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await dbWrite.insert(agentNodeIncarnationHistories).values({
+        docker_node_record_id: TARGET_NODE_RECORD_ID,
+        node_id: "restore-target-a",
+        node_incarnation: OTHER_NODE_INCARNATION,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        host_key_fingerprint: "SHA256:test-only-host-key",
+        attested_at: new Date(TARGET_NODE_ATTESTED_AT.getTime() - 60_000),
+      });
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("ambiguous multi-incarnation history");
+      const [node] = await dbWrite.select().from(dockerNodes);
+      expect(node?.allocated_count).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fails closed when an older B history predates the current A history",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await dbWrite.delete(agentNodeIncarnationHistories);
+      await dbWrite.insert(agentNodeIncarnationHistories).values({
+        docker_node_record_id: TARGET_NODE_RECORD_ID,
+        node_id: "restore-target-a",
+        node_incarnation: OTHER_NODE_INCARNATION,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        host_key_fingerprint: "SHA256:test-only-host-key",
+        attested_at: new Date(TARGET_NODE_ATTESTED_AT.getTime() - 60_000),
+      });
+      await dbWrite.insert(agentNodeIncarnationHistories).values({
+        docker_node_record_id: TARGET_NODE_RECORD_ID,
+        node_id: "restore-target-a",
+        node_incarnation: TARGET_NODE_INCARNATION,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        host_key_fingerprint: "SHA256:test-only-host-key",
+        attested_at: TARGET_NODE_ATTESTED_AT,
+      });
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("ambiguous multi-incarnation history");
+      const [node] = await dbWrite.select().from(dockerNodes);
+      expect(node?.allocated_count).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a fresh-created exact node delete/reinsert as defense in depth",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await seedTargetNode({
+        createdAt: new Date(TARGET_NODE_ATTESTED_AT.getTime() + 1_000),
+        recordHistory: false,
+      });
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("lacks exact immutable node-incarnation history");
+      const [node] = await dbWrite.select().from(dockerNodes);
+      expect(node?.allocated_count).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fails while incarnation is NULL and accepts exact host-key CAS re-attestation",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      const request = {
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      } as const;
+      await dockerNodesRepository.invalidateNodeIncarnation({
+        id: TARGET_NODE_RECORD_ID,
+        nodeId: "restore-target-a",
+        expectedIncarnation: TARGET_NODE_INCARNATION,
+        expectedHostKeyFingerprint: "SHA256:test-only-host-key",
+      });
+      await expect(reserveAgentBackupRestoreTarget(request)).rejects.toThrow(
+        "node incarnation changed",
+      );
+
+      const reattested = await dockerNodesRepository.attestNodeIncarnation({
+        id: TARGET_NODE_RECORD_ID,
+        nodeId: "restore-target-a",
+        expectedIncarnation: null,
+        expectedHostKeyFingerprint: "SHA256:test-only-host-key",
+        observedIncarnation: TARGET_NODE_INCARNATION,
+      });
+      expect(reattested.id).toBe(TARGET_NODE_RECORD_ID);
+      const reserved = await reserveAgentBackupRestoreTarget(request);
+      expect(reserved.replayed).toBe(false);
+      expect(reserved.target.nodeIncarnation).toBe(TARGET_NODE_INCARNATION);
     },
     TIMEOUT,
   );
@@ -682,6 +909,39 @@ describe("restore operation spine", () => {
     TIMEOUT,
   );
 
+  test("keeps open and target reservation on the canonical multi-authority lock order", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "..", "agent-backup-restore-operations.ts"),
+      "utf8",
+    );
+    const open = source.slice(
+      source.indexOf("export async function openAgentBackupRestoreOperation"),
+      source.indexOf("export async function claimAgentBackupRestoreOperation"),
+    );
+    expectTokensInOrder(open, [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(",
+    ]);
+
+    const reserve = source.slice(
+      source.indexOf("export async function reserveAgentBackupRestoreTarget"),
+      source.indexOf("export async function advanceAgentBackupRestoreOperation"),
+    );
+    const reserveTransaction = reserve.slice(reserve.indexOf("return await dbWrite.transaction"));
+    expectTokensInOrder(reserveTransaction, [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      ".from(dockerNodes)",
+      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(",
+    ]);
+  });
+
   test(
     "refuses to open once the catalogue revision has moved past the lease epoch",
     async () => {
@@ -710,28 +970,35 @@ describe("restore operation spine", () => {
   );
 
   test(
-    "claims exclusively and refuses a second live claim",
+    "claims exclusively under concurrent workers without a lock cycle",
     async () => {
       await seedLease();
       const { operation } = await openAgentBackupRestoreOperation({
         authority: authorityReceipt(),
         leaseId: LEASE_ID,
       });
-      const claim = await claimAgentBackupRestoreOperation({
-        operationId: operation.id,
-        ownerId: "restore-worker",
-        claimMs: 60_000,
-      });
-      expect(claim.operation.claim_owner).toBe("restore-worker");
-      expect(claim.operation.attempts).toBe(1);
-
-      await expect(
+      const claims = await Promise.allSettled([
         claimAgentBackupRestoreOperation({
           operationId: operation.id,
           ownerId: "restore-worker",
           claimMs: 60_000,
         }),
-      ).rejects.toThrow("claimed by another worker");
+        claimAgentBackupRestoreOperation({
+          operationId: operation.id,
+          ownerId: "restore-worker",
+          claimMs: 60_000,
+        }),
+      ]);
+      expect(claims.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+      const successful = claims.find((result) => result.status === "fulfilled");
+      const rejected = claims.find((result) => result.status === "rejected");
+      expect(successful?.status === "fulfilled" && successful.value.operation.claim_owner).toBe(
+        "restore-worker",
+      );
+      expect(successful?.status === "fulfilled" && successful.value.operation.attempts).toBe(1);
+      expect(rejected?.status === "rejected" ? String(rejected.reason) : "").toContain(
+        "claimed by another worker",
+      );
     },
     TIMEOUT,
   );
@@ -902,7 +1169,7 @@ describe("restore operation spine", () => {
           authority: { ...authorityReceipt(), agentId: OTHER_AGENT },
           leaseId: LEASE_ID,
         }),
-      ).rejects.toThrow("Restore lease authority does not match");
+      ).rejects.toThrow("Restore backup authority does not match");
       expect(await dbWrite.select().from(agentBackupRestoreOperations)).toEqual([]);
     },
     TIMEOUT,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
@@ -7,7 +7,17 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
-import { AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1 } from "@elizaos/shared";
+import {
+  AGENT_BACKUP_MANIFEST_FORMAT,
+  AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  type AgentBackupManifestV3Draft,
+  canonicalizeAgentBackupManifestV3,
+  createAgentBackupManifestV3,
+} from "@elizaos/shared";
 
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
@@ -30,6 +40,7 @@ import {
   AGENT_VAULT_KEY_KMS_CONTEXT_DERIVATION,
   agentVaultKeyGenerations,
 } from "../../schemas/agent-vault-key-authority";
+import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
@@ -40,6 +51,7 @@ import {
   failAgentBackupRestoreOperation,
   heartbeatAgentBackupRestoreOperation,
   openAgentBackupRestoreOperation,
+  reserveAgentBackupRestoreTarget,
 } from "../agent-backup-restore-operations";
 
 const TIMEOUT = 60_000;
@@ -58,7 +70,107 @@ const KEY_BUNDLE = Buffer.alloc(AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedByte
   "base64",
 );
 const VAULT_GENERATION = "00000000-0000-4000-8000-00000000f009";
+const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f010";
+const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f011";
+const OTHER_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f012";
+const OTHER_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f013";
 let schemaFailure = "";
+let manifestFixture: Readonly<{ canonicalDraft: string; digest: string }>;
+
+async function buildManifestFixture(): Promise<typeof manifestFixture> {
+  const emptyComponent = (name: "character" | "database" | "media" | "state-files" | "vault") => ({
+    name,
+    format: "raw-v1",
+    compression: "none" as const,
+    payloadContentHmacSha256: SHA,
+    state: { kind: "full" as const, resultContentHmacSha256: SHA },
+    totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+    chunks: [],
+  });
+  const draft: AgentBackupManifestV3Draft = {
+    format: AGENT_BACKUP_MANIFEST_FORMAT,
+    schemaVersion: 3,
+    operationId: OPERATION_ID,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    identity: {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      lifecycleRevision: "7",
+    },
+    source: {
+      kind: "robot",
+      provider: "hetzner",
+      nodeRecordId: "00000000-0000-4000-8000-00000000f00a",
+      nodeIncarnation: "00000000-0000-4000-8000-00000000f00b",
+      nodeId: "restore-source-node",
+      containerId: "c".repeat(64),
+    },
+    runtime: {
+      imageDigest: `sha256:${SHA}`,
+      agentSchemaVersion: "2.0.0",
+      databaseSchemaVersion: "1",
+      plugins: [],
+    },
+    chain: { kind: "full", baseOperationId: null, parentOperationId: null, depth: 0 },
+    components: [
+      emptyComponent("character"),
+      emptyComponent("database"),
+      emptyComponent("media"),
+      emptyComponent("state-files"),
+      emptyComponent("vault"),
+    ],
+    watermarks: [{ namespace: "database.lsn", value: "0/1" }],
+    totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+    vaultKeyAuthority: {
+      format: AGENT_VAULT_KEY_AUTHORITY_FORMAT,
+      generationId: VAULT_GENERATION,
+      receiptDerivation: AGENT_VAULT_KEY_AUTHORITY_RECEIPT_DERIVATION,
+      receiptDigest: RECEIPT_SHA,
+    },
+    encryption: {
+      algorithm: "AES-256-GCM",
+      chunkEnvelope: "aes-256-gcm-v1",
+      nonceBytes: 12,
+      tagBytes: 16,
+      noncePlacement: "prefix",
+      tagPlacement: "suffix",
+      aad: { version: 1, derivation: "elizaos.agent-backup.chunk-aad.v1" },
+      kms: { provider: "steward", keyId: `org:${ORG_ID}/dek/v1`, keyVersion: 1 },
+      operationKeyBundle: {
+        format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        generationId: "00000000-0000-4000-8000-00000000f00c",
+        plaintextBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.plaintextBytes,
+        dek: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek,
+        contentHmac: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac,
+        wrapped: {
+          ref: `backup-key-bundle:${OPERATION_ID}`,
+          bytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes,
+          sha256: SHA,
+          localReceiptDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+          localReceiptDigest: SHA,
+          contextDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+        },
+      },
+    },
+    integrity: {
+      framedContentHmacSha256: SHA,
+      contentAddressing: {
+        algorithm: "HMAC-SHA-256",
+        scope: "operation",
+        derivation: AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+        keyBundleFormat: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        keyOffsetBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.offsetBytes,
+        keyBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes,
+      },
+    },
+  };
+  const manifest = await createAgentBackupManifestV3(draft);
+  return Object.freeze({
+    canonicalDraft: canonicalizeAgentBackupManifestV3(draft),
+    digest: manifest.integrity.manifestSha256,
+  });
+}
 
 function authorityReceipt(): AgentBackupRestoreLeaseAuthorityReceipt {
   return {
@@ -68,7 +180,7 @@ function authorityReceipt(): AgentBackupRestoreLeaseAuthorityReceipt {
     operationId: OPERATION_ID,
     sourceActivationGeneration: ACTIVATION_GENERATION,
     sourceLifecycleRevision: "7",
-    expectedManifestSha256: SHA,
+    expectedManifestSha256: manifestFixture.digest,
     restoreAttemptId: ATTEMPT_ID,
     leaseId: LEASE_ID,
     ownerId: "restore-worker",
@@ -89,7 +201,7 @@ async function seedLease(expiresInMs = 600_000): Promise<void> {
     operation_id: OPERATION_ID,
     activation_generation: ACTIVATION_GENERATION,
     lifecycle_revision: 7n,
-    expected_manifest_sha256: SHA,
+    expected_manifest_sha256: manifestFixture.digest,
     copy_role: "primary",
     restore_attempt_id: ATTEMPT_ID,
     owner_id: "restore-worker",
@@ -97,6 +209,54 @@ async function seedLease(expiresInMs = 600_000): Promise<void> {
     catalog_epoch: 3n,
     expires_at: new Date(Date.now() + expiresInMs),
   });
+}
+
+async function seedTargetNode(
+  input: {
+    id?: string;
+    nodeId?: string;
+    incarnation?: string | null;
+    capacity?: number;
+    allocatedCount?: number;
+    enabled?: boolean;
+    status?: "healthy" | "degraded" | "offline" | "unknown";
+    placementState?: "open" | "cordoned" | "evacuating" | "drained";
+    capacityProvisional?: boolean;
+  } = {},
+): Promise<void> {
+  await dbWrite.insert(dockerNodes).values({
+    id: input.id ?? TARGET_NODE_RECORD_ID,
+    node_id: input.nodeId ?? "restore-target-a",
+    hostname: "restore-target.invalid",
+    capacity: input.capacity ?? 2,
+    allocated_count: input.allocatedCount ?? 0,
+    enabled: input.enabled ?? true,
+    status: input.status ?? "healthy",
+    placement_state: input.placementState ?? "open",
+    host_key_fingerprint: "SHA256:test-only-host-key",
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: input.incarnation === undefined ? TARGET_NODE_INCARNATION : input.incarnation,
+    metadata: input.capacityProvisional ? { capacityProvisional: true } : {},
+  });
+}
+
+async function openAndClaim(): Promise<{
+  operationId: string;
+  claimGeneration: string;
+}> {
+  await seedLease();
+  const { operation } = await openAgentBackupRestoreOperation({
+    authority: authorityReceipt(),
+    leaseId: LEASE_ID,
+  });
+  const claim = await claimAgentBackupRestoreOperation({
+    operationId: operation.id,
+    ownerId: "restore-worker",
+    claimMs: 60_000,
+  });
+  return { operationId: operation.id, claimGeneration: claim.claimGeneration };
 }
 
 /** Walks the machine one adjacent step at a time, re-claiming per phase. */
@@ -111,12 +271,27 @@ async function walkTo(operationId: string, target: AgentBackupRestorePhase): Pro
     "probed",
     "published",
   ];
+  await seedTargetNode();
+  let claim = await claimAgentBackupRestoreOperation({
+    operationId,
+    ownerId: "restore-worker",
+    claimMs: 60_000,
+  });
+  await reserveAgentBackupRestoreTarget({
+    operationId,
+    ownerId: "restore-worker",
+    claimGeneration: claim.claimGeneration,
+    targetNodeRecordId: TARGET_NODE_RECORD_ID,
+    targetNodeIncarnation: TARGET_NODE_INCARNATION,
+  });
   for (let index = 0; order[index] !== target; index += 1) {
-    const claim = await claimAgentBackupRestoreOperation({
-      operationId,
-      ownerId: "restore-worker",
-      claimMs: 60_000,
-    });
+    if (index > 0) {
+      claim = await claimAgentBackupRestoreOperation({
+        operationId,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+    }
     await advanceAgentBackupRestoreOperation({
       operationId,
       ownerId: "restore-worker",
@@ -129,6 +304,7 @@ async function walkTo(operationId: string, target: AgentBackupRestorePhase): Pro
 
 beforeAll(async () => {
   try {
+    manifestFixture = await buildManifestFixture();
     const { apply } = await pushSchema(
       {
         organizations,
@@ -140,6 +316,7 @@ beforeAll(async () => {
         agentBackupRestoreLeases,
         agentBackupRestoreOperations,
         agentVaultKeyGenerations,
+        dockerNodes,
       } as never,
       dbWrite as never,
     );
@@ -153,6 +330,7 @@ beforeEach(async () => {
   expect(schemaFailure).toBe("");
   await dbWrite.delete(agentBackupRestoreOperations);
   await dbWrite.delete(agentBackupRestoreLeases);
+  await dbWrite.delete(dockerNodes);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentVaultKeyGenerations);
   await dbWrite.delete(agentBackupCatalogAuthorities);
@@ -211,8 +389,8 @@ beforeEach(async () => {
     retention_until: new Date("2026-12-01T00:00:00.000Z"),
     manifest_format: "elizaos.agent-backup",
     manifest_version: 3,
-    manifest_digest: SHA,
-    manifest_canonical_draft: "{}",
+    manifest_digest: manifestFixture.digest,
+    manifest_canonical_draft: manifestFixture.canonicalDraft,
     manifest_object_count: 1,
     object_inventory_digest: SHA,
     image_digest: `sha256:${SHA}`,
@@ -245,6 +423,233 @@ afterAll(async () => {
 });
 
 describe("restore operation spine", () => {
+  test(
+    "reserves exact existing capacity and replays without consuming a second slot",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      const request = {
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      } as const;
+      const results = await Promise.all([
+        reserveAgentBackupRestoreTarget(request),
+        reserveAgentBackupRestoreTarget(request),
+      ]);
+      const reserved = results.find((result) => !result.replayed);
+      const replay = results.find((result) => result.replayed);
+      expect(reserved).toBeDefined();
+      expect(replay).toBeDefined();
+      expect(reserved.target).toEqual({
+        nodeRecordId: TARGET_NODE_RECORD_ID,
+        nodeId: "restore-target-a",
+        nodeIncarnation: TARGET_NODE_INCARNATION,
+        imageDigest: `sha256:${SHA}`,
+      });
+      expect(reserved.operation.expected_node_record_id).toBe(TARGET_NODE_RECORD_ID);
+      expect(reserved.operation.expected_node_incarnation).toBe(TARGET_NODE_INCARNATION);
+      expect(reserved.operation.expected_image_digest).toBe(`sha256:${SHA}`);
+      const [node] = await dbWrite.select().from(dockerNodes);
+      expect(node?.allocated_count).toBe(1);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects expired lease, stale claim, and wrong incarnation before reserving capacity",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      const request = {
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      } as const;
+
+      await expect(
+        reserveAgentBackupRestoreTarget({ ...request, claimGeneration: FENCE }),
+      ).rejects.toThrow("claim is not live");
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...request,
+          targetNodeIncarnation: OTHER_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("node incarnation changed");
+      await dbWrite
+        .update(agentBackupRestoreLeases)
+        .set({ expires_at: new Date(Date.now() - 1_000) })
+        .where(eq(agentBackupRestoreLeases.id, LEASE_ID));
+      await expect(reserveAgentBackupRestoreTarget(request)).rejects.toThrow(
+        "lease is expired or released",
+      );
+
+      const [node] = await dbWrite.select().from(dockerNodes);
+      const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
+      expect(node?.allocated_count).toBe(0);
+      expect(operation?.expected_node_record_id).toBeNull();
+      expect(operation?.expected_node_incarnation).toBeNull();
+      expect(operation?.expected_image_digest).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "refuses saturated or provisional capacity without autoscale or target reselection",
+    async () => {
+      await seedTargetNode({ capacity: 1, allocatedCount: 1 });
+      await seedTargetNode({
+        id: OTHER_NODE_RECORD_ID,
+        nodeId: "restore-target-b",
+        incarnation: OTHER_NODE_INCARNATION,
+        capacity: 8,
+      });
+      const authority = await openAndClaim();
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("no existing capacity");
+
+      for (const ineligible of [
+        { enabled: false },
+        { enabled: true, status: "degraded" as const },
+        { status: "healthy" as const, placement_state: "cordoned" as const },
+        { placement_state: "open" as const, metadata: { capacityProvisional: true } },
+      ]) {
+        await dbWrite
+          .update(dockerNodes)
+          .set({
+            allocated_count: 0,
+            enabled: true,
+            status: "healthy",
+            placement_state: "open",
+            metadata: {},
+            ...ineligible,
+          })
+          .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+        await expect(
+          reserveAgentBackupRestoreTarget({
+            ...authority,
+            ownerId: "restore-worker",
+            targetNodeRecordId: TARGET_NODE_RECORD_ID,
+            targetNodeIncarnation: TARGET_NODE_INCARNATION,
+          }),
+        ).rejects.toThrow("not an enabled, healthy, open existing node");
+      }
+
+      const nodes = await dbWrite.select().from(dockerNodes);
+      expect(nodes).toHaveLength(2);
+      expect(nodes.find((node) => node.id === OTHER_NODE_RECORD_ID)?.allocated_count).toBe(0);
+      const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
+      expect(operation?.expected_node_record_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "makes divergent replay and node-incarnation ABA conflicts without reselection",
+    async () => {
+      await seedTargetNode();
+      await seedTargetNode({
+        id: OTHER_NODE_RECORD_ID,
+        nodeId: "restore-target-b",
+        incarnation: OTHER_NODE_INCARNATION,
+      });
+      const authority = await openAndClaim();
+      const first = await reserveAgentBackupRestoreTarget({
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      });
+      expect(first.replayed).toBe(false);
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: OTHER_NODE_RECORD_ID,
+          targetNodeIncarnation: OTHER_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("replay authority mismatch");
+      await dbWrite
+        .update(dockerNodes)
+        .set({ node_incarnation: "00000000-0000-4000-8000-00000000f014" })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("node incarnation changed");
+
+      const nodes = await dbWrite.select().from(dockerNodes);
+      expect(nodes.find((node) => node.id === TARGET_NODE_RECORD_ID)?.allocated_count).toBe(1);
+      expect(nodes.find((node) => node.id === OTHER_NODE_RECORD_ID)?.allocated_count).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a target after catalogue invalidation without consuming capacity",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await dbWrite
+        .update(agentBackupCatalogAuthorities)
+        .set({ catalog_revision: 4n })
+        .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("invalidated by a catalogue revision");
+      const [node] = await dbWrite.select().from(dockerNodes);
+      const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
+      expect(node?.allocated_count).toBe(0);
+      expect(operation?.expected_node_record_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a catalogue image that differs from the canonical manifest",
+    async () => {
+      await seedTargetNode();
+      const authority = await openAndClaim();
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({ image_digest: `sha256:${"e".repeat(64)}` })
+        .where(eq(agentSandboxBackups.id, BACKUP_ID));
+
+      await expect(
+        reserveAgentBackupRestoreTarget({
+          ...authority,
+          ownerId: "restore-worker",
+          targetNodeRecordId: TARGET_NODE_RECORD_ID,
+          targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        }),
+      ).rejects.toThrow("differs from its exact manifest-v3 authority");
+      const [node] = await dbWrite.select().from(dockerNodes);
+      const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
+      expect(node?.allocated_count).toBe(0);
+      expect(operation?.expected_image_digest).toBeNull();
+    },
+    TIMEOUT,
+  );
+
   test(
     "opens once under concurrent response-loss replay and DB-refuses divergent authority",
     async () => {
@@ -332,8 +737,9 @@ describe("restore operation spine", () => {
   );
 
   test(
-    "advances forward under a live claim and refuses a stale claim generation",
+    "refuses to leave reserved without target authority, then advances after exact reservation",
     async () => {
+      await seedTargetNode();
       await seedLease();
       const { operation } = await openAgentBackupRestoreOperation({
         authority: authorityReceipt(),
@@ -343,6 +749,29 @@ describe("restore operation spine", () => {
         operationId: operation.id,
         ownerId: "restore-worker",
         claimMs: 60_000,
+      });
+      await expect(
+        advanceAgentBackupRestoreOperation({
+          operationId: operation.id,
+          ownerId: "restore-worker",
+          claimGeneration: claim.claimGeneration,
+          fromPhase: "reserved",
+          toPhase: "vault_seeded",
+        }),
+      ).rejects.toThrow("cannot leave target reservation");
+      const [stillReserved] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      expect(stillReserved?.phase).toBe("reserved");
+      expect(stillReserved?.expected_node_record_id).toBeNull();
+
+      await reserveAgentBackupRestoreTarget({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: claim.claimGeneration,
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
       });
       const advanced = await advanceAgentBackupRestoreOperation({
         operationId: operation.id,

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-authority.ts
@@ -1,6 +1,20 @@
 /** Shared fail-closed state predicate for dormant restore authority. */
 
+import { ElizaError } from "@elizaos/core";
 import type { AgentBackupCatalogState } from "../schemas/agent-sandboxes";
+
+/** Typed validation and invariant failure for dormant restore authority. */
+export class AgentBackupRestoreAuthorityError extends ElizaError {
+  override readonly name = "AgentBackupRestoreAuthorityError";
+
+  constructor(code: string, message: string, options?: { cause?: unknown; field?: string }) {
+    super(message, {
+      code,
+      cause: options?.cause,
+      context: options?.field ? { field: options.field } : undefined,
+    });
+  }
+}
 
 export type AgentBackupRestorableCatalogState = Extract<
   AgentBackupCatalogState,

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -1,6 +1,6 @@
 /** Appends and replays immutable restore authorities without wiring a production coordinator. */
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 import {
   assertAgentBackupCatalogTransition,
   requireBoundedIdentity,
@@ -25,7 +25,7 @@ import {
 } from "../schemas/agent-backup-restore-history";
 import { agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
 import { agentVaultKeyBackupBindings } from "../schemas/agent-vault-key-authority";
-import { dockerNodes } from "../schemas/docker-nodes";
+import { type DockerNode, dockerNodes } from "../schemas/docker-nodes";
 import { AgentBackupCatalogConflictError } from "./agent-backup-catalog";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
@@ -40,6 +40,79 @@ function requireUuid(value: string, field: string): string {
 
 function conflict(message: string): never {
   throw new AgentBackupCatalogConflictError(message);
+}
+
+/**
+ * Prove that an already row-locked mutable node still names one exact,
+ * unambiguous append-only boot authority for that record.
+ *
+ * The history reads deliberately stay MVCC reads. The caller owns the node's
+ * `FOR UPDATE` lock, so no concurrent attestation can change that node while
+ * this proof runs; locking append-only history rows would only add an
+ * unnecessary lock class. This schema has no durable causal ordinal for
+ * histories, so timestamps or transaction ids cannot safely distinguish an
+ * old B -> A from an A -> B -> A replay. Restore therefore fails closed when
+ * this node record has ever carried any different incarnation. Such a record
+ * remains ineligible until a lifecycle/re-creation contract with durable row
+ * generations is migrated.
+ *
+ * A -> NULL -> A is intentionally not an A -> B -> A replay: while NULL, the
+ * mutable row fails this proof; an exact CAS re-attestation of the same Linux
+ * boot UUID under the same host-key authority may reuse its immutable A row.
+ * The created-at check catches ordinary exact-id delete/reinsert accidents, but
+ * it is only defense in depth and is never used to order immutable histories.
+ */
+export async function proveUnambiguousAgentNodeIncarnationForLockedNode(
+  tx: DbTransaction,
+  node: Readonly<DockerNode>,
+  expectedIncarnation: string,
+): Promise<void> {
+  if (
+    node.node_incarnation !== expectedIncarnation ||
+    (node.fleet_kind !== "robot" && node.fleet_kind !== "cloud") ||
+    node.infrastructure_provider !== "hetzner" ||
+    !node.host_key_fingerprint
+  ) {
+    conflict("Restore target lacks exact immutable node-incarnation history");
+  }
+
+  const [history] = await tx
+    .select()
+    .from(agentNodeIncarnationHistories)
+    .where(
+      and(
+        eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
+        eq(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation),
+      ),
+    )
+    .limit(1);
+  if (
+    !history ||
+    history.docker_node_record_id !== node.id ||
+    history.node_incarnation !== expectedIncarnation ||
+    history.node_id !== node.node_id ||
+    history.fleet_kind !== node.fleet_kind ||
+    history.infrastructure_provider !== node.infrastructure_provider ||
+    history.provider_server_id !== node.provider_server_id ||
+    history.host_key_fingerprint !== node.host_key_fingerprint ||
+    node.created_at > history.attested_at
+  ) {
+    conflict("Restore target lacks exact immutable node-incarnation history");
+  }
+
+  const [differentIncarnation] = await tx
+    .select({ id: agentNodeIncarnationHistories.id })
+    .from(agentNodeIncarnationHistories)
+    .where(
+      and(
+        eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
+        ne(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation),
+      ),
+    )
+    .limit(1);
+  if (differentIncarnation) {
+    conflict("Restore target node record has ambiguous multi-incarnation history");
+  }
 }
 
 async function lockCurrentNodeHistory(
@@ -107,6 +180,7 @@ async function lockCurrentNodeHistory(
   ) {
     conflict("Target node incarnation conflicts with immutable history");
   }
+  await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, input.nodeIncarnation);
   return history;
 }
 

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-lease.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-lease.ts
@@ -202,10 +202,29 @@ export async function acquireAgentBackupRestoreLease(params: {
         and(
           eq(agentBackupRestoreLeases.organization_id, params.organizationId),
           eq(agentBackupRestoreLeases.restore_attempt_id, params.restoreAttemptId),
+          eq(agentBackupRestoreLeases.backup_id, params.backupId),
         ),
       )
       .for("update")
       .limit(1);
+    if (!existingAttempt) {
+      // A replay bound to another backup is only an authority conflict. Do not
+      // wait on its lease after taking this agent's catalogue lock: exact
+      // restore consumers take that lease before the catalogue lock.
+      const [divergentAttempt] = await tx
+        .select({ id: agentBackupRestoreLeases.id })
+        .from(agentBackupRestoreLeases)
+        .where(
+          and(
+            eq(agentBackupRestoreLeases.organization_id, params.organizationId),
+            eq(agentBackupRestoreLeases.restore_attempt_id, params.restoreAttemptId),
+          ),
+        )
+        .limit(1);
+      if (divergentAttempt) {
+        throw new AgentBackupCatalogConflictError("Restore attempt replay authority mismatch");
+      }
+    }
     const [unreleased] = await tx
       .select()
       .from(agentBackupRestoreLeases)

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-lease.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-lease.ts
@@ -3,10 +3,6 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
-import {
-  requireBoundedIdentity,
-  requireSha256Hex,
-} from "../../lib/services/agent-backup-catalog-state";
 import { isValidUUID } from "../../lib/utils/validation";
 import { dbWrite } from "../helpers";
 import {
@@ -21,7 +17,10 @@ import {
   lockAgentBackupCatalogAuthority,
 } from "./agent-backup-catalog";
 import type { AgentBackupRestoreSourceV3Input } from "./agent-backup-restore";
-import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
+import {
+  AgentBackupRestoreAuthorityError,
+  hasAgentBackupRestoreAuthority,
+} from "./agent-backup-restore-authority";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 export type AgentBackupRestoreLeaseAcquisition =
@@ -70,31 +69,69 @@ function leaseAuthorityReceipt(
 
 function requireUuid(value: string, field: string): string {
   if (!isValidUUID(value) || value !== value.toLowerCase()) {
-    throw new Error(`${field} must be a canonical lowercase UUID`);
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a canonical lowercase UUID`,
+      { field },
+    );
   }
   return value;
 }
 
 function requireCanonicalUint64(value: string, field: string): bigint {
   if (!/^(0|[1-9][0-9]*)$/.test(value)) {
-    throw new Error(`${field} must be a canonical unsigned decimal integer`);
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a canonical unsigned decimal integer`,
+      { field },
+    );
   }
   const parsed = BigInt(value);
-  if (parsed > 18_446_744_073_709_551_615n) throw new Error(`${field} must fit uint64`);
+  if (parsed > 18_446_744_073_709_551_615n) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must fit uint64`,
+      { field },
+    );
+  }
   return parsed;
 }
 
 function requireOwnerId(value: string): string {
-  requireBoundedIdentity(value, "ownerId");
-  if (Buffer.byteLength(value, "utf8") > 255) {
-    throw new Error("ownerId must contain at most 255 UTF-8 bytes");
+  if (
+    value.length === 0 ||
+    value.length > 512 ||
+    /^\s|\s$/.test(value) ||
+    /[\u0000-\u001f\u007f]/.test(value) ||
+    Buffer.byteLength(value, "utf8") > 255
+  ) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "ownerId must be canonical and contain 1-255 UTF-8 bytes",
+      { field: "ownerId" },
+    );
   }
   return value;
 }
 
 function requireCopyRole(value: AgentBackupCopyRole): AgentBackupCopyRole {
   if (value !== "primary" && value !== "secondary") {
-    throw new Error("copyRole must be primary or secondary");
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "copyRole must be primary or secondary",
+      { field: "copyRole" },
+    );
+  }
+  return value;
+}
+
+function requireSha256(value: string, field: string): string {
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a lowercase sha256 digest`,
+      { field },
+    );
   }
   return value;
 }
@@ -120,13 +157,17 @@ export async function acquireAgentBackupRestoreLease(params: {
     params.sourceLifecycleRevision,
     "sourceLifecycleRevision",
   );
-  requireSha256Hex(params.expectedManifestSha256, "expectedManifestSha256");
+  requireSha256(params.expectedManifestSha256, "expectedManifestSha256");
   requireCopyRole(params.copyRole);
   requireUuid(params.restoreAttemptId, "restoreAttemptId");
   requireOwnerId(params.ownerId);
   const generation = requireUuid(params.fencingToken ?? randomUUID(), "fencingToken");
   if (!Number.isSafeInteger(params.leaseMs) || params.leaseMs < 1 || params.leaseMs > 3_600_000) {
-    throw new Error("leaseMs must be a safe integer between 1 and 3600000");
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "leaseMs must be a safe integer between 1 and 3600000",
+      { field: "leaseMs" },
+    );
   }
 
   return dbWrite.transaction(async (tx) => {
@@ -379,7 +420,7 @@ export async function renewAgentBackupRestoreLease(params: {
     params.sourceLifecycleRevision,
     "sourceLifecycleRevision",
   );
-  requireSha256Hex(params.expectedManifestSha256, "expectedManifestSha256");
+  requireSha256(params.expectedManifestSha256, "expectedManifestSha256");
   requireCopyRole(params.copyRole);
   requireUuid(params.restoreAttemptId, "restoreAttemptId");
   requireUuid(params.leaseId, "leaseId");
@@ -387,7 +428,11 @@ export async function renewAgentBackupRestoreLease(params: {
   const catalogEpoch = requireCanonicalUint64(params.catalogEpoch, "catalogEpoch");
   requireOwnerId(params.ownerId);
   if (!Number.isSafeInteger(params.leaseMs) || params.leaseMs < 1 || params.leaseMs > 3_600_000) {
-    throw new Error("leaseMs must be a safe integer between 1 and 3600000");
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "leaseMs must be a safe integer between 1 and 3600000",
+      { field: "leaseMs" },
+    );
   }
 
   return dbWrite.transaction(async (tx) => {
@@ -530,7 +575,7 @@ export async function releaseAgentBackupRestoreLease(
     params.sourceLifecycleRevision,
     "sourceLifecycleRevision",
   );
-  requireSha256Hex(params.expectedManifestSha256, "expectedManifestSha256");
+  requireSha256(params.expectedManifestSha256, "expectedManifestSha256");
   requireCopyRole(params.copyRole);
   requireUuid(params.restoreAttemptId, "restoreAttemptId");
   requireUuid(params.leaseId, "leaseId");

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
@@ -11,7 +11,7 @@
  */
 
 import { Buffer } from "node:buffer";
-import { and, eq, notInArray } from "drizzle-orm";
+import { and, eq, isNotNull, notInArray, sql } from "drizzle-orm";
 import { requireBoundedIdentity } from "../../lib/services/agent-backup-catalog-state";
 import { isValidUUID } from "../../lib/utils/validation";
 import { dbWrite } from "../helpers";
@@ -21,10 +21,14 @@ import {
   agentBackupRestoreLeases,
   agentBackupRestoreOperations,
 } from "../schemas/agent-backup-catalog";
+import { agentSandboxBackups } from "../schemas/agent-sandboxes";
+import { dockerNodes, PLACEABLE_NODE_STATE } from "../schemas/docker-nodes";
 import {
   AgentBackupCatalogConflictError,
   lockAgentBackupCatalogAuthority,
 } from "./agent-backup-catalog";
+import { parseAgentBackupManifestV3Authority } from "./agent-backup-restore";
+import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
 import type { AgentBackupRestoreLeaseAuthorityReceipt } from "./agent-backup-restore-lease";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
@@ -57,6 +61,19 @@ export interface AgentBackupRestoreOperationClaim {
   operation: Readonly<AgentBackupRestoreOperation>;
   claimGeneration: string;
   databaseNow: Date;
+}
+
+export interface AgentBackupRestoreTargetAuthority {
+  nodeRecordId: string;
+  nodeId: string;
+  nodeIncarnation: string;
+  imageDigest: string;
+}
+
+export interface ReserveAgentBackupRestoreTargetResult {
+  operation: Readonly<AgentBackupRestoreOperation>;
+  target: Readonly<AgentBackupRestoreTargetAuthority>;
+  replayed: boolean;
 }
 
 function requireOwnerId(value: string): string {
@@ -286,6 +303,290 @@ export async function claimAgentBackupRestoreOperation(params: {
 }
 
 /**
+ * Reserve one caller-selected, already-attested Docker target before any remote
+ * restore effect. This repository never discovers, autoscales, or reselects a
+ * node: the exact record/incarnation pair is the request authority.
+ *
+ * Capacity and the operation target commit in the same transaction. A lost
+ * response can therefore replay the exact tuple without consuming a second
+ * slot, while any different tuple is an explicit conflict.
+ *
+ * Definition-only integration guard: no production caller may use this until
+ * shared workload reconciliation counts restore ownership and its
+ * settlement/release path. The API-boundary test enforces that handoff.
+ */
+export async function reserveAgentBackupRestoreTarget(params: {
+  operationId: string;
+  ownerId: string;
+  claimGeneration: string;
+  targetNodeRecordId: string;
+  targetNodeIncarnation: string;
+}): Promise<ReserveAgentBackupRestoreTargetResult> {
+  const operationId = requireUuid(params.operationId, "operationId");
+  const claimGeneration = requireUuid(params.claimGeneration, "claimGeneration");
+  const targetNodeRecordId = requireUuid(params.targetNodeRecordId, "targetNodeRecordId");
+  const targetNodeIncarnation = requireUuid(params.targetNodeIncarnation, "targetNodeIncarnation");
+  requireOwnerId(params.ownerId);
+
+  // This first read supplies immutable keys for the global lock order. The row
+  // is locked and compared again below before any capacity or target write.
+  const [operationAuthority] = await dbWrite
+    .select()
+    .from(agentBackupRestoreOperations)
+    .where(eq(agentBackupRestoreOperations.id, operationId))
+    .limit(1);
+  if (!operationAuthority) {
+    throw new AgentBackupCatalogConflictError("Restore operation is missing");
+  }
+
+  return await dbWrite.transaction(async (tx) => {
+    // Global backup writers lock backup -> catalogue authority before lease.
+    // The operation lock comes before the lease here so an ordinary claimant
+    // (operation -> lease) can finish instead of forming an AB-BA cycle.
+    const [backup] = await tx
+      .select({
+        catalogState: agentSandboxBackups.catalog_state,
+        manifestVersion: agentSandboxBackups.manifest_version,
+        canonicalManifestDraft: agentSandboxBackups.manifest_canonical_draft,
+        imageDigest: agentSandboxBackups.image_digest,
+      })
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, operationAuthority.backup_id),
+          eq(agentSandboxBackups.catalog_organization_id, operationAuthority.organization_id),
+          eq(agentSandboxBackups.catalog_agent_id, operationAuthority.agent_id),
+          eq(agentSandboxBackups.backup_operation_id, operationAuthority.expected_operation_id),
+          eq(
+            agentSandboxBackups.lifecycle_generation,
+            operationAuthority.expected_activation_generation,
+          ),
+          eq(
+            agentSandboxBackups.lifecycle_revision,
+            operationAuthority.expected_lifecycle_revision,
+          ),
+          eq(agentSandboxBackups.manifest_digest, operationAuthority.expected_manifest_sha256),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !backup ||
+      !hasAgentBackupRestoreAuthority(backup.catalogState) ||
+      backup.manifestVersion !== 3 ||
+      !backup.canonicalManifestDraft ||
+      !backup.imageDigest
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore target source is absent, non-restorable, or lacks manifest-v3 authority",
+      );
+    }
+    const parsedManifest = await parseAgentBackupManifestV3Authority({
+      canonicalManifestDraft: backup.canonicalManifestDraft,
+      expectedManifestSha256: operationAuthority.expected_manifest_sha256,
+    });
+    const manifest = parsedManifest.manifest;
+    if (
+      manifest.operationId !== operationAuthority.expected_operation_id ||
+      manifest.identity.organizationId !== operationAuthority.organization_id ||
+      manifest.identity.agentId !== operationAuthority.agent_id ||
+      manifest.identity.activationGeneration !==
+        operationAuthority.expected_activation_generation ||
+      manifest.identity.lifecycleRevision !==
+        operationAuthority.expected_lifecycle_revision.toString() ||
+      manifest.runtime.imageDigest !== backup.imageDigest
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore target image differs from its exact manifest-v3 authority",
+      );
+    }
+
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      operationAuthority.organization_id,
+      operationAuthority.agent_id,
+    );
+    const [operation] = await tx
+      .select()
+      .from(agentBackupRestoreOperations)
+      .where(eq(agentBackupRestoreOperations.id, operationId))
+      .for("update")
+      .limit(1);
+    if (!operation) {
+      throw new AgentBackupCatalogConflictError("Restore operation is missing");
+    }
+    if (
+      operation.organization_id !== operationAuthority.organization_id ||
+      operation.agent_id !== operationAuthority.agent_id ||
+      operation.backup_id !== operationAuthority.backup_id ||
+      operation.restore_attempt_id !== operationAuthority.restore_attempt_id ||
+      operation.lease_id !== operationAuthority.lease_id ||
+      operation.lease_generation !== operationAuthority.lease_generation ||
+      operation.lease_owner_id !== operationAuthority.lease_owner_id ||
+      operation.catalog_epoch !== operationAuthority.catalog_epoch ||
+      operation.copy_role !== operationAuthority.copy_role ||
+      operation.expected_operation_id !== operationAuthority.expected_operation_id ||
+      operation.expected_manifest_sha256 !== operationAuthority.expected_manifest_sha256 ||
+      operation.expected_activation_generation !==
+        operationAuthority.expected_activation_generation ||
+      operation.expected_lifecycle_revision !== operationAuthority.expected_lifecycle_revision
+    ) {
+      throw new AgentBackupCatalogConflictError("Restore operation authority changed before lock");
+    }
+    if (catalogAuthority.catalog_revision !== operation.catalog_epoch) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore target authority was invalidated by a catalogue revision",
+      );
+    }
+    if (
+      operation.phase !== "reserved" &&
+      !(operation.phase === "failed_retryable" && operation.resume_phase === "reserved")
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        `Restore target cannot be reserved while operation is in ${operation.phase}`,
+      );
+    }
+
+    const [lease] = await tx
+      .select()
+      .from(agentBackupRestoreLeases)
+      .where(
+        and(
+          eq(agentBackupRestoreLeases.id, operation.lease_id),
+          eq(agentBackupRestoreLeases.organization_id, operation.organization_id),
+          eq(agentBackupRestoreLeases.agent_id, operation.agent_id),
+          eq(agentBackupRestoreLeases.backup_id, operation.backup_id),
+          eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+          eq(
+            agentBackupRestoreLeases.activation_generation,
+            operation.expected_activation_generation,
+          ),
+          eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
+          eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+          eq(agentBackupRestoreLeases.restore_attempt_id, operation.restore_attempt_id),
+          eq(agentBackupRestoreLeases.owner_id, operation.lease_owner_id),
+          eq(agentBackupRestoreLeases.generation, operation.lease_generation),
+          eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!lease) {
+      throw new AgentBackupCatalogConflictError("Restore lease fence was lost");
+    }
+
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, targetNodeRecordId))
+      .for("update")
+      .limit(1);
+    if (!node) {
+      throw new AgentBackupCatalogConflictError("Restore target node is missing");
+    }
+    if (node.node_incarnation !== targetNodeIncarnation) {
+      throw new AgentBackupCatalogConflictError("Restore target node incarnation changed");
+    }
+
+    // The node lock can wait behind another allocator. Re-read the primary DB
+    // clock only after every authority lock so no expired claim/lease commits.
+    const databaseNow = await readPostLockDatabaseNow(tx);
+    if (lease.released_at !== null || lease.expires_at <= databaseNow) {
+      throw new AgentBackupCatalogConflictError("Restore lease is expired or released");
+    }
+    if (
+      operation.claim_owner !== params.ownerId ||
+      operation.claim_generation !== claimGeneration ||
+      operation.claim_expires_at === null ||
+      operation.claim_expires_at <= databaseNow
+    ) {
+      throw new AgentBackupCatalogConflictError("Restore operation claim is not live");
+    }
+
+    const target = Object.freeze({
+      nodeRecordId: node.id,
+      nodeId: node.node_id,
+      nodeIncarnation: targetNodeIncarnation,
+      imageDigest: manifest.runtime.imageDigest,
+    });
+    const targetAlreadyRecorded = operation.expected_node_record_id !== null;
+    if (targetAlreadyRecorded) {
+      if (
+        operation.expected_node_record_id !== target.nodeRecordId ||
+        operation.expected_node_incarnation !== target.nodeIncarnation ||
+        operation.expected_image_digest !== target.imageDigest
+      ) {
+        throw new AgentBackupCatalogConflictError("Restore target replay authority mismatch");
+      }
+      return { operation: Object.freeze(operation), target, replayed: true };
+    }
+    if (operation.expected_node_incarnation !== null || operation.expected_image_digest !== null) {
+      throw new AgentBackupCatalogConflictError("Restore target authority is only partially set");
+    }
+    if (
+      !node.enabled ||
+      node.status !== "healthy" ||
+      node.placement_state !== PLACEABLE_NODE_STATE ||
+      node.metadata.capacityProvisional === true
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore target is not an enabled, healthy, open existing node",
+      );
+    }
+    if (node.allocated_count >= node.capacity) {
+      throw new AgentBackupCatalogConflictError("Restore target has no existing capacity");
+    }
+
+    const [reservedNode] = await tx
+      .update(dockerNodes)
+      .set({
+        allocated_count: sql`${dockerNodes.allocated_count} + 1`,
+        updated_at: databaseNow,
+      })
+      .where(
+        and(
+          eq(dockerNodes.id, targetNodeRecordId),
+          eq(dockerNodes.node_incarnation, targetNodeIncarnation),
+          eq(dockerNodes.enabled, true),
+          eq(dockerNodes.status, "healthy"),
+          eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
+          sql`COALESCE(${dockerNodes.metadata}->>'capacityProvisional', 'false') <> 'true'`,
+          sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
+        ),
+      )
+      .returning({ id: dockerNodes.id });
+    if (!reservedNode) {
+      throw new AgentBackupCatalogConflictError("Restore target capacity reservation lost its CAS");
+    }
+
+    const [reservedOperation] = await tx
+      .update(agentBackupRestoreOperations)
+      .set({
+        expected_node_record_id: target.nodeRecordId,
+        expected_node_incarnation: target.nodeIncarnation,
+        expected_image_digest: target.imageDigest,
+        updated_at: databaseNow,
+      })
+      .where(
+        and(
+          eq(agentBackupRestoreOperations.id, operationId),
+          eq(agentBackupRestoreOperations.phase, operation.phase),
+          eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
+          sql`${agentBackupRestoreOperations.expected_node_record_id} IS NULL`,
+          sql`${agentBackupRestoreOperations.expected_node_incarnation} IS NULL`,
+          sql`${agentBackupRestoreOperations.expected_image_digest} IS NULL`,
+        ),
+      )
+      .returning();
+    if (!reservedOperation) {
+      throw new AgentBackupCatalogConflictError("Restore target reservation lost its CAS");
+    }
+    return { operation: Object.freeze(reservedOperation), target, replayed: false };
+  });
+}
+
+/**
  * Advance one phase under a live claim, optionally recording the side effect's
  * identity in the same statement that moves the phase — so the record and the
  * transition cannot disagree.
@@ -297,10 +598,7 @@ export async function advanceAgentBackupRestoreOperation(params: {
   fromPhase: AgentBackupRestorePhase;
   toPhase: AgentBackupRestorePhase;
   recordedIdentity?: {
-    nodeRecordId?: string;
-    nodeIncarnation?: string;
     containerId?: string;
-    imageDigest?: string;
   };
   receiptDigest?: string;
 }): Promise<Readonly<AgentBackupRestoreOperation>> {
@@ -322,19 +620,7 @@ export async function advanceAgentBackupRestoreOperation(params: {
     throw new AgentBackupCatalogConflictError(`${params.toPhase} is not a resumable phase`);
   }
   const identity = params.recordedIdentity ?? {};
-  if ((identity.nodeRecordId === undefined) !== (identity.nodeIncarnation === undefined)) {
-    throw new AgentBackupCatalogConflictError(
-      "Recording a node identity requires both the record id and the incarnation",
-    );
-  }
-  if (identity.nodeRecordId !== undefined) requireUuid(identity.nodeRecordId, "nodeRecordId");
-  if (identity.nodeIncarnation !== undefined) {
-    requireUuid(identity.nodeIncarnation, "nodeIncarnation");
-  }
   if (identity.containerId !== undefined) requireSha256(identity.containerId, "containerId");
-  if (identity.imageDigest !== undefined && !/^sha256:[0-9a-f]{64}$/.test(identity.imageDigest)) {
-    throw new AgentBackupCatalogConflictError("imageDigest must be a canonical sha256 reference");
-  }
   if (params.receiptDigest !== undefined) requireSha256(params.receiptDigest, "receiptDigest");
   if ((params.toPhase === "finalized") !== (params.receiptDigest !== undefined)) {
     throw new AgentBackupCatalogConflictError(
@@ -382,6 +668,18 @@ export async function advanceAgentBackupRestoreOperation(params: {
       throw new AgentBackupCatalogConflictError("Restore operation claim is not live");
     }
 
+    const targetAuthorityRequired = params.toPhase !== "reserved";
+    if (
+      targetAuthorityRequired &&
+      (operation.expected_node_record_id === null ||
+        operation.expected_node_incarnation === null ||
+        operation.expected_image_digest === null)
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore operation cannot leave target reservation without complete target authority",
+      );
+    }
+
     if (resuming && operation.resume_phase !== params.toPhase) {
       throw new AgentBackupCatalogConflictError(
         `Restore operation must resume ${operation.resume_phase}, not ${params.toPhase}`,
@@ -396,17 +694,8 @@ export async function advanceAgentBackupRestoreOperation(params: {
         claim_owner: null,
         claim_generation: null,
         claim_expires_at: null,
-        ...(identity.nodeRecordId !== undefined
-          ? { expected_node_record_id: identity.nodeRecordId }
-          : {}),
-        ...(identity.nodeIncarnation !== undefined
-          ? { expected_node_incarnation: identity.nodeIncarnation }
-          : {}),
         ...(identity.containerId !== undefined
           ? { expected_container_id: identity.containerId }
-          : {}),
-        ...(identity.imageDigest !== undefined
-          ? { expected_image_digest: identity.imageDigest }
           : {}),
         ...(params.receiptDigest !== undefined
           ? { receipt_digest: params.receiptDigest, completed_at: databaseNow }
@@ -417,6 +706,13 @@ export async function advanceAgentBackupRestoreOperation(params: {
           eq(agentBackupRestoreOperations.id, operationId),
           eq(agentBackupRestoreOperations.phase, params.fromPhase),
           eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
+          targetAuthorityRequired
+            ? and(
+                isNotNull(agentBackupRestoreOperations.expected_node_record_id),
+                isNotNull(agentBackupRestoreOperations.expected_node_incarnation),
+                isNotNull(agentBackupRestoreOperations.expected_image_digest),
+              )
+            : undefined,
         ),
       )
       .returning();

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
@@ -29,6 +29,7 @@ import {
 } from "./agent-backup-catalog";
 import { parseAgentBackupManifestV3Authority } from "./agent-backup-restore";
 import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
+import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
 import type { AgentBackupRestoreLeaseAuthorityReceipt } from "./agent-backup-restore-lease";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
@@ -98,6 +99,17 @@ function requireUuid(value: string, field: string): string {
   return value;
 }
 
+function requireCanonicalUint64(value: string, field: string): bigint {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new AgentBackupCatalogConflictError(`${field} must be a canonical uint64`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > 18_446_744_073_709_551_615n) {
+    throw new AgentBackupCatalogConflictError(`${field} must fit uint64`);
+  }
+  return parsed;
+}
+
 /**
  * Record the attempt so later phases have somewhere durable to land. Replaying
  * the same attempt returns the existing row; replaying it with different
@@ -110,16 +122,63 @@ export async function openAgentBackupRestoreOperation(
   const organizationId = requireUuid(authority.organizationId, "organizationId");
   const agentId = requireUuid(authority.agentId, "agentId");
   const backupId = requireUuid(authority.backupId, "backupId");
+  const expectedOperationId = requireUuid(authority.operationId, "operationId");
+  const expectedActivationGeneration = requireUuid(
+    authority.sourceActivationGeneration,
+    "sourceActivationGeneration",
+  );
+  const expectedLifecycleRevision = requireCanonicalUint64(
+    authority.sourceLifecycleRevision,
+    "sourceLifecycleRevision",
+  );
+  const expectedManifestSha256 = requireSha256(
+    authority.expectedManifestSha256,
+    "expectedManifestSha256",
+  );
   const restoreAttemptId = requireUuid(authority.restoreAttemptId, "restoreAttemptId");
   const leaseId = requireUuid(input.leaseId, "leaseId");
   const fencingToken = requireUuid(authority.fencingToken, "fencingToken");
+  const catalogEpoch = requireCanonicalUint64(authority.catalogEpoch, "catalogEpoch");
   requireOwnerId(authority.ownerId);
 
   return await dbWrite.transaction(async (tx) => {
-    // Catalogue authority before lease: acquire/renew/release all take the
-    // authority first, and taking them the other way round here would deadlock
-    // a replay against a concurrent renewal.
-    const catalogAuthority = await lockAgentBackupCatalogAuthority(tx, organizationId, agentId);
+    // The exact backup is the creation mutex for this durable attempt. Taking
+    // it first lets concurrent response-loss replays observe the row inserted
+    // by the winner before either transaction reaches lease/catalogue locks.
+    const [backup] = await tx
+      .select({ id: agentSandboxBackups.id })
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, backupId),
+          eq(agentSandboxBackups.catalog_organization_id, organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, agentId),
+          eq(agentSandboxBackups.backup_operation_id, expectedOperationId),
+          eq(agentSandboxBackups.lifecycle_generation, expectedActivationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, expectedLifecycleRevision),
+          eq(agentSandboxBackups.manifest_digest, expectedManifestSha256),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!backup) {
+      throw new AgentBackupCatalogConflictError("Restore backup authority does not match");
+    }
+
+    // An existing operation is locked before its lease. If it is absent, the
+    // backup lock above serializes creation and makes the later insert unique.
+    const [existing] = await tx
+      .select()
+      .from(agentBackupRestoreOperations)
+      .where(
+        and(
+          eq(agentBackupRestoreOperations.organization_id, organizationId),
+          eq(agentBackupRestoreOperations.restore_attempt_id, restoreAttemptId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+
     const [lease] = await tx
       .select()
       .from(agentBackupRestoreLeases)
@@ -129,9 +188,15 @@ export async function openAgentBackupRestoreOperation(
           eq(agentBackupRestoreLeases.organization_id, organizationId),
           eq(agentBackupRestoreLeases.agent_id, agentId),
           eq(agentBackupRestoreLeases.backup_id, backupId),
+          eq(agentBackupRestoreLeases.operation_id, expectedOperationId),
+          eq(agentBackupRestoreLeases.activation_generation, expectedActivationGeneration),
+          eq(agentBackupRestoreLeases.lifecycle_revision, expectedLifecycleRevision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, expectedManifestSha256),
+          eq(agentBackupRestoreLeases.copy_role, authority.copyRole),
           eq(agentBackupRestoreLeases.restore_attempt_id, restoreAttemptId),
           eq(agentBackupRestoreLeases.generation, fencingToken),
           eq(agentBackupRestoreLeases.owner_id, authority.ownerId),
+          eq(agentBackupRestoreLeases.catalog_epoch, catalogEpoch),
         ),
       )
       .for("update")
@@ -139,6 +204,8 @@ export async function openAgentBackupRestoreOperation(
     if (!lease) {
       throw new AgentBackupCatalogConflictError("Restore lease authority does not match");
     }
+
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(tx, organizationId, agentId);
 
     // The catalogue epoch is re-proved here, not inherited from the receipt: a
     // revision advanced between acquire and open invalidates the attempt, and an
@@ -154,17 +221,6 @@ export async function openAgentBackupRestoreOperation(
       throw new AgentBackupCatalogConflictError("Restore lease is expired or released");
     }
 
-    const [existing] = await tx
-      .select()
-      .from(agentBackupRestoreOperations)
-      .where(
-        and(
-          eq(agentBackupRestoreOperations.organization_id, organizationId),
-          eq(agentBackupRestoreOperations.restore_attempt_id, restoreAttemptId),
-        ),
-      )
-      .for("update")
-      .limit(1);
     if (existing) {
       if (
         existing.agent_id !== agentId ||
@@ -340,9 +396,9 @@ export async function reserveAgentBackupRestoreTarget(params: {
   }
 
   return await dbWrite.transaction(async (tx) => {
-    // Global backup writers lock backup -> catalogue authority before lease.
-    // The operation lock comes before the lease here so an ordinary claimant
-    // (operation -> lease) can finish instead of forming an AB-BA cycle.
+    // Multi-authority restore work uses backup -> operation -> lease -> node ->
+    // catalogue. The operation lock comes before the lease so an ordinary
+    // claimant (operation -> lease) can finish without an AB-BA cycle.
     const [backup] = await tx
       .select({
         catalogState: agentSandboxBackups.catalog_state,
@@ -401,11 +457,6 @@ export async function reserveAgentBackupRestoreTarget(params: {
       );
     }
 
-    const catalogAuthority = await lockAgentBackupCatalogAuthority(
-      tx,
-      operationAuthority.organization_id,
-      operationAuthority.agent_id,
-    );
     const [operation] = await tx
       .select()
       .from(agentBackupRestoreOperations)
@@ -432,11 +483,6 @@ export async function reserveAgentBackupRestoreTarget(params: {
       operation.expected_lifecycle_revision !== operationAuthority.expected_lifecycle_revision
     ) {
       throw new AgentBackupCatalogConflictError("Restore operation authority changed before lock");
-    }
-    if (catalogAuthority.catalog_revision !== operation.catalog_epoch) {
-      throw new AgentBackupCatalogConflictError(
-        "Restore target authority was invalidated by a catalogue revision",
-      );
     }
     if (
       operation.phase !== "reserved" &&
@@ -488,9 +534,22 @@ export async function reserveAgentBackupRestoreTarget(params: {
     if (node.node_incarnation !== targetNodeIncarnation) {
       throw new AgentBackupCatalogConflictError("Restore target node incarnation changed");
     }
+    await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, targetNodeIncarnation);
 
-    // The node lock can wait behind another allocator. Re-read the primary DB
-    // clock only after every authority lock so no expired claim/lease commits.
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      operation.organization_id,
+      operation.agent_id,
+    );
+    if (catalogAuthority.catalog_revision !== operation.catalog_epoch) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore target authority was invalidated by a catalogue revision",
+      );
+    }
+
+    // The node or catalogue lock can wait behind another authority writer.
+    // Re-read the primary DB clock only after every authority lock so no
+    // expired claim/lease commits.
     const databaseNow = await readPostLockDatabaseNow(tx);
     if (lease.released_at !== null || lease.expires_at <= databaseNow) {
       throw new AgentBackupCatalogConflictError("Restore lease is expired or released");

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore.ts
@@ -115,6 +115,51 @@ function frozenManifest(manifest: AgentBackupManifestV3): AgentBackupManifestV3 
   return manifest;
 }
 
+/**
+ * Parse one catalogue-stored manifest draft and prove that its supplied digest
+ * is the digest of the same canonical v3 document. Callers still have to bind
+ * the returned manifest to their own locked catalogue row and identity tuple.
+ */
+export async function parseAgentBackupManifestV3Authority(input: {
+  canonicalManifestDraft: string;
+  expectedManifestSha256: string;
+}): Promise<
+  Readonly<{
+    manifest: AgentBackupManifestV3;
+    canonicalManifestDraft: string;
+  }>
+> {
+  const manifestInput = manifestWithDigest(
+    input.canonicalManifestDraft,
+    input.expectedManifestSha256,
+  );
+  let manifest: AgentBackupManifestV3;
+  try {
+    manifest = await parseAgentBackupManifestV3(manifestInput);
+  } catch (cause) {
+    throw new AgentBackupCatalogConflictError("Restore source manifest-v3 validation failed", {
+      cause,
+    });
+  }
+  const { manifestSha256: _manifestSha256, ...draftIntegrity } = manifest.integrity;
+  const canonicalDraft = canonicalizeAgentBackupManifestV3({
+    ...manifest,
+    integrity: draftIntegrity,
+  } as AgentBackupManifestV3Draft);
+  if (
+    canonicalDraft !== input.canonicalManifestDraft ||
+    manifest.integrity.manifestSha256 !== input.expectedManifestSha256
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Restore source manifest-v3 differs from its canonical digest authority",
+    );
+  }
+  return Object.freeze({
+    manifest: frozenManifest(manifest),
+    canonicalManifestDraft: canonicalDraft,
+  });
+}
+
 export interface AgentBackupRestoreSourceV3Input {
   organizationId: string;
   agentId: string;
@@ -281,26 +326,12 @@ export async function loadAgentBackupRestoreSourceV3(
         "Restore source lease is absent, expired, released, or fenced",
       );
     }
-    const manifestInput = manifestWithDigest(
-      backup.manifest_canonical_draft,
-      input.expectedManifestSha256,
-    );
-    let manifest: AgentBackupManifestV3;
-    try {
-      manifest = await parseAgentBackupManifestV3(manifestInput);
-    } catch (cause) {
-      throw new AgentBackupCatalogConflictError("Restore source manifest-v3 validation failed", {
-        cause,
-      });
-    }
-    const { manifestSha256: _manifestSha256, ...draftIntegrity } = manifest.integrity;
-    const canonicalDraft = canonicalizeAgentBackupManifestV3({
-      ...manifest,
-      integrity: draftIntegrity,
-    } as AgentBackupManifestV3Draft);
+    const parsedManifest = await parseAgentBackupManifestV3Authority({
+      canonicalManifestDraft: backup.manifest_canonical_draft,
+      expectedManifestSha256: input.expectedManifestSha256,
+    });
+    const { manifest, canonicalManifestDraft: canonicalDraft } = parsedManifest;
     if (
-      canonicalDraft !== backup.manifest_canonical_draft ||
-      manifest.integrity.manifestSha256 !== input.expectedManifestSha256 ||
       manifest.operationId !== input.operationId ||
       manifest.identity.organizationId !== input.organizationId ||
       manifest.identity.agentId !== input.agentId ||

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore.ts
@@ -17,10 +17,6 @@ import {
   parseAgentBackupManifestV3,
 } from "@elizaos/shared";
 import { and, eq } from "drizzle-orm";
-import {
-  requireBoundedIdentity,
-  requireSha256Hex,
-} from "../../lib/services/agent-backup-catalog-state";
 import { isValidUUID } from "../../lib/utils/validation";
 import { dbWrite } from "../helpers";
 import {
@@ -40,25 +36,70 @@ import {
   agentBackupObjectInventoryDigest,
   lockAgentBackupCatalogAuthority,
 } from "./agent-backup-catalog";
-import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
+import {
+  AgentBackupRestoreAuthorityError,
+  hasAgentBackupRestoreAuthority,
+} from "./agent-backup-restore-authority";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const UINT64_MAX = 18_446_744_073_709_551_615n;
 
 function requireUuid(value: string, field: string): string {
   if (!isValidUUID(value) || value !== value.toLowerCase()) {
-    throw new Error(`${field} must be a canonical lowercase UUID`);
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a canonical lowercase UUID`,
+      { field },
+    );
   }
   return value;
 }
 
 function requireCanonicalUint64(value: string, field: string): bigint {
   if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
-    throw new Error(`${field} must be a canonical unsigned decimal integer`);
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a canonical unsigned decimal integer`,
+      { field },
+    );
   }
   const parsed = BigInt(value);
-  if (parsed > UINT64_MAX) throw new Error(`${field} must fit uint64`);
+  if (parsed > UINT64_MAX) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must fit uint64`,
+      { field },
+    );
+  }
   return parsed;
+}
+
+function requireSha256(value: string, field: string): string {
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      `${field} must be a lowercase sha256 digest`,
+      { field },
+    );
+  }
+  return value;
+}
+
+function requireOwnerId(value: string): string {
+  if (
+    value.length === 0 ||
+    value.length > 512 ||
+    /^\s|\s$/.test(value) ||
+    /[\u0000-\u001f\u007f]/.test(value) ||
+    Buffer.byteLength(value, "utf8") > 255
+  ) {
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "ownerId must be canonical and contain 1-255 UTF-8 bytes",
+      { field: "ownerId" },
+    );
+  }
+  return value;
 }
 
 function parseCanonicalBase64(value: string, expectedBytes: number): Uint8Array {
@@ -85,6 +126,7 @@ function manifestWithDigest(canonicalDraft: string, manifestSha256: string): unk
   let draft: unknown;
   try {
     draft = JSON.parse(canonicalDraft);
+    // error-policy:J3 stored manifest bytes are untrusted until explicitly parsed.
   } catch (cause) {
     throw new AgentBackupCatalogConflictError("Restore source manifest is not valid JSON", {
       cause,
@@ -136,6 +178,7 @@ export async function parseAgentBackupManifestV3Authority(input: {
   let manifest: AgentBackupManifestV3;
   try {
     manifest = await parseAgentBackupManifestV3(manifestInput);
+    // error-policy:J3 a stored manifest is invalid until the canonical parser accepts it.
   } catch (cause) {
     throw new AgentBackupCatalogConflictError("Restore source manifest-v3 validation failed", {
       cause,
@@ -211,13 +254,17 @@ function validateInput(input: Readonly<AgentBackupRestoreSourceV3Input>): {
   requireUuid(input.backupId, "backupId");
   requireUuid(input.operationId, "operationId");
   requireUuid(input.sourceActivationGeneration, "sourceActivationGeneration");
-  requireSha256Hex(input.expectedManifestSha256, "expectedManifestSha256");
+  requireSha256(input.expectedManifestSha256, "expectedManifestSha256");
   requireUuid(input.restoreAttemptId, "restoreAttemptId");
   requireUuid(input.leaseId, "leaseId");
-  requireBoundedIdentity(input.ownerId, "ownerId");
+  requireOwnerId(input.ownerId);
   requireUuid(input.fencingToken, "fencingToken");
   if (input.copyRole !== "primary" && input.copyRole !== "secondary") {
-    throw new Error("copyRole must be primary or secondary");
+    throw new AgentBackupRestoreAuthorityError(
+      "AGENT_BACKUP_RESTORE_INPUT_INVALID",
+      "copyRole must be primary or secondary",
+      { field: "copyRole" },
+    );
   }
   return {
     sourceLifecycleRevision: requireCanonicalUint64(

--- a/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
@@ -2,6 +2,7 @@
 
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes as nodeRandomBytes, timingSafeEqual } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import { type KmsClient, orgKey } from "@elizaos/core/security/kms";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { isValidUUID } from "../../lib/utils/validation";
@@ -46,16 +47,11 @@ const DEFAULT_RESTORE_VAULT_HANDOFF_TIMEOUT_MS = 30_000;
 const MAX_RESTORE_VAULT_HANDOFF_TIMEOUT_MS = 60_000;
 const RESTORE_VAULT_HANDOFF_AUTHORITY_MARGIN_MS = 1_000;
 
-export class AgentVaultKeyAuthorityError extends Error {
+export class AgentVaultKeyAuthorityError extends ElizaError {
   override readonly name = "AgentVaultKeyAuthorityError";
 
-  constructor(
-    readonly code: string,
-    message: string,
-    options?: { cause?: unknown },
-  ) {
-    super(message, { cause: options?.cause });
-    Object.setPrototypeOf(this, new.target.prototype);
+  constructor(code: string, message: string, options?: { cause?: unknown }) {
+    super(message, { code, cause: options?.cause });
   }
 }
 
@@ -396,6 +392,7 @@ async function decryptGeneration(
     } finally {
       decrypted.fill(0);
     }
+    // error-policy:J2 KMS failures are wrapped with stable vault authority context.
   } catch (error) {
     if (error instanceof AgentVaultKeyAuthorityError) throw error;
     throw new AgentVaultKeyAuthorityError(
@@ -676,6 +673,7 @@ export async function createOrRotateAgentVaultKeyGeneration(
       generation: Object.freeze({ ...committed.generation }),
       secret,
     };
+    // error-policy:J2 database/KMS failures are wrapped after transient key zeroization.
   } catch (error) {
     const keyToZero = transientRawKey as Uint8Array | null;
     keyToZero?.fill(0);

--- a/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
@@ -24,6 +24,10 @@ import {
   lockAgentBackupCatalogAuthority,
   stampAgentBackupCatalogRevision,
 } from "./agent-backup-catalog";
+import {
+  type AgentBackupRestoreSourceV3Input,
+  loadAgentBackupRestoreSourceV3,
+} from "./agent-backup-restore";
 
 const RAW_KEY_BYTES = 32;
 const PASSPHRASE_BYTES = RAW_KEY_BYTES * 2;
@@ -839,4 +843,69 @@ export async function bindAgentBackupVaultKeyGeneration(
     }
     return Object.freeze({ ...existing });
   });
+}
+
+export interface AgentBackupRestoreVaultPassphraseInput extends AgentBackupRestoreSourceV3Input {
+  vaultKeyGenerationId: string;
+  vaultKeyAuthorityReceiptDigest: string;
+}
+
+export interface AgentBackupRestoreVaultPassphraseOptions {
+  kmsClient?: KmsClient;
+}
+
+async function loadAgentBackupRestoreVaultGeneration(
+  input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
+): Promise<Readonly<AgentVaultKeyGeneration>> {
+  requireCanonicalUuid(input.vaultKeyGenerationId, "vaultKeyGenerationId");
+  requireDigest(input.vaultKeyAuthorityReceiptDigest, "vaultKeyAuthorityReceiptDigest");
+  const source = await loadAgentBackupRestoreSourceV3(input);
+  if (
+    source.vaultKeyAuthority.generationId !== input.vaultKeyGenerationId ||
+    source.vaultKeyAuthority.authorityReceiptDigest !== input.vaultKeyAuthorityReceiptDigest
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Restore vault-key authority differs from its exact manifest-v3 source",
+    );
+  }
+
+  const [generation] = await dbWrite
+    .select()
+    .from(agentVaultKeyGenerations)
+    .where(
+      and(
+        eq(agentVaultKeyGenerations.organization_id, input.organizationId),
+        eq(agentVaultKeyGenerations.agent_id, input.agentId),
+        eq(agentVaultKeyGenerations.generation_id, input.vaultKeyGenerationId),
+        eq(agentVaultKeyGenerations.authority_receipt_digest, input.vaultKeyAuthorityReceiptDigest),
+      ),
+    )
+    .limit(1);
+  if (!generation) {
+    throw new AgentBackupCatalogConflictError(
+      "Restore source is missing its exact retained vault-key generation",
+    );
+  }
+  validateGenerationIntegrity(generation);
+  return Object.freeze({ ...generation });
+}
+
+/**
+ * Expose only a callback-scoped byte passphrase after two identical restore
+ * authority proofs around the lock-free KMS unwrap.
+ */
+export async function withAgentBackupRestoreVaultPassphrase<T>(
+  input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
+  use: (passphrase: Uint8Array) => Promise<T> | T,
+  options: Readonly<AgentBackupRestoreVaultPassphraseOptions> = {},
+): Promise<T> {
+  const generation = await loadAgentBackupRestoreVaultGeneration(input);
+  const rawKey = await decryptGeneration(generation, options.kmsClient ?? getKmsClient());
+  const secret = new AgentVaultKeySecretHandle(rawKey);
+  try {
+    await loadAgentBackupRestoreVaultGeneration(input);
+    return await secret.withPassphrase(use);
+  } finally {
+    secret.release();
+  }
 }

--- a/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
@@ -7,7 +7,11 @@ import { and, eq, isNull, sql } from "drizzle-orm";
 import { isValidUUID } from "../../lib/utils/validation";
 import { getKmsClient } from "../crypto/kms-client";
 import { dbWrite } from "../helpers";
-import { agentBackupCatalogAuthorities } from "../schemas/agent-backup-catalog";
+import {
+  agentBackupCatalogAuthorities,
+  agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
+} from "../schemas/agent-backup-catalog";
 import { agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
 import {
   AGENT_VAULT_KEY_AUTHORITY_FORMAT,
@@ -19,6 +23,7 @@ import {
   agentVaultKeyBackupBindings,
   agentVaultKeyGenerations,
 } from "../schemas/agent-vault-key-authority";
+import { dockerNodes, PLACEABLE_NODE_STATE } from "../schemas/docker-nodes";
 import {
   AgentBackupCatalogConflictError,
   lockAgentBackupCatalogAuthority,
@@ -28,6 +33,7 @@ import {
   type AgentBackupRestoreSourceV3Input,
   loadAgentBackupRestoreSourceV3,
 } from "./agent-backup-restore";
+import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const RAW_KEY_BYTES = 32;
 const PASSPHRASE_BYTES = RAW_KEY_BYTES * 2;
@@ -846,6 +852,11 @@ export async function bindAgentBackupVaultKeyGeneration(
 }
 
 export interface AgentBackupRestoreVaultPassphraseInput extends AgentBackupRestoreSourceV3Input {
+  /** Durable restore coordinator row; distinct from the source backup operation. */
+  restoreOperationId: string;
+  restoreClaimGeneration: string;
+  targetNodeRecordId: string;
+  targetNodeIncarnation: string;
   vaultKeyGenerationId: string;
   vaultKeyAuthorityReceiptDigest: string;
 }
@@ -856,7 +867,12 @@ export interface AgentBackupRestoreVaultPassphraseOptions {
 
 async function loadAgentBackupRestoreVaultGeneration(
   input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
-): Promise<Readonly<AgentVaultKeyGeneration>> {
+): Promise<
+  Readonly<{
+    generation: Readonly<AgentVaultKeyGeneration>;
+    manifestImageDigest: string;
+  }>
+> {
   requireCanonicalUuid(input.vaultKeyGenerationId, "vaultKeyGenerationId");
   requireDigest(input.vaultKeyAuthorityReceiptDigest, "vaultKeyAuthorityReceiptDigest");
   const source = await loadAgentBackupRestoreSourceV3(input);
@@ -887,7 +903,158 @@ async function loadAgentBackupRestoreVaultGeneration(
     );
   }
   validateGenerationIntegrity(generation);
-  return Object.freeze({ ...generation });
+  return Object.freeze({
+    generation: Object.freeze({ ...generation }),
+    manifestImageDigest: source.manifest.runtime.imageDigest,
+  });
+}
+
+/**
+ * Prove that this callback still belongs to one live, claimed, target-pinned
+ * restore. Locks follow catalogue -> operation -> lease -> node, and the KMS
+ * call happens only after this transaction has released every lock.
+ */
+async function proveAgentBackupRestoreVaultTargetAuthority(
+  input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
+  manifestImageDigest: string,
+): Promise<void> {
+  const restoreOperationId = requireCanonicalUuid(input.restoreOperationId, "restoreOperationId");
+  const restoreClaimGeneration = requireCanonicalUuid(
+    input.restoreClaimGeneration,
+    "restoreClaimGeneration",
+  );
+  const targetNodeRecordId = requireCanonicalUuid(input.targetNodeRecordId, "targetNodeRecordId");
+  const targetNodeIncarnation = requireCanonicalUuid(
+    input.targetNodeIncarnation,
+    "targetNodeIncarnation",
+  );
+  const sourceLifecycleRevision = requireCanonicalUint64(
+    input.sourceLifecycleRevision,
+    "sourceLifecycleRevision",
+  );
+  const catalogEpoch = requireCanonicalUint64(input.catalogEpoch, "catalogEpoch");
+
+  await dbWrite.transaction(async (tx) => {
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      input.organizationId,
+      input.agentId,
+    );
+    if (catalogAuthority.catalog_revision !== catalogEpoch) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault target was invalidated by a catalogue revision",
+      );
+    }
+
+    const [operation] = await tx
+      .select()
+      .from(agentBackupRestoreOperations)
+      .where(eq(agentBackupRestoreOperations.id, restoreOperationId))
+      .for("update")
+      .limit(1);
+    if (!operation) {
+      throw new AgentBackupCatalogConflictError("Restore vault operation is missing");
+    }
+    if (
+      operation.organization_id !== input.organizationId ||
+      operation.agent_id !== input.agentId ||
+      operation.backup_id !== input.backupId ||
+      operation.restore_attempt_id !== input.restoreAttemptId ||
+      operation.lease_id !== input.leaseId ||
+      operation.lease_generation !== input.fencingToken ||
+      operation.lease_owner_id !== input.ownerId ||
+      operation.catalog_epoch !== catalogEpoch ||
+      operation.copy_role !== input.copyRole ||
+      operation.expected_operation_id !== input.operationId ||
+      operation.expected_activation_generation !== input.sourceActivationGeneration ||
+      operation.expected_lifecycle_revision !== sourceLifecycleRevision ||
+      operation.expected_manifest_sha256 !== input.expectedManifestSha256
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault operation differs from its exact source and lease authority",
+      );
+    }
+    if (
+      operation.phase !== "reserved" &&
+      !(operation.phase === "failed_retryable" && operation.resume_phase === "reserved")
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        `Restore vault operation is not resumable from reserved (phase ${operation.phase})`,
+      );
+    }
+    if (
+      operation.expected_node_record_id !== targetNodeRecordId ||
+      operation.expected_node_incarnation !== targetNodeIncarnation ||
+      operation.expected_image_digest !== manifestImageDigest
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault operation lacks its exact complete target authority",
+      );
+    }
+
+    const [lease] = await tx
+      .select()
+      .from(agentBackupRestoreLeases)
+      .where(
+        and(
+          eq(agentBackupRestoreLeases.id, input.leaseId),
+          eq(agentBackupRestoreLeases.organization_id, input.organizationId),
+          eq(agentBackupRestoreLeases.agent_id, input.agentId),
+          eq(agentBackupRestoreLeases.backup_id, input.backupId),
+          eq(agentBackupRestoreLeases.operation_id, input.operationId),
+          eq(agentBackupRestoreLeases.activation_generation, input.sourceActivationGeneration),
+          eq(agentBackupRestoreLeases.lifecycle_revision, sourceLifecycleRevision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, input.expectedManifestSha256),
+          eq(agentBackupRestoreLeases.copy_role, input.copyRole),
+          eq(agentBackupRestoreLeases.restore_attempt_id, input.restoreAttemptId),
+          eq(agentBackupRestoreLeases.owner_id, input.ownerId),
+          eq(agentBackupRestoreLeases.generation, input.fencingToken),
+          eq(agentBackupRestoreLeases.catalog_epoch, catalogEpoch),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!lease) {
+      throw new AgentBackupCatalogConflictError("Restore vault lease fence was lost");
+    }
+
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, targetNodeRecordId))
+      .for("update")
+      .limit(1);
+    if (!node || node.node_incarnation !== targetNodeIncarnation) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault target node record or incarnation was lost",
+      );
+    }
+
+    // Read the primary clock only after all authority locks: a wait on the node
+    // must not let an expired claim or lease authorize secret material.
+    const databaseNow = await readPostLockDatabaseNow(tx);
+    if (lease.released_at !== null || lease.expires_at <= databaseNow) {
+      throw new AgentBackupCatalogConflictError("Restore vault lease is expired or released");
+    }
+    if (
+      operation.claim_owner !== input.ownerId ||
+      operation.claim_generation !== restoreClaimGeneration ||
+      operation.claim_expires_at === null ||
+      operation.claim_expires_at <= databaseNow
+    ) {
+      throw new AgentBackupCatalogConflictError("Restore vault operation claim is not live");
+    }
+    if (
+      !node.enabled ||
+      node.status !== "healthy" ||
+      node.placement_state !== PLACEABLE_NODE_STATE ||
+      node.metadata.capacityProvisional === true
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault target is not an enabled, healthy, open existing node",
+      );
+    }
+  });
 }
 
 /**
@@ -899,11 +1066,13 @@ export async function withAgentBackupRestoreVaultPassphrase<T>(
   use: (passphrase: Uint8Array) => Promise<T> | T,
   options: Readonly<AgentBackupRestoreVaultPassphraseOptions> = {},
 ): Promise<T> {
-  const generation = await loadAgentBackupRestoreVaultGeneration(input);
-  const rawKey = await decryptGeneration(generation, options.kmsClient ?? getKmsClient());
+  const beforeKms = await loadAgentBackupRestoreVaultGeneration(input);
+  await proveAgentBackupRestoreVaultTargetAuthority(input, beforeKms.manifestImageDigest);
+  const rawKey = await decryptGeneration(beforeKms.generation, options.kmsClient ?? getKmsClient());
   const secret = new AgentVaultKeySecretHandle(rawKey);
   try {
-    await loadAgentBackupRestoreVaultGeneration(input);
+    const afterKms = await loadAgentBackupRestoreVaultGeneration(input);
+    await proveAgentBackupRestoreVaultTargetAuthority(input, afterKms.manifestImageDigest);
     return await secret.withPassphrase(use);
   } finally {
     secret.release();

--- a/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
@@ -33,6 +33,8 @@ import {
   type AgentBackupRestoreSourceV3Input,
   loadAgentBackupRestoreSourceV3,
 } from "./agent-backup-restore";
+import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
+import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const RAW_KEY_BYTES = 32;
@@ -40,6 +42,9 @@ const PASSPHRASE_BYTES = RAW_KEY_BYTES * 2;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const UINT64_MAX = 18_446_744_073_709_551_615n;
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const DEFAULT_RESTORE_VAULT_HANDOFF_TIMEOUT_MS = 30_000;
+const MAX_RESTORE_VAULT_HANDOFF_TIMEOUT_MS = 60_000;
+const RESTORE_VAULT_HANDOFF_AUTHORITY_MARGIN_MS = 1_000;
 
 export class AgentVaultKeyAuthorityError extends Error {
   override readonly name = "AgentVaultKeyAuthorityError";
@@ -253,15 +258,22 @@ export class AgentVaultKeySecretHandle {
     return this.rawKey === null;
   }
 
-  async withPassphrase<T>(use: (passphrase: Uint8Array) => Promise<T> | T): Promise<T> {
+  async withPassphrase<T>(
+    use: (passphrase: Uint8Array) => Promise<T> | T,
+    signal?: AbortSignal,
+  ): Promise<T> {
     if (!this.rawKey) {
       authorityError("AGENT_VAULT_KEY_HANDLE_RELEASED", "Vault-key handle was already released");
     }
     const passphrase = rawKeyToPassphrase(this.rawKey);
+    const zeroize = () => passphrase.fill(0);
+    signal?.addEventListener("abort", zeroize, { once: true });
     try {
+      signal?.throwIfAborted();
       return await use(passphrase);
     } finally {
-      passphrase.fill(0);
+      signal?.removeEventListener("abort", zeroize);
+      zeroize();
     }
   }
 
@@ -863,6 +875,53 @@ export interface AgentBackupRestoreVaultPassphraseInput extends AgentBackupResto
 
 export interface AgentBackupRestoreVaultPassphraseOptions {
   kmsClient?: KmsClient;
+  /** Hard deadline for the one remote vault handoff; defaults to 30 seconds. */
+  handoffTimeoutMs?: number;
+}
+
+function requireRestoreVaultHandoffTimeoutMs(value: number | undefined): number {
+  const timeoutMs = value ?? DEFAULT_RESTORE_VAULT_HANDOFF_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    timeoutMs > MAX_RESTORE_VAULT_HANDOFF_TIMEOUT_MS
+  ) {
+    authorityError(
+      "AGENT_VAULT_KEY_INPUT_INVALID",
+      `handoffTimeoutMs must be an integer between 1 and ${MAX_RESTORE_VAULT_HANDOFF_TIMEOUT_MS}`,
+    );
+  }
+  return timeoutMs;
+}
+
+interface AgentBackupRestoreVaultTargetHandoff<T> {
+  run: (signal: AbortSignal) => Promise<T> | T;
+}
+
+async function runBoundedAgentBackupRestoreVaultTargetHandoff<T>(
+  handoff: Readonly<AgentBackupRestoreVaultTargetHandoff<T>>,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeoutError = new AgentVaultKeyAuthorityError(
+    "AGENT_VAULT_KEY_HANDOFF_TIMEOUT",
+    `Restore vault handoff exceeded ${timeoutMs}ms`,
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => handoff.run(controller.signal)),
+      deadline,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 async function loadAgentBackupRestoreVaultGeneration(
@@ -911,13 +970,29 @@ async function loadAgentBackupRestoreVaultGeneration(
 
 /**
  * Prove that this callback still belongs to one live, claimed, target-pinned
- * restore. Locks follow catalogue -> operation -> lease -> node, and the KMS
- * call happens only after this transaction has released every lock.
+ * restore. Locks follow backup -> operation -> lease -> node -> catalogue.
+ *
+ * The optional handoff runs only after the final proof and while every authority
+ * lock is still held. It is reserved for one bounded, timeout-protected remote
+ * vault operation and must never issue or re-enter primary-DB work.
  */
 async function proveAgentBackupRestoreVaultTargetAuthority(
   input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
   manifestImageDigest: string,
-): Promise<void> {
+  handoffTimeoutMs: number,
+): Promise<void>;
+async function proveAgentBackupRestoreVaultTargetAuthority<T>(
+  input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
+  manifestImageDigest: string,
+  handoffTimeoutMs: number,
+  handoff: Readonly<AgentBackupRestoreVaultTargetHandoff<T>>,
+): Promise<T>;
+async function proveAgentBackupRestoreVaultTargetAuthority(
+  input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
+  manifestImageDigest: string,
+  handoffTimeoutMs: number,
+  handoff?: Readonly<AgentBackupRestoreVaultTargetHandoff<unknown>>,
+): Promise<unknown> {
   const restoreOperationId = requireCanonicalUuid(input.restoreOperationId, "restoreOperationId");
   const restoreClaimGeneration = requireCanonicalUuid(
     input.restoreClaimGeneration,
@@ -934,15 +1009,39 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
   );
   const catalogEpoch = requireCanonicalUint64(input.catalogEpoch, "catalogEpoch");
 
-  await dbWrite.transaction(async (tx) => {
-    const catalogAuthority = await lockAgentBackupCatalogAuthority(
-      tx,
-      input.organizationId,
-      input.agentId,
-    );
-    if (catalogAuthority.catalog_revision !== catalogEpoch) {
+  return await dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select({
+        catalogState: agentSandboxBackups.catalog_state,
+        manifestVersion: agentSandboxBackups.manifest_version,
+      })
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, input.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+          eq(agentSandboxBackups.backup_operation_id, input.operationId),
+          eq(agentSandboxBackups.lifecycle_generation, input.sourceActivationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, sourceLifecycleRevision),
+          eq(agentSandboxBackups.manifest_digest, input.expectedManifestSha256),
+          eq(agentSandboxBackups.image_digest, manifestImageDigest),
+          eq(agentSandboxBackups.vault_key_generation_id, input.vaultKeyGenerationId),
+          eq(
+            agentSandboxBackups.vault_key_authority_receipt_digest,
+            input.vaultKeyAuthorityReceiptDigest,
+          ),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !backup ||
+      !hasAgentBackupRestoreAuthority(backup.catalogState) ||
+      backup.manifestVersion !== 3
+    ) {
       throw new AgentBackupCatalogConflictError(
-        "Restore vault target was invalidated by a catalogue revision",
+        "Restore vault backup authority is absent, non-restorable, or no longer exact",
       );
     }
 
@@ -1029,9 +1128,21 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
         "Restore vault target node record or incarnation was lost",
       );
     }
+    await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, targetNodeIncarnation);
+
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      input.organizationId,
+      input.agentId,
+    );
+    if (catalogAuthority.catalog_revision !== catalogEpoch) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault target was invalidated by a catalogue revision",
+      );
+    }
 
     // Read the primary clock only after all authority locks: a wait on the node
-    // must not let an expired claim or lease authorize secret material.
+    // or catalogue must not let an expired claim or lease authorize material.
     const databaseNow = await readPostLockDatabaseNow(tx);
     if (lease.released_at !== null || lease.expires_at <= databaseNow) {
       throw new AgentBackupCatalogConflictError("Restore vault lease is expired or released");
@@ -1054,26 +1165,71 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
         "Restore vault target is not an enabled, healthy, open existing node",
       );
     }
+
+    const requiredUntil =
+      databaseNow.getTime() + handoffTimeoutMs + RESTORE_VAULT_HANDOFF_AUTHORITY_MARGIN_MS;
+    if (
+      lease.expires_at.getTime() < requiredUntil ||
+      operation.claim_expires_at.getTime() < requiredUntil
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore vault lease and claim do not cover the bounded remote handoff plus authority margin",
+      );
+    }
+
+    if (handoff) {
+      const result = await runBoundedAgentBackupRestoreVaultTargetHandoff(
+        handoff,
+        handoffTimeoutMs,
+      );
+      const afterHandoffDatabaseNow = await readPostLockDatabaseNow(tx);
+      if (
+        lease.expires_at <= afterHandoffDatabaseNow ||
+        operation.claim_expires_at <= afterHandoffDatabaseNow
+      ) {
+        throw new AgentBackupCatalogConflictError(
+          "Restore vault lease or claim expired during the remote handoff",
+        );
+      }
+      return result;
+    }
   });
 }
 
 /**
  * Expose only a callback-scoped byte passphrase after two identical restore
- * authority proofs around the lock-free KMS unwrap.
+ * authority proofs around the lock-free KMS unwrap. `use` is one idempotent,
+ * fully-awaited remote vault operation. It must honor the AbortSignal, enforce
+ * the pinned host key and Linux boot UUID again on the remote transport, and
+ * never issue or re-enter primary-DB code because the second proof keeps every
+ * authority lock through the handoff. A remote effect may already exist when a
+ * timeout, post-handoff expiry, or transaction commit fails, so replay must be
+ * safe and exact.
  */
 export async function withAgentBackupRestoreVaultPassphrase<T>(
   input: Readonly<AgentBackupRestoreVaultPassphraseInput>,
-  use: (passphrase: Uint8Array) => Promise<T> | T,
+  use: (passphrase: Uint8Array, signal: AbortSignal) => Promise<T> | T,
   options: Readonly<AgentBackupRestoreVaultPassphraseOptions> = {},
 ): Promise<T> {
+  const handoffTimeoutMs = requireRestoreVaultHandoffTimeoutMs(options.handoffTimeoutMs);
   const beforeKms = await loadAgentBackupRestoreVaultGeneration(input);
-  await proveAgentBackupRestoreVaultTargetAuthority(input, beforeKms.manifestImageDigest);
+  await proveAgentBackupRestoreVaultTargetAuthority(
+    input,
+    beforeKms.manifestImageDigest,
+    handoffTimeoutMs,
+  );
   const rawKey = await decryptGeneration(beforeKms.generation, options.kmsClient ?? getKmsClient());
   const secret = new AgentVaultKeySecretHandle(rawKey);
   try {
     const afterKms = await loadAgentBackupRestoreVaultGeneration(input);
-    await proveAgentBackupRestoreVaultTargetAuthority(input, afterKms.manifestImageDigest);
-    return await secret.withPassphrase(use);
+    return await proveAgentBackupRestoreVaultTargetAuthority(
+      input,
+      afterKms.manifestImageDigest,
+      handoffTimeoutMs,
+      {
+        run: (signal) => secret.withPassphrase((passphrase) => use(passphrase, signal), signal),
+      },
+    );
   } finally {
     secret.release();
   }

--- a/packages/cloud/shared/src/db/repositories/primary-database-clock.test.ts
+++ b/packages/cloud/shared/src/db/repositories/primary-database-clock.test.ts
@@ -1,0 +1,18 @@
+/** Deterministic boundary tests for primary-database clock failures. */
+
+import { expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import type { DbTransaction } from "../client";
+import { readPostLockDatabaseNow } from "./primary-database-clock";
+
+test("fails with a typed invariant when the primary clock row is absent", async () => {
+  const tx = {
+    execute: async () => ({ rows: [] }),
+  } as unknown as DbTransaction;
+  const clock = readPostLockDatabaseNow(tx);
+  await expect(clock).rejects.toBeInstanceOf(ElizaError);
+  await expect(clock).rejects.toMatchObject({
+    code: "PRIMARY_DATABASE_CLOCK_UNAVAILABLE",
+    severity: "fatal",
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/primary-database-clock.ts
+++ b/packages/cloud/shared/src/db/repositories/primary-database-clock.ts
@@ -1,5 +1,6 @@
 /** Post-lock primary-database clock authority for lease decisions. */
 
+import { ElizaError } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
@@ -14,7 +15,10 @@ export async function readPostLockDatabaseNow(tx: DbTransaction): Promise<Date> 
       ? clock.database_now
       : new Date(clock?.database_now ?? Number.NaN);
   if (!Number.isFinite(databaseNow.getTime())) {
-    throw new Error("Primary database clock is unavailable");
+    throw new ElizaError("Primary database clock is unavailable", {
+      code: "PRIMARY_DATABASE_CLOCK_UNAVAILABLE",
+      severity: "fatal",
+    });
   }
   return databaseNow;
 }


### PR DESCRIPTION
# Relates to

Relates to #20732. This is the definition-only C1a authority slice; it does not close the issue or activate restore.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is based on `origin/develop@40b04ccf80a255c4f7378862fd29e18ec5afe7a2` with zero conflicts.
- [x] The exact public head `929aa2cc987ed75654990e8119f55344589f3442` passed the focused PGlite, real PostgreSQL, boundary, lock-order, typecheck, and formatting gates below.
- [x] The full monorepo verify was run after sync; its unrelated `@elizaos/ui#lint:check` baseline blocker is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@40b04ccf80a255c4f7378862fd29e18ec5afe7a2`; zero conflicts.
- [x] The base range added no changes to any C1a path.
- [x] `bun run verify` reached 86 successful tasks out of 138 before the unrelated base failure below.

# Risks

Medium, constrained by a hard dormant boundary:

- This adds DB authority and callback-scoped secret-opening primitives, but deliberately adds no production caller or top-level export.
- The current node-history schema has no durable occurrence token. This PR therefore fails closed for any node record that has ever carried a different non-null incarnation. A separate occurrence-token migration is required before activation; this PR does not claim general ABA-safe node reuse.
- `allocated_count` ownership is not durable across shared reconciliation. The boundary must not be lifted until shared allocator ownership, settlement/release, and anti-double-count integration land in coordination with #22916.
- The vault callback is trusted, bounded, fully awaited, remote-only, and must honor its `AbortSignal`; it must not re-enter the locked DB authority.
- No migration, real KMS call, SSH, container operation, provisioning, autoscale, routing change, or deployment is introduced.

# Background

## What does this PR do?

- Reserves one caller-selected existing Docker node record and exact incarnation under a live restore claim, lease, and catalogue epoch.
- Uses the canonical multi-authority order backup → operation → lease → node → immutable node history → catalogue, then reads the primary DB clock after the final lock.
- Validates the target image against the canonical manifest-v3 digest and persists node record, incarnation, and image digest in the same transaction as the capacity CAS.
- Makes response-loss replay idempotent and rejects divergence, stale catalogue authority, invalid claims/leases, saturated or provisional nodes, target reselection, autoscale, and environment fallback.
- Keeps cross-backup restore-attempt divergence out of the blocking lease lock, closing the catalogue/lease deadlock found by the real PostgreSQL proof.
- Prevents the generic phase-advance API from writing target identity or leaving `reserved` without the complete target triplet.
- Proves the exact target before KMS unwrap, re-proves it after KMS, and executes the trusted byte callback while the second authority transaction still holds its locks. The handoff has a 1–60 second bound, a 1 second lease/claim margin, cooperative cancellation, post-callback DB-clock proof, and synchronous zeroization.
- Rejects any immutable history for a different incarnation on the selected node record. This conservative rule is intentionally availability-reducing until the occurrence-token migration lands.
- Keeps every new API definition-only until durable allocation ownership and quarantined creation are ready.

## What kind of change is this?

Feature: non-breaking, dormant repository authority for the next #20732 slice.

# Documentation changes needed?

No user-facing documentation change is needed because the API remains definition-only. The integration prohibitions are documented in JSDoc and enforced by the boundary test.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts`
2. `packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts`
3. `packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts`
4. `packages/cloud/shared/src/db/repositories/agent-backup-restore-lease.ts`
5. `packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts`
6. `packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts`

## Detailed testing steps

All exact-head commands used Bun 1.3.14 and Node 24.15.0 through `mise`.

- Restore operation + restore/vault authority PGlite suites: 46 pass, 0 fail, 333 assertions.
- Dormant boundary + global lock-order suites: 9 pass, 0 fail, 143 assertions.
- Real PostgreSQL lock integration suite: 8 pass, 0 fail, 36 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: pass.
- `@elizaos/cloud-shared#lint:check` during the full verify: pass, 2,138 files checked.
- Targeted Biome on all eight changed files: pass.
- `git diff --check`: pass.
- Independent security and concurrency reviews: GO for this dormant slice; no actionable P0–P2 finding.

# Evidence Gate

[Exact-head validation receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23027-exact-head-validation.md)


<!-- evidence-head:929aa2cc987ed75654990e8119f55344589f3442 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository-only DB authority; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - repository-only DB authority; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - definition-only repository slice with no callable user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend effect; exact PGlite and real PostgreSQL lock proofs are documented above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, action, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external artifact; database assertions verify the exact authority transitions.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual or rendered-text surface changes.

# Evidence Details

## Known gaps / failures

`mise exec -- bun run verify` reached 86 successful tasks out of 138 and then failed in `@elizaos/ui#lint:check` on `packages/ui/src/api/client-cloud.ts`: duplicate/redeclared `desktopHttpTransportForUrl` and `fetchAgentTransport` imports. `git diff --exit-code origin/develop -- packages/ui/src/api/client-cloud.ts` returned 0, proving that blocker is byte-identical to the exact base and unrelated to this PR. The changed `cloud-shared` package lint, typecheck, focused tests, real PostgreSQL proofs, and diff integrity all pass.

There is intentionally no deployment instruction: do not add a production caller or lift the dormant API boundary in this PR. Activation additionally requires the occurrence-token migration and shared allocation ownership.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza"} -->
