### PR TITLE
fix(plugin-signal): fail-closed ghost accountId so it cannot inherit owner env tokens

### DIFF
--- a/plugins/plugin-signal/src/accounts.test.ts
+++ b/plugins/plugin-signal/src/accounts.test.ts
@@ -3,8 +3,10 @@
  * covering case-insensitive account-id normalization between enumeration
  * (`listSignalAccountIds`) and lookup (`getAccountConfig`/`resolveSignalAccount`).
  * Regression coverage for issue #22680, where a non-lowercase account key
- * silently dropped its per-account overrides. Uses a hand-built fake runtime;
- * no live signal-cli.
+ * silently dropped its per-account overrides. Also fail-closes ghost /
+ * unrecognized accountIds so they cannot inherit the owner's
+ * SIGNAL_ACCOUNT_NUMBER or signal-cli transport. Uses a hand-built fake
+ * runtime; no live signal-cli.
  */
 import type { Character, IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -133,5 +135,69 @@ describe("resolveSignalAccount case-insensitive lookup (issue #22680)", () => {
     expect(resolved.account).toBe("+15550001111");
     expect(resolved.configured).toBe(true);
     expect(listEnabledSignalAccounts(rt)).toHaveLength(1);
+  });
+});
+
+describe("resolveSignalAccount owner-bind fail-closed", () => {
+  const ownerEnv = {
+    SIGNAL_ACCOUNT_NUMBER: "+15551212000",
+    SIGNAL_HTTP_URL: "http://owner-cli:8080",
+    SIGNAL_AUTH_DIR: "/owner/signal",
+    SIGNAL_CLI_PATH: "/owner/signal-cli",
+  };
+
+  it("lets the default account inherit owner env identity and transport", () => {
+    const rt = createRuntime(undefined, ownerEnv);
+    const resolved = resolveSignalAccount(rt, "default");
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.account).toBe("+15551212000");
+    expect(resolved.baseUrl).toBe("http://owner-cli:8080");
+    expect(resolved.config.authDir).toBe("/owner/signal");
+    expect(resolved.config.cliPath).toBe("/owner/signal-cli");
+    expect(resolved.configured).toBe(true);
+  });
+
+  it("does not give a ghost accountId the owner phone number or daemon", () => {
+    const rt = createRuntime(
+      { accounts: { work: { account: "+15550001111", enabled: true } } },
+      ownerEnv
+    );
+    const ghost = resolveSignalAccount(rt, "ghost-account");
+    expect(ghost.accountId).toBe("ghost-account");
+    expect(ghost.account).toBeUndefined();
+    expect(ghost.baseUrl).toBe("http://127.0.0.1:8080");
+    expect(ghost.config.authDir).toBeUndefined();
+    expect(ghost.config.cliPath).toBeUndefined();
+    expect(ghost.configured).toBe(false);
+  });
+
+  it("does not let a named account without its own number inherit env identity", () => {
+    const rt = createRuntime({ accounts: { work: { enabled: true } } }, ownerEnv);
+    const work = resolveSignalAccount(rt, "work");
+    expect(work.accountId).toBe("work");
+    expect(work.account).toBeUndefined();
+    expect(work.baseUrl).toBe("http://127.0.0.1:8080");
+    expect(work.configured).toBe(false);
+  });
+
+  it("keeps a named account's own number and does not attach owner env transport", () => {
+    const rt = createRuntime(
+      {
+        accounts: {
+          work: {
+            enabled: true,
+            account: "+15550001111",
+            httpUrl: "http://127.0.0.1:9999",
+          },
+        },
+      },
+      ownerEnv
+    );
+    const work = resolveSignalAccount(rt, "work");
+    expect(work.account).toBe("+15550001111");
+    expect(work.baseUrl).toBe("http://127.0.0.1:9999");
+    expect(work.config.authDir).toBeUndefined();
+    expect(work.config.cliPath).toBeUndefined();
+    expect(work.configured).toBe(true);
   });
 });

--- a/plugins/plugin-signal/src/accounts.ts
+++ b/plugins/plugin-signal/src/accounts.ts
@@ -6,6 +6,9 @@
  * The service and the connector-account provider both read accounts through
  * here. Account IDs are lowercased via `normalizeAccountId`, and `"default"`
  * (`DEFAULT_ACCOUNT_ID`) is the sentinel for single-account env-only setups.
+ * Named or unrecognized accountIds fail closed: they cannot inherit the
+ * owner's `SIGNAL_ACCOUNT_NUMBER` / signal-cli transport from env or the
+ * top-level character `settings.signal` identity fields.
  */
 import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 
@@ -251,11 +254,23 @@ function mergeSignalAccountConfig(runtime: IAgentRuntime, accountId: string): Si
   const { accounts: _ignored, ...baseConfig } = multiConfig;
   const accountConfig = getAccountConfig(runtime, accountId) ?? {};
 
-  // Get environment/runtime settings for the base config
-  const envAccount = runtime.getSetting("SIGNAL_ACCOUNT_NUMBER") as string | undefined;
-  const envHttpUrl = runtime.getSetting("SIGNAL_HTTP_URL") as string | undefined;
-  const envAuthDir = runtime.getSetting("SIGNAL_AUTH_DIR") as string | undefined;
-  const envCliPath = runtime.getSetting("SIGNAL_CLI_PATH") as string | undefined;
+  // Only the implicit default account may inherit owner env / top-level
+  // character identity and signal-cli transport. A ghost or named accountId
+  // must not launch against the owner's phone number or daemon.
+  const allowOwnerBind = accountId === DEFAULT_ACCOUNT_ID;
+
+  const envAccount = allowOwnerBind
+    ? (runtime.getSetting("SIGNAL_ACCOUNT_NUMBER") as string | undefined)
+    : undefined;
+  const envHttpUrl = allowOwnerBind
+    ? (runtime.getSetting("SIGNAL_HTTP_URL") as string | undefined)
+    : undefined;
+  const envAuthDir = allowOwnerBind
+    ? (runtime.getSetting("SIGNAL_AUTH_DIR") as string | undefined)
+    : undefined;
+  const envCliPath = allowOwnerBind
+    ? (runtime.getSetting("SIGNAL_CLI_PATH") as string | undefined)
+    : undefined;
   const envIgnoreGroups = runtime.getSetting("SIGNAL_SHOULD_IGNORE_GROUP_MESSAGES") as
     | string
     | undefined;
@@ -268,7 +283,21 @@ function mergeSignalAccountConfig(runtime: IAgentRuntime, accountId: string): Si
     shouldIgnoreGroupMessages: envIgnoreGroups?.toLowerCase() === "true",
   };
 
-  // Merge order: env defaults < base config < account config
+  const ownerIdentity = allowOwnerBind
+    ? filterDefined({
+        account: baseConfig.account,
+        httpUrl: baseConfig.httpUrl,
+        authDir: baseConfig.authDir,
+      })
+    : {};
+  const {
+    account: _baseAccount,
+    httpUrl: _baseHttpUrl,
+    authDir: _baseAuthDir,
+    ...basePolicy
+  } = baseConfig;
+
+  // Merge order: env defaults < shared policy < default-only identity < account
   // Filter undefined values to prevent them from overwriting defined values
   const normalizedDm = filterDefined({
     policy: multiConfig.dmPolicy,
@@ -281,7 +310,8 @@ function mergeSignalAccountConfig(runtime: IAgentRuntime, accountId: string): Si
 
   return {
     ...filterDefined(envConfig),
-    ...filterDefined(baseConfig),
+    ...filterDefined(basePolicy),
+    ...ownerIdentity,
     ...filterDefined(accountConfig),
     ...(Object.keys(normalizedDm).length > 0 ? { dm: normalizedDm } : {}),
   };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE
auth-bind audit on a live Signal product path. No new issue filed (mission
forbids self-directed issue creation). Same owner-token inherit class as
#23070 (X) and #23082 (Slack), different host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on ghost / unrecognized Signal `accountId` so it cannot inherit
owner env number or daemon. Honest default-only env deployments still resolve.
No schema or storage migration.

# Background

## What does this PR do?

`mergeSignalAccountConfig` always spread `SIGNAL_ACCOUNT_NUMBER` / `SIGNAL_HTTP_URL` / `SIGNAL_AUTH_DIR` / `SIGNAL_CLI_PATH` (and the top-level character `settings.signal` identity fields) onto every accountId. A ghost or unrecognized id therefore resolved as `configured: true` against the owner's phone number and signal-cli daemon — the same owner-token inherit class as Slack/X, on a connector that was not default-gated.

This head lets only the implicit `default` account inherit owner env / top-level identity and transport. Named and unrecognized accountIds keep shared DM policy defaults but do not receive the owner's number or daemon. Honest default-only env deployments still resolve.

Origin `develop` `a61d938a9e48`: `resolveSignalAccount(runtime, "ghost-account")` with `SIGNAL_ACCOUNT_NUMBER=+15551212000` and `SIGNAL_HTTP_URL=http://owner-cli:8080` returned that owner number, owner daemon URL, and `configured: true`.

Overlay `bun test plugins/plugin-signal/src/accounts.test.ts` → 11/11, including ghost/named fail-closed and default env inherit still works.

Occupancy-FREE host `plugins/plugin-signal/src/accounts.ts`. Not leftover-tax. Not X/Slack/Instagram/Discord. Not `#23036` `index.ts`. Not `#23085` ReDoS.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-signal/src/accounts.ts` and `plugins/plugin-signal/src/accounts.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:2ed3edb7efa8ba43a7dc3294127a7f5e761feb7e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; Signal account resolver is runtime logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; Signal account resolver is runtime logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
origin develop a61d938a9e48
resolveSignalAccount(runtime, "ghost-account")
SIGNAL_ACCOUNT_NUMBER=+15551212000
SIGNAL_HTTP_URL=http://owner-cli:8080
result: owner number + owner daemon + configured true

overlay bun test plugins/plugin-signal/src/accounts.test.ts
11/11 including ghost/named fail-closed and default env inherit
head 2ed3edb7efa8ba43a7dc3294127a7f5e761feb7e
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

