### PR TITLE
fix(cloud): exclude warm-pool capacity from billing

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/compute-billing-recovery.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/compute-billing-recovery.pglite.test.ts
@@ -189,6 +189,103 @@ async function seed(balance = "10.000000") {
 }
 
 describe("compute billing recovery", () => {
+  test("Dedicated warm-pool capacity is outside every billing lifecycle path", async () => {
+    const { org, user, sandbox, lastBilledAt } = await seed();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ pool_status: "unclaimed" })
+      .where(eq(agentSandboxes.id, sandbox.id));
+    const now = new Date("2026-08-19T04:30:00.000Z");
+
+    const billableWhileRunning = await agentBillingRepository.listBillableSandboxes(
+      now,
+      new Date("2026-08-19T03:30:00.000Z"),
+    );
+    expect(billableWhileRunning.runningSandboxes.map((row) => row.id)).not.toContain(sandbox.id);
+
+    const input = {
+      sandboxId: sandbox.id,
+      organizationId: org.id,
+      userId: user.id,
+      agentName: "pool-capacity",
+      hourlyRate: 0.01,
+      billingDescription: "must remain exempt",
+      lowCreditWarningAmount: 1,
+      now,
+    };
+    await expect(agentBillingRepository.recordHourlyBilling(input)).resolves.toEqual({
+      status: "already_billed_recently",
+    });
+    await expect(
+      agentBillingRepository.settleAccruedBillingBeforeLifecycle(sandbox.id, org.id, now),
+    ).resolves.toEqual({ status: "already_billed_recently" });
+
+    await agentBillingRepository.scheduleShutdownWarning(
+      sandbox.id,
+      org.id,
+      now,
+      new Date("2026-08-19T05:30:00.000Z"),
+    );
+    await agentBillingRepository.suspendSandboxForInsufficientCredits(sandbox.id, org.id, now);
+
+    const [afterRejectedTransitions] = await dbWrite
+      .select({
+        billing_status: agentSandboxes.billing_status,
+        shutdown_warning_sent_at: agentSandboxes.shutdown_warning_sent_at,
+        scheduled_shutdown_at: agentSandboxes.scheduled_shutdown_at,
+      })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(afterRejectedTransitions).toEqual({
+      billing_status: "active",
+      shutdown_warning_sent_at: null,
+      scheduled_shutdown_at: null,
+    });
+
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ status: "stopped", last_backup_at: now })
+      .where(eq(agentSandboxes.id, sandbox.id));
+    const billableWhileStopped = await agentBillingRepository.listBillableSandboxes(
+      now,
+      new Date("2026-08-19T03:30:00.000Z"),
+    );
+    expect(billableWhileStopped.stoppedWithBackups.map((row) => row.id)).not.toContain(sandbox.id);
+
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ billing_status: "suspended" })
+      .where(eq(agentSandboxes.id, sandbox.id));
+    await agentBillingRepository.reactivateSandboxBillingAfterFunding(
+      sandbox.id,
+      new Date("2026-08-19T04:31:00.000Z"),
+      org.id,
+    );
+
+    const [stored] = await dbWrite
+      .select({
+        billing_status: agentSandboxes.billing_status,
+        last_billed_at: agentSandboxes.last_billed_at,
+        shutdown_warning_sent_at: agentSandboxes.shutdown_warning_sent_at,
+        scheduled_shutdown_at: agentSandboxes.scheduled_shutdown_at,
+      })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(stored).toEqual({
+      billing_status: "suspended",
+      last_billed_at: lastBilledAt,
+      shutdown_warning_sent_at: null,
+      scheduled_shutdown_at: null,
+    });
+    const [balance] = await dbWrite
+      .select({ credit_balance: organizations.credit_balance })
+      .from(organizations)
+      .where(eq(organizations.id, org.id));
+    expect(balance.credit_balance).toBe("10.000000");
+    expect(await dbWrite.select().from(agentBillingRecords)).toHaveLength(0);
+    expect(await dbWrite.select().from(creditTransactions)).toHaveLength(0);
+  });
+
   test("a delayed run charges the full elapsed interval and a concurrent replay is a no-op", async () => {
     const { org, user, sandbox } = await seed();
     const now = new Date("2026-08-19T04:30:00.000Z");

--- a/packages/cloud/shared/src/db/repositories/agent-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing.ts
@@ -111,6 +111,7 @@ export class AgentBillingRepository {
             eq(agentSandboxes.status, "running"),
             sql`${agentSandboxes.execution_tier} <> 'shared'`,
             isNull(agentSandboxes.deleted_at),
+            isNull(agentSandboxes.pool_status),
             // Defence in depth, aligned with the six sibling predicates here.
             // The charge itself is already safe: recordHourlyBillingWithOptions
             // claims the row with this same guard on its SELECT ... FOR UPDATE,
@@ -139,6 +140,7 @@ export class AgentBillingRepository {
             eq(agentSandboxes.status, "stopped"),
             sql`${agentSandboxes.execution_tier} <> 'shared'`,
             isNull(agentSandboxes.deleted_at),
+            isNull(agentSandboxes.pool_status),
             sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
             inArray(agentSandboxes.billing_status, BILLABLE_BILLING_STATUSES),
             isNotNull(agentSandboxes.last_backup_at),
@@ -203,6 +205,7 @@ export class AgentBillingRepository {
         and(
           eq(agentSandboxes.id, sandboxId),
           eq(agentSandboxes.organization_id, organizationId),
+          isNull(agentSandboxes.pool_status),
           sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
         ),
       );
@@ -223,6 +226,7 @@ export class AgentBillingRepository {
         and(
           eq(agentSandboxes.id, sandboxId),
           eq(agentSandboxes.organization_id, organizationId),
+          isNull(agentSandboxes.pool_status),
           sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
         ),
       );
@@ -245,6 +249,7 @@ export class AgentBillingRepository {
         and(
           eq(agentSandboxes.id, sandboxId),
           ...(organizationId ? [eq(agentSandboxes.organization_id, organizationId)] : []),
+          isNull(agentSandboxes.pool_status),
           ne(agentSandboxes.billing_status, "exempt"),
           sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
         ),
@@ -295,6 +300,7 @@ export class AgentBillingRepository {
         and(
           eq(agentSandboxes.id, sandboxId),
           eq(agentSandboxes.organization_id, organizationId),
+          isNull(agentSandboxes.pool_status),
           sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
         ),
       )
@@ -338,6 +344,7 @@ export class AgentBillingRepository {
             eq(agentSandboxes.id, input.sandboxId),
             eq(agentSandboxes.organization_id, input.organizationId),
             isNull(agentSandboxes.deleted_at),
+            isNull(agentSandboxes.pool_status),
             sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
           ),
         )
@@ -442,6 +449,7 @@ export class AgentBillingRepository {
           and(
             eq(agentSandboxes.id, input.sandboxId),
             eq(agentSandboxes.organization_id, input.organizationId),
+            isNull(agentSandboxes.pool_status),
             sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
           ),
         );

--- a/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
@@ -89,6 +89,7 @@ mock.module("../../db/client", () => ({
     select: () => makeBuilder(),
   },
   dbWrite: {
+    select: () => makeBuilder(),
     update() {
       dbWriteUpdateCalls += 1;
       const builder = {

--- a/packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts
@@ -1,0 +1,169 @@
+/** Proves active billing excludes pool capacity while retaining claimed Dedicated resources. */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../db/schemas/api-keys";
+import { containers } from "../../db/schemas/containers";
+import { creditTransactions } from "../../db/schemas/credit-transactions";
+import { organizations } from "../../db/schemas/organizations";
+import { userCharacters } from "../../db/schemas/user-characters";
+import { users } from "../../db/schemas/users";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const { activeBillingService } = await import("./active-billing");
+
+const PGLITE_TIMEOUT = 60_000;
+let organizationId = "";
+let userId = "";
+let enqueueSuspendCalls = 0;
+let enqueueDeleteCalls = 0;
+let triggerImmediateCalls = 0;
+let restoredSpies: Array<{ mockRestore: () => void }> = [];
+
+beforeAll(async () => {
+  const schema = {
+    organizations,
+    users,
+    userCharacters,
+    apiKeys,
+    agentSandboxes,
+    containers,
+    creditTransactions,
+  };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  enqueueSuspendCalls = 0;
+  enqueueDeleteCalls = 0;
+  triggerImmediateCalls = 0;
+  restoredSpies = [
+    spyOn(provisioningJobService, "enqueueAgentSuspendOnce").mockImplementation(async () => {
+      enqueueSuspendCalls += 1;
+      return { job: { id: crypto.randomUUID() } as never, created: true };
+    }),
+    spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockImplementation(async () => {
+      enqueueDeleteCalls += 1;
+      return { job: { id: crypto.randomUUID() } as never, created: true };
+    }),
+    spyOn(provisioningJobService, "triggerImmediate").mockImplementation(async () => {
+      triggerImmediateCalls += 1;
+    }),
+  ];
+  await dbWrite.delete(creditTransactions);
+  await dbWrite.delete(containers);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(apiKeys);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Active Billing Pool", slug: `pool-${crypto.randomUUID()}` })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: `steward-${crypto.randomUUID()}`, organization_id: org.id })
+    .returning();
+  organizationId = org.id;
+  userId = user.id;
+});
+
+afterEach(() => {
+  for (const activeSpy of restoredSpies) activeSpy.mockRestore();
+  restoredSpies = [];
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+async function seedDedicated(poolStatus: "unclaimed" | null): Promise<string> {
+  const [row] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: organizationId,
+      user_id: userId,
+      agent_name: poolStatus === null ? "claimed-user-agent" : "sentinel-capacity",
+      status: "running",
+      execution_tier: "dedicated-always",
+      pool_status: poolStatus,
+      billing_status: "active",
+      last_billed_at: new Date("2026-08-20T00:00:00.000Z"),
+      node_id: "node-1",
+      container_name: `agent-${crypto.randomUUID()}`,
+    })
+    .returning();
+  return row.id;
+}
+
+describe("active billing warm-pool authority", () => {
+  test("list exposes the claimed Dedicated resource but never its pool-owned sibling", async () => {
+    const poolId = await seedDedicated("unclaimed");
+    const claimedId = await seedDedicated(null);
+
+    const resources = await activeBillingService.listActiveResources(organizationId);
+    const ids = resources.map((resource) => resource.resourceId);
+    expect(ids).toContain(claimedId);
+    expect(ids).not.toContain(poolId);
+  });
+
+  test("pool capacity cannot be cancelled or mutated through the billing surface", async () => {
+    const poolId = await seedDedicated("unclaimed");
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId,
+        resourceId: poolId,
+        resourceType: "agent_sandbox",
+      }),
+    ).rejects.toThrow("Billable resource not found");
+    expect(enqueueSuspendCalls).toBe(0);
+    expect(enqueueDeleteCalls).toBe(0);
+    expect(triggerImmediateCalls).toBe(0);
+    const [stored] = await dbWrite
+      .select({ billing_status: agentSandboxes.billing_status })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, poolId));
+    expect(stored.billing_status).toBe("active");
+  });
+
+  test("a claimed slot remains cancellable and billable once pool_status is null", async () => {
+    const claimedId = await seedDedicated(null);
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId,
+        resourceId: claimedId,
+        resourceType: "agent_sandbox",
+      }),
+    ).resolves.toMatchObject({ stoppedBilling: true });
+    expect(enqueueSuspendCalls).toBe(1);
+    expect(triggerImmediateCalls).toBe(1);
+    const [stored] = await dbWrite
+      .select({ billing_status: agentSandboxes.billing_status })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, claimedId));
+    expect(stored.billing_status).toBe("suspended");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -5,7 +5,7 @@
  * one primary-database observation boundary.
  */
 
-import { and, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { type Database, dbRead, dbWrite } from "../../db/client";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
@@ -136,6 +136,7 @@ class ActiveBillingService {
           and(
             eq(agentSandboxes.organization_id, organizationId),
             sql`${agentSandboxes.execution_tier} <> 'shared'`,
+            isNull(agentSandboxes.pool_status),
             inArray(agentSandboxes.billing_status, ["active", "warning", "shutdown_pending"]),
             or(
               eq(agentSandboxes.status, "running"),
@@ -369,7 +370,9 @@ class ActiveBillingService {
     }
 
     if (!resourceType || resourceType === "agent_sandbox") {
-      const [agent] = await dbRead
+      // pool_status is the server-owned capacity authority. Authorize against
+      // the primary immediately before enqueueing any infrastructure side effect.
+      const [agent] = await dbWrite
         .select()
         .from(agentSandboxes)
         .where(
@@ -377,6 +380,7 @@ class ActiveBillingService {
             eq(agentSandboxes.id, resourceId),
             eq(agentSandboxes.organization_id, organizationId),
             sql`${agentSandboxes.execution_tier} <> 'shared'`,
+            isNull(agentSandboxes.pool_status),
           ),
         )
         .limit(1);
@@ -439,6 +443,7 @@ class ActiveBillingService {
             and(
               eq(agentSandboxes.id, resourceId),
               eq(agentSandboxes.organization_id, organizationId),
+              isNull(agentSandboxes.pool_status),
               sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
             ),
           )
@@ -446,13 +451,14 @@ class ActiveBillingService {
         const effective =
           updated ??
           (
-            await dbRead
+            await dbWrite
               .select()
               .from(agentSandboxes)
               .where(
                 and(
                   eq(agentSandboxes.id, resourceId),
                   eq(agentSandboxes.organization_id, organizationId),
+                  isNull(agentSandboxes.pool_status),
                 ),
               )
               .limit(1)


### PR DESCRIPTION
<!-- evidence-head:ebdb255204a8ea4ce41d6643c272e28c8c60980c -->

## Summary

- exclude rows with pool_status from every compute-billing selection and lifecycle transition
- authorize Active Billing list/cancel operations against claimed Dedicated rows only
- read cancellation authority from the primary database before any infrastructure side effect
- keep claimed slots billable/cancellable once pool_status is null
- add real PGlite coverage for running and stopped pool rows, debit/ledger, settlement, warning, suspension, reactivation, listing, and cancellation

## Restack

The dependency #23128 is merged. This branch is restacked onto current develop as one implementation commit containing exactly the intended five files. Exact head: ebdb255204a8ea4ce41d6643c272e28c8c60980c.

## Rollout boundary

This is the application guard release only. It deliberately contains no migration, warm-pool row rewrite, provisioning lifecycle change, provider change, or pricing policy change.

The guard must be deployed to the API and every provisioning/billing worker, with old processes drained or restarted and exact-SHA authority proved, before any follow-up warm-pool billing migration is applied.

## Validation

- exact Bun 1.3.14, isolated targeted suites: 46 passed, 145 assertions
- packages/cloud/shared typecheck
- Biome on all 5 changed files
- git diff --check
- GitHub comparison against the current #23128 head: exactly 5 files, merge state clean

Refs #22947.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI path changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - real PGlite billing validation is documented above; no protected backend was mutated.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend surface changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic billing authority does not involve a model.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the real PGlite row, ledger, transition, and side-effect assertions are the domain evidence.


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:ai-provider -->
- AI provider: OpenAI
<!-- attribution-row:ai-model -->
- AI model: gpt-5.6-sol
<!-- attribution-row:agent-tooling -->
- Agent tooling: Codex Desktop
<!-- attribution-row:contribution-skill -->
- Contribution skill: packages/skills/skills/contribute-to-eliza
<!-- attribution-row:attribution-status -->
- Attribution status: self-reported
