### PR TITLE
ci: add scheduled develop-health lane as canonical trunk signal

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,6 +22,17 @@ branch; it does not replace the merge-candidate admission check above.
 `nightly.yml` calls the same CI workflow once per day and adds macOS and Windows
 core smoke tests. It never publishes packages or creates releases.
 
+`develop-health.yml` is the canonical uncontended trunk-health lane (#19181).
+Push-triggered develop runs supersede each other during merge waves, so this
+lane runs the repository verify gate on the live develop tip four times a day
+(and on manual dispatch) from a single hosted runner, in a fixed
+never-cancelled concurrency group, and publishes the outcome as a
+`develop-health` commit status on the exact SHA it measured. A missing status
+means no measurement concluded; a red status means develop is actually red —
+the lane exists to keep those two states distinguishable while the fleet is
+saturated.
+[![develop health](https://github.com/elizaOS/eliza/actions/workflows/develop-health.yml/badge.svg?branch=develop)](https://github.com/elizaOS/eliza/actions/workflows/develop-health.yml)
+
 ## Scheduled security analysis
 
 `codeql.yml` runs JavaScript/TypeScript CodeQL analysis only on its weekly

--- a/.github/workflows/develop-health.yml
+++ b/.github/workflows/develop-health.yml
@@ -1,0 +1,96 @@
+# Scheduled, low-footprint canonical health signal for the develop branch
+# (#19181). During merge waves nearly every push-triggered CI run on develop
+# is superseded before finishing, so the branch's true state becomes
+# unobservable through Actions. This lane always checks out the current
+# develop tip on a single hosted runner, runs the repository verify gate, and
+# publishes the outcome as a `develop-health` commit status on the exact SHA
+# it measured — a timestamped signal that survives push storms because it
+# never shares a concurrency group with push-triggered runs and never
+# cancels in progress. It intentionally stays one job wide: fleet saturation
+# is the failure mode being observed, so the observer must not add fan-out.
+name: Develop Health
+
+on:
+  schedule:
+    # Offset from nightly.yml (04:00 UTC) so the two scheduled signals never
+    # contend with each other for the same queue slot.
+    - cron: "17 1,7,13,19 * * *"
+  workflow_dispatch:
+
+# One fixed group, never cancelled: a queued scheduled run coalesces (GitHub
+# keeps at most one pending run per group) and a running health read always
+# concludes, which is the entire point of the lane.
+concurrency:
+  group: develop-health
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CI: "true"
+  NODE_NO_WARNINGS: "1"
+  NODE_OPTIONS: "--max-old-space-size=8192"
+
+jobs:
+  verify:
+    name: Verify develop tip
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    # Commit statuses are the one write this lane performs; scope it to the
+    # job so no other job added later inherits it silently.
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      # Always measure the live develop tip, not the ref the workflow file
+      # was resolved from, so a manual dispatch during a merge wave reads the
+      # branch as it stands right now.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: develop
+          fetch-depth: 0
+          submodules: false
+
+      - name: Record measured SHA
+        id: tip
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Run repository verify gate
+        run: bun run verify
+
+      # The status lands on the measured SHA even when verify fails, so the
+      # canonical signal distinguishes "develop is red" from "no run
+      # concluded" — the ambiguity #19181 exists to remove. A cancelled run
+      # posts nothing, which is correct: cancellation is not a measurement.
+      - name: Publish develop-health commit status
+        if: success() || failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.tip.outputs.sha }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          state="failure"
+          description="bun run verify failed on the develop tip"
+          if [ "$OUTCOME" = "success" ]; then
+            state="success"
+            description="bun run verify passed on the develop tip"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$state" \
+            -f context="develop-health" \
+            -f description="$description" \
+            -f target_url="$RUN_URL"

--- a/packages/scripts/__tests__/develop-health-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-health-workflow.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pins the develop-health.yml canonical trunk-signal contract (#19181).
+ * During merge waves push-triggered CI runs on develop are superseded before
+ * concluding, so the lane exists to produce a signal that always terminates:
+ * it must stay schedule/dispatch-only, never cancel in progress, never share
+ * a ref-scoped concurrency group with push runs, measure the live develop
+ * tip, stay one job wide, and publish a `develop-health` commit status on
+ * the exact SHA it measured. Deterministic, reads the real workflow file.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workflowPath = join(
+  repoRoot,
+  ".github",
+  "workflows",
+  "develop-health.yml",
+);
+const source = readFileSync(workflowPath, "utf8");
+
+interface Step {
+  uses?: string;
+  run?: string;
+  if?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+}
+
+const workflow = Bun.YAML.parse(source) as {
+  on?: Record<string, unknown>;
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  permissions?: Record<string, string>;
+  jobs?: Record<
+    string,
+    {
+      "runs-on"?: string;
+      "timeout-minutes"?: number;
+      permissions?: Record<string, string>;
+      steps?: Step[];
+    }
+  >;
+};
+
+describe("develop-health.yml canonical trunk-signal contract", () => {
+  test("triggers only on schedule and manual dispatch, never on push", () => {
+    const triggers = Object.keys(workflow.on ?? {}).sort();
+    expect(triggers).toEqual(["schedule", "workflow_dispatch"]);
+  });
+
+  test("uses one fixed concurrency group that never cancels in progress", () => {
+    // A ref- or run-scoped group would either park the lane behind the
+    // develop push queue or allow unbounded pile-up; a fixed group bounds it
+    // to one running plus one pending run.
+    expect(workflow.concurrency?.group).toBe("develop-health");
+    expect(workflow.concurrency?.group).not.toContain("${{");
+    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+  });
+
+  test("stays one job wide so the observer does not add fleet fan-out", () => {
+    const jobs = Object.keys(workflow.jobs ?? {});
+    expect(jobs).toEqual(["verify"]);
+    const steps = workflow.jobs?.verify?.steps ?? [];
+    expect(steps.some((step) => step.uses?.startsWith("./"))).toBe(false);
+  });
+
+  test("checks out the live develop tip on a hosted runner", () => {
+    const job = workflow.jobs?.verify;
+    expect(job?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(job?.["timeout-minutes"]).toBeGreaterThanOrEqual(60);
+    const checkout = job?.steps?.find((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.with?.ref).toBe("develop");
+  });
+
+  test("runs the repository verify gate", () => {
+    const steps = workflow.jobs?.verify?.steps ?? [];
+    expect(steps.some((step) => step.run === "bun run verify")).toBe(true);
+  });
+
+  test("publishes a develop-health commit status on success and failure", () => {
+    const status = workflow.jobs?.verify?.steps?.find((step) =>
+      step.run?.includes("statuses/"),
+    );
+    expect(status?.if).toBe("success() || failure()");
+    expect(status?.run).toContain('context="develop-health"');
+    // The status must land on the measured SHA, not github.sha, so a manual
+    // dispatch resolved from an older workflow revision still stamps the tip
+    // it actually verified.
+    expect(status?.env?.SHA).toBe("${{ steps.tip.outputs.sha }}");
+  });
+
+  test("grants status writes only at the job scope", () => {
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.jobs?.verify?.permissions?.statuses).toBe("write");
+  });
+
+  test("pins toolchain versions to the repository contract", () => {
+    expect(source).toContain('bun-version: "1.3.14"');
+    expect(source).toContain('node-version: "24.15.0"');
+  });
+});


### PR DESCRIPTION
Fixes #19181

## What

Adds `.github/workflows/develop-health.yml` — the scheduled, uncontended canonical trunk-health lane the issue (and the maintainer's close comment) called for. During merge waves, push-triggered CI runs on `develop` supersede each other before concluding, so a missing green run is indistinguishable from a red branch. This lane removes that ambiguity:

- **schedule (4x/day, offset from nightly) + `workflow_dispatch` only** — never shares a concurrency group with push runs.
- **Fixed `develop-health` concurrency group, `cancel-in-progress: false`** — a started health read always concludes; queued scheduled runs coalesce (GitHub keeps one pending per group), so the lane cannot pile up.
- **Single hosted job** — the observer adds one runner of load, not a CI fan-out, since fleet saturation is the failure mode being observed.
- **Always checks out the live `develop` tip** (`ref: develop`) and runs the repository gate `bun run verify`.
- **Publishes a `develop-health` commit status on the exact measured SHA**, on success *and* failure (job-scoped `statuses: write`). No status = no measurement concluded; red status = develop is actually red.
- Documented in `.github/workflows/README.md` with a badge.

Contract test `packages/scripts/__tests__/develop-health-workflow.test.ts` pins the trigger set, the fixed never-cancelled concurrency group, the one-job footprint, the develop-tip checkout, the verify gate, the measured-SHA status semantics, and the toolchain pins — same style as `quality-workflow-concurrency.test.ts`.

## Deconfliction

This is the "scheduled canonical health lane ... scoped workflow PR" remainder named when the issue was first closed. It does not touch runner-fleet capacity: the dedicated prod-ops runner pool (provisioning, runner group, Terraform plan/apply) remains NubsCarson's claimed ops lane and is the genuinely human/operator-only remainder of #19181.

## Verification

- `bun test packages/scripts/__tests__/develop-health-workflow.test.ts packages/scripts/__tests__/workflow-trigger-policy.test.ts packages/scripts/__tests__/workflow-call-permissions.test.ts` — 20 pass / 0 fail.
- `actionlint .github/workflows/develop-health.yml` — clean.
- Trigger policy: schedule + dispatch only, no push/pull_request trigger, so the policy test's develop-push accounting is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
