### PR TITLE
feat(observability): correlate agent inference turns with Cloud gateway traces

### DIFF
--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -106,6 +106,7 @@ function parseInferenceTimingLog(log: Log): InferenceTurnSummary | null {
 
   return {
     turnId,
+    traceId: typeof metadata.traceId === "string" ? metadata.traceId : null,
     label,
     roomId: typeof body.roomId === "string" ? body.roomId : null,
     modelProvider:

--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -8,6 +8,7 @@
  */
 import type http from "node:http";
 import type { InferenceTurnSummary, Log } from "@elizaos/core";
+import { INFERENCE_TRACE_ID_PATTERN } from "@elizaos/core";
 import { parseCanonicalInteger } from "@elizaos/shared";
 import { ensureRouteAuthorized } from "./auth.ts";
 import {
@@ -106,7 +107,14 @@ function parseInferenceTimingLog(log: Log): InferenceTurnSummary | null {
 
   return {
     turnId,
-    traceId: typeof metadata.traceId === "string" ? metadata.traceId : null,
+    // Persisted metadata is replayed from storage, so the id is re-validated
+    // rather than trusted: anything that is not a well-formed trace id (including
+    // logs written before correlation existed) rehydrates as an explicit null.
+    traceId:
+      typeof metadata.traceId === "string" &&
+      INFERENCE_TRACE_ID_PATTERN.test(metadata.traceId)
+        ? metadata.traceId
+        : null,
     label,
     roomId: typeof body.roomId === "string" ? body.roomId : null,
     modelProvider:

--- a/packages/app-core/src/api/dev-voice-latency-route.test.ts
+++ b/packages/app-core/src/api/dev-voice-latency-route.test.ts
@@ -5,7 +5,14 @@
  * loopback-only rejection, and prod-disabled behavior.
  */
 import { Socket } from "node:net";
-import { AgentRuntime, type Log, type UUID } from "@elizaos/core";
+import {
+  AgentRuntime,
+  INFERENCE_TRACE_ID_PATTERN,
+  InferenceTurnTimer,
+  type Log,
+  persistInferenceTimingSummary,
+  type UUID,
+} from "@elizaos/core";
 import {
   afterAll,
   afterEach,
@@ -271,6 +278,9 @@ describe("GET /api/dev/inference-timing", () => {
     expect(payload.turns).toHaveLength(1);
     expect(payload.turns[0]).toMatchObject({
       turnId: "persisted-flow-1",
+      // Persisted before trace correlation existed: rehydrates as an explicit
+      // null rather than a fabricated id.
+      traceId: null,
       timeToFirstTokenMs: 90,
       timeToFirstVisibleMs: 100,
       timeToReplyMs: 140,
@@ -286,6 +296,87 @@ describe("GET /api/dev/inference-timing", () => {
       providerName: "KNOWLEDGE",
       successes: 1,
     });
+  });
+
+  it("round-trips a real turn's trace id through persistence and rehydration", async () => {
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    const roomId = "00000000-0000-0000-0000-000000000043" as UUID;
+    const timer = new InferenceTurnTimer({
+      turnId: "trace-roundtrip-1",
+      label: "chat-request",
+    });
+    const created: Array<{ body: unknown }> = [];
+    vi.spyOn(runtime, "createLogs").mockImplementation(async (logs) => {
+      created.push(...logs);
+    });
+    await persistInferenceTimingSummary(
+      runtime,
+      { id: "00000000-0000-0000-0000-0000000000aa" as UUID, roomId } as never,
+      timer.close(),
+    );
+    expect(created).toHaveLength(1);
+
+    vi.spyOn(runtime, "getLogs").mockResolvedValue([
+      {
+        type: "inference_timing",
+        entityId: runtime.agentId,
+        roomId,
+        createdAt: new Date(),
+        body: created[0].body,
+      } as Log,
+    ]);
+    const state: CompatRuntimeState = {
+      current: runtime,
+      pendingAgentName: null,
+      pendingRestartReasons: [],
+    };
+    const { req, res, captured } = makeReqRes({
+      url: "/api/dev/inference-timing?limit=1",
+    });
+
+    await expect(handleDevCompatRoutes(req, res, state)).resolves.toBe(true);
+
+    const payload = JSON.parse(captured.body ?? "{}");
+    expect(timer.traceId).toMatch(INFERENCE_TRACE_ID_PATTERN);
+    expect(payload.turns[0].traceId).toBe(timer.traceId);
+  });
+
+  it("rehydrates a malformed persisted trace id as null rather than surfacing it", async () => {
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    vi.spyOn(runtime, "getLogs").mockResolvedValue([
+      {
+        type: "inference_timing",
+        entityId: runtime.agentId,
+        roomId: "00000000-0000-0000-0000-000000000044" as UUID,
+        createdAt: new Date(),
+        body: {
+          runId: "trace-malformed-1",
+          source: "inference_timing",
+          startTime: 1_000,
+          endTime: 1_010,
+          duration: 10,
+          metadata: {
+            label: "chat-request",
+            traceId: "<script>alert(1)</script>",
+            spans: [],
+            marks: [],
+            byName: {},
+            anomalies: [],
+          },
+        },
+      } as Log,
+    ]);
+    const state: CompatRuntimeState = {
+      current: runtime,
+      pendingAgentName: null,
+      pendingRestartReasons: [],
+    };
+    const { req, res, captured } = makeReqRes({
+      url: "/api/dev/inference-timing?limit=1",
+    });
+
+    await expect(handleDevCompatRoutes(req, res, state)).resolves.toBe(true);
+    expect(JSON.parse(captured.body ?? "{}").turns[0].traceId).toBeNull();
   });
 
   it("rejects non-loopback callers before reading persisted telemetry", async () => {

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -5,6 +5,7 @@
  * format / dev-payload registry. Deterministic — no live model.
  */
 import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors";
 import {
 	buildInferenceFlowBreakdown,
 	buildInferenceTimingDevPayload,
@@ -521,22 +522,36 @@ describe("turn trace correlation (#16079)", () => {
 			label: "test",
 		});
 		expect(timer.traceId).toBe(upstream);
-		expect(
-			() =>
-				new InferenceTurnTimer({
-					turnId: "trace-d",
-					traceId: "not-a-trace-id",
-					label: "test",
-				}),
-		).toThrow(/32 lowercase hex/);
-		expect(
-			() =>
-				new InferenceTurnTimer({
-					turnId: "trace-e",
-					traceId: "A".repeat(32),
-					label: "test",
-				}),
-		).toThrow(/32 lowercase hex/);
+
+		// Rejection is a structured domain failure, not a bare Error: callers
+		// classify on the code, and the raw caller-supplied id must never be
+		// echoed back into the error context.
+		for (const [turnId, bad] of [
+			["trace-bad-shape", "not-a-trace-id"],
+			["trace-bad-case", "A".repeat(32)],
+			["trace-too-long", `${upstream}0`],
+			["trace-too-short", upstream.slice(0, 31)],
+			["trace-empty", ""],
+		] as const) {
+			let thrown: unknown;
+			try {
+				new InferenceTurnTimer({ turnId, traceId: bad, label: "test" });
+			} catch (error) {
+				thrown = error;
+			}
+			expect(thrown).toBeInstanceOf(ElizaError);
+			const elizaError = thrown as ElizaError;
+			expect(elizaError.code).toBe("INFERENCE_TRACE_ID_INVALID");
+			expect(elizaError.severity).toBe("fatal");
+			expect(elizaError.context).toEqual({
+				turnId,
+				traceIdLength: bad.length,
+			});
+			if (bad !== "") {
+				expect(JSON.stringify(elizaError.context)).not.toContain(bad);
+				expect(elizaError.message).not.toContain(bad);
+			}
+		}
 	});
 
 	it("carries the trace id into the summary and formatted line", () => {

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -12,9 +12,11 @@ import {
 	formatInferenceTimingSummary,
 	getInferenceTimer,
 	INFERENCE_MARKS,
+	INFERENCE_TRACE_ID_PATTERN,
 	InferenceTurnTimer,
 	inferenceTimingRegistry,
 	markInference,
+	mintInferenceTraceId,
 	nextInferenceTurnId,
 	recordInferenceSpan,
 	runWithInferenceTiming,
@@ -499,5 +501,56 @@ describe("emit + format + registry", () => {
 				execution: expect.objectContaining({ p95: 5 }),
 			}),
 		);
+	});
+});
+
+describe("turn trace correlation (#16079)", () => {
+	it("mints a distinct 32-lowercase-hex trace id per turn", () => {
+		const a = new InferenceTurnTimer({ turnId: "trace-a", label: "test" });
+		const b = new InferenceTurnTimer({ turnId: "trace-b", label: "test" });
+		expect(a.traceId).toMatch(INFERENCE_TRACE_ID_PATTERN);
+		expect(b.traceId).toMatch(INFERENCE_TRACE_ID_PATTERN);
+		expect(a.traceId).not.toBe(b.traceId);
+	});
+
+	it("adopts a caller-propagated trace id and rejects malformed ones", () => {
+		const upstream = mintInferenceTraceId();
+		const timer = new InferenceTurnTimer({
+			turnId: "trace-c",
+			traceId: upstream,
+			label: "test",
+		});
+		expect(timer.traceId).toBe(upstream);
+		expect(
+			() =>
+				new InferenceTurnTimer({
+					turnId: "trace-d",
+					traceId: "not-a-trace-id",
+					label: "test",
+				}),
+		).toThrow(/32 lowercase hex/);
+		expect(
+			() =>
+				new InferenceTurnTimer({
+					turnId: "trace-e",
+					traceId: "A".repeat(32),
+					label: "test",
+				}),
+		).toThrow(/32 lowercase hex/);
+	});
+
+	it("carries the trace id into the summary and formatted line", () => {
+		const timer = new InferenceTurnTimer({ turnId: "trace-f", label: "test" });
+		const s = timer.close();
+		expect(s.traceId).toBe(timer.traceId);
+		expect(formatInferenceTimingSummary(s)).toContain(`trace=${timer.traceId}`);
+	});
+
+	it("exposes the active turn's trace id through the ALS context", () => {
+		const timer = new InferenceTurnTimer({ turnId: "trace-g", label: "test" });
+		runWithInferenceTiming(timer, () => {
+			expect(getInferenceTimer()?.traceId).toBe(timer.traceId);
+		});
+		expect(getInferenceTimer()).toBeUndefined();
 	});
 });

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -1,8 +1,9 @@
 /**
  * Covers InferenceTurnTimer and the inference-timing AsyncLocalStorage helpers:
  * span roll-up by name, request-boundary milestone derivation, duplicate-mark
- * anomaly detection, ALS attribution across async boundaries, and the emit /
- * format / dev-payload registry. Deterministic — no live model.
+ * anomaly detection, ALS attribution across async boundaries, the emit /
+ * format / dev-payload registry, and per-turn trace-id minting, adoption, and
+ * structured rejection. Deterministic — no live model.
  */
 import { describe, expect, it } from "vitest";
 import { ElizaError } from "../errors";

--- a/packages/core/src/inference-timing.ts
+++ b/packages/core/src/inference-timing.ts
@@ -17,8 +17,16 @@
  * {@link markInference}). When no timer is active the helpers are zero-cost
  * no-ops, so instrumentation is safe to leave on every code path.
  *
+ * Each turn also carries a `traceId` — a bounded 32-lowercase-hex id, minted
+ * here or adopted from an upstream hop — that outbound callers propagate so a
+ * turn's local spans join the records of downstream services (e.g. the elizaOS
+ * Cloud gateway) that key their own events to the same id. The format doubles
+ * as a W3C `traceparent` trace-id so a hop can forward it without re-minting.
+ *
  * A missing measurement is recorded as missing, never synthesized (AGENTS.md
  * §3 / §8): derived metrics whose endpoint mark was never recorded stay `null`.
+ * The same rule governs the trace id: a summary rehydrated from a log written
+ * before correlation existed reports `traceId: null` rather than a fresh id.
  *
  * Logger only, `[InferenceTiming]` prefix (AGENTS.md §9).
  */

--- a/packages/core/src/inference-timing.ts
+++ b/packages/core/src/inference-timing.ts
@@ -64,6 +64,14 @@ export const INFERENCE_MARKS = {
 
 export interface InferenceTurnSummary {
 	turnId: string;
+	/**
+	 * Gateway-compatible correlation id (32 lowercase hex, #16079). Sent as
+	 * `X-Eliza-Trace-Id` on elizaOS Cloud calls so one id joins the turn's
+	 * local spans with the gateway's structured events and Server-Timing.
+	 * Null only for summaries rehydrated from logs persisted before trace
+	 * correlation existed — never fabricated for such turns.
+	 */
+	traceId: string | null;
 	label: string;
 	roomId: string | null;
 	modelProvider: string | null;
@@ -316,8 +324,21 @@ export function buildInferenceFlowBreakdown(
 
 const DEFAULT_MAX_SPANS = 512;
 
+/** Shape accepted by the Cloud gateway's bounded trace-id validator. */
+export const INFERENCE_TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+/**
+ * Mint a bounded, gateway-valid correlation id (32 lowercase hex). The format
+ * doubles as a W3C `traceparent` trace-id, so downstream hops can adopt it
+ * without re-minting.
+ */
+export function mintInferenceTraceId(): string {
+	return crypto.randomUUID().replace(/-/g, "");
+}
+
 export class InferenceTurnTimer {
 	readonly turnId: string;
+	readonly traceId: string;
 	readonly label: string;
 	readonly roomId: string | null;
 	readonly t0EpochMs: number;
@@ -331,12 +352,24 @@ export class InferenceTurnTimer {
 
 	constructor(args: {
 		turnId: string;
+		/** Caller-propagated id (e.g. from an upstream hop); minted when absent.
+		 *  Must match {@link INFERENCE_TRACE_ID_PATTERN}. */
+		traceId?: string;
 		label: string;
 		roomId?: string | null;
 		t0EpochMs?: number;
 		maxSpans?: number;
 	}) {
 		this.turnId = args.turnId;
+		if (
+			args.traceId !== undefined &&
+			!INFERENCE_TRACE_ID_PATTERN.test(args.traceId)
+		) {
+			throw new Error(
+				`InferenceTurnTimer: traceId must be 32 lowercase hex characters, got ${args.traceId.length} chars`,
+			);
+		}
+		this.traceId = args.traceId ?? mintInferenceTraceId();
 		this.label = args.label;
 		this.roomId = args.roomId ?? null;
 		this.t0EpochMs = args.t0EpochMs ?? Date.now();
@@ -432,6 +465,7 @@ export class InferenceTurnTimer {
 
 		return {
 			turnId: this.turnId,
+			traceId: this.traceId,
 			label: this.label,
 			roomId: this.roomId,
 			modelProvider: this.modelProvider,
@@ -890,7 +924,8 @@ export function formatInferenceTimingSummary(s: InferenceTurnSummary): string {
 	}
 	const head = `[InferenceTiming] ${s.label}`;
 	const provider = s.modelProvider ? ` provider=${s.modelProvider}` : "";
-	return `${head}${provider} ${parts.join(" ")}`;
+	const trace = s.traceId ? ` trace=${s.traceId}` : "";
+	return `${head}${provider}${trace} ${parts.join(" ")}`;
 }
 
 /**

--- a/packages/core/src/inference-timing.ts
+++ b/packages/core/src/inference-timing.ts
@@ -23,6 +23,7 @@
  * Logger only, `[InferenceTiming]` prefix (AGENTS.md §9).
  */
 
+import { ElizaError } from "./errors";
 import { logger } from "./logger";
 
 // ---------------------------------------------------------------------------
@@ -365,8 +366,18 @@ export class InferenceTurnTimer {
 			args.traceId !== undefined &&
 			!INFERENCE_TRACE_ID_PATTERN.test(args.traceId)
 		) {
-			throw new Error(
-				`InferenceTurnTimer: traceId must be 32 lowercase hex characters, got ${args.traceId.length} chars`,
+			throw new ElizaError(
+				"InferenceTurnTimer: traceId must be 32 lowercase hex characters",
+				{
+					code: "INFERENCE_TRACE_ID_INVALID",
+					severity: "fatal",
+					// The id itself is caller-propagated and may be attacker-influenced,
+					// so only its shape is recorded, never the value.
+					context: {
+						turnId: args.turnId,
+						traceIdLength: args.traceId.length,
+					},
+				},
 			);
 		}
 		this.traceId = args.traceId ?? mintInferenceTraceId();

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10594,6 +10594,7 @@ export async function persistInferenceTimingSummary(
 				duration: summary.totalMs ?? undefined,
 				metadata: {
 					label: summary.label,
+					traceId: summary.traceId,
 					modelProvider: summary.modelProvider,
 					timeToFirstTokenMs: summary.timeToFirstTokenMs,
 					timeToFirstVisibleMs: summary.timeToFirstVisibleMs,

--- a/plugins/plugin-elizacloud/__tests__/unit/trace-correlation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/trace-correlation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Covers the turn-to-gateway trace correlation helpers (#16079): outbound
+ * trace-header attachment, strict parsing of the gateway's echoed
+ * `X-Eliza-Preforward-Ms` decomposition, and folding echoed telemetry back
+ * into the real inference-timing turn. Deterministic; uses the real
+ * `@elizaos/core` InferenceTurnTimer and real `Response` objects — no mocks.
+ */
+import { InferenceTurnTimer, runWithInferenceTiming } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  ELIZA_PREFORWARD_HEADER,
+  ELIZA_TRACE_ID_HEADER,
+  parseGatewayPreforwardHeader,
+  recordGatewayResponseTelemetry,
+  withInferenceTraceHeader,
+} from "../../src/utils/trace-correlation";
+
+const timer = () => new InferenceTurnTimer({ turnId: "t", label: "test" });
+
+function gatewayResponse(headers: Record<string, string>): Response {
+  return new Response(null, { headers });
+}
+
+describe("withInferenceTraceHeader", () => {
+  it("attaches the active turn's trace id and preserves existing headers", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      const headers = withInferenceTraceHeader({ "X-Eliza-Model-Type": "TEXT_LARGE" });
+      expect(headers[ELIZA_TRACE_ID_HEADER]).toBe(t.traceId);
+      expect(headers["X-Eliza-Model-Type"]).toBe("TEXT_LARGE");
+    });
+  });
+
+  it("leaves headers untouched outside a timed turn", () => {
+    const headers = withInferenceTraceHeader({ "X-Eliza-Model-Type": "TEXT_LARGE" });
+    expect(ELIZA_TRACE_ID_HEADER in headers).toBe(false);
+  });
+});
+
+describe("parseGatewayPreforwardHeader", () => {
+  it("parses the gateway's frozen five-field decomposition", () => {
+    expect(parseGatewayPreforwardHeader("total=142.5;auth=4;mid=0;reserve=3;setup=135.5")).toEqual({
+      totalMs: 142.5,
+      authMs: 4,
+      midMs: 0,
+      reserveMs: 3,
+      setupMs: 135.5,
+    });
+  });
+
+  it.each([
+    [null, "absent header"],
+    ["", "empty value"],
+    ["total=1;auth=2;mid=3;reserve=4", "missing field"],
+    ["total=1;auth=2;mid=3;reserve=4;setup=5;setup=6", "duplicate field"],
+    ["total=1;auth=2;mid=3;reserve=4;setup=-1", "negative duration"],
+    ["total=1;auth=2;mid=3;reserve=4;setup=NaN", "non-finite duration"],
+    ["total=9999999999;auth=2;mid=3;reserve=4;setup=5", "absurd duration"],
+    ["total=1;auth=2;mid=3;reserve=4;bogus=5", "unknown field"],
+    [`total=1;auth=2;mid=3;reserve=4;setup=${"5".repeat(300)}`, "oversized value"],
+  ])("rejects %s (%s) as a whole", (value) => {
+    expect(parseGatewayPreforwardHeader(value)).toBeNull();
+  });
+});
+
+describe("recordGatewayResponseTelemetry", () => {
+  it("records a correlated gateway span when the gateway echoes the turn's id", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      recordGatewayResponseTelemetry(
+        gatewayResponse({
+          [ELIZA_TRACE_ID_HEADER]: t.traceId,
+          [ELIZA_PREFORWARD_HEADER]: "total=142;auth=4;mid=54;reserve=3;setup=81",
+        }),
+        "chat/completions"
+      );
+    });
+    const s = t.close();
+    const span = s.spans.find((entry) => entry.name === "cloud.gateway-preforward");
+    expect(span).toBeDefined();
+    expect(span?.durationMs).toBe(142);
+    expect(span?.meta).toMatchObject({
+      route: "chat/completions",
+      authMs: 4,
+      midMs: 54,
+      reserveMs: 3,
+      setupMs: 81,
+      correlated: true,
+      gatewayTraceId: t.traceId,
+    });
+  });
+
+  it("marks an uncorrelated span when the gateway minted its own id", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      recordGatewayResponseTelemetry(
+        gatewayResponse({
+          [ELIZA_TRACE_ID_HEADER]: "123e4567-e89b-42d3-a456-426614174000",
+          [ELIZA_PREFORWARD_HEADER]: "total=10;auth=1;mid=2;reserve=3;setup=4",
+        }),
+        "responses"
+      );
+    });
+    const span = t.close().spans.find((entry) => entry.name === "cloud.gateway-preforward");
+    expect(span?.meta).toMatchObject({
+      correlated: false,
+      gatewayTraceId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+  });
+
+  it("drops an invalid echoed id but keeps the timing decomposition", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      recordGatewayResponseTelemetry(
+        gatewayResponse({
+          [ELIZA_TRACE_ID_HEADER]: "<script>alert(1)</script>",
+          [ELIZA_PREFORWARD_HEADER]: "total=10;auth=1;mid=2;reserve=3;setup=4",
+        }),
+        "responses"
+      );
+    });
+    const span = t.close().spans.find((entry) => entry.name === "cloud.gateway-preforward");
+    expect(span?.durationMs).toBe(10);
+    expect(span?.meta?.correlated).toBe(false);
+    expect(span?.meta && "gatewayTraceId" in span.meta).toBe(false);
+  });
+
+  it("records nothing when the preforward header is missing or invalid", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      recordGatewayResponseTelemetry(gatewayResponse({}), "chat/completions");
+      recordGatewayResponseTelemetry(
+        gatewayResponse({ [ELIZA_PREFORWARD_HEADER]: "total=1;auth=broken" }),
+        "chat/completions"
+      );
+    });
+    expect(t.close().spans.some((entry) => entry.name === "cloud.gateway-preforward")).toBe(false);
+  });
+
+  it("is a no-op outside a timed turn", () => {
+    expect(() =>
+      recordGatewayResponseTelemetry(
+        gatewayResponse({ [ELIZA_PREFORWARD_HEADER]: "total=1;auth=1;mid=1;reserve=1;setup=1" }),
+        "chat/completions"
+      )
+    ).not.toThrow();
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/trace-correlation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/trace-correlation.test.ts
@@ -52,6 +52,12 @@ describe("parseGatewayPreforwardHeader", () => {
     [null, "absent header"],
     ["", "empty value"],
     ["total=1;auth=2;mid=3;reserve=4", "missing field"],
+    ["total=;auth=2;mid=3;reserve=4;setup=5", "emptied field value"],
+    ["total=   ;auth=2;mid=3;reserve=4;setup=5", "whitespace-only field value"],
+    ["total=0x64;auth=2;mid=3;reserve=4;setup=5", "hex literal"],
+    ["total=1e3;auth=2;mid=3;reserve=4;setup=5", "exponent notation"],
+    ["total=+5;auth=2;mid=3;reserve=4;setup=5", "signed value"],
+    ["total=Infinity;auth=2;mid=3;reserve=4;setup=5", "infinite value"],
     ["total=1;auth=2;mid=3;reserve=4;setup=5;setup=6", "duplicate field"],
     ["total=1;auth=2;mid=3;reserve=4;setup=-1", "negative duration"],
     ["total=1;auth=2;mid=3;reserve=4;setup=NaN", "non-finite duration"],
@@ -134,6 +140,21 @@ describe("recordGatewayResponseTelemetry", () => {
         "chat/completions"
       );
     });
+    expect(t.close().spans.some((entry) => entry.name === "cloud.gateway-preforward")).toBe(false);
+  });
+
+  it("records nothing when an intermediary empties every field value", () => {
+    const t = timer();
+    runWithInferenceTiming(t, () => {
+      recordGatewayResponseTelemetry(
+        gatewayResponse({
+          [ELIZA_PREFORWARD_HEADER]: "total=;auth=;mid=;reserve=;setup=",
+        }),
+        "chat/completions"
+      );
+    });
+    // A recorded 0ms span would be indistinguishable from a genuinely instant
+    // gateway; absence of attribution must stay visible as absence.
     expect(t.close().spans.some((entry) => entry.name === "cloud.gateway-preforward")).toBe(false);
   });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -24,6 +24,10 @@ import {
   timeInferenceSpan,
 } from "@elizaos/core";
 import {
+  recordGatewayResponseTelemetry,
+  withInferenceTraceHeader,
+} from "../utils/trace-correlation";
+import {
   getActionPlannerModel,
   getLargeModel,
   getMediumModel,
@@ -555,7 +559,10 @@ export async function requestNativeWithWarmingRetry(
   for (;;) {
     const response = await withNativeChatLimit(doRequest, label);
     const bodyText = await response.text();
-    if (response.status !== 503) return { response, bodyText };
+    if (response.status !== 503) {
+      recordGatewayResponseTelemetry(response, label);
+      return { response, bodyText };
+    }
     const delayMs = nextWarmingRetryDelayMs(state, response, bodyText);
     if (delayMs === undefined) return { response, bodyText };
     logger.warn(
@@ -1279,10 +1286,10 @@ async function generateTextWithModel(
     requestBody.temperature = params.temperature;
   }
 
-  const responsesHeaders: Record<string, string> = {
+  const responsesHeaders: Record<string, string> = withInferenceTraceHeader({
     "X-Eliza-Llm-Purpose": getPurposeForModelType(modelType),
     "X-Eliza-Model-Type": modelType,
-  };
+  });
   if (isSpanSamplerHonoringModel(modelName)) {
     const samplerHeader = buildSpanSamplerHeader(params.spanSamplerPlan);
     if (samplerHeader) {
@@ -1379,10 +1386,10 @@ export async function generateNativeChatCompletion(
     context.systemPrompt,
     runtime
   );
-  const headers: Record<string, string> = {
+  const headers: Record<string, string> = withInferenceTraceHeader({
     "X-Eliza-Llm-Purpose": getPurposeForModelType(modelType),
     "X-Eliza-Model-Type": modelType,
-  };
+  });
   // Per-span sampler overrides only ride along when the resolved model is a
   // fork-built eliza-1 deployment that knows how to honor the header. Other
   // upstreams (OpenAI / Anthropic / generic OpenRouter) strip unknown headers
@@ -1802,10 +1809,10 @@ export async function streamNativeChatCompletion(
   // can meter the streamed call accurately.
   requestBody.stream_options = { include_usage: true };
 
-  const headers: Record<string, string> = {
+  const headers: Record<string, string> = withInferenceTraceHeader({
     "X-Eliza-Llm-Purpose": getPurposeForModelType(modelType),
     "X-Eliza-Model-Type": modelType,
-  };
+  });
   if (isSpanSamplerHonoringModel(context.modelName)) {
     const samplerHeader = buildSpanSamplerHeader(params.spanSamplerPlan);
     if (samplerHeader) {
@@ -1870,6 +1877,9 @@ export async function streamNativeChatCompletion(
     );
     await sleepMs(delayMs);
   }
+  // Recorded before the ok-check so a failed forward still keeps its gateway
+  // decomposition on the turn — errors are where attribution matters most.
+  recordGatewayResponseTelemetry(response, "chat/completions:stream");
 
   if (!response.ok) {
     let errorBody: { message?: string } | undefined;

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -559,10 +559,11 @@ export async function requestNativeWithWarmingRetry(
   for (;;) {
     const response = await withNativeChatLimit(doRequest, label);
     const bodyText = await response.text();
-    if (response.status !== 503) {
-      recordGatewayResponseTelemetry(response, label);
-      return { response, bodyText };
-    }
+    // Recorded before the status check so the give-up 503 keeps its gateway
+    // decomposition too — a turn that burned the whole warming ladder is
+    // exactly the turn whose pre-forward attribution matters.
+    recordGatewayResponseTelemetry(response, label);
+    if (response.status !== 503) return { response, bodyText };
     const delayMs = nextWarmingRetryDelayMs(state, response, bodyText);
     if (delayMs === undefined) return { response, bodyText };
     logger.warn(

--- a/plugins/plugin-elizacloud/src/utils/trace-correlation.ts
+++ b/plugins/plugin-elizacloud/src/utils/trace-correlation.ts
@@ -1,0 +1,123 @@
+/**
+ * Turn-to-gateway trace correlation for elizaOS Cloud text calls (#16079).
+ *
+ * The Cloud gateway accepts a bounded `X-Eliza-Trace-Id` request header,
+ * validates it, keys its structured preforward/auth events to it, and echoes
+ * it (plus a frozen `X-Eliza-Preforward-Ms` decomposition and Server-Timing)
+ * on the response. Without a caller-supplied id the gateway mints its own,
+ * leaving the agent-side turn and the gateway's events unjoinable. These
+ * helpers close that gap: outbound requests carry the active inference turn's
+ * trace id, and the echoed gateway telemetry is folded back into the same
+ * turn as a `cloud.gateway-preforward` span, so one id follows the turn from
+ * the runtime through the gateway's own logs.
+ *
+ * All helpers are no-ops when no turn timer is active, matching the
+ * inference-timing contract that instrumentation is safe on every code path.
+ * Response headers are treated as untrusted input: an id or timing header
+ * that fails strict validation is dropped, never coerced into fake data.
+ */
+
+import { getInferenceTimer, recordInferenceSpan } from "@elizaos/core";
+
+/** Request/response correlation header understood by the Cloud gateway. */
+export const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
+/** Frozen gateway pre-forward decomposition echoed on gateway responses. */
+export const ELIZA_PREFORWARD_HEADER = "X-Eliza-Preforward-Ms";
+
+/** Ids the gateway's bounded validator accepts back verbatim. */
+const GATEWAY_TRACE_ID = /^[0-9a-f]{32}$/;
+/** Ids the gateway may echo: the caller's 32-hex id or a gateway-minted UUID. */
+const ECHOED_TRACE_ID =
+  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
+
+/**
+ * Attach the active turn's trace id to an outbound header record. Mutates and
+ * returns `headers`; a call outside a timed turn leaves them unchanged.
+ */
+export function withInferenceTraceHeader(
+  headers: Record<string, string>
+): Record<string, string> {
+  const timer = getInferenceTimer();
+  if (timer && GATEWAY_TRACE_ID.test(timer.traceId)) {
+    headers[ELIZA_TRACE_ID_HEADER] = timer.traceId;
+  }
+  return headers;
+}
+
+/** Frozen pre-forward decomposition parsed from the gateway response. */
+export interface GatewayPreforwardBreakdown {
+  totalMs: number;
+  authMs: number;
+  midMs: number;
+  reserveMs: number;
+  setupMs: number;
+}
+
+const PREFORWARD_FIELDS = ["total", "auth", "mid", "reserve", "setup"] as const;
+const MAX_PREFORWARD_MS = 3_600_000;
+
+/**
+ * Strictly parse `X-Eliza-Preforward-Ms`
+ * (`total=<ms>;auth=<ms>;mid=<ms>;reserve=<ms>;setup=<ms>`). Any missing,
+ * duplicate, non-finite, negative, or absurd (> 1h) field invalidates the
+ * whole header — a partial decomposition would misattribute time.
+ */
+export function parseGatewayPreforwardHeader(
+  value: string | null
+): GatewayPreforwardBreakdown | null {
+  if (!value || value.length > 256) return null;
+  const fields = new Map<string, number>();
+  for (const part of value.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq <= 0) return null;
+    const name = part.slice(0, eq).trim();
+    const parsed = Number(part.slice(eq + 1).trim());
+    if (
+      !(PREFORWARD_FIELDS as readonly string[]).includes(name) ||
+      fields.has(name) ||
+      !Number.isFinite(parsed) ||
+      parsed < 0 ||
+      parsed > MAX_PREFORWARD_MS
+    ) {
+      return null;
+    }
+    fields.set(name, parsed);
+  }
+  if (fields.size !== PREFORWARD_FIELDS.length) return null;
+  return {
+    totalMs: fields.get("total") as number,
+    authMs: fields.get("auth") as number,
+    midMs: fields.get("mid") as number,
+    reserveMs: fields.get("reserve") as number,
+    setupMs: fields.get("setup") as number,
+  };
+}
+
+/**
+ * Fold the gateway's echoed telemetry into the active turn as a
+ * `cloud.gateway-preforward` span whose meta records the decomposition and
+ * whether the gateway adopted the turn's own trace id (`correlated`). Missing
+ * or invalid telemetry records nothing — absence stays visible as absence.
+ */
+export function recordGatewayResponseTelemetry(
+  response: Pick<Response, "headers">,
+  route: string
+): void {
+  const timer = getInferenceTimer();
+  if (!timer) return;
+  const breakdown = parseGatewayPreforwardHeader(
+    response.headers.get(ELIZA_PREFORWARD_HEADER)
+  );
+  if (!breakdown) return;
+  const echoed = response.headers.get(ELIZA_TRACE_ID_HEADER)?.trim().toLowerCase();
+  const gatewayTraceId = echoed && ECHOED_TRACE_ID.test(echoed) ? echoed : undefined;
+  recordInferenceSpan("cloud.gateway-preforward", breakdown.totalMs, {
+    route,
+    authMs: breakdown.authMs,
+    midMs: breakdown.midMs,
+    reserveMs: breakdown.reserveMs,
+    setupMs: breakdown.setupMs,
+    correlated: gatewayTraceId === timer.traceId,
+    ...(gatewayTraceId ? { gatewayTraceId } : {}),
+  });
+}

--- a/plugins/plugin-elizacloud/src/utils/trace-correlation.ts
+++ b/plugins/plugin-elizacloud/src/utils/trace-correlation.ts
@@ -55,6 +55,13 @@ export interface GatewayPreforwardBreakdown {
 
 const PREFORWARD_FIELDS = ["total", "auth", "mid", "reserve", "setup"] as const;
 const MAX_PREFORWARD_MS = 3_600_000;
+/**
+ * Plain non-negative decimal only. `Number()` alone would coerce `""`, a
+ * whitespace-only value, `0x64`, `1e3`, or `+5` into a finite number, so an
+ * emptied or rewritten field would land as a fake `0ms` span instead of
+ * invalidating the header.
+ */
+const PREFORWARD_VALUE = /^\d+(?:\.\d+)?$/;
 
 /**
  * Strictly parse `X-Eliza-Preforward-Ms`
@@ -71,7 +78,9 @@ export function parseGatewayPreforwardHeader(
     const eq = part.indexOf("=");
     if (eq <= 0) return null;
     const name = part.slice(0, eq).trim();
-    const parsed = Number(part.slice(eq + 1).trim());
+    const rawValue = part.slice(eq + 1).trim();
+    if (!PREFORWARD_VALUE.test(rawValue)) return null;
+    const parsed = Number(rawValue);
     if (
       !(PREFORWARD_FIELDS as readonly string[]).includes(name) ||
       fields.has(name) ||


### PR DESCRIPTION


## Review follow-up (c2505aa)

Applied on review of `3e7f8219`:

- **Strict pre-forward field values.** `parseGatewayPreforwardHeader` documented an all-or-nothing contract but used bare `Number()`, so `total=`, a whitespace-only value, `0x64`, `1e3`, and `+5` all coerced to a finite number. An emptied header produced a `cloud.gateway-preforward` span of `0ms` — indistinguishable from a genuinely instant gateway, i.e. fabricated timing where absence should stay visible. Values now must match `/^\d+(?:\.\d+)?$/`.
- **Warming-retry give-up 503 no longer drops telemetry**, matching the streaming path's stated rule that errors are where attribution matters most.
- **Rehydration re-validates `traceId`** against `INFERENCE_TRACE_ID_PATTERN`, so a malformed persisted value surfaces as an explicit `null` instead of being replayed as a trace id. Pre-change logs still rehydrate as `null`, never fabricated.
- **Persist → rehydrate roundtrip is now tested** end to end with a real `InferenceTurnTimer` and the real `persistInferenceTimingSummary`, plus the pre-change-log `traceId: null` case and the seven header rows that previously slipped through.

Re-run: plugin-elizacloud `trace-correlation` 24/24 (was 17), app-core dev-compat suites 60/60 (was 56), core `inference-timing` 22/22, `plugin-elizacloud` + `app-core` typecheck clean (only the pre-existing stale-dist `packages/agent` errors remain), Biome clean.
