### PR TITLE
fix(plugin-telegram): fail-closed ghost accountId so it cannot inherit owner tokens

### DIFF
--- a/plugins/plugin-telegram/src/accounts.test.ts
+++ b/plugins/plugin-telegram/src/accounts.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for Telegram multi-account resolution in `accounts.ts`.
+ * Fail-closes ghost / unrecognized accountIds so they cannot inherit the
+ * owner's character-level `settings.telegram.botToken` (or env
+ * `TELEGRAM_BOT_TOKEN`). Uses a hand-built fake runtime; no live Telegram API.
+ */
+import type { Character, IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  listEnabledTelegramAccounts,
+  resolveTelegramAccount,
+  type TelegramMultiAccountConfig,
+} from "./accounts";
+
+function createRuntime(
+  telegram?: TelegramMultiAccountConfig,
+  env?: Record<string, string | undefined>,
+): IAgentRuntime {
+  const character: Partial<Character> = {
+    settings: telegram ? { telegram } : {},
+  };
+  const settings = env ?? {};
+  return {
+    agentId: "agent-1",
+    character: character as Character,
+    getSetting: vi.fn((key: string) => settings[key] ?? null),
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const savedBotToken = process.env.TELEGRAM_BOT_TOKEN;
+const savedApiRoot = process.env.TELEGRAM_API_ROOT;
+
+afterEach(() => {
+  if (savedBotToken === undefined) {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
+  }
+  if (savedApiRoot === undefined) {
+    delete process.env.TELEGRAM_API_ROOT;
+  } else {
+    process.env.TELEGRAM_API_ROOT = savedApiRoot;
+  }
+});
+
+describe("resolveTelegramAccount owner-bind fail-closed", () => {
+  it("lets the default account inherit character-level botToken", () => {
+    const rt = createRuntime({ botToken: "owner-bot-token" });
+    const resolved = resolveTelegramAccount(rt, "default");
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.botToken).toBe("owner-bot-token");
+  });
+
+  it("still binds omitted accountId to the default owner botToken", () => {
+    const rt = createRuntime({ botToken: "owner-bot-token" });
+    const omitted = resolveTelegramAccount(rt);
+    expect(omitted.accountId).toBe("default");
+    expect(omitted.botToken).toBe("owner-bot-token");
+  });
+
+  it("lets the default account inherit env TELEGRAM_BOT_TOKEN", () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    const rt = createRuntime(undefined, {
+      TELEGRAM_BOT_TOKEN: "env-bot-token",
+    });
+    const resolved = resolveTelegramAccount(rt, "default");
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.botToken).toBe("env-bot-token");
+  });
+
+  it("does not give a ghost accountId the owner character botToken", () => {
+    const rt = createRuntime({
+      botToken: "owner-bot-token",
+      accounts: { work: { botToken: "work-bot-token", enabled: true } },
+    });
+    const ghost = resolveTelegramAccount(rt, "ghost-account");
+    expect(ghost.accountId).toBe("ghost-account");
+    expect(ghost.botToken).toBeUndefined();
+  });
+
+  it("does not inherit env TELEGRAM_BOT_TOKEN for a ghost accountId", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    const rt = createRuntime(undefined, {
+      TELEGRAM_BOT_TOKEN: "env-bot-token",
+    });
+    const ghost = resolveTelegramAccount(rt, "ghost-account");
+    expect(ghost.accountId).toBe("ghost-account");
+    expect(ghost.botToken).toBeUndefined();
+  });
+
+  it("does not let a named account without its own token inherit character botToken", () => {
+    const rt = createRuntime({
+      botToken: "owner-bot-token",
+      accounts: { work: { enabled: true } },
+    });
+    const work = resolveTelegramAccount(rt, "work");
+    expect(work.accountId).toBe("work");
+    expect(work.botToken).toBeUndefined();
+  });
+
+  it("keeps a named account's own botToken and does not attach the owner token", () => {
+    const rt = createRuntime({
+      botToken: "owner-bot-token",
+      accounts: {
+        work: {
+          enabled: true,
+          botToken: "work-bot-token",
+        },
+      },
+    });
+    const work = resolveTelegramAccount(rt, "work");
+    expect(work.accountId).toBe("work");
+    expect(work.botToken).toBe("work-bot-token");
+  });
+
+  it("does not list ghost or tokenless named accounts as enabled bots", () => {
+    const rt = createRuntime({
+      botToken: "owner-bot-token",
+      accounts: {
+        work: { enabled: true },
+        personal: { enabled: true, botToken: "personal-bot-token" },
+      },
+    });
+    const enabled = listEnabledTelegramAccounts(rt);
+    expect(enabled.map((account) => account.accountId)).toEqual(["personal"]);
+    expect(enabled[0]?.botToken).toBe("personal-bot-token");
+  });
+});

--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -4,6 +4,9 @@
  * `TELEGRAM_BOT_TOKEN`/env fallbacks and resolves each enabled account to a
  * `ResolvedTelegramAccount` the service launches a bot for. `default` is the
  * synthetic id for the single-account configuration.
+ * Named or unrecognized accountIds fail closed: they cannot inherit the
+ * owner's character-level `settings.telegram.botToken` or env
+ * `TELEGRAM_BOT_TOKEN`.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 
@@ -119,9 +122,13 @@ export function resolveTelegramAccount(
   const normalizedAccountId = normalizeTelegramAccountId(accountId);
   const multi = getTelegramMultiAccountConfig(runtime);
   const accountConfig = getAccountConfig(runtime, normalizedAccountId) ?? {};
+  // Only the implicit default account may inherit owner env / top-level
+  // character botToken. A ghost or named accountId must not launch against
+  // the owner's Telegram bot.
+  const allowOwnerBind = normalizedAccountId === DEFAULT_ACCOUNT_ID;
   const merged: TelegramAccountConfig = {
     enabled: multi.enabled,
-    botToken: multi.botToken,
+    botToken: allowOwnerBind ? multi.botToken : undefined,
     apiRoot: multi.apiRoot,
     ...accountConfig,
   };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No `mission-ready` issue exists for this hole. Operator-authorized occupancy-FREE
auth-bind audit on a live Telegram product path. No new issue filed (mission
forbids self-directed issue creation). Same owner-token inherit class as
#23070 (X), #23082 (Slack), #23088 (Signal), #23133 (BlueBubbles),
#23139 (Matrix), and #23143 (Google Chat), different host.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed on ghost / unrecognized Telegram `accountId` so it cannot
inherit owner `settings.telegram.botToken` or env `TELEGRAM_BOT_TOKEN`.
Honest default-only deployments still resolve. Shared `apiRoot` / enabled
defaults stay inherited. No schema or storage migration.

# Background

## What does this PR do?

`resolveTelegramAccount` already refused env `TELEGRAM_BOT_TOKEN` for
non-default accountIds, but still copied top-level
`character.settings.telegram.botToken` into every merged account config
before that gate. A ghost or unrecognized id therefore resolved against
the owner's Telegram bot. `resolveAccountIdFromContext` /
`resolveAccountIdForTarget` accept that id from request context, target,
and metadata.

This head lets only the implicit `default` account inherit owner env /
top-level character botToken. Named and unrecognized accountIds keep
shared apiRoot and enabled defaults but do not receive the owner's bot
token. Honest default-only deployments still resolve.

Origin `develop` `5472d83903c15e79851dc6aa0f29dd10089da3cf`:
`resolveTelegramAccount(runtime, "ghost-account")` with character
`settings.telegram.botToken=owner-bot-token` returned that owner token.

Overlay `vitest run src/accounts.test.ts` → 8/8 on this head,
including ghost/named fail-closed and default character/env inherit still
works. The same new cases against RAW origin `accounts.ts` are 3 failed /
5 passed (ghost inherits owner bind).

Occupancy-FREE host `plugins/plugin-telegram/src/accounts.ts`.
Nubs #23068 occupies adjacent telegram setup/auth files, not
`accounts.ts`. Not leftover-tax. Not Signal/X/Slack/Instagram/
BlueBubbles/Matrix/Google Chat. Not `connector-account-provider.ts`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/accounts.ts` and
`plugins/plugin-telegram/src/accounts.test.ts`.

## Detailed testing steps

Automated tests are acceptable. See the domain-artifact transcript.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:7358e0e91cbb71fe05368e452b00d8a54b9ea79c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; Telegram account resolver is runtime logic only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; Telegram account resolver is runtime logic only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; focused unit proof is the domain artifact.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
origin develop 5472d83903c15e79851dc6aa0f29dd10089da3cf
resolveTelegramAccount(runtime, "ghost-account")
character.settings.telegram.botToken=owner-bot-token
result: owner-bot-token

overlay vitest run src/accounts.test.ts
RAW origin accounts.ts: 3 failed / 5 passed (ghost inherits owner bind)
overlay head: 8/8 including ghost/named fail-closed and default inherit
head 7358e0e91cbb71fe05368e452b00d8a54b9ea79c
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run verify` was not rerun on this head. Focused package tests and the
origin reproduction in Background are the proof. Fork cannot upload
`pr-evidence` release assets, so the domain receipt is inline.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-bot]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
