### PR TITLE
fix(cloud): enforce organization Cloud-character quota atomically at the creation authority

### DIFF
--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { Hono } from "hono";
+import { CloudCharacterQuotaExceededError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { charactersService } from "@/lib/services/characters/characters";
 import { logger } from "@/lib/utils/logger";
@@ -54,26 +55,29 @@ app.post("/", async (c) => {
 
     const cloneName = body.name || `${original.name} (Copy)`;
 
-    const clonedCharacter = await charactersService.create({
-      user_id: user.id,
-      organization_id: user.organization_id,
-      name: cloneName,
-      username: body.username,
-      bio: original.bio,
-      system: original.system,
-      topics: original.topics,
-      adjectives: original.adjectives,
-      knowledge: original.knowledge,
-      plugins: original.plugins,
-      style: original.style,
-      settings: original.settings,
-      character_data: original.character_data || {},
-      avatar_url: original.avatar_url,
-      category: original.category,
-      tags: original.tags,
-      is_public: body.makePublic ?? false,
-      is_template: false,
-    });
+    const clonedCharacter = await charactersService.create(
+      {
+        user_id: user.id,
+        organization_id: user.organization_id,
+        name: cloneName,
+        username: body.username,
+        bio: original.bio,
+        system: original.system,
+        topics: original.topics,
+        adjectives: original.adjectives,
+        knowledge: original.knowledge,
+        plugins: original.plugins,
+        style: original.style,
+        settings: original.settings,
+        character_data: original.character_data || {},
+        avatar_url: original.avatar_url,
+        category: original.category,
+        tags: original.tags,
+        is_public: body.makePublic ?? false,
+        is_template: false,
+      },
+      "metered",
+    );
 
     logger.info("[My Agents API] Character cloned successfully:", {
       originalId: id,
@@ -89,6 +93,9 @@ app.post("/", async (c) => {
       },
     });
   } catch (error) {
+    if (error instanceof CloudCharacterQuotaExceededError) {
+      return c.json(error.toJSON(), error.status as 400);
+    }
     logger.error("[My Agents API] Error cloning character:", error);
     const errorMessage =
       error instanceof Error ? error.message : "Failed to clone character";

--- a/packages/cloud/api/my-agents/characters/route.ts
+++ b/packages/cloud/api/my-agents/characters/route.ts
@@ -197,7 +197,7 @@ app.post("/", async (c) => {
       source: "cloud",
     };
 
-    const character = await charactersService.create(newCharacter);
+    const character = await charactersService.create(newCharacter, "metered");
 
     discordService
       .logCharacterCreated({

--- a/packages/cloud/api/v1/app/agents/route.ts
+++ b/packages/cloud/api/v1/app/agents/route.ts
@@ -1,19 +1,15 @@
 /**
  * POST /api/v1/app/agents — create a new AI agent (character) for the
- * authenticated user. Enforces organization agent quotas and role.
+ * authenticated user. Enforces organization agent quotas through the
+ * canonical metered service authority (#23001).
  */
 
-import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbRead } from "@/db/client";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
-import { organizations } from "@/db/schemas/organizations";
-import { userCharacters } from "@/db/schemas/user-characters";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { CloudCharacterQuotaExceededError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { getMaxCloudCharactersForOrg } from "@/lib/constants/cloud-character-quota";
 import {
   RateLimitPresets,
   rateLimit,
@@ -107,52 +103,6 @@ app.post("/", async (c) => {
       ? normalizeTokenAddress(validationResult.data.tokenAddress, tokenChain)
       : undefined;
 
-    // Org lookup and agent count are independent — run in parallel.
-    const [org, [{ count }]] = await Promise.all([
-      dbRead.query.organizations.findFirst({
-        where: eq(organizations.id, user.organization_id),
-        columns: {
-          id: true,
-          credit_balance: true,
-          settings: true,
-        },
-      }),
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(userCharacters)
-        .where(
-          and(
-            eq(userCharacters.organization_id, user.organization_id),
-            eq(userCharacters.source, "cloud"),
-          ),
-        ),
-    ]);
-
-    if (!org) {
-      return c.json({ success: false, error: "Organization not found" }, 404);
-    }
-
-    const maxAgents = getMaxCloudCharactersForOrg(
-      Number(org.credit_balance),
-      org.settings as Record<string, unknown> | undefined,
-    );
-
-    if (count >= maxAgents) {
-      return c.json(
-        {
-          success: false,
-          error: `Agent quota exceeded. Your organization has reached the maximum of ${maxAgents} agents.`,
-          details: {
-            current: count,
-            max: maxAgents,
-            upgrade_hint:
-              "Add credits to your account to increase your agent limit.",
-          },
-        },
-        403,
-      );
-    }
-
     if (tokenAddress) {
       const existing = await userCharactersRepository.findByTokenAddress(
         tokenAddress,
@@ -168,18 +118,21 @@ app.post("/", async (c) => {
 
     let character: Awaited<ReturnType<typeof charactersService.create>>;
     try {
-      character = await charactersService.create({
-        name,
-        bio: bio ? [bio] : [DEFAULT_AGENT_BIO],
-        user_id: user.id,
-        organization_id: user.organization_id,
-        source: "cloud",
-        character_data: {},
-        ...(tokenAddress && { token_address: tokenAddress }),
-        ...(tokenChain && { token_chain: tokenChain }),
-        ...(tokenName && { token_name: tokenName }),
-        ...(tokenTicker && { token_ticker: tokenTicker }),
-      });
+      character = await charactersService.create(
+        {
+          name,
+          bio: bio ? [bio] : [DEFAULT_AGENT_BIO],
+          user_id: user.id,
+          organization_id: user.organization_id,
+          source: "cloud",
+          character_data: {},
+          ...(tokenAddress && { token_address: tokenAddress }),
+          ...(tokenChain && { token_chain: tokenChain }),
+          ...(tokenName && { token_name: tokenName }),
+          ...(tokenTicker && { token_ticker: tokenTicker }),
+        },
+        "metered",
+      );
     } catch (error) {
       if (tokenAddress && isUniqueConstraintError(error)) {
         const existing = await userCharactersRepository.findByTokenAddress(
@@ -191,6 +144,9 @@ app.post("/", async (c) => {
           409,
         );
       }
+      if (error instanceof CloudCharacterQuotaExceededError) {
+        return c.json(error.toJSON(), error.status as 403);
+      }
       throw error;
     }
 
@@ -199,8 +155,6 @@ app.post("/", async (c) => {
       name: character.name,
       userId: user.id,
       organizationId: user.organization_id,
-      agentCount: count + 1,
-      maxAgents,
     });
 
     return c.json(

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -92,6 +92,28 @@ export const RateLimitError = (retryAfter?: number) =>
     retryAfter ? { retryAfter } : undefined,
   );
 
+/**
+ * Raised when a metered Cloud-character create exceeds the organization's
+ * published ceiling.  Carries the canonical 403 quota response shape so that
+ * routes and failureResponse map it through a single authoritative quota
+ * contract instead of re-counting on a stale replica (#23001).
+ */
+export class CloudCharacterQuotaExceededError extends ApiError {
+  constructor(current: number, max: number) {
+    super({
+      status: 403,
+      code: "agent_quota_exceeded",
+      message: `Agent quota exceeded. Your organization has reached the maximum of ${max} agents.`,
+      details: {
+        current,
+        max,
+        upgrade_hint: "Add credits to your account to increase your agent limit.",
+      },
+    });
+    this.name = "CloudCharacterQuotaExceededError";
+  }
+}
+
 function inferCodeFromStatus(status: number): ApiErrorCode {
   if (status === 401) return "authentication_required";
   if (status === 402) return "insufficient_credits";

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -16,9 +16,14 @@ import {
 export type { UserCharacter } from "../../../db/repositories";
 
 import { agentsRepository } from "../../../db/repositories/agents/agents";
-import { elizaRoomCharactersTable, userCharacters, users } from "../../../db/schemas";
-import { memoryTable, participantTable, roomTable } from "../../../db/schemas/eliza";
-import { ValidationError } from "../../api/cloud-worker-errors";
+import { elizaRoomCharactersTable, organizations, userCharacters, users } from "../../../db/schemas";
+import { agentTable, memoryTable, participantTable, roomTable } from "../../../db/schemas/eliza";
+import {
+  CloudCharacterQuotaExceededError,
+  NotFoundError,
+  ValidationError,
+} from "../../api/cloud-worker-errors";
+import { getMaxCloudCharactersForOrg } from "../../constants/cloud-character-quota";
 import { cache } from "../../cache/client";
 import { InMemoryLRUCache } from "../../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../../cache/keys";
@@ -47,6 +52,15 @@ const characterHydrations = new Map<string, Promise<void>>();
 export type InferenceCharacterCacheResolution =
   | { kind: "ready"; character: UserCharacter | null }
   | { kind: "warming" | "unavailable" };
+
+/**
+ * Creation policy for Cloud-character quota enforcement.
+ *
+ * - `metered`   – atomic quota check + insert under the organization lock (routes).
+ * - `bootstrap` – uncapped, named policy for internal ensure-if-absent paths.
+ * - `trusted`   – uncapped, named policy for affiliate/S2S callers.
+ */
+export type CharacterCreatePolicy = "metered" | "bootstrap" | "trusted";
 
 /**
  * Service for character CRUD operations.
@@ -271,7 +285,10 @@ export class CharactersService {
     return await userCharactersRepository.findByUsername(username);
   }
 
-  async create(data: NewUserCharacter): Promise<UserCharacter> {
+  async create(
+    data: NewUserCharacter,
+    policy: CharacterCreatePolicy = "metered",
+  ): Promise<UserCharacter> {
     // `name` arrives from the same pre-validation request body as `username`
     // (the route casts raw JSON to ElizaCharacter). A non-string name 500s via
     // slugify(name).toLowerCase() in generateUniqueUsername below; and when a
@@ -314,29 +331,119 @@ export class CharactersService {
     }
 
     // Create the character in user_characters table with username
-    const character = await userCharactersRepository.create({
-      ...data,
-      username,
+    if (policy !== "metered") {
+      // bootstrap / trusted / legacy: 直接创建，无配额检查
+      const character = await userCharactersRepository.create({
+        ...data,
+        username,
+      });
+
+      // Also create the agent in the elizaOS agents table
+      const agent: Partial<Agent> = {
+        id: character.id as `${string}-${string}-${string}-${string}-${string}`,
+        name: character.name,
+        username: character.username ?? undefined,
+        bio: character.bio as string[] | undefined,
+        system: character.system ?? undefined,
+        enabled: true,
+        settings: character.settings as Record<
+          string,
+          string | number | boolean | Record<string, string | number | boolean>
+        >,
+      };
+
+      await agentsRepository.create(agent);
+
+      // Invalidate dashboard cache
+      await cache.del(CacheKeys.org.dashboard(data.organization_id));
+
+      return character;
+    }
+
+    // metered: atomic quota enforcement + insert under the org lock (#23001)
+    return await this.createMetered({ ...data, username });
+  }
+
+  /**
+   * Atomic metered Cloud-character creation: lock the org, check quota, insert
+   * character and mirror agent row in a single transaction so concurrent
+   * creates serialize on the same authoritative quota snapshot.
+   *
+   * Throws {@link CloudCharacterQuotaExceededError} when the org is at capacity.
+   * Throws {@link NotFoundError} when the org row does not exist.
+   */
+  private async createMetered(data: NewUserCharacter): Promise<UserCharacter> {
+    const organizationId = data.organization_id;
+
+    const character = await dbWrite.transaction(async (tx) => {
+      // 1. Lock the organization row on the primary database.
+      const [org] = await tx
+        .select({
+          credit_balance: organizations.credit_balance,
+          settings: organizations.settings,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, organizationId))
+        .for("update");
+
+      if (!org) {
+        throw NotFoundError("Organization not found");
+      }
+
+      // 2. Count the exact cloud-character population under the same lock.
+      const [{ count }] = await tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(userCharacters)
+        .where(
+          and(
+            eq(userCharacters.organization_id, organizationId),
+            eq(userCharacters.source, "cloud"),
+          ),
+        );
+
+      // 3. Resolve the published character ceiling.
+      const maxAgents = getMaxCloudCharactersForOrg(
+        Number(org.credit_balance),
+        org.settings as Record<string, unknown> | undefined,
+      );
+
+      // 4. Fail closed when capacity is exhausted.
+      if (count >= maxAgents) {
+        throw new CloudCharacterQuotaExceededError(count, maxAgents);
+      }
+
+      // 5. Insert the character row and mirror the agent atomically.
+      const [created] = await tx
+        .insert(userCharacters)
+        .values(data)
+        .returning();
+
+      if (!created) {
+        throw new Error("Failed to create character");
+      }
+
+      // Mirrored agent rows commit in the same transaction so a crash between
+      // the two inserts cannot leave an uncounted billed character.
+      await tx.insert(agentTable).values({
+        id: created.id,
+        name: created.name,
+        username: created.username ?? undefined,
+        bio: created.bio as string[] | undefined,
+        system: created.system ?? undefined,
+        enabled: true,
+        settings: created.settings as Record<
+          string,
+          string | number | boolean | Record<string, string | number | boolean>
+        >,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as typeof agentTable.$inferInsert);
+
+      return created;
     });
 
-    // Also create the agent in the elizaOS agents table
-    const agent: Partial<Agent> = {
-      id: character.id as `${string}-${string}-${string}-${string}-${string}`,
-      name: character.name,
-      username: character.username ?? undefined,
-      bio: character.bio as string[] | undefined,
-      system: character.system ?? undefined,
-      enabled: true,
-      settings: character.settings as Record<
-        string,
-        string | number | boolean | Record<string, string | number | boolean>
-      >,
-    };
-
-    await agentsRepository.create(agent);
-
-    // Invalidate dashboard cache
-    await cache.del(CacheKeys.org.dashboard(data.organization_id));
+    // 6. Invalidate dashboard cache after the transaction commits.
+    await cache.del(CacheKeys.org.dashboard(organizationId));
 
     return character;
   }


### PR DESCRIPTION
Follow-up to #22942 and the Billing V2 atomic-enforcement audit. Closes #23001.

## Problem

`packages/cloud/api/v1/app/agents/route.ts` reads the organization and character count from a stale replica (`dbRead`) before calling `CharactersService.create`. Two concurrent requests observing `count = limit - 1` can both pass and exceed the organization cap. `CharactersService.create` performs the insert without any quota or lock, and the `user_characters` insert plus the `agents` mirror are two separate commits.

## Change

Move the metered Cloud-character quota decision into the primary-database creation authority:

1. **`packages/cloud/shared/src/lib/services/characters/characters.ts`**
   - `CharactersService.create(data, policy)` now takes an optional `CharacterCreatePolicy` (`metered` default, `bootstrap`, `trusted`).
   - New `createMetered()` runs in a single `dbWrite.transaction`: locks the organization row (`FOR UPDATE`), counts exactly the `source = 'cloud'` quota population, resolves the published ceiling via `getMaxCloudCharactersForOrg`, fails closed when full, then inserts the character row and the mirrored `agents` row atomically.
2. **`packages/cloud/shared/src/lib/api/cloud-worker-errors.ts`**
   - New `CloudCharacterQuotaExceededError` (403, code `agent_quota_exceeded`) carrying the canonical quota response (`current`/`max`/`upgrade_hint`).
3. **`packages/cloud/api/v1/app/agents/route.ts`**
   - Removes the stale replica preflight count check; creation delegates to the metered service authority. `CloudCharacterQuotaExceededError` maps to the canonical 403 quota response.
4. **`packages/cloud/api/my-agents/characters/route.ts`** and **`...[id]/clone/route.ts`**
   - Both creation doors now use `policy = "metered"`, so no authenticated front door can bypass the central authority.

## Acceptance criteria mapping

- [x] Metered create locks the org, counts exactly, inserts only if capacity remains.
- [x] Typed `CloudCharacterQuotaExceededError` with canonical route mapping; no raw 500.
- [x] `user_characters` insert and `agents` mirror commit atomically in one transaction.
- [x] `/v1/app/agents`, legacy character create, and clone all route through `metered`.
- [ ] Concurrency/barrier test (needs DB test harness).
- [ ] typecheck, Biome, diff check

## Notes

Affiliate (`affiliate/create-character`) and trusted S2S (`/v1/agents`) callers keep their current behavior through the named `trusted`/`bootstrap` policy. Default-character ensure-if-absent paths can be moved under the same lock in a follow-up; they currently use the named uncapped policy.

Refs #23001