### PR TITLE
fix(ui): remove duplicate cloud transport imports

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -29,8 +29,6 @@ import {
   normalizeDirectCloudSharedAgentApiBase,
 } from "../utils/cloud-agent-base";
 import { ElizaClient } from "./client-base";
-import { desktopHttpTransportForUrl } from "./desktop-http-transport";
-import { fetchAgentTransport, type AgentRequestTransport } from "./transport";
 import type {
   ApiError,
   CloudApiKeySummary,


### PR DESCRIPTION
# Relates to

Closes #23063.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` / `bun run verify` limitations are recorded below with the exact local environment blocker; focused and package lint checks ran after sync.
- [x] A reviewer can confirm the change from the two-line exact diff and attached command output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a9b9152b54b339928a68b95b8d292d55b68e2059:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@a9b9152b54b339928a68b95b8d292d55b68e2059`; zero conflicts.
- [x] The local dependency/disk limitation is documented in **Known gaps / failures**; exact-head CI is required before merge.

# Risks

Low. This removes one duplicate runtime import pair and one unused type import. It changes no call site, exported type, transport behavior, UI, provider, database, or deployment configuration. The only affected boundary is module import hygiene.

# Background

## What does this PR do?

It leaves the canonical lower import locations in place and removes the duplicate earlier imports of `desktopHttpTransportForUrl` and `fetchAgentTransport`, including the unused `AgentRequestTransport` type. This restores Biome `organizeImports` / `noRedeclare` without reverting the trusted Cloud HTTPS desktop bridge from #22950.

## What kind of change is this?

Bug fix (non-breaking import-only correction).

# Documentation changes needed?

No. Runtime behavior and public contracts are unchanged.

# Testing

## Where should a reviewer start?

Review the complete diff in `packages/ui/src/api/client-cloud.ts`: it is exactly two deleted import lines.

## Detailed testing steps

```text
bunx @biomejs/biome check packages/ui/src/api/client-cloud.ts
Checked 1 file in 152ms. No fixes applied.

bun run --cwd packages/ui lint:check
Checked 3081 files in 1938ms. No fixes applied.
Found 5 pre-existing noDocumentCookie warnings; zero errors.

git diff --check
PASS
```

A fresh exact-head workflow run must prove the previously failing Quality import diagnostics are gone and attribute every remaining red by exact baseline name.

# Evidence Gate

<!-- evidence-head:c4e8479cc394ba9fd44e940a2adad8224a03e3c5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the `.ts` import-only diff has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the `.ts` import-only diff has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user flow or behavior change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no request, response, state, or runtime behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model path changes.

## Backend + frontend logs

N/A - import organization only; no runtime path changes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered output changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT changes.

## Known gaps / failures

- The host volume reached 100% while creating this isolated worktree, so a fresh full `bun install` could not complete. A regenerable `node_modules` cache from the already-merged old #22941 worktree was removed to recover space; no tracked/user source was removed.
- A temporary dependency link was sufficient for Biome but incomplete for the full workspace graph. `packages/ui` typecheck therefore stopped on missing third-party modules such as `drizzle-orm`, `@noble/hashes`, and `lucide-react`, with no diagnostic attributed to the changed import block.
- A focused four-file test attempt recorded the existing `cloud-login-callsite-contract` violation and three dependency-resolution errors from that incomplete install; it did not expose a changed-import failure. Fresh exact-head CI is the acceptance authority for this import-only fix.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@a9b9152b54b339928a68b95b8d292d55b68e2059:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-v2-ci-import-hygiene]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@a9b9152b54b339928a68b95b8d292d55b68e2059:packages/skills/skills/contribute-to-eliza"} -->