### PR TITLE
fix(voice): seed the Steward session in the real-audio voice smoke lanes

### DIFF
--- a/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
@@ -36,6 +36,7 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import { seedStewardSession } from "./helpers/test-auth";
 
 // Real fake-device audio plus ui-smoke live-stack setup can exceed the default
 // smoke timeout on loaded developer machines.
@@ -829,6 +830,9 @@ async function prepareTranscriptTestPage(
   probes: TranscriptProbes,
 ): Promise<void> {
   await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+  // Fresh pages skip the shared beforeEach, so re-seed the Steward session
+  // here — without it the cloud-only auth gate (#20483) parks the mic tap.
+  await seedStewardSession(page);
   await installDefaultAppRoutes(page);
   await installTranscriptBackendMocks(page, probes);
 }
@@ -904,6 +908,11 @@ async function captureTranscriptRecordViaControlPath(
 
 test.beforeEach(async ({ page }) => {
   await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+  // The production web bundle brands itself cloud-only, and the shell auth
+  // gate (#20483) silently no-ops mic/transcription engagement without a
+  // usable Steward session — seed the canonical signed-in session so the
+  // real capture path under test can run.
+  await seedStewardSession(page);
   await installDefaultAppRoutes(page);
 });
 

--- a/packages/app/test/ui-smoke/voice-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/voice-realaudio.spec.ts
@@ -28,6 +28,7 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import { seedStewardSession } from "./helpers/test-auth";
 import { selectVoiceTrajectory } from "./voice-live-trajectory";
 
 const EXPECTED_PHRASE = "what time is it";
@@ -427,6 +428,12 @@ async function installVoiceBackendMocks(page: Page): Promise<void> {
 
 test.beforeEach(async ({ page }) => {
   await seedAppStorage(page);
+  // The production web bundle this lane serves brands itself cloud-only, and
+  // the shell auth gate (#20483) silently parks every mic engagement behind
+  // Cloud sign-in when no usable Steward session exists — turning each tap
+  // into a dead no-op long before getUserMedia runs. These cells assert the
+  // signed-in voice pipeline, so seed the canonical session up front.
+  await seedStewardSession(page);
   await installDefaultAppRoutes(page);
   await installVoiceBackendMocks(page);
 });


### PR DESCRIPTION
Fixes #16937

## What

The cloud-only shell auth gate (#20483) silently no-ops every composer-mic engagement when no usable Steward session token is stored — `toggleHandsFree` hits `authGate.gated` and returns before `getUserMedia` ever runs. The production web bundle the ui-smoke live stack serves resolves `shouldUseCloudOnlyBranding() === true` (not dev, no injected API base, not native), so every `voice-realaudio` / `transcript-realaudio` cell died at the first mic tap: aria-label stuck at `"talk"`, no capture, no notice.

This is precisely why:
- the `voice-web-live-railway` job failed its **"Record visible mic, silence, and TTS-drop failure cells"** step in run [32359151898](https://github.com/elizaOS/eliza/actions/runs/32359151898) (dispatched today against `develop@e8bfd8830e51b` to re-test the cell after #22533 merged), and
- the earlier live web run 31789351777 stalled on "auth" (the abandoned `fix/voice-live-railway-auth` follow-up).

Fix: seed the canonical signed-in Steward session (existing `test/ui-smoke/helpers/test-auth.ts` contract) in both specs' `beforeEach`, plus `prepareTranscriptTestPage` for the parity test that opens fresh pages outside the shared fixture. Spec-only change; no product code touched.

## Root-cause trace

Instrumented `toggleHandsFree` and re-ran the failing cell locally: `mic:tap → mic:branch{toggle-handsfree} → handsfree:enter{gated: true, realtimeVoiceEnabled: false, micPermission: granted}` — then `recoverGatedCapture()` with phase `needs-auth` calls `requestSignIn()` (no visible notice), i.e. the silent dead tap the failing assertions captured.

## Verification (local, darwin, exact matrix commands the CI job runs)

- `bun run voice:matrix -- --run --require-green --platform web.failure-paths` → **pass=1 fail=0** (was pass=0 fail=1; all three cells — mic denied notice + no phantom capture, silent capture no phantom send, TTS drop fails closed + recovery — now pass)
- `bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts` → **5 passed, 1 skipped** (the live Railway cell keeps its explicit ungated skip)
- `bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts` → **4 passed**
- `bun run --cwd packages/app lint:check` → clean
- `bun run --cwd packages/app typecheck` → fails on pre-existing `plugins/plugin-elizacloud` ↔ `@elizaos/cloud-sdk` export drift (`isCliLoginSessionId`), untouched by this spec-only diff

## Remaining #16937 acceptance (human/owner)

- Set `ELIZA_VOICE_WEB_LIVE_READY=1` repo variable (or dispatch `voice-live-e2e.yml` with `run_web_live_railway=true`) for a green scheduled run of `web.live.railway-roundtrip` with the provisioned `CEREBRAS_API_KEY`/`ELIZACLOUD_API_KEY`.
- Owner-operated macOS/Windows physical-mic desktop captures and bundle inspection per the #22533 review notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)