### PR TITLE
fix(cloud): keep gateway reminders executable after cutover

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -791,6 +791,94 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
+  test("keeps a Telegram reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+
+    const response = await request({
+      ...valid,
+      message: "Remind me in 2 minutes to stretch",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: expect.stringMatching(/^personal:/),
+          runtime: "shared",
+        },
+        reply: "hello from Eliza",
+      },
+    });
+    expect(bridge).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
+      expect.stringMatching(/^personal:/),
+      "Remind me in 2 minutes to stretch",
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      "telegram:eliza:42",
+      "platform",
+      {
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456789",
+      },
+    );
+  });
+
+  test("keeps a Discord reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    const discordUserId = "123456789012345678";
+
+    const response = await request({
+      platform: "discord",
+      discordUserId,
+      discordUsername: "shaw",
+      displayName: "Shaw",
+      messageId: "discord:reminder-42",
+      message: "Remind me in 2 minutes to stretch",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: expect.stringMatching(/^personal:/),
+          runtime: "shared",
+        },
+        reply: "hello from Eliza",
+      },
+    });
+    expect(bridge).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
+      expect.stringMatching(/^personal:/),
+      "Remind me in 2 minutes to stretch",
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      "discord:reminder-42",
+      "platform",
+      {
+        platform: "discord",
+        discordUserId,
+      },
+    );
+  });
+
   test("idempotently resumes stopped Dedicated and asks the gateway to retry", async () => {
     activeTarget = {
       id: "00000000-0000-4000-8000-000000000020",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -16,6 +16,7 @@ import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversat
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
+import { resolveSharedCapabilityIntent } from "@/lib/services/shared-runtime/shared-capability-wall";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
@@ -60,6 +61,16 @@ const SAFE_ERROR_NAMES = new Set([
 function safeErrorName(error: unknown): string {
   const name = error instanceof Error ? error.name : "";
   return SAFE_ERROR_NAMES.has(name) ? name : "OtherError";
+}
+
+function isGatewayNativeReminderTurn(message: string): boolean {
+  const resolution = resolveSharedCapabilityIntent(message, {
+    reminders: true,
+  });
+  return (
+    resolution?.kind === "enabled-primary" &&
+    resolution.primary.capability === "reminders"
+  );
 }
 
 const telegramVoiceNoteSchema = z.object({
@@ -329,18 +340,17 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
-    const personalPrewarm = dedicated
-      ? null
-      : (() => {
-          const startedAt = performance.now();
-          const timing = prewarmPersonalSharedAgentTurnCaches(
-            agent,
-            worker.namespace,
-            { warmConversation: isNewPersonalAccount },
-          ).then(() => performance.now() - startedAt);
-          worker.executionCtx.waitUntil(timing);
-          return timing;
-        })();
+    const startPersonalPrewarm = () => {
+      const startedAt = performance.now();
+      const timing = prewarmPersonalSharedAgentTurnCaches(
+        agent,
+        worker.namespace,
+        { warmConversation: isNewPersonalAccount },
+      ).then(() => performance.now() - startedAt);
+      worker.executionCtx.waitUntil(timing);
+      return timing;
+    };
+    let personalPrewarm = dedicated ? null : startPersonalPrewarm();
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -424,7 +434,17 @@ app.post("/", async (c) => {
         agent.id,
       );
     }
-    if (dedicated) {
+    // Connector-native reminders stay on the server-owned Personal Shared
+    // scheduler even after a Dedicated cutover. Dedicated containers receive
+    // the conversational turn through the bridge, but do not own the trusted
+    // Telegram/Discord/Blooio delivery credential needed to persist and fire a
+    // reminder back into this verified DM.
+    const gatewayNativeReminderTurn =
+      isGatewayNativeReminderTurn(deliveryMessage);
+    if (dedicated && gatewayNativeReminderTurn && !personalPrewarm) {
+      personalPrewarm = startPersonalPrewarm();
+    }
+    if (dedicated && !gatewayNativeReminderTurn) {
       stage = "dedicated_runtime";
       const dedicatedStartedAt = performance.now();
       const preparation = await preparePersonalDedicatedDelivery(


### PR DESCRIPTION
## Summary
- keep verified Telegram, Discord, and Blooio reminder commands on the server-owned Personal Shared scheduler after a Dedicated cutover
- preserve the Dedicated bridge for ordinary conversational turns
- add Telegram and Discord regression coverage for the post-cutover branch

## Verification
- `bun test packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts` (30 pass)
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts` (75 pass)
- `bunx biome check packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts`
- `bun run --cwd packages/cloud/api typecheck` (includes production Worker dry-run bundle)

## Live defect
Production Telegram conversational QA succeeds, but a post-cutover reminder currently returns: `I can’t set reminders from external API messages.` This change keeps the reminder on the only runtime that owns the trusted current-DM destination and cron dispatcher.