### PR TITLE
fix(plugin-slack): fail-closed ghost accountId so it cannot inherit owner tokens

### DIFF
--- a/plugins/plugin-slack/src/accounts.test.ts
+++ b/plugins/plugin-slack/src/accounts.test.ts
@@ -234,3 +234,77 @@ describe("resolveSlackAccount role wiring", () => {
     expect(account.role).toBe("OWNER");
   });
 });
+
+describe("resolveSlackAccount ghost accountId fail-closed", () => {
+  it("does not inherit owner settings tokens for an explicit ghost accountId", () => {
+    const runtime = createRuntime({
+      botToken: "xoxb-owner",
+      appToken: "xapp-owner",
+      userToken: "xoxp-owner",
+      signingSecret: "sign-owner",
+    });
+
+    const ghost = resolveSlackAccount(runtime, "ghost-account");
+    expect(ghost.accountId).toBe("ghost-account");
+    expect(ghost.botToken).toBeUndefined();
+    expect(ghost.appToken).toBeUndefined();
+    expect(ghost.userToken).toBeUndefined();
+    expect(ghost.signingSecret).toBeUndefined();
+  });
+
+  it("still binds omitted accountId to the default owner tokens", () => {
+    const runtime = createRuntime({
+      botToken: "xoxb-owner",
+      appToken: "xapp-owner",
+      userToken: "xoxp-owner",
+      signingSecret: "sign-owner",
+    });
+
+    const omitted = resolveSlackAccount(runtime);
+    expect(omitted.accountId).toBe("default");
+    expect(omitted.botToken).toBe("xoxb-owner");
+    expect(omitted.appToken).toBe("xapp-owner");
+    expect(omitted.userToken).toBe("xoxp-owner");
+    expect(omitted.signingSecret).toBe("sign-owner");
+  });
+
+  it("does not inherit env signing secret for a ghost accountId", () => {
+    const runtime = createRuntime(undefined, {
+      SLACK_BOT_TOKEN: "xoxb-env",
+      SLACK_APP_TOKEN: "xapp-env",
+      SLACK_USER_TOKEN: "xoxp-env",
+      SLACK_SIGNING_SECRET: "sign-env",
+    });
+
+    const ghost = resolveSlackAccount(runtime, "ghost-account");
+    expect(ghost.botToken).toBeUndefined();
+    expect(ghost.appToken).toBeUndefined();
+    expect(ghost.userToken).toBeUndefined();
+    expect(ghost.signingSecret).toBeUndefined();
+
+    const def = resolveSlackAccount(runtime);
+    expect(def.accountId).toBe("default");
+    expect(def.botToken).toBe("xoxb-env");
+    expect(def.signingSecret).toBe("sign-env");
+  });
+
+  it("does not inherit base vault tokens for a ghost accountId", () => {
+    const runtime = createRuntime(undefined, undefined, {
+      botToken: "xoxb-vault",
+      appToken: "xapp-vault",
+      userToken: "xoxp-vault",
+      signingSecret: "sign-vault",
+    });
+
+    const ghost = resolveSlackAccount(runtime, "ghost-account");
+    expect(ghost.botToken).toBeUndefined();
+    expect(ghost.appToken).toBeUndefined();
+    expect(ghost.userToken).toBeUndefined();
+    expect(ghost.signingSecret).toBeUndefined();
+
+    const def = resolveSlackAccount(runtime);
+    expect(def.accountId).toBe("default");
+    expect(def.botToken).toBe("xoxb-vault");
+    expect(def.appToken).toBe("xapp-vault");
+  });
+});

--- a/plugins/plugin-slack/src/accounts.ts
+++ b/plugins/plugin-slack/src/accounts.ts
@@ -319,6 +319,16 @@ function filterDefined<T extends object>(obj: T): Partial<T> {
   ) as Partial<T>;
 }
 
+function stripSlackCredentials<T extends SlackAccountConfig>(
+  config: T,
+): Partial<T> {
+  const next: Partial<T> = { ...config };
+  for (const key of SLACK_CREDENTIAL_KEYS) {
+    delete next[key];
+  }
+  return next;
+}
+
 function mergeSlackAccountConfig(
   runtime: IAgentRuntime,
   accountId: string,
@@ -350,10 +360,18 @@ function mergeSlackAccountConfig(
   };
 
   // Merge order: env defaults < base config < account config
-  // Filter undefined values to prevent them from overwriting defined values
+  // Filter undefined values to prevent them from overwriting defined values.
+  // Named / ghost accountIds inherit policy defaults only. Owner bot, app,
+  // user, and signing credentials stay on the default account so an explicit
+  // unknown accountId cannot send or verify as the owner.
+  const inheritedBase =
+    accountId === DEFAULT_ACCOUNT_ID
+      ? filterDefined(baseConfig)
+      : filterDefined(stripSlackCredentials(baseConfig));
+
   return {
     ...filterDefined(envConfig),
-    ...filterDefined(baseConfig),
+    ...inheritedBase,
     ...filterDefined(accountConfig),
   };
 }
@@ -400,10 +418,12 @@ export function resolveSlackAccount(
       ? "env"
       : "none";
 
-  // Resolve signing secret
-  const signingSecret =
-    merged.signingSecret ??
-    (runtime.getSetting("SLACK_SIGNING_SECRET") as string);
+  // Resolve signing secret. Env fallback is default-account only, matching
+  // bot / app / user token inheritance.
+  const envSigningSecret = allowEnv
+    ? (runtime.getSetting("SLACK_SIGNING_SECRET") as string)
+    : undefined;
+  const signingSecret = merged.signingSecret ?? envSigningSecret;
 
   // Resolve user token
   const envUserToken = allowEnv


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE hang / 500 / auth-bind / input-boundary audit on a live product path. No new issue filed (mission forbids self-directed issue creation).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed or timeout on hostile / hung / malformed input. Honest product
paths are unchanged. No schema, API contract, or storage migration.

# Background

## What does this PR do?

## What changed

`plugins/plugin-slack/src/accounts.ts` `mergeSlackAccountConfig` / `resolveSlackAccount` on `origin/develop` `f6c2143d1197` merges owner `botToken` / `appToken` / `userToken` / `signingSecret` from settings and the vault onto every account, including an explicit ghost `accountId`. Env `SLACK_SIGNING_SECRET` was also not default-gated (unlike bot/app/user env tokens).

Independent origin proof:

```text
ORIGIN settings ghost {accountId: ghost-account, botToken: xoxb-owner, signingSecret: sign-owner} leaked True
ORIGIN settings omitted still binds default + owner keys
ORIGIN env ghost signingSecret=sign-env leakedSigning True
OVERLAY settings/env ghost leaked False; omitted still binds default
```

This head lets named/ghost accounts inherit policy only. Owner credentials stay on `default`. Env signing secret is default-gated like the other env tokens. A configured `work` account still keeps its own tokens.

Not leftover-tax. Not a twin of Instagram #23062 or X #23070 (different host). Did not edit HARD_SKIP `connector-account-provider.ts`. Occupancy-FREE.

## Scope

- `plugins/plugin-slack/src/accounts.ts`
- `plugins/plugin-slack/src/accounts.test.ts` (4 new)

## Why this is unowned

Live occupancy: no open Eliza PR touches these files. Absent from factory occupancy JSON. HARD_SKIP is `plugins/plugin-slack/src/connector-account-provider.ts`, not `accounts.ts`.

## Verification

Exact candidate head: `204cda791b54dfe2c87c59d32bcccdc6f514cbce`
Base: `f6c2143d119768d8ed53c8e1aa62e203311f45f7`

- Origin ghost `accountId` inherits owner settings tokens and env signing secret
- Overlay: same calls return empty credentials
- `bunx vitest run src/accounts.test.ts` (recorded via proof-run)

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Focused unit tests in this diff and the origin hang / 500 / auth-bind writeup
in Background.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:204cda791b54dfe2c87c59d32bcccdc6f514cbce -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; runtime or plugin logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
ORIGIN settings ghost {accountId: ghost-account, botToken: xoxb-owner, signingSecret: sign-owner} leaked True
ORIGIN settings omitted still binds default + owner keys
ORIGIN env ghost signingSecret=sign-env leakedSigning True
OVERLAY settings/env ghost leaked False; omitted still binds default

```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
