### PR TITLE
fix(plugin-google-workspace): bind owner ADC to the default account

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/accounts.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/accounts.test.ts
@@ -156,7 +156,9 @@ describe("resolveGoogleChatAccountSettings owner-bind fail-closed", () => {
       {
         googleChat: {
           ...ownerCharacter.googleChat,
-          accounts: { partner: { enabled: true, audience: "https://partner.example.com/googlechat" } },
+          accounts: {
+            partner: { enabled: true, audience: "https://partner.example.com/googlechat" },
+          },
         },
       }
     );
@@ -196,6 +198,23 @@ describe("resolveGoogleChatAccountSettings owner-bind fail-closed", () => {
     const def = resolveGoogleChatAccountSettings(rt, "default");
     expect(def.serviceAccount).toBe('{"client_email":"env@example.com"}');
     expect(def.serviceAccountFile).toBe("/env/sa.json");
+  });
+
+  it("binds application-default credentials only to the default account", () => {
+    const previous = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/owner/application-default.json";
+    try {
+      const rt = runtime();
+      expect(resolveGoogleChatAccountSettings(rt, "default").serviceAccountFile).toBe(
+        "/owner/application-default.json"
+      );
+      expect(
+        resolveGoogleChatAccountSettings(rt, "ghost-account").serviceAccountFile
+      ).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      else process.env.GOOGLE_APPLICATION_CREDENTIALS = previous;
+    }
   });
 
   it("fails closed when readGoogleChatAccountId supplies a ghost id from request metadata", () => {

--- a/plugins/plugin-google-workspace/src/chat/accounts.ts
+++ b/plugins/plugin-google-workspace/src/chat/accounts.ts
@@ -218,7 +218,8 @@ export function resolveGoogleChatAccountSettings(
       account.serviceAccountKeyFile ??
       (allowOwnerBind ? base.serviceAccountFile : undefined) ??
       (allowOwnerBind ? base.serviceAccountKeyFile : undefined) ??
-      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE") : undefined),
+      (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE") : undefined) ??
+      (allowOwnerBind ? process.env.GOOGLE_APPLICATION_CREDENTIALS : undefined),
     audienceType: (account.audienceType ??
       base.audienceType ??
       (allowOwnerBind ? envOrSetting(runtime, "GOOGLE_CHAT_AUDIENCE_TYPE") : undefined) ??

--- a/plugins/plugin-google-workspace/src/chat/connector.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/connector.test.ts
@@ -101,12 +101,40 @@ describe("Google Chat message connector", () => {
     );
   });
 
+  it("does not let a named account inherit owner application-default credentials", async () => {
+    const previous = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/owner/application-default.json";
+    try {
+      const runtimeInstance = runtime({
+        getSetting: vi.fn((key: string) =>
+          key === "GOOGLE_CHAT_ACCOUNTS"
+            ? JSON.stringify({
+                workspace: {
+                  enabled: true,
+                  audience: "https://example.com/googlechat",
+                },
+              })
+            : null
+        ),
+        reportError: vi.fn(),
+      });
+
+      await expect(GoogleChatService.start(runtimeInstance)).rejects.toBeInstanceOf(
+        GoogleChatConfigurationError
+      );
+    } finally {
+      if (previous === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      else process.env.GOOGLE_APPLICATION_CREDENTIALS = previous;
+    }
+  });
+
   it("registers connector metadata and routes space sends", async () => {
     const runtimeInstance = runtime();
     const service = Object.create(GoogleChatService.prototype) as GoogleChatService;
     (service as { settings: { accountId: string } }).settings = {
       accountId: "workspace",
     };
+    (service as { auth: object }).auth = {};
     const sendMessageSpy = vi
       .spyOn(service, "sendMessage")
       .mockResolvedValue({ success: true, space: "spaces/AAA" });

--- a/plugins/plugin-google-workspace/src/chat/service.ts
+++ b/plugins/plugin-google-workspace/src/chat/service.ts
@@ -507,12 +507,10 @@ export class GoogleChatService extends Service implements IGoogleChatService {
 
   private validateSettings(settings: GoogleChatSettings): void {
     if (!settings.serviceAccount && !settings.serviceAccountFile) {
-      if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        throw new GoogleChatConfigurationError(
-          "Google Chat requires service account credentials. Set GOOGLE_CHAT_SERVICE_ACCOUNT, GOOGLE_CHAT_SERVICE_ACCOUNT_FILE, or GOOGLE_APPLICATION_CREDENTIALS.",
-          "GOOGLE_CHAT_SERVICE_ACCOUNT"
-        );
-      }
+      throw new GoogleChatConfigurationError(
+        "Google Chat requires service account credentials. Set GOOGLE_CHAT_SERVICE_ACCOUNT, GOOGLE_CHAT_SERVICE_ACCOUNT_FILE, or GOOGLE_APPLICATION_CREDENTIALS.",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT"
+      );
     }
 
     if (!settings.audience) {
@@ -545,9 +543,10 @@ export class GoogleChatService extends Service implements IGoogleChatService {
       });
     }
 
-    return new GoogleAuth({
-      scopes: [CHAT_SCOPE],
-    });
+    throw new GoogleChatConfigurationError(
+      "Google Chat service account credentials were not resolved for this account.",
+      "GOOGLE_CHAT_SERVICE_ACCOUNT"
+    );
   }
 
   private async testConnection(state = this.getState()): Promise<void> {


### PR DESCRIPTION
## Summary

Preserves the original #23143 fix and closes the remaining credential-authority bypass: named or unrecognized Google Chat accounts can no longer inherit the process-wide GOOGLE_APPLICATION_CREDENTIALS / ambient ADC identity.

The default account still supports the legacy owner ADC path. Named accounts must resolve explicit per-account credentials before GoogleChatService starts.

Supersedes #23143 after review found the ambient-ADC fallback outside its resolver boundary.

## Validation

- accounts.test.ts + connector.test.ts: 34/34 passed
- Biome on all four changed files: passed
- git diff --check: passed
- package typecheck: passed after the owning core workspace was built

## Evidence

Deterministic production-boundary coverage proves the default account may use owner ADC, while a configured named account with no explicit credentials fails closed even when owner ADC is present.

<!-- evidence-head:6bc5601b28db5c27ee7ab1d13fab9e3c78ac9e82 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent completion
Contribution skill revision: N/A - repository completion workflow; no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository completion workflow; no contribution skill used"} -->