### PR TITLE
fix(plugin-sql): bound connector account JSON

### DIFF
--- a/packages/core/src/database/connector-json.test.ts
+++ b/packages/core/src/database/connector-json.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Exercises the shared connector JSON projection through descriptor-only,
+ * bounded production exports before storage adapters persist or audit data.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	CONNECTOR_JSON_BOUNDED,
+	CONNECTOR_JSON_UNBOUNDED,
+	cloneConnectorJsonObject,
+	cloneConnectorJsonValue,
+	MAX_CONNECTOR_JSON_DEPTH,
+	MAX_CONNECTOR_JSON_NODES,
+	MAX_CONNECTOR_JSON_STRING_BYTES,
+	redactConnectorJsonAudit,
+} from "./connector-json";
+
+describe("connector JSON projection", () => {
+	it("clones honest values without sharing mutable descendants", () => {
+		const shared = { value: "kept" };
+		const source = {
+			list: [shared, null],
+			repeated: shared,
+			when: new Date("2026-01-02T03:04:05.000Z"),
+		};
+
+		const cloned = cloneConnectorJsonObject(source);
+		expect(cloned).toEqual({
+			list: [{ value: "kept" }, null],
+			repeated: { value: "kept" },
+			when: "2026-01-02T03:04:05.000Z",
+		});
+		(source.list[0] as { value: string }).value = "changed";
+		expect(cloned.list).toEqual([{ value: "kept" }, null]);
+	});
+
+	it("rejects cycles, depth, width, and oversized leaves with one typed code", () => {
+		const cycle: Record<string, unknown> = {};
+		cycle.self = cycle;
+		const deep: Record<string, unknown> = {};
+		let cursor = deep;
+		for (let index = 0; index <= MAX_CONNECTOR_JSON_DEPTH; index += 1) {
+			cursor.next = {};
+			cursor = cursor.next as Record<string, unknown>;
+		}
+		const wide = Array.from({ length: MAX_CONNECTOR_JSON_NODES }, () => null);
+		const oversized = "😀".repeat(MAX_CONNECTOR_JSON_STRING_BYTES / 4 + 1);
+
+		for (const value of [cycle, deep, { wide }, { oversized }]) {
+			expect(() => cloneConnectorJsonObject(value)).toThrowError(
+				expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+			);
+		}
+	});
+
+	it("rejects every non-JSON primitive without normalizing values", () => {
+		for (const value of [
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			Number.NEGATIVE_INFINITY,
+			undefined,
+			1n,
+			Symbol("not-json"),
+			() => undefined,
+		]) {
+			expect(() => cloneConnectorJsonObject({ value })).toThrowError(
+				expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+			);
+		}
+	});
+
+	it("bounds reflection before inspecting every property descriptor", () => {
+		let descriptorCalls = 0;
+		const keys = Array.from(
+			{ length: MAX_CONNECTOR_JSON_NODES },
+			(_, index) => `key-${index}`,
+		);
+		const target = Object.fromEntries(keys.map((key) => [key, null]));
+		const wideProxy = new Proxy(target, {
+			getOwnPropertyDescriptor(currentTarget, key) {
+				descriptorCalls += 1;
+				return Reflect.getOwnPropertyDescriptor(currentTarget, key);
+			},
+			ownKeys() {
+				return keys;
+			},
+		});
+
+		expect(() => cloneConnectorJsonObject(wideProxy)).toThrowError(
+			expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+		);
+		expect(descriptorCalls).toBe(0);
+	});
+
+	it("rejects oversized arrays before inspecting indexed descriptors", () => {
+		let indexDescriptorCalls = 0;
+		const wideArray = new Proxy(
+			Array.from({ length: MAX_CONNECTOR_JSON_NODES }, () => null),
+			{
+				getOwnPropertyDescriptor(target, key) {
+					if (key !== "length") indexDescriptorCalls += 1;
+					return Reflect.getOwnPropertyDescriptor(target, key);
+				},
+			},
+		);
+
+		expect(() => cloneConnectorJsonObject({ wideArray })).toThrowError(
+			expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+		);
+		expect(indexDescriptorCalls).toBe(0);
+	});
+
+	it("never invokes accessors and rejects revoked or callable proxies", () => {
+		let calls = 0;
+		const accessor = Object.defineProperty({}, "secret", {
+			enumerable: true,
+			get() {
+				calls += 1;
+				return "leaked";
+			},
+		});
+		const callable = new Proxy(() => undefined, {
+			get() {
+				calls += 1;
+				return undefined;
+			},
+		});
+		const revoked = Proxy.revocable({}, {});
+		revoked.revoke();
+
+		for (const value of [
+			accessor,
+			{ callable },
+			{ missing: undefined },
+			revoked.proxy,
+		]) {
+			expect(() => cloneConnectorJsonObject(value)).toThrowError(
+				expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+			);
+		}
+		expect(calls).toBe(0);
+	});
+
+	it("keeps audit events visible while redacting secrets and hostile branches", () => {
+		let calls = 0;
+		const metadata = Object.defineProperties(
+			{ nonFinite: Number.NaN, token: "secret", safe: { value: "visible" } },
+			{
+				hostile: {
+					enumerable: true,
+					get() {
+						calls += 1;
+						return "leaked";
+					},
+				},
+			},
+		);
+
+		expect(
+			redactConnectorJsonAudit(metadata, (key) => key === "token"),
+		).toEqual({
+			nonFinite: CONNECTOR_JSON_BOUNDED,
+			token: "[REDACTED]",
+			safe: { value: "visible" },
+			hostile: CONNECTOR_JSON_BOUNDED,
+		});
+		expect(calls).toBe(0);
+
+		const revoked = Proxy.revocable<Record<string, unknown>>({}, {});
+		revoked.revoke();
+		expect(redactConnectorJsonAudit(revoked.proxy, () => false)).toEqual({
+			bounded: CONNECTOR_JSON_BOUNDED,
+		});
+	});
+
+	it("preserves literal bounded-marker strings in every projection mode", () => {
+		const value = {
+			list: [
+				CONNECTOR_JSON_BOUNDED,
+				"middle",
+				[CONNECTOR_JSON_BOUNDED, "last"],
+			],
+		};
+
+		expect(cloneConnectorJsonObject(value)).toEqual(value);
+		expect(cloneConnectorJsonValue(value)).toEqual(value);
+		expect(redactConnectorJsonAudit(value, () => false)).toEqual(value);
+	});
+
+	it("bounds hostile audit array elements without dropping honest siblings", () => {
+		const cycle: unknown[] = [];
+		cycle.push(cycle);
+		const accessor = Object.defineProperty([], "0", {
+			configurable: true,
+			enumerable: true,
+			get() {
+				throw new Error("must not run");
+			},
+		});
+		Object.defineProperty(accessor, "length", { value: 2 });
+		Object.defineProperty(accessor, "1", {
+			configurable: true,
+			enumerable: true,
+			value: "after-accessor",
+		});
+
+		const redacted = redactConnectorJsonAudit(
+			{
+				accessor,
+				cycle: [cycle, "after-cycle"],
+				unsupported: [1n, "after-bigint"],
+			},
+			() => false,
+		);
+
+		expect(redacted).toEqual({
+			accessor: [CONNECTOR_JSON_BOUNDED, "after-accessor"],
+			cycle: [[CONNECTOR_JSON_BOUNDED], "after-cycle"],
+			unsupported: [CONNECTOR_JSON_BOUNDED, "after-bigint"],
+		});
+	});
+
+	it("stops safely once the aggregate node budget is exhausted", () => {
+		const values = Array.from({ length: MAX_CONNECTOR_JSON_NODES }, () => null);
+		const redacted = redactConnectorJsonAudit(
+			{ values, mustNotSurvive: "past-budget" },
+			() => false,
+		);
+
+		expect(redacted.values).toBe(CONNECTOR_JSON_BOUNDED);
+		expect(redacted).not.toHaveProperty("mustNotSurvive");
+	});
+});

--- a/packages/core/src/database/connector-json.ts
+++ b/packages/core/src/database/connector-json.ts
@@ -1,0 +1,397 @@
+/**
+ * Descriptor-only JSON projection shared by connector-account storage adapters.
+ * Writes fail typed before persistence; audit metadata replaces hostile or
+ * over-budget branches with a visible sentinel so diagnostics are not lost.
+ */
+
+import { ElizaError } from "../errors";
+import type { ConnectorAccountJsonObject, JsonValue } from "../types";
+
+export const CONNECTOR_JSON_UNBOUNDED = "CONNECTOR_JSON_UNBOUNDED";
+export const CONNECTOR_JSON_BOUNDED = "[BOUNDED]";
+export const MAX_CONNECTOR_JSON_DEPTH = 16;
+export const MAX_CONNECTOR_JSON_NODES = 2_048;
+export const MAX_CONNECTOR_JSON_STRING_BYTES = 64 * 1024;
+
+type OverflowMode = "throw" | "sentinel";
+const BOUNDED_BRANCH = Symbol("connector-json-bounded-branch");
+const BOUNDED_EXHAUSTED = Symbol("connector-json-bounded-exhausted");
+type BoundedResult = typeof BOUNDED_BRANCH | typeof BOUNDED_EXHAUSTED;
+type OverflowReason =
+	| "accessor"
+	| "cycle"
+	| "depth"
+	| "leaf"
+	| "nodes"
+	| "reflection";
+
+const utf8Encoder = new TextEncoder();
+
+export class ConnectorJsonUnboundedError extends ElizaError {
+	override readonly name = "ConnectorJsonUnboundedError";
+
+	constructor(
+		reason: OverflowReason,
+		context: Record<string, unknown> = {},
+		cause?: unknown,
+	) {
+		super(`connector account JSON is unbounded (${reason})`, {
+			code: CONNECTOR_JSON_UNBOUNDED,
+			context: { reason, ...context },
+			severity: "fatal",
+			...(cause !== undefined ? { cause } : {}),
+		});
+	}
+}
+
+interface WalkState {
+	nodes: number;
+	readonly seen: WeakSet<object>;
+}
+
+interface WalkOptions {
+	readonly mode: OverflowMode;
+	readonly redactKey?: (key: string) => boolean;
+}
+
+function overflow(
+	options: WalkOptions,
+	reason: OverflowReason,
+	context: Record<string, unknown> = {},
+	cause?: unknown,
+): BoundedResult {
+	if (options.mode === "sentinel") {
+		return reason === "nodes" ? BOUNDED_EXHAUSTED : BOUNDED_BRANCH;
+	}
+	throw new ConnectorJsonUnboundedError(reason, context, cause);
+}
+
+function charge(
+	state: WalkState,
+	amount: number,
+	options: WalkOptions,
+): BoundedResult | undefined {
+	state.nodes += amount;
+	if (state.nodes > MAX_CONNECTOR_JSON_NODES) {
+		return overflow(options, "nodes", { nodes: state.nodes });
+	}
+	return undefined;
+}
+
+function chargeText(
+	value: string,
+	state: WalkState,
+	options: WalkOptions,
+	kind: "keyBytes" | "stringBytes",
+): BoundedResult | undefined {
+	const bytes = utf8Encoder.encode(value).byteLength;
+	if (bytes > MAX_CONNECTOR_JSON_STRING_BYTES) {
+		return overflow(options, "leaf", { [kind]: bytes });
+	}
+	return charge(state, Math.max(1, Math.ceil(bytes / 1024)), options);
+}
+
+function defineOwn(
+	target: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): void {
+	Object.defineProperty(target, key, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
+}
+
+function genuineDateIso(value: object): string | undefined {
+	try {
+		Date.prototype.getTime.call(value);
+		return Date.prototype.toISOString.call(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function ownKeys(
+	value: object,
+	options: WalkOptions,
+): readonly PropertyKey[] | BoundedResult {
+	try {
+		return Reflect.ownKeys(value);
+	} catch (error) {
+		return overflow(options, "reflection", {}, error);
+	}
+}
+
+function ownDescriptor(
+	value: object,
+	key: PropertyKey,
+	options: WalkOptions,
+): PropertyDescriptor | undefined | BoundedResult {
+	try {
+		return Object.getOwnPropertyDescriptor(value, key);
+	} catch (error) {
+		return overflow(options, "reflection", { key: String(key) }, error);
+	}
+}
+
+function objectPrototype(
+	value: object,
+	options: WalkOptions,
+): object | null | BoundedResult {
+	try {
+		return Object.getPrototypeOf(value) as object | null;
+	} catch (error) {
+		return overflow(options, "reflection", {}, error);
+	}
+}
+
+function walkPrimitive(
+	value: unknown,
+	inArray: boolean,
+	state: WalkState,
+	options: WalkOptions,
+): { handled: false } | { handled: true; value: unknown; skip?: boolean } {
+	if (value === null) {
+		return { handled: true, value: charge(state, 1, options) ?? null };
+	}
+	switch (typeof value) {
+		case "string":
+			return {
+				handled: true,
+				value: chargeText(value, state, options, "stringBytes") ?? value,
+			};
+		case "number":
+			if (!Number.isFinite(value)) {
+				return {
+					handled: true,
+					value: overflow(options, "leaf", { type: "non-finite-number" }),
+				};
+			}
+			return {
+				handled: true,
+				value: charge(state, 1, options) ?? value,
+			};
+		case "boolean":
+			return { handled: true, value: charge(state, 1, options) ?? value };
+		case "undefined":
+		case "function":
+		case "symbol":
+			if (options.mode === "throw") {
+				return {
+					handled: true,
+					value: overflow(options, "leaf", { type: typeof value }),
+				};
+			}
+			if (!inArray) {
+				return { handled: true, value: CONNECTOR_JSON_BOUNDED };
+			}
+			return {
+				handled: true,
+				value: charge(state, 1, options) ?? CONNECTOR_JSON_BOUNDED,
+			};
+		case "bigint":
+			return {
+				handled: true,
+				value: overflow(options, "leaf", { type: "bigint" }),
+			};
+		case "object":
+			return { handled: false };
+	}
+	return { handled: false };
+}
+
+function walk(
+	value: unknown,
+	depth: number,
+	inArray: boolean,
+	state: WalkState,
+	options: WalkOptions,
+): unknown | BoundedResult {
+	const primitive = walkPrimitive(value, inArray, state, options);
+	if (primitive.handled) return primitive.skip ? undefined : primitive.value;
+
+	const objectValue = value as object;
+	const dateIso = genuineDateIso(objectValue);
+	if (dateIso !== undefined) {
+		return chargeText(dateIso, state, options, "stringBytes") ?? dateIso;
+	}
+	if (depth > MAX_CONNECTOR_JSON_DEPTH) {
+		return overflow(options, "depth", { depth });
+	}
+	if (state.seen.has(objectValue)) {
+		return overflow(options, "cycle", { depth });
+	}
+	const containerHit = charge(state, 1, options);
+	if (containerHit !== undefined) return containerHit;
+
+	let isArray: boolean;
+	try {
+		isArray = Array.isArray(objectValue);
+	} catch (error) {
+		return overflow(options, "reflection", {}, error);
+	}
+	state.seen.add(objectValue);
+	try {
+		if (isArray) {
+			const lengthDescriptor = ownDescriptor(objectValue, "length", options);
+			if (
+				lengthDescriptor === BOUNDED_BRANCH ||
+				lengthDescriptor === BOUNDED_EXHAUSTED
+			) {
+				return lengthDescriptor;
+			}
+			if (
+				!lengthDescriptor ||
+				!("value" in lengthDescriptor) ||
+				typeof lengthDescriptor.value !== "number" ||
+				!Number.isSafeInteger(lengthDescriptor.value) ||
+				lengthDescriptor.value < 0
+			) {
+				return overflow(options, "reflection", { field: "length" });
+			}
+			const length = lengthDescriptor.value;
+			if (length > MAX_CONNECTOR_JSON_NODES - state.nodes) {
+				return overflow(options, "nodes", { nodes: state.nodes + length });
+			}
+			const output: unknown[] = [];
+			for (let index = 0; index < length; index += 1) {
+				const descriptor = ownDescriptor(objectValue, String(index), options);
+				if (descriptor === BOUNDED_BRANCH || descriptor === BOUNDED_EXHAUSTED) {
+					output.push(CONNECTOR_JSON_BOUNDED);
+					if (descriptor === BOUNDED_EXHAUSTED) break;
+					continue;
+				}
+				if (!descriptor) {
+					const hit = charge(state, 1, options);
+					output.push(hit === undefined ? null : CONNECTOR_JSON_BOUNDED);
+					if (hit !== undefined) break;
+					continue;
+				}
+				if (!("value" in descriptor)) {
+					overflow(options, "accessor", { index });
+					output.push(CONNECTOR_JSON_BOUNDED);
+					continue;
+				}
+				const cloned = walk(descriptor.value, depth + 1, true, state, options);
+				if (cloned === BOUNDED_BRANCH || cloned === BOUNDED_EXHAUSTED) {
+					output.push(CONNECTOR_JSON_BOUNDED);
+					if (cloned === BOUNDED_EXHAUSTED) break;
+					continue;
+				}
+				output.push(cloned);
+			}
+			return output;
+		}
+
+		const prototype = objectPrototype(objectValue, options);
+		if (prototype === BOUNDED_BRANCH || prototype === BOUNDED_EXHAUSTED) {
+			return prototype;
+		}
+		if (prototype !== Object.prototype && prototype !== null) {
+			return overflow(options, "leaf", { type: "non-plain-object" });
+		}
+		const keys = ownKeys(objectValue, options);
+		if (keys === BOUNDED_BRANCH || keys === BOUNDED_EXHAUSTED) return keys;
+		if (keys.length > MAX_CONNECTOR_JSON_NODES - state.nodes) {
+			return overflow(options, "nodes", { nodes: state.nodes + keys.length });
+		}
+		const output: Record<string, unknown> = {};
+		for (const key of keys) {
+			if (typeof key !== "string") continue;
+			const descriptor = ownDescriptor(objectValue, key, options);
+			if (descriptor === BOUNDED_BRANCH || descriptor === BOUNDED_EXHAUSTED) {
+				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
+				if (descriptor === BOUNDED_EXHAUSTED) break;
+				continue;
+			}
+			if (!descriptor) {
+				const missing = overflow(options, "reflection", { key });
+				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
+				if (missing === BOUNDED_EXHAUSTED) break;
+				continue;
+			}
+			if (!descriptor.enumerable) continue;
+			const keyHit = chargeText(key, state, options, "keyBytes");
+			if (keyHit !== undefined) {
+				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
+				if (keyHit === BOUNDED_EXHAUSTED) break;
+				continue;
+			}
+			if (options.redactKey?.(key)) {
+				defineOwn(output, key, "[REDACTED]");
+				continue;
+			}
+			if (!("value" in descriptor)) {
+				overflow(options, "accessor", { key });
+				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
+				continue;
+			}
+			const cloned = walk(descriptor.value, depth + 1, false, state, options);
+			if (cloned === BOUNDED_BRANCH || cloned === BOUNDED_EXHAUSTED) {
+				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
+				if (cloned === BOUNDED_EXHAUSTED) break;
+				continue;
+			}
+			if (cloned !== undefined) defineOwn(output, key, cloned);
+		}
+		return output;
+	} finally {
+		state.seen.delete(objectValue);
+	}
+}
+
+/** Clone a connector JSON object and fail typed before any persistence. */
+export function cloneConnectorJsonObject(
+	value: ConnectorAccountJsonObject | undefined,
+): ConnectorAccountJsonObject {
+	if (value === undefined) return {};
+	const cloned = walk(
+		value,
+		0,
+		false,
+		{ nodes: 0, seen: new WeakSet() },
+		{ mode: "throw" },
+	);
+	if (cloned === null || typeof cloned !== "object" || Array.isArray(cloned)) {
+		throw new ConnectorJsonUnboundedError("leaf", { type: "non-object-root" });
+	}
+	return cloned as ConnectorAccountJsonObject;
+}
+
+/** Redact and bound audit metadata without dropping the diagnostic event. */
+export function redactConnectorJsonAudit(
+	value: Record<string, unknown> | undefined,
+	redactKey: (key: string) => boolean,
+): ConnectorAccountJsonObject {
+	const redacted = walk(
+		value ?? {},
+		0,
+		false,
+		{ nodes: 0, seen: new WeakSet() },
+		{ mode: "sentinel", redactKey },
+	);
+	if (redacted === BOUNDED_BRANCH || redacted === BOUNDED_EXHAUSTED) {
+		return { bounded: CONNECTOR_JSON_BOUNDED };
+	}
+	if (
+		redacted === null ||
+		typeof redacted !== "object" ||
+		Array.isArray(redacted)
+	) {
+		return { bounded: CONNECTOR_JSON_BOUNDED };
+	}
+	return redacted as ConnectorAccountJsonObject;
+}
+
+/** Clone a JSON value for adapter read isolation. */
+export function cloneConnectorJsonValue(value: unknown): JsonValue {
+	return walk(
+		value,
+		0,
+		false,
+		{ nodes: 0, seen: new WeakSet() },
+		{ mode: "throw" },
+	) as JsonValue;
+}

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -46,7 +46,6 @@ import type {
 	GetConnectorAccountParams,
 	GetOAuthFlowStateParams,
 	IDatabaseAdapter,
-	JsonValue,
 	ListConnectorAccountCredentialRefsParams,
 	ListConnectorAccountsParams,
 	Log,
@@ -80,6 +79,10 @@ import { MemoryType } from "../types";
 import { normalizePairingPageOptions } from "../types/pairing";
 import { DEFAULT_UUID } from "../types/primitives";
 import { isPlainObject } from "../utils/type-guards";
+import {
+	cloneConnectorJsonObject,
+	redactConnectorJsonAudit,
+} from "./connector-json";
 import {
 	canRequesterMutateDocument,
 	DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
@@ -149,48 +152,15 @@ function connectorDateToMillis(
 	return value instanceof Date ? value.getTime() : value;
 }
 
-function cloneConnectorJsonObject(
-	value: ConnectorAccountJsonObject | undefined,
-): ConnectorAccountJsonObject {
-	return value
-		? (JSON.parse(JSON.stringify(value)) as ConnectorAccountJsonObject)
-		: {};
-}
-
-const CONNECTOR_AUDIT_REDACTED = "[REDACTED]";
 const CONNECTOR_AUDIT_SECRET_KEY_PATTERN =
 	/(access|refresh|id)?_?token|secret|password|credential|authorization|cookie|code[_-]?verifier|codeVerifier|client[_-]?secret|api_?key|private_?key|oauth_?code|state/i;
-
-function redactConnectorAuditValue(value: unknown): JsonValue {
-	if (value === null || value === undefined) return null;
-	if (Array.isArray(value)) return value.map(redactConnectorAuditValue);
-	if (typeof value === "object") {
-		const redacted: ConnectorAccountJsonObject = {};
-		for (const [key, item] of Object.entries(
-			value as Record<string, unknown>,
-		)) {
-			redacted[key] = CONNECTOR_AUDIT_SECRET_KEY_PATTERN.test(key)
-				? CONNECTOR_AUDIT_REDACTED
-				: redactConnectorAuditValue(item);
-		}
-		return redacted;
-	}
-	if (
-		typeof value === "string" ||
-		typeof value === "number" ||
-		typeof value === "boolean"
-	) {
-		return value;
-	}
-	return String(value);
-}
 
 function redactConnectorAuditMetadata(
 	metadata: Record<string, unknown> | undefined,
 ): ConnectorAccountJsonObject {
-	return redactConnectorAuditValue(
-		metadata ?? {},
-	) as ConnectorAccountJsonObject;
+	return redactConnectorJsonAudit(metadata, (key) =>
+		CONNECTOR_AUDIT_SECRET_KEY_PATTERN.test(key),
+	);
 }
 
 async function sha256Hex(value: string): Promise<string> {
@@ -2179,6 +2149,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			: undefined;
 		const now = Date.now();
 		const id = params.id ?? existing?.id ?? randomUuid();
+		const profile = cloneConnectorJsonObject(
+			params.profile !== undefined ? params.profile : existing?.profile,
+		);
+		const metadata = cloneConnectorJsonObject(
+			params.metadata !== undefined ? params.metadata : existing?.metadata,
+		);
 		if (existing) {
 			this.connectorAccountIdsByKey.delete(
 				connectorAccountKey({
@@ -2228,14 +2204,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			capabilities: params.capabilities
 				? [...params.capabilities]
 				: [...(existing?.capabilities ?? [])],
-			profile:
-				params.profile !== undefined
-					? cloneConnectorJsonObject(params.profile)
-					: cloneConnectorJsonObject(existing?.profile),
-			metadata:
-				params.metadata !== undefined
-					? cloneConnectorJsonObject(params.metadata)
-					: cloneConnectorJsonObject(existing?.metadata),
+			profile,
+			metadata,
 			connectedAt: connectedAt ?? existing?.connectedAt ?? now,
 			lastSyncAt: lastSyncAt !== undefined ? lastSyncAt : existing?.lastSyncAt,
 			deletedAt: deletedAt === undefined ? null : deletedAt,
@@ -2370,7 +2340,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		this.connectorAuditEvents.push(record);
 		return {
 			...record,
-			metadata: cloneConnectorJsonObject(record.metadata),
+			metadata: redactConnectorJsonAudit(record.metadata, () => false),
 		};
 	}
 

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -41,6 +41,7 @@ export {
 	SERVICE_ROUTE_ACCOUNT_STRATEGIES,
 } from "./contracts/service-routing-types";
 export * from "./database";
+export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -37,6 +37,7 @@ export {
 } from "./constants";
 export * from "./contracts/computer-use";
 export * from "./database";
+export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -97,6 +97,7 @@ export {
 } from "./contracts/service-routing";
 export * from "./contracts/wallet";
 export * from "./database";
+export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";

--- a/plugins/plugin-sql/src/__tests__/integration/connectorAccount.store.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/connectorAccount.store.real.test.ts
@@ -4,7 +4,14 @@
  * isolated PGlite/Postgres adapter via `BaseDrizzleAdapter` delegation — no
  * mocked adapter.
  */
-import type { UUID } from "@elizaos/core";
+import {
+  CONNECTOR_JSON_BOUNDED,
+  CONNECTOR_JSON_UNBOUNDED,
+  type ConnectorAccountJsonObject,
+  MAX_CONNECTOR_JSON_DEPTH,
+  MAX_CONNECTOR_JSON_NODES,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";
 import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
@@ -79,6 +86,104 @@ describe("ConnectorAccountStore (via BaseDrizzleAdapter delegation)", () => {
         accountKey: "user-renamed",
       })
     ).resolves.toMatchObject({ id: initial.id });
+  });
+
+  it("rejects hostile connector JSON before changing the persisted account", async () => {
+    const initial = await adapter.upsertConnectorAccount({
+      provider: "github",
+      accountKey: "bounded-user",
+      displayName: "Before",
+      profile: { safe: "persisted" },
+    });
+    let accessorCalls = 0;
+    const hostile = Object.defineProperty({}, "secret", {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return "must-not-run";
+      },
+    }) as ConnectorAccountJsonObject;
+
+    await expect(
+      adapter.upsertConnectorAccount({
+        id: initial.id,
+        provider: "github",
+        accountKey: "bounded-user",
+        displayName: "After",
+        profile: hostile,
+      })
+    ).rejects.toMatchObject({ code: CONNECTOR_JSON_UNBOUNDED });
+    expect(accessorCalls).toBe(0);
+    await expect(adapter.getConnectorAccount({ id: initial.id })).resolves.toMatchObject({
+      displayName: "Before",
+      profile: { safe: "persisted" },
+    });
+  });
+
+  it("enforces exact depth and node boundaries while accepting shared DAGs and cloning reads", async () => {
+    const nested = (levels: number): ConnectorAccountJsonObject => {
+      const root: ConnectorAccountJsonObject = {};
+      let cursor = root;
+      for (let index = 0; index < levels; index += 1) {
+        const next: ConnectorAccountJsonObject = {};
+        cursor.next = next;
+        cursor = next;
+      }
+      cursor.value = "leaf";
+      return root;
+    };
+    const shared = { value: "shared" };
+    const acceptedWidth = Object.fromEntries(
+      Array.from({ length: Math.floor((MAX_CONNECTOR_JSON_NODES - 1) / 2) }, (_, index) => [
+        `k${index}`,
+        null,
+      ])
+    );
+    const rejectedWidth = { ...acceptedWidth, overflow: null };
+
+    const account = await adapter.upsertConnectorAccount({
+      provider: "github",
+      accountKey: "json-boundaries",
+      profile: {
+        nested: nested(MAX_CONNECTOR_JSON_DEPTH - 1),
+        literal: [CONNECTOR_JSON_BOUNDED, "kept"],
+      },
+      metadata: { first: shared, second: shared },
+    });
+    const literalRead = await adapter.getConnectorAccount({ id: account.id });
+    if (!literalRead) throw new Error("Expected connector account");
+    expect(literalRead.profile.literal).toEqual([CONNECTOR_JSON_BOUNDED, "kept"]);
+    await expect(
+      adapter.upsertConnectorAccount({
+        id: account.id,
+        provider: "github",
+        accountKey: "json-boundaries",
+        profile: nested(MAX_CONNECTOR_JSON_DEPTH + 1),
+      })
+    ).rejects.toMatchObject({ code: CONNECTOR_JSON_UNBOUNDED });
+    await expect(
+      adapter.upsertConnectorAccount({
+        id: account.id,
+        provider: "github",
+        accountKey: "json-boundaries",
+        profile: acceptedWidth,
+      })
+    ).resolves.toMatchObject({ profile: acceptedWidth });
+    await expect(
+      adapter.upsertConnectorAccount({
+        id: account.id,
+        provider: "github",
+        accountKey: "json-boundaries",
+        profile: rejectedWidth,
+      })
+    ).rejects.toMatchObject({ code: CONNECTOR_JSON_UNBOUNDED });
+
+    const firstRead = await adapter.getConnectorAccount({ id: account.id });
+    if (!firstRead) throw new Error("Expected connector account");
+    firstRead.profile.mutated = true;
+    await expect(adapter.getConnectorAccount({ id: account.id })).resolves.not.toMatchObject({
+      profile: { mutated: true },
+    });
   });
 
   it("soft-deletes by composite key and hides the deleted account from normal reads", async () => {
@@ -276,6 +381,65 @@ describe("ConnectorAccountStore (via BaseDrizzleAdapter delegation)", () => {
       (entry) => "client_secret" in entry.metadata
     );
     expect(redacted?.metadata.client_secret).toBe("[REDACTED]");
+  });
+
+  it("persists a visible bounded sentinel instead of dropping hostile audit metadata", async () => {
+    const account = await adapter.upsertConnectorAccount({
+      provider: "twitter",
+      accountKey: "audit-bounds",
+    });
+    let accessorCalls = 0;
+    const metadata = Object.defineProperty({ note: "visible" }, "hostile", {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return "must-not-run";
+      },
+    });
+
+    const event = await adapter.appendConnectorAccountAuditEvent({
+      accountId: account.id,
+      action: "account.audit-bounded",
+      metadata,
+    });
+    expect(accessorCalls).toBe(0);
+    expect(event.metadata).toEqual({
+      note: "visible",
+      hostile: CONNECTOR_JSON_BOUNDED,
+    });
+
+    const cycle: unknown[] = [];
+    cycle.push(cycle);
+    const arrayWithAccessor = Object.defineProperty([], "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return "must-not-run";
+      },
+    });
+    Object.defineProperty(arrayWithAccessor, "length", { value: 2 });
+    Object.defineProperty(arrayWithAccessor, "1", {
+      configurable: true,
+      enumerable: true,
+      value: "after-hostile",
+    });
+
+    const roundTrip = await adapter.appendConnectorAccountAuditEvent({
+      accountId: account.id,
+      action: "account.audit-array-bounds",
+      metadata: {
+        literal: [CONNECTOR_JSON_BOUNDED, "kept"],
+        accessor: arrayWithAccessor,
+        cycle: [cycle, "after-cycle"],
+      },
+    });
+    expect(accessorCalls).toBe(0);
+    expect(roundTrip.metadata).toEqual({
+      literal: [CONNECTOR_JSON_BOUNDED, "kept"],
+      accessor: [CONNECTOR_JSON_BOUNDED, "after-hostile"],
+      cycle: [[CONNECTOR_JSON_BOUNDED], "after-cycle"],
+    });
   });
 
   it("hashes oauth state, treats consume as single-use, and ignores expired flows", async () => {

--- a/plugins/plugin-sql/src/stores/connectorAccount.store.ts
+++ b/plugins/plugin-sql/src/stores/connectorAccount.store.ts
@@ -25,7 +25,6 @@ import type {
   DeleteConnectorAccountParams,
   GetConnectorAccountCredentialRefParams,
   GetConnectorAccountParams,
-  JsonValue,
   ListConnectorAccountCredentialRefsParams,
   ListConnectorAccountsParams,
   OAuthFlowRecord,
@@ -33,6 +32,7 @@ import type {
   UpsertConnectorAccountParams,
   UUID,
 } from "@elizaos/core";
+import { cloneConnectorJsonObject, redactConnectorJsonAudit } from "@elizaos/core";
 import { and, desc, eq, gt, isNull, type SQL, sql } from "drizzle-orm";
 import {
   authOwnerBindingTable,
@@ -44,34 +44,13 @@ import {
 import type { DrizzleDatabase } from "../types";
 import type { Store, StoreContext } from "./types";
 
-const CONNECTOR_AUDIT_REDACTED = "[REDACTED]";
 const CONNECTOR_AUDIT_SECRET_KEY_PATTERN =
   /(access|refresh|id)?_?token|secret|password|credential|authorization|cookie|code[_-]?verifier|codeVerifier|client[_-]?secret|api_?key|private_?key|oauth_?code|state/i;
-
-function redactConnectorAuditValue(value: unknown): JsonValue {
-  if (value === null || value === undefined) return null;
-  if (Array.isArray(value)) {
-    return value.map(redactConnectorAuditValue) as JsonValue;
-  }
-  if (typeof value === "object") {
-    const redacted: ConnectorAccountJsonObject = {};
-    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-      redacted[key] = CONNECTOR_AUDIT_SECRET_KEY_PATTERN.test(key)
-        ? CONNECTOR_AUDIT_REDACTED
-        : redactConnectorAuditValue(item);
-    }
-    return redacted;
-  }
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return value;
-  }
-  return String(value);
-}
 
 function redactConnectorAuditMetadata(
   metadata: Record<string, unknown> | undefined
 ): ConnectorAccountJsonObject {
-  return redactConnectorAuditValue(metadata ?? {}) as ConnectorAccountJsonObject;
+  return redactConnectorJsonAudit(metadata, (key) => CONNECTOR_AUDIT_SECRET_KEY_PATTERN.test(key));
 }
 
 function sha256Hex(value: string): string {
@@ -91,7 +70,7 @@ function paramDateToDate(value: number | Date | null | undefined): Date | null |
 
 function asJsonObject(value: unknown): ConnectorAccountJsonObject {
   if (value && typeof value === "object" && !Array.isArray(value)) {
-    return value as ConnectorAccountJsonObject;
+    return cloneConnectorJsonObject(value as ConnectorAccountJsonObject);
   }
   return {};
 }
@@ -291,6 +270,8 @@ export class ConnectorAccountStore implements Store {
       const connectedAt = paramDateToDate(params.connectedAt);
       const lastSyncAt = paramDateToDate(params.lastSyncAt);
       const deletedAt = paramDateToDate(params.deletedAt);
+      const profile = cloneConnectorJsonObject(params.profile);
+      const metadata = cloneConnectorJsonObject(params.metadata);
 
       const insertValues: typeof connectorAccountsTable.$inferInsert = {
         agentId,
@@ -308,8 +289,8 @@ export class ConnectorAccountStore implements Store {
         status: params.status ?? "connected",
         scopes: params.scopes ? [...params.scopes] : [],
         capabilities: params.capabilities ? [...params.capabilities] : [],
-        profile: params.profile ?? {},
-        metadata: params.metadata ?? {},
+        profile,
+        metadata,
         ...(params.id ? { id: params.id } : {}),
         ...(connectedAt !== undefined ? { connectedAt: connectedAt ?? new Date() } : {}),
         ...(lastSyncAt !== undefined ? { lastSyncAt } : {}),
@@ -331,8 +312,8 @@ export class ConnectorAccountStore implements Store {
       if (params.status !== undefined) updateSet.status = params.status;
       if (params.scopes !== undefined) updateSet.scopes = [...params.scopes];
       if (params.capabilities !== undefined) updateSet.capabilities = [...params.capabilities];
-      if (params.profile !== undefined) updateSet.profile = params.profile;
-      if (params.metadata !== undefined) updateSet.metadata = params.metadata;
+      if (params.profile !== undefined) updateSet.profile = profile;
+      if (params.metadata !== undefined) updateSet.metadata = metadata;
       if (connectedAt !== undefined && connectedAt !== null) {
         updateSet.connectedAt = connectedAt;
       }
@@ -462,6 +443,7 @@ export class ConnectorAccountStore implements Store {
       }
       const expiresAt = paramDateToDate(params.expiresAt);
       const lastVerifiedAt = paramDateToDate(params.lastVerifiedAt);
+      const metadata = cloneConnectorJsonObject(params.metadata);
 
       const insertValues: typeof connectorAccountCredentialsTable.$inferInsert = {
         accountId: params.accountId,
@@ -469,7 +451,7 @@ export class ConnectorAccountStore implements Store {
         provider: account.provider,
         credentialType: params.credentialType,
         vaultRef: params.vaultRef,
-        metadata: params.metadata ?? {},
+        metadata,
         ...(expiresAt !== undefined ? { expiresAt } : {}),
         ...(lastVerifiedAt !== undefined ? { lastVerifiedAt } : {}),
       };
@@ -478,7 +460,7 @@ export class ConnectorAccountStore implements Store {
         vaultRef: params.vaultRef,
         updatedAt: new Date(),
       };
-      if (params.metadata !== undefined) updateSet.metadata = params.metadata;
+      if (params.metadata !== undefined) updateSet.metadata = metadata;
       if (expiresAt !== undefined) updateSet.expiresAt = expiresAt;
       if (lastVerifiedAt !== undefined) updateSet.lastVerifiedAt = lastVerifiedAt;
 
@@ -628,6 +610,7 @@ export class ConnectorAccountStore implements Store {
       const explicitExpiresAt = paramDateToDate(params.expiresAt);
       const ttlMs = params.ttlMs ?? 10 * 60_000;
       const expiresAt = explicitExpiresAt ?? new Date(now.getTime() + ttlMs);
+      const metadata = cloneConnectorJsonObject(params.metadata);
 
       const insertValues: typeof oauthFlowsTable.$inferInsert = {
         stateHash,
@@ -637,7 +620,7 @@ export class ConnectorAccountStore implements Store {
         redirectUri: params.redirectUri ?? null,
         codeVerifierRef: params.codeVerifierRef ?? null,
         scopes: params.scopes ? [...params.scopes] : [],
-        metadata: params.metadata ?? {},
+        metadata,
         expiresAt,
       };
 
@@ -651,7 +634,7 @@ export class ConnectorAccountStore implements Store {
             redirectUri: params.redirectUri ?? null,
             codeVerifierRef: params.codeVerifierRef ?? null,
             scopes: params.scopes ? [...params.scopes] : [],
-            metadata: params.metadata ?? {},
+            metadata,
             expiresAt,
             consumedAt: null,
             consumedBy: null,
@@ -758,9 +741,10 @@ export class ConnectorAccountStore implements Store {
       }
       if (params.scopes !== undefined) updateSet.scopes = [...params.scopes];
       if (params.metadata !== undefined) {
+        const metadata = cloneConnectorJsonObject(params.metadata);
         updateSet.metadata = {
-          ...existing.metadata,
-          ...params.metadata,
+          ...cloneConnectorJsonObject(existing.metadata),
+          ...metadata,
         };
       }
       if (params.expiresAt !== undefined) {


### PR DESCRIPTION
## Summary

- extract a shared descriptor-only, depth/node/UTF-8-bounded connector JSON projector for every core target
- apply write-strict, read-clone, and audit-lenient polarity to both the in-memory and production SQL connector stores
- prove cycles, 16/17 depth, exact node boundary, flat width, shared DAGs, accessor/revoked/callable inputs, read isolation, and no-row-change rejection against real PGlite

Closes #23029

Supersedes #22973 with the shared implementation required by the production SQL path; that older PR remains separately dispositioned until independent review confirms this exact head.

## Exact-head verification

Exact head: `52feca36611360b64d0bd2b88796499ab6d7e985`

Exact parent/base: `7a2207ac2b00192ed828ee7eb72afb842662d7ec`

- shared projector + in-memory connector store: 11/11 passed
- real PGlite connector-account storage: 10/10 passed in 97.48s
- all four core runtime bundles (node/browser/edge/testing): built successfully
- TypeScript declaration emission reached the checkout's pre-existing `markdown-it` package-export typing mismatch; no changed-file diagnostic was emitted
- pinned Biome on all eight changed files and `git diff --check`: passed
- independent source audit confirmed private overflow control signals, sibling-preserving audit behavior, strict pre-persistence rejection, and read isolation
- the eight changed paths had no intervening overlap through the live `develop` snapshot; GitHub reported mergeable/clean

## Security and compatibility

- strict writes reject cycles, accessors, revoked/callable proxies, unsupported leaves, depth >16, node overflow, and UTF-8 leaves over 64 KiB before persistence
- audit writes retain the event and replace only hostile or over-budget branches with `[BOUNDED]`; secret-key redaction remains recursive
- reads clone database JSON, so caller mutation cannot alter adapter-held or row-decoded state
- shared-reference DAGs and honest Date values remain supported; own `__proto__` is copied as inert data

## Evidence Gate

<!-- evidence-head:52feca36611360b64d0bd2b88796499ab6d7e985 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered pixels or layout changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered pixels or layout changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-blob real-PGlite transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23156-pglite-52feca3.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior or prompt changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Independent exact-head review artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23156-connector-json-domain-52feca3.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->