### PR TITLE
fix(agent): scope the cloud-managed GitHub token to its owning agent runtime

### DIFF
--- a/packages/agent/src/runtime/cloud-github-token.test.ts
+++ b/packages/agent/src/runtime/cloud-github-token.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Agent-scoped binding of the cloud-managed GitHub OAuth token (#15904).
+ *
+ * Exercises `autoFetchCloudGithubToken` against a stubbed global `fetch` and
+ * `bindCloudGithubTokenToRuntime` against minimal in-memory runtimes.
+ * Deterministic, no network. The load-bearing contract under test: the fetch
+ * NEVER writes `process.env.GITHUB_TOKEN`, the bind lands the token only in
+ * the owning runtime's secrets, and a co-tenant runtime in the same process
+ * can neither observe nor be overwritten by another agent's token.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  autoFetchCloudGithubToken,
+  bindCloudGithubTokenToRuntime,
+} from "./eliza.ts";
+
+const ENV_KEYS = [
+  "GITHUB_TOKEN",
+  "GITHUB_PAT",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+  "ELIZAOS_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+const realFetch = globalThis.fetch;
+
+function fakeRuntime(initialSecrets: Record<string, string> = {}) {
+  const secrets: Record<string, string> = { ...initialSecrets };
+  return {
+    secrets,
+    getSetting: (key: string) => secrets[key] ?? null,
+    setSetting: (
+      key: string,
+      value: string | boolean | null,
+      secret = false,
+    ) => {
+      void secret;
+      if (value === null) delete secrets[key];
+      else secrets[key] = String(value);
+    },
+  };
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+function armCloudEnv() {
+  process.env.ELIZAOS_CLOUD_API_KEY = "test-cloud-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL = "https://cloud.test";
+  process.env.ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT = "managed";
+}
+
+describe("autoFetchCloudGithubToken", () => {
+  it("returns the token without writing process.env.GITHUB_TOKEN", async () => {
+    armCloudEnv();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { accessToken: "gho_agent_a", githubUsername: "octo-a" },
+          }),
+          { status: 200 },
+        ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await autoFetchCloudGithubToken("agent-a");
+
+    expect(result).toEqual({
+      accessToken: "gho_agent_a",
+      githubUsername: "octo-a",
+    });
+    expect(process.env.GITHUB_TOKEN).toBeUndefined();
+    const requestedUrl = String(fetchMock.mock.calls[0]?.[0]);
+    expect(requestedUrl).toBe(
+      "https://cloud.test/api/v1/managed/agents/agent-a/github/token",
+    );
+  });
+
+  it("skips the fetch entirely when a host env token is present", async () => {
+    armCloudEnv();
+    process.env.GITHUB_TOKEN = "host-level-token";
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(process.env.GITHUB_TOKEN).toBe("host-level-token");
+  });
+
+  it("returns null (no env mutation) on 404, non-OK, and malformed bodies", async () => {
+    armCloudEnv();
+    const cases = [
+      new Response("", { status: 404 }),
+      new Response("", { status: 500 }),
+      new Response(JSON.stringify({ success: true, data: {} }), {
+        status: 200,
+      }),
+    ];
+    for (const response of cases) {
+      globalThis.fetch = vi.fn(async () => response) as unknown as typeof fetch;
+      expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
+      expect(process.env.GITHUB_TOKEN).toBeUndefined();
+    }
+  });
+
+  it("returns null without fetching when cloud credentials or agent id are absent", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
+    armCloudEnv();
+    expect(await autoFetchCloudGithubToken(undefined)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the network fetch rejects", async () => {
+    armCloudEnv();
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
+    expect(process.env.GITHUB_TOKEN).toBeUndefined();
+  });
+});
+
+describe("bindCloudGithubTokenToRuntime", () => {
+  it("binds the token into the owning runtime's secrets only", () => {
+    const runtimeA = fakeRuntime();
+    const runtimeB = fakeRuntime();
+
+    const bound = bindCloudGithubTokenToRuntime(runtimeA, {
+      accessToken: "gho_agent_a",
+      githubUsername: "octo-a",
+    });
+
+    expect(bound).toBe(true);
+    expect(runtimeA.getSetting("GITHUB_TOKEN")).toBe("gho_agent_a");
+    // Co-tenant isolation: agent B resolves nothing, and the process env
+    // stays untouched for spawned subprocesses of other agents.
+    expect(runtimeB.getSetting("GITHUB_TOKEN")).toBeNull();
+    expect(process.env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("never overwrites an already-resolved token on the runtime", () => {
+    const runtime = fakeRuntime({ GITHUB_TOKEN: "gho_existing" });
+    const bound = bindCloudGithubTokenToRuntime(runtime, {
+      accessToken: "gho_late_fetch",
+      githubUsername: "octo-late",
+    });
+    expect(bound).toBe(false);
+    expect(runtime.getSetting("GITHUB_TOKEN")).toBe("gho_existing");
+  });
+
+  it("is a no-op for null or empty fetch results", () => {
+    const runtime = fakeRuntime();
+    expect(bindCloudGithubTokenToRuntime(runtime, null)).toBe(false);
+    expect(
+      bindCloudGithubTokenToRuntime(runtime, {
+        accessToken: "",
+        githubUsername: null,
+      }),
+    ).toBe(false);
+    expect(runtime.getSetting("GITHUB_TOKEN")).toBeNull();
+  });
+
+  it("keeps two agents' cloud tokens fully independent", () => {
+    const runtimeA = fakeRuntime();
+    const runtimeB = fakeRuntime();
+
+    bindCloudGithubTokenToRuntime(runtimeA, {
+      accessToken: "gho_agent_a",
+      githubUsername: "octo-a",
+    });
+    bindCloudGithubTokenToRuntime(runtimeB, {
+      accessToken: "gho_agent_b",
+      githubUsername: "octo-b",
+    });
+
+    // The later bind must not become the earlier agent's identity — the
+    // last-writer-wins overwrite was the core #15904 defect.
+    expect(runtimeA.getSetting("GITHUB_TOKEN")).toBe("gho_agent_a");
+    expect(runtimeB.getSetting("GITHUB_TOKEN")).toBe("gho_agent_b");
+    expect(process.env.GITHUB_TOKEN).toBeUndefined();
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2176,30 +2176,46 @@ export async function autoResolveDiscordAppId(
 }
 
 /**
- * Fetch GitHub OAuth token from cloud if available and no local token is set.
+ * Result of the cloud GitHub token fetch: the OAuth access token that the
+ * cloud minted for ONE managed agent, plus the GitHub login for boot logging.
+ * The token is agent identity material and must stay scoped to that agent —
+ * it is bound into the owning runtime's secrets via
+ * {@link bindCloudGithubTokenToRuntime}, never written to `process.env`
+ * (#15904: a process-global write leaks one agent's GitHub identity to every
+ * co-tenant agent in the host and lets a later fetch overwrite an earlier
+ * agent's credential).
+ */
+export interface CloudGithubTokenResult {
+  accessToken: string;
+  githubUsername: string | null;
+}
+
+/**
+ * Fetch the GitHub OAuth token the cloud holds for this managed agent, if any.
  * Called during async runtime init after cloud config is applied.
  *
- * Flow: If the agent has a managed GitHub connection in the cloud, and no
- * local GITHUB_TOKEN is set, fetch the OAuth token from the cloud API and
- * inject it into process.env so plugins (plugin-github, git-workspace-service)
- * can use it for API calls and git credential helpers.
+ * Returns the token instead of applying it anywhere: the caller binds it to
+ * the specific runtime that owns `agentId` with
+ * {@link bindCloudGithubTokenToRuntime}. A host-level GITHUB_TOKEN/GITHUB_PAT
+ * in the launch env still wins (it was folded into runtime settings at
+ * construction), so the fetch is skipped entirely in that case.
  */
 /** @internal Exported for testing. */
 export async function autoFetchCloudGithubToken(
   agentId?: string,
   timeoutMs = 3_000,
-): Promise<void> {
+): Promise<CloudGithubTokenResult | null> {
   // Skip if a local token is already configured
-  if (process.env.GITHUB_TOKEN || process.env.GITHUB_PAT) return;
+  if (process.env.GITHUB_TOKEN || process.env.GITHUB_PAT) return null;
 
   // Need cloud credentials and an agent ID
   const cloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY?.trim();
   const cloudBaseUrl =
     process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || "https://api.eliza.app";
-  if (!cloudApiKey || !agentId) return;
+  if (!cloudApiKey || !agentId) return null;
 
   const managedNs = readAliasedEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT");
-  if (!managedNs) return;
+  if (!managedNs) return null;
 
   try {
     const url = `${cloudBaseUrl}/api/v1/${managedNs}/agents/${encodeURIComponent(agentId)}/github/token`;
@@ -2218,22 +2234,50 @@ export async function autoFetchCloudGithubToken(
           `[eliza] Failed to fetch cloud GitHub token: ${res.status}`,
         );
       }
-      return;
+      return null;
     }
 
     const body = (await res.json()) as {
       success?: boolean;
       data?: { accessToken?: string; githubUsername?: string };
     };
-    if (!body.success || !body.data?.accessToken) return;
+    if (!body.success || !body.data?.accessToken) return null;
 
-    process.env.GITHUB_TOKEN = body.data.accessToken;
     logger.info(
       `[eliza] Fetched GitHub token from cloud for @${body.data.githubUsername || "unknown"}`,
     );
+    return {
+      accessToken: body.data.accessToken,
+      githubUsername: body.data.githubUsername ?? null,
+    };
   } catch (err) {
+    // error-policy:J4 boot-time cloud probe is best-effort; a missing managed
+    // GitHub connection degrades to "no token bound" and the connect UI stays
+    // the recovery path.
     logger.info(`[eliza] Could not fetch cloud GitHub token: ${err}`);
+    return null;
   }
+}
+
+/**
+ * Bind a cloud-fetched GitHub token to the runtime that owns it, as an
+ * agent-scoped secret resolved by `runtime.getSetting("GITHUB_TOKEN")`.
+ * Idempotent, and a no-op when the runtime already resolves a token (an
+ * explicit host env or per-agent secret always wins over the cloud fetch).
+ * Deliberately never touches `process.env`: subprocess spawners must pass the
+ * agent's own resolved token explicitly (see workspace-service), so one
+ * agent's cloud GitHub identity can never leak to co-tenant agents (#15904).
+ */
+/** @internal Exported for testing. */
+export function bindCloudGithubTokenToRuntime(
+  runtime: Pick<IAgentRuntime, "getSetting" | "setSetting">,
+  result: CloudGithubTokenResult | null,
+): boolean {
+  if (!result?.accessToken) return false;
+  const existing = runtime.getSetting("GITHUB_TOKEN");
+  if (typeof existing === "string" && existing.trim()) return false;
+  runtime.setSetting("GITHUB_TOKEN", result.accessToken, true);
+  return true;
 }
 
 /**
@@ -4008,9 +4052,11 @@ export async function startEliza(
   applyCloudConfigToEnv(config);
 
   // Kick off the Discord App ID lookup and the cloud GitHub token fetch (both
-  // network, up to a 3s timeout each) without blocking. They only write
-  // DISCORD_APPLICATION_ID and GITHUB_TOKEN respectively — env vars that no
-  // BLOCKING_CORE_PLUGIN reads. The Discord connector and GitHub/git plugins
+  // network, up to a 3s timeout each) without blocking. The Discord lookup
+  // writes DISCORD_APPLICATION_ID (an env var no BLOCKING_CORE_PLUGIN reads);
+  // the GitHub fetch returns a token that is bound to the owning runtime's
+  // agent-scoped secrets at the join site — never process.env (#15904). The
+  // Discord connector and GitHub/git plugins
   // both live in the DEFERRED set, so these joins are awaited inside
   // runDeferredBoot() (before the deferred plugin waves register), not on the
   // gated blocking path. Firing them here lets the round-trips overlap the
@@ -5461,8 +5507,14 @@ export async function startEliza(
       requiredPluginNames: REQUIRED_BLOCKING_CORE_PLUGINS,
       waitForBlockingEnvironment: async () => {
         // In block-deferred mode the Discord/GitHub plugins register here (not
-        // in runDeferredBoot), so join the env-var lookups before this wave.
-        await Promise.all([discordAppIdPromise, cloudGithubTokenPromise]);
+        // in runDeferredBoot), so join the boot lookups before this wave. The
+        // cloud GitHub token binds to THIS runtime's secrets only — never
+        // process.env (#15904).
+        const [, cloudGithubToken] = await Promise.all([
+          discordAppIdPromise,
+          cloudGithubTokenPromise,
+        ]);
+        bindCloudGithubTokenToRuntime(runtime, cloudGithubToken);
       },
       initializeCoreRuntime,
       ...(opts?.abortSignal ? { abortSignal: opts.abortSignal } : {}),
@@ -5661,14 +5713,17 @@ export async function startEliza(
 
     // Join the boot-time network lookups (Discord App ID, cloud GitHub token)
     // before resolving the deferred plugin set — the Discord connector and the
-    // GitHub/git plugins live in this deferred wave and read the env vars these
-    // promises write. Also join the Claude Code OAuth probe (informational
-    // logging only). All self-handle their errors, so this only waits.
-    await Promise.all([
+    // GitHub/git plugins live in this deferred wave. The cloud GitHub token is
+    // bound to this runtime's agent-scoped secrets, never process.env, so a
+    // co-tenant agent can neither read nor overwrite it (#15904). Also join
+    // the Claude Code OAuth probe (informational logging only). All
+    // self-handle their errors, so this only waits.
+    const [, cloudGithubToken] = await Promise.all([
       discordAppIdPromise,
       cloudGithubTokenPromise,
       subscriptionCredentialsDeferredPromise,
     ]);
+    bindCloudGithubTokenToRuntime(runtime, cloudGithubToken);
     abortSignal.throwIfAborted();
     bootTimer.lap("deferred:env-lookups");
 


### PR DESCRIPTION
Fixes #15904

## What

The cloud-managed GitHub OAuth token fetched at boot (`autoFetchCloudGithubToken` in `packages/agent/src/runtime/eliza.ts`) was written into `process.env.GITHUB_TOKEN`. On a shared multi-agent process this leaked one agent's GitHub identity to every co-tenant agent and let a later fetch/connect overwrite an earlier agent's credential — the exact last-writer-wins defect confirmed in the 2026-08-15 status recheck (`packages/agent/src/runtime/eliza.ts:2226` in that comment's line numbering).

This PR removes that process-global write and binds the token per agent:

- `autoFetchCloudGithubToken` now **returns** `CloudGithubTokenResult | null` and never touches `process.env`.
- New `bindCloudGithubTokenToRuntime(runtime, result)` binds the token into the **owning runtime's agent-scoped secrets** (`runtime.setSetting("GITHUB_TOKEN", token, true)`), where every per-agent consumer (`plugin-agent-orchestrator` workspace spawns, `plugin-github`, wave supervisor) already resolves it via `runtime.getSetting("GITHUB_TOKEN")`. It is idempotent and never overwrites an already-resolved token.
- Both boot join sites (block-deferred `waitForBlockingEnvironment` and `runDeferredBoot`) apply the bind to the runtime that owns the fetched `agentId`.
- An explicit host-level `GITHUB_TOKEN`/`GITHUB_PAT` in the launch env still wins: the fetch is skipped entirely (unchanged guard), and that value was already folded into runtime settings at construction.

Side benefit: `getSetting()` deliberately never reads live `process.env`, so the old post-construction env write was invisible to `getSetting` consumers anyway — the token only leaked to subprocesses and env readers. The agent-scoped bind makes the cloud token actually resolvable by the owning runtime.

## Scope

This lands the sharpest multi-agent leak (the cloud-managed per-agent token). The remaining #15904 work — replacing the documented single-user host PAT storage (`applySavedTokenToEnv`, first-run/config.env persistence) with agent-scoped guided-auth storage plus its legacy-migration policy, and the **live device-flow proof** — still requires the owner-facing blocker recorded on the issue: an elizaOS-owned GitHub OAuth App public Client ID with Device Flow enabled plus one human device-code approval (see closed draft #16339 and the 2026-07-23 triage). Those host-level writes are user-entered PATs under the documented single-user model, not the cross-agent cloud path fixed here.

## Verification

- `bunx vitest run src/runtime/cloud-github-token.test.ts` (packages/agent): **9/9 passed** — fetch returns token without env mutation; skips on host env token; null on 404/500/malformed/network-error with no env mutation; bind lands in owning runtime's secrets only; co-tenant runtime resolves nothing; never overwrites an existing token; two agents' tokens stay independent (last-writer-wins regression test).
- `bun run typecheck` (packages/agent): exit 0.
- `biome check` on touched files: clean.

Remaining human step (unchanged from issue triage): provision the elizaOS GitHub OAuth Client ID and perform one live device-code grant to capture the end-to-end live evidence for the guided flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
