### PR TITLE
fix(scenario-runner): keep inline view plugin out of preflight

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -1214,6 +1214,30 @@ describe("deterministic action coverage", () => {
     ).toEqual(expected);
   });
 
+  it("keeps scenario-local active-view routes out of package preflight", async () => {
+    const loaded = await loadAllScenarios(scenarioDir);
+    for (const id of [
+      "deterministic-active-view-agent-surface",
+      "live-active-view-agent-surface",
+    ]) {
+      const scenario = loaded.find(
+        (entry) => entry.scenario.id === id,
+      )?.scenario;
+      expect(scenario, `missing active-view scenario ${id}`).toBeDefined();
+      expect(scenario?.requires?.plugins).toEqual([
+        "@elizaos/plugin-app-control",
+      ]);
+
+      const source = readFileSync(
+        resolve(scenarioDir, `${id}.scenario.ts`),
+        "utf8",
+      );
+      expect(source).toContain(
+        "runtime.registerPlugin(scenarioViewsRoutePlugin)",
+      );
+    }
+  });
+
   it("strict LLM-routed scenarios declare planner/response fixtures for their routed actions", async () => {
     const problems: string[] = [];
 

--- a/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
@@ -413,7 +413,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: ["@elizaos/plugin-app-control", "scenario-active-view-routes"],
+    plugins: ["@elizaos/plugin-app-control"],
   },
   seed: [
     {

--- a/packages/scenario-runner/test/scenarios/live-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-active-view-agent-surface.scenario.ts
@@ -333,7 +333,7 @@ export default scenario({
   tags: ["live", "app-control", "views", "active-view"],
   isolation: "shared-runtime",
   requires: {
-    plugins: ["@elizaos/plugin-app-control", "scenario-active-view-routes"],
+    plugins: ["@elizaos/plugin-app-control"],
   },
   seed: [
     {


### PR DESCRIPTION
## Summary

- removes the scenario-local active-view route wrapper from package preflight in both deterministic and live scenarios
- preserves preflight for the installable @elizaos/plugin-app-control package
- adds a focused contract proving both scenarios register the inline wrapper through their seed instead

Closes #22851
Relates to #22896

## Exact-head evidence

Exact head: `1113533b38e42b5f52eaef65d8b63102fd1eb0ed`
Base: `develop@61af9b80a81dc3dc0548841efff18e7532745438`
The current-base three-way replay preserved the newer deterministic-action coverage edits and the PR correction in one clean rebased tree.

## Evidence

- PASS: real deterministic-active-view-agent-surface through production runtime assembly, 1 passed / 0 failed / 0 skipped; scenario duration 3,760 ms; report and run-viewer bundles produced
- PASS: focused deterministic action coverage test, 18/18
- PASS: scenario-runner build
- PASS: Biome check on all three changed files
- PASS: guide parity, 156 tracked CLAUDE.md/AGENTS.md pairs
- PASS: git diff --check
- PASS: rebased onto current origin/develop and bun install with Bun 1.3.14
- BASE FAILURE: package typecheck reports existing unresolved optional/private workspace packages and LifeOps schema type failures outside this three-file diff.

The first direct scenario attempt was stopped during silent one-time PGlite/plugin migrations. A debug-visible rerun completed successfully and confirmed the original scenario-active-view-routes package-resolution failure is absent.

## Evidence Gate

<!-- evidence-head:1113533b38e42b5f52eaef65d8b63102fd1eb0ed -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - scenario-runner preflight correction; no rendered product UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - scenario-runner preflight correction; no rendered product UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the deterministic production-runtime scenario receipt is summarized above; no deployed backend changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or console surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic fixture execution changed only package preflight ownership.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - scenario and run-viewer bundles were ephemeral deterministic test output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@a61d938a9e48d437c4a92570bdb028330ff49eaf:packages/skills/skills/contribute-to-eliza"} -->