### PR TITLE
feat(plugin-finances): expose normalized finance capabilities and receipts

### DIFF
--- a/plugins/plugin-finances/AGENTS.md
+++ b/plugins/plugin-finances/AGENTS.md
@@ -40,6 +40,13 @@ and on `@elizaos/plugin-elizacloud` for the managed Plaid / PayPal clients.
   OWNER_FINANCES dispatch + parameter schema. PA imports these; the registered
   `OWNER_FINANCES` umbrella action stays in PA because it also routes
   `subscription_*` to PA's Gmail/browser-orchestrating subscription back-end.
+- Normalized capability layer (`src/finance-capabilities.ts`) — provider-neutral
+  pure calculations behind the `balances`, `budget_status`, `subscriptions`, and
+  `anomalies` subactions. Every capability response carries
+  `FinanceCapabilityMeta` (freshness + calculation method), and the internal
+  writes (`add_source`, `remove_source`, `import_csv`) return a
+  `FinanceWriteReceipt`. Read/derive only — nothing here initiates payments,
+  transfers, or trading, and receipts never carry credentials.
 
 **Views**
 - `finances` — `FinancesView` component, path `/finances`, bundle
@@ -65,6 +72,7 @@ src/
   types.ts                        View DTOs (FinancesViewProps etc.)
   finances-service.ts             FinancesService (payments back-end)
   finance-normalize.ts            FinancesServiceError + input normalizers
+  finance-capabilities.ts         Normalized capability calcs + metadata/receipts
   payment-types.ts                Payment / dashboard / spending types
   payment-recurrence.ts           Recurring-charge detection + merchant normalize
   payment-csv-import.ts           CSV parser → ParsedCsvTransaction

--- a/plugins/plugin-finances/CLAUDE.md
+++ b/plugins/plugin-finances/CLAUDE.md
@@ -40,6 +40,13 @@ and on `@elizaos/plugin-elizacloud` for the managed Plaid / PayPal clients.
   OWNER_FINANCES dispatch + parameter schema. PA imports these; the registered
   `OWNER_FINANCES` umbrella action stays in PA because it also routes
   `subscription_*` to PA's Gmail/browser-orchestrating subscription back-end.
+- Normalized capability layer (`src/finance-capabilities.ts`) — provider-neutral
+  pure calculations behind the `balances`, `budget_status`, `subscriptions`, and
+  `anomalies` subactions. Every capability response carries
+  `FinanceCapabilityMeta` (freshness + calculation method), and the internal
+  writes (`add_source`, `remove_source`, `import_csv`) return a
+  `FinanceWriteReceipt`. Read/derive only — nothing here initiates payments,
+  transfers, or trading, and receipts never carry credentials.
 
 **Views**
 - `finances` — `FinancesView` component, path `/finances`, bundle
@@ -65,6 +72,7 @@ src/
   types.ts                        View DTOs (FinancesViewProps etc.)
   finances-service.ts             FinancesService (payments back-end)
   finance-normalize.ts            FinancesServiceError + input normalizers
+  finance-capabilities.ts         Normalized capability calcs + metadata/receipts
   payment-types.ts                Payment / dashboard / spending types
   payment-recurrence.ts           Recurring-charge detection + merchant normalize
   payment-csv-import.ts           CSV parser → ParsedCsvTransaction

--- a/plugins/plugin-finances/README.md
+++ b/plugins/plugin-finances/README.md
@@ -8,6 +8,7 @@ Owner-facing finance dashboard for elizaOS: balance summary, transactions, and r
 - `runPaymentsHandler`, `MONEY_PARAMETERS`, `OWNER_FINANCE_SIMILES`, `MONEY_TAGS`, `MONEY_CONTEXTS` (`src/actions/finances.ts`) — the payments OWNER_FINANCES dispatch and parameter schema. `@elizaos/plugin-personal-assistant` imports these; the registered `OWNER_FINANCES` umbrella action stays in PA because it also routes `subscription_*` to PA's subscription back-end.
 - `FinancesService` (`src/finances-service.ts`) — payment sources, CSV import, transactions, spending summaries, recurring-charge detection, and email bills. Holds its own runtime + `FinancesRepository`.
 - `FinancesRepository` (`src/db/finances-repository.ts`) — raw SQL over `app_finances`.
+- Normalized capability layer (`src/finance-capabilities.ts`) — provider-neutral `balances`, `budget_status`, `subscriptions`, and `anomalies` subactions with freshness/calculation metadata (`FinanceCapabilityMeta`) on reads and `FinanceWriteReceipt` receipts on internal writes. Read/derive only; no payments or trading.
 
 **View**
 - `finances` — `FinancesView` at `/finances` with balance summary, transactions, and recurring charges. Bundle: `dist/views/bundle.js`.

--- a/plugins/plugin-finances/src/actions/finances.ts
+++ b/plugins/plugin-finances/src/actions/finances.ts
@@ -27,6 +27,7 @@ import {
   buildWriteReceipt,
   computeBudgetStatus,
   computeSourceBalances,
+  countDistinctSources,
   detectAnomalies,
   normalizeSubscriptions,
 } from "../finance-capabilities.ts";
@@ -488,14 +489,15 @@ async function runPaymentsActionInner(
         categoryColumn: params.categoryColumn,
       });
       const summary = `Imported ${result.inserted} transaction${result.inserted === 1 ? "" : "s"} (${result.skipped} already on file, ${result.errors.length} error${result.errors.length === 1 ? "" : "s"}).`;
-      const applied = result.errors.length === 0 || result.inserted > 0;
+      const succeeded = result.errors.length === 0 || result.inserted > 0;
       return {
-        success: applied,
+        success: succeeded,
         text: summary,
         data: {
           result,
-          // A receipt is only issued when the import actually changed state.
-          ...(applied
+          // A receipt is only issued when the import actually changed state;
+          // an all-duplicate replay (inserted=0) succeeds but mutates nothing.
+          ...(result.inserted > 0
             ? {
                 receipt: buildWriteReceipt({
                   capability: "finance.import_csv",
@@ -629,7 +631,7 @@ async function runPaymentsActionInner(
             capability: "finance.budget_status",
             now,
             transactions,
-            sourceCount: params.sourceId ? 1 : 0,
+            sourceCount: countDistinctSources(transactions),
             method: "user_supplied_input",
             windowDays,
             notes: [
@@ -650,6 +652,23 @@ async function runPaymentsActionInner(
         (total, sub) => total + sub.annualizedCostUsd,
         0,
       );
+      // Freshness reflects the transaction rows the recurring-charge
+      // aggregates were derived from, not a fabricated empty ledger.
+      let latestChargeDataAt: string | null = null;
+      let chargeTransactionCount = 0;
+      const chargeSourceIds = new Set<string>();
+      for (const charge of charges) {
+        if (
+          latestChargeDataAt === null ||
+          charge.latestSeenAt > latestChargeDataAt
+        ) {
+          latestChargeDataAt = charge.latestSeenAt;
+        }
+        chargeTransactionCount += charge.occurrenceCount;
+        for (const sourceId of charge.sourceIds) {
+          chargeSourceIds.add(sourceId);
+        }
+      }
       return {
         success: true,
         text:
@@ -662,7 +681,9 @@ async function runPaymentsActionInner(
             capability: "finance.subscriptions",
             now,
             transactions: [],
-            sourceCount: params.sourceId ? 1 : 0,
+            latestDataAt: latestChargeDataAt,
+            transactionCount: chargeTransactionCount,
+            sourceCount: chargeSourceIds.size,
             method: "derived_from_transactions",
             windowDays: params.sinceDays ?? null,
             notes: [
@@ -674,24 +695,20 @@ async function runPaymentsActionInner(
     }
     case "anomalies": {
       const now = new Date();
+      const windowDays = Math.max(
+        7,
+        Math.min(
+          365,
+          typeof params.sinceDays === "number" &&
+            Number.isFinite(params.sinceDays)
+            ? Math.trunc(params.sinceDays)
+            : 90,
+        ),
+      );
       const transactions = await service.listTransactions({
         sourceId: params.sourceId ?? null,
         sinceAt: new Date(
-          now.getTime() -
-            Math.max(
-              7,
-              Math.min(
-                365,
-                typeof params.sinceDays === "number" &&
-                  Number.isFinite(params.sinceDays)
-                  ? Math.trunc(params.sinceDays)
-                  : 90,
-              ),
-            ) *
-              24 *
-              60 *
-              60 *
-              1000,
+          now.getTime() - windowDays * 24 * 60 * 60 * 1000,
         ).toISOString(),
       });
       const anomalies = detectAnomalies(transactions);
@@ -707,8 +724,9 @@ async function runPaymentsActionInner(
             capability: "finance.anomalies",
             now,
             transactions,
-            sourceCount: params.sourceId ? 1 : 0,
+            sourceCount: countDistinctSources(transactions),
             method: "derived_from_transactions",
+            windowDays,
             notes: [
               "Heuristic detection over settled debits: same-merchant same-amount charges within 3 days, and debits >= 2.5x a merchant's prior average. Flags are candidates for human review, not confirmed errors.",
             ],

--- a/plugins/plugin-finances/src/actions/finances.ts
+++ b/plugins/plugin-finances/src/actions/finances.ts
@@ -22,6 +22,14 @@ import {
   decodeChildcareWorkScenarioInput,
   evaluateChildcareWorkScenario,
 } from "../childcare-work-scenario.ts";
+import {
+  buildCapabilityMeta,
+  buildWriteReceipt,
+  computeBudgetStatus,
+  computeSourceBalances,
+  detectAnomalies,
+  normalizeSubscriptions,
+} from "../finance-capabilities.ts";
 import { FinancesServiceError } from "../finance-normalize.ts";
 import {
   FinancesService,
@@ -68,6 +76,7 @@ export const MONEY_PARAMETERS: readonly {
     name: "subaction",
     description:
       "dashboard | list_sources | add_source | remove_source | import_csv | list_transactions | spending_summary | recurring_charges " +
+      "| balances | budget_status | subscriptions | anomalies " +
       "| childcare_work_scenario | subscription_audit | subscription_cancel | subscription_status. Defaults to dashboard for ambiguous intents.",
     required: false,
     schema: { type: "string" },
@@ -170,6 +179,13 @@ export const MONEY_PARAMETERS: readonly {
     schema: { type: "boolean" },
   },
   {
+    name: "budgetUsd",
+    description:
+      "For budget_status: the user-supplied budget in USD to compare spend against.",
+    required: false,
+    schema: { type: "number" },
+  },
+  {
     name: "scenarioJson",
     description:
       "For childcare_work_scenario: JSON using childcare-work-scenario.v1. Every material category must be known, explicitly not_applicable, or missing; missing values never become zero.",
@@ -254,6 +270,10 @@ type PaymentsSubaction =
   | "list_transactions"
   | "spending_summary"
   | "recurring_charges"
+  | "balances"
+  | "budget_status"
+  | "subscriptions"
+  | "anomalies"
   | "childcare_work_scenario";
 
 type PaymentsActionParams = {
@@ -274,6 +294,7 @@ type PaymentsActionParams = {
   limit?: number;
   merchantContains?: string;
   onlyDebits?: boolean;
+  budgetUsd?: number;
   scenarioJson?: string;
 };
 
@@ -311,6 +332,10 @@ function normalizeSubaction(value: unknown): PaymentsSubaction | null {
     "list_transactions",
     "spending_summary",
     "recurring_charges",
+    "balances",
+    "budget_status",
+    "subscriptions",
+    "anomalies",
     "childcare_work_scenario",
   ];
   return (subactions as string[]).includes(normalized)
@@ -409,7 +434,16 @@ async function runPaymentsActionInner(
       return {
         success: true,
         text: `Added ${source.kind} source "${source.label}".`,
-        data: { source },
+        data: {
+          source,
+          receipt: buildWriteReceipt({
+            capability: "finance.add_source",
+            operation: "create",
+            entityType: "payment_source",
+            entityId: source.id,
+            now: new Date(),
+          }),
+        },
       };
     }
     case "remove_source": {
@@ -424,7 +458,16 @@ async function runPaymentsActionInner(
       return {
         success: true,
         text: "Payment source removed.",
-        data: { sourceId: params.sourceId },
+        data: {
+          sourceId: params.sourceId,
+          receipt: buildWriteReceipt({
+            capability: "finance.remove_source",
+            operation: "delete",
+            entityType: "payment_source",
+            entityId: params.sourceId,
+            now: new Date(),
+          }),
+        },
       };
     }
     case "import_csv": {
@@ -445,10 +488,30 @@ async function runPaymentsActionInner(
         categoryColumn: params.categoryColumn,
       });
       const summary = `Imported ${result.inserted} transaction${result.inserted === 1 ? "" : "s"} (${result.skipped} already on file, ${result.errors.length} error${result.errors.length === 1 ? "" : "s"}).`;
+      const applied = result.errors.length === 0 || result.inserted > 0;
       return {
-        success: result.errors.length === 0 || result.inserted > 0,
+        success: applied,
         text: summary,
-        data: { result },
+        data: {
+          result,
+          // A receipt is only issued when the import actually changed state.
+          ...(applied
+            ? {
+                receipt: buildWriteReceipt({
+                  capability: "finance.import_csv",
+                  operation: "import",
+                  entityType: "transactions",
+                  entityId: params.sourceId,
+                  now: new Date(),
+                  counts: {
+                    inserted: result.inserted,
+                    skipped: result.skipped,
+                    errors: result.errors.length,
+                  },
+                }),
+              }
+            : {}),
+        },
       };
     }
     case "list_transactions": {
@@ -488,6 +551,169 @@ async function runPaymentsActionInner(
         success: true,
         text: `Detected ${charges.length} recurring charge${charges.length === 1 ? "" : "s"} worth ~$${annualized.toFixed(2)}/yr.`,
         data: { charges },
+      };
+    }
+    case "balances": {
+      const now = new Date();
+      const [sources, transactions] = await Promise.all([
+        service.listPaymentSources(),
+        service.listTransactions({ sourceId: params.sourceId ?? null }),
+      ]);
+      const scoped = params.sourceId
+        ? sources.filter((source) => source.id === params.sourceId)
+        : sources;
+      const balances = computeSourceBalances(scoped, transactions);
+      return {
+        success: true,
+        text:
+          balances.length === 0
+            ? "No payment sources connected, so no balances can be derived."
+            : `Derived ledger balances for ${balances.length} source${balances.length === 1 ? "" : "s"} (net flow of credits minus settled debits, not institution-reported balances).`,
+        data: {
+          balances,
+          meta: buildCapabilityMeta({
+            capability: "finance.balances",
+            now,
+            transactions,
+            sourceCount: scoped.length,
+            method: "derived_from_transactions",
+            notes: [
+              "Net flow is derived from the imported/synced transaction ledger; it is not an institution-reported balance.",
+              "Pending transactions are excluded from settled figures and reported separately.",
+            ],
+          }),
+        },
+      };
+    }
+    case "budget_status": {
+      if (
+        typeof params.budgetUsd !== "number" ||
+        !Number.isFinite(params.budgetUsd) ||
+        params.budgetUsd <= 0
+      ) {
+        return {
+          success: false,
+          text: "budget_status requires a positive budgetUsd amount to compare spend against.",
+          data: { error: "MISSING_BUDGET_AMOUNT" },
+        };
+      }
+      const now = new Date();
+      const windowDays = Math.max(
+        1,
+        Math.min(
+          365,
+          typeof params.windowDays === "number" &&
+            Number.isFinite(params.windowDays)
+            ? Math.trunc(params.windowDays)
+            : 30,
+        ),
+      );
+      const transactions = await service.listTransactions({
+        sourceId: params.sourceId ?? null,
+        sinceAt: new Date(
+          now.getTime() - windowDays * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      });
+      const budget = computeBudgetStatus({
+        transactions,
+        budgetUsd: params.budgetUsd,
+        windowDays,
+        now,
+      });
+      return {
+        success: true,
+        text: `Spent $${budget.spentUsd.toFixed(2)} of the $${budget.budgetUsd.toFixed(2)} budget over ${budget.windowDays} days (${budget.status.replace(/_/g, " ")}).`,
+        data: {
+          budget,
+          meta: buildCapabilityMeta({
+            capability: "finance.budget_status",
+            now,
+            transactions,
+            sourceCount: params.sourceId ? 1 : 0,
+            method: "user_supplied_input",
+            windowDays,
+            notes: [
+              "The budget amount is supplied by the user; spend is derived from settled debit transactions in the window.",
+            ],
+          }),
+        },
+      };
+    }
+    case "subscriptions": {
+      const now = new Date();
+      const charges = await service.getRecurringCharges({
+        sourceId: params.sourceId ?? null,
+        sinceDays: params.sinceDays ?? null,
+      });
+      const subscriptions = normalizeSubscriptions(charges);
+      const annualized = subscriptions.reduce(
+        (total, sub) => total + sub.annualizedCostUsd,
+        0,
+      );
+      return {
+        success: true,
+        text:
+          subscriptions.length === 0
+            ? "No subscription-like recurring charges detected."
+            : `Detected ${subscriptions.length} likely subscription${subscriptions.length === 1 ? "" : "s"} totaling ~$${annualized.toFixed(2)}/yr.`,
+        data: {
+          subscriptions,
+          meta: buildCapabilityMeta({
+            capability: "finance.subscriptions",
+            now,
+            transactions: [],
+            sourceCount: params.sourceId ? 1 : 0,
+            method: "derived_from_transactions",
+            windowDays: params.sinceDays ?? null,
+            notes: [
+              "Subscriptions are inferred from regular-cadence recurring debits with detection confidence >= 0.5; this is detection, not billing-provider data.",
+            ],
+          }),
+        },
+      };
+    }
+    case "anomalies": {
+      const now = new Date();
+      const transactions = await service.listTransactions({
+        sourceId: params.sourceId ?? null,
+        sinceAt: new Date(
+          now.getTime() -
+            Math.max(
+              7,
+              Math.min(
+                365,
+                typeof params.sinceDays === "number" &&
+                  Number.isFinite(params.sinceDays)
+                  ? Math.trunc(params.sinceDays)
+                  : 90,
+              ),
+            ) *
+              24 *
+              60 *
+              60 *
+              1000,
+        ).toISOString(),
+      });
+      const anomalies = detectAnomalies(transactions);
+      return {
+        success: true,
+        text:
+          anomalies.length === 0
+            ? `No duplicate-charge or amount-spike anomalies detected across ${transactions.length} transactions.`
+            : `Flagged ${anomalies.length} possible anomal${anomalies.length === 1 ? "y" : "ies"} (duplicate charges or amount spikes) for review.`,
+        data: {
+          anomalies,
+          meta: buildCapabilityMeta({
+            capability: "finance.anomalies",
+            now,
+            transactions,
+            sourceCount: params.sourceId ? 1 : 0,
+            method: "derived_from_transactions",
+            notes: [
+              "Heuristic detection over settled debits: same-merchant same-amount charges within 3 days, and debits >= 2.5x a merchant's prior average. Flags are candidates for human review, not confirmed errors.",
+            ],
+          }),
+        },
       };
     }
   }

--- a/plugins/plugin-finances/src/finance-capabilities.test.ts
+++ b/plugins/plugin-finances/src/finance-capabilities.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Deterministic unit tests for the provider-neutral finance capability layer:
+ * balance derivation, budget status, anomaly detection, subscription
+ * normalization, capability metadata, and write receipts. Pure-function
+ * harness — real inputs shaped like repository rows, no mocks of the system
+ * under test, no I/O. Covers multi-account and multi-currency ledgers,
+ * pending rows, duplicate charges, empty inputs, and adversarial merchant
+ * strings.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildCapabilityMeta,
+  buildWriteReceipt,
+  computeBudgetStatus,
+  computeSourceBalances,
+  detectAnomalies,
+  isPendingTransaction,
+  normalizeSubscriptions,
+} from "./finance-capabilities.ts";
+import type {
+  LifeOpsPaymentSource,
+  LifeOpsPaymentTransaction,
+  LifeOpsRecurringCharge,
+} from "./payment-types.ts";
+
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+function source(
+  overrides: Partial<LifeOpsPaymentSource> & { id: string },
+): LifeOpsPaymentSource {
+  return {
+    agentId: "agent-1",
+    kind: "manual",
+    label: overrides.id,
+    institution: null,
+    accountMask: null,
+    status: "active",
+    lastSyncedAt: null,
+    transactionCount: 0,
+    metadata: {},
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+let txSeq = 0;
+function tx(
+  overrides: Partial<LifeOpsPaymentTransaction> & {
+    sourceId: string;
+    postedAt: string;
+    amountUsd: number;
+  },
+): LifeOpsPaymentTransaction {
+  txSeq += 1;
+  return {
+    id: `tx-${txSeq}`,
+    agentId: "agent-1",
+    externalId: null,
+    direction: "debit",
+    merchantRaw: "Merchant",
+    merchantNormalized: "merchant",
+    description: null,
+    category: null,
+    currency: "USD",
+    metadata: {},
+    createdAt: overrides.postedAt,
+    ...overrides,
+  };
+}
+
+describe("computeSourceBalances", () => {
+  it("derives per-source net flow across multiple accounts", () => {
+    const sources = [source({ id: "a" }), source({ id: "b" })];
+    const balances = computeSourceBalances(sources, [
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 100,
+        direction: "credit",
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-02T00:00:00.000Z",
+        amountUsd: 40,
+      }),
+      tx({
+        sourceId: "b",
+        postedAt: "2026-08-03T00:00:00.000Z",
+        amountUsd: 25,
+      }),
+    ]);
+    expect(balances).toHaveLength(2);
+    const a = balances.find((b) => b.sourceId === "a");
+    const b = balances.find((row) => row.sourceId === "b");
+    expect(a?.netFlowUsd).toBe(60);
+    expect(a?.settledCreditsUsd).toBe(100);
+    expect(a?.settledDebitsUsd).toBe(40);
+    expect(a?.latestActivityAt).toBe("2026-08-02T00:00:00.000Z");
+    expect(b?.netFlowUsd).toBe(-25);
+  });
+
+  it("excludes pending rows from settled figures and reports them separately", () => {
+    const balances = computeSourceBalances(
+      [source({ id: "a" })],
+      [
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 10,
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-02T00:00:00.000Z",
+          amountUsd: 55.5,
+          metadata: { pending: true },
+        }),
+      ],
+    );
+    expect(balances[0].netFlowUsd).toBe(-10);
+    expect(balances[0].settledTransactionCount).toBe(1);
+    expect(balances[0].pendingCount).toBe(1);
+    expect(balances[0].pendingDebitsUsd).toBe(55.5);
+  });
+
+  it("surfaces every observed currency instead of silently merging", () => {
+    const balances = computeSourceBalances(
+      [source({ id: "a" })],
+      [
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 10,
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-02T00:00:00.000Z",
+          amountUsd: 12,
+          currency: "EUR",
+        }),
+      ],
+    );
+    expect(balances[0].currencies).toEqual(["EUR", "USD"]);
+  });
+
+  it("returns a zeroed record with null freshness for a source with no rows", () => {
+    const balances = computeSourceBalances([source({ id: "empty" })], []);
+    expect(balances[0].settledTransactionCount).toBe(0);
+    expect(balances[0].latestActivityAt).toBeNull();
+    expect(balances[0].currencies).toEqual([]);
+  });
+});
+
+describe("computeBudgetStatus", () => {
+  const inWindow = "2026-08-15T00:00:00.000Z";
+  it("classifies under, near-limit, and over budget", () => {
+    const rows = [
+      tx({ sourceId: "a", postedAt: inWindow, amountUsd: 45 }),
+      tx({ sourceId: "a", postedAt: inWindow, amountUsd: 46 }),
+    ];
+    const under = computeBudgetStatus({
+      transactions: rows,
+      budgetUsd: 200,
+      windowDays: 30,
+      now: NOW,
+    });
+    expect(under.status).toBe("under_budget");
+    expect(under.spentUsd).toBe(91);
+    expect(under.remainingUsd).toBe(109);
+
+    const near = computeBudgetStatus({
+      transactions: rows,
+      budgetUsd: 100,
+      windowDays: 30,
+      now: NOW,
+    });
+    expect(near.status).toBe("near_limit");
+
+    const over = computeBudgetStatus({
+      transactions: rows,
+      budgetUsd: 90,
+      windowDays: 30,
+      now: NOW,
+    });
+    expect(over.status).toBe("over_budget");
+    expect(over.remainingUsd).toBe(-1);
+  });
+
+  it("ignores credits, pending rows, and rows outside the window", () => {
+    const status = computeBudgetStatus({
+      transactions: [
+        tx({ sourceId: "a", postedAt: inWindow, amountUsd: 30 }),
+        tx({
+          sourceId: "a",
+          postedAt: inWindow,
+          amountUsd: 500,
+          direction: "credit",
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: inWindow,
+          amountUsd: 99,
+          metadata: { pending: true },
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: "2026-01-01T00:00:00.000Z",
+          amountUsd: 999,
+        }),
+      ],
+      budgetUsd: 100,
+      windowDays: 30,
+      now: NOW,
+    });
+    expect(status.spentUsd).toBe(30);
+    expect(status.settledTransactionCount).toBe(1);
+    expect(status.pendingExcludedCount).toBe(1);
+    expect(status.status).toBe("under_budget");
+  });
+
+  it("handles an empty ledger as zero spend, not an error", () => {
+    const status = computeBudgetStatus({
+      transactions: [],
+      budgetUsd: 50,
+      windowDays: 7,
+      now: NOW,
+    });
+    expect(status.spentUsd).toBe(0);
+    expect(status.utilization).toBe(0);
+    expect(status.status).toBe("under_budget");
+  });
+});
+
+describe("detectAnomalies", () => {
+  it("flags same-source same-amount charges within 3 days as possible duplicates", () => {
+    const anomalies = detectAnomalies([
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 14.99,
+        merchantNormalized: "netflix",
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-02T12:00:00.000Z",
+        amountUsd: 14.99,
+        merchantNormalized: "netflix",
+      }),
+    ]);
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].kind).toBe("possible_duplicate_charge");
+    expect(anomalies[0].transactionIds).toHaveLength(2);
+  });
+
+  it("groups adversarial merchant strings via the normalized name", () => {
+    const anomalies = detectAnomalies([
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 9.99,
+        merchantRaw: "NETFLlX.COM*8873",
+        merchantNormalized: "netflix",
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T06:00:00.000Z",
+        amountUsd: 9.99,
+        merchantRaw: "Netflix",
+        merchantNormalized: "netflix",
+      }),
+    ]);
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].merchantNormalized).toBe("netflix");
+  });
+
+  it("does not flag duplicates across different sources, amounts, or beyond 3 days", () => {
+    const anomalies = detectAnomalies([
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 14.99,
+      }),
+      tx({
+        sourceId: "b",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 14.99,
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-10T00:00:00.000Z",
+        amountUsd: 14.99,
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-10T01:00:00.000Z",
+        amountUsd: 15.99,
+      }),
+    ]);
+    expect(anomalies).toEqual([]);
+  });
+
+  it("never raises anomalies from pending rows (pending+settled pairs are normal)", () => {
+    const anomalies = detectAnomalies([
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 42,
+        metadata: { pending: true },
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-02T00:00:00.000Z",
+        amountUsd: 42,
+      }),
+    ]);
+    expect(anomalies).toEqual([]);
+  });
+
+  it("flags an amount spike only with enough history and a material delta", () => {
+    const history = [
+      tx({
+        sourceId: "a",
+        postedAt: "2026-05-01T00:00:00.000Z",
+        amountUsd: 12,
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-06-01T00:00:00.000Z",
+        amountUsd: 11,
+      }),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-07-01T00:00:00.000Z",
+        amountUsd: 13,
+      }),
+    ];
+    const spike = detectAnomalies([
+      ...history,
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 95,
+      }),
+    ]);
+    expect(spike).toHaveLength(1);
+    expect(spike[0].kind).toBe("amount_spike");
+    expect(spike[0].amountUsd).toBe(95);
+
+    // Two prior charges is not enough history to call anything a spike.
+    const thinHistory = detectAnomalies([
+      ...history.slice(0, 2),
+      tx({
+        sourceId: "a",
+        postedAt: "2026-08-01T00:00:00.000Z",
+        amountUsd: 95,
+      }),
+    ]);
+    expect(thinHistory).toEqual([]);
+  });
+
+  it("returns an empty list for an empty ledger", () => {
+    expect(detectAnomalies([])).toEqual([]);
+  });
+});
+
+describe("normalizeSubscriptions", () => {
+  function charge(
+    overrides: Partial<LifeOpsRecurringCharge>,
+  ): LifeOpsRecurringCharge {
+    return {
+      merchantNormalized: "netflix",
+      merchantDisplay: "Netflix",
+      cadence: "monthly",
+      averageAmountUsd: 14.99,
+      lastAmountUsd: 14.99,
+      annualizedCostUsd: 179.88,
+      occurrenceCount: 6,
+      firstSeenAt: "2026-02-01T00:00:00.000Z",
+      latestSeenAt: "2026-08-01T00:00:00.000Z",
+      nextExpectedAt: "2026-09-01T00:00:00.000Z",
+      sourceIds: ["a"],
+      sampleTransactionIds: ["tx-1"],
+      confidence: 0.9,
+      category: "entertainment",
+      ...overrides,
+    };
+  }
+
+  it("keeps regular-cadence confident charges and drops irregular/low-confidence ones", () => {
+    const subs = normalizeSubscriptions([
+      charge({}),
+      charge({ merchantNormalized: "gym", cadence: "irregular" }),
+      charge({ merchantNormalized: "shady", confidence: 0.2 }),
+    ]);
+    expect(subs).toHaveLength(1);
+    expect(subs[0].merchantNormalized).toBe("netflix");
+  });
+
+  it("sorts by annualized cost descending and handles the empty case", () => {
+    const subs = normalizeSubscriptions([
+      charge({ merchantNormalized: "cheap", annualizedCostUsd: 60 }),
+      charge({ merchantNormalized: "pricey", annualizedCostUsd: 600 }),
+    ]);
+    expect(subs.map((s) => s.merchantNormalized)).toEqual(["pricey", "cheap"]);
+    expect(normalizeSubscriptions([])).toEqual([]);
+  });
+});
+
+describe("buildCapabilityMeta / buildWriteReceipt / isPendingTransaction", () => {
+  it("reports freshness from consumed rows and null for empty input", () => {
+    const meta = buildCapabilityMeta({
+      capability: "finance.balances",
+      now: NOW,
+      transactions: [
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 1,
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-05T00:00:00.000Z",
+          amountUsd: 2,
+        }),
+      ],
+      sourceCount: 1,
+      method: "derived_from_transactions",
+      windowDays: 30,
+      notes: ["derived"],
+    });
+    expect(meta.provider).toBe("plugin-finances");
+    expect(meta.generatedAt).toBe(NOW.toISOString());
+    expect(meta.freshness.latestDataAt).toBe("2026-08-05T00:00:00.000Z");
+    expect(meta.freshness.transactionCount).toBe(2);
+    expect(meta.calculation.windowDays).toBe(30);
+
+    const empty = buildCapabilityMeta({
+      capability: "finance.balances",
+      now: NOW,
+      transactions: [],
+      sourceCount: 0,
+      method: "derived_from_transactions",
+    });
+    expect(empty.freshness.latestDataAt).toBeNull();
+    expect(empty.calculation.windowDays).toBeNull();
+  });
+
+  it("issues unique receipts describing the write without payload data", () => {
+    const first = buildWriteReceipt({
+      capability: "finance.import_csv",
+      operation: "import",
+      entityType: "transactions",
+      entityId: "source-1",
+      now: NOW,
+      counts: { inserted: 3, skipped: 1, errors: 0 },
+    });
+    const second = buildWriteReceipt({
+      capability: "finance.add_source",
+      operation: "create",
+      entityType: "payment_source",
+      entityId: "source-2",
+      now: NOW,
+    });
+    expect(first.receiptId).not.toBe(second.receiptId);
+    expect(first.outcome).toBe("applied");
+    expect(first.counts).toEqual({ inserted: 3, skipped: 1, errors: 0 });
+    expect(second.counts).toBeNull();
+    expect(first.occurredAt).toBe(NOW.toISOString());
+    expect(Object.keys(first).sort()).toEqual([
+      "capability",
+      "counts",
+      "entityId",
+      "entityType",
+      "occurredAt",
+      "operation",
+      "outcome",
+      "receiptId",
+    ]);
+  });
+
+  it("only treats an explicit boolean pending flag as pending", () => {
+    expect(
+      isPendingTransaction(
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 1,
+          metadata: { pending: true },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPendingTransaction(
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 1,
+          metadata: { pending: "yes" },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-finances/src/finance-capabilities.test.ts
+++ b/plugins/plugin-finances/src/finance-capabilities.test.ts
@@ -14,6 +14,7 @@ import {
   buildWriteReceipt,
   computeBudgetStatus,
   computeSourceBalances,
+  countDistinctSources,
   detectAnomalies,
   isPendingTransaction,
   normalizeSubscriptions,
@@ -444,6 +445,55 @@ describe("buildCapabilityMeta / buildWriteReceipt / isPendingTransaction", () =>
     });
     expect(empty.freshness.latestDataAt).toBeNull();
     expect(empty.calculation.windowDays).toBeNull();
+  });
+
+  it("honors explicit freshness for aggregate-input capabilities", () => {
+    const meta = buildCapabilityMeta({
+      capability: "finance.subscriptions",
+      now: NOW,
+      transactions: [],
+      latestDataAt: "2026-08-10T00:00:00.000Z",
+      transactionCount: 12,
+      sourceCount: 2,
+      method: "derived_from_transactions",
+    });
+    expect(meta.freshness.latestDataAt).toBe("2026-08-10T00:00:00.000Z");
+    expect(meta.freshness.transactionCount).toBe(12);
+    expect(meta.freshness.sourceCount).toBe(2);
+
+    const explicitlyEmpty = buildCapabilityMeta({
+      capability: "finance.subscriptions",
+      now: NOW,
+      transactions: [],
+      latestDataAt: null,
+      transactionCount: 0,
+      sourceCount: 0,
+      method: "derived_from_transactions",
+    });
+    expect(explicitlyEmpty.freshness.latestDataAt).toBeNull();
+  });
+
+  it("counts distinct sources across consumed rows", () => {
+    expect(countDistinctSources([])).toBe(0);
+    expect(
+      countDistinctSources([
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-01T00:00:00.000Z",
+          amountUsd: 1,
+        }),
+        tx({
+          sourceId: "a",
+          postedAt: "2026-08-02T00:00:00.000Z",
+          amountUsd: 2,
+        }),
+        tx({
+          sourceId: "b",
+          postedAt: "2026-08-03T00:00:00.000Z",
+          amountUsd: 3,
+        }),
+      ]),
+    ).toBe(2);
   });
 
   it("issues unique receipts describing the write without payload data", () => {

--- a/plugins/plugin-finances/src/finance-capabilities.ts
+++ b/plugins/plugin-finances/src/finance-capabilities.ts
@@ -53,6 +53,10 @@ export interface FinanceCapabilityMeta {
  * Receipt for a successful internal write (add/remove source, CSV import).
  * Describes what changed in `app_finances` without exposing row payloads or
  * credentials, so the planner and audit surfaces can cite the mutation.
+ * Receipts are non-authoritative response annotations minted per response —
+ * they are not persisted and carry no idempotency key, so a retried action
+ * yields a fresh `receiptId`; the underlying entity ids remain the stable
+ * handles for reconciliation.
  */
 export interface FinanceWriteReceipt {
   receiptId: string;
@@ -98,7 +102,13 @@ function latestPostedAt(
   return latest;
 }
 
-/** Builds the shared freshness/calculation metadata for one capability run. */
+/**
+ * Builds the shared freshness/calculation metadata for one capability run.
+ * Freshness defaults to the transaction rows the calculation consumed; a
+ * capability whose input is already an aggregate (e.g. recurring charges)
+ * passes explicit `latestDataAt`/`transactionCount` describing the rows that
+ * aggregate was derived from instead of fabricating an empty ledger.
+ */
 export function buildCapabilityMeta(args: {
   capability: string;
   now: Date;
@@ -107,14 +117,19 @@ export function buildCapabilityMeta(args: {
   method: FinanceCalculationMethod;
   windowDays?: number | null;
   notes?: readonly string[];
+  latestDataAt?: string | null;
+  transactionCount?: number;
 }): FinanceCapabilityMeta {
   return {
     capability: args.capability,
     provider: "plugin-finances",
     generatedAt: args.now.toISOString(),
     freshness: {
-      latestDataAt: latestPostedAt(args.transactions),
-      transactionCount: args.transactions.length,
+      latestDataAt:
+        args.latestDataAt !== undefined
+          ? args.latestDataAt
+          : latestPostedAt(args.transactions),
+      transactionCount: args.transactionCount ?? args.transactions.length,
       sourceCount: args.sourceCount,
     },
     calculation: {
@@ -123,6 +138,17 @@ export function buildCapabilityMeta(args: {
       notes: args.notes ?? [],
     },
   };
+}
+
+/** Number of distinct payment sources represented in a set of rows. */
+export function countDistinctSources(
+  transactions: readonly LifeOpsPaymentTransaction[],
+): number {
+  const sources = new Set<string>();
+  for (const tx of transactions) {
+    sources.add(tx.sourceId);
+  }
+  return sources.size;
 }
 
 /** True when the transaction is flagged pending by its originating provider. */

--- a/plugins/plugin-finances/src/finance-capabilities.ts
+++ b/plugins/plugin-finances/src/finance-capabilities.ts
@@ -1,0 +1,404 @@
+/**
+ * Provider-neutral finance capability layer: normalized balance, budget,
+ * subscription, and anomaly calculations plus the freshness/calculation
+ * metadata and internal-write receipts the OWNER_FINANCES action attaches to
+ * every capability response.
+ *
+ * Everything here is a deterministic pure function over already-loaded rows —
+ * no I/O, no provider SDK types. The action layer (`src/actions/finances.ts`)
+ * loads rows through `FinancesService` and passes an explicit `now`, so the
+ * same inputs always produce the same outputs in tests and at runtime. All
+ * capabilities are read/derive only: nothing in this module initiates a
+ * payment, transfer, or trade, and receipts describe only writes to the
+ * plugin's own `app_finances` tables. Receipts and metadata never carry
+ * tokens, account numbers, or other credentials.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  LifeOpsPaymentSource,
+  LifeOpsPaymentTransaction,
+  LifeOpsRecurringCharge,
+} from "./payment-types.ts";
+
+/** Discriminates how a capability value was produced. */
+export type FinanceCalculationMethod =
+  | "derived_from_transactions"
+  | "provider_reported"
+  | "user_supplied_input";
+
+/**
+ * Freshness and provenance metadata attached to every capability response.
+ * `latestDataAt` is the newest posting timestamp among the rows the
+ * calculation actually consumed (null when the input set is empty), which is
+ * distinct from `generatedAt` (when the calculation ran).
+ */
+export interface FinanceCapabilityMeta {
+  capability: string;
+  provider: "plugin-finances";
+  generatedAt: string;
+  freshness: {
+    latestDataAt: string | null;
+    transactionCount: number;
+    sourceCount: number;
+  };
+  calculation: {
+    method: FinanceCalculationMethod;
+    windowDays: number | null;
+    notes: readonly string[];
+  };
+}
+
+/**
+ * Receipt for a successful internal write (add/remove source, CSV import).
+ * Describes what changed in `app_finances` without exposing row payloads or
+ * credentials, so the planner and audit surfaces can cite the mutation.
+ */
+export interface FinanceWriteReceipt {
+  receiptId: string;
+  capability: string;
+  operation: "create" | "delete" | "import";
+  entityType: "payment_source" | "transactions";
+  entityId: string;
+  occurredAt: string;
+  outcome: "applied";
+  counts: { inserted: number; skipped: number; errors: number } | null;
+}
+
+/** Builds a write receipt for a completed internal mutation. */
+export function buildWriteReceipt(args: {
+  capability: string;
+  operation: FinanceWriteReceipt["operation"];
+  entityType: FinanceWriteReceipt["entityType"];
+  entityId: string;
+  now: Date;
+  counts?: { inserted: number; skipped: number; errors: number };
+}): FinanceWriteReceipt {
+  return {
+    receiptId: randomUUID(),
+    capability: args.capability,
+    operation: args.operation,
+    entityType: args.entityType,
+    entityId: args.entityId,
+    occurredAt: args.now.toISOString(),
+    outcome: "applied",
+    counts: args.counts ?? null,
+  };
+}
+
+function latestPostedAt(
+  transactions: readonly LifeOpsPaymentTransaction[],
+): string | null {
+  let latest: string | null = null;
+  for (const tx of transactions) {
+    if (latest === null || tx.postedAt > latest) {
+      latest = tx.postedAt;
+    }
+  }
+  return latest;
+}
+
+/** Builds the shared freshness/calculation metadata for one capability run. */
+export function buildCapabilityMeta(args: {
+  capability: string;
+  now: Date;
+  transactions: readonly LifeOpsPaymentTransaction[];
+  sourceCount: number;
+  method: FinanceCalculationMethod;
+  windowDays?: number | null;
+  notes?: readonly string[];
+}): FinanceCapabilityMeta {
+  return {
+    capability: args.capability,
+    provider: "plugin-finances",
+    generatedAt: args.now.toISOString(),
+    freshness: {
+      latestDataAt: latestPostedAt(args.transactions),
+      transactionCount: args.transactions.length,
+      sourceCount: args.sourceCount,
+    },
+    calculation: {
+      method: args.method,
+      windowDays: args.windowDays ?? null,
+      notes: args.notes ?? [],
+    },
+  };
+}
+
+/** True when the transaction is flagged pending by its originating provider. */
+export function isPendingTransaction(tx: LifeOpsPaymentTransaction): boolean {
+  return tx.metadata.pending === true;
+}
+
+/**
+ * Net derived balance for one payment source. Balances are derived from the
+ * transaction ledger (credits minus debits), not reported by an institution,
+ * and the metadata says so; pending amounts are tracked separately and never
+ * folded into the settled figure. `currencies` lists every original currency
+ * observed so multi-currency sources are visible rather than silently merged.
+ */
+export interface FinanceSourceBalance {
+  sourceId: string;
+  label: string;
+  kind: LifeOpsPaymentSource["kind"];
+  netFlowUsd: number;
+  settledDebitsUsd: number;
+  settledCreditsUsd: number;
+  pendingCount: number;
+  pendingDebitsUsd: number;
+  settledTransactionCount: number;
+  currencies: readonly string[];
+  latestActivityAt: string | null;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/** Derives per-source balances from the transaction ledger. */
+export function computeSourceBalances(
+  sources: readonly LifeOpsPaymentSource[],
+  transactions: readonly LifeOpsPaymentTransaction[],
+): FinanceSourceBalance[] {
+  const bySource = new Map<string, LifeOpsPaymentTransaction[]>();
+  for (const tx of transactions) {
+    const list = bySource.get(tx.sourceId);
+    if (list) {
+      list.push(tx);
+    } else {
+      bySource.set(tx.sourceId, [tx]);
+    }
+  }
+  return sources.map((source) => {
+    const rows = bySource.get(source.id) ?? [];
+    let debits = 0;
+    let credits = 0;
+    let pendingCount = 0;
+    let pendingDebits = 0;
+    let settledCount = 0;
+    const currencies = new Set<string>();
+    for (const tx of rows) {
+      currencies.add(tx.currency);
+      if (isPendingTransaction(tx)) {
+        pendingCount += 1;
+        if (tx.direction === "debit") {
+          pendingDebits += tx.amountUsd;
+        }
+        continue;
+      }
+      settledCount += 1;
+      if (tx.direction === "debit") {
+        debits += tx.amountUsd;
+      } else {
+        credits += tx.amountUsd;
+      }
+    }
+    return {
+      sourceId: source.id,
+      label: source.label,
+      kind: source.kind,
+      netFlowUsd: round2(credits - debits),
+      settledDebitsUsd: round2(debits),
+      settledCreditsUsd: round2(credits),
+      pendingCount,
+      pendingDebitsUsd: round2(pendingDebits),
+      settledTransactionCount: settledCount,
+      currencies: Array.from(currencies).sort(),
+      latestActivityAt: latestPostedAt(rows),
+    };
+  });
+}
+
+/**
+ * Budget evaluation for a user-supplied budget over a rolling window. The
+ * budget amount itself is an input, never inferred, so the status carries
+ * `user_supplied_input` calculation metadata.
+ */
+export interface FinanceBudgetStatus {
+  budgetUsd: number;
+  windowDays: number;
+  spentUsd: number;
+  remainingUsd: number;
+  utilization: number;
+  status: "under_budget" | "near_limit" | "over_budget";
+  settledTransactionCount: number;
+  pendingExcludedCount: number;
+}
+
+/** Compares settled debit spend inside the window against a supplied budget. */
+export function computeBudgetStatus(args: {
+  transactions: readonly LifeOpsPaymentTransaction[];
+  budgetUsd: number;
+  windowDays: number;
+  now: Date;
+}): FinanceBudgetStatus {
+  const windowStart = new Date(
+    args.now.getTime() - args.windowDays * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  let spent = 0;
+  let settledCount = 0;
+  let pendingExcluded = 0;
+  for (const tx of args.transactions) {
+    if (tx.postedAt < windowStart || tx.direction !== "debit") {
+      continue;
+    }
+    if (isPendingTransaction(tx)) {
+      pendingExcluded += 1;
+      continue;
+    }
+    spent += tx.amountUsd;
+    settledCount += 1;
+  }
+  const spentRounded = round2(spent);
+  const utilization =
+    args.budgetUsd > 0 ? round2(spentRounded / args.budgetUsd) : 0;
+  return {
+    budgetUsd: args.budgetUsd,
+    windowDays: args.windowDays,
+    spentUsd: spentRounded,
+    remainingUsd: round2(args.budgetUsd - spentRounded),
+    utilization,
+    status:
+      spentRounded > args.budgetUsd
+        ? "over_budget"
+        : utilization >= 0.9
+          ? "near_limit"
+          : "under_budget",
+    settledTransactionCount: settledCount,
+    pendingExcludedCount: pendingExcluded,
+  };
+}
+
+/** One detected irregularity in the transaction ledger. */
+export interface FinanceAnomaly {
+  kind: "possible_duplicate_charge" | "amount_spike";
+  merchantNormalized: string;
+  merchantDisplay: string;
+  transactionIds: readonly string[];
+  amountUsd: number;
+  detail: string;
+}
+
+const DUPLICATE_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+const SPIKE_MULTIPLIER = 2.5;
+const SPIKE_MIN_HISTORY = 3;
+const SPIKE_MIN_DELTA_USD = 20;
+
+/**
+ * Flags possible duplicate charges (same source, merchant, and amount posted
+ * within 3 days under distinct ids) and amount spikes (a debit at least 2.5x
+ * a merchant's average across 3+ prior settled debits, and at least $20 over
+ * it). Pending rows never generate anomalies: providers routinely post a
+ * pending row and its settled duplicate. Merchant comparison uses the
+ * normalized name so adversarial raw strings ("NETFLlX.COM*8873") group with
+ * their real merchant instead of dodging detection.
+ */
+export function detectAnomalies(
+  transactions: readonly LifeOpsPaymentTransaction[],
+): FinanceAnomaly[] {
+  const settledDebits = transactions
+    .filter((tx) => tx.direction === "debit" && !isPendingTransaction(tx))
+    .sort((a, b) => a.postedAt.localeCompare(b.postedAt));
+
+  const anomalies: FinanceAnomaly[] = [];
+  const reportedDuplicatePairs = new Set<string>();
+
+  for (let i = 0; i < settledDebits.length; i += 1) {
+    const tx = settledDebits[i];
+    for (let j = i + 1; j < settledDebits.length; j += 1) {
+      const other = settledDebits[j];
+      const gap =
+        new Date(other.postedAt).getTime() - new Date(tx.postedAt).getTime();
+      if (gap > DUPLICATE_WINDOW_MS) {
+        break;
+      }
+      if (
+        other.sourceId === tx.sourceId &&
+        other.merchantNormalized === tx.merchantNormalized &&
+        other.amountUsd === tx.amountUsd &&
+        other.id !== tx.id
+      ) {
+        const pairKey = [tx.id, other.id].sort().join(":");
+        if (!reportedDuplicatePairs.has(pairKey)) {
+          reportedDuplicatePairs.add(pairKey);
+          anomalies.push({
+            kind: "possible_duplicate_charge",
+            merchantNormalized: tx.merchantNormalized,
+            merchantDisplay: tx.merchantRaw,
+            transactionIds: [tx.id, other.id],
+            amountUsd: tx.amountUsd,
+            detail: `Two $${tx.amountUsd.toFixed(2)} charges from the same merchant and source within 3 days.`,
+          });
+        }
+      }
+    }
+  }
+
+  const history = new Map<string, number[]>();
+  for (const tx of settledDebits) {
+    const prior = history.get(tx.merchantNormalized) ?? [];
+    if (prior.length >= SPIKE_MIN_HISTORY) {
+      const average = prior.reduce((sum, v) => sum + v, 0) / prior.length;
+      if (
+        tx.amountUsd >= average * SPIKE_MULTIPLIER &&
+        tx.amountUsd - average >= SPIKE_MIN_DELTA_USD
+      ) {
+        anomalies.push({
+          kind: "amount_spike",
+          merchantNormalized: tx.merchantNormalized,
+          merchantDisplay: tx.merchantRaw,
+          transactionIds: [tx.id],
+          amountUsd: tx.amountUsd,
+          detail: `$${tx.amountUsd.toFixed(2)} is ${(tx.amountUsd / average).toFixed(1)}x this merchant's $${average.toFixed(2)} average across ${prior.length} prior charges.`,
+        });
+      }
+    }
+    prior.push(tx.amountUsd);
+    history.set(tx.merchantNormalized, prior);
+  }
+
+  return anomalies;
+}
+
+/**
+ * Provider-neutral subscription record projected from recurring-charge
+ * detection: regular-cadence recurring debits with detection confidence, kept
+ * distinct from the write-side subscription audit/cancellation tables.
+ */
+export interface FinanceSubscriptionRecord {
+  merchantNormalized: string;
+  merchantDisplay: string;
+  cadence: LifeOpsRecurringCharge["cadence"];
+  averageAmountUsd: number;
+  annualizedCostUsd: number;
+  nextExpectedAt: string | null;
+  latestSeenAt: string;
+  confidence: number;
+  sourceIds: readonly string[];
+}
+
+const SUBSCRIPTION_MIN_CONFIDENCE = 0.5;
+
+/** Projects regular-cadence recurring charges into subscription records. */
+export function normalizeSubscriptions(
+  charges: readonly LifeOpsRecurringCharge[],
+): FinanceSubscriptionRecord[] {
+  return charges
+    .filter(
+      (charge) =>
+        charge.cadence !== "irregular" &&
+        charge.confidence >= SUBSCRIPTION_MIN_CONFIDENCE,
+    )
+    .map((charge) => ({
+      merchantNormalized: charge.merchantNormalized,
+      merchantDisplay: charge.merchantDisplay,
+      cadence: charge.cadence,
+      averageAmountUsd: charge.averageAmountUsd,
+      annualizedCostUsd: charge.annualizedCostUsd,
+      nextExpectedAt: charge.nextExpectedAt,
+      latestSeenAt: charge.latestSeenAt,
+      confidence: charge.confidence,
+      sourceIds: charge.sourceIds,
+    }))
+    .sort((a, b) => b.annualizedCostUsd - a.annualizedCostUsd);
+}

--- a/plugins/plugin-finances/src/index.ts
+++ b/plugins/plugin-finances/src/index.ts
@@ -59,6 +59,22 @@ export {
   lifeSubscriptionCandidates,
 } from "./db/schema.ts";
 export {
+  buildCapabilityMeta,
+  buildWriteReceipt,
+  computeBudgetStatus,
+  computeSourceBalances,
+  detectAnomalies,
+  type FinanceAnomaly,
+  type FinanceBudgetStatus,
+  type FinanceCalculationMethod,
+  type FinanceCapabilityMeta,
+  type FinanceSourceBalance,
+  type FinanceSubscriptionRecord,
+  type FinanceWriteReceipt,
+  isPendingTransaction,
+  normalizeSubscriptions,
+} from "./finance-capabilities.ts";
+export {
   FinancesServiceError,
   financeErrorMessage,
 } from "./finance-normalize.ts";

--- a/plugins/plugin-finances/src/index.ts
+++ b/plugins/plugin-finances/src/index.ts
@@ -63,6 +63,7 @@ export {
   buildWriteReceipt,
   computeBudgetStatus,
   computeSourceBalances,
+  countDistinctSources,
   detectAnomalies,
   type FinanceAnomaly,
   type FinanceBudgetStatus,

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -13,12 +13,13 @@
  * methods needing Eliza Cloud) are deliberately out of scope.
  */
 
-import type { AgentRuntime } from "@elizaos/core";
+import type { AgentRuntime, HandlerOptions, Memory } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   createRealTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../packages/app-core/test/helpers/real-runtime.ts";
+import { runPaymentsHandler } from "../src/actions/finances.ts";
 import { FinancesRepository } from "../src/db/finances-repository.ts";
 import { FinancesService } from "../src/finances-service.ts";
 import financesPlugin from "../src/plugin.ts";
@@ -298,5 +299,218 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
     expect(electric).toBeTruthy();
     expect(electric?.amountUsd).toBe(87.42);
     expect(electric?.dueDate).toBe("2026-07-01");
+  });
+
+  describe("normalized capability subactions via runPaymentsHandler (real DB)", () => {
+    function actionMessage(): Memory {
+      return {
+        entityId: runtime.agentId,
+        roomId: runtime.agentId,
+        content: { text: "" },
+      };
+    }
+    const run = (parameters: Record<string, unknown>) =>
+      runPaymentsHandler(runtime, actionMessage(), undefined, {
+        parameters,
+      } as HandlerOptions);
+
+    it("add_source and remove_source return internal-write receipts", async () => {
+      const added = await run({
+        subaction: "add_source",
+        kind: "manual",
+        label: "Receipted account",
+      });
+      expect(added.success).toBe(true);
+      const addedData = added.data as {
+        source: { id: string };
+        receipt: {
+          receiptId: string;
+          capability: string;
+          operation: string;
+          entityId: string;
+          outcome: string;
+        };
+      };
+      expect(addedData.receipt.capability).toBe("finance.add_source");
+      expect(addedData.receipt.operation).toBe("create");
+      expect(addedData.receipt.entityId).toBe(addedData.source.id);
+      expect(addedData.receipt.outcome).toBe("applied");
+
+      const removed = await run({
+        subaction: "remove_source",
+        sourceId: addedData.source.id,
+      });
+      expect(removed.success).toBe(true);
+      const removedData = removed.data as {
+        receipt: { capability: string; operation: string; entityId: string };
+      };
+      expect(removedData.receipt.capability).toBe("finance.remove_source");
+      expect(removedData.receipt.operation).toBe("delete");
+      expect(removedData.receipt.entityId).toBe(addedData.source.id);
+      expect(removedData.receipt.entityId).not.toBe(
+        addedData.receipt.receiptId,
+      );
+    });
+
+    it("balances derives per-source figures with freshness metadata", async () => {
+      const source = await service.addPaymentSource({
+        kind: "manual",
+        label: "Balances account",
+      });
+      const postedAt = new Date(Date.now() - 86_400_000).toISOString();
+      await repository.insertPaymentTransaction({
+        id: "txn-balance-credit",
+        agentId: runtime.agentId,
+        sourceId: source.id,
+        externalId: null,
+        postedAt,
+        amountUsd: 250,
+        direction: "credit",
+        merchantRaw: "ACME Payroll",
+        merchantNormalized: "acme payroll",
+        description: null,
+        category: null,
+        currency: "USD",
+        metadata: {},
+        createdAt: new Date().toISOString(),
+      });
+      await repository.insertPaymentTransaction({
+        id: "txn-balance-pending",
+        agentId: runtime.agentId,
+        sourceId: source.id,
+        externalId: null,
+        postedAt,
+        amountUsd: 40,
+        direction: "debit",
+        merchantRaw: "Pending Store",
+        merchantNormalized: "pending store",
+        description: null,
+        category: null,
+        currency: "USD",
+        metadata: { pending: true },
+        createdAt: new Date().toISOString(),
+      });
+
+      const result = await run({ subaction: "balances", sourceId: source.id });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        balances: {
+          sourceId: string;
+          netFlowUsd: number;
+          pendingCount: number;
+          latestActivityAt: string | null;
+        }[];
+        meta: {
+          capability: string;
+          provider: string;
+          freshness: { latestDataAt: string | null; transactionCount: number };
+          calculation: { method: string };
+        };
+      };
+      expect(data.balances).toHaveLength(1);
+      expect(data.balances[0].netFlowUsd).toBe(250);
+      expect(data.balances[0].pendingCount).toBe(1);
+      expect(data.meta.capability).toBe("finance.balances");
+      expect(data.meta.provider).toBe("plugin-finances");
+      expect(data.meta.calculation.method).toBe("derived_from_transactions");
+      expect(data.meta.freshness.latestDataAt).toBe(postedAt);
+    });
+
+    it("budget_status rejects a missing budget and evaluates a supplied one", async () => {
+      const missing = await run({ subaction: "budget_status" });
+      expect(missing.success).toBe(false);
+      expect((missing.data as { error: string }).error).toBe(
+        "MISSING_BUDGET_AMOUNT",
+      );
+
+      const source = await service.addPaymentSource({
+        kind: "manual",
+        label: "Budget account",
+      });
+      await repository.insertPaymentTransaction({
+        id: "txn-budget-1",
+        agentId: runtime.agentId,
+        sourceId: source.id,
+        externalId: null,
+        postedAt: new Date(Date.now() - 3_600_000).toISOString(),
+        amountUsd: 120,
+        direction: "debit",
+        merchantRaw: "Grocer",
+        merchantNormalized: "grocer",
+        description: null,
+        category: null,
+        currency: "USD",
+        metadata: {},
+        createdAt: new Date().toISOString(),
+      });
+      const result = await run({
+        subaction: "budget_status",
+        sourceId: source.id,
+        budgetUsd: 100,
+        windowDays: 30,
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        budget: { spentUsd: number; status: string; remainingUsd: number };
+        meta: { calculation: { method: string; windowDays: number | null } };
+      };
+      expect(data.budget.spentUsd).toBe(120);
+      expect(data.budget.status).toBe("over_budget");
+      expect(data.budget.remainingUsd).toBe(-20);
+      expect(data.meta.calculation.method).toBe("user_supplied_input");
+      expect(data.meta.calculation.windowDays).toBe(30);
+    });
+
+    it("anomalies flags a real duplicate charge and subscriptions handles empty data", async () => {
+      const source = await service.addPaymentSource({
+        kind: "manual",
+        label: "Anomaly account",
+      });
+      const base = Date.now() - 2 * 86_400_000;
+      for (const [index, offsetHours] of [0, 12].entries()) {
+        await repository.insertPaymentTransaction({
+          id: `txn-dupe-${index}`,
+          agentId: runtime.agentId,
+          sourceId: source.id,
+          externalId: null,
+          postedAt: new Date(base + offsetHours * 3_600_000).toISOString(),
+          amountUsd: 14.99,
+          direction: "debit",
+          merchantRaw: index === 0 ? "NETFLlX.COM*8873" : "Netflix",
+          merchantNormalized: "netflix",
+          description: null,
+          category: null,
+          currency: "USD",
+          metadata: {},
+          createdAt: new Date().toISOString(),
+        });
+      }
+      const result = await run({ subaction: "anomalies", sourceId: source.id });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        anomalies: { kind: string; transactionIds: string[] }[];
+        meta: { capability: string };
+      };
+      expect(data.anomalies).toHaveLength(1);
+      expect(data.anomalies[0].kind).toBe("possible_duplicate_charge");
+      expect(data.anomalies[0].transactionIds.sort()).toEqual([
+        "txn-dupe-0",
+        "txn-dupe-1",
+      ]);
+      expect(data.meta.capability).toBe("finance.anomalies");
+
+      const subs = await run({
+        subaction: "subscriptions",
+        sourceId: source.id,
+      });
+      expect(subs.success).toBe(true);
+      const subsData = subs.data as {
+        subscriptions: unknown[];
+        meta: { capability: string };
+      };
+      // Two occurrences 12 hours apart are not a regular-cadence subscription.
+      expect(subsData.subscriptions).toEqual([]);
+      expect(subsData.meta.capability).toBe("finance.subscriptions");
+    });
   });
 });

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -352,6 +352,43 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
       );
     });
 
+    it("import_csv issues a receipt only when rows were actually inserted", async () => {
+      const source = await service.addPaymentSource({
+        kind: "csv",
+        label: "CSV receipt account",
+      });
+      const csvText =
+        "Date,Amount,Merchant\n2026-08-01,-12.50,Coffee Shop\n2026-08-02,-30.00,Grocer\n";
+      const first = await run({
+        subaction: "import_csv",
+        sourceId: source.id,
+        csvText,
+      });
+      expect(first.success).toBe(true);
+      const firstData = first.data as {
+        result: { inserted: number; skipped: number };
+        receipt?: { capability: string; counts: { inserted: number } | null };
+      };
+      expect(firstData.result.inserted).toBe(2);
+      expect(firstData.receipt?.capability).toBe("finance.import_csv");
+      expect(firstData.receipt?.counts?.inserted).toBe(2);
+
+      // An all-duplicate replay succeeds but mutates nothing: no receipt.
+      const replay = await run({
+        subaction: "import_csv",
+        sourceId: source.id,
+        csvText,
+      });
+      expect(replay.success).toBe(true);
+      const replayData = replay.data as {
+        result: { inserted: number; skipped: number };
+        receipt?: unknown;
+      };
+      expect(replayData.result.inserted).toBe(0);
+      expect(replayData.result.skipped).toBe(2);
+      expect(replayData.receipt).toBeUndefined();
+    });
+
     it("balances derives per-source figures with freshness metadata", async () => {
       const source = await service.addPaymentSource({
         kind: "manual",


### PR DESCRIPTION
Fixes #19894

## What

Adds a provider-neutral normalized finance capability layer to `@elizaos/plugin-finances`, with freshness/calculation metadata on reads and receipts on internal writes. Read/derive only — nothing implies payments or trading.

**New module `src/finance-capabilities.ts`** (pure, deterministic, no I/O):
- `computeSourceBalances` — per-source ledger-derived net flow (credits minus settled debits). Pending rows are excluded from settled figures and reported separately; every observed currency is surfaced instead of silently merged; metadata explicitly states balances are transaction-derived, not institution-reported.
- `computeBudgetStatus` — user-supplied budget vs settled debit spend in a rolling window (`under_budget` / `near_limit` / `over_budget`), with pending/credit/out-of-window rows excluded and counted.
- `detectAnomalies` — possible duplicate charges (same source/merchant/amount within 3 days) and amount spikes (>= 2.5x a merchant's average over 3+ prior charges, >= $20 delta). Uses the normalized merchant name so adversarial raw strings ("NETFLlX.COM*8873") group with their real merchant; pending rows never generate anomalies.
- `normalizeSubscriptions` — regular-cadence recurring charges (confidence >= 0.5) projected into provider-neutral subscription records.
- `buildCapabilityMeta` — `FinanceCapabilityMeta` on every capability response: `generatedAt`, freshness (`latestDataAt` of consumed rows, counts), and calculation provenance (`derived_from_transactions` | `provider_reported` | `user_supplied_input`, window, notes).
- `buildWriteReceipt` — `FinanceWriteReceipt` (id, capability, operation, entity, occurredAt, outcome, counts) with no credentials or row payloads.

**Action surface (`src/actions/finances.ts`)**: four new OWNER_FINANCES subactions — `balances`, `budget_status` (requires `budgetUsd`, rejects missing/non-positive), `subscriptions`, `anomalies` — and receipts attached to the existing internal writes (`add_source`, `remove_source`, `import_csv`; the CSV receipt is only issued when state actually changed). All exported from the package barrel; docs (CLAUDE.md/AGENTS.md/README) updated.

## Tests

- `src/finance-capabilities.test.ts` — 17 deterministic unit tests over the pure layer: multi-account, multi-currency, pending rows, duplicate/near-duplicate/cross-source negatives, adversarial merchant strings, thin-history spike suppression, empty ledgers, receipt shape/uniqueness, strict pending-flag typing.
- `test/finances.real-db.test.ts` — 4 new real-PGLite integration tests driving `runPaymentsHandler` end to end: write receipts on add/remove source, derived balances + freshness metadata from real rows, budget_status invalid-input + over-budget evaluation, and a real duplicate-charge anomaly plus designed-empty subscriptions.

Results: `bun run --cwd plugins/plugin-finances test` — 12 files, 118 tests passed. Package lint clean; package typecheck clean for plugin-finances sources (the only remaining tsc errors are pre-existing on origin/develop in `packages/ui/src/api/client-cloud.ts` — duplicate `desktopHttpTransportForUrl`/`fetchAgentTransport` imports — untouched by this PR).

## Evidence / notes

- The real path exercised is the PGLite-backed runtime with the plugin's actual `app_finances` schema migration; capability numbers were asserted against inserted rows (e.g. derived net flow 250 with 1 pending row excluded, over-budget remaining -20, duplicate pair `txn-dupe-0`/`txn-dupe-1`).
- No UI change; app visual audit N/A.
- No credentials appear in fixtures, receipts, metadata, or logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-head:de32a5c08a2692860b6b011721bfeaa60718c190 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped backend, runtime, adapter, policy, or test-infrastructure change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped backend, runtime, adapter, policy, or test-infrastructure change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic package, real-database, or local-stack validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend runtime surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production model or prompt acceptance claim is made by this scoped change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts, assertions, typechecks, and known unrelated baseline limitations are recorded in the Tests, Validation, Evidence, or Proof section above.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->