### PR TITLE
fix(cloud): add canonical billing snapshot v2

### DIFF
--- a/packages/cloud/api/__tests__/billing-limits-route.pglite.test.ts
+++ b/packages/cloud/api/__tests__/billing-limits-route.pglite.test.ts
@@ -10,6 +10,7 @@ import { createHash } from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AccountBillingSnapshot } from "../../shared/src/types/account-billing-snapshot";
 
 const PREVIOUS_ENV = {
   DATABASE_URL: process.env.DATABASE_URL,
@@ -36,17 +37,25 @@ const ORG_A = "11111111-1111-4111-8111-111111111111";
 const ORG_B = "22222222-2222-4222-8222-222222222222";
 const ORG_CORRUPT = "33333333-3333-4333-8333-333333333333";
 const ORG_BAD_BALANCE = "44444444-4444-4444-8444-444444444444";
+const ORG_CONTAINER_BOUNDARY = "55555555-5555-4555-8555-555555555555";
+const ORG_STORAGE_BOUNDARY = "66666666-6666-4666-8666-666666666666";
 const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
 const USER_B = "bbbbbbbb-2222-4222-8222-222222222222";
 const USER_CORRUPT = "cccccccc-3333-4333-8333-333333333333";
 const USER_BAD_BALANCE = "dddddddd-4444-4444-8444-444444444444";
 const USER_NO_ORG = "eeeeeeee-5555-4555-8555-555555555555";
+const USER_CONTAINER_BOUNDARY = "ffffffff-6666-4666-8666-666666666666";
+const USER_STORAGE_BOUNDARY = "abababab-7777-4777-8777-777777777777";
 const STEWARD_B = `steward-${USER_B}`;
 const STEWARD_NO_ORG = `steward-${USER_NO_ORG}`;
 const KEY_A = "eliza_billing_limits_route_org_a";
 const KEY_STALE_B = "eliza_billing_limits_route_stale_org_b";
 const KEY_CORRUPT = "eliza_billing_limits_route_corrupt";
 const KEY_BAD_BALANCE = "eliza_billing_limits_route_bad_balance";
+const KEY_CONTAINER_BOUNDARY = "eliza_billing_limits_container_boundary";
+const KEY_STORAGE_BOUNDARY = "eliza_billing_limits_storage_boundary";
+const CONTAINER_A_RUNNING = "aaaaaaaa-0000-4000-8000-000000000001";
+const SANDBOX_A_RUNNING = "aaaaaaaa-0000-4000-8000-000000000002";
 
 const ENV = {
   NODE_ENV: "test",
@@ -54,56 +63,12 @@ const ENV = {
   STEWARD_SESSION_SECRET: STEWARD_SECRET,
   RATE_LIMIT_DISABLED: "true",
   RATE_LIMIT_MULTIPLIER: "100",
+  AUTO_TOP_UP_DURABLE_ENABLED: "false",
 } as unknown as AppEnv["Bindings"];
-
-type LimitState = "available" | "at-limit" | "over-limit" | "unavailable";
-
-interface CountedLimitItem {
-  source: string;
-  state: LimitState;
-  used?: number;
-  limit?: number;
-  reason?: string;
-}
-
-interface SandboxLimitItem {
-  source: string;
-  used?: number;
-  nonEagerCreate: { state: LimitState; limit?: number; reason?: string };
-  eagerManagedCreate: { state: LimitState; limit?: number; reason?: string };
-  state: LimitState;
-  nonEagerCreateLimit?: number;
-  eagerManagedCreateLimit?: number;
-  reason?: string;
-}
-
-interface StorageLimitItem {
-  source: string;
-  state: LimitState;
-  bytesUsed?: string;
-  bytesLimit?: string;
-  reason?: string;
-}
-
-interface RateLimitItem {
-  source: string;
-  state: LimitState;
-  completionsRpm?: number;
-  embeddingsRpm?: number;
-  reason?: string;
-}
 
 interface LimitsResponse {
   success: true;
-  data: {
-    observedAt: string;
-    cloudCharacters: CountedLimitItem;
-    agentSandboxes: SandboxLimitItem;
-    containers: CountedLimitItem;
-    apps: CountedLimitItem;
-    storage: StorageLimitItem;
-    inferenceRateLimits: RateLimitItem;
-  };
+  data: AccountBillingSnapshot;
 }
 
 interface ErrorResponse {
@@ -159,6 +124,11 @@ beforeAll(async () => {
       creditTransactions: schemas.creditTransactions,
       orgRateLimitOverrides: schemas.orgRateLimitOverrides,
       orgStorageQuota: schemas.orgStorageQuota,
+      autoTopUpAttempts: schemas.autoTopUpAttempts,
+      autoTopUpControl: schemas.autoTopUpControl,
+      autoTopUpLegacyPaymentQuarantine:
+        schemas.autoTopUpLegacyPaymentQuarantine,
+      computeBillingRateSegments: schemas.computeBillingRateSegments,
       apps: schemas.apps,
       appDeploymentStatusEnum: schemas.appDeploymentStatusEnum,
       appReviewStatusEnum: schemas.appReviewStatusEnum,
@@ -198,6 +168,18 @@ beforeAll(async () => {
       slug: "billing-limits-bad-balance",
       credit_balance: "25",
     },
+    {
+      id: ORG_CONTAINER_BOUNDARY,
+      name: "Billing Limits Container Boundary",
+      slug: "billing-limits-container-boundary",
+      credit_balance: "25",
+    },
+    {
+      id: ORG_STORAGE_BOUNDARY,
+      name: "Billing Limits Storage Boundary",
+      slug: "billing-limits-storage-boundary",
+      credit_balance: "0",
+    },
   ]);
 
   await dbWrite.insert(schemas.users).values([
@@ -236,6 +218,20 @@ beforeAll(async () => {
       role: "viewer",
       steward_user_id: STEWARD_NO_ORG,
     },
+    {
+      id: USER_CONTAINER_BOUNDARY,
+      email: "billing-limits-container-boundary@test.test",
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      role: "member",
+      steward_user_id: `steward-${USER_CONTAINER_BOUNDARY}`,
+    },
+    {
+      id: USER_STORAGE_BOUNDARY,
+      email: "billing-limits-storage-boundary@test.test",
+      organization_id: ORG_STORAGE_BOUNDARY,
+      role: "member",
+      steward_user_id: `steward-${USER_STORAGE_BOUNDARY}`,
+    },
   ]);
 
   await dbWrite.insert(schemas.apiKeys).values([
@@ -266,6 +262,20 @@ beforeAll(async () => {
       key_prefix: KEY_BAD_BALANCE.slice(0, 12),
       organization_id: ORG_BAD_BALANCE,
       user_id: USER_BAD_BALANCE,
+    },
+    {
+      name: "billing limits container boundary",
+      key_hash: sha256Hex(KEY_CONTAINER_BOUNDARY),
+      key_prefix: KEY_CONTAINER_BOUNDARY.slice(0, 12),
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+    },
+    {
+      name: "billing limits storage boundary",
+      key_hash: sha256Hex(KEY_STORAGE_BOUNDARY),
+      key_prefix: KEY_STORAGE_BOUNDARY.slice(0, 12),
+      organization_id: ORG_STORAGE_BOUNDARY,
+      user_id: USER_STORAGE_BOUNDARY,
     },
   ]);
 
@@ -299,6 +309,7 @@ beforeAll(async () => {
     ...(
       ["pending", "provisioning", "running", "stopped", "sleeping"] as const
     ).map((status) => ({
+      ...(status === "running" ? { id: SANDBOX_A_RUNNING } : {}),
       organization_id: ORG_A,
       user_id: USER_A,
       agent_name: `Limits A ${status}`,
@@ -334,6 +345,10 @@ beforeAll(async () => {
   await dbWrite.insert(schemas.organizationConfig).values([
     { organization_id: ORG_A, settings: { max_containers: 2 } },
     { organization_id: ORG_CORRUPT, settings: {} },
+    {
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      settings: { max_containers: 5 },
+    },
   ]);
 
   // Invalid JSON shapes are impossible through the typed write boundary, so
@@ -351,6 +366,7 @@ beforeAll(async () => {
 
   await dbWrite.insert(schemas.containers).values([
     {
+      id: CONTAINER_A_RUNNING,
       name: "Limits A running",
       project_name: "limits-a-running",
       organization_id: ORG_A,
@@ -385,7 +401,64 @@ beforeAll(async () => {
       user_id: USER_B,
       status: "running",
     },
+    ...(
+      [
+        "pending",
+        "running",
+        "cleanup_required",
+        "future_operator_hold",
+      ] as const
+    ).map((status, index) => ({
+      name: `Limits boundary included ${status}`,
+      project_name: `limits-boundary-included-${index}`,
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+      status,
+    })),
+    ...(["deleting", "deleted"] as const).map((status, index) => ({
+      name: `Limits boundary excluded ${status}`,
+      project_name: `limits-boundary-excluded-${index}`,
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+      status,
+    })),
   ]);
+
+  await dbWrite.insert(schemas.computeBillingRateSegments).values([
+    {
+      organization_id: ORG_A,
+      workload_kind: "container",
+      workload_id: CONTAINER_A_RUNNING,
+      lifecycle_revision: 1,
+      billing_state: "running",
+      rate_per_hour: "0.100000",
+      effective_at: new Date("2020-01-01T10:00:00.000Z"),
+    },
+    {
+      organization_id: ORG_A,
+      workload_kind: "container",
+      workload_id: CONTAINER_A_RUNNING,
+      lifecycle_revision: 2,
+      billing_state: "running",
+      rate_per_hour: "0.123456",
+      effective_at: new Date("2020-01-01T11:00:00.000Z"),
+    },
+    {
+      organization_id: ORG_A,
+      workload_kind: "container",
+      workload_id: CONTAINER_A_RUNNING,
+      lifecycle_revision: 3,
+      billing_state: "running",
+      rate_per_hour: "9.999999",
+      effective_at: new Date("2099-01-01T00:00:00.000Z"),
+    },
+  ]);
+
+  await dbWrite.insert(schemas.autoTopUpControl).values({
+    singleton: true,
+    mode: "paused",
+    paused_at: new Date("2020-01-01T09:00:00.000Z"),
+  });
 
   await dbWrite.insert(schemas.apps).values([
     {
@@ -539,6 +612,23 @@ describe("GET /api/v1/billing/limits with PGlite", () => {
   test("reports canonical counted rows, overrides, split sandbox caps, and exact bytes", async () => {
     const data = await readySnapshot(await getLimits({ key: KEY_A }));
 
+    expect(data.schemaVersion).toBe(2);
+    expect(new Date(data.v2.snapshotStartedAt).toISOString()).toBe(
+      data.v2.snapshotStartedAt,
+    );
+    expect(new Date(data.v2.snapshotCompletedAt).toISOString()).toBe(
+      data.v2.snapshotCompletedAt,
+    );
+    expect(data.v2.balance).toEqual({
+      status: "available",
+      source: "organizations",
+      observedAt: data.observedAt,
+      value: {
+        balance: { value: "25.000000", unit: "usd", currency: "USD" },
+        revision: "0",
+      },
+    });
+
     expect(data.cloudCharacters).toEqual({
       source: "cloud-character-quota",
       state: "over-limit",
@@ -579,10 +669,277 @@ describe("GET /api/v1/billing/limits with PGlite", () => {
       embeddingsRpm: 200,
     });
 
+    expect(data.v2.limits.agentSandboxes.nonEagerCreate).toMatchObject({
+      used: {
+        status: "available",
+        source: "agent-sandbox-quota",
+        observedAt: data.observedAt,
+        value: { value: "3", unit: "count" },
+      },
+      reserved: {
+        status: "available",
+        value: { value: "2", unit: "count" },
+      },
+      deleting: {
+        status: "available",
+        value: { value: "2", unit: "count" },
+      },
+    });
+    expect(data.v2.limits.containers).toMatchObject({
+      used: { status: "available", value: { value: "2", unit: "count" } },
+      reserved: {
+        status: "available",
+        value: { value: "0", unit: "count" },
+      },
+      deleting: {
+        status: "available",
+        value: { value: "1", unit: "count" },
+      },
+    });
+    expect(data.v2.limits.storage).toMatchObject({
+      used: {
+        status: "available",
+        value: { value: "9007199254740993", unit: "byte" },
+      },
+      remaining: {
+        status: "available",
+        value: { value: "0", unit: "byte" },
+      },
+      reserved: {
+        status: "unavailable",
+        error: {
+          code: "storage_reservation_decomposition_unavailable",
+          retryable: false,
+        },
+      },
+    });
+    expect(data.v2.limits.inference.completions).toMatchObject({
+      used: {
+        status: "unavailable",
+        error: { code: "inference_window_peek_unavailable", retryable: false },
+      },
+      limit: {
+        status: "available",
+        source: "org-rate-limits",
+        value: { value: "777", unit: "request_per_minute" },
+      },
+    });
+    expect(data.v2.limits.inference.weekly).toMatchObject({
+      used: { status: "unknown_policy", blockedBy: ["#22962"] },
+      reserved: { status: "unknown_policy", blockedBy: ["#22962"] },
+      remaining: { status: "unknown_policy", blockedBy: ["#22962"] },
+      resetAt: { status: "unknown_policy", blockedBy: ["#22962"] },
+    });
+    expect(data.v2.tier.configured).toMatchObject({
+      status: "available",
+      value: {
+        tierSourceCreditTotalObserved: {
+          value: "10.000000",
+          unit: "usd",
+          currency: "USD",
+        },
+      },
+    });
+    expect(data.v2.limits.apiKeys).toMatchObject({
+      used: { status: "available", value: { value: "2", unit: "count" } },
+      limit: { status: "unknown_policy", blockedBy: ["#22958"] },
+      remaining: { status: "unknown_policy", blockedBy: ["#22958"] },
+    });
+    expect(data.v2.autoTopUp.control).toMatchObject({
+      status: "available",
+      source: "auto_top_up_control",
+      observedAt: data.observedAt,
+      value: { mode: "paused" },
+    });
+    expect(data.v2.activeCompute.resources.status).toBe("available");
+    if (data.v2.activeCompute.resources.status !== "available") {
+      throw new Error("active compute resources unexpectedly unavailable");
+    }
+    const runningContainer = data.v2.activeCompute.resources.value.find(
+      (resource) => resource.resourceId === CONTAINER_A_RUNNING,
+    );
+    expect(runningContainer).toMatchObject({
+      resourceType: "container",
+      rateSegment: {
+        status: "available",
+        source: "compute_billing_rate_segments",
+        value: {
+          workloadKind: "container",
+          billingState: "running",
+          effectiveAt: "2020-01-01T11:00:00.000Z",
+        },
+      },
+      ratePerHour: {
+        status: "available",
+        source: "compute_billing_rate_segments",
+        value: { value: "0.123456", unit: "usd_per_hour", currency: "USD" },
+      },
+      estimatedRecurringComputeCostPerDay: {
+        status: "available",
+        value: { value: "2.962944", unit: "usd_per_day", currency: "USD" },
+      },
+    });
+
     const serialized = JSON.stringify(data);
     expect(serialized).not.toContain("canCreate");
-    expect(serialized).not.toContain("standardRpm");
-    expect(serialized).not.toContain("strictRpm");
+    expect(serialized).not.toContain("paidCreditsObserved");
+    expect(serialized).not.toContain('"tierName"');
+  });
+
+  test("matches container admission at N-1, N, and N+1 for unknown live statuses", async () => {
+    const assertBoundary = async (expected: {
+      state: "available" | "at-limit" | "over-limit";
+      counted: number;
+      used: string;
+      reserved: string;
+    }) => {
+      const data = await readySnapshot(
+        await getLimits({ key: KEY_CONTAINER_BOUNDARY }),
+      );
+      expect(data.containers).toEqual({
+        source: "container-quota",
+        state: expected.state,
+        used: expected.counted,
+        limit: 5,
+      });
+      expect(data.v2.limits.containers).toMatchObject({
+        used: {
+          status: "available",
+          value: { value: expected.used, unit: "count" },
+        },
+        reserved: {
+          status: "available",
+          value: { value: expected.reserved, unit: "count" },
+        },
+        deleting: { status: "available", value: { value: "1", unit: "count" } },
+        remaining: {
+          status: "available",
+          value: {
+            value: expected.counted < 5 ? String(5 - expected.counted) : "0",
+            unit: "count",
+          },
+        },
+      });
+    };
+
+    await assertBoundary({
+      state: "available",
+      counted: 4,
+      used: "3",
+      reserved: "1",
+    });
+
+    const { containersRepository, QuotaExceededError } = await import(
+      "@/db/repositories/containers"
+    );
+    await containersRepository.createWithQuotaCheck({
+      name: "Limits boundary pending",
+      project_name: "limits-boundary-pending",
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+    });
+    await assertBoundary({
+      state: "at-limit",
+      counted: 5,
+      used: "3",
+      reserved: "2",
+    });
+
+    const rejectedAdmission = containersRepository.createWithQuotaCheck({
+      name: "Limits boundary rejected",
+      project_name: "limits-boundary-rejected",
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+    });
+    await expect(rejectedAdmission).rejects.toBeInstanceOf(QuotaExceededError);
+    await expect(rejectedAdmission).rejects.toMatchObject({
+      current: 5,
+      max: 5,
+    });
+    await assertBoundary({
+      state: "at-limit",
+      counted: 5,
+      used: "3",
+      reserved: "2",
+    });
+
+    const { dbWrite } = await import("@/db/client");
+    const { containers } = await import("@/db/schemas/containers");
+    await dbWrite.insert(containers).values({
+      name: "Limits boundary future state",
+      project_name: "limits-boundary-future-state",
+      organization_id: ORG_CONTAINER_BOUNDARY,
+      user_id: USER_CONTAINER_BOUNDARY,
+      status: "future_manual_hold",
+    });
+    await assertBoundary({
+      state: "over-limit",
+      counted: 6,
+      used: "4",
+      reserved: "2",
+    });
+  });
+
+  test("matches fresh-org storage defaults and atomic admission at N and N+1", async () => {
+    const before = await readySnapshot(
+      await getLimits({ key: KEY_STORAGE_BOUNDARY }),
+    );
+    expect(before.storage).toEqual({
+      source: "org-storage-quota",
+      state: "available",
+      bytesUsed: "0",
+      bytesLimit: "5368709120",
+    });
+    expect(before.v2.limits.storage).toMatchObject({
+      used: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: "0", unit: "byte" },
+      },
+      limit: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: "5368709120", unit: "byte" },
+      },
+      remaining: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: "5368709120", unit: "byte" },
+      },
+    });
+
+    const { DEFAULT_ORG_STORAGE_BYTES_LIMIT, orgStorageQuotaRepository } =
+      await import("@/db/repositories/org-storage-quota");
+    expect(
+      await orgStorageQuotaRepository.tryReserveBytes(
+        ORG_STORAGE_BOUNDARY,
+        DEFAULT_ORG_STORAGE_BYTES_LIMIT,
+      ),
+    ).toBe(DEFAULT_ORG_STORAGE_BYTES_LIMIT);
+
+    const atLimit = await readySnapshot(
+      await getLimits({ key: KEY_STORAGE_BOUNDARY }),
+    );
+    expect(atLimit.storage).toMatchObject({
+      state: "at-limit",
+      bytesUsed: "5368709120",
+    });
+    expect(atLimit.v2.limits.storage.remaining).toMatchObject({
+      status: "available",
+      source: "org-storage-quota",
+      value: { value: "0", unit: "byte" },
+    });
+
+    expect(
+      await orgStorageQuotaRepository.tryReserveBytes(ORG_STORAGE_BOUNDARY, 1n),
+    ).toBeNull();
+    const overAttempt = await readySnapshot(
+      await getLimits({ key: KEY_STORAGE_BOUNDARY }),
+    );
+    expect(overAttempt.storage).toMatchObject({
+      state: "at-limit",
+      bytesUsed: "5368709120",
+    });
   });
 
   test("allows a viewer but ignores a forged query organization", async () => {

--- a/packages/cloud/api/__tests__/billing-limits-snapshot.test.ts
+++ b/packages/cloud/api/__tests__/billing-limits-snapshot.test.ts
@@ -1,9 +1,8 @@
 /**
- * Exercises the real GET /api/v1/billing/limits Hono route with mocked auth
- * and data boundaries. Pins the #19777 route contract: the organization comes
- * exclusively from the authenticated membership (a client-supplied org id is
- * ignored), viewers may read the snapshot, and an auth failure never leaks a
- * body. Snapshot assembly itself is covered in cloud-shared.
+ * Exercises the real GET /api/v1/billing/limits Hono boundary with mocked
+ * authentication and read-only data adapters. The canonical primary reader
+ * receives only the organization resolved from auth; query parameters never
+ * become a tenant-selection seam.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -15,6 +14,62 @@ const requireUserOrApiKeyWithOrg = mock(
     organization_id: "org-authed",
     role: "viewer",
   }),
+);
+
+const readPrimaryAccountBillingSnapshot = mock(
+  async (organizationId: string) => {
+    seenOrgIds.push(organizationId);
+    return {
+      observedAt: "2026-08-20T12:00:00.000Z",
+      organization: {
+        creditBalance: "15.000000",
+        balanceRevision: "9007199254740993",
+        balanceDecreaseRevision: "2",
+        coveredBalanceDecreaseRevision: "1",
+        settings: {},
+        isActive: true,
+        stripeCustomerIdPresent: false,
+        stripeCustomerIdValid: false,
+        defaultPaymentMethodIdPresent: false,
+        defaultPaymentMethodIdValid: false,
+        autoTopUpEnabled: false,
+        autoTopUpThreshold: null,
+        autoTopUpAmount: null,
+      },
+      cloudCharacterCount: "2",
+      sandboxCounts: { used: "1", reserved: "1", deleting: "0" },
+      containerCounts: { used: "0", reserved: "0", deleting: "0" },
+      containerSettings: {},
+      appCount: "1",
+      apiKeyCount: "1",
+      storageQuota: { bytesUsed: "42", bytesLimit: "1000" },
+      configuredTier: {
+        status: "available" as const,
+        tier: {
+          tierName: "paid",
+          completionsRpm: 60,
+          embeddingsRpm: 120,
+          standardRpm: 30,
+          strictRpm: 5,
+        },
+        tierSourceCreditTotal: "15.000000",
+        overrides: {
+          completionsRpm: null,
+          embeddingsRpm: null,
+          standardRpm: null,
+          strictRpm: null,
+        },
+      },
+      autoTopUp: {
+        control: null,
+        customerBindingAuthoritative: false,
+        blockingAttempt: false,
+        blockingLegacyQuarantine: false,
+      },
+      activeResources: [],
+      latestRateSegments: [],
+    };
+  },
 );
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -33,59 +88,29 @@ mock.module("@/lib/api/cloud-worker-errors", () => ({
 mock.module("@/lib/utils/logger", () => ({
   logger: { error: mock(), warn: mock(), info: mock() },
 }));
-mock.module("@/db/client", () => ({
-  dbRead: {
-    query: {
-      organizations: {
-        findFirst: async () => ({ credit_balance: "15", settings: {} }),
-      },
-    },
-    select: () => ({
-      from: () => ({
-        where: async () => [{ count: 2 }],
-      }),
-    }),
-  },
+mock.module("@/db/repositories/account-billing-snapshot", () => ({
+  readPrimaryAccountBillingSnapshot,
 }));
 mock.module("@/db/repositories/org-storage-quota", () => ({
   DEFAULT_ORG_STORAGE_BYTES_LIMIT: 5n * 1024n * 1024n * 1024n,
-  orgStorageQuotaRepository: {
-    findByOrganization: async (orgId: string) => {
-      seenOrgIds.push(orgId);
-      return { bytes_used: 42n, bytes_limit: 1000n };
-    },
-  },
 }));
 mock.module("@/lib/services/apps", () => ({
-  appsService: {
-    countByOrganization: async (orgId: string) => {
-      seenOrgIds.push(orgId);
-      return 1;
-    },
-  },
   getMaxAppsPerOrg: () => 25,
 }));
-mock.module("@/lib/services/container-quota", () => ({
-  containerQuotaService: {
-    checkQuota: async (orgId: string) => {
-      seenOrgIds.push(orgId);
-      return { allowed: true, current: 0, max: 10 };
-    },
-  },
+mock.module("@/lib/constants/agent-sandbox-quota", () => ({
+  getMaxNonTerminalAgentsForOrg: (balance: number | undefined) =>
+    balance === undefined ? 5 : 100,
 }));
-mock.module("@/lib/services/eliza-sandbox", () => ({
-  QUOTA_COUNTED_STATUSES: [
-    "pending",
-    "provisioning",
-    "running",
-    "stopped",
-    "sleeping",
-  ],
+mock.module("@/lib/constants/cloud-character-quota", () => ({
+  getMaxCloudCharactersForOrg: () => 100,
+}));
+mock.module("@/lib/constants/pricing", () => ({
+  getMaxContainersForOrg: () => 10,
 }));
 mock.module("@/lib/services/org-rate-limits", () => ({
-  readOrgTierFromSources: async (orgId: string) => {
-    seenOrgIds.push(orgId);
-    return { completionsRpm: 60, embeddingsRpm: 120 };
+  getOrgTierCacheOnly: async (organizationId: string) => {
+    seenOrgIds.push(organizationId);
+    return { kind: "warming" as const, cacheRead: "miss" as const };
   },
 }));
 
@@ -96,41 +121,62 @@ describe("GET /api/v1/billing/limits", () => {
   beforeEach(() => {
     seenOrgIds.length = 0;
     requireUserOrApiKeyWithOrg.mockClear();
+    readPrimaryAccountBillingSnapshot.mockClear();
     requireUserOrApiKeyWithOrg.mockImplementation(async () => ({
       organization_id: "org-authed",
       role: "viewer",
     }));
   });
 
-  test("a viewer reads the snapshot scoped to the authenticated org", async () => {
+  test("a viewer reads the additive snapshot scoped to the authenticated org", async () => {
     const response = await app.request("/api/v1/billing/limits");
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       success: boolean;
-      data: Record<string, Record<string, unknown>> & { observedAt: string };
+      data: {
+        schemaVersion: number;
+        observedAt: string;
+        storage: Record<string, unknown>;
+        v2: {
+          balance: Record<string, unknown>;
+          limits: { storage: { reserved: Record<string, unknown> } };
+        };
+      };
     };
     expect(body.success).toBe(true);
-    expect(typeof body.data.observedAt).toBe("string");
+    expect(body.data.schemaVersion).toBe(2);
+    expect(body.data.observedAt).toBe("2026-08-20T12:00:00.000Z");
     expect(body.data.storage).toEqual({
       source: "org-storage-quota",
       state: "available",
       bytesUsed: "42",
       bytesLimit: "1000",
     });
-    // Every boundary was queried with the AUTHENTICATED org.
+    expect(body.data.v2.balance).toMatchObject({
+      status: "available",
+      source: "organizations",
+      value: {
+        balance: { value: "15.000000", unit: "usd", currency: "USD" },
+        revision: "9007199254740993",
+      },
+    });
+    expect(body.data.v2.limits.storage.reserved).toMatchObject({
+      status: "unavailable",
+      error: { code: "storage_reservation_decomposition_unavailable" },
+    });
     expect(new Set(seenOrgIds)).toEqual(new Set(["org-authed"]));
   });
 
   test("a client-supplied organization id is ignored", async () => {
     const response = await app.request(
-      "/api/v1/billing/limits?organizationId=org-else",
+      "/api/v1/billing/limits?organizationId=org-forged",
     );
     expect(response.status).toBe(200);
     expect(seenOrgIds.every((id) => id === "org-authed")).toBe(true);
-    expect(seenOrgIds.some((id) => id === "org-else")).toBe(false);
+    expect(seenOrgIds.some((id) => id === "org-forged")).toBe(false);
   });
 
-  test("an auth failure yields the failure envelope, not a snapshot", async () => {
+  test("an auth failure yields the failure envelope without reading an organization", async () => {
     requireUserOrApiKeyWithOrg.mockImplementation(async () => {
       throw new Error("Unauthorized");
     });
@@ -138,6 +184,7 @@ describe("GET /api/v1/billing/limits", () => {
     expect(response.status).toBe(401);
     const body = (await response.json()) as { success: boolean };
     expect(body.success).toBe(false);
+    expect(readPrimaryAccountBillingSnapshot).not.toHaveBeenCalled();
     expect(seenOrgIds).toHaveLength(0);
   });
 });

--- a/packages/cloud/api/v1/billing/limits/route.ts
+++ b/packages/cloud/api/v1/billing/limits/route.ts
@@ -1,35 +1,27 @@
 /**
- * Serves a read-only, organization-scoped snapshot of the account limits the backend
- * actually enforces (#19777). The organization comes exclusively from the
- * authenticated user / API-key membership — no client-supplied org id — and
- * viewers may read it (nothing here mutates or reveals secrets). Assembly and
- * failure semantics live in `account-limits-snapshot.ts`; this route only
- * wires the canonical enforcement sources.
+ * Serves the read-only, organization-scoped billing snapshot (#22954), with
+ * its additive v2 observations and exact temporary v1 limits projection. The
+ * organization comes exclusively from authenticated user/API-key membership;
+ * no client-supplied id is a tenant-selection seam. Assembly and failure
+ * semantics live in `account-limits-snapshot.ts`; this route only wires the
+ * canonical enforcement sources.
  */
 
-import { ElizaError } from "@elizaos/core";
-import { and, eq, inArray, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { dbRead } from "@/db/client";
-import {
-  DEFAULT_ORG_STORAGE_BYTES_LIMIT,
-  orgStorageQuotaRepository,
-} from "@/db/repositories/org-storage-quota";
-import { agentSandboxes } from "@/db/schemas/agent-sandboxes";
-import { userCharacters } from "@/db/schemas/user-characters";
+import { readPrimaryAccountBillingSnapshot } from "@/db/repositories/account-billing-snapshot";
+import { DEFAULT_ORG_STORAGE_BYTES_LIMIT } from "@/db/repositories/org-storage-quota";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { getMaxCloudCharactersForOrg } from "@/lib/constants/cloud-character-quota";
+import { getMaxContainersForOrg } from "@/lib/constants/pricing";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { buildAccountLimitsSnapshot } from "@/lib/services/account-limits-snapshot";
-import { appsService, getMaxAppsPerOrg } from "@/lib/services/apps";
-import { containerQuotaService } from "@/lib/services/container-quota";
-import { QUOTA_COUNTED_STATUSES } from "@/lib/services/eliza-sandbox";
-import { readOrgTierFromSources } from "@/lib/services/org-rate-limits";
+import { buildAccountBillingSnapshot } from "@/lib/services/account-limits-snapshot";
+import { getMaxAppsPerOrg } from "@/lib/services/apps";
+import { getOrgTierCacheOnly } from "@/lib/services/org-rate-limits";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -42,82 +34,17 @@ app.get("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const organizationId = user.organization_id;
 
-    const snapshot = await buildAccountLimitsSnapshot({
-      orgBilling: async () => {
-        const org = await dbRead.query.organizations.findFirst({
-          where: (table, { eq: whereEq }) => whereEq(table.id, organizationId),
-          columns: { credit_balance: true, settings: true },
-        });
-        if (!org) {
-          throw new ElizaError(
-            "Organization account-limit source is unavailable",
-            {
-              code: "ACCOUNT_LIMIT_SOURCE_UNAVAILABLE",
-              context: { organizationId, source: "organizations" },
-              severity: "fatal",
-            },
-          );
-        }
-        return {
-          creditBalance: Number(org.credit_balance),
-          settings: org.settings,
-        };
-      },
-      cloudCharacterCount: async () => {
-        const [{ count } = { count: Number.NaN }] = await dbRead
-          .select({ count: sql<number>`count(*)::int` })
-          .from(userCharacters)
-          .where(
-            and(
-              eq(userCharacters.organization_id, organizationId),
-              eq(userCharacters.source, "cloud"),
-            ),
-          );
-        return count;
-      },
-      sandboxQuotaCount: async () => {
-        // Mirrors `assertOrgAgentQuota`'s counted set exactly: quota-holding
-        // statuses (including stopped/sleeping), non-pool rows only.
-        const [{ count } = { count: Number.NaN }] = await dbRead
-          .select({ count: sql<number>`count(*)::int` })
-          .from(agentSandboxes)
-          .where(
-            and(
-              eq(agentSandboxes.organization_id, organizationId),
-              sql`${agentSandboxes.pool_status} IS NULL`,
-              inArray(agentSandboxes.status, QUOTA_COUNTED_STATUSES),
-            ),
-          );
-        return count;
-      },
-      containerQuota: async () => {
-        const quota = await containerQuotaService.checkQuota(organizationId);
-        return {
-          current: quota.current,
-          max: quota.max,
-          sourceUnavailable: quota.availability === "unavailable",
-        };
-      },
-      appCount: () => appsService.countByOrganization(organizationId),
-      appLimit: async () => getMaxAppsPerOrg(),
-      storageQuota: async () => {
-        const row =
-          await orgStorageQuotaRepository.findByOrganization(organizationId);
-        if (!row) return null;
-        return { bytesUsed: row.bytes_used, bytesLimit: row.bytes_limit };
-      },
-      inferenceRateTier: async () => {
-        // This is an observation-only GET. Read the authoritative DB sources
-        // without hydrating or mutating the inference admission cache.
-        const tier = await readOrgTierFromSources(organizationId);
-        return {
-          completionsRpm: tier.completionsRpm,
-          embeddingsRpm: tier.embeddingsRpm,
-        };
-      },
+    const snapshot = await buildAccountBillingSnapshot({
+      primary: () => readPrimaryAccountBillingSnapshot(organizationId),
+      appLimit: getMaxAppsPerOrg,
       maxCloudCharacters: getMaxCloudCharactersForOrg,
       maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg,
+      maxContainers: getMaxContainersForOrg,
+      runtimeTierCache: () => getOrgTierCacheOnly(organizationId),
+      autoTopUpRuntimeEnabled: () =>
+        c.env?.AUTO_TOP_UP_DURABLE_ENABLED === "true",
       defaultStorageBytesLimit: DEFAULT_ORG_STORAGE_BYTES_LIMIT,
+      now: () => new Date(),
     });
 
     return c.json({ success: true, data: snapshot });

--- a/packages/cloud/shared/src/db/repositories/__tests__/account-billing-snapshot-aggregates.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/account-billing-snapshot-aggregates.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Verifies that every PostgreSQL aggregate family required by the account
+ * billing snapshot distinguishes a present SQL-produced zero from an absent
+ * aggregate row. The latter must fail closed before DTO assembly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import {
+  type AccountBillingAggregateSource,
+  requireAccountBillingAggregateRow,
+} from "../account-billing-snapshot-aggregates";
+
+const REQUIRED_AGGREGATES: AccountBillingAggregateSource[] = [
+  "cloud_characters",
+  "agent_sandboxes",
+  "containers",
+  "apps",
+  "api_keys",
+  "tier_source_credits",
+];
+
+describe("account billing aggregate rows", () => {
+  test.each(REQUIRED_AGGREGATES)("fails closed when %s returns no row", (source) => {
+    let thrown: unknown;
+    try {
+      requireAccountBillingAggregateRow([], source);
+    } catch (error) {
+      // error-policy:J4 — capture the deliberate fail-closed source error so
+      // its stable code and provenance can be asserted below.
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+      context: { source, reason: "missing_aggregate_row" },
+    });
+  });
+
+  test.each(REQUIRED_AGGREGATES)(
+    "accepts %s zero only when an aggregate row is present",
+    (source) => {
+      const sqlAggregateRow = { value: "0" };
+      expect(requireAccountBillingAggregateRow([sqlAggregateRow], source)).toBe(sqlAggregateRow);
+    },
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/account-billing-snapshot-primary-values.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/account-billing-snapshot-primary-values.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Verifies that customer-binding authority rows preserve real boolean values
+ * while missing or malformed primary data fails closed with typed provenance.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { requireCustomerBindingAuthoritativeRow } from "../account-billing-snapshot-primary-values";
+
+describe("account billing customer-binding authority", () => {
+  test.each([
+    {
+      name: "missing row",
+      rows: [],
+      code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+      reason: "missing_scalar_row",
+      field: undefined,
+    },
+    {
+      name: "null scalar",
+      rows: [{ authoritative: null }],
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      reason: "non_boolean_scalar",
+      field: "stripe_customer_binding_is_authoritative.authoritative",
+    },
+    {
+      name: "non-boolean scalar",
+      rows: [{ authoritative: "false" }],
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      reason: "non_boolean_scalar",
+      field: "stripe_customer_binding_is_authoritative.authoritative",
+    },
+  ])("fails closed on $name", ({ rows, code, reason, field }) => {
+    let thrown: unknown;
+    try {
+      requireCustomerBindingAuthoritativeRow(rows);
+    } catch (error) {
+      // error-policy:J4 — capture the deliberate fail-closed source error so
+      // its stable code and provenance can be asserted below.
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      code,
+      context: {
+        source: "stripe_customer_binding_authority",
+        reason,
+        ...(field === undefined ? {} : { field }),
+      },
+    });
+  });
+
+  test.each([
+    { authoritative: false, expected: false },
+    { authoritative: true, expected: true },
+  ])("preserves a real $authoritative value", ({ authoritative, expected }) => {
+    expect(requireCustomerBindingAuthoritativeRow([{ authoritative }])).toBe(expected);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/account-billing-snapshot-aggregates.ts
+++ b/packages/cloud/shared/src/db/repositories/account-billing-snapshot-aggregates.ts
@@ -1,0 +1,31 @@
+/**
+ * Guards the PostgreSQL aggregate-row invariant used by the account billing
+ * snapshot. Aggregate queries must return one row even for an empty relation;
+ * only values produced by that row (`COUNT` or SQL `COALESCE`) may represent
+ * zero. A missing row is a source failure, never an implicit healthy zero.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export type AccountBillingAggregateSource =
+  | "cloud_characters"
+  | "agent_sandboxes"
+  | "containers"
+  | "apps"
+  | "api_keys"
+  | "tier_source_credits";
+
+export function requireAccountBillingAggregateRow<T>(
+  rows: readonly T[],
+  source: AccountBillingAggregateSource,
+): T {
+  const row = rows[0];
+  if (row === undefined || row === null) {
+    throw new ElizaError(`Account billing aggregate ${source} did not return its required row`, {
+      code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+      context: { source, reason: "missing_aggregate_row" },
+      severity: "fatal",
+    });
+  }
+  return row;
+}

--- a/packages/cloud/shared/src/db/repositories/account-billing-snapshot-primary-values.ts
+++ b/packages/cloud/shared/src/db/repositories/account-billing-snapshot-primary-values.ts
@@ -1,0 +1,46 @@
+/**
+ * Validates scalar rows returned by PostgreSQL functions that feed the
+ * account billing snapshot. Missing rows and malformed scalar values remain
+ * distinguishable primary-source failures instead of becoming business data.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+const CUSTOMER_BINDING_AUTHORITY_SOURCE = "stripe_customer_binding_authority";
+const CUSTOMER_BINDING_AUTHORITY_FIELD = "stripe_customer_binding_is_authoritative.authoritative";
+
+/** Require one actual boolean authority result; `false` is valid business data. */
+export function requireCustomerBindingAuthoritativeRow(rows: readonly unknown[]): boolean {
+  const row = rows[0];
+  if (row === undefined || row === null) {
+    throw new ElizaError(
+      "Account billing customer-binding authority did not return its required row",
+      {
+        code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+        context: {
+          source: CUSTOMER_BINDING_AUTHORITY_SOURCE,
+          reason: "missing_scalar_row",
+        },
+        severity: "fatal",
+      },
+    );
+  }
+
+  const authoritative =
+    typeof row === "object" && "authoritative" in row
+      ? (row as { authoritative: unknown }).authoritative
+      : undefined;
+  if (typeof authoritative !== "boolean") {
+    throw new ElizaError("Account billing customer-binding authority did not return a boolean", {
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      context: {
+        source: CUSTOMER_BINDING_AUTHORITY_SOURCE,
+        field: CUSTOMER_BINDING_AUTHORITY_FIELD,
+        reason: "non_boolean_scalar",
+      },
+      severity: "fatal",
+    });
+  }
+
+  return authoritative;
+}

--- a/packages/cloud/shared/src/db/repositories/account-billing-snapshot.ts
+++ b/packages/cloud/shared/src/db/repositories/account-billing-snapshot.ts
@@ -1,0 +1,496 @@
+/**
+ * Coherent primary-database read model for the account billing snapshot.
+ *
+ * All PostgreSQL-backed fields are read from one primary REPEATABLE READ,
+ * READ ONLY transaction. No legacy billing shadow is imported or queried;
+ * `organizations` is the sole billing authority.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import {
+  type ActiveBillableResource,
+  activeBillingService,
+} from "../../lib/services/active-billing";
+import {
+  ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES,
+  type OrgTierData,
+  resolveOrgTierFromSourceValues,
+} from "../../lib/services/org-rate-limits";
+import { dbRead } from "../client";
+import { sqlRows } from "../execute-helpers";
+import { agentSandboxes } from "../schemas/agent-sandboxes";
+import { apiKeys } from "../schemas/api-keys";
+import { apps } from "../schemas/apps";
+import {
+  autoTopUpAttempts,
+  autoTopUpControl,
+  autoTopUpLegacyPaymentQuarantine,
+} from "../schemas/auto-top-up-attempts";
+import { computeBillingRateSegments } from "../schemas/compute-billing-rate-segments";
+import { containers } from "../schemas/containers";
+import { creditTransactions } from "../schemas/credit-transactions";
+import { orgRateLimitOverrides } from "../schemas/org-rate-limit-overrides";
+import { orgStorageQuota } from "../schemas/org-storage-quota";
+import { organizationConfig } from "../schemas/organization-config";
+import { organizations } from "../schemas/organizations";
+import { userCharacters } from "../schemas/user-characters";
+import { requireAccountBillingAggregateRow } from "./account-billing-snapshot-aggregates";
+import { requireCustomerBindingAuthoritativeRow } from "./account-billing-snapshot-primary-values";
+
+export interface PrimaryStatusCounts {
+  used: string;
+  reserved: string;
+  deleting: string;
+}
+
+export interface PrimaryComputeRateSegment {
+  workloadKind: "agent" | "container";
+  workloadId: string;
+  billingState: string;
+  ratePerHour: string;
+  effectiveAt: Date | string;
+}
+
+export interface PrimaryAccountBillingReadModel {
+  observedAt: string;
+  organization: {
+    creditBalance: string;
+    balanceRevision: string;
+    balanceDecreaseRevision: string;
+    coveredBalanceDecreaseRevision: string | null;
+    settings: unknown;
+    isActive: boolean;
+    stripeCustomerIdPresent: boolean;
+    stripeCustomerIdValid: boolean;
+    defaultPaymentMethodIdPresent: boolean;
+    defaultPaymentMethodIdValid: boolean;
+    autoTopUpEnabled: boolean;
+    autoTopUpThreshold: string | null;
+    autoTopUpAmount: string | null;
+  };
+  cloudCharacterCount: string;
+  sandboxCounts: PrimaryStatusCounts;
+  containerCounts: PrimaryStatusCounts;
+  containerSettings: unknown;
+  appCount: string;
+  apiKeyCount: string;
+  storageQuota: { bytesUsed: string; bytesLimit: string } | null;
+  configuredTier:
+    | {
+        status: "available";
+        tier: OrgTierData;
+        tierSourceCreditTotal: string;
+        overrides: {
+          completionsRpm: number | null;
+          embeddingsRpm: number | null;
+          standardRpm: number | null;
+          strictRpm: number | null;
+        };
+      }
+    | { status: "unavailable"; code: "configured_tier_invalid" };
+  autoTopUp: {
+    control: {
+      mode: "paused" | "durable";
+      pausedAt: Date;
+      legacyReconciledThrough: Date | null;
+    } | null;
+    customerBindingAuthoritative: boolean;
+    blockingAttempt: boolean;
+    blockingLegacyQuarantine: boolean;
+  };
+  activeResources: ActiveBillableResource[];
+  latestRateSegments: PrimaryComputeRateSegment[];
+}
+
+function exactInteger(value: unknown, field: string): string {
+  const normalized = typeof value === "string" || typeof value === "number" ? String(value) : "";
+  if (!/^\d+$/.test(normalized)) {
+    throw new ElizaError(`Account billing ${field} is not an exact non-negative integer`, {
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      context: { field },
+      severity: "fatal",
+    });
+  }
+  return normalized.replace(/^0+(?=\d)/, "");
+}
+
+function exactDecimal(value: unknown, field: string): string {
+  const normalized = typeof value === "string" || typeof value === "number" ? String(value) : "";
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(normalized)) {
+    throw new ElizaError(`Account billing ${field} is not an exact non-negative decimal`, {
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      context: { field },
+      severity: "fatal",
+    });
+  }
+  return normalized;
+}
+
+function iso(value: Date | string, field: string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new ElizaError(`Account billing ${field} timestamp is invalid`, {
+      code: "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+      context: { field },
+      severity: "fatal",
+    });
+  }
+  return parsed.toISOString();
+}
+
+/**
+ * Read one organization only. Callers must pass the organization id resolved
+ * by authentication; this function has no user-controlled organization seam.
+ */
+export async function readPrimaryAccountBillingSnapshot(
+  organizationId: string,
+): Promise<PrimaryAccountBillingReadModel> {
+  return dbRead.transaction(
+    async (tx) => {
+      const [clock] = await sqlRows<{ observed_at: Date | string }>(
+        tx,
+        sql`SELECT transaction_timestamp() AS observed_at`,
+      );
+      if (!clock) {
+        throw new ElizaError("Account billing primary clock is unavailable", {
+          code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+          severity: "fatal",
+        });
+      }
+      const observedAt = iso(clock.observed_at, "observed_at");
+
+      const [organization] = await tx
+        .select({
+          creditBalance: organizations.credit_balance,
+          balanceRevision: sql<string>`${organizations.balance_revision}::text`,
+          balanceDecreaseRevision: sql<string>`${organizations.balance_decrease_revision}::text`,
+          coveredBalanceDecreaseRevision: sql<
+            string | null
+          >`${organizations.auto_top_up_covered_balance_decrease_revision}::text`,
+          settings: organizations.settings,
+          isActive: organizations.is_active,
+          stripeCustomerId: organizations.stripe_customer_id,
+          defaultPaymentMethod: organizations.stripe_default_payment_method,
+          autoTopUpEnabled: organizations.auto_top_up_enabled,
+          autoTopUpThreshold: organizations.auto_top_up_threshold,
+          autoTopUpAmount: organizations.auto_top_up_amount,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, organizationId))
+        .limit(1);
+
+      if (!organization) {
+        throw new ElizaError("Authenticated organization billing authority was not found", {
+          code: "ACCOUNT_BILLING_ORGANIZATION_NOT_FOUND",
+          context: { organizationId },
+          severity: "fatal",
+        });
+      }
+
+      const [
+        cloudCharacterRows,
+        sandboxRows,
+        containerRows,
+        containerConfig,
+        appRows,
+        apiKeyRows,
+        storageRows,
+        tierSourceCreditRows,
+        tierOverride,
+        controlRows,
+        blockingAttemptRows,
+        blockingLegacyRows,
+      ] = await Promise.all([
+        tx
+          .select({ count: sql<string>`COALESCE(count(*), 0)::text` })
+          .from(userCharacters)
+          .where(
+            and(
+              eq(userCharacters.organization_id, organizationId),
+              eq(userCharacters.source, "cloud"),
+            ),
+          ),
+        tx
+          .select({
+            used: sql<string>`COALESCE(count(*) FILTER (WHERE ${agentSandboxes.status} IN ('running','stopped','sleeping')), 0)::text`,
+            reserved: sql<string>`COALESCE(count(*) FILTER (WHERE ${agentSandboxes.status} IN ('pending','provisioning')), 0)::text`,
+            deleting: sql<string>`COALESCE(count(*) FILTER (WHERE ${agentSandboxes.status} IN ('deletion_pending','deletion_failed')), 0)::text`,
+          })
+          .from(agentSandboxes)
+          .where(
+            and(
+              eq(agentSandboxes.organization_id, organizationId),
+              isNull(agentSandboxes.pool_status),
+            ),
+          ),
+        tx
+          .select({
+            used: sql<string>`COALESCE(count(*) FILTER (WHERE ${containers.status} NOT IN ('pending','building','deploying','deleting','deleted')), 0)::text`,
+            reserved: sql<string>`COALESCE(count(*) FILTER (WHERE ${containers.status} IN ('pending','building','deploying')), 0)::text`,
+            deleting: sql<string>`COALESCE(count(*) FILTER (WHERE ${containers.status} = 'deleting'), 0)::text`,
+          })
+          .from(containers)
+          .where(eq(containers.organization_id, organizationId)),
+        tx.query.organizationConfig.findFirst({
+          where: eq(organizationConfig.organization_id, organizationId),
+          columns: { settings: true },
+        }),
+        tx
+          .select({ count: sql<string>`COALESCE(count(*), 0)::text` })
+          .from(apps)
+          .where(eq(apps.organization_id, organizationId)),
+        tx
+          .select({ count: sql<string>`COALESCE(count(*), 0)::text` })
+          .from(apiKeys)
+          .where(eq(apiKeys.organization_id, organizationId)),
+        tx
+          .select({
+            bytesUsed: sql<string>`${orgStorageQuota.bytes_used}::text`,
+            bytesLimit: sql<string>`${orgStorageQuota.bytes_limit}::text`,
+          })
+          .from(orgStorageQuota)
+          .where(eq(orgStorageQuota.organization_id, organizationId))
+          .limit(1),
+        tx
+          .select({
+            tierSourceCreditTotal: sql<string>`COALESCE(SUM(${creditTransactions.amount}), '0')::text`,
+          })
+          .from(creditTransactions)
+          .where(
+            and(
+              eq(creditTransactions.organization_id, organizationId),
+              eq(creditTransactions.type, "credit"),
+              sql`COALESCE(${creditTransactions.metadata}->>'type', '') NOT IN (${sql.join(
+                ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((type) => sql`${type}`),
+                sql`, `,
+              )})`,
+            ),
+          ),
+        tx.query.orgRateLimitOverrides.findFirst({
+          where: eq(orgRateLimitOverrides.organization_id, organizationId),
+          columns: {
+            completions_rpm: true,
+            embeddings_rpm: true,
+            standard_rpm: true,
+            strict_rpm: true,
+          },
+        }),
+        tx
+          .select({
+            mode: autoTopUpControl.mode,
+            pausedAt: autoTopUpControl.paused_at,
+            legacyReconciledThrough: autoTopUpControl.legacy_reconciled_through,
+          })
+          .from(autoTopUpControl)
+          .where(eq(autoTopUpControl.singleton, true))
+          .limit(1),
+        tx
+          .select({ id: autoTopUpAttempts.id })
+          .from(autoTopUpAttempts)
+          .where(
+            and(
+              eq(autoTopUpAttempts.organization_id, organizationId),
+              inArray(autoTopUpAttempts.status, [
+                "claimed",
+                "payment_pending",
+                "payment_succeeded",
+                "manual_review",
+              ]),
+            ),
+          )
+          .limit(1),
+        tx
+          .select({ id: autoTopUpLegacyPaymentQuarantine.id })
+          .from(autoTopUpLegacyPaymentQuarantine)
+          .where(
+            and(
+              eq(autoTopUpLegacyPaymentQuarantine.organization_id, organizationId),
+              inArray(autoTopUpLegacyPaymentQuarantine.status, ["unresolved", "manual_review"]),
+            ),
+          )
+          .limit(1),
+      ]);
+
+      const cloudCharacterAggregate = requireAccountBillingAggregateRow(
+        cloudCharacterRows,
+        "cloud_characters",
+      );
+      const sandboxAggregate = requireAccountBillingAggregateRow(sandboxRows, "agent_sandboxes");
+      const containerAggregate = requireAccountBillingAggregateRow(containerRows, "containers");
+      const appAggregate = requireAccountBillingAggregateRow(appRows, "apps");
+      const apiKeyAggregate = requireAccountBillingAggregateRow(apiKeyRows, "api_keys");
+      const tierSourceCreditAggregate = requireAccountBillingAggregateRow(
+        tierSourceCreditRows,
+        "tier_source_credits",
+      );
+
+      let configuredTier: PrimaryAccountBillingReadModel["configuredTier"];
+      try {
+        const tierSourceCreditTotal = exactDecimal(
+          tierSourceCreditAggregate.tierSourceCreditTotal,
+          "tier-source credit total",
+        );
+        const tierResolution = resolveOrgTierFromSourceValues(
+          organizationId,
+          tierSourceCreditTotal,
+          tierOverride,
+        );
+        configuredTier = {
+          status: "available",
+          tier: tierResolution.tierData,
+          tierSourceCreditTotal,
+          overrides: {
+            completionsRpm: tierOverride?.completions_rpm ?? null,
+            embeddingsRpm: tierOverride?.embeddings_rpm ?? null,
+            standardRpm: tierOverride?.standard_rpm ?? null,
+            strictRpm: tierOverride?.strict_rpm ?? null,
+          },
+        };
+      } catch (error) {
+        // error-policy:J4 — only typed persisted tier-source corruption is
+        // exposed as unavailable; query and programming failures still abort.
+        if (
+          !(error instanceof ElizaError) ||
+          (error.code !== "ORG_RATE_LIMIT_SOURCE_INVALID" &&
+            error.code !== "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE")
+        ) {
+          throw error;
+        }
+        configuredTier = { status: "unavailable", code: "configured_tier_invalid" };
+      }
+
+      const stripeCustomerIdPresent = Boolean(organization.stripeCustomerId);
+      const stripeCustomerIdValid =
+        typeof organization.stripeCustomerId === "string" &&
+        organization.stripeCustomerId.length > 0 &&
+        organization.stripeCustomerId === organization.stripeCustomerId.trim();
+      const defaultPaymentMethodIdPresent = Boolean(organization.defaultPaymentMethod);
+      const defaultPaymentMethodIdValid =
+        typeof organization.defaultPaymentMethod === "string" &&
+        organization.defaultPaymentMethod.length > 0 &&
+        organization.defaultPaymentMethod === organization.defaultPaymentMethod.trim();
+
+      let customerBindingAuthoritative = false;
+      if (stripeCustomerIdValid) {
+        const bindingRows = await sqlRows<{ authoritative: unknown }>(
+          tx,
+          sql`SELECT "stripe_customer_binding_is_authoritative"(
+            ${organizationId}::uuid,
+            ${organization.stripeCustomerId}::text
+          ) AS authoritative`,
+        );
+        customerBindingAuthoritative = requireCustomerBindingAuthoritativeRow(bindingRows);
+      }
+
+      // Consume the existing active-billing selector under this transaction;
+      // do not duplicate its billable resource predicate in the snapshot.
+      const activeResources = await activeBillingService.listActiveResources(organizationId, tx);
+      const activeIds = activeResources.map((resource) => resource.resourceId);
+      const rateRows =
+        activeIds.length === 0
+          ? []
+          : await tx
+              .select({
+                workloadKind: computeBillingRateSegments.workload_kind,
+                workloadId: computeBillingRateSegments.workload_id,
+                billingState: computeBillingRateSegments.billing_state,
+                ratePerHour: computeBillingRateSegments.rate_per_hour,
+                effectiveAt: computeBillingRateSegments.effective_at,
+              })
+              .from(computeBillingRateSegments)
+              .where(
+                and(
+                  eq(computeBillingRateSegments.organization_id, organizationId),
+                  inArray(computeBillingRateSegments.workload_id, activeIds),
+                  sql`${computeBillingRateSegments.effective_at} <= transaction_timestamp()`,
+                ),
+              )
+              .orderBy(
+                desc(computeBillingRateSegments.effective_at),
+                desc(computeBillingRateSegments.id),
+              );
+      const latestRateSegments: PrimaryComputeRateSegment[] = [];
+      const seenRates = new Set<string>();
+      for (const row of rateRows) {
+        const key = `${row.workloadKind}:${row.workloadId}`;
+        if (seenRates.has(key)) continue;
+        seenRates.add(key);
+        latestRateSegments.push(row);
+      }
+
+      const control = controlRows[0];
+
+      return {
+        observedAt,
+        organization: {
+          creditBalance: String(organization.creditBalance),
+          balanceRevision: exactInteger(
+            organization.balanceRevision,
+            "organizations.balance_revision",
+          ),
+          balanceDecreaseRevision: exactInteger(
+            organization.balanceDecreaseRevision,
+            "organizations.balance_decrease_revision",
+          ),
+          coveredBalanceDecreaseRevision:
+            organization.coveredBalanceDecreaseRevision === null
+              ? null
+              : exactInteger(
+                  organization.coveredBalanceDecreaseRevision,
+                  "organizations.auto_top_up_covered_balance_decrease_revision",
+                ),
+          settings: organization.settings,
+          isActive: organization.isActive,
+          stripeCustomerIdPresent,
+          stripeCustomerIdValid,
+          defaultPaymentMethodIdPresent,
+          defaultPaymentMethodIdValid,
+          autoTopUpEnabled: organization.autoTopUpEnabled === true,
+          autoTopUpThreshold:
+            organization.autoTopUpThreshold === null
+              ? null
+              : String(organization.autoTopUpThreshold),
+          autoTopUpAmount:
+            organization.autoTopUpAmount === null ? null : String(organization.autoTopUpAmount),
+        },
+        cloudCharacterCount: exactInteger(cloudCharacterAggregate.count, "cloud characters"),
+        sandboxCounts: {
+          used: exactInteger(sandboxAggregate.used, "used sandboxes"),
+          reserved: exactInteger(sandboxAggregate.reserved, "reserved sandboxes"),
+          deleting: exactInteger(sandboxAggregate.deleting, "deleting sandboxes"),
+        },
+        containerCounts: {
+          used: exactInteger(containerAggregate.used, "used containers"),
+          reserved: exactInteger(containerAggregate.reserved, "reserved containers"),
+          deleting: exactInteger(containerAggregate.deleting, "deleting containers"),
+        },
+        containerSettings: containerConfig?.settings,
+        appCount: exactInteger(appAggregate.count, "apps"),
+        apiKeyCount: exactInteger(apiKeyAggregate.count, "api keys"),
+        storageQuota: storageRows[0]
+          ? {
+              bytesUsed: String(storageRows[0].bytesUsed),
+              bytesLimit: String(storageRows[0].bytesLimit),
+            }
+          : null,
+        configuredTier,
+        autoTopUp: {
+          control: control
+            ? {
+                mode: control.mode,
+                pausedAt: control.pausedAt,
+                legacyReconciledThrough: control.legacyReconciledThrough,
+              }
+            : null,
+          customerBindingAuthoritative,
+          blockingAttempt: blockingAttemptRows.length > 0,
+          blockingLegacyQuarantine: blockingLegacyRows.length > 0,
+        },
+        activeResources,
+        latestRateSegments,
+      };
+    },
+    { isolationLevel: "repeatable read", accessMode: "read only" },
+  );
+}

--- a/packages/cloud/shared/src/lib/services/account-billing-snapshot.v2.test.ts
+++ b/packages/cloud/shared/src/lib/services/account-billing-snapshot.v2.test.ts
@@ -1,0 +1,886 @@
+/**
+ * Exercises deterministic v2 billing-snapshot assembly across exact values,
+ * explicit policy gaps, source outages, and canonical compute-rate segments.
+ * The primary read model is mocked; PGlite route coverage proves the database
+ * query and transaction boundary separately.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { DrizzleQueryError } from "drizzle-orm";
+import type { PrimaryAccountBillingReadModel } from "../../db/repositories/account-billing-snapshot";
+import {
+  type AccountBillingSnapshotSources,
+  buildAccountBillingSnapshot,
+} from "./account-limits-snapshot";
+
+const PRIMARY_OBSERVED_AT = "2026-08-20T12:00:00.000Z";
+const DEFAULT_STORAGE_LIMIT = 5n * 1024n * 1024n * 1024n;
+
+function healthyPrimary(
+  overrides: Partial<PrimaryAccountBillingReadModel> = {},
+): PrimaryAccountBillingReadModel {
+  return {
+    observedAt: PRIMARY_OBSERVED_AT,
+    organization: {
+      creditBalance: "9.000000",
+      balanceRevision: "9007199254740993",
+      balanceDecreaseRevision: "9007199254740995",
+      coveredBalanceDecreaseRevision: "9007199254740994",
+      settings: {},
+      isActive: true,
+      stripeCustomerIdPresent: true,
+      stripeCustomerIdValid: true,
+      defaultPaymentMethodIdPresent: true,
+      defaultPaymentMethodIdValid: true,
+      autoTopUpEnabled: true,
+      autoTopUpThreshold: "10.00",
+      autoTopUpAmount: "25.00",
+    },
+    cloudCharacterCount: "4",
+    sandboxCounts: { used: "3", reserved: "2", deleting: "2" },
+    containerCounts: { used: "2", reserved: "3", deleting: "1" },
+    containerSettings: {},
+    appCount: "2",
+    apiKeyCount: "3",
+    storageQuota: {
+      bytesUsed: "9007199254740993",
+      bytesLimit: "9007199254741000",
+    },
+    configuredTier: {
+      status: "available",
+      tier: {
+        tierName: "custom",
+        completionsRpm: 777,
+        embeddingsRpm: 200,
+        standardRpm: 60,
+        strictRpm: 10,
+      },
+      tierSourceCreditTotal: "10.123456",
+      overrides: {
+        completionsRpm: 777,
+        embeddingsRpm: null,
+        standardRpm: null,
+        strictRpm: null,
+      },
+    },
+    autoTopUp: {
+      control: {
+        mode: "durable",
+        pausedAt: new Date("2026-08-20T10:00:00.000Z"),
+        legacyReconciledThrough: new Date("2026-08-20T11:00:00.000Z"),
+      },
+      customerBindingAuthoritative: true,
+      blockingAttempt: false,
+      blockingLegacyQuarantine: false,
+    },
+    activeResources: [
+      {
+        resourceType: "container",
+        resourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        name: "exact-rate-container",
+        status: "running",
+        billingStatus: "active",
+        unitPrice: 99,
+        billingInterval: "day",
+        lastBilledAt: null,
+        nextBillingAt: null,
+        estimatedNextBillingAt: null,
+        totalBilled: 0,
+        cancelEndpoint:
+          "/api/v1/billing/resources/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/cancel?resourceType=container",
+        cancelAction: "stop",
+        metadata: {},
+      },
+    ],
+    latestRateSegments: [
+      {
+        workloadKind: "container",
+        workloadId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        billingState: "running",
+        ratePerHour: "0.123456",
+        effectiveAt: new Date("2026-08-20T11:30:00.000Z"),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function healthySources(
+  primary: PrimaryAccountBillingReadModel = healthyPrimary(),
+  overrides: Partial<AccountBillingSnapshotSources> = {},
+): AccountBillingSnapshotSources {
+  return {
+    primary: async () => primary,
+    appLimit: () => 25,
+    maxCloudCharacters: () => 5,
+    maxNonTerminalAgents: (balance) => (balance === undefined ? 5 : 100),
+    maxContainers: () => 5,
+    runtimeTierCache: async () => ({
+      kind: "ready",
+      tier: {
+        tierName: "custom",
+        completionsRpm: 777,
+        embeddingsRpm: 200,
+        standardRpm: 60,
+        strictRpm: 10,
+      },
+    }),
+    autoTopUpRuntimeEnabled: () => true,
+    defaultStorageBytesLimit: DEFAULT_STORAGE_LIMIT,
+    now: () => new Date("2026-08-20T12:00:01.000Z"),
+    ...overrides,
+  };
+}
+
+describe("buildAccountBillingSnapshot v2", () => {
+  test("is additive, exact, source-provenanced, and projects the unchanged v1 shape", async () => {
+    const snapshot = await buildAccountBillingSnapshot(healthySources());
+
+    expect(Object.keys(snapshot).sort()).toEqual([
+      "agentSandboxes",
+      "apps",
+      "cloudCharacters",
+      "containers",
+      "inferenceRateLimits",
+      "observedAt",
+      "schemaVersion",
+      "storage",
+      "v2",
+    ]);
+    expect(snapshot.schemaVersion).toBe(2);
+    expect(snapshot.observedAt).toBe(PRIMARY_OBSERVED_AT);
+    expect(snapshot.cloudCharacters).toEqual({
+      source: "cloud-character-quota",
+      state: "available",
+      used: 4,
+      limit: 5,
+    });
+    expect(snapshot.agentSandboxes).toMatchObject({
+      source: "agent-sandbox-quota",
+      used: 5,
+      nonEagerCreate: { state: "at-limit", limit: 5 },
+      eagerManagedCreate: { state: "available", limit: 100 },
+    });
+    expect(snapshot.containers).toEqual({
+      source: "container-quota",
+      state: "at-limit",
+      used: 5,
+      limit: 5,
+    });
+    expect(snapshot.storage).toEqual({
+      source: "org-storage-quota",
+      state: "available",
+      bytesUsed: "9007199254740993",
+      bytesLimit: "9007199254741000",
+    });
+
+    expect(snapshot.v2.snapshotStartedAt).toBe("2026-08-20T12:00:01.000Z");
+    expect(snapshot.v2.snapshotCompletedAt).toBe("2026-08-20T12:00:01.000Z");
+    expect(snapshot.v2.balance).toEqual({
+      status: "available",
+      source: "organizations",
+      observedAt: PRIMARY_OBSERVED_AT,
+      value: {
+        balance: { value: "9.000000", unit: "usd", currency: "USD" },
+        revision: "9007199254740993",
+      },
+    });
+    expect(snapshot.v2.limits.storage.used).toMatchObject({
+      status: "available",
+      source: "org-storage-quota",
+      observedAt: PRIMARY_OBSERVED_AT,
+      value: { value: "9007199254740993", unit: "byte" },
+    });
+    expect(snapshot.v2.limits.storage.remaining).toMatchObject({
+      status: "available",
+      value: { value: "7", unit: "byte" },
+    });
+    expect(snapshot.v2.limits.storage.reserved).toMatchObject({
+      status: "unavailable",
+      error: {
+        code: "storage_reservation_decomposition_unavailable",
+        retryable: false,
+      },
+    });
+    expect(snapshot.v2.limits.inference.completions).toMatchObject({
+      used: {
+        status: "unavailable",
+        source: "inference-admission-gate-do",
+        error: { code: "inference_window_peek_unavailable", retryable: false },
+      },
+      reserved: {
+        status: "not_applicable",
+        source: "inference-admission-gate-do",
+      },
+      limit: {
+        status: "available",
+        source: "org-rate-limits",
+        value: { value: "777", unit: "request_per_minute" },
+      },
+    });
+    expect(snapshot.v2.limits.apiKeys.limit).toMatchObject({
+      status: "unknown_policy",
+      source: "api_keys",
+      blockedBy: ["#22958"],
+    });
+    expect(snapshot.v2.tier.eligibilityPolicy).toMatchObject({
+      status: "unknown_policy",
+      blockedBy: ["#23019"],
+    });
+    expect(snapshot.v2.tier.configured).toMatchObject({
+      status: "available",
+      value: {
+        selectorKey: "custom",
+        tierSourceCreditTotalObserved: {
+          value: "10.123456",
+          unit: "usd",
+          currency: "USD",
+        },
+      },
+    });
+    expect(snapshot.v2.limits.inference.weekly).toMatchObject({
+      used: { status: "unknown_policy", blockedBy: ["#22962"] },
+      reserved: { status: "unknown_policy", blockedBy: ["#22962"] },
+      remaining: { status: "unknown_policy", blockedBy: ["#22962"] },
+      resetAt: { status: "unknown_policy", blockedBy: ["#22962"] },
+    });
+    expect(snapshot.v2.paymentMethodPresence).toMatchObject({
+      status: "available",
+      value: {
+        customerIdPresent: true,
+        defaultPaymentMethodIdPresent: true,
+      },
+    });
+    expect(snapshot.v2.autoTopUp.readiness).toMatchObject({
+      status: "available",
+      value: { canStartNewAttempt: true, blockers: [] },
+    });
+    expect(snapshot.v2.activeCompute.resources).toMatchObject({
+      status: "available",
+      value: [
+        {
+          name: "exact-rate-container",
+          rateSegment: {
+            status: "available",
+            source: "compute_billing_rate_segments",
+            value: {
+              workloadKind: "container",
+              billingState: "running",
+              effectiveAt: "2026-08-20T11:30:00.000Z",
+            },
+          },
+          ratePerHour: {
+            status: "available",
+            source: "compute_billing_rate_segments",
+            value: { value: "0.123456", unit: "usd_per_hour", currency: "USD" },
+          },
+          estimatedRecurringComputeCostPerDay: {
+            status: "available",
+            value: { value: "2.962944", unit: "usd_per_day", currency: "USD" },
+          },
+        },
+      ],
+    });
+    expect(snapshot.v2.activeCompute.estimatedRecurringComputeCostPerDay).toMatchObject({
+      status: "available",
+      source: "compute_billing_rate_segments",
+      value: { value: "2.962944", unit: "usd_per_day", currency: "USD" },
+    });
+    expect(snapshot.v2.activeCompute.scope).toMatchObject({
+      status: "available",
+      value: {
+        organizationScoped: true,
+        selectors: {
+          containers: {
+            lifecycleStatuses: ["running"],
+            billingStatuses: ["active", "warning", "shutdown_pending"],
+          },
+          agentSandboxes: {
+            excludedExecutionTiers: ["shared"],
+            lifecyclePredicates: [
+              { status: "running", requiresLastBackup: false },
+              { status: "stopped", requiresLastBackup: true },
+            ],
+          },
+        },
+        rateAuthority: {
+          source: "compute_billing_rate_segments",
+          selection: "latest_effective_at_or_before_primary_transaction",
+        },
+      },
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("paidCreditsObserved");
+    expect(JSON.stringify(snapshot)).not.toContain('"tierName"');
+  });
+
+  test("preserves N-1, N, and N+1 parity for each landed count authority", async () => {
+    const cases = [
+      { used: "4", expectedState: "available", expectedRemaining: "1" },
+      { used: "5", expectedState: "at-limit", expectedRemaining: "0" },
+      { used: "6", expectedState: "over-limit", expectedRemaining: "0" },
+    ] as const;
+
+    for (const fixture of cases) {
+      const snapshot = await buildAccountBillingSnapshot(
+        healthySources(
+          healthyPrimary({
+            cloudCharacterCount: fixture.used,
+            sandboxCounts: { used: fixture.used, reserved: "0", deleting: "0" },
+            containerCounts: { used: fixture.used, reserved: "0", deleting: "0" },
+            appCount: fixture.used,
+            storageQuota: { bytesUsed: fixture.used, bytesLimit: "5" },
+          }),
+          { appLimit: () => 5 },
+        ),
+      );
+      expect(snapshot.cloudCharacters.state).toBe(fixture.expectedState);
+      expect(snapshot.agentSandboxes.nonEagerCreate.state).toBe(fixture.expectedState);
+      expect(snapshot.containers.state).toBe(fixture.expectedState);
+      expect(snapshot.apps.state).toBe(fixture.expectedState);
+      expect(snapshot.storage.state).toBe(fixture.expectedState);
+      expect(snapshot.v2.limits.cloudCharacters.remaining).toMatchObject({
+        status: "available",
+        value: { value: fixture.expectedRemaining, unit: "count" },
+      });
+      expect(snapshot.v2.limits.agentSandboxes.nonEagerCreate.remaining).toMatchObject({
+        status: "available",
+        value: { value: fixture.expectedRemaining, unit: "count" },
+      });
+      expect(snapshot.v2.limits.containers.remaining).toMatchObject({
+        status: "available",
+        value: { value: fixture.expectedRemaining, unit: "count" },
+      });
+      expect(snapshot.v2.limits.apps.remaining).toMatchObject({
+        status: "available",
+        value: { value: fixture.expectedRemaining, unit: "count" },
+      });
+      expect(snapshot.v2.limits.storage.remaining).toMatchObject({
+        status: "available",
+        value: { value: fixture.expectedRemaining, unit: "byte" },
+      });
+    }
+  });
+
+  test("keeps exact six-decimal balance boundaries aligned with canonical tier helpers", async () => {
+    const cases = [
+      { balance: "0.999999", characters: 5, sandboxes: 5, containers: 1 },
+      { balance: "1.000000", characters: 20, sandboxes: 20, containers: 5 },
+      { balance: "1.000001", characters: 20, sandboxes: 20, containers: 5 },
+      { balance: "9.999999", characters: 20, sandboxes: 20, containers: 5 },
+      { balance: "10.000000", characters: 100, sandboxes: 100, containers: 25 },
+      { balance: "10.000001", characters: 100, sandboxes: 100, containers: 25 },
+      { balance: "99.999999", characters: 100, sandboxes: 100, containers: 25 },
+      { balance: "100.000000", characters: 500, sandboxes: 500, containers: 100 },
+      { balance: "100.000001", characters: 500, sandboxes: 500, containers: 100 },
+    ];
+    const tierIndex = (balance: number): number =>
+      balance >= 100 ? 3 : balance >= 10 ? 2 : balance >= 1 ? 1 : 0;
+
+    for (const fixture of cases) {
+      const primary = healthyPrimary({
+        organization: {
+          ...healthyPrimary().organization,
+          creditBalance: fixture.balance,
+        },
+      });
+      const snapshot = await buildAccountBillingSnapshot(
+        healthySources(primary, {
+          // These tables mirror the landed helpers' tested 1/10/100 balance
+          // thresholds while keeping this test isolated from Bun route mocks.
+          maxCloudCharacters: (balance) => [5, 20, 100, 500][tierIndex(balance)]!,
+          maxNonTerminalAgents: (balance) =>
+            balance === undefined ? 5 : [5, 20, 100, 500][tierIndex(balance)]!,
+          maxContainers: (balance) => [1, 5, 25, 100][tierIndex(balance)]!,
+        }),
+      );
+
+      expect(snapshot.cloudCharacters.limit).toBe(fixture.characters);
+      expect(snapshot.agentSandboxes.eagerManagedCreate.limit).toBe(fixture.sandboxes);
+      expect(snapshot.containers.limit).toBe(fixture.containers);
+      expect(snapshot.v2.balance).toMatchObject({
+        status: "available",
+        value: { balance: { value: fixture.balance, unit: "usd", currency: "USD" } },
+      });
+      if (fixture.balance === "9.999999") {
+        expect(snapshot.v2.autoTopUp.readiness).toMatchObject({
+          status: "available",
+          value: { canStartNewAttempt: true, blockers: [] },
+        });
+      }
+    }
+  });
+
+  test("rejects excess monetary precision instead of rounding an authority", async () => {
+    const base = healthyPrimary();
+    const [balanceSnapshot, autoTopUpSnapshot] = await Promise.all([
+      buildAccountBillingSnapshot(
+        healthySources(
+          healthyPrimary({
+            organization: { ...base.organization, creditBalance: "9.0000001" },
+          }),
+        ),
+      ),
+      buildAccountBillingSnapshot(
+        healthySources(
+          healthyPrimary({
+            organization: { ...base.organization, autoTopUpAmount: "25.001" },
+          }),
+        ),
+      ),
+    ]);
+
+    expect(balanceSnapshot.v2.balance).toMatchObject({
+      status: "unavailable",
+      source: "organizations",
+      error: { code: "invalid_balance_authority", retryable: false },
+    });
+    expect(balanceSnapshot.v2.limits.cloudCharacters.limit).toMatchObject({
+      status: "unavailable",
+      error: { code: "character_limit_unavailable", retryable: false },
+    });
+    expect(autoTopUpSnapshot.v2.autoTopUp.configuration).toMatchObject({
+      status: "unavailable",
+      source: "organizations",
+      error: { code: "auto_top_up_configuration_invalid", retryable: false },
+    });
+  });
+
+  test("turns an expected primary outage into explicit unavailable observations", async () => {
+    const snapshot = await buildAccountBillingSnapshot(
+      healthySources(healthyPrimary(), {
+        primary: async () => {
+          throw new DrizzleQueryError("select primary snapshot", [], new Error("offline"));
+        },
+      }),
+    );
+
+    expect(snapshot.schemaVersion).toBe(2);
+    expect(snapshot.cloudCharacters).toMatchObject({
+      state: "unavailable",
+      reason: "source read failed",
+    });
+    expect(snapshot.v2.balance).toMatchObject({
+      status: "unavailable",
+      source: "primary-account-billing-snapshot",
+      error: { code: "primary_source_unavailable", retryable: true },
+    });
+    expect(snapshot.v2.limits.storage.used).toMatchObject({
+      status: "unavailable",
+      error: { code: "primary_source_unavailable", retryable: true },
+    });
+    expect(snapshot.v2.tier.eligibilityPolicy).toMatchObject({
+      status: "unknown_policy",
+      blockedBy: ["#23019"],
+    });
+    expect(snapshot.v2.tier.runtimeCache).toMatchObject({
+      status: "available",
+      source: "org-rate-limit-cache",
+      value: { selectorKey: "custom", completionsRpm: "777" },
+    });
+    expect(snapshot.v2.autoTopUp.runtimeSwitch).toMatchObject({
+      status: "available",
+      source: "AUTO_TOP_UP_DURABLE_ENABLED",
+      value: { enabled: true },
+    });
+    expect(snapshot.v2.limits.inference.completions).toMatchObject({
+      used: {
+        status: "unavailable",
+        source: "inference-admission-gate-do",
+        error: { code: "inference_window_peek_unavailable", retryable: false },
+      },
+      limit: {
+        status: "unavailable",
+        source: "primary-account-billing-snapshot",
+        error: { code: "primary_source_unavailable", retryable: true },
+      },
+    });
+    expect(snapshot.v2.limits.inference.weekly).toMatchObject({
+      used: {
+        status: "unknown_policy",
+        source: "weekly-inference-policy",
+        blockedBy: ["#22962"],
+      },
+      remaining: { status: "unknown_policy", blockedBy: ["#22962"] },
+      resetAt: { status: "unknown_policy", blockedBy: ["#22962"] },
+    });
+  });
+
+  test("settles an immediate cache failure without masking delayed organization-not-found", async () => {
+    const primaryError = new ElizaError("organization missing", {
+      code: "ACCOUNT_BILLING_ORGANIZATION_NOT_FOUND",
+      severity: "fatal",
+    });
+    let cacheCalls = 0;
+    const outcome = buildAccountBillingSnapshot(
+      healthySources(healthyPrimary(), {
+        primary: async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+          throw primaryError;
+        },
+        runtimeTierCache: () => {
+          cacheCalls += 1;
+          return Promise.reject(new TypeError("immediate cache defect"));
+        },
+      }),
+    );
+
+    await expect(outcome).rejects.toBe(primaryError);
+    expect(cacheCalls).toBe(1);
+  });
+
+  test("settles an immediate cache failure without masking a delayed unexpected primary error", async () => {
+    const primaryError = new TypeError("delayed primary defect");
+    let cacheCalls = 0;
+    const outcome = buildAccountBillingSnapshot(
+      healthySources(healthyPrimary(), {
+        primary: async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+          throw primaryError;
+        },
+        runtimeTierCache: () => {
+          cacheCalls += 1;
+          return Promise.reject(new TypeError("immediate cache defect"));
+        },
+      }),
+    );
+
+    await expect(outcome).rejects.toBe(primaryError);
+    expect(cacheCalls).toBe(1);
+  });
+
+  test("keeps a delayed typed primary outage authoritative over an immediate cache failure", async () => {
+    const primaryError = new ElizaError("primary source offline", {
+      code: "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+      severity: "fatal",
+    });
+    let cacheCalls = 0;
+    const snapshot = await buildAccountBillingSnapshot(
+      healthySources(healthyPrimary(), {
+        primary: async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+          throw primaryError;
+        },
+        runtimeTierCache: () => {
+          cacheCalls += 1;
+          return Promise.reject(new TypeError("immediate cache defect"));
+        },
+      }),
+    );
+
+    expect(cacheCalls).toBe(1);
+    expect(snapshot.v2.balance).toMatchObject({
+      status: "unavailable",
+      source: "primary-account-billing-snapshot",
+      error: { code: "primary_source_unavailable", retryable: true },
+    });
+    expect(snapshot.v2.tier.runtimeCache).toMatchObject({
+      status: "unavailable",
+      source: "org-rate-limit-cache",
+      error: { code: "runtime_tier_cache_error", retryable: true },
+    });
+  });
+
+  test("waits for cache settlement before surfacing an early assembly defect", async () => {
+    let cacheSettled = false;
+    const malformedPrimary = healthyPrimary();
+    malformedPrimary.organization =
+      null as unknown as PrimaryAccountBillingReadModel["organization"];
+
+    const outcome = buildAccountBillingSnapshot(
+      healthySources(malformedPrimary, {
+        runtimeTierCache: async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          cacheSettled = true;
+          return {
+            kind: "unavailable",
+            cacheRead: "unavailable",
+          };
+        },
+      }),
+    );
+
+    await expect(outcome).rejects.toBeInstanceOf(TypeError);
+    expect(cacheSettled).toBe(true);
+  });
+
+  test("projects a fresh organization's canonical lazy storage default in v1 and v2", async () => {
+    const snapshot = await buildAccountBillingSnapshot(
+      healthySources(healthyPrimary({ storageQuota: null })),
+    );
+
+    expect(snapshot.storage).toEqual({
+      source: "org-storage-quota",
+      state: "available",
+      bytesUsed: "0",
+      bytesLimit: DEFAULT_STORAGE_LIMIT.toString(),
+    });
+    expect(snapshot.v2.limits.storage).toMatchObject({
+      used: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: "0", unit: "byte" },
+      },
+      limit: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: DEFAULT_STORAGE_LIMIT.toString(), unit: "byte" },
+      },
+      remaining: {
+        status: "available",
+        source: "org-storage-quota-default",
+        value: { value: DEFAULT_STORAGE_LIMIT.toString(), unit: "byte" },
+      },
+      reserved: {
+        status: "unavailable",
+        error: { code: "storage_reservation_decomposition_unavailable", retryable: false },
+      },
+    });
+  });
+
+  test("fails closed on an invalid lazy storage default in both projections", async () => {
+    const snapshot = await buildAccountBillingSnapshot({
+      ...healthySources(healthyPrimary({ storageQuota: null })),
+      defaultStorageBytesLimit: -1n,
+    });
+
+    expect(snapshot.storage).toEqual({
+      source: "org-storage-quota",
+      state: "unavailable",
+      reason: "source read failed",
+    });
+    expect(snapshot.v2.limits.storage.used).toMatchObject({
+      status: "unavailable",
+      error: { code: "storage_quota_invalid", retryable: false },
+    });
+  });
+
+  test("keeps common billing readiness separate from auto-top-up capability blockers", async () => {
+    const base = healthyPrimary();
+    const snapshot = await buildAccountBillingSnapshot(
+      healthySources(
+        healthyPrimary({
+          organization: {
+            ...base.organization,
+            creditBalance: "9.000001",
+            balanceDecreaseRevision: "3",
+            coveredBalanceDecreaseRevision: "3",
+            isActive: false,
+            stripeCustomerIdPresent: true,
+            stripeCustomerIdValid: false,
+            defaultPaymentMethodIdPresent: true,
+            defaultPaymentMethodIdValid: false,
+            autoTopUpThreshold: "1000.01",
+            autoTopUpAmount: "0.99",
+          },
+          autoTopUp: {
+            control: {
+              mode: "paused",
+              pausedAt: new Date("2026-08-20T10:00:00.000Z"),
+              legacyReconciledThrough: null,
+            },
+            customerBindingAuthoritative: false,
+            blockingAttempt: true,
+            blockingLegacyQuarantine: true,
+          },
+        }),
+        { autoTopUpRuntimeEnabled: () => false },
+      ),
+    );
+
+    expect(snapshot.v2.billingReadiness).toMatchObject({
+      status: "available",
+      value: {
+        ready: false,
+        blockers: [
+          "invalid_customer_id",
+          "invalid_default_payment_method_id",
+          "customer_binding_not_authoritative",
+        ],
+      },
+    });
+    expect(snapshot.v2.autoTopUp.readiness).toMatchObject({
+      status: "available",
+      value: {
+        canStartNewAttempt: false,
+        blockers: [
+          "invalid_customer_id",
+          "invalid_default_payment_method_id",
+          "customer_binding_not_authoritative",
+          "inactive_organization",
+          "invalid_threshold",
+          "invalid_amount",
+          "runtime_switch_disabled",
+          "cutover_paused",
+          "blocking_attempt",
+          "legacy_quarantine",
+          "balance_not_rearmed",
+        ],
+      },
+    });
+  });
+
+  test.each([
+    {
+      name: "missing",
+      segments: [],
+      code: "active_compute_rate_segment_missing",
+    },
+    {
+      name: "future-only",
+      segments: [
+        {
+          workloadKind: "container" as const,
+          workloadId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          billingState: "running",
+          ratePerHour: "0.123456",
+          effectiveAt: new Date("2026-08-20T12:00:01.000Z"),
+        },
+      ],
+      code: "active_compute_rate_segment_future_only",
+    },
+    {
+      name: "wrong workload kind",
+      segments: [
+        {
+          workloadKind: "agent" as const,
+          workloadId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          billingState: "running",
+          ratePerHour: "0.123456",
+          effectiveAt: new Date("2026-08-20T11:30:00.000Z"),
+        },
+      ],
+      code: "active_compute_rate_segment_kind_mismatch",
+    },
+    {
+      name: "wrong billing state",
+      segments: [
+        {
+          workloadKind: "container" as const,
+          workloadId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          billingState: "not_billable",
+          ratePerHour: "0.123456",
+          effectiveAt: new Date("2026-08-20T11:30:00.000Z"),
+        },
+      ],
+      code: "active_compute_rate_segment_state_mismatch",
+    },
+  ])(
+    "preserves active resource identity when its rate segment is $name",
+    async ({ segments, code }) => {
+      const snapshot = await buildAccountBillingSnapshot(
+        healthySources(healthyPrimary({ latestRateSegments: segments })),
+      );
+
+      expect(snapshot.v2.activeCompute.resources.status).toBe("available");
+      if (snapshot.v2.activeCompute.resources.status !== "available") {
+        throw new Error("active resource identities unexpectedly unavailable");
+      }
+      expect(snapshot.v2.activeCompute.resources.value).toHaveLength(1);
+      expect(snapshot.v2.activeCompute.resources.value[0]).toMatchObject({
+        resourceType: "container",
+        resourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        name: "exact-rate-container",
+        rateSegment: { status: "unavailable", error: { code, retryable: false } },
+        ratePerHour: { status: "unavailable", error: { code, retryable: false } },
+        estimatedRecurringComputeCostPerDay: {
+          status: "unavailable",
+          error: { code, retryable: false },
+        },
+      });
+      expect(snapshot.v2.activeCompute.estimatedRecurringComputeCostPerDay).toMatchObject({
+        status: "unavailable",
+        source: "compute_billing_rate_segments",
+        error: { code: "active_compute_rate_incomplete", retryable: false },
+      });
+    },
+  );
+
+  test("keeps valid per-resource rates in a mixed snapshot while withholding the aggregate", async () => {
+    const base = healthyPrimary();
+    const agentId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const snapshot = await buildAccountBillingSnapshot(
+      healthySources(
+        healthyPrimary({
+          activeResources: [
+            base.activeResources[0]!,
+            {
+              ...base.activeResources[0]!,
+              resourceType: "agent_sandbox",
+              resourceId: agentId,
+              name: "missing-rate-agent",
+              status: "running",
+              billingInterval: "hour",
+              cancelAction: "suspend_billing",
+              cancelEndpoint: `/api/v1/billing/resources/${agentId}/cancel?resourceType=agent_sandbox`,
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(snapshot.v2.activeCompute.resources.status).toBe("available");
+    if (snapshot.v2.activeCompute.resources.status !== "available") {
+      throw new Error("mixed active resources unexpectedly unavailable");
+    }
+    expect(snapshot.v2.activeCompute.resources.value[0]?.ratePerHour.status).toBe("available");
+    expect(snapshot.v2.activeCompute.resources.value[1]).toMatchObject({
+      resourceId: agentId,
+      ratePerHour: {
+        status: "unavailable",
+        error: { code: "active_compute_rate_segment_missing" },
+      },
+    });
+    expect(snapshot.v2.activeCompute.estimatedRecurringComputeCostPerDay).toMatchObject({
+      status: "unavailable",
+      error: { code: "active_compute_rate_incomplete" },
+    });
+  });
+
+  test("rethrows active-compute programming defects instead of hiding the resource list", async () => {
+    await expect(
+      buildAccountBillingSnapshot(
+        healthySources(
+          healthyPrimary({
+            activeResources: [
+              null as unknown as PrimaryAccountBillingReadModel["activeResources"][number],
+            ],
+          }),
+        ),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  test("rethrows unexpected cache and runtime-switch adapter failures", async () => {
+    await expect(
+      buildAccountBillingSnapshot(
+        healthySources(healthyPrimary(), {
+          runtimeTierCache: async () => {
+            throw new TypeError("cache adapter defect");
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      buildAccountBillingSnapshot(
+        healthySources(healthyPrimary(), {
+          autoTopUpRuntimeEnabled: () => {
+            throw new TypeError("environment adapter defect");
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  test("does not hide an unexpected implementation defect as source unavailability", async () => {
+    await expect(
+      buildAccountBillingSnapshot(
+        healthySources(healthyPrimary(), {
+          primary: async () => {
+            throw new TypeError("programming defect");
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/account-limits-snapshot.ts
+++ b/packages/cloud/shared/src/lib/services/account-limits-snapshot.ts
@@ -1,95 +1,54 @@
 /**
- * Read-only, organization-scoped snapshot of the account limits the Cloud
- * backend actually enforces today (#19777): Cloud characters, managed agent
- * sandboxes, containers, apps, quota-accounted upload storage, and the
- * configured per-minute inference caps.
+ * Assembles the read-only, organization-scoped billing and quota contract
+ * consumed by Cloud account surfaces. The v2 snapshot preserves exact decimal
+ * values, primary-transaction coherence, per-datum availability, and the
+ * canonical create-time counting predicates; the top-level v1 fields are a
+ * temporary compatibility projection of those same observations.
  *
- * Contract rules this module owns:
- *  - every ceiling comes from the SAME canonical helper its create-time
- *    enforcement uses (`getMaxCloudCharactersForOrg`,
- *    `getMaxNonTerminalAgentsForOrg`, container quota repository, apps
- *    service, `org_storage_quota` row, org rate tier) — never a re-derived
- *    number that can drift;
- *  - each item names its server source and carries an explicit
- *    available / at-limit / over-limit / unavailable state;
- *  - a source that cannot be read becomes a visibly distinct `unavailable`
- *    item with a reason — never a free-tier value, zero usage, or
- *    success-by-default;
- *  - storage bytes serialize as exact decimal strings (bigint-safe);
- *  - no `canCreate` boolean: the sandbox item reports the non-eager create
- *    ceiling and the balance-tiered eager managed-create ceiling separately
- *    and leaves the decision to the enforcing route.
+ * Undecided policy is explicit, and missing rate or quota authorities never
+ * become plausible prices, entitlements, or zero usage.
  */
 
 import { ElizaError } from "@elizaos/core";
+import Decimal from "decimal.js";
 import { DrizzleError, DrizzleQueryError } from "drizzle-orm";
+import type {
+  PrimaryAccountBillingReadModel,
+  PrimaryComputeRateSegment,
+} from "../../db/repositories/account-billing-snapshot";
+import type {
+  AccountBillingSnapshot,
+  AccountBillingSnapshotV2,
+  AccountLimitsSnapshotV1 as AccountLimitsSnapshot,
+  ActiveComputeRateSegmentSnapshot,
+  ActiveComputeResourceSnapshot,
+  AutoTopUpReadinessBlockerCode,
+  BillingReadinessBlockerCode,
+  CountedLimitItem,
+  ExactBillingUnit,
+  ExactBillingValue,
+  InferenceRateLimitItem,
+  LimitCountPolicy,
+  LimitItemState,
+  Observed,
+  ObservedLimitSnapshot,
+  SandboxCreateLimitItem,
+  SandboxLimitItem,
+  StorageLimitItem,
+} from "../../types/account-billing-snapshot";
 
-export type LimitItemState = "available" | "at-limit" | "over-limit" | "unavailable";
-
-export interface CountedLimitItem {
-  /** Server module that owns the create-time enforcement of this ceiling. */
-  source: string;
-  state: LimitItemState;
-  used?: number;
-  limit?: number;
-  /** Present only when `state` is `unavailable`. */
-  reason?: string;
-}
-
-export interface SandboxCreateLimitItem {
-  state: LimitItemState;
-  limit?: number;
-  reason?: string;
-}
-
-export interface SandboxLimitItem {
-  source: string;
-  /** Quota-holding (non-pool, counted-status) sandboxes right now. */
-  used?: number;
-  /** Fixed ceiling applied when the create path has no funded-balance input. */
-  nonEagerCreate: SandboxCreateLimitItem;
-  /** Balance-tiered ceiling applied by eager managed-create paths. */
-  eagerManagedCreate: SandboxCreateLimitItem;
-  /** @deprecated Use `eagerManagedCreate.state`; retained for v1 compatibility. */
-  state: LimitItemState;
-  /** @deprecated Use `nonEagerCreate.limit`; retained for v1 compatibility. */
-  nonEagerCreateLimit?: number;
-  /** @deprecated Use `eagerManagedCreate.limit`; retained for v1 compatibility. */
-  eagerManagedCreateLimit?: number;
-  /** @deprecated Use the reason on the corresponding create path. */
-  reason?: string;
-}
-
-export interface StorageLimitItem {
-  source: string;
-  state: LimitItemState;
-  /** Exact decimal string of bytes used (bigint-safe). */
-  bytesUsed?: string;
-  /** Exact decimal string of the byte ceiling (bigint-safe). */
-  bytesLimit?: string;
-  reason?: string;
-}
-
-export interface InferenceRateLimitItem {
-  source: string;
-  state: LimitItemState;
-  /** Configured per-minute completions cap for this org's tier + overrides. */
-  completionsRpm?: number;
-  /** Configured per-minute embeddings cap for this org's tier + overrides. */
-  embeddingsRpm?: number;
-  reason?: string;
-}
-
-export interface AccountLimitsSnapshot {
-  /** Single observation timestamp for every item in this snapshot. */
-  observedAt: string;
-  cloudCharacters: CountedLimitItem;
-  agentSandboxes: SandboxLimitItem;
-  containers: CountedLimitItem;
-  apps: CountedLimitItem;
-  storage: StorageLimitItem;
-  inferenceRateLimits: InferenceRateLimitItem;
-}
+export type {
+  AccountBillingSnapshot,
+  AccountBillingSnapshotV2,
+  AccountLimitsSnapshotV1,
+  AccountLimitsSnapshotV1 as AccountLimitsSnapshot,
+  CountedLimitItem,
+  InferenceRateLimitItem,
+  LimitItemState,
+  SandboxCreateLimitItem,
+  SandboxLimitItem,
+  StorageLimitItem,
+} from "../../types/account-billing-snapshot";
 
 /**
  * Injected readers. Each maps 1:1 onto the enforcement source it mirrors; the
@@ -425,4 +384,1210 @@ export async function buildAccountLimitsSnapshot(
     storage,
     inferenceRateLimits,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical additive v2 snapshot (#22954).
+// ---------------------------------------------------------------------------
+
+export type RuntimeTierCacheObservation =
+  | {
+      kind: "ready";
+      tier: {
+        tierName: string;
+        completionsRpm: number;
+        embeddingsRpm: number;
+        standardRpm: number;
+        strictRpm: number;
+      };
+    }
+  | {
+      kind: "warming" | "unavailable";
+      cacheRead: "miss" | "invalid" | "unavailable" | "error";
+    };
+
+export interface AccountBillingSnapshotSources {
+  primary(): Promise<PrimaryAccountBillingReadModel>;
+  appLimit(): number;
+  maxCloudCharacters(creditBalance: number, settings?: unknown): number;
+  maxNonTerminalAgents(creditBalance: number | undefined): number;
+  maxContainers(creditBalance: number, settings?: unknown): number;
+  runtimeTierCache(): Promise<RuntimeTierCacheObservation>;
+  autoTopUpRuntimeEnabled(): boolean;
+  defaultStorageBytesLimit: bigint;
+  now(): Date;
+}
+
+const EXPECTED_BILLING_SNAPSHOT_PRIMARY_ERROR_CODES = new Set([
+  "ACCOUNT_BILLING_PRIMARY_SOURCE_UNAVAILABLE",
+  "INVALID_ACCOUNT_BILLING_PRIMARY_SOURCE",
+]);
+
+function isExpectedBillingSnapshotPrimaryFailure(error: unknown): boolean {
+  return (
+    error instanceof DrizzleError ||
+    error instanceof DrizzleQueryError ||
+    (error instanceof ElizaError && EXPECTED_BILLING_SNAPSHOT_PRIMARY_ERROR_CODES.has(error.code))
+  );
+}
+
+function available<T>(source: string, observedAt: string, value: T): Observed<T> {
+  return { status: "available", source, observedAt, value };
+}
+
+function unavailable<T>(
+  source: string,
+  observedAt: string,
+  code: string,
+  retryable: boolean,
+): Observed<T> {
+  return { status: "unavailable", source, observedAt, error: { code, retryable } };
+}
+
+function unknownPolicy<T>(source: string, observedAt: string, blockedBy: string[]): Observed<T> {
+  return { status: "unknown_policy", source, observedAt, blockedBy };
+}
+
+function notApplicable<T>(source: string, observedAt: string, reason: string): Observed<T> {
+  return { status: "not_applicable", source, observedAt, reason };
+}
+
+function exactValue(value: string, unit: ExactBillingUnit): ExactBillingValue {
+  return {
+    value,
+    unit,
+    ...(unit.startsWith("usd") ? { currency: "USD" as const } : {}),
+  };
+}
+
+function canonicalInteger(raw: unknown, field: string): string {
+  const value = typeof raw === "string" || typeof raw === "number" ? String(raw) : "";
+  if (!/^\d+$/.test(value)) {
+    throw invalidSourceData(`${field} is not an exact non-negative integer`);
+  }
+  return value.replace(/^0+(?=\d)/, "");
+}
+
+function canonicalDecimal(raw: unknown, scale: number, field: string): string {
+  const value = typeof raw === "string" || typeof raw === "number" ? String(raw) : "";
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value)) {
+    throw invalidSourceData(`${field} is not an exact non-negative decimal`);
+  }
+  const fraction = value.split(".")[1] ?? "";
+  if (fraction.slice(scale).replaceAll("0", "").length > 0) {
+    throw invalidSourceData(`${field} has precision beyond its authoritative scale`);
+  }
+  const decimal = new Decimal(value);
+  if (!decimal.isFinite() || decimal.isNegative()) {
+    throw invalidSourceData(`${field} is not an exact non-negative decimal`);
+  }
+  return decimal.toFixed(scale);
+}
+
+function decimalForQuota(raw: unknown, field: string): number {
+  const canonical = canonicalDecimal(raw, 6, field);
+  // The landed quota helpers still accept a JS number. This adapter is used
+  // only to call those canonical threshold resolvers; the monetary observation
+  // and every serialized comparison value remain the exact decimal string.
+  const numeric = new Decimal(canonical).toNumber();
+  if (!Number.isFinite(numeric)) {
+    throw invalidSourceData(`${field} cannot be compared with the quota authority`);
+  }
+  return numeric;
+}
+
+function exactRemaining(limit: string, used: string, reserved: string): string {
+  const remaining = BigInt(limit) - BigInt(used) - BigInt(reserved);
+  return (remaining > 0n ? remaining : 0n).toString();
+}
+
+function observedCountLimit(input: {
+  source: string;
+  observedAt: string;
+  used: string;
+  reserved: string;
+  deleting: string;
+  limit: Observed<ExactBillingValue>;
+  policy: LimitCountPolicy;
+}): ObservedLimitSnapshot {
+  const { source, observedAt, used, reserved, deleting, limit, policy } = input;
+  const remaining =
+    limit.status === "available"
+      ? available(
+          source,
+          observedAt,
+          exactValue(exactRemaining(limit.value.value, used, reserved), "count"),
+        )
+      : unavailable<ExactBillingValue>(source, observedAt, "limit_unavailable", false);
+  return {
+    used: available(source, observedAt, exactValue(used, "count")),
+    reserved: available(source, observedAt, exactValue(reserved, "count")),
+    deleting: available(source, observedAt, exactValue(deleting, "count")),
+    limit,
+    remaining,
+    resetAt: notApplicable(source, observedAt, "lifecycle_count_has_no_periodic_reset"),
+    countsTowardLimit: available(source, observedAt, policy),
+  };
+}
+
+function unavailableLimit(
+  source: string,
+  observedAt: string,
+  code: string,
+  retryable: boolean,
+): ObservedLimitSnapshot {
+  return {
+    used: unavailable(source, observedAt, code, retryable),
+    reserved: unavailable(source, observedAt, code, retryable),
+    deleting: unavailable(source, observedAt, code, retryable),
+    limit: unavailable(source, observedAt, code, retryable),
+    remaining: unavailable(source, observedAt, code, retryable),
+    resetAt: unavailable(source, observedAt, code, retryable),
+    countsTowardLimit: unavailable(source, observedAt, code, retryable),
+  };
+}
+
+function unknownPolicyLimit(
+  source: string,
+  observedAt: string,
+  blockedBy: string[],
+): ObservedLimitSnapshot {
+  return {
+    used: unknownPolicy(source, observedAt, blockedBy),
+    reserved: unknownPolicy(source, observedAt, blockedBy),
+    deleting: unknownPolicy(source, observedAt, blockedBy),
+    limit: unknownPolicy(source, observedAt, blockedBy),
+    remaining: unknownPolicy(source, observedAt, blockedBy),
+    resetAt: unknownPolicy(source, observedAt, blockedBy),
+    countsTowardLimit: unknownPolicy(source, observedAt, blockedBy),
+  };
+}
+
+function safeV1Integer(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function v1Classify(used: string, limit: string): LimitItemState {
+  const usedExact = BigInt(used);
+  const limitExact = BigInt(limit);
+  if (usedExact > limitExact) return "over-limit";
+  if (usedExact === limitExact) return "at-limit";
+  return "available";
+}
+
+function v1Counted(
+  source: string,
+  used: string,
+  limit: Observed<ExactBillingValue>,
+): CountedLimitItem {
+  if (limit.status !== "available") {
+    return { source, state: "unavailable", reason: "source read failed" };
+  }
+  const usedNumber = safeV1Integer(used);
+  const limitNumber = safeV1Integer(limit.value.value);
+  if (usedNumber === null || limitNumber === null || limitNumber <= 0) {
+    return { source, state: "unavailable", reason: "source read failed" };
+  }
+  return {
+    source,
+    state: v1Classify(used, limit.value.value),
+    used: usedNumber,
+    limit: limitNumber,
+  };
+}
+
+function unavailableV1Snapshot(observedAt: string): AccountLimitsSnapshot {
+  const counted = (source: string): CountedLimitItem => ({
+    source,
+    state: "unavailable",
+    reason: "source read failed",
+  });
+  return {
+    observedAt,
+    cloudCharacters: counted("cloud-character-quota"),
+    agentSandboxes: {
+      source: "agent-sandbox-quota",
+      state: "unavailable",
+      reason: "source read failed",
+      nonEagerCreate: { state: "unavailable", reason: "source read failed" },
+      eagerManagedCreate: { state: "unavailable", reason: "source read failed" },
+    },
+    containers: counted("container-quota"),
+    apps: counted("apps-service"),
+    storage: {
+      source: "org-storage-quota",
+      state: "unavailable",
+      reason: "source read failed",
+    },
+    inferenceRateLimits: {
+      source: "org-rate-limits",
+      state: "unavailable",
+      reason: "source read failed",
+    },
+  };
+}
+
+function allUnavailableV2(
+  snapshotStartedAt: string,
+  snapshotCompletedAt: string,
+  observedAt: string,
+): AccountBillingSnapshotV2 {
+  const primaryLimit = unavailableLimit(
+    "primary-account-billing-snapshot",
+    observedAt,
+    "primary_source_unavailable",
+    true,
+  );
+  const primary = <T>() =>
+    unavailable<T>(
+      "primary-account-billing-snapshot",
+      observedAt,
+      "primary_source_unavailable",
+      true,
+    );
+  return {
+    snapshotStartedAt,
+    snapshotCompletedAt,
+    balance: primary(),
+    paymentMethodPresence: primary(),
+    billingReadiness: primary(),
+    autoTopUp: {
+      configuration: primary(),
+      runtimeSwitch: primary(),
+      control: primary(),
+      customerBinding: primary(),
+      blockingState: primary(),
+      rearm: primary(),
+      readiness: primary(),
+    },
+    tier: {
+      configured: primary(),
+      eligibilityPolicy: unknownPolicy("org-rate-limits", observedAt, ["#23019"]),
+      runtimeCache: unavailable(
+        "org-rate-limit-cache",
+        observedAt,
+        "primary_source_unavailable",
+        true,
+      ),
+    },
+    limits: {
+      apiKeys: primaryLimit,
+      cloudCharacters: primaryLimit,
+      agentSandboxes: { nonEagerCreate: primaryLimit, eagerManagedCreate: primaryLimit },
+      containers: primaryLimit,
+      apps: primaryLimit,
+      storage: primaryLimit,
+      inference: {
+        completions: primaryLimit,
+        embeddings: primaryLimit,
+        weekly: unknownPolicyLimit("weekly-inference-policy", observedAt, ["#22962"]),
+      },
+    },
+    activeCompute: {
+      resources: primary(),
+      estimatedRecurringComputeCostPerDay: primary(),
+      scope: primary(),
+    },
+  };
+}
+
+async function observeRuntimeTierCache(
+  sources: AccountBillingSnapshotSources,
+  observedAt: string,
+): Promise<AccountBillingSnapshotV2["tier"]["runtimeCache"]> {
+  const cache = await sources.runtimeTierCache();
+  if (cache.kind === "ready") {
+    return available("org-rate-limit-cache", observedAt, {
+      selectorKey: cache.tier.tierName,
+      completionsRpm: String(cache.tier.completionsRpm),
+      embeddingsRpm: String(cache.tier.embeddingsRpm),
+      standardRpm: String(cache.tier.standardRpm),
+      strictRpm: String(cache.tier.strictRpm),
+    });
+  }
+  return unavailable(
+    "org-rate-limit-cache",
+    observedAt,
+    `runtime_tier_cache_${cache.cacheRead}`,
+    true,
+  );
+}
+
+function observeAutoTopUpRuntimeSwitch(
+  sources: AccountBillingSnapshotSources,
+  observedAt: string,
+): AccountBillingSnapshotV2["autoTopUp"]["runtimeSwitch"] {
+  return available("AUTO_TOP_UP_DURABLE_ENABLED", observedAt, {
+    enabled: sources.autoTopUpRuntimeEnabled(),
+  });
+}
+
+function inferenceWindowLimit(
+  endpoint: "completions" | "embeddings",
+  configuredLimit: Observed<ExactBillingValue>,
+  observedAt: string,
+): ObservedLimitSnapshot {
+  const source = "inference-admission-gate-do";
+  return {
+    used: unavailable(source, observedAt, "inference_window_peek_unavailable", false),
+    reserved: notApplicable(source, observedAt, "request_windows_have_no_reserved_state"),
+    deleting: notApplicable(source, observedAt, "request_windows_have_no_deleting_state"),
+    limit: configuredLimit,
+    remaining: unavailable(source, observedAt, "inference_window_peek_unavailable", false),
+    resetAt: unavailable(source, observedAt, "inference_window_peek_unavailable", false),
+    countsTowardLimit: available(source, observedAt, {
+      included: [
+        `valid ${endpoint} /rate-limit checks in the active window, including over-limit checks`,
+      ],
+      excluded: ["invalid requests rejected before counter mutation"],
+    }),
+  };
+}
+
+const ACTIVE_COMPUTE_RATE_SOURCE = "compute_billing_rate_segments";
+const ACTIVE_COMPUTE_BILLING_STATUSES = new Set(["active", "warning", "shutdown_pending"]);
+
+interface ActiveComputeRateResult {
+  rateSegment: ActiveComputeResourceSnapshot["rateSegment"];
+  ratePerHour: ActiveComputeResourceSnapshot["ratePerHour"];
+  estimatedRecurringComputeCostPerDay: ActiveComputeResourceSnapshot["estimatedRecurringComputeCostPerDay"];
+  dailyForAggregate: Decimal | null;
+}
+
+function unavailableActiveComputeRate(observedAt: string, code: string): ActiveComputeRateResult {
+  return {
+    rateSegment: unavailable(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, code, false),
+    ratePerHour: unavailable(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, code, false),
+    estimatedRecurringComputeCostPerDay: unavailable(
+      ACTIVE_COMPUTE_RATE_SOURCE,
+      observedAt,
+      code,
+      false,
+    ),
+    dailyForAggregate: null,
+  };
+}
+
+function expectedActiveComputeSegment(resource: {
+  resourceType: string;
+  status: string;
+  billingStatus: string;
+  metadata: Record<string, unknown>;
+}):
+  | { workloadKind: "agent" | "container"; billingState: "running" | "backup" }
+  | { errorCode: string } {
+  if (!ACTIVE_COMPUTE_BILLING_STATUSES.has(resource.billingStatus)) {
+    return { errorCode: "active_compute_resource_selector_mismatch" };
+  }
+  if (resource.resourceType === "container") {
+    return resource.status === "running"
+      ? { workloadKind: "container", billingState: "running" }
+      : { errorCode: "active_compute_resource_selector_mismatch" };
+  }
+  if (resource.resourceType === "agent_sandbox") {
+    if (resource.status === "running") {
+      return { workloadKind: "agent", billingState: "running" };
+    }
+    if (resource.status === "stopped" && typeof resource.metadata.lastBackupAt === "string") {
+      return { workloadKind: "agent", billingState: "backup" };
+    }
+    return { errorCode: "active_compute_resource_selector_mismatch" };
+  }
+  return { errorCode: "active_compute_resource_kind_invalid" };
+}
+
+function observeActiveComputeRate(
+  resource: PrimaryAccountBillingReadModel["activeResources"][number],
+  rateSegments: PrimaryComputeRateSegment[],
+  observedAt: string,
+): ActiveComputeRateResult {
+  const expected = expectedActiveComputeSegment(resource);
+  if ("errorCode" in expected) {
+    return unavailableActiveComputeRate(observedAt, expected.errorCode);
+  }
+
+  const workloadSegments = rateSegments.filter(
+    (segment) => segment.workloadId === resource.resourceId,
+  );
+  const kindSegments = workloadSegments.filter(
+    (segment) => segment.workloadKind === expected.workloadKind,
+  );
+  if (kindSegments.length === 0) {
+    return unavailableActiveComputeRate(
+      observedAt,
+      workloadSegments.length > 0
+        ? "active_compute_rate_segment_kind_mismatch"
+        : "active_compute_rate_segment_missing",
+    );
+  }
+
+  const snapshotTime = Date.parse(observedAt);
+  if (!Number.isFinite(snapshotTime)) {
+    return unavailableActiveComputeRate(observedAt, "active_compute_snapshot_timestamp_invalid");
+  }
+  const eligible: Array<{ segment: PrimaryComputeRateSegment; effectiveAt: Date }> = [];
+  for (const segment of kindSegments) {
+    const effectiveAt =
+      segment.effectiveAt instanceof Date ? segment.effectiveAt : new Date(segment.effectiveAt);
+    if (!Number.isFinite(effectiveAt.getTime())) {
+      return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_invalid");
+    }
+    if (effectiveAt.getTime() <= snapshotTime) eligible.push({ segment, effectiveAt });
+  }
+  if (eligible.length === 0) {
+    return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_future_only");
+  }
+  eligible.sort((left, right) => right.effectiveAt.getTime() - left.effectiveAt.getTime());
+  const { segment, effectiveAt } = eligible[0]!;
+  if (segment.billingState !== expected.billingState) {
+    return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_state_mismatch");
+  }
+
+  let hourlyExact: string;
+  try {
+    hourlyExact = canonicalDecimal(
+      segment.ratePerHour,
+      6,
+      "compute_billing_rate_segments.rate_per_hour",
+    );
+  } catch (error) {
+    // error-policy:J4 — malformed canonical segment numerics make only that
+    // resource's rate unavailable; unrelated implementation errors escape.
+    if (!(error instanceof ElizaError) || error.code !== "INVALID_ACCOUNT_LIMIT_SOURCE") {
+      throw error;
+    }
+    return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_invalid");
+  }
+  const dailyExact = new Decimal(hourlyExact).mul(24).toDecimalPlaces(6, Decimal.ROUND_HALF_UP);
+  const rateSegmentValue: ActiveComputeRateSegmentSnapshot = {
+    workloadKind: expected.workloadKind,
+    billingState: expected.billingState,
+    effectiveAt: effectiveAt.toISOString(),
+  };
+  return {
+    rateSegment: available(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, rateSegmentValue),
+    ratePerHour: available(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, {
+      ...exactValue(hourlyExact, "usd_per_hour"),
+      unit: "usd_per_hour",
+      currency: "USD",
+    }),
+    estimatedRecurringComputeCostPerDay: available(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, {
+      ...exactValue(dailyExact.toFixed(6), "usd_per_day"),
+      unit: "usd_per_day",
+      currency: "USD",
+    }),
+    dailyForAggregate: dailyExact,
+  };
+}
+
+/**
+ * Builds the additive v2 contract and its temporary v1 projection. No source
+ * reader in this function mutates a provider, cache, Durable Object, or claim
+ * path; externally owned runtime state is cache-only or explicitly unavailable.
+ */
+export async function buildAccountBillingSnapshot(
+  sources: AccountBillingSnapshotSources,
+): Promise<AccountBillingSnapshot> {
+  const snapshotStartedAt = sources.now().toISOString();
+  const switchObservedAt = sources.now().toISOString();
+  const runtimeSwitch = observeAutoTopUpRuntimeSwitch(sources, switchObservedAt);
+  const cacheObservedAt = sources.now().toISOString();
+  // `allSettled` attaches its rejection observer immediately. The outer
+  // `finally` also awaits it on every return/throw after this point, so an
+  // eager cache rejection can neither become unhandled nor mask a primary or
+  // downstream assembly error.
+  const runtimeCacheSettlementsPromise = Promise.allSettled([
+    observeRuntimeTierCache(sources, cacheObservedAt),
+  ] as const);
+  try {
+    let primary: PrimaryAccountBillingReadModel;
+    try {
+      primary = await sources.primary();
+    } catch (error) {
+      // error-policy:J4 — only expected primary read failures become a fully
+      // explicit unavailable snapshot; missing tenancy and defects still abort.
+      if (error instanceof ElizaError && error.code === "ACCOUNT_BILLING_ORGANIZATION_NOT_FOUND") {
+        throw error;
+      }
+      // Expected source failures become explicit observations. Programming
+      // defects must still fail the request so they cannot masquerade as a
+      // successfully assembled (but entirely unavailable) snapshot.
+      if (!isExpectedBillingSnapshotPrimaryFailure(error)) throw error;
+      const observedAt = sources.now().toISOString();
+      const [runtimeCacheSettlement] = await runtimeCacheSettlementsPromise;
+      // error-policy:J4 — the primary outage remains authoritative. A
+      // concurrent cache defect is represented as secondary unavailability
+      // instead of replacing that fail-closed primary outcome.
+      const runtimeCache: AccountBillingSnapshotV2["tier"]["runtimeCache"] =
+        runtimeCacheSettlement.status === "fulfilled"
+          ? runtimeCacheSettlement.value
+          : unavailable("org-rate-limit-cache", cacheObservedAt, "runtime_tier_cache_error", true);
+      const inferenceObservedAt = sources.now().toISOString();
+      const snapshotCompletedAt = sources.now().toISOString();
+      const v2 = allUnavailableV2(snapshotStartedAt, snapshotCompletedAt, observedAt);
+      v2.autoTopUp.runtimeSwitch = runtimeSwitch;
+      v2.tier.runtimeCache = runtimeCache;
+      const configuredLimit = unavailable<ExactBillingValue>(
+        "primary-account-billing-snapshot",
+        observedAt,
+        "primary_source_unavailable",
+        true,
+      );
+      v2.limits.inference = {
+        completions: inferenceWindowLimit("completions", configuredLimit, inferenceObservedAt),
+        embeddings: inferenceWindowLimit("embeddings", configuredLimit, inferenceObservedAt),
+        weekly: unknownPolicyLimit("weekly-inference-policy", observedAt, ["#22962"]),
+      };
+      return {
+        schemaVersion: 2,
+        ...unavailableV1Snapshot(observedAt),
+        v2,
+      };
+    }
+
+    const observedAt = primary.observedAt;
+    const balanceSource = "organizations";
+    let balance: Observed<
+      AccountBillingSnapshotV2["balance"] extends Observed<infer T> ? T : never
+    >;
+    let balanceForQuota: number | null = null;
+    try {
+      const amount = canonicalDecimal(
+        primary.organization.creditBalance,
+        6,
+        "organizations.credit_balance",
+      );
+      balanceForQuota = decimalForQuota(amount, "organizations.credit_balance");
+      balance = available(balanceSource, observedAt, {
+        balance: { ...exactValue(amount, "usd"), unit: "usd", currency: "USD" },
+        revision: canonicalInteger(
+          primary.organization.balanceRevision,
+          "organizations.balance_revision",
+        ),
+      });
+    } catch (error) {
+      // error-policy:J4 — typed balance corruption degrades balance-derived
+      // fields without inventing a fallback tier.
+      unavailableReason(error);
+      balance = unavailable(balanceSource, observedAt, "invalid_balance_authority", false);
+    }
+
+    const characterSource = "cloud-character-quota";
+    const characterUsed = canonicalInteger(primary.cloudCharacterCount, "cloud character count");
+    let characterLimit: Observed<ExactBillingValue>;
+    try {
+      if (balanceForQuota === null) throw invalidSourceData("balance source unavailable");
+      const limit = sources.maxCloudCharacters(balanceForQuota, primary.organization.settings);
+      if (!isUsableLimit(limit)) throw invalidSourceData("cloud character limit is invalid");
+      characterLimit = available(characterSource, observedAt, exactValue(String(limit), "count"));
+    } catch (error) {
+      // error-policy:J4 — typed character-cap source failures degrade this cap;
+      // unrelated helper defects still escape through unavailableReason.
+      unavailableReason(error);
+      characterLimit = unavailable(
+        characterSource,
+        observedAt,
+        "character_limit_unavailable",
+        false,
+      );
+    }
+    const cloudCharacters = observedCountLimit({
+      source: characterSource,
+      observedAt,
+      used: characterUsed,
+      reserved: "0",
+      deleting: "0",
+      limit: characterLimit,
+      policy: {
+        included: ["user_characters.source=cloud"],
+        excluded: ["user_characters.source!=cloud"],
+      },
+    });
+    cloudCharacters.reserved = notApplicable(
+      characterSource,
+      observedAt,
+      "character_creation_has_no_separate_reserved_lifecycle",
+    );
+    cloudCharacters.deleting = notApplicable(
+      characterSource,
+      observedAt,
+      "character_deletion_has_no_separate_counted_state",
+    );
+
+    const sandboxSource = "agent-sandbox-quota";
+    const sandboxUsed = canonicalInteger(primary.sandboxCounts.used, "used sandboxes");
+    const sandboxReserved = canonicalInteger(primary.sandboxCounts.reserved, "reserved sandboxes");
+    const sandboxDeleting = canonicalInteger(primary.sandboxCounts.deleting, "deleting sandboxes");
+    let nonEagerLimit: Observed<ExactBillingValue>;
+    let eagerLimit: Observed<ExactBillingValue>;
+    try {
+      const limit = sources.maxNonTerminalAgents(undefined);
+      if (!isUsableLimit(limit)) throw invalidSourceData("non-eager sandbox limit is invalid");
+      nonEagerLimit = available(sandboxSource, observedAt, exactValue(String(limit), "count"));
+    } catch (error) {
+      // error-policy:J4 — typed fixed sandbox-cap failures degrade only this cap.
+      unavailableReason(error);
+      nonEagerLimit = unavailable(sandboxSource, observedAt, "sandbox_limit_unavailable", false);
+    }
+    try {
+      if (balanceForQuota === null) throw invalidSourceData("balance source unavailable");
+      const limit = sources.maxNonTerminalAgents(balanceForQuota);
+      if (!isUsableLimit(limit)) throw invalidSourceData("eager sandbox limit is invalid");
+      eagerLimit = available(sandboxSource, observedAt, exactValue(String(limit), "count"));
+    } catch (error) {
+      // error-policy:J4 — typed balance-derived sandbox-cap failures degrade only
+      // the eager cap; the non-eager result remains independent.
+      unavailableReason(error);
+      eagerLimit = unavailable(sandboxSource, observedAt, "sandbox_limit_unavailable", false);
+    }
+    const sandboxPolicy: LimitCountPolicy = {
+      included: ["pending", "provisioning", "running", "stopped", "sleeping"],
+      excluded: ["pool rows", "disconnected", "error", "deletion_pending", "deletion_failed"],
+    };
+    const agentSandboxes = {
+      nonEagerCreate: observedCountLimit({
+        source: sandboxSource,
+        observedAt,
+        used: sandboxUsed,
+        reserved: sandboxReserved,
+        deleting: sandboxDeleting,
+        limit: nonEagerLimit,
+        policy: sandboxPolicy,
+      }),
+      eagerManagedCreate: observedCountLimit({
+        source: sandboxSource,
+        observedAt,
+        used: sandboxUsed,
+        reserved: sandboxReserved,
+        deleting: sandboxDeleting,
+        limit: eagerLimit,
+        policy: sandboxPolicy,
+      }),
+    };
+
+    const containerSource = "container-quota";
+    const containerUsed = canonicalInteger(primary.containerCounts.used, "used containers");
+    const containerReserved = canonicalInteger(
+      primary.containerCounts.reserved,
+      "reserved containers",
+    );
+    const containerDeleting = canonicalInteger(
+      primary.containerCounts.deleting,
+      "deleting containers",
+    );
+    let containerLimit: Observed<ExactBillingValue>;
+    try {
+      if (balanceForQuota === null) throw invalidSourceData("balance source unavailable");
+      const limit = sources.maxContainers(balanceForQuota, primary.containerSettings);
+      if (!isUsableLimit(limit)) throw invalidSourceData("container limit is invalid");
+      containerLimit = available(containerSource, observedAt, exactValue(String(limit), "count"));
+    } catch (error) {
+      // error-policy:J4 — typed container-cap failures are explicit and never
+      // replaced with a permissive default.
+      unavailableReason(error);
+      containerLimit = unavailable(
+        containerSource,
+        observedAt,
+        "container_limit_unavailable",
+        false,
+      );
+    }
+    const containerLimits = observedCountLimit({
+      source: containerSource,
+      observedAt,
+      used: containerUsed,
+      reserved: containerReserved,
+      deleting: containerDeleting,
+      limit: containerLimit,
+      policy: {
+        included: [
+          "every containers row whose status is NOT IN ('deleting','deleted')",
+          "pending/building/deploying are reported as reserved; every other included status is used",
+        ],
+        excluded: ["status=deleting", "status=deleted"],
+      },
+    });
+
+    const appSource = "apps-service";
+    const appUsed = canonicalInteger(primary.appCount, "app count");
+    let appLimit: Observed<ExactBillingValue>;
+    try {
+      const limit = sources.appLimit();
+      if (!isUsableLimit(limit)) throw invalidSourceData("app limit is invalid");
+      appLimit = available(appSource, observedAt, exactValue(String(limit), "count"));
+    } catch (error) {
+      // error-policy:J4 — typed app-cap configuration failures are explicit;
+      // programming defects still abort.
+      unavailableReason(error);
+      appLimit = unavailable(appSource, observedAt, "app_limit_unavailable", false);
+    }
+    const appLimits = observedCountLimit({
+      source: appSource,
+      observedAt,
+      used: appUsed,
+      reserved: "0",
+      deleting: "0",
+      limit: appLimit,
+      policy: { included: ["all apps rows"], excluded: [] },
+    });
+    appLimits.reserved = notApplicable(appSource, observedAt, "apps_have_no_reserved_state");
+    appLimits.deleting = notApplicable(appSource, observedAt, "apps_have_no_deleting_quota_state");
+
+    const storageSource = "org-storage-quota";
+    const storageValueSource =
+      primary.storageQuota === null ? "org-storage-quota-default" : storageSource;
+    let storageUsed: string | null = null;
+    let storageLimitValue: string | null = null;
+    try {
+      if (primary.storageQuota === null) {
+        storageUsed = "0";
+        storageLimitValue = canonicalInteger(
+          sources.defaultStorageBytesLimit.toString(),
+          "default storage bytes limit",
+        );
+      } else {
+        storageUsed = canonicalInteger(primary.storageQuota.bytesUsed, "storage bytes used");
+        storageLimitValue = canonicalInteger(
+          primary.storageQuota.bytesLimit,
+          "storage bytes limit",
+        );
+      }
+    } catch (error) {
+      // error-policy:J4 — typed persisted/default quota corruption degrades only
+      // storage; unexpected failures still abort snapshot assembly.
+      unavailableReason(error);
+      storageUsed = null;
+      storageLimitValue = null;
+    }
+    const storageLimits: ObservedLimitSnapshot =
+      storageUsed !== null && storageLimitValue !== null
+        ? {
+            used: available(storageValueSource, observedAt, exactValue(storageUsed, "byte")),
+            reserved: unavailable(
+              storageValueSource,
+              observedAt,
+              "storage_reservation_decomposition_unavailable",
+              false,
+            ),
+            deleting: unavailable(
+              storageValueSource,
+              observedAt,
+              "storage_deletion_decomposition_unavailable",
+              false,
+            ),
+            limit: available(storageValueSource, observedAt, exactValue(storageLimitValue, "byte")),
+            remaining: available(
+              storageValueSource,
+              observedAt,
+              exactValue(exactRemaining(storageLimitValue, storageUsed, "0"), "byte"),
+            ),
+            resetAt: notApplicable(
+              storageValueSource,
+              observedAt,
+              "storage_quota_has_no_periodic_reset",
+            ),
+            countsTowardLimit: available(
+              storageValueSource,
+              observedAt,
+              primary.storageQuota === null
+                ? {
+                    included: [
+                      "zero bytes until first atomic reservation creates org_storage_quota",
+                    ],
+                    excluded: [],
+                  }
+                : {
+                    included: ["bytes represented by org_storage_quota.bytes_used"],
+                    excluded: [],
+                  },
+            ),
+          }
+        : unavailableLimit(storageSource, observedAt, "storage_quota_invalid", false);
+
+    const apiKeySource = "api_keys";
+    const apiKeyUsed = canonicalInteger(primary.apiKeyCount, "api key count");
+    const apiKeyLimits: ObservedLimitSnapshot = {
+      used: available(apiKeySource, observedAt, exactValue(apiKeyUsed, "count")),
+      reserved: notApplicable(apiKeySource, observedAt, "api_keys_have_no_reserved_state"),
+      deleting: notApplicable(apiKeySource, observedAt, "api_key_inventory_is_row_based"),
+      limit: unknownPolicy(apiKeySource, observedAt, ["#22958"]),
+      remaining: unknownPolicy(apiKeySource, observedAt, ["#22958"]),
+      resetAt: unknownPolicy(apiKeySource, observedAt, ["#22958"]),
+      countsTowardLimit: unknownPolicy(apiKeySource, observedAt, ["#22958"]),
+    };
+
+    let configuredTier: AccountBillingSnapshotV2["tier"]["configured"];
+    if (primary.configuredTier.status === "available") {
+      const tier = primary.configuredTier;
+      configuredTier = available("org-rate-limits", observedAt, {
+        selectorKey: tier.tier.tierName,
+        tierSourceCreditTotalObserved: {
+          ...exactValue(
+            canonicalDecimal(tier.tierSourceCreditTotal, 6, "tier-source credit total observed"),
+            "usd",
+          ),
+          unit: "usd",
+          currency: "USD",
+        },
+        overrides: {
+          completionsRpm:
+            tier.overrides.completionsRpm === null ? null : String(tier.overrides.completionsRpm),
+          embeddingsRpm:
+            tier.overrides.embeddingsRpm === null ? null : String(tier.overrides.embeddingsRpm),
+          standardRpm:
+            tier.overrides.standardRpm === null ? null : String(tier.overrides.standardRpm),
+          strictRpm: tier.overrides.strictRpm === null ? null : String(tier.overrides.strictRpm),
+        },
+        completionsRpm: String(tier.tier.completionsRpm),
+        embeddingsRpm: String(tier.tier.embeddingsRpm),
+        standardRpm: String(tier.tier.standardRpm),
+        strictRpm: String(tier.tier.strictRpm),
+      });
+    } else {
+      configuredTier = unavailable(
+        "org-rate-limits",
+        observedAt,
+        primary.configuredTier.code,
+        false,
+      );
+    }
+
+    const inferenceObservedAt = sources.now().toISOString();
+    const configuredInferenceLimit = (
+      endpoint: "completions" | "embeddings",
+    ): Observed<ExactBillingValue> =>
+      configuredTier.status === "available"
+        ? available(
+            "org-rate-limits",
+            observedAt,
+            exactValue(
+              endpoint === "completions"
+                ? configuredTier.value.completionsRpm
+                : configuredTier.value.embeddingsRpm,
+              "request_per_minute",
+            ),
+          )
+        : unavailable("org-rate-limits", observedAt, "configured_tier_unavailable", false);
+    const inference = {
+      completions: inferenceWindowLimit(
+        "completions",
+        configuredInferenceLimit("completions"),
+        inferenceObservedAt,
+      ),
+      embeddings: inferenceWindowLimit(
+        "embeddings",
+        configuredInferenceLimit("embeddings"),
+        inferenceObservedAt,
+      ),
+      weekly: unknownPolicyLimit("weekly-inference-policy", observedAt, ["#22962"]),
+    };
+
+    const [runtimeCacheSettlement] = await runtimeCacheSettlementsPromise;
+    if (runtimeCacheSettlement.status === "rejected") {
+      throw runtimeCacheSettlement.reason;
+    }
+    const runtimeCache = runtimeCacheSettlement.value;
+
+    const paymentPresence = available("organizations", observedAt, {
+      customerIdPresent: primary.organization.stripeCustomerIdPresent,
+      defaultPaymentMethodIdPresent: primary.organization.defaultPaymentMethodIdPresent,
+    });
+    const billingBlockers: BillingReadinessBlockerCode[] = [];
+    if (!primary.organization.stripeCustomerIdPresent) {
+      billingBlockers.push("missing_customer_id");
+    } else if (!primary.organization.stripeCustomerIdValid) {
+      billingBlockers.push("invalid_customer_id");
+    }
+    if (!primary.organization.defaultPaymentMethodIdPresent) {
+      billingBlockers.push("missing_default_payment_method_id");
+    } else if (!primary.organization.defaultPaymentMethodIdValid) {
+      billingBlockers.push("invalid_default_payment_method_id");
+    }
+    if (!primary.autoTopUp.customerBindingAuthoritative) {
+      billingBlockers.push("customer_binding_not_authoritative");
+    }
+    const billingReadiness = available(
+      "organizations+stripe-customer-binding-authority",
+      observedAt,
+      {
+        ready: billingBlockers.length === 0,
+        blockers: billingBlockers,
+      },
+    );
+
+    let autoTopUpConfiguration: AccountBillingSnapshotV2["autoTopUp"]["configuration"];
+    try {
+      autoTopUpConfiguration = available("organizations", observedAt, {
+        accountActive: primary.organization.isActive,
+        enabled: primary.organization.autoTopUpEnabled,
+        threshold:
+          primary.organization.autoTopUpThreshold === null
+            ? null
+            : {
+                ...exactValue(
+                  canonicalDecimal(
+                    primary.organization.autoTopUpThreshold,
+                    2,
+                    "auto top-up threshold",
+                  ),
+                  "usd",
+                ),
+                unit: "usd",
+                currency: "USD",
+              },
+        amount:
+          primary.organization.autoTopUpAmount === null
+            ? null
+            : {
+                ...exactValue(
+                  canonicalDecimal(primary.organization.autoTopUpAmount, 2, "auto top-up amount"),
+                  "usd",
+                ),
+                unit: "usd",
+                currency: "USD",
+              },
+      });
+    } catch (error) {
+      // error-policy:J4 — malformed persisted auto-top-up values degrade the
+      // configuration/readiness observations without changing common billing readiness.
+      unavailableReason(error);
+      autoTopUpConfiguration = unavailable(
+        "organizations",
+        observedAt,
+        "auto_top_up_configuration_invalid",
+        false,
+      );
+    }
+    const control = primary.autoTopUp.control
+      ? available("auto_top_up_control", observedAt, {
+          mode: primary.autoTopUp.control.mode,
+          pausedAt: primary.autoTopUp.control.pausedAt.toISOString(),
+          legacyReconciledThrough:
+            primary.autoTopUp.control.legacyReconciledThrough?.toISOString() ?? null,
+        })
+      : unavailable<
+          AccountBillingSnapshotV2["autoTopUp"]["control"] extends Observed<infer T> ? T : never
+        >("auto_top_up_control", observedAt, "auto_top_up_control_missing", false);
+    const customerBinding = available("stripe-customer-binding-authority", observedAt, {
+      authoritative: primary.autoTopUp.customerBindingAuthoritative,
+    });
+    const blockingState = available("auto_top_up_attempts+legacy_quarantine", observedAt, {
+      durableAttempt: primary.autoTopUp.blockingAttempt,
+      legacyQuarantine: primary.autoTopUp.blockingLegacyQuarantine,
+    });
+    const coveredRevision = primary.organization.coveredBalanceDecreaseRevision;
+    const rearmed =
+      coveredRevision === null ||
+      BigInt(primary.organization.balanceDecreaseRevision) > BigInt(coveredRevision);
+    const rearm = available("organizations", observedAt, {
+      balanceDecreaseRevision: primary.organization.balanceDecreaseRevision,
+      coveredBalanceDecreaseRevision: coveredRevision,
+      rearmed,
+    });
+
+    let autoTopUpReadiness: AccountBillingSnapshotV2["autoTopUp"]["readiness"];
+    if (
+      autoTopUpConfiguration.status !== "available" ||
+      runtimeSwitch.status !== "available" ||
+      control.status !== "available" ||
+      balance.status !== "available"
+    ) {
+      autoTopUpReadiness = unavailable(
+        "auto-top-up-readiness",
+        sources.now().toISOString(),
+        "auto_top_up_readiness_incomplete",
+        false,
+      );
+    } else {
+      const config = autoTopUpConfiguration.value;
+      const threshold = config.threshold === null ? null : new Decimal(config.threshold.value);
+      const amount = config.amount === null ? null : new Decimal(config.amount.value);
+      const thresholdValid = threshold !== null && threshold.gte(0) && threshold.lte(1000);
+      const amountValid = amount !== null && amount.gte(1) && amount.lte(1000);
+      const belowThreshold =
+        thresholdValid && new Decimal(balance.value.balance.value).lt(threshold!);
+      const blockers: AutoTopUpReadinessBlockerCode[] = [...billingBlockers];
+      if (!config.accountActive) blockers.push("inactive_organization");
+      if (!config.enabled) blockers.push("disabled_by_organization");
+      if (config.threshold === null) blockers.push("missing_threshold");
+      else if (!thresholdValid) blockers.push("invalid_threshold");
+      if (config.amount === null) blockers.push("missing_amount");
+      else if (!amountValid) blockers.push("invalid_amount");
+      if (thresholdValid && !belowThreshold) blockers.push("balance_at_or_above_threshold");
+      if (!runtimeSwitch.value.enabled) blockers.push("runtime_switch_disabled");
+      if (control.value.mode !== "durable") blockers.push("cutover_paused");
+      if (primary.autoTopUp.blockingAttempt) blockers.push("blocking_attempt");
+      if (primary.autoTopUp.blockingLegacyQuarantine) blockers.push("legacy_quarantine");
+      if (!rearmed) blockers.push("balance_not_rearmed");
+      autoTopUpReadiness = available("auto-top-up-readiness", sources.now().toISOString(), {
+        canStartNewAttempt: blockers.length === 0,
+        blockers,
+      });
+    }
+
+    let totalDaily = new Decimal(0);
+    let activeRateIncomplete = false;
+    const resources: ActiveComputeResourceSnapshot[] = primary.activeResources.map((resource) => {
+      const rate = observeActiveComputeRate(resource, primary.latestRateSegments, observedAt);
+      if (rate.dailyForAggregate === null) {
+        activeRateIncomplete = true;
+      } else {
+        totalDaily = totalDaily.plus(rate.dailyForAggregate);
+      }
+      return {
+        resourceType: resource.resourceType,
+        resourceId: resource.resourceId,
+        name: resource.name,
+        status: resource.status,
+        billingStatus: resource.billingStatus,
+        rateSegment: rate.rateSegment,
+        ratePerHour: rate.ratePerHour,
+        estimatedRecurringComputeCostPerDay: rate.estimatedRecurringComputeCostPerDay,
+      };
+    });
+    const activeResources = available("active-billing-service", observedAt, resources);
+    const activeDailyCost: AccountBillingSnapshotV2["activeCompute"]["estimatedRecurringComputeCostPerDay"] =
+      activeRateIncomplete
+        ? unavailable(
+            ACTIVE_COMPUTE_RATE_SOURCE,
+            observedAt,
+            "active_compute_rate_incomplete",
+            false,
+          )
+        : available(ACTIVE_COMPUTE_RATE_SOURCE, observedAt, {
+            ...exactValue(
+              totalDaily.toDecimalPlaces(6, Decimal.ROUND_HALF_UP).toFixed(6),
+              "usd_per_day",
+            ),
+            unit: "usd_per_day",
+            currency: "USD",
+          });
+
+    const snapshotCompletedAt = sources.now().toISOString();
+    const v2: AccountBillingSnapshotV2 = {
+      snapshotStartedAt,
+      snapshotCompletedAt,
+      balance,
+      paymentMethodPresence: paymentPresence,
+      billingReadiness,
+      autoTopUp: {
+        configuration: autoTopUpConfiguration,
+        runtimeSwitch,
+        control,
+        customerBinding,
+        blockingState,
+        rearm,
+        readiness: autoTopUpReadiness,
+      },
+      tier: {
+        configured: configuredTier,
+        eligibilityPolicy: unknownPolicy("org-rate-limits", observedAt, ["#23019"]),
+        runtimeCache,
+      },
+      limits: {
+        apiKeys: apiKeyLimits,
+        cloudCharacters,
+        agentSandboxes,
+        containers: containerLimits,
+        apps: appLimits,
+        storage: storageLimits,
+        inference,
+      },
+      activeCompute: {
+        resources: activeResources,
+        estimatedRecurringComputeCostPerDay: activeDailyCost,
+        scope: available("active-billing-service", observedAt, {
+          organizationScoped: true,
+          selectors: {
+            containers: {
+              lifecycleStatuses: ["running"],
+              billingStatuses: ["active", "warning", "shutdown_pending"],
+            },
+            agentSandboxes: {
+              excludedExecutionTiers: ["shared"],
+              lifecyclePredicates: [
+                { status: "running", requiresLastBackup: false },
+                { status: "stopped", requiresLastBackup: true },
+              ],
+              billingStatuses: ["active", "warning", "shutdown_pending"],
+            },
+          },
+          rateAuthority: {
+            source: "compute_billing_rate_segments",
+            selection: "latest_effective_at_or_before_primary_transaction",
+          },
+        }),
+      },
+    };
+
+    const cloudV1 = v1Counted(characterSource, characterUsed, characterLimit);
+    const sandboxCounted = (BigInt(sandboxUsed) + BigInt(sandboxReserved)).toString();
+    const nonEagerV1 = v1Counted(sandboxSource, sandboxCounted, nonEagerLimit);
+    const eagerV1 = v1Counted(sandboxSource, sandboxCounted, eagerLimit);
+    const agentV1: SandboxLimitItem = {
+      source: sandboxSource,
+      ...(safeV1Integer(sandboxCounted) === null ? {} : { used: safeV1Integer(sandboxCounted)! }),
+      nonEagerCreate: {
+        state: nonEagerV1.state,
+        ...(nonEagerV1.limit === undefined ? {} : { limit: nonEagerV1.limit }),
+        ...(nonEagerV1.reason === undefined ? {} : { reason: nonEagerV1.reason }),
+      },
+      eagerManagedCreate: {
+        state: eagerV1.state,
+        ...(eagerV1.limit === undefined ? {} : { limit: eagerV1.limit }),
+        ...(eagerV1.reason === undefined ? {} : { reason: eagerV1.reason }),
+      },
+      state: eagerV1.state,
+      ...(nonEagerV1.limit === undefined ? {} : { nonEagerCreateLimit: nonEagerV1.limit }),
+      ...(eagerV1.limit === undefined ? {} : { eagerManagedCreateLimit: eagerV1.limit }),
+      ...(eagerV1.reason === undefined ? {} : { reason: eagerV1.reason }),
+    };
+    const containerCounted = (BigInt(containerUsed) + BigInt(containerReserved)).toString();
+    const containerV1 = v1Counted(containerSource, containerCounted, containerLimit);
+    const appsV1 = v1Counted(appSource, appUsed, appLimit);
+    // Project only the values that passed the same canonical validation as v2.
+    // In particular, a malformed lazy-row default must not become a plausible
+    // v1 limit merely because the organization has no persisted row yet.
+    const storageProjectionUsed = storageUsed;
+    const storageProjectionLimit = storageLimitValue;
+    const storageV1: StorageLimitItem =
+      storageProjectionUsed !== null && storageProjectionLimit !== null
+        ? {
+            source: storageSource,
+            state: v1Classify(storageProjectionUsed, storageProjectionLimit),
+            bytesUsed: storageProjectionUsed,
+            bytesLimit: storageProjectionLimit,
+          }
+        : { source: storageSource, state: "unavailable", reason: "source read failed" };
+    const inferenceV1: InferenceRateLimitItem =
+      configuredTier.status === "available"
+        ? {
+            source: "org-rate-limits",
+            state: "available",
+            completionsRpm: Number(configuredTier.value.completionsRpm),
+            embeddingsRpm: Number(configuredTier.value.embeddingsRpm),
+          }
+        : {
+            source: "org-rate-limits",
+            state: "unavailable",
+            reason: "source read failed",
+          };
+
+    return {
+      schemaVersion: 2,
+      observedAt,
+      cloudCharacters: cloudV1,
+      agentSandboxes: agentV1,
+      containers: containerV1,
+      apps: appsV1,
+      storage: storageV1,
+      inferenceRateLimits: inferenceV1,
+      v2,
+    };
+  } finally {
+    // `Promise.allSettled` itself cannot reject. Awaiting it here guarantees
+    // the cache reader has terminated before any assembly exit is observable.
+    await runtimeCacheSettlementsPromise;
+  }
 }

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -1,6 +1,12 @@
-// Coordinates cloud service active billing behavior behind route handlers.
+/**
+ * Selects organization-scoped billable compute resources and coordinates
+ * their ledger and cancellation operations. Snapshot callers may supply an
+ * open read transaction so resource identity and canonical rate segments share
+ * one primary-database observation boundary.
+ */
+
 import { and, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
-import { dbRead, dbWrite } from "../../db/client";
+import { type Database, dbRead, dbWrite } from "../../db/client";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
 import { creditTransactions } from "../../db/schemas/credit-transactions";
@@ -103,9 +109,17 @@ function detectLedgerResource(metadata: Record<string, unknown>): {
 }
 
 class ActiveBillingService {
-  async listActiveResources(organizationId: string): Promise<ActiveBillableResource[]> {
+  async listActiveResources(
+    organizationId: string,
+    /**
+     * Optional coherent read handle. The billing snapshot passes its open
+     * REPEATABLE READ transaction so this canonical selector is consumed
+     * without re-querying the primary outside the snapshot boundary.
+     */
+    database: Pick<Database, "select"> = dbRead,
+  ): Promise<ActiveBillableResource[]> {
     const [containerRows, agentRows] = await Promise.all([
-      dbRead
+      database
         .select()
         .from(containers)
         .where(
@@ -115,7 +129,7 @@ class ActiveBillingService {
             inArray(containers.billing_status, ["active", "warning", "shutdown_pending"]),
           ),
         ),
-      dbRead
+      database
         .select()
         .from(agentSandboxes)
         .where(
@@ -542,6 +556,8 @@ async function cancelContainerInfrastructure(
       message: "Container runtime was stopped and removed from the Docker node.",
     };
   } catch (error) {
+    // error-policy:J1 — cancellation translates infrastructure failure into a
+    // structured partial-success result after billing has already been stopped.
     const message = error instanceof Error ? error.message : String(error);
     logger.warn("[active-billing] Container infrastructure cancellation failed", {
       containerId,
@@ -609,6 +625,8 @@ async function cancelAgentInfrastructure(
           : "Managed agent stop queued; the orchestrator will shut down the container with a pre-shutdown snapshot when available.",
     };
   } catch (error) {
+    // error-policy:J1 — enqueue/cancellation failure is returned as the
+    // structured infrastructure-action result consumed by the route boundary.
     const message = error instanceof Error ? error.message : String(error);
     logger.warn("[active-billing] Agent infrastructure cancellation failed", {
       agentId,

--- a/packages/cloud/shared/src/lib/services/org-rate-limits-cache-only.test.ts
+++ b/packages/cloud/shared/src/lib/services/org-rate-limits-cache-only.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let spendReads = 0;
 let overrideReads = 0;
-let totalSpend = "0";
+let tierSourceCreditTotal = "0";
 let overrideError: Error | null = null;
 
 mock.module("../../db/helpers", () => ({
@@ -19,7 +19,7 @@ mock.module("../../db/helpers", () => ({
       from: () => ({
         where: async () => {
           spendReads += 1;
-          return [{ totalSpend }];
+          return [{ tierSourceCreditTotal }];
         },
       }),
     }),
@@ -47,7 +47,7 @@ const orgId = () => `org-tier-${++sequence}`;
 beforeEach(() => {
   spendReads = 0;
   overrideReads = 0;
-  totalSpend = "0";
+  tierSourceCreditTotal = "0";
   overrideError = null;
   __clearOrgTierHydrationsForTests();
 });
@@ -77,7 +77,7 @@ describe("organization rate-limit tier cache-only resolution", () => {
 
   test("returns warming on a miss and retains hydration under waitUntil", async () => {
     const org = orgId();
-    totalSpend = "7";
+    tierSourceCreditTotal = "7";
     await cache.del(CacheKeys.org.rateLimitTier(org));
     const background: Promise<unknown>[] = [];
 

--- a/packages/cloud/shared/src/lib/services/org-rate-limits-sources.test.ts
+++ b/packages/cloud/shared/src/lib/services/org-rate-limits-sources.test.ts
@@ -12,7 +12,7 @@ type RpmOverride = {
   strict_rpm: number | null;
 };
 
-let totalSpend: unknown = "0";
+let tierSourceCreditTotal: unknown = "0";
 let override: RpmOverride | undefined;
 let cacheWrites = 0;
 
@@ -20,7 +20,7 @@ mock.module("../../db/helpers", () => ({
   dbRead: {
     select: () => ({
       from: () => ({
-        where: async () => [{ totalSpend }],
+        where: async () => [{ tierSourceCreditTotal }],
       }),
     }),
   },
@@ -53,18 +53,18 @@ const noOverride = (): RpmOverride => ({
 });
 
 beforeEach(() => {
-  totalSpend = "0";
+  tierSourceCreditTotal = "0";
   override = undefined;
   cacheWrites = 0;
 });
 
 describe("authoritative organization rate-limit tier reads", () => {
-  test.each(["NaN", "-1"])("rejects the corrupt paid-credit total %s", async (value) => {
-    totalSpend = value;
+  test.each(["NaN", "-1"])("rejects the corrupt tier-source credit total %s", async (value) => {
+    tierSourceCreditTotal = value;
 
     await expect(readOrgTierFromSources("org-corrupt-spend")).rejects.toMatchObject({
       code: "ORG_RATE_LIMIT_SOURCE_INVALID",
-      context: { field: "paid_credit_total" },
+      context: { field: "tier_source_credit_total" },
     });
     expect(cacheWrites).toBe(0);
   });
@@ -83,7 +83,7 @@ describe("authoritative organization rate-limit tier reads", () => {
   );
 
   test("returns a valid custom override without writing the inference cache", async () => {
-    totalSpend = "7.25";
+    tierSourceCreditTotal = "7.25";
     override = {
       ...noOverride(),
       completions_rpm: 240,
@@ -101,7 +101,7 @@ describe("authoritative organization rate-limit tier reads", () => {
   });
 
   test("recalculation caches the same authoritative result", async () => {
-    totalSpend = "100";
+    tierSourceCreditTotal = "100";
     override = { ...noOverride(), embeddings_rpm: 900 };
 
     const observed = await readOrgTierFromSources("org-shared-calculation");

--- a/packages/cloud/shared/src/lib/services/org-rate-limits.ts
+++ b/packages/cloud/shared/src/lib/services/org-rate-limits.ts
@@ -1,10 +1,10 @@
 /**
  * Per-organization rate limit tier service.
  *
- * Automatically computes a rate limit tier based on cumulative paid credits,
- * merges any manual overrides from the org_rate_limit_overrides table,
- * and caches the result in the configured shared cache for fast lookups.
- * Worker inference reads that cache only and hydrates Postgres state off path.
+ * Resolves the legacy rate-limit selector from its current credit-ledger input,
+ * merges manual overrides, and caches the result for inference admission.
+ * Which economic credit provenances should qualify remains policy work in
+ * #23019; selector keys such as `paid` are not subscription labels.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -35,8 +35,16 @@ export interface OrgTierData {
   strictRpm: number;
 }
 
+export interface OrgTierOverrideValues {
+  completions_rpm: number | null;
+  embeddings_rpm: number | null;
+  standard_rpm: number | null;
+  strict_rpm: number | null;
+}
+
 // ---------------------------------------------------------------------------
-// Tier thresholds — ordered highest-first for threshold matching
+// Legacy selector thresholds — ordered highest-first for threshold matching.
+// Names such as `paid` are internal keys, not product or subscription labels.
 // ---------------------------------------------------------------------------
 
 const TIER_THRESHOLDS: ReadonlyArray<
@@ -72,8 +80,12 @@ const TIER_THRESHOLDS: ReadonlyArray<
 const SORTED_THRESHOLDS = [...TIER_THRESHOLDS].sort((a, b) => b.minSpend - a.minSpend);
 const FREE_TIER = SORTED_THRESHOLDS[SORTED_THRESHOLDS.length - 1];
 
-/** Credit transaction metadata types that represent free/bonus credits (excluded from spend). */
-const FREE_CREDIT_TYPES = ["initial_free_credits", "wallet_signup", "signup_code_bonus"];
+/** Metadata markers excluded by the current selector; #23019 owns economic qualification. */
+export const ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES = [
+  "initial_free_credits",
+  "wallet_signup",
+  "signup_code_bonus",
+] as const;
 
 export interface OrgTierCacheExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
@@ -131,55 +143,43 @@ export function __clearOrgTierHydrationsForTests(): void {
   orgTierHydrations.clear();
 }
 
-function parsePaidCreditTotal(value: unknown, orgId: string): number {
+function parseTierSourceCreditTotal(value: unknown, orgId: string): number {
   const normalized = typeof value === "string" || typeof value === "number" ? String(value) : "";
   if (!/^[+-]?(?:\d+|\d*\.\d+)$/.test(normalized)) {
-    throw new ElizaError("Organization paid-credit total is not a valid NUMERIC", {
+    throw new ElizaError("Organization tier-source credit total is not a valid NUMERIC", {
       code: "ORG_RATE_LIMIT_SOURCE_INVALID",
-      context: { orgId, field: "paid_credit_total" },
+      context: { orgId, field: "tier_source_credit_total" },
       severity: "fatal",
     });
   }
 
   const parsed = Number(normalized);
   if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new ElizaError("Organization paid-credit total is not a valid non-negative value", {
-      code: "ORG_RATE_LIMIT_SOURCE_INVALID",
-      context: { orgId, field: "paid_credit_total" },
-      severity: "fatal",
-    });
+    throw new ElizaError(
+      "Organization tier-source credit total is not a valid non-negative value",
+      {
+        code: "ORG_RATE_LIMIT_SOURCE_INVALID",
+        context: { orgId, field: "tier_source_credit_total" },
+        severity: "fatal",
+      },
+    );
   }
   return parsed;
 }
 
-// ---------------------------------------------------------------------------
-// Core functions
-// ---------------------------------------------------------------------------
-
-async function calculateOrgTierFromSources(
+/**
+ * Pure tier resolver shared by the normal source reader and the coherent
+ * account-billing snapshot transaction. Keeping threshold/override semantics
+ * here prevents the snapshot from maintaining a second policy table.
+ */
+export function resolveOrgTierFromSourceValues(
   orgId: string,
-): Promise<{ tierData: OrgTierData; totalSpend: number }> {
-  const [creditResult, override] = await Promise.all([
-    dbRead
-      .select({
-        totalSpend: sql<string>`COALESCE(SUM(${creditTransactions.amount}), '0')`,
-      })
-      .from(creditTransactions)
-      .where(
-        and(
-          eq(creditTransactions.organization_id, orgId),
-          eq(creditTransactions.type, "credit"),
-          sql`COALESCE(${creditTransactions.metadata}->>'type', '') NOT IN (${sql.join(
-            FREE_CREDIT_TYPES.map((t) => sql`${t}`),
-            sql`, `,
-          )})`,
-        ),
-      ),
-    orgRateLimitOverridesRepository.findByOrganizationId(orgId),
-  ]);
-
-  const totalSpend = parsePaidCreditTotal(creditResult[0]?.totalSpend, orgId);
-  const matchedTier = SORTED_THRESHOLDS.find((t) => totalSpend >= t.minSpend) ?? FREE_TIER;
+  tierSourceCreditTotal: unknown,
+  override?: OrgTierOverrideValues,
+): { tierData: OrgTierData; tierSourceCreditTotal: number } {
+  const parsedTierSourceCreditTotal = parseTierSourceCreditTotal(tierSourceCreditTotal, orgId);
+  const matchedTier =
+    SORTED_THRESHOLDS.find((tier) => parsedTierSourceCreditTotal >= tier.minSpend) ?? FREE_TIER;
 
   let tierData: OrgTierData = {
     tierName: matchedTier.name,
@@ -212,7 +212,36 @@ async function calculateOrgTierFromSources(
     });
   }
 
-  return { tierData, totalSpend };
+  return { tierData, tierSourceCreditTotal: parsedTierSourceCreditTotal };
+}
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+async function calculateOrgTierFromSources(
+  orgId: string,
+): Promise<{ tierData: OrgTierData; tierSourceCreditTotal: number }> {
+  const [creditResult, override] = await Promise.all([
+    dbRead
+      .select({
+        tierSourceCreditTotal: sql<string>`COALESCE(SUM(${creditTransactions.amount}), '0')`,
+      })
+      .from(creditTransactions)
+      .where(
+        and(
+          eq(creditTransactions.organization_id, orgId),
+          eq(creditTransactions.type, "credit"),
+          sql`COALESCE(${creditTransactions.metadata}->>'type', '') NOT IN (${sql.join(
+            ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((t) => sql`${t}`),
+            sql`, `,
+          )})`,
+        ),
+      ),
+    orgRateLimitOverridesRepository.findByOrganizationId(orgId),
+  ]);
+
+  return resolveOrgTierFromSourceValues(orgId, creditResult[0]?.tierSourceCreditTotal, override);
 }
 
 /**
@@ -227,12 +256,12 @@ export async function readOrgTierFromSources(orgId: string): Promise<OrgTierData
 /**
  * Recalculates an org's rate limit tier from the DB and caches the result.
  *
- * The tier is based on cumulative **paid** credits (purchases via Stripe).
- * Free/bonus credits are excluded. An org that bought $100 of credits is tier
- * "growth" regardless of how much they consumed.
+ * The current selector sums credit rows except its legacy excluded metadata
+ * markers. That input is observable implementation state, not a ratified
+ * definition of paid spend; #23019 owns the qualification policy.
  */
 export async function recalculateOrgTier(orgId: string): Promise<OrgTierData> {
-  const { tierData, totalSpend } = await calculateOrgTierFromSources(orgId);
+  const { tierData, tierSourceCreditTotal } = await calculateOrgTierFromSources(orgId);
 
   // Cache is non-fatal: a later request can re-read the database.
   try {
@@ -249,7 +278,7 @@ export async function recalculateOrgTier(orgId: string): Promise<OrgTierData> {
   logger.debug("[OrgRateLimits] Tier computed", {
     orgId,
     tier: tierData.tierName,
-    totalSpend,
+    tierSourceCreditTotal,
   });
 
   return tierData;

--- a/packages/cloud/shared/src/types/account-billing-snapshot.ts
+++ b/packages/cloud/shared/src/types/account-billing-snapshot.ts
@@ -1,0 +1,340 @@
+/**
+ * Versioned, server-owned account billing snapshot transport contract.
+ *
+ * Every v2 datum is an explicit observation. Consumers must branch on
+ * `status`; missing authorities and undecided policy are never encoded as
+ * zero, false, or an absent property.
+ */
+
+export type ObservationStatus = "available" | "unavailable" | "unknown_policy" | "not_applicable";
+
+interface ObservationProvenance {
+  /** Stable server-side authority or adapter that produced this observation. */
+  source: string;
+  /** Timestamp for this source, which may differ from the primary snapshot. */
+  observedAt: string;
+}
+
+export interface AvailableObservation<T> extends ObservationProvenance {
+  status: "available";
+  value: T;
+}
+
+export interface UnavailableObservation extends ObservationProvenance {
+  status: "unavailable";
+  error: {
+    /** Stable machine-readable reason; never a raw provider/database error. */
+    code: string;
+    retryable: boolean;
+  };
+}
+
+export interface UnknownPolicyObservation extends ObservationProvenance {
+  status: "unknown_policy";
+  /** Issue/decision identifiers that must be resolved before a value exists. */
+  blockedBy: string[];
+}
+
+export interface NotApplicableObservation extends ObservationProvenance {
+  status: "not_applicable";
+  reason: string;
+}
+
+export type Observed<T> =
+  | AvailableObservation<T>
+  | UnavailableObservation
+  | UnknownPolicyObservation
+  | NotApplicableObservation;
+
+export type ExactBillingUnit =
+  | "count"
+  | "byte"
+  | "request_per_minute"
+  | "usd"
+  | "usd_per_hour"
+  | "usd_per_day";
+
+/** Exact base-10 value. It is deliberately never a JavaScript number. */
+export interface ExactBillingValue {
+  value: string;
+  unit: ExactBillingUnit;
+  currency?: "USD";
+}
+
+export interface LimitCountPolicy {
+  included: string[];
+  excluded: string[];
+}
+
+/**
+ * Common quota shape. Every field is observed independently because one
+ * authority can expose aggregate occupancy without reservation/deletion
+ * decomposition (storage), or configuration without a live counter (DO RPM).
+ */
+export interface ObservedLimitSnapshot {
+  used: Observed<ExactBillingValue>;
+  reserved: Observed<ExactBillingValue>;
+  deleting: Observed<ExactBillingValue>;
+  limit: Observed<ExactBillingValue>;
+  remaining: Observed<ExactBillingValue>;
+  resetAt: Observed<string | null>;
+  countsTowardLimit: Observed<LimitCountPolicy>;
+}
+
+export interface AccountBalanceSnapshot {
+  balance: ExactBillingValue & { unit: "usd"; currency: "USD" };
+  /** Exact bigint revision serialized as base-10 text. */
+  revision: string;
+}
+
+export interface PaymentMethodPresenceSnapshot {
+  /** Presence of the persisted `organizations.stripe_customer_id`; no provider lookup is implied. */
+  customerIdPresent: boolean;
+  /** Presence of the persisted `organizations.stripe_default_payment_method`. */
+  defaultPaymentMethodIdPresent: boolean;
+}
+
+export type BillingReadinessBlockerCode =
+  | "missing_customer_id"
+  | "invalid_customer_id"
+  | "missing_default_payment_method_id"
+  | "invalid_default_payment_method_id"
+  | "customer_binding_not_authoritative";
+
+export interface BillingReadinessSnapshot {
+  ready: boolean;
+  blockers: BillingReadinessBlockerCode[];
+}
+
+export interface AutoTopUpConfigurationSnapshot {
+  accountActive: boolean;
+  enabled: boolean;
+  threshold: (ExactBillingValue & { unit: "usd"; currency: "USD" }) | null;
+  amount: (ExactBillingValue & { unit: "usd"; currency: "USD" }) | null;
+}
+
+export interface AutoTopUpControlSnapshot {
+  mode: "paused" | "durable";
+  pausedAt: string;
+  legacyReconciledThrough: string | null;
+}
+
+export interface AutoTopUpBlockingSnapshot {
+  durableAttempt: boolean;
+  legacyQuarantine: boolean;
+}
+
+export interface AutoTopUpRearmSnapshot {
+  balanceDecreaseRevision: string;
+  coveredBalanceDecreaseRevision: string | null;
+  rearmed: boolean;
+}
+
+export type AutoTopUpReadinessBlockerCode =
+  | BillingReadinessBlockerCode
+  | "inactive_organization"
+  | "disabled_by_organization"
+  | "missing_threshold"
+  | "invalid_threshold"
+  | "missing_amount"
+  | "invalid_amount"
+  | "balance_at_or_above_threshold"
+  | "runtime_switch_disabled"
+  | "cutover_paused"
+  | "blocking_attempt"
+  | "legacy_quarantine"
+  | "balance_not_rearmed";
+
+export interface AutoTopUpSnapshot {
+  configuration: Observed<AutoTopUpConfigurationSnapshot>;
+  runtimeSwitch: Observed<{ enabled: boolean }>;
+  control: Observed<AutoTopUpControlSnapshot>;
+  customerBinding: Observed<{ authoritative: boolean }>;
+  blockingState: Observed<AutoTopUpBlockingSnapshot>;
+  rearm: Observed<AutoTopUpRearmSnapshot>;
+  readiness: Observed<{
+    canStartNewAttempt: boolean;
+    blockers: AutoTopUpReadinessBlockerCode[];
+  }>;
+}
+
+export interface ConfiguredInferenceTierSnapshot {
+  /** Legacy runtime selector key; values such as `paid` are not economic labels. */
+  selectorKey: string;
+  /**
+   * Input observed by the current tier selector after its legacy metadata
+   * exclusions. Economic qualification remains undecided by #23019.
+   */
+  tierSourceCreditTotalObserved: ExactBillingValue & { unit: "usd"; currency: "USD" };
+  overrides: {
+    completionsRpm: string | null;
+    embeddingsRpm: string | null;
+    standardRpm: string | null;
+    strictRpm: string | null;
+  };
+  completionsRpm: string;
+  embeddingsRpm: string;
+  standardRpm: string;
+  strictRpm: string;
+}
+
+export interface RuntimeInferenceTierSnapshot {
+  /** Cache copy of the legacy runtime selector key, not a product label. */
+  selectorKey: string;
+  completionsRpm: string;
+  embeddingsRpm: string;
+  standardRpm: string;
+  strictRpm: string;
+}
+
+export interface AccountTierSnapshot {
+  configured: Observed<ConfiguredInferenceTierSnapshot>;
+  /** Eligibility provenance is unresolved by #23019 even when current code resolves a tier. */
+  eligibilityPolicy: Observed<never>;
+  /** Cache-only runtime state; this observation never hydrates or mutates it. */
+  runtimeCache: Observed<RuntimeInferenceTierSnapshot>;
+}
+
+export type ActiveComputeResourceType = "container" | "agent_sandbox";
+
+export interface ActiveComputeRateSegmentSnapshot {
+  workloadKind: "agent" | "container";
+  billingState: "running" | "backup";
+  effectiveAt: string;
+}
+
+export interface ActiveComputeResourceSnapshot {
+  resourceType: ActiveComputeResourceType;
+  resourceId: string;
+  name: string;
+  status: string;
+  billingStatus: string;
+  rateSegment: Observed<ActiveComputeRateSegmentSnapshot>;
+  ratePerHour: Observed<ExactBillingValue & { unit: "usd_per_hour"; currency: "USD" }>;
+  estimatedRecurringComputeCostPerDay: Observed<
+    ExactBillingValue & { unit: "usd_per_day"; currency: "USD" }
+  >;
+}
+
+export interface ActiveComputeScopeSnapshot {
+  organizationScoped: true;
+  selectors: {
+    containers: {
+      lifecycleStatuses: string[];
+      billingStatuses: string[];
+    };
+    agentSandboxes: {
+      excludedExecutionTiers: string[];
+      lifecyclePredicates: Array<{
+        status: string;
+        requiresLastBackup: boolean;
+      }>;
+      billingStatuses: string[];
+    };
+  };
+  rateAuthority: {
+    source: "compute_billing_rate_segments";
+    selection: "latest_effective_at_or_before_primary_transaction";
+  };
+}
+
+export interface ActiveComputeSnapshot {
+  resources: Observed<ActiveComputeResourceSnapshot[]>;
+  estimatedRecurringComputeCostPerDay: Observed<
+    ExactBillingValue & { unit: "usd_per_day"; currency: "USD" }
+  >;
+  scope: Observed<ActiveComputeScopeSnapshot>;
+}
+
+export interface AccountBillingLimitsV2 {
+  apiKeys: ObservedLimitSnapshot;
+  cloudCharacters: ObservedLimitSnapshot;
+  agentSandboxes: {
+    nonEagerCreate: ObservedLimitSnapshot;
+    eagerManagedCreate: ObservedLimitSnapshot;
+  };
+  containers: ObservedLimitSnapshot;
+  apps: ObservedLimitSnapshot;
+  storage: ObservedLimitSnapshot;
+  inference: {
+    completions: ObservedLimitSnapshot;
+    embeddings: ObservedLimitSnapshot;
+    /** Undecided weekly contract; every datum stays explicit until #22962 resolves it. */
+    weekly: ObservedLimitSnapshot;
+  };
+}
+
+export interface AccountBillingSnapshotV2 {
+  snapshotStartedAt: string;
+  snapshotCompletedAt: string;
+  balance: Observed<AccountBalanceSnapshot>;
+  paymentMethodPresence: Observed<PaymentMethodPresenceSnapshot>;
+  billingReadiness: Observed<BillingReadinessSnapshot>;
+  autoTopUp: AutoTopUpSnapshot;
+  tier: AccountTierSnapshot;
+  limits: AccountBillingLimitsV2;
+  activeCompute: ActiveComputeSnapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Temporary v1 compatibility projection.
+// ---------------------------------------------------------------------------
+
+export type LimitItemState = "available" | "at-limit" | "over-limit" | "unavailable";
+
+export interface CountedLimitItem {
+  source: string;
+  state: LimitItemState;
+  used?: number;
+  limit?: number;
+  reason?: string;
+}
+
+export interface SandboxCreateLimitItem {
+  state: LimitItemState;
+  limit?: number;
+  reason?: string;
+}
+
+export interface SandboxLimitItem {
+  source: string;
+  used?: number;
+  nonEagerCreate: SandboxCreateLimitItem;
+  eagerManagedCreate: SandboxCreateLimitItem;
+  state: LimitItemState;
+  nonEagerCreateLimit?: number;
+  eagerManagedCreateLimit?: number;
+  reason?: string;
+}
+
+export interface StorageLimitItem {
+  source: string;
+  state: LimitItemState;
+  bytesUsed?: string;
+  bytesLimit?: string;
+  reason?: string;
+}
+
+export interface InferenceRateLimitItem {
+  source: string;
+  state: LimitItemState;
+  completionsRpm?: number;
+  embeddingsRpm?: number;
+  reason?: string;
+}
+
+export interface AccountLimitsSnapshotV1 {
+  observedAt: string;
+  cloudCharacters: CountedLimitItem;
+  agentSandboxes: SandboxLimitItem;
+  containers: CountedLimitItem;
+  apps: CountedLimitItem;
+  storage: StorageLimitItem;
+  inferenceRateLimits: InferenceRateLimitItem;
+}
+
+/** Additive route response: the seven v1 fields remain top-level. */
+export interface AccountBillingSnapshot extends AccountLimitsSnapshotV1 {
+  schemaVersion: 2;
+  v2: AccountBillingSnapshotV2;
+}

--- a/packages/cloud/shared/src/types/index.ts
+++ b/packages/cloud/shared/src/types/index.ts
@@ -1,4 +1,5 @@
 /** Barrel for the cloud transport types: API DTOs, Worker env bindings, and Stripe queue payloads. */
+export * from "./account-billing-snapshot.ts";
 export * from "./cloud-api.ts";
 export * from "./cloud-worker-env.ts";
 export * from "./stripe-queue-message.ts";


### PR DESCRIPTION
Closes #22954.

## What this lands

- adds an additive `schemaVersion: 2` canonical account-billing snapshot while preserving the six legacy top-level fields;
- reads primary PostgreSQL authorities in one org-scoped, read-only repeatable-read transaction;
- exposes exact/provenanced balance, payment-method readiness, auto-top-up readiness, tier inputs, resource limits, storage, active compute, and explicit unavailable/unknown-policy states;
- keeps common billing readiness separate from auto-top-up capability readiness;
- aligns snapshot count semantics with atomic admission authorities at N-1/N/N+1;
- preserves active compute identities but withholds rates/cost aggregates when canonical rate segments are missing, future, wrong-kind, or wrong-state;
- represents the unresolved weekly inference policy and tier-source qualification explicitly as dependencies on #22962 and #23019;
- fails closed on missing/malformed aggregate or scalar authority rows instead of fabricating healthy zero/false observations.

## Compatibility and safety

- no database migration or provider call;
- no Stripe, payment, production, or infrastructure mutation;
- caller-supplied organization identifiers are ignored; auth-scoped organization authority is used;
- legacy v1 projection remains available for current clients.

## Verification

- Bun 1.3.14 snapshot/helper suite: 37 passed, 169 assertions;
- Bun 1.3.14 org-tier source suite: 7 passed, 14 assertions;
- API route unit suite: 3 passed, 15 assertions;
- PGlite route/admission suite: 9 passed, 116 assertions;
- shared TypeScript `tsc --noEmit`: passed;
- Biome: 15 changed files passed;
- tenant-scope gate: 123 repository files passed;
- `git diff --check`: passed;
- independent final review: no P0-P3 findings.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@e38ecc71039441d729032e95134290a996cbc28e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-v2-snapshot]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@e38ecc71039441d729032e95134290a996cbc28e:packages/skills/skills/contribute-to-eliza"} -->
