### PR TITLE
fix(core): add missing flat entrypoints and build validation

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -1321,6 +1321,22 @@ export async function generateTypeScriptDeclarations() {
 		"dist/roles.js",
 		`// Roles subpath entry point (explicit)\nexport * from './node/roles.js';\n`,
 	);
+	await fs.writeFile(
+		"dist/client-public.js",
+		`// Client-public subpath entry point (explicit)\nexport * from './node/client-public.js';\n`,
+	);
+	await fs.writeFile(
+		"dist/atomic-json.js",
+		`// Atomic-json subpath entry point (explicit)\nexport * from './node/utils/atomic-json.js';\n`,
+	);
+	await fs.writeFile(
+		"dist/security/kms.js",
+		`// Security/kms subpath entry point (explicit)\nexport * from './node/security/kms/index.js';\n`,
+	);
+	await fs.writeFile(
+		"dist/security/mcp-server-config.js",
+		`// Security/mcp-server-config subpath entry point (explicit)\nexport * from './node/security/mcp-server-config.js';\n`,
+	);
 	// Create main index.d.ts to re-export all types from node build
 	// This ensures TypeScript resolves all exports when using moduleResolution: bundler
 	// Note: Use .js extension for NodeNext module resolution compatibility
@@ -1331,6 +1347,48 @@ export async function generateTypeScriptDeclarations() {
 
 	// Ensure testing module directory and declarations exist
 	await fs.mkdir("dist/testing", { recursive: true });
+
+	// Verify all flat entrypoints exist — prevents regressions like #22847
+	// where a subpath export in package.json has no corresponding dist/<subpath>.js
+	const pkg = JSON.parse(
+		await fs.readFile("package.json", "utf-8"),
+	) as { exports?: Record<string, unknown> };
+	const missing: string[] = [];
+	for (const [exportPath, config] of Object.entries(pkg.exports ?? {})) {
+		if (
+			!exportPath.startsWith("./") ||
+			exportPath === "./package.json" ||
+			exportPath.includes("*")
+		) {
+			continue;
+		}
+		const subpath = exportPath.slice(2); // strip ./
+		const flatFile = `dist/${subpath}.js`;
+		if (await fs.stat(flatFile).catch(() => null)) {
+			continue; // flat entrypoint already exists
+		}
+		// Check if the default/import target exists in dist/node/ or dist/
+		const defaultPath =
+			typeof config === "object" && config !== null
+				? (config.default ?? config.import ?? "")
+				: "";
+		if (
+			typeof defaultPath === "string" &&
+			defaultPath.endsWith(".js") &&
+			!(await fs
+				.stat(defaultPath.replace(/^\.\//, ""))
+				.catch(() => null))
+		) {
+			missing.push(
+				`${exportPath}: flat entrypoint ${flatFile} missing and default target ${defaultPath} not found`,
+			);
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing flat entrypoints for subpath exports:\n${missing.join("\n")}`,
+		);
+	}
 
 	const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 	console.log(`✅ TypeScript declarations generated in ${duration}s`);

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -1350,6 +1350,11 @@ export async function generateTypeScriptDeclarations() {
 
 	// Verify all flat entrypoints exist — prevents regressions like #22847
 	// where a subpath export in package.json has no corresponding dist/<subpath>.js
+	//
+	// Strategy: for file-style subpaths whose default/import resolves to a
+	// specific .js file inside a subdirectory (dist/node/..., dist/browser/...),
+	// assert that a flat dist/<subpath>.js exists. Directory-style subpaths
+	// (./node, ./browser, ./edge, ./testing) and wildcards are skipped.
 	const pkg = JSON.parse(
 		await fs.readFile("package.json", "utf-8"),
 	) as { exports?: Record<string, unknown> };
@@ -1367,22 +1372,28 @@ export async function generateTypeScriptDeclarations() {
 		if (await fs.stat(flatFile).catch(() => null)) {
 			continue; // flat entrypoint already exists
 		}
-		// Check if the default/import target exists in dist/node/ or dist/
+		// Determine if this is a file-style subpath that needs a flat entrypoint.
+		// Extract the default/import path from the export config.
 		const defaultPath =
 			typeof config === "object" && config !== null
 				? (config.default ?? config.import ?? "")
 				: "";
-		if (
-			typeof defaultPath === "string" &&
-			defaultPath.endsWith(".js") &&
-			!(await fs
-				.stat(defaultPath.replace(/^\.\//, ""))
-				.catch(() => null))
-		) {
-			missing.push(
-				`${exportPath}: flat entrypoint ${flatFile} missing and default target ${defaultPath} not found`,
-			);
+		if (typeof defaultPath !== "string" || !defaultPath.endsWith(".js")) {
+			continue; // not a file-style export
 		}
+		// Skip directory-style subpaths: if defaultPath resolves to
+		//   dist/<dir>/index.js  or  dist/<dir>/index.<variant>.js
+		// (e.g. dist/node/index.node.js, dist/testing/index.js)
+		// it resolves to a directory, not a flat entrypoint.
+		const relative = defaultPath.replace(/^\.\//, "");
+		const dirIndex = relative.match(/^dist\/[^/]+\/index(?:\.[^.]+)?\.js$/);
+		if (dirIndex) {
+			continue;
+		}
+		// For file-style subpaths the flat entrypoint is mandatory.
+		missing.push(
+			`${exportPath}: flat entrypoint ${flatFile} is missing (build must emit it as a re-export)`,
+		);
 	}
 	if (missing.length > 0) {
 		throw new Error(


### PR DESCRIPTION
## What

Adds missing flat re-export entrypoints for subpath exports and automatic build validation to prevent future regressions.

## Why

Several subpath exports in `package.json` use conditional `node`/`browser` paths (e.g., `./dist/node/utils/atomic-json.js`) but lack a corresponding `dist/<subpath>.js` flat entrypoint. This breaks workspace alias resolution (`@elizaos/core/* → dist/*`) used by `packages/shared` and other consumers.

The affected entrypoints:
- `dist/client-public.js` → `./node/client-public.js`
- `dist/atomic-json.js` → `./node/utils/atomic-json.js`
- `dist/security/kms.js` → `./node/security/kms/index.js`
- `dist/security/mcp-server-config.js` → `./node/security/mcp-server-config.js`

These are imported by 25+ files across `packages/agent`, `packages/cloud`, `packages/shared`, and `plugins/`.

## How

1. Added `fs.writeFile()` calls following the existing pattern (same as `roles.js`)
2. Added automatic validation after build that reads `package.json` exports, checks each `./subpath` without wildcards has a corresponding `dist/<subpath>.js`, and fails the build if any are missing

## Verification

- [x] All 4 flat entrypoints created after build
- [x] `packages/core build` passes (7.25s)
- [x] `packages/shared build` passes (3.0s)
- [x] `packages/core typecheck` passes
- [x] `packages/shared typecheck` passes
- [x] Unit tests pass (52/52)

## Related

Related-to: #22847

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: mimo / mimo-v2.5
Client / agent tooling: freebuff
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [fix-build-entrypoints]
<!-- slop-contribution-attribution:v1 {"provider":"mimo","model":"mimo-v2.5","client":"freebuff","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0G7881K0NRVZADZ3JBY6MQR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-20T18:34:36.467Z","completed_at":"2026-08-20T18:53:31.525Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T18:34:37.533Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"339b60c73807386e5281b4844d438db1d78a3f31f926b9088d9e4bd69937a77f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7b463e28-78ef-4a90-9457-d4a7b2ea3363","object_id":"sha256:339b60c73807386e5281b4844d438db1d78a3f31f926b9088d9e4bd69937a77f","sha256":"339b60c73807386e5281b4844d438db1d78a3f31f926b9088d9e4bd69937a77f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQBaqeKWcU3z_fov6SsDE3PiDCD4T41ubCN81pBw1ulY","device_key_id":"97077c6aca711e726a90a181897cbdaccf280694a4c1569bac6d6e788493463f","device_signature":"f-qrZi2ke58GBhprBn04ICgNXbGhBctB7ers9bP6QgeThojKlH-M86g0pdVZD-xxmGOv_zk4gGd6siHSzh4gDw"}} -->