### PR TITLE
fix: passkey autofill hijacks new-email signup on eliza login (drop webauthn autocomplete token) — port of steward #690

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -219,14 +219,20 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
   });
 
-  it("renders passkey and webauthn autocomplete after a positive capability probe", async () => {
+  it("renders passkey but never arms webauthn autofill after a positive capability probe", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
 
     renderSection();
 
     const input = await screen.findByPlaceholderText("you@example.com");
-    expect(input.getAttribute("autocomplete")).toBe("email webauthn");
+    // Regression guard (port of Steward #690): even when passkeys are
+    // available, the email input must NOT carry the "webauthn" autocomplete
+    // token. That token arms browser conditional-mediation autofill, which
+    // prompts for an existing account's discoverable credential when a
+    // brand-new email is typed and hijacks signup. Passkey sign-in stays
+    // available only through the explicit Passkey button (email-scoped).
+    expect(input.getAttribute("autocomplete")).toBe("email");
     expect(screen.getByRole("button", { name: /Passkey/i })).toBeTruthy();
 
     fireEvent.change(input, { target: { value: "person@example.com" } });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1864,7 +1864,13 @@ export default function StewardLoginSection() {
           }}
           disabled={isLoading}
           className="hosted-signin-focus-emphasis w-full min-h-touch rounded-md border border-input bg-bg-elevated px-4 py-3 text-txt outline-none transition-colors placeholder:text-muted hover:border-border-strong disabled:opacity-50"
-          autoComplete={showPasskey ? "email webauthn" : "email"}
+          // Do NOT add the "webauthn" autocomplete token here. It arms browser
+          // conditional-mediation passkey autofill, which prompts for an
+          // EXISTING account's discoverable credential the moment a brand-new
+          // email is typed, hijacking signup. The explicit Passkey button below
+          // still offers email-scoped passkey sign-in via handlePasskey().
+          // Port of Steward PR #690.
+          autoComplete="email"
         />
       </div>
 


### PR DESCRIPTION
## Summary

Port of Steward **#690** into eliza cloud's **own** inline login component.

Eliza cloud does not consume Steward's `@stwd/react` `StewardLogin`; it ships its own copy, `StewardLoginSection` (`tenantId: "elizacloud"`), driving the Steward SDK directly. So the merged + validated Steward #690 fix never reached eliza users, and the new-email account-hijack-on-signup bug was **live on eliza.app/login**.

## The bug (identical to #690)

On the login form, typing a **brand-new** email triggered a browser passkey prompt for an **existing** account's discoverable credential, blocking signup.

Cause: the email input carried
```tsx
autoComplete={showPasskey ? "email webauthn" : "email"}
```
The `webauthn` token arms browser conditional-mediation / password-manager passkey autofill. As soon as a positive passkey capability probe flips `showPasskey`, the token is present and the browser offers a discoverable credential the instant an email is typed — hijacking signup for new emails.

## Fix

Drop **only** the `webauthn` token:
```tsx
autoComplete="email"
```

Removed webauthn autocomplete tokens (file:line):
- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx:1867` — `autoComplete={showPasskey ? "email webauthn" : "email"}` → `autoComplete="email"` (with an inline comment guard)

## Completeness check (mirrors #690)

`webauthn` autofill was the **only** conditional-mediation arm in the eliza frontend. Grepped `packages/ui/src` for `mediation`, `conditional`, `credentials.get`, `browserSupportsWebAuthnAutofill`, `isConditionalMediationAvailable`, and `"email webauthn"` — the single non-test occurrence was this input. There is **no** programmatic conditional `credentials.get()`, so removing the attribute is sufficient; nothing else re-arms autofill.

## Returning-user passkey is unaffected

The explicit **Passkey** button calls
```ts
auth.signInWithPasskey(email.trim(), { fallbackToRegistration: false })
```
which is **email-scoped** and completely independent of the input's `autoComplete`. Returning users still sign in with a passkey via the button; only the silent autofill hijack on the input is removed.

## Test

Updated the existing regression test in `steward-login-section.passkey-capability.test.tsx`:
- `"renders passkey but never arms webauthn autofill after a positive capability probe"` now asserts `input.getAttribute("autocomplete") === "email"` **even when passkeys are available** (`capabilityRef.usable = true`), and still verifies the explicit Passkey button routes to `signInWithPasskey`.

All login-page tests pass:
```
Test Files  15 passed (15)
      Tests  82 passed (82)
```

## Scope

Only the `webauthn`-token removal + the mirrored regression assertion. No unrelated changes, no security weakening, no deploy/merge. New branch off `develop`.

Ref: Steward **#690** (merged + validated — two independent reviews + a third lane).
