### PR TITLE
fix(plugin-signal): default unset SIGNAL_CLI_PATH instead of throwing

### DIFF
--- a/plugins/plugin-signal/src/index.init.test.ts
+++ b/plugins/plugin-signal/src/index.init.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit coverage for Signal plugin `init()` when optional `SIGNAL_CLI_PATH` is
+ * missing. `IAgentRuntime.getSetting()` returns `null` for unset keys; init
+ * must default to `signal-cli` instead of throwing on `.trim()`. Fake runtime
+ * only — no live signal-cli or network.
+ */
+import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import signalPlugin from "./index.ts";
+import { DEFAULT_SIGNAL_CLI_PATH } from "./service.ts";
+
+function createRuntime(
+  settings: Record<string, string | boolean | number | null> = {}
+): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    getSetting: (key: string) => (Object.hasOwn(settings, key) ? settings[key] : null),
+    getService: () => null,
+  } as unknown as IAgentRuntime;
+}
+
+describe("signalPlugin.init SIGNAL_CLI_PATH defaulting", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes an init hook", () => {
+    expect(signalPlugin.init).toEqual(expect.any(Function));
+  });
+
+  it("does not throw when SIGNAL_ACCOUNT_NUMBER is set and SIGNAL_CLI_PATH is unset", async () => {
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+    await expect(
+      signalPlugin.init?.({}, createRuntime({ SIGNAL_ACCOUNT_NUMBER: "+15551234567" }))
+    ).resolves.toBeUndefined();
+
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "local-cli",
+        cliPath: DEFAULT_SIGNAL_CLI_PATH,
+      }),
+      "Signal plugin configuration validated successfully"
+    );
+  });
+
+  it("does not throw when both SIGNAL_ACCOUNT_NUMBER and SIGNAL_CLI_PATH are unset", async () => {
+    vi.spyOn(logger, "info").mockImplementation(() => undefined);
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+    await expect(signalPlugin.init?.({}, createRuntime())).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ src: "plugin:signal" }),
+      "SIGNAL_ACCOUNT_NUMBER not provided - Signal plugin is loaded but will not be functional"
+    );
+  });
+
+  it.each([true, 1] as const)(
+    "defaults SIGNAL_CLI_PATH when getSetting returns non-string %p",
+    async (value) => {
+      const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+      await expect(
+        signalPlugin.init?.(
+          {},
+          createRuntime({
+            SIGNAL_ACCOUNT_NUMBER: "+15551234567",
+            SIGNAL_CLI_PATH: value,
+          })
+        )
+      ).resolves.toBeUndefined();
+
+      expect(info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cliPath: DEFAULT_SIGNAL_CLI_PATH,
+        }),
+        "Signal plugin configuration validated successfully"
+      );
+    }
+  );
+
+  it.each(["", "   "] as const)(
+    "defaults blank SIGNAL_CLI_PATH %p to signal-cli",
+    async (value) => {
+      const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+      await expect(
+        signalPlugin.init?.(
+          {},
+          createRuntime({
+            SIGNAL_ACCOUNT_NUMBER: "+15551234567",
+            SIGNAL_CLI_PATH: value,
+          })
+        )
+      ).resolves.toBeUndefined();
+
+      expect(info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cliPath: DEFAULT_SIGNAL_CLI_PATH,
+        }),
+        "Signal plugin configuration validated successfully"
+      );
+    }
+  );
+
+  it("honors an explicit trimmed SIGNAL_CLI_PATH", async () => {
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+    await expect(
+      signalPlugin.init?.(
+        {},
+        createRuntime({
+          SIGNAL_ACCOUNT_NUMBER: "+15551234567",
+          SIGNAL_CLI_PATH: " /opt/signal-cli ",
+        })
+      )
+    ).resolves.toBeUndefined();
+
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cliPath: "/opt/signal-cli",
+      }),
+      "Signal plugin configuration validated successfully"
+    );
+  });
+});

--- a/plugins/plugin-signal/src/index.ts
+++ b/plugins/plugin-signal/src/index.ts
@@ -61,15 +61,19 @@ const signalPlugin: Plugin = {
     // Register the cross-connector triage adapter for the "signal" source.
     registerSignalTriageAdapter();
 
-    const accountNumber = runtime.getSetting("SIGNAL_ACCOUNT_NUMBER") as string;
-    const httpUrl = runtime.getSetting("SIGNAL_HTTP_URL") as string;
-    const cliPath = runtime.getSetting("SIGNAL_CLI_PATH") as string;
-    const effectiveCliPath = cliPath.trim() || DEFAULT_SIGNAL_CLI_PATH;
-    const ignoreGroups = runtime.getSetting("SIGNAL_SHOULD_IGNORE_GROUP_MESSAGES") as string;
+    const accountNumber = runtime.getSetting("SIGNAL_ACCOUNT_NUMBER");
+    const httpUrl = runtime.getSetting("SIGNAL_HTTP_URL");
+    const cliPath = runtime.getSetting("SIGNAL_CLI_PATH");
+    // getSetting returns null for an unset key. SIGNAL_CLI_PATH is optional and
+    // must default to the signal-cli binary name rather than throw on .trim().
+    const configuredCliPath =
+      typeof cliPath === "string" && cliPath.trim().length > 0 ? cliPath.trim() : undefined;
+    const effectiveCliPath = configuredCliPath ?? DEFAULT_SIGNAL_CLI_PATH;
+    const ignoreGroups = runtime.getSetting("SIGNAL_SHOULD_IGNORE_GROUP_MESSAGES");
 
     // Log configuration status
-    const maskNumber = (number: string | undefined): string => {
-      if (!number || number.trim() === "") return "[not set]";
+    const maskNumber = (number: string | boolean | number | null): string => {
+      if (typeof number !== "string" || number.trim() === "") return "[not set]";
       if (number.length <= 6) return "***";
       return `${number.slice(0, 3)}...${number.slice(-2)}`;
     };
@@ -81,14 +85,14 @@ const signalPlugin: Plugin = {
         settings: {
           accountNumber: maskNumber(accountNumber),
           httpUrl: httpUrl || "[not set]",
-          cliPath: cliPath ? cliPath : `[default: ${DEFAULT_SIGNAL_CLI_PATH}]`,
+          cliPath: configuredCliPath ?? `[default: ${DEFAULT_SIGNAL_CLI_PATH}]`,
           ignoreGroups: ignoreGroups || "false",
         },
       },
       "Signal plugin initializing"
     );
 
-    if (!accountNumber || accountNumber.trim() === "") {
+    if (typeof accountNumber !== "string" || accountNumber.trim() === "") {
       logger.warn(
         { src: "plugin:signal", agentId: runtime.agentId },
         "SIGNAL_ACCOUNT_NUMBER not provided - Signal plugin is loaded but will not be functional"


### PR DESCRIPTION
# Relates to

Fixes #23032

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2e964683c6001d9d33a37e1f7c81d6caf70de093:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Plugin `init()` is logging/validation only. The change stops a TypeError on
the documented default (`SIGNAL_CLI_PATH` unset) and still honors an explicit
path. It does not start signal-cli, change pairing, or alter send/receive.

# Background

## What does this PR do?

`plugin-signal` `init()` called `.trim()` on `runtime.getSetting("SIGNAL_CLI_PATH")`
before applying `DEFAULT_SIGNAL_CLI_PATH`. `getSetting()` returns `null` for a
missing key, so the documented default boot (required `SIGNAL_ACCOUNT_NUMBER`,
optional CLI path) threw `TypeError` and never finished plugin init.

Treat unset, non-string, and blank `SIGNAL_CLI_PATH` as `signal-cli`. Keep an
explicit trimmed path. Guard the account-number check the same way so a missing
account still takes the existing warn-and-return path instead of crashing first.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

No. README / AGENTS.md already describe `SIGNAL_CLI_PATH` as optional with
default `signal-cli`. Init now matches that contract.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-signal/src/index.ts` — defaulting of `SIGNAL_CLI_PATH`.
2. `plugins/plugin-signal/src/index.init.test.ts` — fake-runtime coverage of the
   real `init` export.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-signal test
bun run --cwd plugins/plugin-signal typecheck
bun run --cwd plugins/plugin-signal lint
```

Or exercise `init` with a fake runtime whose `getSetting("SIGNAL_CLI_PATH")` is
`null` and `SIGNAL_ACCOUNT_NUMBER` is `+15551234567`. Before this change that
throws; after, it logs configuration validated with `cliPath=signal-cli`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2e964683c6001d9d33a37e1f7c81d6caf70de093 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - plugin init TypeError; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - plugin init TypeError; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - plugin init TypeError; no rendered UI surface
<!-- evidence-row:backend-logs -->
- [ ] N/A - structured init logs and vitest output are pasted inline in Evidence Details; fork contributor cannot upload to the pr-evidence release
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request or console path; plugin init only
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic plugin init; no model invocation
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - crash is before daemon start or persistence
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic plugin init; no model invocation.

## Backend + frontend logs

Frontend: N/A - no UI.

Backend: `plugin.init()` logs on the fake runtime after the fix:

```
Info [PLUGIN:SIGNAL] Signal plugin initializing (settings={"accountNumber":"+15...67","httpUrl":"[not set]","cliPath":"[default: signal-cli]","ignoreGroups":"false"})
Info [PLUGIN:SIGNAL] Signal plugin configuration validated successfully (mode=local-cli, cliPath=signal-cli)
```

Missing both settings no longer throws; it takes the existing warn path:

```
Warn [PLUGIN:SIGNAL] SIGNAL_ACCOUNT_NUMBER not provided - Signal plugin is loaded but will not be functional
```

Package tests: 9 files, 73 passed, including 8 new `index.init.test.ts` cases.

## Screenshots (before / after) + video walkthrough

N/A - plugin init TypeError, no rendered visual surface.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

`bun run verify` failed on this checkout after rebase onto `origin/develop`
(`b73d8ea66c`) with an unrelated blocker: `@elizaos/ui#lint:check` reports
duplicate imports in `packages/ui/src/api/client-cloud.ts`
(`desktopHttpTransportForUrl`, `fetchAgentTransport`). That file is not in this
diff. i18n locale-key drift on the same `develop` head is likewise pre-existing.

Package-local proof for this change:

- `bun run --cwd plugins/plugin-signal test` — 9 files, 73 tests passed
- `bun run --cwd plugins/plugin-signal typecheck` — passed
- `bun run --cwd plugins/plugin-signal lint` — passed (Biome schema 2.5.7 vs
  2.5.8 info only, repo-wide)
- `node packages/scripts/run-turbo.mjs run typecheck lint:check --filter=@elizaos/plugin-signal` — 59 tasks successful

AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@2e964683c6001d9d33a37e1f7c81d6caf70de093:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"elizaOS/eliza@2e964683c6001d9d33a37e1f7c81d6caf70de093:packages/skills/skills/contribute-to-eliza"} -->

