### PR TITLE
fix(cloud): require action proof for shared reminders

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -791,6 +791,94 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
+  test("keeps a Telegram reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+
+    const response = await request({
+      ...valid,
+      message: "Remind me in 2 minutes to stretch",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: expect.stringMatching(/^personal:/),
+          runtime: "shared",
+        },
+        reply: "hello from Eliza",
+      },
+    });
+    expect(bridge).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
+      expect.stringMatching(/^personal:/),
+      "Remind me in 2 minutes to stretch",
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      "telegram:eliza:42",
+      "platform",
+      {
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456789",
+      },
+    );
+  });
+
+  test("keeps a Discord reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    const discordUserId = "123456789012345678";
+
+    const response = await request({
+      platform: "discord",
+      discordUserId,
+      discordUsername: "shaw",
+      displayName: "Shaw",
+      messageId: "discord:reminder-42",
+      message: "Remind me in 2 minutes to stretch",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: expect.stringMatching(/^personal:/),
+          runtime: "shared",
+        },
+        reply: "hello from Eliza",
+      },
+    });
+    expect(bridge).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
+      expect.stringMatching(/^personal:/),
+      "Remind me in 2 minutes to stretch",
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      "discord:reminder-42",
+      "platform",
+      {
+        platform: "discord",
+        discordUserId,
+      },
+    );
+  });
+
   test("idempotently resumes stopped Dedicated and asks the gateway to retry", async () => {
     activeTarget = {
       id: "00000000-0000-4000-8000-000000000020",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -16,6 +16,7 @@ import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversat
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
+import { resolveSharedCapabilityIntent } from "@/lib/services/shared-runtime/shared-capability-wall";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
@@ -60,6 +61,16 @@ const SAFE_ERROR_NAMES = new Set([
 function safeErrorName(error: unknown): string {
   const name = error instanceof Error ? error.name : "";
   return SAFE_ERROR_NAMES.has(name) ? name : "OtherError";
+}
+
+function isGatewayNativeReminderTurn(message: string): boolean {
+  const resolution = resolveSharedCapabilityIntent(message, {
+    reminders: true,
+  });
+  return (
+    resolution?.kind === "enabled-primary" &&
+    resolution.primary.capability === "reminders"
+  );
 }
 
 const telegramVoiceNoteSchema = z.object({
@@ -329,18 +340,17 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
-    const personalPrewarm = dedicated
-      ? null
-      : (() => {
-          const startedAt = performance.now();
-          const timing = prewarmPersonalSharedAgentTurnCaches(
-            agent,
-            worker.namespace,
-            { warmConversation: isNewPersonalAccount },
-          ).then(() => performance.now() - startedAt);
-          worker.executionCtx.waitUntil(timing);
-          return timing;
-        })();
+    const startPersonalPrewarm = () => {
+      const startedAt = performance.now();
+      const timing = prewarmPersonalSharedAgentTurnCaches(
+        agent,
+        worker.namespace,
+        { warmConversation: isNewPersonalAccount },
+      ).then(() => performance.now() - startedAt);
+      worker.executionCtx.waitUntil(timing);
+      return timing;
+    };
+    let personalPrewarm = dedicated ? null : startPersonalPrewarm();
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -424,7 +434,17 @@ app.post("/", async (c) => {
         agent.id,
       );
     }
-    if (dedicated) {
+    // Connector-native reminders stay on the server-owned Personal Shared
+    // scheduler even after a Dedicated cutover. Dedicated containers receive
+    // the conversational turn through the bridge, but do not own the trusted
+    // Telegram/Discord/Blooio delivery credential needed to persist and fire a
+    // reminder back into this verified DM.
+    const gatewayNativeReminderTurn =
+      isGatewayNativeReminderTurn(deliveryMessage);
+    if (dedicated && gatewayNativeReminderTurn && !personalPrewarm) {
+      personalPrewarm = startPersonalPrewarm();
+    }
+    if (dedicated && !gatewayNativeReminderTurn) {
       stage = "dedicated_runtime";
       const dedicatedStartedAt = performance.now();
       const preparation = await preparePersonalDedicatedDelivery(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -11,6 +11,7 @@ import { ChannelType } from "@elizaos/core/edge";
 let providerConfigured = true;
 let runtimeFailure: Error | null = null;
 let streamFailure: Error | null = null;
+let runtimeActionResults: Array<Record<string, unknown>> | undefined;
 const runtimeInputs: Array<Record<string, unknown>> = [];
 const streamInputs: Array<Record<string, unknown>> = [];
 
@@ -32,6 +33,7 @@ mock.module("./shared-eliza-runtime", () => ({
       ],
       model: String(input.model),
       degraded: false,
+      ...(runtimeActionResults ? { actionResults: runtimeActionResults } : {}),
     };
   },
   runSharedElizaRuntimeTurnStream: async (input: Record<string, unknown>) => {
@@ -54,6 +56,7 @@ beforeEach(() => {
   providerConfigured = true;
   runtimeFailure = null;
   streamFailure = null;
+  runtimeActionResults = undefined;
   runtimeInputs.length = 0;
   streamInputs.length = 0;
 });
@@ -95,6 +98,42 @@ describe("Shared turn AgentRuntime boundary", () => {
       authenticatedPersonalSharedUser: true,
       channel: { type: ChannelType.VOICE_DM, source: "client_chat" },
     });
+  });
+
+  test("requires a grounded reminder action result before accepting an executable reminder reply", async () => {
+    const reminderInput = {
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "Remind me in 2 minutes to stretch",
+      execution: {
+        agentKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true as const,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram" as const,
+            project: "eliza-app",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    };
+
+    const error = await runSharedAgentTurn(reminderInput).catch((caught) => caught as Error);
+    expect(error.message).toContain("AgentRuntime turn failed");
+    expect((error.cause as Error).message).toContain("without an action result");
+    expect(JSON.stringify(runtimeInputs[0])).toContain("Call REMINDERS before any terminal answer");
+    expect(JSON.stringify(runtimeInputs[0])).toContain("never invent success");
+
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "REMINDERS", operation: "create" },
+      },
+    ];
+    const result = await runSharedAgentTurn(reminderInput);
+    expect(result.reply).toBe("runtime reply");
   });
 
   test("routes unsupported capabilities through the model with a truthful constraint", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -291,6 +291,7 @@ function buildSharedRuntimeSystem(
   capabilities: { webSearch: boolean; reminders: boolean; todos: boolean; media: boolean },
   recallContext?: string,
   blockedCapabilities: SharedCapabilityWall[] = [],
+  requiredAction?: "REMINDERS" | "TODO",
 ): string {
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
@@ -325,8 +326,32 @@ function buildSharedRuntimeSystem(
         "Never imply that an unavailable action succeeded.",
     );
   }
+  if (requiredAction) {
+    parts.push(
+      "Current-turn execution requirement:\n" +
+        `- The user's current message is an executable ${requiredAction === "REMINDERS" ? "reminder" : "todo"} request, and ${requiredAction} is available for this verified account.\n` +
+        `- Call ${requiredAction} before any terminal answer. A plain-text acknowledgement such as "done", "saved", or "scheduled" is not an execution result.\n` +
+        `- If the request is incomplete or cannot be applied, call ${requiredAction} anyway and use its grounded clarification or failure result; never invent success.`,
+    );
+  }
   if (recallContext?.trim()) parts.push(recallContext.trim());
   return parts.join("\n\n") || `You are ${character.name}, a helpful assistant.`;
+}
+
+function requiredActionForResolution(
+  resolution: SharedCapabilityResolution | null,
+): "REMINDERS" | "TODO" | undefined {
+  if (resolution?.kind !== "enabled-primary") return undefined;
+  if (resolution.primary.capability === "reminders") return "REMINDERS";
+  if (resolution.primary.capability === "todos") return "TODO";
+  return undefined;
+}
+
+function hasRequiredActionResult(
+  turn: RunSharedAgentTurnResult,
+  actionName: "REMINDERS" | "TODO",
+): boolean {
+  return Boolean(turn.actionResults?.some((result) => result.data?.actionName === actionName));
 }
 
 export function appendSharedTurn(
@@ -440,6 +465,7 @@ export async function runSharedAgentTurn(
     todos: todosEnabled,
   };
   const resolution = capabilityResolution(input, capabilities);
+  const requiredAction = requiredActionForResolution(resolution);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -474,6 +500,7 @@ export async function runSharedAgentTurn(
             },
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,
+            requiredAction,
           ),
         },
         execution,
@@ -483,6 +510,11 @@ export async function runSharedAgentTurn(
       capabilityWall,
       blockedSecondary,
     );
+    if (requiredAction && !hasRequiredActionResult(turn, requiredAction)) {
+      throw new Error(
+        `Eliza Shared runtime completed an executable ${requiredAction} request without an action result`,
+      );
+    }
   } catch (error) {
     // error-policy:J2 the runtime is the sole inference engine; preserve its
     // cause while adding the agent/model identity used by billing boundaries.
@@ -517,6 +549,7 @@ export async function runSharedAgentTurnStream(
     todos: todosEnabled,
   };
   const resolution = capabilityResolution(input, capabilities);
+  const requiredAction = requiredActionForResolution(resolution);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -550,6 +583,7 @@ export async function runSharedAgentTurnStream(
             },
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,
+            requiredAction,
           ),
         },
         execution,


### PR DESCRIPTION
## Summary
- mark enabled reminder and todo commands as action-required in the Shared runtime prompt
- reject success-sounding reminder/todo replies unless the matching action returned a grounded result
- cover the fail-closed reminder postcondition and successful receipt path

## Live defect
A Telegram staging reminder returned `done` but created no reminder record. This keeps the conversational response model-owned while making action execution and receipts authoritative.

## Verification
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts` (9 pass)
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts` (6 pass)
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts` (21 pass)
- `bun test packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts` (30 pass)
- `bunx biome check ...`
- `bun run --cwd packages/cloud/api typecheck` (includes production Worker dry-run)