### PR TITLE
test(app): add privacy-safe Cloud live evidence foundations

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -1,0 +1,272 @@
+/** Unit coverage for the privacy-safe Cloud history-continuity contract. */
+
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type CloudLiveContinuityEvidenceInput,
+  classifyForbiddenAgentMutation,
+  compareCloudLiveRuntimeBindings,
+  createCloudLiveContinuityEvidence,
+  createCloudLiveNetworkAudit,
+  parseCloudLiveContinuityEvidence,
+  readCloudLiveContinuityEvidence,
+  writeCloudLiveContinuityEvidence,
+} from "./cloud-live-continuity-contract";
+
+const temporaryDirectories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+function passingInput(): CloudLiveContinuityEvidenceInput {
+  const history = {
+    historyGetSucceeded: true,
+    challengeUserLinePresent: true,
+    challengeAssistantLinePresent: true,
+  } as const;
+  return {
+    challengeTurnCount: 1,
+    noAdditionalChatSendAfterChallenge: true,
+    personalIdentityEndpointPassed: true,
+    reload: history,
+    freshContext: {
+      ...history,
+      createdWithoutStorageState: true,
+      serviceWorkersBlocked: true,
+    },
+    bindingReuse: {
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+    },
+    forbiddenAgentMutationCount: 0,
+    cleanupDisposition: "no-test-owned-agent",
+    conversationHistoryDisposition: "preserved",
+  };
+}
+
+describe("forbidden Cloud agent mutations", () => {
+  it("matches only the bounded lifecycle set on observable client paths", () => {
+    for (const [method, path, expected] of [
+      ["POST", "/api/v1/eliza/agents", "create"],
+      ["POST", "/api/cloud/v1/eliza/agents", "create"],
+      ["POST", "/api/compat/agents", "create"],
+      ["POST", "/api/cloud/compat/agents", "create"],
+      ["POST", "/api/cloud/agents", "create"],
+      ["POST", "/api/v1/eliza/agents/a%2Fb/provision", "provision"],
+      ["POST", "/api/cloud/v1/eliza/agents/a%2Fb/provision", "provision"],
+      ["POST", "/api/cloud/agents/a%2Fb/provision", "provision"],
+      ["POST", "/api/cloud/agents/a%2Fb/connect", "provision"],
+      ["POST", "/api/compat/agents/a%2Fb/launch", "provision"],
+      ["POST", "/api/cloud/compat/agents/a%2Fb/launch", "provision"],
+      ["POST", "/api/v1/eliza/agents/a%2Fb/upgrade-tier", "upgrade-tier"],
+      ["POST", "/api/cloud/v1/eliza/agents/a%2Fb/upgrade-tier", "upgrade-tier"],
+      [
+        "POST",
+        "/api/v1/eliza/agents/a%2Fb/upgrade-tier/cutover",
+        "upgrade-tier-cutover",
+      ],
+      [
+        "POST",
+        "/api/cloud/v1/eliza/agents/a%2Fb/upgrade-tier/cutover",
+        "upgrade-tier-cutover",
+      ],
+      ["DELETE", "/api/v1/eliza/agents/a%2Fb", "delete"],
+      ["DELETE", "/api/cloud/v1/eliza/agents/a%2Fb", "delete"],
+      ["DELETE", "/api/compat/agents/a%2Fb", "delete"],
+      ["DELETE", "/api/cloud/compat/agents/a%2Fb", "delete"],
+      ["POST", "/api/cloud/agents/a%2Fb/shutdown", "delete"],
+    ] as const) {
+      expect(classifyForbiddenAgentMutation(method, path)).toBe(expected);
+    }
+  });
+
+  it("never counts chat, safe actions, wrong verbs, or lookalike routes", () => {
+    const agent = "https://api.test/api/v1/eliza/agents/private";
+    for (const [method, suffix] of [
+      ["POST", "/api/conversations/private/messages"],
+      ["POST", "/api/conversations/private/messages/stream"],
+      ["POST", "/resume"],
+      ["POST", "/sleep"],
+      ["POST", "/snapshot"],
+      ["POST", "/write"],
+      ["GET", "/provision"],
+      ["DELETE", "/api/conversations/private"],
+      ["POST", "/upgrade-tier/cutover/extra"],
+    ] as const) {
+      expect(
+        classifyForbiddenAgentMutation(method, `${agent}${suffix}`),
+      ).toBeNull();
+    }
+    expect(
+      classifyForbiddenAgentMutation(
+        "POST",
+        "https://api.test/api/v1/eliza/personal",
+      ),
+    ).toBeNull();
+    for (const [method, path] of [
+      ["POST", "/api/compat/agents/id/provision"],
+      ["POST", "/api/cloud/compat/agents/id/provision"],
+      ["GET", "/api/compat/agents/id/launch"],
+      ["DELETE", "/api/cloud/compat/agents/id/launch"],
+      ["POST", "/api/compat/agents/id/launch/extra"],
+      ["POST", "/api/cloud/compat/agents/id/launch/extra"],
+      ["POST", "/api/cloud/agents/id/shutdown/extra"],
+      ["POST", "/api/cloud/agents/id/write"],
+    ] as const) {
+      expect(classifyForbiddenAgentMutation(method, path)).toBeNull();
+    }
+  });
+
+  it("reduces retry attempts with one clientMessageId to one logical send", () => {
+    const audit = createCloudLiveNetworkAudit();
+    const history =
+      "https://api.test/api/v1/eliza/agents/private/api/conversations/private/messages";
+    audit.observeRequest("GET", history);
+    audit.observeResponse("GET", history, 200);
+    audit.observeResponse("GET", "/api/v1/eliza/personal", 200);
+    const firstLogicalTurn = JSON.stringify({
+      text: "private prompt",
+      clientMessageId: "private-idempotency-key",
+    });
+    audit.observeRequest("POST", `${history}/stream`, firstLogicalTurn);
+    audit.observeRequest("POST", `${history}/stream`, firstLogicalTurn);
+    audit.observeResponse("POST", `${history}/stream`, 202);
+    audit.observeResponse("POST", `${history}/stream`, 503);
+    audit.observeResponse("POST", `${history}/stream`, 409);
+    audit.observeResponse("POST", `${history}/stream`, 302);
+    audit.observeRequest(
+      "POST",
+      `${history.replace("/private/messages", "/other/messages")}/stream`,
+      firstLogicalTurn,
+    );
+    audit.observeRequest(
+      "POST",
+      `${history}/stream`,
+      JSON.stringify({ clientMessageId: "second-private-id" }),
+    );
+    audit.observeRequest("POST", `${history}/stream`, "not-json");
+    audit.observeRequest(
+      "POST",
+      "https://api.test/api/v1/eliza/agents/private/provision",
+    );
+    const snapshot = audit.snapshot();
+    expect(snapshot).toEqual({
+      forbiddenAgentMutationCount: 1,
+      chatSendAttemptCount: 5,
+      logicalChatSendCount: 3,
+      unidentifiedChatSendAttemptCount: 1,
+      successfulChatSendResponseCount: 1,
+      clientErrorChatSendResponseCount: 1,
+      serverErrorChatSendResponseCount: 1,
+      otherChatSendResponseCount: 1,
+      successfulPersonalIdentityGetCount: 1,
+      successfulHistoryGetCount: 1,
+    });
+    expect(JSON.stringify(snapshot)).not.toMatch(
+      /api\.test|private|idempotency|prompt/,
+    );
+  });
+});
+
+describe("privacy-safe continuity evidence", () => {
+  it("reduces private bindings to booleans", () => {
+    const reference = {
+      personalIdentity: "private-personal",
+      runtimeBinding: "private-runtime",
+      runtime: "shared" as const,
+      apiBase: "https://api.example.test/runtime/",
+    };
+    const comparison = compareCloudLiveRuntimeBindings(reference, {
+      ...reference,
+      apiBase: "https://api.example.test/runtime",
+    });
+    expect(comparison).toEqual({
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+    });
+    expect(JSON.stringify(comparison)).not.toMatch(/private|example\.test/);
+  });
+
+  it("emits the flat closed proof and honest cleanup semantics", () => {
+    expect(createCloudLiveContinuityEvidence(passingInput())).toEqual({
+      schemaVersion: 1,
+      lane: "app-live-e2e-cloud-staging",
+      challengeTurnCount: 1,
+      noAdditionalChatSendAfterChallenge: true,
+      personalIdentityEndpointPassed: true,
+      reloadHistoryPassed: true,
+      freshContextHistoryPassed: true,
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+      forbiddenAgentMutationCount: 0,
+      cleanupDisposition: "no-test-owned-agent",
+      conversationHistoryDisposition: "preserved",
+    });
+  });
+
+  it("fails closed on a second challenge, incomplete proof, or mutation", () => {
+    expect(() =>
+      createCloudLiveContinuityEvidence({
+        ...passingInput(),
+        challengeTurnCount: 2,
+      }),
+    ).toThrow("must be one");
+    expect(() =>
+      createCloudLiveContinuityEvidence({
+        ...passingInput(),
+        reload: { ...passingInput().reload, challengeUserLinePresent: false },
+      }),
+    ).toThrow("reload.challengeUserLinePresent must be true");
+    expect(() =>
+      createCloudLiveContinuityEvidence({
+        ...passingInput(),
+        personalIdentityEndpointPassed: false,
+      }),
+    ).toThrow("personalIdentityEndpointPassed must be true");
+    expect(() =>
+      createCloudLiveContinuityEvidence({
+        ...passingInput(),
+        forbiddenAgentMutationCount: 1,
+      }),
+    ).toThrow("must be zero");
+  });
+
+  it("rejects any extra or non-passing JSON field", () => {
+    const valid = createCloudLiveContinuityEvidence(passingInput());
+    expect(() =>
+      parseCloudLiveContinuityEvidence({ ...valid, runtimeId: "private" }),
+    ).toThrow("exact closed schema");
+    expect(() =>
+      parseCloudLiveContinuityEvidence({
+        ...valid,
+        freshContextHistoryPassed: false,
+      }),
+    ).toThrow("freshContextHistoryPassed is invalid");
+  });
+
+  it("writes mode 0600, refuses overwrite, and persists no private value", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cloud-continuity-"));
+    temporaryDirectories.push(directory);
+    const outputPath = join(directory, "nested", "continuity.json");
+    await writeCloudLiveContinuityEvidence(outputPath, passingInput());
+    expect(await readCloudLiveContinuityEvidence(outputPath)).toEqual(
+      createCloudLiveContinuityEvidence(passingInput()),
+    );
+    expect((await stat(outputPath)).mode & 0o777).toBe(0o600);
+    expect(await readFile(outputPath, "utf8")).not.toMatch(
+      /private|prompt|reply|token|runtimeId|agentId/,
+    );
+    await expect(
+      writeCloudLiveContinuityEvidence(outputPath, passingInput()),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -1,0 +1,420 @@
+/** Closed, privacy-safe continuity evidence for the real Cloud UI lane. */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const LANE = "app-live-e2e-cloud-staging";
+
+const DIRECT_AGENTS = "/api/v1/eliza/agents";
+const DIRECT_COMPAT_AGENTS = "/api/compat/agents";
+const COMPAT_PROXY_AGENTS = "/api/cloud/compat/agents";
+const V1_PROXY_AGENTS = "/api/cloud/v1/eliza/agents";
+const LEGACY_CLOUD_AGENTS = "/api/cloud/agents";
+
+export type ForbiddenAgentMutation =
+  | "create"
+  | "provision"
+  | "upgrade-tier"
+  | "upgrade-tier-cutover"
+  | "delete";
+
+export interface CloudLiveRuntimeBinding {
+  /** Private Personal Eliza identity. Never serialize this value. */
+  personalIdentity: string;
+  /** Private runtime binding. Never serialize this value. */
+  runtimeBinding: string;
+  runtime: "shared" | "dedicated";
+  /** Private runtime adapter base. Never serialize this value. */
+  apiBase: string;
+}
+
+export interface CloudLiveBindingReuse {
+  personalIdentityReused: boolean;
+  runtimeBindingReused: boolean;
+  apiBaseReused: boolean;
+}
+
+export interface CloudLiveHistoryObservation {
+  historyGetSucceeded: boolean;
+  challengeUserLinePresent: boolean;
+  challengeAssistantLinePresent: boolean;
+}
+
+export interface CloudLiveContinuityEvidenceInput {
+  challengeTurnCount: number;
+  noAdditionalChatSendAfterChallenge: boolean;
+  personalIdentityEndpointPassed: boolean;
+  reload: CloudLiveHistoryObservation;
+  freshContext: CloudLiveHistoryObservation & {
+    createdWithoutStorageState: boolean;
+    serviceWorkersBlocked: boolean;
+  };
+  bindingReuse: CloudLiveBindingReuse;
+  forbiddenAgentMutationCount: number;
+  cleanupDisposition: "no-test-owned-agent";
+  conversationHistoryDisposition: "preserved";
+}
+
+const VERIFIED_EVIDENCE = {
+  schemaVersion: 1,
+  lane: LANE,
+  challengeTurnCount: 1,
+  noAdditionalChatSendAfterChallenge: true,
+  personalIdentityEndpointPassed: true,
+  reloadHistoryPassed: true,
+  freshContextHistoryPassed: true,
+  personalIdentityReused: true,
+  runtimeBindingReused: true,
+  apiBaseReused: true,
+  forbiddenAgentMutationCount: 0,
+  cleanupDisposition: "no-test-owned-agent",
+  conversationHistoryDisposition: "preserved",
+} as const;
+
+export type CloudLiveContinuityEvidence = typeof VERIFIED_EVIDENCE;
+
+function fail(message: string): never {
+  throw new Error(`[cloud-live-continuity] ${message}`);
+}
+
+function requestPath(rawUrl: string): string {
+  try {
+    const pathname = new URL(rawUrl, "https://cloud-live.invalid").pathname;
+    return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Exact forbidden set for this read-only lane. Agent chat and every other
+ * agent-scoped operation intentionally fall through.
+ */
+export function classifyForbiddenAgentMutation(
+  method: string,
+  rawUrl: string,
+): ForbiddenAgentMutation | null {
+  const verb = method.trim().toUpperCase();
+  const pathname = requestPath(rawUrl);
+  for (const base of [DIRECT_AGENTS, V1_PROXY_AGENTS] as const) {
+    if (pathname === base) return verb === "POST" ? "create" : null;
+    if (!pathname.startsWith(`${base}/`)) continue;
+    const target = pathname
+      .slice(base.length + 1)
+      .match(/^[^/]+(?:\/(provision|upgrade-tier(?:\/cutover)?))?$/);
+    if (!target) return null;
+    if (!target[1]) return verb === "DELETE" ? "delete" : null;
+    if (verb !== "POST") return null;
+    if (target[1] === "provision") return "provision";
+    return target[1] === "upgrade-tier"
+      ? "upgrade-tier"
+      : "upgrade-tier-cutover";
+  }
+
+  for (const base of [DIRECT_COMPAT_AGENTS, COMPAT_PROXY_AGENTS] as const) {
+    if (verb === "POST" && pathname === base) return "create";
+    if (!pathname.startsWith(`${base}/`)) continue;
+    const target = pathname.slice(base.length + 1);
+    if (verb === "DELETE" && !target.includes("/")) return "delete";
+    if (verb === "POST" && /^[^/]+\/launch$/.test(target)) return "provision";
+  }
+
+  if (verb === "POST" && pathname === LEGACY_CLOUD_AGENTS) return "create";
+  if (verb === "POST" && pathname.startsWith(`${LEGACY_CLOUD_AGENTS}/`)) {
+    const target = pathname.slice(LEGACY_CLOUD_AGENTS.length + 1);
+    if (/^[^/]+\/(?:provision|connect)$/.test(target)) return "provision";
+    if (/^[^/]+\/shutdown$/.test(target)) return "delete";
+  }
+  return null;
+}
+
+function isHistoryGet(method: string, rawUrl: string): boolean {
+  return (
+    method.trim().toUpperCase() === "GET" &&
+    /\/api\/conversations\/[^/]+\/messages$/.test(requestPath(rawUrl))
+  );
+}
+
+function chatSendScope(method: string, rawUrl: string): string {
+  if (method.trim().toUpperCase() !== "POST") return "";
+  try {
+    const parsed = new URL(rawUrl, "https://cloud-live.invalid");
+    const pathname = requestPath(rawUrl);
+    if (!/\/api\/conversations\/[^/]+\/messages(?:\/stream)?$/.test(pathname)) {
+      return "";
+    }
+    return `${parsed.origin}${pathname.replace(/\/stream$/, "")}`;
+  } catch {
+    return "";
+  }
+}
+
+function isPersonalIdentityGet(method: string, rawUrl: string): boolean {
+  return (
+    method.trim().toUpperCase() === "GET" &&
+    requestPath(rawUrl) === "/api/v1/eliza/personal"
+  );
+}
+
+function chatClientMessageId(postData: string | null | undefined): string {
+  try {
+    const parsed = JSON.parse(postData ?? "") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return "";
+    const clientMessageId = (parsed as Record<string, unknown>).clientMessageId;
+    return typeof clientMessageId === "string" && clientMessageId.length > 0
+      ? clientMessageId
+      : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Counts only; request URLs and their embedded IDs are never retained. */
+export function createCloudLiveNetworkAudit(): {
+  observeRequest(
+    method: string,
+    rawUrl: string,
+    postData?: string | null,
+  ): void;
+  observeResponse(method: string, rawUrl: string, status: number): void;
+  snapshot(): {
+    forbiddenAgentMutationCount: number;
+    chatSendAttemptCount: number;
+    logicalChatSendCount: number;
+    unidentifiedChatSendAttemptCount: number;
+    successfulChatSendResponseCount: number;
+    clientErrorChatSendResponseCount: number;
+    serverErrorChatSendResponseCount: number;
+    otherChatSendResponseCount: number;
+    successfulPersonalIdentityGetCount: number;
+    successfulHistoryGetCount: number;
+  };
+} {
+  let forbiddenAgentMutationCount = 0;
+  let chatSendAttemptCount = 0;
+  let unidentifiedChatSendAttemptCount = 0;
+  const logicalChatSendIds = new Set<string>();
+  let successfulChatSendResponseCount = 0;
+  let clientErrorChatSendResponseCount = 0;
+  let serverErrorChatSendResponseCount = 0;
+  let otherChatSendResponseCount = 0;
+  let successfulPersonalIdentityGetCount = 0;
+  let successfulHistoryGetCount = 0;
+  return {
+    observeRequest(method, rawUrl, postData) {
+      if (classifyForbiddenAgentMutation(method, rawUrl)) {
+        forbiddenAgentMutationCount += 1;
+      }
+      const scope = chatSendScope(method, rawUrl);
+      if (scope) {
+        chatSendAttemptCount += 1;
+        const clientMessageId = chatClientMessageId(postData);
+        if (clientMessageId) {
+          // Server idempotency is scoped to the runtime/conversation, not the
+          // clientMessageId globally. Keep the private scope/key in memory only.
+          logicalChatSendIds.add(`${scope}\u0000${clientMessageId}`);
+        } else unidentifiedChatSendAttemptCount += 1;
+      }
+    },
+    observeResponse(method, rawUrl, status) {
+      if (chatSendScope(method, rawUrl)) {
+        if (status >= 200 && status < 300) {
+          successfulChatSendResponseCount += 1;
+        } else if (status >= 400 && status < 500) {
+          clientErrorChatSendResponseCount += 1;
+        } else if (status >= 500 && status < 600) {
+          serverErrorChatSendResponseCount += 1;
+        } else {
+          otherChatSendResponseCount += 1;
+        }
+      }
+      if (status >= 200 && status < 300 && isHistoryGet(method, rawUrl)) {
+        successfulHistoryGetCount += 1;
+      }
+      if (
+        status >= 200 &&
+        status < 300 &&
+        isPersonalIdentityGet(method, rawUrl)
+      ) {
+        successfulPersonalIdentityGetCount += 1;
+      }
+    },
+    snapshot: () => ({
+      forbiddenAgentMutationCount,
+      chatSendAttemptCount,
+      logicalChatSendCount: logicalChatSendIds.size,
+      unidentifiedChatSendAttemptCount,
+      successfulChatSendResponseCount,
+      clientErrorChatSendResponseCount,
+      serverErrorChatSendResponseCount,
+      otherChatSendResponseCount,
+      successfulPersonalIdentityGetCount,
+      successfulHistoryGetCount,
+    }),
+  };
+}
+
+function normalizedApiBase(apiBase: string): string {
+  try {
+    const parsed = new URL(apiBase);
+    return `${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return "";
+  }
+}
+
+/** Reduce private values to publishable booleans before they leave memory. */
+export function compareCloudLiveRuntimeBindings(
+  reference: CloudLiveRuntimeBinding,
+  candidate: CloudLiveRuntimeBinding,
+): CloudLiveBindingReuse {
+  const referenceBase = normalizedApiBase(reference.apiBase);
+  return {
+    personalIdentityReused:
+      reference.personalIdentity.length > 0 &&
+      candidate.personalIdentity === reference.personalIdentity,
+    runtimeBindingReused:
+      reference.runtimeBinding.length > 0 &&
+      candidate.runtimeBinding === reference.runtimeBinding &&
+      candidate.runtime === reference.runtime,
+    apiBaseReused:
+      referenceBase.length > 0 &&
+      normalizedApiBase(candidate.apiBase) === referenceBase,
+  };
+}
+
+function requireTrue(value: unknown, label: string): void {
+  if (value !== true) fail(`${label} must be true`);
+}
+
+function requireClosedRecord(
+  value: unknown,
+  keys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    fail(`${label} must use the exact closed schema`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireObservation(
+  observation: CloudLiveHistoryObservation,
+  label: string,
+): void {
+  requireTrue(observation.historyGetSucceeded, `${label}.historyGetSucceeded`);
+  requireTrue(
+    observation.challengeUserLinePresent,
+    `${label}.challengeUserLinePresent`,
+  );
+  requireTrue(
+    observation.challengeAssistantLinePresent,
+    `${label}.challengeAssistantLinePresent`,
+  );
+}
+
+const EVIDENCE_KEYS = Object.keys(VERIFIED_EVIDENCE) as Array<
+  keyof CloudLiveContinuityEvidence
+>;
+
+export function createCloudLiveContinuityEvidence(
+  input: CloudLiveContinuityEvidenceInput,
+): CloudLiveContinuityEvidence {
+  if (input.challengeTurnCount !== 1) fail("challengeTurnCount must be one");
+  requireTrue(
+    input.noAdditionalChatSendAfterChallenge,
+    "noAdditionalChatSendAfterChallenge",
+  );
+  requireTrue(
+    input.personalIdentityEndpointPassed,
+    "personalIdentityEndpointPassed",
+  );
+  requireObservation(input.reload, "reload");
+  requireObservation(input.freshContext, "freshContext");
+  requireTrue(
+    input.freshContext.createdWithoutStorageState,
+    "freshContext.createdWithoutStorageState",
+  );
+  requireTrue(
+    input.freshContext.serviceWorkersBlocked,
+    "freshContext.serviceWorkersBlocked",
+  );
+  for (const key of [
+    "personalIdentityReused",
+    "runtimeBindingReused",
+    "apiBaseReused",
+  ] as const) {
+    requireTrue(input.bindingReuse[key], `bindingReuse.${key}`);
+  }
+  if (input.forbiddenAgentMutationCount !== 0) {
+    fail("forbiddenAgentMutationCount must be zero");
+  }
+  if (input.cleanupDisposition !== "no-test-owned-agent") {
+    fail("cleanupDisposition must be no-test-owned-agent");
+  }
+  if (input.conversationHistoryDisposition !== "preserved") {
+    fail("conversationHistoryDisposition must be preserved");
+  }
+
+  return { ...VERIFIED_EVIDENCE };
+}
+
+export function parseCloudLiveContinuityEvidence(
+  value: unknown,
+): CloudLiveContinuityEvidence {
+  const evidence = requireClosedRecord(value, EVIDENCE_KEYS, "artifact");
+  for (const key of EVIDENCE_KEYS) {
+    if (evidence[key] !== VERIFIED_EVIDENCE[key]) {
+      fail(`artifact.${key} is invalid`);
+    }
+  }
+  return { ...VERIFIED_EVIDENCE };
+}
+
+export async function writeCloudLiveContinuityEvidence(
+  outputPath: string,
+  input: CloudLiveContinuityEvidenceInput,
+): Promise<string> {
+  if (!outputPath.trim()) fail("output path must not be empty");
+  const resolvedPath = resolve(outputPath);
+  const evidence = createCloudLiveContinuityEvidence(input);
+  await mkdir(dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, `${JSON.stringify(evidence, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  return resolvedPath;
+}
+
+export async function readCloudLiveContinuityEvidence(
+  inputPath: string,
+): Promise<CloudLiveContinuityEvidence> {
+  if (!inputPath.trim()) fail("input path must not be empty");
+  return parseCloudLiveContinuityEvidence(
+    JSON.parse(await readFile(resolve(inputPath), "utf8")) as unknown,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    if (process.argv.length !== 3) {
+      fail("usage: bun cloud-live-continuity-contract.ts <artifact.json>");
+    }
+    await readCloudLiveContinuityEvidence(process.argv[2]);
+    process.stdout.write("verified");
+  } catch (error) {
+    // error-policy:J1 fail closed without printing the artifact or private data.
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/app/test/liveness-contract.ts
+++ b/packages/app/test/liveness-contract.ts
@@ -5,7 +5,10 @@
  * fail) lives in the dependency-free `liveness-contract.mjs`; this file only
  * adds the DOM driving so browser-based onboarding lanes (cloud-live and the
  * web/desktop paths) end the same way: send a message, wait for the assistant
- * reply, assert liveness.
+ * reply, assert liveness. The timed variant additionally waits for the thread
+ * to settle, re-reads the same fresh row, and measures from initiation of the
+ * UI send action through final validation; it is full-turn latency, not
+ * first-token latency.
  *
  * Reply selection is fail-closed by construction (#16936 review): the assistant
  * row count is snapshotted before send, only rows that did not exist before the
@@ -56,12 +59,52 @@ export interface LivenessChatOptions {
   label?: string;
 }
 
+export interface TimedLivenessReply {
+  /** Validated, trimmed assistant reply. Never persist this in CI metadata. */
+  reply: string;
+  /** Composer send click to the settled, validated assistant turn. */
+  firstTurnLatencyMs: number;
+}
+
+interface RenderedReplyMeasurement {
+  reply: string;
+  sendActionStartedAt: number;
+}
+
 function chatComposer(page: Page): Locator {
   return page.locator(CHAT_COMPOSER_SELECTOR).first();
 }
 
 function chatSendButton(page: Page): Locator {
   return page.locator(CHAT_SEND_SELECTOR).first();
+}
+
+async function acceptedReplyText(
+  row: Locator,
+  challengeToken: string | undefined,
+): Promise<string> {
+  if ((await row.getAttribute("data-failure"))?.trim()) return "";
+  if ((await row.locator('[data-testid="thread-line-retry"]').count()) > 0)
+    return "";
+  // Mirror the iOS driver's classification: a row whose overlay body is
+  // explicitly in the status phase is a pending placeholder. A row with no
+  // overlay marker is a plain chat surface, where the typing indicator renders
+  // as a sibling and any non-empty matched row is assistant content.
+  const overlayBodies = await row
+    .locator('[data-testid="overlay-assistant-turn-body"]')
+    .count();
+  if (overlayBodies > 0) {
+    const replyBodies = await row
+      .locator(
+        '[data-testid="overlay-assistant-turn-body"][data-phase="reply"]',
+      )
+      .count();
+    if (replyBodies === 0) return "";
+  }
+  const text = (await row.textContent())?.trim() ?? "";
+  if (!text) return "";
+  if (challengeToken && !text.toLowerCase().includes(challengeToken)) return "";
+  return text;
 }
 
 /**
@@ -71,10 +114,11 @@ function chatSendButton(page: Page): Locator {
  * post-onboarding). Kept separate from the assertion so a caller can inspect
  * the reply before enforcing the contract.
  */
-export async function sendChatAndReadReply(
+async function sendChatAndMeasureRenderedReply(
   page: Page,
   options: LivenessChatOptions = {},
-): Promise<string> {
+  waitForSettledTurn: boolean,
+): Promise<RenderedReplyMeasurement> {
   const replyTimeoutMs = options.replyTimeoutMs ?? DEFAULT_REPLY_TIMEOUT_MS;
   const composer = chatComposer(page);
   await expect(composer).toBeVisible({ timeout: 60_000 });
@@ -82,6 +126,7 @@ export async function sendChatAndReadReply(
   const priorCount = await assistantRows.count();
   await composer.fill(options.prompt ?? DEFAULT_PROMPT);
   await expect(chatSendButton(page)).toBeEnabled();
+  const sendStartedAt = performance.now();
   await chatSendButton(page).click();
 
   // Only rows beyond the pre-send snapshot can satisfy the turn: the pre-existing
@@ -93,33 +138,17 @@ export async function sendChatAndReadReply(
   // transcript only appends during a turn, so indices ≥ the snapshot are
   // exactly this run's rows.
   const token = options.challengeToken?.trim().toLowerCase();
-  let replyText: string | null = null;
+  const replyMatch = { text: "", rowIndex: -1 };
   await expect
     .poll(
       async () => {
         const count = await assistantRows.count();
         for (let i = priorCount; i < count; i += 1) {
           const row = assistantRows.nth(i);
-          // Mirror the iOS driver's classification: a row whose overlay body
-          // is explicitly in the status phase is the pending placeholder; a
-          // row with no overlay marker at all is a plain chat surface (the
-          // typing indicator renders as a sibling there, never as a row), so
-          // any matched row counts.
-          const overlayBodies = await row
-            .locator('[data-testid="overlay-assistant-turn-body"]')
-            .count();
-          if (overlayBodies > 0) {
-            const replyBodies = await row
-              .locator(
-                '[data-testid="overlay-assistant-turn-body"][data-phase="reply"]',
-              )
-              .count();
-            if (replyBodies === 0) continue;
-          }
-          const text = (await row.textContent())?.trim() ?? "";
+          const text = await acceptedReplyText(row, token);
           if (!text) continue;
-          if (token && !text.toLowerCase().includes(token)) continue;
-          replyText = text;
+          replyMatch.text = text;
+          replyMatch.rowIndex = i;
           return text;
         }
         return "";
@@ -132,11 +161,50 @@ export async function sendChatAndReadReply(
       },
     )
     .toMatch(/\S/);
-  // The poll's winning element and the returned text are the same value; never
-  // re-resolve a locator after the wait (the row may have kept streaming).
-  if (replyText === null)
+
+  if (!replyMatch.text || replyMatch.rowIndex < priorCount) {
     throw new Error("liveness reply poll ended without a reply");
-  return replyText;
+  }
+
+  let measuredReply = replyMatch.text;
+  if (waitForSettledTurn) {
+    // `data-phase="reply"` flips when the first content renders, so it cannot
+    // be the end boundary for a conservatively named first-turn metric. The
+    // overlay thread content owns the authoritative responding state. Only the
+    // timed Cloud lane opts into this overlay-specific boundary; the historic
+    // string APIs remain usable by plain chat surfaces.
+    const remainingTimeoutMs = Math.max(
+      1,
+      Math.ceil(sendStartedAt + replyTimeoutMs - performance.now()),
+    );
+    await expect(
+      page
+        .getByTestId("chat-thread-scroll")
+        .locator('[data-slot="message-scroller-content"][aria-busy="false"]')
+        .first(),
+    ).toBeVisible({ timeout: remainingTimeoutMs });
+    const settledReply = await acceptedReplyText(
+      assistantRows.nth(replyMatch.rowIndex),
+      token,
+    );
+    if (!settledReply) {
+      throw new Error(
+        "fresh assistant row was empty or invalid after the turn settled",
+      );
+    }
+    measuredReply = settledReply;
+  }
+  return {
+    reply: measuredReply,
+    sendActionStartedAt: sendStartedAt,
+  };
+}
+
+export async function sendChatAndReadReply(
+  page: Page,
+  options: LivenessChatOptions = {},
+): Promise<string> {
+  return (await sendChatAndMeasureRenderedReply(page, options, false)).reply;
 }
 
 /**
@@ -157,4 +225,30 @@ export async function assertOnboardingLiveness(
         label: options.label,
       })
     : assertLiveReply(reply, { label: options.label });
+}
+
+/**
+ * Apply the onboarding liveness contract and separately return full-turn
+ * latency. The duration starts immediately before the composer send click and
+ * ends only after the overlay reports idle, the same fresh assistant row is
+ * re-read, and its settled text passes the liveness contract. It does not claim
+ * transport first-token timing.
+ */
+export async function assertOnboardingLivenessWithTiming(
+  page: Page,
+  options: LivenessChatOptions = {},
+): Promise<TimedLivenessReply> {
+  const measured = await sendChatAndMeasureRenderedReply(page, options, true);
+  const reply = options.challengeToken
+    ? assertLiveChallengeReply(measured.reply, {
+        challengeToken: options.challengeToken,
+        label: options.label,
+      })
+    : assertLiveReply(measured.reply, { label: options.label });
+  return {
+    reply,
+    firstTurnLatencyMs: Math.ceil(
+      performance.now() - measured.sendActionStartedAt,
+    ),
+  };
 }

--- a/packages/app/test/staging-cloud-chat-latency-evidence.test.ts
+++ b/packages/app/test/staging-cloud-chat-latency-evidence.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Deterministically verifies the staging chat-latency artifact's closed,
+ * privacy-safe schema and its on-disk round trip without a live Cloud call.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createStagingCloudChatLatencyEvidence,
+  parseStagingCloudChatLatencyEvidence,
+  readStagingCloudChatLatencyEvidence,
+  writeStagingCloudChatLatencyEvidence,
+} from "./staging-cloud-chat-latency-evidence";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("staging Cloud chat latency evidence", () => {
+  it("contains only fixed labels and the measured duration", () => {
+    const evidence = createStagingCloudChatLatencyEvidence(12_345);
+    expect(evidence).toEqual({
+      schemaVersion: 1,
+      lane: "app-live-e2e-cloud-staging",
+      metric: "first-turn-latency",
+      definition:
+        "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency",
+      firstTurnLatencyMs: 12_345,
+    });
+    expect(Object.keys(evidence).sort()).toEqual([
+      "definition",
+      "firstTurnLatencyMs",
+      "lane",
+      "metric",
+      "schemaVersion",
+    ]);
+  });
+
+  it("rejects missing, extra, mislabeled, and invalid duration values", () => {
+    const valid = createStagingCloudChatLatencyEvidence(1);
+    expect(() =>
+      parseStagingCloudChatLatencyEvidence({ ...valid, prompt: "secret" }),
+    ).toThrow("exact closed schema");
+    expect(() =>
+      parseStagingCloudChatLatencyEvidence({ ...valid, metric: "first-token" }),
+    ).toThrow("labels do not match");
+    for (const latency of [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      expect(() => createStagingCloudChatLatencyEvidence(latency)).toThrow(
+        "positive safe integer",
+      );
+    }
+  });
+
+  it("writes and reads the exact privacy-safe JSON artifact", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "staging-chat-latency-"));
+    temporaryDirectories.push(directory);
+    const outputPath = join(directory, "nested", "latency.json");
+
+    expect(await writeStagingCloudChatLatencyEvidence(outputPath, 8_765)).toBe(
+      outputPath,
+    );
+    expect(await readStagingCloudChatLatencyEvidence(outputPath)).toEqual(
+      createStagingCloudChatLatencyEvidence(8_765),
+    );
+
+    const raw = await readFile(outputPath, "utf8");
+    expect(raw).toBe(
+      `${JSON.stringify(createStagingCloudChatLatencyEvidence(8_765), null, 2)}\n`,
+    );
+    expect(raw).not.toMatch(
+      /authorization|bearer|api.?key|credential|prompt|response|reply/i,
+    );
+    await expect(
+      writeStagingCloudChatLatencyEvidence(outputPath, 9_999),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/app/test/staging-cloud-chat-latency-evidence.ts
+++ b/packages/app/test/staging-cloud-chat-latency-evidence.ts
@@ -1,0 +1,131 @@
+/**
+ * Produces and validates the staging Cloud chat-latency handoff artifact.
+ * Its closed schema carries one duration and fixed labels only: no prompt,
+ * assistant text, credential, account, agent, conversation, or provider ID can
+ * enter the workflow artifact consumed by the staging receipt writer.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const SCHEMA_VERSION = 1;
+const LANE = "app-live-e2e-cloud-staging";
+const METRIC = "first-turn-latency";
+const DEFINITION =
+  "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency";
+
+export interface StagingCloudChatLatencyEvidence {
+  schemaVersion: 1;
+  lane: typeof LANE;
+  metric: typeof METRIC;
+  definition: typeof DEFINITION;
+  firstTurnLatencyMs: number;
+}
+
+function fail(message: string): never {
+  throw new Error(`[staging-cloud-chat-latency] ${message}`);
+}
+
+function positiveDuration(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    fail("value must be a positive safe integer duration in milliseconds");
+  }
+  return value as number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === [...expected].sort()[index])
+  );
+}
+
+export function createStagingCloudChatLatencyEvidence(
+  firstTurnLatencyMs: number,
+): StagingCloudChatLatencyEvidence {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    lane: LANE,
+    metric: METRIC,
+    definition: DEFINITION,
+    firstTurnLatencyMs: positiveDuration(firstTurnLatencyMs),
+  };
+}
+
+export function parseStagingCloudChatLatencyEvidence(
+  value: unknown,
+): StagingCloudChatLatencyEvidence {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "definition",
+      "firstTurnLatencyMs",
+      "lane",
+      "metric",
+      "schemaVersion",
+    ])
+  ) {
+    fail("artifact must use the exact closed schema");
+  }
+  if (value.schemaVersion !== SCHEMA_VERSION) {
+    fail(`schemaVersion must be ${SCHEMA_VERSION}`);
+  }
+  if (
+    value.lane !== LANE ||
+    value.metric !== METRIC ||
+    value.definition !== DEFINITION
+  ) {
+    fail("artifact labels do not match the staging chat latency contract");
+  }
+  return createStagingCloudChatLatencyEvidence(
+    positiveDuration(value.firstTurnLatencyMs),
+  );
+}
+
+export async function writeStagingCloudChatLatencyEvidence(
+  outputPath: string,
+  firstTurnLatencyMs: number,
+): Promise<string> {
+  if (!outputPath.trim()) fail("output path must not be empty");
+  const resolvedPath = resolve(outputPath);
+  const evidence = createStagingCloudChatLatencyEvidence(firstTurnLatencyMs);
+  await mkdir(dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, `${JSON.stringify(evidence, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  return resolvedPath;
+}
+
+export async function readStagingCloudChatLatencyEvidence(
+  inputPath: string,
+): Promise<StagingCloudChatLatencyEvidence> {
+  if (!inputPath.trim()) fail("input path must not be empty");
+  const raw = await readFile(resolve(inputPath), "utf8");
+  return parseStagingCloudChatLatencyEvidence(JSON.parse(raw) as unknown);
+}
+
+if (import.meta.main) {
+  try {
+    if (process.argv.length !== 3) {
+      fail("usage: bun staging-cloud-chat-latency-evidence.ts <artifact.json>");
+    }
+    const evidence = await readStagingCloudChatLatencyEvidence(process.argv[2]);
+    process.stdout.write(String(evidence.firstTurnLatencyMs));
+  } catch (error) {
+    // error-policy:J1 the CLI boundary reports invalid or unreadable evidence
+    // and exits non-zero so a successful smoke cannot publish a receipt without
+    // its independently measured latency.
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1111,6 +1111,7 @@ export const ChatMessage = memo(function ChatMessage({
         align={isUser ? "end" : "start"}
         data-testid="thread-line"
         data-role={message.role}
+        data-failure={isAssistant ? message.failureKind : undefined}
         // A very short opacity-only entrance keeps fast-model turns immediate
         // without fighting the scroller's bottom anchor.
         initial={initial}

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -5301,21 +5301,25 @@ describe("ChatOverlay — routed OS-intent composer prefill (#9148, #16441)", ()
     expect(controller.send).toHaveBeenCalledWith("what's the weather?");
   });
 
-  it("does NOT show Retry on an unrecoverable failure (no_provider / insufficient_credits)", () => {
+  it("marks a non-retryable normal assistant failure without showing Retry", () => {
     const controller = makeController({
       messages: [
         { id: "u1", role: "user", content: "hi", createdAt: 1 },
         {
           id: "a1",
           role: "assistant",
-          content: "",
+          content: "The required capability is unavailable.",
           createdAt: 2,
-          failureKind: "insufficient_credits",
+          failureKind: "missing_capability",
         },
       ],
     } as unknown as Partial<ShellController>);
     render(<ChatOverlay controller={controller} />);
     fireEvent.focus(screen.getByLabelText("message"));
+    const failedTurn = screen
+      .getByText("The required capability is unavailable.")
+      .closest('[data-testid="thread-line"]');
+    expect(failedTurn?.getAttribute("data-failure")).toBe("missing_capability");
     expect(screen.queryByTestId("thread-line-retry")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Adds the deterministic foundations needed to make App Live Cloud evidence closed, privacy-safe, and fail-closed:

- defines a closed continuity contract for one logical challenge turn, reload history, fresh-context history, Personal identity/runtime/API binding reuse, and zero create/provision/upgrade/delete traffic;
- measures full first-turn latency from the composer send click through the settled, validated assistant turn — explicitly not first-token latency;
- rejects failed and retry assistant rows through a non-visual `data-failure` marker;
- keeps prompts, replies, challenge tokens, and private account/agent/conversation identifiers out of evidence.

This is the foundations-only slice. The live workflow and receipt wiring follow in the stacked activation PR #23132.

## Context

This builds on the already merged staging lane, renderer-origin pin, and exact-SHA receipt work in #20421, #22171, and #22436. It addresses only the remaining evidence contracts around Personal identity resolution + chat; it does not reintroduce provisioning into onboarding.

## Testing

Current head: `c8a8137fd0222be171baeda084845d724ad3600c`, rebased exactly on `develop@b03a88700485fcd1b905aa2d8e6f09b8a521882f` through a clean three-way replay.

- continuity and latency contract tests: 11 passed
- `ChatOverlay.test.tsx`: 200 passed with the package runner
- Biome and diff check: passed
- independent replay review: no P0–P2 findings
- exact-head CI dispatch: https://github.com/elizaOS/eliza/actions/runs/32432536371

The local UI typecheck could not be rerun in the lightweight worktree because package-local generated dependencies are not installed there; the exact-head CI is authoritative for the refreshed tree.

## Known gaps / non-goals

- No live staging success is claimed by this foundations-only PR.
- Deployed staging Pages bytes still require a separate browser proof.
- The proposed reuse semantics are `no-test-owned-agent` with history preserved; maintainer acceptance is still required before that can close the cleanup acceptance row.
- Current staging API authority is `https://api-staging.eliza.app`.

Refs #18076 — intentionally does not close it.


## Evidence Gate

<!-- evidence-head:c8a8137fd0222be171baeda084845d724ad3600c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-contract foundation; the one UI change is a non-visual failure-state data attribute.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered pixels or styling changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the live staging workflow is intentionally in stacked PR #23132.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend changed; deterministic contract results are summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no production frontend request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no production prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - continuity and latency contracts are asserted by committed deterministic tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visible text or pixels changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository completion workflow; no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`