### PR TITLE
fix(cloud): deliver Telegram reminders through edge bot

### DIFF
--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import {
+  dispatchPersonalTelegramReminder,
   handlePersonalTelegramEdge,
   type TelegramEdgeDeps,
 } from "../eliza-app/webhook/_telegram-edge";
@@ -17,6 +18,8 @@ interface LedgerValue {
   processing?: boolean;
   plan?: string[];
   chunks?: Map<number, "uncertain" | "delivered">;
+  acceptedAt?: string;
+  providerMessageIds?: string[];
 }
 
 type RunTurn = NonNullable<
@@ -44,11 +47,18 @@ function namespace(): {
               chunkDigests?: string[];
               chunkIndex?: number;
               chunkDigest?: string;
+              providerMessageId?: string;
             };
             const key = `${name}:${body.messageId}`;
             const value = values.get(key) ?? {};
             if (body.operation === "read") {
               return Response.json({ state: value.delivery ?? null });
+            }
+            if (body.operation === "read_receipt") {
+              return Response.json({
+                acceptedAt: value.acceptedAt ?? null,
+                providerMessageIds: value.providerMessageIds ?? [],
+              });
             }
             if (body.operation === "claim_processing") {
               if (value.processing) return Response.json({ claimed: false });
@@ -94,6 +104,15 @@ function namespace(): {
             }
             if (body.operation === "mark_chunk_delivered") {
               value.chunks.set(chunkIndex, "delivered");
+              if (body.providerMessageId) {
+                value.acceptedAt ??= new Date().toISOString();
+                value.providerMessageIds = Array.from(
+                  new Set([
+                    ...(value.providerMessageIds ?? []),
+                    body.providerMessageId,
+                  ]),
+                );
+              }
               values.set(key, value);
               return Response.json({ delivered: true });
             }
@@ -171,6 +190,32 @@ afterEach(() => {
 });
 
 describe("Personal Shared Telegram edge", () => {
+  test("delivers reminders with the edge bot and returns a durable duplicate receipt", async () => {
+    const ledger = namespace();
+    let sends = 0;
+    globalThis.fetch = mock(async (input) => {
+      if (String(input).endsWith("/sendMessage")) sends += 1;
+      return Response.json({ ok: true, result: { message_id: 9010 } });
+    }) as unknown as typeof fetch;
+    const env = {
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+    } as AppEnv["Bindings"];
+    const input = {
+      project: "eliza-app",
+      chatId: "123456",
+      text: "time to stretch",
+      idempotencyKey: "reminder-1:2026-08-20T19:30:00.000Z",
+    };
+
+    const delivered = await dispatchPersonalTelegramReminder(env, input);
+    const duplicate = await dispatchPersonalTelegramReminder(env, input);
+
+    expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9010"] });
+    expect(duplicate).toEqual(delivered);
+    expect(sends).toBe(1);
+  });
+
   test("runs the canonical turn and Telegram egress once without a Railway hop", async () => {
     const ledger = namespace();
     const turn = mock(async () =>

--- a/packages/cloud/api/cron/shared-scheduled-tasks/route.ts
+++ b/packages/cloud/api/cron/shared-scheduled-tasks/route.ts
@@ -1,18 +1,27 @@
 /** Fires due Shared reminders through the canonical scheduler and trusted gateway. */
 
 import { Hono } from "hono";
+import { isPersonalSharedTelegramEdgeEnabled } from "@/api-app/personal-shared-telegram-edge";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
 import { processDueSharedReminders } from "@/lib/services/shared-runtime/shared-reminder-cron";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { dispatchPersonalTelegramReminder } from "../../eliza-app/webhook/_telegram-edge";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
     requireCronSecret(c);
-    const stats = await processDueSharedReminders(c.env);
+    const stats = await processDueSharedReminders(c.env, {
+      ...(isPersonalSharedTelegramEdgeEnabled(c.env)
+        ? {
+            telegramDispatch: (input) =>
+              dispatchPersonalTelegramReminder(c.env, input),
+          }
+        : {}),
+    });
     logger.info("[SharedReminders] scheduled task sweep complete", stats);
     return c.json({ success: true, stats });
   } catch (error) {

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -15,6 +15,7 @@ import {
   resolveTelegramVoiceNote,
   sendTelegramReply,
   sendTelegramTyping,
+  TelegramApiResponseError,
   type TelegramConnectorConfig,
   type TelegramConnectorEvent,
   verifyTelegramWebhook,
@@ -63,7 +64,29 @@ interface LedgerResponse {
   state?: TelegramDeliveryState | null;
   claimed?: boolean;
   plan?: "prepared" | "conflict";
+  acceptedAt?: unknown;
+  providerMessageIds?: unknown;
 }
+
+export interface PersonalTelegramReminderDispatchInput {
+  project: string;
+  chatId: string;
+  text: string;
+  idempotencyKey: string;
+}
+
+export type PersonalTelegramReminderDispatchResult =
+  | {
+      ok: true;
+      acceptedAt: string;
+      providerMessageIds: string[];
+    }
+  | {
+      ok: false;
+      acceptance: "not_accepted" | "unknown";
+      message: string;
+      retryAfterMinutes?: number;
+    };
 
 function readEnvString(env: AppEnv["Bindings"], key: string): string | null {
   const value = env[key];
@@ -307,16 +330,115 @@ async function edgeLedger(
         chunkDigest,
       });
     },
-    async markChunkDelivered(chunkIndex, chunkDigest) {
+    async markChunkDelivered(chunkIndex, chunkDigest, providerMessageId) {
       await callLedger(stub, event.messageId, "mark_chunk_delivered", {
         chunkIndex,
         chunkDigest,
+        providerMessageId,
       });
     },
     async markDelivered() {
       await callLedger(stub, event.messageId, "mark_delivered");
     },
   };
+}
+
+async function readEdgeReceipt(
+  env: AppEnv["Bindings"],
+  project: string,
+  event: TelegramConnectorEvent,
+): Promise<{ acceptedAt: string; providerMessageIds: string[] } | null> {
+  const namespace = env.PERSONAL_TELEGRAM_DELIVERIES;
+  if (!namespace) return null;
+  const stub = namespace.getByName(
+    `telegram:${project}:personal-shared:${event.senderId}`,
+  );
+  const body = await callLedger(stub, event.messageId, "read_receipt");
+  const acceptedAt =
+    typeof body.acceptedAt === "string" &&
+    Number.isFinite(Date.parse(body.acceptedAt))
+      ? body.acceptedAt
+      : null;
+  const providerMessageIds = Array.isArray(body.providerMessageIds)
+    ? body.providerMessageIds.filter(
+        (value): value is string =>
+          typeof value === "string" && /^\d{1,32}$/.test(value),
+      )
+    : [];
+  return acceptedAt && providerMessageIds.length > 0
+    ? { acceptedAt, providerMessageIds }
+    : null;
+}
+
+/**
+ * Delivers a scheduled Personal Shared Telegram reminder with the same bot and
+ * exact-once Durable Object ledger as conversational edge replies.
+ */
+export async function dispatchPersonalTelegramReminder(
+  env: AppEnv["Bindings"],
+  input: PersonalTelegramReminderDispatchInput,
+): Promise<PersonalTelegramReminderDispatchResult> {
+  const botToken = readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_TOKEN");
+  if (!botToken) {
+    return {
+      ok: false,
+      acceptance: "not_accepted",
+      message: "Telegram connector is not configured",
+    };
+  }
+  const event: TelegramConnectorEvent = {
+    platform: "telegram",
+    messageId: input.idempotencyKey,
+    platformRecordId: input.idempotencyKey,
+    chatId: input.chatId,
+    chatType: "private",
+    senderId: input.chatId,
+    text: "",
+    isCommand: false,
+    rawPayload: { source: "shared-reminder" },
+  };
+  try {
+    const ledger = await edgeLedger(env, input.project, event);
+    const outcome = await executeTelegramDelivery(ledger, async (hooks) => {
+      await sendTelegramReply({ botToken }, event, input.text, logger, hooks);
+    });
+    if (outcome === "uncertain" || outcome === "in_progress") {
+      return {
+        ok: false,
+        acceptance: "unknown",
+        message: `Telegram reminder delivery is ${outcome}`,
+      };
+    }
+    const receipt = await readEdgeReceipt(env, input.project, event);
+    return receipt
+      ? { ok: true, ...receipt }
+      : {
+          ok: false,
+          acceptance: "unknown",
+          message: "Telegram returned no durable provider receipt",
+        };
+  } catch (error) {
+    if (error instanceof TelegramApiResponseError) {
+      return {
+        ok: false,
+        acceptance: "not_accepted",
+        message: error.message,
+        ...(error.errorCode === 429 && error.retryAfterSeconds
+          ? {
+              retryAfterMinutes: Math.max(
+                1,
+                Math.ceil(error.retryAfterSeconds / 60),
+              ),
+            }
+          : {}),
+      };
+    }
+    return {
+      ok: false,
+      acceptance: "unknown",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function startTyping(

--- a/packages/cloud/api/src/personal-telegram-delivery.test.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.test.ts
@@ -15,8 +15,17 @@ class MemoryStorage {
     return this.values.get(key) as T | undefined;
   }
 
-  async put(key: string, value: unknown): Promise<void> {
-    this.values.set(key, structuredClone(value));
+  async put(
+    key: string | Record<string, unknown>,
+    value?: unknown,
+  ): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [entryKey, entryValue] of Object.entries(key)) {
+      this.values.set(entryKey, structuredClone(entryValue));
+    }
   }
 
   async delete(key: string | string[]): Promise<boolean | number> {
@@ -152,6 +161,42 @@ describe("PersonalTelegramDelivery", () => {
     });
     expect((await object.fetch(operation("../secret", "read"))).status).toBe(
       400,
+    );
+  });
+
+  test("persists provider receipts for reminder idempotency keys", async () => {
+    const object = new PersonalTelegramDelivery(
+      durableState(),
+      {} as AppEnv["Bindings"],
+    );
+    const messageId = "reminder-1:2026-08-20T19:30:00.000Z";
+    const chunkDigest = "b".repeat(64);
+    await object.fetch(
+      operation(messageId, "prepare_plan", { chunkDigests: [chunkDigest] }),
+    );
+    await object.fetch(
+      operation(messageId, "claim_chunk", { chunkIndex: 0, chunkDigest }),
+    );
+    const marked = await object.fetch(
+      operation(messageId, "mark_chunk_delivered", {
+        chunkIndex: 0,
+        chunkDigest,
+        providerMessageId: "9004",
+      }),
+    );
+
+    expect(marked.status).toBe(200);
+    expect(
+      await json(object.fetch(operation(messageId, "read_receipt"))),
+    ).toMatchObject({ providerMessageIds: ["9004"] });
+    expect(
+      (await json(object.fetch(operation(messageId, "read_receipt")))) as {
+        acceptedAt: string;
+      },
+    ).toEqual(
+      expect.objectContaining({
+        acceptedAt: expect.stringMatching(/^2026-|^2027-/),
+      }),
     );
   });
 

--- a/packages/cloud/api/src/personal-telegram-delivery.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.ts
@@ -11,11 +11,13 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 export const PERSONAL_TELEGRAM_DELIVERY_PATH = "/v1/delivery";
 const PROCESSING_TTL_MS = 120_000;
 const DELIVERY_TTL_MS = 30 * 24 * 60 * 60_000;
-const MESSAGE_ID_RE = /^\d{1,32}$/;
+const MESSAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,199}$/;
+const PROVIDER_MESSAGE_ID_RE = /^\d{1,32}$/;
 
 type DeliveryState = "uncertain" | "delivered";
 type DeliveryOperation =
   | "read"
+  | "read_receipt"
   | "claim_processing"
   | "release_processing"
   | "prepare_plan"
@@ -37,6 +39,12 @@ interface DeliveryRequest {
   chunkDigests?: string[];
   chunkIndex?: number;
   chunkDigest?: string;
+  providerMessageId?: string;
+}
+
+interface DeliveryReceipt {
+  acceptedAt: string;
+  providerMessageIds: string[];
 }
 
 const CHUNK_DIGEST_RE = /^[0-9a-f]{64}$/;
@@ -54,6 +62,7 @@ function isDeliveryRequest(value: unknown): value is DeliveryRequest {
   const operation = candidate.operation;
   if (
     operation === "read" ||
+    operation === "read_receipt" ||
     operation === "claim_processing" ||
     operation === "release_processing" ||
     operation === "mark_uncertain" ||
@@ -70,7 +79,7 @@ function isDeliveryRequest(value: unknown): value is DeliveryRequest {
       )
     );
   }
-  return (
+  const validChunkOperation =
     (operation === "read_chunk" ||
       operation === "claim_chunk" ||
       operation === "release_chunk" ||
@@ -80,7 +89,13 @@ function isDeliveryRequest(value: unknown): value is DeliveryRequest {
     candidate.chunkIndex >= 0 &&
     candidate.chunkIndex < MAX_REPLY_CHUNKS &&
     typeof candidate.chunkDigest === "string" &&
-    CHUNK_DIGEST_RE.test(candidate.chunkDigest)
+    CHUNK_DIGEST_RE.test(candidate.chunkDigest);
+  if (!validChunkOperation) return false;
+  return (
+    operation !== "mark_chunk_delivered" ||
+    candidate.providerMessageId === undefined ||
+    (typeof candidate.providerMessageId === "string" &&
+      PROVIDER_MESSAGE_ID_RE.test(candidate.providerMessageId))
   );
 }
 
@@ -90,6 +105,10 @@ function processingKey(messageId: string): string {
 
 function deliveryKey(messageId: string): string {
   return `delivery:${messageId}`;
+}
+
+function receiptKey(messageId: string): string {
+  return `receipt:${messageId}`;
 }
 
 function planKey(messageId: string): string {
@@ -153,6 +172,14 @@ export class PersonalTelegramDelivery {
     if (input.operation === "read") {
       const state = await this.readExpiring<DeliveryState>(deliveryStorageKey);
       return Response.json({ state });
+    }
+    if (input.operation === "read_receipt") {
+      const receipt = await this.readExpiring<DeliveryReceipt>(
+        receiptKey(input.messageId),
+      );
+      return Response.json(
+        receipt ?? { acceptedAt: null, providerMessageIds: [] },
+      );
     }
     if (input.operation === "claim_processing") {
       const existing = await this.readExpiring<boolean>(processingStorageKey);
@@ -222,10 +249,33 @@ export class PersonalTelegramDelivery {
         return Response.json({ claimed: true });
       }
       const expiresAt = Date.now() + DELIVERY_TTL_MS;
-      await this.state.storage.put(storageKey, {
+      const delivered = {
         value: "delivered",
         expiresAt,
-      } satisfies ExpiringState<DeliveryState>);
+      } satisfies ExpiringState<DeliveryState>;
+      if (input.providerMessageId) {
+        const receiptStorageKey = receiptKey(input.messageId);
+        const existingReceipt =
+          await this.readExpiring<DeliveryReceipt>(receiptStorageKey);
+        const receipt = {
+          value: {
+            acceptedAt: existingReceipt?.acceptedAt ?? new Date().toISOString(),
+            providerMessageIds: Array.from(
+              new Set([
+                ...(existingReceipt?.providerMessageIds ?? []),
+                input.providerMessageId,
+              ]),
+            ),
+          },
+          expiresAt,
+        } satisfies ExpiringState<DeliveryReceipt>;
+        await this.state.storage.put({
+          [storageKey]: delivered,
+          [receiptStorageKey]: receipt,
+        });
+      } else {
+        await this.state.storage.put(storageKey, delivered);
+      }
       await this.scheduleCleanup(expiresAt);
       return Response.json({ delivered: true });
     }

--- a/packages/cloud/services/_common/src/telegram-delivery.ts
+++ b/packages/cloud/services/_common/src/telegram-delivery.ts
@@ -21,7 +21,11 @@ export interface TelegramDeliveryLedger {
   ): Promise<TelegramDeliveryState | null>;
   claimChunk(chunkIndex: number, chunkDigest: string): Promise<boolean>;
   releaseChunk(chunkIndex: number, chunkDigest: string): Promise<void>;
-  markChunkDelivered(chunkIndex: number, chunkDigest: string): Promise<void>;
+  markChunkDelivered(
+    chunkIndex: number,
+    chunkDigest: string,
+    providerMessageId?: string,
+  ): Promise<void>;
   markDelivered(): Promise<void>;
 }
 
@@ -106,12 +110,12 @@ export async function executeTelegramDelivery(
       activeChunk = { index, digest };
       return true;
     },
-    async accepted(index) {
+    async accepted(index, _chunk, providerMessageId) {
       const digest = requireChunk(index);
       if (activeChunk?.index !== index || activeChunk.digest !== digest) {
         throw new Error("Telegram accepted an unclaimed delivery chunk");
       }
-      await ledger.markChunkDelivered(index, digest);
+      await ledger.markChunkDelivered(index, digest, providerMessageId);
       activeChunk = null;
     },
     async rejected(index) {

--- a/packages/cloud/services/_common/tests/telegram-delivery.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-delivery.test.ts
@@ -15,6 +15,7 @@ function memoryLedger(initial: TelegramDeliveryState | null = null): {
     processing: boolean;
     plan: string[] | null;
     chunks: Map<number, TelegramDeliveryState>;
+    providerMessageIds: Map<number, string>;
   };
 } {
   const state = {
@@ -22,6 +23,7 @@ function memoryLedger(initial: TelegramDeliveryState | null = null): {
     processing: false,
     plan: null as string[] | null,
     chunks: new Map<number, TelegramDeliveryState>(),
+    providerMessageIds: new Map<number, string>(),
   };
   return {
     state,
@@ -57,8 +59,11 @@ function memoryLedger(initial: TelegramDeliveryState | null = null): {
       async releaseChunk(index) {
         state.chunks.delete(index);
       },
-      async markChunkDelivered(index) {
+      async markChunkDelivered(index, _digest, providerMessageId) {
         state.chunks.set(index, "delivered");
+        if (providerMessageId) {
+          state.providerMessageIds.set(index, providerMessageId);
+        }
       },
       async markDelivered() {
         state.delivery = "delivered";
@@ -84,6 +89,7 @@ describe("executeTelegramDelivery", () => {
     expect(outcome).toBe("delivered");
     expect(claimObserved).toBe(true);
     expect(memory.state.chunks.get(0)).toBe("delivered");
+    expect(memory.state.providerMessageIds.get(0)).toBe("provider-1");
     expect(memory.state.delivery).toBe("delivered");
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
@@ -146,6 +146,50 @@ describe("Shared reminder cron", () => {
     );
   });
 
+  test("uses edge-owned Telegram delivery with a durable provider receipt", async () => {
+    const telegramDispatch = mock(async () => ({
+      ok: true as const,
+      acceptedAt: "2026-08-20T19:30:00.100Z",
+      providerMessageIds: ["9010"],
+    }));
+    globalThis.fetch = mock(async () => {
+      throw new Error("Railway egress must not run");
+    }) as typeof fetch;
+    const dispatcher = sharedReminderDispatcher(
+      {
+        SHARED_RUNTIME_CONVERSATIONS: env.SHARED_RUNTIME_CONVERSATIONS,
+      } as never,
+      "personal:00000000-0000-5000-8000-000000000000",
+      { telegramDispatch },
+    );
+
+    const result = await dispatcher.dispatch({
+      taskId: "edge-reminder",
+      promptInstructions: "time to stretch",
+      firedAtIso: "2026-08-20T19:30:00.000Z",
+      metadata: {
+        dispatchIdempotencyKey: "edge-reminder:2026-08-20T19:30:00.000Z",
+        delivery: {
+          platform: "telegram",
+          project: "eliza-app",
+          chatId: "123456789",
+        },
+      },
+    });
+
+    expect(telegramDispatch).toHaveBeenCalledWith({
+      project: "eliza-app",
+      chatId: "123456789",
+      text: "time to stretch",
+      idempotencyKey: "edge-reminder:2026-08-20T19:30:00.000Z",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: true,
+      metadata: { providerMessageIds: ["9010"] },
+    });
+  });
+
   test("fails closed before egress when trusted delivery metadata is absent", async () => {
     createSharedScheduledTaskRunner.mockImplementationOnce((_agentId, dispatcher) => ({
       async fireWithResult() {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -48,6 +48,34 @@ type GatewayDeliveryResponse = {
   retryable?: unknown;
 };
 
+export interface SharedTelegramReminderDispatchInput {
+  project: string;
+  chatId: string;
+  text: string;
+  idempotencyKey: string;
+}
+
+export type SharedTelegramReminderDispatchResult =
+  | {
+      ok: true;
+      acceptedAt: string;
+      providerMessageIds: string[];
+    }
+  | {
+      ok: false;
+      acceptance: "not_accepted" | "unknown";
+      message: string;
+      retryAfterMinutes?: number;
+    };
+
+export type SharedTelegramReminderDispatch = (
+  input: SharedTelegramReminderDispatchInput,
+) => Promise<SharedTelegramReminderDispatchResult>;
+
+interface SharedReminderDispatcherOptions {
+  telegramDispatch?: SharedTelegramReminderDispatch;
+}
+
 async function readGatewayDeliveryResponse(
   response: Response,
 ): Promise<GatewayDeliveryResponse | undefined> {
@@ -60,11 +88,11 @@ async function readGatewayDeliveryResponse(
   }
 }
 
-export function sharedReminderDispatcher(env: Bindings, agentId?: string): ScheduledTaskDispatcher {
-  const secret = env.GATEWAY_INTERNAL_SECRET;
-  if (!secret) {
-    throw new Error("GATEWAY_INTERNAL_SECRET is not configured");
-  }
+export function sharedReminderDispatcher(
+  env: Bindings,
+  agentId?: string,
+  options: SharedReminderDispatcherOptions = {},
+): ScheduledTaskDispatcher {
   return {
     async dispatch(record) {
       const delivery = reminderDelivery(record);
@@ -82,99 +110,140 @@ export function sharedReminderDispatcher(env: Bindings, agentId?: string): Sched
           message: `Reminder text exceeds the ${SHARED_REMINDER_MAX_TEXT_LENGTH}-character connector limit.`,
         };
       }
-      const baseUrl =
-        delivery.platform === "discord" ? discordGatewayBaseUrl(env) : gatewayBaseUrl(env);
-      let response: Response;
-      try {
-        response = await fetch(`${baseUrl}/internal/deliver`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Internal-Secret": secret,
-          },
-          body: JSON.stringify({
-            ...delivery,
-            text,
-            idempotencyKey,
-          }),
-          signal: AbortSignal.timeout(10_000),
+      let acceptedAt: string | undefined;
+      let providerMessageIds: string[] = [];
+      if (delivery.platform === "telegram" && options.telegramDispatch) {
+        const result = await options.telegramDispatch({
+          project: delivery.project,
+          chatId: delivery.chatId,
+          text,
+          idempotencyKey,
         });
-      } catch (error) {
-        // error-policy:J1 connector dispatch returns an explicit unknown-acceptance failure.
-        return {
-          ok: false,
-          reason: "transport_error",
-          userActionable: false,
-          acceptance: "unknown",
-          message: error instanceof Error ? error.message : String(error),
-        };
-      }
-      const result = await readGatewayDeliveryResponse(response);
-      if (response.status === 409 || response.status === 429) {
-        return {
-          ok: false,
-          reason: "rate_limited",
-          retryAfterMinutes: 1,
-          userActionable: false,
-          acceptance: "not_accepted",
-        };
-      }
-      if (response.status === 401 || response.status === 403) {
-        return {
-          ok: false,
-          reason: "auth_expired",
-          userActionable: false,
-          acceptance: "not_accepted",
-        };
-      }
-      if (!response.ok) {
-        if (result?.acceptance === "not_accepted" && result.retryable === true) {
-          const retryAfterSeconds = Number(response.headers.get("Retry-After") ?? "60");
+        if (!result.ok) {
+          return {
+            ok: false,
+            reason: result.retryAfterMinutes ? "rate_limited" : "transport_error",
+            ...(result.retryAfterMinutes ? { retryAfterMinutes: result.retryAfterMinutes } : {}),
+            userActionable: false,
+            acceptance: result.acceptance,
+            message: result.message,
+          };
+        }
+        acceptedAt = result.acceptedAt;
+        providerMessageIds = result.providerMessageIds;
+      } else {
+        const secret = env.GATEWAY_INTERNAL_SECRET;
+        if (!secret) {
+          throw new Error("GATEWAY_INTERNAL_SECRET is not configured");
+        }
+        const baseUrl =
+          delivery.platform === "discord" ? discordGatewayBaseUrl(env) : gatewayBaseUrl(env);
+        let response: Response;
+        try {
+          response = await fetch(`${baseUrl}/internal/deliver`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Internal-Secret": secret,
+            },
+            body: JSON.stringify({
+              ...delivery,
+              text,
+              idempotencyKey,
+            }),
+            signal: AbortSignal.timeout(10_000),
+          });
+        } catch (error) {
+          // error-policy:J1 connector dispatch returns an explicit unknown-acceptance failure.
+          return {
+            ok: false,
+            reason: "transport_error",
+            userActionable: false,
+            acceptance: "unknown",
+            message: error instanceof Error ? error.message : String(error),
+          };
+        }
+        const result = await readGatewayDeliveryResponse(response);
+        if (response.status === 409 || response.status === 429) {
           return {
             ok: false,
             reason: "rate_limited",
-            retryAfterMinutes:
-              Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
-                ? Math.max(1, Math.ceil(retryAfterSeconds / 60))
-                : 1,
+            retryAfterMinutes: 1,
             userActionable: false,
             acceptance: "not_accepted",
           };
         }
-        return {
-          ok: false,
-          reason: "transport_error",
-          userActionable: false,
-          acceptance: result?.acceptance === "not_accepted" ? "not_accepted" : "unknown",
-        };
+        if (response.status === 401 || response.status === 403) {
+          return {
+            ok: false,
+            reason: "auth_expired",
+            userActionable: false,
+            acceptance: "not_accepted",
+          };
+        }
+        if (!response.ok) {
+          if (result?.acceptance === "not_accepted" && result.retryable === true) {
+            const retryAfterSeconds = Number(response.headers.get("Retry-After") ?? "60");
+            return {
+              ok: false,
+              reason: "rate_limited",
+              retryAfterMinutes:
+                Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+                  ? Math.max(1, Math.ceil(retryAfterSeconds / 60))
+                  : 1,
+              userActionable: false,
+              acceptance: "not_accepted",
+            };
+          }
+          return {
+            ok: false,
+            reason: "transport_error",
+            userActionable: false,
+            acceptance: result?.acceptance === "not_accepted" ? "not_accepted" : "unknown",
+          };
+        }
+        if (
+          response.status === 202 ||
+          result?.acceptanceUnknown === true ||
+          result?.acceptance === "unknown"
+        ) {
+          return {
+            ok: false,
+            reason: "transport_error",
+            userActionable: true,
+            acceptance: "unknown",
+            message: "Reminder delivery could not be confirmed; it was not recorded as fired.",
+          };
+        }
+        acceptedAt =
+          typeof result?.acceptedAt === "string" && Number.isFinite(Date.parse(result.acceptedAt))
+            ? result.acceptedAt
+            : undefined;
+        providerMessageIds = Array.isArray(result?.providerMessageIds)
+          ? result.providerMessageIds.filter(
+              (id): id is string => typeof id === "string" && id.length > 0,
+            )
+          : [];
+        if (
+          result?.success !== true ||
+          result.idempotencyKey !== idempotencyKey ||
+          !acceptedAt ||
+          providerMessageIds.length === 0
+        ) {
+          return {
+            ok: false,
+            reason: "transport_error",
+            userActionable: true,
+            acceptance: "unknown",
+            message: "Reminder delivery returned no verifiable provider receipt.",
+          };
+        }
       }
       if (
-        response.status === 202 ||
-        result?.acceptanceUnknown === true ||
-        result?.acceptance === "unknown"
-      ) {
-        return {
-          ok: false,
-          reason: "transport_error",
-          userActionable: true,
-          acceptance: "unknown",
-          message: "Reminder delivery could not be confirmed; it was not recorded as fired.",
-        };
-      }
-      const acceptedAt =
-        typeof result?.acceptedAt === "string" && Number.isFinite(Date.parse(result.acceptedAt))
-          ? result.acceptedAt
-          : undefined;
-      const providerMessageIds = Array.isArray(result?.providerMessageIds)
-        ? result.providerMessageIds.filter(
-            (id): id is string => typeof id === "string" && id.length > 0,
-          )
-        : [];
-      if (
-        result?.success !== true ||
-        result.idempotencyKey !== idempotencyKey ||
         !acceptedAt ||
-        providerMessageIds.length === 0
+        !Number.isFinite(Date.parse(acceptedAt)) ||
+        providerMessageIds.length === 0 ||
+        providerMessageIds.some((id) => typeof id !== "string" || !id)
       ) {
         return {
           ok: false,
@@ -242,7 +311,11 @@ export function sharedReminderDispatcher(env: Bindings, agentId?: string): Sched
 
 export async function processDueSharedReminders(
   env: Bindings,
-  options: { now?: Date; limit?: number } = {},
+  options: {
+    now?: Date;
+    limit?: number;
+    telegramDispatch?: SharedTelegramReminderDispatch;
+  } = {},
 ) {
   const now = options.now ?? new Date();
   const limit = Math.min(Math.max(Math.trunc(options.limit ?? 100), 1), 500);
@@ -276,7 +349,9 @@ export async function processDueSharedReminders(
       batch.map((item) =>
         createSharedScheduledTaskRunner(
           item.agentId,
-          sharedReminderDispatcher(env, item.agentId),
+          sharedReminderDispatcher(env, item.agentId, {
+            telegramDispatch: options.telegramDispatch,
+          }),
         ).fireWithResult(
           item.taskId,
           item.recovery ? { recoverFiredAtIso: item.firedAtIso } : { allowTerminalRefire: true },


### PR DESCRIPTION
## Summary\n- route Personal Shared Telegram reminders through the same Cloudflare edge bot as live replies when the protected edge cutover is enabled\n- persist provider message IDs in the exact-once Durable Object ledger so duplicate cron attempts return a verifiable receipt without resending\n- preserve Railway gateway delivery for Discord, Blooio, and non-edge Telegram\n\n## Verification\n- focused Telegram delivery, Durable Object, edge, and Shared reminder tests\n- cloud-services-common typecheck\n- Cloud API typecheck and production Worker dry-run\n- Biome and git diff checks