### PR TITLE
fix(agent): fail closed on cyclic character-history walks

### DIFF
--- a/packages/agent/src/api/character-routes.test.ts
+++ b/packages/agent/src/api/character-routes.test.ts
@@ -2,12 +2,36 @@
  * Exercises the character-history pagination boundary with a pure parser and
  * a mocked route context; no HTTP server, database, or live model is used.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MAX_CHARACTER_HISTORY_WALK_DEPTH } from "../services/character-history.ts";
 import {
   handleCharacterRoutes,
   parseCharacterHistoryLimit,
 } from "./character-routes.ts";
+import { invalidateConversationConnectionTopology } from "./conversation-connection-readiness.ts";
+
+// Instrument the real invalidation collaborator: the spy still delegates to the
+// live implementation, so call counts are observed on the actual code path.
+vi.mock("./conversation-connection-readiness.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("./conversation-connection-readiness.ts")
+    >();
+  return {
+    ...actual,
+    invalidateConversationConnectionTopology: vi.fn(
+      actual.invalidateConversationConnectionTopology,
+    ),
+  };
+});
+
+const invalidateTopologySpy = vi.mocked(
+  invalidateConversationConnectionTopology,
+);
+
+beforeEach(() => {
+  invalidateTopologySpy.mockClear();
+});
 
 describe("parseCharacterHistoryLimit", () => {
   it("keeps the default and accepts complete safe decimals", () => {
@@ -134,7 +158,6 @@ function makePutRuntime(character: Record<string, unknown>) {
 }
 
 describe("PUT /api/character stage-then-commit", () => {
-
   it("keeps runtime/update/history/topology untouched when the second bound fails", async () => {
     const character = {
       name: "Ada",
@@ -182,6 +205,7 @@ describe("PUT /api/character stage-then-commit", () => {
     expect(updateAgent).not.toHaveBeenCalled();
     expect(createMemory).not.toHaveBeenCalled();
     expect(json).not.toHaveBeenCalled();
+    expect(invalidateTopologySpy).not.toHaveBeenCalled();
   });
 
   it("does not mutate runtime when a revoked Array Proxy is submitted", async () => {
@@ -222,6 +246,7 @@ describe("PUT /api/character stage-then-commit", () => {
     expect(character).toEqual(original);
     expect(updateAgent).not.toHaveBeenCalled();
     expect(createMemory).not.toHaveBeenCalled();
+    expect(invalidateTopologySpy).not.toHaveBeenCalled();
   });
 
   it("commits runtime mutation only after both history bounds succeed", async () => {
@@ -259,5 +284,171 @@ describe("PUT /api/character stage-then-commit", () => {
       {},
       expect.objectContaining({ ok: true, agentName: "Eve" }),
     );
+    expect(invalidateTopologySpy).toHaveBeenCalledTimes(1);
+    expect(invalidateTopologySpy).toHaveBeenCalledWith(runtime);
+  });
+});
+
+describe("PUT /api/character descriptor-only staging", () => {
+  it("never runs submitted Proxy get/has traps while renaming examples", async () => {
+    let trapCalls = 0;
+    const trapHandler = {
+      get(target: object, key: PropertyKey, receiver: unknown) {
+        trapCalls += 1;
+        return Reflect.get(target, key, receiver);
+      },
+      has(target: object, key: PropertyKey) {
+        trapCalls += 1;
+        return Reflect.has(target, key);
+      },
+    };
+    const submittedExamples = new Proxy(
+      [
+        {
+          examples: [
+            { name: "{{agentName}}", content: { text: "hi from {{name}}" } },
+          ],
+        },
+      ],
+      trapHandler,
+    );
+    const submittedBio = new Proxy(["staged bio"], trapHandler);
+
+    const character = {
+      name: "Ada",
+      bio: ["old"],
+      messageExamples: [
+        { examples: [{ name: "Ada", content: { text: "hi" } }] },
+      ],
+    };
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const json = vi.fn();
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: { agentName: "Ada", runtime },
+      json,
+      error,
+      readJsonBody: vi.fn(async () => ({
+        name: "Eve",
+        bio: submittedBio,
+        messageExamples: submittedExamples,
+      })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(trapCalls).toBe(0);
+    expect(character.name).toBe("Eve");
+    expect(character.bio).toEqual(["staged bio"]);
+    expect(character.messageExamples).toEqual([
+      { examples: [{ name: "Eve", content: { text: "hi from Eve" } }] },
+    ]);
+    expect(updateAgent).toHaveBeenCalledTimes(1);
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(invalidateTopologySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a submitted accessor without invoking it or mutating anything", async () => {
+    const hostileContent: Record<string, unknown> = { text: "hi" };
+    let accessorCalls = 0;
+    Object.defineProperty(hostileContent, "leak", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        accessorCalls += 1;
+        throw new Error("ACCESSOR_INVOKED");
+      },
+    });
+    const hostileBio: string[] = ["kept"];
+    Object.defineProperty(hostileBio, "0", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        accessorCalls += 1;
+        throw new Error("BIO_ACCESSOR_INVOKED");
+      },
+    });
+
+    const character = {
+      name: "Ada",
+      bio: ["old"],
+      messageExamples: [
+        { examples: [{ name: "Ada", content: { text: "hi" } }] },
+      ],
+    };
+    const original = structuredClone(character);
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const json = vi.fn();
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: { agentName: "Ada", runtime },
+      json,
+      error,
+      readJsonBody: vi.fn(async () => ({
+        name: "Eve",
+        bio: hostileBio,
+        messageExamples: [
+          { examples: [{ name: "Eve", content: hostileContent }] },
+        ],
+      })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(accessorCalls).toBe(0);
+    expect(error).toHaveBeenCalledWith(
+      {},
+      "Character payload exceeds the history walk budget",
+      400,
+    );
+    expect(character).toEqual(original);
+    expect(updateAgent).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+    expect(invalidateTopologySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unbounded submitted bio before any runtime mutation", async () => {
+    const character = { name: "Ada", bio: ["old"] };
+    const original = structuredClone(character);
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: { agentName: "Ada", runtime },
+      json: vi.fn(),
+      error,
+      readJsonBody: vi.fn(async () => ({
+        name: "Eve",
+        bio: [nestArr(MAX_CHARACTER_HISTORY_WALK_DEPTH + 4)],
+      })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      {},
+      "Character payload exceeds the history walk budget",
+      400,
+    );
+    expect(character).toEqual(original);
+    expect(updateAgent).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(invalidateTopologySpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/character-routes.test.ts
+++ b/packages/agent/src/api/character-routes.test.ts
@@ -66,3 +66,46 @@ describe("GET /api/character/history", () => {
     expect(json).not.toHaveBeenCalled();
   });
 });
+
+describe("PUT /api/character history walk", () => {
+  it("returns 400 instead of RangeError on cyclic messageExamples", async () => {
+    const cyclic: Record<string, unknown> = { text: "hi" };
+    cyclic.self = cyclic;
+    const updateAgent = vi.fn();
+    const createMemory = vi.fn();
+    const json = vi.fn();
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: {
+        agentName: "Ada",
+        runtime: {
+          agentId: "agent",
+          character: {
+            name: "Ada",
+            messageExamples: [[{ name: "Ada", content: cyclic }]],
+          },
+          updateAgent,
+          createMemory,
+        } as never,
+      },
+      json,
+      error,
+      readJsonBody: vi.fn(async () => ({ name: "Ada" })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      {},
+      "Character payload exceeds the history walk budget",
+      400,
+    );
+    expect(updateAgent).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/character-routes.test.ts
+++ b/packages/agent/src/api/character-routes.test.ts
@@ -452,3 +452,187 @@ describe("PUT /api/character descriptor-only staging", () => {
     expect(invalidateTopologySpy).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * `CharacterSchema` accepts `{"username":""}`, `{"bio":""}`, `{"style":{}}`,
+ * and the empty-array forms: that is how a caller CLEARS a character field.
+ * Field PRESENCE must therefore survive staging independently of the
+ * history-display normalization, which deliberately omits empty values.
+ */
+/** Read one argument off a `vi.fn()` call without fighting its empty tuple type. */
+function mockCallArg(
+  fn: ReturnType<typeof vi.fn>,
+  call: number,
+  index: number,
+): unknown {
+  return (fn.mock.calls as unknown as unknown[][])[call]?.[index];
+}
+
+function makeClearRuntime() {
+  const character: Record<string, unknown> = {
+    name: "Ada",
+    username: "ada_live",
+    bio: ["a long standing bio"],
+    system: "live system",
+    adjectives: ["curious"],
+    topics: ["math"],
+    style: { all: ["terse"], chat: ["warm"] },
+    postExamples: ["a post"],
+    messageExamples: [{ examples: [{ name: "Ada", content: { text: "hi" } }] }],
+  };
+  const updateAgent = vi.fn(async () => undefined);
+  const createMemory = vi.fn(async () => undefined);
+  const config = { agents: { list: [{ id: "main", default: true }] } };
+  const saveConfig = vi.fn();
+  return {
+    character,
+    updateAgent,
+    createMemory,
+    config,
+    saveConfig,
+    runtime: {
+      agentId: "agent",
+      character,
+      updateAgent,
+      createMemory,
+    } as never,
+  };
+}
+
+async function putClear(
+  fixture: ReturnType<typeof makeClearRuntime>,
+  body: Record<string, unknown>,
+) {
+  const json = vi.fn();
+  const error = vi.fn();
+  const handled = await handleCharacterRoutes({
+    req: {} as never,
+    res: {} as never,
+    method: "PUT",
+    pathname: "/api/character",
+    state: {
+      agentName: "Ada",
+      runtime: fixture.runtime,
+      config: fixture.config,
+    },
+    json,
+    error,
+    saveConfig: fixture.saveConfig,
+    readJsonBody: vi.fn(async () => body),
+    pickRandomNames: vi.fn(),
+    validateCharacter: vi.fn(() => ({ success: true })),
+  } as never);
+  expect(handled).toBe(true);
+  expect(error).not.toHaveBeenCalled();
+  return { json, error };
+}
+
+describe("PUT /api/character clears schema-valid empty values", () => {
+  it("clears username with an empty string", async () => {
+    const fixture = makeClearRuntime();
+    const { json } = await putClear(fixture, { username: "" });
+
+    expect(fixture.character.username).toBe("");
+    expect(json).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        ok: true,
+        character: expect.objectContaining({ username: "" }),
+      }),
+    );
+    expect(fixture.updateAgent).toHaveBeenCalledTimes(1);
+    // History display deliberately omits an empty username (unchanged from the
+    // base route), but the live character and the response are cleared.
+    const metadata = mockCallArg(fixture.updateAgent, 0, 1) as {
+      metadata: { character: Record<string, unknown> };
+    };
+    expect(Object.hasOwn(metadata.metadata.character, "username")).toBe(false);
+    // The clear is a real history change: username present before, absent after.
+    expect(fixture.createMemory).toHaveBeenCalledTimes(1);
+    const memory = mockCallArg(fixture.createMemory, 0, 0) as {
+      metadata: {
+        fieldsChanged: string[];
+        changes: Array<Record<string, unknown>>;
+      };
+    };
+    expect(memory.metadata.fieldsChanged).toContain("username");
+    expect(memory.metadata.changes[0]).toEqual({
+      field: "username",
+      before: "ada_live",
+    });
+  });
+
+  it("clears bio with an empty string", async () => {
+    const fixture = makeClearRuntime();
+    await putClear(fixture, { bio: "" });
+
+    expect(fixture.character.bio).toEqual([""]);
+    const metadata = mockCallArg(fixture.updateAgent, 0, 1) as {
+      metadata: { character: { bio?: string[] } };
+    };
+    expect(metadata.metadata.character.bio).toEqual([""]);
+    expect(fixture.saveConfig).toHaveBeenCalledTimes(1);
+    expect(fixture.config.agents.list[0]).toEqual(
+      expect.objectContaining({ bio: [""] }),
+    );
+  });
+
+  it("clears style with an empty object", async () => {
+    const fixture = makeClearRuntime();
+    await putClear(fixture, { style: {} });
+
+    expect(fixture.character.style).toEqual({});
+    expect(fixture.saveConfig).toHaveBeenCalledTimes(1);
+    expect(fixture.config.agents.list[0]).toEqual(
+      expect.objectContaining({ style: {} }),
+    );
+    // Style is absent from the history snapshot once it holds no known arrays.
+    const metadata = mockCallArg(fixture.updateAgent, 0, 1) as {
+      metadata: { character: Record<string, unknown> };
+    };
+    expect(Object.hasOwn(metadata.metadata.character, "style")).toBe(false);
+    expect(fixture.createMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the empty-collection forms", async () => {
+    const fixture = makeClearRuntime();
+    await putClear(fixture, {
+      system: "",
+      adjectives: [],
+      topics: [],
+      postExamples: [],
+      messageExamples: [],
+    });
+
+    expect(fixture.character.system).toBe("");
+    expect(fixture.character.adjectives).toEqual([]);
+    expect(fixture.character.topics).toEqual([]);
+    expect(fixture.character.postExamples).toEqual([]);
+    expect(fixture.character.messageExamples).toEqual([]);
+    expect(fixture.config.agents.list[0]).toEqual(
+      expect.objectContaining({
+        system: "",
+        adjectives: [],
+        topics: [],
+        postExamples: [],
+        messageExamples: [],
+      }),
+    );
+  });
+
+  it("keeps untouched fields when one field is cleared", async () => {
+    const fixture = makeClearRuntime();
+    await putClear(fixture, { username: "" });
+
+    expect(fixture.character.name).toBe("Ada");
+    expect(fixture.character.bio).toEqual(["a long standing bio"]);
+    expect(fixture.character.style).toEqual({
+      all: ["terse"],
+      chat: ["warm"],
+    });
+    expect(fixture.character.messageExamples).toEqual([
+      { examples: [{ name: "Ada", content: { text: "hi" } }] },
+    ]);
+    expect(invalidateTopologySpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/character-routes.test.ts
+++ b/packages/agent/src/api/character-routes.test.ts
@@ -3,6 +3,7 @@
  * a mocked route context; no HTTP server, database, or live model is used.
  */
 import { describe, expect, it, vi } from "vitest";
+import { MAX_CHARACTER_HISTORY_WALK_DEPTH } from "../services/character-history.ts";
 import {
   handleCharacterRoutes,
   parseCharacterHistoryLimit,
@@ -107,5 +108,156 @@ describe("PUT /api/character history walk", () => {
     );
     expect(updateAgent).not.toHaveBeenCalled();
     expect(json).not.toHaveBeenCalled();
+  });
+});
+
+function nestArr(depth: number): unknown {
+  let value: unknown = "leaf";
+  for (let i = 0; i < depth; i += 1) value = [value];
+  return value;
+}
+
+function makePutRuntime(character: Record<string, unknown>) {
+  const updateAgent = vi.fn(async () => undefined);
+  const createMemory = vi.fn(async () => undefined);
+  return {
+    character,
+    updateAgent,
+    createMemory,
+    runtime: {
+      agentId: "agent",
+      character,
+      updateAgent,
+      createMemory,
+    } as never,
+  };
+}
+
+describe("PUT /api/character stage-then-commit", () => {
+
+  it("keeps runtime/update/history/topology untouched when the second bound fails", async () => {
+    const character = {
+      name: "Ada",
+      bio: ["honest"],
+      messageExamples: [[{ name: "Ada", content: { text: "hi" } }]],
+    };
+    const original = structuredClone(character);
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const json = vi.fn();
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: {
+        agentName: "Ada",
+        runtime,
+      },
+      json,
+      error,
+      readJsonBody: vi.fn(async () => {
+        const cyclic: Record<string, unknown> = {
+          text: "hi",
+          extra: nestArr(80),
+        };
+        cyclic.self = cyclic;
+        return {
+          name: "Eve",
+          bio: ["mutated"],
+          messageExamples: [{ examples: [{ name: "Eve", content: cyclic }] }],
+        };
+      }),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      {},
+      "Character payload exceeds the history walk budget",
+      400,
+    );
+    expect(character).toEqual(original);
+    expect(updateAgent).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate runtime when a revoked Array Proxy is submitted", async () => {
+    const { proxy, revoke } = Proxy.revocable(
+      [[{ name: "Eve", content: { text: "hi" } }]],
+      {},
+    );
+    revoke();
+    const character = {
+      name: "Ada",
+      messageExamples: [[{ name: "Ada", content: { text: "hi" } }]],
+    };
+    const original = structuredClone(character);
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: { agentName: "Ada", runtime },
+      json: vi.fn(),
+      error,
+      readJsonBody: vi.fn(async () => ({
+        name: "Eve",
+        messageExamples: proxy,
+      })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      {},
+      "Character payload exceeds the history walk budget",
+      400,
+    );
+    expect(character).toEqual(original);
+    expect(updateAgent).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+
+  it("commits runtime mutation only after both history bounds succeed", async () => {
+    const character = {
+      name: "Ada",
+      bio: ["old"],
+      messageExamples: [[{ name: "Ada", content: { text: "hi" } }]],
+    };
+    const { updateAgent, createMemory, runtime } = makePutRuntime(character);
+    const json = vi.fn();
+    const error = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "PUT",
+      pathname: "/api/character",
+      state: { agentName: "Ada", runtime },
+      json,
+      error,
+      readJsonBody: vi.fn(async () => ({
+        name: "Eve",
+        bio: ["new"],
+      })),
+      pickRandomNames: vi.fn(),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(character.name).toBe("Eve");
+    expect(character.bio).toEqual(["new"]);
+    expect(updateAgent).toHaveBeenCalledTimes(1);
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ ok: true, agentName: "Eve" }),
+    );
   });
 });

--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -13,12 +13,12 @@ import { ModelType } from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import { PostCharacterGenerateRequestSchema } from "@elizaos/shared";
 import {
-  CHARACTER_HISTORY_UNBOUNDED,
-  CharacterHistoryError,
   buildCharacterHistorySnapshot,
+  type CharacterHistorySnapshot,
   isCharacterHistoryUnbounded,
   listCharacterHistory,
   type RuntimeCharacterLike,
+  readOwnDataValue,
   recordCharacterHistory,
 } from "../services/character-history.ts";
 import { invalidateConversationConnectionTopology } from "./conversation-connection-readiness.ts";
@@ -144,50 +144,62 @@ function shouldRewriteExampleSpeakerName(
   return false;
 }
 
-function normalizeCharacterMessageExamplesForName(
+function isSnapshotRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Rewrite one already-snapshotted example. The input comes from
+ * `buildCharacterHistorySnapshot`, so it is inert own data — plain reads,
+ * spreads and `.map` here cannot run an accessor or a Proxy trap.
+ */
+function rewriteSnapshotExample(
+  example: unknown,
+  nextName: string,
+  previousName?: string,
+): CharacterMessageExample {
+  const base = isSnapshotRecord(example) ? example : {};
+  const speakerName = typeof base.name === "string" ? base.name : "";
+  const content = isSnapshotRecord(base.content) ? base.content : {};
+  const text = typeof content.text === "string" ? content.text : "";
+
+  return {
+    ...base,
+    name: shouldRewriteExampleSpeakerName(speakerName, previousName)
+      ? nextName
+      : replaceCharacterNameTokens(speakerName, nextName),
+    content: {
+      ...content,
+      text: replaceCharacterNameTokens(text, nextName),
+    },
+  } as CharacterMessageExample;
+}
+
+/**
+ * Rewrite speaker names / name tokens on the trusted snapshot only. Staging
+ * snapshots first and rewriting second is what keeps the PUT path
+ * descriptor-only: nothing here ever touches the submitted graph.
+ */
+function rewriteSnapshotMessageExamplesForName(
   messageExamples: unknown,
   nextName: string,
   previousName?: string,
 ): CharacterMessageExampleGroup[] | undefined {
-  if (!isArrayOrUnbounded(messageExamples)) {
+  if (!Array.isArray(messageExamples)) {
     return undefined;
   }
 
   return messageExamples.map((group) => {
-    const examples = isArrayOrUnbounded(
-      (group as CharacterMessageExampleGroup | null)?.examples,
-    )
-      ? (group as CharacterMessageExampleGroup).examples
-      : [];
-
+    const examples =
+      isSnapshotRecord(group) && Array.isArray(group.examples)
+        ? group.examples
+        : [];
     return {
-      examples: examples.map((example) => ({
-        ...example,
-        name: shouldRewriteExampleSpeakerName(example.name, previousName)
-          ? nextName
-          : replaceCharacterNameTokens(example.name, nextName),
-        content: {
-          ...example.content,
-          text: replaceCharacterNameTokens(example.content.text, nextName),
-        },
-      })),
+      examples: examples.map((example) =>
+        rewriteSnapshotExample(example, nextName, previousName),
+      ),
     };
   });
-}
-
-
-
-function isArrayOrUnbounded(value: unknown): value is unknown[] {
-  try {
-    return Array.isArray(value);
-  } catch (cause) {
-    const error = new CharacterHistoryError(
-      "Character history value exceeds the walk budget",
-      CHARACTER_HISTORY_UNBOUNDED,
-    );
-    (error as Error & { cause?: unknown }).cause = cause;
-    throw error;
-  }
 }
 
 type CharacterPutTarget = {
@@ -202,47 +214,86 @@ type CharacterPutTarget = {
   postExamples?: string[];
 };
 
-function overlayCharacterPutBody(
+/** Character fields `PUT /api/character` may overlay. */
+const CHARACTER_PUT_FIELDS = [
+  "name",
+  "username",
+  "bio",
+  "system",
+  "adjectives",
+  "topics",
+  "style",
+  "messageExamples",
+  "postExamples",
+] as const;
+
+type CharacterPutField = (typeof CHARACTER_PUT_FIELDS)[number];
+
+/**
+ * Stage the next character by *reference* only: every field is taken from a
+ * single own-data-descriptor read of the submitted body, falling back to the
+ * live character. No submitted value is traversed here — that happens once, in
+ * `buildCharacterHistorySnapshot`, under the walk budget.
+ */
+function stageCharacterPut(
+  character: unknown,
+  body: Record<string, unknown>,
+): RuntimeCharacterLike {
+  const staged: Record<string, unknown> = {};
+  for (const field of CHARACTER_PUT_FIELDS) {
+    const submitted = readOwnDataValue(body, field);
+    staged[field] =
+      submitted != null ? submitted : readOwnDataValue(character, field);
+  }
+  return staged as RuntimeCharacterLike;
+}
+
+/**
+ * Commit the validated snapshot onto the live character. Only fields the body
+ * actually submitted are overwritten (plus message examples on a rename), and
+ * every committed value comes from the bounded snapshot rather than the raw
+ * request graph.
+ */
+function commitCharacterSnapshot(
   target: CharacterPutTarget,
   body: Record<string, unknown>,
-  nextCharacterName: string,
-  previousCharacterName?: string,
+  snapshot: CharacterHistorySnapshot,
+  messageExamples: CharacterMessageExampleGroup[] | undefined,
 ): void {
-  if (body.name != null) target.name = String(body.name);
-  if (body.username != null) target.username = String(body.username);
-  if (body.bio != null) {
-    target.bio = Array.isArray(body.bio)
-      ? (body.bio as string[])
-      : [String(body.bio)];
+  const submitted = new Set<CharacterPutField>();
+  for (const field of CHARACTER_PUT_FIELDS) {
+    if (readOwnDataValue(body, field) != null) submitted.add(field);
   }
-  if (body.system != null) target.system = String(body.system);
-  if (body.adjectives != null) {
-    target.adjectives = body.adjectives as string[];
+
+  if (submitted.has("name") && snapshot.name !== undefined) {
+    target.name = snapshot.name;
   }
-  if (body.topics != null) {
-    target.topics = body.topics as string[];
+  if (submitted.has("username") && snapshot.username !== undefined) {
+    target.username = snapshot.username;
   }
-  if (body.style != null) {
-    target.style = body.style;
+  if (submitted.has("bio") && snapshot.bio !== undefined) {
+    target.bio = snapshot.bio;
   }
-  if (body.messageExamples != null) {
-    target.messageExamples = normalizeCharacterMessageExamplesForName(
-      body.messageExamples,
-      nextCharacterName,
-      previousCharacterName,
-    );
-  } else if (body.name != null) {
-    const normalizedExamples = normalizeCharacterMessageExamplesForName(
-      target.messageExamples,
-      nextCharacterName,
-      previousCharacterName,
-    );
-    if (normalizedExamples) {
-      target.messageExamples = normalizedExamples;
-    }
+  if (submitted.has("system") && snapshot.system !== undefined) {
+    target.system = snapshot.system;
   }
-  if (body.postExamples != null) {
-    target.postExamples = body.postExamples as string[];
+  if (submitted.has("adjectives") && snapshot.adjectives !== undefined) {
+    target.adjectives = snapshot.adjectives;
+  }
+  if (submitted.has("topics") && snapshot.topics !== undefined) {
+    target.topics = snapshot.topics;
+  }
+  if (submitted.has("style") && snapshot.style !== undefined) {
+    target.style = snapshot.style;
+  }
+  if (submitted.has("postExamples") && snapshot.postExamples !== undefined) {
+    target.postExamples = snapshot.postExamples;
+  }
+  if (
+    (submitted.has("messageExamples") || submitted.has("name")) &&
+    messageExamples !== undefined
+  ) {
+    target.messageExamples = messageExamples;
   }
 }
 
@@ -509,7 +560,7 @@ export async function handleCharacterRoutes(
     const runtime = state.runtime;
     if (runtime) {
       const character = runtime.character;
-      let previousCharacter;
+      let previousCharacter: CharacterHistorySnapshot;
       try {
         previousCharacter = buildCharacterHistorySnapshot(
           character as RuntimeCharacterLike,
@@ -522,41 +573,44 @@ export async function handleCharacterRoutes(
         }
         throw err;
       }
+      const liveCharacterName = readOwnDataValue(character, "name");
       const previousCharacterName =
-        typeof character.name === "string" ? character.name : undefined;
+        typeof liveCharacterName === "string" ? liveCharacterName : undefined;
+      const submittedName = readOwnDataValue(body, "name");
       const nextStoredCharacterName =
-        body.name != null ? String(body.name) : previousCharacterName;
+        submittedName != null ? String(submittedName) : previousCharacterName;
       const nextCharacterName =
-        typeof body.name === "string" && body.name.trim()
-          ? body.name.trim()
-          : typeof character.name === "string" && character.name.trim()
-            ? character.name.trim()
+        typeof submittedName === "string" && submittedName.trim()
+          ? submittedName.trim()
+          : previousCharacterName?.trim()
+            ? previousCharacterName.trim()
             : state.agentName;
 
-      const stagedCharacter: RuntimeCharacterLike = {
-        name: typeof character.name === "string" ? character.name : undefined,
-        username:
-          typeof character.username === "string"
-            ? character.username
-            : undefined,
-        bio: character.bio as RuntimeCharacterLike["bio"],
-        system:
-          typeof character.system === "string" ? character.system : undefined,
-        adjectives: character.adjectives,
-        topics: (character as { topics?: string[] }).topics,
-        style: character.style,
-        messageExamples: character.messageExamples,
-        postExamples: character.postExamples,
-      };
-      let charData;
+      // One bounded, descriptor-only snapshot of the whole next character; the
+      // submitted graph is never traversed outside this call.
+      let charData: CharacterHistorySnapshot;
+      let nextMessageExamples: CharacterMessageExampleGroup[] | undefined;
       try {
-        overlayCharacterPutBody(
-          stagedCharacter,
-          body,
-          nextCharacterName,
-          previousCharacterName,
+        charData = buildCharacterHistorySnapshot(
+          stageCharacterPut(character, body),
         );
-        charData = buildCharacterHistorySnapshot(stagedCharacter);
+        const rewritesExamples =
+          submittedName != null ||
+          readOwnDataValue(body, "messageExamples") != null;
+        nextMessageExamples = rewritesExamples
+          ? rewriteSnapshotMessageExamplesForName(
+              charData.messageExamples,
+              nextCharacterName,
+              previousCharacterName,
+            )
+          : undefined;
+        if (nextMessageExamples !== undefined) {
+          charData = {
+            ...charData,
+            messageExamples:
+              nextMessageExamples as unknown as CharacterHistorySnapshot["messageExamples"],
+          };
+        }
       } catch (err) {
         // error-policy:J3 Zod-accepted passthrough extras can still overflow.
         if (isCharacterHistoryUnbounded(err)) {
@@ -572,11 +626,11 @@ export async function handleCharacterRoutes(
       ) {
         invalidateConversationConnectionTopology(runtime);
       }
-      overlayCharacterPutBody(
+      commitCharacterSnapshot(
         character as CharacterPutTarget,
         body,
-        nextCharacterName,
-        previousCharacterName,
+        charData,
+        nextMessageExamples,
       );
 
       // Persist character fields to DB so edits survive restarts
@@ -606,7 +660,8 @@ export async function handleCharacterRoutes(
 
     syncRuntimeCharacterToConfig(state, saveConfig);
 
-    if (body.name) state.agentName = String(body.name);
+    const submittedAgentName = readOwnDataValue(body, "name");
+    if (submittedAgentName) state.agentName = String(submittedAgentName);
     json(res, {
       ok: true,
       character: state.runtime?.character ?? body,

--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -14,6 +14,7 @@ import type { RouteRequestContext } from "@elizaos/shared";
 import { PostCharacterGenerateRequestSchema } from "@elizaos/shared";
 import {
   buildCharacterHistorySnapshot,
+  isCharacterHistoryUnbounded,
   listCharacterHistory,
   type RuntimeCharacterLike,
   recordCharacterHistory,
@@ -435,9 +436,19 @@ export async function handleCharacterRoutes(
     const runtime = state.runtime;
     if (runtime) {
       const character = runtime.character;
-      const previousCharacter = buildCharacterHistorySnapshot(
-        character as RuntimeCharacterLike,
-      );
+      let previousCharacter;
+      try {
+        previousCharacter = buildCharacterHistorySnapshot(
+          character as RuntimeCharacterLike,
+        );
+      } catch (err) {
+        // error-policy:J3 cyclic/over-deep live character is invalid input.
+        if (isCharacterHistoryUnbounded(err)) {
+          error(res, "Character payload exceeds the history walk budget", 400);
+          return true;
+        }
+        throw err;
+      }
       const previousCharacterName =
         typeof character.name === "string" ? character.name : undefined;
       const nextStoredCharacterName =
@@ -495,22 +506,32 @@ export async function handleCharacterRoutes(
       }
 
       // Persist character fields to DB so edits survive restarts
-      const charData = buildCharacterHistorySnapshot(
-        character as RuntimeCharacterLike,
-      );
-      await runtime.updateAgent(runtime.agentId, {
-        name: character.name,
-        metadata: {
-          ...(runtime.character as { metadata?: Record<string, unknown> })
-            .metadata,
-          character: charData,
-        },
-      });
-      await recordCharacterHistory(runtime, {
-        previousCharacter,
-        nextCharacter: character as RuntimeCharacterLike,
-        source: "manual",
-      });
+      let charData;
+      try {
+        charData = buildCharacterHistorySnapshot(
+          character as RuntimeCharacterLike,
+        );
+        await runtime.updateAgent(runtime.agentId, {
+          name: character.name,
+          metadata: {
+            ...(runtime.character as { metadata?: Record<string, unknown> })
+              .metadata,
+            character: charData,
+          },
+        });
+        await recordCharacterHistory(runtime, {
+          previousCharacter,
+          nextCharacter: character as RuntimeCharacterLike,
+          source: "manual",
+        });
+      } catch (err) {
+        // error-policy:J3 Zod-accepted passthrough extras can still overflow.
+        if (isCharacterHistoryUnbounded(err)) {
+          error(res, "Character payload exceeds the history walk budget", 400);
+          return true;
+        }
+        throw err;
+      }
     }
 
     syncRuntimeCharacterToConfig(state, saveConfig);

--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -15,11 +15,14 @@ import { PostCharacterGenerateRequestSchema } from "@elizaos/shared";
 import {
   buildCharacterHistorySnapshot,
   type CharacterHistorySnapshot,
+  createHistoryWalkContext,
+  type HistoryWalkContext,
   isCharacterHistoryUnbounded,
   listCharacterHistory,
   type RuntimeCharacterLike,
   readOwnDataValue,
   recordCharacterHistory,
+  toBoundedCharacterValue,
 } from "../services/character-history.ts";
 import { invalidateConversationConnectionTopology } from "./conversation-connection-readiness.ts";
 
@@ -230,70 +233,98 @@ const CHARACTER_PUT_FIELDS = [
 type CharacterPutField = (typeof CHARACTER_PUT_FIELDS)[number];
 
 /**
- * Stage the next character by *reference* only: every field is taken from a
- * single own-data-descriptor read of the submitted body, falling back to the
- * live character. No submitted value is traversed here — that happens once, in
- * `buildCharacterHistorySnapshot`, under the walk budget.
+ * The presence-aware staged DTO for one `PUT /api/character`.
+ *
+ * `values` holds one bounded, descriptor-only, commit-shaped value per
+ * character field — submitted fields from the request, the rest from the live
+ * character. `submitted` records which fields the request actually carried.
+ *
+ * Presence is tracked here rather than inferred from the history snapshot:
+ * `CharacterSchema` accepts `{"username":""}`, `{"bio":""}` and `{"style":{}}`
+ * as the way a caller CLEARS a field, and the history snapshot deliberately
+ * omits those empty values for display. Using the snapshot as the value
+ * authority silently dropped such a clear.
+ */
+type StagedCharacterPut = {
+  values: Record<string, unknown>;
+  submitted: Set<CharacterPutField>;
+};
+
+/** Base-route commit shape for one submitted field, applied to bounded data. */
+function shapeSubmittedField(
+  field: CharacterPutField,
+  value: unknown,
+): unknown {
+  if (value === undefined) return undefined;
+  if (field === "name" || field === "username" || field === "system") {
+    return String(value);
+  }
+  if (field === "bio") {
+    return Array.isArray(value) ? value : [String(value)];
+  }
+  return value;
+}
+
+/**
+ * Stage the next character. Every value crosses the boundary exactly once,
+ * through `toBoundedCharacterValue`: a single own-data-descriptor read of the
+ * body (falling back to the live character), then one bounded descriptor walk
+ * charged to the shared `ctx`. Nothing downstream touches the submitted graph.
  */
 function stageCharacterPut(
   character: unknown,
   body: Record<string, unknown>,
-): RuntimeCharacterLike {
-  const staged: Record<string, unknown> = {};
+  ctx: HistoryWalkContext,
+): StagedCharacterPut {
+  const values: Record<string, unknown> = {};
+  const submitted = new Set<CharacterPutField>();
+
   for (const field of CHARACTER_PUT_FIELDS) {
-    const submitted = readOwnDataValue(body, field);
-    staged[field] =
-      submitted != null ? submitted : readOwnDataValue(character, field);
+    const raw = readOwnDataValue(body, field);
+    if (raw != null) {
+      submitted.add(field);
+      values[field] = shapeSubmittedField(
+        field,
+        toBoundedCharacterValue(raw, ctx),
+      );
+      continue;
+    }
+    values[field] = toBoundedCharacterValue(
+      readOwnDataValue(character, field),
+      ctx,
+    );
   }
-  return staged as RuntimeCharacterLike;
+
+  return { values, submitted };
 }
 
 /**
- * Commit the validated snapshot onto the live character. Only fields the body
- * actually submitted are overwritten (plus message examples on a rename), and
- * every committed value comes from the bounded snapshot rather than the raw
- * request graph.
+ * Commit the staged DTO onto the live character. Only fields the request
+ * submitted are overwritten (plus message examples on a rename), and every
+ * committed value is the bounded staged value — never the raw request graph,
+ * and never the history snapshot.
  */
-function commitCharacterSnapshot(
+function commitStagedCharacter(
   target: CharacterPutTarget,
-  body: Record<string, unknown>,
-  snapshot: CharacterHistorySnapshot,
-  messageExamples: CharacterMessageExampleGroup[] | undefined,
+  staged: StagedCharacterPut,
 ): void {
-  const submitted = new Set<CharacterPutField>();
   for (const field of CHARACTER_PUT_FIELDS) {
-    if (readOwnDataValue(body, field) != null) submitted.add(field);
+    if (field === "messageExamples") continue;
+    if (!staged.submitted.has(field)) continue;
+    const value = staged.values[field];
+    if (value === undefined) continue;
+    (target as Record<string, unknown>)[field] = value;
   }
 
-  if (submitted.has("name") && snapshot.name !== undefined) {
-    target.name = snapshot.name;
-  }
-  if (submitted.has("username") && snapshot.username !== undefined) {
-    target.username = snapshot.username;
-  }
-  if (submitted.has("bio") && snapshot.bio !== undefined) {
-    target.bio = snapshot.bio;
-  }
-  if (submitted.has("system") && snapshot.system !== undefined) {
-    target.system = snapshot.system;
-  }
-  if (submitted.has("adjectives") && snapshot.adjectives !== undefined) {
-    target.adjectives = snapshot.adjectives;
-  }
-  if (submitted.has("topics") && snapshot.topics !== undefined) {
-    target.topics = snapshot.topics;
-  }
-  if (submitted.has("style") && snapshot.style !== undefined) {
-    target.style = snapshot.style;
-  }
-  if (submitted.has("postExamples") && snapshot.postExamples !== undefined) {
-    target.postExamples = snapshot.postExamples;
-  }
-  if (
-    (submitted.has("messageExamples") || submitted.has("name")) &&
-    messageExamples !== undefined
+  // Message examples also change on a rename, and the base route clears them
+  // when the request submits a non-array, so presence is decided separately.
+  if (staged.submitted.has("messageExamples")) {
+    target.messageExamples = staged.values.messageExamples;
+  } else if (
+    staged.submitted.has("name") &&
+    staged.values.messageExamples !== undefined
   ) {
-    target.messageExamples = messageExamples;
+    target.messageExamples = staged.values.messageExamples;
   }
 }
 
@@ -586,31 +617,35 @@ export async function handleCharacterRoutes(
             ? previousCharacterName.trim()
             : state.agentName;
 
-      // One bounded, descriptor-only snapshot of the whole next character; the
-      // submitted graph is never traversed outside this call.
+      // Stage the whole next character once, under one bounded descriptor walk;
+      // the submitted graph is never traversed outside this call. The staged
+      // DTO is the value authority for the live character (presence preserved),
+      // and the history snapshot is derived from it afterwards.
+      let staged: StagedCharacterPut;
       let charData: CharacterHistorySnapshot;
-      let nextMessageExamples: CharacterMessageExampleGroup[] | undefined;
       try {
-        charData = buildCharacterHistorySnapshot(
-          stageCharacterPut(character, body),
-        );
-        const rewritesExamples =
-          submittedName != null ||
-          readOwnDataValue(body, "messageExamples") != null;
-        nextMessageExamples = rewritesExamples
-          ? rewriteSnapshotMessageExamplesForName(
-              charData.messageExamples,
-              nextCharacterName,
-              previousCharacterName,
-            )
-          : undefined;
-        if (nextMessageExamples !== undefined) {
-          charData = {
-            ...charData,
-            messageExamples:
-              nextMessageExamples as unknown as CharacterHistorySnapshot["messageExamples"],
-          };
+        staged = stageCharacterPut(character, body, createHistoryWalkContext());
+        if (
+          staged.submitted.has("name") ||
+          staged.submitted.has("messageExamples")
+        ) {
+          const rewritten = rewriteSnapshotMessageExamplesForName(
+            staged.values.messageExamples,
+            nextCharacterName,
+            previousCharacterName,
+          );
+          if (
+            rewritten !== undefined ||
+            staged.submitted.has("messageExamples")
+          ) {
+            staged.values.messageExamples = rewritten;
+          }
         }
+        // Derived from staged plain data, so this walk cannot reach the
+        // request graph; it re-applies the history-display normalization only.
+        charData = buildCharacterHistorySnapshot(
+          staged.values as RuntimeCharacterLike,
+        );
       } catch (err) {
         // error-policy:J3 Zod-accepted passthrough extras can still overflow.
         if (isCharacterHistoryUnbounded(err)) {
@@ -626,12 +661,7 @@ export async function handleCharacterRoutes(
       ) {
         invalidateConversationConnectionTopology(runtime);
       }
-      commitCharacterSnapshot(
-        character as CharacterPutTarget,
-        body,
-        charData,
-        nextMessageExamples,
-      );
+      commitStagedCharacter(character as CharacterPutTarget, staged);
 
       // Persist character fields to DB so edits survive restarts
       try {

--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -13,6 +13,8 @@ import { ModelType } from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import { PostCharacterGenerateRequestSchema } from "@elizaos/shared";
 import {
+  CHARACTER_HISTORY_UNBOUNDED,
+  CharacterHistoryError,
   buildCharacterHistorySnapshot,
   isCharacterHistoryUnbounded,
   listCharacterHistory,
@@ -147,12 +149,12 @@ function normalizeCharacterMessageExamplesForName(
   nextName: string,
   previousName?: string,
 ): CharacterMessageExampleGroup[] | undefined {
-  if (!Array.isArray(messageExamples)) {
+  if (!isArrayOrUnbounded(messageExamples)) {
     return undefined;
   }
 
   return messageExamples.map((group) => {
-    const examples = Array.isArray(
+    const examples = isArrayOrUnbounded(
       (group as CharacterMessageExampleGroup | null)?.examples,
     )
       ? (group as CharacterMessageExampleGroup).examples
@@ -171,6 +173,77 @@ function normalizeCharacterMessageExamplesForName(
       })),
     };
   });
+}
+
+
+
+function isArrayOrUnbounded(value: unknown): value is unknown[] {
+  try {
+    return Array.isArray(value);
+  } catch (cause) {
+    const error = new CharacterHistoryError(
+      "Character history value exceeds the walk budget",
+      CHARACTER_HISTORY_UNBOUNDED,
+    );
+    (error as Error & { cause?: unknown }).cause = cause;
+    throw error;
+  }
+}
+
+type CharacterPutTarget = {
+  name?: string;
+  username?: string;
+  bio?: string | string[];
+  system?: string;
+  adjectives?: string[];
+  topics?: string[];
+  style?: unknown;
+  messageExamples?: unknown;
+  postExamples?: string[];
+};
+
+function overlayCharacterPutBody(
+  target: CharacterPutTarget,
+  body: Record<string, unknown>,
+  nextCharacterName: string,
+  previousCharacterName?: string,
+): void {
+  if (body.name != null) target.name = String(body.name);
+  if (body.username != null) target.username = String(body.username);
+  if (body.bio != null) {
+    target.bio = Array.isArray(body.bio)
+      ? (body.bio as string[])
+      : [String(body.bio)];
+  }
+  if (body.system != null) target.system = String(body.system);
+  if (body.adjectives != null) {
+    target.adjectives = body.adjectives as string[];
+  }
+  if (body.topics != null) {
+    target.topics = body.topics as string[];
+  }
+  if (body.style != null) {
+    target.style = body.style;
+  }
+  if (body.messageExamples != null) {
+    target.messageExamples = normalizeCharacterMessageExamplesForName(
+      body.messageExamples,
+      nextCharacterName,
+      previousCharacterName,
+    );
+  } else if (body.name != null) {
+    const normalizedExamples = normalizeCharacterMessageExamplesForName(
+      target.messageExamples,
+      nextCharacterName,
+      previousCharacterName,
+    );
+    if (normalizedExamples) {
+      target.messageExamples = normalizedExamples;
+    }
+  }
+  if (body.postExamples != null) {
+    target.postExamples = body.postExamples as string[];
+  }
 }
 
 function syncRuntimeCharacterToConfig(
@@ -460,57 +533,54 @@ export async function handleCharacterRoutes(
             ? character.name.trim()
             : state.agentName;
 
+      const stagedCharacter: RuntimeCharacterLike = {
+        name: typeof character.name === "string" ? character.name : undefined,
+        username:
+          typeof character.username === "string"
+            ? character.username
+            : undefined,
+        bio: character.bio as RuntimeCharacterLike["bio"],
+        system:
+          typeof character.system === "string" ? character.system : undefined,
+        adjectives: character.adjectives,
+        topics: (character as { topics?: string[] }).topics,
+        style: character.style,
+        messageExamples: character.messageExamples,
+        postExamples: character.postExamples,
+      };
+      let charData;
+      try {
+        overlayCharacterPutBody(
+          stagedCharacter,
+          body,
+          nextCharacterName,
+          previousCharacterName,
+        );
+        charData = buildCharacterHistorySnapshot(stagedCharacter);
+      } catch (err) {
+        // error-policy:J3 Zod-accepted passthrough extras can still overflow.
+        if (isCharacterHistoryUnbounded(err)) {
+          error(res, "Character payload exceeds the history walk budget", 400);
+          return true;
+        }
+        throw err;
+      }
+
       if (
         nextStoredCharacterName !== undefined &&
         nextStoredCharacterName !== previousCharacterName
       ) {
         invalidateConversationConnectionTopology(runtime);
       }
-      if (body.name != null) character.name = String(body.name);
-      if (body.username != null) character.username = String(body.username);
-      if (body.bio != null) {
-        character.bio = Array.isArray(body.bio)
-          ? (body.bio as string[])
-          : [String(body.bio)];
-      }
-      if (body.system != null) character.system = String(body.system);
-      if (body.adjectives != null) {
-        character.adjectives = body.adjectives as string[];
-      }
-      if (body.topics != null) {
-        (character as { topics?: string[] }).topics = body.topics as string[];
-      }
-      if (body.style != null) {
-        character.style = body.style as NonNullable<typeof character.style>;
-      }
-      if (body.messageExamples != null) {
-        character.messageExamples = normalizeCharacterMessageExamplesForName(
-          body.messageExamples,
-          nextCharacterName,
-          previousCharacterName,
-        ) as NonNullable<typeof character.messageExamples>;
-      } else if (body.name != null) {
-        const normalizedExamples = normalizeCharacterMessageExamplesForName(
-          character.messageExamples,
-          nextCharacterName,
-          previousCharacterName,
-        );
-        if (normalizedExamples) {
-          character.messageExamples = normalizedExamples as NonNullable<
-            typeof character.messageExamples
-          >;
-        }
-      }
-      if (body.postExamples != null) {
-        character.postExamples = body.postExamples as string[];
-      }
+      overlayCharacterPutBody(
+        character as CharacterPutTarget,
+        body,
+        nextCharacterName,
+        previousCharacterName,
+      );
 
       // Persist character fields to DB so edits survive restarts
-      let charData;
       try {
-        charData = buildCharacterHistorySnapshot(
-          character as RuntimeCharacterLike,
-        );
         await runtime.updateAgent(runtime.agentId, {
           name: character.name,
           metadata: {

--- a/packages/agent/src/services/character-history.test.ts
+++ b/packages/agent/src/services/character-history.test.ts
@@ -121,4 +121,27 @@ describe("listCharacterHistory limit guard", () => {
     expect(result.map((entry) => entry.id)).toEqual(["m-1999", "m-1998"]);
     expect(result).toHaveLength(2);
   });
+
+  it("omits over-depth and over-node rows while filling the requested limit", async () => {
+    const overDepth = makeMemory(2001);
+    let nested: Record<string, unknown> = {};
+    overDepth.metadata.before = nested;
+    for (let depth = 0; depth <= 64; depth += 1) {
+      const child: Record<string, unknown> = {};
+      nested.child = child;
+      nested = child;
+    }
+    const overNode = makeMemory(2000);
+    const sparse: unknown[] = [];
+    sparse.length = 100_001;
+    overNode.metadata.before = { messageExamples: sparse };
+    const valid = [makeMemory(1999), makeMemory(1998), makeMemory(1997)];
+    const getMemories = vi.fn(async () => [overDepth, overNode, ...valid]);
+    const runtime = { agentId: "agent-123", getMemories } as never;
+
+    const result = await listCharacterHistory(runtime, 2);
+
+    expect(result.map((entry) => entry.id)).toEqual(["m-1999", "m-1998"]);
+    expect(result).toHaveLength(2);
+  });
 });

--- a/packages/agent/src/services/character-history.test.ts
+++ b/packages/agent/src/services/character-history.test.ts
@@ -106,4 +106,19 @@ describe("listCharacterHistory limit guard", () => {
     expect(zero).toHaveLength(1);
     expect(zero).not.toHaveLength(20);
   });
+
+  it("omits poisoned rows and fills the requested limit with adjacent valid history", async () => {
+    const poisoned = makeMemory(2000);
+    const cyclic: Record<string, unknown> = { name: "poisoned" };
+    cyclic.self = cyclic;
+    poisoned.metadata.before = cyclic;
+    const valid = [makeMemory(1999), makeMemory(1998), makeMemory(1997)];
+    const getMemories = vi.fn(async () => [poisoned, ...valid]);
+    const runtime = { agentId: "agent-123", getMemories } as never;
+
+    const result = await listCharacterHistory(runtime, 2);
+
+    expect(result.map((entry) => entry.id)).toEqual(["m-1999", "m-1998"]);
+    expect(result).toHaveLength(2);
+  });
 });

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -190,7 +190,7 @@ function mapOwnArrayData<T>(
   return mapped;
 }
 
-function createHistoryWalkContext(): HistoryWalkContext {
+export function createHistoryWalkContext(): HistoryWalkContext {
   return { visits: 0, visiting: new WeakSet<object>() };
 }
 
@@ -214,7 +214,7 @@ export type RuntimeCharacterLike = {
 
 export type CharacterHistorySource = "manual" | "agent" | "restore";
 
-type CharacterHistoryValue =
+export type CharacterHistoryValue =
   | string
   | number
   | boolean
@@ -471,6 +471,23 @@ const CHARACTER_STYLE_KEYS = ["all", "chat", "post"] as const;
  * unwrapped `Array.isArray` runs on caller-supplied values, and one hostile
  * field cannot spend an independent walk budget.
  */
+/**
+ * Bounded, descriptor-only projection of ONE caller-supplied value into inert
+ * plain data (arrays keep holes, objects become null-prototype records).
+ *
+ * This is the value authority for staging a `PUT /api/character` field: unlike
+ * {@link buildCharacterHistorySnapshot} it preserves *presence*, so a
+ * schema-valid empty clear (`""`, `{}`, `[]`) survives staging instead of being
+ * normalized away by the history-display rules. Shares `ctx`, so every staged
+ * field is charged to one aggregate walk budget.
+ */
+export function toBoundedCharacterValue(
+  value: unknown,
+  ctx: HistoryWalkContext,
+): CharacterHistoryValue | undefined {
+  return toCharacterHistoryValue(value, 0, ctx);
+}
+
 export function buildCharacterHistorySnapshot(
   character: RuntimeCharacterLike,
   ctx: HistoryWalkContext = createHistoryWalkContext(),

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -5,7 +5,13 @@
  * agent / restore). Also parses those memory rows back into typed history
  * entries and lists them newest-first for the character-history surface.
  */
-import { type IAgentRuntime, type Memory, MemoryType } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  isElizaError,
+  type Memory,
+  MemoryType,
+} from "@elizaos/core";
 
 export const CHARACTER_HISTORY_TABLE = "character_modifications";
 export const MAX_CHARACTER_HISTORY_LIMIT = 100;
@@ -19,40 +25,32 @@ export const MAX_CHARACTER_HISTORY_WALK_DEPTH = 64;
 export const MAX_CHARACTER_HISTORY_WALK_NODES = 100_000;
 export const CHARACTER_HISTORY_UNBOUNDED = "CHARACTER_HISTORY_UNBOUNDED";
 
-export class CharacterHistoryError extends Error {
-  readonly code?: string;
-  constructor(message: string, code?: string) {
-    super(message);
-    this.name = "CharacterHistoryError";
-    if (code) this.code = code;
-  }
-}
-
+/** True when `error` is the typed unbounded-walk domain failure. */
 export function isCharacterHistoryUnbounded(error: unknown): boolean {
-  return (
-    error instanceof CharacterHistoryError &&
-    error.code === CHARACTER_HISTORY_UNBOUNDED
-  );
+  return isElizaError(error) && error.code === CHARACTER_HISTORY_UNBOUNDED;
 }
 
-type HistoryWalkContext = {
+/** Shared budget/cycle state for one bounded character walk. */
+export type HistoryWalkContext = {
   visits: number;
   visiting: WeakSet<object>;
 };
 
+/**
+ * The one domain failure this module raises. `ElizaError` carries the typed
+ * `code`, the structured `context`, and the preserved `cause` chain the
+ * fast-fail error policy requires of new/rewritten throw sites.
+ */
 function failHistoryUnbounded(
   context: Record<string, unknown>,
   cause?: unknown,
 ): never {
-  const error = new CharacterHistoryError(
-    "Character history value exceeds the walk budget",
-    CHARACTER_HISTORY_UNBOUNDED,
-  );
-  if (cause !== undefined) {
-    (error as Error & { cause?: unknown }).cause = cause;
-  }
-  (error as Error & { context?: Record<string, unknown> }).context = context;
-  throw error;
+  throw new ElizaError("Character history value exceeds the walk budget", {
+    code: CHARACTER_HISTORY_UNBOUNDED,
+    severity: "fatal",
+    context,
+    ...(cause !== undefined ? { cause } : {}),
+  });
 }
 
 function reserveHistoryVisits(ctx: HistoryWalkContext, count: number): void {
@@ -81,17 +79,38 @@ function inspectHistory<T>(operation: string, inspect: () => T): T {
   }
 }
 
-function ownEnumerableStringKeys(value: object): string[] {
-  const keys: string[] = [];
+/** One enumerable own *data* property, captured by a single descriptor read. */
+type HistoryDataEntry = { key: string; value: unknown };
+
+/**
+ * Capture every enumerable own string-keyed data property in ONE descriptor
+ * read per key. Reading the descriptor twice (once to filter keys, once to take
+ * the value) lets a Proxy drift between a benign descriptor and a different one,
+ * so the walkers consume this stable snapshot and never re-reflect on the
+ * source object.
+ */
+function ownEnumerableDataEntries(value: object): HistoryDataEntry[] {
+  const entries: HistoryDataEntry[] = [];
   for (const key of inspectHistory("ownKeys", () => Reflect.ownKeys(value))) {
     if (typeof key !== "string") continue;
     const descriptor = inspectHistory("getOwnPropertyDescriptor", () =>
       Object.getOwnPropertyDescriptor(value, key),
     );
     if (!descriptor?.enumerable) continue;
-    keys.push(key);
+    if (!("value" in descriptor)) {
+      failHistoryUnbounded({ accessor: true, key });
+    }
+    entries.push({ key, value: descriptor.value });
   }
-  return keys;
+  return entries;
+}
+
+function sortHistoryEntriesByKey(
+  entries: HistoryDataEntry[],
+): HistoryDataEntry[] {
+  return entries.sort((left, right) =>
+    left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+  );
 }
 
 function ownValueDescriptor(
@@ -108,6 +127,15 @@ function ownValueDescriptor(
   return descriptor;
 }
 
+/**
+ * Descriptor-only single-property read. Returns `undefined` when the key is not
+ * an own property and fails closed when it is an accessor, so callers can stage
+ * submitted/live values without running getters or Proxy `get`/`has` traps.
+ */
+export function readOwnDataValue(value: unknown, key: string): unknown {
+  if (value === null || typeof value !== "object") return undefined;
+  return ownValueDescriptor(value, key)?.value;
+}
 
 function isArrayValue(value: object): boolean {
   return inspectHistory("isArray", () => Array.isArray(value));
@@ -131,11 +159,22 @@ function ownArrayLength(value: object): number {
   return length;
 }
 
+/**
+ * Map an array's own numeric data properties, holes preserved.
+ *
+ * The whole *logical* length is reserved in the walk budget BEFORE the output
+ * is sized and before any index descriptor is probed. Charging only for the
+ * present elements let a graph of nested 100k-slot sparse arrays spend one
+ * visit per container while performing millions of descriptor probes and
+ * allocating millions of output slots.
+ */
 function mapOwnArrayData<T>(
   value: object,
+  ctx: HistoryWalkContext,
   mapEntry: (entry: unknown) => T,
 ): T[] {
   const length = ownArrayLength(value);
+  reserveHistoryVisits(ctx, length);
   const mapped: T[] = [];
   mapped.length = length;
   for (let index = 0; index < length; index += 1) {
@@ -267,10 +306,16 @@ function cloneIfDefined<T>(value: T): T {
   return value === undefined ? value : cloneJson(value);
 }
 
+/**
+ * `reserved` is set by container walks that already charged this value's slot
+ * to the budget (every array slot and every object entry is reserved up front),
+ * so a node is never counted twice.
+ */
 function normalizeForCompare(
   value: unknown,
   depth = 0,
   ctx: HistoryWalkContext = createHistoryWalkContext(),
+  reserved = false,
 ): unknown {
   if (depth > MAX_CHARACTER_HISTORY_WALK_DEPTH) {
     failHistoryUnbounded({
@@ -278,22 +323,27 @@ function normalizeForCompare(
       max: MAX_CHARACTER_HISTORY_WALK_DEPTH,
     });
   }
-  reserveHistoryVisits(ctx, 1);
+  if (!reserved) reserveHistoryVisits(ctx, 1);
   if (value === null || typeof value !== "object") {
     return value;
   }
   enterHistoryContainer(value, ctx);
   try {
     if (isArrayValue(value)) {
-      return mapOwnArrayData(value, (entry) =>
-        normalizeForCompare(entry, depth + 1, ctx),
+      return mapOwnArrayData(value, ctx, (entry) =>
+        normalizeForCompare(entry, depth + 1, ctx, true),
       );
     }
+    const entries = sortHistoryEntriesByKey(ownEnumerableDataEntries(value));
+    reserveHistoryVisits(ctx, entries.length);
     const normalized = createHistoryRecord<unknown>();
-    for (const key of ownEnumerableStringKeys(value).sort()) {
-      const descriptor = ownValueDescriptor(value, key);
-      if (!descriptor) continue;
-      normalized[key] = normalizeForCompare(descriptor.value, depth + 1, ctx);
+    for (const entry of entries) {
+      normalized[entry.key] = normalizeForCompare(
+        entry.value,
+        depth + 1,
+        ctx,
+        true,
+      );
     }
     return normalized;
   } finally {
@@ -348,6 +398,7 @@ function toCharacterHistoryValue(
   value: unknown,
   depth = 0,
   ctx: HistoryWalkContext = createHistoryWalkContext(),
+  reserved = false,
 ): CharacterHistoryValue | undefined {
   if (depth > MAX_CHARACTER_HISTORY_WALK_DEPTH) {
     failHistoryUnbounded({
@@ -355,7 +406,7 @@ function toCharacterHistoryValue(
       max: MAX_CHARACTER_HISTORY_WALK_DEPTH,
     });
   }
-  reserveHistoryVisits(ctx, 1);
+  if (!reserved) reserveHistoryVisits(ctx, 1);
   if (
     value === null ||
     typeof value === "string" ||
@@ -374,20 +425,22 @@ function toCharacterHistoryValue(
     if (isArrayValue(value)) {
       return mapOwnArrayData(
         value,
-        (entry) => toCharacterHistoryValue(entry, depth + 1, ctx) ?? null,
+        ctx,
+        (entry) => toCharacterHistoryValue(entry, depth + 1, ctx, true) ?? null,
       ) as CharacterHistoryValue[];
     }
+    const entries = ownEnumerableDataEntries(value);
+    reserveHistoryVisits(ctx, entries.length);
     const normalized = createHistoryRecord<CharacterHistoryValue | undefined>();
-    for (const key of ownEnumerableStringKeys(value)) {
-      const descriptor = ownValueDescriptor(value, key);
-      if (!descriptor) continue;
+    for (const entry of entries) {
       const normalizedEntry = toCharacterHistoryValue(
-        descriptor.value,
+        entry.value,
         depth + 1,
         ctx,
+        true,
       );
       if (normalizedEntry !== undefined) {
-        normalized[key] = normalizedEntry;
+        normalized[entry.key] = normalizedEntry;
       }
     }
     return normalized;
@@ -396,60 +449,91 @@ function toCharacterHistoryValue(
   }
 }
 
+/** Descriptor-only, budget-charged array field read. */
+function snapshotArrayField(
+  value: unknown,
+  ctx: HistoryWalkContext,
+): CharacterHistoryValue[] | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  if (!isArrayValue(value)) return undefined;
+  const walked = toCharacterHistoryValue(value, 0, ctx);
+  return Array.isArray(walked) ? walked : undefined;
+}
+
+const CHARACTER_STYLE_KEYS = ["all", "chat", "post"] as const;
+
+/**
+ * Build the bounded snapshot of a character.
+ *
+ * Every field is read through own *data* descriptors and walked with a single
+ * shared budget, so this is the one trusted, descriptor-only projection of a
+ * live or submitted character: no accessor, no Proxy `get`/`has` trap, and no
+ * unwrapped `Array.isArray` runs on caller-supplied values, and one hostile
+ * field cannot spend an independent walk budget.
+ */
 export function buildCharacterHistorySnapshot(
   character: RuntimeCharacterLike,
+  ctx: HistoryWalkContext = createHistoryWalkContext(),
 ): CharacterHistorySnapshot {
   const snapshot: CharacterHistorySnapshot = {};
+  if (character === null || typeof character !== "object") return snapshot;
+  reserveHistoryVisits(ctx, 1);
 
-  if (typeof character.name === "string" && character.name.trim()) {
-    snapshot.name = character.name.trim();
+  const name = readOwnDataValue(character, "name");
+  if (typeof name === "string" && name.trim()) {
+    snapshot.name = name.trim();
   }
-  if (typeof character.username === "string" && character.username.trim()) {
-    snapshot.username = character.username.trim();
+  const username = readOwnDataValue(character, "username");
+  if (typeof username === "string" && username.trim()) {
+    snapshot.username = username.trim();
   }
-  if (Array.isArray(character.bio)) {
-    snapshot.bio = [...character.bio];
-  } else if (typeof character.bio === "string" && character.bio.trim()) {
-    snapshot.bio = [character.bio];
+  const bio = readOwnDataValue(character, "bio");
+  const bioArray = snapshotArrayField(bio, ctx);
+  if (bioArray) {
+    snapshot.bio = bioArray as string[];
+  } else if (typeof bio === "string" && bio.trim()) {
+    snapshot.bio = [bio];
   }
-  if (typeof character.system === "string") {
-    snapshot.system = character.system;
+  const system = readOwnDataValue(character, "system");
+  if (typeof system === "string") {
+    snapshot.system = system;
   }
-  if (Array.isArray(character.adjectives)) {
-    snapshot.adjectives = [...character.adjectives];
-  }
-  if (Array.isArray(character.topics)) {
-    snapshot.topics = [...character.topics];
-  }
-  if (character.style) {
-    const style = {
-      ...(Array.isArray(character.style.all)
-        ? { all: [...character.style.all] }
-        : {}),
-      ...(Array.isArray(character.style.chat)
-        ? { chat: [...character.style.chat] }
-        : {}),
-      ...(Array.isArray(character.style.post)
-        ? { post: [...character.style.post] }
-        : {}),
-    };
-    if (Object.keys(style).length > 0) {
-      snapshot.style = style;
+  const adjectives = snapshotArrayField(
+    readOwnDataValue(character, "adjectives"),
+    ctx,
+  );
+  if (adjectives) snapshot.adjectives = adjectives as string[];
+  const topics = snapshotArrayField(readOwnDataValue(character, "topics"), ctx);
+  if (topics) snapshot.topics = topics as string[];
+
+  const styleValue = readOwnDataValue(character, "style");
+  if (styleValue !== null && typeof styleValue === "object") {
+    const walkedStyle = toCharacterHistoryValue(styleValue, 0, ctx);
+    if (walkedStyle !== null && typeof walkedStyle === "object") {
+      const style: NonNullable<CharacterHistorySnapshot["style"]> = {};
+      for (const key of CHARACTER_STYLE_KEYS) {
+        const entry = Object.hasOwn(walkedStyle, key)
+          ? (walkedStyle as Record<string, CharacterHistoryValue>)[key]
+          : undefined;
+        if (Array.isArray(entry)) style[key] = entry as string[];
+      }
+      if (Object.keys(style).length > 0) {
+        snapshot.style = style;
+      }
     }
   }
-  if (
-    character.messageExamples !== null &&
-    typeof character.messageExamples === "object" &&
-    isArrayValue(character.messageExamples)
-  ) {
-    const messageExamples = toCharacterHistoryValue(character.messageExamples);
-    if (Array.isArray(messageExamples)) {
-      snapshot.messageExamples = messageExamples;
-    }
-  }
-  if (Array.isArray(character.postExamples)) {
-    snapshot.postExamples = [...character.postExamples];
-  }
+
+  const messageExamples = snapshotArrayField(
+    readOwnDataValue(character, "messageExamples"),
+    ctx,
+  );
+  if (messageExamples) snapshot.messageExamples = messageExamples;
+
+  const postExamples = snapshotArrayField(
+    readOwnDataValue(character, "postExamples"),
+    ctx,
+  );
+  if (postExamples) snapshot.postExamples = postExamples as string[];
 
   return snapshot;
 }
@@ -626,12 +710,8 @@ export function parseCharacterHistoryEntry(
           ),
     fieldsChanged,
     changes,
-    before: isRecord(metadata.before)
-      ? safeCloneSnapshot(metadata.before)
-      : {},
-    after: isRecord(metadata.after)
-      ? safeCloneSnapshot(metadata.after)
-      : {},
+    before: isRecord(metadata.before) ? safeCloneSnapshot(metadata.before) : {},
+    after: isRecord(metadata.after) ? safeCloneSnapshot(metadata.after) : {},
   };
 }
 

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -639,10 +639,19 @@ export async function recordCharacterHistory(
 }
 
 function cloneSnapshotOrNull(
-  value: Record<string, unknown>,
+  value: unknown,
+  ctx: HistoryWalkContext,
 ): CharacterHistorySnapshot | null {
   try {
-    return cloneJson(value) as CharacterHistorySnapshot;
+    const cloned = toCharacterHistoryValue(value, 0, ctx);
+    if (
+      cloned === null ||
+      typeof cloned !== "object" ||
+      Array.isArray(cloned)
+    ) {
+      return null;
+    }
+    return cloned as CharacterHistorySnapshot;
   } catch (error) {
     // error-policy:J3 omit a poisoned stored row instead of fabricating a snapshot.
     if (isCharacterHistoryUnbounded(error)) {
@@ -655,6 +664,7 @@ function cloneSnapshotOrNull(
 export function parseCharacterHistoryEntry(
   memory: Memory,
 ): CharacterHistoryEntry | null {
+  const walkContext = createHistoryWalkContext();
   const metadata = isRecord(memory.metadata) ? memory.metadata : null;
   if (!metadata) {
     return null;
@@ -686,10 +696,10 @@ export function parseCharacterHistoryEntry(
     let after: CharacterHistoryValue | undefined;
     try {
       before = Object.hasOwn(rawChange, "before")
-        ? toCharacterHistoryValue(rawChange.before)
+        ? toCharacterHistoryValue(rawChange.before, 0, walkContext)
         : undefined;
       after = Object.hasOwn(rawChange, "after")
-        ? toCharacterHistoryValue(rawChange.after)
+        ? toCharacterHistoryValue(rawChange.after, 0, walkContext)
         : undefined;
     } catch (error) {
       // error-policy:J3 a poisoned stored change is not a live input 500.
@@ -714,14 +724,14 @@ export function parseCharacterHistoryEntry(
         ? memory.createdAt
         : 0;
 
-  const before = isRecord(metadata.before)
-    ? cloneSnapshotOrNull(metadata.before)
+  const before = Object.hasOwn(metadata, "before")
+    ? cloneSnapshotOrNull(metadata.before, walkContext)
     : {};
   if (before === null) {
     return null;
   }
-  const after = isRecord(metadata.after)
-    ? cloneSnapshotOrNull(metadata.after)
+  const after = Object.hasOwn(metadata, "after")
+    ? cloneSnapshotOrNull(metadata.after, walkContext)
     : {};
   if (after === null) {
     return null;

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -108,6 +108,49 @@ function ownValueDescriptor(
   return descriptor;
 }
 
+
+function isArrayValue(value: object): boolean {
+  return inspectHistory("isArray", () => Array.isArray(value));
+}
+
+function createHistoryRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function ownArrayLength(value: object): number {
+  const descriptor = ownValueDescriptor(value, "length");
+  const length = descriptor?.value;
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > MAX_CHARACTER_HISTORY_WALK_NODES
+  ) {
+    failHistoryUnbounded({ arrayLength: length });
+  }
+  return length;
+}
+
+function mapOwnArrayData<T>(
+  value: object,
+  mapEntry: (entry: unknown) => T,
+): T[] {
+  const length = ownArrayLength(value);
+  const mapped: T[] = [];
+  mapped.length = length;
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = inspectHistory("getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, String(index)),
+    );
+    if (!descriptor) continue;
+    if (!("value" in descriptor)) {
+      failHistoryUnbounded({ accessor: true, key: String(index) });
+    }
+    mapped[index] = mapEntry(descriptor.value);
+  }
+  return mapped;
+}
+
 function createHistoryWalkContext(): HistoryWalkContext {
   return { visits: 0, visiting: new WeakSet<object>() };
 }
@@ -241,10 +284,12 @@ function normalizeForCompare(
   }
   enterHistoryContainer(value, ctx);
   try {
-    if (Array.isArray(value)) {
-      return value.map((entry) => normalizeForCompare(entry, depth + 1, ctx));
+    if (isArrayValue(value)) {
+      return mapOwnArrayData(value, (entry) =>
+        normalizeForCompare(entry, depth + 1, ctx),
+      );
     }
-    const normalized: Record<string, unknown> = {};
+    const normalized = createHistoryRecord<unknown>();
     for (const key of ownEnumerableStringKeys(value).sort()) {
       const descriptor = ownValueDescriptor(value, key);
       if (!descriptor) continue;
@@ -326,12 +371,13 @@ function toCharacterHistoryValue(
   }
   enterHistoryContainer(value, ctx);
   try {
-    if (Array.isArray(value)) {
-      return value.map(
+    if (isArrayValue(value)) {
+      return mapOwnArrayData(
+        value,
         (entry) => toCharacterHistoryValue(entry, depth + 1, ctx) ?? null,
       ) as CharacterHistoryValue[];
     }
-    const normalized: Record<string, CharacterHistoryValue | undefined> = {};
+    const normalized = createHistoryRecord<CharacterHistoryValue | undefined>();
     for (const key of ownEnumerableStringKeys(value)) {
       const descriptor = ownValueDescriptor(value, key);
       if (!descriptor) continue;
@@ -391,7 +437,11 @@ export function buildCharacterHistorySnapshot(
       snapshot.style = style;
     }
   }
-  if (Array.isArray(character.messageExamples)) {
+  if (
+    character.messageExamples !== null &&
+    typeof character.messageExamples === "object" &&
+    isArrayValue(character.messageExamples)
+  ) {
     const messageExamples = toCharacterHistoryValue(character.messageExamples);
     if (Array.isArray(messageExamples)) {
       snapshot.messageExamples = messageExamples;

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -638,15 +638,15 @@ export async function recordCharacterHistory(
   };
 }
 
-function safeCloneSnapshot(
+function cloneSnapshotOrNull(
   value: Record<string, unknown>,
-): CharacterHistorySnapshot {
+): CharacterHistorySnapshot | null {
   try {
     return cloneJson(value) as CharacterHistorySnapshot;
   } catch (error) {
-    // error-policy:J3 stored snapshot poison should not 500 the list path.
+    // error-policy:J3 omit a poisoned stored row instead of fabricating a snapshot.
     if (isCharacterHistoryUnbounded(error)) {
-      return {};
+      return null;
     }
     throw error;
   }
@@ -714,6 +714,19 @@ export function parseCharacterHistoryEntry(
         ? memory.createdAt
         : 0;
 
+  const before = isRecord(metadata.before)
+    ? cloneSnapshotOrNull(metadata.before)
+    : {};
+  if (before === null) {
+    return null;
+  }
+  const after = isRecord(metadata.after)
+    ? cloneSnapshotOrNull(metadata.after)
+    : {};
+  if (after === null) {
+    return null;
+  }
+
   return {
     id: typeof memory.id === "string" ? memory.id : undefined,
     timestamp,
@@ -727,8 +740,8 @@ export function parseCharacterHistoryEntry(
           ),
     fieldsChanged,
     changes,
-    before: isRecord(metadata.before) ? safeCloneSnapshot(metadata.before) : {},
-    after: isRecord(metadata.after) ? safeCloneSnapshot(metadata.after) : {},
+    before,
+    after,
   };
 }
 

--- a/packages/agent/src/services/character-history.ts
+++ b/packages/agent/src/services/character-history.ts
@@ -9,6 +9,108 @@ import { type IAgentRuntime, type Memory, MemoryType } from "@elizaos/core";
 
 export const CHARACTER_HISTORY_TABLE = "character_modifications";
 export const MAX_CHARACTER_HISTORY_LIMIT = 100;
+/**
+ * Honest character snapshots are a handful of objects deep. Zod
+ * `contentSchema.passthrough()` still admits extra keys that `JSON.parse`
+ * already accepted, including a 20k-deep nest (~40 KiB) that then
+ * RangeError'd `toCharacterHistoryValue` on origin develop.
+ */
+export const MAX_CHARACTER_HISTORY_WALK_DEPTH = 64;
+export const MAX_CHARACTER_HISTORY_WALK_NODES = 100_000;
+export const CHARACTER_HISTORY_UNBOUNDED = "CHARACTER_HISTORY_UNBOUNDED";
+
+export class CharacterHistoryError extends Error {
+  readonly code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "CharacterHistoryError";
+    if (code) this.code = code;
+  }
+}
+
+export function isCharacterHistoryUnbounded(error: unknown): boolean {
+  return (
+    error instanceof CharacterHistoryError &&
+    error.code === CHARACTER_HISTORY_UNBOUNDED
+  );
+}
+
+type HistoryWalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+function failHistoryUnbounded(
+  context: Record<string, unknown>,
+  cause?: unknown,
+): never {
+  const error = new CharacterHistoryError(
+    "Character history value exceeds the walk budget",
+    CHARACTER_HISTORY_UNBOUNDED,
+  );
+  if (cause !== undefined) {
+    (error as Error & { cause?: unknown }).cause = cause;
+  }
+  (error as Error & { context?: Record<string, unknown> }).context = context;
+  throw error;
+}
+
+function reserveHistoryVisits(ctx: HistoryWalkContext, count: number): void {
+  if (count > MAX_CHARACTER_HISTORY_WALK_NODES - ctx.visits) {
+    failHistoryUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_CHARACTER_HISTORY_WALK_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function enterHistoryContainer(value: object, ctx: HistoryWalkContext): void {
+  if (ctx.visiting.has(value)) {
+    failHistoryUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+}
+
+function inspectHistory<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+    failHistoryUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownEnumerableStringKeys(value: object): string[] {
+  const keys: string[] = [];
+  for (const key of inspectHistory("ownKeys", () => Reflect.ownKeys(value))) {
+    if (typeof key !== "string") continue;
+    const descriptor = inspectHistory("getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (!descriptor?.enumerable) continue;
+    keys.push(key);
+  }
+  return keys;
+}
+
+function ownValueDescriptor(
+  value: object,
+  key: string,
+): PropertyDescriptor | undefined {
+  const descriptor = inspectHistory("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key),
+  );
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) {
+    failHistoryUnbounded({ accessor: true, key });
+  }
+  return descriptor;
+}
+
+function createHistoryWalkContext(): HistoryWalkContext {
+  return { visits: 0, visiting: new WeakSet<object>() };
+}
 
 export type RuntimeCharacterLike = {
   name?: string;
@@ -110,25 +212,48 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function cloneJson<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch (cause) {
+    // error-policy:J2 stringify/parse overflow or cycle is unbounded input.
+    failHistoryUnbounded({ clone: true }, cause);
+  }
 }
 
 function cloneIfDefined<T>(value: T): T {
   return value === undefined ? value : cloneJson(value);
 }
 
-function normalizeForCompare(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => normalizeForCompare(entry));
+function normalizeForCompare(
+  value: unknown,
+  depth = 0,
+  ctx: HistoryWalkContext = createHistoryWalkContext(),
+): unknown {
+  if (depth > MAX_CHARACTER_HISTORY_WALK_DEPTH) {
+    failHistoryUnbounded({
+      depth,
+      max: MAX_CHARACTER_HISTORY_WALK_DEPTH,
+    });
   }
-  if (isRecord(value)) {
+  reserveHistoryVisits(ctx, 1);
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  enterHistoryContainer(value, ctx);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => normalizeForCompare(entry, depth + 1, ctx));
+    }
     const normalized: Record<string, unknown> = {};
-    for (const key of Object.keys(value).sort()) {
-      normalized[key] = normalizeForCompare(value[key]);
+    for (const key of ownEnumerableStringKeys(value).sort()) {
+      const descriptor = ownValueDescriptor(value, key);
+      if (!descriptor) continue;
+      normalized[key] = normalizeForCompare(descriptor.value, depth + 1, ctx);
     }
     return normalized;
+  } finally {
+    ctx.visiting.delete(value);
   }
-  return value;
 }
 
 function areEqualForHistory(previous: unknown, next: unknown): boolean {
@@ -176,7 +301,16 @@ function buildHistorySummary(
 
 function toCharacterHistoryValue(
   value: unknown,
+  depth = 0,
+  ctx: HistoryWalkContext = createHistoryWalkContext(),
 ): CharacterHistoryValue | undefined {
+  if (depth > MAX_CHARACTER_HISTORY_WALK_DEPTH) {
+    failHistoryUnbounded({
+      depth,
+      max: MAX_CHARACTER_HISTORY_WALK_DEPTH,
+    });
+  }
+  reserveHistoryVisits(ctx, 1);
   if (
     value === null ||
     typeof value === "string" ||
@@ -187,22 +321,33 @@ function toCharacterHistoryValue(
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : undefined;
   }
-  if (Array.isArray(value)) {
-    return value.map(
-      (entry) => toCharacterHistoryValue(entry) ?? null,
-    ) as CharacterHistoryValue[];
+  if (typeof value !== "object") {
+    return undefined;
   }
-  if (isRecord(value)) {
+  enterHistoryContainer(value, ctx);
+  try {
+    if (Array.isArray(value)) {
+      return value.map(
+        (entry) => toCharacterHistoryValue(entry, depth + 1, ctx) ?? null,
+      ) as CharacterHistoryValue[];
+    }
     const normalized: Record<string, CharacterHistoryValue | undefined> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      const normalizedEntry = toCharacterHistoryValue(entry);
+    for (const key of ownEnumerableStringKeys(value)) {
+      const descriptor = ownValueDescriptor(value, key);
+      if (!descriptor) continue;
+      const normalizedEntry = toCharacterHistoryValue(
+        descriptor.value,
+        depth + 1,
+        ctx,
+      );
       if (normalizedEntry !== undefined) {
         normalized[key] = normalizedEntry;
       }
     }
     return normalized;
+  } finally {
+    ctx.visiting.delete(value);
   }
-  return undefined;
 }
 
 export function buildCharacterHistorySnapshot(
@@ -342,6 +487,20 @@ export async function recordCharacterHistory(
   };
 }
 
+function safeCloneSnapshot(
+  value: Record<string, unknown>,
+): CharacterHistorySnapshot {
+  try {
+    return cloneJson(value) as CharacterHistorySnapshot;
+  } catch (error) {
+    // error-policy:J3 stored snapshot poison should not 500 the list path.
+    if (isCharacterHistoryUnbounded(error)) {
+      return {};
+    }
+    throw error;
+  }
+}
+
 export function parseCharacterHistoryEntry(
   memory: Memory,
 ): CharacterHistoryEntry | null {
@@ -372,12 +531,22 @@ export function parseCharacterHistoryEntry(
     ) {
       return null;
     }
-    const before = Object.hasOwn(rawChange, "before")
-      ? toCharacterHistoryValue(rawChange.before)
-      : undefined;
-    const after = Object.hasOwn(rawChange, "after")
-      ? toCharacterHistoryValue(rawChange.after)
-      : undefined;
+    let before: CharacterHistoryValue | undefined;
+    let after: CharacterHistoryValue | undefined;
+    try {
+      before = Object.hasOwn(rawChange, "before")
+        ? toCharacterHistoryValue(rawChange.before)
+        : undefined;
+      after = Object.hasOwn(rawChange, "after")
+        ? toCharacterHistoryValue(rawChange.after)
+        : undefined;
+    } catch (error) {
+      // error-policy:J3 a poisoned stored change is not a live input 500.
+      if (isCharacterHistoryUnbounded(error)) {
+        return null;
+      }
+      throw error;
+    }
 
     changes.push({
       field: field as CharacterHistoryField,
@@ -408,10 +577,10 @@ export function parseCharacterHistoryEntry(
     fieldsChanged,
     changes,
     before: isRecord(metadata.before)
-      ? (cloneJson(metadata.before) as CharacterHistorySnapshot)
+      ? safeCloneSnapshot(metadata.before)
       : {},
     after: isRecord(metadata.after)
-      ? (cloneJson(metadata.after) as CharacterHistorySnapshot)
+      ? safeCloneSnapshot(metadata.after)
       : {},
   };
 }

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -121,4 +121,140 @@ describe("character-history fail-closed walk", () => {
     } as never);
     expect(parsed).toBeNull();
   });
+
+  it("wraps a revoked Array Proxy instead of leaking TypeError", () => {
+    const { proxy, revoke } = Proxy.revocable(["leaf"], {});
+    revoke();
+    try {
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: proxy,
+      });
+      throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CharacterHistoryError);
+      expect((error as CharacterHistoryError).code).toBe(
+        CHARACTER_HISTORY_UNBOUNDED,
+      );
+      expect(error).not.toBeInstanceOf(TypeError);
+    }
+  });
+
+  it("does not run ordinary array Proxy get/has traps", () => {
+    const target = [[{ name: "Ada", content: { text: "hi" } }]];
+    let getTrap = 0;
+    const proxy = new Proxy(target, {
+      get(nextTarget, key, receiver) {
+        getTrap += 1;
+        return Reflect.get(nextTarget, key, receiver);
+      },
+      has() {
+        throw new Error("HAS_TRAP");
+      },
+    });
+    const snapshot = buildCharacterHistorySnapshot({
+      name: "Ada",
+      messageExamples: proxy,
+    });
+    expect(getTrap).toBe(0);
+    expect(snapshot.messageExamples).toEqual(target);
+  });
+
+  it("fail-closed on array index accessors without invoking them", () => {
+    const hostile: unknown[] = ["placeholder"];
+    Object.defineProperty(hostile, "0", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("ACCESSOR_INVOKED");
+      },
+    });
+    try {
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: hostile,
+      });
+      throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CharacterHistoryError);
+      expect((error as CharacterHistoryError).code).toBe(
+        CHARACTER_HISTORY_UNBOUNDED,
+      );
+      expect(String(error)).not.toContain("ACCESSOR_INVOKED");
+    }
+  });
+
+  it("preserves sparse holes and maps explicit undefined to null", () => {
+    const sparse: unknown[] = ["a"];
+    sparse[2] = "c";
+    sparse[3] = undefined;
+    const snapshot = buildCharacterHistorySnapshot({
+      name: "Ada",
+      messageExamples: sparse,
+    });
+    const walked = snapshot.messageExamples as unknown[];
+    expect(Object.hasOwn(walked, "0")).toBe(true);
+    expect(Object.hasOwn(walked, "1")).toBe(false);
+    expect(walked[0]).toBe("a");
+    expect(walked[2]).toBe("c");
+    expect(walked[3]).toBeNull();
+  });
+
+  it("keeps top and nested enumerable __proto__ as inert own data", () => {
+    const pollutedKey = "__proto_pollute_23130";
+    const protoDesc = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      pollutedKey,
+    );
+    try {
+      const top: Record<string, unknown> = { text: "top" };
+      Object.defineProperty(top, "__proto__", {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: { [pollutedKey]: "top" },
+      });
+      const nested: Record<string, unknown> = { text: "nested" };
+      Object.defineProperty(nested, "__proto__", {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: { [pollutedKey]: "nested" },
+      });
+      const snapshot = buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [[{ name: "Ada", content: { text: "top", child: nested } }]],
+      });
+      // attach top-level __proto__ on the first example content via a dedicated object
+      const topSnapshot = buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [[{ name: "Ada", content: top }]],
+      });
+      const walkedTop = (
+        topSnapshot.messageExamples as Array<
+          Array<{ content: Record<string, unknown> }>
+        >
+      )[0][0].content;
+      const walkedNested = (
+        snapshot.messageExamples as Array<
+          Array<{ content: Record<string, unknown> }>
+        >
+      )[0][0].content.child as Record<string, unknown>;
+      expect(Object.getPrototypeOf(walkedTop)).toBeNull();
+      expect(Object.getPrototypeOf(walkedNested)).toBeNull();
+      expect(Object.hasOwn(walkedTop, "__proto__")).toBe(true);
+      expect(Object.hasOwn(walkedNested, "__proto__")).toBe(true);
+      expect(walkedTop["__proto__"]).toEqual({ [pollutedKey]: "top" });
+      expect(walkedNested["__proto__"]).toEqual({ [pollutedKey]: "nested" });
+      expect(
+        Object.prototype.hasOwnProperty.call(Object.prototype, pollutedKey),
+      ).toBe(false);
+    } finally {
+      if (protoDesc) {
+        Object.defineProperty(Object.prototype, pollutedKey, protoDesc);
+      } else {
+        Reflect.deleteProperty(Object.prototype, pollutedKey);
+      }
+    }
+  });
 });

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -265,6 +265,25 @@ describe("character-history fail-closed walk", () => {
     expect(parsed).toBeNull();
   });
 
+  it("skips a poisoned stored snapshot instead of fabricating an empty one", () => {
+    const cyclic: Record<string, unknown> = { name: "Ada" };
+    cyclic.self = cyclic;
+    const parsed = parseCharacterHistoryEntry({
+      content: { text: "change" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        service: "character_history",
+        action: "character_updated",
+        timestamp: 1,
+        historySource: "manual",
+        changes: [{ field: "name", before: "a", after: "b" }],
+        before: cyclic,
+        after: { name: "b" },
+      },
+    } as never);
+    expect(parsed).toBeNull();
+  });
+
   it("wraps a revoked Array Proxy instead of leaking TypeError", () => {
     const { proxy, revoke } = Proxy.revocable(["leaf"], {});
     revoke();

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Fail-closed character-history walk for Zod-accepted messageExamples.
+ *
+ * Origin develop JSON.parse + validateCharacter accepted content.passthrough
+ * extra keys, including a 20k-deep nest (~40 KiB) and cyclic in-memory
+ * graphs, then RangeError'd in toCharacterHistoryValue during
+ * buildCharacterHistorySnapshot. Depth/node/cycle fail-closed replaces
+ * that with CharacterHistoryError CHARACTER_HISTORY_UNBOUNDED.
+ */
+import { MemoryType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  CHARACTER_HISTORY_UNBOUNDED,
+  CharacterHistoryError,
+  MAX_CHARACTER_HISTORY_WALK_DEPTH,
+  buildCharacterHistorySnapshot,
+  parseCharacterHistoryEntry,
+} from "./character-history.ts";
+
+function nestArr(depth: number): unknown {
+  let value: unknown = "leaf";
+  for (let i = 0; i < depth; i += 1) value = [value];
+  return value;
+}
+
+function expectUnbounded(fn: () => unknown): void {
+  try {
+    fn();
+    throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+  } catch (error) {
+    expect(error).toBeInstanceOf(CharacterHistoryError);
+    expect((error as CharacterHistoryError).code).toBe(
+      CHARACTER_HISTORY_UNBOUNDED,
+    );
+    expect(error).not.toBeInstanceOf(RangeError);
+  }
+}
+
+describe("character-history fail-closed walk", () => {
+  it("still snapshots an honest character with message examples", () => {
+    const snapshot = buildCharacterHistorySnapshot({
+      name: "Ada",
+      messageExamples: [[{ name: "Ada", content: { text: "hi" } }]],
+    });
+    expect(snapshot.name).toBe("Ada");
+    expect(snapshot.messageExamples).toEqual([
+      [{ name: "Ada", content: { text: "hi" } }],
+    ]);
+  });
+
+  it("fail-closed on a cyclic messageExamples graph instead of RangeError", () => {
+    const cyclic: Record<string, unknown> = { text: "hi" };
+    cyclic.self = cyclic;
+    expectUnbounded(() =>
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [[{ name: "Ada", content: cyclic }]],
+      }),
+    );
+  });
+
+  it("fail-closed on over-deep nests before the walk RangeErrors", () => {
+    expectUnbounded(() =>
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: nestArr(MAX_CHARACTER_HISTORY_WALK_DEPTH + 8),
+      }),
+    );
+  });
+
+  it("fail-closed after JSON.parse accepts a 20k-deep passthrough extra", () => {
+    const raw = JSON.stringify({
+      name: "Ada",
+      messageExamples: [
+        [{ name: "Ada", content: { text: "hi", extra: nestArr(20_000) } }],
+      ],
+    });
+    const parsed = JSON.parse(raw) as {
+      name: string;
+      messageExamples: unknown;
+    };
+    expect(typeof parsed).toBe("object");
+    expectUnbounded(() => buildCharacterHistorySnapshot(parsed));
+  });
+
+  it("does not invoke enumerable getters while snapshotting", () => {
+    const hostile: Record<string, unknown> = { text: "hi" };
+    Object.defineProperty(hostile, "secret", {
+      enumerable: true,
+      get() {
+        throw new Error("GETTER_INVOKED");
+      },
+    });
+    try {
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [[{ name: "Ada", content: hostile }]],
+      });
+      throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CharacterHistoryError);
+      expect((error as CharacterHistoryError).code).toBe(
+        CHARACTER_HISTORY_UNBOUNDED,
+      );
+      expect(String(error)).not.toContain("GETTER_INVOKED");
+    }
+  });
+
+  it("parseCharacterHistoryEntry skips a cyclic stored change instead of throwing", () => {
+    const cyclic: Record<string, unknown> = { text: "hi" };
+    cyclic.self = cyclic;
+    const parsed = parseCharacterHistoryEntry({
+      content: { text: "change" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        service: "character_history",
+        action: "character_updated",
+        timestamp: 1,
+        historySource: "manual",
+        fieldsChanged: ["messageExamples"],
+        changes: [{ field: "messageExamples", before: cyclic, after: { name: "b" } }],
+        before: { name: "a" },
+        after: { name: "b" },
+      },
+    } as never);
+    expect(parsed).toBeNull();
+  });
+});

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -5,15 +5,16 @@
  * extra keys, including a 20k-deep nest (~40 KiB) and cyclic in-memory
  * graphs, then RangeError'd in toCharacterHistoryValue during
  * buildCharacterHistorySnapshot. Depth/node/cycle fail-closed replaces
- * that with CharacterHistoryError CHARACTER_HISTORY_UNBOUNDED.
+ * that with a typed ElizaError CHARACTER_HISTORY_UNBOUNDED, and every array
+ * reserves its whole logical length in the shared aggregate walk budget.
  */
-import { MemoryType } from "@elizaos/core";
+import { ElizaError, isElizaError, MemoryType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
-  CHARACTER_HISTORY_UNBOUNDED,
-  CharacterHistoryError,
-  MAX_CHARACTER_HISTORY_WALK_DEPTH,
   buildCharacterHistorySnapshot,
+  CHARACTER_HISTORY_UNBOUNDED,
+  MAX_CHARACTER_HISTORY_WALK_DEPTH,
+  MAX_CHARACTER_HISTORY_WALK_NODES,
   parseCharacterHistoryEntry,
 } from "./character-history.ts";
 
@@ -23,15 +24,19 @@ function nestArr(depth: number): unknown {
   return value;
 }
 
+function sparse(length: number): unknown[] {
+  const value: unknown[] = [];
+  value.length = length;
+  return value;
+}
+
 function expectUnbounded(fn: () => unknown): void {
   try {
     fn();
     throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
   } catch (error) {
-    expect(error).toBeInstanceOf(CharacterHistoryError);
-    expect((error as CharacterHistoryError).code).toBe(
-      CHARACTER_HISTORY_UNBOUNDED,
-    );
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe(CHARACTER_HISTORY_UNBOUNDED);
     expect(error).not.toBeInstanceOf(RangeError);
   }
 }
@@ -94,12 +99,148 @@ describe("character-history fail-closed walk", () => {
       });
       throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
     } catch (error) {
-      expect(error).toBeInstanceOf(CharacterHistoryError);
-      expect((error as CharacterHistoryError).code).toBe(
-        CHARACTER_HISTORY_UNBOUNDED,
-      );
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CHARACTER_HISTORY_UNBOUNDED);
       expect(String(error)).not.toContain("GETTER_INVOKED");
     }
+  });
+
+  it("raises a typed ElizaError carrying code, severity, context and cause", () => {
+    const cyclic: Record<string, unknown> = { text: "hi" };
+    cyclic.self = cyclic;
+    try {
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [[{ name: "Ada", content: cyclic }]],
+      });
+      throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+    } catch (error) {
+      expect(isElizaError(error)).toBe(true);
+      const typed = error as ElizaError;
+      expect(typed.code).toBe(CHARACTER_HISTORY_UNBOUNDED);
+      expect(typed.severity).toBe("fatal");
+      expect(typed.context).toMatchObject({ cycle: true });
+    }
+
+    const { proxy, revoke } = Proxy.revocable(["leaf"], {});
+    revoke();
+    try {
+      buildCharacterHistorySnapshot({ name: "Ada", messageExamples: proxy });
+      throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
+    } catch (error) {
+      expect(isElizaError(error)).toBe(true);
+      const typed = error as ElizaError;
+      expect(typed.code).toBe(CHARACTER_HISTORY_UNBOUNDED);
+      expect(typed.context).toMatchObject({ inspection: "isArray" });
+      expect(typed.cause).toBeInstanceOf(TypeError);
+    }
+  });
+
+  it("reserves every logical array slot in the aggregate walk budget", () => {
+    // character + outer array + 2 outer slots + 2 * childLength == budget.
+    const childLength = Math.floor((MAX_CHARACTER_HISTORY_WALK_NODES - 4) / 2);
+    expect(childLength).toBe(49_998);
+    expect(1 + 1 + 2 + childLength * 2).toBe(MAX_CHARACTER_HISTORY_WALK_NODES);
+
+    const snapshot = buildCharacterHistorySnapshot({
+      name: "Ada",
+      messageExamples: [sparse(childLength), sparse(childLength)],
+    });
+    const walked = snapshot.messageExamples as unknown[];
+    expect(walked).toHaveLength(2);
+    expect((walked[0] as unknown[]).length).toBe(childLength);
+
+    // One extra slot per nested array crosses the aggregate boundary even
+    // though the graph still holds only three array containers.
+    expectUnbounded(() =>
+      buildCharacterHistorySnapshot({
+        name: "Ada",
+        messageExamples: [sparse(childLength + 1), sparse(childLength + 1)],
+      }),
+    );
+  });
+
+  it("charges a single sparse array its exact logical length", () => {
+    // character + array container leaves exactly budget - 2 logical slots.
+    const exact = MAX_CHARACTER_HISTORY_WALK_NODES - 2;
+    expect(
+      (
+        buildCharacterHistorySnapshot({ messageExamples: sparse(exact) })
+          .messageExamples as unknown[]
+      ).length,
+    ).toBe(exact);
+    expectUnbounded(() =>
+      buildCharacterHistorySnapshot({ messageExamples: sparse(exact + 1) }),
+    );
+  });
+
+  it("charges sparse slots across sibling character fields", () => {
+    const half = Math.floor(MAX_CHARACTER_HISTORY_WALK_NODES / 2);
+    expectUnbounded(() =>
+      buildCharacterHistorySnapshot({
+        bio: sparse(half) as string[],
+        topics: sparse(half) as string[],
+        postExamples: sparse(half) as string[],
+      }),
+    );
+  });
+
+  it("reads each enumerable own descriptor exactly once", () => {
+    const target = { text: "first" };
+    let descriptorReads = 0;
+    const drifting = new Proxy(target, {
+      getOwnPropertyDescriptor(inner, key) {
+        if (key === "text") {
+          descriptorReads += 1;
+          return {
+            value: descriptorReads === 1 ? "first" : "drifted",
+            enumerable: true,
+            configurable: true,
+            writable: true,
+          };
+        }
+        return Reflect.getOwnPropertyDescriptor(inner, key);
+      },
+    });
+
+    const snapshot = buildCharacterHistorySnapshot({
+      name: "Ada",
+      messageExamples: [{ examples: [{ name: "Ada", content: drifting }] }],
+    });
+    const walked = snapshot.messageExamples as Array<{
+      examples: Array<{ content: Record<string, unknown> }>;
+    }>;
+    expect(descriptorReads).toBe(1);
+    expect(walked[0].examples[0].content.text).toBe("first");
+  });
+
+  it("fail-closed when a drifting descriptor turns into an accessor", () => {
+    let descriptorReads = 0;
+    const drifting = new Proxy(
+      { text: "first" },
+      {
+        getOwnPropertyDescriptor(inner, key) {
+          if (key === "text") {
+            descriptorReads += 1;
+            if (descriptorReads > 1) {
+              return {
+                get() {
+                  throw new Error("ACCESSOR_INVOKED");
+                },
+                enumerable: true,
+                configurable: true,
+              };
+            }
+          }
+          return Reflect.getOwnPropertyDescriptor(inner, key);
+        },
+      },
+    );
+    const snapshot = buildCharacterHistorySnapshot({
+      messageExamples: [{ examples: [{ name: "Ada", content: drifting }] }],
+    });
+    expect(descriptorReads).toBe(1);
+    expect(String(JSON.stringify(snapshot))).toContain("first");
   });
 
   it("parseCharacterHistoryEntry skips a cyclic stored change instead of throwing", () => {
@@ -114,7 +255,9 @@ describe("character-history fail-closed walk", () => {
         timestamp: 1,
         historySource: "manual",
         fieldsChanged: ["messageExamples"],
-        changes: [{ field: "messageExamples", before: cyclic, after: { name: "b" } }],
+        changes: [
+          { field: "messageExamples", before: cyclic, after: { name: "b" } },
+        ],
         before: { name: "a" },
         after: { name: "b" },
       },
@@ -132,10 +275,8 @@ describe("character-history fail-closed walk", () => {
       });
       throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
     } catch (error) {
-      expect(error).toBeInstanceOf(CharacterHistoryError);
-      expect((error as CharacterHistoryError).code).toBe(
-        CHARACTER_HISTORY_UNBOUNDED,
-      );
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CHARACTER_HISTORY_UNBOUNDED);
       expect(error).not.toBeInstanceOf(TypeError);
     }
   });
@@ -176,10 +317,8 @@ describe("character-history fail-closed walk", () => {
       });
       throw new Error("expected CHARACTER_HISTORY_UNBOUNDED");
     } catch (error) {
-      expect(error).toBeInstanceOf(CharacterHistoryError);
-      expect((error as CharacterHistoryError).code).toBe(
-        CHARACTER_HISTORY_UNBOUNDED,
-      );
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(CHARACTER_HISTORY_UNBOUNDED);
       expect(String(error)).not.toContain("ACCESSOR_INVOKED");
     }
   });
@@ -223,7 +362,9 @@ describe("character-history fail-closed walk", () => {
       });
       const snapshot = buildCharacterHistorySnapshot({
         name: "Ada",
-        messageExamples: [[{ name: "Ada", content: { text: "top", child: nested } }]],
+        messageExamples: [
+          [{ name: "Ada", content: { text: "top", child: nested } }],
+        ],
       });
       // attach top-level __proto__ on the first example content via a dedicated object
       const topSnapshot = buildCharacterHistorySnapshot({
@@ -246,9 +387,7 @@ describe("character-history fail-closed walk", () => {
       expect(Object.hasOwn(walkedNested, "__proto__")).toBe(true);
       expect(walkedTop["__proto__"]).toEqual({ [pollutedKey]: "top" });
       expect(walkedNested["__proto__"]).toEqual({ [pollutedKey]: "nested" });
-      expect(
-        Object.prototype.hasOwnProperty.call(Object.prototype, pollutedKey),
-      ).toBe(false);
+      expect(Object.hasOwn(Object.prototype, pollutedKey)).toBe(false);
     } finally {
       if (protoDesc) {
         Object.defineProperty(Object.prototype, pollutedKey, protoDesc);

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -1,12 +1,8 @@
 /**
- * Fail-closed character-history walk for Zod-accepted messageExamples.
+ * Exercises bounded character-history snapshot construction and persisted-entry parsing.
  *
- * Origin develop JSON.parse + validateCharacter accepted content.passthrough
- * extra keys, including a 20k-deep nest (~40 KiB) and cyclic in-memory
- * graphs, then RangeError'd in toCharacterHistoryValue during
- * buildCharacterHistorySnapshot. Depth/node/cycle fail-closed replaces
- * that with a typed ElizaError CHARACTER_HISTORY_UNBOUNDED, and every array
- * reserves its whole logical length in the shared aggregate walk budget.
+ * The deterministic harness covers depth, node, descriptor, accessor, proxy,
+ * cycle, and sparse-array limits without external services.
  */
 import { ElizaError, isElizaError, MemoryType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -284,6 +284,79 @@ describe("character-history fail-closed walk", () => {
     expect(parsed).toBeNull();
   });
 
+  it.each([
+    ["over-depth", nestArr(MAX_CHARACTER_HISTORY_WALK_DEPTH + 1)],
+    [
+      "over-node",
+      (() => {
+        const sparse: unknown[] = [];
+        sparse.length = MAX_CHARACTER_HISTORY_WALK_NODES + 1;
+        return sparse;
+      })(),
+    ],
+  ])("skips a %s stored snapshot before emission", (_label, poisoned) => {
+    const parsed = parseCharacterHistoryEntry({
+      content: { text: "change" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        service: "character_history",
+        action: "character_updated",
+        timestamp: 1,
+        historySource: "manual",
+        changes: [{ field: "name", before: "a", after: "b" }],
+        before: poisoned,
+        after: { name: "b" },
+      },
+    } as never);
+    expect(parsed).toBeNull();
+  });
+
+  it("preserves an honest empty stored snapshot", () => {
+    const parsed = parseCharacterHistoryEntry({
+      content: { text: "change" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        service: "character_history",
+        action: "character_updated",
+        timestamp: 1,
+        historySource: "manual",
+        changes: [{ field: "name", before: "a", after: "b" }],
+        before: {},
+        after: {},
+      },
+    } as never);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.before).toEqual({});
+    expect(parsed?.after).toEqual({});
+  });
+
+  it("skips a stored snapshot accessor without invoking it", () => {
+    let calls = 0;
+    const poisoned: Record<string, unknown> = {};
+    Object.defineProperty(poisoned, "name", {
+      enumerable: true,
+      get() {
+        calls += 1;
+        return "poisoned";
+      },
+    });
+    const parsed = parseCharacterHistoryEntry({
+      content: { text: "change" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        service: "character_history",
+        action: "character_updated",
+        timestamp: 1,
+        historySource: "manual",
+        changes: [{ field: "name", before: "a", after: "b" }],
+        before: poisoned,
+        after: { name: "b" },
+      },
+    } as never);
+    expect(parsed).toBeNull();
+    expect(calls).toBe(0);
+  });
+
   it("wraps a revoked Array Proxy instead of leaking TypeError", () => {
     const { proxy, revoke } = Proxy.revocable(["leaf"], {});
     revoke();

--- a/packages/agent/src/services/character-history.walk-bound.test.ts
+++ b/packages/agent/src/services/character-history.walk-bound.test.ts
@@ -69,12 +69,8 @@ describe("character-history fail-closed walk", () => {
   });
 
   it("fail-closed after JSON.parse accepts a 20k-deep passthrough extra", () => {
-    const raw = JSON.stringify({
-      name: "Ada",
-      messageExamples: [
-        [{ name: "Ada", content: { text: "hi", extra: nestArr(20_000) } }],
-      ],
-    });
+    const extra = `${"[".repeat(20_000)}"leaf"${"]".repeat(20_000)}`;
+    const raw = `{"name":"Ada","messageExamples":[[{"name":"Ada","content":{"text":"hi","extra":${extra}}}]]}`;
     const parsed = JSON.parse(raw) as {
       name: string;
       messageExamples: unknown;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23297 (scoped owning issue for this exact hole, filed at maintainer
request on the second CR round). Same-PR Shaw CR on #23130: BLOCKED at
`54ba11d3273da9e52075517a047c9ce51dc60f1d`, CHANGES_REQUESTED at
`7cc8ad359809ec3a332c2c791d63745ba34ce9ed`, CHANGES REQUIRED at
`56695765d31111feaba7903db74bbcca1080f81a`. Occupancy-FREE character-history
walk + `PUT /api/character` atomicity. Not a config-secret redaction host, not
agent-export canonicalize, not a connector ghost-accountId host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6 (heads through `7cc8ad35`), anthropic/claude-opus-5 (CHANGES_REQUESTED repair heads `56695765`, `354b61ab`), openai/gpt-5 (delivery repair `b678154c`)
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app; OpenAI Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed descriptor-only array walks, null-prototype history objects,
and stage-then-commit on `PUT /api/character` so a Zod-valid unbounded graph
cannot leak Proxy traps, mutate `Object.prototype` via `__proto__`, or leave
`runtime.character` partially written on 400. Honest snapshots still persist.
No schema or storage migration. Did not edit HARD_SKIP `server.ts`, occupied
config-redaction hosts, `schema-compat.ts`, `secret-swap.ts`,
`inMemoryAdapter.ts`, or `agent-export.ts`.

# Background

## What does this PR do?

`packages/agent/src/services/character-history.ts` is the live snapshot walk
for `PUT /api/character`. Origin `develop` recursed with `Object.entries` and
`Array.isArray` + `.map()`, so a cyclic or 20k-deep `content` graph that
`JSON.parse` + Zod `contentSchema.passthrough()` already accepted RangeError'd
the walk. The first head failed closed on depth/cycle, but Shaw blocked
`54ba11d3273da9e52075517a047c9ce51dc60f1d`:

1. Both walkers called `Array.isArray` outside `inspectHistory` and traversed
   with `.map()`, so a revoked Array Proxy leaked `TypeError` and ordinary
   array accessors / Proxy `get`/`has` traps ran.
2. Object output used `{}` plus assignment, so an enumerable own `__proto__`
   key mutated the result prototype.
3. `PUT /api/character` mutated `runtime.character` field-by-field *before*
   the second bound, so a 400 left the live runtime partially written.

Head `7cc8ad35` fixed those three, and Shaw then left CHANGES_REQUESTED with
five further reachable gaps. This head (`56695765d31111feaba7903db74bbcca1080f81a`)
answers each one:

1. **Aggregate array budget.** `mapOwnArrayData` now takes the walk context and
   reserves the array's whole *logical* length before sizing output or probing
   a single index descriptor, so many nested 100,000-slot sparse arrays can no
   longer spend one visit per container. Container walks reserve their slots /
   entries, and the recursive call is told the slot is already charged, so no
   node is counted twice.
2. **Descriptor-only PUT staging.** `normalizeCharacterMessageExamplesForName`
   is gone. The route stages every field by a single own-data-descriptor read,
   builds ONE bounded snapshot (`buildCharacterHistorySnapshot`), and only then
   rewrites speaker names / `{{agentName}}` tokens on that trusted snapshot.
   `buildCharacterHistorySnapshot` itself now reads `bio`, `adjectives`,
   `topics`, `style`, `postExamples` and `messageExamples` through the same
   bounded descriptor walk instead of unwrapped `Array.isArray` + spread, and
   the commit writes snapshot values, not raw request values.
3. **Single reflection.** `ownEnumerableDataEntries` captures each enumerable
   own data descriptor exactly once; both walkers consume that stable snapshot
   and never re-reflect, so a `Proxy` cannot drift between two reads.
4. **Real topology observation.** The atomicity tests instrument the actual
   collaborator (`invalidateConversationConnectionTopology`, spied via
   `vi.mock` + `importOriginal` so the real implementation still runs): zero
   calls on every rejection, exactly one on an accepted rename.
5. **Typed domain failure.** The unbounded-walk failure is now `ElizaError`
   with `code: "CHARACTER_HISTORY_UNBOUNDED"`, `severity: "fatal"`, structured
   `context`, and the preserved `cause` chain — the bespoke
   `CharacterHistoryError` class is deleted.

`PUT` returns 400 with zero runtime, update, history or topology mutation on
rejection.

**Round 2 (head `354b61ab49b123a6510c82b184a3a0941c4e8d0c`).** Shaw's exact-head
rereview of `56695765` credited the resource/reflection repairs and found one
reachable compatibility regression the stage/commit split had introduced: it
used the **history snapshot** as the value authority for the live character,
but that snapshot deliberately omits empty values. `CharacterSchema` accepts
`{"username":""}`, `{"bio":""}` and `{"style":{}}` — that is how a caller
CLEARS a field — and `buildCharacterHistorySnapshot` drops an empty `username`
and an empty-string `bio` (both gated on `.trim()`) and an empty `style` (set
only when a known array exists), so the PUT returned success while the old
values stayed live and the response/config disagreed with the submitted clear.

Field **presence** is now tracked separately from history-display
normalization. `stageCharacterPut` returns a presence-aware DTO — one bounded,
descriptor-only, commit-shaped value per field (submitted fields from the
request, the rest from the live character) plus the set of fields the request
actually carried — `commitStagedCharacter` writes the live character from that
DTO, and the possibly-omitting history snapshot is derived from the staged
plain data afterwards. Every value still crosses the boundary exactly once,
through `toBoundedCharacterValue`, on one shared walk budget, so none of the
round-1 descriptor-only / aggregate-budget guarantees are relaxed.

Rebased delivery candidate onto live `origin/develop` `1ca8a8780e06`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Shaw BLOCKED comment on exact head `54ba11d3273da9e52075517a047c9ce51dc60f1d`.
Same-PR repair. `contentSchema.passthrough()` still admits extra keys that
`JSON.parse` already accepted; the walker must stay descriptor-only and the
route must stay atomic.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/character-history.ts`,
`packages/agent/src/services/character-history.walk-bound.test.ts`,
`packages/agent/src/api/character-routes.ts`,
`packages/agent/src/api/character-routes.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0d32c156ac23db2a1a0ca59b1bbbae0db1d58ff8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; character-history walk is runtime logic only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; character-history walk is runtime logic only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
delivery candidate exact head 0d32c156ac23db2a1a0ca59b1bbbae0db1d58ff8
rebase origin/develop 84bbd770c78e0051b36abf6995b0c356e125b66f

$ bun --conditions=eliza-source test packages/agent/src/services/character-history.walk-bound.test.ts \
    packages/agent/src/services/character-history.test.ts
30 pass, 0 fail; 101 expect calls

$ bun x biome check [all five PR source/test files]
Checked 5 files; exit 0. git diff --check: clean.

Delivery regressions route every persisted before/after value through one shared bounded descriptor walker, reject depth >64 and aggregate nodes >100,000 before emission, preserve honest empty snapshots, never invoke accessors, omit cycles, and refill list limits past poisoned rows. Direct persisted over-depth/over-node plus list-fill coverage passes. A post-rebase rerun could not collect because the shared sparse dependency tree lacks uuid and /prompts; the exact repair tree is unchanged from the green pre-rebase run.

Header-only delivery cleanup: machine token-stream proof confirmed the walk-bound test header changed comments only; five-file Biome and diff-check pass.

Historical contributor receipt:
head 354b61ab49b123a6510c82b184a3a0941c4e8d0c
rebase origin/develop 84f58095b90b

$ bun x vitest run packages/agent/src/api/character-routes.test.ts \
    packages/agent/src/services/character-history.walk-bound.test.ts \
    packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
Test Files  3 passed (3)
     Tests  33 passed (33)

$ bun x biome check packages/agent/src/services/character-history.ts \
    packages/agent/src/api/character-routes.ts \
    packages/agent/src/api/character-routes.test.ts \
    packages/agent/src/services/character-history.walk-bound.test.ts
Checked 4 files. 0 errors (2 pre-existing noProto warnings in the
__proto__ regression, which asserts __proto__ stays inert own data).

New regressions for this CHANGES_REQUESTED round (all 5 findings):
  reserves every logical array slot in the aggregate walk budget
    - character + outer array + 2 slots + 2 x 49,998 == 100,000 -> accepted
    - one extra slot per child                      -> CHARACTER_HISTORY_UNBOUNDED
  charges a single sparse array its exact logical length (budget-2 ok, +1 fails)
  charges sparse slots across sibling character fields (bio/topics/postExamples)
  reads each enumerable own descriptor exactly once (drifting Proxy: reads == 1)
  fail-closed when a drifting descriptor turns into an accessor
  raises a typed ElizaError carrying code, severity, context and cause
  PUT never runs submitted Proxy get/has traps while renaming examples
    - trapCalls == 0, rename still applied, topology invalidated exactly once
  PUT rejects a submitted accessor without invoking it or mutating anything
    - accessorCalls == 0, 400, character deep-equals original,
      updateAgent/createMemory/topology: 0 calls
  PUT rejects an unbounded submitted bio before any runtime mutation

Round-2 regressions (schema-valid clear operations, each starting from a
non-empty live character and asserting live value + JSON response +
persisted updateAgent metadata + saved config + recorded history change):
  clears username with an empty string
    - character.username === "", response character.username === "",
      updateAgent metadata.character omits username (history display),
      history change {field: "username", before: "ada_live"} with no `after`
  clears bio with an empty string
    - character.bio === [""], metadata.character.bio === [""],
      saved config agents.list[0].bio === [""]
  clears style with an empty object
    - character.style === {}, saved config style === {},
      metadata.character omits style, exactly one history memory
  clears the empty-collection forms
    - system "", adjectives [], topics [], postExamples [], messageExamples []
      all land in the live character and in the saved config
  keeps untouched fields when one field is cleared
    - name/bio/style/messageExamples unchanged, topology never invalidated

Counter-check (regressions are real): with only the two source files
reverted to head 7cc8ad35, 15 of 27 round-1 tests fail; reverted to head
56695765, the 3 clear-operation regressions fail (username/bio/style).
Restoring the fix returns 33/33.

Baseline reproduction on origin/develop (scratch probe over
`git show origin/develop:packages/agent/src/{services/character-history,api/character-routes}.ts`):
  CYCLE:   RangeError Maximum call stack size exceeded
  DEEP:    RangeError Maximum call stack size exceeded (20k-deep JSON.parse-accepted extra)
  REVOKED: TypeError Cannot perform 'IsArray' on a proxy that has been revoked
  PUT hostile body: 1 submitted accessor invoked, 4 Proxy get traps,
    runtime.character left mutated (name "Eve", bio ["mutated"]), route threw RangeError
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head; the exact focused history suites and scoped Biome/diff checks above are the proof. The post-rebase collection blocker is recorded in the domain receipt. Fork cannot upload `pr-evidence` release
assets, so the domain receipt is inline.

`bun run --cwd packages/agent typecheck` exits 1 on this head **and on
`origin/develop` unchanged**: the workspace is not built, so `tsc` cannot
resolve `@elizaos/plugin-capacitor-bridge/*`, `@elizaos/plugin-wallet/*`,
`@elizaos/cloud-routing`, `@elizaos/plugin-video/vision/notes`,
`@elizaos/plugin-todos/edge` and `@elizaos/plugin-sql`. Zero reported errors are
in the files this PR touches (`tsc` output filtered for `character` is empty).
Unrelated `packages/agent/src/api/*` and `packages/agent/src/services/*` test
files also fail to load
under vitest for the same unbuilt-workspace reason
(`avatar-routes` -> `@elizaos/plugin-discord`, `dispatch-route-*` ->
`@elizaos/plugin-capacitor-bridge`, `agent-backup-v2-capture` /
`connector-credential-store.runtime` -> `@elizaos/plugin-sql`) or because they
are `bun:test` files run under vitest (`audio-redaction-word-budget`); none of
them import character-history or character-routes.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->

