### PR TITLE
fix(cloud): keep post-cutover reminders on Dedicated

### DIFF
--- a/packages/cloud/api/__tests__/shared-runtime-cutover-reminder.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/shared-runtime-cutover-reminder.miniflare.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Runs the production Shared conversation coordinator in Workerd and proves a
+ * committed Personal Shared -> Dedicated cutover cannot reopen Shared for a
+ * reminder turn.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Miniflare } from "miniflare";
+
+const RUNTIME_BOUNDARIES = {
+  apiErrors:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]api[\\/]errors\.ts$/,
+  apnsProvider:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]mobile-push[\\/]apns-provider\.ts$/,
+  cloudBindings:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]runtime[\\/]cloud-bindings\.ts$/,
+  databaseClient:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]db[\\/]client\.ts$/,
+  historyRepository:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]db[\\/]repositories[\\/]shared-runtime-history\.ts$/,
+  logger:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]utils[\\/]logger\.ts$/,
+  sharedElizaRuntime:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]shared-runtime[\\/]shared-eliza-runtime\.ts$/,
+  sharedRuntimeChat:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]shared-runtime[\\/]shared-runtime-chat\.ts$/,
+  cachedAgentDates:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]shared-runtime[\\/]cached-agent-dates\.ts$/,
+  tierUpgradeTarget:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]agent-tier-upgrade-target\.ts$/,
+} as const;
+
+const RUNTIME_STUBS = {
+  apiErrors: `
+    export class InsufficientCreditsError extends Error {}
+    export class RateLimitError extends Error {}
+  `,
+  apnsProvider: `
+    export function resolveCloudApnsConfig() { return null; }
+    export class CloudApnsProvider {
+      async send() { throw new Error("APNs is outside this cutover test"); }
+    }
+  `,
+  cachedAgentDates: `
+    export function rehydrateCachedAgentDates(agent) { return agent; }
+  `,
+  cloudBindings: `
+    export async function runWithCloudBindingsAsync(_bindings, operation) {
+      return await operation();
+    }
+  `,
+  coreEdge: `
+    export const ChannelType = {
+      SELF: "SELF",
+      DM: "DM",
+      GROUP: "GROUP",
+      VOICE_DM: "VOICE_DM",
+      VOICE_GROUP: "VOICE_GROUP",
+      FEED: "FEED",
+      THREAD: "THREAD",
+      WORLD: "WORLD",
+      FORUM: "FORUM",
+      AUTONOMOUS: "AUTONOMOUS",
+      API: "API",
+    };
+  `,
+  databaseClient: `
+    export async function runWithDbCacheAsync(operation) {
+      return await operation();
+    }
+  `,
+  historyRepository: `
+    export const sharedRuntimeHistoryRepository = {
+      async get() { return []; },
+      async merge() {},
+      async deleteByAgent() {},
+    };
+  `,
+  logger: `
+    export const logger = {
+      debug() {}, info() {}, warn() {}, error() {},
+    };
+  `,
+  sharedElizaRuntime: "export async function prewarmSharedElizaRuntime() {}",
+  sharedRuntimeChat: `
+    export const sharedRuntimeChatService = {
+      async getHistory(agentId, roomId, store) {
+        return await store.load(agentId, roomId);
+      },
+      async bridge() {
+        await fetch("https://model-probe.test/v1/chat/completions", {
+          method: "POST",
+          body: "unexpected-shared-reminder-inference",
+        });
+        throw new Error("Committed cutover reached Shared inference");
+      },
+      async stream() {
+        await fetch("https://model-probe.test/v1/chat/completions", {
+          method: "POST",
+          body: "unexpected-shared-reminder-inference",
+        });
+        throw new Error("Committed cutover reached Shared inference");
+      },
+      async recordLifecycleEvent() {
+        throw new Error("Lifecycle writes are outside this cutover test");
+      },
+    };
+  `,
+  tierUpgradeTarget:
+    "export async function findActivePersonalDedicatedTarget() { return null; }",
+} as const;
+
+describe("Personal Shared cutover reminder containment in Workerd", () => {
+  let buildDirectory: string;
+  let miniflare: Miniflare;
+  const modelRequests: string[] = [];
+
+  beforeAll(async () => {
+    const apiDirectory = fileURLToPath(new URL("../", import.meta.url));
+    buildDirectory = await mkdtemp(
+      join(tmpdir(), "shared-cutover-reminder-workerd-"),
+    );
+    const coordinatorSource = fileURLToPath(
+      new URL("../src/shared-runtime-conversation.ts", import.meta.url),
+    );
+    const sharedSourceDirectory = fileURLToPath(
+      new URL("../../shared/src/", import.meta.url),
+    );
+    const entrypoint = join(buildDirectory, "worker.ts");
+    await Bun.write(
+      entrypoint,
+      `
+        import { SharedRuntimeConversation } from ${JSON.stringify(coordinatorSource)};
+
+        export class TestSharedRuntimeConversation extends SharedRuntimeConversation {
+          constructor(state, env) {
+            super(state, env);
+            this.testState = state;
+          }
+
+          async fetch(request) {
+            if (new URL(request.url).pathname === "/__test/seed") {
+              const body = await request.json();
+              await this.testState.storage.put("conversation", body.conversation);
+              return Response.json({ success: true });
+            }
+            return await super.fetch(request);
+          }
+        }
+
+        export default {
+          async fetch(request, env) {
+            const name = request.headers.get("x-test-room");
+            if (!name) return new Response("missing room", { status: 400 });
+            const id = env.SHARED_RUNTIME_CONVERSATIONS.idFromName(name);
+            return await env.SHARED_RUNTIME_CONVERSATIONS.get(id).fetch(request);
+          },
+        };
+      `,
+    );
+
+    const outputPath = join(buildDirectory, "worker.mjs");
+    const buildScriptPath = join(buildDirectory, "build-worker.mjs");
+    await Bun.write(
+      buildScriptPath,
+      `
+        import { join } from "node:path";
+
+        const boundary = (source) => new RegExp(source);
+        const result = await Bun.build({
+          entrypoints: [process.env.SHARED_CUTOVER_ENTRYPOINT],
+          format: "esm",
+          target: "browser",
+          conditions: ["worker", "browser"],
+          external: ["node:*"],
+          plugins: [{
+            name: "shared-cutover-reminder-runtime-boundaries",
+            setup(build) {
+              build.onResolve({ filter: /^@elizaos\\/core\\/edge$/ }, () => ({
+                path: "core-edge",
+                namespace: "shared-cutover-test-stub",
+              }));
+              build.onLoad(
+                { filter: /^core-edge$/, namespace: "shared-cutover-test-stub" },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.coreEdge)} }),
+              );
+              build.onResolve({ filter: /^@\\/(?:db|lib|types)\\// }, (args) => ({
+                path: join(
+                  process.env.SHARED_CUTOVER_SHARED_SOURCE,
+                  args.path.slice(2) + ".ts",
+                ),
+              }));
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.databaseClient.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.databaseClient)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.cloudBindings.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.cloudBindings)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.sharedRuntimeChat.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.sharedRuntimeChat)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.cachedAgentDates.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.cachedAgentDates)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.sharedElizaRuntime.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.sharedElizaRuntime)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.historyRepository.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.historyRepository)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.tierUpgradeTarget.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.tierUpgradeTarget)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.logger.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.logger)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.apnsProvider.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.apnsProvider)} }),
+              );
+              build.onLoad(
+                { filter: boundary(${JSON.stringify(RUNTIME_BOUNDARIES.apiErrors.source)}) },
+                () => ({ loader: "ts", contents: ${JSON.stringify(RUNTIME_STUBS.apiErrors)} }),
+              );
+            },
+          }],
+        });
+        if (!result.success) {
+          for (const log of result.logs) console.error(log);
+          process.exit(1);
+        }
+        const output = result.outputs[0];
+        if (!output) throw new Error("Shared cutover test Worker was not emitted");
+        await Bun.write(process.env.SHARED_CUTOVER_OUTPUT, output);
+      `,
+    );
+    const bundle = Bun.spawn({
+      cmd: [process.execPath, buildScriptPath],
+      cwd: apiDirectory,
+      env: {
+        ...process.env,
+        SHARED_CUTOVER_ENTRYPOINT: entrypoint,
+        SHARED_CUTOVER_OUTPUT: outputPath,
+        SHARED_CUTOVER_SHARED_SOURCE: sharedSourceDirectory,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [bundleExitCode, bundleStderr, bundleStdout] = await Promise.all([
+      bundle.exited,
+      new Response(bundle.stderr).text(),
+      new Response(bundle.stdout).text(),
+    ]);
+    if (bundleExitCode !== 0) {
+      throw new Error(
+        `Failed to bundle Shared cutover reminder test Worker:\n${bundleStderr}${bundleStdout}`,
+      );
+    }
+
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-06-01",
+      compatibilityFlags: ["nodejs_compat"],
+      modules: true,
+      script: await readFile(outputPath, "utf8"),
+      outboundService: async (request: Request) => {
+        modelRequests.push(request.url);
+        return Response.json(
+          { error: "unexpected inference" },
+          { status: 500 },
+        );
+      },
+      durableObjects: {
+        SHARED_RUNTIME_CONVERSATIONS: {
+          className: "TestSharedRuntimeConversation",
+          useSQLite: true,
+        },
+      },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await miniflare?.dispose();
+    if (buildDirectory) await rm(buildDirectory, { recursive: true });
+  });
+
+  async function post(
+    room: string,
+    path: string,
+    body: Record<string, unknown>,
+  ) {
+    return await miniflare.dispatchFetch(`https://runtime.test${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-room": room,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("a committed seal rejects a reminder before history mutation or inference", async () => {
+    const personalAgent = {
+      id: "personal:cutover-reminder-miniflare",
+      organization_id: "organization-cutover-miniflare",
+      user_id: "user-cutover-miniflare",
+      character_id: null,
+      agent_name: "Eliza",
+      agent_config: { character: { name: "Eliza" } },
+      execution_tier: "shared",
+    };
+    const history = [
+      {
+        id: "turn-before-cutover",
+        role: "user",
+        content: "This conversation belongs to Shared before cutover.",
+        createdAt: 1_787_184_000_000,
+      },
+    ];
+    const token = "personal-cutover:source:dedicated";
+
+    const seeded = await post(personalAgent.id, "/__test/seed", {
+      conversation: {
+        agentId: personalAgent.id,
+        channelId: personalAgent.id,
+        history,
+        dirty: false,
+        version: 1,
+      },
+    });
+    expect(seeded.status, await seeded.text()).toBe(200);
+
+    const sealed = await post(personalAgent.id, "/cutover-seal", {
+      operation: "cutover-seal",
+      agentId: personalAgent.id,
+      roomId: personalAgent.id,
+      token,
+      leaseMs: 60_000,
+      organizationId: personalAgent.organization_id,
+      dedicatedAgentId: "dedicated-agent-miniflare",
+    });
+    const sealedBody = await sealed.text();
+    expect(sealed.status, sealedBody).toBe(200);
+    expect(JSON.parse(sealedBody)).toEqual({ success: true, history });
+
+    const committed = await post(personalAgent.id, "/cutover-commit", {
+      operation: "cutover-commit",
+      token,
+    });
+    expect(committed.status, await committed.text()).toBe(200);
+
+    const reminder = await post(personalAgent.id, "/personal-bridge", {
+      operation: "personal-bridge",
+      agent: personalAgent,
+      rpc: {
+        jsonrpc: "2.0",
+        id: "telegram:reminder-after-cutover",
+        method: "message.send",
+        params: {
+          text: "Remind me in 2 minutes to stretch",
+          roomId: personalAgent.id,
+          conversationId: personalAgent.id,
+          clientMessageId: "telegram:reminder-after-cutover",
+          platformName: "telegram",
+          source: "telegram",
+        },
+      },
+    });
+    const reminderBody = await reminder.text();
+    expect(reminder.status, reminderBody).toBe(409);
+    expect(JSON.parse(reminderBody)).toEqual({
+      success: false,
+      error: "This personal Eliza is active on Dedicated.",
+      code: "personal_eliza_dedicated",
+      retryable: false,
+    });
+
+    const after = await post(personalAgent.id, "/history", {
+      operation: "history",
+      agentId: personalAgent.id,
+      roomId: personalAgent.id,
+    });
+    const afterBody = await after.text();
+    expect(after.status, afterBody).toBe(200);
+    expect(JSON.parse(afterBody)).toEqual({ history });
+    expect(modelRequests).toEqual([]);
+  }, 120_000);
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -769,6 +769,58 @@ describe("personal Shared messaging deliveries", () => {
     expect(bridge).toHaveBeenCalledTimes(1);
   });
 
+  test("keeps a Blooio reminder on Dedicated after cutover without Shared prewarm", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    const reminder = "Remind me in 2 minutes to stretch";
+
+    const response = await request({
+      ...validPhone,
+      messageId: "blooio:reminder-42",
+      message: reminder,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: expect.stringMatching(/^personal:/),
+          runtime: "dedicated",
+          activeAgentId: "00000000-0000-4000-8000-000000000020",
+        },
+        account: {
+          userId: "00000000-0000-4000-8000-000000000002",
+          organizationId: "00000000-0000-4000-8000-000000000001",
+        },
+        reply: "hello from Dedicated",
+      },
+    });
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(bridge).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      "00000000-0000-4000-8000-000000000001",
+      expect.objectContaining({
+        id: "blooio:reminder-42",
+        method: "message.send",
+        params: expect.objectContaining({
+          text: reminder,
+          roomId: expect.stringMatching(/^personal:/),
+          conversationId: expect.stringMatching(/^personal:/),
+          clientMessageId: "blooio:reminder-42",
+          platformName: "blooio",
+          source: "blooio",
+        }),
+      }),
+    );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(runtimeWaitUntil).not.toHaveBeenCalled();
+  });
+
   test("auto-registers a first Discord DM in the same personal room", async () => {
     personalDeliveryIsNew = true;
     const discordUserId = ["123456789", "012345678"].join("");
@@ -863,16 +915,17 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
-  test("keeps a Telegram reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+  test("keeps a Telegram reminder on Dedicated after cutover without reopening Shared", async () => {
     activeTarget = {
       id: "00000000-0000-4000-8000-000000000020",
       status: "running",
       bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
     };
+    const reminder = "Remind me in 2 minutes to stretch";
 
     const response = await request({
       ...valid,
-      message: "Remind me in 2 minutes to stretch",
+      message: reminder,
     });
 
     expect(response.status).toBe(200);
@@ -881,37 +934,46 @@ describe("personal Shared messaging deliveries", () => {
       data: {
         identity: {
           id: expect.stringMatching(/^personal:/),
-          runtime: "shared",
+          runtime: "dedicated",
+          activeAgentId: "00000000-0000-4000-8000-000000000020",
         },
-        reply: "hello from Eliza",
+        reply: "hello from Dedicated",
       },
     });
-    expect(bridge).not.toHaveBeenCalled();
-    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
-    expect(sharedRestMessageSend).toHaveBeenCalledWith(
-      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
-      expect.stringMatching(/^personal:/),
-      "Remind me in 2 minutes to stretch",
-      "Eliza",
-      runtimeExecutionCtx,
-      namespace,
-      "telegram:eliza:42",
-      "platform",
-      {
-        platform: "telegram",
-        project: "eliza-app",
-        chatId: "123456789",
-      },
+    expect(bridge).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      "00000000-0000-4000-8000-000000000001",
+      expect.objectContaining({
+        id: "telegram:eliza:42",
+        method: "message.send",
+        params: expect.objectContaining({
+          text: reminder,
+          roomId: expect.stringMatching(/^personal:/),
+          conversationId: expect.stringMatching(/^personal:/),
+          clientMessageId: "telegram:eliza:42",
+          platformName: "telegram",
+          source: "telegram",
+        }),
+      }),
     );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(runtimeWaitUntil).not.toHaveBeenCalled();
   });
 
-  test("keeps a Discord reminder on the trusted gateway scheduler after Dedicated cutover", async () => {
+  test("keeps a Discord reminder on Dedicated after cutover without reopening Shared", async () => {
     activeTarget = {
       id: "00000000-0000-4000-8000-000000000020",
       status: "running",
       bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
     };
-    const discordUserId = "123456789012345678";
+    const discordUserId = ["123456789", "012345678"].join("");
+    const reminder = "Remind me in 2 minutes to stretch";
+    bridge.mockImplementationOnce(async () => ({
+      jsonrpc: "2.0" as const,
+      id: "discord:reminder-42",
+      result: { text: "hello from Dedicated" },
+    }));
 
     const response = await request({
       platform: "discord",
@@ -919,7 +981,7 @@ describe("personal Shared messaging deliveries", () => {
       discordUsername: "shaw",
       displayName: "Shaw",
       messageId: "discord:reminder-42",
-      message: "Remind me in 2 minutes to stretch",
+      message: reminder,
     });
 
     expect(response.status).toBe(200);
@@ -928,27 +990,31 @@ describe("personal Shared messaging deliveries", () => {
       data: {
         identity: {
           id: expect.stringMatching(/^personal:/),
-          runtime: "shared",
+          runtime: "dedicated",
+          activeAgentId: "00000000-0000-4000-8000-000000000020",
         },
-        reply: "hello from Eliza",
+        reply: "hello from Dedicated",
       },
     });
-    expect(bridge).not.toHaveBeenCalled();
-    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
-    expect(sharedRestMessageSend).toHaveBeenCalledWith(
-      expect.objectContaining({ id: expect.stringMatching(/^personal:/) }),
-      expect.stringMatching(/^personal:/),
-      "Remind me in 2 minutes to stretch",
-      "Eliza",
-      runtimeExecutionCtx,
-      namespace,
-      "discord:reminder-42",
-      "platform",
-      {
-        platform: "discord",
-        discordUserId,
-      },
+    expect(bridge).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      "00000000-0000-4000-8000-000000000001",
+      expect.objectContaining({
+        id: "discord:reminder-42",
+        method: "message.send",
+        params: expect.objectContaining({
+          text: reminder,
+          roomId: expect.stringMatching(/^personal:/),
+          conversationId: expect.stringMatching(/^personal:/),
+          clientMessageId: "discord:reminder-42",
+          platformName: "discord",
+          source: "discord",
+        }),
+      }),
     );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(runtimeWaitUntil).not.toHaveBeenCalled();
   });
 
   test("idempotently resumes stopped Dedicated and asks the gateway to retry", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -19,7 +19,6 @@ import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversat
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
-import { resolveSharedCapabilityIntent } from "@/lib/services/shared-runtime/shared-capability-wall";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
@@ -65,16 +64,6 @@ const SAFE_ERROR_NAMES = new Set([
 function safeErrorName(error: unknown): string {
   const name = error instanceof Error ? error.name : "";
   return SAFE_ERROR_NAMES.has(name) ? name : "OtherError";
-}
-
-function isGatewayNativeReminderTurn(message: string): boolean {
-  const resolution = resolveSharedCapabilityIntent(message, {
-    reminders: true,
-  });
-  return (
-    resolution?.kind === "enabled-primary" &&
-    resolution.primary.capability === "reminders"
-  );
 }
 
 const telegramVoiceNoteSchema = z.object({
@@ -344,24 +333,31 @@ app.post("/", async (c) => {
       dedicated = delivery.dedicatedTarget;
       isNewPersonalAccount = delivery.isNew;
     }
-    const accountMs = performance.now() - accountStartedAt;
-    const accountTiming = `account;dur=${accountMs.toFixed(1)};desc="${accountResolution}"`;
-    c.header("Server-Timing", accountTiming);
     const agent = personalSharedAgent({
       userId: account.userId,
       organizationId: account.organizationId,
     });
-    const startPersonalPrewarm = () => {
-      const startedAt = performance.now();
-      const timing = prewarmPersonalSharedAgentTurnCaches(
-        agent,
-        worker.namespace,
-        { warmConversation: isNewPersonalAccount },
-      ).then(() => performance.now() - startedAt);
-      worker.executionCtx.waitUntil(timing);
-      return timing;
-    };
-    let personalPrewarm = dedicated ? null : startPersonalPrewarm();
+    if (dedicated === undefined) {
+      dedicated = await findActivePersonalDedicatedTarget(
+        account.organizationId,
+        agent.id,
+      );
+    }
+    const accountMs = performance.now() - accountStartedAt;
+    const accountTiming = `account;dur=${accountMs.toFixed(1)};desc="${accountResolution}"`;
+    c.header("Server-Timing", accountTiming);
+    const personalPrewarm = dedicated
+      ? null
+      : (() => {
+          const startedAt = performance.now();
+          const timing = prewarmPersonalSharedAgentTurnCaches(
+            agent,
+            worker.namespace,
+            { warmConversation: isNewPersonalAccount },
+          ).then(() => performance.now() - startedAt);
+          worker.executionCtx.waitUntil(timing);
+          return timing;
+        })();
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -439,23 +435,7 @@ app.post("/", async (c) => {
         },
       });
     }
-    if (dedicated === undefined) {
-      dedicated = await findActivePersonalDedicatedTarget(
-        account.organizationId,
-        agent.id,
-      );
-    }
-    // Connector-native reminders stay on the server-owned Personal Shared
-    // scheduler even after a Dedicated cutover. Dedicated containers receive
-    // the conversational turn through the bridge, but do not own the trusted
-    // Telegram/Discord/Blooio delivery credential needed to persist and fire a
-    // reminder back into this verified DM.
-    const gatewayNativeReminderTurn =
-      isGatewayNativeReminderTurn(deliveryMessage);
-    if (dedicated && gatewayNativeReminderTurn && !personalPrewarm) {
-      personalPrewarm = startPersonalPrewarm();
-    }
-    if (dedicated && !gatewayNativeReminderTurn) {
+    if (dedicated) {
       stage = "dedicated_runtime";
       const dedicatedStartedAt = performance.now();
       const preparation = await preparePersonalDedicatedDelivery(


### PR DESCRIPTION
<!-- evidence-head:37fdcb420b8afacd8526c9dd2942777a859cb25d -->

## Summary

- resolve the active Personal Dedicated target before any Shared prewarm
- keep Telegram, Discord, and Blooio reminder turns on the Dedicated bridge after cutover
- add a real Miniflare SQLite Durable Object proof that a committed cutover rejects Shared reminder inference

## Context

PR #23065 routed reminder-shaped turns back through Personal Shared after a committed Shared-to-Dedicated cutover. The production Durable Object fence rejects that bridge. This PR restores the authoritative Dedicated route. The Workerd test proves why the Shared alternative is invalid; the route tests bind the actual fix.

The immediate user-visible result is an honest Dedicated response rather than a Shared 409 or a falsely accepted Shared reminder. A Dedicated runtime that still lacks external-message reminder capability can continue to return its explicit refusal; completing that runtime capability and protected connector proof remains tracked by #20274.

## Verification

- Bun 1.3.14: route suite 32/32 and Workerd suite 1/1, 156 assertions total
- Cloud API build was green on the original patch-equivalent head; exact rebased-head typecheck was attempted but the shared host exhausted Node's 4 GiB heap while other package gates were running
- changed-file Biome and `git diff --check` passed on the original patch-equivalent head
- `git range-diff` marks the rebase onto current `develop` patch-equivalent

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI path changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - exact focused backend validation is documented above; no protected backend was mutated.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend surface changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic lifecycle routing does not invoke a model in this proof.

<!-- evidence-row:domain-artifacts -->
- [x] Workerd/SQLite assertion proves a committed cutover returns 409 before history mutation or inference; route tests prove all three connectors select Dedicated without Shared prewarm.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:ai-provider -->
- AI provider: OpenAI
<!-- attribution-row:ai-model -->
- AI model: gpt-5.6-sol
<!-- attribution-row:agent-tooling -->
- Agent tooling: Codex Desktop
<!-- attribution-row:contribution-skill -->
- Contribution skill: packages/skills/skills/contribute-to-eliza
<!-- attribution-row:attribution-status -->
- Attribution status: self-reported

Refs #20274
