### PR TITLE
fix(local-inference): honor iOS Low Data Mode (isConstrained) as metered

### DIFF
--- a/plugins/plugin-local-inference/__tests__/services/network-policy.test.ts
+++ b/plugins/plugin-local-inference/__tests__/services/network-policy.test.ts
@@ -252,6 +252,134 @@ describe("platform probe factories", () => {
 		}
 	});
 
+	// Regression for #23026: Low Data Mode (`NWPath.isConstrained === true`)
+	// is a first-class metering signal per the plugin contract in
+	// `plugin-native-network-policy/src/definitions.ts`. An iOS user on
+	// unmetered Wi-Fi who enabled Low Data Mode reports
+	// `isExpensive=false, isConstrained=true`; the probe must classify that
+	// as metered so a multi-GB voice-model pull prompts instead of silently
+	// downloading against the user's explicit "limit non-essential traffic".
+	function withIosPathHints<T>(
+		hints: { isExpensive: boolean; isConstrained: boolean } | "throws",
+		fn: () => Promise<T>,
+	): Promise<T> {
+		const g = globalThis as unknown as {
+			ElizaNetworkPolicy?: {
+				getPathHints?: () => Promise<{
+					isExpensive: boolean;
+					isConstrained: boolean;
+				}>;
+			};
+		};
+		const prev = g.ElizaNetworkPolicy;
+		g.ElizaNetworkPolicy = {
+			getPathHints: async () => {
+				if (hints === "throws") throw new Error("simulated native error");
+				return hints;
+			},
+		};
+		const restore = () => {
+			if (prev === undefined) delete g.ElizaNetworkPolicy;
+			else g.ElizaNetworkPolicy = prev;
+		};
+		return fn().finally(restore);
+	}
+
+	it("Capacitor iOS probe treats Low Data Mode (isConstrained=true) as metered", async () => {
+		await withIosPathHints(
+			{ isExpensive: false, isConstrained: true },
+			async () => {
+				const state = await capacitorIosProbe().probe();
+				expect(state.metered).toBe(true);
+			},
+		);
+	});
+
+	it("Capacitor iOS probe reports metered=false when neither flag is set", async () => {
+		await withIosPathHints(
+			{ isExpensive: false, isConstrained: false },
+			async () => {
+				const state = await capacitorIosProbe().probe();
+				expect(state.metered).toBe(false);
+			},
+		);
+	});
+
+	it("Capacitor iOS probe keeps metered=true when only isExpensive is set (regression guard)", async () => {
+		await withIosPathHints(
+			{ isExpensive: true, isConstrained: false },
+			async () => {
+				const state = await capacitorIosProbe().probe();
+				expect(state.metered).toBe(true);
+			},
+		);
+	});
+
+	it("Capacitor iOS probe reports metered=true when both flags are set", async () => {
+		await withIosPathHints(
+			{ isExpensive: true, isConstrained: true },
+			async () => {
+				const state = await capacitorIosProbe().probe();
+				expect(state.metered).toBe(true);
+			},
+		);
+	});
+
+	it("Capacitor iOS probe falls back to metered=null when the path-hints shim throws", async () => {
+		await withIosPathHints("throws", async () => {
+			const state = await capacitorIosProbe().probe();
+			expect(state.metered).toBeNull();
+		});
+	});
+
+	it("Low Data Mode iOS state flips the download decision from auto to metered-ask", async () => {
+		// End-to-end proof through describeRuntimeNetwork: a Wi-Fi link with
+		// Low Data Mode engaged and a 3 GB estimated pull must no longer
+		// auto-download. Stub both the Capacitor connection-type bridge and
+		// the iOS path-hints shim so the injected iOS probe sees `wifi`.
+		const g = globalThis as unknown as {
+			Capacitor?: unknown;
+		};
+		const prevCap = g.Capacitor;
+		g.Capacitor = {
+			Plugins: {
+				Network: {
+					getStatus: async () => ({
+						connected: true,
+						connectionType: "wifi" as const,
+					}),
+				},
+			},
+		};
+		const threeGigabytes = 3 * 1024 * 1024 * 1024;
+		// Outside the default 22:00-08:00 quiet hours so the flip is caused by
+		// metering, not the clock.
+		const noon = new Date(2024, 0, 1, 12, 0, 0);
+		try {
+			await withIosPathHints(
+				{ isExpensive: false, isConstrained: true },
+				async () => {
+					const snapshot = await describeRuntimeNetwork({
+						probe: capacitorIosProbe(),
+						estimatedBytes: threeGigabytes,
+						now: noon,
+					});
+					expect(snapshot.state).toEqual({
+						connectionType: "wifi",
+						metered: true,
+					});
+					expect(snapshot.class).toBe("wifi-metered");
+					expect(snapshot.decision.allow).toBe(false);
+					expect(snapshot.decision.reason).toBe("metered-ask");
+					expect(snapshot.decision.estimatedBytes).toBe(threeGigabytes);
+				},
+			);
+		} finally {
+			if (prevCap === undefined) delete g.Capacitor;
+			else g.Capacitor = prevCap;
+		}
+	});
+
 	it("Capacitor Android probe falls back to metered=null when the native shim throws", async () => {
 		const g = globalThis as unknown as {
 			ElizaNetworkPolicy?: {

--- a/plugins/plugin-local-inference/src/services/network-policy.ts
+++ b/plugins/plugin-local-inference/src/services/network-policy.ts
@@ -143,11 +143,18 @@ export function capacitorAndroidProbe(): NetworkProbe {
 
 /**
  * Capacitor iOS probe (R5 §4.2). Connection type from `@capacitor/network`
- * plus iOS `NWPathMonitor.currentPath.isExpensive` via the
- * `@elizaos/capacitor-network-policy` Capacitor plugin at
+ * plus iOS `NWPathMonitor.currentPath.isExpensive` and `.isConstrained` via
+ * the `@elizaos/capacitor-network-policy` Capacitor plugin at
  * `plugins/plugin-native-network-policy/`. The plugin exposes
  * `(window as any).ElizaNetworkPolicy.getPathHints()`; falls back to
  * `metered: null` when the bridge is missing.
+ *
+ * Both hints fold into the `metered` signal: `isExpensive` is Apple's
+ * "treat as metered" flag, and `isConstrained` (Low Data Mode) means the
+ * user explicitly asked the OS to limit non-essential traffic, which the
+ * plugin contract (`plugin-native-network-policy/src/definitions.ts`)
+ * requires the updater to honor as metered so a multi-GB voice-model pull
+ * prompts instead of silently downloading.
  */
 export function capacitorIosProbe(): NetworkProbe {
 	return {
@@ -164,7 +171,10 @@ export function capacitorIosProbe(): NetworkProbe {
 							? "none"
 							: "unknown";
 			const hints = await readIosPathHintsShim();
-			const metered = hints === null ? null : Boolean(hints.isExpensive);
+			const metered =
+				hints === null
+					? null
+					: Boolean(hints.isExpensive) || Boolean(hints.isConstrained);
 			return { connectionType: ctype, metered };
 		},
 	};


### PR DESCRIPTION
# Relates to

Closes #23026

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; focused package checks pass (see logs).
      `bun run verify` was not run in full on this constrained device; the
      unrelated blocker is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after decision snapshot and failing-then-passing test logs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch is based on the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** for the
      device blocker; focused package `typecheck` + targeted `biome check` +
      the full plugin test file were run instead.

# Risks

Low. The change is a one-line widening of a metering signal inside the iOS
network probe (`capacitorIosProbe`), plus its doc comment and regression tests.
It only ever flips a previously-`false` metered value to `true` when iOS Low
Data Mode is engaged (`NWPath.isConstrained === true`); it never relaxes an
existing metered classification. The worst-case behavioral effect is that a
Low-Data-Mode iOS user is now **prompted** before a multi-GB download instead of
being charged silently — the safer direction, and exactly the documented
contract.

# Background

## What does this PR do?

The `@elizaos/capacitor-network-policy` plugin contract
(`plugins/plugin-native-network-policy/src/definitions.ts`) documents
`PathHints.isConstrained` — iOS `NWPath.isConstrained`, i.e. **Low Data Mode** —
as a first-class metering signal:

> `NWPath.isConstrained` — true when Low Data Mode is engaged. The voice-updater
> treats this as "metered" because the user has explicitly asked the OS to limit
> non-essential traffic.

But the sole consumer, `capacitorIosProbe()` in
`plugins/plugin-local-inference/src/services/network-policy.ts`, computed:

```ts
const metered = hints === null ? null : Boolean(hints.isExpensive);
```

and never read `isConstrained` — even though `readIosPathHintsShim()` already
fetched it and then discarded it. An iOS user on **unmetered Wi-Fi** with Low
Data Mode enabled (`isExpensive=false, isConstrained=true`) was therefore
classified `metered=false` → `wifi-unmetered` → `applyNetworkPolicy` returned
`auto`, silently auto-downloading multi-GB voice models against the user's
explicit "limit non-essential traffic" preference — the exact surprise the
contract promises to prevent.

The fix folds the constrained flag into the metered signal:

```ts
const metered =
  hints === null
    ? null
    : Boolean(hints.isExpensive) || Boolean(hints.isConstrained);
```

`readIosPathHintsShim()` already returns both booleans, so no shim change is
needed and the `plugin-native-network-policy` contract is unchanged.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

The iOS-probe doc comment in `network-policy.ts` was updated to state that both
`isExpensive` and `isConstrained` fold into the `metered` signal and why. No
separate docs site change is required — the plugin contract already documented
the intended behavior; this PR makes the consumer honor it.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/__tests__/services/network-policy.test.ts` — the
new tests near the existing iOS-probe cases. Run:

```bash
bun install --frozen-lockfile
node packages/shared/scripts/generate-keywords.mjs   # generate i18n keyword data
cd plugins/plugin-local-inference
./node_modules/.bin/vitest run __tests__/services/network-policy.test.ts
```

## Detailed testing steps

Added regression coverage for the previously-unpinned matrix (mirrors the
existing `network-policy.test.ts` stub-on-`globalThis.ElizaNetworkPolicy`
pattern with save/restore):

1. `isExpensive=false, isConstrained=true` → `metered=true` (the failing case,
   Low Data Mode).
2. `isExpensive=false, isConstrained=false` → `metered=false`.
3. `isExpensive=true, isConstrained=false` → `metered=true` (regression guard
   for the pre-existing `isExpensive` behavior).
4. `isExpensive=true, isConstrained=true` → `metered=true`.
5. shim throws → `metered=null` (unknown → `ask`, never fake-valid).
6. End-to-end `describeRuntimeNetwork` snapshot: a Low-Data-Mode iOS Wi-Fi state
   with a 3 GiB `estimatedBytes` at noon (outside default quiet hours) now
   resolves to `class=wifi-metered`, `allow=false`, `reason=metered-ask` — the
   decision flip from silent auto-download to a user prompt.

# Evidence Gate

<!-- evidence-head:50687808070a699abe596e3b7e56a25af8f1b418 -->

This is a pure backend/runtime logic change in a network-policy probe. There is
no rendered UI surface, so screenshot/video/OCR rows are `N/A`. Evidence is the
failing-then-passing Vitest reproduction and the before/after decision snapshot.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface; this changes the iOS network-probe metering computation in plugin-local-inference.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface; this changes the iOS network-probe metering computation in plugin-local-inference.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive UI flow; the behavior is a probe classification exercised by the attached tests.`
<!-- evidence-row:backend-logs -->
- [x] Failing-then-passing Vitest reproduction of the real iOS probe path (inline logs below).

<details>
<summary>Backend/runtime logs — failing (pre-fix) then passing (post-fix) reproduction output</summary>

```text
########## FAILING (pre-fix: metered = hints === null ? null : Boolean(hints.isExpensive)) ##########
 RUN  v4.1.10 plugins/plugin-local-inference
 ❯ __tests__/services/_repro.test.ts (1 test | 1 failed) 12ms
   × repro #23026: Low Data Mode must be metered > isExpensive=false, isConstrained=true -> metered=true
     → AssertionError: expected false to be true // Object.is equality
        - Expected  true
        + Received  false
 Test Files  1 failed (1)
      Tests  1 failed (1)

########## PASSING (post-fix: isConstrained folded into metered) ##########
 RUN  v4.1.10 plugins/plugin-local-inference
 ✓ __tests__/services/_repro.test.ts (1 test) 
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved; the metering signal is computed in-process from the iOS path-hints shim.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a deterministic network-policy classifier fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: before/after `describeRuntimeNetwork` decision snapshot showing the `auto → metered-ask` flip at 3 GiB (inline below).

<details>
<summary>Domain artifact output — before/after decision snapshot for a Low-Data-Mode iOS state</summary>

```text
Low Data Mode iOS, connectionType=wifi, estimatedBytes=3221225472 (3 GiB), 12:00 (outside default 22:00-08:00 quiet hours)
BEFORE (probe read isExpensive only -> metered=false): class=wifi-unmetered allow=true  reason=auto        estimatedBytes=3221225472
AFTER  (isConstrained folded in     -> metered=true ): class=wifi-metered   allow=false reason=metered-ask estimatedBytes=3221225472
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface to OCR.`

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic classifier change; no live-model run applicable.

## Backend + frontend logs

Failing-then-passing reproduction of the exact contract (pre-fix source from the
parent commit fails; post-fix passes). Full logs also attached as an artifact on
the `backend-logs` row.

<details>
<summary>Failing (pre-fix) → Passing (post-fix) Vitest reproduction</summary>

```text
########## FAILING (pre-fix: metered = hints === null ? null : Boolean(hints.isExpensive)) ##########
 ❯ __tests__/services/_repro.test.ts (1 test | 1 failed) 12ms
   × repro #23026: Low Data Mode must be metered > isExpensive=false, isConstrained=true -> metered=true
     → expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed (1)

########## PASSING (post-fix: isConstrained folded into metered) ##########
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

</details>

<details>
<summary>Full plugin-local-inference network-policy suite (23 passed)</summary>

```text
 RUN  v4.1.10 plugins/plugin-local-inference
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no interactive UI flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Domain artifact — before/after decision snapshot

Same Low-Data-Mode iOS Wi-Fi state, 3 GiB (`estimatedBytes=3221225472`) pull at
12:00 (outside the default `22:00–08:00` quiet hours), through the real
`describeRuntimeNetwork` path. `BEFORE` uses the parent commit's probe source;
`AFTER` uses this PR's source:

```text
BEFORE: metered=false class=wifi-unmetered allow=true  reason=auto        estimatedBytes=3221225472
AFTER:  metered=true  class=wifi-metered   allow=false reason=metered-ask estimatedBytes=3221225472
```

The user is now prompted (`allow=false, reason=metered-ask`) instead of being
silently charged for a multi-GB download (`allow=true, reason=auto`).

## Known gaps / failures

- **`bun run verify` not run in full.** On this constrained Raspberry Pi worktree
  the full repository `verify` gate (workspace-wide build + typecheck + lint +
  audits) is not feasible to run end to end. Instead I ran the owning package's
  focused checks against a fully built `@elizaos/core` / `@elizaos/shared` /
  `@elizaos/cloud/routing` / `@elizaos/logger`: `tsc --noEmit -p tsconfig.json`
  (exit 0), `biome check` on the changed source file (clean; the test file is
  biome-ignored by repo config), and the complete
  `network-policy.test.ts` file (23/23 passing). The change is confined to one
  plugin source file plus its test.
- The i18n generated file `packages/core/src/i18n/generated/validation-keyword-data.ts`
  must be generated (`node packages/shared/scripts/generate-keywords.mjs`) before
  running tests in a fresh checkout; it is a normal build prerequisite, not part
  of this diff.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza"} -->
