### PR TITLE
fix(ui): retain full generated TTS responses in byte LRU

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.playback-grace.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.playback-grace.test.tsx
@@ -381,8 +381,9 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
     });
   });
 
-  it("serves a repeated short utterance from the audio cache without refetching", async () => {
-    const uniqueText = "cache me please, a short cacheable reply";
+  it("serves a repeated full response from the audio cache without refetching", async () => {
+    const uniqueText =
+      "Cache this complete generated response even though it is deliberately longer than ten speech tokens.";
     const { result } = renderVoiceChat({ provider: "local-inference" });
 
     act(() => {
@@ -409,7 +410,7 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
       expect(createdSources.length).toBeGreaterThan(1);
       expect(createdSources[1]?.start).toHaveBeenCalledWith(0);
     });
-    // The second identical, short, cacheable utterance is served from
+    // The second identical complete response is served from
     // globalAudioCache — no second network fetch.
     expect(
       fetchedUrls.filter((url) => url.includes("/api/tts/local-inference"))

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -94,13 +94,13 @@ import {
   describeTtsCloudFetchTargetForDebug,
   describeTtsFetchTargetForDebug,
   getSpeechRecognitionCtor,
-  globalAudioCache,
   isAbortError,
   localePrefix,
-  MAX_CACHED_SEGMENTS,
   matchesVoiceLocale,
   normalizeSpeechLocale,
   type QueueAssistantSpeechOptions,
+  readCachedAudio,
+  rememberCachedAudio,
   resolveEffectiveVoiceConfig,
   resolveVoiceMode,
   resolveVoiceProxyEndpoint,
@@ -561,11 +561,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   const rememberCachedSegment = useCallback(
     (key: string, bytes: Uint8Array) => {
-      globalAudioCache.delete(key);
-      globalAudioCache.set(key, bytes);
-      if (globalAudioCache.size <= MAX_CACHED_SEGMENTS) return;
-      const oldest = globalAudioCache.keys().next().value;
-      if (oldest) globalAudioCache.delete(oldest);
+      rememberCachedAudio(key, bytes);
     },
     [],
   );
@@ -1574,12 +1570,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         (shouldCacheGeneratedSpeech(text, task.segment)
           ? makeElevenCacheKey(text, elConfig)
           : undefined);
-      const cachedBytes = cacheKey ? globalAudioCache.get(cacheKey) : undefined;
+      const cachedBytes = cacheKey ? readCachedAudio(cacheKey) : undefined;
       let audioBytes: Uint8Array | null = null;
       let cached = false;
 
       if (cacheKey && cachedBytes) {
-        rememberCachedSegment(cacheKey, cachedBytes);
         audioBytes = cachedBytes.slice();
         cached = true;
       }
@@ -1810,12 +1805,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         (shouldCacheGeneratedSpeech(text, task.segment)
           ? makeElizaCloudCacheKey(text)
           : undefined);
-      const cachedBytes = cacheKey ? globalAudioCache.get(cacheKey) : undefined;
+      const cachedBytes = cacheKey ? readCachedAudio(cacheKey) : undefined;
       let audioBytes: Uint8Array | null = null;
       let cached = false;
 
       if (cacheKey && cachedBytes) {
-        rememberCachedSegment(cacheKey, cachedBytes);
         audioBytes = cachedBytes.slice();
         cached = true;
       }
@@ -2047,12 +2041,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         (shouldCacheGeneratedSpeech(text, task.segment)
           ? makeLocalInferenceCacheKey(text)
           : undefined);
-      const cachedBytes = cacheKey ? globalAudioCache.get(cacheKey) : undefined;
+      const cachedBytes = cacheKey ? readCachedAudio(cacheKey) : undefined;
       let audioBytes: Uint8Array | null = null;
       let cached = false;
 
       if (cacheKey && cachedBytes) {
-        rememberCachedSegment(cacheKey, cachedBytes);
         audioBytes = cachedBytes.slice();
         cached = true;
       }

--- a/packages/ui/src/voice/__tests__/audio-cache.test.ts
+++ b/packages/ui/src/voice/__tests__/audio-cache.test.ts
@@ -1,0 +1,42 @@
+/** Verifies the process-wide synthesized-audio cache's byte-bounded LRU contract. */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  globalAudioCache,
+  MAX_CACHED_AUDIO_BYTES,
+  readCachedAudio,
+  rememberCachedAudio,
+} from "../voice-chat-types";
+
+afterEach(() => {
+  globalAudioCache.clear();
+});
+
+describe("generated audio cache", () => {
+  it("retains an entry exactly at the byte budget", () => {
+    const bytes = new Uint8Array(MAX_CACHED_AUDIO_BYTES);
+    rememberCachedAudio("exact", bytes);
+    expect(readCachedAudio("exact")).toBe(bytes);
+  });
+
+  it("rejects a single response larger than the byte budget", () => {
+    rememberCachedAudio(
+      "oversized",
+      new Uint8Array(MAX_CACHED_AUDIO_BYTES + 1),
+    );
+    expect(globalAudioCache.has("oversized")).toBe(false);
+  });
+
+  it("evicts the least-recently-used audio by cumulative bytes", () => {
+    const half = Math.floor(MAX_CACHED_AUDIO_BYTES / 2);
+    rememberCachedAudio("oldest", new Uint8Array(half));
+    rememberCachedAudio("recent", new Uint8Array(half));
+    expect(readCachedAudio("oldest")).toBeDefined();
+
+    rememberCachedAudio("new", new Uint8Array(1));
+
+    expect(globalAudioCache.has("recent")).toBe(false);
+    expect(globalAudioCache.has("oldest")).toBe(true);
+    expect(globalAudioCache.has("new")).toBe(true);
+  });
+});

--- a/packages/ui/src/voice/__tests__/sentence-streaming.test.ts
+++ b/packages/ui/src/voice/__tests__/sentence-streaming.test.ts
@@ -67,13 +67,13 @@ describe("shouldCacheGeneratedSpeech", () => {
     ).toBe(true);
   });
 
-  it("does not cache longer or remainder clips", () => {
+  it("caches complete long responses but not streaming remainders", () => {
     expect(
       shouldCacheGeneratedSpeech(
         "This sentence is deliberately longer than ten speech tokens for cache discipline.",
         "full",
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(shouldCacheGeneratedSpeech("short follow up", "remainder")).toBe(
       false,
     );

--- a/packages/ui/src/voice/voice-chat-playback.ts
+++ b/packages/ui/src/voice/voice-chat-playback.ts
@@ -7,7 +7,6 @@ import { sanitizeSpeechText } from "@elizaos/shared";
 import {
   MAX_SPOKEN_CHARS,
   MOUTH_OPEN_STEP,
-  SHORT_AUDIO_CACHE_MAX_TOKENS,
   type SpeechSegmentKind,
 } from "./voice-chat-types";
 
@@ -27,13 +26,10 @@ export function countSpeechTokens(input: string): number {
 }
 
 export function shouldCacheGeneratedSpeech(
-  input: string,
+  _input: string,
   segment: SpeechSegmentKind,
 ): boolean {
-  return (
-    segment !== "remainder" &&
-    countSpeechTokens(input) <= SHORT_AUDIO_CACHE_MAX_TOKENS
-  );
+  return segment !== "remainder";
 }
 
 export function capSpeechLength(input: string): string {

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -381,9 +381,10 @@ export interface AssistantSpeechState {
 export const DEFAULT_ELEVEN_MODEL = "eleven_flash_v2_5";
 export const DEFAULT_ELEVEN_VOICE = "EXAVITQu4vr4xnSDxMaL";
 export const MAX_SPOKEN_CHARS = 4000;
-export const MAX_CACHED_SEGMENTS = 128;
-/** Cache only short generated clips aggressively; common acknowledgements stay hot. */
-export const SHORT_AUDIO_CACHE_MAX_TOKENS = 10;
+/** Bound retained synthesized audio by bytes rather than utterance count. */
+export const MAX_CACHED_AUDIO_BYTES = 32 * 1024 * 1024;
+/** Secondary metadata bound for pathological streams of tiny audio payloads. */
+export const MAX_CACHED_AUDIO_ENTRIES = 4096;
 /** First assistant clip: start synthesis after this much speakable text (avoids one-word TTS). */
 export const ASSISTANT_TTS_FIRST_FLUSH_CHARS = 24;
 /** Later clips: batch for better prosody (avoid token-thin slices). */
@@ -397,6 +398,44 @@ export const REDACTED_SECRET = "[REDACTED]";
 export const MOUTH_OPEN_STEP = 0.02;
 
 export const globalAudioCache = new Map<string, Uint8Array>();
+
+function cachedAudioBytes(): number {
+  let total = 0;
+  for (const bytes of globalAudioCache.values()) {
+    total += bytes.byteLength;
+  }
+  return total;
+}
+
+/** Read and promote a retained synthesized response in LRU order. */
+export function readCachedAudio(key: string): Uint8Array | undefined {
+  const bytes = globalAudioCache.get(key);
+  if (!bytes) return undefined;
+  globalAudioCache.delete(key);
+  globalAudioCache.set(key, bytes);
+  return bytes;
+}
+
+/** Retain synthesized bytes while enforcing the process-wide byte LRU budget. */
+export function rememberCachedAudio(key: string, bytes: Uint8Array): void {
+  globalAudioCache.delete(key);
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_CACHED_AUDIO_BYTES) {
+    return;
+  }
+
+  globalAudioCache.set(key, bytes);
+  let totalBytes = cachedAudioBytes();
+  while (
+    totalBytes > MAX_CACHED_AUDIO_BYTES ||
+    globalAudioCache.size > MAX_CACHED_AUDIO_ENTRIES
+  ) {
+    const oldestKey = globalAudioCache.keys().next().value;
+    if (typeof oldestKey !== "string") break;
+    const oldestBytes = globalAudioCache.get(oldestKey);
+    globalAudioCache.delete(oldestKey);
+    totalBytes -= oldestBytes?.byteLength ?? 0;
+  }
+}
 
 // ── Voice config helpers ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- retain complete generated TTS responses for replay across ElevenLabs, Eliza Cloud, and local inference
- replace the 128-response cache cap with a 32 MiB byte-bounded LRU plus a high metadata safety bound
- preserve streamed remainder behavior and prove long-response replay through the real voice hook

Refs #23079

## Exact-head verification

Exact head: `15d34285ce60417f775e41216ce749b2042d7e80`

Base: `42f1ce487a6ddf1168862cff3c168d307a8000db`

- focused cache and real hook playback suites: 32/32 passed
- pinned Biome on all six changed files: passed
- `git diff --check`: passed
- package typecheck: passed
- publishable package build: passed; 46 runtime exports verified

## Scope

This is the immediate client-retention slice from #23079. It does not add a backend cache or claim demand/latency measurements for a shared synthesized-audio service, so the parent issue remains open for its data-gated follow-up.

## Evidence Gate

<!-- evidence-head:15d34285ce60417f775e41216ce749b2042d7e80 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this is client-only in-memory retention with no backend change.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser console or live network surface changed; the deterministic real-hook request boundary is recorded in the domain artifact.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior or prompt changed.
<!-- evidence-row:domain-artifacts -->
- [x] [exact-head retention, eviction, and replay contract](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23138-tts-cache-domain.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

## Risk

Retaining long generated responses increases client memory use, bounded by a 32 MiB cumulative payload budget and a 4096-entry metadata ceiling. Streaming remainder clips remain uncached, avoiding retention of incremental duplicates.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->


