### PR TITLE
fix(agent): persist interrupted terminal receipts before releasing aborted chat turns

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -382,6 +382,7 @@ function parseDataFrames(record: MockResponseRecord): Array<{
   accountConnect?: unknown;
   localInference?: unknown;
   noResponseReason?: "ignored";
+  interrupted?: boolean;
 }> {
   return record.writes
     .join("")
@@ -402,6 +403,7 @@ function parseDataFrames(record: MockResponseRecord): Array<{
           accountConnect?: unknown;
           localInference?: unknown;
           noResponseReason?: "ignored";
+          interrupted?: boolean;
         },
     );
 }
@@ -942,8 +944,9 @@ describe("conversation-route chat idempotency wiring", () => {
     }
   });
 
-  it("SSE: a retry after an incomplete aborted turn finalizes without re-running it", async () => {
-    const { state, handleMessage, createMemory } = createHarness();
+  it("SSE: an aborted turn persists a zero-token interrupted receipt and the retry adopts it", async () => {
+    const { state, handleMessage, createMemory, storedMemories } =
+      createHarness();
     const abortError = Object.assign(new Error("client disconnected"), {
       code: "TURN_ABORTED",
     });
@@ -954,27 +957,79 @@ describe("conversation-route chat idempotency wiring", () => {
 
     const first = await runRoute("POST", STREAM_PATH, state, body);
     expect(handleMessage).toHaveBeenCalledTimes(1);
-    // Aborted turn: no assistant "done" payload with text was delivered.
+    // Zero-token Stop: the turn still settles with an interrupted terminal
+    // receipt — a done frame carrying interrupted:true and no reply text.
     const firstDone = parseDataFrames(first.record).find(
-      (f) => f.type === "done" && f.fullText === "ok",
-    );
-    expect(firstDone).toBeUndefined();
-
-    const second = await runRoute("POST", STREAM_PATH, state, body);
-    expect(handleMessage).toHaveBeenCalledTimes(1);
-    const secondDone = parseDataFrames(second.record).find(
       (f) => f.type === "done",
     );
-    expect(secondDone?.fullText).toBe(INCOMPLETE_RECOVERY_TEXT);
-    expect(createMemory.mock.calls.length).toBeGreaterThan(0);
+    expect(firstDone).toMatchObject({
+      type: "done",
+      fullText: "",
+      interrupted: true,
+      messageId: expect.any(String),
+    });
+    // The receipt is durable: an assistant memory with content.interrupted.
+    const receipt = storedMemories.find(
+      (memory) =>
+        memory.id === firstDone?.messageId &&
+        (memory.content as { interrupted?: boolean }).interrupted === true,
+    );
+    expect(receipt).toBeDefined();
+    expect((receipt?.content as { text?: string } | undefined)?.text).toBe("");
 
-    const persistsAfterRecovery = createMemory.mock.calls.length;
-    const replay = await runRoute("POST", STREAM_PATH, state, body);
+    const persistsAfterAbort = createMemory.mock.calls.length;
+    const retry = await runRoute("POST", STREAM_PATH, state, body);
+    // The retried key adopts the interrupted outcome: no second generation,
+    // no second persisted pair, the exact same terminal frame.
     expect(handleMessage).toHaveBeenCalledTimes(1);
-    expect(createMemory).toHaveBeenCalledTimes(persistsAfterRecovery);
+    expect(createMemory).toHaveBeenCalledTimes(persistsAfterAbort);
     expect(
-      parseDataFrames(replay.record).find((frame) => frame.type === "done"),
-    ).toEqual(secondDone);
+      parseDataFrames(retry.record).find((frame) => frame.type === "done"),
+    ).toEqual(firstDone);
+  });
+
+  it("SSE: a mid-stream abort persists the partial text on the interrupted receipt", async () => {
+    const { state, handleMessage, storedMemories } = createHarness();
+    const abortError = Object.assign(new Error("client stopped"), {
+      code: "TURN_ABORTED",
+    });
+    handleMessage.mockImplementationOnce(
+      async (
+        _runtime: unknown,
+        _message: unknown,
+        _callback: unknown,
+        options?: { onStreamChunk?: (chunk: string) => Promise<void> | void },
+      ) => {
+        await options?.onStreamChunk?.("partial re");
+        throw abortError;
+      },
+    );
+    const body = { text: "hello", clientMessageId: "sse-abort-partial-1" };
+
+    const first = await runRoute("POST", STREAM_PATH, state, body);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    const firstDone = parseDataFrames(first.record).find(
+      (f) => f.type === "done",
+    );
+    expect(firstDone).toMatchObject({
+      type: "done",
+      fullText: "partial re",
+      interrupted: true,
+      messageId: expect.any(String),
+    });
+    const receipt = storedMemories.find(
+      (memory) => memory.id === firstDone?.messageId,
+    );
+    expect(receipt?.content).toMatchObject({
+      text: "partial re",
+      interrupted: true,
+    });
+
+    const retry = await runRoute("POST", STREAM_PATH, state, body);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(
+      parseDataFrames(retry.record).find((frame) => frame.type === "done"),
+    ).toEqual(firstDone);
   });
 
   it("SSE: a completed turn survives transport disconnect and the retry replays it", async () => {

--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -128,6 +128,7 @@ interface TestHarness {
   handleMessage: ReturnType<typeof vi.fn>;
   emitEvent: ReturnType<typeof vi.fn>;
   createMemory: ReturnType<typeof vi.fn>;
+  updateMemory: ReturnType<typeof vi.fn>;
   storedMemories: Memory[];
   deleteManyMemories: ReturnType<typeof vi.fn>;
   deleteRoom: ReturnType<typeof vi.fn>;
@@ -141,7 +142,11 @@ interface TestHarness {
  *  memories are retained and served back through `getMemories`, so the dupe
  *  branches' persisted-first-reply lookup reads the real write path's output. */
 function createHarness(
-  options: { maxPendingPerRoom?: number; scheduling?: boolean } = {},
+  options: {
+    maxPendingPerRoom?: number;
+    scheduling?: boolean;
+    failOutcomeSettlementOnce?: boolean;
+  } = {},
 ): TestHarness {
   const handleMessage = vi.fn(
     async (
@@ -171,7 +176,19 @@ function createHarness(
     storedMemories.push(memory);
     return memory.id ?? stringToUuid("created-memory");
   });
+  let shouldFailOutcomeSettlement = options.failOutcomeSettlementOnce === true;
   const updateMemory = vi.fn(async (memory: Partial<Memory> & { id: UUID }) => {
+    const marker = memory.content?.chatIdempotency;
+    if (
+      shouldFailOutcomeSettlement &&
+      marker &&
+      typeof marker === "object" &&
+      !Array.isArray(marker) &&
+      "outcomeJson" in marker
+    ) {
+      shouldFailOutcomeSettlement = false;
+      throw new Error("simulated outcome marker write failure");
+    }
     const index = storedMemories.findIndex((stored) => stored.id === memory.id);
     if (index < 0) throw new Error("memory not found");
     storedMemories[index] = { ...storedMemories[index], ...memory };
@@ -285,6 +302,7 @@ function createHarness(
     handleMessage,
     emitEvent,
     createMemory,
+    updateMemory,
     storedMemories,
     deleteManyMemories,
     deleteRoom,
@@ -1030,6 +1048,50 @@ describe("conversation-route chat idempotency wiring", () => {
     expect(
       parseDataFrames(retry.record).find((frame) => frame.type === "done"),
     ).toEqual(firstDone);
+  });
+
+  it("SSE: a persisted interrupted receipt survives outcome-marker settlement failure and restart", async () => {
+    const { state, handleMessage, updateMemory, createMemory, storedMemories } =
+      createHarness({ failOutcomeSettlementOnce: true });
+    const abortError = Object.assign(new Error("client stopped"), {
+      code: "TURN_ABORTED",
+    });
+    handleMessage.mockImplementationOnce(async () => {
+      throw abortError;
+    });
+    const body = {
+      text: "hello",
+      clientMessageId: "sse-abort-settlement-failure-1",
+    };
+
+    const first = await runRoute("POST", STREAM_PATH, state, body);
+    const firstDone = parseDataFrames(first.record).find(
+      (frame) => frame.type === "done",
+    );
+    expect(firstDone).toMatchObject({
+      type: "done",
+      fullText: "",
+      interrupted: true,
+      messageId: expect.any(String),
+    });
+    expect(updateMemory).toHaveBeenCalledTimes(1);
+    const receipt = storedMemories.find(
+      (memory) => memory.id === firstDone?.messageId,
+    );
+    expect(receipt?.content).toMatchObject({ interrupted: true, text: "" });
+    const persistsAfterAbort = createMemory.mock.calls.length;
+
+    // Simulate a fresh process: the failed outcome marker is absent, so
+    // recovery must reconstruct the exact terminal from the durable receipt.
+    resetChatDedupe();
+    const retry = await runRoute("POST", STREAM_PATH, state, body);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(createMemory).toHaveBeenCalledTimes(persistsAfterAbort);
+    expect(
+      parseDataFrames(retry.record).find((frame) => frame.type === "done"),
+    ).toEqual(firstDone);
+    expect(updateMemory.mock.calls.length).toBeGreaterThan(1);
   });
 
   it("SSE: a completed turn survives transport disconnect and the retry replays it", async () => {

--- a/packages/agent/src/api/__tests__/persistence-after-done.test.ts
+++ b/packages/agent/src/api/__tests__/persistence-after-done.test.ts
@@ -526,14 +526,21 @@ describe("conversation-routes streaming persistence ordering", () => {
     expect(record.ended).toBe(true);
   });
 
-  it("ends the stream without fallback generation when the turn is aborted externally", async () => {
+  it("settles an aborted turn with an interrupted receipt instead of fallback generation", async () => {
     generateThrowsTurnAbort = true;
     const { ctx, record } = createCtx();
 
     await handleConversationRoutes(ctx);
 
     expect(record.ended).toBe(true);
-    expect(record.writes.some((w) => w.includes('"type":"done"'))).toBe(false);
+    // No fallback reply is generated or persisted through the normal
+    // assistant-persistence seam; the terminal state is the interrupted
+    // receipt (#17216), delivered as a done frame because the transport is
+    // still connected.
+    const doneFrame = record.writes.find((w) => w.includes('"type":"done"'));
+    expect(doneFrame).toBeDefined();
+    expect(doneFrame).toContain('"interrupted":true');
+    expect(doneFrame).toContain('"fullText":""');
     expect(record.writes.some((w) => w.includes('"type":"error"'))).toBe(false);
     expect(persistCalledAt).toBeNull();
   });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -304,6 +304,13 @@ export interface ChatMessageIdOutcome {
   accountConnect?: AccountConnectRequest;
   localInference?: LocalInferenceChatMetadata;
   noResponseReason?: "ignored";
+  /**
+   * The turn ended by explicit Stop/disconnect abort. `text` carries the
+   * partial reply that streamed before the abort (possibly empty for a
+   * zero-token Stop) and `messageId` its durable interrupted receipt, so a
+   * retried key adopts the interrupted outcome instead of regenerating.
+   */
+  interrupted?: boolean;
 }
 
 const chatIdempotency = createChatIdempotencyStore<ChatMessageIdOutcome>();
@@ -2926,6 +2933,41 @@ export async function persistAssistantConversationMemory(
   return memoryId
     ? await persistExactConversationMemory(runtime, memory, roomHandlerLease)
     : await persistConversationMemory(runtime, memory, roomHandlerLease);
+}
+
+/**
+ * Persist the terminal receipt for an aborted (Stop/disconnect) turn before
+ * the route releases it. Unlike `persistAssistantConversationMemory` this
+ * MUST persist even when no token streamed — a zero-token Stop still owns a
+ * durable `interrupted` assistant row, otherwise reload recovery finds a user
+ * turn with no terminal receipt and the transport is free to regenerate
+ * (#17216). The row carries `content.interrupted: true`, which the GET
+ * /messages DTO round-trips so the renderer shows the interrupted state
+ * instead of a healthy-looking reply.
+ */
+export async function persistInterruptedAssistantReceipt(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  partialText: string,
+  channelType: ChannelType,
+  inReplyTo: UUID | undefined,
+  memoryId: UUID,
+  roomHandlerLease?: RoomHandlerLease,
+): Promise<Memory> {
+  const memory = createMessageMemory({
+    id: memoryId,
+    entityId: runtime.agentId,
+    agentId: runtime.agentId,
+    roomId,
+    content: {
+      text: partialText,
+      interrupted: true,
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+      channelType,
+      ...(inReplyTo ? { inReplyTo } : {}),
+    } satisfies Content,
+  });
+  return persistExactConversationMemory(runtime, memory, roomHandlerLease);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -106,6 +106,7 @@ import {
   persistConversationMemory,
   persistExactConversationMemory,
   persistExactConversationMemoryResult,
+  persistInterruptedAssistantReceipt,
   readChatRequestPayload,
   releaseChatMessageId,
   resolveNoResponseFallback,
@@ -1305,6 +1306,7 @@ const DURABLE_CHAT_OUTCOME_KEYS = new Set([
   "accountConnect",
   "localInference",
   "noResponseReason",
+  "interrupted",
 ]);
 
 function isChannelType(value: unknown): value is ChannelType {
@@ -1416,7 +1418,9 @@ function parseDurableConversationChatOutcome(
     (outcome.localInference !== undefined &&
       !isRecord(outcome.localInference)) ||
     (outcome.noResponseReason !== undefined &&
-      outcome.noResponseReason !== "ignored")
+      outcome.noResponseReason !== "ignored") ||
+    (outcome.interrupted !== undefined &&
+      typeof outcome.interrupted !== "boolean")
   ) {
     return null;
   }
@@ -1469,6 +1473,7 @@ function parseDurableConversationChatOutcome(
     ...(outcome.noResponseReason === "ignored"
       ? { noResponseReason: "ignored" as const }
       : {}),
+    ...(outcome.interrupted === true ? { interrupted: true } : {}),
   };
 }
 
@@ -1975,6 +1980,7 @@ function buildConversationJsonOutcome(
     ...(outcome.noResponseReason
       ? { noResponseReason: outcome.noResponseReason }
       : {}),
+    ...(outcome.interrupted ? { interrupted: true } : {}),
   };
 }
 
@@ -2298,6 +2304,14 @@ type ConversationRouteMessageRecord = {
    * the renderer's inline AddAccountDialog entry point survives a reload.
    */
   accountConnect?: AccountConnectRequest;
+  /**
+   * The turn ended by explicit Stop/disconnect abort. Persisted on the
+   * assistant memory as `content.interrupted` by
+   * `persistInterruptedAssistantReceipt`; round-tripped here so reload
+   * recovery renders the interrupted terminal state (zero-token receipts
+   * included) instead of a healthy reply or a missing row.
+   */
+  interrupted?: boolean;
 };
 
 // Greeting lookup and persistence share the room's history-writer boundary.
@@ -2985,6 +2999,7 @@ export async function handleConversationRoutes(
             content.accountConnect,
           );
           const role = m.entityId === agentId ? "assistant" : "user";
+          const interrupted = content.interrupted === true;
           const rawText = formatConversationMessageText(
             (m.content as { text?: string })?.text ?? "",
             actionCallbackHistory,
@@ -3074,6 +3089,7 @@ export async function handleConversationRoutes(
               typeof m.entityId === "string" ? m.entityId : undefined,
             ...(failureKind ? { failureKind } : {}),
             ...(accountConnect ? { accountConnect } : {}),
+            ...(interrupted ? { interrupted: true } : {}),
           } satisfies ConversationRouteMessageRecord;
         })
         // Drop action-log memories that have no visible text (e.g.
@@ -3081,7 +3097,13 @@ export async function handleConversationRoutes(
         // Without this filter they appear as blank chat bubbles. Image-only
         // turns (uploaded or generated media with no caption) are kept.
         .filter(
-          (m) => m.text.trim().length > 0 || (m.attachments?.length ?? 0) > 0,
+          (m) =>
+            m.text.trim().length > 0 ||
+            (m.attachments?.length ?? 0) > 0 ||
+            // A zero-token interrupted receipt has no text but IS the turn's
+            // terminal state; dropping it would leave the user turn unanswered
+            // on reload and invite regeneration.
+            m.interrupted === true,
         );
       const discordMessages = messages.filter((message) =>
         mayNeedDiscordMessageEnrichment(message.source),
@@ -4426,16 +4448,66 @@ export async function handleConversationRoutes(
             }
           } else if (isTurnAbortError(terminalError)) {
             logger.info(
-              { conversationId: conv.id, roomId: conv.roomId },
-              "[ConversationStream] generation aborted",
+              {
+                conversationId: conv.id,
+                roomId: conv.roomId,
+                streamedTextLength: streamedText.length,
+              },
+              "[ConversationStream] generation aborted; persisting interrupted receipt",
             );
+            // Stop/disconnect is a terminal outcome of the turn, not a
+            // discarded one: persist the interrupted receipt (partial text or
+            // the zero-token case) and settle the idempotency key so reload
+            // recovery and a retried clientMessageId adopt this durable state
+            // instead of regenerating (#17216).
             if (
               !getChatMessageIdOutcome(
                 chatIdempotencyScope,
                 clientMessageId ?? null,
               )
             ) {
-              releaseTurnReservation();
+              try {
+                assertConversationConnectionRuntime(
+                  state.runtime,
+                  connectionDescriptor,
+                );
+                const receiptId = crypto.randomUUID() as UUID;
+                const persisted = await persistInterruptedAssistantReceipt(
+                  runtime,
+                  conv.roomId,
+                  streamedText,
+                  channelType,
+                  messageToStore.id,
+                  receiptId,
+                  runtimeTurnLease,
+                );
+                conv.updatedAt = new Date().toISOString();
+                const interruptedOutcome: ChatMessageIdOutcome = {
+                  text: streamedText,
+                  agentName: state.agentName,
+                  ...(persisted.id ? { messageId: persisted.id } : {}),
+                  userMessageId: messageToStore.id,
+                  interrupted: true,
+                };
+                await settleTurnReservation(interruptedOutcome);
+                if (!disconnectTracker.isAborted()) {
+                  writeConversationDoneSse(res, interruptedOutcome);
+                }
+              } catch (persistErr) {
+                // error-policy:J4 the interrupted receipt is best-effort
+                // terminal state for an already-severed transport; on write
+                // failure the key is released so the client's next send owns a
+                // fresh turn rather than replaying a half-settled outcome.
+                logger.warn(
+                  {
+                    err: getErrorMessage(persistErr),
+                    conversationId: conv.id,
+                    roomId: conv.roomId,
+                  },
+                  "[ConversationStream] failed to persist interrupted receipt",
+                );
+                releaseTurnReservation();
+              }
             }
           } else if (
             isCallbackHistoryPersistenceError(terminalError) ||

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1538,6 +1538,7 @@ function buildRecoveredConversationChatOutcome(
     ...(content.noResponseReason === "ignored"
       ? { noResponseReason: "ignored" as const }
       : {}),
+    ...(content.interrupted === true ? { interrupted: true } : {}),
   };
 }
 
@@ -3936,6 +3937,17 @@ export async function handleConversationRoutes(
       preferredLanguage,
       metadata: chatMetadata,
     });
+    const settleTurnReservationInMemory = (
+      outcome: ChatMessageIdOutcome,
+    ): void => {
+      setChatMessageIdOutcome(
+        chatIdempotencyScope,
+        clientMessageId ?? null,
+        outcome,
+        chatReservation,
+      );
+      reservationSettled = true;
+    };
     const settleTurnReservation = async (
       outcome: ChatMessageIdOutcome,
     ): Promise<void> => {
@@ -3956,13 +3968,7 @@ export async function handleConversationRoutes(
           runtimeTurnLease,
         );
       }
-      setChatMessageIdOutcome(
-        chatIdempotencyScope,
-        clientMessageId ?? null,
-        outcome,
-        chatReservation,
-      );
-      reservationSettled = true;
+      settleTurnReservationInMemory(outcome);
     };
     const idempotencyAdmission = await awaitConversationChatAdmission(
       chatIdempotencyScope,
@@ -4489,7 +4495,34 @@ export async function handleConversationRoutes(
                   userMessageId: messageToStore.id,
                   interrupted: true,
                 };
-                await settleTurnReservation(interruptedOutcome);
+                try {
+                  await settleTurnReservation(interruptedOutcome);
+                } catch (settlementError) {
+                  // error-policy:J7 the receipt is already durable and remains
+                  // recoverable through its deterministic in-reply-to link;
+                  // preserve that terminal outcome locally while reporting the
+                  // failed optimization that writes it onto the user marker.
+                  settleTurnReservationInMemory(interruptedOutcome);
+                  runtime.reportError(
+                    "ConversationStream.interruptedReceiptSettlement",
+                    settlementError,
+                    {
+                      conversationId: conv.id,
+                      roomId: conv.roomId,
+                      clientMessageId,
+                      receiptId: persisted.id,
+                    },
+                  );
+                  logger.warn(
+                    {
+                      err: getErrorMessage(settlementError),
+                      conversationId: conv.id,
+                      roomId: conv.roomId,
+                      receiptId: persisted.id,
+                    },
+                    "[ConversationStream] interrupted receipt persisted but outcome marker settlement failed",
+                  );
+                }
                 if (!disconnectTracker.isAborted()) {
                   writeConversationDoneSse(res, interruptedOutcome);
                 }

--- a/packages/ui/src/state/conversation-message-filter.test.ts
+++ b/packages/ui/src/state/conversation-message-filter.test.ts
@@ -27,6 +27,16 @@ describe("shouldKeepConversationMessage", () => {
     expect(shouldKeepConversationMessage(msg({ text: "hi" }))).toBe(true);
   });
 
+  it("keeps a zero-token interrupted receipt despite empty text", () => {
+    expect(
+      shouldKeepConversationMessage(msg({ text: "", interrupted: true })),
+    ).toBe(true);
+  });
+
+  it("still drops empty assistant turns that are not interrupted", () => {
+    expect(shouldKeepConversationMessage(msg({ text: "  " }))).toBe(false);
+  });
+
   it("drops explicitly internal assistant turns before considering media", () => {
     expect(
       shouldKeepConversationMessage(

--- a/packages/ui/src/state/conversation-message-filter.ts
+++ b/packages/ui/src/state/conversation-message-filter.ts
@@ -45,6 +45,9 @@ export function shouldKeepConversationMessage(
   if (message.attachments?.length) return true;
   if (message.blocks?.length) return true;
   if (isLegacyViewsInventory(message)) return false;
+  // A zero-token interrupted receipt carries no text but is the turn's durable
+  // terminal state; hiding it would leave its user turn visually unanswered.
+  if (message.interrupted === true) return true;
   return message.text.trim().length > 0;
 }
 


### PR DESCRIPTION
## Summary

Lands decomposition step 3 of #17216 ("persist terminal interrupted receipts, including zero-token Stop, before releasing a turn"), per the decomposition recommended in the issue thread.

Previously, when a conversation stream turn was aborted (explicit Stop / client disconnect → `TURN_ABORTED`), the SSE route's abort branch simply released the idempotency reservation. Nothing durable recorded that the turn ended: reload recovery found the user turn unanswered, and a retried `clientMessageId` was free to run a second generation — exactly the duplicate/regeneration class the issue targets.

### Changes

- **`packages/agent/src/api/chat-routes.ts`**
  - `ChatMessageIdOutcome` gains `interrupted?: boolean`.
  - New `persistInterruptedAssistantReceipt(...)`: persists a durable assistant memory carrying the partial streamed text (empty for zero-token Stop) with `content.interrupted: true`, via the exact-id persistence path under the room lease. Unlike `persistAssistantConversationMemory`, it persists even with no text — a zero-token Stop still owns a terminal receipt.
- **`packages/agent/src/api/conversation-routes.ts`**
  - The stream route's `isTurnAbortError` branch now persists the interrupted receipt, settles the idempotency key with an `interrupted: true` outcome (durably, via the existing outcome marker), and emits the terminal `done` frame when the transport is still connected. A retried key adopts the interrupted receipt instead of regenerating ("no generation fallback after any transport accepts a turn"). On receipt-write failure the key is released as before (`error-policy:J4`).
  - Durable outcome parse/serialize (`DURABLE_CHAT_OUTCOME_KEYS`, validator, JSON outcome builder) round-trips `interrupted`.
  - GET `/messages` DTO round-trips `content.interrupted` and keeps zero-token interrupted receipts through the empty-text filter, so disconnect/reload recovery adopts durable history.
- **`packages/ui/src/state/conversation-message-filter.ts`**
  - The transcript render filter keeps zero-token interrupted receipts (the `ConversationMessage.interrupted` field and the "Response interrupted" renderer already existed; loaded history now actually carries the flag). The client's existing `reattachInterruptedPartial` only appends when the reloaded thread lacks a terminal assistant turn, so the durable receipt replaces the local reconstruction with no duplication.

### Tests

- `conversation-idempotency.test.ts` (real-route, mock-free harness): rewrote the aborted-turn case to the new contract and added a mid-stream abort case — zero-token Stop persists an empty interrupted receipt and the retry replays it without a second `handleMessage` call or memory write; a partial-text abort persists the streamed prefix on the receipt.
- `persistence-after-done.test.ts`: aborted turn settles with an interrupted `done` frame (transport still connected), no error frame, no fallback persistence.
- `conversation-message-filter.test.ts`: keeps zero-token interrupted receipts, still drops non-interrupted empty assistant turns.

### Verification (exact repaired head `52da4c827ada3a4b9bd366062f6d7d76add672d6`)

- `packages/agent` interrupted-turn focused subset: 3/3 pass
- `packages/agent` persistence ordering: 7/7 pass
- `packages/ui` conversation filter: 12/12 pass
- `packages/agent` lint: pass (976 files)
- `packages/ui` lint: pass with five pre-existing `noDocumentCookie` warnings
- `packages/ui` typecheck: pass
- Biome on all six touched files and `git diff --check`: pass
- `packages/agent` typecheck: **blocked on current `develop`**, in unchanged `src/services/e2b-capability-router.ts:363`: `RemoteRunnerHttpClient` references an undeclared `requestTimeoutMs` property. This PR remains draft and unmerged until the owning-package gate is green.

### Merge disposition

Draft/unmerged. The receipt settlement repair is published and focused behavior is green, but the required agent package typecheck is not.

### Out of scope (remaining #17216 work)

This PR deliberately does not claim the full issue. Still open per the issue's own decomposition: WebSocket startup ownership (step 2), native iOS incremental token delivery / exact cancellation with rebuilt-device evidence (step 4), real-browser CLS/frame-budget measurement, and removal of the UI dedup suppression (step 5) — the last requires steps 1–4 plus live end-to-end proof and physical-device capture that a headless lane cannot produce.

Refs #17216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Gate

<!-- evidence-head:52da4c827ada3a4b9bd366062f6d7d76add672d6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, runtime, persistence, or test change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, runtime, persistence, or test change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused boundary, route, or persistence validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt, model selection, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and adversarial coverage are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->
