### PR TITLE
feat(corpus): snapshot-consistent Gmail collector with history reconciliation

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -62,6 +62,14 @@ implements `getProfile`, `listMessageIds`, `getMessage` (`format: "full"`),
 `getAttachment`, and `listHistory`, translating HTTP failures into
 `GmailTransportError` with the upstream status and any `Retry-After` hint.
 
+The adapter must pass Gmail responses through unprojected. In particular
+`listHistory` has to forward `messagesAdded`, `messagesDeleted`,
+`labelsAdded`, `labelsRemoved`, `nextPageToken`, and the page's terminal
+`historyId`: labels decide both inclusion (`DRAFT`/`CHAT`) and direction
+(`SENT`), so an adapter that returns only add/delete events leaves stale
+verdicts frozen in the corpus. `getMessage` must surface a deleted message as
+`GmailTransportError` with status 404 rather than an empty object.
+
 ```ts
 import { collectGmail, type GmailTransport } from "@elizaos/corpus-tools";
 
@@ -83,8 +91,15 @@ Behavior contract:
   staging JSONL so an interrupted run resumes without refetching.
 - A completed checkpoint is never trusted indefinitely: the next run
   reconciles through `users.history.list` from the checkpointed history id,
-  applying additions and deletions; an expired/invalid history id (HTTP
-  404/400) triggers a full rescan.
+  applying additions, deletions, and label changes; a relabeled id drops its
+  cached exclusion/staging verdict and is refetched, so a draft that becomes
+  real mail enters the corpus and a message relabeled `CHAT` leaves it. The
+  checkpoint then advances to the terminal `historyId` of the pages actually
+  applied (never backwards), not to the pre-reconciliation profile snapshot.
+  An expired/invalid history id (HTTP 404/400) triggers a full rescan.
+- A message deleted between `messages.list` and `messages.get` (HTTP 404) is
+  recorded as a deletion in `missingAtFetch` and excluded, not treated as a
+  fatal transport failure.
 - 429/5xx transport failures retry with bounded exponential backoff,
   honoring the server retry hint.
 - Ids are account-namespaced (`gmail:<account>:<messageId>`); direction is
@@ -92,9 +107,17 @@ Behavior contract:
   label; text prefers `text/plain` and falls back to stripped `text/html`;
   attachment bytes are fetched only to compute SHA-256 and size, and
   attachment-only messages are counted, never given fabricated text.
-- Output is private (0600 files, 0700 directories), account-isolated under
-  `gmail/<account>/`, byte-stable on rerun, serialized by a per-account
-  fail-closed lock, and committed by a validated `manifest.json`.
+- Output is private (0600 files, 0700 directories) and account-isolated under
+  `gmail/<segment>/`, where `<segment>` is the sanitized, collision-free
+  account segment (`corpusAccountSegment`) rather than the raw address, so an
+  address can never steer writes or the stale-shard sweep outside `outDir`.
+  Shards are byte-stable on rerun and committed by a validated
+  `manifest.json`.
+- Concurrency is serialized by a per-account lease file recording PID,
+  hostname and process start time. A live owner fails the second run closed
+  with `GMAIL_COLLECT_OUTPUT_BUSY`; a lease abandoned by SIGKILL/OOM is
+  detected as dead and recovered on the next run, so crash resume never needs
+  manual filesystem repair.
 
 Live-run acceptance evidence (two owner-authorized accounts, refresh-token
 exercise, interruption/resume, quota behavior, manual shard inspection) is

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -106,7 +106,16 @@ Behavior contract:
   alias-aware (`From` versus the account plus `aliasEmails`) or `SENT`
   label; text prefers `text/plain` and falls back to stripped `text/html`;
   attachment bytes are fetched only to compute SHA-256 and size, and
-  attachment-only messages are counted, never given fabricated text.
+  attachment-only messages are counted, never given fabricated text — the
+  empty-text verdict is reached before the attachment fetch, so a dropped
+  message spends no quota and `attachmentsHashed` counts only attachments that
+  reached the corpus.
+- Shards no longer named by a run are swept, but a run that emitted **no**
+  messages refuses to sweep and fails with
+  `GMAIL_COLLECT_EMPTY_SWEEP_REFUSED`. An expired history id forces a full
+  rescan, and a transiently empty listing on that path would otherwise unlink
+  the only local copy of the owner's mail. Pass `allowEmptySweep: true` to
+  delete once the empty result has been confirmed.
 - Output is private (0600 files, 0700 directories) and account-isolated under
   `gmail/<segment>/`, where `<segment>` is the sanitized, collision-free
   account segment (`corpusAccountSegment`) rather than the raw address, so an
@@ -117,7 +126,9 @@ Behavior contract:
   hostname and process start time. A live owner fails the second run closed
   with `GMAIL_COLLECT_OUTPUT_BUSY`; a lease abandoned by SIGKILL/OOM is
   detected as dead and recovered on the next run, so crash resume never needs
-  manual filesystem repair.
+  manual filesystem repair. Recovery displaces the dead record with an atomic
+  `rename` rather than an unlink, so two runs racing to recover the same
+  abandoned lease cannot both end up holding the account.
 
 Live-run acceptance evidence (two owner-authorized accounts, refresh-token
 exercise, interruption/resume, quota behavior, manual shard inspection) is

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -52,6 +52,53 @@ committed synthetic tree under
 Gmail mock consumes this loader via `ELIZA_CORPUS_DIR` /
 `startMocks({ corpusDir })` (see
 `packages/scenario-runner/test/mocks/scripts/google-gmail-corpus.ts`).
+## Gmail collector
+
+`collectGmail` (`src/collectors/gmail.ts`) collects one Gmail account into
+validated monthly shards through an injected `GmailTransport`. The package
+never holds OAuth material: a live run wraps the existing account-scoped
+plugin-google Gmail client (`gmail.read` scope) in a small adapter that
+implements `getProfile`, `listMessageIds`, `getMessage` (`format: "full"`),
+`getAttachment`, and `listHistory`, translating HTTP failures into
+`GmailTransportError` with the upstream status and any `Retry-After` hint.
+
+```ts
+import { collectGmail, type GmailTransport } from "@elizaos/corpus-tools";
+
+const result = await collectGmail({
+  transport: makePluginGoogleTransport(accountRef), // owner-side adapter
+  accountEmail: "owner@example.com",
+  aliasEmails: ["owner.alias@example.com"],
+  outDir: "data",
+});
+```
+
+Behavior contract:
+
+- The query is the frozen UTC corpus window expressed in epoch seconds
+  (Gmail's `after:yyyy/mm/dd` is local-timezone and would shift the cutoff);
+  chats are excluded and drafts are dropped by label.
+- Pagination runs to exhaustion with a durable checkpoint per page under
+  `data/.state/gmail-<account>.json`; fetched rows append to a private
+  staging JSONL so an interrupted run resumes without refetching.
+- A completed checkpoint is never trusted indefinitely: the next run
+  reconciles through `users.history.list` from the checkpointed history id,
+  applying additions and deletions; an expired/invalid history id (HTTP
+  404/400) triggers a full rescan.
+- 429/5xx transport failures retry with bounded exponential backoff,
+  honoring the server retry hint.
+- Ids are account-namespaced (`gmail:<account>:<messageId>`); direction is
+  alias-aware (`From` versus the account plus `aliasEmails`) or `SENT`
+  label; text prefers `text/plain` and falls back to stripped `text/html`;
+  attachment bytes are fetched only to compute SHA-256 and size, and
+  attachment-only messages are counted, never given fabricated text.
+- Output is private (0600 files, 0700 directories), account-isolated under
+  `gmail/<account>/`, byte-stable on rerun, serialized by a per-account
+  fail-closed lock, and committed by a validated `manifest.json`.
+
+Live-run acceptance evidence (two owner-authorized accounts, refresh-token
+exercise, interruption/resume, quota behavior, manual shard inspection) is
+owner-only and stays local; share only sanitized aggregate counts and digests.
 
 ## Reviewed sensitive deletion
 

--- a/packages/corpus-tools/src/collectors/gmail.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.test.ts
@@ -394,6 +394,17 @@ async function collect(
   });
 }
 
+/**
+ * A pid that is provably gone: a real child is started and awaited to exit, so
+ * the planted lease names a dead owner rather than a guessed number that could
+ * belong to a live process on the runner.
+ */
+async function deadPid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  return child.pid as number;
+}
+
 function lockPathFor(outDir: string): string {
   return path.join(outDir, ".state", `gmail-${ACCOUNT_SEGMENT}.lock`);
 }
@@ -432,10 +443,32 @@ function spawnLockHolder(outDir: string, readyPath: string): ChildProcess {
     ].join("\n"),
     "utf8",
   );
-  return spawn("bun", [script], { stdio: "ignore" });
+  // `--conditions=eliza-source` is how this repository resolves `@elizaos/*`
+  // to TypeScript sources without a prior build; vitest applies it to the
+  // parent, and without it the child resolves the unbuilt `dist` entry and
+  // dies before it can take the lease.
+  const child = spawn("bun", ["--conditions=eliza-source", script], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  // Without this the child's own failures (a missing `bun`, an unresolvable
+  // import) surface only as an opaque 30s readiness timeout, so its stderr is
+  // buffered and reported by `waitForFile`.
+  childStderr.set(child, "");
+  child.stderr?.on("data", (chunk: Buffer) => {
+    childStderr.set(child, `${childStderr.get(child) ?? ""}${chunk}`);
+  });
+  child.on("error", (error) => {
+    childStderr.set(child, `${childStderr.get(child) ?? ""}${error.message}\n`);
+  });
+  return child;
 }
 
-async function waitForFile(filePath: string): Promise<void> {
+const childStderr = new WeakMap<ChildProcess, string>();
+
+async function waitForFile(
+  filePath: string,
+  child?: ChildProcess,
+): Promise<void> {
   for (let attempt = 0; attempt < 600; attempt += 1) {
     try {
       await fs.stat(filePath);
@@ -444,7 +477,12 @@ async function waitForFile(filePath: string): Promise<void> {
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }
-  throw new Error(`child process never reported ready at ${filePath}`);
+  const stderr = child ? childStderr.get(child) : undefined;
+  throw new Error(
+    `child process never reported ready at ${filePath}${
+      stderr ? `\nchild stderr:\n${stderr}` : ""
+    }`,
+  );
 }
 
 describe("collectGmail", () => {
@@ -458,7 +496,13 @@ describe("collectGmail", () => {
     expect(result.summary.skippedOutsideWindow).toBe(1);
     expect(result.summary.skippedDrafts).toBe(1);
     expect(result.summary.skippedNoText).toBe(1);
-    expect(result.summary.attachmentsHashed).toBe(2);
+    // Only attachments on messages that reached the corpus are fetched and
+    // counted: the attachment-only message is dropped for empty text before
+    // its bytes are downloaded, so the counter describes the emitted shards.
+    expect(result.summary.attachmentsHashed).toBe(1);
+    expect(
+      transport.calls.filter((call) => call.startsWith("attachment:")),
+    ).toHaveLength(1);
     expect(result.manifest.totals.messages).toBe(3);
     expect(result.shardPaths).toHaveLength(2);
     // Exhaustive pagination: 6 ids at page size 2 needs 3 list pages.
@@ -816,7 +860,7 @@ describe("collectGmail", () => {
     const readyPath = path.join(outDir, "child-ready");
     const child = spawnLockHolder(outDir, readyPath);
     try {
-      await waitForFile(readyPath);
+      await waitForFile(readyPath, child);
 
       // A live competing owner still blocks this account.
       const blocked = new FakeGmailTransport(ACCOUNT, baseSpecs());
@@ -847,6 +891,83 @@ describe("collectGmail", () => {
       code: "ENOENT",
     });
   }, 60_000);
+
+  it("refuses to sweep existing shards when a rescan lists nothing", async () => {
+    const outDir = await makeTempDir();
+    const good = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const first = await collect(good, outDir);
+    expect(first.shardPaths.length).toBeGreaterThan(0);
+    const shardDir = path.join(outDir, "gmail", ACCOUNT_SEGMENT);
+    const before = (await fs.readdir(shardDir)).sort();
+
+    // No historyDelta means users.history.list reports the checkpoint expired,
+    // which forces a full rescan; this mailbox then lists zero messages.
+    const empty = new FakeGmailTransport(ACCOUNT, []);
+    await expect(collect(empty, outDir)).rejects.toMatchObject({
+      code: "GMAIL_COLLECT_EMPTY_SWEEP_REFUSED",
+    });
+
+    // The refusal must be fail-closed: the shards are still on disk.
+    expect((await fs.readdir(shardDir)).sort()).toEqual(before);
+    expect(before.some((entry) => entry.endsWith(".jsonl"))).toBe(true);
+  });
+
+  it("sweeps shards on an empty run only when the caller opts in", async () => {
+    const outDir = await makeTempDir();
+    await collect(new FakeGmailTransport(ACCOUNT, baseSpecs()), outDir);
+    const shardDir = path.join(outDir, "gmail", ACCOUNT_SEGMENT);
+
+    const empty = new FakeGmailTransport(ACCOUNT, []);
+    const result = await collect(empty, outDir, { allowEmptySweep: true });
+    expect(result.summary.mode).toBe("rescan");
+    expect(result.summary.listedIds).toBe(0);
+    expect(
+      (await fs.readdir(shardDir)).filter((entry) => entry.endsWith(".jsonl")),
+    ).toEqual([]);
+  });
+
+  it("never lets two concurrent runs recover the same abandoned lease", async () => {
+    // The stale-recovery branch is the one place the lease can be displaced,
+    // so it is exercised repeatedly: a single interleaving in which both runs
+    // judge the same dead record and then both take the account is a defect.
+    for (let trial = 0; trial < 30; trial += 1) {
+      const outDir = await makeTempDir();
+      await fs.mkdir(path.join(outDir, ".state"), { recursive: true });
+      await fs.writeFile(
+        lockPathFor(outDir),
+        `${JSON.stringify({
+          pid: await deadPid(),
+          hostname: os.hostname(),
+          startTimeMs: null,
+          acquiredAtMs: Date.now(),
+        })}\n`,
+        "utf8",
+      );
+
+      const settled = await Promise.allSettled([
+        collect(new FakeGmailTransport(ACCOUNT, baseSpecs()), outDir),
+        collect(new FakeGmailTransport(ACCOUNT, baseSpecs()), outDir),
+      ]);
+      const fulfilled = settled.filter((entry) => entry.status === "fulfilled");
+      expect(fulfilled).toHaveLength(1);
+      for (const entry of settled) {
+        if (entry.status === "rejected") {
+          expect(entry.reason).toMatchObject({
+            code: "GMAIL_COLLECT_OUTPUT_BUSY",
+          });
+        }
+      }
+      // The winner releases cleanly and leaves no takeover residue behind.
+      await expect(fs.stat(lockPathFor(outDir))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(
+        (await fs.readdir(path.join(outDir, ".state"))).filter((entry) =>
+          entry.includes(".stale-"),
+        ),
+      ).toEqual([]);
+    }
+  }, 120_000);
 
   it("writes private modes on shards, checkpoints, and state directories", async () => {
     const outDir = await makeTempDir();

--- a/packages/corpus-tools/src/collectors/gmail.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Deterministic unit and integration coverage for the Gmail collector against
+ * an in-memory fake transport that speaks real Gmail API response shapes. The
+ * harness is real at the filesystem boundary (shards, checkpoints, staging,
+ * manifest under a temp directory) with no network and no mocked module
+ * collaborators; retries use an injected recording sleep.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CORPUS_ANCHOR_MS, CORPUS_CUTOFF_MS } from "../schema.ts";
+import { validateCorpusTarget } from "../validator.ts";
+import {
+  collectGmail,
+  type GmailTransport,
+  GmailTransportError,
+  gmailCorpusQuery,
+} from "./gmail.ts";
+
+const ACCOUNT = "owner@example.com";
+const ALIAS = "owner.alias@example.com";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gmail-collect-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+function b64url(text: string): string {
+  return Buffer.from(text, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+interface FakeMessageSpec {
+  id: string;
+  threadId?: string;
+  ts: number;
+  from: string;
+  to?: string;
+  cc?: string;
+  subject?: string;
+  labelIds?: string[];
+  textPlain?: string;
+  textHtml?: string;
+  attachments?: Array<{ filename: string; mimeType: string; bytes: Buffer }>;
+  snippet?: string;
+}
+
+function buildApiMessage(spec: FakeMessageSpec): {
+  message: Record<string, unknown>;
+  attachmentBytes: Map<string, Buffer>;
+} {
+  const headers = [
+    { name: "From", value: spec.from },
+    ...(spec.to ? [{ name: "To", value: spec.to }] : []),
+    ...(spec.cc ? [{ name: "Cc", value: spec.cc }] : []),
+    ...(spec.subject ? [{ name: "Subject", value: spec.subject }] : []),
+  ];
+  const attachmentBytes = new Map<string, Buffer>();
+  const parts: Array<Record<string, unknown>> = [];
+  if (spec.textPlain !== undefined) {
+    parts.push({
+      partId: "0",
+      mimeType: "text/plain",
+      filename: "",
+      body: { data: b64url(spec.textPlain), size: spec.textPlain.length },
+    });
+  }
+  if (spec.textHtml !== undefined) {
+    parts.push({
+      partId: "1",
+      mimeType: "text/html",
+      filename: "",
+      body: { data: b64url(spec.textHtml), size: spec.textHtml.length },
+    });
+  }
+  for (const [index, attachment] of (spec.attachments ?? []).entries()) {
+    const attachmentId = `att-${spec.id}-${index}`;
+    attachmentBytes.set(attachmentId, attachment.bytes);
+    parts.push({
+      partId: `${2 + index}`,
+      mimeType: attachment.mimeType,
+      filename: attachment.filename,
+      body: { attachmentId, size: attachment.bytes.byteLength },
+    });
+  }
+  return {
+    message: {
+      id: spec.id,
+      threadId: spec.threadId ?? `thread-${spec.id}`,
+      labelIds: spec.labelIds ?? ["INBOX"],
+      snippet: spec.snippet ?? spec.textPlain?.slice(0, 40) ?? "",
+      internalDate: String(spec.ts),
+      payload: {
+        partId: "",
+        mimeType: "multipart/mixed",
+        filename: "",
+        headers,
+        body: { size: 0 },
+        parts,
+      },
+    },
+    attachmentBytes,
+  };
+}
+
+interface HistoryDeltaSpec {
+  added?: FakeMessageSpec[];
+  deletedIds?: string[];
+  expired?: boolean;
+}
+
+class FakeGmailTransport implements GmailTransport {
+  readonly calls: string[] = [];
+  historyId = "1000";
+  pageSize = 2;
+  historyDelta: HistoryDeltaSpec | undefined;
+  failGetMessageOnce = new Set<string>();
+  failListPageTokens = new Map<string, number>();
+  quota429sRemaining = 0;
+  quotaRetryAfterMs: number | undefined;
+
+  private readonly messages = new Map<string, Record<string, unknown>>();
+  private readonly attachments = new Map<string, Buffer>();
+  private order: string[] = [];
+
+  constructor(
+    private readonly accountEmail: string,
+    specs: FakeMessageSpec[],
+  ) {
+    for (const spec of specs) this.addMessage(spec);
+  }
+
+  addMessage(spec: FakeMessageSpec): void {
+    const built = buildApiMessage(spec);
+    this.messages.set(spec.id, built.message);
+    for (const [id, bytes] of built.attachmentBytes) {
+      this.attachments.set(`${spec.id}:${id}`, bytes);
+    }
+    this.order.push(spec.id);
+  }
+
+  removeMessage(id: string): void {
+    this.messages.delete(id);
+    this.order = this.order.filter((existing) => existing !== id);
+  }
+
+  async getProfile(): Promise<unknown> {
+    this.calls.push("getProfile");
+    return { emailAddress: this.accountEmail, historyId: this.historyId };
+  }
+
+  async listMessageIds(query: string, pageToken?: string): Promise<unknown> {
+    this.calls.push(`list:${pageToken ?? "first"}`);
+    if (this.quota429sRemaining > 0) {
+      this.quota429sRemaining -= 1;
+      throw new GmailTransportError("quota", {
+        status: 429,
+        retryAfterMs: this.quotaRetryAfterMs,
+      });
+    }
+    const key = pageToken ?? "first";
+    const failures = this.failListPageTokens.get(key) ?? 0;
+    if (failures > 0) {
+      this.failListPageTokens.set(key, failures - 1);
+      throw new GmailTransportError("backend", { status: 503 });
+    }
+    expect(query).toBe(gmailCorpusQuery());
+    const start = pageToken ? Number(pageToken) : 0;
+    const slice = this.order.slice(start, start + this.pageSize);
+    const nextStart = start + this.pageSize;
+    return {
+      messages: slice.map((id) => ({
+        id,
+        threadId: String(this.messages.get(id)?.threadId ?? `thread-${id}`),
+      })),
+      ...(nextStart < this.order.length
+        ? { nextPageToken: String(nextStart) }
+        : {}),
+    };
+  }
+
+  async getMessage(messageId: string): Promise<unknown> {
+    this.calls.push(`get:${messageId}`);
+    if (this.failGetMessageOnce.has(messageId)) {
+      this.failGetMessageOnce.delete(messageId);
+      throw new GmailTransportError("boom", { status: 500 });
+    }
+    const message = this.messages.get(messageId);
+    if (!message) throw new GmailTransportError("missing", { status: 404 });
+    return message;
+  }
+
+  async getAttachment(
+    messageId: string,
+    attachmentId: string,
+  ): Promise<Uint8Array> {
+    this.calls.push(`attachment:${messageId}:${attachmentId}`);
+    const bytes = this.attachments.get(`${messageId}:${attachmentId}`);
+    if (!bytes) throw new GmailTransportError("missing", { status: 404 });
+    return new Uint8Array(bytes);
+  }
+
+  async listHistory(
+    startHistoryId: string,
+    _pageToken?: string,
+  ): Promise<unknown> {
+    this.calls.push(`history:${startHistoryId}`);
+    const delta = this.historyDelta;
+    if (!delta || delta.expired) {
+      throw new GmailTransportError("history expired", { status: 404 });
+    }
+    for (const spec of delta.added ?? []) {
+      if (!this.messages.has(spec.id)) this.addMessage(spec);
+    }
+    return {
+      history: [
+        {
+          messagesAdded: (delta.added ?? []).map((spec) => ({
+            message: { id: spec.id },
+          })),
+          messagesDeleted: (delta.deletedIds ?? []).map((id) => ({
+            message: { id },
+          })),
+        },
+      ],
+      historyId: this.historyId,
+    };
+  }
+}
+
+const T0 = CORPUS_CUTOFF_MS + 24 * 3600 * 1000;
+const MONTH = 32 * 24 * 3600 * 1000;
+
+function baseSpecs(): FakeMessageSpec[] {
+  return [
+    {
+      id: "m1",
+      ts: T0,
+      from: "Alice Sender <alice@example.net>",
+      to: `Owner <${ACCOUNT}>`,
+      cc: "bob@example.net, Carol <carol@example.net>",
+      subject: "Hello there",
+      textPlain: "First inbound message body",
+    },
+    {
+      id: "m2",
+      ts: T0 + 3600 * 1000,
+      from: `Owner <${ACCOUNT}>`,
+      to: "alice@example.net",
+      subject: "Re: Hello there",
+      labelIds: ["SENT"],
+      textPlain: "Outbound reply body",
+      attachments: [
+        {
+          filename: "notes.pdf",
+          mimeType: "application/pdf",
+          bytes: Buffer.from("fake-pdf-bytes"),
+        },
+      ],
+    },
+    {
+      id: "m3",
+      ts: T0 + MONTH,
+      from: `Aliased Owner <${ALIAS}>`,
+      to: "dave@example.net",
+      subject: "From my alias",
+      labelIds: ["INBOX"],
+      textHtml: "<p>Hello &amp; <b>welcome</b></p>",
+    },
+    {
+      id: "m4",
+      ts: T0 + MONTH + 3600 * 1000,
+      from: "eve@example.net",
+      to: ACCOUNT,
+      subject: "Attachment only",
+      attachments: [
+        {
+          filename: "image.png",
+          mimeType: "image/png",
+          bytes: Buffer.from("png-bytes"),
+        },
+      ],
+    },
+    {
+      id: "m5",
+      ts: CORPUS_ANCHOR_MS + 1000,
+      from: "late@example.net",
+      to: ACCOUNT,
+      subject: "Too late",
+      textPlain: "outside window",
+    },
+    {
+      id: "m6",
+      ts: T0,
+      from: ACCOUNT,
+      subject: "A draft",
+      labelIds: ["DRAFT"],
+      textPlain: "draft body",
+    },
+  ];
+}
+
+async function collect(
+  transport: GmailTransport,
+  outDir: string,
+  overrides: Partial<Parameters<typeof collectGmail>[0]> = {},
+) {
+  return collectGmail({
+    transport,
+    accountEmail: ACCOUNT,
+    aliasEmails: [ALIAS],
+    outDir,
+    sleep: async () => {},
+    ...overrides,
+  });
+}
+
+describe("collectGmail", () => {
+  it("collects a full window with pagination, MIME, direction, and attachment hashes", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const result = await collect(transport, outDir);
+
+    expect(result.summary.mode).toBe("full");
+    expect(result.summary.listedIds).toBe(6);
+    expect(result.summary.skippedOutsideWindow).toBe(1);
+    expect(result.summary.skippedDrafts).toBe(1);
+    expect(result.summary.skippedNoText).toBe(1);
+    expect(result.summary.attachmentsHashed).toBe(2);
+    expect(result.manifest.totals.messages).toBe(3);
+    expect(result.shardPaths).toHaveLength(2);
+    // Exhaustive pagination: 6 ids at page size 2 needs 3 list pages.
+    expect(
+      transport.calls.filter((call) => call.startsWith("list:")),
+    ).toHaveLength(3);
+
+    const rows = (
+      await fs.readFile(
+        path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(rows.map((row) => row.id)).toEqual([
+      `gmail:${ACCOUNT}:m1`,
+      `gmail:${ACCOUNT}:m2`,
+    ]);
+    expect(rows[0].direction).toBe("in");
+    expect(rows[0].senderId).toBe("alice@example.net");
+    expect(rows[0].senderDisplay).toBe("Alice Sender");
+    expect(rows[0].recipients.map((r: { id: string }) => r.id)).toEqual([
+      ACCOUNT,
+      "bob@example.net",
+      "carol@example.net",
+    ]);
+    expect(rows[0].labels).toEqual(["gmail:inbox"]);
+    expect(rows[1].direction).toBe("out");
+    expect(rows[1].attachments).toEqual([
+      {
+        filename: "notes.pdf",
+        mimeType: "application/pdf",
+        sha256: createHash("sha256").update("fake-pdf-bytes").digest("hex"),
+        bytes: 14,
+      },
+    ]);
+
+    const august = JSON.parse(
+      (
+        await fs.readFile(
+          path.join(outDir, "gmail", ACCOUNT, "2024-08.jsonl"),
+          "utf8",
+        )
+      ).trim(),
+    );
+    expect(august.direction).toBe("out"); // alias-aware without SENT label
+    expect(august.text).toBe("Hello & welcome");
+
+    const validation = await validateCorpusTarget(outDir);
+    expect(validation.issues).toEqual([]);
+    expect(validation.ok).toBe(true);
+  });
+
+  it("is idempotent: a second run reconciles history and reuses byte-identical shards", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    await collect(transport, outDir);
+    const shardPath = path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl");
+    const before = await fs.readFile(shardPath, "utf8");
+    const statBefore = await fs.stat(shardPath);
+
+    transport.historyDelta = {}; // no changes since checkpoint
+    const second = await collect(transport, outDir);
+    expect(second.summary.mode).toBe("incremental");
+    expect(second.summary.fetched).toBe(0);
+    expect(second.summary.reusedFromStaging).toBe(3);
+    const statAfter = await fs.stat(shardPath);
+    expect(await fs.readFile(shardPath, "utf8")).toBe(before);
+    expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+  });
+
+  it("resumes an interrupted listing from the checkpointed page token without refetching staged mail", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    // Second page fails through all attempts; first page of ids gets staged.
+    transport.failListPageTokens.set("2", 99);
+    await expect(
+      collect(transport, outDir, { maxAttempts: 2 }),
+    ).rejects.toMatchObject({ code: "GMAIL_COLLECT_TRANSPORT_FAILED" });
+
+    const resumed = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const result = await collect(resumed, outDir);
+    expect(result.summary.mode).toBe("resume");
+    // Listing resumes at the persisted token instead of the first page.
+    expect(resumed.calls.filter((call) => call.startsWith("list:"))).toEqual([
+      "list:2",
+      "list:4",
+    ]);
+    expect(result.manifest.totals.messages).toBe(3);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("retries quota exhaustion with the server retry-after hint before succeeding", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    transport.quota429sRemaining = 2;
+    transport.quotaRetryAfterMs = 1234;
+    const sleeps: number[] = [];
+    const result = await collect(transport, outDir, {
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(result.summary.retriedCalls).toBe(2);
+    expect(sleeps).toEqual([1234, 1234]);
+    expect(result.manifest.totals.messages).toBe(3);
+  });
+
+  it("applies history additions and deletions on incremental runs", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    await collect(transport, outDir);
+
+    transport.historyDelta = {
+      added: [
+        {
+          id: "m7",
+          ts: T0 + 2 * MONTH,
+          from: "frank@example.net",
+          to: ACCOUNT,
+          subject: "Brand new",
+          textPlain: "new mail after first snapshot",
+        },
+      ],
+      deletedIds: ["m1"],
+    };
+    const result = await collect(transport, outDir);
+    expect(result.summary.mode).toBe("incremental");
+    expect(result.summary.removedByHistory).toBe(1);
+    expect(result.summary.fetched).toBe(1);
+    expect(result.manifest.totals.messages).toBe(3);
+
+    const july = await fs.readFile(
+      path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl"),
+      "utf8",
+    );
+    expect(july).not.toContain(`gmail:${ACCOUNT}:m1`);
+    expect(
+      await fs.readFile(
+        path.join(outDir, "gmail", ACCOUNT, "2024-09.jsonl"),
+        "utf8",
+      ),
+    ).toContain(`gmail:${ACCOUNT}:m7`);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("falls back to a full rescan when the checkpointed history id has expired", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    await collect(transport, outDir);
+
+    transport.historyDelta = { expired: true };
+    const result = await collect(transport, outDir);
+    expect(result.summary.mode).toBe("rescan");
+    // A rescan trusts nothing: every id is listed and refetched.
+    expect(result.summary.reusedFromStaging).toBe(0);
+    expect(result.summary.fetched).toBe(6);
+    expect(result.manifest.totals.messages).toBe(3);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("enforces account isolation when the transport resolves another mailbox", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport("other@example.com", []);
+    await expect(collect(transport, outDir)).rejects.toMatchObject({
+      code: "GMAIL_COLLECT_ACCOUNT_MISMATCH",
+    });
+  });
+
+  it("fails closed when another collector holds the account lock", async () => {
+    const outDir = await makeTempDir();
+    const lockPath = path.join(
+      outDir,
+      ".state",
+      "gmail-owner_example_com.lock",
+    );
+    await fs.mkdir(lockPath, { recursive: true });
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    await expect(collect(transport, outDir)).rejects.toMatchObject({
+      code: "GMAIL_COLLECT_OUTPUT_BUSY",
+    });
+  });
+
+  it("writes private modes on shards, checkpoints, and state directories", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const result = await collect(transport, outDir);
+    if (process.platform !== "win32") {
+      const shardMode = (await fs.stat(result.shardPaths[0])).mode & 0o777;
+      expect(shardMode).toBe(0o600);
+      const checkpointMode =
+        (await fs.stat(result.checkpointPath)).mode & 0o777;
+      expect(checkpointMode).toBe(0o600);
+      const stateDirMode =
+        (await fs.stat(path.join(outDir, ".state"))).mode & 0o777;
+      expect(stateDirMode).toBe(0o700);
+    }
+  });
+
+  it("rejects a malformed transport response instead of fabricating rows", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    transport.getMessage = async () => ({ nonsense: true });
+    await expect(collect(transport, outDir)).rejects.toMatchObject({
+      code: "GMAIL_COLLECT_BAD_RESPONSE",
+    });
+  });
+
+  it("recovers a torn staging row by refetching only that message", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    // Interrupt after the first fetch batch by failing m3 through all attempts.
+    transport.failGetMessageOnce.add("m3");
+    await expect(
+      collect(transport, outDir, { maxAttempts: 1 }),
+    ).rejects.toMatchObject({ code: "GMAIL_COLLECT_TRANSPORT_FAILED" });
+
+    // Corrupt the staged tail as an interrupted append would.
+    const stagingPath = path.join(
+      outDir,
+      ".state",
+      "gmail-owner_example_com-staging.ndjson",
+    );
+    const staged = await fs.readFile(stagingPath, "utf8");
+    await fs.writeFile(stagingPath, `${staged.trimEnd().slice(0, -5)}\n`);
+
+    const resumed = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const result = await collect(resumed, outDir);
+    expect(result.summary.mode).toBe("resume");
+    expect(result.manifest.totals.messages).toBe(3);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+});

--- a/packages/corpus-tools/src/collectors/gmail.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.test.ts
@@ -5,13 +5,14 @@
  * manifest under a temp directory) with no network and no mocked module
  * collaborators; retries use an injected recording sleep.
  */
+import { type ChildProcess, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { promises as fs } from "node:fs";
+import { promises as fs, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CORPUS_ANCHOR_MS, CORPUS_CUTOFF_MS } from "../schema.ts";
-import { validateCorpusTarget } from "../validator.ts";
+import { corpusAccountSegment, validateCorpusTarget } from "../validator.ts";
 import {
   collectGmail,
   type GmailTransport,
@@ -21,6 +22,7 @@ import {
 
 const ACCOUNT = "owner@example.com";
 const ALIAS = "owner.alias@example.com";
+const ACCOUNT_SEGMENT = corpusAccountSegment(ACCOUNT);
 
 const tempDirs: string[] = [];
 
@@ -118,10 +120,21 @@ function buildApiMessage(spec: FakeMessageSpec): {
   };
 }
 
+interface LabelChangeSpec {
+  id: string;
+  added?: string[];
+  removed?: string[];
+}
+
 interface HistoryDeltaSpec {
   added?: FakeMessageSpec[];
   deletedIds?: string[];
+  labelChanges?: LabelChangeSpec[];
   expired?: boolean;
+  /** Terminal `historyId` of the last history page, when it advanced. */
+  terminalHistoryId?: string;
+  /** Split the events across two pages to exercise history pagination. */
+  paginate?: boolean;
 }
 
 class FakeGmailTransport implements GmailTransport {
@@ -157,6 +170,11 @@ class FakeGmailTransport implements GmailTransport {
   removeMessage(id: string): void {
     this.messages.delete(id);
     this.order = this.order.filter((existing) => existing !== id);
+  }
+
+  /** Deletes the message body while the id stays in an already-served list page. */
+  vanishAfterListing(id: string): void {
+    this.messages.delete(id);
   }
 
   async getProfile(): Promise<unknown> {
@@ -215,11 +233,23 @@ class FakeGmailTransport implements GmailTransport {
     return new Uint8Array(bytes);
   }
 
+  /** Applies a label change to the stored message, as Gmail would. */
+  private applyLabelChange(change: LabelChangeSpec): string[] {
+    const message = this.messages.get(change.id);
+    const labels = new Set<string>(
+      Array.isArray(message?.labelIds) ? (message.labelIds as string[]) : [],
+    );
+    for (const label of change.added ?? []) labels.add(label);
+    for (const label of change.removed ?? []) labels.delete(label);
+    if (message) message.labelIds = [...labels];
+    return [...labels];
+  }
+
   async listHistory(
     startHistoryId: string,
-    _pageToken?: string,
+    pageToken?: string,
   ): Promise<unknown> {
-    this.calls.push(`history:${startHistoryId}`);
+    this.calls.push(`history:${startHistoryId}:${pageToken ?? "first"}`);
     const delta = this.historyDelta;
     if (!delta || delta.expired) {
       throw new GmailTransportError("history expired", { status: 404 });
@@ -227,18 +257,52 @@ class FakeGmailTransport implements GmailTransport {
     for (const spec of delta.added ?? []) {
       if (!this.messages.has(spec.id)) this.addMessage(spec);
     }
+    const labelRecords = (delta.labelChanges ?? []).map((change) => {
+      const labelIds = this.applyLabelChange(change);
+      return {
+        ...(change.added && change.added.length > 0
+          ? {
+              labelsAdded: [
+                {
+                  message: { id: change.id, labelIds },
+                  labelIds: change.added,
+                },
+              ],
+            }
+          : {}),
+        ...(change.removed && change.removed.length > 0
+          ? {
+              labelsRemoved: [
+                {
+                  message: { id: change.id, labelIds },
+                  labelIds: change.removed,
+                },
+              ],
+            }
+          : {}),
+      };
+    });
+    const messageRecord = {
+      messagesAdded: (delta.added ?? []).map((spec) => ({
+        message: { id: spec.id },
+      })),
+      messagesDeleted: (delta.deletedIds ?? []).map((id) => ({
+        message: { id },
+      })),
+    };
+    const terminal = delta.terminalHistoryId ?? this.historyId;
+    if (delta.paginate && pageToken === undefined) {
+      // The first page carries only the message events and a stale marker; the
+      // terminal marker must come from the last page.
+      return {
+        history: [messageRecord],
+        nextPageToken: "history-2",
+        historyId: startHistoryId,
+      };
+    }
     return {
-      history: [
-        {
-          messagesAdded: (delta.added ?? []).map((spec) => ({
-            message: { id: spec.id },
-          })),
-          messagesDeleted: (delta.deletedIds ?? []).map((id) => ({
-            message: { id },
-          })),
-        },
-      ],
-      historyId: this.historyId,
+      history: delta.paginate ? labelRecords : [messageRecord, ...labelRecords],
+      historyId: terminal,
     };
   }
 }
@@ -330,6 +394,59 @@ async function collect(
   });
 }
 
+function lockPathFor(outDir: string): string {
+  return path.join(outDir, ".state", `gmail-${ACCOUNT_SEGMENT}.lock`);
+}
+
+/**
+ * Runs a real second collector process that takes the account lease and then
+ * blocks forever inside the transport, so the parent can SIGKILL it and prove
+ * the abandoned lease is recoverable. `bun` is the repository-pinned runtime
+ * and executes the TypeScript entrypoint directly.
+ */
+function spawnLockHolder(outDir: string, readyPath: string): ChildProcess {
+  const script = path.join(outDir, "lock-holder.ts");
+  writeFileSync(
+    script,
+    [
+      `import { promises as fs } from "node:fs";`,
+      `import { collectGmail } from ${JSON.stringify(
+        path.join(import.meta.dirname, "gmail.ts"),
+      )};`,
+      `const transport = {`,
+      `  async getProfile() {`,
+      `    await fs.writeFile(${JSON.stringify(readyPath)}, "ready");`,
+      `    await new Promise(() => {});`,
+      `    return {};`,
+      `  },`,
+      `  async listMessageIds() { throw new Error("unreachable"); },`,
+      `  async getMessage() { throw new Error("unreachable"); },`,
+      `  async getAttachment() { throw new Error("unreachable"); },`,
+      `  async listHistory() { throw new Error("unreachable"); },`,
+      `};`,
+      `await collectGmail({`,
+      `  transport,`,
+      `  accountEmail: ${JSON.stringify(ACCOUNT)},`,
+      `  outDir: ${JSON.stringify(outDir)},`,
+      `});`,
+    ].join("\n"),
+    "utf8",
+  );
+  return spawn("bun", [script], { stdio: "ignore" });
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    try {
+      await fs.stat(filePath);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error(`child process never reported ready at ${filePath}`);
+}
+
 describe("collectGmail", () => {
   it("collects a full window with pagination, MIME, direction, and attachment hashes", async () => {
     const outDir = await makeTempDir();
@@ -351,7 +468,7 @@ describe("collectGmail", () => {
 
     const rows = (
       await fs.readFile(
-        path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl"),
+        path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-07.jsonl"),
         "utf8",
       )
     )
@@ -384,7 +501,7 @@ describe("collectGmail", () => {
     const august = JSON.parse(
       (
         await fs.readFile(
-          path.join(outDir, "gmail", ACCOUNT, "2024-08.jsonl"),
+          path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-08.jsonl"),
           "utf8",
         )
       ).trim(),
@@ -401,7 +518,12 @@ describe("collectGmail", () => {
     const outDir = await makeTempDir();
     const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
     await collect(transport, outDir);
-    const shardPath = path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl");
+    const shardPath = path.join(
+      outDir,
+      "gmail",
+      ACCOUNT_SEGMENT,
+      "2024-07.jsonl",
+    );
     const before = await fs.readFile(shardPath, "utf8");
     const statBefore = await fs.stat(shardPath);
 
@@ -477,17 +599,174 @@ describe("collectGmail", () => {
     expect(result.manifest.totals.messages).toBe(3);
 
     const july = await fs.readFile(
-      path.join(outDir, "gmail", ACCOUNT, "2024-07.jsonl"),
+      path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-07.jsonl"),
       "utf8",
     );
     expect(july).not.toContain(`gmail:${ACCOUNT}:m1`);
     expect(
       await fs.readFile(
-        path.join(outDir, "gmail", ACCOUNT, "2024-09.jsonl"),
+        path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-09.jsonl"),
         "utf8",
       ),
     ).toContain(`gmail:${ACCOUNT}:m7`);
     expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("re-evaluates label history: DRAFT removal, SENT addition, and CHAT addition", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const first = await collect(transport, outDir);
+    expect(first.summary.skippedDrafts).toBe(1);
+    expect(first.manifest.totals.messages).toBe(3);
+
+    // m6 leaves DRAFT and becomes real sent mail; m1 gains SENT (direction
+    // flips); m3 becomes a chat row and must leave the corpus. The events are
+    // paginated and arrive alongside an unrelated add and delete.
+    transport.historyDelta = {
+      added: [
+        {
+          id: "m7",
+          ts: T0 + 2 * MONTH,
+          from: "frank@example.net",
+          to: ACCOUNT,
+          subject: "Brand new",
+          textPlain: "new mail after first snapshot",
+        },
+      ],
+      deletedIds: ["m4"],
+      labelChanges: [
+        { id: "m6", removed: ["DRAFT"], added: ["SENT"] },
+        { id: "m1", added: ["SENT"] },
+        { id: "m3", added: ["CHAT"] },
+      ],
+      paginate: true,
+      terminalHistoryId: "2500",
+    };
+    const second = await collect(transport, outDir);
+    expect(second.summary.mode).toBe("incremental");
+    expect(second.summary.relabeledByHistory).toBe(3);
+    // Both history pages were consumed.
+    expect(
+      transport.calls.filter((call) => call.startsWith("history:")),
+    ).toEqual(["history:1000:first", "history:1000:history-2"]);
+    expect(second.summary.skippedChats).toBe(1);
+    expect(second.summary.skippedDrafts).toBe(0);
+
+    const july = (
+      await fs.readFile(
+        path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-07.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const byId = new Map(july.map((row) => [row.id, row]));
+    // The former draft is now collected instead of frozen in excludedIds.
+    expect(byId.has(`gmail:${ACCOUNT}:m6`)).toBe(true);
+    // A SENT label added after the fact flips a stale inbound verdict.
+    expect(byId.get(`gmail:${ACCOUNT}:m1`)?.direction).toBe("out");
+    // The message relabeled CHAT is gone from the August shard.
+    const augustPath = path.join(
+      outDir,
+      "gmail",
+      ACCOUNT_SEGMENT,
+      "2024-08.jsonl",
+    );
+    await expect(fs.stat(augustPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("checkpoints the terminal history id from the response, never moving backwards", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const first = await collect(transport, outDir);
+    const readCheckpoint = async () =>
+      JSON.parse(await fs.readFile(first.checkpointPath, "utf8"));
+    expect((await readCheckpoint()).historyId).toBe("1000");
+
+    // The mailbox moved during reconciliation: the profile snapshot is stale
+    // and only the terminal marker of the applied pages is authoritative.
+    transport.historyDelta = { terminalHistoryId: "4242" };
+    await collect(transport, outDir);
+    expect((await readCheckpoint()).historyId).toBe("4242");
+
+    // A page that reports an older marker must never rewind the checkpoint.
+    transport.historyDelta = { terminalHistoryId: "17" };
+    await collect(transport, outDir);
+    expect((await readCheckpoint()).historyId).toBe("4242");
+  });
+
+  it("treats a message deleted between listing and fetch as a deletion, not a fatal error", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const listed = transport.listMessageIds.bind(transport);
+    transport.listMessageIds = async (query: string, pageToken?: string) => {
+      const page = await listed(query, pageToken);
+      // m2 vanishes right after it is listed, exactly as a concurrent delete
+      // between users.messages.list and users.messages.get would.
+      transport.vanishAfterListing("m2");
+      return page;
+    };
+    const result = await collect(transport, outDir);
+    expect(result.summary.missingAtFetch).toBe(1);
+    expect(result.manifest.totals.messages).toBe(2);
+    expect(
+      await fs.readFile(
+        path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-07.jsonl"),
+        "utf8",
+      ),
+    ).not.toContain(`gmail:${ACCOUNT}:m2`);
+    // The dead id is remembered so later runs never refetch it.
+    const checkpoint = JSON.parse(
+      await fs.readFile(result.checkpointPath, "utf8"),
+    );
+    expect(checkpoint.excludedIds).toContain("m2");
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("keeps accounts in distinct directories inside outDir and rejects path-bearing addresses", async () => {
+    const outDir = await makeTempDir();
+    // Two distinct addresses whose sanitized spelling is identical.
+    const first = "a.b@example.com";
+    const second = "a-b@example.com";
+    expect(corpusAccountSegment(first)).not.toBe(corpusAccountSegment(second));
+
+    for (const account of [first, second]) {
+      const transport = new FakeGmailTransport(account, [
+        {
+          id: `${account}-m1`,
+          ts: T0,
+          from: "alice@example.net",
+          to: account,
+          subject: "Hello",
+          textPlain: "body",
+        },
+      ]);
+      const result = await collectGmail({
+        transport,
+        accountEmail: account,
+        outDir,
+        sleep: async () => {},
+      });
+      for (const shardPath of result.shardPaths) {
+        expect(path.relative(outDir, shardPath).startsWith("..")).toBe(false);
+      }
+    }
+    const accountDirs = await fs.readdir(path.join(outDir, "gmail"));
+    expect(accountDirs).toHaveLength(2);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+
+    // A traversal payload never reaches path.join in the first place.
+    const escaping = "a@../../etc.x";
+    await expect(
+      collectGmail({
+        transport: new FakeGmailTransport(escaping, []),
+        accountEmail: escaping,
+        outDir,
+        sleep: async () => {},
+      }),
+    ).rejects.toMatchObject({ code: "GMAIL_COLLECT_BAD_ACCOUNT" });
   });
 
   it("falls back to a full rescan when the checkpointed history id has expired", async () => {
@@ -513,19 +792,61 @@ describe("collectGmail", () => {
     });
   });
 
-  it("fails closed when another collector holds the account lock", async () => {
+  it("fails closed when a live process holds the account lease", async () => {
     const outDir = await makeTempDir();
-    const lockPath = path.join(
-      outDir,
-      ".state",
-      "gmail-owner_example_com.lock",
+    await fs.mkdir(path.join(outDir, ".state"), { recursive: true });
+    // This very process is a provably live, identity-matching owner.
+    await fs.writeFile(
+      lockPathFor(outDir),
+      `${JSON.stringify({
+        pid: process.pid,
+        hostname: os.hostname(),
+        startTimeMs: null,
+        acquiredAtMs: Date.now(),
+      })}\n`,
     );
-    await fs.mkdir(lockPath, { recursive: true });
     const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
     await expect(collect(transport, outDir)).rejects.toMatchObject({
       code: "GMAIL_COLLECT_OUTPUT_BUSY",
     });
   });
+
+  it("recovers a lease abandoned by a killed collector process", async () => {
+    const outDir = await makeTempDir();
+    const readyPath = path.join(outDir, "child-ready");
+    const child = spawnLockHolder(outDir, readyPath);
+    try {
+      await waitForFile(readyPath);
+
+      // A live competing owner still blocks this account.
+      const blocked = new FakeGmailTransport(ACCOUNT, baseSpecs());
+      await expect(collect(blocked, outDir)).rejects.toMatchObject({
+        code: "GMAIL_COLLECT_OUTPUT_BUSY",
+      });
+
+      const exited = new Promise<void>((resolve) =>
+        child.once("exit", resolve),
+      );
+      child.kill("SIGKILL");
+      await exited;
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+    }
+
+    // The killed process left its lease record behind; the next run must
+    // recover it instead of failing GMAIL_COLLECT_OUTPUT_BUSY forever.
+    expect(await fs.readFile(lockPathFor(outDir), "utf8")).toContain('"pid"');
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const result = await collect(transport, outDir);
+    expect(result.manifest.totals.messages).toBe(3);
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+    // The lease is released on the normal path.
+    await expect(fs.stat(lockPathFor(outDir))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  }, 60_000);
 
   it("writes private modes on shards, checkpoints, and state directories", async () => {
     const outDir = await makeTempDir();
@@ -565,7 +886,7 @@ describe("collectGmail", () => {
     const stagingPath = path.join(
       outDir,
       ".state",
-      "gmail-owner_example_com-staging.ndjson",
+      `gmail-${ACCOUNT_SEGMENT}-staging.ndjson`,
     );
     const staged = await fs.readFile(stagingPath, "utf8");
     await fs.writeFile(stagingPath, `${staged.trimEnd().slice(0, -5)}\n`);

--- a/packages/corpus-tools/src/collectors/gmail.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.test.ts
@@ -1018,4 +1018,50 @@ describe("collectGmail", () => {
     expect(result.manifest.totals.messages).toBe(3);
     expect((await validateCorpusTarget(outDir)).ok).toBe(true);
   });
+
+  // The relabel and crash-resume cases are covered separately above; this is
+  // the composition of the two, which is where the durability gap lived. A
+  // relabeled id has its staging verdict dropped in memory while the
+  // checkpoint advances historyId past the label event. If the process dies in
+  // between, the resume reloads the stale verdict from the staging file and no
+  // future incremental run ever re-sees that event.
+  it("does not resurrect a stale verdict when a relabel refetch crashes", async () => {
+    const outDir = await makeTempDir();
+    const transport = new FakeGmailTransport(ACCOUNT, baseSpecs());
+    const first = await collect(transport, outDir);
+    expect(first.manifest.totals.messages).toBe(3);
+
+    // m1 gains SENT, so its direction must flip from "in" to "out".
+    transport.historyDelta = {
+      added: [],
+      deletedIds: [],
+      labelChanges: [{ id: "m1", added: ["SENT"] }],
+      terminalHistoryId: "2500",
+    };
+
+    // Crash while refetching the relabeled id, after the checkpoint advanced.
+    const realGet = transport.getMessage.bind(transport);
+    transport.getMessage = async (messageId: string) => {
+      if (messageId === "m1") throw new Error("collector died mid-refetch");
+      return realGet(messageId);
+    };
+    await expect(collect(transport, outDir)).rejects.toThrow();
+
+    // A healthy third run must still produce the corrected direction.
+    transport.getMessage = realGet;
+    transport.historyDelta = undefined;
+    await collect(transport, outDir);
+
+    const july = (
+      await fs.readFile(
+        path.join(outDir, "gmail", ACCOUNT_SEGMENT, "2024-07.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const m1 = july.find((row) => row.id === `gmail:${ACCOUNT}:m1`);
+    expect(m1?.direction).toBe("out");
+  });
 });

--- a/packages/corpus-tools/src/collectors/gmail.ts
+++ b/packages/corpus-tools/src/collectors/gmail.ts
@@ -1222,6 +1222,21 @@ export async function collectGmail(
           ),
           completed: false,
         };
+        // Compact the staging file BEFORE persisting the checkpoint. The
+        // relabeled ids were dropped from `staging` in memory only, while this
+        // checkpoint advances `historyId` past the label event. A crash in
+        // between resumes from a checkpoint that will never re-see that event
+        // and reloads the stale verdict from the staging file — permanently,
+        // until an expired-history full rescan.
+        {
+          const stagedBody = [...staging.values()]
+            .map((row) => JSON.stringify(row))
+            .join("\n");
+          await writePrivateAtomic(
+            stagingPath,
+            stagedBody.length > 0 ? `${stagedBody}\n` : "",
+          );
+        }
         await saveCheckpoint(checkpoint);
       }
     } else if (checkpoint) {

--- a/packages/corpus-tools/src/collectors/gmail.ts
+++ b/packages/corpus-tools/src/collectors/gmail.ts
@@ -3,11 +3,13 @@
  * collector never holds OAuth material: callers inject a `GmailTransport`
  * (normally an adapter over the plugin-google account-scoped client) and this
  * module owns exhaustive pagination inside the frozen UTC corpus window,
- * bounded quota retries, durable per-account checkpoints with crash-safe
- * resume, real Gmail History reconciliation for completed checkpoints (an
- * expired history id triggers a full rescan rather than trusting the old
- * marker), alias/SENT-aware direction, MIME text extraction, attachment
- * SHA-256 hashing, and idempotent private monthly shards.
+ * bounded quota retries, durable per-account checkpoints guarded by a
+ * PID/start-time lease that a killed process cannot leave held forever, real
+ * Gmail History reconciliation for completed checkpoints (message, deletion and
+ * label events; an expired history id triggers a full rescan rather than
+ * trusting the old marker), alias/SENT-aware direction, MIME text extraction,
+ * attachment SHA-256 hashing, and idempotent private monthly shards written
+ * under a sanitized account segment.
  *
  * Compromises kept at this boundary: attachment-only messages carry no
  * fabricated text and are counted instead of emitted; `replyToId` is not
@@ -16,9 +18,12 @@
  * the local output tree, and all output is written mode 0600 under 0700
  * directories.
  */
+import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { ElizaError } from "@elizaos/core";
 import { z } from "zod";
 import {
@@ -34,6 +39,7 @@ import {
 import {
   buildCorpusManifest,
   type CorpusValidationIssue,
+  corpusAccountSegment,
 } from "../validator.ts";
 
 const PRIVATE_DIRECTORY_MODE = 0o700;
@@ -43,6 +49,13 @@ const DEFAULT_BACKOFF_BASE_MS = 1_000;
 const MAX_BACKOFF_MS = 64_000;
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const CHECKPOINT_SCHEMA_VERSION = 1;
+/**
+ * Only used when a lease cannot be identified (unparsable record, or a host
+ * whose process start times are unreadable). A lease whose owner process is
+ * provably gone is recovered immediately, without waiting out this bound.
+ */
+const LOCK_UNIDENTIFIED_STALE_MS = 6 * 60 * 60 * 1000;
+const LOCK_ACQUIRE_ATTEMPTS = 4;
 
 /** Typed transport failure; `status` drives retry and history-expiry logic. */
 export class GmailTransportError extends Error {
@@ -66,6 +79,12 @@ export class GmailTransportError extends Error {
  * (`format: "full"`), `users.messages.attachments.get`, and
  * `users.history.list`; adapters translate HTTP/auth failures into
  * `GmailTransportError` with the upstream status.
+ *
+ * `listHistory` must forward every history-record field the collector consumes
+ * — `messagesAdded`, `messagesDeleted`, `labelsAdded`, `labelsRemoved`, the
+ * page's terminal `historyId`, and `nextPageToken` — because labels decide both
+ * inclusion (DRAFT/CHAT) and direction (SENT). An adapter that projects the
+ * response down to add/delete events freezes stale verdicts in the corpus.
  */
 export interface GmailTransport {
   getProfile(): Promise<unknown>;
@@ -99,6 +118,10 @@ export interface GmailCollectSummary {
   fetched: number;
   reusedFromStaging: number;
   removedByHistory: number;
+  /** Ids re-evaluated because Gmail history reported a label change. */
+  relabeledByHistory: number;
+  /** Ids that vanished between listing and fetch; treated as deletions. */
+  missingAtFetch: number;
   skippedOutsideWindow: number;
   skippedDrafts: number;
   skippedChats: number;
@@ -165,6 +188,11 @@ const gmailMessageSchema = z.object({
   payload: gmailPartSchema,
 });
 
+const gmailLabelChangeSchema = z.object({
+  message: z.object({ id: z.string().min(1) }),
+  labelIds: z.array(z.string().min(1)).optional(),
+});
+
 const gmailHistoryPageSchema = z.object({
   history: z
     .array(
@@ -175,6 +203,8 @@ const gmailHistoryPageSchema = z.object({
         messagesDeleted: z
           .array(z.object({ message: z.object({ id: z.string().min(1) }) }))
           .optional(),
+        labelsAdded: z.array(gmailLabelChangeSchema).optional(),
+        labelsRemoved: z.array(gmailLabelChangeSchema).optional(),
       }),
     )
     .optional(),
@@ -248,7 +278,7 @@ export function gmailCorpusQuery(): string {
 
 function canonicalEmail(value: string, location: string): string {
   const email = value.trim().toLowerCase();
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+  if (!/^[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+$/.test(email)) {
     throw collectError(
       "GMAIL_COLLECT_BAD_ACCOUNT",
       `${location} must be a canonical email address`,
@@ -259,7 +289,7 @@ function canonicalEmail(value: string, location: string): string {
 }
 
 function accountFileSlug(email: string): string {
-  return email.replace(/[^a-z0-9]+/g, "_");
+  return corpusAccountSegment(email);
 }
 
 function decodeBase64Url(data: string): Buffer {
@@ -405,6 +435,178 @@ async function readOptionalFile(filePath: string): Promise<string | undefined> {
       error,
     );
   }
+}
+
+const execFileAsync = promisify(execFile);
+
+const lockLeaseSchema = z.object({
+  pid: z.number().int().positive(),
+  hostname: z.string().min(1),
+  /** Owner process start time; `null` when the platform cannot report it. */
+  startTimeMs: z.number().int().nonnegative().nullable(),
+  acquiredAtMs: z.number().int().nonnegative(),
+});
+
+type LockLease = z.infer<typeof lockLeaseSchema>;
+
+/**
+ * Second-resolution start time of a live process, used to distinguish a real
+ * lease owner from a recycled PID. Returns `undefined` when the platform
+ * cannot answer, which makes the caller fall back to the age bound.
+ */
+async function processStartTimeMs(pid: number): Promise<number | undefined> {
+  if (process.platform === "linux") {
+    const raw = await readOptionalFile(`/proc/${pid}/stat`);
+    if (raw === undefined) return undefined;
+    // Field 22 (starttime, clock ticks since boot) follows the comm field,
+    // which may itself contain spaces inside parentheses.
+    const fields = raw.slice(raw.lastIndexOf(") ") + 2).split(" ");
+    const ticks = Number(fields[19]);
+    if (!Number.isFinite(ticks)) return undefined;
+    return Math.floor((ticks / 100) * 1000);
+  }
+  if (process.platform === "darwin") {
+    try {
+      const { stdout } = await execFileAsync("ps", [
+        "-p",
+        String(pid),
+        "-o",
+        "lstart=",
+      ]);
+      const parsed = Date.parse(stdout.trim());
+      return Number.isFinite(parsed) ? parsed : undefined;
+    } catch {
+      // error-policy:J3 an unreadable/absent process is an explicit "unknown"
+      // start time, never a fabricated identity match.
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // error-policy:J3 EPERM means the pid exists under another user; only
+    // ESRCH proves the owner is gone.
+    return isRecord(error) && error.code === "EPERM";
+  }
+}
+
+/** Whether a lease record still names a live, identity-matching owner. */
+async function isLeaseHeld(lease: LockLease, nowMs: number): Promise<boolean> {
+  if (lease.hostname !== os.hostname()) {
+    // A foreign host's liveness is unknowable here; fail closed until the
+    // record ages out.
+    return nowMs - lease.acquiredAtMs < LOCK_UNIDENTIFIED_STALE_MS;
+  }
+  if (!isProcessAlive(lease.pid)) return false;
+  const startTimeMs = await processStartTimeMs(lease.pid);
+  if (startTimeMs === undefined || lease.startTimeMs === null) {
+    return nowMs - lease.acquiredAtMs < LOCK_UNIDENTIFIED_STALE_MS;
+  }
+  // A live pid whose start time moved is a recycled pid, not the owner.
+  return Math.abs(startTimeMs - lease.startTimeMs) <= 1_000;
+}
+
+/**
+ * Takes the per-account collector lease. The record carries PID, hostname and
+ * process start time so a lease abandoned by SIGKILL/OOM is recovered on the
+ * next run, while a lease whose owner is still running stays fail-closed.
+ */
+async function acquireAccountLock(lockPath: string): Promise<LockLease> {
+  const lease: LockLease = {
+    pid: process.pid,
+    hostname: os.hostname(),
+    startTimeMs: (await processStartTimeMs(process.pid)) ?? null,
+    acquiredAtMs: Date.now(),
+  };
+  const body = `${JSON.stringify(lease)}\n`;
+
+  for (let attempt = 1; attempt <= LOCK_ACQUIRE_ATTEMPTS; attempt += 1) {
+    try {
+      const handle = await fs.open(lockPath, "wx", PRIVATE_FILE_MODE);
+      try {
+        await handle.writeFile(body, "utf8");
+      } finally {
+        await handle.close();
+      }
+      return lease;
+    } catch (error) {
+      // error-policy:J2 only a contended lease is retried; anything else is a
+      // typed state-write failure for the caller.
+      if (!isRecord(error) || error.code !== "EEXIST") {
+        throw collectError(
+          "GMAIL_COLLECT_STATE_WRITE_FAILED",
+          "Gmail collector state lock could not be acquired",
+          { lockPath },
+          error,
+        );
+      }
+    }
+
+    const raw = await readOptionalFile(lockPath);
+    if (raw === undefined) continue; // the holder released between calls
+    const now = Date.now();
+    let held: boolean;
+    const parsed = (() => {
+      try {
+        return lockLeaseSchema.safeParse(JSON.parse(raw));
+      } catch {
+        // error-policy:J3 a torn lease record cannot identify an owner.
+        return undefined;
+      }
+    })();
+    if (parsed?.success) {
+      held = await isLeaseHeld(parsed.data, now);
+    } else {
+      const stat = await fs.stat(lockPath).catch(() => undefined);
+      held =
+        stat === undefined || now - stat.mtimeMs < LOCK_UNIDENTIFIED_STALE_MS;
+    }
+    if (held) {
+      throw collectError(
+        "GMAIL_COLLECT_OUTPUT_BUSY",
+        "Gmail collector state lock is held by a live collector for this account",
+        { lockPath, holder: parsed?.success ? parsed.data : "unidentified" },
+      );
+    }
+    await fs.rm(lockPath, { force: true });
+  }
+
+  throw collectError(
+    "GMAIL_COLLECT_OUTPUT_BUSY",
+    "Gmail collector state lock could not be acquired after stale recovery",
+    { lockPath, attempts: LOCK_ACQUIRE_ATTEMPTS },
+  );
+}
+
+/** Releases the lease only when this process still owns the record. */
+async function releaseAccountLock(
+  lockPath: string,
+  lease: LockLease,
+): Promise<void> {
+  const raw = await readOptionalFile(lockPath);
+  if (raw === undefined) return;
+  let current: unknown;
+  try {
+    current = JSON.parse(raw);
+  } catch {
+    // error-policy:J3 an unidentifiable record is not provably ours to remove.
+    return;
+  }
+  const parsed = lockLeaseSchema.safeParse(current);
+  if (
+    !parsed.success ||
+    parsed.data.pid !== lease.pid ||
+    parsed.data.hostname !== lease.hostname ||
+    parsed.data.acquiredAtMs !== lease.acquiredAtMs
+  ) {
+    return;
+  }
+  await fs.rm(lockPath, { force: true });
 }
 
 interface RunContext {
@@ -556,9 +758,25 @@ async function fetchAndNormalize(
   accountEmail: string,
   ownerAddresses: ReadonlySet<string>,
 ): Promise<CorpusMessage | undefined> {
-  const raw = await withRetry(ctx, `messages.get(${messageId})`, () =>
-    ctx.options.transport.getMessage(messageId),
-  );
+  let raw: unknown;
+  try {
+    raw = await withRetry(ctx, `messages.get(${messageId})`, () =>
+      ctx.options.transport.getMessage(messageId),
+    );
+  } catch (error) {
+    // error-policy:J4 a 404 means the message was deleted between listing and
+    // fetch; that is a mailbox state, not a run-fatal transport failure. It is
+    // recorded as an exclusion so later runs never refetch the dead id.
+    if (
+      error instanceof ElizaError &&
+      error.cause instanceof GmailTransportError &&
+      error.cause.status === 404
+    ) {
+      ctx.summary.missingAtFetch += 1;
+      return undefined;
+    }
+    throw error;
+  }
   const result = normalizeGmailMessage(
     raw,
     accountEmail,
@@ -673,6 +891,14 @@ async function listAllIds(
 interface HistoryDelta {
   added: Set<string>;
   deleted: Set<string>;
+  /**
+   * Ids whose label set changed. Labels decide both inclusion (DRAFT/CHAT) and
+   * direction (SENT), so these must be refetched and re-evaluated rather than
+   * left on their previous verdict.
+   */
+  relabeled: Set<string>;
+  /** Terminal marker from the last history page; the authoritative checkpoint. */
+  terminalHistoryId?: string;
   expired: boolean;
 }
 
@@ -682,6 +908,8 @@ async function listHistoryDelta(
 ): Promise<HistoryDelta> {
   const added = new Set<string>();
   const deleted = new Set<string>();
+  const relabeled = new Set<string>();
+  let terminalHistoryId: string | undefined;
   let pageToken: string | undefined;
   do {
     let raw: unknown;
@@ -697,7 +925,7 @@ async function listHistoryDelta(
         error.cause instanceof GmailTransportError &&
         (error.cause.status === 404 || error.cause.status === 400)
       ) {
-        return { added, deleted, expired: true };
+        return { added, deleted, relabeled, expired: true };
       }
       throw error;
     }
@@ -712,19 +940,36 @@ async function listHistoryDelta(
       for (const entry of record.messagesDeleted ?? []) {
         deleted.add(entry.message.id);
       }
+      for (const entry of [
+        ...(record.labelsAdded ?? []),
+        ...(record.labelsRemoved ?? []),
+      ]) {
+        relabeled.add(entry.message.id);
+      }
+    }
+    if (page.historyId !== undefined) {
+      terminalHistoryId = String(page.historyId);
     }
     pageToken = page.nextPageToken;
   } while (pageToken !== undefined);
-  return { added, deleted, expired: false };
+  return { added, deleted, relabeled, terminalHistoryId, expired: false };
+}
+
+/** Gmail history ids are monotonic; never move a checkpoint backwards. */
+function maxHistoryId(left: string, right: string): string {
+  return BigInt(left) >= BigInt(right) ? left : right;
 }
 
 /** Writes the desired Gmail shard set idempotently; unchanged shards are reused. */
 async function writeShards(
   messages: CorpusMessage[],
   outDir: string,
-  accountEmail: string,
+  accountSlug: string,
 ): Promise<{ paths: string[]; written: number; reused: number }> {
-  const shardDir = path.join(outDir, "gmail", accountEmail);
+  // The path segment is the sanitized slug, never the raw address: an address
+  // is untrusted input and a raw join would let it escape `outDir` and let the
+  // stale-shard sweep below unlink files outside the account directory.
+  const shardDir = path.join(outDir, "gmail", accountSlug);
   await ensurePrivateDir(path.join(outDir, "gmail"));
   await ensurePrivateDir(shardDir);
 
@@ -797,6 +1042,8 @@ export async function collectGmail(
       fetched: 0,
       reusedFromStaging: 0,
       removedByHistory: 0,
+      relabeledByHistory: 0,
+      missingAtFetch: 0,
       skippedOutsideWindow: 0,
       skippedDrafts: 0,
       skippedChats: 0,
@@ -818,29 +1065,17 @@ export async function collectGmail(
   const stagingPath = path.join(stateDir, `gmail-${slug}-staging.ndjson`);
   const lockPath = path.join(stateDir, `gmail-${slug}.lock`);
 
-  try {
-    await fs.mkdir(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
-  } catch (error) {
-    // error-policy:J2 a held lock means another collector owns this account.
-    throw collectError(
-      isRecord(error) && error.code === "EEXIST"
-        ? "GMAIL_COLLECT_OUTPUT_BUSY"
-        : "GMAIL_COLLECT_STATE_WRITE_FAILED",
-      "Gmail collector state lock could not be acquired",
-      { lockPath },
-      error,
-    );
-  }
+  const lease = await acquireAccountLock(lockPath);
 
   const releaseLock = async (suppress: boolean): Promise<void> => {
     try {
-      await fs.rmdir(lockPath);
+      await releaseAccountLock(lockPath, lease);
     } catch (error) {
-      // error-policy:J6 lock teardown failure only leaves a stale lock behind;
-      // the next run fails closed with GMAIL_COLLECT_OUTPUT_BUSY. On the
+      // error-policy:J6 teardown failure only leaves a lease record behind;
+      // it names this dead process and the next run recovers it. On the
       // failure path the original collection error must not be masked.
       if (suppress) return;
-      if (!isRecord(error) || error.code !== "ENOENT") throw error;
+      throw error;
     }
   };
 
@@ -904,11 +1139,26 @@ export async function collectGmail(
         // A history-added id may have been excluded before (e.g. a sent
         // draft); it must be re-evaluated rather than stay excluded.
         for (const id of delta.added) excluded.delete(id);
+        // A label change can flip inclusion (DRAFT/CHAT) or direction (SENT)
+        // without any messagesAdded event, so drop every cached verdict for
+        // the affected ids and force a refetch.
+        for (const id of delta.relabeled) {
+          if (delta.deleted.has(id)) continue;
+          ids.add(id);
+          excluded.delete(id);
+          staging.delete(`gmail:${accountEmail}:${id}`);
+          ctx.summary.relabeledByHistory += 1;
+        }
         checkpoint = {
           ...checkpoint,
           ids: [...ids],
           excludedIds: [...excluded],
-          historyId: profileHistoryId,
+          // The authoritative marker is the terminal history id of the pages
+          // just applied, not the pre-reconciliation profile snapshot.
+          historyId: maxHistoryId(
+            checkpoint.historyId,
+            delta.terminalHistoryId ?? profileHistoryId,
+          ),
           completed: false,
         };
         await saveCheckpoint(checkpoint);
@@ -984,11 +1234,7 @@ export async function collectGmail(
       await writePrivateAtomic(stagingPath, body.length > 0 ? `${body}\n` : "");
     }
 
-    const shardResult = await writeShards(
-      collected,
-      options.outDir,
-      accountEmail,
-    );
+    const shardResult = await writeShards(collected, options.outDir, slug);
     ctx.summary.shardCount = shardResult.paths.length;
 
     const { manifest, issues } = await buildCorpusManifest(
@@ -1003,7 +1249,7 @@ export async function collectGmail(
       );
     }
     await writePrivateAtomic(
-      path.join(options.outDir, "gmail", accountEmail, "summary.json"),
+      path.join(options.outDir, "gmail", slug, "summary.json"),
       `${JSON.stringify(ctx.summary, null, 2)}\n`,
     );
     await writePrivateAtomic(

--- a/packages/corpus-tools/src/collectors/gmail.ts
+++ b/packages/corpus-tools/src/collectors/gmail.ts
@@ -108,6 +108,13 @@ export interface GmailCollectorOptions {
   backoffBaseMs?: number;
   /** Injectable delay, defaulting to a real timer. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Permits the stale-shard sweep to delete existing shards on a run that
+   * emitted no messages. Off by default: an empty listing is far more often a
+   * transient Gmail condition than a genuinely emptied mailbox, and the shards
+   * are the only local copy of the owner's mail.
+   */
+  allowEmptySweep?: boolean;
 }
 
 export interface GmailCollectSummary {
@@ -573,7 +580,42 @@ async function acquireAccountLock(lockPath: string): Promise<LockLease> {
         { lockPath, holder: parsed?.success ? parsed.data : "unidentified" },
       );
     }
-    await fs.rm(lockPath, { force: true });
+    // Unlinking `lockPath` directly would be a TOCTOU hole: between the read
+    // above and the removal, another recoverer can have swept the same dead
+    // record and installed its own live lease, which the removal would then
+    // destroy, leaving two collectors on one account. `rename` is atomic, so
+    // exactly one recoverer wins the right to displace a record; the loser's
+    // rename fails and it falls through to the `wx` open, where it sees the
+    // winner's lease. The renamed body is compared against the record this
+    // process judged dead, and a record that changed underneath is put back
+    // rather than discarded.
+    const takeoverPath = `${lockPath}.stale-${process.pid}-${now}`;
+    try {
+      await fs.rename(lockPath, takeoverPath);
+    } catch (error) {
+      // error-policy:J3 losing the takeover race is an expected outcome; the
+      // next `wx` attempt observes whichever lease actually won.
+      if (!isRecord(error) || error.code !== "ENOENT") {
+        throw collectError(
+          "GMAIL_COLLECT_STATE_WRITE_FAILED",
+          "Gmail collector stale lease could not be displaced",
+          { lockPath },
+          error,
+        );
+      }
+      continue;
+    }
+    const takenOver = await readOptionalFile(takeoverPath);
+    if (takenOver !== raw) {
+      try {
+        await fs.rename(takeoverPath, lockPath);
+      } catch {
+        // error-policy:J6 the restore is best effort; if it fails the record is
+        // gone and the next `wx` attempt re-establishes a single owner.
+      }
+      continue;
+    }
+    await fs.rm(takeoverPath, { force: true });
   }
 
   throw collectError(
@@ -785,6 +827,15 @@ async function fetchAndNormalize(
   );
   if (!result) return undefined;
 
+  if (result.normalized.text.trim().length === 0) {
+    // Attachment-only or bodyless mail is counted, never given fabricated text.
+    // Decided before the attachment loop below so a message that will be
+    // dropped neither spends quota on its attachment bytes nor inflates
+    // `attachmentsHashed` past the attachments actually present in the corpus.
+    ctx.summary.skippedNoText += 1;
+    return undefined;
+  }
+
   for (const part of result.parts) {
     if (!part.filename || !part.body?.attachmentId) continue;
     const bytes = await withRetry(ctx, `attachments.get(${messageId})`, () =>
@@ -802,11 +853,6 @@ async function fetchAndNormalize(
     });
   }
 
-  if (result.normalized.text.trim().length === 0) {
-    // Attachment-only or bodyless mail is counted, never given fabricated text.
-    ctx.summary.skippedNoText += 1;
-    return undefined;
-  }
   return corpusMessageSchema.parse(result.normalized);
 }
 
@@ -965,6 +1011,7 @@ async function writeShards(
   messages: CorpusMessage[],
   outDir: string,
   accountSlug: string,
+  allowEmptySweep: boolean,
 ): Promise<{ paths: string[]; written: number; reused: number }> {
   // The path segment is the sanitized slug, never the raw address: an address
   // is untrusted input and a raw join would let it escape `outDir` and let the
@@ -1001,10 +1048,24 @@ async function writeShards(
     paths.push(shardPath);
   }
 
-  for (const entry of await fs.readdir(shardDir)) {
-    if (/^\d{4}-\d{2}\.jsonl$/.test(entry) && !wanted.has(entry)) {
-      await fs.unlink(path.join(shardDir, entry));
-    }
+  const stale = (await fs.readdir(shardDir)).filter(
+    (entry) => /^\d{4}-\d{2}\.jsonl$/.test(entry) && !wanted.has(entry),
+  );
+  // A run that emitted nothing has no evidence that the mailbox is empty: a
+  // transient backend condition, a momentarily non-matching query, or an
+  // adapter returning an empty page all reach here after an expired history id
+  // forces a full rescan. Sweeping on that signal would unlink the only local
+  // copy of the owner's mail, so an emptying run fails closed and the operator
+  // opts in explicitly once the emptiness is confirmed.
+  if (messages.length === 0 && stale.length > 0 && !allowEmptySweep) {
+    throw collectError(
+      "GMAIL_COLLECT_EMPTY_SWEEP_REFUSED",
+      "Gmail run produced no messages but existing shards would be deleted; rerun with allowEmptySweep once the empty result is confirmed",
+      { shardDir, staleShards: stale.sort() },
+    );
+  }
+  for (const entry of stale) {
+    await fs.unlink(path.join(shardDir, entry));
   }
   return { paths, written, reused };
 }
@@ -1234,7 +1295,12 @@ export async function collectGmail(
       await writePrivateAtomic(stagingPath, body.length > 0 ? `${body}\n` : "");
     }
 
-    const shardResult = await writeShards(collected, options.outDir, slug);
+    const shardResult = await writeShards(
+      collected,
+      options.outDir,
+      slug,
+      options.allowEmptySweep ?? false,
+    );
     ctx.summary.shardCount = shardResult.paths.length;
 
     const { manifest, issues } = await buildCorpusManifest(

--- a/packages/corpus-tools/src/collectors/gmail.ts
+++ b/packages/corpus-tools/src/collectors/gmail.ts
@@ -1,0 +1,1027 @@
+/**
+ * Snapshot-consistent Gmail API collector for the local personal corpus. The
+ * collector never holds OAuth material: callers inject a `GmailTransport`
+ * (normally an adapter over the plugin-google account-scoped client) and this
+ * module owns exhaustive pagination inside the frozen UTC corpus window,
+ * bounded quota retries, durable per-account checkpoints with crash-safe
+ * resume, real Gmail History reconciliation for completed checkpoints (an
+ * expired history id triggers a full rescan rather than trusting the old
+ * marker), alias/SENT-aware direction, MIME text extraction, attachment
+ * SHA-256 hashing, and idempotent private monthly shards.
+ *
+ * Compromises kept at this boundary: attachment-only messages carry no
+ * fabricated text and are counted instead of emitted; `replyToId` is not
+ * mapped because Gmail exposes RFC 822 references rather than same-shard
+ * corpus ids; drafts and chat rows are excluded. Raw mail bytes never leave
+ * the local output tree, and all output is written mode 0600 under 0700
+ * directories.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import { z } from "zod";
+import {
+  CORPUS_ANCHOR_ISO,
+  CORPUS_ANCHOR_MS,
+  CORPUS_CUTOFF_ISO,
+  CORPUS_CUTOFF_MS,
+  type CorpusManifest,
+  type CorpusMessage,
+  type CorpusRecipient,
+  corpusMessageSchema,
+} from "../schema.ts";
+import {
+  buildCorpusManifest,
+  type CorpusValidationIssue,
+} from "../validator.ts";
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BACKOFF_BASE_MS = 1_000;
+const MAX_BACKOFF_MS = 64_000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const CHECKPOINT_SCHEMA_VERSION = 1;
+
+/** Typed transport failure; `status` drives retry and history-expiry logic. */
+export class GmailTransportError extends Error {
+  readonly status: number;
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    options: { status: number; retryAfterMs?: number; cause?: unknown },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "GmailTransportError";
+    this.status = options.status;
+    this.retryAfterMs = options.retryAfterMs;
+  }
+}
+
+/**
+ * Minimal authenticated Gmail surface the collector consumes. Methods mirror
+ * `users.getProfile`, `users.messages.list`, `users.messages.get`
+ * (`format: "full"`), `users.messages.attachments.get`, and
+ * `users.history.list`; adapters translate HTTP/auth failures into
+ * `GmailTransportError` with the upstream status.
+ */
+export interface GmailTransport {
+  getProfile(): Promise<unknown>;
+  listMessageIds(query: string, pageToken?: string): Promise<unknown>;
+  getMessage(messageId: string): Promise<unknown>;
+  getAttachment(messageId: string, attachmentId: string): Promise<Uint8Array>;
+  listHistory(startHistoryId: string, pageToken?: string): Promise<unknown>;
+}
+
+export interface GmailCollectorOptions {
+  transport: GmailTransport;
+  /** Owner account email the transport must resolve to; enforces isolation. */
+  accountEmail: string;
+  /** Additional send-as addresses treated as the owner for direction. */
+  aliasEmails?: readonly string[];
+  /** Root under which `gmail/<account>/<yyyy-mm>.jsonl` is written. */
+  outDir: string;
+  /** Retry bound per transport call. */
+  maxAttempts?: number;
+  /** Backoff base for retryable statuses without a Retry-After hint. */
+  backoffBaseMs?: number;
+  /** Injectable delay, defaulting to a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface GmailCollectSummary {
+  schemaVersion: 1;
+  accountEmail: string;
+  mode: "full" | "resume" | "incremental" | "rescan";
+  listedIds: number;
+  fetched: number;
+  reusedFromStaging: number;
+  removedByHistory: number;
+  skippedOutsideWindow: number;
+  skippedDrafts: number;
+  skippedChats: number;
+  skippedNoText: number;
+  attachmentsHashed: number;
+  retriedCalls: number;
+  shardCount: number;
+}
+
+export interface GmailCollectResult {
+  summary: GmailCollectSummary;
+  manifest: CorpusManifest;
+  issues: CorpusValidationIssue[];
+  shardPaths: string[];
+  checkpointPath: string;
+}
+
+const gmailProfileSchema = z.object({
+  emailAddress: z.string().trim().min(3),
+  historyId: z.union([z.string().regex(/^\d+$/), z.number().int().positive()]),
+});
+
+const gmailListPageSchema = z.object({
+  messages: z
+    .array(z.object({ id: z.string().min(1), threadId: z.string().min(1) }))
+    .optional(),
+  nextPageToken: z.string().min(1).optional(),
+});
+
+const gmailBodySchema = z.object({
+  data: z.string().optional(),
+  attachmentId: z.string().min(1).optional(),
+  size: z.number().int().nonnegative().optional(),
+});
+
+interface GmailPartInput {
+  partId?: string;
+  mimeType?: string;
+  filename?: string;
+  headers?: Array<{ name: string; value: string }>;
+  body?: z.infer<typeof gmailBodySchema>;
+  parts?: GmailPartInput[];
+}
+
+const gmailPartSchema: z.ZodType<GmailPartInput> = z.lazy(() =>
+  z.object({
+    partId: z.string().optional(),
+    mimeType: z.string().optional(),
+    filename: z.string().optional(),
+    headers: z
+      .array(z.object({ name: z.string(), value: z.string() }))
+      .optional(),
+    body: gmailBodySchema.optional(),
+    parts: z.array(gmailPartSchema).optional(),
+  }),
+);
+
+const gmailMessageSchema = z.object({
+  id: z.string().min(1),
+  threadId: z.string().min(1),
+  labelIds: z.array(z.string().min(1)).optional(),
+  snippet: z.string().optional(),
+  internalDate: z.string().regex(/^\d+$/),
+  payload: gmailPartSchema,
+});
+
+const gmailHistoryPageSchema = z.object({
+  history: z
+    .array(
+      z.object({
+        messagesAdded: z
+          .array(z.object({ message: z.object({ id: z.string().min(1) }) }))
+          .optional(),
+        messagesDeleted: z
+          .array(z.object({ message: z.object({ id: z.string().min(1) }) }))
+          .optional(),
+      }),
+    )
+    .optional(),
+  nextPageToken: z.string().min(1).optional(),
+  historyId: z
+    .union([z.string().regex(/^\d+$/), z.number().int().positive()])
+    .optional(),
+});
+
+const checkpointSchema = z.object({
+  schemaVersion: z.literal(CHECKPOINT_SCHEMA_VERSION),
+  accountEmail: z.string().min(3),
+  query: z.string().min(1),
+  cutoffIso: z.literal(CORPUS_CUTOFF_ISO),
+  historyId: z.string().regex(/^\d+$/),
+  pageToken: z.string().min(1).optional(),
+  listComplete: z.boolean(),
+  ids: z.array(z.string().min(1)),
+  /** Ids fetched and deliberately not emitted (drafts, chats, out-of-window,
+   * no-text); persisted so incremental runs do not refetch them forever. */
+  excludedIds: z.array(z.string().min(1)).default([]),
+  completed: z.boolean(),
+});
+
+type GmailCheckpoint = z.infer<typeof checkpointSchema>;
+
+function collectError(
+  code: string,
+  message: string,
+  context: Record<string, unknown> = {},
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, { code, context, cause });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBoundary<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  location: string,
+): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw collectError(
+      "GMAIL_COLLECT_BAD_RESPONSE",
+      `${location} did not match the expected Gmail API shape`,
+      {
+        location,
+        issues: parsed.error.issues.map(
+          (issue) => `${issue.path.join(".")}: ${issue.message}`,
+        ),
+      },
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * The corpus window is expressed in epoch seconds because Gmail's
+ * `after:yyyy/mm/dd` form is interpreted in the mailbox's local timezone and
+ * would shift the frozen UTC cutoff by up to a day.
+ */
+export function gmailCorpusQuery(): string {
+  const afterSec = Math.floor(CORPUS_CUTOFF_MS / 1000);
+  const beforeSec = Math.ceil(CORPUS_ANCHOR_MS / 1000);
+  return `after:${afterSec} before:${beforeSec} -in:chats`;
+}
+
+function canonicalEmail(value: string, location: string): string {
+  const email = value.trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw collectError(
+      "GMAIL_COLLECT_BAD_ACCOUNT",
+      `${location} must be a canonical email address`,
+      { location },
+    );
+  }
+  return email;
+}
+
+function accountFileSlug(email: string): string {
+  return email.replace(/[^a-z0-9]+/g, "_");
+}
+
+function decodeBase64Url(data: string): Buffer {
+  return Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .trim();
+}
+
+interface ParsedAddress {
+  address?: string;
+  display?: string;
+}
+
+function parseAddress(raw: string): ParsedAddress {
+  const angled = raw.match(/^\s*(?:"?([^"<]*)"?\s*)?<([^<>\s]+@[^<>\s]+)>\s*$/);
+  if (angled) {
+    const display = angled[1]?.trim();
+    return {
+      address: angled[2].toLowerCase(),
+      display: display && display.length > 0 ? display : undefined,
+    };
+  }
+  const bare = raw.trim();
+  if (/^[^\s@]+@[^\s@]+$/.test(bare)) {
+    return { address: bare.toLowerCase() };
+  }
+  return { display: bare.length > 0 ? bare : undefined };
+}
+
+function splitAddressList(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inQuotes = false;
+  let current = "";
+  for (const char of value) {
+    if (char === '"') inQuotes = !inQuotes;
+    if (!inQuotes) {
+      if (char === "<") depth += 1;
+      if (char === ">") depth = Math.max(0, depth - 1);
+      if (char === "," && depth === 0) {
+        parts.push(current);
+        current = "";
+        continue;
+      }
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+function headerValue(
+  headers: Array<{ name: string; value: string }> | undefined,
+  name: string,
+): string | undefined {
+  const match = headers?.find(
+    (header) => header.name.toLowerCase() === name.toLowerCase(),
+  );
+  const value = match?.value.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+interface FlattenedPart {
+  mimeType: string;
+  filename?: string;
+  body?: z.infer<typeof gmailBodySchema>;
+}
+
+function flattenParts(part: GmailPartInput, into: FlattenedPart[]): void {
+  if (part.parts && part.parts.length > 0) {
+    for (const child of part.parts) flattenParts(child, into);
+    return;
+  }
+  into.push({
+    mimeType: (part.mimeType ?? "application/octet-stream").toLowerCase(),
+    filename:
+      part.filename && part.filename.trim().length > 0
+        ? part.filename
+        : undefined,
+    body: part.body,
+  });
+}
+
+function extractText(parts: FlattenedPart[]): string {
+  const plain = parts.find(
+    (part) => part.mimeType === "text/plain" && !part.filename,
+  );
+  if (plain?.body?.data) {
+    return decodeBase64Url(plain.body.data).toString("utf8").trim();
+  }
+  const html = parts.find(
+    (part) => part.mimeType === "text/html" && !part.filename,
+  );
+  if (html?.body?.data) {
+    return stripHtml(decodeBase64Url(html.body.data).toString("utf8"));
+  }
+  return "";
+}
+
+async function ensurePrivateDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  if (process.platform !== "win32") {
+    await fs.chmod(dir, PRIVATE_DIRECTORY_MODE);
+  }
+}
+
+async function writePrivateAtomic(
+  filePath: string,
+  body: string,
+): Promise<void> {
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await fs.writeFile(tempPath, body, {
+    encoding: "utf8",
+    mode: PRIVATE_FILE_MODE,
+  });
+  await fs.rename(tempPath, filePath);
+}
+
+async function readOptionalFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    // error-policy:J3 a missing state file is the explicit fresh-run state.
+    if (isRecord(error) && error.code === "ENOENT") return undefined;
+    throw collectError(
+      "GMAIL_COLLECT_STATE_READ_FAILED",
+      "Gmail collector state file could not be read",
+      { filePath },
+      error,
+    );
+  }
+}
+
+interface RunContext {
+  options: Required<
+    Pick<GmailCollectorOptions, "maxAttempts" | "backoffBaseMs" | "sleep">
+  > &
+    GmailCollectorOptions;
+  summary: GmailCollectSummary;
+}
+
+async function withRetry<T>(
+  ctx: RunContext,
+  operation: string,
+  call: () => Promise<T>,
+): Promise<T> {
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    try {
+      return await call();
+    } catch (error) {
+      // error-policy:J2 bounded quota/5xx retry; terminal failures rethrow typed.
+      const retryable =
+        error instanceof GmailTransportError &&
+        RETRYABLE_STATUSES.has(error.status);
+      if (!retryable || attempt >= ctx.options.maxAttempts) {
+        throw collectError(
+          "GMAIL_COLLECT_TRANSPORT_FAILED",
+          `Gmail ${operation} failed after ${attempt} attempt(s)`,
+          {
+            operation,
+            attempts: attempt,
+            status:
+              error instanceof GmailTransportError ? error.status : undefined,
+          },
+          error,
+        );
+      }
+      ctx.summary.retriedCalls += 1;
+      const transportError = error as GmailTransportError;
+      const backoff = Math.min(
+        ctx.options.backoffBaseMs * 2 ** (attempt - 1),
+        MAX_BACKOFF_MS,
+      );
+      await ctx.options.sleep(transportError.retryAfterMs ?? backoff);
+    }
+  }
+}
+
+/** Pre-validation candidate row; text may still be empty and attachments unfilled. */
+interface CandidateGmailMessage {
+  normalized: Omit<CorpusMessage, "subject" | "snippet" | "replyToId"> & {
+    subject?: string;
+    snippet?: string;
+  };
+  parts: FlattenedPart[];
+}
+
+function normalizeGmailMessage(
+  raw: unknown,
+  accountEmail: string,
+  ownerAddresses: ReadonlySet<string>,
+  summary: GmailCollectSummary,
+): CandidateGmailMessage | undefined {
+  const message = parseBoundary(
+    gmailMessageSchema,
+    raw,
+    "users.messages.get response",
+  );
+  const labelIds = message.labelIds ?? [];
+  if (labelIds.includes("DRAFT")) {
+    summary.skippedDrafts += 1;
+    return undefined;
+  }
+  if (labelIds.includes("CHAT")) {
+    summary.skippedChats += 1;
+    return undefined;
+  }
+  const ts = Number(message.internalDate);
+  if (
+    !Number.isSafeInteger(ts) ||
+    ts < CORPUS_CUTOFF_MS ||
+    ts > CORPUS_ANCHOR_MS
+  ) {
+    summary.skippedOutsideWindow += 1;
+    return undefined;
+  }
+
+  const headers = message.payload.headers;
+  const fromRaw = headerValue(headers, "From");
+  const from = fromRaw ? parseAddress(fromRaw) : {};
+  const fromOwner =
+    from.address !== undefined && ownerAddresses.has(from.address);
+  const direction: "in" | "out" =
+    fromOwner || labelIds.includes("SENT") ? "out" : "in";
+
+  const parts: FlattenedPart[] = [];
+  flattenParts(message.payload, parts);
+  const text = extractText(parts);
+
+  const recipients: CorpusRecipient[] = [];
+  for (const headerName of ["To", "Cc"]) {
+    const value = headerValue(headers, headerName);
+    if (!value) continue;
+    for (const entry of splitAddressList(value)) {
+      const parsed = parseAddress(entry);
+      const id = parsed.address ?? parsed.display;
+      if (!id) continue;
+      recipients.push({
+        id,
+        address: parsed.address,
+        display: parsed.display,
+      });
+    }
+  }
+
+  return {
+    normalized: {
+      id: `gmail:${accountEmail}:${message.id}`,
+      platform: "gmail" as const,
+      accountId: accountEmail,
+      threadId: `gmail:${accountEmail}:thread:${message.threadId}`,
+      ts,
+      direction,
+      senderId:
+        from.address ?? (direction === "out" ? accountEmail : "unknown"),
+      senderDisplay:
+        from.display ??
+        from.address ??
+        (direction === "out" ? accountEmail : "unknown"),
+      recipients,
+      subject: headerValue(headers, "Subject"),
+      snippet:
+        message.snippet && message.snippet.trim().length > 0
+          ? message.snippet
+          : undefined,
+      labels: labelIds.map((label) => `gmail:${label.toLowerCase()}`),
+      text,
+      attachments: [],
+      scrubState: "raw" as const,
+    },
+    parts,
+  };
+}
+
+async function fetchAndNormalize(
+  ctx: RunContext,
+  messageId: string,
+  accountEmail: string,
+  ownerAddresses: ReadonlySet<string>,
+): Promise<CorpusMessage | undefined> {
+  const raw = await withRetry(ctx, `messages.get(${messageId})`, () =>
+    ctx.options.transport.getMessage(messageId),
+  );
+  const result = normalizeGmailMessage(
+    raw,
+    accountEmail,
+    ownerAddresses,
+    ctx.summary,
+  );
+  if (!result) return undefined;
+
+  for (const part of result.parts) {
+    if (!part.filename || !part.body?.attachmentId) continue;
+    const bytes = await withRetry(ctx, `attachments.get(${messageId})`, () =>
+      ctx.options.transport.getAttachment(
+        messageId,
+        part.body?.attachmentId as string,
+      ),
+    );
+    ctx.summary.attachmentsHashed += 1;
+    result.normalized.attachments.push({
+      filename: part.filename,
+      mimeType: part.mimeType,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      bytes: bytes.byteLength,
+    });
+  }
+
+  if (result.normalized.text.trim().length === 0) {
+    // Attachment-only or bodyless mail is counted, never given fabricated text.
+    ctx.summary.skippedNoText += 1;
+    return undefined;
+  }
+  return corpusMessageSchema.parse(result.normalized);
+}
+
+async function loadCheckpoint(
+  checkpointPath: string,
+  accountEmail: string,
+  query: string,
+): Promise<GmailCheckpoint | undefined> {
+  const raw = await readOptionalFile(checkpointPath);
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // error-policy:J3 a corrupt checkpoint is an explicit rescan trigger.
+    return undefined;
+  }
+  const checkpoint = checkpointSchema.safeParse(parsed);
+  if (!checkpoint.success) return undefined;
+  if (
+    checkpoint.data.accountEmail !== accountEmail ||
+    checkpoint.data.query !== query
+  ) {
+    return undefined;
+  }
+  return checkpoint.data;
+}
+
+async function loadStaging(
+  stagingPath: string,
+  accountEmail: string,
+): Promise<Map<string, CorpusMessage>> {
+  const rows = new Map<string, CorpusMessage>();
+  const raw = await readOptionalFile(stagingPath);
+  if (raw === undefined) return rows;
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // error-policy:J3 a torn trailing row from a crash is dropped and refetched.
+      continue;
+    }
+    const message = corpusMessageSchema.safeParse(parsed);
+    if (!message.success || message.data.accountId !== accountEmail) continue;
+    rows.set(message.data.id, message.data);
+  }
+  return rows;
+}
+
+async function listAllIds(
+  ctx: RunContext,
+  query: string,
+  checkpoint: GmailCheckpoint,
+  saveCheckpoint: (next: GmailCheckpoint) => Promise<void>,
+): Promise<GmailCheckpoint> {
+  let state = checkpoint;
+  const seen = new Set(state.ids);
+  while (!state.listComplete) {
+    const pageToken = state.pageToken;
+    const page = parseBoundary(
+      gmailListPageSchema,
+      await withRetry(ctx, "messages.list", () =>
+        ctx.options.transport.listMessageIds(query, pageToken),
+      ),
+      "users.messages.list response",
+    );
+    // Pagination under mailbox mutation may repeat ids across pages.
+    for (const entry of page.messages ?? []) seen.add(entry.id);
+    state = {
+      ...state,
+      ids: [...seen],
+      pageToken: page.nextPageToken,
+      listComplete: page.nextPageToken === undefined,
+    };
+    await saveCheckpoint(state);
+  }
+  return state;
+}
+
+interface HistoryDelta {
+  added: Set<string>;
+  deleted: Set<string>;
+  expired: boolean;
+}
+
+async function listHistoryDelta(
+  ctx: RunContext,
+  startHistoryId: string,
+): Promise<HistoryDelta> {
+  const added = new Set<string>();
+  const deleted = new Set<string>();
+  let pageToken: string | undefined;
+  do {
+    let raw: unknown;
+    try {
+      raw = await withRetry(ctx, "history.list", () =>
+        ctx.options.transport.listHistory(startHistoryId, pageToken),
+      );
+    } catch (error) {
+      // error-policy:J4 an expired/invalid history id is Gmail's documented
+      // signal that the delta is unavailable; the caller performs a full rescan.
+      if (
+        error instanceof ElizaError &&
+        error.cause instanceof GmailTransportError &&
+        (error.cause.status === 404 || error.cause.status === 400)
+      ) {
+        return { added, deleted, expired: true };
+      }
+      throw error;
+    }
+    const page = parseBoundary(
+      gmailHistoryPageSchema,
+      raw,
+      "users.history.list response",
+    );
+    for (const record of page.history ?? []) {
+      for (const entry of record.messagesAdded ?? [])
+        added.add(entry.message.id);
+      for (const entry of record.messagesDeleted ?? []) {
+        deleted.add(entry.message.id);
+      }
+    }
+    pageToken = page.nextPageToken;
+  } while (pageToken !== undefined);
+  return { added, deleted, expired: false };
+}
+
+/** Writes the desired Gmail shard set idempotently; unchanged shards are reused. */
+async function writeShards(
+  messages: CorpusMessage[],
+  outDir: string,
+  accountEmail: string,
+): Promise<{ paths: string[]; written: number; reused: number }> {
+  const shardDir = path.join(outDir, "gmail", accountEmail);
+  await ensurePrivateDir(path.join(outDir, "gmail"));
+  await ensurePrivateDir(shardDir);
+
+  const buckets = new Map<string, CorpusMessage[]>();
+  for (const message of messages) {
+    const month = new Date(message.ts).toISOString().slice(0, 7);
+    const bucket = buckets.get(month) ?? [];
+    bucket.push(message);
+    buckets.set(month, bucket);
+  }
+
+  const paths: string[] = [];
+  const wanted = new Set<string>();
+  let written = 0;
+  let reused = 0;
+  for (const [month, bucket] of [...buckets.entries()].sort()) {
+    bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+    const fileName = `${month}.jsonl`;
+    wanted.add(fileName);
+    const shardPath = path.join(shardDir, fileName);
+    const body = `${bucket.map((row) => JSON.stringify(row)).join("\n")}\n`;
+    const existing = await readOptionalFile(shardPath);
+    if (existing === body) {
+      reused += 1;
+    } else {
+      await writePrivateAtomic(shardPath, body);
+      written += 1;
+    }
+    paths.push(shardPath);
+  }
+
+  for (const entry of await fs.readdir(shardDir)) {
+    if (/^\d{4}-\d{2}\.jsonl$/.test(entry) && !wanted.has(entry)) {
+      await fs.unlink(path.join(shardDir, entry));
+    }
+  }
+  return { paths, written, reused };
+}
+
+/**
+ * Collects one Gmail account into canonical local corpus shards. Reruns are
+ * idempotent: an interrupted run resumes from the durable checkpoint and
+ * staging file, and a completed checkpoint is reconciled through Gmail
+ * History instead of being trusted indefinitely.
+ */
+export async function collectGmail(
+  options: GmailCollectorOptions,
+): Promise<GmailCollectResult> {
+  const accountEmail = canonicalEmail(options.accountEmail, "accountEmail");
+  const ownerAddresses = new Set([
+    accountEmail,
+    ...(options.aliasEmails ?? []).map((alias, index) =>
+      canonicalEmail(alias, `aliasEmails[${index}]`),
+    ),
+  ]);
+  const ctx: RunContext = {
+    options: {
+      ...options,
+      maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      backoffBaseMs: options.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS,
+      sleep:
+        options.sleep ??
+        ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms))),
+    },
+    summary: {
+      schemaVersion: 1,
+      accountEmail,
+      mode: "full",
+      listedIds: 0,
+      fetched: 0,
+      reusedFromStaging: 0,
+      removedByHistory: 0,
+      skippedOutsideWindow: 0,
+      skippedDrafts: 0,
+      skippedChats: 0,
+      skippedNoText: 0,
+      attachmentsHashed: 0,
+      retriedCalls: 0,
+      shardCount: 0,
+    },
+  };
+  const query = gmailCorpusQuery();
+
+  const stateDir = path.join(options.outDir, ".state");
+  await ensurePrivateDir(options.outDir);
+  await ensurePrivateDir(stateDir);
+  const slug = accountFileSlug(accountEmail);
+  const checkpointPath = path.join(stateDir, `gmail-${slug}.json`);
+  // Staging must not use the .jsonl extension: the manifest builder sweeps
+  // every .jsonl under outDir and would reject this non-shard file.
+  const stagingPath = path.join(stateDir, `gmail-${slug}-staging.ndjson`);
+  const lockPath = path.join(stateDir, `gmail-${slug}.lock`);
+
+  try {
+    await fs.mkdir(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+  } catch (error) {
+    // error-policy:J2 a held lock means another collector owns this account.
+    throw collectError(
+      isRecord(error) && error.code === "EEXIST"
+        ? "GMAIL_COLLECT_OUTPUT_BUSY"
+        : "GMAIL_COLLECT_STATE_WRITE_FAILED",
+      "Gmail collector state lock could not be acquired",
+      { lockPath },
+      error,
+    );
+  }
+
+  const releaseLock = async (suppress: boolean): Promise<void> => {
+    try {
+      await fs.rmdir(lockPath);
+    } catch (error) {
+      // error-policy:J6 lock teardown failure only leaves a stale lock behind;
+      // the next run fails closed with GMAIL_COLLECT_OUTPUT_BUSY. On the
+      // failure path the original collection error must not be masked.
+      if (suppress) return;
+      if (!isRecord(error) || error.code !== "ENOENT") throw error;
+    }
+  };
+
+  let result: GmailCollectResult;
+  try {
+    result = await runCollection();
+  } catch (error) {
+    await releaseLock(true);
+    throw error;
+  }
+  await releaseLock(false);
+  return result;
+
+  async function runCollection(): Promise<GmailCollectResult> {
+    const profile = parseBoundary(
+      gmailProfileSchema,
+      await withRetry(ctx, "getProfile", () =>
+        ctx.options.transport.getProfile(),
+      ),
+      "users.getProfile response",
+    );
+    const profileEmail = canonicalEmail(
+      profile.emailAddress,
+      "profile.emailAddress",
+    );
+    if (profileEmail !== accountEmail) {
+      throw collectError(
+        "GMAIL_COLLECT_ACCOUNT_MISMATCH",
+        "Gmail transport is authorized for a different account",
+        { expected: accountEmail, actual: profileEmail },
+      );
+    }
+    const profileHistoryId = String(profile.historyId);
+
+    const saveCheckpoint = async (next: GmailCheckpoint): Promise<void> => {
+      await writePrivateAtomic(
+        checkpointPath,
+        `${JSON.stringify(next, null, 2)}\n`,
+      );
+    };
+
+    let checkpoint = await loadCheckpoint(checkpointPath, accountEmail, query);
+    let staging = await loadStaging(stagingPath, accountEmail);
+
+    if (checkpoint?.completed) {
+      const delta = await listHistoryDelta(ctx, checkpoint.historyId);
+      if (delta.expired) {
+        ctx.summary.mode = "rescan";
+        checkpoint = undefined;
+        staging = new Map();
+      } else {
+        ctx.summary.mode = "incremental";
+        const ids = new Set(checkpoint.ids);
+        for (const id of delta.added) ids.add(id);
+        const excluded = new Set(checkpoint.excludedIds);
+        for (const id of delta.deleted) {
+          if (ids.delete(id)) ctx.summary.removedByHistory += 1;
+          excluded.delete(id);
+          staging.delete(`gmail:${accountEmail}:${id}`);
+        }
+        // A history-added id may have been excluded before (e.g. a sent
+        // draft); it must be re-evaluated rather than stay excluded.
+        for (const id of delta.added) excluded.delete(id);
+        checkpoint = {
+          ...checkpoint,
+          ids: [...ids],
+          excludedIds: [...excluded],
+          historyId: profileHistoryId,
+          completed: false,
+        };
+        await saveCheckpoint(checkpoint);
+      }
+    } else if (checkpoint) {
+      ctx.summary.mode = "resume";
+    }
+
+    if (!checkpoint) {
+      if (ctx.summary.mode !== "rescan") ctx.summary.mode = "full";
+      staging = new Map();
+      await fs.rm(stagingPath, { force: true });
+      checkpoint = {
+        schemaVersion: CHECKPOINT_SCHEMA_VERSION,
+        accountEmail,
+        query,
+        cutoffIso: CORPUS_CUTOFF_ISO,
+        // The snapshot marker is captured before listing so mailbox changes
+        // during this run are reconciled by the next incremental run.
+        historyId: profileHistoryId,
+        listComplete: false,
+        ids: [],
+        excludedIds: [],
+        completed: false,
+      };
+      await saveCheckpoint(checkpoint);
+    }
+
+    checkpoint = await listAllIds(ctx, query, checkpoint, saveCheckpoint);
+    ctx.summary.listedIds = checkpoint.ids.length;
+
+    const wantedCorpusIds = new Set<string>();
+    const collected: CorpusMessage[] = [];
+    const excludedIds = new Set(checkpoint.excludedIds);
+    let stagingDirty = false;
+    for (const messageId of [...checkpoint.ids].sort()) {
+      const corpusId = `gmail:${accountEmail}:${messageId}`;
+      if (wantedCorpusIds.has(corpusId)) continue;
+      wantedCorpusIds.add(corpusId);
+      if (excludedIds.has(messageId)) continue;
+      const staged = staging.get(corpusId);
+      if (staged) {
+        ctx.summary.reusedFromStaging += 1;
+        collected.push(staged);
+        continue;
+      }
+      const normalized = await fetchAndNormalize(
+        ctx,
+        messageId,
+        accountEmail,
+        ownerAddresses,
+      );
+      ctx.summary.fetched += 1;
+      if (!normalized) {
+        excludedIds.add(messageId);
+        continue;
+      }
+      collected.push(normalized);
+      staging.set(corpusId, normalized);
+      await fs.appendFile(stagingPath, `${JSON.stringify(normalized)}\n`, {
+        mode: PRIVATE_FILE_MODE,
+      });
+      stagingDirty = true;
+    }
+
+    // Compact staging when history removals or dedup dropped rows so a
+    // deleted message cannot resurrect from stale staging on a later resume.
+    const staleStaging = [...staging.keys()].some(
+      (id) => !wantedCorpusIds.has(id),
+    );
+    if (staleStaging || stagingDirty) {
+      const body = collected.map((row) => JSON.stringify(row)).join("\n");
+      await writePrivateAtomic(stagingPath, body.length > 0 ? `${body}\n` : "");
+    }
+
+    const shardResult = await writeShards(
+      collected,
+      options.outDir,
+      accountEmail,
+    );
+    ctx.summary.shardCount = shardResult.paths.length;
+
+    const { manifest, issues } = await buildCorpusManifest(
+      options.outDir,
+      CORPUS_ANCHOR_ISO,
+    );
+    if (issues.length > 0) {
+      throw collectError(
+        "GMAIL_COLLECT_MANIFEST_INVALID",
+        "Gmail output failed corpus manifest validation",
+        { issueCount: issues.length, issues },
+      );
+    }
+    await writePrivateAtomic(
+      path.join(options.outDir, "gmail", accountEmail, "summary.json"),
+      `${JSON.stringify(ctx.summary, null, 2)}\n`,
+    );
+    await writePrivateAtomic(
+      path.join(options.outDir, "manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+    await saveCheckpoint({
+      ...checkpoint,
+      excludedIds: [...excludedIds].sort(),
+      completed: true,
+    });
+
+    return {
+      summary: ctx.summary,
+      manifest,
+      issues,
+      shardPaths: shardResult.paths,
+      checkpointPath,
+    };
+  }
+}

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -2,6 +2,7 @@
  * Public entry for corpus schema consumers, validators, and archive
  * collectors.
  */
+export * from "./collectors/gmail.ts";
 export * from "./collectors/telegram-desktop.ts";
 export * from "./collectors/x-archive.ts";
 export * from "./loader.ts";

--- a/packages/corpus-tools/src/validator.ts
+++ b/packages/corpus-tools/src/validator.ts
@@ -57,6 +57,17 @@ function sha256(bytes: string): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+/**
+ * Filesystem-safe, collision-free directory segment for an account id. Account
+ * ids are source-controlled strings (an email address, a handle) and must never
+ * reach `path.join` unsanitized; the digest suffix keeps distinct accounts that
+ * sanitize to the same characters in distinct directories.
+ */
+export function corpusAccountSegment(accountId: string): string {
+  const sanitized = accountId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  return `${sanitized}-${sha256(accountId).slice(0, 12)}`;
+}
+
 function isCorpusPlatform(value: string | undefined): value is CorpusPlatform {
   return corpusPlatforms.some((platform) => platform === value);
 }
@@ -181,7 +192,10 @@ export function parseCorpusShard(
   for (const message of result.messages) {
     if (
       message.platform !== pathInfo.platform ||
-      message.accountId !== pathInfo.accountId ||
+      // Collectors whose account id is not filesystem-safe write the sanitized
+      // segment instead of the raw id; both spellings identify the account.
+      (message.accountId !== pathInfo.accountId &&
+        corpusAccountSegment(message.accountId) !== pathInfo.accountId) ||
       new Date(message.ts).toISOString().slice(0, 7) !== pathInfo.month
     ) {
       result.issues.push({

--- a/packages/corpus-tools/src/validator.ts
+++ b/packages/corpus-tools/src/validator.ts
@@ -61,10 +61,15 @@ function sha256(bytes: string): string {
  * Filesystem-safe, collision-free directory segment for an account id. Account
  * ids are source-controlled strings (an email address, a handle) and must never
  * reach `path.join` unsanitized; the digest suffix keeps distinct accounts that
- * sanitize to the same characters in distinct directories.
+ * sanitize to the same characters in distinct directories. The readable prefix
+ * is truncated so a long address cannot push the segment past the 255-byte
+ * filename limit; collision-freedom rests on the digest, not the prefix.
  */
 export function corpusAccountSegment(accountId: string): string {
-  const sanitized = accountId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const sanitized = accountId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .slice(0, 100);
   return `${sanitized}-${sha256(accountId).slice(0, 12)}`;
 }
 
@@ -193,7 +198,10 @@ export function parseCorpusShard(
     if (
       message.platform !== pathInfo.platform ||
       // Collectors whose account id is not filesystem-safe write the sanitized
-      // segment instead of the raw id; both spellings identify the account.
+      // segment instead of the raw id, so both spellings are accepted for every
+      // platform. `corpusAccountSegment` is deterministic and collision-free,
+      // so accepting it does not let a shard claim another account's id; the
+      // collectors that still write raw ids simply never match that branch.
       (message.accountId !== pathInfo.accountId &&
         corpusAccountSegment(message.accountId) !== pathInfo.accountId) ||
       new Date(message.ts).toISOString().slice(0, 7) !== pathInfo.month


### PR DESCRIPTION
Fixes #14758

## What this PR delivers

A local-only, snapshot-consistent, multi-account Gmail collector in
`packages/corpus-tools`, complete and reviewable on its own. The scope of this
PR is the collector library and its contract: the module, its transport seam,
its durable state machine, its tests, and the package README adapter contract.
Nothing in this PR depends on the linked issue staying open; the issue tracks
the wider corpus program, this PR carries one finished component of it.

`collectGmail` (`src/collectors/gmail.ts`) takes an injected `GmailTransport`
(profile / paginated list / full message / attachment / history) and produces
validated private monthly shards. The package never holds OAuth material: a
live run wraps the existing account-scoped plugin-google Gmail client
(`gmail.read`) in an adapter whose contract is documented in the package
README.

### Collection semantics

- Frozen UTC window expressed in **epoch seconds** (`after:<sec> before:<sec>`)
  because Gmail's `after:yyyy/mm/dd` is local-timezone and would shift the
  frozen cutoff; chats excluded, drafts dropped by label.
- Exhaustive pagination with a durable per-page checkpoint plus an append-only
  staging file, so an interrupted run resumes at the persisted page token
  without refetching staged mail; torn staging tails are dropped and refetched;
  excluded ids are checkpointed so incremental runs do not refetch them.
- Bounded 429/5xx retries with exponential backoff honoring `Retry-After`.
- Account-namespaced ids (`gmail:<account>:<messageId>`), alias-aware and
  `SENT`-aware direction, `text/plain` preferred over stripped `text/html`,
  attachment bytes fetched only to compute SHA-256 + size, attachment-only
  messages counted and never given fabricated text.
- `getProfile` must resolve to the requested mailbox
  (`GMAIL_COLLECT_ACCOUNT_MISMATCH`); output is 0600 under 0700, byte-stable on
  rerun, and committed last by a schema-validated `manifest.json`.

### Correctness fixes in the current revision

Four defects found in review of the previous head are fixed here, each with a
test that fails without the fix:

1. **Crash-safe resume is now real.** The directory `mkdir` lock is replaced by
   a per-account lease record carrying PID, hostname, and process start time. A
   collector killed by SIGKILL/OOM used to leave the lock directory behind and
   wedge the account at `GMAIL_COLLECT_OUTPUT_BUSY` forever; the lease is now
   recognized as dead and recovered, while a still-running owner keeps failing
   the second run closed. Proven by a real subprocess that takes the lease,
   blocks, is SIGKILLed, and is then recovered by the next run.
2. **Label history is reconciled.** `users.history.list` also emits
   `labelsAdded`/`labelsRemoved`, and labels decide inclusion (`DRAFT`/`CHAT`)
   and direction (`SENT`). Label events are parsed and applied: a relabeled id
   drops its cached exclusion and staging verdict and is refetched, so a draft
   that becomes real mail enters the corpus, a message relabeled `CHAT` leaves
   it, and a late `SENT` label flips a stale inbound verdict. The transport
   interface and README adapter contract now require the unprojected history
   response.
3. **No path traversal or account collision through `accountEmail`.** Shards
   are written under the sanitized, collision-free `corpusAccountSegment`
   instead of the raw address, so an address can neither escape `outDir` (the
   stale-shard sweep unlinks inside that directory) nor collide with a
   different account that sanitizes identically. Path-bearing addresses are
   also rejected at validation.
4. **A message deleted mid-run is not fatal.** A 404 from `messages.get`
   between listing and fetch is recorded in `missingAtFetch` and excluded
   rather than aborting the run with `GMAIL_COLLECT_TRANSPORT_FAILED`.
5. **Exact checkpoint semantics.** The incremental checkpoint advances to the
   terminal `historyId` of the history pages actually applied, monotonically,
   instead of the `getProfile` snapshot captured before reconciliation.

No MBOX fallback was built, per the triage instruction (only if live API
evidence establishes a real blocker).

## Verification at this head

| Gate | Result |
| --- | --- |
| `bun run --cwd packages/corpus-tools test` | 7 files, **91/91 passed** |
| `bun run --cwd packages/corpus-tools typecheck` | clean |
| `bun run --cwd packages/corpus-tools lint` | clean |
| Frontend evidence (screenshots/video/console) | N/A — no UI surface in this PR |
| Live-model trajectories | N/A — no model call path in this PR |

```
Test Files  7 passed (7)
     Tests  91 passed (91)
```

The Gmail suite covers full-window pagination/MIME/direction/attachment hashing
plus `corpus validate`; idempotent incremental rerun with byte-identical shard
reuse; interrupted-list resume from the checkpointed page token; quota 429 retry
honoring `Retry-After`; history additions, deletions, and label events across
paginated history; expired-history full rescan; terminal-historyId checkpointing
with a monotonic guard; mid-run 404 deletion; account isolation, collision, and
traversal; subprocess kill/restart lease recovery with a live owner still
blocked; private file modes; malformed-response rejection; torn-staging
recovery.

## Live receipts before this PR leaves draft

This PR stays draft until the owner-held Google Cloud OAuth state lands (per the
maintainer's credential acceptance queue) and the live receipts below are
attached **to this PR**. They are this PR's own acceptance gate, not deferred
work for the issue:

1. Two real Gmail accounts authorized through plugin-google OAuth (`gmail.read`),
   exercising refresh tokens.
2. `collectGmail` run per account over the full frozen window through the
   adapter: full, incremental, and crash/restart resume, plus an observed live
   quota retry.
3. Owner inspection of shards, checkpoints, attachment hashes, and
   `manifest.json`, and `corpus validate data` on the produced tree.
4. Only sanitized aggregate counts and digests posted here; raw mail, mailbox
   contents, and credentials stay local (#14773).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
