### PR TITLE
fix(ui): export BlockList from the Storybook node:net stub

### DIFF
--- a/packages/ui/test/stubs/node-net.ts
+++ b/packages/ui/test/stubs/node-net.ts
@@ -24,6 +24,24 @@ export const isIP = () => 0;
 export const isIPv4 = () => false;
 export const isIPv6 = () => false;
 
+// Named-imported by shared/src/loopback-trust.ts, which entered the Storybook
+// graph via the UI barrel (shared/src/index.ts). Trust evaluation never runs
+// during a render; keep the throwing-on-use contract.
+export class BlockList {
+  addAddress() {
+    return notAvailable("BlockList.addAddress");
+  }
+  addRange() {
+    return notAvailable("BlockList.addRange");
+  }
+  addSubnet() {
+    return notAvailable("BlockList.addSubnet");
+  }
+  check() {
+    return notAvailable("BlockList.check");
+  }
+}
+
 export default {
   Socket,
   Server,
@@ -33,4 +51,5 @@ export default {
   isIP,
   isIPv4,
   isIPv6,
+  BlockList,
 };


### PR DESCRIPTION
Fixes #23112.

The UI Story Gate has been red on **every develop run since ~04:00 UTC today** (20 consecutive runs — catalog build + all 8 shards + verdict), so every merge today landed without its coverage. Single cause, before any story renders:

```
[MISSING_EXPORT] "BlockList" is not exported by "test/stubs/node-net.ts"
  ╭─[ ../shared/src/loopback-trust.ts:1:10 ]
```

`loopback-trust.ts` has done the named `{ BlockList, isIP }` import since #22503; this morning's merges made it reachable from the Storybook graph via the shared barrel (`shared/src/index.ts` ← `overlay-app-registry.ts` ← `AppWindowRenderer.stories.tsx`), and the browser stub only exported `isIP`.

## Change

One file: `BlockList` added to the stub under its stated contract — surface provided so module init succeeds, every method throws if actually used (trust evaluation never runs during a render). Named export + default aggregate, matching the existing `Socket`/`Server` members.

## Proof

Local run of the gate's exact command (`bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet`):
- pristine develop → the exact CI `MISSING_EXPORT`, exit 1 (this baseline IS the mutation for the fix);
- with this change → **build completed successfully, exit 0** (31 MB catalog).

Post-merge, the next develop Story Gate run is the end-to-end confirmation — I'll watch it.
