### PR TITLE
fix(app-core): fail closed on cyclic GET /api/config redaction walks

### DIFF
--- a/packages/app-core/src/api/server-config-filter.ts
+++ b/packages/app-core/src/api/server-config-filter.ts
@@ -1,5 +1,7 @@
 /** Config/env filtering — strip sensitive keys from API responses. */
 
+import { ElizaError } from "@elizaos/core";
+
 /**
  * Env keys that must never be returned in GET /api/config responses.
  * Covers private keys, auth tokens, and database credentials.
@@ -29,53 +31,198 @@ export const SENSITIVE_ENV_RESPONSE_KEYS = new Set([
 const SENSITIVE_RESPONSE_KEY_RE =
   /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|(?<!max)tokens?$/i;
 
-function redactValue(value: unknown): unknown {
+/** Honest GET /api/config payloads are a handful of objects deep. */
+export const MAX_CONFIG_FILTER_DEPTH = 32;
+/**
+ * Node ceiling across the whole redaction walk, including sparse array holes.
+ * Well above an ordinary character/config document; bounds synthetic graphs
+ * that would otherwise RangeError or hang the authorized config route.
+ */
+export const MAX_CONFIG_FILTER_NODES = 100_000;
+export const CONFIG_FILTER_UNBOUNDED = "CONFIG_FILTER_UNBOUNDED";
+
+type FilterWalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failConfigFilterUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  throw new ElizaError(
+    "Config response exceeds the sensitive-key filter walk budget",
+    {
+      code: CONFIG_FILTER_UNBOUNDED,
+      context,
+      cause,
+      severity: "fatal",
+    },
+  );
+}
+
+function reserveFilterVisits(ctx: FilterWalkContext, count: number): void {
+  if (count > MAX_CONFIG_FILTER_NODES - ctx.visits) {
+    failConfigFilterUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_CONFIG_FILTER_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function enterFilterContainer(value: object, ctx: FilterWalkContext): void {
+  if (ctx.visiting.has(value)) {
+    failConfigFilterUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+}
+
+function inspectFilter<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+    failConfigFilterUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownEnumerableStringKeys(value: object): string[] {
+  const keys: string[] = [];
+  for (const key of inspectFilter("ownKeys", () => Reflect.ownKeys(value))) {
+    if (typeof key !== "string") continue;
+    const descriptor = inspectFilter("getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (!descriptor?.enumerable) continue;
+    keys.push(key);
+  }
+  return keys;
+}
+
+function ownValueDescriptor(
+  value: object,
+  key: string,
+): PropertyDescriptor | undefined {
+  const descriptor = inspectFilter("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) {
+    failConfigFilterUnbounded({ accessor: true, key });
+  }
+  return descriptor;
+}
+
+function ownArrayLength(value: unknown[]): number {
+  const descriptor = ownValueDescriptor(value, "length");
+  if (
+    !descriptor ||
+    !Number.isSafeInteger(descriptor.value) ||
+    descriptor.value < 0
+  ) {
+    failConfigFilterUnbounded({ invalidArrayLength: true });
+  }
+  return descriptor.value;
+}
+
+function redactLeaf(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "string") return value.trim() ? "[REDACTED]" : "";
-  if (typeof value === "number" || typeof value === "boolean")
+  if (typeof value === "number" || typeof value === "boolean") {
     return "[REDACTED]";
-  if (Array.isArray(value)) return value.map(redactValue);
-  if (typeof value === "object") {
-    const redacted: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(
-      value as Record<string, unknown>,
-    )) {
-      redacted[key] = redactValue(child);
-    }
-    return redacted;
   }
   return "[REDACTED]";
 }
 
-function redactConfigDeep(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map(redactConfigDeep);
-  if (typeof value === "object") {
-    const redacted: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(
-      value as Record<string, unknown>,
-    )) {
-      redacted[key] = SENSITIVE_RESPONSE_KEY_RE.test(key)
-        ? redactValue(child)
-        : redactConfigDeep(child);
-    }
-    return redacted;
+function walkConfigFilter(
+  value: unknown,
+  depth: number,
+  ctx: FilterWalkContext,
+  redactAll: boolean,
+  visitAlreadyReserved = false,
+): unknown {
+  if (depth > MAX_CONFIG_FILTER_DEPTH) {
+    failConfigFilterUnbounded({
+      depth,
+      max: MAX_CONFIG_FILTER_DEPTH,
+    });
   }
-  return value;
+  if (!visitAlreadyReserved) reserveFilterVisits(ctx, 1);
+  if (value === null || value === undefined) return value;
+  if (typeof value !== "object") {
+    return redactAll ? redactLeaf(value) : value;
+  }
+
+  enterFilterContainer(value, ctx);
+  try {
+    if (Array.isArray(value)) {
+      const length = ownArrayLength(value);
+      reserveFilterVisits(ctx, length);
+      const next: unknown[] = [];
+      next.length = length;
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownValueDescriptor(value, String(index));
+        if (!descriptor) continue;
+        next[index] = walkConfigFilter(
+          descriptor.value,
+          depth + 1,
+          ctx,
+          redactAll,
+          true,
+        );
+      }
+      return next;
+    }
+
+    const keys = ownEnumerableStringKeys(value);
+    reserveFilterVisits(ctx, keys.length);
+    const out: Record<string, unknown> = {};
+    for (const key of keys) {
+      const descriptor = ownValueDescriptor(value, key);
+      if (!descriptor) continue;
+      const childRedactAll = redactAll || SENSITIVE_RESPONSE_KEY_RE.test(key);
+      out[key] = walkConfigFilter(
+        descriptor.value,
+        depth + 1,
+        ctx,
+        childRedactAll,
+        true,
+      );
+    }
+    return out;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}
+
+function newFilterWalkContext(): FilterWalkContext {
+  return { visits: 0, visiting: new WeakSet<object>() };
 }
 
 /**
  * Strip sensitive env vars from a config object before it is sent in a GET
  * /api/config response. Returns a shallow-cloned config with a filtered env
  * block — the original object is never mutated.
+ *
+ * Depth, node, and cycle limits are load-bearing: origin `develop` RangeError'd
+ * a cyclic config graph and invoked enumerable getters during the walk, which
+ * hangs the authorized config route. Descriptor-only reads so a getter cannot
+ * pin GET /api/config.
  */
 export function filterConfigEnvForResponse(
   config: Record<string, unknown>,
 ): Record<string, unknown> {
-  const redactedConfig = redactConfigDeep(config) as Record<string, unknown>;
+  const redactedConfig = walkConfigFilter(
+    config,
+    0,
+    newFilterWalkContext(),
+    false,
+  ) as Record<string, unknown>;
   const env = redactedConfig.env;
-  if (!env || typeof env !== "object" || Array.isArray(env))
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
     return redactedConfig;
+  }
 
   const filteredEnv: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(env as Record<string, unknown>)) {

--- a/packages/app-core/test/server-config-filter.test.ts
+++ b/packages/app-core/test/server-config-filter.test.ts
@@ -1,6 +1,11 @@
 /** Exercises server config filter behavior with deterministic app-core test fixtures. */
 import { describe, expect, test } from "vitest";
-import { filterConfigEnvForResponse } from "../src/api/server-config-filter";
+import { ElizaError } from "@elizaos/core";
+import {
+  CONFIG_FILTER_UNBOUNDED,
+  MAX_CONFIG_FILTER_DEPTH,
+  filterConfigEnvForResponse,
+} from "../src/api/server-config-filter";
 
 describe("filterConfigEnvForResponse", () => {
   test("redacts nested secret-shaped config values", () => {
@@ -60,5 +65,56 @@ describe("filterConfigEnvForResponse", () => {
       SAFE_FLAG: "1",
       OPENAI_API_KEY: "[REDACTED]",
     });
+  });
+
+  test("fail-closed on a cyclic config graph instead of RangeError", () => {
+    const cyclic: Record<string, unknown> = {
+      env: { SAFE_FLAG: "1" },
+      cloud: { apiKey: "eliza_secret" },
+    };
+    cyclic.self = cyclic;
+
+    try {
+      filterConfigEnvForResponse(cyclic);
+      throw new Error("expected CONFIG_FILTER_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CONFIG_FILTER_UNBOUNDED);
+      expect(error).not.toBeInstanceOf(RangeError);
+    }
+  });
+
+  test("fail-closed on over-deep config nests before the walk RangeErrors", () => {
+    let nest: Record<string, unknown> = { leaf: "ok" };
+    for (let i = 0; i < MAX_CONFIG_FILTER_DEPTH + 8; i += 1) {
+      nest = { nest };
+    }
+
+    try {
+      filterConfigEnvForResponse(nest);
+      throw new Error("expected CONFIG_FILTER_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CONFIG_FILTER_UNBOUNDED);
+    }
+  });
+
+  test("does not invoke enumerable getters while redacting", () => {
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "apiKey", {
+      enumerable: true,
+      get() {
+        throw new Error("GETTER_INVOKED");
+      },
+    });
+
+    try {
+      filterConfigEnvForResponse({ cloud: hostile });
+      throw new Error("expected CONFIG_FILTER_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CONFIG_FILTER_UNBOUNDED);
+      expect(String(error)).not.toContain("GETTER_INVOKED");
+    }
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE
hang / 500 / overflow audit on a live app-core product path. No new issue filed
(mission forbids self-directed issue creation). Leftover GET `/api/config`
redaction walk; not a connector ghost-accountId host and not a ReDoS host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on cyclic, over-deep, over-wide, or accessor-bearing config
graphs so GET `/api/config` cannot RangeError or hang. Honest character/config
payloads still redact the same secret-shaped keys. No schema or storage
migration. Did not edit HARD_SKIP `server.ts`.

# Background

## What does this PR do?

`packages/app-core/src/api/server-config-filter.ts` `filterConfigEnvForResponse`
is the live GET `/api/config` redaction walk. On origin `develop` `a61d938a9e48`
it recursed with `Object.entries`, so a cyclic config graph RangeError'd and an
enumerable getter was invoked (a hanging getter pins the authorized route).

Independent origin proof:

```text
origin develop a61d938a9e48
honest small config: ok 0.215ms
cyclic self-ref: THROW 35.537ms RangeError Maximum call stack size exceeded
enumerable getter: THROW GETTER_INVOKED
enumerable getter 50ms spin: ok 49.274ms (getter invoked)
```

This head walks with descriptor-only reads, a depth/node/cycle budget, and
throws typed `CONFIG_FILTER_UNBOUNDED` instead of RangeError. Honest nested
`apiKey` / `GITHUB_TOKEN` / `GH_PAT` redaction is unchanged.

Occupancy-FREE host `packages/app-core/src/api/server-config-filter.ts`
(`scannedAt=2026-08-20T21:01:24.506Z`). App-core leftover. Not leftover-tax of
#23088 / #23082 / #23070 ghost-accountId. Not a ReDoS twin of #23085 / #23076.
Not a cloud JSON 500 reprint. Not HARD_SKIP `server.ts`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/server-config-filter.ts` and
`packages/app-core/test/server-config-filter.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:6ebfb9128c5920a5e7c0e8a121f3bae49d74e957 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; config filter is runtime logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; config filter is runtime logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
origin develop a61d938a9e48
filterConfigEnvForResponse(cyclic) -> RangeError Maximum call stack size exceeded
enumerable getter invoked (GETTER_INVOKED / 50ms spin)

overlay bun/vitest packages/app-core/test/server-config-filter.test.ts
6/6 including cyclic/over-deep/getter fail-closed and honest redaction
head 6ebfb9128c5920a5e7c0e8a121f3bae49d74e957
cyclic -> ElizaError CONFIG_FILTER_UNBOUNDED 0.163ms
getter -> ElizaError CONFIG_FILTER_UNBOUNDED 0.026ms (getter not invoked)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
