### PR TITLE
fix(documents): publish updateDocument revisions atomically across real SQL adapters

### DIFF
--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -828,6 +828,21 @@ export function queryDocumentFragmentsInMemory(
 			) {
 				return false;
 			}
+			// Attempt fencing: a parent that committed an update attempt token
+			// only exposes fragments staged by that attempt (same rule as the
+			// SQL adapters), so losing concurrent generations stay invisible.
+			const parentAttempt = (
+				(parent.metadata ?? {}) as { revisionAttemptId?: unknown }
+			).revisionAttemptId;
+			const fragmentAttempt = (
+				(memory.metadata ?? {}) as unknown as { revisionAttemptId?: unknown }
+			).revisionAttemptId;
+			if (
+				typeof parentAttempt === "string" &&
+				fragmentAttempt !== parentAttempt
+			) {
+				return false;
+			}
 			if (params.roomId && parent.roomId !== params.roomId) return false;
 			if (params.worldId && parent.worldId !== params.worldId) return false;
 			if (params.entityId && parent.entityId !== params.entityId) return false;

--- a/packages/core/src/features/documents/service-update-atomic-revision.test.ts
+++ b/packages/core/src/features/documents/service-update-atomic-revision.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Proves updateDocument publishes document revisions atomically (#16021): the
+ * replacement fragment generation is staged reader-invisible before the parent
+ * compare-and-swap commits, every failure (embed outage, Nth insert, CAS
+ * conflict, discard outage) preserves the complete prior committed revision,
+ * and readers never observe zero, partial, or mixed fragment generations.
+ * Integration-backed: a real AgentRuntime over a real PGLite SQL adapter
+ * (plugin-sql); only the embedding model handler is injected.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AgentRuntime } from "../../runtime.ts";
+import { createTestRuntime } from "../../testing/pglite-runtime.ts";
+import type { Memory, UUID } from "../../types/index.ts";
+import { ModelType } from "../../types/index.ts";
+import { DocumentService } from "./service.ts";
+
+const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
+
+const V1_TEXT = [
+	"Version one alpha: original refund policy paragraph for the atomic test.",
+	"Version one bravo: original service level agreement paragraph retained.",
+	"Version one charlie: original data retention paragraph kept verbatim.",
+].join("\n\n");
+
+const V2_TEXT = [
+	"Version two alpha: revised refund policy paragraph replaces the original.",
+	"Version two bravo: revised service level agreement paragraph installed.",
+].join("\n\n");
+
+let runtime: AgentRuntime;
+let cleanup: () => Promise<void>;
+let service: DocumentService;
+let embedShouldFail = false;
+let embedGate: Promise<void> | undefined;
+let notifyEmbed: (() => void) | undefined;
+let docCounter = 0;
+
+function readerContext() {
+	return {
+		agentId: runtime.agentId,
+		requesterEntityId: runtime.agentId,
+		requesterRoomIds: [runtime.agentId as UUID],
+		requesterRole: "OWNER" as const,
+	};
+}
+
+/** Committed fragments as an authorized reader sees them. */
+async function visibleFragmentTexts(documentId: UUID): Promise<string[]> {
+	const fragments = await runtime.adapter.queryDocumentFragments({
+		...readerContext(),
+		limit: 1_000,
+	});
+	return fragments
+		.filter(
+			(memory) =>
+				(memory.metadata as { documentId?: string } | undefined)?.documentId ===
+				documentId,
+		)
+		.map((memory) => memory.content.text ?? "");
+}
+
+/** Raw rows in the fragment table for a document, visibility rules bypassed. */
+async function rawFragmentsFor(documentId: UUID): Promise<Memory[]> {
+	const memories = await runtime.getMemories({
+		tableName: DOCUMENT_FRAGMENTS_TABLE,
+		agentId: runtime.agentId,
+		count: 10_000,
+	});
+	return memories.filter(
+		(memory) =>
+			(memory.metadata as { documentId?: string } | undefined)?.documentId ===
+			documentId,
+	);
+}
+
+async function seedDocument(): Promise<UUID> {
+	docCounter += 1;
+	// addDocument derives a content-based document id, so every seed gets
+	// unique content and the returned id is authoritative.
+	const result = await service.addDocument({
+		agentId: runtime.agentId,
+		content: `Seed lane ${docCounter}.\n\n${V1_TEXT}`,
+		contentType: "text/plain",
+		scope: "agent-private",
+		originalFilename: `atomic-update-${docCounter}.txt`,
+		worldId: runtime.agentId as UUID,
+		roomId: runtime.agentId as UUID,
+		entityId: runtime.agentId as UUID,
+	});
+	expect(result.fragmentCount).toBeGreaterThan(0);
+	return result.clientDocumentId as UUID;
+}
+
+async function expectCommittedV1(documentId: UUID): Promise<void> {
+	const parent = await runtime.getMemoryById(documentId);
+	expect(parent?.content?.text).toContain("Version one alpha");
+	const visible = await visibleFragmentTexts(documentId);
+	expect(visible.length).toBeGreaterThan(0);
+	expect(visible.join(" ")).toContain("Version one alpha");
+	expect(visible.join(" ")).not.toContain("Version two");
+}
+
+beforeAll(async () => {
+	({ runtime, cleanup } = await createTestRuntime({
+		characterName: "AtomicUpdateAgent",
+		embeddingDimensions: 384,
+	}));
+	const embed = async () => {
+		notifyEmbed?.();
+		await embedGate;
+		if (embedShouldFail) {
+			throw new Error("injected embedding provider outage");
+		}
+		return Array.from({ length: 384 }, (_, i) => ((i % 7) + 1) / 10);
+	};
+	runtime.registerModel(
+		ModelType.TEXT_EMBEDDING,
+		async () => embed(),
+		"atomic-update-test",
+		1_000,
+	);
+	runtime.registerModel(
+		ModelType.TEXT_EMBEDDING_BATCH,
+		async (_runtime, params: { texts?: string[] }) => {
+			const texts = Array.isArray(params.texts) ? params.texts : [];
+			return Promise.all(texts.map(() => embed()));
+		},
+		"atomic-update-test",
+		1_000,
+	);
+	service = new DocumentService(runtime);
+}, 180_000);
+
+afterAll(async () => {
+	await cleanup();
+});
+
+describe("updateDocument atomic revision publication (#16021)", () => {
+	it("publishes the complete new generation and removes the superseded one", async () => {
+		const documentId = await seedDocument();
+		const updated = await service.updateDocument({
+			documentId,
+			content: V2_TEXT,
+		});
+		expect(updated.fragmentCount).toBeGreaterThan(0);
+
+		const parent = await runtime.getMemoryById(documentId);
+		expect(parent?.content?.text).toBe(V2_TEXT);
+		const metadata = parent?.metadata as
+			| { documentRevision?: number; revisionAttemptId?: string }
+			| undefined;
+		expect(metadata?.documentRevision).toBe(1);
+		expect(typeof metadata?.revisionAttemptId).toBe("string");
+
+		const visible = await visibleFragmentTexts(documentId);
+		expect(visible).toHaveLength(updated.fragmentCount);
+		expect(visible.join(" ")).toContain("Version two alpha");
+		expect(visible.join(" ")).not.toContain("Version one");
+		// Superseded generation is physically gone, not just invisible.
+		expect(await rawFragmentsFor(documentId)).toHaveLength(
+			updated.fragmentCount,
+		);
+	}, 120_000);
+
+	it("preserves the complete old revision when embedding fails mid-update", async () => {
+		const documentId = await seedDocument();
+		embedShouldFail = true;
+		try {
+			await expect(
+				service.updateDocument({ documentId, content: V2_TEXT }),
+			).rejects.toThrow(/stage replacement fragments/);
+		} finally {
+			embedShouldFail = false;
+		}
+		await expectCommittedV1(documentId);
+		// Staged partials were discarded from storage too.
+		const raw = await rawFragmentsFor(documentId);
+		expect(
+			raw.filter((memory) => memory.content.text?.includes("Version two")),
+		).toHaveLength(0);
+	}, 120_000);
+
+	it("preserves the old revision when the Nth fragment insert fails", async () => {
+		const documentId = await seedDocument();
+		// Long enough to split into multiple fragments so the injected outage
+		// hits the Nth insert, leaving a genuinely partial staged generation.
+		const longV2 = Array.from(
+			{ length: 200 },
+			(_, i) => `Version two long paragraph ${i}: ${V2_TEXT}`,
+		).join("\n\n");
+		const realCreateMemory = runtime.createMemory.bind(runtime);
+		let fragmentWrites = 0;
+		runtime.createMemory = async (memory, tableName, unique) => {
+			if (
+				tableName === DOCUMENT_FRAGMENTS_TABLE &&
+				memory.content.text?.includes("Version two")
+			) {
+				fragmentWrites += 1;
+				if (fragmentWrites >= 2) {
+					throw new Error("injected Nth fragment insert outage");
+				}
+			}
+			return realCreateMemory(memory, tableName, unique);
+		};
+		try {
+			await expect(
+				service.updateDocument({ documentId, content: longV2 }),
+			).rejects.toThrow(/stage replacement fragments/);
+		} finally {
+			runtime.createMemory = realCreateMemory;
+		}
+		expect(fragmentWrites).toBeGreaterThanOrEqual(2);
+		await expectCommittedV1(documentId);
+		const raw = await rawFragmentsFor(documentId);
+		expect(
+			raw.filter((memory) => memory.content.text?.includes("Version two")),
+		).toHaveLength(0);
+	}, 120_000);
+
+	it("keeps the old revision committed when a concurrent writer wins the CAS", async () => {
+		const documentId = await seedDocument();
+		const adapter = runtime.adapter;
+		const realCompareAndSwap = adapter.compareAndSwapDocument.bind(adapter);
+		adapter.compareAndSwapDocument = async () => ({ status: "conflict" });
+		try {
+			await expect(
+				service.updateDocument({ documentId, content: V2_TEXT }),
+			).rejects.toThrow(/authorization changed before update/);
+		} finally {
+			adapter.compareAndSwapDocument = realCompareAndSwap;
+		}
+		await expectCommittedV1(documentId);
+		const raw = await rawFragmentsFor(documentId);
+		expect(
+			raw.filter((memory) => memory.content.text?.includes("Version two")),
+		).toHaveLength(0);
+	}, 120_000);
+
+	it("readers see only the complete old generation while an update is staging", async () => {
+		const documentId = await seedDocument();
+		const committedBefore = await visibleFragmentTexts(documentId);
+		expect(committedBefore.length).toBeGreaterThan(0);
+
+		let releaseEmbed!: () => void;
+		embedGate = new Promise<void>((resolve) => {
+			releaseEmbed = resolve;
+		});
+		let enteredEmbed!: () => void;
+		const embeddingStarted = new Promise<void>((resolve) => {
+			enteredEmbed = resolve;
+		});
+		notifyEmbed = enteredEmbed;
+
+		const update = service.updateDocument({ documentId, content: V2_TEXT });
+		await embeddingStarted;
+		notifyEmbed = undefined;
+
+		// Mid-staging: the committed revision is still complete and exclusive.
+		const midUpdate = await visibleFragmentTexts(documentId);
+		expect(midUpdate).toEqual(committedBefore);
+		expect((await runtime.getMemoryById(documentId))?.content?.text).toContain(
+			"Version one alpha",
+		);
+
+		releaseEmbed();
+		embedGate = undefined;
+		const updated = await update;
+		const after = await visibleFragmentTexts(documentId);
+		expect(after).toHaveLength(updated.fragmentCount);
+		expect(after.join(" ")).toContain("Version two alpha");
+		expect(after.join(" ")).not.toContain("Version one");
+	}, 120_000);
+
+	it("leaves discard leftovers invisible when staged cleanup is unavailable", async () => {
+		const documentId = await seedDocument();
+		const realDeleteMemory = runtime.deleteMemory.bind(runtime);
+		const realCompareAndSwap = runtime.adapter.compareAndSwapDocument.bind(
+			runtime.adapter,
+		);
+		runtime.adapter.compareAndSwapDocument = async () => ({
+			status: "conflict",
+		});
+		runtime.deleteMemory = async () => {
+			throw new Error("injected discard outage");
+		};
+		try {
+			await expect(
+				service.updateDocument({ documentId, content: V2_TEXT }),
+			).rejects.toThrow(/authorization changed before update/);
+		} finally {
+			runtime.deleteMemory = realDeleteMemory;
+			runtime.adapter.compareAndSwapDocument = realCompareAndSwap;
+		}
+		// Leftover staged rows exist in storage but never reach readers: the
+		// committed parent still declares revision 0 with no attempt token.
+		const raw = await rawFragmentsFor(documentId);
+		expect(
+			raw.filter((memory) => memory.content.text?.includes("Version two"))
+				.length,
+		).toBeGreaterThan(0);
+		await expectCommittedV1(documentId);
+
+		// The next successful update sweeps the stale staged generation.
+		const recovered = await service.updateDocument({
+			documentId,
+			content: V2_TEXT,
+		});
+		const swept = await rawFragmentsFor(documentId);
+		expect(swept).toHaveLength(recovered.fragmentCount);
+		const visible = await visibleFragmentTexts(documentId);
+		expect(visible).toHaveLength(recovered.fragmentCount);
+		expect(visible.join(" ")).not.toContain("Version one");
+	}, 120_000);
+
+	it("fences same-revision fragments from a different update attempt", async () => {
+		const documentId = await seedDocument();
+		const updated = await service.updateDocument({
+			documentId,
+			content: V2_TEXT,
+		});
+		// Simulate a losing concurrent attempt that staged the same revision
+		// number under a different attempt token and failed to discard it.
+		await runtime.createMemory(
+			{
+				id: runtime.createRunId(),
+				agentId: runtime.agentId,
+				roomId: runtime.agentId,
+				entityId: runtime.agentId,
+				content: { text: "Version rogue: losing attempt fragment" },
+				metadata: {
+					type: "fragment",
+					documentId,
+					position: 0,
+					documentRevision: 1,
+					revisionAttemptId: runtime.createRunId(),
+				} as unknown as Memory["metadata"],
+			},
+			DOCUMENT_FRAGMENTS_TABLE,
+		);
+		const visible = await visibleFragmentTexts(documentId);
+		expect(visible).toHaveLength(updated.fragmentCount);
+		expect(visible.join(" ")).not.toContain("Version rogue");
+	}, 120_000);
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -2292,6 +2292,9 @@ export class DocumentService extends Service {
 			timestamp: Date.now(),
 			editedAt: Date.now(),
 			documentRevision: snapshot.revision + 1,
+			// Fences this attempt's staged fragments: concurrent updates stage the
+			// same revision number, so readers additionally match this token.
+			revisionAttemptId: this.runtime.createRunId(),
 		};
 
 		const replacement: Memory = {
@@ -2304,44 +2307,11 @@ export class DocumentService extends Service {
 			metadata: updatedMetadata,
 			createdAt: existingDocument.createdAt,
 		};
-		const mutation = await this.runtime.adapter.compareAndSwapDocument({
-			...requestContext,
-			documentId: options.documentId,
-			expected: snapshot,
-			replacement,
-		});
-		if (mutation.status !== "updated") {
-			throw new ElizaError("Document authorization changed before update", {
-				code:
-					mutation.status === "forbidden"
-						? "DOCUMENT_MUTATION_FORBIDDEN"
-						: mutation.status === "not_found"
-							? "DOCUMENT_NOT_FOUND"
-							: "DOCUMENT_MUTATION_CONFLICT",
-				context: { documentId: options.documentId, status: mutation.status },
-			});
-		}
-
-		const existingFragments = await this.runtime.getMemories({
-			tableName: DOCUMENT_FRAGMENTS_TABLE,
-			agentId: this.runtime.agentId,
-			roomId: existingDocument.roomId,
-			count: 10_000,
-		});
-		const relatedFragments = existingFragments.filter((fragment) => {
-			const metadata = fragment.metadata as Record<string, unknown> | undefined;
-			return (
-				this.isDocumentFragmentMemory(fragment) &&
-				metadata?.documentId === options.documentId
-			);
-		});
-
-		for (const fragment of relatedFragments) {
-			if (typeof fragment.id === "string") {
-				await this.runtime.deleteMemory(fragment.id as UUID);
-			}
-		}
-
+		// Stage the complete replacement generation BEFORE touching the parent.
+		// Fragments inherit documentRevision R+1 from updatedMetadata while the
+		// parent still publishes revision R, and the adapter's fragment reader
+		// joins on matching fragment/parent documentRevision, so staged fragments
+		// stay invisible to concurrent readers until the CAS commit below.
 		const fragments = await this.splitAndCreateFragments(
 			{
 				id: options.documentId,
@@ -2356,15 +2326,139 @@ export class DocumentService extends Service {
 				entityId: existingDocument.entityId,
 			},
 		);
+		try {
+			await this.processDocumentFragmentsBatched(fragments, {
+				continueOnError: false,
+			});
+		} catch (stagingError) {
+			// error-policy:J2 Discard the partially staged (reader-invisible)
+			// generation, then rethrow with document identity; the committed
+			// revision R parent and its fragments are untouched.
+			await this.discardStagedFragments(options.documentId, fragments);
+			throw new ElizaError(
+				`Failed to stage replacement fragments for document ${options.documentId}`,
+				{
+					code: "DOCUMENT_UPDATE_STAGING_FAILED",
+					context: {
+						documentId: options.documentId,
+						stagedFragmentCount: fragments.length,
+					},
+					cause: stagingError,
+				},
+			);
+		}
 
-		await this.processDocumentFragmentsBatched(fragments, {
-			continueOnError: false,
+		// The single-statement compare-and-swap is the atomic commit point on
+		// real SQL adapters: it flips the parent from revision R to R+1, which
+		// simultaneously hides the old generation and exposes the staged one.
+		const mutation = await this.runtime.adapter.compareAndSwapDocument({
+			...requestContext,
+			documentId: options.documentId,
+			expected: snapshot,
+			replacement,
+		});
+		if (mutation.status !== "updated") {
+			await this.discardStagedFragments(options.documentId, fragments);
+			throw new ElizaError("Document authorization changed before update", {
+				code:
+					mutation.status === "forbidden"
+						? "DOCUMENT_MUTATION_FORBIDDEN"
+						: mutation.status === "not_found"
+							? "DOCUMENT_NOT_FOUND"
+							: "DOCUMENT_MUTATION_CONFLICT",
+				context: { documentId: options.documentId, status: mutation.status },
+			});
+		}
+
+		await this.removeSupersededFragments(options.documentId, fragments, {
+			roomId: existingDocument.roomId,
 		});
 
 		return {
 			documentId: options.documentId,
 			fragmentCount: fragments.length,
 		};
+	}
+
+	/**
+	 * Delete a staged-but-never-committed fragment generation. Callers invoke
+	 * this only while the parent still publishes the prior revision, so every
+	 * row removed here was reader-invisible; any row this pass fails to delete
+	 * stays invisible and is swept by the next successful update's
+	 * {@link removeSupersededFragments} pass.
+	 */
+	private async discardStagedFragments(
+		documentId: UUID,
+		fragments: Memory[],
+	): Promise<void> {
+		for (const fragment of fragments) {
+			if (typeof fragment.id !== "string") continue;
+			try {
+				await this.runtime.deleteMemory(fragment.id as UUID);
+			} catch (cleanupError) {
+				// error-policy:J7 Discard is best effort and must not mask the
+				// staging or CAS failure being propagated; the leftover row is
+				// reader-invisible (revision mismatch) and swept later.
+				this.runtime.reportError(
+					"DocumentService.discardStagedFragments",
+					cleanupError instanceof Error
+						? cleanupError
+						: new Error(String(cleanupError)),
+					{ documentId, fragmentId: fragment.id },
+				);
+			}
+		}
+	}
+
+	/**
+	 * Remove every fragment of a document that is not part of the just-committed
+	 * generation. Runs only after the parent CAS commit, so every row deleted
+	 * here is already invisible to readers (its documentRevision no longer
+	 * matches the parent); failure is storage garbage, not data exposure.
+	 */
+	private async removeSupersededFragments(
+		documentId: UUID,
+		committedFragments: Memory[],
+		scope: { roomId: UUID },
+	): Promise<void> {
+		const committedIds = new Set(
+			committedFragments
+				.map((fragment) => fragment.id)
+				.filter((id): id is UUID => typeof id === "string"),
+		);
+		try {
+			const existingFragments = await this.runtime.getMemories({
+				tableName: DOCUMENT_FRAGMENTS_TABLE,
+				agentId: this.runtime.agentId,
+				roomId: scope.roomId,
+				count: 10_000,
+			});
+			for (const fragment of existingFragments) {
+				const metadata = fragment.metadata as
+					| Record<string, unknown>
+					| undefined;
+				if (
+					!this.isDocumentFragmentMemory(fragment) ||
+					metadata?.documentId !== documentId ||
+					typeof fragment.id !== "string" ||
+					committedIds.has(fragment.id as UUID)
+				) {
+					continue;
+				}
+				await this.runtime.deleteMemory(fragment.id as UUID);
+			}
+		} catch (cleanupError) {
+			// error-policy:J7 The update already committed; superseded rows are
+			// reader-invisible and the next successful update sweeps them again,
+			// so cleanup failure is reported instead of failing the update.
+			this.runtime.reportError(
+				"DocumentService.removeSupersededFragments",
+				cleanupError instanceof Error
+					? cleanupError
+					: new Error(String(cleanupError)),
+				{ documentId },
+			);
+		}
 	}
 
 	async _internalAddDocument(

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -231,6 +231,13 @@ export interface DocumentMemoryMetadata
 	addedAt?: number;
 	ingestionAttemptId?: UUID;
 	ingestionState?: "pending" | "ready" | "failed";
+	/**
+	 * Token of the update attempt that committed this document revision.
+	 * Fragment readers require fragments to carry the same token whenever the
+	 * parent declares one, fencing off same-revision generations staged by
+	 * concurrent update attempts that lost the compare-and-swap.
+	 */
+	revisionAttemptId?: UUID;
 	title?: string;
 	filename?: string;
 	originalFilename?: string;
@@ -261,6 +268,8 @@ export interface DocumentFragmentMemoryMetadata
 	addedByRole?: DocumentAddedByRole;
 	addedFrom?: DocumentAddedFrom;
 	addedAt?: number;
+	/** Update attempt that staged this fragment; must match the parent's committed token to be readable. */
+	revisionAttemptId?: UUID;
 	position: number;
 	source?: string;
 	documentTitle?: string;

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2163,6 +2163,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         validDocumentRevision(fragment.metadata),
         sql`${documentRevisionExpression(fragment.metadata)}
           = ${documentRevisionExpression(parent.metadata)}`,
+        // When the parent commits an update attempt token, only fragments
+        // staged by that attempt are readable; concurrent losing attempts
+        // stage the same revision number but a different token.
+        sql`(
+          NOT (${parent.metadata} ? 'revisionAttemptId')
+          OR ${fragment.metadata}->>'revisionAttemptId'
+            = ${parent.metadata}->>'revisionAttemptId'
+        )`,
         documentVisibilityCondition(params, parent.metadata),
       ];
       if (!hasGlobalVisibility) {


### PR DESCRIPTION
Fixes #16021

## Problem
`updateDocument` committed the parent compare-and-swap FIRST (bumping `documentRevision` and instantly hiding every committed fragment from the revision-joined readers), then deleted old fragments one by one, then embedded and inserted the replacements. Consequences:

- every edit exposed a zero-fragment window to concurrent readers;
- an embedding outage or Nth fragment insert failure destroyed the committed revision and left the document with zero/partial fragment state, with no compensation;
- a failed CAS-loser path did not exist at all, and two concurrent updates staging the same revision number could leak mixed generations.

The create path was already fixed on develop (pending→ready ingestion state machine); this lands the consolidated update-path residual from the issue triage.

## Fix (stage → commit → sweep)
`packages/core/src/features/documents/service.ts`:
1. **Stage first:** the complete replacement generation is embedded and persisted while the parent still publishes revision R. Fragments inherit `documentRevision: R+1` and a fresh `revisionAttemptId`, so the adapters' fragment readers (which join `fragment.documentRevision = parent.documentRevision`) keep them invisible.
2. **Atomic commit:** the existing single-row `compareAndSwapDocument` (SELECT … FOR UPDATE + conditional UPDATE inside the adapter transaction) flips the parent to R+1 — simultaneously exposing the complete new generation and hiding the old one. Snapshot compare includes `revision`, so concurrent writers conflict instead of interleaving.
3. **Failure paths:** staging failure throws typed `DOCUMENT_UPDATE_STAGING_FAILED` (cause preserved) and discards the staged, reader-invisible rows; a CAS conflict discards them too and keeps the existing typed conflict errors. Discard failures are reported (`error-policy:J7`) — leftovers stay invisible and are swept by the next successful update.
4. **Post-commit sweep:** superseded fragments (already invisible) are deleted after commit; failure is storage garbage, never data exposure (`error-policy:J7`).

**Concurrent-attempt fencing** (`plugins/plugin-sql/src/base.ts` + in-memory twin `packages/core/src/database/document-list-query.ts`): when the parent declares a committed `revisionAttemptId`, only fragments carrying the same token are readable. Two concurrent updates both stage revision R+1; without the fence the loser's staged rows would match the winner's committed revision number and surface as mixed reads. Legacy documents without the token are unaffected.

`packages/core/src/features/documents/types.ts`: adds the optional `revisionAttemptId` metadata field on document + fragment metadata.

## Verification
New integration suite `packages/core/src/features/documents/service-update-atomic-revision.test.ts` — real `AgentRuntime` over the real PGLite `plugin-sql` adapter (Pg/Neon share the same `BaseDrizzleAdapter` SQL paths); only the embedding model handler is injected. **7/7 passing:**

- happy path publishes the complete new generation and physically removes the superseded one;
- embedding outage mid-update → old revision complete and exclusive, staged partials discarded;
- Nth fragment insert outage (multi-fragment replacement) → same guarantee;
- concurrent writer wins the CAS → old revision intact, staged generation discarded;
- reader during staging (gated embed) sees exactly the complete old generation, then exactly the complete new one after commit;
- discard outage leaves leftovers reader-invisible; the next successful update sweeps them;
- same-revision fragments from a different (losing) attempt are fenced out of reads.

- `packages/core` full documents suite: **294/294 passed**
- `packages/core` typecheck: pass · lint: pass (7 pre-existing warnings, untouched files)
- `plugins/plugin-sql` typecheck + lint: pass
- `plugins/plugin-sql` real integration `document-list-query.real.test.ts`: 13 passed, 1 skipped, 1 failed — the failure (`keeps entityId as isolation context`, a `getMemories` parity case) is **pre-existing**: reproduced identically with this branch's changes stashed on clean develop.

## Notes / residual
- Fragments written before this change carry no `revisionAttemptId`; the fence only activates once a document's parent commits one (first post-fix update), so legacy read behavior is unchanged.
- A crash between staging and CAS leaves reader-invisible staged rows until the next successful update sweeps them — same storage-garbage class the create path accepts, never reader-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)