### PR TITLE
fix(plugin-openai): stop image-description parser from truncating descriptions on the word "title"

### DIFF
--- a/plugins/plugin-openai/__tests__/rest-handlers.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/rest-handlers.shape.test.ts
@@ -249,6 +249,63 @@ describe("OpenAI REST handler request shapes", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // Builds a mocked vision chat-completion whose single message content is
+  // `content`, so the assertions exercise the real title/description parser.
+  function mockVisionResponse(content: string) {
+    return vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-5-mini",
+            choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 5, completion_tokens: 6, total_tokens: 11 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+    );
+  }
+
+  async function runDescribe(content: string) {
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockVisionResponse(content) as typeof fetch);
+    return handleImageDescription(createRuntime(), {
+      imageUrl: "https://example.com/image.png",
+    });
+  }
+
+  it("keeps the full description when the vision text mentions 'title' mid-sentence", async () => {
+    const content =
+      'The image shows a book with the title "War and Peace" on its cover. It is placed on a wooden desk.';
+    await expect(runDescribe(content)).resolves.toEqual({
+      title: "Image Analysis",
+      description: content,
+    });
+  });
+
+  it("treats a single-line response with no title prefix as the full description", async () => {
+    const content = "A movie poster. The title reads Inception in bold letters across the middle.";
+    await expect(runDescribe(content)).resolves.toEqual({
+      title: "Image Analysis",
+      description: content,
+    });
+  });
+
+  it("preserves the content of a single-line 'Title:' response instead of emptying it", async () => {
+    const content = "Title: A serene mountain landscape at dusk with snow-capped peaks.";
+    await expect(runDescribe(content)).resolves.toEqual({
+      title: "Image Analysis",
+      description: "A serene mountain landscape at dusk with snow-capped peaks.",
+    });
+  });
+
+  it("still splits the canonical 'Title: X\\nDescription: Y' contract shape", async () => {
+    await expect(
+      runDescribe("Title: Sunset\nDescription: A beautiful sunset over the ocean.")
+    ).resolves.toEqual({ title: "Sunset", description: "A beautiful sunset over the ocean." });
+  });
+
   it("surfaces image-description provider errors with status and response body", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(
       vi.fn(

--- a/plugins/plugin-openai/models/image.ts
+++ b/plugins/plugin-openai/models/image.ts
@@ -119,13 +119,49 @@ export async function handleImageGeneration(
   }));
 }
 
-function parseTitleFromResponse(content: string): string {
-  const titleMatch = content.match(/title[:\s]+(.+?)(?:\n|$)/i);
-  return titleMatch?.[1]?.trim() ?? "Image Analysis";
-}
+const DEFAULT_IMAGE_TITLE = "Image Analysis";
 
-function parseDescriptionFromResponse(content: string): string {
-  return content.replace(/title[:\s]+(.+?)(?:\n|$)/i, "").trim();
+// A genuine title line must be the first non-blank content the model emitted,
+// e.g. "Title: <text>". Anchoring to the start prevents a mid-sentence mention
+// of the word "title" (books, posters, signs, UI screenshots) from hijacking
+// the split and truncating the description the agent reasons over.
+const LEADING_TITLE_LINE = /^\s*title\s*[:-]\s*(.*?)(?:\r?\n|$)/i;
+const LEADING_DESCRIPTION_LABEL = /^\s*description\s*[:-]\s*/i;
+
+/**
+ * Splits a vision model's reply into a `{ title, description }` pair. The
+ * documented contract shape is a leading `Title:` line followed by the
+ * description body (optionally prefixed with a `Description:` label). Any reply
+ * that does not start with a title line is treated as description-only so the
+ * required `description` field always carries the real image content instead of
+ * a silently truncated or emptied value.
+ */
+function parseImageDescriptionResponse(content: string): {
+  title: string;
+  description: string;
+} {
+  const trimmed = content.trim();
+  const titleLine = trimmed.match(LEADING_TITLE_LINE);
+
+  if (!titleLine) {
+    return { title: DEFAULT_IMAGE_TITLE, description: trimmed };
+  }
+
+  const titleText = titleLine[1]?.trim() ?? "";
+  const remainder = trimmed.slice(titleLine[0].length).trim();
+
+  if (remainder.length > 0) {
+    const description = remainder.replace(LEADING_DESCRIPTION_LABEL, "").trim();
+    return {
+      title: titleText.length > 0 ? titleText : DEFAULT_IMAGE_TITLE,
+      description,
+    };
+  }
+
+  // Single labelled line with no separate body: the labelled text is the only
+  // content the model returned, so preserve it as the description rather than
+  // dropping it and fall back to the default title.
+  return { title: DEFAULT_IMAGE_TITLE, description: titleText };
 }
 
 export async function handleImageDescription(
@@ -237,8 +273,5 @@ export async function handleImageDescription(
     throw new Error("OpenAI API returned empty image description");
   }
 
-  return {
-    title: parseTitleFromResponse(content),
-    description: parseDescriptionFromResponse(content),
-  };
+  return parseImageDescriptionResponse(content);
 }


### PR DESCRIPTION
# Relates to

Closes #23071

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning-package gates (`test`, `typecheck`, `lint`)
      were run after sync; see **Known gaps / failures** for the repo-wide
      `bun run verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after table and the failing-then-passing test run below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3b2fc2a4e5a08411bf6d8c5bb16662144dd1ef61:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`f6c2143d11`); zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** (repo-wide
      gate not run to completion on this constrained ARM builder; the owning
      package's `test`, `typecheck`, and `lint` all pass).

# Risks

Low. The change is confined to `plugins/plugin-openai/models/image.ts` parsing
of vision output into the `{ title, description }` DTO. No public export, type,
route, or config surface changes. The canonical `Title: X\nDescription: Y`
contract shape is preserved (regression-guarded); the only behavioral change is
that descriptions are no longer truncated/emptied and titles are no longer
fabricated from mid-text.

# Background

## What does this PR do?

`handleImageDescription` is registered as the `ModelType.IMAGE_DESCRIPTION`
handler (see `plugins/plugin-openai/index.ts`), so its `{ title, description }`
result is what every agent receives for a described image/attachment.

The two parsers used an **unanchored, case-insensitive** regex
`/title[:\s]+(.+?)(?:\n|$)/i` that matched the word "title" **anywhere** in the
model output, not just a leading `Title:` line. Because the capture `.+?` is
bounded by newline-or-end, on a single-line reply it consumes to end of string.
On real vision output this caused a data-integrity defect on a required DTO
field:

1. A normal description that merely mentions "title" (books, movie/album
   posters, signs, document/UI screenshots — extremely common) was silently
   **truncated** at the word "title", and the `title` field was filled with the
   wrong tail.
2. A single-line `Title: ...` reply yielded an **empty** `description`.

The fix anchors title extraction to a genuine leading title line
(`/^\s*title\s*[:-]\s*(.*?)(?:\r?\n|$)/i`), splits the description on that first
line, strips an optional leading `Description:` label, and otherwise returns the
full content as the description with the default `Image Analysis` title. A
single labelled line with no separate body now preserves its text as the
description instead of dropping it. This keeps the existing multi-line contract
working while never touching a mid-text "title" word.

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity defect).

## Before / after

Handler `handleImageDescription` (`ModelType.IMAGE_DESCRIPTION`) returns the
`{ title, description }` DTO every agent reasons over.

| Vision output (single message content) | BEFORE title | BEFORE description | AFTER title | AFTER description |
|---|---|---|---|---|
| `The image shows a book with the title "War and Peace" on its cover. It is placed on a wooden desk.` | `"War and Peace" on its cover. It is placed on a wooden desk.` | `The image shows a book with the` ❌ TRUNCATED | `Image Analysis` | full sentence ✅ |
| `Title: A serene mountain landscape at dusk with snow-capped peaks reflecting in a lake.` | `A serene mountain landscape…` | `` ❌ EMPTY | `Image Analysis` | full sentence ✅ |
| `A movie poster. The title reads Inception in bold letters across the middle.` | `reads Inception in bold letters across the middle.` | `A movie poster. The` ❌ TRUNCATED | `Image Analysis` | full sentence ✅ |
| `Title: Sunset\nDescription: A beautiful sunset over the ocean.` (canonical) | `Sunset` | `Description: A beautiful sunset over the ocean.` | `Sunset` ✅ | `A beautiful sunset over the ocean.` ✅ (label stripped) |

# Documentation changes needed?

No documentation change required. The plugin surface table in
`plugins/plugin-openai/CLAUDE.md` already lists `IMAGE_DESCRIPTION →
handleImageDescription`; the `{ title, description }` DTO shape is unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/__tests__/rest-handlers.shape.test.ts` — four new cases
drive the real handler through a mocked `fetch` and assert the exact
`{ title, description }` DTO for: mid-text "title", single-line no-prefix,
single-line `Title:`, and the canonical multi-line shape (regression guard).

## Detailed testing steps

```bash
bun run --cwd packages/core build          # dependency of the plugin under test
bun run --cwd plugins/plugin-openai test __tests__/rest-handlers.shape.test.ts
bun run --cwd plugins/plugin-openai typecheck
bun run --cwd plugins/plugin-openai lint
```

# Evidence Gate

<!-- evidence-head:8837058338ab16bdbd103c13947a078a6a78e5e1 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a model-provider parser in @elizaos/plugin-openai (model handlers only, no views).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; model-provider parser change only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; change is a pure parsing function exercised by unit tests below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - @elizaos/plugin-openai registers model handlers only (no server process); the real handleImageDescription path is exercised end-to-end through mocked fetch, with the failing-then-passing vitest run embedded inline in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic parsing of a fixed model reply; no model sampling is exercised or changed. Vision requests are mocked so the assertions are hermetic and reproducible.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the { title, description } DTO; its before/after values are embedded inline as a table and asserted in the four regression tests.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - <reason>`: The changed code path is deterministic string parsing of a
fixed vision reply, not model sampling. The four regression tests supply the
exact reply content and assert the resulting DTO, which is hermetic and more
reproducible than a live sample for this defect.

## Backend + frontend logs

Backend: the plugin exposes model handlers only (no server process). The real
`handleImageDescription` path is driven end-to-end through a mocked `fetch` in
the test suite. Failing-then-passing evidence:

<details>
<summary>BEFORE — buggy parser from <code>origin/develop</code>, new regression cases fail</summary>

```
 ❯ __tests__/rest-handlers.shape.test.ts (17 tests | 4 failed)
     × keeps the full description when the vision text mentions 'title' mid-sentence 14ms
     × treats a single-line response with no title prefix as the full description 4ms
     × preserves the content of a single-line 'Title:' response instead of emptying it 5ms
     × still splits the canonical 'Title: X\nDescription: Y' contract shape 3ms

 Test Files  1 failed (1)
      Tests  4 failed | 13 passed (17)
```
</details>

<details>
<summary>AFTER — with the fix, all cases pass</summary>

```
$ vitest run --config ./vitest.config.ts __tests__/rest-handlers.shape.test.ts

 RUN  v4.1.10 plugins/plugin-openai

 Test Files  1 passed (1)
      Tests  17 passed (17)
```
</details>

<details>
<summary>Typecheck + lint (owning package)</summary>

```
$ bun run --cwd plugins/plugin-openai typecheck
$ tsc --noEmit -p tsconfig.json      # exit 0, no diagnostics

$ bun run --cwd plugins/plugin-openai lint
$ bunx @biomejs/biome check --write --unsafe .
Checked 63 files in 453ms.
```
</details>

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no rendered UI; @elizaos/plugin-openai registers model handlers only.`

### After

`N/A - no rendered UI; @elizaos/plugin-openai registers model handlers only.`

### Walkthrough video

`N/A - no user-facing flow; the deterministic parser is fully covered by the unit tests above.`

## Audio / voice walkthrough

`N/A - not a voice/transcript/TTS/STT change.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this constrained ARM
  builder (the full workspace build/verify is heavy). Instead the owning
  package's `test`, `typecheck`, and `lint` were run and pass, and
  `@elizaos/core` (the plugin's only runtime dependency for these tests) was
  built successfully first. The change is isolated to a single parsing function
  with no export/type/config surface change.
- Immutable GitHub attachment URLs could not be minted from this environment, so
  the real logs and the before/after DTO table are embedded inline above rather
  than linked as uploaded artifacts. All output is genuine and reproducible with
  the commands in **Detailed testing steps**.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@3b2fc2a4e5a08411bf6d8c5bb16662144dd1ef61:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@3b2fc2a4e5a08411bf6d8c5bb16662144dd1ef61:packages/skills/skills/contribute-to-eliza"} -->

