### PR TITLE
fix(plugin-bluebubbles): fail-closed ghost accountId so it cannot inherit owner env credentials

### DIFF
--- a/plugins/plugin-bluebubbles/src/accounts.test.ts
+++ b/plugins/plugin-bluebubbles/src/accounts.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for BlueBubbles multi-account resolution in `accounts.ts`.
+ * Fail-closes ghost / unrecognized accountIds so they cannot inherit the
+ * owner's BLUEBUBBLES_SERVER_URL, BLUEBUBBLES_PASSWORD, webhook, or
+ * auto-start. Uses a hand-built fake runtime; no live BlueBubbles server.
+ */
+import type { Character, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	listEnabledBlueBubblesAccounts,
+	resolveBlueBubblesAccount,
+	type BlueBubblesMultiAccountConfig,
+} from "./accounts";
+
+function createRuntime(
+	bluebubbles?: BlueBubblesMultiAccountConfig,
+	env?: Record<string, string | undefined>,
+): IAgentRuntime {
+	const character: Partial<Character> = {
+		settings: bluebubbles ? { bluebubbles } : {},
+	};
+	const settings = env ?? {};
+	return {
+		agentId: "agent-1",
+		character: character as Character,
+		getSetting: (key: string) => settings[key] ?? null,
+	} as unknown as IAgentRuntime;
+}
+
+describe("resolveBlueBubblesAccount owner-bind fail-closed", () => {
+	const ownerEnv = {
+		BLUEBUBBLES_SERVER_URL: "http://owner.example:1234",
+		BLUEBUBBLES_PASSWORD: "owner-password",
+		BLUEBUBBLES_WEBHOOK_PATH: "/owner-hook",
+		BLUEBUBBLES_AUTOSTART_COMMAND: "/owner/BlueBubbles.app",
+	};
+
+	it("lets the default account inherit owner env identity and transport", () => {
+		const rt = createRuntime(undefined, ownerEnv);
+		const resolved = resolveBlueBubblesAccount(rt, "default");
+		expect(resolved.accountId).toBe("default");
+		expect(resolved.serverUrl).toBe("http://owner.example:1234");
+		expect(resolved.configured).toBe(true);
+		expect(resolved.config?.password).toBe("owner-password");
+		expect(resolved.config?.webhookPath).toBe("/owner-hook");
+		expect(resolved.config?.autoStartCommand).toBe("/owner/BlueBubbles.app");
+	});
+
+	it("does not give a ghost accountId the owner server URL or password", () => {
+		const rt = createRuntime(
+			{ accounts: { work: { serverUrl: "http://work.example:1234", password: "work-secret" } } },
+			ownerEnv,
+		);
+		const ghost = resolveBlueBubblesAccount(rt, "ghost-account");
+		expect(ghost.accountId).toBe("ghost-account");
+		expect(ghost.serverUrl).toBe("");
+		expect(ghost.configured).toBe(false);
+		expect(ghost.config).toBeNull();
+	});
+
+	it("does not let a named account without its own creds inherit env identity", () => {
+		const rt = createRuntime({ accounts: { work: { enabled: true } } }, ownerEnv);
+		const work = resolveBlueBubblesAccount(rt, "work");
+		expect(work.accountId).toBe("work");
+		expect(work.serverUrl).toBe("");
+		expect(work.configured).toBe(false);
+		expect(work.config).toBeNull();
+	});
+
+	it("keeps a named account's own server and does not attach owner env transport", () => {
+		const rt = createRuntime(
+			{
+				accounts: {
+					work: {
+						enabled: true,
+						serverUrl: "http://work.example:1234",
+						password: "work-secret",
+						webhookPath: "/work-hook",
+					},
+				},
+			},
+			ownerEnv,
+		);
+		const work = resolveBlueBubblesAccount(rt, "work");
+		expect(work.accountId).toBe("work");
+		expect(work.serverUrl).toBe("http://work.example:1234");
+		expect(work.configured).toBe(true);
+		expect(work.config?.password).toBe("work-secret");
+		expect(work.config?.webhookPath).toBe("/work-hook");
+		expect(work.config?.autoStartCommand).toBeUndefined();
+	});
+
+	it("lists only accounts that own their own credentials", () => {
+		const rt = createRuntime(
+			{
+				accounts: {
+					work: {
+						serverUrl: "http://work.example:1234",
+						password: "work-secret",
+					},
+					ghosty: { enabled: true },
+				},
+			},
+			ownerEnv,
+		);
+		const enabled = listEnabledBlueBubblesAccounts(rt);
+		expect(enabled.map((item) => item.accountId).sort()).toEqual([
+			"default",
+			"work",
+		]);
+	});
+});

--- a/plugins/plugin-bluebubbles/src/accounts.ts
+++ b/plugins/plugin-bluebubbles/src/accounts.ts
@@ -8,6 +8,9 @@
  *
  * Source of truth is `character.settings.bluebubbles` plus env-var fallbacks
  * (BLUEBUBBLES_SERVER_URL, BLUEBUBBLES_PASSWORD, BLUEBUBBLES_DM_POLICY, ...).
+ * Only the implicit `default` account may inherit owner env / top-level
+ * identity and transport. Named or unrecognized accountIds fail closed: they
+ * cannot inherit the owner's server URL, password, webhook, or auto-start.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
@@ -245,8 +248,9 @@ function getAccountConfig(
  * Resolves a complete BlueBubbles account configuration as a
  * `BlueBubblesConfig` (the shape consumed by the existing service code).
  *
- * Returns `null` if neither account-specific nor base config / env defaults
- * provide a complete (`serverUrl`, `password`) pair.
+ * Returns `null` if neither account-specific nor (for the implicit default
+ * account only) base config / env defaults provide a complete (`serverUrl`,
+ * `password`) pair. Ghost / named accountIds cannot inherit owner credentials.
  */
 export function resolveBlueBubblesAccount(
 	runtime: IAgentRuntime,
@@ -274,44 +278,55 @@ export function resolveBlueBubblesAccount(
 	const accountEnabled = accountConfig.enabled !== false;
 	const enabled = baseEnabled && accountEnabled;
 
+	// Only the implicit default account may inherit owner env / top-level
+	// identity and transport. A ghost or named accountId cannot send as the
+	// owner's BlueBubbles server.
+	const allowOwnerBind = normalizedAccountId === DEFAULT_ACCOUNT_ID;
+
 	const serverUrl =
 		firstNonEmptyString(
 			accountConfig.serverUrl,
-			multiConfig.serverUrl,
-			envServerUrl,
+			allowOwnerBind ? multiConfig.serverUrl : undefined,
+			allowOwnerBind ? envServerUrl : undefined,
 		) ?? "";
 	const password =
 		firstNonEmptyString(
 			accountConfig.password,
-			multiConfig.password,
-			envPassword,
+			allowOwnerBind ? multiConfig.password : undefined,
+			allowOwnerBind ? envPassword : undefined,
 		) ?? "";
 
 	const configured = Boolean(serverUrl && password);
-	const webhookPath =
-		accountConfig.webhookPath ??
-		multiConfig.webhookPath ??
-		getStringSetting(runtime, "BLUEBUBBLES_WEBHOOK_PATH") ??
-		undefined;
-	const autoStartCommand =
-		accountConfig.autoStartCommand ??
-		multiConfig.autoStartCommand ??
-		getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_COMMAND");
-	const autoStartArgs =
-		accountConfig.autoStartArgs ??
-		multiConfig.autoStartArgs ??
-		envAutoStartArgs;
-	const autoStartCwd =
-		accountConfig.autoStartCwd ??
-		multiConfig.autoStartCwd ??
-		getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_CWD");
+	const webhookPath = allowOwnerBind
+		? (accountConfig.webhookPath ??
+				multiConfig.webhookPath ??
+				getStringSetting(runtime, "BLUEBUBBLES_WEBHOOK_PATH") ??
+				undefined)
+		: accountConfig.webhookPath;
+	const autoStartCommand = allowOwnerBind
+		? (accountConfig.autoStartCommand ??
+				multiConfig.autoStartCommand ??
+				getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_COMMAND"))
+		: accountConfig.autoStartCommand;
+	const autoStartArgs = allowOwnerBind
+		? (accountConfig.autoStartArgs ??
+				multiConfig.autoStartArgs ??
+				envAutoStartArgs)
+		: accountConfig.autoStartArgs;
+	const autoStartCwd = allowOwnerBind
+		? (accountConfig.autoStartCwd ??
+				multiConfig.autoStartCwd ??
+				getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_CWD"))
+		: accountConfig.autoStartCwd;
 	const autoStartWaitMs =
 		accountConfig.autoStartWaitMs ??
-		multiConfig.autoStartWaitMs ??
-		parseNonNegativeInt(
-			getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_WAIT_MS"),
-			15000,
-		);
+		(allowOwnerBind
+			? (multiConfig.autoStartWaitMs ??
+				parseNonNegativeInt(
+					getStringSetting(runtime, "BLUEBUBBLES_AUTOSTART_WAIT_MS"),
+					15000,
+				))
+			: 15000);
 	const dmPolicy =
 		accountConfig.dmPolicy ??
 		multiConfig.dmPolicy ??


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE
auth-bind audit on a live BlueBubbles product path. No new issue filed (mission
forbids self-directed issue creation). Same owner-token inherit class as
#23070 (X), #23082 (Slack), and #23088 (Signal), different host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on ghost / unrecognized BlueBubbles `accountId` so it cannot
inherit owner env server URL, password, webhook, or auto-start. Honest
default-only env deployments still resolve. No schema or storage migration.

# Background

## What does this PR do?

`resolveBlueBubblesAccount` always fell through `accountConfig` to top-level
`character.settings.bluebubbles` and then `BLUEBUBBLES_SERVER_URL` /
`BLUEBUBBLES_PASSWORD` / webhook / auto-start for every accountId. A ghost or
unrecognized id therefore resolved as `configured: true` against the owner's
BlueBubbles server and password — the same owner-token inherit class as
Signal/Slack/X, on a connector that was not default-gated.

This head lets only the implicit `default` account inherit owner env / top-level
identity and transport. Named and unrecognized accountIds keep shared DM/group
policy defaults but do not receive the owner's server URL, password, webhook, or
auto-start. Honest default-only env deployments still resolve.

Origin `develop` `e38ecc71039441d729032e95134290a996cbc28e`:
`resolveBlueBubblesAccount(runtime, "ghost-account")` with
`BLUEBUBBLES_SERVER_URL=http://owner.example:1234` and
`BLUEBUBBLES_PASSWORD=owner-password` returned that owner URL, owner password,
and `configured: true`.

Overlay `bunx vitest run plugins/plugin-bluebubbles/src/accounts.test.ts` → 5/5
on this head, including ghost/named fail-closed and default env inherit still
works. The same file against RAW origin `accounts.ts` is 4 failed / 1 passed
(ghost inherits owner URL+password). Existing
`__tests__/environment.test.ts` stays 9/9.

Occupancy-FREE host `plugins/plugin-bluebubbles/src/accounts.ts`. Not leftover-tax.
Not Signal/X/Slack/Instagram. Not `connector-account-provider.ts`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-bluebubbles/src/accounts.ts` and
`plugins/plugin-bluebubbles/src/accounts.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:5ace67044835ea29921bc50b16954abb51715dea -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; BlueBubbles account resolver is runtime logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; BlueBubbles account resolver is runtime logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
origin develop e38ecc71039441d729032e95134290a996cbc28e
resolveBlueBubblesAccount(runtime, "ghost-account")
BLUEBUBBLES_SERVER_URL=http://owner.example:1234
BLUEBUBBLES_PASSWORD=owner-password
result: owner URL + owner password + configured true

overlay bunx vitest run plugins/plugin-bluebubbles/src/accounts.test.ts
RAW origin accounts.ts: 4 failed / 1 passed (ghost inherits owner bind)
overlay head: 5/5 including ghost/named fail-closed and default env inherit
environment.test.ts: 9/9 unchanged
head 5ace67044835ea29921bc50b16954abb51715dea
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
