### PR TITLE
fix(cloud): enforce atomic character quotas

### DIFF
--- a/packages/cloud/api/__tests__/character-field-shape-guard-sweep.test.ts
+++ b/packages/cloud/api/__tests__/character-field-shape-guard-sweep.test.ts
@@ -88,9 +88,16 @@ beforeAll(async () => {
     );
     await apply();
 
-    await dbWrite
-      .insert(organizations)
-      .values([{ id: ORG, name: "Org", slug: "org-shape-sweep" }]);
+    await dbWrite.insert(organizations).values([
+      {
+        id: ORG,
+        name: "Org",
+        slug: "org-shape-sweep",
+        // This sweep creates more than the default quota of five characters
+        // while exercising unrelated JSON-shape guards.
+        settings: { max_agents: 20 },
+      },
+    ]);
     await dbWrite.insert(users).values([
       {
         id: USER,

--- a/packages/cloud/api/affiliate/create-character/route.policy.test.ts
+++ b/packages/cloud/api/affiliate/create-character/route.policy.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Exercises the affiliate character front door with deterministic auth and
+ * persistence collaborators, pinning its named trusted creation policy.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const validateApiKey = mock(async () => ({
+  id: "key-1",
+  organization_id: "org-1",
+  is_active: true,
+  expires_at: null,
+}));
+const createAnonymousUser = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const createSession = mock(async () => ({ id: "session-row-1" }));
+const createCharacter = mock(async (input: Record<string, unknown>) => ({
+  id: "character-1",
+  name: input.name,
+  avatar_url: input.avatar_url ?? null,
+}));
+
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey,
+    incrementUsage: async () => undefined,
+  },
+}));
+mock.module("@/lib/services/organizations", () => ({
+  organizationsService: {
+    getById: async () => ({ id: "org-1" }),
+  },
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { create: createAnonymousUser },
+}));
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: { create: createSession },
+}));
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { create: createCharacter },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/affiliate/create-character creation policy", () => {
+  test("uses the audited affiliate trusted policy", async () => {
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer affiliate-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          character: { name: "Affiliate Agent", bio: "Affiliate bio" },
+          affiliateId: "affiliate-1",
+        }),
+      }),
+      {
+        ANON_MESSAGE_LIMIT: "5",
+        NEXT_PUBLIC_APP_URL: "https://app.example.test",
+      },
+      {
+        waitUntil: () => undefined,
+        passThroughOnException: () => undefined,
+        props: {},
+      } as never,
+    );
+
+    expect(response.status).toBe(201);
+    expect(createCharacter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "org-1",
+        user_id: "user-1",
+        name: "Affiliate Agent",
+      }),
+      {
+        policy: {
+          mode: "trusted",
+          caller: "affiliate-create-character",
+        },
+      },
+    );
+  });
+});

--- a/packages/cloud/api/affiliate/create-character/route.ts
+++ b/packages/cloud/api/affiliate/create-character/route.ts
@@ -311,50 +311,58 @@ app.post("/", async (c) => {
       avatarUrl: resolvedAvatarUrl ?? undefined,
     };
 
-    const createdCharacter = await charactersService.create({
-      organization_id: appOwnerOrg.id,
-      user_id: anonymousUser.id,
-      name: elizaCharacter.name,
-      bio: elizaCharacter.bio,
-      message_examples: (elizaCharacter.messageExamples ?? []) as Record<
-        string,
-        unknown
-      >[][],
-      post_examples: [],
-      topics: elizaCharacter.topics ?? [],
-      adjectives: elizaCharacter.adjectives ?? [],
-      knowledge: [],
-      plugins: [],
-      settings: (elizaCharacter.settings ?? {}) as Record<
-        string,
-        string | number | boolean | Record<string, unknown>
-      >,
-      secrets: (elizaCharacter.secrets ?? {}) as Record<
-        string,
-        string | number | boolean
-      >,
-      style: elizaCharacter.style ?? {},
-      character_data: {
-        ...elizaCharacter,
-        lore: character.lore ?? [],
-        affiliate: {
-          affiliateId,
-          // The org sponsoring this guest's usage (the application owner).
-          sponsorOrganizationId: appOwnerOrg.id,
-          source: metadata?.source,
-          vibe: metadata?.vibe,
-          backstory: metadata?.backstory,
-          instagram: metadata?.instagram,
-          twitter: metadata?.twitter,
-          socialContent: metadata?.socialContent,
-          imageUrls: httpImageUrls,
-          createdAt: new Date().toISOString(),
+    const createdCharacter = await charactersService.create(
+      {
+        organization_id: appOwnerOrg.id,
+        user_id: anonymousUser.id,
+        name: elizaCharacter.name,
+        bio: elizaCharacter.bio,
+        message_examples: (elizaCharacter.messageExamples ?? []) as Record<
+          string,
+          unknown
+        >[][],
+        post_examples: [],
+        topics: elizaCharacter.topics ?? [],
+        adjectives: elizaCharacter.adjectives ?? [],
+        knowledge: [],
+        plugins: [],
+        settings: (elizaCharacter.settings ?? {}) as Record<
+          string,
+          string | number | boolean | Record<string, unknown>
+        >,
+        secrets: (elizaCharacter.secrets ?? {}) as Record<
+          string,
+          string | number | boolean
+        >,
+        style: elizaCharacter.style ?? {},
+        character_data: {
+          ...elizaCharacter,
+          lore: character.lore ?? [],
+          affiliate: {
+            affiliateId,
+            // The org sponsoring this guest's usage (the application owner).
+            sponsorOrganizationId: appOwnerOrg.id,
+            source: metadata?.source,
+            vibe: metadata?.vibe,
+            backstory: metadata?.backstory,
+            instagram: metadata?.instagram,
+            twitter: metadata?.twitter,
+            socialContent: metadata?.socialContent,
+            imageUrls: httpImageUrls,
+            createdAt: new Date().toISOString(),
+          },
+        } as Record<string, unknown>,
+        is_template: false,
+        is_public: false,
+        avatar_url: resolvedAvatarUrl,
+      },
+      {
+        policy: {
+          mode: "trusted",
+          caller: "affiliate-create-character",
         },
-      } as Record<string, unknown>,
-      is_template: false,
-      is_public: false,
-      avatar_url: resolvedAvatarUrl,
-    });
+      },
+    );
 
     if (typeof c.executionCtx?.waitUntil === "function") {
       c.executionCtx.waitUntil(

--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.test.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
 
 import type { UserCharacter } from "@/db/repositories/characters";
@@ -170,6 +171,7 @@ describe("clone character route — cross-tenant IDOR guard", () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({ user_id: CALLER_ID }),
+      { policy: { mode: "metered" } },
     );
   });
 
@@ -203,6 +205,32 @@ describe("clone character route — cross-tenant IDOR guard", () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({ user_id: CALLER_ID }),
+      { policy: { mode: "metered" } },
     );
+  });
+
+  test("maps the central Cloud-character quota error canonically", async () => {
+    getById.mockResolvedValueOnce(
+      buildCharacter({
+        user_id: CALLER_ID,
+        is_public: false,
+        is_template: false,
+      }),
+    );
+    create.mockRejectedValueOnce(
+      new ElizaError("quota", {
+        code: "CLOUD_CHARACTER_QUOTA_EXCEEDED",
+        context: { current: 5, limit: 5 },
+      }),
+    );
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "agent_quota_exceeded",
+      details: { current: 5, max: 5 },
+    });
   });
 });

--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { Hono } from "hono";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { charactersService } from "@/lib/services/characters/characters";
 import { logger } from "@/lib/utils/logger";
@@ -54,26 +55,29 @@ app.post("/", async (c) => {
 
     const cloneName = body.name || `${original.name} (Copy)`;
 
-    const clonedCharacter = await charactersService.create({
-      user_id: user.id,
-      organization_id: user.organization_id,
-      name: cloneName,
-      username: body.username,
-      bio: original.bio,
-      system: original.system,
-      topics: original.topics,
-      adjectives: original.adjectives,
-      knowledge: original.knowledge,
-      plugins: original.plugins,
-      style: original.style,
-      settings: original.settings,
-      character_data: original.character_data || {},
-      avatar_url: original.avatar_url,
-      category: original.category,
-      tags: original.tags,
-      is_public: body.makePublic ?? false,
-      is_template: false,
-    });
+    const clonedCharacter = await charactersService.create(
+      {
+        user_id: user.id,
+        organization_id: user.organization_id,
+        name: cloneName,
+        username: body.username,
+        bio: original.bio,
+        system: original.system,
+        topics: original.topics,
+        adjectives: original.adjectives,
+        knowledge: original.knowledge,
+        plugins: original.plugins,
+        style: original.style,
+        settings: original.settings,
+        character_data: original.character_data || {},
+        avatar_url: original.avatar_url,
+        category: original.category,
+        tags: original.tags,
+        is_public: body.makePublic ?? false,
+        is_template: false,
+      },
+      { policy: { mode: "metered" } },
+    );
 
     logger.info("[My Agents API] Character cloned successfully:", {
       originalId: id,
@@ -90,16 +94,7 @@ app.post("/", async (c) => {
     });
   } catch (error) {
     logger.error("[My Agents API] Error cloning character:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Failed to clone character";
-    const isValidationError =
-      errorMessage.includes("username") || errorMessage.includes("Username");
-    const status: 400 | 404 | 500 = isValidationError
-      ? 400
-      : error instanceof Error && error.message.includes("not found")
-        ? 404
-        : 500;
-    return c.json({ success: false, error: errorMessage }, status);
+    return failureResponse(c, error);
   }
 });
 

--- a/packages/cloud/api/my-agents/characters/route.json.test.ts
+++ b/packages/cloud/api/my-agents/characters/route.json.test.ts
@@ -1,5 +1,6 @@
 /** Exercises malformed request input with deterministic route collaborators. */
 import { describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 const created = {
   id: "00000000-0000-4000-8000-0000000000ee",
@@ -76,6 +77,30 @@ describe("POST /api/my-agents/characters request validation", () => {
       body: JSON.stringify({ name: "demo" }),
     });
     expect(response.status).toBe(200);
-    expect(create).toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith(expect.any(Object), {
+      policy: { mode: "metered" },
+    });
+  });
+
+  test("maps the central Cloud-character quota error canonically", async () => {
+    create.mockRejectedValueOnce(
+      new ElizaError("quota", {
+        code: "CLOUD_CHARACTER_QUOTA_EXCEEDED",
+        context: { current: 5, limit: 5 },
+      }),
+    );
+
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "capped" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "agent_quota_exceeded",
+      details: { current: 5, max: 5 },
+    });
   });
 });

--- a/packages/cloud/api/my-agents/characters/route.ts
+++ b/packages/cloud/api/my-agents/characters/route.ts
@@ -197,7 +197,9 @@ app.post("/", async (c) => {
       source: "cloud",
     };
 
-    const character = await charactersService.create(newCharacter);
+    const character = await charactersService.create(newCharacter, {
+      policy: { mode: "metered" },
+    });
 
     discordService
       .logCharacterCreated({

--- a/packages/cloud/api/src/inference-chat-csrf.test.ts
+++ b/packages/cloud/api/src/inference-chat-csrf.test.ts
@@ -20,7 +20,7 @@ import type { ExecutionContext as HonoExecutionContext } from "hono";
 
 process.env.NODE_ENV ||= "test";
 
-mock.module("@/db/schemas", () => ({}));
+mock.module("@/db/schemas", () => ({ organizations: {} }));
 mock.module("@/db/schemas/eliza", () => ({}));
 
 import { stewardCookieNames } from "@/lib/auth/steward-cookies";

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -277,6 +277,12 @@ describe("service agent provisioning route", () => {
         token_address: "0x0000000000000000000000000000000000000009",
         token_chain: "bsc",
       }),
+      {
+        policy: {
+          mode: "trusted",
+          caller: "service-api-v1-agents",
+        },
+      },
     );
     expect(createAgent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -288,21 +288,29 @@ app.post("/", async (c) => {
 
     let character: Awaited<ReturnType<typeof charactersService.create>>;
     try {
-      character = await charactersService.create({
-        name: agentName,
-        bio: p.character?.bio
-          ? [p.character.bio]
-          : [`Agent for ${p.tokenName}`],
-        user_id: ownerUserId,
-        organization_id: ownerOrganizationId,
-        source: "cloud",
-        character_data: p.character?.config ?? {},
-        avatar_url: p.character?.avatar ?? null,
-        token_address: normalizedTokenAddress,
-        token_chain: p.chain,
-        token_name: p.tokenName,
-        token_ticker: p.tokenTicker,
-      });
+      character = await charactersService.create(
+        {
+          name: agentName,
+          bio: p.character?.bio
+            ? [p.character.bio]
+            : [`Agent for ${p.tokenName}`],
+          user_id: ownerUserId,
+          organization_id: ownerOrganizationId,
+          source: "cloud",
+          character_data: p.character?.config ?? {},
+          avatar_url: p.character?.avatar ?? null,
+          token_address: normalizedTokenAddress,
+          token_chain: p.chain,
+          token_name: p.tokenName,
+          token_ticker: p.tokenTicker,
+        },
+        {
+          policy: {
+            mode: "trusted",
+            caller: "service-api-v1-agents",
+          },
+        },
+      );
     } catch (error) {
       if (isUniqueConstraintError(error)) {
         const existing = await userCharactersRepository.findByTokenAddress(

--- a/packages/cloud/api/v1/app/agents/route.json.test.ts
+++ b/packages/cloud/api/v1/app/agents/route.json.test.ts
@@ -2,15 +2,24 @@
 import { describe, expect, mock, test } from "bun:test";
 
 const createCharacter = mock(async (input: Record<string, unknown>) => ({
-  id: "character-1",
-  name: input.name,
-  username: "smoke-agent",
-  bio: input.bio,
-  created_at: new Date("2026-01-01T00:00:00.000Z"),
-  token_address: null,
-  token_chain: null,
-  token_name: null,
-  token_ticker: null,
+  character: {
+    id: "character-1",
+    name: input.name,
+    username: "smoke-agent",
+    bio: input.bio,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    token_address: null,
+    token_chain: null,
+    token_name: null,
+    token_ticker: null,
+  },
+  created: true,
+  quota: {
+    currentBefore: 0,
+    currentAfter: 1,
+    limit: 5,
+    limitSource: "organizations.credit_balance",
+  },
 }));
 
 const countAgents = mock(async () => [{ count: 0 }]);
@@ -60,7 +69,7 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
-  charactersService: { create: createCharacter },
+  charactersService: { createWithReceipt: createCharacter },
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/app/agents/route.test.ts
+++ b/packages/cloud/api/v1/app/agents/route.test.ts
@@ -1,5 +1,6 @@
 // Exercises cloud API v1 app agents route.test behavior with deterministic Worker route fixtures.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
@@ -14,16 +15,26 @@ const findLatestByCharacterId = mock(
   async (): Promise<{ id: string } | null> => null,
 );
 const createCharacter = mock(async (input: Record<string, unknown>) => ({
-  id: "character-1",
-  name: input.name,
-  username: "smoke-agent",
-  bio: input.bio,
-  created_at: new Date("2026-01-01T00:00:00.000Z"),
-  token_address: input.token_address ?? null,
-  token_chain: input.token_chain ?? null,
-  token_name: input.token_name ?? null,
-  token_ticker: input.token_ticker ?? null,
+  character: {
+    id: "character-1",
+    name: input.name,
+    username: "smoke-agent",
+    bio: input.bio,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    token_address: input.token_address ?? null,
+    token_chain: input.token_chain ?? null,
+    token_name: input.token_name ?? null,
+    token_ticker: input.token_ticker ?? null,
+  },
+  created: true,
+  quota: {
+    currentBefore: 2,
+    currentAfter: 3,
+    limit: 5,
+    limitSource: "organizations.credit_balance",
+  },
 }));
+const loggerInfo = mock(() => undefined);
 
 const findOrg = mock(async () => ({
   id: "org-1",
@@ -71,13 +82,13 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
 
 mock.module("@/lib/services/characters/characters", () => ({
   charactersService: {
-    create: createCharacter,
+    createWithReceipt: createCharacter,
   },
 }));
 
 mock.module("@/lib/utils/logger", () => ({
   logger: {
-    info: mock(() => undefined),
+    info: loggerInfo,
     error: mock(() => undefined),
   },
 }));
@@ -91,6 +102,7 @@ describe("app agent creation route", () => {
     findLatestByCharacterId.mockClear();
     findLatestByCharacterId.mockResolvedValue(null);
     createCharacter.mockClear();
+    loggerInfo.mockClear();
     findOrg.mockClear();
     countAgents.mockClear();
     select.mockClear();
@@ -127,7 +139,73 @@ describe("app agent creation route", () => {
         token_address: "0x0000000000000000000000000000000000000009",
         token_chain: "bsc",
       }),
+      { policy: { mode: "metered" } },
     );
+    expect(findOrg).not.toHaveBeenCalled();
+    expect(countAgents).not.toHaveBeenCalled();
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "[Agents API] Created agent: character-1",
+      expect.objectContaining({
+        agentCount: 3,
+        maxAgents: 5,
+      }),
+    );
+  });
+
+  test("maps the central typed quota rejection without consulting a replica preflight", async () => {
+    createCharacter.mockRejectedValueOnce(
+      new ElizaError("quota", {
+        code: "CLOUD_CHARACTER_QUOTA_EXCEEDED",
+        context: { current: 5, limit: 5 },
+      }),
+    );
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Capped Agent" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error:
+        "Agent quota exceeded. Your organization has reached the maximum of 5 agents.",
+      code: "agent_quota_exceeded",
+      details: {
+        current: 5,
+        max: 5,
+        upgrade_hint:
+          "Add credits to your account to increase your agent limit.",
+      },
+    });
+    expect(findOrg).not.toHaveBeenCalled();
+    expect(countAgents).not.toHaveBeenCalled();
+  });
+
+  test("preserves the organization-not-found response at the central authority", async () => {
+    createCharacter.mockRejectedValueOnce(
+      new ElizaError("missing", {
+        code: "CHARACTER_ORGANIZATION_NOT_FOUND",
+      }),
+    );
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Missing Org Agent" }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Organization not found",
+      code: "resource_not_found",
+    });
   });
 
   test("duplicate token response uses linked sandbox id instead of character id", async () => {

--- a/packages/cloud/api/v1/app/agents/route.ts
+++ b/packages/cloud/api/v1/app/agents/route.ts
@@ -3,22 +3,20 @@
  * authenticated user. Enforces organization agent quotas and role.
  */
 
-import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbRead } from "@/db/client";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
-import { organizations } from "@/db/schemas/organizations";
-import { userCharacters } from "@/db/schemas/user-characters";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { getMaxCloudCharactersForOrg } from "@/lib/constants/cloud-character-quota";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { charactersService } from "@/lib/services/characters/characters";
+import {
+  charactersService,
+  type MeteredCharacterCreationReceipt,
+} from "@/lib/services/characters/characters";
 import { isUniqueConstraintError } from "@/lib/utils/db-errors";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
@@ -107,52 +105,6 @@ app.post("/", async (c) => {
       ? normalizeTokenAddress(validationResult.data.tokenAddress, tokenChain)
       : undefined;
 
-    // Org lookup and agent count are independent — run in parallel.
-    const [org, [{ count }]] = await Promise.all([
-      dbRead.query.organizations.findFirst({
-        where: eq(organizations.id, user.organization_id),
-        columns: {
-          id: true,
-          credit_balance: true,
-          settings: true,
-        },
-      }),
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(userCharacters)
-        .where(
-          and(
-            eq(userCharacters.organization_id, user.organization_id),
-            eq(userCharacters.source, "cloud"),
-          ),
-        ),
-    ]);
-
-    if (!org) {
-      return c.json({ success: false, error: "Organization not found" }, 404);
-    }
-
-    const maxAgents = getMaxCloudCharactersForOrg(
-      Number(org.credit_balance),
-      org.settings as Record<string, unknown> | undefined,
-    );
-
-    if (count >= maxAgents) {
-      return c.json(
-        {
-          success: false,
-          error: `Agent quota exceeded. Your organization has reached the maximum of ${maxAgents} agents.`,
-          details: {
-            current: count,
-            max: maxAgents,
-            upgrade_hint:
-              "Add credits to your account to increase your agent limit.",
-          },
-        },
-        403,
-      );
-    }
-
     if (tokenAddress) {
       const existing = await userCharactersRepository.findByTokenAddress(
         tokenAddress,
@@ -166,20 +118,23 @@ app.post("/", async (c) => {
       }
     }
 
-    let character: Awaited<ReturnType<typeof charactersService.create>>;
+    let creation: MeteredCharacterCreationReceipt;
     try {
-      character = await charactersService.create({
-        name,
-        bio: bio ? [bio] : [DEFAULT_AGENT_BIO],
-        user_id: user.id,
-        organization_id: user.organization_id,
-        source: "cloud",
-        character_data: {},
-        ...(tokenAddress && { token_address: tokenAddress }),
-        ...(tokenChain && { token_chain: tokenChain }),
-        ...(tokenName && { token_name: tokenName }),
-        ...(tokenTicker && { token_ticker: tokenTicker }),
-      });
+      creation = await charactersService.createWithReceipt(
+        {
+          name,
+          bio: bio ? [bio] : [DEFAULT_AGENT_BIO],
+          user_id: user.id,
+          organization_id: user.organization_id,
+          source: "cloud",
+          character_data: {},
+          ...(tokenAddress && { token_address: tokenAddress }),
+          ...(tokenChain && { token_chain: tokenChain }),
+          ...(tokenName && { token_name: tokenName }),
+          ...(tokenTicker && { token_ticker: tokenTicker }),
+        },
+        { policy: { mode: "metered" } },
+      );
     } catch (error) {
       if (tokenAddress && isUniqueConstraintError(error)) {
         const existing = await userCharactersRepository.findByTokenAddress(
@@ -194,13 +149,15 @@ app.post("/", async (c) => {
       throw error;
     }
 
+    const { character, quota } = creation;
+
     logger.info(`[Agents API] Created agent: ${character.id}`, {
       agentId: character.id,
       name: character.name,
       userId: user.id,
       organizationId: user.organization_id,
-      agentCount: count + 1,
-      maxAgents,
+      agentCount: quota.currentAfter,
+      maxAgents: quota.limit,
     });
 
     return c.json(

--- a/packages/cloud/shared/src/db/repositories/agents/agents.ts
+++ b/packages/cloud/shared/src/db/repositories/agents/agents.ts
@@ -11,6 +11,7 @@
 import type { Agent } from "@elizaos/core";
 import { eq, inArray } from "drizzle-orm";
 import { logger } from "../../../lib/utils/logger";
+import type { DbTransaction } from "../../client";
 import { dbRead, dbWrite } from "../../helpers";
 import { agentTable } from "../../schemas/eliza";
 
@@ -119,7 +120,7 @@ export class AgentsRepository {
    * @returns True if successful, false if agent with same ID already exists.
    * @throws Error if creation fails for reasons other than duplicate ID.
    */
-  async create(agent: Partial<Agent>): Promise<boolean> {
+  async create(agent: Partial<Agent>, tx?: DbTransaction): Promise<boolean> {
     if (!agent.name) {
       throw new Error("[AgentsRepository] Cannot create agent without a name");
     }
@@ -127,11 +128,17 @@ export class AgentsRepository {
     // Check for existing agent with the same ID only (names can be duplicated)
     // Use the write connection so the duplicate check sees the latest row.
     if (agent.id) {
-      const existing = await dbWrite
-        .select({ id: agentTable.id })
-        .from(agentTable)
-        .where(eq(agentTable.id, agent.id))
-        .limit(1);
+      const existing = tx
+        ? await tx
+            .select({ id: agentTable.id })
+            .from(agentTable)
+            .where(eq(agentTable.id, agent.id))
+            .limit(1)
+        : await dbWrite
+            .select({ id: agentTable.id })
+            .from(agentTable)
+            .where(eq(agentTable.id, agent.id))
+            .limit(1);
 
       if (existing.length > 0) {
         logger.warn("[AgentsRepository] Attempted duplicate agent create", {
@@ -141,17 +148,46 @@ export class AgentsRepository {
       }
     }
 
-    await dbWrite.insert(agentTable).values({
+    const insert = {
       ...agent,
       name: agent.name,
       createdAt: toDate(agent.createdAt),
       updatedAt: toDate(agent.updatedAt),
-    } as typeof agentTable.$inferInsert);
+    } as typeof agentTable.$inferInsert;
+    if (tx) {
+      await tx.insert(agentTable).values(insert);
+    } else {
+      await dbWrite.insert(agentTable).values(insert);
+    }
 
     logger.debug("[AgentsRepository] Created agent", {
       agentId: agent.id,
     });
     return true;
+  }
+
+  /**
+   * Idempotently ensures the character runtime mirror inside the caller's
+   * writer transaction. An existing ID is healthy, not a duplicate-create
+   * warning; other constraint failures still reject the transaction.
+   */
+  async ensure(agent: Partial<Agent>, tx: DbTransaction): Promise<void> {
+    if (!agent.id || !agent.name) {
+      throw new Error("[AgentsRepository] Cannot ensure agent without an ID and name");
+    }
+
+    const insert = {
+      ...agent,
+      id: agent.id,
+      name: agent.name,
+      createdAt: toDate(agent.createdAt),
+      updatedAt: toDate(agent.updatedAt),
+    } as typeof agentTable.$inferInsert;
+
+    await tx.insert(agentTable).values(insert).onConflictDoNothing({ target: agentTable.id });
+    logger.debug("[AgentsRepository] Ensured agent", {
+      agentId: agent.id,
+    });
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/characters.ts
+++ b/packages/cloud/shared/src/db/repositories/characters.ts
@@ -2,7 +2,9 @@
 import { and, desc, eq, inArray, or, SQL, sql } from "drizzle-orm";
 import type { SearchFilters, SortOptions } from "../../lib/types/my-agents";
 import { normalizeTokenAddress } from "../../lib/utils/token-address";
+import type { DbTransaction } from "../client";
 import { dbRead, dbWrite } from "../helpers";
+import { agentTable } from "../schemas/eliza";
 import { elizaRoomCharactersTable } from "../schemas/eliza-room-characters";
 import {
   type NewUserCharacter,
@@ -270,20 +272,28 @@ export class UserCharactersRepository {
   /**
    * Checks if a username exists.
    */
-  async usernameExists(username: string): Promise<boolean> {
-    const result = await dbRead
-      .select({ id: userCharacters.id })
-      .from(userCharacters)
-      .where(eq(userCharacters.username, username.toLowerCase()))
-      .limit(1);
+  async usernameExists(username: string, tx?: DbTransaction): Promise<boolean> {
+    const result = tx
+      ? await tx
+          .select({ id: userCharacters.id })
+          .from(userCharacters)
+          .where(eq(userCharacters.username, username.toLowerCase()))
+          .limit(1)
+      : await dbRead
+          .select({ id: userCharacters.id })
+          .from(userCharacters)
+          .where(eq(userCharacters.username, username.toLowerCase()))
+          .limit(1);
     return result.length > 0;
   }
 
   /**
    * Gets all existing usernames (for bulk uniqueness check).
    */
-  async getAllUsernames(): Promise<Set<string>> {
-    const result = await dbRead.select({ username: userCharacters.username }).from(userCharacters);
+  async getAllUsernames(tx?: DbTransaction): Promise<Set<string>> {
+    const result = tx
+      ? await tx.select({ username: userCharacters.username }).from(userCharacters)
+      : await dbRead.select({ username: userCharacters.username }).from(userCharacters);
 
     const usernames = new Set<string>();
     for (const row of result) {
@@ -348,9 +358,10 @@ export class UserCharactersRepository {
 
   /**
    * Checks whether an organization has any character of the given source.
-   * Bounded existence probe for hot paths (e.g. the session-time
-   * default-character self-heal) — never use listByOrganization just to test
-   * emptiness, character rows are fat and the list is unbounded.
+   * Bounded existence probe for callers that only need emptiness — never use
+   * listByOrganization just to test it, character rows are fat and the list
+   * is unbounded. Default-character self-heal uses the stronger mirror-health
+   * probe below.
    */
   async existsForOrganization(
     organizationId: string,
@@ -364,6 +375,31 @@ export class UserCharactersRepository {
       )
       .limit(1);
     return result.length > 0;
+  }
+
+  /**
+   * Read-intent bootstrap fast path. The oldest Cloud character is the same
+   * candidate the locked bootstrap authority repairs; it is healthy only when
+   * its runtime mirror is visible in the same replica query.
+   *
+   * Replica lag can produce a false negative, which safely falls back to the
+   * primary locked ensure. This probe never authorizes a create.
+   */
+  async hasHealthyCloudCharacterMirror(organizationId: string): Promise<boolean> {
+    const [candidate] = await dbRead
+      .select({
+        characterId: userCharacters.id,
+        mirrorId: agentTable.id,
+      })
+      .from(userCharacters)
+      .leftJoin(agentTable, eq(agentTable.id, userCharacters.id))
+      .where(
+        and(eq(userCharacters.organization_id, organizationId), eq(userCharacters.source, "cloud")),
+      )
+      .orderBy(userCharacters.created_at, userCharacters.id)
+      .limit(1);
+
+    return Boolean(candidate?.characterId && candidate.mirrorId === candidate.characterId);
   }
 
   /**
@@ -447,10 +483,15 @@ export class UserCharactersRepository {
   }
 
   /**
-   * Creates a new character.
+   * Creates a new character inside the caller's writer transaction.
+   *
+   * Character creation authority lives in CharactersService: callers must
+   * hold its organization lock and quota decision transaction. Requiring the
+   * transaction here prevents this public repository from becoming an
+   * accidental uncapped create path.
    */
-  async create(data: NewUserCharacter): Promise<UserCharacter> {
-    const [character] = await dbWrite.insert(userCharacters).values(data).returning();
+  async create(data: NewUserCharacter, tx: DbTransaction): Promise<UserCharacter> {
+    const [character] = await tx.insert(userCharacters).values(data).returning();
     return character;
   }
 
@@ -705,6 +746,16 @@ export class UserCharactersRepository {
       .where(eq(userCharacters.id, id));
   }
 }
+
+type AssertTrue<T extends true> = T;
+
+/**
+ * Compile-time fence: changing create's writer transaction back to optional
+ * makes this exported contract fail the shared package typecheck.
+ */
+export type UserCharacterCreateTransactionContract = AssertTrue<
+  1 extends Parameters<UserCharactersRepository["create"]>["length"] ? false : true
+>;
 
 /**
  * Singleton instance of UserCharactersRepository.

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -258,6 +258,49 @@ export function failureResponse(c: Context, error: unknown): Response {
       400,
     );
   }
+  if (
+    error instanceof Error &&
+    (error as { code?: unknown }).code === "CHARACTER_ORGANIZATION_NOT_FOUND"
+  ) {
+    return c.json(
+      {
+        success: false,
+        error: "Organization not found",
+        code: "resource_not_found" as const,
+      },
+      404,
+    );
+  }
+  if (
+    error instanceof Error &&
+    (error as { code?: unknown }).code === "CLOUD_CHARACTER_QUOTA_EXCEEDED"
+  ) {
+    const context = (error as { context?: Record<string, unknown> }).context;
+    const current = context?.current;
+    const limit = context?.limit;
+    if (
+      typeof current === "number" &&
+      Number.isSafeInteger(current) &&
+      current >= 0 &&
+      typeof limit === "number" &&
+      Number.isSafeInteger(limit) &&
+      limit > 0
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: `Agent quota exceeded. Your organization has reached the maximum of ${limit} agents.`,
+          code: "agent_quota_exceeded" as const,
+          details: {
+            current,
+            max: limit,
+            upgrade_hint: "Add credits to your account to increase your agent limit.",
+          },
+        },
+        403,
+      );
+    }
+  }
   if (error instanceof ApiError) {
     return c.json(error.toJSON(), error.status as 400);
   }

--- a/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
@@ -12,7 +12,7 @@
  * harness: cache/token-verify/db services are in-memory mocks; no live model.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const existingUser = {
   id: "user-1",
@@ -26,6 +26,8 @@ const existingUser = {
 };
 
 let characterCreateCalls: Array<Record<string, unknown>> = [];
+let characterHealthProbeCalls: string[] = [];
+let characterBootstrapHealthy = false;
 
 mock.module("./cache/client", () => ({
   cache: {
@@ -87,7 +89,10 @@ mock.module("./services/api-keys", () => ({
 }));
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: async () => false,
+    hasHealthyCloudCharacterMirror: async (organizationId: string) => {
+      characterHealthProbeCalls.push(organizationId);
+      return characterBootstrapHealthy;
+    },
     create: async (data: Record<string, unknown>) => {
       characterCreateCalls.push(data);
       return { id: "char-1" };
@@ -124,10 +129,14 @@ mock.module("./services/email", () => ({
 
 const { getCurrentUserFromRequest } = await import("./auth");
 
+beforeEach(() => {
+  characterCreateCalls = [];
+  characterHealthProbeCalls = [];
+  characterBootstrapHealthy = false;
+});
+
 describe("session-resolution default-character self-heal", () => {
   test("cache miss for an existing user with a character-less org re-seeds the default Eliza", async () => {
-    characterCreateCalls = [];
-
     const request = new Request("http://localhost/api/anything", {
       headers: { cookie: "steward-token=tok-abc" },
     });
@@ -141,6 +150,20 @@ describe("session-resolution default-character self-heal", () => {
     expect(characterCreateCalls[0].name).toBe("Eliza");
     expect(characterCreateCalls[0].user_id).toBe("user-1");
     expect(characterCreateCalls[0].organization_id).toBe("org-1");
+    expect(characterHealthProbeCalls).toEqual(["org-1"]);
+  });
+
+  test("healthy cache miss uses the read probe without entering bootstrap", async () => {
+    characterBootstrapHealthy = true;
+    const request = new Request("http://localhost/api/anything", {
+      headers: { cookie: "steward-token=tok-abc" },
+    });
+
+    const user = await getCurrentUserFromRequest(request);
+
+    expect(user?.id).toBe("user-1");
+    expect(characterHealthProbeCalls).toEqual(["org-1"]);
+    expect(characterCreateCalls).toHaveLength(0);
   });
 
   test("the default API-key self-heal is AWAITED, not void-fired (Workers cancels un-awaited promises)", async () => {

--- a/packages/cloud/shared/src/lib/auth.ts
+++ b/packages/cloud/shared/src/lib/auth.ts
@@ -205,8 +205,9 @@ export async function getCurrentUserFromRequest(
       // forever. Awaited, not void-fired: this runs on Cloudflare Workers,
       // where an un-awaited promise may be cancelled once the response
       // returns — the exact failure mode that loses the signup-time create.
-      // Idempotent (one indexed SELECT per session-cache miss; seeds only
-      // when the org has zero characters) and it never rejects.
+      // The healthy path is one read-intent character+mirror probe and opens
+      // no writer transaction. Missing/incoherent state falls back to the
+      // organization-locked bootstrap ensure; the helper never rejects.
       await ensureDefaultCharacter(user.id, user.organization_id);
     } else {
       logger.error("[AUTH] User missing organization_id:", user.id);

--- a/packages/cloud/shared/src/lib/services/characters/characters-quota.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters-quota.pglite.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Real-PGlite proof for the Cloud-character creation authority. The suite
+ * drives the real service, repositories, transaction, quota resolver, and
+ * character/runtime-mirror tables; Redis is the only substituted boundary.
+ * PGlite's single writer is not the lock proof: the mocked service trace
+ * separately enforces advisory-lock-before-exists/scan ordering.
+ */
+
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq, sql } from "drizzle-orm";
+import { agentTable } from "../../../db/schemas/eliza";
+import {
+  organizationBalanceRevisionSequence,
+  organizations,
+} from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+import { generateUniqueUsername, generateUsernameFromName } from "../../utils/agent-username";
+
+const PGLITE_TIMEOUT = 60_000;
+const FREE_TIER_LIMIT = 5;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let CharactersService: typeof import("./characters").CharactersService;
+let CloudCharacterQuotaExceededError: typeof import("./characters").CloudCharacterQuotaExceededError;
+
+let sequence = 0;
+function unique(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${sequence}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOrganization(): Promise<string> {
+  const [organization] = await dbWrite
+    .insert(organizations)
+    .values({
+      name: unique("org"),
+      slug: unique("org"),
+      credit_balance: "0.000000",
+      settings: {},
+    })
+    .returning();
+  return organization.id;
+}
+
+async function seedUser(organizationId: string): Promise<string> {
+  const [user] = await dbWrite
+    .insert(users)
+    .values({
+      steward_user_id: unique("steward"),
+      organization_id: organizationId,
+    })
+    .returning();
+  return user.id;
+}
+
+async function seedCloudPopulation(
+  organizationId: string,
+  userId: string,
+  count: number,
+): Promise<void> {
+  if (count === 0) return;
+  await dbWrite.insert(userCharacters).values(
+    Array.from({ length: count }, (_, index) => ({
+      organization_id: organizationId,
+      user_id: userId,
+      name: `Seed ${index}`,
+      username: unique("seed"),
+      bio: ["seed"],
+      character_data: {},
+      source: "cloud",
+    })),
+  );
+}
+
+async function cloudCount(organizationId: string): Promise<number> {
+  const [row] = await dbWrite
+    .select({ count: sql<number>`count(*)::int` })
+    .from(userCharacters)
+    .where(
+      and(eq(userCharacters.organization_id, organizationId), eq(userCharacters.source, "cloud")),
+    );
+  return Number(row?.count ?? 0);
+}
+
+async function mirrorCount(characterId: string): Promise<number> {
+  const rows = await dbWrite
+    .select({ id: agentTable.id })
+    .from(agentTable)
+    .where(eq(agentTable.id, characterId));
+  return rows.length;
+}
+
+function characterData(organizationId: string, userId: string, name: string) {
+  return {
+    organization_id: organizationId,
+    user_id: userId,
+    name,
+    username: unique("character"),
+    bio: [name],
+    character_data: {},
+    source: "cloud",
+  } as const;
+}
+
+function automaticCharacterData(organizationId: string, userId: string, name: string) {
+  return {
+    organization_id: organizationId,
+    user_id: userId,
+    name,
+    bio: [name],
+    character_data: {},
+    source: "cloud",
+  } as const;
+}
+
+function releaseTogether<T>(attempts: Array<() => Promise<T>>): Promise<PromiseSettledResult<T>[]> {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const running = attempts.map(async (attempt) => {
+    await gate;
+    return attempt();
+  });
+  release();
+  return Promise.allSettled(running);
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({ CharactersService, CloudCharacterQuotaExceededError } = await import("./characters"));
+
+  const { apply } = await pushSchema(
+    {
+      organizations,
+      organizationBalanceRevisionSequence,
+      users,
+      userCharacters,
+      agentTable,
+    } as never,
+    dbWrite as never,
+  );
+  await apply();
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("CharactersService.create — atomic Cloud-character authority", () => {
+  test(
+    "metered success returns the quota decision from the locked transaction",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      await seedCloudPopulation(organizationId, userId, 2);
+      const service = new CharactersService();
+
+      const receipt = await service.createWithReceipt(
+        characterData(organizationId, userId, "Receipt"),
+        { policy: { mode: "metered" } },
+      );
+
+      expect(receipt.created).toBe(true);
+      expect(receipt.quota).toEqual({
+        currentBefore: 2,
+        currentAfter: 3,
+        limit: FREE_TIER_LIMIT,
+        limitSource: "organizations.credit_balance",
+      });
+      expect(await cloudCount(organizationId)).toBe(3);
+      expect(await mirrorCount(receipt.character.id)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "limit - 1 plus two released creates yields one success, one typed rejection, and one mirror",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      await seedCloudPopulation(organizationId, userId, FREE_TIER_LIMIT - 1);
+      const service = new CharactersService();
+
+      const results = await releaseTogether([
+        () =>
+          service.create(characterData(organizationId, userId, "Concurrent A"), {
+            policy: { mode: "metered" },
+          }),
+        () =>
+          service.create(characterData(organizationId, userId, "Concurrent B"), {
+            policy: { mode: "metered" },
+          }),
+      ]);
+
+      const fulfilled = results.filter(
+        (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof service.create>>> =>
+          result.status === "fulfilled",
+      );
+      const rejected = results.filter(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].reason).toBeInstanceOf(CloudCharacterQuotaExceededError);
+      expect(rejected[0].reason).toMatchObject({
+        code: "CLOUD_CHARACTER_QUOTA_EXCEEDED",
+        current: FREE_TIER_LIMIT,
+        limit: FREE_TIER_LIMIT,
+      });
+      expect(await cloudCount(organizationId)).toBe(FREE_TIER_LIMIT);
+      expect(await mirrorCount(fulfilled[0].value.id)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "capacity is organization-scoped when capped A and limit - 1 B create together",
+    async () => {
+      const organizationA = await seedOrganization();
+      const userA = await seedUser(organizationA);
+      const organizationB = await seedOrganization();
+      const userB = await seedUser(organizationB);
+      await seedCloudPopulation(organizationA, userA, FREE_TIER_LIMIT);
+      await seedCloudPopulation(organizationB, userB, FREE_TIER_LIMIT - 1);
+      const service = new CharactersService();
+
+      const [resultA, resultB] = await releaseTogether([
+        () =>
+          service.create(characterData(organizationA, userA, "Org A"), {
+            policy: { mode: "metered" },
+          }),
+        () =>
+          service.create(characterData(organizationB, userB, "Org B"), {
+            policy: { mode: "metered" },
+          }),
+      ]);
+
+      expect(resultA.status).toBe("rejected");
+      if (resultA.status === "rejected") {
+        expect(resultA.reason).toBeInstanceOf(CloudCharacterQuotaExceededError);
+      }
+      expect(resultB.status).toBe("fulfilled");
+      expect(await cloudCount(organizationA)).toBe(FREE_TIER_LIMIT);
+      expect(await cloudCount(organizationB)).toBe(FREE_TIER_LIMIT);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent bootstrap ensures converge on one character and one runtime mirror",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      const service = new CharactersService();
+      const defaultData = characterData(organizationId, userId, "Default Eliza");
+
+      const results = await releaseTogether([
+        () => service.create(defaultData, { policy: { mode: "bootstrap" } }),
+        () => service.create(defaultData, { policy: { mode: "bootstrap" } }),
+      ]);
+
+      expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+      const ids = results.map((result) =>
+        result.status === "fulfilled" ? result.value.id : "rejected",
+      );
+      expect(new Set(ids).size).toBe(1);
+      expect(await cloudCount(organizationId)).toBe(1);
+      expect(await mirrorCount(ids[0])).toBe(1);
+      expect(await service.hasHealthyCloudCharacterMirror(organizationId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "cross-org concurrent bootstraps allocate distinct automatic usernames and mirrors",
+    async () => {
+      const organizationA = await seedOrganization();
+      const userA = await seedUser(organizationA);
+      const organizationB = await seedOrganization();
+      const userB = await seedUser(organizationB);
+      const service = new CharactersService();
+      const sharedName = unique("Cross Org Default");
+      const baseUsername = generateUsernameFromName(sharedName);
+      const suffixedUsername = generateUniqueUsername(baseUsername, new Set([baseUsername]));
+
+      const results = await releaseTogether([
+        () =>
+          service.create(automaticCharacterData(organizationA, userA, sharedName), {
+            policy: { mode: "bootstrap" },
+          }),
+        () =>
+          service.create(automaticCharacterData(organizationB, userB, sharedName), {
+            policy: { mode: "bootstrap" },
+          }),
+      ]);
+
+      expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+      const created = results.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      expect(created).toHaveLength(2);
+      expect(new Set(created.map((character) => character.username)).size).toBe(2);
+      expect(created.map((character) => character.username).sort()).toEqual(
+        [baseUsername, suffixedUsername].sort(),
+      );
+      expect(await cloudCount(organizationA)).toBe(1);
+      expect(await cloudCount(organizationB)).toBe(1);
+      expect(await mirrorCount(created[0].id)).toBe(1);
+      expect(await mirrorCount(created[1].id)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "cross-org automatic and explicit claims converge without a raw unique failure",
+    async () => {
+      const explicitOrganization = await seedOrganization();
+      const explicitUser = await seedUser(explicitOrganization);
+      const automaticOrganization = await seedOrganization();
+      const automaticUser = await seedUser(automaticOrganization);
+      const service = new CharactersService();
+      const sharedName = unique("Mixed Claim");
+      const baseUsername = generateUsernameFromName(sharedName);
+      const suffixedUsername = generateUniqueUsername(baseUsername, new Set([baseUsername]));
+
+      const results = await releaseTogether([
+        () =>
+          service.create(
+            {
+              ...automaticCharacterData(explicitOrganization, explicitUser, sharedName),
+              username: baseUsername,
+            },
+            { policy: { mode: "bootstrap" } },
+          ),
+        () =>
+          service.create(automaticCharacterData(automaticOrganization, automaticUser, sharedName), {
+            policy: { mode: "bootstrap" },
+          }),
+      ]);
+
+      const fulfilled = results.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      const rejected = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      expect(fulfilled.length + rejected.length).toBe(2);
+      expect(fulfilled.length).toBeGreaterThanOrEqual(1);
+      expect(new Set(fulfilled.map((character) => character.username)).size).toBe(fulfilled.length);
+      if (fulfilled.length === 2) {
+        expect(fulfilled.map((character) => character.username).sort()).toEqual(
+          [baseUsername, suffixedUsername].sort(),
+        );
+      } else {
+        expect(rejected).toHaveLength(1);
+        expect(rejected[0]).toMatchObject({
+          status: 400,
+          code: "validation_error",
+          message: "Username is already taken",
+        });
+      }
+      expect(await cloudCount(explicitOrganization)).toBe(
+        fulfilled.some((character) => character.organization_id === explicitOrganization) ? 1 : 0,
+      );
+      expect(await cloudCount(automaticOrganization)).toBe(
+        fulfilled.some((character) => character.organization_id === automaticOrganization) ? 1 : 0,
+      );
+      for (const character of fulfilled) {
+        expect(await mirrorCount(character.id)).toBe(1);
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent bootstrap repairs one legacy character without duplicating its mirror",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      const [legacyCharacter] = await dbWrite
+        .insert(userCharacters)
+        .values(characterData(organizationId, userId, "Legacy Eliza"))
+        .returning();
+      expect(await mirrorCount(legacyCharacter.id)).toBe(0);
+
+      const service = new CharactersService();
+      expect(await service.hasHealthyCloudCharacterMirror(organizationId)).toBe(false);
+      const { logger } = await import("../../utils/logger");
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => undefined);
+      const defaultData = characterData(organizationId, userId, "Default Eliza");
+      try {
+        const results = await releaseTogether([
+          () => service.create(defaultData, { policy: { mode: "bootstrap" } }),
+          () => service.create(defaultData, { policy: { mode: "bootstrap" } }),
+        ]);
+
+        expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+        const ids = results.map((result) =>
+          result.status === "fulfilled" ? result.value.id : "rejected",
+        );
+        expect(new Set(ids)).toEqual(new Set([legacyCharacter.id]));
+        expect(await cloudCount(organizationId)).toBe(1);
+        expect(await mirrorCount(legacyCharacter.id)).toBe(1);
+        expect(await service.hasHealthyCloudCharacterMirror(organizationId)).toBe(true);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "named trusted caller remains exempt at the cap while joining the canonical population",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      await seedCloudPopulation(organizationId, userId, FREE_TIER_LIMIT);
+      const service = new CharactersService();
+
+      const created = await service.create(characterData(organizationId, userId, "Trusted"), {
+        policy: {
+          mode: "trusted",
+          caller: "service-api-v1-agents",
+        },
+      });
+
+      expect(await cloudCount(organizationId)).toBe(FREE_TIER_LIMIT + 1);
+      expect(await mirrorCount(created.id)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a mirror conflict rolls the character insert back in the same transaction",
+    async () => {
+      const organizationId = await seedOrganization();
+      const userId = await seedUser(organizationId);
+      const characterId = crypto.randomUUID();
+      await dbWrite.insert(agentTable).values({
+        id: characterId,
+        name: "Pre-existing mirror",
+      });
+      const service = new CharactersService();
+
+      await expect(
+        service.create(
+          {
+            ...characterData(organizationId, userId, "Mirror conflict"),
+            id: characterId,
+          },
+          {
+            policy: {
+              mode: "trusted",
+              caller: "affiliate-create-character",
+            },
+          },
+        ),
+      ).rejects.toMatchObject({ code: "CHARACTER_AGENT_MIRROR_CONFLICT" });
+
+      const persisted = await dbWrite
+        .select({ id: userCharacters.id })
+        .from(userCharacters)
+        .where(eq(userCharacters.id, characterId));
+      expect(persisted).toHaveLength(0);
+      expect(await mirrorCount(characterId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/characters/characters.test.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.test.ts
@@ -3,20 +3,86 @@
  * completing the slice #13706 left open for name/#13761 closed for name).
  * Blank usernames are provided-but-unset and must auto-generate; a genuinely
  * invalid provided username must fail as caller error (400 ValidationError),
- * never a raw 500. Repositories and cache are mocked; the real
- * validateUsername/generateUniqueUsername logic runs unmocked.
+ * never a raw 500. Transaction traces prove automatic and explicit claims use
+ * the same global advisory lock before their scan/check and insert;
+ * repositories and cache are mocked while username utilities run unmocked.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { UserCharacterCreateTransactionContract } from "../../../db/repositories/characters";
 import type { NewUserCharacter } from "../../../db/schemas/user-characters";
+
+const REPOSITORY_CREATE_REQUIRES_TRANSACTION: UserCharacterCreateTransactionContract = true;
 
 const usernameExistsCalls: string[] = [];
 const createCalls: Array<{ username?: string | null }> = [];
+const characterCreateTransactions: unknown[] = [];
 const agentCreateCalls: unknown[] = [];
+const agentCreateTransactions: unknown[] = [];
 const cacheDelCalls: string[] = [];
+const transactionContexts: unknown[] = [];
+const transactionConfigs: unknown[] = [];
+const healthyMirrorProbeCalls: string[] = [];
+const usernameScanTransactions: unknown[] = [];
+const usernameExistsTransactions: unknown[] = [];
+const authorityTrace: string[] = [];
+const executedSql: string[] = [];
 
 let usernameExistsResult = false;
 let existingUsernames = new Set<string>();
+let healthyMirrorResult = false;
+
+const transaction = mock(
+  async (
+    run: (tx: { select: (fields?: Record<string, unknown>) => unknown }) => Promise<unknown>,
+    config?: unknown,
+  ) => {
+    const tx = {
+      execute: async (query: unknown) => {
+        const rendered = JSON.stringify(query);
+        executedSql.push(rendered);
+        if (rendered.includes("set_config")) {
+          authorityTrace.push("configure-timeouts");
+        }
+        if (rendered.includes("pg_advisory_xact_lock")) {
+          authorityTrace.push("username-lock");
+        }
+        return { rows: [] };
+      },
+      select: (fields = {}) => {
+        if (Object.hasOwn(fields, "creditBalance")) {
+          return {
+            from: () => ({
+              where: () => ({
+                limit: () => ({
+                  for: async () => {
+                    authorityTrace.push("organization-lock");
+                    return [{ id: ORG_ID, creditBalance: "0.000000", settings: {} }];
+                  },
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: async () => [{ count: 0 }],
+          }),
+        };
+      },
+    };
+    transactionContexts.push(tx);
+    transactionConfigs.push(config);
+    return run(tx);
+  },
+);
+
+mock.module("../../../db/client", () => ({
+  db: {},
+  dbRead: {},
+  dbWrite: { transaction },
+  getDbConnectionInfo: () => ({ databaseUrlConfigured: true }),
+}));
 
 // Mock the submodule characters.ts imports through the "../../../db/repositories"
 // barrel (which re-exports "./characters"), not the barrel itself — the barrel
@@ -24,24 +90,38 @@ let existingUsernames = new Set<string>();
 // modules in the same import graph (usersService) need untouched.
 mock.module("../../../db/repositories/characters", () => ({
   userCharactersRepository: {
-    usernameExists: async (username: string) => {
+    usernameExists: async (username: string, tx: unknown) => {
+      authorityTrace.push("username-exists");
       usernameExistsCalls.push(username);
+      usernameExistsTransactions.push(tx);
       return usernameExistsResult;
     },
-    create: async (data: { username?: string | null }) => {
+    create: async (data: { username?: string | null }, tx: unknown) => {
+      authorityTrace.push("character-insert");
       createCalls.push(data);
+      characterCreateTransactions.push(tx);
       return { id: "char-1", ...data };
     },
-    getAllUsernames: async () => existingUsernames,
+    getAllUsernames: async (tx: unknown) => {
+      authorityTrace.push("username-scan");
+      usernameScanTransactions.push(tx);
+      return existingUsernames;
+    },
+    hasHealthyCloudCharacterMirror: async (organizationId: string) => {
+      healthyMirrorProbeCalls.push(organizationId);
+      return healthyMirrorResult;
+    },
   },
 }));
 
 mock.module("../../../db/repositories/agents/agents", () => ({
   agentsRepository: {
-    create: async (agent: unknown) => {
+    create: async (agent: unknown, tx: unknown) => {
       agentCreateCalls.push(agent);
+      agentCreateTransactions.push(tx);
       return true;
     },
+    ensure: async () => undefined,
   },
 }));
 
@@ -55,6 +135,7 @@ mock.module("../../cache/client", () => ({
 
 const ORG_ID = "22222222-2222-4222-8222-222222222222";
 const USER_ID = "11111111-1111-4111-8111-111111111111";
+const METERED_POLICY = { policy: { mode: "metered" as const } };
 
 function baseData(overrides: Record<string, unknown> = {}): NewUserCharacter {
   return {
@@ -71,16 +152,50 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
   beforeEach(() => {
     usernameExistsCalls.length = 0;
     createCalls.length = 0;
+    characterCreateTransactions.length = 0;
     agentCreateCalls.length = 0;
+    agentCreateTransactions.length = 0;
     cacheDelCalls.length = 0;
+    transactionContexts.length = 0;
+    transactionConfigs.length = 0;
+    healthyMirrorProbeCalls.length = 0;
+    usernameScanTransactions.length = 0;
+    usernameExistsTransactions.length = 0;
+    authorityTrace.length = 0;
+    executedSql.length = 0;
+    transaction.mockClear();
     usernameExistsResult = false;
     existingUsernames = new Set<string>();
+    healthyMirrorResult = false;
+  });
+
+  test("a healthy character+mirror probe stays read-only and opens no writer transaction", async () => {
+    const { charactersService } = await import("./characters");
+    healthyMirrorResult = true;
+
+    await expect(charactersService.hasHealthyCloudCharacterMirror(ORG_ID)).resolves.toBe(true);
+
+    expect(healthyMirrorProbeCalls).toEqual([ORG_ID]);
+    expect(transaction).not.toHaveBeenCalled();
+    expect(characterCreateTransactions).toHaveLength(0);
+    expect(agentCreateTransactions).toHaveLength(0);
+  });
+
+  test("repository create requires and receives the authority transaction", async () => {
+    const { charactersService } = await import("./characters");
+
+    expect(REPOSITORY_CREATE_REQUIRES_TRANSACTION).toBe(true);
+    await charactersService.create(baseData({ username: "transaction-bound" }), METERED_POLICY);
+
+    expect(transactionContexts).toHaveLength(1);
+    expect(characterCreateTransactions).toEqual([transactionContexts[0]]);
+    expect(agentCreateTransactions).toEqual([transactionContexts[0]]);
   });
 
   test("empty string username auto-generates (empty-is-unset contract), no throw", async () => {
     const { charactersService } = await import("./characters");
 
-    const character = await charactersService.create(baseData({ username: "" }));
+    const character = await charactersService.create(baseData({ username: "" }), METERED_POLICY);
 
     expect(createCalls).toHaveLength(1);
     const created = createCalls[0];
@@ -89,13 +204,35 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
     expect(character.id).toBe("char-1");
   });
 
+  test("automatic allocation takes the bounded global xact lock before scan and insert", async () => {
+    const { charactersService } = await import("./characters");
+
+    await charactersService.create(baseData({ username: null }), METERED_POLICY);
+
+    expect(authorityTrace).toEqual([
+      "organization-lock",
+      "configure-timeouts",
+      "username-lock",
+      "username-scan",
+      "character-insert",
+    ]);
+    expect(usernameScanTransactions).toEqual([transactionContexts[0]]);
+    expect(transactionConfigs).toEqual([{ isolationLevel: "read committed" }]);
+    const timeoutSql = executedSql.find((statement) => statement.includes("set_config"));
+    const lockSql = executedSql.find((statement) => statement.includes("pg_advisory_xact_lock"));
+    expect(timeoutSql).toContain("10000ms");
+    expect(timeoutSql).toContain("30000ms");
+    expect(lockSql).toContain("cloud-character");
+    expect(lockSql).toContain("username-claim");
+  });
+
   test("too-short provided username throws ValidationError -> 400, not a plain Error/500", async () => {
     const { charactersService } = await import("./characters");
     const { ApiError } = await import("../../api/cloud-worker-errors");
 
     let caught: unknown;
     try {
-      await charactersService.create(baseData({ username: "ab" }));
+      await charactersService.create(baseData({ username: "ab" }), METERED_POLICY);
     } catch (error) {
       caught = error;
     }
@@ -108,14 +245,28 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
     expect(createCalls).toHaveLength(0);
   });
 
-  test("valid provided username is normalized, checked for uniqueness, and used as-is", async () => {
+  test("explicit claim takes the same bounded global lock before exists and insert", async () => {
     const { charactersService } = await import("./characters");
 
-    const character = await charactersService.create(baseData({ username: "Valid-Name" }));
+    const character = await charactersService.create(
+      baseData({ username: "Valid-Name" }),
+      METERED_POLICY,
+    );
 
     expect(usernameExistsCalls).toEqual(["valid-name"]);
+    expect(authorityTrace).toEqual([
+      "organization-lock",
+      "configure-timeouts",
+      "username-lock",
+      "username-exists",
+      "character-insert",
+    ]);
+    expect(usernameExistsTransactions).toEqual([transactionContexts[0]]);
     expect(createCalls[0].username).toBe("valid-name");
     expect(character.id).toBe("char-1");
+    const lockSql = executedSql.find((statement) => statement.includes("pg_advisory_xact_lock"));
+    expect(lockSql).toContain("cloud-character");
+    expect(lockSql).toContain("username-claim");
   });
 
   test("duplicate provided username throws ValidationError -> 400, not a plain Error/500", async () => {
@@ -125,7 +276,7 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
 
     let caught: unknown;
     try {
-      await charactersService.create(baseData({ username: "taken-name" }));
+      await charactersService.create(baseData({ username: "taken-name" }), METERED_POLICY);
     } catch (error) {
       caught = error;
     }
@@ -145,7 +296,7 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
 
     let caught: unknown;
     try {
-      await charactersService.create(baseData({ username: 42 }));
+      await charactersService.create(baseData({ username: 42 }), METERED_POLICY);
     } catch (error) {
       caught = error;
     }
@@ -154,6 +305,27 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
     const apiError = caught as InstanceType<typeof ApiError>;
     expect(apiError.status).toBe(400);
     expect(apiError.code).toBe("validation_error");
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test("missing or unknown policies fail closed before opening a transaction", async () => {
+    const { charactersService } = await import("./characters");
+
+    await expect(
+      charactersService.create(baseData({ username: "valid-name" }), undefined as never),
+    ).rejects.toMatchObject({ code: "CHARACTER_CREATION_POLICY_REQUIRED" });
+    await expect(
+      charactersService.create(baseData({ username: "valid-name" }), {
+        policy: { mode: "unknown" },
+      } as never),
+    ).rejects.toMatchObject({ code: "CHARACTER_CREATION_POLICY_REQUIRED" });
+    await expect(
+      charactersService.create(baseData({ username: "valid-name" }), {
+        policy: { mode: "trusted", caller: "unregistered-caller" },
+      } as never),
+    ).rejects.toMatchObject({ code: "CHARACTER_CREATION_POLICY_REQUIRED" });
+
+    expect(transaction).not.toHaveBeenCalled();
     expect(createCalls).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -4,9 +4,9 @@
  * PERFORMANCE: Character data is cached in Redis for fast runtime access.
  */
 
-import type { Agent } from "@elizaos/core";
+import { type Agent, ElizaError } from "@elizaos/core";
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
-import { dbRead, dbWrite } from "../../../db/client";
+import { type DbTransaction, dbRead, dbWrite } from "../../../db/client";
 import {
   type NewUserCharacter,
   type UserCharacter,
@@ -16,12 +16,21 @@ import {
 export type { UserCharacter } from "../../../db/repositories";
 
 import { agentsRepository } from "../../../db/repositories/agents/agents";
-import { elizaRoomCharactersTable, userCharacters, users } from "../../../db/schemas";
+import {
+  elizaRoomCharactersTable,
+  organizations,
+  userCharacters,
+  users,
+} from "../../../db/schemas";
 import { memoryTable, participantTable, roomTable } from "../../../db/schemas/eliza";
 import { ValidationError } from "../../api/cloud-worker-errors";
 import { cache } from "../../cache/client";
 import { InMemoryLRUCache } from "../../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../../cache/keys";
+import {
+  type CloudCharacterLimitSource,
+  resolveMaxCloudCharactersForOrg,
+} from "../../constants/cloud-character-quota";
 import type { ElizaCharacter } from "../../types/eliza-character";
 import {
   generateUniqueUsername,
@@ -35,6 +44,10 @@ import { usersService } from "../users";
 // Cache key for character data (longer TTL since characters rarely change)
 const characterCacheKey = (id: string) => `character:data:${id}`;
 const CHARACTER_CACHE_TTL = CacheTTL.agent.characterData; // 1 hour
+const USERNAME_AUTHORITY_LOCK_TIMEOUT_MS = 10_000;
+const USERNAME_AUTHORITY_STATEMENT_TIMEOUT_MS = 30_000;
+const USERNAME_AUTHORITY_LOCK_NAMESPACE = "cloud-character";
+const USERNAME_AUTHORITY_LOCK_KEY = "username-claim";
 
 /**
  * PERF: In-memory cache for character data (60s TTL).
@@ -47,6 +60,140 @@ const characterHydrations = new Map<string, Promise<void>>();
 export type InferenceCharacterCacheResolution =
   | { kind: "ready"; character: UserCharacter | null }
   | { kind: "warming" | "unavailable" };
+
+export type CharacterCreationPolicy =
+  | { mode: "metered" }
+  | { mode: "bootstrap" }
+  | {
+      mode: "trusted";
+      caller: "affiliate-create-character" | "service-api-v1-agents";
+    };
+
+export interface CharacterCreationOptions {
+  policy: CharacterCreationPolicy;
+}
+
+export interface CharacterCreationQuotaReceipt {
+  currentBefore: number;
+  currentAfter: number;
+  limit: number;
+  limitSource: CloudCharacterLimitSource;
+}
+
+export interface CharacterCreationReceipt {
+  character: UserCharacter;
+  created: boolean;
+  quota?: CharacterCreationQuotaReceipt;
+}
+
+export interface MeteredCharacterCreationReceipt extends CharacterCreationReceipt {
+  created: true;
+  quota: CharacterCreationQuotaReceipt;
+}
+
+const TRUSTED_CHARACTER_CREATION_CALLERS = new Set([
+  "affiliate-create-character",
+  "service-api-v1-agents",
+]);
+
+function requireCharacterCreationPolicy(
+  options: CharacterCreationOptions | undefined,
+): CharacterCreationPolicy {
+  const candidate: unknown = options?.policy;
+  if (candidate !== null && typeof candidate === "object" && !Array.isArray(candidate)) {
+    const record = candidate as Record<string, unknown>;
+    if (record.mode === "metered" || record.mode === "bootstrap") {
+      return { mode: record.mode };
+    }
+    if (
+      record.mode === "trusted" &&
+      typeof record.caller === "string" &&
+      TRUSTED_CHARACTER_CREATION_CALLERS.has(record.caller)
+    ) {
+      return {
+        mode: "trusted",
+        caller: record.caller as "affiliate-create-character" | "service-api-v1-agents",
+      };
+    }
+  }
+
+  throw new ElizaError("Character creation requires a valid explicit quota policy", {
+    code: "CHARACTER_CREATION_POLICY_REQUIRED",
+    severity: "fatal",
+  });
+}
+
+/** Raised when a metered character create observes no remaining org capacity. */
+export class CloudCharacterQuotaExceededError extends ElizaError {
+  override readonly name = "CloudCharacterQuotaExceededError";
+  readonly organizationId: string;
+  readonly current: number;
+  readonly limit: number;
+  readonly limitSource: CloudCharacterLimitSource;
+
+  constructor(params: {
+    organizationId: string;
+    current: number;
+    limit: number;
+    limitSource: CloudCharacterLimitSource;
+  }) {
+    super(
+      `Agent quota exceeded. Your organization has reached the maximum of ${params.limit} agents.`,
+      {
+        code: "CLOUD_CHARACTER_QUOTA_EXCEEDED",
+        context: params,
+        severity: "ephemeral",
+      },
+    );
+    this.organizationId = params.organizationId;
+    this.current = params.current;
+    this.limit = params.limit;
+    this.limitSource = params.limitSource;
+  }
+}
+
+function mirroredAgent(character: UserCharacter): Partial<Agent> {
+  return {
+    id: character.id as `${string}-${string}-${string}-${string}-${string}`,
+    name: character.name,
+    username: character.username ?? undefined,
+    bio: character.bio as string[] | undefined,
+    system: character.system ?? undefined,
+    enabled: true,
+    settings: character.settings as Record<
+      string,
+      string | number | boolean | Record<string, string | number | boolean>
+    >,
+  };
+}
+
+/** Ensures a lock waiter scans from a fresh snapshot after its predecessor commits. */
+async function withCharacterCreationTransaction<T>(
+  operation: (tx: DbTransaction) => Promise<T>,
+): Promise<T> {
+  return await dbWrite.transaction(operation, { isolationLevel: "read committed" });
+}
+
+/**
+ * Serializes every username claim across organizations.
+ *
+ * The username index is global, while the create authority's row lock is
+ * intentionally per organization. This transaction-scoped advisory lock must
+ * therefore be held before either an explicit existence check or an automatic
+ * global scan chooses a candidate, and through the insert that claims it. The
+ * caller pins READ COMMITTED so a waiter scans from a fresh snapshot after the
+ * preceding lock holder commits.
+ */
+async function lockUsernameClaimAuthority(tx: DbTransaction): Promise<void> {
+  await tx.execute(sql`
+    SELECT
+      set_config('lock_timeout', ${`${USERNAME_AUTHORITY_LOCK_TIMEOUT_MS}ms`}, TRUE),
+      set_config('statement_timeout', ${`${USERNAME_AUTHORITY_STATEMENT_TIMEOUT_MS}ms`}, TRUE)
+  `);
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${USERNAME_AUTHORITY_LOCK_NAMESPACE}), hashtext(${USERNAME_AUTHORITY_LOCK_KEY}))`,
+  );
+}
 
 /**
  * Service for character CRUD operations.
@@ -196,11 +343,21 @@ export class CharactersService {
 
   /**
    * Bounded existence probe: does the organization have any cloud character?
-   * For hot paths that only need emptiness (default-character provisioning),
-   * where listByOrganization would fetch every fat character row.
+   * For callers that only need emptiness, where listByOrganization would
+   * fetch every fat character row. Default-character self-heal uses the
+   * stronger mirror-health probe below.
    */
   async existsForOrganization(organizationId: string): Promise<boolean> {
     return await userCharactersRepository.existsForOrganization(organizationId, "cloud");
+  }
+
+  /**
+   * Read-only fast path for default-character self-heal. A false result is not
+   * authority to create; Steward routes it to create(..., bootstrap), where
+   * the primary organization lock makes the final ensure decision.
+   */
+  async hasHealthyCloudCharacterMirror(organizationId: string): Promise<boolean> {
+    return await userCharactersRepository.hasHealthyCloudCharacterMirror(organizationId);
   }
 
   async listPublic(options?: {
@@ -225,9 +382,9 @@ export class CharactersService {
    * Generate a unique username for a character.
    * Uses the name to create a slug, then ensures uniqueness.
    */
-  async generateUniqueUsername(name: string): Promise<string> {
+  async generateUniqueUsername(name: string, tx?: DbTransaction): Promise<string> {
     // Get all existing usernames
-    const existingUsernames = await userCharactersRepository.getAllUsernames();
+    const existingUsernames = await userCharactersRepository.getAllUsernames(tx);
 
     // Add reserved usernames
     for (const reserved of RESERVED_USERNAMES) {
@@ -271,7 +428,27 @@ export class CharactersService {
     return await userCharactersRepository.findByUsername(username);
   }
 
-  async create(data: NewUserCharacter): Promise<UserCharacter> {
+  async create(data: NewUserCharacter, options: CharacterCreationOptions): Promise<UserCharacter> {
+    return (await this.createWithReceipt(data, options)).character;
+  }
+
+  /**
+   * Creates a character and returns the decision made inside the authoritative
+   * transaction. Metered HTTP callers use the receipt to preserve authoritative
+   * quota observability without issuing a stale post-commit replica read.
+   */
+  async createWithReceipt(
+    data: NewUserCharacter,
+    options: { policy: { mode: "metered" } },
+  ): Promise<MeteredCharacterCreationReceipt>;
+  async createWithReceipt(
+    data: NewUserCharacter,
+    options: CharacterCreationOptions,
+  ): Promise<CharacterCreationReceipt>;
+  async createWithReceipt(
+    data: NewUserCharacter,
+    options: CharacterCreationOptions,
+  ): Promise<CharacterCreationReceipt> {
     // `name` arrives from the same pre-validation request body as `username`
     // (the route casts raw JSON to ElizaCharacter). A non-string name 500s via
     // slugify(name).toLowerCase() in generateUniqueUsername below; and when a
@@ -282,20 +459,24 @@ export class CharactersService {
       throw ValidationError("Invalid name: must be a non-empty string");
     }
 
-    // Generate username if not provided
+    const policy = requireCharacterCreationPolicy(options);
+
+    const source = data.source ?? "cloud";
+    if (source !== "cloud") {
+      throw ValidationError("CharactersService.create only accepts Cloud characters");
+    }
+
+    // Format validation is request-local. Global uniqueness is resolved later
+    // on the same primary transaction as the quota and inserts.
     let username = data.username;
-    if (username === undefined || username === null || username === "") {
-      // Blank is provided-but-unset (empty-is-unset contract), same as omitting the field.
-      username = await this.generateUniqueUsername(data.name);
-      logger.info(`[Characters] Generated username: @${username} for "${data.name}"`);
-    } else if (typeof username !== "string") {
-      // Character creation receives request bodies before route-level shape
-      // validation, so username can be any JSON value. Rejecting here keeps
-      // create/update behavior aligned and prevents validateUsername from
-      // turning malformed input into a TypeError 500 (#13637 class).
-      throw ValidationError("Invalid username: must be a string");
-    } else {
-      // Validate provided username
+    if (username !== undefined && username !== null && username !== "") {
+      if (typeof username !== "string") {
+        // Character creation receives request bodies before route-level shape
+        // validation, so username can be any JSON value. Rejecting here keeps
+        // create/update behavior aligned and prevents validateUsername from
+        // turning malformed input into a TypeError 500 (#13637 class).
+        throw ValidationError("Invalid username: must be a string");
+      }
       const validation = validateUsername(username);
       if (!validation.valid) {
         // A genuinely-invalid provided username is caller error, not a server
@@ -303,42 +484,147 @@ export class CharactersService {
         throw ValidationError(`Invalid username: ${validation.error}`);
       }
 
-      // Use normalized (lowercased) username from validation
       username = validation.normalized!;
-
-      // Check uniqueness
-      const exists = await userCharactersRepository.usernameExists(username);
-      if (exists) {
-        throw ValidationError("Username is already taken");
-      }
     }
 
-    // Create the character in user_characters table with username
-    const character = await userCharactersRepository.create({
-      ...data,
-      username,
+    const result = await withCharacterCreationTransaction<CharacterCreationReceipt>(async (tx) => {
+      // The organization row is the per-tenant serialization authority. The
+      // billing inputs, exact Cloud population, decision, character insert,
+      // and required runtime mirror therefore share one primary transaction.
+      const [organization] = await tx
+        .select({
+          id: organizations.id,
+          creditBalance: organizations.credit_balance,
+          settings: organizations.settings,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, data.organization_id))
+        .limit(1)
+        .for("update");
+
+      if (!organization) {
+        throw new ElizaError("Character organization not found", {
+          code: "CHARACTER_ORGANIZATION_NOT_FOUND",
+          context: { organizationId: data.organization_id },
+          severity: "fatal",
+        });
+      }
+
+      const [population] = await tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(userCharacters)
+        .where(
+          and(
+            eq(userCharacters.organization_id, data.organization_id),
+            eq(userCharacters.source, "cloud"),
+          ),
+        );
+      const current = Number(population?.count ?? 0);
+
+      if (policy.mode === "bootstrap" && current > 0) {
+        const [existing] = await tx
+          .select()
+          .from(userCharacters)
+          .where(
+            and(
+              eq(userCharacters.organization_id, data.organization_id),
+              eq(userCharacters.source, "cloud"),
+            ),
+          )
+          .orderBy(userCharacters.created_at, userCharacters.id)
+          .limit(1);
+        if (!existing) {
+          throw new ElizaError("Cloud character count and rows disagree", {
+            code: "CLOUD_CHARACTER_POPULATION_INCONSISTENT",
+            context: { organizationId: data.organization_id, current },
+            severity: "fatal",
+          });
+        }
+
+        // Bootstrap doubles as repair for a pre-existing character whose
+        // legacy two-step create crashed before its runtime mirror was written.
+        await agentsRepository.ensure(mirroredAgent(existing), tx);
+        return { character: existing, created: false };
+      }
+
+      let quota: CharacterCreationQuotaReceipt | undefined;
+      if (policy.mode === "metered") {
+        const resolution = resolveMaxCloudCharactersForOrg(
+          Number(organization.creditBalance),
+          organization.settings,
+        );
+        if (current >= resolution.limit) {
+          throw new CloudCharacterQuotaExceededError({
+            organizationId: data.organization_id,
+            current,
+            limit: resolution.limit,
+            limitSource: resolution.source,
+          });
+        }
+        quota = {
+          currentBefore: current,
+          currentAfter: current + 1,
+          limit: resolution.limit,
+          limitSource: resolution.source,
+        };
+      }
+
+      // All insertion paths take the same global namespace authority after
+      // their organization lock. This uniform order cannot cycle, and makes
+      // the explicit check and automatic scan authoritative against each
+      // other until the unique claim commits.
+      await lockUsernameClaimAuthority(tx);
+
+      if (username === undefined || username === null || username === "") {
+        // Blank is provided-but-unset (empty-is-unset contract), same as
+        // omitting the field. Bootstrap checks existing rows before reaching
+        // this point so concurrent ensure calls never fail on their shared
+        // deterministic username.
+        username = await this.generateUniqueUsername(data.name, tx);
+        logger.info(`[Characters] Generated username: @${username} for "${data.name}"`);
+      } else if (await userCharactersRepository.usernameExists(username, tx)) {
+        throw ValidationError("Username is already taken");
+      }
+
+      const character = await userCharactersRepository.create(
+        {
+          ...data,
+          source: "cloud",
+          username,
+        },
+        tx,
+      );
+      const mirrorCreated = await agentsRepository.create(mirroredAgent(character), tx);
+      if (!mirrorCreated) {
+        throw new ElizaError("Character runtime mirror already exists", {
+          code: "CHARACTER_AGENT_MIRROR_CONFLICT",
+          context: {
+            organizationId: data.organization_id,
+            characterId: character.id,
+          },
+          severity: "fatal",
+        });
+      }
+
+      return {
+        character,
+        created: true,
+        ...(quota ? { quota } : {}),
+      };
     });
 
-    // Also create the agent in the elizaOS agents table
-    const agent: Partial<Agent> = {
-      id: character.id as `${string}-${string}-${string}-${string}-${string}`,
-      name: character.name,
-      username: character.username ?? undefined,
-      bio: character.bio as string[] | undefined,
-      system: character.system ?? undefined,
-      enabled: true,
-      settings: character.settings as Record<
-        string,
-        string | number | boolean | Record<string, string | number | boolean>
-      >,
-    };
+    if (policy.mode === "trusted") {
+      logger.info("[Characters] Trusted character quota policy used", {
+        caller: policy.caller,
+        organizationId: data.organization_id,
+        characterId: result.character.id,
+      });
+    }
+    if (result.created) {
+      await cache.del(CacheKeys.org.dashboard(data.organization_id));
+    }
 
-    await agentsRepository.create(agent);
-
-    // Invalidate dashboard cache
-    await cache.del(CacheKeys.org.dashboard(data.organization_id));
-
-    return character;
+    return result;
   }
 
   async update(id: string, data: Partial<NewUserCharacter>): Promise<UserCharacter | undefined> {

--- a/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
@@ -11,19 +11,45 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let orgCharacters: Array<{ id: string }> = [];
 let createFailuresRemaining = 0;
 let createCalls: Array<Record<string, unknown>> = [];
+let createOptions: unknown[] = [];
+let mirroredCharacterIds = new Set<string>();
+let healthProbeCalls: string[] = [];
+let loggerWarnCalls: unknown[][] = [];
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: async () => orgCharacters.length > 0,
-    create: async (data: Record<string, unknown>) => {
+    hasHealthyCloudCharacterMirror: async (organizationId: string) => {
+      healthProbeCalls.push(organizationId);
+      const existing = orgCharacters[0];
+      return Boolean(existing && mirroredCharacterIds.has(existing.id));
+    },
+    create: async (data: Record<string, unknown>, options: unknown) => {
       createCalls.push(data);
+      createOptions.push(options);
       if (createFailuresRemaining > 0) {
         createFailuresRemaining--;
         throw new Error("db write failed");
       }
+      const existing = orgCharacters[0];
+      if (existing) {
+        mirroredCharacterIds.add(existing.id);
+        return existing;
+      }
       const created = { id: `char-${createCalls.length}` };
       orgCharacters.push(created);
+      mirroredCharacterIds.add(created.id);
       return created;
+    },
+  },
+}));
+
+mock.module("./utils/logger", () => ({
+  logger: {
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: (...args: unknown[]) => {
+      loggerWarnCalls.push(args);
     },
   },
 }));
@@ -81,6 +107,10 @@ beforeEach(() => {
   orgCharacters = [];
   createFailuresRemaining = 0;
   createCalls = [];
+  createOptions = [];
+  mirroredCharacterIds = new Set<string>();
+  healthProbeCalls = [];
+  loggerWarnCalls = [];
 });
 
 describe("ensureDefaultCharacter self-heal", () => {
@@ -102,12 +132,34 @@ describe("ensureDefaultCharacter self-heal", () => {
     expect(createCalls[1].name).toBe("Eliza");
     expect(createCalls[1].user_id).toBe("user-1");
     expect(createCalls[1].organization_id).toBe("org-1");
+    expect(mirroredCharacterIds).toEqual(new Set(["char-2"]));
+    expect(createOptions).toEqual([
+      { policy: { mode: "bootstrap" } },
+      { policy: { mode: "bootstrap" } },
+    ]);
+    expect(healthProbeCalls).toEqual(["org-1", "org-1"]);
   });
 
-  test("no-op when the organization already has a character", async () => {
+  test("an existing legacy character still reaches bootstrap and repairs its mirror", async () => {
     orgCharacters = [{ id: "char-existing" }];
     await ensureDefaultCharacter("user-1", "org-1");
-    expect(createCalls.length).toBe(0);
+    expect(createCalls).toHaveLength(1);
+    expect(createOptions).toEqual([{ policy: { mode: "bootstrap" } }]);
+    expect(orgCharacters).toEqual([{ id: "char-existing" }]);
+    expect(mirroredCharacterIds).toEqual(new Set(["char-existing"]));
+    expect(healthProbeCalls).toEqual(["org-1"]);
+  });
+
+  test("a healthy character+mirror uses only the read probe, with no writer path or warning", async () => {
+    orgCharacters = [{ id: "char-healthy" }];
+    mirroredCharacterIds.add("char-healthy");
+
+    await ensureDefaultCharacter("user-1", "org-1");
+
+    expect(healthProbeCalls).toEqual(["org-1"]);
+    expect(createCalls).toHaveLength(0);
+    expect(createOptions).toHaveLength(0);
+    expect(loggerWarnCalls).toHaveLength(0);
   });
 
   test("never rejects, so void-firing from session resolution is safe", async () => {

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -118,7 +118,7 @@ mock.module("./services/api-keys", () => {
 });
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: async () => false,
+    hasHealthyCloudCharacterMirror: async () => false,
     create: async () => {
       const v = await characterCreate.promise;
       characterCreateResolved = true;

--- a/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
@@ -128,7 +128,7 @@ mock.module("./services/api-keys", () => ({
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: async () => false,
+    hasHealthyCloudCharacterMirror: async () => false,
     create: async () => ({ id: "char-1" }),
   },
 }));

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -90,7 +90,7 @@ mock.module("./services/api-keys", () => ({
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: async () => false,
+    hasHealthyCloudCharacterMirror: async () => false,
     create: async () => ({ id: "char-1" }),
   },
 }));

--- a/packages/cloud/shared/src/lib/steward-sync-phone-convergence.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-phone-convergence.test.ts
@@ -48,7 +48,7 @@ mock.module("./services/api-keys", () => ({
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: characterExists,
+    hasHealthyCloudCharacterMirror: characterExists,
     create: mock(async () => undefined),
   },
 }));

--- a/packages/cloud/shared/src/lib/steward-sync-telegram-convergence.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-telegram-convergence.test.ts
@@ -164,7 +164,7 @@ mock.module("./services/api-keys", () => ({
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    existsForOrganization: mock(async () => false),
+    hasHealthyCloudCharacterMirror: mock(async () => false),
     create: createCharacter,
   },
 }));

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -1146,8 +1146,8 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
 }
 
 /**
- * Ensures an account has a default Eliza character, seeding one from the
- * default template when the organization has none.
+ * Ensures an account has a default Eliza character and matching runtime
+ * mirror, seeding from the default template when the organization has none.
  *
  * Idempotent and never rejects. Called from two places: the one-time
  * new-user signup branch above, and every session-cache miss
@@ -1155,7 +1155,10 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
  * path: a create that fails at signup is swallowed here (signup must not
  * fail over provisioning), so without the session-time re-run the account
  * would stay character-less forever — the default character is
- * deterministically reconstructable, so re-seeding is always safe.
+ * deterministically reconstructable, so re-seeding is always safe. A healthy
+ * character+mirror pair exits through a read-intent probe; absent or
+ * inconsistent state reaches CharactersService's locked bootstrap authority,
+ * whose ensure-if-absent also repairs legacy character rows.
  */
 export async function ensureDefaultCharacter(
   userId: string,
@@ -1167,18 +1170,21 @@ export async function ensureDefaultCharacter(
   }
 
   try {
-    if (await charactersService.existsForOrganization(organizationId)) {
+    if (await charactersService.hasHealthyCloudCharacterMirror(organizationId)) {
       return;
     }
 
     const defaultData = getDefaultElizaCharacterData();
-    await charactersService.create({
-      ...defaultData,
-      user_id: userId,
-      organization_id: organizationId,
-    });
+    await charactersService.create(
+      {
+        ...defaultData,
+        user_id: userId,
+        organization_id: organizationId,
+      },
+      { policy: { mode: "bootstrap" } },
+    );
 
-    logger.info(`[StewardSync] Created default Eliza character for user ${userId}`);
+    logger.info(`[StewardSync] Ensured default Eliza character for user ${userId}`);
   } catch (error) {
     // error-policy:J1 provisioning boundary: a default-character failure
     // must not fail signup or session resolution; it is logged here and


### PR DESCRIPTION
# Relates to

Closes #23001.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@a61d938a9e48d437c4a92570bdb028330ff49eaf` with zero conflicts.
- [x] Focused package tests, real PGlite transaction tests, Biome, and diff gates ran after sync; exact unrelated typecheck blockers are recorded below.
- [x] A reviewer can verify the transaction ordering, typed route behavior, and final database counts from the test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact latest `origin/develop`; zero conflicts.
- [x] The quota patch-id stayed stable across the sync; the only post-sync correction is the schema-mock export parity fix, and no incoming commit touched the resulting 27 changed paths.
- [x] Exact unrelated typecheck/root-baseline blockers are documented in **Known gaps / failures**.

# Risks

Medium. This moves Cloud-character quota admission into the primary writer transaction and requires every creation caller to choose a named policy. A mistake could reject or over-admit character creation, or leave the character/mirror split. The implementation therefore locks the organization, serializes the globally unique username claim, counts the exact `source = 'cloud'` population, and inserts `user_characters` plus the required `agents` mirror in one transaction. Lock waits are bounded.

# Background

## What does this PR do?

- Adds mandatory `metered`, `bootstrap`, and `trusted` creation policies with no implicit uncapped default.
- Makes metered creation authoritative on the primary database under one `READ COMMITTED` transaction: organization row lock → billing/settings snapshot → exact Cloud-character count → global username advisory lock → username recheck/scan → character + mirror inserts.
- Returns a typed `CloudCharacterQuotaExceededError` and maps front doors to the canonical quota response.
- Routes `/v1/app/agents`, legacy create, and clone through `metered`; Steward default repair through `bootstrap`; affiliate and trusted S2S through explicit `trusted` policy.
- Removes the stale replica preflight from `/v1/app/agents`.
- Keeps the healthy default-character auth path read-only and repairs only missing/incoherent character/mirror state.
- Adds real PGlite quota/rollback/concurrency tests plus discriminating SQL-order traces.

## What kind of change is this?

Bug fix: non-breaking enforcement hardening at an existing quota boundary.

# Documentation changes needed?

No public documentation change. Tier values and billing policy are unchanged; this PR makes the already-published character limit enforceable atomically.

# Testing

## Where should a reviewer start?

Start at `CharactersService.create` and `characters-quota.pglite.test.ts`, then inspect the three metered front doors and named trusted/bootstrap callers.

## Detailed testing steps

Exact rebased head `89ee643953607986dac66dac83af670cb44be9d7` on Bun `1.3.14`:

```text
All 16 changed test files: 79/79 pass, 361 assertions
- CharactersService and receipt tests: 9/9
- PGlite quota, receipt, rollback, multi-org and race cases: 9/9
- Steward/auth/convergence regressions: 28/28
- API front doors and policies: 30/30
- Chat CSRF reachability regression: 3/3

Biome packages/cloud/shared: 2139 files, pass
Biome packages/cloud/api: 1303 files, pass
git diff --check: pass
git show --check: pass
```

The PGlite suite proves final rows and rollback behavior for limit−1 with two releases, organization isolation, concurrent bootstrap, explicit-vs-auto global usernames, trusted policy accounting, and character+mirror atomicity. Trace tests independently assert `org FOR UPDATE → bounded global username advisory → exists/scan → inserts` on the same transaction.

# Evidence Gate

<!-- evidence-head:89ee643953607986dac66dac83af670cb44be9d7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server/domain `.ts` changes have no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server/domain `.ts` changes have no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow changes.
<!-- evidence-row:backend-logs -->
- [x] Focused route/service/PGlite command results are included above; no live backend or production mutation is required or authorized.

<details><summary>Focused backend verification transcript</summary>

```text
CharactersService and SQL-order traces: 9/9 tests passed; the trace records org FOR UPDATE, bounded shared username advisory, recheck, then both inserts.
Authenticated API front doors and explicit policy mapping: 30/30 tests passed with canonical typed quota responses and zero bypass side effects.
Steward/auth bootstrap and mirror repair: 28/28 tests passed; the healthy cache-miss path remains read-only and repair commits before caching.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state/render change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action change.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite assertions inspect the final `user_characters` and `agents` rows, exact quota count, typed rejection, and transaction rollback; results are summarized above.

<details><summary>PGlite domain-state transcript</summary>

```text
PGlite quota/concurrency/receipt suite: 9/9 tests passed; limit−1 plus two metered creates yields one commit, one typed refusal, and final count equal to the cap.
Organization isolation, concurrent bootstrap, and explicit-vs-auto username claims leave the expected distinct rows and exactly one mirror per committed character.
Forced mirror failure rolls the transaction back completely: neither user_characters nor agents retains a partial row; trusted creates remain counted by the same snapshot population.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path.

## Backend + frontend logs

Backend transaction and route evidence is the 79-test changed-file result above. Frontend N/A.

## Screenshots (before / after) + video walkthrough

N/A - no rendered output.

## Audio / voice walkthrough

N/A - no audio or voice path.

## Known gaps / failures

- PGlite serializes its writer, so it is not presented as proof of true PostgreSQL multi-connection lock contention. Discriminating trace tests prove the exact lock/recheck/insert order and shared transaction; fresh exact-head CI is required before merge.
- Full shared/API typechecks on this local dependency graph remain red only on existing `plugin-elizacloud` missing dependency/type diagnostics, `_telegram-edge.ts`, and `packages/cloud/api/v1/users.ts:1401`; neither names a changed file. Focused tests and both package Biome gates are green.
- The prior Quality debts were merged through #23084 and #23080. This rebased head must now prove the full mock-export audit and all changed-path gates on exact-head CI; any remaining red will be compared by exact name/signature to `develop@a61d938a`.
- No provider, production, staging, secret, migration, or real billing/resource mutation was performed.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-v2-atomic-character-quota]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza"} -->