### PR TITLE
fix(agent): fail closed on cyclic agent-export canonicalize walks

### DIFF
--- a/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
+++ b/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
@@ -12,7 +12,10 @@ import {
   AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
   AgentExportError,
   canonicalize,
+  digestCollection,
+  MANIFEST_COLLECTIONS,
   MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
+  MAX_AGENT_EXPORT_CANONICALIZE_NODES,
   verifyExportManifest,
 } from "./agent-export.ts";
 
@@ -33,6 +36,36 @@ function expectUnbounded(fn: () => unknown): void {
     );
     expect(error).not.toBeInstanceOf(RangeError);
   }
+}
+
+function emptyPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    exportedAt: "2026-08-21T00:00:00.000Z",
+    sourceAgentId: "agent-1",
+    agent: { name: "Ada" },
+    entities: [],
+    memories: [],
+    components: [],
+    rooms: [],
+    participants: [],
+    relationships: [],
+    worlds: [],
+    tasks: [],
+    logs: [],
+    ...overrides,
+  };
+}
+
+function manifestFor(payload: Record<string, unknown>) {
+  const components: Record<string, ReturnType<typeof digestCollection>> = {};
+  for (const name of MANIFEST_COLLECTIONS) {
+    const items = payload[name];
+    components[name] = digestCollection(
+      Array.isArray(items) ? items : [],
+    );
+  }
+  return { algorithm: "sha256" as const, components };
 }
 
 describe("canonicalize fail-closed walk", () => {
@@ -86,26 +119,182 @@ describe("canonicalize fail-closed walk", () => {
     cyclic.self = cyclic;
     expectUnbounded(() =>
       verifyExportManifest({
-        version: 1,
-        exportedAt: "2026-08-21T00:00:00.000Z",
-        sourceAgentId: "agent-1",
-        agent: { name: "Ada" },
-        entities: [],
-        memories: [cyclic as never],
-        components: [],
-        rooms: [],
-        participants: [],
-        relationships: [],
-        worlds: [],
-        tasks: [],
-        logs: [],
+        ...emptyPayload({ memories: [cyclic] }),
         manifest: {
           algorithm: "sha256",
           components: {
             memories: { sha256: "abc", count: 1 },
           },
         },
-      }),
+      } as never),
     );
+  });
+
+  it("ordinary Proxy object/array keep honest canonical bytes", () => {
+    expect(canonicalize(new Proxy({ b: 1, a: 2 }, {}))).toBe('{"a":2,"b":1}');
+    expect(canonicalize(new Proxy([2, 1], {}))).toBe("[2,1]");
+  });
+
+  it("revoked object and array Proxies fail closed instead of TypeError", () => {
+    const objectPair = Proxy.revocable({ a: 1 }, {});
+    objectPair.revoke();
+    expectUnbounded(() => canonicalize(objectPair.proxy));
+    const arrayPair = Proxy.revocable([1, 2], {});
+    arrayPair.revoke();
+    expectUnbounded(() => canonicalize(arrayPair.proxy));
+  });
+
+  it("does not invoke own or inherited array accessors", () => {
+    const ownHostile: unknown[] = [];
+    Object.defineProperty(ownHostile, "0", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("ARRAY_OWN_ACCESSOR");
+      },
+    });
+    try {
+      canonicalize(ownHostile);
+      throw new Error("expected AGENT_EXPORT_CANONICALIZE_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentExportError);
+      expect((error as AgentExportError).code).toBe(
+        AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+      );
+      expect(String(error)).not.toContain("ARRAY_OWN_ACCESSOR");
+    }
+
+    let inheritedInvoked = false;
+    Object.defineProperty(Array.prototype, "1", {
+      configurable: true,
+      enumerable: false,
+      get() {
+        inheritedInvoked = true;
+        return "PWN";
+      },
+    });
+    try {
+      const sparse = [0];
+      sparse.length = 3;
+      sparse[2] = 2;
+      expect(canonicalize(sparse)).toBe("[0,,2]");
+      expect(inheritedInvoked).toBe(false);
+    } finally {
+      Reflect.deleteProperty(Array.prototype, "1");
+    }
+  });
+
+  it("fail-closed on a huge sparse length before allocating the join", () => {
+    const sparse: unknown[] = [];
+    sparse.length = MAX_AGENT_EXPORT_CANONICALIZE_NODES + 1;
+    expectUnbounded(() => canonicalize(sparse));
+  });
+
+  it("captures one object descriptor snapshot so Proxy drift cannot change the walk", () => {
+    let reads = 0;
+    const drifted = new Proxy(
+      { a: 1 },
+      {
+        ownKeys() {
+          return ["a"];
+        },
+        getOwnPropertyDescriptor() {
+          reads += 1;
+          if (reads === 1) {
+            return {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: 1,
+            };
+          }
+          throw new Error("DESCRIPTOR_DRIFT");
+        },
+      },
+    );
+    expect(canonicalize(drifted)).toBe('{"a":1}');
+    expect(reads).toBe(1);
+  });
+
+  it("preserves sparse-hole canonical string and undefined-as-null array slots", () => {
+    const sparse = [1];
+    sparse[2] = 3;
+    expect(canonicalize(sparse)).toBe("[1,,3]");
+    expect(canonicalize([1, undefined, 3])).toBe("[1,null,3]");
+  });
+
+  it("verifyExportManifest keeps honest output and fail-closed revoked/sparse/drift", () => {
+    const memories = [{ id: "mem-1", text: "hi", skip: undefined }];
+    const honest = emptyPayload({ memories });
+    const result = verifyExportManifest({
+      ...honest,
+      manifest: manifestFor(honest),
+    } as never);
+    expect(result.present).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.mismatches).toEqual([]);
+
+    const revoked = Proxy.revocable([{ id: "mem-1" }], {});
+    revoked.revoke();
+    expectUnbounded(() =>
+      verifyExportManifest({
+        ...emptyPayload({ memories: revoked.proxy }),
+        manifest: {
+          algorithm: "sha256",
+          components: { memories: { sha256: "abc", count: 1 } },
+        },
+      } as never),
+    );
+
+    const huge: unknown[] = [];
+    huge.length = MAX_AGENT_EXPORT_CANONICALIZE_NODES + 1;
+    expectUnbounded(() =>
+      verifyExportManifest({
+        ...emptyPayload({ memories: huge }),
+        manifest: {
+          algorithm: "sha256",
+          components: { memories: { sha256: "abc", count: 1 } },
+        },
+      } as never),
+    );
+
+    let reads = 0;
+    const drifted = new Proxy(
+      [{ id: "mem-1" }],
+      {
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "length") {
+            return {
+              configurable: false,
+              enumerable: false,
+              writable: true,
+              value: 1,
+            };
+          }
+          reads += 1;
+          if (reads === 1) {
+            return {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: { id: "mem-1" },
+            };
+          }
+          throw new Error("DESCRIPTOR_DRIFT");
+        },
+      },
+    );
+    const driftedPayload = emptyPayload({ memories: drifted });
+    const driftedResult = verifyExportManifest({
+      ...driftedPayload,
+      manifest: {
+        algorithm: "sha256",
+        components: {
+          ...manifestFor(emptyPayload({ memories: [{ id: "mem-1" }] }))
+            .components,
+        },
+      },
+    } as never);
+    expect(driftedResult.ok).toBe(true);
   });
 });

--- a/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
+++ b/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Fail-closed canonicalize walk for agent export integrity digests.
+ *
+ * Origin develop JSON.parse'd a 20k-deep nest (legal, ~120 KiB, under the
+ * 16 MiB gunzip cap) then RangeError'd in canonicalize during
+ * verifyExportManifest. Cyclic graphs and enumerable getters did the same.
+ * Depth/node/cycle fail-closed replaces that with AgentExportError
+ * AGENT_EXPORT_CANONICALIZE_UNBOUNDED.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+  AgentExportError,
+  canonicalize,
+  MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
+  verifyExportManifest,
+} from "./agent-export.ts";
+
+function nest(depth: number): unknown {
+  let value: unknown = 1;
+  for (let i = 0; i < depth; i += 1) value = { a: value };
+  return value;
+}
+
+function expectUnbounded(fn: () => unknown): void {
+  try {
+    fn();
+    throw new Error("expected AGENT_EXPORT_CANONICALIZE_UNBOUNDED");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AgentExportError);
+    expect((error as AgentExportError).code).toBe(
+      AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+    );
+    expect(error).not.toBeInstanceOf(RangeError);
+  }
+}
+
+describe("canonicalize fail-closed walk", () => {
+  it("still sorts keys and drops undefined (stable across key order)", () => {
+    expect(canonicalize({ b: 1, a: 2 })).toBe(canonicalize({ a: 2, b: 1 }));
+    expect(canonicalize({ a: 1, b: undefined })).toBe(canonicalize({ a: 1 }));
+    expect(canonicalize({ z: { b: 1, a: 2 } })).toBe('{"z":{"a":2,"b":1}}');
+  });
+
+  it("fail-closed on a cyclic export graph instead of RangeError", () => {
+    const cyclic: Record<string, unknown> = { id: "mem-1", text: "hi" };
+    cyclic.self = cyclic;
+    expectUnbounded(() => canonicalize(cyclic));
+  });
+
+  it("fail-closed on over-deep nests before the walk RangeErrors", () => {
+    expectUnbounded(() =>
+      canonicalize(nest(MAX_AGENT_EXPORT_CANONICALIZE_DEPTH + 8)),
+    );
+  });
+
+  it("fail-closed after JSON.parse accepts a 20k-deep import nest", () => {
+    const raw = `${'{"a":'.repeat(20_000)}1${"}".repeat(20_000)}`;
+    const parsed = JSON.parse(raw) as unknown;
+    expect(typeof parsed).toBe("object");
+    expectUnbounded(() => canonicalize(parsed));
+  });
+
+  it("does not invoke enumerable getters while canonicalizing", () => {
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "secret", {
+      enumerable: true,
+      get() {
+        throw new Error("GETTER_INVOKED");
+      },
+    });
+    try {
+      canonicalize({ id: "mem-1", content: hostile });
+      throw new Error("expected AGENT_EXPORT_CANONICALIZE_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentExportError);
+      expect((error as AgentExportError).code).toBe(
+        AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+      );
+      expect(String(error)).not.toContain("GETTER_INVOKED");
+    }
+  });
+
+  it("verifyExportManifest fail-closed on a cyclic memory collection", () => {
+    const cyclic: Record<string, unknown> = { id: "mem-1", text: "hi" };
+    cyclic.self = cyclic;
+    expectUnbounded(() =>
+      verifyExportManifest({
+        version: 1,
+        exportedAt: "2026-08-21T00:00:00.000Z",
+        sourceAgentId: "agent-1",
+        agent: { name: "Ada" },
+        entities: [],
+        memories: [cyclic as never],
+        components: [],
+        rooms: [],
+        participants: [],
+        relationships: [],
+        worlds: [],
+        tasks: [],
+        logs: [],
+        manifest: {
+          algorithm: "sha256",
+          components: {
+            memories: { sha256: "abc", count: 1 },
+          },
+        },
+      }),
+    );
+  });
+});

--- a/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
+++ b/packages/agent/src/services/agent-export.canonicalize-bound.test.ts
@@ -7,6 +7,7 @@
  * Depth/node/cycle fail-closed replaces that with AgentExportError
  * AGENT_EXPORT_CANONICALIZE_UNBOUNDED.
  */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
@@ -25,17 +26,23 @@ function nest(depth: number): unknown {
   return value;
 }
 
-function expectUnbounded(fn: () => unknown): void {
+function expectUnbounded(fn: () => unknown): AgentExportError {
+  let threw = false;
+  let caught: unknown;
   try {
     fn();
-    throw new Error("expected AGENT_EXPORT_CANONICALIZE_UNBOUNDED");
   } catch (error) {
-    expect(error).toBeInstanceOf(AgentExportError);
-    expect((error as AgentExportError).code).toBe(
-      AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
-    );
-    expect(error).not.toBeInstanceOf(RangeError);
+    threw = true;
+    caught = error;
   }
+  expect(threw).toBe(true);
+  expect(caught).toBeInstanceOf(AgentExportError);
+  expect(caught).toBeInstanceOf(ElizaError);
+  expect(caught).not.toBeInstanceOf(RangeError);
+  expect((caught as AgentExportError).code).toBe(
+    AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+  );
+  return caught as AgentExportError;
 }
 
 function emptyPayload(overrides: Record<string, unknown> = {}) {
@@ -61,9 +68,7 @@ function manifestFor(payload: Record<string, unknown>) {
   const components: Record<string, ReturnType<typeof digestCollection>> = {};
   for (const name of MANIFEST_COLLECTIONS) {
     const items = payload[name];
-    components[name] = digestCollection(
-      Array.isArray(items) ? items : [],
-    );
+    components[name] = digestCollection(Array.isArray(items) ? items : []);
   }
   return { algorithm: "sha256" as const, components };
 }
@@ -135,13 +140,70 @@ describe("canonicalize fail-closed walk", () => {
     expect(canonicalize(new Proxy([2, 1], {}))).toBe("[2,1]");
   });
 
-  it("revoked object and array Proxies fail closed instead of TypeError", () => {
+  it("revoked object and array Proxies fail closed, preserving the native TypeError cause", () => {
     const objectPair = Proxy.revocable({ a: 1 }, {});
     objectPair.revoke();
-    expectUnbounded(() => canonicalize(objectPair.proxy));
+    const objectError = expectUnbounded(() => canonicalize(objectPair.proxy));
+    expect(objectError.cause).toBeInstanceOf(TypeError);
+    expect(objectError.context).toEqual({ inspection: "isArray" });
+    expect(objectError.severity).toBe("fatal");
+
     const arrayPair = Proxy.revocable([1, 2], {});
     arrayPair.revoke();
-    expectUnbounded(() => canonicalize(arrayPair.proxy));
+    const arrayError = expectUnbounded(() => canonicalize(arrayPair.proxy));
+    expect(arrayError.cause).toBeInstanceOf(TypeError);
+    expect(arrayError.context).toEqual({ inspection: "isArray" });
+    expect(arrayError.severity).toBe("fatal");
+  });
+
+  it("never echoes an attacker-controlled property name in public error context", () => {
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "AWS_SECRET_ACCESS_KEY", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        return "leaked";
+      },
+    });
+    const error = expectUnbounded(() => canonicalize(hostile));
+    expect(error.context).toEqual({ accessor: true, container: "object" });
+    expect(JSON.stringify(error.context ?? {})).not.toContain(
+      "AWS_SECRET_ACCESS_KEY",
+    );
+    expect(error.message).not.toContain("AWS_SECRET_ACCESS_KEY");
+  });
+
+  it("rejects a wide object on its key list, before any descriptor read or sort", () => {
+    const keys = Array.from(
+      { length: MAX_AGENT_EXPORT_CANONICALIZE_NODES + 1 },
+      (_value, index) => `k${index}`,
+    );
+    let descriptorReads = 0;
+    const wide = new Proxy(
+      {},
+      {
+        ownKeys() {
+          return keys;
+        },
+        getOwnPropertyDescriptor() {
+          descriptorReads += 1;
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: 1,
+          };
+        },
+      },
+    );
+    const error = expectUnbounded(() => canonicalize(wide));
+    // Breadth is charged off Reflect.ownKeys alone: no trap descriptor scan,
+    // no snapshot allocation, no O(n log n) sort before the rejection.
+    expect(descriptorReads).toBe(0);
+    expect(error.context).toEqual({
+      visits: MAX_AGENT_EXPORT_CANONICALIZE_NODES + 2,
+      maxNodes: MAX_AGENT_EXPORT_CANONICALIZE_NODES,
+    });
   });
 
   it("does not invoke own or inherited array accessors", () => {
@@ -164,8 +226,12 @@ describe("canonicalize fail-closed walk", () => {
       expect(String(error)).not.toContain("ARRAY_OWN_ACCESSOR");
     }
 
+    // A local prototype chained to Array.prototype, never Array.prototype
+    // itself: mutating the global would be observable by every other test in
+    // this concurrently executed suite, finally-block or not.
     let inheritedInvoked = false;
-    Object.defineProperty(Array.prototype, "1", {
+    const hostileProto: unknown[] = Object.create(Array.prototype);
+    Object.defineProperty(hostileProto, "1", {
       configurable: true,
       enumerable: false,
       get() {
@@ -173,15 +239,14 @@ describe("canonicalize fail-closed walk", () => {
         return "PWN";
       },
     });
-    try {
-      const sparse = [0];
-      sparse.length = 3;
-      sparse[2] = 2;
-      expect(canonicalize(sparse)).toBe("[0,,2]");
-      expect(inheritedInvoked).toBe(false);
-    } finally {
-      Reflect.deleteProperty(Array.prototype, "1");
-    }
+    const sparse = [0];
+    sparse.length = 3;
+    sparse[2] = 2;
+    Object.setPrototypeOf(sparse, hostileProto);
+    expect(sparse[1]).toBe("PWN");
+    inheritedInvoked = false;
+    expect(canonicalize(sparse)).toBe("[0,,2]");
+    expect(inheritedInvoked).toBe(false);
   });
 
   it("fail-closed on a huge sparse length before allocating the join", () => {
@@ -259,31 +324,28 @@ describe("canonicalize fail-closed walk", () => {
     );
 
     let reads = 0;
-    const drifted = new Proxy(
-      [{ id: "mem-1" }],
-      {
-        getOwnPropertyDescriptor(target, key) {
-          if (key === "length") {
-            return {
-              configurable: false,
-              enumerable: false,
-              writable: true,
-              value: 1,
-            };
-          }
-          reads += 1;
-          if (reads === 1) {
-            return {
-              configurable: true,
-              enumerable: true,
-              writable: true,
-              value: { id: "mem-1" },
-            };
-          }
-          throw new Error("DESCRIPTOR_DRIFT");
-        },
+    const drifted = new Proxy([{ id: "mem-1" }], {
+      getOwnPropertyDescriptor(_target, key) {
+        if (key === "length") {
+          return {
+            configurable: false,
+            enumerable: false,
+            writable: true,
+            value: 1,
+          };
+        }
+        reads += 1;
+        if (reads === 1) {
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: { id: "mem-1" },
+          };
+        }
+        throw new Error("DESCRIPTOR_DRIFT");
       },
-    );
+    });
     const driftedPayload = emptyPayload({ memories: drifted });
     const driftedResult = verifyExportManifest({
       ...driftedPayload,
@@ -296,5 +358,56 @@ describe("canonicalize fail-closed walk", () => {
       },
     } as never);
     expect(driftedResult.ok).toBe(true);
+  });
+
+  it("reads the root array length exactly once per digest, through verifyExportManifest", () => {
+    const items = [{ id: "mem-1", text: "hi" }];
+    let lengthReads = 0;
+    const counted = new Proxy(items, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "length") lengthReads += 1;
+        return Object.getOwnPropertyDescriptor(target, key);
+      },
+    });
+
+    const digest = digestCollection(counted as unknown as unknown[]);
+    expect(lengthReads).toBe(1);
+    expect(digest).toEqual(digestCollection(items));
+
+    lengthReads = 0;
+    const honest = emptyPayload({ memories: items });
+    const result = verifyExportManifest({
+      ...emptyPayload({ memories: counted }),
+      manifest: manifestFor(honest),
+    } as never);
+    expect(result.present).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.mismatches).toEqual([]);
+    expect(lengthReads).toBe(1);
+  });
+
+  it("cannot publish a digest and a count from different length snapshots", () => {
+    const items = [{ id: "mem-1" }, { id: "mem-2" }];
+    let lengthReads = 0;
+    // Second and later `length` reads would report a shorter array. With one
+    // capture the drift is unreachable; two reads published count=1 alongside
+    // two-item canonical bytes (and a Proxy invariant TypeError besides).
+    const drifting = new Proxy(items, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "length") {
+          lengthReads += 1;
+          return {
+            configurable: false,
+            enumerable: false,
+            writable: true,
+            value: lengthReads === 1 ? 2 : 1,
+          };
+        }
+        return Object.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    const digest = digestCollection(drifting as unknown as unknown[]);
+    expect(lengthReads).toBe(1);
+    expect(digest).toEqual(digestCollection(items));
   });
 });

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -35,7 +35,7 @@ import type {
   UUID,
   World,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { ElizaError, type ElizaErrorOptions, logger } from "@elizaos/core";
 import * as zod from "zod";
 import {
   isStoredMediaUrl,
@@ -211,12 +211,22 @@ export const MAX_AGENT_EXPORT_CANONICALIZE_NODES = 100_000;
 export const AGENT_EXPORT_CANONICALIZE_UNBOUNDED =
   "AGENT_EXPORT_CANONICALIZE_UNBOUNDED";
 
-export class AgentExportError extends Error {
-  readonly code?: string;
-  constructor(message: string, code?: string) {
-    super(message);
-    this.name = "AgentExportError";
-    if (code) this.code = code;
+/** Default classification for export/import failures without a finer code. */
+export const AGENT_EXPORT_FAILED = "AGENT_EXPORT_FAILED";
+
+/**
+ * Export/import domain failure. Extends {@link ElizaError} so every throw site
+ * carries a machine-classifiable `code`, structured `context`, and a preserved
+ * `cause` chain (error policy #12263) instead of casting fields onto a bare
+ * `Error`. `instanceof AgentExportError` keeps working for existing callers.
+ */
+export class AgentExportError extends ElizaError {
+  override readonly name: string = "AgentExportError";
+  constructor(
+    message: string,
+    options: Omit<ElizaErrorOptions, "code"> & { code?: string } = {},
+  ) {
+    super(message, { ...options, code: options.code ?? AGENT_EXPORT_FAILED });
   }
 }
 
@@ -229,15 +239,18 @@ function failCanonicalizeUnbounded(
   context: Record<string, unknown>,
   cause?: unknown,
 ): never {
-  const error = new AgentExportError(
+  // Context is deliberately structural only (never a reflected property name):
+  // the walk runs on attacker-supplied import payloads and the error surfaces
+  // in API responses and logs.
+  throw new AgentExportError(
     "Export payload exceeds the canonicalize walk budget",
-    AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+    {
+      code: AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+      cause,
+      context,
+      severity: "fatal",
+    },
   );
-  if (cause !== undefined) {
-    (error as Error & { cause?: unknown }).cause = cause;
-  }
-  (error as Error & { context?: Record<string, unknown> }).context = context;
-  throw error;
 }
 
 function reserveCanonicalizeVisits(
@@ -276,22 +289,19 @@ function isCanonicalizeArray(value: object): boolean {
   return inspectCanonicalize("isArray", () => Array.isArray(value));
 }
 
-function ownValueDescriptor(
-  value: object,
-  key: string,
-): PropertyDescriptor | undefined {
-  const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
-    Object.getOwnPropertyDescriptor(value, key),
-  );
-  if (!descriptor) return undefined;
-  if (!("value" in descriptor)) {
-    failCanonicalizeUnbounded({ accessor: true, key });
-  }
-  return descriptor;
-}
-
+/**
+ * Reads `length` off an array exactly once, as an own data descriptor, so a
+ * Proxy cannot serve a different value to a second reader. Callers that also
+ * need the length (e.g. a manifest `count`) must reuse the returned number
+ * rather than calling this again.
+ */
 function ownArrayLength(value: object): number {
-  const descriptor = ownValueDescriptor(value, "length");
+  const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, "length"),
+  );
+  if (descriptor && !("value" in descriptor)) {
+    failCanonicalizeUnbounded({ accessor: true, property: "length" });
+  }
   if (
     !descriptor ||
     typeof descriptor.value !== "number" ||
@@ -308,19 +318,29 @@ type CanonicalizeDataSnapshot = {
   value: unknown;
 };
 
-/** One getOwnPropertyDescriptor per key. Prevents Proxy descriptor drift. */
-function ownEnumerableDataSnapshot(value: object): CanonicalizeDataSnapshot[] {
+/**
+ * One getOwnPropertyDescriptor per key (prevents Proxy descriptor drift), with
+ * the object's breadth charged to the node budget BEFORE any descriptor trap
+ * runs, before the snapshot array is allocated and before the O(n log n) sort.
+ * A hostile wide object or `ownKeys` Proxy is rejected on the key list alone.
+ * The reservation covers every child, so the walks below run with
+ * `visitAlreadyReserved`.
+ */
+function ownEnumerableDataSnapshot(
+  value: object,
+  ctx: CanonicalizeWalkContext,
+): CanonicalizeDataSnapshot[] {
+  const keys = inspectCanonicalize("ownKeys", () => Reflect.ownKeys(value));
+  reserveCanonicalizeVisits(ctx, keys.length);
   const snapshot: CanonicalizeDataSnapshot[] = [];
-  for (const key of inspectCanonicalize("ownKeys", () =>
-    Reflect.ownKeys(value),
-  )) {
+  for (const key of keys) {
     if (typeof key !== "string") continue;
     const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
       Object.getOwnPropertyDescriptor(value, key),
     );
     if (!descriptor?.enumerable) continue;
     if (!("value" in descriptor)) {
-      failCanonicalizeUnbounded({ accessor: true, key });
+      failCanonicalizeUnbounded({ accessor: true, container: "object" });
     }
     if (descriptor.value === undefined) continue;
     snapshot.push({ key, value: descriptor.value });
@@ -336,6 +356,11 @@ function canonicalizeWalk(
   depth: number,
   ctx: CanonicalizeWalkContext,
   visitAlreadyReserved = false,
+  /**
+   * Array length already read by the caller (root only). Reusing it keeps the
+   * digest and the manifest `count` on one immutable snapshot.
+   */
+  knownArrayLength?: number,
 ): string {
   if (depth > MAX_AGENT_EXPORT_CANONICALIZE_DEPTH) {
     failCanonicalizeUnbounded({
@@ -351,34 +376,37 @@ function canonicalizeWalk(
   enterCanonicalizeContainer(value, ctx);
   try {
     if (isCanonicalizeArray(value)) {
-      const length = ownArrayLength(value);
+      const length = knownArrayLength ?? ownArrayLength(value);
       reserveCanonicalizeVisits(ctx, length);
       // String-build so inherited Array.prototype index accessors cannot
       // trap assignment into a preallocated parts array.
       let body = "";
       for (let index = 0; index < length; index += 1) {
         if (index > 0) body += ",";
-        const descriptor = inspectCanonicalize(
-          "getOwnPropertyDescriptor",
-          () => Object.getOwnPropertyDescriptor(value, String(index)),
+        const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
+          Object.getOwnPropertyDescriptor(value, String(index)),
         );
         if (!descriptor) {
           // Sparse hole: keep the prior map()+join() empty-slot string.
           continue;
         }
         if (!("value" in descriptor)) {
-          failCanonicalizeUnbounded({ accessor: true, key: String(index) });
+          failCanonicalizeUnbounded({
+            accessor: true,
+            container: "array",
+            index,
+          });
         }
         body += canonicalizeWalk(descriptor.value, depth + 1, ctx, true);
       }
       return `[${body}]`;
     }
 
-    const snapshot = ownEnumerableDataSnapshot(value);
+    const snapshot = ownEnumerableDataSnapshot(value, ctx);
     return `{${snapshot
       .map(
         (entry) =>
-          `${JSON.stringify(entry.key)}:${canonicalizeWalk(entry.value, depth + 1, ctx)}`,
+          `${JSON.stringify(entry.key)}:${canonicalizeWalk(entry.value, depth + 1, ctx, true)}`,
       )
       .join(",")}}`;
   } finally {
@@ -386,11 +414,18 @@ function canonicalizeWalk(
   }
 }
 
+function canonicalizeRoot(value: unknown, knownArrayLength?: number): string {
+  return canonicalizeWalk(
+    value,
+    0,
+    { visits: 0, visiting: new WeakSet<object>() },
+    false,
+    knownArrayLength,
+  );
+}
+
 export function canonicalize(value: unknown): string {
-  return canonicalizeWalk(value, 0, {
-    visits: 0,
-    visiting: new WeakSet<object>(),
-  });
+  return canonicalizeRoot(value);
 }
 
 function sha256Hex(input: string): string {
@@ -406,9 +441,13 @@ export function digestCollection(items: unknown[]): AgentExportComponentDigest {
     typeof items === "object" &&
     isCanonicalizeArray(items)
   ) {
+    // One `length` descriptor read feeds BOTH the canonical bytes and `count`.
+    // Reading it twice let a legal Array Proxy drift (or throw) between the two
+    // reads and publish a digest and a count taken from different snapshots.
+    const length = ownArrayLength(items);
     return {
-      sha256: sha256Hex(canonicalize(items)),
-      count: ownArrayLength(items),
+      sha256: sha256Hex(canonicalizeRoot(items, length)),
+      count: length,
     };
   }
   return {

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -196,21 +196,157 @@ export interface ExportSizeEstimate {
  * collection's digest reproducible across the export → gzip → encrypt → decrypt
  * → gunzip → `JSON.parse` round-trip, regardless of in-memory key ordering, so
  * the digest computed at export equals the one recomputed at import.
+ *
+ * Honest export collections are a handful of objects deep. A decrypted import
+ * can still be legal JSON that `JSON.parse` accepts (depth 20k in ~120 KiB,
+ * well under the 16 MiB gunzip cap) and then stack-overflow the digest walk.
  */
-export function canonicalize(value: unknown): string {
+export const MAX_AGENT_EXPORT_CANONICALIZE_DEPTH = 64;
+/**
+ * Node ceiling across the whole canonicalize walk, including array slots.
+ * Bounds cyclic or accessor-bearing graphs that would otherwise RangeError
+ * `exportAgent` / `verifyExportManifest` on import.
+ */
+export const MAX_AGENT_EXPORT_CANONICALIZE_NODES = 100_000;
+export const AGENT_EXPORT_CANONICALIZE_UNBOUNDED =
+  "AGENT_EXPORT_CANONICALIZE_UNBOUNDED";
+
+export class AgentExportError extends Error {
+  readonly code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "AgentExportError";
+    if (code) this.code = code;
+  }
+}
+
+type CanonicalizeWalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failCanonicalizeUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  const error = new AgentExportError(
+    "Export payload exceeds the canonicalize walk budget",
+    AGENT_EXPORT_CANONICALIZE_UNBOUNDED,
+  );
+  if (cause !== undefined) {
+    (error as Error & { cause?: unknown }).cause = cause;
+  }
+  (error as Error & { context?: Record<string, unknown> }).context = context;
+  throw error;
+}
+
+function reserveCanonicalizeVisits(
+  ctx: CanonicalizeWalkContext,
+  count: number,
+): void {
+  if (count > MAX_AGENT_EXPORT_CANONICALIZE_NODES - ctx.visits) {
+    failCanonicalizeUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_AGENT_EXPORT_CANONICALIZE_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function enterCanonicalizeContainer(
+  value: object,
+  ctx: CanonicalizeWalkContext,
+): void {
+  if (ctx.visiting.has(value)) {
+    failCanonicalizeUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+}
+
+function inspectCanonicalize<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+    failCanonicalizeUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownEnumerableStringKeys(value: object): string[] {
+  const keys: string[] = [];
+  for (const key of inspectCanonicalize("ownKeys", () =>
+    Reflect.ownKeys(value),
+  )) {
+    if (typeof key !== "string") continue;
+    const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (!descriptor?.enumerable) continue;
+    keys.push(key);
+  }
+  return keys;
+}
+
+function ownValueDescriptor(
+  value: object,
+  key: string,
+): PropertyDescriptor | undefined {
+  const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) {
+    failCanonicalizeUnbounded({ accessor: true, key });
+  }
+  return descriptor;
+}
+
+function canonicalizeWalk(
+  value: unknown,
+  depth: number,
+  ctx: CanonicalizeWalkContext,
+): string {
+  if (depth > MAX_AGENT_EXPORT_CANONICALIZE_DEPTH) {
+    failCanonicalizeUnbounded({
+      depth,
+      max: MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
+    });
+  }
+  reserveCanonicalizeVisits(ctx, 1);
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value ?? null);
   }
-  if (Array.isArray(value)) {
-    return `[${value.map((v) => canonicalize(v)).join(",")}]`;
+
+  enterCanonicalizeContainer(value, ctx);
+  try {
+    if (Array.isArray(value)) {
+      return `[${value
+        .map((entry) => canonicalizeWalk(entry, depth + 1, ctx))
+        .join(",")}]`;
+    }
+
+    const keys = ownEnumerableStringKeys(value)
+      .filter((key) => {
+        const descriptor = ownValueDescriptor(value, key);
+        return descriptor ? descriptor.value !== undefined : false;
+      })
+      .sort();
+    return `{${keys
+      .map((key) => {
+        const descriptor = ownValueDescriptor(value, key);
+        return `${JSON.stringify(key)}:${canonicalizeWalk(descriptor?.value, depth + 1, ctx)}`;
+      })
+      .join(",")}}`;
+  } finally {
+    ctx.visiting.delete(value);
   }
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj)
-    .filter((k) => obj[k] !== undefined)
-    .sort();
-  return `{${keys
-    .map((k) => `${JSON.stringify(k)}:${canonicalize(obj[k])}`)
-    .join(",")}}`;
+}
+
+export function canonicalize(value: unknown): string {
+  return canonicalizeWalk(value, 0, {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  });
 }
 
 function sha256Hex(input: string): string {
@@ -606,17 +742,6 @@ function unpackFile(fileBuffer: Buffer): {
   }
 
   return { salt, iv, tag, ciphertext, iterations };
-}
-
-// ---------------------------------------------------------------------------
-// Custom error class
-// ---------------------------------------------------------------------------
-
-export class AgentExportError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AgentExportError";
-  }
 }
 
 async function gunzipWithSizeLimit(

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -272,19 +272,8 @@ function inspectCanonicalize<T>(operation: string, inspect: () => T): T {
   }
 }
 
-function ownEnumerableStringKeys(value: object): string[] {
-  const keys: string[] = [];
-  for (const key of inspectCanonicalize("ownKeys", () =>
-    Reflect.ownKeys(value),
-  )) {
-    if (typeof key !== "string") continue;
-    const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
-      Object.getOwnPropertyDescriptor(value, key),
-    );
-    if (!descriptor?.enumerable) continue;
-    keys.push(key);
-  }
-  return keys;
+function isCanonicalizeArray(value: object): boolean {
+  return inspectCanonicalize("isArray", () => Array.isArray(value));
 }
 
 function ownValueDescriptor(
@@ -301,10 +290,52 @@ function ownValueDescriptor(
   return descriptor;
 }
 
+function ownArrayLength(value: object): number {
+  const descriptor = ownValueDescriptor(value, "length");
+  if (
+    !descriptor ||
+    typeof descriptor.value !== "number" ||
+    !Number.isSafeInteger(descriptor.value) ||
+    descriptor.value < 0
+  ) {
+    failCanonicalizeUnbounded({ invalidArrayLength: true });
+  }
+  return descriptor.value as number;
+}
+
+type CanonicalizeDataSnapshot = {
+  key: string;
+  value: unknown;
+};
+
+/** One getOwnPropertyDescriptor per key. Prevents Proxy descriptor drift. */
+function ownEnumerableDataSnapshot(value: object): CanonicalizeDataSnapshot[] {
+  const snapshot: CanonicalizeDataSnapshot[] = [];
+  for (const key of inspectCanonicalize("ownKeys", () =>
+    Reflect.ownKeys(value),
+  )) {
+    if (typeof key !== "string") continue;
+    const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (!descriptor?.enumerable) continue;
+    if (!("value" in descriptor)) {
+      failCanonicalizeUnbounded({ accessor: true, key });
+    }
+    if (descriptor.value === undefined) continue;
+    snapshot.push({ key, value: descriptor.value });
+  }
+  snapshot.sort((left, right) =>
+    left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+  );
+  return snapshot;
+}
+
 function canonicalizeWalk(
   value: unknown,
   depth: number,
   ctx: CanonicalizeWalkContext,
+  visitAlreadyReserved = false,
 ): string {
   if (depth > MAX_AGENT_EXPORT_CANONICALIZE_DEPTH) {
     failCanonicalizeUnbounded({
@@ -312,30 +343,43 @@ function canonicalizeWalk(
       max: MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
     });
   }
-  reserveCanonicalizeVisits(ctx, 1);
+  if (!visitAlreadyReserved) reserveCanonicalizeVisits(ctx, 1);
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value ?? null);
   }
 
   enterCanonicalizeContainer(value, ctx);
   try {
-    if (Array.isArray(value)) {
-      return `[${value
-        .map((entry) => canonicalizeWalk(entry, depth + 1, ctx))
-        .join(",")}]`;
+    if (isCanonicalizeArray(value)) {
+      const length = ownArrayLength(value);
+      reserveCanonicalizeVisits(ctx, length);
+      // String-build so inherited Array.prototype index accessors cannot
+      // trap assignment into a preallocated parts array.
+      let body = "";
+      for (let index = 0; index < length; index += 1) {
+        if (index > 0) body += ",";
+        const descriptor = inspectCanonicalize(
+          "getOwnPropertyDescriptor",
+          () => Object.getOwnPropertyDescriptor(value, String(index)),
+        );
+        if (!descriptor) {
+          // Sparse hole: keep the prior map()+join() empty-slot string.
+          continue;
+        }
+        if (!("value" in descriptor)) {
+          failCanonicalizeUnbounded({ accessor: true, key: String(index) });
+        }
+        body += canonicalizeWalk(descriptor.value, depth + 1, ctx, true);
+      }
+      return `[${body}]`;
     }
 
-    const keys = ownEnumerableStringKeys(value)
-      .filter((key) => {
-        const descriptor = ownValueDescriptor(value, key);
-        return descriptor ? descriptor.value !== undefined : false;
-      })
-      .sort();
-    return `{${keys
-      .map((key) => {
-        const descriptor = ownValueDescriptor(value, key);
-        return `${JSON.stringify(key)}:${canonicalizeWalk(descriptor?.value, depth + 1, ctx)}`;
-      })
+    const snapshot = ownEnumerableDataSnapshot(value);
+    return `{${snapshot
+      .map(
+        (entry) =>
+          `${JSON.stringify(entry.key)}:${canonicalizeWalk(entry.value, depth + 1, ctx)}`,
+      )
       .join(",")}}`;
   } finally {
     ctx.visiting.delete(value);
@@ -354,12 +398,24 @@ function sha256Hex(input: string): string {
 }
 
 /** sha256 of a collection's canonical JSON, plus its length. */
-export function digestCollection(items: unknown[]): AgentExportComponentDigest {
-  const list = Array.isArray(items) ? items : [];
-  return { sha256: sha256Hex(canonicalize(list)), count: list.length };
-}
-
 const EMPTY_MANIFEST_COLLECTION: unknown[] = [];
+
+export function digestCollection(items: unknown[]): AgentExportComponentDigest {
+  if (
+    items != null &&
+    typeof items === "object" &&
+    isCanonicalizeArray(items)
+  ) {
+    return {
+      sha256: sha256Hex(canonicalize(items)),
+      count: ownArrayLength(items),
+    };
+  }
+  return {
+    sha256: sha256Hex(canonicalize(EMPTY_MANIFEST_COLLECTION)),
+    count: 0,
+  };
+}
 
 /** The collection arrays the manifest covers, read off a payload-like object. */
 function manifestCollectionsOf(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23294 — scoped owning issue filed at maintainer request
("Open/link a scoped issue", 2026-08-21T00:57:28Z CHANGES_REQUESTED).

Operator-authorized occupancy-FREE hang / 500 / overflow audit on a live agent
product path. Same-PR repair, no twin. Shaw BLOCKED head
`5c312ff1637f4a60f8784f16b1ea851efc65ae94` (`Array.isArray` outside inspect,
`.map()` accessor/sparse allocation, double-read object descriptors) and then
requested changes on head `68aa257d0120c8da8c5b99a7ba1a8d759238a391` (object
breadth reflected/sorted before the budget, double `length` reflection in
`digestCollection`, missing revoked-Proxy `.cause` assertions, echoed accessor
key names, global `Array.prototype` mutation in a test, bespoke `AgentExportError`).
Do not merge either of those heads. Agent-export integrity digest walk only. Did
not touch schema-compat, secret-swap, inMemoryAdapter, or character-history.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on cyclic, over-deep, over-wide, accessor-bearing, or
hostile-Proxy export graphs so `canonicalize` / `verifyExportManifest` /
`importAgent` cannot RangeError or leak a raw TypeError on legal JSON the
gunzip+parse path already accepted. Honest small export collections still emit
the same key-sorted digest, including sparse-hole canonical strings. No schema
or storage migration. Did not edit HARD_SKIP `server.ts`, schema-compat,
secret-swap, inMemoryAdapter, character-history, or occupied config-redaction
hosts.

# Background

## What does this PR do?

`packages/agent/src/services/agent-export.ts` `canonicalize` is the live
integrity-digest walk for `exportAgent` and `importAgent`
(`verifyExportManifest` → `digestCollection`). On origin `develop` it recursed
with `Object.keys` / `obj[k]`, so a cyclic export graph RangeError'd, an
enumerable getter was invoked, and a 20k-deep nest that `JSON.parse` already
accepted then stack-overflowed the digest walk.

The first head (`5c312ff1637f4a60f8784f16b1ea851efc65ae94`) bounded depth, node
count, cycles, and own accessors, but Shaw BLOCKED it: `Array.isArray(value)`
sat outside `inspectCanonicalize` (revoked Array Proxy leaked raw `TypeError`);
array `.map()` used ordinary `has`/`get` and allocated the mapped output before
the 100,000-node budget could stop a huge sparse length; object keys reflected
once then re-read each descriptor in filter+map, allowing Proxy descriptor drift.

The second head (`68aa257d0120c8da8c5b99a7ba1a8d759238a391`) wrapped array
classification and length reflection, pre-reserved the validated array-slot
budget, walked own numeric data descriptors (preserving the prior sparse-hole
canonical string), and captured one enumerable data-descriptor snapshot per
object key — but Shaw requested changes on it: object breadth was still
reflected, snapshotted and sorted before the node budget applied;
`digestCollection` read the root array `length` twice; the revoked-Proxy tests
never asserted the preserved native `TypeError` `.cause`; accessor errors echoed
attacker-controlled property names into public context; the inherited-accessor
test mutated global `Array.prototype` inside a concurrently executed suite; and
`AgentExportError` was a bespoke `Error` with `cause`/`context` cast on.

This head (`c6effa769f021b052c50168f0339288c9decffeb`) closes all six:

- `ownEnumerableDataSnapshot` now takes the walk context and charges
  `Reflect.ownKeys(...).length` to the node budget **before** any descriptor
  trap runs, before the snapshot array is allocated and before the
  `O(n log n)` sort; the reservation covers every child, so child walks run with
  `visitAlreadyReserved`.
- `digestCollection` captures the root array `length` exactly once and feeds
  that same immutable value into both the canonical bytes and the manifest
  `count` (via an internal `canonicalizeRoot(value, knownArrayLength)`).
- Error `context` is structural only (`{ accessor: true, container: "object" }`,
  `{ inspection: "isArray" }`, `{ visits, maxNodes }`) and never carries a
  reflected property name.
- `AgentExportError extends ElizaError`, so `code` / `context` / `cause` /
  `severity` are first-class per the fast-fail error policy (#12263) instead of
  cast-on fields. Every existing `new AgentExportError("…")` call site keeps
  working and now classifies as `AGENT_EXPORT_FAILED` by default;
  `instanceof AgentExportError` in `server.ts` is unchanged.
- The inherited-accessor regression installs the hostile getter on a local
  prototype chained to `Array.prototype` and `setPrototypeOf`s only the test
  array, so no other test in the suite can observe it.

Independent origin proof (pre-fix):

```text
origin develop ead81e8725bd
honest small object: ok 0ms
cyclic self-ref: THROW 7ms RangeError Maximum call stack size exceeded
JSON.parse nest 20000 (120001 bytes): ok 0ms
parse+canonicalize nest 20000: THROW 15ms RangeError Maximum call stack size exceeded
enumerable getter: THROW GETTER_INVOKED
verifyExportManifest(cyclic memory + sha256 manifest): RangeError
```

Occupancy-FREE host `packages/agent/src/services/agent-export.ts`. Agent leftover.
Not a twin of #23123 / #23115 config-redaction, #23159 schema-compat, #23178
secret-swap, or #23130 character-history. Not leftover-tax of #23034. Not HARD_SKIP
`server.ts`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Import of a password-valid `.eliza-agent` archive already gunzips and
`JSON.parse`s attacker-controlled collections before the integrity digest.
Zod only checks `id: string` on memory/entity rows, so a legal deep, cyclic,
revoked-Proxy, or accessor-bearing graph reaches `canonicalize` and 500s the
import. Fail-closed before the stack overflows or a getter runs.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/agent-export.ts` and
`packages/agent/src/services/agent-export.canonicalize-bound.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0cbc1961a754f7852a39d865f72b6ce650d7fb60 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; export canonicalize is runtime logic only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; export canonicalize is runtime logic only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
exact reviewed head 0cbc1961a754f7852a39d865f72b6ce650d7fb60
source repair c6effa769f021b052c50168f0339288c9decffeb
base origin/develop 289804ee04121a0294e5949bd608a47acf30197d
Shaw CHANGES_REQUESTED on 68aa257d: object breadth reflected/sorted before the
budget, digestCollection double length reflection, missing revoked-Proxy .cause
assertions + echoed accessor key names, global Array.prototype mutation in a
test, bespoke AgentExportError instead of ElizaError.

$ ./node_modules/.bin/vitest run \
    packages/agent/src/services/agent-export.canonicalize-bound.test.ts \
    packages/agent/src/services/agent-export.media.test.ts \
    packages/agent/src/services/agent-export.password.test.ts \
    packages/agent/src/services/agent-export.roundtrip.test.ts \
    packages/agent/src/api/agent-transfer-routes.test.ts \
    --coverage.enabled=false
 Test Files  5 passed (5)
      Tests  42 passed (42)
proof-run.mjs recorded PROOF at c6effa769 -> exit 0

Post-rebase exact-head rerun at 0cbc1961a754:
- canonicalize-bound production suite: 17/17 pass
- Biome: 2/2 changed files clean
- packages/agent build: pass; 199 relative imports rewritten

$ bunx @biomejs/biome check packages/agent/src/services/agent-export.ts \
    packages/agent/src/services/agent-export.canonicalize-bound.test.ts
Checked 2 files. No fixes applied.  (exit 0)

$ bun run --cwd packages/agent typecheck
27 pre-existing errors, 0 in agent-export.* — identical count to the untouched
tree (missing optional plugin builds: @elizaos/plugin-capacitor-bridge,
plugin-wallet, cloud-routing, mammoth, plugin-pty/video/vision/notes/todos).

canonicalize-bound.test.ts now has 17 cases. New in this head:
- wide object (100,001 ownKeys Proxy) rejected on the key list alone:
  descriptor traps invoked = 0, context {visits:100002, maxNodes:100000}
- root array length read exactly once per digest, asserted through
  verifyExportManifest (lengthReads === 1, ok === true, mismatches [])
- length-drift Proxy cannot split digest bytes from count
- revoked object AND array Proxy: .cause instanceof TypeError,
  context {inspection:"isArray"}, severity "fatal"
- accessor error context never echoes the property name
  ({accessor:true, container:"object"}; "AWS_SECRET_ACCESS_KEY" absent)
- inherited array accessor installed on a LOCAL prototype, not Array.prototype
Retained: honest key-sort + undefined-drop; cyclic / over-deep / JSON.parse-20k
fail-closed; enumerable getter not invoked; ordinary Proxy honest bytes; own
array accessor not invoked; huge sparse length fail-closed before alloc;
one-pass object descriptor snapshot; sparse-hole `[1,,3]` + undefined-as-null;
verifyExportManifest honest match and revoked/sparse/drift fail-closed.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. After rebasing, pinned Bun 1.3.14 /
Node 24.15 verification passed the 17-case production-path suite, Biome on both
touched files, and the complete `packages/agent` build. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

`bun run --cwd packages/agent typecheck` is red on this checkout for 27
pre-existing reasons unrelated to this PR (unbuilt optional plugin packages:
`@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet`,
`@elizaos/cloud-routing`, `mammoth`, `plugin-pty` / `-video` / `-vision` /
`-notes` / `-todos`, plus one tuple-index error in
`src/runtime/cloud-github-token.test.ts`). The count is identical with and
without this diff and none of the errors are in `agent-export.*`.

This branch was rebased onto `origin/develop`
`289804ee04121a0294e5949bd608a47acf30197d` with zero conflicts, then the
focused suite, Biome, and package build were rerun on the rebased head.

The source repair was produced at
`c6effa769f021b052c50168f0339288c9decffeb` with Anthropic `claude-opus-5` via
Claude Code, then rebased without source changes as
`0cbc1961a754f7852a39d865f72b6ce650d7fb60`; the earlier heads on this branch
were xAI `grok-4.6` as declared in the footer below.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->