### PR TITLE
fix(embeddings): strictly validate EMBEDDING_DIMENSIONS as a positive integer

### DIFF
--- a/plugins/plugin-embeddings/__tests__/config.test.ts
+++ b/plugins/plugin-embeddings/__tests__/config.test.ts
@@ -80,6 +80,36 @@ describe("plugin-embeddings config", () => {
     expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "768" }))).toBe(768);
   });
 
+  it("accepts a valid positive integer, trimming surrounding whitespace", () => {
+    expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "3072" }))).toBe(3072);
+    expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "  768  " }))).toBe(768);
+  });
+
+  it("returns the default for unset or blank-only EMBEDDING_DIMENSIONS", () => {
+    expect(getEmbeddingDimensions(makeRuntime())).toBe(1536);
+    expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "" }))).toBe(1536);
+    expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "   " }))).toBe(1536);
+  });
+
+  it("rejects mixed/trailing-character values instead of silently truncating (issue #23028)", () => {
+    // Regression: Number.parseInt("1536abc", 10) used to return 1536, silently
+    // accepting a malformed vector width. It must now throw.
+    expect(() => getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "1536abc" }))).toThrow(
+      "Setting 'EMBEDDING_DIMENSIONS' must be a valid integer, got: 1536abc"
+    );
+    expect(() => getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "12px" }))).toThrow(
+      /must be a valid integer/
+    );
+  });
+
+  it("rejects fractional, scientific, zero, negative, and non-numeric values", () => {
+    for (const bad of ["3.5", "1e3", "0", "-5", "abc", "0x10", "+7", "1_000"]) {
+      expect(() => getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: bad }))).toThrow(
+        `Setting 'EMBEDDING_DIMENSIONS' must be a valid integer, got: ${bad}`
+      );
+    }
+  });
+
   it("hasEmbeddingConfig is true when EITHER url or key is set", () => {
     expect(hasEmbeddingConfig(makeRuntime())).toBe(false);
     expect(hasEmbeddingConfig(makeRuntime({ EMBEDDING_BASE_URL: "https://x/v1" }))).toBe(true);

--- a/plugins/plugin-embeddings/src/utils/config.ts
+++ b/plugins/plugin-embeddings/src/utils/config.ts
@@ -31,17 +31,32 @@ export function getSetting(
     : resolveSetting(runtime, key, { defaultValue });
 }
 
+/**
+ * Resolve a numeric setting that must be a strict positive integer.
+ *
+ * Only accepts a value when the ENTIRE trimmed string is a run of digits
+ * denoting a value `> 0`. Unlike `Number.parseInt`, which stops at the first
+ * non-numeric character and silently truncates (`"1536abc"` -> `1536`,
+ * `"3.5"` -> `3`), any mixed, fractional, scientific, zero, or negative input
+ * is rejected with the same error so a malformed vector width can never be
+ * partially accepted (issue #23028). Unset/empty returns the default. Callers
+ * (dimensions, counts) are always positive integers.
+ */
 export function getNumericSetting(
   runtime: IAgentRuntime,
   key: string,
   defaultValue: number
 ): number {
   const value = getSetting(runtime, key);
-  if (value === undefined || value.trim() === "") {
+  const trimmed = value?.trim();
+  if (trimmed === undefined || trimmed === "") {
     return defaultValue;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) {
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`Setting '${key}' must be a valid integer, got: ${value}`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(`Setting '${key}' must be a valid integer, got: ${value}`);
   }
   return parsed;


### PR DESCRIPTION
# Relates to

Closes #23028

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test, typecheck, lint) pass. Full `bun run verify` was not run on this constrained machine — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run in full; see **Known gaps / failures**. Focused package test/typecheck/lint all pass.

# Risks

Low. Single-function change to `getNumericSetting` in `plugins/plugin-embeddings/src/utils/config.ts`. Its only caller is `getEmbeddingDimensions` (verified by grep), which has always semantically required a positive integer. The change tightens validation of already-invalid input; the accept path for legitimate positive integers (with optional surrounding whitespace) and the unset/empty → default path are unchanged.

# Background

## What does this PR do?

Malformed `EMBEDDING_DIMENSIONS` values were partially accepted. `getNumericSetting` used `Number.parseInt(value, 10)`, which stops at the first non-numeric character and silently truncates:

- `"1536abc"` → `1536`
- `"12px"`  → `12`
- `"3.5"`   → `3`

Zero, negative, and fractional values were likewise mis-handled. Because the embedding dimension is part of the database vector schema, a silently wrong width sizes vectors incorrectly and breaks storage/search — exactly the kind of config mistake this masked.

The fix replaces the lenient `parseInt` with strict whole-string validation: the entire trimmed value must be a run of digits (`/^\\d+$/`) denoting a value `> 0`. Any mixed, trailing-character, fractional, scientific, zero, or negative input is now rejected with the **same** existing error, keeping the contract and message stable:

```
Setting '<key>' must be a valid integer, got: <value>
```

Unset/empty input still returns the configured default (`1536`), and a valid integer with surrounding whitespace (e.g. `"  768  "`) is trimmed and accepted.

Scope note: `getNumericSetting` is shared, but a repo-wide grep confirms `getEmbeddingDimensions` is its only caller inside `plugins/plugin-embeddings`, and dimensions/counts are always positive integers — so a single strict positive-integer parser is correct here.

Related follow-up (out of scope, intentionally not touched): `packages/core/src/provisioning.ts` `parseDim` also uses `parseInt` and would partially accept `"1536abc"`. It intentionally *falls back* (skips) rather than throwing, so hardening it requires different handling (resolve to `NaN`, never throw) and its own regression test; left as a noted follow-up to keep this diff tight.

## What kind of change is this?

Bug fix (non-breaking; rejects previously-mis-accepted invalid input).

# Documentation changes needed?

No. The `EMBEDDING_DIMENSIONS` contract (positive integer, supported `VECTOR_DIMS`) is unchanged; this makes the parser honor it. The plugin AGENTS.md already documents the supported-dimension contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-embeddings/__tests__/config.test.ts` — new regression cases for `getEmbeddingDimensions`/`getNumericSetting`.

## Detailed testing steps

Run the focused suite from the repo root (source-aliased root vitest config):

```bash
bunx vitest run plugins/plugin-embeddings/__tests__/config.test.ts
```

Failing-before / passing-after was verified by stashing only the source fix and re-running the tests: with the old `parseInt`, the two new rejection tests fail (`"1536abc"` wrongly returns `1536` and does not throw); with the fix, all 15 pass.

New assertions cover: valid `"768"`/`"3072"`; trimmed `"  768  "` → 768; unset/`""`/`"   "` → default 1536; and rejection of `"1536abc"`, `"12px"`, `"3.5"`, `"1e3"`, `"0"`, `"-5"`, `"abc"`, `"0x10"`, `"+7"`, `"1_000"`.

# Evidence Gate

<!-- evidence-head:ac8fa3f266180cef73000324fae32bd42b80b095 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this is a config-parser change in a backend plugin.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; this is a config-parser change in a backend plugin.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; behavior is a pure function exercised by unit tests.
<!-- evidence-row:backend-logs -->
- [x] Focused test output (failing-before / passing-after) attached under **Evidence Details**.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes; only config parsing.
<!-- evidence-row:domain-artifacts -->
- [x] Failing-then-passing test reproduction attached under **Evidence Details**.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt/agent behavior changed.

## Backend + frontend logs

Passing-after (all 15 tests green):

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Failing-before (fix stashed, old `parseInt` restored, tests unchanged):

```
 FAIL  plugins/plugin-embeddings/__tests__/config.test.ts > ... > rejects mixed/trailing-character values instead of silently truncating (issue #23028)
AssertionError: expected [Function] to throw an error
      Tests  2 failed | 13 passed (15)
```

Typecheck (after building `@elizaos/core` locally so its d.ts resolve): `tsc --noEmit -p tsconfig.json` — clean, no output.
Lint: `biome check .` — `Checked 24 files ... No fixes applied.`

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- Full `bun run verify` was not executed on this machine: `bun install` requires `--minimum-release-age=0` to bypass a host-level minimum-release-age policy blocking a recently-published transitive `viem` version, and a full workspace verify is heavy for this constrained environment. Instead the owning package's gates were run and pass: focused vitest (15/15, plus full plugin suite 61/61), `typecheck` (clean after a local `@elizaos/core` build), and `biome check` (clean). The change is a self-contained pure-function fix with no cross-package surface.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@b73d8ea66c546fbc6f6f64ff6ac704b336e691c4:packages/skills/skills/contribute-to-eliza"} -->
