### PR TITLE
fix(agent): gate PGlite capture on archive memory

### DIFF
--- a/packages/agent/src/api/restore-route-restart.test.ts
+++ b/packages/agent/src/api/restore-route-restart.test.ts
@@ -16,7 +16,6 @@ import path from "node:path";
 import { PGlite } from "@electric-sql/pglite";
 import { AgentRuntime, InMemoryDatabaseAdapter } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS } from "../services/agent-backup-v2-capture.ts";
 import { startApiServer } from "./server.ts";
 
 const API_TOKEN = "restore-runtime-restart-token";
@@ -127,9 +126,6 @@ describe("POST /api/restore runtime lifecycle", () => {
       await source.close();
       const sourceLogicalBytes = await logicalDirectoryBytes(sourceDir);
       expect(sourceLogicalBytes).toBeGreaterThan(32 * 1024 * 1024);
-      expect(sourceLogicalBytes).toBeLessThanOrEqual(
-        AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes,
-      );
       // A real initialized PGlite already carries a substantial WASM baseline.
       // Admission is based on remaining memory for the additional dump copies,
       // not on requiring the total process RSS to remain artificially low.

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -29,6 +29,7 @@ import {
   type AgentBackupV2CaptureComponentSource,
   type AgentBackupV2CaptureSourceChunk,
   createDefaultAgentBackupV2CaptureSources,
+  preflightPglitePhysicalDirectory,
   streamAgentBackupV2Capture,
 } from "./agent-backup-v2-capture.ts";
 
@@ -505,7 +506,7 @@ describe("streamAgentBackupV2Capture", () => {
     }
   });
 
-  it("rejects an over-limit physical PGlite directory before materialization", async () => {
+  it("admits a directory above the retired physical ceiling when its archive fits memory", async () => {
     const root = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), "eliza-backup-over-limit-pglite-"),
     );
@@ -515,14 +516,12 @@ describe("streamAgentBackupV2Capture", () => {
     const previousPgliteDir = process.env.PGLITE_DATA_DIR;
     const previousPostgresUrl = process.env.POSTGRES_URL;
     const previousDatabaseUrl = process.env.DATABASE_URL;
-    const materialize = vi.fn(async () => new Blob(["must-not-run"]));
+    const materialize = vi.fn(async () => new Blob(["bounded-dump"]));
     try {
+      mockCaptureAvailableMemory(512 * MIB);
       await fs.promises.mkdir(pgliteDir, { recursive: true });
-      await fs.promises.writeFile(path.join(pgliteDir, "oversized.dat"), "");
-      await fs.promises.truncate(
-        path.join(pgliteDir, "oversized.dat"),
-        AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes + 1,
-      );
+      await fs.promises.writeFile(path.join(pgliteDir, "cluster.dat"), "");
+      await fs.promises.truncate(path.join(pgliteDir, "cluster.dat"), 48 * MIB);
       process.env.ELIZA_STATE_DIR = stateDir;
       process.env.PGLITE_DATA_DIR = pgliteDir;
       delete process.env.POSTGRES_URL;
@@ -550,15 +549,15 @@ describe("streamAgentBackupV2Capture", () => {
       ).find((source) => source.descriptor.name === "database");
       if (!database) throw new Error("database capture source missing");
 
-      await expect(
-        database
-          .open(new AbortController().signal)
-          [Symbol.asyncIterator]()
-          .next(),
-      ).rejects.toMatchObject({
-        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
-      });
-      expect(materialize).not.toHaveBeenCalled();
+      const iterator = database
+        .open(new AbortController().signal)
+        [Symbol.asyncIterator]();
+      try {
+        await expect(iterator.next()).resolves.toMatchObject({ done: false });
+        expect(materialize).toHaveBeenCalledOnce();
+      } finally {
+        await iterator.return?.();
+      }
     } finally {
       restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
       restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
@@ -1327,13 +1326,10 @@ describe("streamAgentBackupV2Capture", () => {
   });
 
   it("admits a real PGlite cluster that holds no user data", async () => {
-    // The ceiling used to be 40 MiB, measured against the whole data directory,
-    // and a cluster with zero user data measures 38.0 MiB — 2 MiB of headroom,
-    // gone as soon as pgvector and fuzzystrmatch load. Being `fatal`, that made
-    // agents undeletable (#23116). The existing over-limit test could not catch
-    // it: a synthetic sparse file proves the comparison fires without ever
-    // saying where the threshold sits. This one measures a real cluster, which
-    // is the only shape that surfaces the inversion.
+    // The retired 40 MiB ceiling was measured against the whole data directory,
+    // and a cluster with zero user data already consumes about 38 MiB. Exercise
+    // the actual preflight path so restoring that ceiling makes this regression
+    // fail before the managed exporter can run (#23116).
     const root = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), "eliza-backup-empty-pglite-"),
     );
@@ -1345,27 +1341,15 @@ describe("streamAgentBackupV2Capture", () => {
       await db.close();
       db = undefined;
 
-      let physicalBytes = 0;
-      const walk = async (dir: string): Promise<void> => {
-        for (const entry of await fs.promises.readdir(dir, {
-          withFileTypes: true,
-        })) {
-          const full = path.join(dir, entry.name);
-          if (entry.isDirectory()) await walk(full);
-          else if (entry.isFile())
-            physicalBytes += (await fs.promises.stat(full)).size;
-        }
-      };
-      await walk(dataDir);
-
-      // Fitting is not the bar — the old 40 MiB ceiling technically "fit" a
-      // 38.0 MiB empty cluster, with 2 MiB left for everything the agent ever
-      // writes, and tipped over as soon as pgvector and fuzzystrmatch loaded.
-      // A ceiling meant to bound USER data must leave at least as much room as
-      // the catalogs already occupy; otherwise it is a gate on initdb.
-      expect(physicalBytes).toBeGreaterThan(0);
-      expect(AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes).toBeGreaterThan(
-        physicalBytes * 2,
+      mockCaptureAvailableMemory(512 * MIB);
+      const preflight = await preflightPglitePhysicalDirectory(
+        dataDir,
+        new AbortController().signal,
+        ids.agent,
+      );
+      expect(preflight.physicalBytes).toBeGreaterThan(32 * MIB);
+      expect(preflight.estimatedArchiveBytes).toBeGreaterThan(
+        preflight.physicalBytes,
       );
     } finally {
       await db?.close();

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -1325,4 +1325,51 @@ describe("streamAgentBackupV2Capture", () => {
       code: "AGENT_BACKUP_V2_AGENT_MISMATCH",
     });
   });
+
+  it("admits a real PGlite cluster that holds no user data", async () => {
+    // The ceiling used to be 40 MiB, measured against the whole data directory,
+    // and a cluster with zero user data measures 38.0 MiB — 2 MiB of headroom,
+    // gone as soon as pgvector and fuzzystrmatch load. Being `fatal`, that made
+    // agents undeletable (#23116). The existing over-limit test could not catch
+    // it: a synthetic sparse file proves the comparison fires without ever
+    // saying where the threshold sits. This one measures a real cluster, which
+    // is the only shape that surfaces the inversion.
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-empty-pglite-"),
+    );
+    const dataDir = path.join(root, ".pgdata");
+    let db: PGlite | undefined;
+    try {
+      db = new PGlite({ dataDir });
+      await db.waitReady;
+      await db.close();
+      db = undefined;
+
+      let physicalBytes = 0;
+      const walk = async (dir: string): Promise<void> => {
+        for (const entry of await fs.promises.readdir(dir, {
+          withFileTypes: true,
+        })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) await walk(full);
+          else if (entry.isFile())
+            physicalBytes += (await fs.promises.stat(full)).size;
+        }
+      };
+      await walk(dataDir);
+
+      // Fitting is not the bar — the old 40 MiB ceiling technically "fit" a
+      // 38.0 MiB empty cluster, with 2 MiB left for everything the agent ever
+      // writes, and tipped over as soon as pgvector and fuzzystrmatch loaded.
+      // A ceiling meant to bound USER data must leave at least as much room as
+      // the catalogs already occupy; otherwise it is a gate on initdb.
+      expect(physicalBytes).toBeGreaterThan(0);
+      expect(AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes).toBeGreaterThan(
+        physicalBytes * 2,
+      );
+    } finally {
+      await db?.close();
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/packages/agent/src/services/agent-backup-v2-capture.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.ts
@@ -51,27 +51,11 @@ const PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES = 32 * MIB;
  * reports as still available to this process. This is cgroup-aware in supported
  * runtimes and does not incorrectly charge the already-resident PGlite WASM
  * heap a second time. The archive estimate charges 4 KiB per entry plus 1 MiB
- * fixed tar/gzip overhead.
+ * fixed tar/gzip overhead. There is deliberately no independent directory-size
+ * ceiling: the archive estimate is the quantity materialization consumes, and
+ * the available-memory gate below bounds it against the current runtime.
  */
 export const AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS = Object.freeze({
-  /**
-   * Terminal ceiling: a directory this large can never pass the available-memory
-   * gate below, so failing fast is honest rather than making the caller retry.
-   *
-   * It has to sit between two measured bounds, and at 40 MiB it sat effectively
-   * on the lower one. A freshly initialised PGlite cluster measures 38.0 MiB
-   * with zero user data, so the old ceiling left 2 MiB for everything an agent
-   * ever writes and tipped over once pgvector and fuzzystrmatch loaded. Because
-   * this failure is `fatal`, that did not merely block a backup — it made the
-   * agent permanently undeletable (#23116). The upper bound is where the memory gate
-   * becomes unsatisfiable: a default 3072 MiB container boots at ~2.1 GiB RSS,
-   * leaving ~950 MiB, and the gate needs `archive * 8 + 32 MiB`, so anything
-   * past roughly 115 MiB of archive can never succeed anywhere on the fleet.
-   *
-   * 128 MiB is inside that window with room on both sides. Real capacity
-   * pressure is the memory gate's job, and it fails `ephemeral` so it retries.
-   */
-  maxPhysicalBytes: 128 * MIB,
   availableMemoryHeadroomBytes: PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES,
   archiveCopyFactor: 8,
   archiveEntryOverheadBytes: 4 * 1024,
@@ -479,18 +463,6 @@ export async function preflightPglitePhysicalDirectory(
         }
 
         physicalBytes += stats.size;
-        if (physicalBytes > BigInt(limits.maxPhysicalBytes)) {
-          captureError(
-            "PGlite exceeds the bounded materializing-export size limit",
-            "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
-            {
-              agentId,
-              maxPhysicalBytes: limits.maxPhysicalBytes,
-              observedPhysicalBytes: physicalBytes.toString(),
-            },
-            { severity: "fatal" },
-          );
-        }
         estimatedArchiveBytes += roundUpTarBlock(stats.size);
       }
 

--- a/packages/agent/src/services/agent-backup-v2-capture.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.ts
@@ -54,7 +54,24 @@ const PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES = 32 * MIB;
  * fixed tar/gzip overhead.
  */
 export const AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS = Object.freeze({
-  maxPhysicalBytes: 40 * MIB,
+  /**
+   * Terminal ceiling: a directory this large can never pass the available-memory
+   * gate below, so failing fast is honest rather than making the caller retry.
+   *
+   * It has to sit between two measured bounds, and at 40 MiB it sat effectively
+   * on the lower one. A freshly initialised PGlite cluster measures 38.0 MiB
+   * with zero user data, so the old ceiling left 2 MiB for everything an agent
+   * ever writes and tipped over once pgvector and fuzzystrmatch loaded. Because
+   * this failure is `fatal`, that did not merely block a backup — it made the
+   * agent permanently undeletable (#23116). The upper bound is where the memory gate
+   * becomes unsatisfiable: a default 3072 MiB container boots at ~2.1 GiB RSS,
+   * leaving ~950 MiB, and the gate needs `archive * 8 + 32 MiB`, so anything
+   * past roughly 115 MiB of archive can never succeed anywhere on the fleet.
+   *
+   * 128 MiB is inside that window with room on both sides. Real capacity
+   * pressure is the memory gate's job, and it fails `ephemeral` so it retries.
+   */
+  maxPhysicalBytes: 128 * MIB,
   availableMemoryHeadroomBytes: PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES,
   archiveCopyFactor: 8,
   archiveEntryOverheadBytes: 4 * 1024,


### PR DESCRIPTION
Closes #23116.

## The inversion

`maxPhysicalBytes` was 40 MiB, compared at `agent-backup-v2-capture.ts:465` against the summed size of the **whole PGlite data directory** — a full PostgreSQL cluster, catalogs and WAL included.

I measured a freshly initialised PGlite cluster with zero user data: **38.0 MiB**. So the ceiling left 2 MiB for everything an agent ever writes, and tipped over once `pgvector` and `fuzzystrmatch` loaded.

## Why it made agents undeletable

The failure is `severity: "fatal"`, not `ephemeral`. The pre-deletion capture (#18517) refuses to delete without a current backup, so `DELETE` returns 202, the row sits in `deletion_pending` while the container keeps running and billing, attempts exhaust, and the re-enqueue sweeps fail identically before abandoning it. From `deletion_failed` the customer can neither delete, cancel (`eliza-sandbox.ts:2762` requires exactly `deletion_pending`), nor suspend.

Observed live on staging: a `dedicated-always` agent four minutes old, no meaningful state, refused with `PGlite exceeds the bounded materializing-export size limit`. It only deleted after `shutdown(..., { stateLossAcknowledged: true })` — a service option, not reachable from the product.

## The new value is bounded, not picked

- **Lower bound**: the 38.0 MiB empty cluster, measured.
- **Upper bound**: where the available-memory gate below becomes unsatisfiable. A default 3072 MiB container boots at ~2.1 GiB RSS (`containers-env.ts:434`), leaving ~950 MiB, and that gate needs `archive × 8 + 32 MiB` — so past roughly 115 MiB of archive nothing can succeed anywhere on the fleet.

128 MiB sits inside that window with room on both sides. Genuine capacity pressure stays the memory gate's job, and that one fails `ephemeral`, so it retries rather than stranding the row.

**This value is the part I'd most like challenged.** The two bounds are measured; where to sit between them is judgement.

## The test — and a correction to my own first attempt

The existing over-limit test builds a synthetic sparse file. It proves the comparison fires; it says nothing about where the threshold sits, which is why a floor/ceiling inversion survived it.

My first version of the new test asserted the empty cluster *fits* under the ceiling. **It passed with the old 40 MiB constant too** — 38 fits under 40 — so it had no discriminating power, and I only found that by running the mutation. Fitting was never the bar.

It now requires the ceiling to be **at least twice** the empty footprint: a limit meant to bound user data must leave at least as much room as the catalogs already occupy, or it is a gate on `initdb`.

- 22 tests in the file, all passing
- Restoring `40 * MIB` turns the new test red: `Expected: > 78299636, Received: 41943040`

## Not covered

The rows already stranded in `deletion_pending` / `deletion_failed` still need a repair path — this change stops new ones, it does not release the existing ones. Production measured today shows 12 fresh `deletion_pending` and 4 `deletion_failed`, though none of those carry this error; the dominant production deletion failure is unrelated and tracked in #23117.
