### PR TITLE
fix(security): replace backtracking SQL regexes with a single-pass lexer

### DIFF
--- a/packages/agent/src/actions/database-readonly.test.ts
+++ b/packages/agent/src/actions/database-readonly.test.ts
@@ -3,10 +3,37 @@
  * These tests keep model-shaped SQL inputs on the same linear sanitizer path as
  * the dashboard API guard without importing the full action runtime graph.
  */
-import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
 import { checkReadOnly } from "../security/sql-readonly-guard.ts";
+import { databaseAction } from "./database.ts";
 
 describe("DATABASE action read-only guard", () => {
+  it("rejects the context-ordering regression before adapter execution", async () => {
+    const execute = vi.fn();
+    const runtime = {
+      adapter: { db: { execute } },
+    } as unknown as IAgentRuntime;
+    const result = await databaseAction.handler(
+      runtime,
+      {} as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "query",
+          sql: "SELECT 'value--'; DELETE FROM memories",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      values: { error: "DATABASE_QUERY_FAILED", reason: "MUTATION_BLOCKED" },
+    });
+    expect(result?.text).toContain("DELETE");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("collapses block-comment-split mutation keywords", () => {
     expect(checkReadOnly("DE/* */LETE FROM memories")).toMatchObject({
       ok: false,
@@ -43,7 +70,7 @@ describe("DATABASE action read-only guard", () => {
     const result = checkReadOnly(sql);
     const elapsed = performance.now() - start;
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toMatchObject({ ok: false });
     expect(elapsed).toBeLessThan(1000);
   });
 
@@ -53,7 +80,7 @@ describe("DATABASE action read-only guard", () => {
     const result = checkReadOnly(sql);
     const elapsed = performance.now() - start;
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toMatchObject({ ok: false });
     expect(elapsed).toBeLessThan(1000);
   });
 });

--- a/packages/agent/src/actions/database.readonly-redos.test.ts
+++ b/packages/agent/src/actions/database.readonly-redos.test.ts
@@ -29,7 +29,7 @@ describe("DATABASE read-only SQL guard", () => {
 
     expect(result).toMatchObject({ ok: false });
     if (!result.ok) {
-      expect(result.reason).toContain('"DELETE"');
+      expect(result.reason).toContain("Unterminated dollar-quoted string");
     }
     expect(elapsed).toBeLessThan(1000);
   });

--- a/packages/agent/src/api/database.query-readonly.test.ts
+++ b/packages/agent/src/api/database.query-readonly.test.ts
@@ -45,6 +45,51 @@ function responseRecorder(): RecordedResponse {
 }
 
 describe("POST /api/database/query read-only guard", () => {
+  it("rejects executable text after a line-comment marker inside a string", async () => {
+    const query = vi.fn();
+    const runtime = { adapter: { db: { query } } } as unknown as AgentRuntime;
+    const res = responseRecorder();
+
+    await expect(
+      handleDatabaseRoute(
+        jsonPost({
+          sql: "SELECT 'value--'; DELETE FROM memories",
+          readOnly: true,
+        }),
+        res,
+        runtime,
+        "/api/database/query",
+      ),
+    ).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: expect.stringContaining("DELETE"),
+    });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("rejects a schema-qualified quoted dangerous callable", async () => {
+    const query = vi.fn();
+    const runtime = { adapter: { db: { query } } } as unknown as AgentRuntime;
+    const res = responseRecorder();
+
+    await expect(
+      handleDatabaseRoute(
+        jsonPost({ sql: 'SELECT "pg_catalog"."pg_sleep"(1)', readOnly: true }),
+        res,
+        runtime,
+        "/api/database/query",
+      ),
+    ).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: expect.stringContaining("PG_SLEEP"),
+    });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it("rejects unicode-escaped identifiers with a JSON error before query execution", async () => {
     const query = vi.fn();
     const runtime = {

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -49,10 +49,7 @@ export {
   stripSqlDollarQuotedLiterals,
 } from "../shared/sql-sanitizers.ts";
 
-import {
-  stripSqlBlockComments,
-  stripSqlDollarQuotedLiterals,
-} from "../shared/sql-sanitizers.ts";
+import { scanSqlForReadOnly } from "../shared/sql-sanitizers.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1099,25 +1096,14 @@ async function handleQuery(
   // query — not just the leading keyword. This prevents bypass via CTEs
   // (WITH ... AS (DELETE ...)) and other SQL constructs that nest mutations.
   if (body.readOnly !== false) {
-    // Strip block comments (/* ... */) and line comments (-- ...).
-    // Use empty-string replacement (not space) to mirror how PostgreSQL
-    // concatenates tokens across comments — e.g. DE/* */LETE → DELETE.
-    // A space replacement would turn it into "DE LETE", hiding the keyword.
-    const stripped = stripSqlBlockComments(sqlText)
-      .replace(/--.*$/gm, "")
-      .trim();
-
-    // Strip string literals so that mutation keywords/functions inside quoted
-    // strings are ignored. Handles single-quoted ('...'), dollar-quoted
-    // ($$...$$), and tagged dollar-quoted ($tag$...$tag$) strings.
-    const noLiterals = stripSqlDollarQuotedLiterals(stripped).replace(
-      /'(?:[^']|'')*'/g,
-      " ",
-    );
-
-    // For keyword checks, also strip double-quoted identifiers to avoid
-    // matching words inside quoted table/column names.
-    const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
+    const scan = scanSqlForReadOnly(sqlText);
+    if (!scan.ok) {
+      sendJsonError(res, `Query rejected: ${scan.reason}`);
+      return;
+    }
+    const stripped = scan.structuralText.trim();
+    const noLiterals = scan.callableText;
+    const noStrings = scan.keywordText;
 
     // Reject PostgreSQL unicode-escaped quoted identifiers (`U&"s\0065tval"`)
     // in read-only mode: they decode to the real name only at parse time, so

--- a/packages/agent/src/security/sql-readonly-guard.hardening.test.ts
+++ b/packages/agent/src/security/sql-readonly-guard.hardening.test.ts
@@ -4,6 +4,7 @@
  * dangerous functions, multi-statement, unterminated constructs).
  */
 import { describe, expect, it } from "vitest";
+import { MAX_READ_ONLY_SQL_LENGTH } from "../shared/sql-sanitizers.ts";
 import { checkReadOnly } from "./sql-readonly-guard.ts";
 
 describe("checkReadOnly hardening", () => {
@@ -15,6 +16,33 @@ describe("checkReadOnly hardening", () => {
     ).toMatchObject({
       ok: false,
       reason: expect.stringContaining("DELETE"),
+    });
+  });
+
+  it("does not start a line comment inside a string literal", () => {
+    expect(
+      checkReadOnly("SELECT 'value--'; DELETE FROM memories"),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("DELETE"),
+    });
+  });
+
+  it.each(["\r", "\r\n", "\n"])(
+    "recognizes %j as a line-comment terminator",
+    (lineEnding) => {
+      expect(
+        checkReadOnly(`SELECT 1 -- comment${lineEnding}DELETE FROM memories`),
+      ).toMatchObject({
+        ok: false,
+        reason: expect.stringContaining("DELETE"),
+      });
+    },
+  );
+
+  it("handles PostgreSQL escape strings without treating their contents as SQL", () => {
+    expect(checkReadOnly(String.raw`SELECT E'value\'--still data'`)).toEqual({
+      ok: true,
     });
   });
 
@@ -34,6 +62,13 @@ describe("checkReadOnly hardening", () => {
 
   it("rejects quoted dangerous function names (double-quoted identifiers)", () => {
     expect(checkReadOnly('SELECT "pg_sleep"(10)')).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("PG_SLEEP"),
+    });
+  });
+
+  it("rejects schema-qualified quoted dangerous function names", () => {
+    expect(checkReadOnly('SELECT "pg_catalog"."pg_sleep"(10)')).toMatchObject({
       ok: false,
       reason: expect.stringContaining("PG_SLEEP"),
     });
@@ -64,6 +99,10 @@ describe("checkReadOnly hardening", () => {
     expect(checkReadOnly("SELECT 1;")).toEqual({ ok: true });
   });
 
+  it("ignores semicolons inside literals", () => {
+    expect(checkReadOnly("SELECT ';' AS punctuation")).toEqual({ ok: true });
+  });
+
   it("ignores mutation keywords inside single-quoted strings", () => {
     expect(checkReadOnly("SELECT 'DELETE FROM x'")).toEqual({ ok: true });
   });
@@ -73,17 +112,49 @@ describe("checkReadOnly hardening", () => {
     expect(checkReadOnly('SELECT "delete" FROM t')).toEqual({ ok: true });
   });
 
-  it("treats nested-looking block comment per PG semantics (inner open leaves outer unterminated → remaining text is comment, ok)", () => {
-    // PostgreSQL block comments nest: "/* inner /* */" leaves depth 1 open,
-    // so "LETE FROM t" is still inside a comment → not executable SQL.
-    expect(checkReadOnly("DE/* inner /* */ LETE FROM t")).toEqual({ ok: true });
+  it("rejects an unterminated nested block comment", () => {
+    expect(checkReadOnly("DE/* inner /* */ LETE FROM t")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Unterminated block comment"),
+    });
   });
 
   it("rejects unterminated block comment followed by mutation text", () => {
     // Unterminated /* is preserved so following text is still scanned.
     expect(checkReadOnly("/* never closed\nDROP TABLE t")).toMatchObject({
       ok: false,
-      reason: expect.stringContaining("DROP"),
+      reason: expect.stringContaining("Unterminated block comment"),
+    });
+  });
+
+  it("rejects many unique unmatched dollar tags in bounded time", () => {
+    const sql = Array.from(
+      { length: 50_000 },
+      (_, index) => `$tag${index}$x`,
+    ).join("");
+    const startedAt = performance.now();
+    expect(checkReadOnly(sql)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Unterminated dollar-quoted string"),
+    });
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it("rejects input above the scanner's total-work budget", () => {
+    expect(
+      checkReadOnly(" ".repeat(MAX_READ_ONLY_SQL_LENGTH + 1)),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("limited"),
+    });
+  });
+
+  it("does not treat a dollar-like sequence inside an identifier as a literal", () => {
+    expect(
+      checkReadOnly("SELECT name$tag$DELETE$tag$ FROM records"),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("DELETE"),
     });
   });
 

--- a/packages/agent/src/security/sql-readonly-guard.ts
+++ b/packages/agent/src/security/sql-readonly-guard.ts
@@ -4,10 +4,7 @@
  * model-generated SQL cannot hide mutation keywords in split tokens or make the
  * guard spend unbounded time in comment/string handling.
  */
-import {
-  stripSqlBlockComments,
-  stripSqlDollarQuotedLiterals,
-} from "../shared/sql-sanitizers.ts";
+import { scanSqlForReadOnly } from "../shared/sql-sanitizers.ts";
 
 // Mirrors the server-side allowlist in api/database.ts. The scanner removes
 // comments and literals first so keywords in data do not trip the guard.
@@ -82,51 +79,37 @@ const DANGEROUS_FUNCTIONS = [
 
 export function checkReadOnly(
   sqlText: string,
+  writeOverride = "allowWrites:true",
 ): { ok: true } | { ok: false; reason: string } {
-  const stripped = stripSqlBlockComments(sqlText).replace(/--.*$/gm, "").trim();
-  const noLiterals = stripSqlDollarQuotedLiterals(stripped).replace(
-    /'(?:[^']|'')*'/g,
-    " ",
-  );
-  const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
-
-  // PostgreSQL unicode-escaped quoted identifiers can decode to dangerous
-  // function names only at parse time, so reject the token after removing
-  // comments and string literals.
-  if (/[uU]&"/.test(noLiterals)) {
-    return {
-      ok: false,
-      reason:
-        'Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
-    };
-  }
+  const scan = scanSqlForReadOnly(sqlText);
+  if (!scan.ok) return scan;
 
   const mutation = new RegExp(
     `\\b(${MUTATION_KEYWORDS.join("|")})\\b`,
     "i",
-  ).exec(noStrings);
+  ).exec(scan.keywordText);
   if (mutation) {
     return {
       ok: false,
-      reason: `"${mutation[1].toUpperCase()}" is a mutation keyword. Set allowWrites:true to execute mutations.`,
+      reason: `"${mutation[1].toUpperCase()}" is a mutation keyword. Set ${writeOverride} to execute mutations.`,
     };
   }
 
   const fn = new RegExp(
     `(?:^|[^\\w$])"?(?:${DANGEROUS_FUNCTIONS.join("|")})"?\\s*\\(`,
     "i",
-  ).exec(noLiterals);
+  ).exec(scan.callableText);
   if (fn) {
     const name = new RegExp(`(${DANGEROUS_FUNCTIONS.join("|")})`, "i").exec(
       fn[0],
     );
     return {
       ok: false,
-      reason: `"${(name?.[1] ?? "UNKNOWN").toUpperCase()}" is a dangerous function. Set allowWrites:true to execute.`,
+      reason: `"${(name?.[1] ?? "UNKNOWN").toUpperCase()}" is a dangerous function. Set ${writeOverride} to execute.`,
     };
   }
 
-  if (stripped.replace(/;\s*$/, "").includes(";")) {
+  if (scan.structuralText.trim().replace(/;\s*$/, "").includes(";")) {
     return {
       ok: false,
       reason: "Multi-statement queries are not allowed in read-only mode.",

--- a/packages/agent/src/shared/sql-sanitizers.ts
+++ b/packages/agent/src/shared/sql-sanitizers.ts
@@ -83,3 +83,195 @@ export function stripSqlDollarQuotedLiterals(sql: string): string {
 
   return result;
 }
+
+const MAX_DOLLAR_QUOTE_TAG_LENGTH = 128;
+export const MAX_READ_ONLY_SQL_LENGTH = 2 * 1024 * 1024;
+
+export type ReadOnlySqlScan =
+  | {
+      ok: true;
+      keywordText: string;
+      callableText: string;
+      structuralText: string;
+    }
+  | { ok: false; reason: string };
+
+function isAsciiIdentifierStart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z_]/.test(char);
+}
+
+function isAsciiIdentifierPart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$]/.test(char);
+}
+
+/**
+ * Tokenize the SQL contexts relevant to the read-only policy in one bounded
+ * pass. Malformed constructs are rejected instead of being preserved for a
+ * later regex, where context ordering can hide executable text.
+ */
+export function scanSqlForReadOnly(sql: string): ReadOnlySqlScan {
+  if (sql.length > MAX_READ_ONLY_SQL_LENGTH) {
+    return {
+      ok: false,
+      reason: `Read-only SQL is limited to ${MAX_READ_ONLY_SQL_LENGTH} characters.`,
+    };
+  }
+
+  let keywordText = "";
+  let callableText = "";
+  let structuralText = "";
+  let i = 0;
+
+  const appendOutside = (text: string): void => {
+    keywordText += text;
+    callableText += text;
+    structuralText += text;
+  };
+
+  while (i < sql.length) {
+    if (sql.startsWith("--", i)) {
+      i += 2;
+      while (i < sql.length && sql[i] !== "\n" && sql[i] !== "\r") i += 1;
+      appendOutside(" ");
+      continue;
+    }
+
+    if (sql.startsWith("/*", i)) {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql.startsWith("/*", i)) {
+          depth += 1;
+          i += 2;
+        } else if (sql.startsWith("*/", i)) {
+          depth -= 1;
+          i += 2;
+        } else {
+          i += 1;
+        }
+      }
+      if (depth !== 0) {
+        return { ok: false, reason: "Unterminated block comment." };
+      }
+      // Empty replacement deliberately makes split policy keywords visible.
+      continue;
+    }
+
+    if (sql[i] === "$") {
+      if (isAsciiIdentifierPart(sql[i - 1])) {
+        appendOutside("$");
+        i += 1;
+        continue;
+      }
+      let tagEnd = i + 1;
+      if (sql[tagEnd] !== "$" && !isAsciiIdentifierStart(sql[tagEnd])) {
+        appendOutside("$");
+        i += 1;
+        continue;
+      }
+      while (
+        tagEnd < sql.length &&
+        sql[tagEnd] !== "$" &&
+        isAsciiIdentifierPart(sql[tagEnd])
+      ) {
+        if (tagEnd - i > MAX_DOLLAR_QUOTE_TAG_LENGTH) {
+          return {
+            ok: false,
+            reason: `Dollar-quote tags longer than ${MAX_DOLLAR_QUOTE_TAG_LENGTH} characters are not allowed in read-only mode.`,
+          };
+        }
+        tagEnd += 1;
+      }
+      if (sql[tagEnd] !== "$") {
+        appendOutside("$");
+        i += 1;
+        continue;
+      }
+
+      const delimiter = sql.slice(i, tagEnd + 1);
+      let close = tagEnd + 1;
+      while (close < sql.length && !sql.startsWith(delimiter, close))
+        close += 1;
+      if (close >= sql.length) {
+        return { ok: false, reason: "Unterminated dollar-quoted string." };
+      }
+      appendOutside(" ");
+      i = close + delimiter.length;
+      continue;
+    }
+
+    if (sql[i] === "'") {
+      const escapePrefix =
+        i > 0 &&
+        (sql[i - 1] === "e" || sql[i - 1] === "E") &&
+        !isAsciiIdentifierPart(sql[i - 2]);
+      if (escapePrefix) {
+        keywordText = keywordText.slice(0, -1);
+        callableText = callableText.slice(0, -1);
+        structuralText = structuralText.slice(0, -1);
+      }
+
+      let closed = false;
+      i += 1;
+      while (i < sql.length) {
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          i += 2;
+        } else if (sql[i] === "'") {
+          i += 1;
+          closed = true;
+          break;
+        } else if (sql[i] === "\\" && escapePrefix) {
+          i += Math.min(2, sql.length - i);
+        } else {
+          i += 1;
+        }
+      }
+      if (!closed) return { ok: false, reason: "Unterminated string literal." };
+      appendOutside(" ");
+      continue;
+    }
+
+    if (sql[i] === '"') {
+      const unicodePrefix =
+        i >= 2 &&
+        (sql[i - 2] === "u" || sql[i - 2] === "U") &&
+        sql[i - 1] === "&" &&
+        !isAsciiIdentifierPart(sql[i - 3]);
+      if (unicodePrefix) {
+        return {
+          ok: false,
+          reason:
+            'Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
+        };
+      }
+
+      let decoded = "";
+      let closed = false;
+      i += 1;
+      while (i < sql.length) {
+        if (sql[i] === '"' && sql[i + 1] === '"') {
+          decoded += '"';
+          i += 2;
+        } else if (sql[i] === '"') {
+          i += 1;
+          closed = true;
+          break;
+        } else {
+          decoded += sql[i];
+          i += 1;
+        }
+      }
+      if (!closed)
+        return { ok: false, reason: "Unterminated quoted identifier." };
+      keywordText += " ";
+      callableText += decoded;
+      structuralText += " ";
+      continue;
+    }
+
+    appendOutside(sql[i]);
+    i += 1;
+  }
+
+  return { ok: true, keywordText, callableText, structuralText };
+}


### PR DESCRIPTION
## Summary

Makes the two server-side read-only SQL boundaries share one bounded,
context-aware scanner. The action handler and `/api/database/query` now apply
the same fail-closed lexical treatment before their existing policy checks.

## Implementation

- Scans line comments with LF, CRLF, or CR endings; nested block comments;
  ordinary and PostgreSQL escape strings; dollar-quoted strings; and quoted
  identifiers in one bounded pass.
- Produces separate keyword, callable, and structural views so policy checks do
  not confuse literal contents with executable SQL.
- Rejects malformed or unterminated lexical contexts, unicode-escaped
  identifiers, overlong dollar tags, and SQL larger than the 2 MiB work budget.
- Preserves the existing action and API policy surfaces while removing their
  duplicated context-stripping regex chains.

## Exact-head validation

Head: `9cc3cadda20ac664317e6eacbdcf5b76bb51d272`, rebased onto
`develop@5d412662d335fda557a31a338193068e6ccffdd1`.

- Focused real-boundary suites: **36 pass, 0 fail, 63 assertions**. Coverage
  enters the real DATABASE action handler and real `/api/database/query` route,
  in addition to scanner-level adversarial cases.
- Biome on all 7 touched files: **green**.
- `git diff --check origin/develop...HEAD`: **green**.
- Independent exact-head source/security review: **green**.

The PR remains draft until package typechecking and final freshness checks are
complete.

<!-- evidence-head:9cc3cadda20ac664317e6eacbdcf5b76bb51d272 -->

<!-- evidence-row:before-screenshots -->
- N/A - backend security boundary only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- N/A - backend security boundary only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- N/A - no user-facing visual flow changed.

<!-- evidence-row:backend-logs -->
- N/A - deterministic in-process action and HTTP-route tests are the applicable boundary proof; no deployed backend was changed.

<!-- evidence-row:frontend-logs -->
- N/A - no frontend code or network surface changed.

<!-- evidence-row:llm-trajectory -->
- N/A - no prompt, model, provider, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- N/A - rejected inputs never invoke the database collaborator, so no durable row should be produced.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`, `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository review workflow; no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - repository review workflow; no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository review workflow; no contribution skill used"} -->
