### PR TITLE
feat(cloud): MCP integration catalog trust, health, and kill switches

### DIFF
--- a/packages/cloud/api/__tests__/mcp-integration-catalog.test.ts
+++ b/packages/cloud/api/__tests__/mcp-integration-catalog.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Contract coverage for the MCP integration catalog trust/health/kill-switch
+ * policy across the public catalog routes and the transport gateway.
+ * Deterministic harness: external collaborators (auth, community registry,
+ * upstream forwarding, logger) are protocol-faithful mocks; the routes and the
+ * policy module under test are real.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getCurrentUser = mock(async () => null);
+mock.module("@/lib/auth/workers-hono-auth", () => ({ getCurrentUser }));
+
+const listPublic = mock(async () => []);
+const toRegistryFormat = mock();
+mock.module("@/lib/services/user-mcps", () => ({
+  userMcpsService: { listPublic, toRegistryFormat },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
+}));
+
+const forwardMcpUpstreamRequest = mock(
+  async () =>
+    new Response(JSON.stringify({ forwarded: true }), { status: 200 }),
+);
+mock.module("@/lib/mcp/mcp-upstream-forward", () => ({
+  forwardMcpUpstreamRequest,
+}));
+
+const {
+  integrationHealth,
+  isKillSwitched,
+  parseKillSwitch,
+  plannerVisibleCapabilities,
+  plannerVisibleFeatures,
+  providerSlugFromEndpoint,
+  resolveIntegrationAvailability,
+} = await import("../src/lib/mcp/integration-catalog");
+const registryRoute = (await import("../mcp/registry/route")).default;
+const listRoute = (await import("../mcp/list/route")).default;
+const { createMcpsTransportApp } = await import(
+  "../src/lib/mcp/mcps-transport-gateway"
+);
+
+interface RegistryEntry {
+  id: string;
+  availability: string;
+  health: string;
+  status: string;
+  features: string[];
+  fullEndpoint: string;
+  configTemplate: { servers: Record<string, unknown> };
+  trust: {
+    publisher: string;
+    provenance: string;
+    authMode: string;
+    domains: string[];
+    reviewedAt: string;
+    capabilities: Array<{ name: string; access: string; reviewed: boolean }>;
+  };
+}
+
+async function fetchRegistry(env: Record<string, string> = {}) {
+  const response = await registryRoute.request("/", undefined, {
+    NEXT_PUBLIC_APP_URL: "https://app.example.test",
+    ...env,
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { registry: RegistryEntry[] };
+}
+
+function transportApp(provider: string) {
+  const host = new Hono();
+  host.route("/:transport", createMcpsTransportApp(provider));
+  return host;
+}
+
+test("parseKillSwitch sanitizes malformed operator input to an inert switch", () => {
+  expect(parseKillSwitch(undefined).all).toBe(false);
+  expect(parseKillSwitch(undefined).ids.size).toBe(0);
+  expect(parseKillSwitch(42).ids.size).toBe(0);
+  expect(parseKillSwitch("  ,, ,").ids.size).toBe(0);
+  const parsed = parseKillSwitch(" GitHub , crypto-prices ");
+  expect(parsed.all).toBe(false);
+  expect(parsed.ids.has("github")).toBe(true);
+  expect(parsed.ids.has("crypto-prices")).toBe(true);
+  expect(parseKillSwitch("all").all).toBe(true);
+  expect(parseKillSwitch("time,*").all).toBe(true);
+});
+
+test("kill switch matches catalog ids, provider slugs, and slug aliases", () => {
+  const env = { MCP_KILL_SWITCH: "crypto-prices" };
+  expect(isKillSwitched(env, "crypto-prices", "crypto")).toBe(true);
+  expect(isKillSwitched(env, "crypto", "crypto")).toBe(true);
+  expect(isKillSwitched(env, "time-server", "time")).toBe(false);
+  expect(isKillSwitched({ MCP_KILL_SWITCH: "all" }, "anything", null)).toBe(
+    true,
+  );
+});
+
+test("availability derives from the transport contract", () => {
+  expect(providerSlugFromEndpoint("/api/mcps/github/streamable-http")).toBe(
+    "github",
+  );
+  expect(providerSlugFromEndpoint("/api/mcp")).toBeNull();
+  expect(resolveIntegrationAvailability({}, "eliza-platform", "/api/mcp")).toBe(
+    "available",
+  );
+  expect(
+    resolveIntegrationAvailability(
+      {},
+      "time-server",
+      "/api/mcps/time/streamable-http",
+    ),
+  ).toBe("available");
+  expect(
+    resolveIntegrationAvailability(
+      {},
+      "github",
+      "/api/mcps/github/streamable-http",
+    ),
+  ).toBe("unconfigured");
+  expect(
+    resolveIntegrationAvailability(
+      { MCP_GITHUB_STREAMABLE_HTTP_URL: "https://mcp.example.test/github" },
+      "github",
+      "/api/mcps/github/streamable-http",
+    ),
+  ).toBe("available");
+  expect(
+    resolveIntegrationAvailability(
+      { MCP_GITHUB_STREAMABLE_HTTP_URL: "   " },
+      "github",
+      "/api/mcps/github/streamable-http",
+    ),
+  ).toBe("unconfigured");
+  expect(
+    resolveIntegrationAvailability(
+      { MCP_KILL_SWITCH: "time" },
+      "time-server",
+      "/api/mcps/time/streamable-http",
+    ),
+  ).toBe("disabled");
+});
+
+test("unreviewed writes are hidden from planner-visible capabilities", () => {
+  const capabilities = [
+    { name: "read_ok", access: "read" as const, reviewed: true },
+    { name: "read_unreviewed", access: "read" as const, reviewed: false },
+    { name: "write_ok", access: "write" as const, reviewed: true },
+    { name: "write_unreviewed", access: "write" as const, reviewed: false },
+  ];
+  const visible = plannerVisibleCapabilities(capabilities).map((c) => c.name);
+  expect(visible).toEqual(["read_ok", "read_unreviewed", "write_ok"]);
+  const trust = {
+    publisher: "test",
+    provenance: "first-party" as const,
+    authMode: "none" as const,
+    domains: [],
+    reviewedAt: "2026-08-20",
+    capabilities,
+  };
+  expect(
+    plannerVisibleFeatures(trust, [
+      "write_unreviewed",
+      "write_ok",
+      "not_in_trust_record",
+    ]),
+  ).toEqual(["write_ok"]);
+});
+
+test("health reflects availability and provenance", () => {
+  expect(integrationHealth("available", "first-party")).toBe("operational");
+  expect(integrationHealth("available", "operator-proxied")).toBe("unknown");
+  expect(integrationHealth("disabled", "first-party")).toBe("unavailable");
+});
+
+test("registry never advertises unconfigured integrations", async () => {
+  const body = await fetchRegistry();
+  const ids = body.registry.map((entry) => entry.id);
+  expect(ids).toContain("crypto-prices");
+  expect(ids).toContain("time-server");
+  expect(ids).toContain("weather");
+  expect(ids).toContain("eliza-platform");
+  expect(ids).not.toContain("github");
+  expect(ids).not.toContain("linear");
+  expect(ids).not.toContain("notion");
+  expect(ids).not.toContain("web-search");
+});
+
+test("registry advertises an operator-proxied integration once configured, with trust metadata", async () => {
+  const body = await fetchRegistry({
+    MCP_GITHUB_STREAMABLE_HTTP_URL: "https://mcp.example.test/github",
+  });
+  const github = body.registry.find((entry) => entry.id === "github");
+  expect(github).toBeDefined();
+  if (!github) throw new Error("github entry missing");
+  expect(github.availability).toBe("available");
+  expect(github.health).toBe("unknown");
+  expect(github.trust.provenance).toBe("operator-proxied");
+  expect(github.trust.authMode).toBe("oauth");
+  expect(github.trust.domains).toContain("api.github.com");
+  expect(github.trust.reviewedAt.length).toBeGreaterThan(0);
+  expect(github.fullEndpoint).toBe(
+    "https://app.example.test/api/mcps/github/streamable-http",
+  );
+});
+
+test("kill-switched registry entry is listed as disabled with connection surface withheld", async () => {
+  const body = await fetchRegistry({ MCP_KILL_SWITCH: "crypto-prices" });
+  const crypto = body.registry.find((entry) => entry.id === "crypto-prices");
+  expect(crypto).toBeDefined();
+  if (!crypto) throw new Error("crypto entry missing");
+  expect(crypto.availability).toBe("disabled");
+  expect(crypto.health).toBe("unavailable");
+  expect(crypto.status).toBe("maintenance");
+  expect(crypto.features).toEqual([]);
+  expect(Object.keys(crypto.configTemplate.servers)).toEqual([]);
+  expect(crypto.fullEndpoint).toBe("");
+  const time = body.registry.find((entry) => entry.id === "time-server");
+  expect(time?.availability).toBe("available");
+});
+
+test("global kill switch disables every platform entry", async () => {
+  const body = await fetchRegistry({ MCP_KILL_SWITCH: "all" });
+  expect(body.registry.length).toBeGreaterThan(0);
+  for (const entry of body.registry) {
+    expect(entry.availability).toBe("disabled");
+    expect(entry.features).toEqual([]);
+  }
+});
+
+test("mcp list annotates definitions and hides tools for kill-switched entries", async () => {
+  const okResponse = await listRoute.request("/", undefined, {});
+  expect(okResponse.status).toBe(200);
+  const okBody = (await okResponse.json()) as {
+    mcps: Array<{
+      id: string;
+      availability: string;
+      health: string;
+      tools: unknown[];
+      trust: { provenance: string };
+    }>;
+    total: number;
+  };
+  expect(okBody.total).toBe(okBody.mcps.length);
+  const platform = okBody.mcps.find((m) => m.id === "eliza-cloud-mcp");
+  expect(platform?.availability).toBe("available");
+  expect(platform?.health).toBe("operational");
+  expect(platform?.tools.length).toBeGreaterThan(0);
+
+  const killedResponse = await listRoute.request("/", undefined, {
+    MCP_KILL_SWITCH: "weather-mcp",
+  });
+  const killedBody = (await killedResponse.json()) as {
+    mcps: Array<{ id: string; availability: string; tools: unknown[] }>;
+  };
+  const weather = killedBody.mcps.find((m) => m.id === "weather-mcp");
+  expect(weather?.availability).toBe("disabled");
+  expect(weather?.tools).toEqual([]);
+});
+
+test("gateway rejects kill-switched providers with 503 before serving or forwarding", async () => {
+  forwardMcpUpstreamRequest.mockClear();
+  const time = transportApp("time");
+  const killed = await time.request(
+    "/streamable-http",
+    { method: "POST" },
+    {
+      MCP_KILL_SWITCH: "time",
+    },
+  );
+  expect(killed.status).toBe(503);
+  const killedBody = (await killed.json()) as { error: string };
+  expect(killedBody.error).toBe("integration_disabled");
+
+  const github = transportApp("github");
+  const killedProxy = await github.request(
+    "/streamable-http",
+    { method: "POST" },
+    {
+      MCP_KILL_SWITCH: "github",
+      MCP_GITHUB_STREAMABLE_HTTP_URL: "https://mcp.example.test/github",
+    },
+  );
+  expect(killedProxy.status).toBe(503);
+  expect(forwardMcpUpstreamRequest).not.toHaveBeenCalled();
+});
+
+test("gateway still answers 501 for unconfigured non-builtin providers and forwards configured ones", async () => {
+  forwardMcpUpstreamRequest.mockClear();
+  const github = transportApp("github");
+  const unconfigured = await github.request(
+    "/streamable-http",
+    { method: "POST" },
+    {},
+  );
+  expect(unconfigured.status).toBe(501);
+
+  const configured = await github.request(
+    "/streamable-http",
+    { method: "POST" },
+    { MCP_GITHUB_STREAMABLE_HTTP_URL: "https://mcp.example.test/github" },
+  );
+  expect(configured.status).toBe(200);
+  expect(forwardMcpUpstreamRequest).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/api/mcp/list/route.ts
+++ b/packages/cloud/api/mcp/list/route.ts
@@ -1,9 +1,18 @@
 /**
- * GET /api/mcp/list — Lists all available MCP server definitions.
+ * GET /api/mcp/list — Lists the MCP server definitions the deployment can
+ * actually serve, annotated with trust, health, and availability from the
+ * integration catalog policy. Kill-switched entries are listed as disabled
+ * with tools withheld; unconfigured entries are not advertised.
  */
 
 import { Hono } from "hono";
 
+import {
+  INTEGRATION_TRUST,
+  integrationHealth,
+  plannerVisibleFeatures,
+  resolveIntegrationAvailability,
+} from "@/api-app/lib/mcp/integration-catalog";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 // MCP definitions with their tools and schemas
@@ -470,12 +479,44 @@ const mcpDefinitions = [
 
 const app = new Hono<AppEnv>();
 
-app.get("/", (c) =>
-  c.json({
-    mcps: mcpDefinitions,
-    total: mcpDefinitions.length,
+app.get("/", (c) => {
+  // Availability gates advertising: unconfigured definitions are withheld and
+  // kill-switched definitions are listed as disabled with tools hidden. Tool
+  // lists are additionally filtered to planner-visible (risk-reviewed)
+  // capability names.
+  const mcps = [];
+  for (const definition of mcpDefinitions) {
+    const trust = INTEGRATION_TRUST[definition.id];
+    if (trust === undefined) continue;
+    const availability = resolveIntegrationAvailability(
+      c.env,
+      definition.id,
+      definition.endpoint,
+    );
+    if (availability === "unconfigured") continue;
+    const disabled = availability === "disabled";
+    const visibleNames = new Set(
+      plannerVisibleFeatures(
+        trust,
+        definition.tools.map((tool) => tool.name),
+      ),
+    );
+    mcps.push({
+      ...definition,
+      availability,
+      health: integrationHealth(availability, trust.provenance),
+      trust,
+      status: disabled ? "disabled" : definition.status,
+      tools: disabled
+        ? []
+        : definition.tools.filter((tool) => visibleNames.has(tool.name)),
+    });
+  }
+  return c.json({
+    mcps,
+    total: mcps.length,
     categories: ["platform", "utilities", "data", "finance"],
-  }),
-);
+  });
+});
 
 export default app;

--- a/packages/cloud/api/mcp/registry/route.ts
+++ b/packages/cloud/api/mcp/registry/route.ts
@@ -1,8 +1,23 @@
-/** Serves the public MCP catalog with validated filters and optional community entries. */
+/**
+ * Serves the public MCP catalog with validated filters and optional community
+ * entries. Platform entries carry trust/health/availability metadata from the
+ * integration catalog policy; unconfigured integrations are never advertised
+ * and kill-switched ones are listed as disabled with their connection surface
+ * withheld.
+ */
 
 // biome-ignore-all lint/suspicious/noTemplateCurlyInString: file contains MCP config templates with literal ${BASE_URL} placeholders for client-side substitution
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  INTEGRATION_TRUST,
+  type IntegrationAvailability,
+  type IntegrationHealth,
+  type IntegrationTrust,
+  integrationHealth,
+  plannerVisibleFeatures,
+  resolveIntegrationAvailability,
+} from "@/api-app/lib/mcp/integration-catalog";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
 import { userMcpsService } from "@/lib/services/user-mcps";
@@ -86,6 +101,9 @@ interface McpRegistryEntry {
 type BuiltInRegistryEntry = McpRegistryEntry & {
   source: "platform";
   fullEndpoint: string;
+  availability: IntegrationAvailability;
+  health: IntegrationHealth;
+  trust: IntegrationTrust;
 };
 type UserRegistryEntry = ReturnType<typeof userMcpsService.toRegistryFormat> & {
   source: "community";
@@ -444,27 +462,58 @@ app.get("/", async (c) => {
 
     const { category, status, limit, search } = validationResult.data;
 
-    // Process built-in registry entries
-    const builtInRegistry: BuiltInRegistryEntry[] = MCP_REGISTRY.map(
-      (entry) => ({
+    // Process built-in registry entries. Availability gates advertising:
+    // unconfigured integrations (their transport would answer 501) are never
+    // listed, and kill-switched entries are listed as disabled with their
+    // connection surface (config template, endpoint) withheld.
+    const builtInRegistry: BuiltInRegistryEntry[] = [];
+    for (const entry of MCP_REGISTRY) {
+      const trust: IntegrationTrust | undefined = INTEGRATION_TRUST[entry.id];
+      if (trust === undefined) {
+        // Fail closed: an entry without a trust record is unreviewed and must
+        // not be advertised at all.
+        logger.warn("[MCP Registry] No trust record; entry withheld", {
+          id: entry.id,
+        });
+        continue;
+      }
+      const availability = resolveIntegrationAvailability(
+        c.env,
+        entry.id,
+        entry.endpoint,
+      );
+      if (availability === "unconfigured") continue;
+      const disabled = availability === "disabled";
+      builtInRegistry.push({
         ...entry,
         source: "platform" as const,
-        configTemplate: {
-          servers: Object.fromEntries(
-            Object.entries(entry.configTemplate.servers).map(([key, value]) => [
-              key,
-              {
-                ...value,
-                url: value.url.replace("${BASE_URL}", ""),
-              },
-            ]),
-          ),
-        },
-        fullEndpoint: entry.endpoint.startsWith("http")
-          ? entry.endpoint
-          : `${baseUrl}${entry.endpoint}`,
-      }),
-    );
+        availability,
+        health: integrationHealth(availability, trust.provenance),
+        trust,
+        status: disabled ? "maintenance" : entry.status,
+        features: disabled ? [] : plannerVisibleFeatures(trust, entry.features),
+        configTemplate: disabled
+          ? { servers: {} }
+          : {
+              servers: Object.fromEntries(
+                Object.entries(entry.configTemplate.servers).map(
+                  ([key, value]) => [
+                    key,
+                    {
+                      ...value,
+                      url: value.url.replace("${BASE_URL}", ""),
+                    },
+                  ],
+                ),
+              ),
+            },
+        fullEndpoint: disabled
+          ? ""
+          : entry.endpoint.startsWith("http")
+            ? entry.endpoint
+            : `${baseUrl}${entry.endpoint}`,
+      });
+    }
 
     // Fetch user MCPs (public, live). The community subset is an enhancement on
     // top of the always-available built-in registry, so a lookup failure/timeout

--- a/packages/cloud/api/src/lib/mcp/integration-catalog.ts
+++ b/packages/cloud/api/src/lib/mcp/integration-catalog.ts
@@ -1,0 +1,309 @@
+/**
+ * Trust, availability, and kill-switch policy for the first-party MCP
+ * integration catalog. The public catalog routes (`mcp/registry`, `mcp/list`)
+ * and the `/api/mcps/:provider/:transport` gateway consult this module so the
+ * platform never advertises an endpoint that would answer 501/unconfigured,
+ * honors the operator kill switch consistently, and only exposes
+ * risk-reviewed write capabilities to planners.
+ *
+ * Availability is derived from the same environment contract the transport
+ * gateway executes (`MCP_<PROVIDER>_STREAMABLE_HTTP_URL` for operator-proxied
+ * providers, built-in Workers transports for time/weather/crypto). The kill
+ * switch is the `MCP_KILL_SWITCH` env var: a comma-separated list of catalog
+ * ids and/or provider slugs, or `all`.
+ */
+
+export type IntegrationAvailability = "available" | "disabled" | "unconfigured";
+export type IntegrationProvenance =
+  | "first-party"
+  | "operator-proxied"
+  | "community";
+export type IntegrationAuthMode = "none" | "session" | "api-key" | "oauth";
+export type IntegrationHealth = "operational" | "unknown" | "unavailable";
+
+export interface IntegrationCapability {
+  readonly name: string;
+  readonly access: "read" | "write";
+  /** True once the capability passed a risk review; unreviewed writes are hidden from planners. */
+  readonly reviewed: boolean;
+}
+
+export interface IntegrationTrust {
+  readonly publisher: string;
+  readonly provenance: IntegrationProvenance;
+  readonly authMode: IntegrationAuthMode;
+  /** Upstream network domains the integration contacts (empty for on-platform tools). */
+  readonly domains: readonly string[];
+  /** ISO date of the most recent capability risk review. */
+  readonly reviewedAt: string;
+  readonly capabilities: readonly IntegrationCapability[];
+}
+
+/** Minimal env shape the policy reads; matches `Bindings`' string index. */
+export interface IntegrationPolicyEnv {
+  readonly [key: string]: unknown;
+}
+
+/** Provider slugs served natively by the Workers transport gateway. */
+const BUILTIN_PROVIDERS = new Set<string>(["time", "weather", "crypto"]);
+
+/** Catalog ids served by `/api/mcp` itself (always deployable with the Worker). */
+const PLATFORM_IDS = new Set<string>(["eliza-platform", "eliza-cloud-mcp"]);
+
+const read = (name: string): IntegrationCapability => ({
+  name,
+  access: "read",
+  reviewed: true,
+});
+const write = (name: string): IntegrationCapability => ({
+  name,
+  access: "write",
+  reviewed: true,
+});
+
+/**
+ * Trust metadata for every first-party catalog entry, keyed by catalog id.
+ * `mcp/list` and `mcp/registry` use different ids for the same integration;
+ * both aliases are present so either surface resolves the same record.
+ */
+export const INTEGRATION_TRUST: Readonly<Record<string, IntegrationTrust>> =
+  (() => {
+    const platform: IntegrationTrust = {
+      publisher: "elizaOS",
+      provenance: "first-party",
+      authMode: "api-key",
+      domains: [],
+      reviewedAt: "2026-08-20",
+      capabilities: [
+        read("check_credits"),
+        read("get_recent_usage"),
+        read("get_usage"),
+        read("search_web"),
+        read("extract_page"),
+        write("browser_session"),
+        write("generate_text"),
+        write("generate_image"),
+        write("save_memory"),
+        read("retrieve_memories"),
+        write("chat_with_agent"),
+        read("list_agents"),
+        read("list_containers"),
+        read("conversation_management"),
+      ],
+    };
+    const time: IntegrationTrust = {
+      publisher: "elizaOS",
+      provenance: "first-party",
+      authMode: "none",
+      domains: [],
+      reviewedAt: "2026-08-20",
+      capabilities: [
+        read("get_current_time"),
+        read("convert_timezone"),
+        read("format_date"),
+        read("calculate_time_diff"),
+        read("list_timezones"),
+      ],
+    };
+    const weather: IntegrationTrust = {
+      publisher: "elizaOS",
+      provenance: "first-party",
+      authMode: "none",
+      domains: ["api.open-meteo.com", "geocoding-api.open-meteo.com"],
+      reviewedAt: "2026-08-20",
+      capabilities: [
+        read("get_current_weather"),
+        read("get_weather_forecast"),
+        read("compare_weather"),
+        read("search_location"),
+      ],
+    };
+    const crypto: IntegrationTrust = {
+      publisher: "elizaOS",
+      provenance: "first-party",
+      authMode: "none",
+      domains: ["api.coingecko.com"],
+      reviewedAt: "2026-08-20",
+      capabilities: [
+        read("get_price"),
+        read("get_market_data"),
+        read("list_trending"),
+      ],
+    };
+    return {
+      "eliza-platform": platform,
+      "eliza-cloud-mcp": platform,
+      "time-server": time,
+      "time-mcp": time,
+      weather,
+      "weather-mcp": weather,
+      "crypto-prices": crypto,
+      "crypto-mcp": crypto,
+      "web-search": {
+        publisher: "elizaOS",
+        provenance: "operator-proxied",
+        authMode: "api-key",
+        domains: [],
+        reviewedAt: "2026-08-20",
+        capabilities: [read("search"), read("fetch_page")],
+      },
+      linear: {
+        publisher: "Linear (proxied by elizaOS)",
+        provenance: "operator-proxied",
+        authMode: "oauth",
+        domains: ["api.linear.app"],
+        reviewedAt: "2026-08-20",
+        capabilities: [
+          read("linear_list_issues"),
+          write("linear_create_issue"),
+          read("linear_list_projects"),
+          read("linear_list_teams"),
+        ],
+      },
+      notion: {
+        publisher: "Notion (proxied by elizaOS)",
+        provenance: "operator-proxied",
+        authMode: "oauth",
+        domains: ["api.notion.com"],
+        reviewedAt: "2026-08-20",
+        capabilities: [
+          read("notion_search"),
+          write("notion_create_page"),
+          read("notion_get_database"),
+          read("notion_query_data_source"),
+        ],
+      },
+      github: {
+        publisher: "GitHub (proxied by elizaOS)",
+        provenance: "operator-proxied",
+        authMode: "oauth",
+        domains: ["api.github.com"],
+        reviewedAt: "2026-08-20",
+        capabilities: [
+          read("github_list_repos"),
+          write("github_create_issue"),
+          read("github_list_prs"),
+          write("github_create_pr"),
+        ],
+      },
+    };
+  })();
+
+/** Env var the transport gateway resolves for an operator-proxied provider. */
+export function upstreamEnvKeyForProvider(provider: string): string {
+  const slug = provider.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase();
+  return `MCP_${slug}_STREAMABLE_HTTP_URL`;
+}
+
+/** Extracts the `/api/mcps/<provider>/...` slug from a catalog endpoint, if any. */
+export function providerSlugFromEndpoint(endpoint: string): string | null {
+  const match = /\/api\/mcps\/([a-z0-9-]+)(?:\/|$)/i.exec(endpoint);
+  return match ? match[1].toLowerCase() : null;
+}
+
+export interface KillSwitchState {
+  readonly all: boolean;
+  readonly ids: ReadonlySet<string>;
+}
+
+/**
+ * Parses `MCP_KILL_SWITCH`. Non-string or empty input yields an inert switch;
+ * tokens are trimmed and lowercased so operator formatting cannot silently
+ * disarm the switch.
+ */
+export function parseKillSwitch(raw: unknown): KillSwitchState {
+  // error-policy:J3 untrusted operator env — malformed input becomes an
+  // explicit inert switch, never a partially-armed guess.
+  if (typeof raw !== "string") return { all: false, ids: new Set() };
+  const tokens = raw
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length > 0);
+  if (tokens.includes("all") || tokens.includes("*")) {
+    return { all: true, ids: new Set(tokens) };
+  }
+  return { all: false, ids: new Set(tokens) };
+}
+
+/**
+ * Catalog-id aliases per gateway provider slug, so a kill-switch token written
+ * as either the slug (`crypto`) or a catalog id (`crypto-prices`, `crypto-mcp`)
+ * disables both the catalog listing and the transport route.
+ */
+const PROVIDER_SLUG_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  time: ["time-server", "time-mcp"],
+  weather: ["weather-mcp"],
+  crypto: ["crypto-prices", "crypto-mcp"],
+  search: ["web-search"],
+};
+
+/** True when the kill switch disables the given catalog id / provider slug. */
+export function isKillSwitched(
+  env: IntegrationPolicyEnv,
+  catalogId: string,
+  providerSlug: string | null,
+): boolean {
+  const state = parseKillSwitch(env.MCP_KILL_SWITCH);
+  if (state.all) return true;
+  if (state.ids.has(catalogId.toLowerCase())) return true;
+  if (providerSlug === null) return false;
+  if (state.ids.has(providerSlug)) return true;
+  const aliases = PROVIDER_SLUG_ALIASES[providerSlug] ?? [];
+  return aliases.some((alias) => state.ids.has(alias));
+}
+
+/**
+ * Resolves whether the catalog may advertise an integration. `unconfigured`
+ * entries must not be listed at all — their transport route answers 501.
+ */
+export function resolveIntegrationAvailability(
+  env: IntegrationPolicyEnv,
+  catalogId: string,
+  endpoint: string,
+): IntegrationAvailability {
+  const providerSlug = providerSlugFromEndpoint(endpoint);
+  if (isKillSwitched(env, catalogId, providerSlug)) return "disabled";
+  if (PLATFORM_IDS.has(catalogId)) return "available";
+  if (providerSlug === null) return "unconfigured";
+  if (BUILTIN_PROVIDERS.has(providerSlug)) return "available";
+  const upstream = env[upstreamEnvKeyForProvider(providerSlug)];
+  return typeof upstream === "string" && upstream.trim().length > 0
+    ? "available"
+    : "unconfigured";
+}
+
+/** Health state the catalog reports; only live probing could upgrade "unknown". */
+export function integrationHealth(
+  availability: IntegrationAvailability,
+  provenance: IntegrationProvenance,
+): IntegrationHealth {
+  if (availability !== "available") return "unavailable";
+  return provenance === "first-party" ? "operational" : "unknown";
+}
+
+/**
+ * Capabilities a planner may see: every reviewed capability plus unreviewed
+ * reads. Unreviewed writes are withheld until a risk review lands.
+ */
+export function plannerVisibleCapabilities(
+  capabilities: readonly IntegrationCapability[],
+): IntegrationCapability[] {
+  return capabilities.filter(
+    (capability) => capability.reviewed || capability.access === "read",
+  );
+}
+
+/**
+ * Filters an advertised feature/tool-name list down to planner-visible
+ * capability names. Names without a trust record are dropped — an unreviewed
+ * capability must never reach the planner by omission.
+ */
+export function plannerVisibleFeatures(
+  trust: IntegrationTrust,
+  features: readonly string[],
+): string[] {
+  const visible = new Set(
+    plannerVisibleCapabilities(trust.capabilities).map((c) => c.name),
+  );
+  return features.filter((feature) => visible.has(feature));
+}

--- a/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.ts
+++ b/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.ts
@@ -11,6 +11,7 @@
 
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { isKillSwitched } from "@/api-app/lib/mcp/integration-catalog";
 import { forwardMcpUpstreamRequest } from "@/lib/mcp/mcp-upstream-forward";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -510,6 +511,17 @@ export function createMcpsTransportApp(provider: string): Hono<AppEnv> {
           allowed: ["mcp", "streamable-http"],
         },
         404,
+      );
+    }
+
+    if (isKillSwitched(c.env, provider, provider)) {
+      return c.json(
+        {
+          success: false,
+          error: "integration_disabled",
+          reason: `The ${provider} integration is disabled by the operator kill switch.`,
+        },
+        503,
       );
     }
 


### PR DESCRIPTION
Refs #19887 (parent #19877)

## What

Adds a typed trust/availability/kill-switch policy for the first-party MCP integration catalog and wires it through every surface that advertises or serves those integrations.

- **New policy module** `packages/cloud/api/src/lib/mcp/integration-catalog.ts`
  - `IntegrationTrust` per catalog entry: publisher, provenance (`first-party` / `operator-proxied` / `community`), auth mode, upstream domains, risk-reviewed capabilities (each read/write + reviewed flag), and review date.
  - `resolveIntegrationAvailability(env, id, endpoint)` derives `available` / `disabled` / `unconfigured` from the exact environment contract the transport gateway executes (`MCP_<PROVIDER>_STREAMABLE_HTTP_URL` for operator-proxied providers; built-in Workers transports for time/weather/crypto; `/api/mcp` for the platform server).
  - `MCP_KILL_SWITCH` env var: comma-separated catalog ids and/or provider slugs, or `all`. Parsing is J3-sanitized — malformed input yields an inert switch, never a partially-armed guess.
  - `plannerVisibleFeatures` hides unreviewed **write** capabilities (and any name without a trust record) from planner-facing feature/tool lists.
- **`GET /api/mcp/registry`** — stops advertising unconfigured integrations (previously `linear`, `notion`, `github`, and the endpoint-less `web-search` were listed even though their transport answers 501). Configured entries gain `availability`, `health`, and `trust`. Kill-switched entries stay listed as `disabled` with features, config template, and endpoint withheld. Entries without a trust record fail closed (withheld, warn-logged).
- **`GET /api/mcp/list`** — same annotation and gating; disabled definitions hide their tool list.
- **`/api/mcps/:provider/:transport` gateway** — answers `503 integration_disabled` for kill-switched providers before serving built-in transports or forwarding upstream. Unconfigured non-builtin providers still answer 501 at the transport (they are just no longer advertised).

## Tests

`packages/cloud/api/__tests__/mcp-integration-catalog.test.ts` (12 tests, deterministic protocol-faithful mocks for auth/community-registry/upstream-forward only — routes and policy are real):

- kill-switch parsing of malformed operator input; id/slug/alias matching; `all`
- availability derivation incl. blank upstream URL and kill-switch precedence
- unreviewed writes hidden from planner-visible capabilities and feature lists
- health derivation (operational / unknown / unavailable)
- registry: unconfigured entries never advertised; configured operator proxy advertised with trust metadata; kill-switched entry listed disabled with connection surface withheld; global kill switch
- list: annotation + tool hiding for disabled entries
- gateway: 503 before serving/forwarding when kill-switched; 501 unconfigured; forward when configured

```
bun test __tests__/mcp-integration-catalog.test.ts   # 12 pass / 0 fail
bun test __tests__/mcp-registry-*.test.ts            # 8 pass / 0 fail (existing)
bun run --cwd packages/cloud/api typecheck           # pass (tsc + worker dry-run bundle)
bun run --cwd packages/cloud/api lint                # pass (biome)
```

Unrelated pre-existing failures in the package's full `bun test __tests__` sweep (stripe queue, messages billing, provisioning gate — PGlite/env-dependent) are untouched by this change; CI lanes are authoritative.

## Notes / remainder

- `MCP_KILL_SWITCH` is an optional operator env var (typed via the `Bindings` string index); it is intentionally absent from `wrangler.toml` defaults — setting it in a deployment env arms it.
- Review dates in the trust records are seeded at this change's review; a human security pass should re-stamp `reviewedAt` (and flip `reviewed` on any newly added write capability) as part of future integration reviews — the hiding mechanism is in place and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-head:7ccc931befdc4230acd18873589155bba3bfbb41 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, Cloud policy, or warm-pool scheduling change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped security, Cloud policy, or warm-pool scheduling change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused package, real-database, static, and boundary validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend runtime surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and fail-closed behavior are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->
