### PR TITLE
fix(shared): fail closed on nested-quantifier plugin-config regex

### DIFF
--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -19,7 +19,9 @@ import {
   MAX_LOGIC_EXPRESSION_NODES,
   MAX_LOGIC_EXPRESSION_PATH_LENGTH,
   MAX_LOGIC_EXPRESSION_PATH_SEGMENTS,
+  MAX_UNTRUSTED_REGEX_INPUT_LENGTH,
   MAX_UNTRUSTED_REGEX_PATTERN_LENGTH,
+  matchesSafeUntrustedRegexPattern,
   runValidation,
   setByPath,
 } from "./config-catalog.js";
@@ -163,13 +165,11 @@ describe("config-catalog built-in validators", () => {
     ).toEqual({ valid: false, errors: ["Must be a finite number"] });
   });
 
-  it("fails closed on nested-quantifier plugin patterns before compile", () => {
+  it("fails closed on nested-quantifier plugin patterns", () => {
     const evil = "^(a+)+$";
     const value = `${"a".repeat(30)}!`;
-    const started = performance.now();
     expect(isSafeUntrustedRegexPattern(evil)).toBe(false);
     expect(builtInValidators.pattern(value, { pattern: evil })).toBe(false);
-    expect(performance.now() - started).toBeLessThan(20);
     expect(
       runValidation(
         {
@@ -188,10 +188,38 @@ describe("config-catalog built-in validators", () => {
     ).toBe(false);
   });
 
+  it.each([
+    ["extra nested group", "^((a+))+$"],
+    ["overlapping alternation", "^(a|aa)+$"],
+    ["two overlapping repetitions", "^a+a+$"],
+    ["two bounded choices", "^a{1,40}a{1,40}$"],
+    ["backreference", "^(a)\\1$"],
+    ["lookahead", "^(?=a)a$"],
+    ["unbounded fixed repetition", "^a{4097}$"],
+  ])("fails closed on %s", (_case, pattern) => {
+    expect(isSafeUntrustedRegexPattern(pattern)).toBe(false);
+  });
+
+  it.each(["^a{2}$", "^a{2,4}$", "\\S", "^[A-Z]{2}[0-9]{4}$"])(
+    "accepts the constrained dialect: %s",
+    (pattern) => {
+      expect(isSafeUntrustedRegexPattern(pattern)).toBe(true);
+    },
+  );
+
   it("fails closed on overlong patterns", () => {
     const overlong = `a${"x".repeat(MAX_UNTRUSTED_REGEX_PATTERN_LENGTH)}`;
     expect(isSafeUntrustedRegexPattern(overlong)).toBe(false);
     expect(builtInValidators.pattern("a", { pattern: overlong })).toBe(false);
+  });
+
+  it("fails closed on an overlong subject before matching", () => {
+    expect(
+      matchesSafeUntrustedRegexPattern(
+        "^a+$",
+        "a".repeat(MAX_UNTRUSTED_REGEX_INPUT_LENGTH + 1),
+      ),
+    ).toBe(false);
   });
 
   it("still accepts an honest format pattern", () => {

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateLogicExpression,
   getByPath,
   isConfigKeySatisfied,
+  isSafeUntrustedRegexPattern,
   LOGIC_EXPRESSION_INVALID,
   LOGIC_EXPRESSION_UNBOUNDED,
   MAX_LOGIC_EXPRESSION_DEPTH,
@@ -18,6 +19,7 @@ import {
   MAX_LOGIC_EXPRESSION_NODES,
   MAX_LOGIC_EXPRESSION_PATH_LENGTH,
   MAX_LOGIC_EXPRESSION_PATH_SEGMENTS,
+  MAX_UNTRUSTED_REGEX_PATTERN_LENGTH,
   runValidation,
   setByPath,
 } from "./config-catalog.js";
@@ -159,6 +161,44 @@ describe("config-catalog built-in validators", () => {
         {},
       ),
     ).toEqual({ valid: false, errors: ["Must be a finite number"] });
+  });
+
+  it("fails closed on nested-quantifier plugin patterns before compile", () => {
+    const evil = "^(a+)+$";
+    const value = `${"a".repeat(30)}!`;
+    const started = performance.now();
+    expect(isSafeUntrustedRegexPattern(evil)).toBe(false);
+    expect(builtInValidators.pattern(value, { pattern: evil })).toBe(false);
+    expect(performance.now() - started).toBeLessThan(20);
+    expect(
+      runValidation(
+        {
+          checks: [{ fn: "pattern", args: { pattern: evil }, message: "bad" }],
+        },
+        value,
+        {},
+      ),
+    ).toEqual({ valid: false, errors: ["bad"] });
+  });
+
+  it("fails closed on quantified-alternation patterns", () => {
+    expect(isSafeUntrustedRegexPattern("^(a|a)+$")).toBe(false);
+    expect(
+      builtInValidators.pattern(`${"a".repeat(28)}b`, { pattern: "^(a|a)+$" }),
+    ).toBe(false);
+  });
+
+  it("fails closed on overlong patterns", () => {
+    const overlong = `a${"x".repeat(MAX_UNTRUSTED_REGEX_PATTERN_LENGTH)}`;
+    expect(isSafeUntrustedRegexPattern(overlong)).toBe(false);
+    expect(builtInValidators.pattern("a", { pattern: overlong })).toBe(false);
+  });
+
+  it("still accepts an honest format pattern", () => {
+    const honest = "^[a-z0-9_-]{1,32}$";
+    expect(isSafeUntrustedRegexPattern(honest)).toBe(true);
+    expect(builtInValidators.pattern("ok_id", { pattern: honest })).toBe(true);
+    expect(builtInValidators.pattern("NO", { pattern: honest })).toBe(false);
   });
 });
 

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -20,9 +20,9 @@
  *
  * `evaluateLogicExpression` is depth-, visit-, and cycle-bounded so a
  * hostile plugin-config `visible` tree cannot stack-overflow the form
- * renderer. Plugin `pattern` validators fail closed on nested-quantifier
- * / quantified-alternation regex so a hostile UI spec cannot hang the
- * form renderer (JS regex is synchronous and cannot be timed out).
+ * renderer. Plugin `pattern` validators use a deliberately constrained regex
+ * dialect so a hostile UI spec cannot hang the form renderer (JS regex is
+ * synchronous and cannot be timed out).
  *
  * @module config-catalog
  */
@@ -58,16 +58,13 @@ export const MAX_UNTRUSTED_REGEX_PATTERN_LENGTH = 200;
 export const MAX_UNTRUSTED_REGEX_INPUT_LENGTH = 4_096;
 
 /**
- * Nested-quantifier and quantified-alternation shapes that backtrack
- * catastrophically on origin (`^(a+)+$` / 28 `a`s → 14s on Node).
- * Matches `(a+)+`, `(a+){2,}`, `(a|a)+`.
- */
-const UNSAFE_UNTRUSTED_REGEX = /([+*?])\)?[+*?{]|(\([^)]*\|[^)]*\))[+*?{]/;
-
-/**
- * True when `pattern` is short, compiles, and is not a nested-quantifier
- * ReDoS shape. Used by catalog and UiRenderer validators so both copies
- * fail closed on the same untrusted compile.
+ * Accept a linear-time subset of JavaScript regex syntax for agent-authored
+ * config validators. Groups, alternation, backreferences, and more than one
+ * variable repetition are excluded; fixed repetitions are bounded by the
+ * subject ceiling. That policy is intentionally stricter than a blacklist:
+ * every accepted expression is a flat sequence with at most one backtracking
+ * choice, so nested or overlapping repetition cannot be smuggled through an
+ * extra grouping layer.
  */
 export function isSafeUntrustedRegexPattern(pattern: string): boolean {
   if (
@@ -76,16 +73,106 @@ export function isSafeUntrustedRegexPattern(pattern: string): boolean {
   ) {
     return false;
   }
-  if (UNSAFE_UNTRUSTED_REGEX.test(pattern)) {
-    return false;
-  }
   try {
     new RegExp(pattern);
-    return true;
   } catch {
     // error-policy:J3 invalid user-supplied regex is not a validator
     return false;
   }
+
+  let hasAtom = false;
+  let variableRepetitions = 0;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+
+    if (char === "\\") {
+      const escaped = pattern[index + 1];
+      if (!escaped || /[1-9k]/.test(escaped)) return false;
+      index += 1;
+      hasAtom = true;
+      continue;
+    }
+
+    if (char === "[") {
+      let closed = false;
+      for (index += 1; index < pattern.length; index += 1) {
+        if (pattern[index] === "\\") {
+          index += 1;
+        } else if (pattern[index] === "]") {
+          closed = true;
+          break;
+        }
+      }
+      if (!closed) return false;
+      hasAtom = true;
+      continue;
+    }
+
+    if (char === "(" || char === ")" || char === "|") return false;
+
+    if (char === "^" || char === "$") {
+      if (
+        (char === "^" && index !== 0) ||
+        (char === "$" && index !== pattern.length - 1)
+      ) {
+        return false;
+      }
+      hasAtom = false;
+      continue;
+    }
+
+    if (char === "*" || char === "+" || char === "?") {
+      if (!hasAtom) return false;
+      variableRepetitions += 1;
+      if (variableRepetitions > 1) return false;
+      hasAtom = false;
+      continue;
+    }
+
+    if (char === "{") {
+      if (!hasAtom) return false;
+      const quantifier = /^\{(\d+)(?:,(\d*))?\}/.exec(pattern.slice(index));
+      if (!quantifier) return false;
+      const minimum = Number(quantifier[1]);
+      const hasComma = quantifier[0].includes(",");
+      const maximum = hasComma
+        ? quantifier[2] === ""
+          ? undefined
+          : Number(quantifier[2])
+        : minimum;
+      if (
+        minimum > MAX_UNTRUSTED_REGEX_INPUT_LENGTH ||
+        (maximum !== undefined && maximum > MAX_UNTRUSTED_REGEX_INPUT_LENGTH)
+      ) {
+        return false;
+      }
+      if (maximum === undefined || maximum !== minimum) {
+        variableRepetitions += 1;
+        if (variableRepetitions > 1) return false;
+      }
+      index += quantifier[0].length - 1;
+      hasAtom = false;
+      continue;
+    }
+
+    if (char === "}") return false;
+    hasAtom = true;
+  }
+  return true;
+}
+
+/** Test an untrusted config value only after applying the shared safe dialect. */
+export function matchesSafeUntrustedRegexPattern(
+  pattern: string,
+  value: string,
+): boolean {
+  if (
+    value.length > MAX_UNTRUSTED_REGEX_INPUT_LENGTH ||
+    !isSafeUntrustedRegexPattern(pattern)
+  ) {
+    return false;
+  }
+  return new RegExp(pattern).test(value);
 }
 
 // ── JSON Schema types (subset we consume) ──────────────────────────────
@@ -740,14 +827,7 @@ export const builtInValidators: Record<string, ValidationFunction> = {
   pattern: (value, args) => {
     if (typeof value !== "string" || typeof args?.pattern !== "string")
       return false;
-    if (value.length > MAX_UNTRUSTED_REGEX_INPUT_LENGTH) return false;
-    if (!isSafeUntrustedRegexPattern(args.pattern)) return false;
-    try {
-      return new RegExp(args.pattern).test(value);
-    } catch {
-      // error-policy:J3 invalid user-supplied regex -> validation fails
-      return false;
-    }
+    return matchesSafeUntrustedRegexPattern(args.pattern, value);
   },
   min: (value, args) =>
     typeof value === "number" &&

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -20,7 +20,9 @@
  *
  * `evaluateLogicExpression` is depth-, visit-, and cycle-bounded so a
  * hostile plugin-config `visible` tree cannot stack-overflow the form
- * renderer.
+ * renderer. Plugin `pattern` validators fail closed on nested-quantifier
+ * / quantified-alternation regex so a hostile UI spec cannot hang the
+ * form renderer (JS regex is synchronous and cannot be timed out).
  *
  * @module config-catalog
  */
@@ -49,6 +51,42 @@ export const MAX_LOGIC_EXPRESSION_PATH_SEGMENTS = 64;
 export const MAX_LOGIC_EXPRESSION_LITERAL_LENGTH = 2_048;
 export const LOGIC_EXPRESSION_UNBOUNDED = "LOGIC_EXPRESSION_UNBOUNDED";
 export const LOGIC_EXPRESSION_INVALID = "LOGIC_EXPRESSION_INVALID";
+
+/** Honest plugin-config patterns are short format strings, not engines. */
+export const MAX_UNTRUSTED_REGEX_PATTERN_LENGTH = 200;
+/** Bound the subject a user-supplied pattern is tested against. */
+export const MAX_UNTRUSTED_REGEX_INPUT_LENGTH = 4_096;
+
+/**
+ * Nested-quantifier and quantified-alternation shapes that backtrack
+ * catastrophically on origin (`^(a+)+$` / 28 `a`s → 14s on Node).
+ * Matches `(a+)+`, `(a+){2,}`, `(a|a)+`.
+ */
+const UNSAFE_UNTRUSTED_REGEX = /([+*?])\)?[+*?{]|(\([^)]*\|[^)]*\))[+*?{]/;
+
+/**
+ * True when `pattern` is short, compiles, and is not a nested-quantifier
+ * ReDoS shape. Used by catalog and UiRenderer validators so both copies
+ * fail closed on the same untrusted compile.
+ */
+export function isSafeUntrustedRegexPattern(pattern: string): boolean {
+  if (
+    pattern.length === 0 ||
+    pattern.length > MAX_UNTRUSTED_REGEX_PATTERN_LENGTH
+  ) {
+    return false;
+  }
+  if (UNSAFE_UNTRUSTED_REGEX.test(pattern)) {
+    return false;
+  }
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    // error-policy:J3 invalid user-supplied regex is not a validator
+    return false;
+  }
+}
 
 // ── JSON Schema types (subset we consume) ──────────────────────────────
 
@@ -702,6 +740,8 @@ export const builtInValidators: Record<string, ValidationFunction> = {
   pattern: (value, args) => {
     if (typeof value !== "string" || typeof args?.pattern !== "string")
       return false;
+    if (value.length > MAX_UNTRUSTED_REGEX_INPUT_LENGTH) return false;
+    if (!isSafeUntrustedRegexPattern(args.pattern)) return false;
     try {
       return new RegExp(args.pattern).test(value);
     } catch {

--- a/packages/ui/src/components/config-ui/config-renderer.tsx
+++ b/packages/ui/src/components/config-ui/config-renderer.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../../config/config-catalog";
 import {
   evaluateFieldVisibility,
+  matchesSafeUntrustedRegexPattern,
   resolveFields,
   runValidation,
 } from "../../config/config-catalog";
@@ -306,16 +307,8 @@ export const ConfigRenderer = forwardRef<
 
       // 3. Pattern validation from hints
       if (field.hint.pattern && typeof value === "string" && value) {
-        try {
-          // Guard against ReDoS: reject overly long or nested-quantifier patterns
-          const pat = field.hint.pattern;
-          if (pat.length <= 200 && !/([+*])\)?[+*]/.test(pat)) {
-            if (!new RegExp(pat).test(value)) {
-              errors.push(field.hint.patternError ?? "Invalid format.");
-            }
-          }
-        } catch {
-          // invalid regex in hint — skip
+        if (!matchesSafeUntrustedRegexPattern(field.hint.pattern, value)) {
+          errors.push(field.hint.patternError ?? "Invalid format.");
         }
       }
 

--- a/packages/ui/src/components/config-ui/ui-renderer.helpers.test.ts
+++ b/packages/ui/src/components/config-ui/ui-renderer.helpers.test.ts
@@ -7,15 +7,25 @@ import { describe, expect, it } from "vitest";
 import { runValidation } from "./ui-renderer.helpers";
 
 describe("UiRenderer pattern validator", () => {
-  it("fails closed on nested-quantifier agent patterns before compile", () => {
-    const started = performance.now();
+  it("fails closed on nested-quantifier agent patterns", () => {
     const errors = runValidation(
       [{ fn: "pattern", args: { pattern: "^(a+)+$" }, message: "bad" }],
       `${"a".repeat(30)}!`,
     );
     expect(errors).toEqual(["bad"]);
-    expect(performance.now() - started).toBeLessThan(20);
   });
+
+  it.each(["^((a+))+$", "^(a|aa)+$", "^a+a+$", "^(a)\\1$"])(
+    "fails closed on adversarial pattern %s",
+    (pattern) => {
+      expect(
+        runValidation(
+          [{ fn: "pattern", args: { pattern }, message: "bad" }],
+          `${"a".repeat(30)}!`,
+        ),
+      ).toEqual(["bad"]);
+    },
+  );
 
   it("still accepts an honest format pattern", () => {
     expect(

--- a/packages/ui/src/components/config-ui/ui-renderer.helpers.test.ts
+++ b/packages/ui/src/components/config-ui/ui-renderer.helpers.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Isolated tests for UiRenderer validation helpers. Agent-authored specs
+ * supply `pattern` strings; nested-quantifier shapes must fail closed
+ * without compiling into a hang.
+ */
+import { describe, expect, it } from "vitest";
+import { runValidation } from "./ui-renderer.helpers";
+
+describe("UiRenderer pattern validator", () => {
+  it("fails closed on nested-quantifier agent patterns before compile", () => {
+    const started = performance.now();
+    const errors = runValidation(
+      [{ fn: "pattern", args: { pattern: "^(a+)+$" }, message: "bad" }],
+      `${"a".repeat(30)}!`,
+    );
+    expect(errors).toEqual(["bad"]);
+    expect(performance.now() - started).toBeLessThan(20);
+  });
+
+  it("still accepts an honest format pattern", () => {
+    expect(
+      runValidation(
+        [
+          {
+            fn: "pattern",
+            args: { pattern: "^[a-z0-9_-]{1,32}$" },
+            message: "bad",
+          },
+        ],
+        "ok_id",
+      ),
+    ).toEqual([]);
+    expect(
+      runValidation(
+        [
+          {
+            fn: "pattern",
+            args: { pattern: "^[a-z0-9_-]{1,32}$" },
+            message: "bad",
+          },
+        ],
+        "NO",
+      ),
+    ).toEqual(["bad"]);
+  });
+});

--- a/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
+++ b/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
@@ -7,8 +7,7 @@
  */
 import {
   getByPath,
-  isSafeUntrustedRegexPattern,
-  MAX_UNTRUSTED_REGEX_INPUT_LENGTH,
+  matchesSafeUntrustedRegexPattern,
 } from "../../config/config-catalog";
 import type {
   AuthState,
@@ -129,15 +128,7 @@ const BUILTIN_VALIDATORS: Record<
     typeof v === "string" && v.length <= Number(args?.length ?? Infinity),
   pattern: (v, args) => {
     if (typeof v !== "string" || !args?.pattern) return true;
-    const pat = String(args.pattern);
-    if (v.length > MAX_UNTRUSTED_REGEX_INPUT_LENGTH) return false;
-    if (!isSafeUntrustedRegexPattern(pat)) return false;
-    try {
-      return new RegExp(pat).test(v);
-    } catch {
-      // error-policy:J3 invalid agent-authored regex -> check fails closed
-      return false;
-    }
+    return matchesSafeUntrustedRegexPattern(String(args.pattern), v);
   },
   min: (v, args) => Number(v) >= Number(args?.value ?? -Infinity),
   max: (v, args) => Number(v) <= Number(args?.value ?? Infinity),

--- a/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
+++ b/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
@@ -5,7 +5,11 @@
  * XSS from agent-authored specs), and enumerates the supported component types.
  * No React — logic only, so it can be unit-tested in isolation.
  */
-import { getByPath } from "../../config/config-catalog";
+import {
+  getByPath,
+  isSafeUntrustedRegexPattern,
+  MAX_UNTRUSTED_REGEX_INPUT_LENGTH,
+} from "../../config/config-catalog";
 import type {
   AuthState,
   UiSpecValidationCheck,
@@ -125,10 +129,14 @@ const BUILTIN_VALIDATORS: Record<
     typeof v === "string" && v.length <= Number(args?.length ?? Infinity),
   pattern: (v, args) => {
     if (typeof v !== "string" || !args?.pattern) return true;
+    const pat = String(args.pattern);
+    if (v.length > MAX_UNTRUSTED_REGEX_INPUT_LENGTH) return false;
+    if (!isSafeUntrustedRegexPattern(pat)) return false;
     try {
-      return new RegExp(String(args.pattern)).test(v);
+      return new RegExp(pat).test(v);
     } catch {
-      return true;
+      // error-policy:J3 invalid agent-authored regex -> check fails closed
+      return false;
     }
   },
   min: (v, args) => Number(v) >= Number(args?.value ?? -Infinity),


### PR DESCRIPTION
Fixes #23248

## Summary

- replaces the bypassable nested-quantifier blacklist with a deliberately constrained, fail-closed regex dialect for agent-authored config validation
- rejects grouping, alternation, lookarounds, backreferences, multiple variable repetitions, oversized repeats, malformed patterns, and oversized subjects
- preserves first-party formats including `^[a-z0-9_-]{1,32}$`, `^[A-Z]{2}[0-9]{4}$`, and the Maps `\S` validator
- routes catalog validation, UiRenderer specs, and ConfigRenderer hint patterns through the same shared matcher; the third path previously retained a separate fail-open heuristic

## Exact-head validation

<!-- evidence-head:22ad43af635352b42aa383ac09640f5de0b39476 -->

Base: `26f68de6438751f3ecfeb62954f32cac53e6204d`

- shared focused suite: 63/63 passed
- UI helper focused suite: 6/6 passed
- Biome on all five touched files: clean
- `git diff --check`: clean
- rebase range-diff: both commits patch-identical after the final `develop` refresh
- package typechecks were attempted; the scripts-skipped partial checkout reports unrelated missing packages/types and no touched-file diagnostic
- `bun run --cwd packages/app audit:app` was attempted repeatedly. All 21 authoritative view bundles built after restoring missing local dependency links, then the audit stopped before Playwright in the existing core declaration build: `markdown-it` resolves but TypeScript rejects the installed `@types/markdown-it` export map. This PR does not touch core markdown or dependency manifests, so no visual pass is claimed.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — no layout, style, copy, or ordinary rendered state changes; the unsafe predecessor can synchronously hang and is covered with deterministic structural regressions instead of an unsafe screenshot run.

<!-- evidence-row:after-screenshots -->
- [x] N/A — the required app audit was attempted but blocked before capture by the unrelated core declaration error recorded above.

<!-- evidence-row:walkthrough-video -->
- [x] N/A — no new user flow; unsupported agent-authored validators now produce the existing invalid-format state.

<!-- evidence-row:backend-logs -->
- [x] N/A — no backend or transport path changes.

<!-- evidence-row:frontend-logs -->
- [x] Focused UI validation suite passed 6/6; the app-audit blocker is recorded above.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, or agent-planning behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Shared suite 63/63 and UI suite 6/6 exercise honest patterns plus extra nesting, overlapping alternation, adjacent variable/bounded repetitions, backreferences, lookarounds, overlong patterns, and overlong subjects.

<!-- evidence-row:ocr-review -->
- [x] N/A — no capture was produced because the audit stopped in the unrelated pre-Playwright core declaration build.

## Risk and compatibility

Unsupported regex features now fail closed rather than executing on the browser main thread. The dialect is intentionally conservative, but it preserves every first-party config/UI-spec pattern found in the repository. No schema, API, storage, network, or visual-design contract changes.

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: xai/grok-4.6; OpenAI Codex maintainer repair/review
- Provenance status: self-reported
