### PR TITLE
fix(cloud): keep the stack when a job fails, bounded

### DIFF
--- a/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
@@ -144,6 +144,48 @@ describe("jobs route", () => {
     });
   });
 
+  test("a stored stack never reaches the owner's response (#23117)", async () => {
+    // The stored value is the operator diagnostic — full frames. The API must
+    // hand back the failure summary only: frames disclose absolute server
+    // paths and internal module layout to a non-admin org member.
+    const storedDiagnostic = [
+      "Error: agent_delete failed",
+      "    at deleteAgent (/srv/eliza/packages/cloud/shared/src/lib/services/eliza-sandbox.ts:2703:11)",
+      "    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
+      "caused by: Error: ENOENT: no such file",
+    ].join("\n");
+    getJobForOrg.mockResolvedValue({
+      id: "job-1",
+      type: "agent_delete",
+      status: "failed",
+      result: null,
+      error: storedDiagnostic,
+      attempts: 2,
+      max_attempts: 2,
+      estimated_completion_at: null,
+      scheduled_for: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date("2026-01-01T00:00:00Z"),
+      updated_at: new Date("2026-01-01T00:00:01Z"),
+    });
+
+    validateServiceKey.mockResolvedValueOnce(null);
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/jobs/job-1", {
+        method: "GET",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: { error: string | null } };
+    expect(body.data.error).toBe("Error: agent_delete failed");
+    expect(body.data.error).not.toContain(" at ");
+    expect(body.data.error).not.toContain("/srv/eliza");
+    expect(body.data.error).not.toContain(".ts:");
+  });
+
   test("service-key polling can read owner-org jobs by id", async () => {
     const response = await app.fetch(
       new Request("https://api.example.test/api/v1/jobs/job-1", {

--- a/packages/cloud/api/v1/jobs/[jobId]/route.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.ts
@@ -10,6 +10,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { validateServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { publicJobErrorSummary } from "@/lib/services/job-error-text";
 import { JOB_TYPES } from "@/lib/services/provisioning-job-types";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { logger } from "@/lib/utils/logger";
@@ -55,7 +56,9 @@ app.get("/", async (c) => {
         type: job.type,
         status: job.status,
         result: job.result,
-        error: job.error,
+        // Operator diagnostic stays in the row; the owner gets the failure
+        // summary without stack frames (server paths, module layout).
+        error: publicJobErrorSummary(job.error),
         attempts: job.attempts,
         maxAttempts: job.max_attempts,
         estimatedCompletionAt: job.estimated_completion_at,

--- a/packages/cloud/shared/src/lib/services/job-error-text.test.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Durable-storage contract for `jobs.error` (#23117 review).
+ *
+ * Four properties are load-bearing and each is pinned against the real
+ * formatter: the text never escapes the advertised ceiling, hostile throws
+ * cannot make the formatter itself throw (it runs before the failed job is
+ * written back), credentials are scrubbed before the value becomes durable,
+ * and the public API summary carries no stack frames.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  finalizeJobErrorText,
+  jobErrorSummary,
+  jobErrorText,
+  publicJobErrorSummary,
+} from "./job-error-text";
+
+const MAX = 4_000;
+
+describe("jobErrorText — ceiling", () => {
+  test("caps at exactly the advertised maximum, suffix included", () => {
+    const error = new Error("x".repeat(10_000));
+    const text = jobErrorText(error);
+    expect(text.length).toBeLessThanOrEqual(MAX);
+    expect(text.endsWith("… truncated")).toBe(true);
+  });
+
+  test("the same ceiling applies to pre-formatted text that bypasses jobErrorText", () => {
+    const text = finalizeJobErrorText("y".repeat(10_000));
+    expect(text.length).toBeLessThanOrEqual(MAX);
+  });
+
+  test("leaves a short stack untouched", () => {
+    const text = jobErrorText(new Error("value.toISOString is not a function"));
+    expect(text).toContain("value.toISOString is not a function");
+    expect(text.endsWith("… truncated")).toBe(false);
+  });
+});
+
+describe("jobErrorText — never throws before the job is written back", () => {
+  test("a null-prototype throw is recorded, not propagated", () => {
+    const hostile = Object.create(null);
+    expect(() => jobErrorText(hostile)).not.toThrow();
+    expect(jobErrorText(hostile).length).toBeGreaterThan(0);
+  });
+
+  test("a throwing stack accessor falls back to the message", () => {
+    const error = new Error("underlying failure");
+    Object.defineProperty(error, "stack", {
+      get() {
+        throw new Error("hostile stack");
+      },
+    });
+    expect(() => jobErrorText(error)).not.toThrow();
+    expect(jobErrorText(error)).toContain("underlying failure");
+  });
+
+  test("a throwing cause accessor ends the chain instead of propagating", () => {
+    const error = new Error("outer");
+    Object.defineProperty(error, "cause", {
+      get() {
+        throw new Error("hostile cause");
+      },
+    });
+    expect(() => jobErrorText(error)).not.toThrow();
+    expect(jobErrorText(error)).toContain("outer");
+  });
+});
+
+describe("jobErrorText — redaction before durable storage", () => {
+  test("a bearer credential in the message does not reach the column", () => {
+    const text = jobErrorText(
+      new Error(
+        "Authorization: Bearer sk-live-abcdef0123456789abcdef0123456789",
+      ),
+    );
+    expect(text).not.toContain("sk-live-abcdef0123456789abcdef0123456789");
+  });
+});
+
+describe("jobErrorText — cause chain", () => {
+  test("retains a wrapped cause that a native stack would drop", () => {
+    const root = new Error("ENOENT: /srv/data/missing");
+    const wrapped = new Error("agent_delete failed", { cause: root });
+    const text = jobErrorText(wrapped);
+    expect(text).toContain("agent_delete failed");
+    expect(text).toContain("ENOENT: /srv/data/missing");
+  });
+
+  test("a cyclic cause chain terminates", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    (a as { cause?: unknown }).cause = b;
+    expect(() => jobErrorText(a)).not.toThrow();
+    expect(jobErrorText(a).length).toBeLessThanOrEqual(MAX);
+  });
+});
+
+describe("jobErrorSummary — safe to embed in a wrapper's message", () => {
+  test("carries no frames, so wrapping does not consume the job budget", () => {
+    const inner = new Error("inner failure");
+    expect(jobErrorSummary(inner)).toBe("inner failure");
+    expect(jobErrorSummary(inner)).not.toMatch(/\n\s+at /);
+  });
+
+  test("a thrown plain object keeps its content instead of [object Object]", () => {
+    const payload = { code: -32000, message: "provisioner refused" };
+    const text = jobErrorText(payload);
+    expect(text).not.toBe("[object Object]");
+    expect(text).toContain("provisioner refused");
+  });
+});
+
+describe("publicJobErrorSummary — API boundary", () => {
+  test("drops stack frames from what the owner can read", () => {
+    const stored = jobErrorText(new Error("agent_delete failed"));
+    expect(stored).toContain("\n    at ");
+    const summary = publicJobErrorSummary(stored);
+    expect(summary).toBe("Error: agent_delete failed");
+    expect(summary).not.toContain("\n");
+    expect(summary).not.toContain(" at ");
+  });
+
+  test("drops the frames' server paths, and keeps a multi-line message body", () => {
+    // The frames are what disclose module layout; the message body is the
+    // operator's own text and the owner needs it. Both halves asserted on a
+    // stack that genuinely carries this file's absolute path.
+    const stored = jobErrorText(
+      new Error("Provisioning failed:\nnode: hetzner-3\nreason: no capacity"),
+    );
+    expect(stored).toContain("job-error-text.test.ts");
+    const summary = publicJobErrorSummary(stored) ?? "";
+    expect(summary).toContain("node: hetzner-3");
+    expect(summary).toContain("reason: no capacity");
+    expect(summary).not.toContain("job-error-text.test.ts");
+    expect(summary).not.toMatch(/\n\s+at /);
+  });
+
+  test("a path inside the message itself is preserved — only frames are cut", () => {
+    // Honest scope: this summary is not a path scrubber. An ENOENT message
+    // names the file the operator asked about; the redactor handles secrets.
+    const stored = jobErrorText(
+      new Error("ENOENT: no such file, open '/srv/eliza/agents/9c1/config.json'"),
+    );
+    expect(publicJobErrorSummary(stored)).toContain("/srv/eliza/agents/9c1");
+  });
+
+  test("null and empty stay null", () => {
+    expect(publicJobErrorSummary(null)).toBeNull();
+    expect(publicJobErrorSummary(undefined)).toBeNull();
+    expect(publicJobErrorSummary("   ")).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/job-error-text.test.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.test.ts
@@ -65,14 +65,32 @@ describe("jobErrorText — never throws before the job is written back", () => {
     expect(() => jobErrorText(error)).not.toThrow();
     expect(jobErrorText(error)).toContain("outer");
   });
+
+  test("hostile and revoked Proxies cannot escape Error classification", () => {
+    const prototypeHostile = new Proxy(Object.create(null), {
+      getPrototypeOf() {
+        throw new Error("hostile prototype");
+      },
+      get() {
+        throw new Error("hostile property read");
+      },
+    });
+    const { proxy: revoked, revoke } = Proxy.revocable(new Error("revoked"), {});
+    revoke();
+
+    for (const hostile of [prototypeHostile, revoked]) {
+      expect(() => jobErrorText(hostile)).not.toThrow();
+      expect(() => jobErrorSummary(hostile)).not.toThrow();
+      expect(jobErrorText(hostile).length).toBeGreaterThan(0);
+      expect(jobErrorSummary(hostile).length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe("jobErrorText — redaction before durable storage", () => {
   test("a bearer credential in the message does not reach the column", () => {
     const text = jobErrorText(
-      new Error(
-        "Authorization: Bearer sk-live-abcdef0123456789abcdef0123456789",
-      ),
+      new Error("Authorization: Bearer sk-live-abcdef0123456789abcdef0123456789"),
     );
     expect(text).not.toContain("sk-live-abcdef0123456789abcdef0123456789");
   });

--- a/packages/cloud/shared/src/lib/services/job-error-text.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.ts
@@ -11,15 +11,182 @@
  * over it failed outright with `invalid memory alloc request size 1130945444`.
  * Cutting on characters rather than bytes keeps multi-byte sequences intact.
  *
- * Dependency-free on purpose so it stays testable without the job service's
- * database import graph.
+ * Three properties this module owes its callers, because the value it produces
+ * is written to `jobs.error` and surfaced by the jobs API:
+ *
+ * - It never throws. `String(value)` throws for a null-prototype object and an
+ *   `Error` can carry a throwing `stack` accessor; this runs *before* the
+ *   failed job is written back, so a throw here would replace the original
+ *   failure and strand the claimed job without its retry/failure transition.
+ * - It redacts before the text becomes durable. The logger's redactor covers
+ *   process logs only — nothing scrubs this DB path, and a stack can carry a
+ *   credential from the frame that raised it.
+ * - It caps at exactly `JOB_ERROR_MAX_CHARS`, suffix included.
  */
+
+import { redactSensitiveText } from "@elizaos/core";
+
 const JOB_ERROR_MAX_CHARS = 4_000;
+const TRUNCATION_SUFFIX = "\n… truncated";
+/** Wrapped throws are common here; deeper chains are noise in a job row. */
+const MAX_CAUSE_DEPTH = 4;
+
+/** Stringify anything without ever throwing (null-prototype, hostile toString). */
+function safeString(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    // A thrown plain object (JSON-RPC error payloads are a live shape on this
+    // path) stringifies to "[object Object]" — as information-free as the rows
+    // this module exists to fix. Serialize it instead.
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !(value instanceof Error) &&
+      typeof (value as { toString?: unknown }).toString !== "function"
+    ) {
+      const json = JSON.stringify(value);
+      if (typeof json === "string") return json;
+    }
+    const coerced = String(value);
+    if (coerced === "[object Object]") {
+      const json = JSON.stringify(value);
+      if (typeof json === "string" && json !== "{}") return json;
+    }
+    return coerced;
+  } catch {
+    // error-policy:J3 untrusted throw value; an unstringifiable one yields an
+    // explicit marker rather than propagating over the original failure.
+    try {
+      return Object.prototype.toString.call(value);
+    } catch {
+      return "[unstringifiable]";
+    }
+  }
+}
+
+/** `error.stack` is an accessor and can throw or be a non-string. */
+function safeStack(error: Error): string {
+  try {
+    const stack = error.stack;
+    if (typeof stack === "string" && stack.trim().length > 0) {
+      return stack.trim();
+    }
+  } catch {
+    // error-policy:J3 hostile stack accessor; fall through to the message.
+  }
+  try {
+    return typeof error.message === "string" && error.message.length > 0
+      ? error.message
+      : safeString(error);
+  } catch {
+    return "[unreadable error]";
+  }
+}
+
+/**
+ * Native stacks do not serialize `cause`, so a wrapped throw loses exactly the
+ * lower-level detail this module exists to retain. Bounded by depth and
+ * cycle-safe: `cause` chains can loop.
+ */
+function describeErrorChain(error: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth += 1) {
+    // Only the cause traversal skips nullish; a job that threw `null`
+    // must still record "null" rather than an empty column.
+    if (depth > 0 && (current === undefined || current === null)) break;
+    if (typeof current === "object" && seen.has(current)) {
+      parts.push("caused by: [circular]");
+      break;
+    }
+    if (typeof current === "object") seen.add(current);
+
+    const text =
+      current instanceof Error ? safeStack(current) : safeString(current);
+    parts.push(depth === 0 ? text : `caused by: ${text}`);
+
+    if (!(current instanceof Error)) break;
+    let next: unknown;
+    try {
+      next = (current as { cause?: unknown }).cause;
+    } catch {
+      // error-policy:J3 hostile cause accessor ends the chain rather than
+      // replacing the failure being recorded.
+      break;
+    }
+    if (next === undefined) break;
+    if (depth === MAX_CAUSE_DEPTH) {
+      parts.push("caused by: [depth limit reached]");
+      break;
+    }
+    current = next;
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Redact and cap any job-error text. Exported so every branch that persists to
+ * `jobs.error` — including pre-formatted ones that bypass `jobErrorText` — ends
+ * at the same ceiling with the same scrubbing.
+ */
+export function finalizeJobErrorText(text: string): string {
+  let redacted: string;
+  try {
+    redacted = redactSensitiveText(text);
+  } catch {
+    // error-policy:J3 the module's contract is that it never throws — this is
+    // its one external call, and it runs before the failed job is written
+    // back. A redactor failure must not strand the job, and unredacted text
+    // must not become durable, so record the failure instead of the text.
+    redacted = "[error text withheld: redaction failed]";
+  }
+  if (redacted.length <= JOB_ERROR_MAX_CHARS) return redacted;
+  const room = JOB_ERROR_MAX_CHARS - TRUNCATION_SUFFIX.length;
+  return `${redacted.slice(0, room)}${TRUNCATION_SUFFIX}`;
+}
 
 export function jobErrorText(error: unknown): string {
-  const raw =
-    error instanceof Error ? (error.stack?.trim() || error.message) : String(error);
-  return raw.length <= JOB_ERROR_MAX_CHARS
-    ? raw
-    : `${raw.slice(0, JOB_ERROR_MAX_CHARS)}\n… truncated`;
+  return finalizeJobErrorText(describeErrorChain(error));
+}
+
+/**
+ * One-line summary of a throw, for embedding in another error's message.
+ * Never throws; carries no frames, so wrapping does not consume the budget
+ * the wrapped error's own `cause` will need.
+ */
+export function jobErrorSummary(error: unknown): string {
+  const text =
+    error instanceof Error
+      ? (() => {
+          try {
+            return typeof error.message === "string" && error.message.length > 0
+              ? error.message
+              : safeString(error);
+          } catch {
+            // error-policy:J3 hostile message accessor.
+            return "[unreadable error]";
+          }
+        })()
+      : safeString(error);
+  return (text.split("\n", 1)[0] ?? "").trim() || "[no error text]";
+}
+
+/**
+ * What the jobs API may return to a caller. The stored text is an operator
+ * diagnostic: even redacted it discloses absolute server paths and internal
+ * module layout, which a non-admin job owner has no business reading. Keep the
+ * first line — the failure summary — and drop the frames.
+ */
+export function publicJobErrorSummary(
+  storedError: string | null | undefined,
+): string | null {
+  if (typeof storedError !== "string") return null;
+  // Split on the frame marker rather than the first newline: an error message
+  // can itself be multi-line ("Provisioning failed:\nnode: …\nreason: …") and
+  // the owner needs that body — it is the frames that disclose server layout.
+  const summary = (storedError.split(/\n\s+at /, 1)[0] ?? "").trim();
+  return summary.length > 0 ? summary : null;
 }

--- a/packages/cloud/shared/src/lib/services/job-error-text.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.ts
@@ -31,6 +31,16 @@ const TRUNCATION_SUFFIX = "\n… truncated";
 /** Wrapped throws are common here; deeper chains are noise in a job row. */
 const MAX_CAUSE_DEPTH = 4;
 
+/** Classify an untrusted throw without allowing Proxy reflection to escape. */
+function safeError(value: unknown): Error | undefined {
+  try {
+    return value instanceof Error ? value : undefined;
+  } catch {
+    // error-policy:J3 a revoked or hostile Proxy can throw from getPrototypeOf.
+    return undefined;
+  }
+}
+
 /** Stringify anything without ever throwing (null-prototype, hostile toString). */
 function safeString(value: unknown): string {
   if (typeof value === "string") return value;
@@ -41,7 +51,7 @@ function safeString(value: unknown): string {
     if (
       value !== null &&
       typeof value === "object" &&
-      !(value instanceof Error) &&
+      !safeError(value) &&
       typeof (value as { toString?: unknown }).toString !== "function"
     ) {
       const json = JSON.stringify(value);
@@ -103,14 +113,14 @@ function describeErrorChain(error: unknown): string {
     }
     if (typeof current === "object") seen.add(current);
 
-    const text =
-      current instanceof Error ? safeStack(current) : safeString(current);
+    const currentError = safeError(current);
+    const text = currentError ? safeStack(currentError) : safeString(current);
     parts.push(depth === 0 ? text : `caused by: ${text}`);
 
-    if (!(current instanceof Error)) break;
+    if (!currentError) break;
     let next: unknown;
     try {
-      next = (current as { cause?: unknown }).cause;
+      next = (currentError as { cause?: unknown }).cause;
     } catch {
       // error-policy:J3 hostile cause accessor ends the chain rather than
       // replacing the failure being recorded.
@@ -158,19 +168,19 @@ export function jobErrorText(error: unknown): string {
  * the wrapped error's own `cause` will need.
  */
 export function jobErrorSummary(error: unknown): string {
-  const text =
-    error instanceof Error
-      ? (() => {
-          try {
-            return typeof error.message === "string" && error.message.length > 0
-              ? error.message
-              : safeString(error);
-          } catch {
-            // error-policy:J3 hostile message accessor.
-            return "[unreadable error]";
-          }
-        })()
-      : safeString(error);
+  const classifiedError = safeError(error);
+  const text = classifiedError
+    ? (() => {
+        try {
+          return typeof classifiedError.message === "string" && classifiedError.message.length > 0
+            ? classifiedError.message
+            : safeString(classifiedError);
+        } catch {
+          // error-policy:J3 hostile message accessor.
+          return "[unreadable error]";
+        }
+      })()
+    : safeString(error);
   return (text.split("\n", 1)[0] ?? "").trim() || "[no error text]";
 }
 
@@ -180,9 +190,7 @@ export function jobErrorSummary(error: unknown): string {
  * module layout, which a non-admin job owner has no business reading. Keep the
  * first line — the failure summary — and drop the frames.
  */
-export function publicJobErrorSummary(
-  storedError: string | null | undefined,
-): string | null {
+export function publicJobErrorSummary(storedError: string | null | undefined): string | null {
   if (typeof storedError !== "string") return null;
   // Split on the frame marker rather than the first newline: an error message
   // can itself be multi-line ("Provisioning failed:\nnode: …\nreason: …") and

--- a/packages/cloud/shared/src/lib/services/job-error-text.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.ts
@@ -1,0 +1,25 @@
+/**
+ * What a failed job records about why it failed.
+ *
+ * Job rows stored `error.message` alone, so `agent_delete` failures have sat at
+ * 35 bytes — "value.toISOString is not a function" — across 342 production
+ * occurrences with nothing to locate the call site from (#23117). One of them
+ * has been undeletable since 2026-07-07 for want of a stack.
+ *
+ * Bounded because the same column is already the wrong size in the other
+ * direction: 33 rows exceed 100 KB from payload dumps, and a grouping query
+ * over it failed outright with `invalid memory alloc request size 1130945444`.
+ * Cutting on characters rather than bytes keeps multi-byte sequences intact.
+ *
+ * Dependency-free on purpose so it stays testable without the job service's
+ * database import graph.
+ */
+const JOB_ERROR_MAX_CHARS = 4_000;
+
+export function jobErrorText(error: unknown): string {
+  const raw =
+    error instanceof Error ? (error.stack?.trim() || error.message) : String(error);
+  return raw.length <= JOB_ERROR_MAX_CHARS
+    ? raw
+    : `${raw.slice(0, JOB_ERROR_MAX_CHARS)}\n… truncated`;
+}

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-error-text.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-error-text.test.ts
@@ -1,0 +1,67 @@
+/**
+ * What a failed job records about why.
+ *
+ * `jobs.error` used to hold `error.message` alone. That is how 342 production
+ * `agent_delete` failures came to share one 35-byte string — "value.toISOString
+ * is not a function" — with nothing to locate the call site from, one of them
+ * stuck since 2026-07-07 (#23117). These tests pin the stack being kept, and
+ * kept bounded: the same column already has 33 rows over 100 KB from payload
+ * dumps, and a grouping query over it failed with
+ * `invalid memory alloc request size 1130945444`.
+ */
+import { describe, expect, test } from "bun:test";
+import { jobErrorText } from "./job-error-text";
+
+describe("jobErrorText", () => {
+  test("keeps the stack, which is the part that locates the bug", () => {
+    function throwingFrame(): never {
+      throw new TypeError("value.toISOString is not a function");
+    }
+
+    let captured: unknown;
+    try {
+      throwingFrame();
+    } catch (error) {
+      captured = error;
+    }
+
+    const text = jobErrorText(captured);
+
+    expect(text).toContain("value.toISOString is not a function");
+    // The message alone was never the problem — this is the half that was missing.
+    expect(text).toContain("throwingFrame");
+    expect(text.split("\n").length).toBeGreaterThan(1);
+  });
+
+  test("falls back to the message when an Error carries no stack", () => {
+    const bald = new Error("no stack here");
+    bald.stack = undefined;
+
+    expect(jobErrorText(bald)).toBe("no stack here");
+  });
+
+  test("accepts a thrown non-Error without losing it", () => {
+    expect(jobErrorText("plain string")).toBe("plain string");
+    expect(jobErrorText(42)).toBe("42");
+    expect(jobErrorText(null)).toBe("null");
+  });
+
+  test("bounds the text so a stack cannot become another oversized row", () => {
+    const huge = new Error("boom");
+    huge.stack = `Error: boom\n${"    at frame\n".repeat(5_000)}`;
+
+    const text = jobErrorText(huge);
+
+    expect(text.length).toBeLessThan(4_200);
+    expect(text).toContain("truncated");
+    // The head survives: truncation must not cost the message itself.
+    expect(text.startsWith("Error: boom")).toBe(true);
+  });
+
+  test("does not annotate text that already fits", () => {
+    const small = new Error("short");
+    small.stack = "Error: short\n    at one frame";
+
+    expect(jobErrorText(small)).not.toContain("truncated");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -490,6 +490,42 @@ describe("executeJob dispatch — success path per job type marks the job comple
       throw new Error("pending cutover audit has no cutover timestamp");
     }
     const retryStartedAt = new Date(Date.parse(pendingAudit.cutoverAt) + 1_000);
+    const hostileRetry = harness(
+      makeJob(arm.type, arm.data, {
+        result: pendingAudit,
+        status: "in_progress",
+        started_at: retryStartedAt,
+        updated_at: retryStartedAt,
+      }),
+    );
+    const { proxy: revokedFailure, revoke } = Proxy.revocable(
+      new Error("cleanup transport failed"),
+      {},
+    );
+    revoke();
+    const hostileConvergeSpy = spyOn(
+      elizaSandboxService,
+      "convergeReplacementCleanupFence",
+    ).mockImplementation(async () => {
+      throw revokedFailure;
+    });
+    try {
+      const deferred = await run(arm.type);
+      expect(deferred).toMatchObject({ succeeded: 0, retried: 1, failed: 0 });
+      expect(hostileRetry.retryLaterSpy).toHaveBeenCalledTimes(1);
+      expect(hostileRetry.retryLaterSpy.mock.calls[0]?.[1]).toContain(
+        "Admin canary cleanup remains pending: [unstringifiable]",
+      );
+    } finally {
+      hostileConvergeSpy.mockRestore();
+      hostileRetry.claimSpy.mockRestore();
+      hostileRetry.recoverSpy.mockRestore();
+      hostileRetry.updateStatusSpy.mockRestore();
+      hostileRetry.updateSpy.mockRestore();
+      hostileRetry.incrementSpy.mockRestore();
+      hostileRetry.retryLaterSpy.mockRestore();
+    }
+
     const retry = harness(
       makeJob(arm.type, arm.data, {
         result: pendingAudit,
@@ -596,6 +632,37 @@ describe("executeJob dispatch — failure path per job type retries (increments 
       }
     });
   }
+
+  test("a hostile thrown Proxy still persists the failed-job transition", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE));
+    const hostile = new Proxy(Object.create(null), {
+      getPrototypeOf() {
+        throw new Error("hostile prototype");
+      },
+      get() {
+        throw new Error("hostile property read");
+      },
+    });
+    const executeDeletionSpy = spyOn(elizaSandboxService, "executeDeletion").mockImplementation(
+      async () => {
+        throw hostile;
+      },
+    );
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ claimed: 1, succeeded: 0, failed: 1 });
+      expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.incrementSpy.mock.calls[0]?.[1]).toBe("[unstringifiable]");
+    } finally {
+      executeDeletionSpy.mockRestore();
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
 
   test("message: bridge error is stored on the job result and the job fails", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }));
@@ -858,7 +925,9 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       expect(res.retried).toBe(1);
       expect(res.failed).toBe(0);
       expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
-      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toBe("readiness probe transport_unresolved");
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toContain(
+        "readiness probe transport_unresolved",
+      );
       expect(ctx.incrementSpy).not.toHaveBeenCalled();
     } finally {
       ctx.claimSpy.mockRestore();
@@ -944,7 +1013,7 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
           id: ctx.job.id,
           result: expect.objectContaining({ error: "readiness probe transport_unresolved" }),
         }),
-        "readiness probe transport_unresolved",
+        expect.stringContaining("readiness probe transport_unresolved"),
         expect.any(Number),
         expect.any(String),
         expect.objectContaining({ maxRequeues: 5 }),

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -107,7 +107,11 @@ import {
   JOB_TYPES,
   type ProvisioningJobType,
 } from "./provisioning-job-types";
-import { jobErrorText } from "./job-error-text";
+import {
+  finalizeJobErrorText,
+  jobErrorSummary,
+  jobErrorText,
+} from "./job-error-text";
 import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
 import {
   isWaifuWebhookTargetUrl,
@@ -3506,7 +3510,7 @@ export class ProvisioningJobService {
     // that has to carry a stack — the 16 conversions below it are log lines.
     const errorMsg =
       err instanceof AppCacheInvalidationRetryError
-        ? formatAppCacheInvalidationError(err)
+        ? finalizeJobErrorText(formatAppCacheInvalidationError(err))
         : jobErrorText(err);
     result?.errors.push({ jobId: job.id, error: errorMsg });
 
@@ -4746,9 +4750,11 @@ export class ProvisioningJobService {
         // error-policy:J2 context-adding rethrow — the queue needs a typed
         // retryable failure while preserving the cleanup cause.
         throw new RetryableReplacementCleanupError(
-          `Admin canary cleanup remains pending: ${
-            jobErrorText(error)
-          }`,
+          // Summary only: the full error travels as `cause` below, and
+          // interpolating its stack here would fill the 4,000-char job budget
+          // with the inner frames, truncating away both the outer frames and
+          // the cause chain at exactly the site #23117 needs them.
+          `Admin canary cleanup remains pending: ${jobErrorSummary(error)}`,
           job,
           { cause: error },
         );

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -99,6 +99,7 @@ import {
   elizaSandboxService,
   SNAPSHOT_ENDPOINT_UNSUPPORTED,
 } from "./eliza-sandbox";
+import { finalizeJobErrorText, jobErrorSummary, jobErrorText } from "./job-error-text";
 import {
   COLD_BOOT_JOB_TYPES,
   COLD_BOOT_STALE_JOB_THRESHOLD_MS,
@@ -107,11 +108,6 @@ import {
   JOB_TYPES,
   type ProvisioningJobType,
 } from "./provisioning-job-types";
-import {
-  finalizeJobErrorText,
-  jobErrorSummary,
-  jobErrorText,
-} from "./job-error-text";
 import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
 import {
   isWaifuWebhookTargetUrl,
@@ -123,6 +119,20 @@ import {
   type WakeRestoreIntegrityFailure,
 } from "./wake-restore-integrity";
 import { hasReadyWarmClaimCredential } from "./warm-claim-key-push";
+
+/** Match a known failure type without trusting a thrown Proxy's prototype trap. */
+function safeErrorKind<T extends Error>(
+  value: unknown,
+  errorClass: abstract new (...args: never[]) => T,
+): value is T {
+  try {
+    return value instanceof errorClass;
+  } catch {
+    // error-policy:J3 hostile thrown value; treat it as an ordinary failure so
+    // the job still reaches its durable retry/failure transition.
+    return false;
+  }
+}
 
 /**
  * Phase 0 fleet measurement emitted by every scheduled-backup sweep (#15783):
@@ -3458,7 +3468,7 @@ export class ProvisioningJobService {
         result.succeeded++;
         stopLeaseHeartbeat();
       } catch (err) {
-        if (err instanceof OperationTimeoutError) {
+        if (safeErrorKind(err, OperationTimeoutError)) {
           const errorMsg = err.message;
           result.failed++;
           result.errors.push({ jobId: job.id, error: errorMsg });
@@ -3506,19 +3516,21 @@ export class ProvisioningJobService {
     err: unknown,
     result?: ProcessingResult,
   ): Promise<void> {
+    const appCacheError = safeErrorKind(err, AppCacheInvalidationRetryError) ? err : undefined;
+    const retryableTransportError = safeErrorKind(err, RetryableProvisionTransportError)
+      ? err
+      : safeErrorKind(err, RetryableReplacementCleanupError)
+        ? err
+        : undefined;
     // This is the value that reaches the `jobs.error` column, so it is the one
     // that has to carry a stack — the 16 conversions below it are log lines.
-    const errorMsg =
-      err instanceof AppCacheInvalidationRetryError
-        ? finalizeJobErrorText(formatAppCacheInvalidationError(err))
-        : jobErrorText(err);
+    const errorMsg = appCacheError
+      ? finalizeJobErrorText(formatAppCacheInvalidationError(appCacheError))
+      : jobErrorText(err);
     result?.errors.push({ jobId: job.id, error: errorMsg });
 
-    if (
-      err instanceof RetryableProvisionTransportError ||
-      err instanceof RetryableReplacementCleanupError
-    ) {
-      const retrySnapshot = err.retrySnapshot;
+    if (retryableTransportError) {
+      const retrySnapshot = retryableTransportError.retrySnapshot;
       const onExhaustedInTx = this.buildPermanentFailureWriteback(retrySnapshot, errorMsg);
       const transition = await this.retryOwnedWrite(job, "retry-later", () =>
         jobsRepository.retryLaterWithoutIncrementingAttempts(
@@ -3526,7 +3538,7 @@ export class ProvisioningJobService {
           errorMsg,
           PROVISION_TRANSPORT_RETRY_DELAY_MS,
           this.executionOwnerId,
-          { maxRequeues: err.maxRequeues, onExhaustedInTx },
+          { maxRequeues: retryableTransportError.maxRequeues, onExhaustedInTx },
         ),
       );
       if (transition?.status === "pending") {
@@ -3535,7 +3547,7 @@ export class ProvisioningJobService {
           jobId: job.id,
           delayMs: PROVISION_TRANSPORT_RETRY_DELAY_MS,
           requeues: transition.retryable_requeues,
-          maxRequeues: err.maxRequeues,
+          maxRequeues: retryableTransportError.maxRequeues,
           error: errorMsg,
         });
       } else if (transition?.status === "failed") {
@@ -3543,7 +3555,7 @@ export class ProvisioningJobService {
         logger.error("[provisioning-jobs] Retryable failure exhausted its requeue budget", {
           jobId: job.id,
           requeues: transition.retryable_requeues,
-          maxRequeues: err.maxRequeues,
+          maxRequeues: retryableTransportError.maxRequeues,
           error: errorMsg,
         });
       } else {
@@ -3570,7 +3582,7 @@ export class ProvisioningJobService {
     // Rollback-safe classification only exists for AGENT_UPGRADE failures
     // (thrown as UpgradeFailedError). For every other job type this is
     // undefined and the writeback ignores it.
-    const upgradeFailure = err instanceof UpgradeFailedError ? err : undefined;
+    const upgradeFailure = safeErrorKind(err, UpgradeFailedError) ? err : undefined;
     const onFailedInTx = this.buildPermanentFailureWriteback(job, errorMsg, upgradeFailure);
     const updated = await this.retryOwnedWrite(job, "increment-attempt", () =>
       jobsRepository.incrementAttempt(
@@ -3582,7 +3594,7 @@ export class ProvisioningJobService {
         this.executionOwnerId,
       ),
     );
-    if (err instanceof AppCacheInvalidationRetryError) {
+    if (appCacheError) {
       const context = {
         jobId: job.id,
         attempts: updated?.attempts ?? job.attempts,
@@ -4742,8 +4754,8 @@ export class ProvisioningJobService {
         );
       } catch (error) {
         if (
-          error instanceof AdminCanaryCleanupExpectationError ||
-          error instanceof AdminCanaryCleanupCommitError
+          safeErrorKind(error, AdminCanaryCleanupExpectationError) ||
+          safeErrorKind(error, AdminCanaryCleanupCommitError)
         ) {
           throw error;
         }
@@ -4926,9 +4938,7 @@ export class ProvisioningJobService {
       const retrySnapshot = await readDurablePendingCutover();
       if (retrySnapshot) {
         throw new RetryableReplacementCleanupError(
-          `Admin canary post-cutover convergence interrupted: ${
-            jobErrorText(error)
-          }`,
+          `Admin canary post-cutover convergence interrupted: ${jobErrorText(error)}`,
           retrySnapshot,
           { cause: error },
         );

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -107,6 +107,7 @@ import {
   JOB_TYPES,
   type ProvisioningJobType,
 } from "./provisioning-job-types";
+import { jobErrorText } from "./job-error-text";
 import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
 import {
   isWaifuWebhookTargetUrl,
@@ -470,6 +471,7 @@ function adminCanaryImageJobResultToRecord(
 function jobAuditTimestamp(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
+
 
 function agentDowngradeJobDataToRecord(data: AgentDowngradeJobData): Record<string, unknown> {
   return { ...data };
@@ -1254,7 +1256,7 @@ export class ProvisioningRecoveryDegradedError extends ElizaError {
         failures: summary.failures.map(({ jobId, jobType, cause }) => ({
           jobId,
           jobType,
-          error: cause instanceof Error ? cause.message : String(cause),
+          error: jobErrorText(cause),
         })),
       },
       severity: "ephemeral",
@@ -1291,7 +1293,7 @@ function assertRecoveryHealthy(
     failures: summary.failures.map(({ jobId, jobType, cause }) => ({
       jobId,
       jobType,
-      error: cause instanceof Error ? cause.message : String(cause),
+      error: jobErrorText(cause),
     })),
   });
   throw new ProvisioningRecoveryDegradedError(phase, summary);
@@ -2247,7 +2249,7 @@ export class ProvisioningJobService {
         logger.error("[provisioning-jobs] Warm-claim credential cleanup failed", {
           agentId: candidate.id,
           orgId: candidate.organization_id,
-          error: error instanceof Error ? error.message : String(error),
+          error: jobErrorText(error),
         });
       }
     }
@@ -2919,7 +2921,7 @@ export class ProvisioningJobService {
       // job; the condition it records is re-observed on the next attempt.
       logger.warn("[provisioning-jobs] failed to record snapshot attempt markers", {
         agentId,
-        error: error instanceof Error ? error.message : String(error),
+        error: jobErrorText(error),
       });
     }
   }
@@ -3050,7 +3052,7 @@ export class ProvisioningJobService {
       } catch (error) {
         logger.warn("[provisioning-jobs] Scheduled backup enqueue failed", {
           agentId: agent.id,
-          error: error instanceof Error ? error.message : String(error),
+          error: jobErrorText(error),
         });
       }
     }
@@ -3108,7 +3110,7 @@ export class ProvisioningJobService {
         return;
       } catch (err) {
         logger.debug("[provisioning-jobs] direct triggerImmediate failed", {
-          error: err instanceof Error ? err.message : String(err),
+          error: jobErrorText(err),
         });
       }
     }
@@ -3131,7 +3133,7 @@ export class ProvisioningJobService {
       });
     } catch (err) {
       logger.debug("[provisioning-jobs] triggerImmediate fire-and-forget failed", {
-        error: err instanceof Error ? err.message : String(err),
+        error: jobErrorText(err),
       });
     }
   }
@@ -3200,7 +3202,7 @@ export class ProvisioningJobService {
             jobId: job.id,
             executionGeneration: job.execution_generation,
             executionOwnerId: this.executionOwnerId,
-            error: error instanceof Error ? error.message : String(error),
+            error: jobErrorText(error),
           });
         })
         .finally(() => {
@@ -3248,7 +3250,7 @@ export class ProvisioningJobService {
           executionOwnerId: this.executionOwnerId,
           operation,
           attempt,
-          error: error instanceof Error ? error.message : String(error),
+          error: jobErrorText(error),
         });
         await this.waitForSettlementRetry(attempt);
       }
@@ -4749,7 +4751,7 @@ export class ProvisioningJobService {
         // retryable failure while preserving the cleanup cause.
         throw new RetryableReplacementCleanupError(
           `Admin canary cleanup remains pending: ${
-            error instanceof Error ? error.message : String(error)
+            jobErrorText(error)
           }`,
           job,
           { cause: error },
@@ -4923,7 +4925,7 @@ export class ProvisioningJobService {
       if (retrySnapshot) {
         throw new RetryableReplacementCleanupError(
           `Admin canary post-cutover convergence interrupted: ${
-            error instanceof Error ? error.message : String(error)
+            jobErrorText(error)
           }`,
           retrySnapshot,
           { cause: error },
@@ -5500,7 +5502,7 @@ export class ProvisioningJobService {
           .catch((error: unknown) => {
             logger.warn("[provisioning-jobs] heartbeat threw", {
               agentId: r.id,
-              error: error instanceof Error ? error.message : String(error),
+              error: jobErrorText(error),
             });
             return false;
           });
@@ -5561,7 +5563,7 @@ export class ProvisioningJobService {
           failed += 1;
           logger.warn("[provisioning-jobs] disconnected recovery failed", {
             agentId: r.id,
-            error: error instanceof Error ? error.message : String(error),
+            error: jobErrorText(error),
           });
         }
       }
@@ -5624,7 +5626,7 @@ export class ProvisioningJobService {
           failed += 1;
           logger.warn("[provisioning-jobs] stuck-provisioning reconcile failed", {
             agentId: r.id,
-            error: error instanceof Error ? error.message : String(error),
+            error: jobErrorText(error),
           });
         }
       }
@@ -5749,7 +5751,7 @@ export class ProvisioningJobService {
         failed += 1;
         logger.warn("[provisioning-jobs] re-enqueue of failed deletion failed", {
           agentId: agent.id,
-          error: error instanceof Error ? error.message : String(error),
+          error: jobErrorText(error),
         });
       }
     }
@@ -5880,7 +5882,7 @@ export class ProvisioningJobService {
     } catch (err) {
       logger.error("[provisioning-jobs] Webhook delivery error", {
         jobId: job.id,
-        error: err instanceof Error ? err.message : String(err),
+        error: jobErrorText(err),
       });
 
       await jobsRepository.update(job.id, {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -472,7 +472,6 @@ function jobAuditTimestamp(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-
 function agentDowngradeJobDataToRecord(data: AgentDowngradeJobData): Record<string, unknown> {
   return { ...data };
 }
@@ -3484,10 +3483,7 @@ export class ProvisioningJobService {
               logger.warn("[provisioning-jobs] Detached settlement supervisor stopped", {
                 jobId: job.id,
                 executionGeneration: job.execution_generation,
-                error:
-                  settlementError instanceof Error
-                    ? settlementError.message
-                    : String(settlementError),
+                error: jobErrorText(settlementError),
               });
             });
           continue;
@@ -3506,12 +3502,12 @@ export class ProvisioningJobService {
     err: unknown,
     result?: ProcessingResult,
   ): Promise<void> {
+    // This is the value that reaches the `jobs.error` column, so it is the one
+    // that has to carry a stack — the 16 conversions below it are log lines.
     const errorMsg =
       err instanceof AppCacheInvalidationRetryError
         ? formatAppCacheInvalidationError(err)
-        : err instanceof Error
-          ? err.message
-          : String(err);
+        : jobErrorText(err);
     result?.errors.push({ jobId: job.id, error: errorMsg });
 
     if (


### PR DESCRIPTION
<!-- evidence-head:f005012764d01350c7bfeca4debf7409d6dc2094 -->

Part of #23117. **This does not fix the `toISOString` bug — it makes the next occurrence diagnosable**, which is the actual blocker.

## Why the bug survived 44 days

I went looking for the offending `.toISOString()` call and could not find it by reading. Then I looked at what the failure record actually contains:

```
jobs.error, agent_delete, 2026-07-26 → 35 bytes
"value.toISOString is not a function"
```

Thirty-five bytes. No frame, no file, no stack. `grep -n "\.stack" provisioning-jobs.ts` returns **nothing** — the service stores `error.message` and discards everything else, at 16 call sites that each open-code `error instanceof Error ? error.message : String(error)`.

So a defect with **342 production occurrences** produces a record that cannot be acted on, and the one row stuck since 2026-07-07 has been unfixable for want of a stack rather than for want of attention.

## The change

Keep the stack; bound it.

The bound is not decoration. The same column is already the wrong size in the *other* direction: 33 rows exceed 100 KB from payload dumps, and a grouping query over it failed outright with `invalid memory alloc request size 1130945444` — I hit that while measuring for the issue. Adding stacks without a ceiling would feed the same problem. The cut is on characters rather than bytes so a multi-byte sequence is never split, and the head survives so the message itself is never the part that gets truncated.

The helper is its own dependency-free module for the same reason `reserved-env-keys.ts` is: importing `provisioning-jobs` to test a pure function drags in the database import graph, and the first version of this test failed with `ENOENT reading .../drizzle-orm`.

## Tests

5 tests. Two mutations, each turning the right test red:

- reverting to `error.message` alone → the stack test **and** the bound test fail
- removing the bound → only the bound test fails

The stack test asserts a named frame (`throwingFrame`) appears, so it fails on any implementation that keeps only the message. The non-`Error` cases (`string`, `number`, `null`) are covered because thrown non-Errors reach the same path.

## What it does not close

The `toISOString` defect itself. The next `agent_delete` failure will carry a stack, and that should be enough to find and fix it in one pass. The rows already stranded still need a repair path — they can be neither deleted, cancelled (`eliza-sandbox.ts:2762` requires exactly `deletion_pending`), nor suspended.

Separately worth its own look: the 33 oversized `jobs.error` rows are payload dumps in a reason column, which is what made the diagnostic query fail in the first place.


## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI path changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - exact focused backend validation results are documented above; no protected backend was mutated.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend surface changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic lifecycle and diagnostic behavior does not involve a model.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact test assertions and the persisted row/state contracts documented above are the domain evidence.


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:ai-provider -->
- AI provider: OpenAI
<!-- attribution-row:ai-model -->
- AI model: gpt-5.6-sol
<!-- attribution-row:agent-tooling -->
- Agent tooling: Codex Desktop
<!-- attribution-row:contribution-skill -->
- Contribution skill: packages/skills/skills/contribute-to-eliza
<!-- attribution-row:attribution-status -->
- Attribution status: self-reported
