### PR TITLE
fix(plugin-google-workspace): fail-closed ghost accountId so it cannot inherit owner tokens

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/accounts.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/accounts.test.ts
@@ -118,3 +118,92 @@ describe("Google Chat account config", () => {
     ]);
   });
 });
+
+describe("resolveGoogleChatAccountSettings owner-bind fail-closed", () => {
+  const ownerCharacter = {
+    googleChat: {
+      serviceAccount: '{"client_email":"owner@example.com"}',
+      serviceAccountFile: "/owner/sa.json",
+      audience: "https://owner.example.com/googlechat",
+      spaces: ["spaces/OWNER"],
+    },
+  };
+  const ownerEnv = {
+    GOOGLE_CHAT_SERVICE_ACCOUNT: '{"client_email":"env@example.com"}',
+    GOOGLE_CHAT_SERVICE_ACCOUNT_FILE: "/env/sa.json",
+    GOOGLE_CHAT_AUDIENCE: "https://env.example.com/googlechat",
+  };
+
+  it("lets the default account inherit owner character service-account credentials", () => {
+    const rt = runtime({}, ownerCharacter);
+    const resolved = resolveGoogleChatAccountSettings(rt, "default");
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.serviceAccount).toBe('{"client_email":"owner@example.com"}');
+    expect(resolved.serviceAccountFile).toBe("/owner/sa.json");
+  });
+
+  it("does not give a ghost accountId the owner service-account JSON or key file", () => {
+    const rt = runtime({}, ownerCharacter);
+    const ghost = resolveGoogleChatAccountSettings(rt, "ghost-account");
+    expect(ghost.accountId).toBe("ghost-account");
+    expect(ghost.serviceAccount).toBeUndefined();
+    expect(ghost.serviceAccountFile).toBeUndefined();
+  });
+
+  it("does not let a named account without its own credentials inherit character tokens", () => {
+    const rt = runtime(
+      {},
+      {
+        googleChat: {
+          ...ownerCharacter.googleChat,
+          accounts: { partner: { enabled: true, audience: "https://partner.example.com/googlechat" } },
+        },
+      }
+    );
+    const partner = resolveGoogleChatAccountSettings(rt, "partner");
+    expect(partner.accountId).toBe("partner");
+    expect(partner.serviceAccount).toBeUndefined();
+    expect(partner.serviceAccountFile).toBeUndefined();
+    expect(partner.audience).toBe("https://partner.example.com/googlechat");
+  });
+
+  it("keeps a named account own credentials and does not attach owner character secrets", () => {
+    const rt = runtime(
+      {},
+      {
+        googleChat: {
+          ...ownerCharacter.googleChat,
+          accounts: {
+            partner: {
+              serviceAccount: '{"client_email":"partner@example.com"}',
+              serviceAccountFile: "/partner/sa.json",
+              audience: "https://partner.example.com/googlechat",
+            },
+          },
+        },
+      }
+    );
+    const partner = resolveGoogleChatAccountSettings(rt, "partner");
+    expect(partner.serviceAccount).toBe('{"client_email":"partner@example.com"}');
+    expect(partner.serviceAccountFile).toBe("/partner/sa.json");
+  });
+
+  it("does not give a ghost accountId owner env credentials either", () => {
+    const rt = runtime(ownerEnv);
+    const ghost = resolveGoogleChatAccountSettings(rt, "ghost-account");
+    expect(ghost.serviceAccount).toBeUndefined();
+    expect(ghost.serviceAccountFile).toBeUndefined();
+    const def = resolveGoogleChatAccountSettings(rt, "default");
+    expect(def.serviceAccount).toBe('{"client_email":"env@example.com"}');
+    expect(def.serviceAccountFile).toBe("/env/sa.json");
+  });
+
+  it("fails closed when readGoogleChatAccountId supplies a ghost id from request metadata", () => {
+    const rt = runtime({}, ownerCharacter);
+    const accountId = readGoogleChatAccountId({ metadata: { accountId: "ghost-account" } });
+    expect(accountId).toBe("ghost-account");
+    const ghost = resolveGoogleChatAccountSettings(rt, accountId);
+    expect(ghost.serviceAccount).toBeUndefined();
+    expect(ghost.serviceAccountFile).toBeUndefined();
+  });
+});

--- a/plugins/plugin-google-workspace/src/chat/accounts.ts
+++ b/plugins/plugin-google-workspace/src/chat/accounts.ts
@@ -4,6 +4,9 @@
  * `GOOGLE_CHAT_ACCOUNTS` JSON map, and `character.settings.googleChat` (or the
  * `google-chat` alias), merging per field. Supplies the service the space list
  * and service-account credentials for each configured account.
+ * Named or unrecognized accountIds fail closed: they cannot inherit the
+ * owner service-account JSON / key file from env or the top-level character
+ * `settings.googleChat` identity fields.
  */
 import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import type { GoogleChatAudienceType, GoogleChatSettings } from "./types.js";
@@ -195,11 +198,11 @@ export function resolveGoogleChatAccountSettings(
   );
   const base = characterConfig(runtime);
   const account = accountConfig(runtime, accountId);
-  const allowEnv = accountId === DEFAULT_GOOGLE_CHAT_ACCOUNT_ID;
+  const allowOwnerBind = accountId === DEFAULT_GOOGLE_CHAT_ACCOUNT_ID;
   const webhookPath =
     account.webhookPath ??
     base.webhookPath ??
-    (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_WEBHOOK_PATH") : undefined) ??
+    (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_WEBHOOK_PATH") : undefined) ??
     "/googlechat";
 
   return {
@@ -207,45 +210,45 @@ export function resolveGoogleChatAccountSettings(
     serviceAccount:
       account.serviceAccount ??
       account.serviceAccountKey ??
-      base.serviceAccount ??
-      base.serviceAccountKey ??
-      (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT") : undefined),
+      (allowOwnerBind ? base.serviceAccount : undefined) ??
+      (allowOwnerBind ? base.serviceAccountKey : undefined) ??
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT") : undefined),
     serviceAccountFile:
       account.serviceAccountFile ??
       account.serviceAccountKeyFile ??
-      base.serviceAccountFile ??
-      base.serviceAccountKeyFile ??
-      (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE") : undefined),
+      (allowOwnerBind ? base.serviceAccountFile : undefined) ??
+      (allowOwnerBind ? base.serviceAccountKeyFile : undefined) ??
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE") : undefined),
     audienceType: (account.audienceType ??
       base.audienceType ??
-      (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_AUDIENCE_TYPE") : undefined) ??
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_AUDIENCE_TYPE") : undefined) ??
       "app-url") as GoogleChatAudienceType,
     audience:
       account.audience ??
       base.audience ??
-      (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_AUDIENCE") : undefined) ??
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_AUDIENCE") : undefined) ??
       "",
     webhookPath: webhookPath.startsWith("/") ? webhookPath : `/${webhookPath}`,
     spaces: spaceList(
       account.spaces ??
         base.spaces ??
-        (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_SPACES") : undefined)
+        (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_SPACES") : undefined)
     ),
     requireMention: boolValue(
       account.requireMention ??
         base.requireMention ??
-        (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_REQUIRE_MENTION") : undefined),
+        (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_REQUIRE_MENTION") : undefined),
       true
     ),
     enabled: boolValue(
       account.enabled ??
         base.enabled ??
-        (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_ENABLED") : undefined),
+        (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_ENABLED") : undefined),
       true
     ),
     botUser:
       account.botUser ??
       base.botUser ??
-      (allowEnv ? envOrSetting(runtime, "GOOGLE_CHAT_BOT_USER") : undefined),
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_BOT_USER") : undefined),
   };
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE
auth-bind audit on a live Google Chat product path. No new issue filed (mission
forbids self-directed issue creation). Same owner-token inherit class as
#23070 (X), #23082 (Slack), #23088 (Signal), #23133 (BlueBubbles), and
#23139 (Matrix), different host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on ghost / unrecognized Google Chat `accountId` so it cannot
inherit owner service-account JSON or key file from env or top-level character
`settings.googleChat` identity. Honest default-only deployments still resolve.
Shared space/audience/policy defaults stay inherited. No schema or storage
migration.

# Background

## What does this PR do?

`resolveGoogleChatAccountSettings` already refused env credentials for
non-default accountIds (`allowEnv`), but still fell through to top-level
`character.settings.googleChat` `serviceAccount` / `serviceAccountKey` /
`serviceAccountFile` / `serviceAccountKeyFile` for every accountId. A ghost or
unrecognized id therefore resolved against the owner's Google Chat
service-account. `readGoogleChatAccountId` accepts that id from request
parameters, data, nested `googleChat`, and metadata.

This head lets only the implicit `default` account inherit owner env /
top-level service-account credentials. Named and unrecognized accountIds keep
shared space and policy defaults but do not receive the owner's service-account
JSON or key file. Honest default-only deployments still resolve.

Origin `develop` `e38ecc71039441d729032e95134290a996cbc28e`:
`resolveGoogleChatAccountSettings(runtime, "ghost-account")` with character
`settings.googleChat.serviceAccount={"client_email":"owner@example.com"}` and
`settings.googleChat.serviceAccountFile=/owner/sa.json` returned that owner
service-account JSON and key file.

Overlay `vitest run src/chat/accounts.test.ts` → 12/12 on this head,
including ghost/named fail-closed and default character/env inherit still
works. The same new cases against RAW origin `accounts.ts` are 3 failed /
9 passed (ghost inherits owner bind).

Occupancy-FREE host `plugins/plugin-google-workspace/src/chat/accounts.ts`.
Not leftover-tax. Not Signal/X/Slack/Instagram/BlueBubbles/Matrix. Not
`connector-account-provider.ts`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/chat/accounts.ts` and
`plugins/plugin-google-workspace/src/chat/accounts.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:de660872655796fa41a1fdfe1d598fc795e81312 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; Google Chat account resolver is runtime logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; Google Chat account resolver is runtime logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
origin develop e38ecc71039441d729032e95134290a996cbc28e
resolveGoogleChatAccountSettings(runtime, "ghost-account")
character.settings.googleChat.serviceAccount={"client_email":"owner@example.com"}
character.settings.googleChat.serviceAccountFile=/owner/sa.json
result: owner service-account JSON + owner key file

overlay vitest run src/chat/accounts.test.ts
RAW origin accounts.ts: 3 failed / 9 passed (ghost inherits owner bind)
overlay head: 12/12 including ghost/named fail-closed and default inherit
head de660872655796fa41a1fdfe1d598fc795e81312
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
