### PR TITLE
feat(cloud): add dormant restore quarantine authority

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -60,6 +60,8 @@ describe("dormant restore API boundary", () => {
       "claimAgentBackupRestoreOperation",
       "reserveAgentBackupRestoreTarget",
       "advanceAgentBackupRestoreOperation",
+      "openAgentBackupRestoreQuarantine",
+      "recordAgentBackupRestoreQuarantinedContainer",
       "recordAgentActivationPublication",
       "authorizeAgentActivationDispatch",
       "recordAgentVaultKeySeedReceipt",
@@ -282,6 +284,55 @@ describe("dormant restore API boundary", () => {
     );
     expect(divergentLookup).not.toContain('.for("update")');
     expect(divergentLookup).toContain("Restore attempt replay authority mismatch");
+  });
+
+  test("keeps the restore quarantine DB-only, target-derived, and route-free", () => {
+    const quarantineSource = readFileSync(
+      join(import.meta.dir, "repositories/agent-backup-restore-quarantine.ts"),
+      "utf8",
+    );
+    expect(quarantineSource).not.toMatch(
+      /DockerSandboxProvider|DockerNodeManager|DockerSSHClient|getAvailableNode|nodeAutoscaler|parseDockerNodes|SandboxRegistry|SANDBOX_REGISTRY|ssh\.exec|process\.env|fetch\s*\(/i,
+    );
+    expect(quarantineSource).toContain("activation_generation: operation.restore_attempt_id");
+
+    const functions = [
+      quarantineSource.slice(
+        quarantineSource.indexOf("export async function openAgentBackupRestoreQuarantine"),
+        quarantineSource.indexOf(
+          "export async function recordAgentBackupRestoreQuarantinedContainer",
+        ),
+      ),
+      quarantineSource.slice(
+        quarantineSource.indexOf(
+          "export async function recordAgentBackupRestoreQuarantinedContainer",
+        ),
+      ),
+    ];
+    const lockAnchors = [
+      ".from(agentSandboxBackups)",
+      ".from(agentBackupRestoreOperations)",
+      ".from(agentBackupRestoreLeases)",
+      ".from(agentSandboxes)",
+      ".from(dockerNodes)",
+      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "lockAgentBackupCatalogAuthority(",
+      "readPostLockDatabaseNow(tx)",
+    ];
+    for (const source of functions) {
+      const transactional = source.slice(source.indexOf("return dbWrite.transaction"));
+      for (let index = 1; index < lockAnchors.length; index += 1) {
+        expect(transactional.indexOf(lockAnchors[index - 1] as string)).toBeLessThan(
+          transactional.indexOf(lockAnchors[index] as string),
+        );
+      }
+      const sandboxMutationStart = source.indexOf(".update(agentSandboxes)");
+      const sandboxMutation = source.slice(
+        source.indexOf(".set({", sandboxMutationStart),
+        source.indexOf(".where(", sandboxMutationStart),
+      );
+      expect(sandboxMutation).not.toMatch(/\n\s+(?:sandbox_id|node_id|image_digest|status):/);
+    }
   });
 
   test("contains no coordinator, capacity, billing, or probe migration in the dormant range", () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
@@ -27,7 +27,7 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import type { AgentBackupRestorePhase } from "../../schemas/agent-backup-catalog";
 import {
@@ -320,6 +320,36 @@ async function openAndClaim(): Promise<{
   return { operationId: operation.id, claimGeneration: claim.claimGeneration };
 }
 
+/**
+ * Test-only stand-in for the separately proven quarantine writer. Keeping this
+ * as a direct fixture lets this suite exercise later generic phases without
+ * introducing a second caller for the dormant production API.
+ */
+async function recordQuarantinedContainerFixture(
+  operationId: string,
+  claimGeneration: string,
+): Promise<void> {
+  const [recorded] = await dbWrite
+    .update(agentBackupRestoreOperations)
+    .set({
+      phase: "container_created",
+      expected_container_id: CONTAINER,
+      claim_owner: null,
+      claim_generation: null,
+      claim_expires_at: null,
+    })
+    .where(
+      and(
+        eq(agentBackupRestoreOperations.id, operationId),
+        eq(agentBackupRestoreOperations.phase, "vault_seeded"),
+        eq(agentBackupRestoreOperations.claim_owner, "restore-worker"),
+        eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
+      ),
+    )
+    .returning();
+  if (!recorded) throw new Error("quarantined container fixture lost its operation CAS");
+}
+
 /** Walks the machine one adjacent step at a time, re-claiming per phase. */
 async function walkTo(operationId: string, target: AgentBackupRestorePhase): Promise<void> {
   const order: AgentBackupRestorePhase[] = [
@@ -352,6 +382,10 @@ async function walkTo(operationId: string, target: AgentBackupRestorePhase): Pro
         ownerId: "restore-worker",
         claimMs: 60_000,
       });
+    }
+    if (order[index + 1] === "container_created") {
+      await recordQuarantinedContainerFixture(operationId, claim.claimGeneration);
+      continue;
     }
     await advanceAgentBackupRestoreOperation({
       operationId,
@@ -940,6 +974,19 @@ describe("restore operation spine", () => {
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(",
     ]);
+
+    const genericAdvance = source.slice(
+      source.indexOf("export async function advanceAgentBackupRestoreOperation"),
+      source.indexOf("export async function heartbeatAgentBackupRestoreOperation"),
+    );
+    const genericAdvanceMutationStart = genericAdvance.indexOf(".set({");
+    const genericAdvanceMutation = genericAdvance.slice(
+      genericAdvanceMutationStart,
+      genericAdvance.indexOf(".where(", genericAdvanceMutationStart),
+    );
+    expect(genericAdvanceMutation).not.toContain("expected_container_id");
+    expect(genericAdvance).toContain('params.toPhase === "container_created"');
+    expect(genericAdvance).toContain('"recordedIdentity" in params');
   });
 
   test(
@@ -1004,7 +1051,7 @@ describe("restore operation spine", () => {
   );
 
   test(
-    "refuses to leave reserved without target authority, then advances after exact reservation",
+    "rejects generic container identity and creation without mutating a reachable operation",
     async () => {
       await seedTargetNode();
       await seedLease();
@@ -1040,27 +1087,78 @@ describe("restore operation spine", () => {
         targetNodeRecordId: TARGET_NODE_RECORD_ID,
         targetNodeIncarnation: TARGET_NODE_INCARNATION,
       });
-      const advanced = await advanceAgentBackupRestoreOperation({
+
+      const [beforeIdentityBypass] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      const legacyIdentityRequest = {
         operationId: operation.id,
         ownerId: "restore-worker",
         claimGeneration: claim.claimGeneration,
         fromPhase: "reserved",
         toPhase: "vault_seeded",
         recordedIdentity: { containerId: CONTAINER },
+      } as unknown as Parameters<typeof advanceAgentBackupRestoreOperation>[0];
+      await expect(advanceAgentBackupRestoreOperation(legacyIdentityRequest)).rejects.toThrow(
+        "Generic restore advance cannot record a container identity",
+      );
+      const [afterIdentityBypass] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      expect(afterIdentityBypass).toEqual(beforeIdentityBypass);
+
+      const advanced = await advanceAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: claim.claimGeneration,
+        fromPhase: "reserved",
+        toPhase: "vault_seeded",
       });
       expect(advanced.phase).toBe("vault_seeded");
-      expect(advanced.expected_container_id).toBe(CONTAINER);
+      expect(advanced.expected_container_id).toBeNull();
       expect(advanced.claim_owner).toBeNull();
 
+      const containerClaim = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      const [beforeTransitionBypass] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
       await expect(
         advanceAgentBackupRestoreOperation({
           operationId: operation.id,
           ownerId: "restore-worker",
-          claimGeneration: claim.claimGeneration,
+          claimGeneration: containerClaim.claimGeneration,
           fromPhase: "vault_seeded",
           toPhase: "container_created",
         }),
-      ).rejects.toThrow("claim is not live");
+      ).rejects.toThrow("must be recorded through quarantine authority");
+      const [afterTransitionBypass] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      expect(afterTransitionBypass).toEqual(beforeTransitionBypass);
+
+      await recordQuarantinedContainerFixture(operation.id, containerClaim.claimGeneration);
+      const postContainerClaim = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      const restoring = await advanceAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: postContainerClaim.claimGeneration,
+        fromPhase: "container_created",
+        toPhase: "restoring",
+      });
+      expect(restoring.phase).toBe("restoring");
+      expect(restoring.expected_container_id).toBe(CONTAINER);
     },
     TIMEOUT,
   );
@@ -1098,6 +1196,113 @@ describe("restore operation spine", () => {
           receiptDigest: SHA,
         }),
       ).rejects.toThrow("cannot advance from reserved to finalized");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "resumes an already-recorded container phase without rewriting its identity",
+    async () => {
+      await seedLease();
+      const { operation } = await openAgentBackupRestoreOperation({
+        authority: authorityReceipt(),
+        leaseId: LEASE_ID,
+      });
+      await walkTo(operation.id, "container_created");
+      const containerClaim = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      const failed = await failAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: containerClaim.claimGeneration,
+        retryable: true,
+        resumePhase: "container_created",
+        errorCode: "CONTAINER_ATTEST_TIMEOUT",
+        error: "container attestation timed out",
+        failureDigest: SHA,
+        retryDelayMs: 0,
+      });
+      expect(failed.phase).toBe("failed_retryable");
+      expect(failed.resume_phase).toBe("container_created");
+      expect(failed.expected_container_id).toBe(CONTAINER);
+
+      const retry = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      const resumed = await advanceAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: retry.claimGeneration,
+        fromPhase: "failed_retryable",
+        toPhase: "container_created",
+      });
+      expect(resumed.phase).toBe("container_created");
+      expect(resumed.resume_phase).toBeNull();
+      expect(resumed.expected_container_id).toBe(failed.expected_container_id);
+      expect(resumed.claim_owner).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "refuses a container-phase retry whose durable container identity is missing",
+    async () => {
+      await seedLease();
+      const { operation } = await openAgentBackupRestoreOperation({
+        authority: authorityReceipt(),
+        leaseId: LEASE_ID,
+      });
+      await walkTo(operation.id, "container_created");
+      const containerClaim = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      await failAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimGeneration: containerClaim.claimGeneration,
+        retryable: true,
+        resumePhase: "container_created",
+        errorCode: "CONTAINER_ATTEST_TIMEOUT",
+        error: "container attestation timed out",
+        failureDigest: SHA,
+        retryDelayMs: 0,
+      });
+      // Test-only corruption fixture: a real dedicated writer never produces
+      // this state, but a generic resume must still fail closed if it observes it.
+      await dbWrite
+        .update(agentBackupRestoreOperations)
+        .set({ expected_container_id: null })
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      const retry = await claimAgentBackupRestoreOperation({
+        operationId: operation.id,
+        ownerId: "restore-worker",
+        claimMs: 60_000,
+      });
+      const [beforeResume] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      await expect(
+        advanceAgentBackupRestoreOperation({
+          operationId: operation.id,
+          ownerId: "restore-worker",
+          claimGeneration: retry.claimGeneration,
+          fromPhase: "failed_retryable",
+          toPhase: "container_created",
+        }),
+      ).rejects.toThrow("cannot resume container_created without a recorded container identity");
+      const [afterResume] = await dbWrite
+        .select()
+        .from(agentBackupRestoreOperations)
+        .where(eq(agentBackupRestoreOperations.id, operation.id));
+      expect(afterResume).toEqual(beforeResume);
     },
     TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
@@ -1,0 +1,936 @@
+/** Real-primary-DB proofs for the dormant restore activation quarantine. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import {
+  AGENT_BACKUP_MANIFEST_FORMAT,
+  AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  type AgentBackupManifestV3Draft,
+  canonicalizeAgentBackupManifestV3,
+  createAgentBackupManifestV3,
+} from "@elizaos/shared";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import {
+  agentBackupCatalogAuthorities,
+  agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
+} from "../../schemas/agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-backup-restore-history";
+import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
+import {
+  AGENT_VAULT_KEY_AUTHORITY_FORMAT,
+  AGENT_VAULT_KEY_AUTHORITY_RECEIPT_DERIVATION,
+} from "../../schemas/agent-vault-key-authority";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+import type { AgentBackupRestoreLeaseAuthorityReceipt } from "../agent-backup-restore-lease";
+import {
+  advanceAgentBackupRestoreOperation,
+  claimAgentBackupRestoreOperation,
+  openAgentBackupRestoreOperation,
+  reserveAgentBackupRestoreTarget,
+} from "../agent-backup-restore-operations";
+import {
+  openAgentBackupRestoreQuarantine,
+  recordAgentBackupRestoreQuarantinedContainer,
+} from "../agent-backup-restore-quarantine";
+
+const TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-00000000e101";
+const USER_ID = "00000000-0000-4000-8000-00000000e102";
+const AGENT_ID = "00000000-0000-4000-8000-00000000e103";
+const BACKUP_ID = "00000000-0000-4000-8000-00000000e104";
+const BACKUP_OPERATION_ID = "00000000-0000-4000-8000-00000000e105";
+const SOURCE_ACTIVATION_GENERATION = "00000000-0000-4000-8000-00000000e106";
+const RESTORE_ATTEMPT_ID = "00000000-0000-4000-8000-00000000e107";
+const LEASE_ID = "00000000-0000-4000-8000-00000000e108";
+const LEASE_GENERATION = "00000000-0000-4000-8000-00000000e109";
+const PREVIOUS_ACTIVATION_GENERATION = "00000000-0000-4000-8000-00000000e10c";
+const PREVIOUS_BOOT_ID = "00000000-0000-4000-8000-00000000e10d";
+const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000e10e";
+const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000e10f";
+const OTHER_NODE_INCARNATION = "00000000-0000-4000-8000-00000000e110";
+const VAULT_GENERATION_ID = "00000000-0000-4000-8000-00000000e111";
+const SOURCE_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000e112";
+const KEY_BUNDLE_GENERATION_ID = "00000000-0000-4000-8000-00000000e113";
+const HASH = "a".repeat(64);
+const OTHER_SHA = "b".repeat(64);
+const IMAGE_DIGEST = `sha256:${"c".repeat(64)}`;
+const CANONICAL_IMAGE_DIGEST = `sha256:${"d".repeat(64)}`;
+const TOKEN_SHA = "e".repeat(64);
+const OTHER_TOKEN_SHA = "f".repeat(64);
+const TOKEN_CIPHERTEXT = "test-only-field-ciphertext-v1";
+const CONTAINER_A = "1".repeat(64);
+const CONTAINER_B = "2".repeat(64);
+const OLD_CONTAINER = "3".repeat(64);
+const KEY_BUNDLE = Buffer.alloc(92, 0x44).toString("base64");
+
+let schemaFailure = "";
+let operationId = "";
+let initialClaimGeneration = "";
+let manifestFixture: Readonly<{ canonicalDraft: string; digest: string }>;
+
+async function buildManifestFixture(): Promise<typeof manifestFixture> {
+  const component = (name: "character" | "database" | "media" | "state-files" | "vault") => ({
+    name,
+    format: "raw-v1",
+    compression: "none" as const,
+    payloadContentHmacSha256: HASH,
+    state: { kind: "full" as const, resultContentHmacSha256: HASH },
+    totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+    chunks: [],
+  });
+  const draft: AgentBackupManifestV3Draft = {
+    format: AGENT_BACKUP_MANIFEST_FORMAT,
+    schemaVersion: 3,
+    operationId: BACKUP_OPERATION_ID,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    identity: {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: SOURCE_ACTIVATION_GENERATION,
+      lifecycleRevision: "4",
+    },
+    source: {
+      kind: "robot",
+      provider: "hetzner",
+      nodeRecordId: SOURCE_NODE_RECORD_ID,
+      nodeIncarnation: PREVIOUS_BOOT_ID,
+      nodeId: "restore-source",
+      containerId: OLD_CONTAINER,
+    },
+    runtime: {
+      imageDigest: IMAGE_DIGEST,
+      agentSchemaVersion: "2.0.0",
+      databaseSchemaVersion: "1",
+      plugins: [],
+    },
+    chain: { kind: "full", baseOperationId: null, parentOperationId: null, depth: 0 },
+    components: [
+      component("character"),
+      component("database"),
+      component("media"),
+      component("state-files"),
+      component("vault"),
+    ],
+    watermarks: [{ namespace: "database.lsn", value: "0/1" }],
+    totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+    vaultKeyAuthority: {
+      format: AGENT_VAULT_KEY_AUTHORITY_FORMAT,
+      generationId: VAULT_GENERATION_ID,
+      receiptDerivation: AGENT_VAULT_KEY_AUTHORITY_RECEIPT_DERIVATION,
+      receiptDigest: HASH,
+    },
+    encryption: {
+      algorithm: "AES-256-GCM",
+      chunkEnvelope: "aes-256-gcm-v1",
+      nonceBytes: 12,
+      tagBytes: 16,
+      noncePlacement: "prefix",
+      tagPlacement: "suffix",
+      aad: { version: 1, derivation: "elizaos.agent-backup.chunk-aad.v1" },
+      kms: { provider: "steward", keyId: `org:${ORG_ID}/dek/v1`, keyVersion: 1 },
+      operationKeyBundle: {
+        format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        generationId: KEY_BUNDLE_GENERATION_ID,
+        plaintextBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.plaintextBytes,
+        dek: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek,
+        contentHmac: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac,
+        wrapped: {
+          ref: `backup-key-bundle:${BACKUP_OPERATION_ID}`,
+          bytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes,
+          sha256: HASH,
+          localReceiptDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+          localReceiptDigest: HASH,
+          contextDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+        },
+      },
+    },
+    integrity: {
+      framedContentHmacSha256: HASH,
+      contentAddressing: {
+        algorithm: "HMAC-SHA-256",
+        scope: "operation",
+        derivation: AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+        keyBundleFormat: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        keyOffsetBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.offsetBytes,
+        keyBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes,
+      },
+    },
+  };
+  const manifest = await createAgentBackupManifestV3(draft);
+  return Object.freeze({
+    canonicalDraft: canonicalizeAgentBackupManifestV3(draft),
+    digest: manifest.integrity.manifestSha256,
+  });
+}
+
+function quarantineTransactionBody(functionName: string, nextFunctionName?: string): string {
+  const source = readFileSync(
+    new URL("../agent-backup-restore-quarantine.ts", import.meta.url),
+    "utf8",
+  );
+  const functionStart = source.indexOf(`export async function ${functionName}`);
+  const transactionStart = source.indexOf("return dbWrite.transaction", functionStart);
+  const functionEnd = nextFunctionName
+    ? source.indexOf(`export async function ${nextFunctionName}`, transactionStart)
+    : source.length;
+  expect(functionStart).toBeGreaterThanOrEqual(0);
+  expect(transactionStart).toBeGreaterThan(functionStart);
+  expect(functionEnd).toBeGreaterThan(transactionStart);
+  return source.slice(transactionStart, functionEnd);
+}
+
+function expectCanonicalQuarantineLockOrder(body: string): void {
+  const anchors = [
+    ".from(agentSandboxBackups)",
+    ".from(agentBackupRestoreOperations)",
+    ".from(agentBackupRestoreLeases)",
+    ".from(agentSandboxes)",
+    ".from(dockerNodes)",
+    "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+    "lockAgentBackupCatalogAuthority(",
+    "readPostLockDatabaseNow(tx)",
+  ];
+  const positions = anchors.map((anchor) => body.indexOf(anchor));
+  expect(positions.every((position) => position >= 0)).toBe(true);
+  expect(positions).toEqual([...positions].sort((left, right) => left - right));
+}
+
+const openInput = () => ({
+  operationId,
+  ownerId: "restore-worker",
+  claimGeneration: initialClaimGeneration,
+  activationTokenSha256: TOKEN_SHA,
+  activationTokenCiphertext: TOKEN_CIPHERTEXT,
+});
+
+function leaseAuthorityReceipt(
+  lease: typeof agentBackupRestoreLeases.$inferSelect,
+  databaseNow: Date,
+): AgentBackupRestoreLeaseAuthorityReceipt {
+  return Object.freeze({
+    lease: Object.freeze({ ...lease }),
+    leaseId: lease.id,
+    organizationId: lease.organization_id,
+    agentId: lease.agent_id,
+    backupId: lease.backup_id,
+    operationId: lease.operation_id,
+    sourceActivationGeneration: lease.activation_generation,
+    sourceLifecycleRevision: lease.lifecycle_revision.toString(),
+    expectedManifestSha256: lease.expected_manifest_sha256,
+    restoreAttemptId: lease.restore_attempt_id,
+    ownerId: lease.owner_id,
+    fencingToken: lease.generation,
+    catalogEpoch: lease.catalog_epoch.toString(),
+    copyRole: lease.copy_role,
+    databaseNow,
+    expiresAt: lease.expires_at,
+  });
+}
+
+async function seedFixture(): Promise<void> {
+  await dbWrite.insert(organizations).values({
+    id: ORG_ID,
+    name: "Restore quarantine",
+    slug: "restore-quarantine",
+  });
+  await dbWrite.insert(users).values({
+    id: USER_ID,
+    steward_user_id: "restore-quarantine-user",
+    organization_id: ORG_ID,
+  });
+  await dbWrite.insert(dockerNodes).values({
+    id: TARGET_NODE_RECORD_ID,
+    node_id: "restore-target",
+    hostname: "restore-target.invalid",
+    capacity: 2,
+    allocated_count: 0,
+    enabled: true,
+    placement_state: "open",
+    status: "healthy",
+    host_key_fingerprint: "SHA256:test-only-target",
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: TARGET_NODE_INCARNATION,
+  });
+  const publishedAt = new Date("2026-08-20T08:00:00.000Z");
+  const dispatchedAt = new Date("2026-08-20T08:00:01.000Z");
+  const completedAt = new Date("2026-08-20T08:00:02.000Z");
+  await dbWrite.insert(agentSandboxes).values({
+    id: AGENT_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    status: "running",
+    execution_tier: "dedicated-always",
+    sandbox_id: "canonical-provider-handle",
+    node_id: "canonical-node",
+    image_digest: CANONICAL_IMAGE_DIGEST,
+    lifecycle_revision: 7,
+    activation_generation: PREVIOUS_ACTIVATION_GENERATION,
+    activation_previous_generation: null,
+    activation_lifecycle_revision: 7n,
+    activation_purpose: "provision",
+    activation_phase: "active",
+    activation_receipt: {} as never,
+    activation_receipt_hash: OTHER_SHA,
+    activation_container_id: OLD_CONTAINER,
+    activation_node_id: "canonical-node",
+    activation_image_digest: CANONICAL_IMAGE_DIGEST,
+    activation_token_hash: OTHER_TOKEN_SHA,
+    activation_token_ciphertext: "old-ciphertext",
+    activation_boot_id: PREVIOUS_BOOT_ID,
+    activation_authority_published_at: publishedAt,
+    activation_funding_revision: 0n,
+    activation_dispatched_at: dispatchedAt,
+    activation_completed_at: completedAt,
+  });
+  await dbWrite.insert(agentBackupCatalogAuthorities).values({
+    organization_id: ORG_ID,
+    agent_id: AGENT_ID,
+    catalog_revision: 3n,
+  });
+  await dbWrite.insert(agentSandboxBackups).values({
+    id: BACKUP_ID,
+    sandbox_record_id: AGENT_ID,
+    snapshot_type: "auto",
+    state_data: { memories: [], config: {}, workspaceFiles: {} },
+    state_data_storage: "inline",
+    size_bytes: 92,
+    backup_kind: "full",
+    backup_operation_id: BACKUP_OPERATION_ID,
+    catalog_version: 2,
+    catalog_state: "protected",
+    catalog_payload_digest: HASH,
+    catalog_revision: 0n,
+    catalog_organization_id: ORG_ID,
+    catalog_agent_id: AGENT_ID,
+    lifecycle_generation: SOURCE_ACTIVATION_GENERATION,
+    lifecycle_revision: 4n,
+    source_provider: "operator-onboarded",
+    source_node_record_id: SOURCE_NODE_RECORD_ID,
+    source_node_id: "restore-source",
+    source_node_incarnation: PREVIOUS_BOOT_ID,
+    source_provider_server_id: null,
+    source_provider_handle: "restore-source-handle",
+    source_container_id: OLD_CONTAINER,
+    retention_reason: "schedule",
+    retention_until: new Date("2026-12-01T00:00:00.000Z"),
+    manifest_format: "elizaos.agent-backup",
+    manifest_version: 3,
+    manifest_digest: manifestFixture.digest,
+    manifest_canonical_draft: manifestFixture.canonicalDraft,
+    manifest_object_count: 1,
+    object_inventory_digest: HASH,
+    image_digest: IMAGE_DIGEST,
+    database_schema_version: "1",
+    plugin_set_digest: HASH,
+    watermark_digest: HASH,
+    raw_size_bytes: 1,
+    compressed_size_bytes: 1,
+    encrypted_size_bytes: 92,
+    kms_key_id: `org:${ORG_ID}/backup/v1`,
+    kms_key_version: 1,
+    operation_key_bundle_generation_id: KEY_BUNDLE_GENERATION_ID,
+    operation_key_bundle_format: "kms-aead-operation-key-bundle-v1",
+    operation_key_bundle_ref: `backup-key-bundle:${BACKUP_OPERATION_ID}`,
+    operation_key_bundle_ciphertext_base64: KEY_BUNDLE,
+    operation_key_bundle_sha256: HASH,
+    operation_key_bundle_size_bytes: 92,
+    operation_key_bundle_context: "{}",
+    operation_key_bundle_context_derivation: "elizaos.agent-backup.operation-key-bundle-context.v1",
+    operation_key_bundle_local_receipt_derivation:
+      "elizaos.kms-aead-operation-key-bundle.local-receipt.v1",
+    operation_key_bundle_local_receipt_digest: HASH,
+    vault_key_generation_id: VAULT_GENERATION_ID,
+    vault_key_authority_receipt_digest: HASH,
+  });
+  const createdAt = new Date(Date.now() - 60_000);
+  const expiresAt = new Date(Date.now() + 600_000);
+  const [lease] = await dbWrite
+    .insert(agentBackupRestoreLeases)
+    .values({
+      id: LEASE_ID,
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      backup_id: BACKUP_ID,
+      operation_id: BACKUP_OPERATION_ID,
+      activation_generation: SOURCE_ACTIVATION_GENERATION,
+      lifecycle_revision: 4n,
+      expected_manifest_sha256: manifestFixture.digest,
+      copy_role: "primary",
+      restore_attempt_id: RESTORE_ATTEMPT_ID,
+      owner_id: "restore-worker",
+      generation: LEASE_GENERATION,
+      catalog_epoch: 3n,
+      created_at: createdAt,
+      expires_at: expiresAt,
+    })
+    .returning();
+  if (!lease) throw new Error("restore lease fixture was not inserted");
+  const opened = await openAgentBackupRestoreOperation({
+    authority: leaseAuthorityReceipt(lease, createdAt),
+    leaseId: LEASE_ID,
+  });
+  const claimed = await claimAgentBackupRestoreOperation({
+    operationId: opened.operation.id,
+    ownerId: "restore-worker",
+    claimMs: 300_000,
+  });
+  await reserveAgentBackupRestoreTarget({
+    operationId: opened.operation.id,
+    ownerId: "restore-worker",
+    claimGeneration: claimed.claimGeneration,
+    targetNodeRecordId: TARGET_NODE_RECORD_ID,
+    targetNodeIncarnation: TARGET_NODE_INCARNATION,
+  });
+  operationId = opened.operation.id;
+  initialClaimGeneration = claimed.claimGeneration;
+}
+
+async function openAndClaimVaultSeeded(): Promise<string> {
+  await openAgentBackupRestoreQuarantine(openInput());
+  await advanceAgentBackupRestoreOperation({
+    operationId,
+    ownerId: "restore-worker",
+    claimGeneration: initialClaimGeneration,
+    fromPhase: "reserved",
+    toPhase: "vault_seeded",
+  });
+  const claim = await claimAgentBackupRestoreOperation({
+    operationId,
+    ownerId: "restore-worker",
+    claimMs: 60_000,
+  });
+  return claim.claimGeneration;
+}
+
+async function readRows() {
+  const [sandbox] = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, AGENT_ID));
+  const [operation] = await dbWrite
+    .select()
+    .from(agentBackupRestoreOperations)
+    .where(eq(agentBackupRestoreOperations.id, operationId));
+  const [node] = await dbWrite
+    .select()
+    .from(dockerNodes)
+    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+  if (!sandbox || !operation || !node) throw new Error("fixture rows are missing");
+  return { sandbox, operation, node };
+}
+
+beforeAll(async () => {
+  try {
+    manifestFixture = await buildManifestFixture();
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentSandboxes,
+        agentSandboxBackups,
+        agentBackupCatalogAuthorities,
+        agentBackupRestoreLeases,
+        agentBackupRestoreOperations,
+        agentNodeIncarnationHistories,
+        dockerNodes,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+    // pushSchema creates the shape, while deployed databases also have the
+    // lifecycle trigger. Install that authority so the CAS is tested honestly.
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION test_advance_agent_sandbox_lifecycle_revision()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+        RETURN NEW;
+      END;
+      $$
+    `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE TRIGGER test_agent_sandboxes_lifecycle_revision_trigger
+      BEFORE UPDATE ON agent_sandboxes
+      FOR EACH ROW EXECUTE FUNCTION test_advance_agent_sandbox_lifecycle_revision()
+    `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION test_journal_node_incarnation()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.node_incarnation IS NULL THEN RETURN NEW; END IF;
+        INSERT INTO agent_node_incarnation_histories (
+          docker_node_record_id, node_id, node_incarnation, fleet_kind,
+          infrastructure_provider, provider_server_id, host_key_fingerprint, attested_at
+        ) VALUES (
+          NEW.id, NEW.node_id, NEW.node_incarnation, NEW.fleet_kind,
+          NEW.infrastructure_provider, NEW.provider_server_id, NEW.host_key_fingerprint,
+          clock_timestamp()
+        ) ON CONFLICT (docker_node_record_id, node_incarnation) DO NOTHING;
+        RETURN NEW;
+      END;
+      $$
+    `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE TRIGGER test_docker_nodes_incarnation_history
+      BEFORE INSERT OR UPDATE OF node_id, node_incarnation, fleet_kind,
+        infrastructure_provider, provider_server_id, host_key_fingerprint
+      ON docker_nodes FOR EACH ROW EXECUTE FUNCTION test_journal_node_incarnation()
+    `),
+    );
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(agentBackupRestoreOperations);
+  await dbWrite.delete(agentBackupRestoreLeases);
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
+  await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentBackupCatalogAuthorities);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+  await seedFixture();
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("restore activation quarantine", () => {
+  test("keeps both writers on backup-operation-lease-sandbox-node-catalogue lock order", () => {
+    expectCanonicalQuarantineLockOrder(
+      quarantineTransactionBody(
+        "openAgentBackupRestoreQuarantine",
+        "recordAgentBackupRestoreQuarantinedContainer",
+      ),
+    );
+    expectCanonicalQuarantineLockOrder(
+      quarantineTransactionBody("recordAgentBackupRestoreQuarantinedContainer"),
+    );
+  });
+
+  test(
+    "opens once, replays exactly, derives the target generation, and preserves the canonical route",
+    async () => {
+      const before = await readRows();
+      const results = await Promise.all([
+        openAgentBackupRestoreQuarantine(openInput()),
+        openAgentBackupRestoreQuarantine(openInput()),
+      ]);
+      expect(results.filter((result) => !result.replayed)).toHaveLength(1);
+      expect(results.filter((result) => result.replayed)).toHaveLength(1);
+
+      const { sandbox, operation, node } = await readRows();
+      expect(sandbox.activation_generation).toBe(RESTORE_ATTEMPT_ID);
+      expect(sandbox.activation_generation).not.toBe(SOURCE_ACTIVATION_GENERATION);
+      expect(sandbox.activation_previous_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+      expect(sandbox.activation_lifecycle_revision).toBe(BigInt(sandbox.lifecycle_revision));
+      expect(sandbox.lifecycle_revision).toBe(8);
+      expect(sandbox.activation_purpose).toBe("restore");
+      expect(sandbox.activation_phase).toBe("container_pending");
+      expect(sandbox.activation_backup_id).toBe(BACKUP_ID);
+      expect(sandbox.activation_backup_hash).toBe(manifestFixture.digest);
+      expect(sandbox.activation_token_hash).toBe(TOKEN_SHA);
+      expect(sandbox.activation_token_ciphertext).toBe(TOKEN_CIPHERTEXT);
+      expect([
+        sandbox.activation_receipt,
+        sandbox.activation_receipt_hash,
+        sandbox.activation_container_id,
+        sandbox.activation_node_id,
+        sandbox.activation_image_digest,
+        sandbox.activation_boot_id,
+        sandbox.activation_authority_published_at,
+        sandbox.activation_funding_revision,
+        sandbox.activation_dispatched_at,
+        sandbox.activation_completed_at,
+      ]).toEqual(Array.from({ length: 10 }, () => null));
+      expect({
+        sandbox_id: sandbox.sandbox_id,
+        node_id: sandbox.node_id,
+        image_digest: sandbox.image_digest,
+        status: sandbox.status,
+      }).toEqual({
+        sandbox_id: before.sandbox.sandbox_id,
+        node_id: before.sandbox.node_id,
+        image_digest: before.sandbox.image_digest,
+        status: before.sandbox.status,
+      });
+      expect(operation.phase).toBe("reserved");
+      expect(operation.claim_generation).toBe(initialClaimGeneration);
+      expect(node.allocated_count).toBe(1);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "makes token and backup divergence conflicts without rewriting quarantine authority",
+    async () => {
+      await openAgentBackupRestoreQuarantine(openInput());
+      const opened = await readRows();
+      await expect(
+        openAgentBackupRestoreQuarantine({
+          ...openInput(),
+          activationTokenSha256: OTHER_TOKEN_SHA,
+        }),
+      ).rejects.toThrow("replay authority mismatch");
+      expect((await readRows()).sandbox.lifecycle_revision).toBe(opened.sandbox.lifecycle_revision);
+
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          activation_backup_hash: OTHER_SHA,
+          activation_lifecycle_revision: sql`${agentSandboxes.lifecycle_revision} + 1`,
+        })
+        .where(eq(agentSandboxes.id, AGENT_ID));
+      const divergent = await readRows();
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "replay authority mismatch",
+      );
+      const after = await readRows();
+      expect(after.sandbox.activation_backup_hash).toBe(OTHER_SHA);
+      expect(after.sandbox.lifecycle_revision).toBe(divergent.sandbox.lifecycle_revision);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects lost claims, expired leases, and catalogue drift before any sandbox write",
+    async () => {
+      await dbWrite
+        .update(agentBackupRestoreOperations)
+        .set({ expected_container_id: CONTAINER_A })
+        .where(eq(agentBackupRestoreOperations.id, operationId));
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "pre-existing container authority",
+      );
+      await dbWrite
+        .update(agentBackupRestoreOperations)
+        .set({ expected_container_id: null })
+        .where(eq(agentBackupRestoreOperations.id, operationId));
+
+      await expect(
+        openAgentBackupRestoreQuarantine({
+          ...openInput(),
+          claimGeneration: LEASE_GENERATION,
+        }),
+      ).rejects.toThrow("claim is not live");
+      expect((await readRows()).sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+
+      await dbWrite
+        .update(agentBackupRestoreLeases)
+        .set({ expires_at: new Date(Date.now() - 1_000) })
+        .where(eq(agentBackupRestoreLeases.id, LEASE_ID));
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "lease is expired or released",
+      );
+      await dbWrite
+        .update(agentBackupRestoreLeases)
+        .set({ expires_at: new Date(Date.now() + 600_000) })
+        .where(eq(agentBackupRestoreLeases.id, LEASE_ID));
+
+      await dbWrite
+        .update(agentBackupCatalogAuthorities)
+        .set({ catalog_revision: 4n })
+        .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "invalidated by a catalogue revision",
+      );
+      const after = await readRows();
+      expect(after.sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+      expect(after.sandbox.lifecycle_revision).toBe(7);
+      expect(after.node.allocated_count).toBe(1);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects a true target-node A-to-B-to-A incarnation replay without mutation",
+    async () => {
+      await dbWrite
+        .update(dockerNodes)
+        .set({ node_incarnation: OTHER_NODE_INCARNATION })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await dbWrite
+        .update(dockerNodes)
+        .set({ node_incarnation: TARGET_NODE_INCARNATION })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      expect((await readRows()).node.node_incarnation).toBe(TARGET_NODE_INCARNATION);
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "ambiguous multi-incarnation history",
+      );
+      const after = await readRows();
+      expect(after.sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+      expect(after.operation.phase).toBe("reserved");
+      expect(after.operation.expected_container_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects an ancient backdated B history before the first quarantine write",
+    async () => {
+      const [history] = await dbWrite
+        .select()
+        .from(agentNodeIncarnationHistories)
+        .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
+      if (!history) throw new Error("restore target history fixture is missing");
+      await dbWrite.insert(agentNodeIncarnationHistories).values({
+        docker_node_record_id: history.docker_node_record_id,
+        node_id: history.node_id,
+        node_incarnation: OTHER_NODE_INCARNATION,
+        fleet_kind: history.fleet_kind,
+        infrastructure_provider: history.infrastructure_provider,
+        provider_server_id: history.provider_server_id,
+        host_key_fingerprint: history.host_key_fingerprint,
+        attested_at: new Date("2000-01-01T00:00:00.000Z"),
+      });
+
+      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+        "ambiguous multi-incarnation history",
+      );
+      const after = await readRows();
+      expect(after.sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+      expect(after.operation.phase).toBe("reserved");
+      expect(after.operation.expected_container_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects first placement after node eligibility drift but preserves exact open replay",
+    async () => {
+      const ineligibleStates = [
+        { enabled: false },
+        { enabled: true, status: "degraded" as const },
+        { status: "healthy" as const, placement_state: "cordoned" as const },
+        { placement_state: "open" as const, metadata: { capacityProvisional: true } },
+      ];
+      for (const state of ineligibleStates) {
+        await dbWrite
+          .update(dockerNodes)
+          .set({
+            enabled: true,
+            status: "healthy",
+            placement_state: "open",
+            metadata: {},
+            ...state,
+          })
+          .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+        await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
+          "no longer eligible for first placement",
+        );
+        expect((await readRows()).sandbox.activation_generation).toBe(
+          PREVIOUS_ACTIVATION_GENERATION,
+        );
+      }
+
+      await dbWrite
+        .update(dockerNodes)
+        .set({ enabled: true, status: "healthy", placement_state: "open", metadata: {} })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await openAgentBackupRestoreQuarantine(openInput());
+      await dbWrite
+        .update(dockerNodes)
+        .set({
+          enabled: false,
+          status: "degraded",
+          placement_state: "cordoned",
+          metadata: { capacityProvisional: true },
+        })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      const replay = await openAgentBackupRestoreQuarantine(openInput());
+      expect(replay.replayed).toBe(true);
+      expect(replay.sandbox.activation_phase).toBe("container_pending");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "records one exact container atomically, clears the claim, and replays without rewind",
+    async () => {
+      const claimGeneration = await openAndClaimVaultSeeded();
+      const request = {
+        operationId,
+        ownerId: "restore-worker",
+        claimGeneration,
+        containerId: CONTAINER_A,
+        expectedActivationTokenSha256: TOKEN_SHA,
+      } as const;
+      const results = await Promise.all([
+        recordAgentBackupRestoreQuarantinedContainer(request),
+        recordAgentBackupRestoreQuarantinedContainer(request),
+      ]);
+      expect(results.filter((result) => !result.replayed)).toHaveLength(1);
+      expect(results.filter((result) => result.replayed)).toHaveLength(1);
+
+      const replay = await recordAgentBackupRestoreQuarantinedContainer(request);
+      expect(replay.replayed).toBe(true);
+      const { sandbox, operation, node } = await readRows();
+      expect(sandbox.activation_generation).toBe(RESTORE_ATTEMPT_ID);
+      expect(sandbox.activation_phase).toBe("restore_pending");
+      expect(sandbox.activation_container_id).toBe(CONTAINER_A);
+      expect(sandbox.activation_node_id).toBe("restore-target");
+      expect(sandbox.activation_image_digest).toBe(IMAGE_DIGEST);
+      expect(sandbox.activation_boot_id).toBe(TARGET_NODE_INCARNATION);
+      expect(sandbox.activation_lifecycle_revision).toBe(BigInt(sandbox.lifecycle_revision));
+      expect(sandbox.lifecycle_revision).toBe(9);
+      expect(sandbox.activation_authority_published_at).toBeNull();
+      expect(sandbox.activation_dispatched_at).toBeNull();
+      expect(sandbox.activation_completed_at).toBeNull();
+      expect(sandbox.sandbox_id).toBe("canonical-provider-handle");
+      expect(sandbox.node_id).toBe("canonical-node");
+      expect(sandbox.image_digest).toBe(CANONICAL_IMAGE_DIGEST);
+      expect(sandbox.status).toBe("running");
+      expect(operation.phase).toBe("container_created");
+      expect(operation.expected_container_id).toBe(CONTAINER_A);
+      expect(operation.claim_owner).toBeNull();
+      expect(operation.claim_generation).toBeNull();
+      expect(operation.claim_expires_at).toBeNull();
+      expect(node.allocated_count).toBe(1);
+
+      await expect(
+        recordAgentBackupRestoreQuarantinedContainer({
+          ...request,
+          containerId: CONTAINER_B,
+        }),
+      ).rejects.toThrow("replay authority mismatch");
+      expect((await readRows()).operation.expected_container_id).toBe(CONTAINER_A);
+
+      await dbWrite
+        .update(dockerNodes)
+        .set({
+          enabled: false,
+          status: "degraded",
+          placement_state: "cordoned",
+          metadata: { capacityProvisional: true },
+        })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      expect((await recordAgentBackupRestoreQuarantinedContainer(request)).replayed).toBe(true);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "allows only one concurrent divergent container contender",
+    async () => {
+      const claimGeneration = await openAndClaimVaultSeeded();
+      const base = {
+        operationId,
+        ownerId: "restore-worker",
+        claimGeneration,
+        expectedActivationTokenSha256: TOKEN_SHA,
+      } as const;
+      const outcomes = await Promise.allSettled([
+        recordAgentBackupRestoreQuarantinedContainer({ ...base, containerId: CONTAINER_A }),
+        recordAgentBackupRestoreQuarantinedContainer({ ...base, containerId: CONTAINER_B }),
+      ]);
+      expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+      expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+      const { sandbox, operation } = await readRows();
+      expect([CONTAINER_A, CONTAINER_B]).toContain(operation.expected_container_id);
+      expect(sandbox.activation_container_id).toBe(operation.expected_container_id);
+      expect(operation.phase).toBe("container_created");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects container recording after node loss without partial phase writes",
+    async () => {
+      const claimGeneration = await openAndClaimVaultSeeded();
+      const request = {
+        operationId,
+        ownerId: "restore-worker",
+        claimGeneration,
+        containerId: CONTAINER_A,
+        expectedActivationTokenSha256: TOKEN_SHA,
+      } as const;
+      await dbWrite
+        .update(dockerNodes)
+        .set({ node_incarnation: OTHER_NODE_INCARNATION })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await expect(recordAgentBackupRestoreQuarantinedContainer(request)).rejects.toThrow(
+        "node incarnation changed",
+      );
+      const after = await readRows();
+      expect(after.sandbox.activation_phase).toBe("container_pending");
+      expect(after.sandbox.activation_container_id).toBeNull();
+      expect(after.operation.phase).toBe("vault_seeded");
+      expect(after.operation.expected_container_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rejects first container binding after placement or lease loss without partial writes",
+    async () => {
+      const claimGeneration = await openAndClaimVaultSeeded();
+      const request = {
+        operationId,
+        ownerId: "restore-worker",
+        claimGeneration,
+        containerId: CONTAINER_A,
+        expectedActivationTokenSha256: TOKEN_SHA,
+      } as const;
+      await dbWrite
+        .update(dockerNodes)
+        .set({ placement_state: "cordoned" })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await expect(recordAgentBackupRestoreQuarantinedContainer(request)).rejects.toThrow(
+        "no longer eligible for first placement",
+      );
+      let after = await readRows();
+      expect(after.sandbox.activation_phase).toBe("container_pending");
+      expect(after.operation.phase).toBe("vault_seeded");
+
+      await dbWrite
+        .update(dockerNodes)
+        .set({ placement_state: "open" })
+        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      await dbWrite
+        .update(agentBackupRestoreLeases)
+        .set({ expires_at: new Date(Date.now() - 1_000) })
+        .where(eq(agentBackupRestoreLeases.id, LEASE_ID));
+      await expect(recordAgentBackupRestoreQuarantinedContainer(request)).rejects.toThrow(
+        "lease is expired or released",
+      );
+      after = await readRows();
+      expect(after.sandbox.activation_phase).toBe("container_pending");
+      expect(after.operation.phase).toBe("vault_seeded");
+      expect(after.operation.claim_generation).toBe(claimGeneration);
+    },
+    TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
@@ -646,9 +646,11 @@ export async function reserveAgentBackupRestoreTarget(params: {
 }
 
 /**
- * Advance one phase under a live claim, optionally recording the side effect's
- * identity in the same statement that moves the phase — so the record and the
- * transition cannot disagree.
+ * Advance one generic phase under a live claim. First container binding is
+ * excluded: its dedicated quarantine writer must update the sandbox ledger and
+ * operation in one transaction. A retry may re-enter an already-bound
+ * `container_created` phase without rewriting that identity. Finalization still
+ * records its receipt in the same statement as the phase transition.
  */
 export async function advanceAgentBackupRestoreOperation(params: {
   operationId: string;
@@ -656,9 +658,6 @@ export async function advanceAgentBackupRestoreOperation(params: {
   claimGeneration: string;
   fromPhase: AgentBackupRestorePhase;
   toPhase: AgentBackupRestorePhase;
-  recordedIdentity?: {
-    containerId?: string;
-  };
   receiptDigest?: string;
 }): Promise<Readonly<AgentBackupRestoreOperation>> {
   const operationId = requireUuid(params.operationId, "operationId");
@@ -678,8 +677,20 @@ export async function advanceAgentBackupRestoreOperation(params: {
   } else if (toRank < 0) {
     throw new AgentBackupCatalogConflictError(`${params.toPhase} is not a resumable phase`);
   }
-  const identity = params.recordedIdentity ?? {};
-  if (identity.containerId !== undefined) requireSha256(identity.containerId, "containerId");
+  const resumingRecordedContainer = resuming && params.toPhase === "container_created";
+  if (params.toPhase === "container_created" && !resumingRecordedContainer) {
+    throw new AgentBackupCatalogConflictError(
+      "Restore container creation must be recorded through quarantine authority",
+    );
+  }
+  // Fail closed for structurally typed or JavaScript callers still sending the
+  // retired generic identity bag. The quarantine writer is the only API allowed
+  // to bind a container id and advance the matching phase atomically.
+  if ("recordedIdentity" in params) {
+    throw new AgentBackupCatalogConflictError(
+      "Generic restore advance cannot record a container identity",
+    );
+  }
   if (params.receiptDigest !== undefined) requireSha256(params.receiptDigest, "receiptDigest");
   if ((params.toPhase === "finalized") !== (params.receiptDigest !== undefined)) {
     throw new AgentBackupCatalogConflictError(
@@ -744,6 +755,11 @@ export async function advanceAgentBackupRestoreOperation(params: {
         `Restore operation must resume ${operation.resume_phase}, not ${params.toPhase}`,
       );
     }
+    if (resumingRecordedContainer && operation.expected_container_id === null) {
+      throw new AgentBackupCatalogConflictError(
+        "Restore operation cannot resume container_created without a recorded container identity",
+      );
+    }
 
     const [advanced] = await tx
       .update(agentBackupRestoreOperations)
@@ -753,9 +769,6 @@ export async function advanceAgentBackupRestoreOperation(params: {
         claim_owner: null,
         claim_generation: null,
         claim_expires_at: null,
-        ...(identity.containerId !== undefined
-          ? { expected_container_id: identity.containerId }
-          : {}),
         ...(params.receiptDigest !== undefined
           ? { receipt_digest: params.receiptDigest, completed_at: databaseNow }
           : {}),
@@ -771,6 +784,9 @@ export async function advanceAgentBackupRestoreOperation(params: {
                 isNotNull(agentBackupRestoreOperations.expected_node_incarnation),
                 isNotNull(agentBackupRestoreOperations.expected_image_digest),
               )
+            : undefined,
+          resumingRecordedContainer
+            ? isNotNull(agentBackupRestoreOperations.expected_container_id)
             : undefined,
         ),
       )

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-quarantine.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-quarantine.ts
@@ -1,0 +1,745 @@
+/**
+ * Database-only authority for a restore container that is not yet routable.
+ *
+ * These writers deliberately stop before Docker, SSH, registry, Redis, or
+ * route publication.  The restore attempt id is the target activation
+ * generation; callers cannot substitute the source generation or mint a
+ * second identity for the same attempt.
+ */
+
+import { Buffer } from "node:buffer";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { requireBoundedIdentity } from "../../lib/services/agent-backup-catalog-state";
+import { isValidUUID } from "../../lib/utils/validation";
+import { dbWrite } from "../helpers";
+import {
+  type AgentBackupRestoreOperation,
+  agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
+} from "../schemas/agent-backup-catalog";
+import { type AgentSandbox, agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
+import { dockerNodes, PLACEABLE_NODE_STATE } from "../schemas/docker-nodes";
+import {
+  AgentBackupCatalogConflictError,
+  lockAgentBackupCatalogAuthority,
+} from "./agent-backup-catalog";
+import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
+import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
+import { readPostLockDatabaseNow } from "./primary-database-clock";
+
+const MAX_TOKEN_CIPHERTEXT_BYTES = 16_384;
+
+export interface OpenAgentBackupRestoreQuarantineInput {
+  operationId: string;
+  ownerId: string;
+  claimGeneration: string;
+  activationTokenSha256: string;
+  activationTokenCiphertext: string;
+}
+
+export interface RecordAgentBackupRestoreQuarantinedContainerInput {
+  operationId: string;
+  ownerId: string;
+  claimGeneration: string;
+  containerId: string;
+  expectedActivationTokenSha256: string;
+}
+
+export interface AgentBackupRestoreQuarantineResult {
+  operation: Readonly<AgentBackupRestoreOperation>;
+  sandbox: Readonly<AgentSandbox>;
+  replayed: boolean;
+}
+
+function conflict(message: string): never {
+  throw new AgentBackupCatalogConflictError(message);
+}
+
+function requireUuid(value: string, field: string): string {
+  if (!isValidUUID(value) || value !== value.toLowerCase()) {
+    throw new AgentBackupCatalogConflictError(`${field} must be a canonical lowercase UUID`);
+  }
+  return value;
+}
+
+function requireSha256(value: string, field: string): string {
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw new AgentBackupCatalogConflictError(`${field} must be a lowercase sha256 digest`);
+  }
+  return value;
+}
+
+function requireContainerId(value: string): string {
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw new AgentBackupCatalogConflictError(
+      "containerId must be a lowercase 64-character Docker ID",
+    );
+  }
+  return value;
+}
+
+function requireTokenCiphertext(value: string): string {
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes < 1 || bytes > MAX_TOKEN_CIPHERTEXT_BYTES || value.includes("\0")) {
+    throw new AgentBackupCatalogConflictError(
+      `activationTokenCiphertext must contain between 1 and ${MAX_TOKEN_CIPHERTEXT_BYTES} UTF-8 bytes`,
+    );
+  }
+  return value;
+}
+
+function immutableOperationAuthorityMatches(
+  operation: AgentBackupRestoreOperation,
+  authority: AgentBackupRestoreOperation,
+): boolean {
+  return (
+    operation.organization_id === authority.organization_id &&
+    operation.agent_id === authority.agent_id &&
+    operation.backup_id === authority.backup_id &&
+    operation.restore_attempt_id === authority.restore_attempt_id &&
+    operation.lease_id === authority.lease_id &&
+    operation.lease_generation === authority.lease_generation &&
+    operation.lease_owner_id === authority.lease_owner_id &&
+    operation.catalog_epoch === authority.catalog_epoch &&
+    operation.copy_role === authority.copy_role &&
+    operation.expected_operation_id === authority.expected_operation_id &&
+    operation.expected_manifest_sha256 === authority.expected_manifest_sha256 &&
+    operation.expected_activation_generation === authority.expected_activation_generation &&
+    operation.expected_lifecycle_revision === authority.expected_lifecycle_revision &&
+    operation.expected_node_record_id === authority.expected_node_record_id &&
+    operation.expected_node_incarnation === authority.expected_node_incarnation &&
+    operation.expected_image_digest === authority.expected_image_digest
+  );
+}
+
+function hasCompleteTargetAuthority(
+  operation: AgentBackupRestoreOperation,
+): operation is AgentBackupRestoreOperation & {
+  expected_node_record_id: string;
+  expected_node_incarnation: string;
+  expected_image_digest: string;
+} {
+  return (
+    operation.expected_node_record_id !== null &&
+    operation.expected_node_incarnation !== null &&
+    operation.expected_image_digest !== null
+  );
+}
+
+function isEligibleForFirstRestorePlacement(node: typeof dockerNodes.$inferSelect): boolean {
+  return (
+    node.enabled &&
+    node.status === "healthy" &&
+    node.placement_state === PLACEABLE_NODE_STATE &&
+    node.metadata.capacityProvisional !== true
+  );
+}
+
+function hasCurrentActivationLifecycle(sandbox: AgentSandbox): boolean {
+  return (
+    sandbox.activation_lifecycle_revision !== null &&
+    sandbox.activation_lifecycle_revision === BigInt(sandbox.lifecycle_revision)
+  );
+}
+
+function hasCommonRestoreQuarantineAuthority(params: {
+  sandbox: AgentSandbox;
+  operation: AgentBackupRestoreOperation;
+  tokenSha256: string;
+}): boolean {
+  const { sandbox, operation } = params;
+  return (
+    sandbox.activation_generation === operation.restore_attempt_id &&
+    hasCurrentActivationLifecycle(sandbox) &&
+    sandbox.activation_purpose === "restore" &&
+    sandbox.activation_backup_id === operation.backup_id &&
+    sandbox.activation_backup_hash === operation.expected_manifest_sha256 &&
+    sandbox.activation_token_hash === params.tokenSha256 &&
+    typeof sandbox.activation_token_ciphertext === "string" &&
+    Buffer.byteLength(sandbox.activation_token_ciphertext, "utf8") >= 1 &&
+    Buffer.byteLength(sandbox.activation_token_ciphertext, "utf8") <= MAX_TOKEN_CIPHERTEXT_BYTES &&
+    sandbox.activation_receipt === null &&
+    sandbox.activation_receipt_hash === null &&
+    sandbox.activation_authority_published_at === null &&
+    sandbox.activation_funding_revision === null &&
+    sandbox.activation_dispatched_at === null &&
+    sandbox.activation_completed_at === null &&
+    sandbox.activation_consent_lifecycle_revision === null &&
+    sandbox.activation_consent_head_backup_id === null &&
+    sandbox.activation_consent_head_backup_hash === null
+  );
+}
+
+function isExactOpenReplay(params: {
+  sandbox: AgentSandbox;
+  operation: AgentBackupRestoreOperation;
+  tokenSha256: string;
+  tokenCiphertext: string;
+}): boolean {
+  return (
+    hasCommonRestoreQuarantineAuthority(params) &&
+    params.sandbox.activation_phase === "container_pending" &&
+    params.sandbox.activation_token_ciphertext === params.tokenCiphertext &&
+    params.sandbox.activation_container_id === null &&
+    params.sandbox.activation_node_id === null &&
+    params.sandbox.activation_image_digest === null &&
+    params.sandbox.activation_boot_id === null
+  );
+}
+
+function isExactContainerReplay(params: {
+  sandbox: AgentSandbox;
+  operation: AgentBackupRestoreOperation;
+  tokenSha256: string;
+  containerId: string;
+  nodeId: string;
+}): boolean {
+  const { sandbox, operation } = params;
+  return (
+    hasCompleteTargetAuthority(operation) &&
+    hasCommonRestoreQuarantineAuthority(params) &&
+    sandbox.activation_phase === "restore_pending" &&
+    sandbox.activation_container_id === params.containerId &&
+    sandbox.activation_node_id === params.nodeId &&
+    sandbox.activation_image_digest === operation.expected_image_digest &&
+    sandbox.activation_boot_id === operation.expected_node_incarnation
+  );
+}
+
+/**
+ * Open the mutable activation quarantine for a reserved restore target.
+ *
+ * The canonical route (`sandbox_id`, `node_id`, `image_digest`, and `status`)
+ * is intentionally untouched. Definition-only: no production caller may use
+ * this until restore allocation ownership has a durable settlement path and
+ * node authority carries a durable incarnation-occurrence token.
+ */
+export async function openAgentBackupRestoreQuarantine(
+  input: Readonly<OpenAgentBackupRestoreQuarantineInput>,
+): Promise<AgentBackupRestoreQuarantineResult> {
+  const operationId = requireUuid(input.operationId, "operationId");
+  const claimGeneration = requireUuid(input.claimGeneration, "claimGeneration");
+  requireBoundedIdentity(input.ownerId, "ownerId");
+  const tokenSha256 = requireSha256(input.activationTokenSha256, "activationTokenSha256");
+  const tokenCiphertext = requireTokenCiphertext(input.activationTokenCiphertext);
+
+  // Immutable pre-read supplies keys for the global backup -> operation ->
+  // lease -> sandbox -> node -> catalogue lock order. It is compared again
+  // after locking and never authorizes a write by itself.
+  const [operationAuthority] = await dbWrite
+    .select()
+    .from(agentBackupRestoreOperations)
+    .where(eq(agentBackupRestoreOperations.id, operationId))
+    .limit(1);
+  if (!operationAuthority) conflict("Restore operation is missing");
+  if (!hasCompleteTargetAuthority(operationAuthority)) {
+    conflict("Restore quarantine requires complete reserved target authority");
+  }
+
+  return dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, operationAuthority.backup_id),
+          eq(agentSandboxBackups.catalog_organization_id, operationAuthority.organization_id),
+          eq(agentSandboxBackups.catalog_agent_id, operationAuthority.agent_id),
+          eq(agentSandboxBackups.backup_operation_id, operationAuthority.expected_operation_id),
+          eq(
+            agentSandboxBackups.lifecycle_generation,
+            operationAuthority.expected_activation_generation,
+          ),
+          eq(
+            agentSandboxBackups.lifecycle_revision,
+            operationAuthority.expected_lifecycle_revision,
+          ),
+          eq(agentSandboxBackups.manifest_digest, operationAuthority.expected_manifest_sha256),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !backup ||
+      !hasAgentBackupRestoreAuthority(backup.catalog_state) ||
+      backup.manifest_version !== 3 ||
+      !backup.manifest_canonical_draft ||
+      backup.image_digest !== operationAuthority.expected_image_digest
+    ) {
+      conflict("Restore quarantine source lost exact manifest-v3 authority");
+    }
+
+    const [operation] = await tx
+      .select()
+      .from(agentBackupRestoreOperations)
+      .where(eq(agentBackupRestoreOperations.id, operationId))
+      .for("update")
+      .limit(1);
+    if (!operation || !immutableOperationAuthorityMatches(operation, operationAuthority)) {
+      conflict("Restore operation authority changed before quarantine lock");
+    }
+    if (!hasCompleteTargetAuthority(operation)) {
+      conflict("Restore quarantine requires complete reserved target authority");
+    }
+    if (operation.phase !== "reserved") {
+      conflict(`Restore quarantine cannot open while operation is in ${operation.phase}`);
+    }
+    if (operation.expected_container_id !== null) {
+      conflict("Restore quarantine cannot open with pre-existing container authority");
+    }
+
+    const [lease] = await tx
+      .select()
+      .from(agentBackupRestoreLeases)
+      .where(
+        and(
+          eq(agentBackupRestoreLeases.id, operation.lease_id),
+          eq(agentBackupRestoreLeases.organization_id, operation.organization_id),
+          eq(agentBackupRestoreLeases.agent_id, operation.agent_id),
+          eq(agentBackupRestoreLeases.backup_id, operation.backup_id),
+          eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+          eq(
+            agentBackupRestoreLeases.activation_generation,
+            operation.expected_activation_generation,
+          ),
+          eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
+          eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+          eq(agentBackupRestoreLeases.restore_attempt_id, operation.restore_attempt_id),
+          eq(agentBackupRestoreLeases.owner_id, operation.lease_owner_id),
+          eq(agentBackupRestoreLeases.generation, operation.lease_generation),
+          eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!lease) conflict("Restore quarantine lease fence was lost");
+
+    const [sandbox] = await tx
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, operation.agent_id),
+          eq(agentSandboxes.organization_id, operation.organization_id),
+          isNull(agentSandboxes.deleted_at),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!sandbox) conflict("Restore quarantine sandbox is missing or deleted");
+
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, operation.expected_node_record_id))
+      .for("update")
+      .limit(1);
+    if (!node || node.node_incarnation !== operation.expected_node_incarnation || !node.node_id) {
+      conflict("Restore quarantine target node incarnation changed");
+    }
+    await proveUnambiguousAgentNodeIncarnationForLockedNode(
+      tx,
+      node,
+      operation.expected_node_incarnation,
+    );
+
+    // Every sandbox-bearing backup writer takes the mutable sandbox and node
+    // before the per-agent catalogue authority. Reversing this pair deadlocks
+    // against capture, vault seeding, or restore finalization on another
+    // backup in the same agent catalogue.
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      operation.organization_id,
+      operation.agent_id,
+    );
+    if (catalogAuthority.catalog_revision !== operation.catalog_epoch) {
+      conflict("Restore quarantine authority was invalidated by a catalogue revision");
+    }
+
+    const databaseNow = await readPostLockDatabaseNow(tx);
+    if (lease.released_at !== null || lease.expires_at <= databaseNow) {
+      conflict("Restore quarantine lease is expired or released");
+    }
+    if (
+      operation.lease_owner_id !== input.ownerId ||
+      operation.claim_owner !== input.ownerId ||
+      operation.claim_generation !== claimGeneration ||
+      operation.claim_expires_at === null ||
+      operation.claim_expires_at <= databaseNow
+    ) {
+      conflict("Restore quarantine operation claim is not live");
+    }
+
+    if (sandbox.activation_generation === operation.restore_attempt_id) {
+      if (
+        !isExactOpenReplay({
+          sandbox,
+          operation,
+          tokenSha256,
+          tokenCiphertext,
+        })
+      ) {
+        conflict("Restore quarantine replay authority mismatch");
+      }
+      return {
+        operation: Object.freeze(operation),
+        sandbox: Object.freeze(sandbox),
+        replayed: true,
+      };
+    }
+    if (!isEligibleForFirstRestorePlacement(node)) {
+      conflict("Restore quarantine target is no longer eligible for first placement");
+    }
+    if (
+      sandbox.activation_generation !== null &&
+      (sandbox.activation_phase !== "active" ||
+        sandbox.activation_purpose === null ||
+        !hasCurrentActivationLifecycle(sandbox))
+    ) {
+      conflict("Restore quarantine cannot replace a non-current activation authority");
+    }
+
+    const previousGeneration = sandbox.activation_generation;
+    const [opened] = await tx
+      .update(agentSandboxes)
+      .set({
+        activation_generation: operation.restore_attempt_id,
+        activation_previous_generation: previousGeneration,
+        // Activation fields participate in the lifecycle trigger. Stamp the
+        // post-update generation, never the stale pre-update generation.
+        activation_lifecycle_revision: sql`${agentSandboxes.lifecycle_revision} + 1`,
+        activation_purpose: "restore",
+        activation_phase: "container_pending",
+        activation_backup_id: operation.backup_id,
+        activation_backup_hash: operation.expected_manifest_sha256,
+        activation_receipt: null,
+        activation_receipt_hash: null,
+        activation_container_id: null,
+        activation_node_id: null,
+        activation_image_digest: null,
+        activation_token_hash: tokenSha256,
+        activation_token_ciphertext: tokenCiphertext,
+        activation_boot_id: null,
+        activation_authority_published_at: null,
+        activation_funding_revision: null,
+        activation_dispatched_at: null,
+        activation_completed_at: null,
+        activation_consent_lifecycle_revision: null,
+        activation_consent_head_backup_id: null,
+        activation_consent_head_backup_hash: null,
+        updated_at: databaseNow,
+      })
+      .where(
+        and(
+          eq(agentSandboxes.id, sandbox.id),
+          eq(agentSandboxes.organization_id, operation.organization_id),
+          eq(agentSandboxes.lifecycle_revision, sandbox.lifecycle_revision),
+          previousGeneration === null
+            ? isNull(agentSandboxes.activation_generation)
+            : eq(agentSandboxes.activation_generation, previousGeneration),
+          isNull(agentSandboxes.deleted_at),
+          sql`${agentSandboxes.lifecycle_revision} < 9223372036854775807`,
+        ),
+      )
+      .returning();
+    if (
+      !opened ||
+      !isExactOpenReplay({
+        sandbox: opened,
+        operation,
+        tokenSha256,
+        tokenCiphertext,
+      })
+    ) {
+      conflict("Restore quarantine open lost its lifecycle CAS");
+    }
+    return {
+      operation: Object.freeze(operation),
+      sandbox: Object.freeze(opened),
+      replayed: false,
+    };
+  });
+}
+
+/**
+ * Bind an already-created immutable Docker container to the quarantine and
+ * atomically advance `vault_seeded -> container_created`.
+ *
+ * This function does not create, inspect, start, or publish the container.
+ * It remains definition-only under the same allocation and node-occurrence
+ * prerequisites as the quarantine opener.
+ */
+export async function recordAgentBackupRestoreQuarantinedContainer(
+  input: Readonly<RecordAgentBackupRestoreQuarantinedContainerInput>,
+): Promise<AgentBackupRestoreQuarantineResult> {
+  const operationId = requireUuid(input.operationId, "operationId");
+  const claimGeneration = requireUuid(input.claimGeneration, "claimGeneration");
+  requireBoundedIdentity(input.ownerId, "ownerId");
+  const containerId = requireContainerId(input.containerId);
+  const tokenSha256 = requireSha256(
+    input.expectedActivationTokenSha256,
+    "expectedActivationTokenSha256",
+  );
+
+  const [operationAuthority] = await dbWrite
+    .select()
+    .from(agentBackupRestoreOperations)
+    .where(eq(agentBackupRestoreOperations.id, operationId))
+    .limit(1);
+  if (!operationAuthority) conflict("Restore operation is missing");
+  if (!hasCompleteTargetAuthority(operationAuthority)) {
+    conflict("Quarantined container requires complete reserved target authority");
+  }
+
+  return dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, operationAuthority.backup_id),
+          eq(agentSandboxBackups.catalog_organization_id, operationAuthority.organization_id),
+          eq(agentSandboxBackups.catalog_agent_id, operationAuthority.agent_id),
+          eq(agentSandboxBackups.backup_operation_id, operationAuthority.expected_operation_id),
+          eq(
+            agentSandboxBackups.lifecycle_generation,
+            operationAuthority.expected_activation_generation,
+          ),
+          eq(
+            agentSandboxBackups.lifecycle_revision,
+            operationAuthority.expected_lifecycle_revision,
+          ),
+          eq(agentSandboxBackups.manifest_digest, operationAuthority.expected_manifest_sha256),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !backup ||
+      !hasAgentBackupRestoreAuthority(backup.catalog_state) ||
+      backup.manifest_version !== 3 ||
+      !backup.manifest_canonical_draft ||
+      backup.image_digest !== operationAuthority.expected_image_digest
+    ) {
+      conflict("Quarantined container source lost exact manifest-v3 authority");
+    }
+
+    const [operation] = await tx
+      .select()
+      .from(agentBackupRestoreOperations)
+      .where(eq(agentBackupRestoreOperations.id, operationId))
+      .for("update")
+      .limit(1);
+    if (!operation || !immutableOperationAuthorityMatches(operation, operationAuthority)) {
+      conflict("Restore operation authority changed before container lock");
+    }
+    if (!hasCompleteTargetAuthority(operation)) {
+      conflict("Quarantined container requires complete reserved target authority");
+    }
+    if (operation.phase !== "vault_seeded" && operation.phase !== "container_created") {
+      conflict(`Quarantined container cannot be recorded while operation is in ${operation.phase}`);
+    }
+
+    const [lease] = await tx
+      .select()
+      .from(agentBackupRestoreLeases)
+      .where(
+        and(
+          eq(agentBackupRestoreLeases.id, operation.lease_id),
+          eq(agentBackupRestoreLeases.organization_id, operation.organization_id),
+          eq(agentBackupRestoreLeases.agent_id, operation.agent_id),
+          eq(agentBackupRestoreLeases.backup_id, operation.backup_id),
+          eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+          eq(
+            agentBackupRestoreLeases.activation_generation,
+            operation.expected_activation_generation,
+          ),
+          eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
+          eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+          eq(agentBackupRestoreLeases.restore_attempt_id, operation.restore_attempt_id),
+          eq(agentBackupRestoreLeases.owner_id, operation.lease_owner_id),
+          eq(agentBackupRestoreLeases.generation, operation.lease_generation),
+          eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!lease) conflict("Quarantined container lease fence was lost");
+
+    const [sandbox] = await tx
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, operation.agent_id),
+          eq(agentSandboxes.organization_id, operation.organization_id),
+          isNull(agentSandboxes.deleted_at),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!sandbox) conflict("Quarantined container sandbox is missing or deleted");
+
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, operation.expected_node_record_id))
+      .for("update")
+      .limit(1);
+    if (!node || node.node_incarnation !== operation.expected_node_incarnation || !node.node_id) {
+      conflict("Quarantined container target node incarnation changed");
+    }
+    await proveUnambiguousAgentNodeIncarnationForLockedNode(
+      tx,
+      node,
+      operation.expected_node_incarnation,
+    );
+
+    const catalogAuthority = await lockAgentBackupCatalogAuthority(
+      tx,
+      operation.organization_id,
+      operation.agent_id,
+    );
+    if (catalogAuthority.catalog_revision !== operation.catalog_epoch) {
+      conflict("Quarantined container authority was invalidated by a catalogue revision");
+    }
+
+    const databaseNow = await readPostLockDatabaseNow(tx);
+    if (lease.released_at !== null || lease.expires_at <= databaseNow) {
+      conflict("Quarantined container lease is expired or released");
+    }
+    if (operation.lease_owner_id !== input.ownerId) {
+      conflict("Quarantined container owner differs from lease authority");
+    }
+
+    if (operation.phase === "container_created") {
+      if (
+        operation.expected_container_id !== containerId ||
+        operation.claim_owner !== null ||
+        operation.claim_generation !== null ||
+        operation.claim_expires_at !== null ||
+        !isExactContainerReplay({
+          sandbox,
+          operation,
+          tokenSha256,
+          containerId,
+          nodeId: node.node_id,
+        })
+      ) {
+        conflict("Quarantined container replay authority mismatch");
+      }
+      return {
+        operation: Object.freeze(operation),
+        sandbox: Object.freeze(sandbox),
+        replayed: true,
+      };
+    }
+
+    if (!isEligibleForFirstRestorePlacement(node)) {
+      conflict("Quarantined container target is no longer eligible for first placement");
+    }
+
+    if (
+      operation.expected_container_id !== null ||
+      operation.claim_owner !== input.ownerId ||
+      operation.claim_generation !== claimGeneration ||
+      operation.claim_expires_at === null ||
+      operation.claim_expires_at <= databaseNow
+    ) {
+      conflict("Quarantined container operation claim is not live");
+    }
+    if (
+      !hasCommonRestoreQuarantineAuthority({ sandbox, operation, tokenSha256 }) ||
+      sandbox.activation_phase !== "container_pending" ||
+      sandbox.activation_container_id !== null ||
+      sandbox.activation_node_id !== null ||
+      sandbox.activation_image_digest !== null ||
+      sandbox.activation_boot_id !== null
+    ) {
+      conflict("Quarantined container mutable activation authority diverged");
+    }
+
+    const [recordedSandbox] = await tx
+      .update(agentSandboxes)
+      .set({
+        activation_lifecycle_revision: sql`${agentSandboxes.lifecycle_revision} + 1`,
+        activation_phase: "restore_pending",
+        activation_container_id: containerId,
+        activation_node_id: node.node_id,
+        activation_image_digest: operation.expected_image_digest,
+        activation_boot_id: operation.expected_node_incarnation,
+        updated_at: databaseNow,
+      })
+      .where(
+        and(
+          eq(agentSandboxes.id, sandbox.id),
+          eq(agentSandboxes.organization_id, operation.organization_id),
+          eq(agentSandboxes.lifecycle_revision, sandbox.lifecycle_revision),
+          eq(agentSandboxes.activation_generation, operation.restore_attempt_id),
+          eq(agentSandboxes.activation_phase, "container_pending"),
+          eq(agentSandboxes.activation_backup_id, operation.backup_id),
+          eq(agentSandboxes.activation_backup_hash, operation.expected_manifest_sha256),
+          eq(agentSandboxes.activation_token_hash, tokenSha256),
+          isNull(agentSandboxes.activation_container_id),
+          isNull(agentSandboxes.activation_node_id),
+          isNull(agentSandboxes.activation_image_digest),
+          isNull(agentSandboxes.activation_boot_id),
+          isNull(agentSandboxes.deleted_at),
+          sql`${agentSandboxes.lifecycle_revision} < 9223372036854775807`,
+        ),
+      )
+      .returning();
+    if (!recordedSandbox) conflict("Quarantined container sandbox CAS was lost");
+
+    const [advancedOperation] = await tx
+      .update(agentBackupRestoreOperations)
+      .set({
+        phase: "container_created",
+        resume_phase: null,
+        expected_container_id: containerId,
+        claim_owner: null,
+        claim_generation: null,
+        claim_expires_at: null,
+        updated_at: databaseNow,
+      })
+      .where(
+        and(
+          eq(agentBackupRestoreOperations.id, operation.id),
+          eq(agentBackupRestoreOperations.phase, "vault_seeded"),
+          eq(agentBackupRestoreOperations.claim_owner, input.ownerId),
+          eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
+          isNull(agentBackupRestoreOperations.expected_container_id),
+          eq(
+            agentBackupRestoreOperations.expected_node_record_id,
+            operation.expected_node_record_id,
+          ),
+          eq(
+            agentBackupRestoreOperations.expected_node_incarnation,
+            operation.expected_node_incarnation,
+          ),
+          eq(agentBackupRestoreOperations.expected_image_digest, operation.expected_image_digest),
+        ),
+      )
+      .returning();
+    if (
+      !advancedOperation ||
+      !isExactContainerReplay({
+        sandbox: recordedSandbox,
+        operation: advancedOperation,
+        tokenSha256,
+        containerId,
+        nodeId: node.node_id,
+      })
+    ) {
+      conflict("Quarantined container operation CAS was lost");
+    }
+
+    return {
+      operation: Object.freeze(advancedOperation),
+      sandbox: Object.freeze(recordedSandbox),
+      replayed: false,
+    };
+  });
+}


### PR DESCRIPTION
# Relates to

Relates to #20732 and stacks on draft #23027. This is the definition-only C1b database quarantine slice; it does not close the issue, create a container, or activate restore.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This draft intentionally targets `feat/20732-restore-target-authority` so its diff contains only C1b.
- [x] Parent head: `6eea92784517e7c3d029ae74230ec7b7b9609649`; exact C1b head: `4444c4d0dd7860a3b278b774c6c81d5c2b4f65e4`.
- [x] Focused PGlite, real PostgreSQL, boundary, lock-order, typecheck, and formatting gates pass on the exact stacked head.
- [ ] Do not retarget to `develop`, mark ready, or merge before #23027 lands and this branch is rebased onto its merge.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Medium, bounded by a definition-only API gate:

- No production caller or top-level export exists.
- The parent C1a schema still lacks a durable node-incarnation occurrence token. A separate migration is mandatory before activation.
- Restore capacity ownership is not durable across the shared allocator reconciler. Settlement/release and anti-double-count integration with #22916 are mandatory before activation.
- A future remote creator must be idempotent and reconcile or clean up a container when the database recorder rejects after a lease, catalogue, node, or placement drift.
- This PR contains no Docker/SSH/provider/registry call, no environment fallback, no migration, no route publication, and no deployment.

# Background

## What does this PR do?

- Opens a target activation quarantine only after the exact restore operation, claim, lease, manifest-v3 source, reserved node target, node history, and catalogue epoch are locked and re-proven.
- Derives the target activation generation from the retry-stable `restore_attempt_id`; callers cannot substitute the source generation or mint a second target identity.
- Writes only the mutable activation ledger. Canonical `sandbox_id`, `node_id`, `image_digest`, `status`, route publication, dispatch, and completion remain untouched.
- Records one already-created 64-character Docker container ID by atomically updating the quarantine ledger and the restore operation from `vault_seeded` to `container_created`, then clears the claim.
- Makes exact response-loss replay idempotent and rejects token, backup, claim, lease, catalogue, node-incarnation, placement, and container divergence without partial writes.
- Uses backup → operation → lease → sandbox → node → immutable node history → catalogue → DB-clock order.
- Removes the generic container-identity writer and blocks generic first entry into `container_created`. A retry may re-enter that phase only when the durable container ID already exists, and never rewrites it.
- Enforces a static definition-only boundary with no Docker provider, node manager, autoscaler, registry, SSH, `process.env`, or network import/call.

## What kind of change is this?

Feature: non-breaking, dormant repository authority for quarantined restore creation.

# Documentation changes needed?

No user-facing documentation change is needed because the API remains definition-only. JSDoc records the occurrence-token and allocation-settlement prerequisites.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/db/repositories/agent-backup-restore-quarantine.ts`
2. `packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts`
3. `packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts`
4. `packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts`
5. `packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts`

## Detailed testing steps

All exact-head commands used Bun 1.3.14 and Node 24.15.0 through `mise`.

- C1a+C1b restore operation, vault authority, and quarantine PGlite suites: 59 pass, 0 fail, 467 assertions.
- Dormant boundary + global lock-order suites: 10 pass, 0 fail, 167 assertions.
- Real PostgreSQL lock integration suite: 8 pass, 0 fail, 36 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: pass.
- Targeted Biome on all five C1b files: pass.
- `git diff --check`: pass.
- Independent final C1b review: 42 pass, 0 fail, 398 assertions; no remaining P0–P2 finding.

# Evidence Gate

<!-- evidence-head:4444c4d0dd7860a3b278b774c6c81d5c2b4f65e4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - repository-only DB authority; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - repository-only DB authority; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - definition-only repository slice with no callable user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend effect; exact PGlite and real PostgreSQL lock proofs are documented above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt, action, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external artifact; database assertions verify quarantine and operation CAS behavior.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual or rendered-text surface changes.

# Evidence Details

This PR must remain dormant and stacked. Activation additionally requires the occurrence-token migration, shared allocation settlement, and an exact-target remote creator with idempotent reconciliation. There is intentionally no deployment instruction.

The parent #23027 records the current unrelated `develop` verify baseline failure in `@elizaos/ui#lint:check`; all changed `cloud-shared` gates listed above pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@4dc489467682e104f727d3bac2a9505ed6b89cdf:packages/skills/skills/contribute-to-eliza"} -->
