### PR TITLE
fix(core): fail closed on cyclic or over-deep Cerebras schema walks

### DIFF
--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -16,7 +16,9 @@ import { describe, expect, it } from "vitest";
 import { ElizaError } from "../../errors";
 import {
 	CEREBRAS_SCHEMA_UNBOUNDED,
+	cloneSchemaForBoundedTransport,
 	isCerebrasSchemaUnbounded,
+	MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
 	MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
 	MAX_CEREBRAS_SCHEMA_WALK_NODES,
 	normalizeSchemaForCerebras,
@@ -400,5 +402,187 @@ describe("normalizeSchemaForCerebras caller-path Shaw CR", () => {
 				(typed.context?.visits as number) > MAX_CEREBRAS_SCHEMA_WALK_NODES,
 			).toBe(true);
 		}
+	});
+});
+
+/**
+ * `cloneSchemaForBoundedTransport` is the safe pre-pass the production
+ * Cerebras path runs BEFORE `sanitizeJsonSchema`. It must carry the same
+ * budgets and descriptor-only reflection as the normalizer while applying
+ * zero Cerebras semantics — closing declared open maps here destroys the
+ * `__eliza_record_entries` reverse transform sanitization builds (#11249).
+ */
+describe("cloneSchemaForBoundedTransport", () => {
+	it("preserves declared open-map semantics verbatim", () => {
+		const declared = {
+			type: "object",
+			properties: {
+				customFields: {
+					type: "object",
+					additionalProperties: { type: "string" },
+				},
+				anything: { type: "object", additionalProperties: true },
+			},
+		};
+		const cloned = cloneSchemaForBoundedTransport(declared) as Record<
+			string,
+			Record<string, Record<string, unknown>>
+		>;
+		expect(cloned).toEqual(declared);
+		expect(cloned).not.toBe(declared);
+		expect(cloned.properties.customFields.additionalProperties).toEqual({
+			type: "string",
+		});
+		expect(cloned.properties.anything.additionalProperties).toBe(true);
+		// No Cerebras closure, no injected empty `properties`, no oneOf rewrite.
+		expect("properties" in cloned.properties.customFields).toBe(false);
+	});
+
+	it("keeps oneOf and a non-object root untouched", () => {
+		const declared = { oneOf: [{ type: "string" }, { type: "number" }] };
+		expect(cloneSchemaForBoundedTransport(declared)).toEqual(declared);
+		expect(cloneSchemaForBoundedTransport("nope")).toBe("nope");
+		expect(cloneSchemaForBoundedTransport(undefined)).toBeUndefined();
+		expect(cloneSchemaForBoundedTransport(null)).toBeNull();
+	});
+
+	it("clones deeply so sanitization cannot mutate the caller's schema", () => {
+		const inner = { type: "string" };
+		const declared = { type: "object", properties: { a: inner, b: inner } };
+		const cloned = cloneSchemaForBoundedTransport(declared) as {
+			properties: Record<string, unknown>;
+		};
+		expect(cloned.properties.a).toEqual({ type: "string" });
+		expect(cloned.properties.a).not.toBe(inner);
+		// Honest DAG: the same object under two keys is not a cycle.
+		expect(cloned.properties.b).toEqual({ type: "string" });
+	});
+
+	it("preserves array holes instead of materializing undefined", () => {
+		const prefixItems: unknown[] = [];
+		prefixItems[0] = { type: "string" };
+		prefixItems[2] = { type: "number" };
+		const cloned = cloneSchemaForBoundedTransport({
+			type: "array",
+			prefixItems,
+		}) as { prefixItems: unknown[] };
+		expect(cloned.prefixItems).toHaveLength(3);
+		expect(1 in cloned.prefixItems).toBe(false);
+		expect(cloned.prefixItems[2]).toEqual({ type: "number" });
+
+		const explicit = cloneSchemaForBoundedTransport({
+			anyOf: [undefined],
+		}) as { anyOf: unknown[] };
+		expect(0 in explicit.anyOf).toBe(true);
+		expect(explicit.anyOf[0]).toBeUndefined();
+	});
+
+	it("fails closed on a cyclic graph", () => {
+		const cyclic: Record<string, unknown> = { type: "object" };
+		cyclic.not = cyclic;
+		const started = Date.now();
+		try {
+			cloneSchemaForBoundedTransport(cyclic);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(Date.now() - started).toBeLessThan(250);
+			expect(expectUnbounded(error).context?.cycle).toBe(true);
+		}
+	});
+
+	it("accepts every schema the walk accepts and fails closed past its own budget", () => {
+		// `deepProperties(n)` is n schema levels = 2n raw levels, so the exact
+		// walk budget sits exactly on the clone budget. Nothing the normalizer
+		// accepts is rejected by the pre-pass.
+		expect(() =>
+			cloneSchemaForBoundedTransport(
+				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH),
+			),
+		).not.toThrow();
+		expect(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH).toBe(
+			MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2,
+		);
+		try {
+			cloneSchemaForBoundedTransport(
+				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 1),
+			);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+			expect(typed.context?.clone).toBe(true);
+		}
+	});
+
+	it("reserves array width before allocating a huge sparse array", () => {
+		const sparse: unknown[] = [];
+		sparse.length = MAX_CEREBRAS_SCHEMA_WALK_NODES + 1;
+		const started = Date.now();
+		try {
+			cloneSchemaForBoundedTransport({ anyOf: sparse });
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(Date.now() - started).toBeLessThan(2000);
+			expect(expectUnbounded(error).context?.maxNodes).toBe(
+				MAX_CEREBRAS_SCHEMA_WALK_NODES,
+			);
+		}
+	});
+
+	it("fails closed on an accessor and on a revoked Proxy", () => {
+		const hostile: Record<string, unknown> = { type: "object" };
+		Object.defineProperty(hostile, "properties", {
+			enumerable: true,
+			get() {
+				throw new Error("getter invoked");
+			},
+		});
+		try {
+			cloneSchemaForBoundedTransport(hostile);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.context?.accessor).toBe(true);
+			expect(typed.message).not.toContain("getter invoked");
+		}
+
+		const { proxy, revoke } = Proxy.revocable([] as unknown[], {});
+		revoke();
+		try {
+			cloneSchemaForBoundedTransport(proxy);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(expectUnbounded(error).cause).toBeInstanceOf(TypeError);
+		}
+	});
+
+	it("never executes get/has/prototype traps", () => {
+		let getHits = 0;
+		let hasHits = 0;
+		let protoHits = 0;
+		const proxy = new Proxy(
+			{ type: "object", properties: { x: { type: "string" } } },
+			{
+				get(t, prop, r) {
+					getHits += 1;
+					return Reflect.get(t, prop, r);
+				},
+				has(t, prop) {
+					hasHits += 1;
+					return Reflect.has(t, prop);
+				},
+				getPrototypeOf(t) {
+					protoHits += 1;
+					return Reflect.getPrototypeOf(t);
+				},
+			},
+		);
+		expect(cloneSchemaForBoundedTransport(proxy)).toEqual({
+			type: "object",
+			properties: { x: { type: "string" } },
+		});
+		expect(getHits).toBe(0);
+		expect(hasHits).toBe(0);
+		expect(protoHits).toBe(0);
 	});
 });

--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -18,7 +18,6 @@ import {
 	CEREBRAS_SCHEMA_UNBOUNDED,
 	cloneSchemaForBoundedTransport,
 	isCerebrasSchemaUnbounded,
-	MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
 	MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
 	MAX_CEREBRAS_SCHEMA_WALK_NODES,
 	normalizeSchemaForCerebras,
@@ -490,18 +489,103 @@ describe("cloneSchemaForBoundedTransport", () => {
 		}
 	});
 
-	it("accepts every schema the walk accepts and fails closed past its own budget", () => {
-		// `deepProperties(n)` is n schema levels = 2n raw levels, so the exact
-		// walk budget sits exactly on the clone budget. Nothing the normalizer
-		// accepts is rejected by the pre-pass.
+	it("accepts and rejects exactly what normalizeSchemaForCerebras does", () => {
+		// Shaw's exact-head repro on fb67e329: the pre-pass counted RAW object
+		// nesting, so a legal `default` annotation nested past its budget was
+		// rejected while the normalizer accepted it. The clone now walks the
+		// same schema-bearing keywords with the same depth accounting, so the
+		// two must agree on every case below.
+		let annotation: Record<string, unknown> = { leaf: true };
+		for (let i = 0; i < MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2 + 1; i += 1) {
+			annotation = { nested: annotation };
+		}
+		let deepAnnotation: Record<string, unknown> = { leaf: true };
+		for (let i = 0; i < 20_000; i += 1) {
+			deepAnnotation = { nested: deepAnnotation };
+		}
+		const cyclicAnnotation: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		cyclicAnnotation.default = cyclicAnnotation;
+		const cyclicKeyword: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		cyclicKeyword.not = cyclicKeyword;
+
+		const cases: Array<[string, unknown]> = [
+			[
+				"shaw repro default",
+				{ type: "object", properties: {}, default: annotation },
+			],
+			[
+				"20k default",
+				{ type: "object", properties: {}, default: deepAnnotation },
+			],
+			[
+				"20k examples",
+				{ type: "object", properties: {}, examples: [deepAnnotation] },
+			],
+			[
+				"20k extension",
+				{ type: "object", properties: {}, "x-vendor": deepAnnotation },
+			],
+			["20k const", { type: "object", properties: {}, const: deepAnnotation }],
+			["cyclic annotation", cyclicAnnotation],
+			["cyclic keyword", cyclicKeyword],
+			["properties at budget", deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH)],
+			[
+				"properties past budget",
+				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 1),
+			],
+		];
+
+		const outcome = (run: () => unknown): string => {
+			try {
+				run();
+				return "accepted";
+			} catch (error) {
+				return `${expectUnbounded(error).context?.max ?? "cycle"}`;
+			}
+		};
+
+		for (const [label, schema] of cases) {
+			expect([
+				label,
+				outcome(() => cloneSchemaForBoundedTransport(schema)),
+			]).toEqual([
+				label,
+				outcome(() =>
+					normalizeSchemaForCerebras(schema, true, { strict: true }),
+				),
+			]);
+		}
+	});
+
+	it("carries annotation data across verbatim without walking it", () => {
+		const deep: Record<string, unknown> = { a: { b: { c: 1 } } };
+		const cloned = cloneSchemaForBoundedTransport({
+			type: "object",
+			properties: {},
+			default: deep,
+			enum: [1, 2],
+			"x-vendor": { deep },
+		}) as Record<string, unknown>;
+		expect(cloned.default).toEqual({ a: { b: { c: 1 } } });
+		expect(cloned.enum).toEqual([1, 2]);
+		expect(cloned["x-vendor"]).toEqual({ deep: { a: { b: { c: 1 } } } });
+		// Annotation values are the immutable descriptor snapshot, carried across
+		// rather than re-walked — exactly what cloneOwnData does in the normalizer.
+		expect(cloned.default).toBe(deep);
+	});
+
+	it("fails closed past the schema depth budget", () => {
 		expect(() =>
 			cloneSchemaForBoundedTransport(
 				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH),
 			),
 		).not.toThrow();
-		expect(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH).toBe(
-			MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2,
-		);
 		try {
 			cloneSchemaForBoundedTransport(
 				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 1),
@@ -509,7 +593,7 @@ describe("cloneSchemaForBoundedTransport", () => {
 			throw new Error("expected unbounded throw");
 		} catch (error) {
 			const typed = expectUnbounded(error);
-			expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+			expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
 			expect(typed.context?.clone).toBe(true);
 		}
 	});

--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -1,16 +1,7 @@
 /**
- * Fail-closed walk budget for `normalizeSchemaForCerebras`.
- * On origin develop the walker recursed with `Object.entries` and no
- * depth/cycle cap, so JSON.parse-legal 8k-deep `properties` nests and
- * cyclic `not` graphs RangeError'd. Overlay throws typed
- * `CEREBRAS_SCHEMA_UNBOUNDED` instead.
- *
- * Shaw CR on #23159 (live head 695b5444): wrap Array.isArray /
- * getPrototypeOf, path-local visiting so honest DAGs pass, and never
- * fall back to a `.length` get trap. Caller-path regressions go through
- * the same `normalizeSchemaForCerebras(schema, true, { strict })`
- * contract as `plugins/plugin-openai/models/text.ts` cerebrasMode.
- * Owning issue is linked from PR #23159 Relates to.
+ * Deterministic hostile-input coverage for the bounded Cerebras schema walk
+ * and its descriptor-only transport clone. The harness exercises the same
+ * normalization contract used by the OpenAI plugin before provider dispatch.
  */
 import { describe, expect, it } from "vitest";
 import { ElizaError } from "../../errors";
@@ -145,7 +136,7 @@ describe("normalizeSchemaForCerebras walk bound", () => {
 	});
 });
 
-describe("normalizeSchemaForCerebras caller-path Shaw CR", () => {
+describe("normalizeSchemaForCerebras hostile caller inputs", () => {
 	it("wraps a revoked Array Proxy as typed unbounded instead of TypeError", () => {
 		const { proxy, revoke } = Proxy.revocable([] as unknown[], {});
 		revoke();
@@ -490,11 +481,9 @@ describe("cloneSchemaForBoundedTransport", () => {
 	});
 
 	it("accepts and rejects exactly what normalizeSchemaForCerebras does", () => {
-		// Shaw's exact-head repro on fb67e329: the pre-pass counted RAW object
-		// nesting, so a legal `default` annotation nested past its budget was
-		// rejected while the normalizer accepted it. The clone now walks the
-		// same schema-bearing keywords with the same depth accounting, so the
-		// two must agree on every case below.
+		// Annotation nesting is not schema nesting. The clone walks the same
+		// schema-bearing keywords with the same depth accounting as the
+		// normalizer, so they must agree on every case below.
 		let annotation: Record<string, unknown> = { leaf: true };
 		for (let i = 0; i < MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2 + 1; i += 1) {
 			annotation = { nested: annotation };

--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Fail-closed walk budget for `normalizeSchemaForCerebras`.
+ * On origin develop the walker recursed with `Object.entries` and no
+ * depth/cycle cap, so JSON.parse-legal 8k-deep `properties` nests and
+ * cyclic `not` graphs RangeError'd. Overlay throws typed
+ * `CEREBRAS_SCHEMA_UNBOUNDED` instead.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../../errors";
+import {
+	CEREBRAS_SCHEMA_UNBOUNDED,
+	isCerebrasSchemaUnbounded,
+	MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+	normalizeSchemaForCerebras,
+} from "../schema-compat";
+
+function deepProperties(depth: number): Record<string, unknown> {
+	let node: Record<string, unknown> = { type: "string" };
+	for (let i = 0; i < depth; i++) {
+		node = { type: "object", properties: { x: node } };
+	}
+	return node;
+}
+
+describe("normalizeSchemaForCerebras walk bound", () => {
+	it("still closes an honest nested object schema", () => {
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			properties: {
+				inner: { type: "object", properties: {}, additionalProperties: false },
+			},
+			required: ["inner"],
+		}) as Record<string, unknown>;
+		const inner = (result.properties as Record<string, Record<string, unknown>>)
+			.inner;
+		expect(inner.properties).toEqual({});
+		expect(inner.additionalProperties).toBe(false);
+	});
+
+	it("fails closed on a cyclic not graph instead of RangeError", () => {
+		const cyclic: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		cyclic.not = cyclic;
+		const started = Date.now();
+		try {
+			normalizeSchemaForCerebras(cyclic, true);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(Date.now() - started).toBeLessThan(250);
+			expect(error).toBeInstanceOf(ElizaError);
+			expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+			expect((error as ElizaError).code).toBe(CEREBRAS_SCHEMA_UNBOUNDED);
+			expect(error).not.toBeInstanceOf(RangeError);
+		}
+	});
+
+	it("fails closed on a JSON.parse-legal over-deep properties nest", () => {
+		const depth = 8000;
+		let raw = '{"type":"string"}';
+		for (let i = 0; i < depth; i++) {
+			raw = `{"type":"object","properties":{"x":${raw}}}`;
+		}
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		expect(parsed.type).toBe("object");
+		const started = Date.now();
+		try {
+			normalizeSchemaForCerebras(parsed, true);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(Date.now() - started).toBeLessThan(250);
+			expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+			expect((error as ElizaError).context?.max).toBe(
+				MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+			);
+			expect(error).not.toBeInstanceOf(RangeError);
+		}
+	});
+
+	it("fails closed on an enumerable getter instead of invoking it", () => {
+		const hostile: Record<string, unknown> = { type: "object" };
+		Object.defineProperty(hostile, "properties", {
+			enumerable: true,
+			get() {
+				throw new Error("getter invoked");
+			},
+		});
+		expect(() => normalizeSchemaForCerebras(hostile, true)).toThrow(ElizaError);
+		try {
+			normalizeSchemaForCerebras(hostile, true);
+		} catch (error) {
+			expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+			expect((error as ElizaError).context?.accessor).toBe(true);
+			expect((error as Error).message).not.toContain("getter invoked");
+		}
+	});
+
+	it("fails closed just past the depth budget", () => {
+		const over = deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 2);
+		expect(() => normalizeSchemaForCerebras(over, true)).toThrow(ElizaError);
+		try {
+			normalizeSchemaForCerebras(over, true);
+		} catch (error) {
+			expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+		}
+	});
+});

--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -18,6 +18,7 @@ import {
 	CEREBRAS_SCHEMA_UNBOUNDED,
 	isCerebrasSchemaUnbounded,
 	MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+	MAX_CEREBRAS_SCHEMA_WALK_NODES,
 	normalizeSchemaForCerebras,
 } from "../schema-compat";
 
@@ -37,10 +38,7 @@ function deepProperties(depth: number): Record<string, unknown> {
  * })`. A throw here is the fail-closed gate before `toolSet` assignment
  * / provider dispatch.
  */
-function normalizeCerebrasToolSchema(
-	schema: unknown,
-	strict = true,
-): unknown {
+function normalizeCerebrasToolSchema(schema: unknown, strict = true): unknown {
 	let providerDispatch = 0;
 	try {
 		const inputSchema = normalizeSchemaForCerebras(schema, true, { strict });
@@ -359,6 +357,7 @@ describe("normalizeSchemaForCerebras caller-path Shaw CR", () => {
 		expect(t.prefixItems).toHaveLength(3);
 		expect((t.prefixItems as unknown[])[0]).toMatchObject({ type: "string" });
 		expect((t.prefixItems as unknown[])[1]).toBeUndefined();
+		expect(1 in (t.prefixItems as unknown[])).toBe(false);
 		expect((t.prefixItems as unknown[])[2]).toMatchObject({ type: "number" });
 	});
 
@@ -378,6 +377,28 @@ describe("normalizeSchemaForCerebras caller-path Shaw CR", () => {
 		} catch (error) {
 			const typed = expectUnbounded(error);
 			expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+		}
+	});
+
+	it("fails closed on an over-wide own-key node before cloning", () => {
+		const wide: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		for (let i = 0; i < MAX_CEREBRAS_SCHEMA_WALK_NODES + 1; i++) {
+			wide[`k${i}`] = true;
+		}
+		const started = Date.now();
+		try {
+			normalizeSchemaForCerebras(wide, true);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			expect(Date.now() - started).toBeLessThan(2000);
+			const typed = expectUnbounded(error);
+			expect(typed.context?.maxNodes).toBe(MAX_CEREBRAS_SCHEMA_WALK_NODES);
+			expect(
+				(typed.context?.visits as number) > MAX_CEREBRAS_SCHEMA_WALK_NODES,
+			).toBe(true);
 		}
 	});
 });

--- a/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts
@@ -4,6 +4,13 @@
  * depth/cycle cap, so JSON.parse-legal 8k-deep `properties` nests and
  * cyclic `not` graphs RangeError'd. Overlay throws typed
  * `CEREBRAS_SCHEMA_UNBOUNDED` instead.
+ *
+ * Shaw CR on #23159 (live head 695b5444): wrap Array.isArray /
+ * getPrototypeOf, path-local visiting so honest DAGs pass, and never
+ * fall back to a `.length` get trap. Caller-path regressions go through
+ * the same `normalizeSchemaForCerebras(schema, true, { strict })`
+ * contract as `plugins/plugin-openai/models/text.ts` cerebrasMode.
+ * Owning issue is linked from PR #23159 Relates to.
  */
 import { describe, expect, it } from "vitest";
 import { ElizaError } from "../../errors";
@@ -20,6 +27,38 @@ function deepProperties(depth: number): Record<string, unknown> {
 		node = { type: "object", properties: { x: node } };
 	}
 	return node;
+}
+
+/**
+ * Production Cerebras tool-schema hop in
+ * `plugins/plugin-openai/models/text.ts` `normalizeNativeToolsForCall`:
+ * `inputSchema = normalizeSchemaForCerebras(inputSchema, true, {
+ *   strict: strict !== false,
+ * })`. A throw here is the fail-closed gate before `toolSet` assignment
+ * / provider dispatch.
+ */
+function normalizeCerebrasToolSchema(
+	schema: unknown,
+	strict = true,
+): unknown {
+	let providerDispatch = 0;
+	try {
+		const inputSchema = normalizeSchemaForCerebras(schema, true, { strict });
+		providerDispatch += 1;
+		return inputSchema;
+	} catch (error) {
+		expect(providerDispatch).toBe(0);
+		throw error;
+	}
+}
+
+function expectUnbounded(error: unknown): ElizaError {
+	expect(error).toBeInstanceOf(ElizaError);
+	expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+	expect((error as ElizaError).code).toBe(CEREBRAS_SCHEMA_UNBOUNDED);
+	expect(error).not.toBeInstanceOf(TypeError);
+	expect(error).not.toBeInstanceOf(RangeError);
+	return error as ElizaError;
 }
 
 describe("normalizeSchemaForCerebras walk bound", () => {
@@ -103,6 +142,242 @@ describe("normalizeSchemaForCerebras walk bound", () => {
 			normalizeSchemaForCerebras(over, true);
 		} catch (error) {
 			expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+		}
+	});
+});
+
+describe("normalizeSchemaForCerebras caller-path Shaw CR", () => {
+	it("wraps a revoked Array Proxy as typed unbounded instead of TypeError", () => {
+		const { proxy, revoke } = Proxy.revocable([] as unknown[], {});
+		revoke();
+		try {
+			normalizeCerebrasToolSchema(proxy);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.cause).toBeInstanceOf(TypeError);
+			expect(typed.context?.inspection).toBe("isArray");
+		}
+	});
+
+	it("wraps a revoked Array Proxy oneOf child and preserves TypeError cause", () => {
+		const { proxy, revoke } = Proxy.revocable([{ type: "string" }], {});
+		revoke();
+		const schema = {
+			type: "object",
+			properties: {},
+			oneOf: proxy,
+		};
+		try {
+			normalizeCerebrasToolSchema(schema);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.cause).toBeInstanceOf(TypeError);
+			expect(typeof typed.context?.inspection).toBe("string");
+		}
+	});
+
+	it("wraps a hostile getPrototypeOf trap instead of leaking TypeError", () => {
+		const items = [{ type: "string" }];
+		const proxy = new Proxy(items, {
+			getPrototypeOf() {
+				throw new TypeError("prototype trap");
+			},
+		});
+		const schema = {
+			type: "object",
+			properties: {
+				xs: { type: "array", items: proxy },
+			},
+		};
+		try {
+			normalizeCerebrasToolSchema(schema);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.cause).toBeInstanceOf(TypeError);
+			expect((typed.cause as Error).message).toContain("prototype trap");
+			expect(typed.context?.inspection).toBe("isArrayRecord");
+		}
+	});
+
+	it("does not fall back to a .length get trap when the own descriptor is hidden", () => {
+		let lengthGets = 0;
+		const items = [{ type: "string" }];
+		const proxy = new Proxy(items, {
+			get(target, prop, receiver) {
+				if (prop === "length") {
+					lengthGets += 1;
+					return 1;
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+			getOwnPropertyDescriptor(target, prop) {
+				if (prop === "length") return undefined;
+				return Reflect.getOwnPropertyDescriptor(target, prop);
+			},
+		});
+		const schema = {
+			type: "object",
+			properties: {
+				xs: { type: "array", items: proxy },
+			},
+		};
+		try {
+			normalizeCerebrasToolSchema(schema);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			// Real Array `length` is non-configurable, so a trap that hides
+			// the descriptor throws a proxy invariant TypeError. That still
+			// must wrap as CEREBRAS_SCHEMA_UNBOUNDED and must not read `.length`.
+			expect(
+				typed.context?.missingOwnLength === true ||
+					typed.context?.inspection === "getOwnPropertyDescriptor",
+			).toBe(true);
+		}
+		expect(lengthGets).toBe(0);
+	});
+
+	it("rejects a non-numeric own length descriptor without reading .length", () => {
+		let lengthGets = 0;
+		const items = [{ type: "string" }];
+		const proxy = new Proxy(items, {
+			get(target, prop, receiver) {
+				if (prop === "length") {
+					lengthGets += 1;
+					return 1;
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+			getOwnPropertyDescriptor(target, prop) {
+				if (prop === "length") {
+					return {
+						value: "trapped",
+						writable: true,
+						enumerable: false,
+						configurable: false,
+					};
+				}
+				return Reflect.getOwnPropertyDescriptor(target, prop);
+			},
+		});
+		const schema = {
+			type: "object",
+			properties: {
+				xs: { type: "array", items: proxy },
+			},
+		};
+		try {
+			normalizeCerebrasToolSchema(schema);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.context?.arrayLength).toBe("trapped");
+		}
+		expect(lengthGets).toBe(0);
+	});
+
+	it("accepts an honest DAG that reuses the same schema object under two properties", () => {
+		const shared = { type: "string" };
+		const dag = {
+			type: "object",
+			properties: {
+				a: shared,
+				b: shared,
+			},
+		};
+		const result = normalizeCerebrasToolSchema(dag) as Record<string, unknown>;
+		const props = result.properties as Record<string, Record<string, unknown>>;
+		expect(props.a.type).toBe("string");
+		expect(props.b.type).toBe("string");
+	});
+
+	it("still rejects a true cycle after path-local visiting unwind", () => {
+		const cyclic: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		cyclic.not = cyclic;
+		try {
+			normalizeCerebrasToolSchema(cyclic);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.context?.cycle).toBe(true);
+		}
+	});
+
+	it("does not execute get/has/prototype traps on an honest object Proxy", () => {
+		const target = {
+			type: "object",
+			properties: { x: { type: "string" } },
+		};
+		let getHits = 0;
+		let hasHits = 0;
+		let protoHits = 0;
+		const proxy = new Proxy(target, {
+			get(t, p, r) {
+				getHits += 1;
+				return Reflect.get(t, p, r);
+			},
+			has(t, p) {
+				hasHits += 1;
+				return Reflect.has(t, p);
+			},
+			getPrototypeOf(t) {
+				protoHits += 1;
+				return Reflect.getPrototypeOf(t);
+			},
+		});
+		const result = normalizeCerebrasToolSchema(proxy) as Record<
+			string,
+			unknown
+		>;
+		expect(result.type).toBe("object");
+		expect(getHits).toBe(0);
+		expect(hasHits).toBe(0);
+		expect(protoHits).toBe(0);
+	});
+
+	it("walks sparse arrays from own length/index descriptors only", () => {
+		const items: unknown[] = [];
+		items[0] = { type: "string" };
+		items[2] = { type: "number" };
+		const schema = {
+			type: "object",
+			properties: {
+				t: { type: "array", prefixItems: items },
+			},
+		};
+		const result = normalizeCerebrasToolSchema(schema) as Record<
+			string,
+			unknown
+		>;
+		const t = (result.properties as Record<string, Record<string, unknown>>).t;
+		expect(t.prefixItems).toHaveLength(3);
+		expect((t.prefixItems as unknown[])[0]).toMatchObject({ type: "string" });
+		expect((t.prefixItems as unknown[])[1]).toBeUndefined();
+		expect((t.prefixItems as unknown[])[2]).toMatchObject({ type: "number" });
+	});
+
+	it("accepts a schema at the exact depth budget and rejects one step past", () => {
+		const atBudget = deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+		const result = normalizeCerebrasToolSchema(atBudget) as Record<
+			string,
+			unknown
+		>;
+		expect(result.type).toBe("object");
+
+		try {
+			normalizeCerebrasToolSchema(
+				deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 1),
+			);
+			throw new Error("expected unbounded throw");
+		} catch (error) {
+			const typed = expectUnbounded(error);
+			expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
 		}
 	});
 });

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -389,8 +389,13 @@ function closedEmptyObjectSchema(): Record<string, unknown> {
 	return { type: "object", properties: {}, additionalProperties: false };
 }
 
-const SCHEMA_ARRAY_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
-const SCHEMA_SINGLE_KEYS = [
+export const JSON_SCHEMA_ARRAY_KEYWORDS = [
+	"anyOf",
+	"oneOf",
+	"allOf",
+	"prefixItems",
+] as const;
+export const JSON_SCHEMA_SINGLE_KEYWORDS = [
 	"contains",
 	"propertyNames",
 	"not",
@@ -403,13 +408,18 @@ const SCHEMA_SINGLE_KEYS = [
 	"contentSchema",
 	"additionalItems",
 ] as const;
-const SCHEMA_MAP_KEYS = [
+export const JSON_SCHEMA_MAP_KEYWORDS = [
 	"properties",
 	"patternProperties",
 	"$defs",
 	"definitions",
 	"dependentSchemas",
 ] as const;
+export const JSON_SCHEMA_MIXED_MAP_KEYWORDS = ["dependencies"] as const;
+
+const SCHEMA_ARRAY_KEYS = JSON_SCHEMA_ARRAY_KEYWORDS;
+const SCHEMA_SINGLE_KEYS = JSON_SCHEMA_SINGLE_KEYWORDS;
+const SCHEMA_MAP_KEYS = JSON_SCHEMA_MAP_KEYWORDS;
 
 function isSchemaRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !safeIsArray(value);

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -29,17 +29,6 @@ export function sanitizeFunctionNameForCerebras(name: string): string {
  */
 export const MAX_CEREBRAS_SCHEMA_WALK_DEPTH = 64;
 export const MAX_CEREBRAS_SCHEMA_WALK_NODES = 100_000;
-/**
- * Raw-object budget for the transport clone. The schema walk counts SCHEMA
- * levels: a keyword container (`properties`, `anyOf`, ...) shares its parent's
- * depth and only its entries cost a level. A structural clone cannot know
- * which keys are keywords, so it counts raw object nesting, where one schema
- * level costs at most two raw levels. Twice the schema budget is therefore the
- * exact equivalent bound: no schema `normalizeSchemaForCerebras` accepts is
- * rejected by the pre-pass, and recursion stays bounded either way.
- */
-export const MAX_CEREBRAS_SCHEMA_CLONE_DEPTH =
-	MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2;
 export const CEREBRAS_SCHEMA_UNBOUNDED = "CEREBRAS_SCHEMA_UNBOUNDED";
 
 type SchemaWalkContext = {
@@ -158,16 +147,21 @@ function hasNonEmptyOwnArray(value: unknown): boolean {
 	return isArrayRecord(value) && ownArrayLength(value) > 0;
 }
 
-function cloneOwnData(
-	value: object,
-	ctx: SchemaWalkContext,
-): Record<string, unknown> {
-	// Reserve the raw own-key width BEFORE allocating the clone. A node
-	// with >100k irrelevant keys must trip MAX_CEREBRAS_SCHEMA_WALK_NODES
-	// instead of copying every enumerable value first.
+type OwnDataEntry = { key: string; value: unknown };
+
+/**
+ * Single-pass immutable snapshot of the own enumerable string-keyed DATA
+ * properties. Every descriptor trap runs exactly once and the captured value
+ * is the one every later step consumes, so a Proxy cannot present a benign
+ * data descriptor during filtering and a different value (or an accessor) on a
+ * second read. The raw own-key width is reserved BEFORE anything is captured,
+ * so a node with >100k irrelevant keys trips MAX_CEREBRAS_SCHEMA_WALK_NODES
+ * instead of allocating first.
+ */
+function ownDataEntries(value: object, ctx: SchemaWalkContext): OwnDataEntry[] {
 	const keys = inspectSchema("ownKeys", () => Reflect.ownKeys(value));
 	reserveSchemaVisits(ctx, keys.length);
-	const entries: Array<{ key: string; value: unknown }> = [];
+	const entries: OwnDataEntry[] = [];
 	for (const key of keys) {
 		if (typeof key !== "string") continue;
 		const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
@@ -179,14 +173,29 @@ function cloneOwnData(
 		}
 		entries.push({ key, value: descriptor.value });
 	}
+	return entries;
+}
+
+function defineOwnData(
+	target: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): void {
+	Object.defineProperty(target, key, {
+		value,
+		enumerable: true,
+		writable: true,
+		configurable: true,
+	});
+}
+
+function cloneOwnData(
+	value: object,
+	ctx: SchemaWalkContext,
+): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
-	for (const entry of entries) {
-		Object.defineProperty(out, entry.key, {
-			value: entry.value,
-			enumerable: true,
-			writable: true,
-			configurable: true,
-		});
+	for (const entry of ownDataEntries(value, ctx)) {
+		defineOwnData(out, entry.key, entry.value);
 	}
 	return out;
 }
@@ -195,63 +204,141 @@ function createSchemaWalkContext(): SchemaWalkContext {
 	return { visits: 0, visiting: new WeakSet<object>() };
 }
 
+function cloneSchemaTransportMap(
+	value: object,
+	depth: number,
+	ctx: SchemaWalkContext,
+): Record<string, unknown> {
+	const mapped: Record<string, unknown> = {};
+	for (const entry of ownDataEntries(value, ctx)) {
+		defineOwnData(
+			mapped,
+			entry.key,
+			cloneSchemaTransportWalk(entry.value, depth + 1, ctx),
+		);
+	}
+	return mapped;
+}
+
+function cloneSchemaTransportArray(
+	value: unknown[],
+	depth: number,
+	ctx: SchemaWalkContext,
+): unknown[] {
+	// Reserve the validated own length BEFORE allocating or scanning, so a huge
+	// sparse array trips the aggregate budget instead of driving descriptor
+	// calls and allocation first.
+	const length = ownArrayLength(value);
+	reserveSchemaVisits(ctx, length);
+	const mapped = new Array(length);
+	for (let index = 0; index < length; index += 1) {
+		const key = String(index);
+		const descriptor = ownValueDescriptor(value, key);
+		// A missing own index is a hole. Leave it a hole: tuple keywords
+		// (`prefixItems`, tuple `items`) distinguish an absent element from an
+		// explicit `undefined`, and the origin `value.map(...)` preserved holes.
+		if (!descriptor) continue;
+		defineOwnData(
+			mapped as unknown as Record<string, unknown>,
+			key,
+			cloneSchemaTransportWalk(descriptor.value, depth + 1, ctx),
+		);
+	}
+	return mapped;
+}
+
+/**
+ * Clone the schema-bearing children of an already-snapshotted node, using the
+ * SAME keyword tables, the same guards, and the same depth accounting as
+ * `walkSchemaChildren`. Keys that are not schema-bearing (`default`,
+ * `examples`, `const`, `enum`, `required`, `x-*` extensions, ...) hold
+ * arbitrary JSON data, not sub-schemas: the normalizer and `sanitizeJsonSchema`
+ * both leave them alone, so the pre-pass leaves them alone too. Their values
+ * are already captured in the immutable descriptor snapshot, so they are
+ * carried across without executing a single accessor.
+ */
+function cloneSchemaTransportChildren(
+	node: Record<string, unknown>,
+	depth: number,
+	ctx: SchemaWalkContext,
+): void {
+	for (const key of SCHEMA_MAP_KEYS) {
+		const value = node[key];
+		if (!isSchemaRecord(value)) continue;
+		node[key] = cloneSchemaTransportMap(value, depth, ctx);
+	}
+
+	for (const key of SCHEMA_ARRAY_KEYS) {
+		const value = node[key];
+		if (!isArrayRecord(value)) continue;
+		node[key] = cloneSchemaTransportArray(value, depth, ctx);
+	}
+
+	const items = node.items;
+	if (isArrayRecord(items)) {
+		node.items = cloneSchemaTransportArray(items, depth, ctx);
+	} else if (items !== undefined) {
+		node.items = cloneSchemaTransportWalk(items, depth + 1, ctx);
+	}
+
+	for (const key of SCHEMA_SINGLE_KEYS) {
+		const value = node[key];
+		if (!isSchemaRecord(value)) continue;
+		node[key] = cloneSchemaTransportWalk(value, depth + 1, ctx);
+	}
+
+	const dependencies = node.dependencies;
+	if (isSchemaRecord(dependencies)) {
+		const mapped: Record<string, unknown> = {};
+		for (const entry of ownDataEntries(dependencies, ctx)) {
+			defineOwnData(
+				mapped,
+				entry.key,
+				isArrayRecord(entry.value)
+					? cloneSchemaTransportArray(entry.value, depth, ctx)
+					: cloneSchemaTransportWalk(entry.value, depth + 1, ctx),
+			);
+		}
+		node.dependencies = mapped;
+	}
+}
+
 function cloneSchemaTransportWalk(
-	value: unknown,
+	schema: unknown,
 	depth: number,
 	ctx: SchemaWalkContext,
 ): unknown {
-	if (!value || typeof value !== "object") return value;
+	// Mirrors normalizeSchemaForCerebrasWalk: a non-object (or an array reached
+	// outside an array-valued keyword) is data, not a schema node, and passes
+	// through untouched.
+	if (!schema || typeof schema !== "object" || safeIsArray(schema)) {
+		return schema;
+	}
 
-	if (depth > MAX_CEREBRAS_SCHEMA_CLONE_DEPTH) {
+	if (depth > MAX_CEREBRAS_SCHEMA_WALK_DEPTH) {
 		failCerebrasSchemaUnbounded({
 			depth,
-			max: MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
+			max: MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
 			clone: true,
 		});
 	}
-	if (ctx.visiting.has(value)) {
+	if (ctx.visiting.has(schema)) {
 		failCerebrasSchemaUnbounded({ cycle: true, depth, clone: true });
 	}
-	ctx.visiting.add(value);
+	ctx.visiting.add(schema);
 	reserveSchemaVisits(ctx, 1);
 
 	try {
-		if (safeIsArray(value)) {
-			// Reserve the declared width BEFORE allocating or scanning, so a
-			// huge sparse array trips the aggregate budget instead of driving
-			// `length` descriptor calls and allocation first.
-			const length = ownArrayLength(value as unknown[]);
-			reserveSchemaVisits(ctx, length);
-			const out = new Array(length);
-			for (let index = 0; index < length; index += 1) {
-				const key = String(index);
-				const descriptor = ownValueDescriptor(value, key);
-				// A missing own index is a hole. Leave it a hole: JSON Schema
-				// tuple keywords (`prefixItems`, tuple `items`) distinguish an
-				// absent element from an explicit `undefined`.
-				if (!descriptor) continue;
-				Object.defineProperty(out, key, {
-					value: cloneSchemaTransportWalk(descriptor.value, depth + 1, ctx),
-					enumerable: true,
-					writable: true,
-					configurable: true,
-				});
-			}
-			return out;
-		}
-
-		const snapshot = cloneOwnData(value, ctx);
-		for (const key of Object.keys(snapshot)) {
-			snapshot[key] = cloneSchemaTransportWalk(snapshot[key], depth + 1, ctx);
-		}
-		return snapshot;
+		const node = cloneOwnData(schema, ctx);
+		cloneSchemaTransportChildren(node, depth, ctx);
+		return node;
 	} finally {
-		ctx.visiting.delete(value);
+		ctx.visiting.delete(schema);
 	}
 }
 
 /**
- * Bounded, descriptor-only structural clone that applies NO Cerebras
+ * Bounded, descriptor-only clone of a tool schema that applies NO Cerebras
  * semantics.
  *
  * The strict Cerebras tool path is
@@ -264,11 +351,20 @@ function cloneSchemaTransportWalk(
  * `sanitizeJsonSchema` needs to build the `__eliza_record_entries` reverse
  * transform (#11249).
  *
- * This clone is the safe pre-pass: same depth / node / path-local-cycle /
- * accessor budgets and the same descriptor-only reflection, but it copies
- * declared shape verbatim (holes included). Sanitization then runs on a plain,
- * budgeted graph with declared semantics intact, and
- * `normalizeSchemaForCerebras` applies provider semantics afterwards.
+ * This clone is the safe pre-pass. It walks EXACTLY the schema-bearing
+ * keywords `normalizeSchemaForCerebras` walks (a superset of the ones
+ * `sanitizeJsonSchema` recurses into), with the same depth accounting, the
+ * same aggregate node budget, the same path-local cycle detection, and the
+ * same descriptor-only reflection — but it copies declared shape verbatim
+ * (holes included) and never descends into annotation/extension data such as
+ * `default`, `examples`, `const`, or `x-*`, which are legal arbitrary JSON and
+ * which the normalizer and the sanitizer both leave untouched. Accepting
+ * exactly what the normalizer accepts is the compatibility contract; the
+ * budgets exist to stop unbounded SCHEMA recursion, not to cap user data.
+ *
+ * Sanitization then runs on a plain, budgeted graph with declared semantics
+ * intact, and `normalizeSchemaForCerebras` applies provider semantics
+ * afterwards.
  */
 export function cloneSchemaForBoundedTransport(schema: unknown): unknown {
 	return cloneSchemaTransportWalk(schema, 0, createSchemaWalkContext());
@@ -399,23 +495,22 @@ function mapSchemaRecord(
 	depth: number,
 	ctx: SchemaWalkContext,
 ): Record<string, unknown> {
-	const keys = ownEnumerableStringKeys(value);
-	reserveSchemaVisits(ctx, keys.length);
+	// One descriptor pass, one immutable snapshot: a Proxy must not be able to
+	// present a data descriptor during filtering and something else on a
+	// second read.
 	const mapped: Record<string, unknown> = {};
-	for (const name of keys) {
-		const descriptor = ownValueDescriptor(value, name);
-		Object.defineProperty(mapped, name, {
-			value: normalizeSchemaForCerebrasWalk(
-				descriptor ? descriptor.value : undefined,
+	for (const entry of ownDataEntries(value, ctx)) {
+		defineOwnData(
+			mapped,
+			entry.key,
+			normalizeSchemaForCerebrasWalk(
+				entry.value,
 				false,
 				options,
 				depth + 1,
 				ctx,
 			),
-			enumerable: true,
-			writable: true,
-			configurable: true,
-		});
+		);
 	}
 	return mapped;
 }
@@ -465,26 +560,21 @@ function walkSchemaChildren(
 
 	const dependencies = node.dependencies;
 	if (isSchemaRecord(dependencies)) {
-		const keys = ownEnumerableStringKeys(dependencies);
-		reserveSchemaVisits(ctx, keys.length);
 		const mapped: Record<string, unknown> = {};
-		for (const name of keys) {
-			const descriptor = ownValueDescriptor(dependencies, name);
-			const dependency = descriptor ? descriptor.value : undefined;
-			Object.defineProperty(mapped, name, {
-				value: isArrayRecord(dependency)
-					? mapSchemaArray(dependency, options, depth, ctx)
+		for (const entry of ownDataEntries(dependencies, ctx)) {
+			defineOwnData(
+				mapped,
+				entry.key,
+				isArrayRecord(entry.value)
+					? mapSchemaArray(entry.value, options, depth, ctx)
 					: normalizeSchemaForCerebrasWalk(
-							dependency,
+							entry.value,
 							false,
 							options,
 							depth + 1,
 							ctx,
 						),
-				enumerable: true,
-				writable: true,
-				configurable: true,
-			});
+			);
 		}
 		node.dependencies = mapped;
 	}

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -29,6 +29,17 @@ export function sanitizeFunctionNameForCerebras(name: string): string {
  */
 export const MAX_CEREBRAS_SCHEMA_WALK_DEPTH = 64;
 export const MAX_CEREBRAS_SCHEMA_WALK_NODES = 100_000;
+/**
+ * Raw-object budget for the transport clone. The schema walk counts SCHEMA
+ * levels: a keyword container (`properties`, `anyOf`, ...) shares its parent's
+ * depth and only its entries cost a level. A structural clone cannot know
+ * which keys are keywords, so it counts raw object nesting, where one schema
+ * level costs at most two raw levels. Twice the schema budget is therefore the
+ * exact equivalent bound: no schema `normalizeSchemaForCerebras` accepts is
+ * rejected by the pre-pass, and recursion stays bounded either way.
+ */
+export const MAX_CEREBRAS_SCHEMA_CLONE_DEPTH =
+	MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2;
 export const CEREBRAS_SCHEMA_UNBOUNDED = "CEREBRAS_SCHEMA_UNBOUNDED";
 
 type SchemaWalkContext = {
@@ -182,6 +193,85 @@ function cloneOwnData(
 
 function createSchemaWalkContext(): SchemaWalkContext {
 	return { visits: 0, visiting: new WeakSet<object>() };
+}
+
+function cloneSchemaTransportWalk(
+	value: unknown,
+	depth: number,
+	ctx: SchemaWalkContext,
+): unknown {
+	if (!value || typeof value !== "object") return value;
+
+	if (depth > MAX_CEREBRAS_SCHEMA_CLONE_DEPTH) {
+		failCerebrasSchemaUnbounded({
+			depth,
+			max: MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
+			clone: true,
+		});
+	}
+	if (ctx.visiting.has(value)) {
+		failCerebrasSchemaUnbounded({ cycle: true, depth, clone: true });
+	}
+	ctx.visiting.add(value);
+	reserveSchemaVisits(ctx, 1);
+
+	try {
+		if (safeIsArray(value)) {
+			// Reserve the declared width BEFORE allocating or scanning, so a
+			// huge sparse array trips the aggregate budget instead of driving
+			// `length` descriptor calls and allocation first.
+			const length = ownArrayLength(value as unknown[]);
+			reserveSchemaVisits(ctx, length);
+			const out = new Array(length);
+			for (let index = 0; index < length; index += 1) {
+				const key = String(index);
+				const descriptor = ownValueDescriptor(value, key);
+				// A missing own index is a hole. Leave it a hole: JSON Schema
+				// tuple keywords (`prefixItems`, tuple `items`) distinguish an
+				// absent element from an explicit `undefined`.
+				if (!descriptor) continue;
+				Object.defineProperty(out, key, {
+					value: cloneSchemaTransportWalk(descriptor.value, depth + 1, ctx),
+					enumerable: true,
+					writable: true,
+					configurable: true,
+				});
+			}
+			return out;
+		}
+
+		const snapshot = cloneOwnData(value, ctx);
+		for (const key of Object.keys(snapshot)) {
+			snapshot[key] = cloneSchemaTransportWalk(snapshot[key], depth + 1, ctx);
+		}
+		return snapshot;
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}
+
+/**
+ * Bounded, descriptor-only structural clone that applies NO Cerebras
+ * semantics.
+ *
+ * The strict Cerebras tool path is
+ * `normalizeNativeToolsForCall -> sanitizeJsonSchema -> normalizeSchemaForCerebras`,
+ * and `sanitizeJsonSchema` uses ordinary spread / `Object.entries` / `.map` /
+ * unbounded recursion, so it must never see a hostile or unbounded graph. But
+ * running the full Cerebras normalizer first is also wrong: it closes every
+ * declared open map (`additionalProperties: true` or a schema value) with
+ * `additionalProperties: false`, which is exactly the signal
+ * `sanitizeJsonSchema` needs to build the `__eliza_record_entries` reverse
+ * transform (#11249).
+ *
+ * This clone is the safe pre-pass: same depth / node / path-local-cycle /
+ * accessor budgets and the same descriptor-only reflection, but it copies
+ * declared shape verbatim (holes included). Sanitization then runs on a plain,
+ * budgeted graph with declared semantics intact, and
+ * `normalizeSchemaForCerebras` applies provider semantics afterwards.
+ */
+export function cloneSchemaForBoundedTransport(schema: unknown): unknown {
+	return cloneSchemaTransportWalk(schema, 0, createSchemaWalkContext());
 }
 
 function hasIllegalCerebrasRoot(node: Record<string, unknown>): boolean {

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -6,12 +6,133 @@
  * schema-bearing keyword so hoisted definitions, conditionals, tuples, and map
  * schemas cannot bypass the wire contract while non-strict schemas retain
  * their permissive semantics.
+ *
+ * User-supplied tool schemas are JSON.parse-legal before this walk
+ * (`plugin-openai` cerebrasMode). An 8k-deep `properties` nest or a cyclic
+ * `not` graph RangeError'd the unbounded recursion on origin develop.
+ * Depth, node, cycle, and accessor budgets fail closed instead.
  */
+import { ElizaError } from "../errors";
 
 const FUNCTION_NAME_PATTERN = /[^a-zA-Z0-9_-]/g;
 
 export function sanitizeFunctionNameForCerebras(name: string): string {
 	return name.replace(FUNCTION_NAME_PATTERN, "_");
+}
+
+/**
+ * Honest tool schemas are a handful of objects deep. JSON.parse still
+ * admits an 8k-deep `properties` nest that then RangeError'd
+ * `normalizeSchemaForCerebras` on origin develop.
+ */
+export const MAX_CEREBRAS_SCHEMA_WALK_DEPTH = 64;
+export const MAX_CEREBRAS_SCHEMA_WALK_NODES = 100_000;
+export const CEREBRAS_SCHEMA_UNBOUNDED = "CEREBRAS_SCHEMA_UNBOUNDED";
+
+type SchemaWalkContext = {
+	visits: number;
+	visiting: WeakSet<object>;
+};
+
+function failCerebrasSchemaUnbounded(
+	context: Record<string, unknown>,
+	cause?: unknown,
+): never {
+	throw new ElizaError("Cerebras tool schema exceeds the walk budget", {
+		code: CEREBRAS_SCHEMA_UNBOUNDED,
+		cause,
+		context,
+		severity: "fatal",
+	});
+}
+
+export function isCerebrasSchemaUnbounded(error: unknown): boolean {
+	return (
+		error instanceof ElizaError && error.code === CEREBRAS_SCHEMA_UNBOUNDED
+	);
+}
+
+function reserveSchemaVisits(ctx: SchemaWalkContext, count: number): void {
+	if (count > MAX_CEREBRAS_SCHEMA_WALK_NODES - ctx.visits) {
+		failCerebrasSchemaUnbounded({
+			visits: ctx.visits + count,
+			maxNodes: MAX_CEREBRAS_SCHEMA_WALK_NODES,
+		});
+	}
+	ctx.visits += count;
+}
+
+function inspectSchema<T>(operation: string, inspect: () => T): T {
+	try {
+		return inspect();
+	} catch (cause) {
+		// error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+		failCerebrasSchemaUnbounded({ inspection: operation }, cause);
+	}
+}
+
+function ownEnumerableStringKeys(value: object): string[] {
+	const keys: string[] = [];
+	for (const key of inspectSchema("ownKeys", () => Reflect.ownKeys(value))) {
+		if (typeof key !== "string") continue;
+		const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
+			Object.getOwnPropertyDescriptor(value, key),
+		);
+		if (!descriptor?.enumerable) continue;
+		keys.push(key);
+	}
+	return keys;
+}
+
+function ownValueDescriptor(
+	value: object,
+	key: string,
+): PropertyDescriptor | undefined {
+	const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
+		Object.getOwnPropertyDescriptor(value, key),
+	);
+	if (!descriptor) return undefined;
+	if (!("value" in descriptor)) {
+		failCerebrasSchemaUnbounded({ accessor: true, key });
+	}
+	return descriptor;
+}
+
+function ownArrayLength(value: unknown[]): number {
+	const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
+		Object.getOwnPropertyDescriptor(value, "length"),
+	);
+	const length =
+		descriptor && "value" in descriptor ? descriptor.value : value.length;
+	if (typeof length !== "number" || !Number.isFinite(length) || length < 0) {
+		failCerebrasSchemaUnbounded({ arrayLength: length });
+	}
+	return Math.trunc(length);
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+	return (
+		Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype
+	);
+}
+
+function cloneOwnData(value: object): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const key of ownEnumerableStringKeys(value)) {
+		const descriptor = ownValueDescriptor(value, key);
+		if (!descriptor) continue;
+		Object.defineProperty(out, key, {
+			value: descriptor.value,
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+	}
+	return out;
+}
+
+function createSchemaWalkContext(): SchemaWalkContext {
+	return { visits: 0, visiting: new WeakSet<object>() };
 }
 
 function hasIllegalCerebrasRoot(node: Record<string, unknown>): boolean {
@@ -108,61 +229,133 @@ export interface CerebrasSchemaNormalizationOptions {
 	strict?: boolean;
 }
 
+function mapSchemaArray(
+	value: unknown[],
+	options: CerebrasSchemaNormalizationOptions,
+	depth: number,
+	ctx: SchemaWalkContext,
+): unknown[] {
+	const length = ownArrayLength(value);
+	reserveSchemaVisits(ctx, length);
+	const mapped: unknown[] = [];
+	for (let index = 0; index < length; index += 1) {
+		const descriptor = ownValueDescriptor(value, String(index));
+		mapped.push(
+			normalizeSchemaForCerebrasWalk(
+				descriptor ? descriptor.value : undefined,
+				false,
+				options,
+				depth + 1,
+				ctx,
+			),
+		);
+	}
+	return mapped;
+}
+
+function mapSchemaRecord(
+	value: object,
+	options: CerebrasSchemaNormalizationOptions,
+	depth: number,
+	ctx: SchemaWalkContext,
+): Record<string, unknown> {
+	const keys = ownEnumerableStringKeys(value);
+	reserveSchemaVisits(ctx, keys.length);
+	const mapped: Record<string, unknown> = {};
+	for (const name of keys) {
+		const descriptor = ownValueDescriptor(value, name);
+		Object.defineProperty(mapped, name, {
+			value: normalizeSchemaForCerebrasWalk(
+				descriptor ? descriptor.value : undefined,
+				false,
+				options,
+				depth + 1,
+				ctx,
+			),
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+	}
+	return mapped;
+}
+
 function walkSchemaChildren(
 	node: Record<string, unknown>,
 	options: CerebrasSchemaNormalizationOptions,
+	depth: number,
+	ctx: SchemaWalkContext,
 ): void {
 	for (const key of SCHEMA_MAP_KEYS) {
 		const value = node[key];
 		if (!isSchemaRecord(value)) continue;
-		node[key] = Object.fromEntries(
-			Object.entries(value).map(([name, schema]) => [
-				name,
-				normalizeSchemaForCerebras(schema, false, options),
-			]),
-		);
+		node[key] = mapSchemaRecord(value, options, depth, ctx);
 	}
 
 	for (const key of SCHEMA_ARRAY_KEYS) {
 		const value = node[key];
-		if (!Array.isArray(value)) continue;
-		node[key] = value.map((schema) =>
-			normalizeSchemaForCerebras(schema, false, options),
-		);
+		if (!isArrayRecord(value)) continue;
+		node[key] = mapSchemaArray(value, options, depth, ctx);
 	}
 
 	const items = node.items;
-	if (Array.isArray(items)) {
-		node.items = items.map((schema) =>
-			normalizeSchemaForCerebras(schema, false, options),
-		);
+	if (isArrayRecord(items)) {
+		node.items = mapSchemaArray(items, options, depth, ctx);
 	} else if (items !== undefined) {
-		node.items = normalizeSchemaForCerebras(items, false, options);
+		node.items = normalizeSchemaForCerebrasWalk(
+			items,
+			false,
+			options,
+			depth + 1,
+			ctx,
+		);
 	}
 
 	for (const key of SCHEMA_SINGLE_KEYS) {
 		const value = node[key];
 		if (!isSchemaRecord(value)) continue;
-		node[key] = normalizeSchemaForCerebras(value, false, options);
+		node[key] = normalizeSchemaForCerebrasWalk(
+			value,
+			false,
+			options,
+			depth + 1,
+			ctx,
+		);
 	}
 
 	const dependencies = node.dependencies;
 	if (isSchemaRecord(dependencies)) {
-		node.dependencies = Object.fromEntries(
-			Object.entries(dependencies).map(([name, dependency]) => [
-				name,
-				Array.isArray(dependency)
-					? [...dependency]
-					: normalizeSchemaForCerebras(dependency, false, options),
-			]),
-		);
+		const keys = ownEnumerableStringKeys(dependencies);
+		reserveSchemaVisits(ctx, keys.length);
+		const mapped: Record<string, unknown> = {};
+		for (const name of keys) {
+			const descriptor = ownValueDescriptor(dependencies, name);
+			const dependency = descriptor ? descriptor.value : undefined;
+			Object.defineProperty(mapped, name, {
+				value: isArrayRecord(dependency)
+					? mapSchemaArray(dependency, options, depth, ctx)
+					: normalizeSchemaForCerebrasWalk(
+							dependency,
+							false,
+							options,
+							depth + 1,
+							ctx,
+						),
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
+		}
+		node.dependencies = mapped;
 	}
 }
 
-export function normalizeSchemaForCerebras(
+function normalizeSchemaForCerebrasWalk(
 	schema: unknown,
-	isRoot = false,
-	options: CerebrasSchemaNormalizationOptions = {},
+	isRoot: boolean,
+	options: CerebrasSchemaNormalizationOptions,
+	depth: number,
+	ctx: SchemaWalkContext,
 ): unknown {
 	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
 		// A missing/non-object tool schema means the tool takes no arguments.
@@ -173,15 +366,29 @@ export function normalizeSchemaForCerebras(
 		}
 		return schema;
 	}
-	let node = { ...(schema as Record<string, unknown>) };
+
+	if (depth > MAX_CEREBRAS_SCHEMA_WALK_DEPTH) {
+		failCerebrasSchemaUnbounded({
+			depth,
+			max: MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+		});
+	}
+	if (ctx.visiting.has(schema)) {
+		failCerebrasSchemaUnbounded({ cycle: true, depth });
+	}
+	ctx.visiting.add(schema);
+	reserveSchemaVisits(ctx, 1);
+
+	let node = cloneOwnData(schema);
 
 	if (isRoot && hasIllegalCerebrasRoot(node)) {
-		// Wrap the original schema under properties.value so the model still
+		// Wrap the cloned schema under properties.value so the model still
 		// emits a structured payload Cerebras's grammar compiler accepts.
-		// Callers that unwrap tool arguments will see { value: <original> }.
+		// Walking the clone (not the original) keeps cycle detection honest
+		// when the illegal root is the same object the children point at.
 		node = {
 			type: "object",
-			properties: { value: schema },
+			properties: { value: node },
 			required: ["value"],
 			additionalProperties: false,
 		};
@@ -202,6 +409,20 @@ export function normalizeSchemaForCerebras(
 		}
 	}
 
-	walkSchemaChildren(node, options);
+	walkSchemaChildren(node, options, depth, ctx);
 	return node;
+}
+
+export function normalizeSchemaForCerebras(
+	schema: unknown,
+	isRoot = false,
+	options: CerebrasSchemaNormalizationOptions = {},
+): unknown {
+	return normalizeSchemaForCerebrasWalk(
+		schema,
+		isRoot,
+		options,
+		0,
+		createSchemaWalkContext(),
+	);
 }

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -10,7 +10,9 @@
  * User-supplied tool schemas are JSON.parse-legal before this walk
  * (`plugin-openai` cerebrasMode). An 8k-deep `properties` nest or a cyclic
  * `not` graph RangeError'd the unbounded recursion on origin develop.
- * Depth, node, cycle, and accessor budgets fail closed instead.
+ * Depth, node, path-local cycle, and accessor budgets fail closed instead.
+ * Array.isArray / getPrototypeOf / length reads stay inside inspectSchema
+ * so a revoked or hostile Array Proxy cannot leak a raw TypeError.
  */
 import { ElizaError } from "../errors";
 
@@ -31,6 +33,7 @@ export const CEREBRAS_SCHEMA_UNBOUNDED = "CEREBRAS_SCHEMA_UNBOUNDED";
 
 type SchemaWalkContext = {
 	visits: number;
+	/** Path-local ancestry only. Entries are deleted on unwind so honest DAGs pass. */
 	visiting: WeakSet<object>;
 };
 
@@ -66,9 +69,16 @@ function inspectSchema<T>(operation: string, inspect: () => T): T {
 	try {
 		return inspect();
 	} catch (cause) {
+		if (isCerebrasSchemaUnbounded(cause)) {
+			throw cause;
+		}
 		// error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
 		failCerebrasSchemaUnbounded({ inspection: operation }, cause);
 	}
+}
+
+function safeIsArray(value: unknown): boolean {
+	return inspectSchema("isArray", () => Array.isArray(value));
 }
 
 function ownEnumerableStringKeys(value: object): string[] {
@@ -102,18 +112,39 @@ function ownArrayLength(value: unknown[]): number {
 	const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
 		Object.getOwnPropertyDescriptor(value, "length"),
 	);
-	const length =
-		descriptor && "value" in descriptor ? descriptor.value : value.length;
+	if (!descriptor || !("value" in descriptor)) {
+		failCerebrasSchemaUnbounded({
+			arrayLength: true,
+			missingOwnLength: true,
+		});
+	}
+	const length = descriptor.value;
 	if (typeof length !== "number" || !Number.isFinite(length) || length < 0) {
 		failCerebrasSchemaUnbounded({ arrayLength: length });
 	}
 	return Math.trunc(length);
 }
 
+function ownArrayValues(value: unknown[]): unknown[] {
+	const length = ownArrayLength(value);
+	const mapped: unknown[] = [];
+	for (let index = 0; index < length; index += 1) {
+		const descriptor = ownValueDescriptor(value, String(index));
+		mapped.push(descriptor ? descriptor.value : undefined);
+	}
+	return mapped;
+}
+
 function isArrayRecord(value: unknown): value is unknown[] {
-	return (
-		Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype
-	);
+	return inspectSchema("isArrayRecord", () => {
+		return (
+			Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype
+		);
+	});
+}
+
+function hasNonEmptyOwnArray(value: unknown): boolean {
+	return isArrayRecord(value) && ownArrayLength(value) > 0;
 }
 
 function cloneOwnData(value: object): Record<string, unknown> {
@@ -137,9 +168,9 @@ function createSchemaWalkContext(): SchemaWalkContext {
 
 function hasIllegalCerebrasRoot(node: Record<string, unknown>): boolean {
 	if (node.type !== "object") return true;
-	if (Array.isArray(node.oneOf) && node.oneOf.length > 0) return true;
-	if (Array.isArray(node.anyOf) && node.anyOf.length > 0) return true;
-	if (Array.isArray(node.enum)) return true;
+	if (hasNonEmptyOwnArray(node.oneOf)) return true;
+	if (hasNonEmptyOwnArray(node.anyOf)) return true;
+	if (isArrayRecord(node.enum)) return true;
 	if (node.not !== undefined) return true;
 	return false;
 }
@@ -177,7 +208,7 @@ const SCHEMA_MAP_KEYS = [
 ] as const;
 
 function isSchemaRecord(value: unknown): value is Record<string, unknown> {
-	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+	return Boolean(value) && typeof value === "object" && !safeIsArray(value);
 }
 
 const OBJECT_SCHEMA_KEYS = [
@@ -198,7 +229,8 @@ function describesObjectSchema(node: Record<string, unknown>): boolean {
 	const type = node.type;
 	return (
 		type === "object" ||
-		(Array.isArray(type) && type.includes("object")) ||
+		(safeIsArray(type) &&
+			ownArrayValues(type as unknown[]).includes("object")) ||
 		OBJECT_SCHEMA_KEYS.some((key) => key in node)
 	);
 }
@@ -209,11 +241,12 @@ function enforceStrictObjectShape(node: Record<string, unknown>): void {
 
 	const properties = node.properties;
 	const hasProperties =
-		isSchemaRecord(properties) && Object.keys(properties).length > 0;
-	const hasAnyOf = Array.isArray(node.anyOf) && node.anyOf.length > 0;
+		isSchemaRecord(properties) &&
+		ownEnumerableStringKeys(properties).length > 0;
+	const hasAnyOf = hasNonEmptyOwnArray(node.anyOf);
 	if (!hasProperties && !hasAnyOf) {
 		node.properties = {};
-		if (Array.isArray(node.required) && node.required.length === 0) {
+		if (isArrayRecord(node.required) && ownArrayLength(node.required) === 0) {
 			delete node.required;
 		}
 	}
@@ -357,7 +390,7 @@ function normalizeSchemaForCerebrasWalk(
 	depth: number,
 	ctx: SchemaWalkContext,
 ): unknown {
-	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+	if (!schema || typeof schema !== "object" || safeIsArray(schema)) {
 		// A missing/non-object tool schema means the tool takes no arguments.
 		if (isRoot) {
 			return options.strict === false
@@ -379,38 +412,44 @@ function normalizeSchemaForCerebrasWalk(
 	ctx.visiting.add(schema);
 	reserveSchemaVisits(ctx, 1);
 
-	let node = cloneOwnData(schema);
+	try {
+		let node = cloneOwnData(schema);
 
-	if (isRoot && hasIllegalCerebrasRoot(node)) {
-		// Wrap the cloned schema under properties.value so the model still
-		// emits a structured payload Cerebras's grammar compiler accepts.
-		// Walking the clone (not the original) keeps cycle detection honest
-		// when the illegal root is the same object the children point at.
-		node = {
-			type: "object",
-			properties: { value: node },
-			required: ["value"],
-			additionalProperties: false,
-		};
-	}
-
-	if (options.strict !== false) {
-		enforceStrictObjectShape(node);
-		// Cerebras's strict grammar compiler rejects `oneOf` outright
-		// ("Unsupported JSON schema fields ... oneOf") while accepting `anyOf`
-		// — verified against the live API with otherwise-identical payloads.
-		// The weakening from exclusive-or to inclusive-or is immaterial here:
-		// constrained generation emits a single value, and runtime validation
-		// re-checks the parsed arguments. Non-strict schemas keep `oneOf`.
-		if (Array.isArray(node.oneOf) && node.oneOf.length > 0) {
-			const existing = Array.isArray(node.anyOf) ? node.anyOf : [];
-			node.anyOf = [...existing, ...node.oneOf];
-			delete node.oneOf;
+		if (isRoot && hasIllegalCerebrasRoot(node)) {
+			// Wrap the cloned schema under properties.value so the model still
+			// emits a structured payload Cerebras's grammar compiler accepts.
+			// Walking the clone (not the original) keeps cycle detection honest
+			// when the illegal root is the same object the children point at.
+			node = {
+				type: "object",
+				properties: { value: node },
+				required: ["value"],
+				additionalProperties: false,
+			};
 		}
-	}
 
-	walkSchemaChildren(node, options, depth, ctx);
-	return node;
+		if (options.strict !== false) {
+			enforceStrictObjectShape(node);
+			// Cerebras's strict grammar compiler rejects `oneOf` outright
+			// ("Unsupported JSON schema fields ... oneOf") while accepting `anyOf`
+			// — verified against the live API with otherwise-identical payloads.
+			// The weakening from exclusive-or to inclusive-or is immaterial here:
+			// constrained generation emits a single value, and runtime validation
+			// re-checks the parsed arguments. Non-strict schemas keep `oneOf`.
+			if (hasNonEmptyOwnArray(node.oneOf)) {
+				const existing = isArrayRecord(node.anyOf)
+					? ownArrayValues(node.anyOf)
+					: [];
+				node.anyOf = [...existing, ...ownArrayValues(node.oneOf as unknown[])];
+				delete node.oneOf;
+			}
+		}
+
+		walkSchemaChildren(node, options, depth, ctx);
+		return node;
+	} finally {
+		ctx.visiting.delete(schema);
+	}
 }
 
 export function normalizeSchemaForCerebras(

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -147,13 +147,31 @@ function hasNonEmptyOwnArray(value: unknown): boolean {
 	return isArrayRecord(value) && ownArrayLength(value) > 0;
 }
 
-function cloneOwnData(value: object): Record<string, unknown> {
+function cloneOwnData(
+	value: object,
+	ctx: SchemaWalkContext,
+): Record<string, unknown> {
+	// Reserve the raw own-key width BEFORE allocating the clone. A node
+	// with >100k irrelevant keys must trip MAX_CEREBRAS_SCHEMA_WALK_NODES
+	// instead of copying every enumerable value first.
+	const keys = inspectSchema("ownKeys", () => Reflect.ownKeys(value));
+	reserveSchemaVisits(ctx, keys.length);
+	const entries: Array<{ key: string; value: unknown }> = [];
+	for (const key of keys) {
+		if (typeof key !== "string") continue;
+		const descriptor = inspectSchema("getOwnPropertyDescriptor", () =>
+			Object.getOwnPropertyDescriptor(value, key),
+		);
+		if (!descriptor?.enumerable) continue;
+		if (!("value" in descriptor)) {
+			failCerebrasSchemaUnbounded({ accessor: true, key });
+		}
+		entries.push({ key, value: descriptor.value });
+	}
 	const out: Record<string, unknown> = {};
-	for (const key of ownEnumerableStringKeys(value)) {
-		const descriptor = ownValueDescriptor(value, key);
-		if (!descriptor) continue;
-		Object.defineProperty(out, key, {
-			value: descriptor.value,
+	for (const entry of entries) {
+		Object.defineProperty(out, entry.key, {
+			value: entry.value,
 			enumerable: true,
 			writable: true,
 			configurable: true,
@@ -270,17 +288,16 @@ function mapSchemaArray(
 ): unknown[] {
 	const length = ownArrayLength(value);
 	reserveSchemaVisits(ctx, length);
-	const mapped: unknown[] = [];
+	const mapped: unknown[] = new Array(length);
 	for (let index = 0; index < length; index += 1) {
 		const descriptor = ownValueDescriptor(value, String(index));
-		mapped.push(
-			normalizeSchemaForCerebrasWalk(
-				descriptor ? descriptor.value : undefined,
-				false,
-				options,
-				depth + 1,
-				ctx,
-			),
+		if (!descriptor) continue;
+		mapped[index] = normalizeSchemaForCerebrasWalk(
+			descriptor.value,
+			false,
+			options,
+			depth + 1,
+			ctx,
 		);
 	}
 	return mapped;
@@ -413,7 +430,7 @@ function normalizeSchemaForCerebrasWalk(
 	reserveSchemaVisits(ctx, 1);
 
 	try {
-		let node = cloneOwnData(schema);
+		let node = cloneOwnData(schema, ctx);
 
 		if (isRoot && hasIllegalCerebrasRoot(node)) {
 			// Wrap the cloned schema under properties.value so the model still

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -546,6 +546,43 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 		expect(getterCalls).toBe(0);
 	});
 
+	it("rejects an enumerable getter without invoking it", () => {
+		let getterCalls = 0;
+		const input = {};
+		Object.defineProperty(input, "hostile", {
+			enumerable: true,
+			get() {
+				getterCalls += 1;
+				return "observed";
+			},
+		});
+
+		expect(() => deepToWellFormedUnicode(input)).toThrowError(
+			expect.objectContaining({
+				code: "WELL_FORMED_UNSAFE_VALUE",
+				context: { operation: "accessor" },
+			}),
+		);
+		expect(getterCalls).toBe(0);
+	});
+
+	it("wraps revoked proxy reflection as a typed wire failure", () => {
+		const { proxy, revoke } = Proxy.revocable({ value: "opaque" }, {});
+		revoke();
+
+		try {
+			deepToWellFormedUnicode(proxy);
+			expect.unreachable("revoked proxy must fail closed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("WELL_FORMED_UNSAFE_VALUE");
+			expect((error as ElizaError).context).toEqual({
+				operation: "reflection",
+			});
+			expect((error as Error).cause).toBeInstanceOf(TypeError);
+		}
+	});
+
 	it("throws WELL_FORMED_UNBOUNDED on a visit-budget array of strings", () => {
 		const input = new Array<string>(MAX_WELL_FORMED_VISITS).fill("ok");
 		try {

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -157,6 +157,23 @@ function failUnbounded(
 	});
 }
 
+function failUnsafeValue(
+	operation: "accessor" | "reflection",
+	cause?: unknown,
+): never {
+	throw new ElizaError(
+		operation === "accessor"
+			? "deepToWellFormedUnicode: enumerable accessor cannot be serialized safely"
+			: "deepToWellFormedUnicode: value cannot be inspected safely",
+		{
+			code: "WELL_FORMED_UNSAFE_VALUE",
+			cause,
+			context: { operation },
+			severity: "fatal",
+		},
+	);
+}
+
 function enterContainer(value: object, depth: number, ctx: WalkCtx): void {
 	if (depth >= MAX_WELL_FORMED_DEPTH) {
 		failUnbounded("depth", { depth, max: MAX_WELL_FORMED_DEPTH });
@@ -223,7 +240,12 @@ function sanitizeObjectPreservingDescriptors<T>(
 		}
 
 		const sanitizedKey = toWellFormedUnicode(key);
-		const entry = "value" in descriptor ? descriptor.value : source[key];
+		// JSON.stringify would execute an enumerable accessor. Reject it without
+		// observation so a provider request can never run caller-controlled code.
+		if (!("value" in descriptor)) {
+			failUnsafeValue("accessor");
+		}
+		const entry = descriptor.value;
 		const sanitizedValue = walkDeep(entry, depth + 1, ctx, true);
 		if (sanitizedKey !== key || sanitizedValue !== entry) {
 			changed = true;
@@ -361,5 +383,12 @@ function walkDeep<T>(
  * `WELL_FORMED_UNBOUNDED` so a hostile nest cannot hang the model call.
  */
 export function deepToWellFormedUnicode<T>(value: T): T {
-	return walkDeep(value, 0, { visits: 0, visiting: new WeakSet<object>() });
+	try {
+		return walkDeep(value, 0, { visits: 0, visiting: new WeakSet<object>() });
+	} catch (error) {
+		// error-policy:J2 Reflection on a revoked or hostile Proxy is translated
+		// into the same typed provider-boundary failure contract.
+		if (error instanceof ElizaError) throw error;
+		return failUnsafeValue("reflection", error);
+	}
 }

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -12,6 +12,7 @@ import {
   ElizaError,
   type IAgentRuntime,
   isCerebrasSchemaUnbounded,
+  MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
   MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
   MAX_CEREBRAS_SCHEMA_WALK_NODES,
 } from "@elizaos/core";
@@ -25,6 +26,7 @@ const aiMocks = vi.hoisted(() => ({
 import {
   handleTextSmall,
   __INTERNAL_normalizeNativeToolsForCall as normalizeNativeToolsForCall,
+  __INTERNAL_restoreRecordArgToolCalls as restoreRecordArgToolCalls,
 } from "../models/text";
 
 vi.mock("ai", () => ({
@@ -144,7 +146,10 @@ describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => 
     } catch (error) {
       expect(Date.now() - started).toBeLessThan(250);
       const typed = expectUnbounded(error);
-      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+      // The bounded transport clone runs first, so the raw-object budget
+      // (two raw levels per schema level) is what rejects this input.
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+      expect(typed.context?.clone).toBe(true);
       expect(aiMocks.generateText).not.toHaveBeenCalled();
     }
   });
@@ -263,7 +268,10 @@ describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => 
       throw new Error("expected unbounded throw");
     } catch (error) {
       const typed = expectUnbounded(error);
-      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+      // The bounded transport clone runs first, so the raw-object budget
+      // (two raw levels per schema level) is what rejects this input.
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+      expect(typed.context?.clone).toBe(true);
       expect(aiMocks.generateText).not.toHaveBeenCalled();
     }
   });
@@ -335,5 +343,139 @@ describe("handleTextSmall Cerebras path never dispatches on unbounded schema", (
       ],
     } as never);
     expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Shaw CR at 4854c203: the bounded pre-pass must NOT apply Cerebras closure
+ * before `sanitizeJsonSchema` runs, or every declared open map is rewritten to
+ * `additionalProperties: false` and the `__eliza_record_entries` reverse
+ * transform (#11249) is never built — the model then sees a closed empty
+ * object and the argument always arrives empty.
+ */
+describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
+  it("emits __eliza_record_entries and records the transform for a schema-valued map", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              customFields: { type: "object", additionalProperties: { type: "string" } },
+            },
+            required: ["customFields"],
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    const customFields = (
+      tool.inputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>
+    ).customFields;
+    const entries = (customFields.properties as Record<string, Record<string, unknown>>)
+      .__eliza_record_entries;
+    expect(entries).toBeDefined();
+    expect(entries.type).toBe("array");
+    const entryItem = entries.items as Record<string, Record<string, unknown>>;
+    expect(entryItem.properties.key).toMatchObject({ type: "string" });
+    expect(entryItem.properties.value).toMatchObject({ type: "string" });
+    // Wire contract still closed for the grammar compiler.
+    expect(customFields.additionalProperties).toBe(false);
+    expect(typeof customFields.description).toBe("string");
+
+    const transforms = result.recordArgTransformsByTool.probe;
+    expect(transforms).toEqual([
+      { path: "$.customFields", entriesKey: "__eliza_record_entries", valueMode: "schema" },
+    ]);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("uses json-string entry values for additionalProperties: true", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: { bag: { type: "object", additionalProperties: true } },
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+    expect(result.recordArgTransformsByTool.probe).toEqual([
+      { path: "$.bag", entriesKey: "__eliza_record_entries", valueMode: "json-string" },
+    ]);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("restores returned tool-call args through the recorded transform", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              customFields: { type: "object", additionalProperties: { type: "string" } },
+            },
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+    const restored = restoreRecordArgToolCalls(
+      [
+        {
+          toolName: "probe",
+          input: {
+            customFields: {
+              __eliza_record_entries: [
+                { key: "team", value: "core" },
+                { key: "tier", value: "gold" },
+              ],
+            },
+          },
+        },
+      ],
+      result.recordArgTransformsByTool
+    ) as Array<{ input: { customFields: Record<string, unknown> } }>;
+    expect(restored[0].input.customFields).toEqual({ team: "core", tier: "gold" });
+  });
+
+  it("carries the open map all the way to the provider request in handleTextSmall", async () => {
+    await handleTextSmall(createRuntime(), {
+      prompt: "probe",
+      tools: [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              customFields: { type: "object", additionalProperties: { type: "string" } },
+            },
+          },
+        },
+      ],
+    } as never);
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+    const call = aiMocks.generateText.mock.calls[0][0] as {
+      tools: Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>;
+    };
+    const customFields = (
+      call.tools.probe.inputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>
+    ).customFields;
+    expect(
+      (customFields.properties as Record<string, unknown>).__eliza_record_entries
+    ).toBeDefined();
   });
 });

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Production-boundary regressions for Shaw CR on #23159 (head after the
+ * prior walker fix). The live Cerebras path is
+ * `normalizeNativeToolsForCall` → `sanitizeJsonSchema` →
+ * `normalizeSchemaForCerebras`. Tests call that real pipeline (and the
+ * `handleTextSmall` model handler that owns it), not a local core wrapper.
+ * A typed `CEREBRAS_SCHEMA_UNBOUNDED` throw is the fail-closed gate before
+ * provider `generateText` dispatch.
+ */
+import {
+  CEREBRAS_SCHEMA_UNBOUNDED,
+  ElizaError,
+  type IAgentRuntime,
+  isCerebrasSchemaUnbounded,
+  MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+  MAX_CEREBRAS_SCHEMA_WALK_NODES,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const aiMocks = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  streamText: vi.fn(),
+}));
+
+import {
+  handleTextSmall,
+  __INTERNAL_normalizeNativeToolsForCall as normalizeNativeToolsForCall,
+} from "../models/text";
+
+vi.mock("ai", () => ({
+  generateText: aiMocks.generateText,
+  streamText: aiMocks.streamText,
+  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  Output: {
+    object: () => ({ name: "object", responseFormat: Promise.resolve({ type: "json" }) }),
+    json: () => ({ name: "json", responseFormat: Promise.resolve({ type: "json" }) }),
+  },
+}));
+
+vi.mock("../providers", () => ({
+  createOpenAIClient: () => ({
+    chat: (modelName: string) => ({ modelName }),
+    responses: (modelName: string) => ({ modelName }),
+  }),
+}));
+
+function expectUnbounded(error: unknown): ElizaError {
+  expect(error).toBeInstanceOf(ElizaError);
+  expect(isCerebrasSchemaUnbounded(error)).toBe(true);
+  expect((error as ElizaError).code).toBe(CEREBRAS_SCHEMA_UNBOUNDED);
+  expect(error).not.toBeInstanceOf(TypeError);
+  expect(error).not.toBeInstanceOf(RangeError);
+  return error as ElizaError;
+}
+
+function callStrictCerebras(schema: unknown) {
+  return normalizeNativeToolsForCall([{ name: "probe", strict: true, parameters: schema }], {
+    cerebrasMode: true,
+  });
+}
+
+function deepProperties(depth: number): Record<string, unknown> {
+  let node: Record<string, unknown> = { type: "string" };
+  for (let i = 0; i < depth; i++) {
+    node = { type: "object", properties: { x: node } };
+  }
+  return node;
+}
+
+function createRuntime(): IAgentRuntime {
+  const runtime = {
+    character: { name: "Ada", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+    getSetting: vi.fn(() => undefined),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+beforeEach(() => {
+  vi.stubEnv("OPENAI_API_KEY", "test-key");
+  vi.stubEnv("OPENAI_SMALL_MODEL", "gpt-oss-120b");
+  vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
+  vi.stubEnv("ELIZA_PROVIDER", undefined);
+  vi.stubEnv("CEREBRAS_API_KEY", undefined);
+  aiMocks.generateText.mockResolvedValue({
+    text: "ok",
+    finishReason: "stop",
+    usage: { inputTokens: 1, outputTokens: 1 },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => {
+  it("still closes an honest nested object schema through the real pipeline", () => {
+    const result = callStrictCerebras({
+      type: "object",
+      properties: {
+        inner: { type: "object", properties: {}, additionalProperties: false },
+      },
+      required: ["inner"],
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    const schema = tool.inputSchema.jsonSchema;
+    const inner = (schema.properties as Record<string, Record<string, unknown>>).inner;
+    expect(inner.properties).toEqual({});
+    expect(inner.additionalProperties).toBe(false);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a cyclic not graph instead of RangeError", () => {
+    const cyclic: Record<string, unknown> = { type: "object", properties: {} };
+    cyclic.not = cyclic;
+    const started = Date.now();
+    try {
+      callStrictCerebras(cyclic);
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      expect(Date.now() - started).toBeLessThan(250);
+      const typed = expectUnbounded(error);
+      expect(typed.context?.cycle).toBe(true);
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+
+  it("fails closed on a JSON.parse-legal over-deep properties nest", () => {
+    const depth = 8000;
+    let raw = '{"type":"string"}';
+    for (let i = 0; i < depth; i++) {
+      raw = `{"type":"object","properties":{"x":${raw}}}`;
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const started = Date.now();
+    try {
+      callStrictCerebras(parsed);
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      expect(Date.now() - started).toBeLessThan(250);
+      const typed = expectUnbounded(error);
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+
+  it("fails closed on an enumerable getter instead of invoking it", () => {
+    const hostile: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(hostile, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("getter invoked");
+      },
+    });
+    try {
+      callStrictCerebras(hostile);
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      const typed = expectUnbounded(error);
+      expect(typed.context?.accessor).toBe(true);
+      expect((typed as Error).message).not.toContain("getter invoked");
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+
+  it("wraps a revoked Array Proxy as typed unbounded instead of TypeError", () => {
+    const { proxy, revoke } = Proxy.revocable([] as unknown[], {});
+    revoke();
+    try {
+      callStrictCerebras(proxy);
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      const typed = expectUnbounded(error);
+      expect(typed.cause).toBeInstanceOf(TypeError);
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not execute get/has/prototype traps on an honest object Proxy", () => {
+    const target = {
+      type: "object",
+      properties: { x: { type: "string" } },
+    };
+    let getHits = 0;
+    let hasHits = 0;
+    let protoHits = 0;
+    const proxy = new Proxy(target, {
+      get(t, prop, r) {
+        getHits += 1;
+        return Reflect.get(t, prop, r);
+      },
+      has(t, prop) {
+        hasHits += 1;
+        return Reflect.has(t, prop);
+      },
+      getPrototypeOf(t) {
+        protoHits += 1;
+        return Reflect.getPrototypeOf(t);
+      },
+    });
+    const result = callStrictCerebras(proxy);
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    expect(tool.inputSchema.jsonSchema.type).toBe("object");
+    expect(getHits).toBe(0);
+    expect(hasHits).toBe(0);
+    expect(protoHits).toBe(0);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("accepts an honest DAG that reuses the same schema object under two properties", () => {
+    const shared = { type: "string" };
+    const result = callStrictCerebras({
+      type: "object",
+      properties: { a: shared, b: shared },
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    const props = tool.inputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>;
+    expect(props.a.type).toBe("string");
+    expect(props.b.type).toBe("string");
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("walks sparse arrays from own length/index descriptors only", () => {
+    const items: unknown[] = [];
+    items[0] = { type: "string" };
+    items[2] = { type: "number" };
+    const result = callStrictCerebras({
+      type: "object",
+      properties: {
+        t: { type: "array", prefixItems: items },
+      },
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    const t = (tool.inputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>).t;
+    expect(t.prefixItems).toHaveLength(3);
+    expect((t.prefixItems as unknown[])[0]).toMatchObject({ type: "string" });
+    expect((t.prefixItems as unknown[])[1]).toBeUndefined();
+    expect(1 in (t.prefixItems as unknown[])).toBe(false);
+    expect((t.prefixItems as unknown[])[2]).toMatchObject({ type: "number" });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("accepts a schema at the exact depth budget and rejects one step past", () => {
+    const atBudget = callStrictCerebras(deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH));
+    const tool = (
+      atBudget.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    expect(tool.inputSchema.jsonSchema.type).toBe("object");
+
+    try {
+      callStrictCerebras(deepProperties(MAX_CEREBRAS_SCHEMA_WALK_DEPTH + 1));
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      const typed = expectUnbounded(error);
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+
+  it("fails closed on an over-wide own-key node before cloning", () => {
+    const wide: Record<string, unknown> = { type: "object", properties: {} };
+    for (let i = 0; i < MAX_CEREBRAS_SCHEMA_WALK_NODES + 1; i++) {
+      wide[`k${i}`] = true;
+    }
+    const started = Date.now();
+    try {
+      callStrictCerebras(wide);
+      throw new Error("expected unbounded throw");
+    } catch (error) {
+      expect(Date.now() - started).toBeLessThan(2000);
+      const typed = expectUnbounded(error);
+      expect(typed.context?.maxNodes).toBe(MAX_CEREBRAS_SCHEMA_WALK_NODES);
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe("handleTextSmall Cerebras path never dispatches on unbounded schema", () => {
+  it("throws typed unbounded and does not call generateText", async () => {
+    const cyclic: Record<string, unknown> = { type: "object", properties: {} };
+    cyclic.not = cyclic;
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "probe",
+        tools: [{ name: "probe", strict: true, parameters: cyclic }],
+      } as never)
+    ).rejects.toSatisfy((error) => {
+      expectUnbounded(error);
+      return true;
+    });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+    expect(aiMocks.streamText).not.toHaveBeenCalled();
+  });
+
+  it("throws typed unbounded for revoked proxy and does not call generateText", async () => {
+    const { proxy, revoke } = Proxy.revocable({ type: "object", properties: {} }, {});
+    revoke();
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "probe",
+        tools: [{ name: "probe", strict: true, parameters: proxy }],
+      } as never)
+    ).rejects.toSatisfy((error) => {
+      expectUnbounded(error);
+      return true;
+    });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("still reaches generateText for an honest closed schema", async () => {
+    await handleTextSmall(createRuntime(), {
+      prompt: "probe",
+      tools: [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: { x: { type: "string" } },
+            required: ["x"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    } as never);
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -8,6 +8,10 @@ import {
   ElizaError,
   type IAgentRuntime,
   isCerebrasSchemaUnbounded,
+  JSON_SCHEMA_ARRAY_KEYWORDS,
+  JSON_SCHEMA_MAP_KEYWORDS,
+  JSON_SCHEMA_MIXED_MAP_KEYWORDS,
+  JSON_SCHEMA_SINGLE_KEYWORDS,
   MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
   MAX_CEREBRAS_SCHEMA_WALK_NODES,
   MAX_WELL_FORMED_DEPTH,
@@ -23,6 +27,7 @@ import {
   handleTextSmall,
   __INTERNAL_normalizeNativeToolsForCall as normalizeNativeToolsForCall,
   __INTERNAL_restoreRecordArgToolCalls as restoreRecordArgToolCalls,
+  __INTERNAL_sanitizeSchemaKeywords as sanitizeSchemaKeywords,
 } from "../models/text";
 
 vi.mock("ai", () => ({
@@ -425,6 +430,15 @@ describe("opaque annotations remain inert until the typed wire boundary", () => 
 
 /** Open-map declarations retain their two-sided strict-safe transformation. */
 describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
+  it("keeps sanitizer recursion in parity with the bounded core keyword tables", () => {
+    expect(sanitizeSchemaKeywords).toEqual({
+      arrays: JSON_SCHEMA_ARRAY_KEYWORDS,
+      maps: JSON_SCHEMA_MAP_KEYWORDS,
+      mixedMaps: JSON_SCHEMA_MIXED_MAP_KEYWORDS,
+      singles: JSON_SCHEMA_SINGLE_KEYWORDS,
+    });
+  });
+
   it("emits __eliza_record_entries and records the transform for a schema-valued map", () => {
     const result = normalizeNativeToolsForCall(
       [
@@ -520,6 +534,172 @@ describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
       result.recordArgTransformsByTool
     ) as Array<{ input: { customFields: Record<string, unknown> } }>;
     expect(restored[0].input.customFields).toEqual({ team: "core", tier: "gold" });
+  });
+
+  it("restores nested open maps inside additionalProperties values", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              customFields: {
+                type: "object",
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    labels: {
+                      type: "object",
+                      additionalProperties: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+    expect(result.recordArgTransformsByTool.probe).toEqual([
+      {
+        path: "$.customFields.*.labels",
+        entriesKey: "__eliza_record_entries",
+        valueMode: "schema",
+      },
+      {
+        path: "$.customFields",
+        entriesKey: "__eliza_record_entries",
+        valueMode: "schema",
+      },
+    ]);
+
+    const restored = restoreRecordArgToolCalls(
+      [
+        {
+          toolName: "probe",
+          input: {
+            customFields: {
+              __eliza_record_entries: [
+                {
+                  key: "first",
+                  value: {
+                    labels: {
+                      __eliza_record_entries: [{ key: "team", value: "core" }],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      result.recordArgTransformsByTool
+    ) as Array<{
+      input: { customFields: Record<string, { labels: Record<string, unknown> }> };
+    }>;
+    expect(restored[0].input.customFields.first.labels).toEqual({ team: "core" });
+  });
+
+  it("preserves and reverses an open map nested under dependentSchemas", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: { mode: { type: "string" } },
+            dependentSchemas: {
+              mode: {
+                properties: {
+                  metadata: {
+                    type: "object",
+                    additionalProperties: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+
+    expect(result.recordArgTransformsByTool.probe).toContainEqual({
+      path: "$.metadata",
+      entriesKey: "__eliza_record_entries",
+      valueMode: "schema",
+    });
+    const restored = restoreRecordArgToolCalls(
+      [
+        {
+          toolName: "probe",
+          input: {
+            mode: "advanced",
+            metadata: {
+              __eliza_record_entries: [{ key: "team", value: "core" }],
+            },
+          },
+        },
+      ],
+      result.recordArgTransformsByTool
+    ) as Array<{ input: { metadata: Record<string, unknown> } }>;
+    expect(restored[0].input.metadata).toEqual({ team: "core" });
+  });
+
+  it("preserves and reverses an open map in the matching prefixItems slot", () => {
+    const result = normalizeNativeToolsForCall(
+      [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              rows: {
+                type: "array",
+                prefixItems: [
+                  { type: "object", additionalProperties: { type: "string" } },
+                  { type: "object", additionalProperties: { type: "number" } },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      { cerebrasMode: true }
+    );
+
+    expect(result.recordArgTransformsByTool.probe).toEqual([
+      {
+        path: "$.rows.items[0]",
+        entriesKey: "__eliza_record_entries",
+        valueMode: "schema",
+      },
+      {
+        path: "$.rows.items[1]",
+        entriesKey: "__eliza_record_entries",
+        valueMode: "schema",
+      },
+    ]);
+    const restored = restoreRecordArgToolCalls(
+      [
+        {
+          toolName: "probe",
+          input: {
+            rows: [
+              { __eliza_record_entries: [{ key: "team", value: "core" }] },
+              { __eliza_record_entries: [{ key: "rank", value: 7 }] },
+            ],
+          },
+        },
+      ],
+      result.recordArgTransformsByTool
+    ) as Array<{ input: { rows: Array<Record<string, unknown>> } }>;
+    expect(restored[0].input.rows).toEqual([{ team: "core" }, { rank: 7 }]);
   });
 
   it("carries the open map all the way to the provider request in handleTextSmall", async () => {

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -1,11 +1,7 @@
 /**
- * Production-boundary regressions for Shaw CR on #23159 (head after the
- * prior walker fix). The live Cerebras path is
- * `normalizeNativeToolsForCall` → `sanitizeJsonSchema` →
- * `normalizeSchemaForCerebras`. Tests call that real pipeline (and the
- * `handleTextSmall` model handler that owns it), not a local core wrapper.
- * A typed `CEREBRAS_SCHEMA_UNBOUNDED` throw is the fail-closed gate before
- * provider `generateText` dispatch.
+ * Production-boundary coverage for bounded Cerebras tool-schema handling.
+ * Tests exercise the real normalization pipeline and model handler, including
+ * fail-closed behavior before provider dispatch.
  */
 import {
   CEREBRAS_SCHEMA_UNBOUNDED,
@@ -346,13 +342,88 @@ describe("handleTextSmall Cerebras path never dispatches on unbounded schema", (
   });
 });
 
-/**
- * Shaw CR at 4854c203: the bounded pre-pass must NOT apply Cerebras closure
- * before `sanitizeJsonSchema` runs, or every declared open map is rewritten to
- * `additionalProperties: false` and the `__eliza_record_entries` reverse
- * transform (#11249) is never built — the model then sees a closed empty
- * object and the argument always arrives empty.
- */
+describe("opaque annotations remain inert until the typed wire boundary", () => {
+  function normalizedDefault(annotation: unknown): unknown {
+    const result = callStrictCerebras({
+      type: "object",
+      properties: { x: { type: "string" } },
+      default: annotation,
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    return tool.inputSchema.jsonSchema.default;
+  }
+
+  async function expectTypedWireRejection(annotation: unknown): Promise<void> {
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "probe",
+        tools: [
+          {
+            name: "probe",
+            strict: true,
+            parameters: {
+              type: "object",
+              properties: { x: { type: "string" } },
+              default: annotation,
+            },
+          },
+        ],
+      } as never)
+    ).rejects.toSatisfy((error) => {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toMatch(/^WELL_FORMED_/);
+      expect(error).not.toBeInstanceOf(TypeError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      return true;
+    });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+    expect(aiMocks.streamText).not.toHaveBeenCalled();
+  }
+
+  it("never evaluates an enumerable annotation getter", async () => {
+    let getterCalls = 0;
+    const annotation = {};
+    Object.defineProperty(annotation, "hostile", {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return "observed";
+      },
+    });
+
+    expect(normalizedDefault(annotation)).toBe(annotation);
+    expect(getterCalls).toBe(0);
+    await expectTypedWireRejection(annotation);
+    expect(getterCalls).toBe(0);
+  });
+
+  it("translates a revoked annotation proxy without dispatch", async () => {
+    const { proxy, revoke } = Proxy.revocable({ value: "opaque" }, {});
+    revoke();
+
+    expect(normalizedDefault(proxy)).toBe(proxy);
+    await expectTypedWireRejection(proxy);
+  });
+
+  it("rejects cyclic annotation data without dispatch", async () => {
+    const annotation: Record<string, unknown> = { value: "opaque" };
+    annotation.self = annotation;
+
+    expect(normalizedDefault(annotation)).toBe(annotation);
+    await expectTypedWireRejection(annotation);
+  });
+
+  it("rejects annotation data past the wire depth cap without dispatch", async () => {
+    const annotation = deepProperties(MAX_WELL_FORMED_DEPTH * 4);
+
+    expect(normalizedDefault(annotation)).toBe(annotation);
+    await expectTypedWireRejection(annotation);
+  });
+});
+
+/** Open-map declarations retain their two-sided strict-safe transformation. */
 describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
   it("emits __eliza_record_entries and records the transform for a schema-valued map", () => {
     const result = normalizeNativeToolsForCall(
@@ -480,13 +551,7 @@ describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
   });
 });
 
-/**
- * Shaw CR at fb67e329: the pre-pass counted raw object nesting, so a legal
- * `default`/`examples`/extension annotation nested past that raw budget was
- * rejected even though `normalizeSchemaForCerebras` and `sanitizeJsonSchema`
- * never descend into annotation data and accept it. The provider path must
- * keep accepting those schemas.
- */
+/** Legal annotation data is opaque to the schema-specific pre-pass. */
 describe("Cerebras mode accepts deep legal annotation data (real caller)", () => {
   function deepAnnotation(depth: number): Record<string, unknown> {
     let node: Record<string, unknown> = { leaf: true };

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -12,9 +12,9 @@ import {
   ElizaError,
   type IAgentRuntime,
   isCerebrasSchemaUnbounded,
-  MAX_CEREBRAS_SCHEMA_CLONE_DEPTH,
   MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
   MAX_CEREBRAS_SCHEMA_WALK_NODES,
+  MAX_WELL_FORMED_DEPTH,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -146,9 +146,9 @@ describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => 
     } catch (error) {
       expect(Date.now() - started).toBeLessThan(250);
       const typed = expectUnbounded(error);
-      // The bounded transport clone runs first, so the raw-object budget
-      // (two raw levels per schema level) is what rejects this input.
-      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+      // The bounded transport clone runs first and uses the same schema-level
+      // depth accounting as the normalizer, so the budget reported is the same.
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
       expect(typed.context?.clone).toBe(true);
       expect(aiMocks.generateText).not.toHaveBeenCalled();
     }
@@ -268,9 +268,9 @@ describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => 
       throw new Error("expected unbounded throw");
     } catch (error) {
       const typed = expectUnbounded(error);
-      // The bounded transport clone runs first, so the raw-object budget
-      // (two raw levels per schema level) is what rejects this input.
-      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_CLONE_DEPTH);
+      // The bounded transport clone runs first and uses the same schema-level
+      // depth accounting as the normalizer, so the budget reported is the same.
+      expect(typed.context?.max).toBe(MAX_CEREBRAS_SCHEMA_WALK_DEPTH);
       expect(typed.context?.clone).toBe(true);
       expect(aiMocks.generateText).not.toHaveBeenCalled();
     }
@@ -477,5 +477,112 @@ describe("Cerebras mode preserves declared open-map semantics (#11249)", () => {
     expect(
       (customFields.properties as Record<string, unknown>).__eliza_record_entries
     ).toBeDefined();
+  });
+});
+
+/**
+ * Shaw CR at fb67e329: the pre-pass counted raw object nesting, so a legal
+ * `default`/`examples`/extension annotation nested past that raw budget was
+ * rejected even though `normalizeSchemaForCerebras` and `sanitizeJsonSchema`
+ * never descend into annotation data and accept it. The provider path must
+ * keep accepting those schemas.
+ */
+describe("Cerebras mode accepts deep legal annotation data (real caller)", () => {
+  function deepAnnotation(depth: number): Record<string, unknown> {
+    let node: Record<string, unknown> = { leaf: true };
+    for (let i = 0; i < depth; i++) {
+      node = { nested: node };
+    }
+    return node;
+  }
+
+  it("accepts a default annotation nested far past the schema depth budget", () => {
+    const annotation = deepAnnotation(MAX_CEREBRAS_SCHEMA_WALK_DEPTH * 2 + 1);
+    const result = callStrictCerebras({
+      type: "object",
+      properties: { x: { type: "string" } },
+      default: annotation,
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    const schema = tool.inputSchema.jsonSchema;
+    expect(schema.type).toBe("object");
+    // Annotation data survives to the wire unchanged (it is not a stripped
+    // strict-unsupported constraint keyword).
+    expect(schema.default).toEqual(annotation);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("accepts 20k-deep examples and x- extension annotations", () => {
+    const annotation = deepAnnotation(20_000);
+    const result = callStrictCerebras({
+      type: "object",
+      properties: { x: { type: "string" } },
+      examples: [annotation],
+      "x-vendor": annotation,
+    });
+    const tool = (
+      result.tools as Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>
+    ).probe;
+    expect(tool.inputSchema.jsonSchema["x-vendor"]).toBe(annotation);
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("keeps a deep annotation on a nested property and still dispatches", async () => {
+    // `handleTextSmall` runs the params through `deepToWellFormedUnicode`,
+    // whose own independent MAX_WELL_FORMED_DEPTH cap governs the whole
+    // payload. Stay inside it so this test measures the schema pre-pass.
+    const annotation = deepAnnotation(MAX_WELL_FORMED_DEPTH - 8);
+    await handleTextSmall(createRuntime(), {
+      prompt: "probe",
+      tools: [
+        {
+          name: "probe",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              x: { type: "string", default: annotation },
+            },
+            required: ["x"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    } as never);
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+    const call = aiMocks.generateText.mock.calls[0][0] as {
+      tools: Record<string, { inputSchema: { jsonSchema: Record<string, unknown> } }>;
+    };
+    const x = (
+      call.tools.probe.inputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>
+    ).x;
+    expect(x.default).toEqual(annotation);
+  });
+
+  it("leaves the deeper handler ceiling to the pre-existing well-formed cap", async () => {
+    // Past MAX_WELL_FORMED_DEPTH the request is rejected by the payload
+    // unicode walk that already existed on origin develop, NOT by the Cerebras
+    // schema pre-pass. Asserting the code proves the pre-pass is not the party
+    // narrowing annotation depth.
+    const annotation = deepAnnotation(MAX_WELL_FORMED_DEPTH * 4);
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "probe",
+        tools: [
+          {
+            name: "probe",
+            strict: true,
+            parameters: { type: "object", properties: {}, default: annotation },
+          },
+        ],
+      } as never)
+    ).rejects.toSatisfy((error) => {
+      expect(isCerebrasSchemaUnbounded(error)).toBe(false);
+      expect((error as ElizaError).code).not.toBe(CEREBRAS_SCHEMA_UNBOUNDED);
+      return true;
+    });
+    expect(aiMocks.generateText).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -732,7 +732,7 @@ function normalizeNativeToolsForCall(
     // A missing schema means the tool takes no arguments. Provider-specific
     // normalization below turns this bare object into the explicit closed
     // shape required by strict grammar compilers.
-    const rawSchema =
+    const declaredSchema =
       tool.parameters ?? functionTool.parameters ?? ({ type: "object" } satisfies JSONSchema7);
     const strict =
       typeof tool.strict === "boolean"
@@ -741,6 +741,20 @@ function normalizeNativeToolsForCall(
           ? functionTool.strict
           : undefined;
     const recordArgTransforms: RecordArgTransform[] = [];
+    // Shaw P1: the production strict Cerebras path used to call
+    // sanitizeJsonSchema (raw Array.isArray / object spread / Object.entries /
+    // .map / unbounded recursion) BEFORE the descriptor-safe walker. An
+    // 8k-deep, cyclic, revoked, or accessor-bearing schema RangeError'd or
+    // leaked a trap there. Run the bounded walk first so sanitization only
+    // ever sees a cloned, budgeted graph. Share the same walker after
+    // sanitization so Cerebras empty-object / oneOf rules still apply to
+    // nodes sanitize introduces.
+    let rawSchema: unknown = declaredSchema;
+    if (options.cerebrasMode) {
+      rawSchema = normalizeSchemaForCerebras(rawSchema, true, {
+        strict: strict !== false,
+      });
+    }
     let inputSchema: JSONSchema7;
     if (strict === false) {
       if (!rawSchema || typeof rawSchema !== "object" || Array.isArray(rawSchema)) {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -19,6 +19,10 @@ import {
   deepToWellFormedUnicode,
   dropDuplicateLeadingSystemMessage,
   ElizaError,
+  JSON_SCHEMA_ARRAY_KEYWORDS,
+  JSON_SCHEMA_MAP_KEYWORDS,
+  JSON_SCHEMA_MIXED_MAP_KEYWORDS,
+  JSON_SCHEMA_SINGLE_KEYWORDS,
   logActiveTrajectoryLlmCall,
   logger,
   ModelType,
@@ -1133,9 +1137,26 @@ function restoreRecordArgAtPath(
     return value.map((item) => restoreRecordArgAtPath(item, rest, transform));
   }
   if (/^items\[\d+\]$/.test(token)) {
-    return Array.isArray(value)
-      ? value.map((item) => restoreRecordArgAtPath(item, rest, transform))
-      : value;
+    if (!Array.isArray(value)) return value;
+    const index = Number.parseInt(token.slice(6, -1), 10);
+    if (index >= value.length) return value;
+    const restored = [...value];
+    restored[index] = restoreRecordArgAtPath(value[index], rest, transform);
+    return restored;
+  }
+  if (token === "*") {
+    const record = asOptionalRecord(value);
+    if (!record) return value;
+    const restored: Record<string, unknown> = Object.create(null);
+    for (const [key, nested] of Object.entries(record)) {
+      Object.defineProperty(restored, key, {
+        configurable: true,
+        enumerable: true,
+        value: restoreRecordArgAtPath(nested, rest, transform),
+        writable: true,
+      });
+    }
+    return restored;
   }
 
   const record = asOptionalRecord(value);
@@ -1353,7 +1374,11 @@ function chooseRecordEntriesKey(properties: Record<string, unknown>): string {
   return `${STRICT_SAFE_RECORD_ENTRIES_KEY}_${index}`;
 }
 
-function strictSafeRecordValueSchema(additionalProperties: unknown): {
+function strictSafeRecordValueSchema(
+  additionalProperties: unknown,
+  transforms?: RecordArgTransform[],
+  path = "$"
+): {
   schema: JSONSchema7;
   mode: RecordArgValueMode;
 } {
@@ -1369,7 +1394,7 @@ function strictSafeRecordValueSchema(additionalProperties: unknown): {
   }
   return {
     mode: "schema",
-    schema: sanitizeJsonSchema(additionalProperties),
+    schema: sanitizeJsonSchema(additionalProperties, false, `${path}.*`, transforms),
   };
 }
 
@@ -1486,7 +1511,9 @@ function sanitizeJsonSchema(
           : {};
       const entriesKey = chooseRecordEntriesKey(properties);
       const { schema: valueSchema, mode } = strictSafeRecordValueSchema(
-        sanitized.additionalProperties
+        sanitized.additionalProperties,
+        transforms,
+        path
       );
       properties[entriesKey] = strictSafeRecordEntriesSchema(valueSchema);
       sanitized.properties = properties;
@@ -1523,37 +1550,68 @@ function sanitizeJsonSchema(
       : sanitizeJsonSchema(sanitized.items, false, `${path}.items`, transforms);
   }
 
-  for (const unionKey of ["anyOf", "oneOf", "allOf"] as const) {
-    const value = sanitized[unionKey];
+  for (const arrayKey of JSON_SCHEMA_ARRAY_KEYWORDS) {
+    const value = sanitized[arrayKey];
     if (Array.isArray(value)) {
-      sanitized[unionKey] = value.map((item, i) =>
-        sanitizeJsonSchema(item, false, `${path}.${unionKey}[${i}]`, transforms)
+      sanitized[arrayKey] = value.map((item, index) =>
+        sanitizeJsonSchema(
+          item,
+          false,
+          arrayKey === "prefixItems" ? `${path}.items[${index}]` : path,
+          transforms
+        )
       );
     }
   }
 
-  // Every other schema-bearing keyword must be walked too, or a stripped
-  // keyword nested inside one survives to the wire. `$defs`/`definitions`
-  // matter most in practice: zod's `toJSONSchema` hoists reused/nullable
-  // sub-schemas into `$defs`, so a `.max()`/`.regex()` on a shared field would
-  // otherwise slip through the strip. `contains`/`propertyNames`/`not`/`if`/
-  // `then`/`else` take a single sub-schema; `patternProperties`/`$defs`/
-  // `definitions` are maps of them.
-  for (const singleKey of ["contains", "propertyNames", "not", "if", "then", "else"] as const) {
+  // Walk the same standard schema-bearing keyword table as the bounded core
+  // clone. `additionalProperties` is handled above because it also creates the
+  // strict-safe record transform. Conditional schemas keep the current
+  // instance path; tuple/item schemas use the array wildcard/index path that
+  // reverse argument restoration understands.
+  for (const singleKey of JSON_SCHEMA_SINGLE_KEYWORDS) {
+    if (singleKey === "additionalProperties") continue;
     const value = sanitized[singleKey];
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      sanitized[singleKey] = sanitizeJsonSchema(value, false, `${path}.${singleKey}`, transforms);
+      const childPath =
+        singleKey === "contains" ||
+        singleKey === "unevaluatedItems" ||
+        singleKey === "additionalItems"
+          ? `${path}.items`
+          : singleKey === "unevaluatedProperties"
+            ? `${path}.*`
+            : path;
+      sanitized[singleKey] = sanitizeJsonSchema(value, false, childPath, transforms);
     }
   }
-  for (const mapKey of ["patternProperties", "$defs", "definitions"] as const) {
+  for (const mapKey of JSON_SCHEMA_MAP_KEYWORDS) {
+    if (mapKey === "properties") continue;
     const value = sanitized[mapKey];
     if (value && typeof value === "object" && !Array.isArray(value)) {
       const walked: Record<string, unknown> = {};
       for (const [key, sub] of Object.entries(value as Record<string, unknown>)) {
-        walked[key] = sanitizeJsonSchema(sub, false, `${path}.${mapKey}.${key}`, transforms);
+        const childPath =
+          mapKey === "dependentSchemas"
+            ? path
+            : mapKey === "patternProperties"
+              ? `${path}.*`
+              : `${path}.${mapKey}.${key}`;
+        walked[key] = sanitizeJsonSchema(sub, false, childPath, transforms);
       }
       sanitized[mapKey] = walked;
     }
+  }
+  for (const mixedMapKey of JSON_SCHEMA_MIXED_MAP_KEYWORDS) {
+    const value = sanitized[mixedMapKey];
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const walked: Record<string, unknown> = {};
+    for (const [key, sub] of Object.entries(value as Record<string, unknown>)) {
+      walked[key] =
+        !sub || typeof sub !== "object" || Array.isArray(sub)
+          ? sub
+          : sanitizeJsonSchema(sub, false, path, transforms);
+    }
+    sanitized[mixedMapKey] = walked;
   }
 
   return sanitized as JSONSchema7;
@@ -2797,6 +2855,13 @@ export const __INTERNAL_normalizeNativeTools = normalizeNativeTools;
 export const __INTERNAL_normalizeNativeToolsForCall = normalizeNativeToolsForCall;
 /** @internal — exported for unit tests only. */
 export const __INTERNAL_restoreRecordArgToolCalls = restoreRecordArgToolCalls;
+/** @internal — exported for schema-keyword parity tests only. */
+export const __INTERNAL_sanitizeSchemaKeywords = {
+  arrays: JSON_SCHEMA_ARRAY_KEYWORDS,
+  maps: JSON_SCHEMA_MAP_KEYWORDS,
+  mixedMaps: JSON_SCHEMA_MIXED_MAP_KEYWORDS,
+  singles: JSON_SCHEMA_SINGLE_KEYWORDS,
+};
 /** @internal — exported for unit tests only. */
 export const __INTERNAL_providerErrorBodyMessage = providerErrorBodyMessage;
 /** @internal — exported for unit tests only. */

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -15,6 +15,7 @@ import {
   assertActiveTrajectoryForLlmCall,
   attestLlmInputSubstring,
   buildCanonicalSystemPrompt,
+  cloneSchemaForBoundedTransport,
   deepToWellFormedUnicode,
   dropDuplicateLeadingSystemMessage,
   ElizaError,
@@ -741,19 +742,19 @@ function normalizeNativeToolsForCall(
           ? functionTool.strict
           : undefined;
     const recordArgTransforms: RecordArgTransform[] = [];
-    // Shaw P1: the production strict Cerebras path used to call
-    // sanitizeJsonSchema (raw Array.isArray / object spread / Object.entries /
-    // .map / unbounded recursion) BEFORE the descriptor-safe walker. An
-    // 8k-deep, cyclic, revoked, or accessor-bearing schema RangeError'd or
-    // leaked a trap there. Run the bounded walk first so sanitization only
-    // ever sees a cloned, budgeted graph. Share the same walker after
-    // sanitization so Cerebras empty-object / oneOf rules still apply to
-    // nodes sanitize introduces.
+    // The production strict Cerebras path used to call sanitizeJsonSchema
+    // (raw Array.isArray / object spread / Object.entries / .map / unbounded
+    // recursion) BEFORE any descriptor-safe walker, so an 8k-deep, cyclic,
+    // revoked, or accessor-bearing schema RangeError'd or leaked a trap
+    // there. The pre-pass is a bounded, descriptor-only STRUCTURAL CLONE, not
+    // Cerebras normalization: running the normalizer here would close every
+    // declared open map with `additionalProperties: false` before
+    // sanitizeJsonSchema could read that declaration and build the
+    // `__eliza_record_entries` reverse transform (#11249). Provider semantics
+    // are applied by the normalizeSchemaForCerebras call after sanitization.
     let rawSchema: unknown = declaredSchema;
     if (options.cerebrasMode) {
-      rawSchema = normalizeSchemaForCerebras(rawSchema, true, {
-        strict: strict !== false,
-      });
+      rawSchema = cloneSchemaForBoundedTransport(rawSchema);
     }
     let inputSchema: JSONSchema7;
     if (strict === false) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #23198. Shaw CHANGES REQUIRED on head
`fb67e32961f8c9b086e9d3bd2bced599ad631fba` (do not merge that head): the
bounded pre-clone walked EVERY object-valued key under a raw-object depth
budget, so legal annotation/extension data (`default`, `examples`,
`const`, `x-*`) was traversed and capped and the pre-pass rejected honest
schemas the live normalizer and sanitizer accept. Same-PR fix on
`fix/hunt-next-18`.
Occupancy-FREE core schema walk plus its plugin-openai caller; not
character-history / agent-export / secret-swap / inMemoryAdapter.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6 (heads through 4854c203), anthropic/claude-opus-5 (this head)
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app (earlier heads), Claude Code (this head)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was rerun on this head; the only failure is the
      unrelated `@elizaos/plugin-maps#typecheck` blocker documented in
      **Known gaps / failures** below.

# Risks

Low. The Cerebras tool path fails closed on cyclic, over-deep, over-wide,
accessor-bearing, or hostile-Proxy JSON Schema graphs before
`sanitizeJsonSchema` touches them, and the pre-pass no longer applies any
provider semantics, so declared open maps keep the `__eliza_record_entries`
reverse mapping they had on origin `develop`. Honest small tool schemas,
shared-ref DAGs, and sparse tuple keywords still behave exactly as before.
No schema or storage migration. Did not edit HARD_SKIP `server.ts`,
plugin-form, catalog ReDoS, wait-for-url, secret-swap, inMemoryAdapter,
character-history, or agent-export.

# Background

## What does this PR do?

`packages/core/src/runtime/schema-compat.ts` `normalizeSchemaForCerebras` is
the live Cerebras tool-schema walk used by `plugins/plugin-openai/models/text.ts`
`normalizeNativeToolsForCall` before a planner/chat hop. On origin `develop`
it recursed with `Object.entries` and no depth/cycle cap, so a cyclic `not`
graph RangeError'd and an 8k-deep `properties` nest that `JSON.parse` already
accepted then stack-overflowed the walk.

Earlier heads bounded depth/node/cycle/accessor reads with typed
`CEREBRAS_SCHEMA_UNBOUNDED`, moved every `Array.isArray` / `getPrototypeOf` /
array-length read inside `inspectSchema`, made cycle detection path-local so
honest DAGs pass, reserved width before allocation, and moved the bounded pass
in front of `sanitizeJsonSchema` so the raw-spread sanitizer can never see an
unbounded or hostile graph.

This head fixes the compatibility defect Shaw found in that ordering. The
pre-pass is now `cloneSchemaForBoundedTransport`: the same descriptor-only
reflection, path-local cycle detection, width-reserved clone, aggregate node
budget and typed failures, but zero Cerebras semantics. Running the full
normalizer there overwrote every declared `additionalProperties` (`true` or
schema-valued) with `false`, and `sanitizeJsonSchema` only builds
`__eliza_record_entries` plus a `RecordArgTransform` when
`additionalProperties !== false` — so a tool such as
`{ customFields: { type: "object", additionalProperties: { type: "string" } } }`
reached the wire as a closed empty object with no entries field and no reverse
mapping. Sanitization now sees a plain, budgeted graph with declared semantics
intact; `normalizeSchemaForCerebras` applies provider closure afterwards, as
on origin `develop`.

This head fixes the compatibility defect Shaw found in that clone. The clone
now mirrors `walkSchemaChildren` exactly — same keyword tables
(`SCHEMA_MAP_KEYS` / `SCHEMA_ARRAY_KEYS` / `SCHEMA_SINGLE_KEYS` / `items` /
`dependencies`), same guards, same depth accounting, same aggregate node budget
and path-local cycle detection — and never descends into annotation or
extension data, which is legal arbitrary JSON that neither the normalizer nor
`sanitizeJsonSchema` walks. Those values ride across in the immutable
descriptor snapshot, so no accessor runs and nothing is capped. Depth is now
counted in schema levels, so `MAX_CEREBRAS_SCHEMA_CLONE_DEPTH` is gone and the
pre-pass reports the same `MAX_CEREBRAS_SCHEMA_WALK_DEPTH` budget as the
normalizer. The clone still covers a superset of the keywords
`sanitizeJsonSchema` recurses into, so the sanitizer's raw
spread / `Object.entries` / `.map` recursion stays bounded.

The same pass collapses the remaining doubled descriptor reads: `ownDataEntries`
takes one immutable `{key, value}` snapshot per node and `cloneOwnData`,
`mapSchemaRecord`, `dependencies`, and the clone all consume it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

See #23198 and Shaw's reviews on #23159. Cerebras mode must fail closed with a
typed cause instead of a `RangeError`/raw `TypeError`, must not change honest
programmatic DAG schemas, and must not silently collapse declared open maps
(#11249).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/models/text.ts` `normalizeNativeToolsForCall` (the real
caller ordering), then `packages/core/src/runtime/schema-compat.ts`
`cloneSchemaForBoundedTransport`, then
`plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts`
and `packages/core/src/runtime/__tests__/schema-compat.walk-bound.test.ts`.

## Detailed testing steps

```
cd packages/core && bun run vitest run \
  src/runtime/__tests__/schema-compat.walk-bound.test.ts \
  src/runtime/__tests__/schema-compat.test.ts
cd plugins/plugin-openai && bun run vitest run \
  __tests__/cerebras-native-tools-walk-bound.shape.test.ts \
  __tests__/sanitize-json-schema.shape.test.ts \
  __tests__/record-args-observability.shape.test.ts \
  __tests__/cerebras-tool-strictness.shape.test.ts \
  __tests__/cerebras-forced-toolchoice.shape.test.ts \
  __tests__/native-plumbing.shape.test.ts \
  __tests__/wire-well-formed.shape.test.ts \
  __tests__/text-wire-contract-lane.shape.test.ts
bun run --cwd packages/core typecheck
bun run --cwd plugins/plugin-openai typecheck
bun run verify
```

Executed proof of the reported defect, run against the reviewed `fb67e329`
module before the fix:

```
let annotation = { leaf: true };
for (let i = 0; i < MAX_CEREBRAS_SCHEMA_CLONE_DEPTH + 1; i++) annotation = { nested: annotation };
const schema = { type: "object", properties: {}, default: annotation };
-> {"normalize":"accepted","clone":{"threw":"CEREBRAS_SCHEMA_UNBOUNDED",
    "context":{"depth":129,"max":128,"clone":true}}}
```

The same probe on this head returns `{"normalize":"accepted","clone":"accepted"}`,
and the parity table in the core suite asserts identical accept/reject for the
repro, 20k-deep `default` / `examples` / `x-*` / `const`, cyclic annotations,
cyclic schema keywords, and both sides of the depth boundary.

The earlier open-map defect proof still holds: reverting only
`plugins/plugin-openai/models/text.ts` to the `4854c203` ordering fails the four
open-map tests (4 failed / 13 skipped).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:414df2036fc0feaf856d9a5d66232bb0a480c18d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; core schema walk plus its provider caller only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; core schema walk plus its provider caller only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop; the provider client is mocked and asserted never called.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live provider call; `generateText` is mocked and the tests assert
      both zero dispatch on rejection and the exact wire schema on success.

<!-- evidence-row:domain-artifacts -->
- [x] Focused unit + production-boundary proof at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head 0330f6b0fbfc97e827263f85c8c4cf2d24f495f0
onto origin/develop f19633d775879b8017fda8bd8b8524229e6555a2

cd packages/core && bun run vitest run \
  src/runtime/__tests__/schema-compat.walk-bound.test.ts \
  src/runtime/__tests__/schema-compat.test.ts
  Test Files  2 passed (2)
  Tests  47 passed (47)

cd plugins/plugin-openai && bun run vitest run \
  __tests__/cerebras-native-tools-walk-bound.shape.test.ts \
  __tests__/sanitize-json-schema.shape.test.ts \
  __tests__/record-args-observability.shape.test.ts \
  __tests__/cerebras-tool-strictness.shape.test.ts \
  __tests__/cerebras-forced-toolchoice.shape.test.ts \
  __tests__/native-plumbing.shape.test.ts \
  __tests__/wire-well-formed.shape.test.ts \
  __tests__/text-wire-contract-lane.shape.test.ts
  Test Files  8 passed (8)
  Tests  168 passed (168)

bun run --cwd packages/core typecheck          exit 0
bun run --cwd plugins/plugin-openai typecheck  exit 0
bunx @biomejs/biome check <4 touched files>    exit 0

bun run verify                                 6m18s (this head)
  Tasks: 249 successful, 358 total
  Failed: @elizaos/plugin-maps#typecheck
    test/scenarios/maps.share-coordinate.scenario.ts(10,8): error TS2307
    Cannot find module '@elizaos/scenario-runner/scenario-assertions'
    (packages/scenario-runner/dist is not built in this tree; unrelated)
  prior run at fb67e329: 21m01s, 259 successful, failed
    @elizaos/shared#typecheck sandbox-registry.test.ts(177,24) TS2769
    (also unrelated; last touched by 4e656c361b4f, an ancestor of the base)

new coverage at this head
  core cloneSchemaForBoundedTransport: declared open maps preserved verbatim
    (additionalProperties true and schema-valued), oneOf untouched, non-object
    root passed through, deep clone (caller schema never mutated), array holes
    preserved (1 in arr === false) with explicit undefined kept, cycle,
    depth budget, sparse width reserved before allocation, accessor,
    revoked Proxy (cause TypeError), zero get/has/prototype traps
  plugin-openai real caller normalizeNativeToolsForCall / handleTextSmall:
    schema-valued open map emits __eliza_record_entries and records
    {path:"$.customFields", entriesKey:"__eliza_record_entries", valueMode:"schema"};
    additionalProperties:true records valueMode:"json-string";
    restoreRecordArgToolCalls maps entries back to {team:"core",tier:"gold"};
    handleTextSmall carries the entries field into the generateText request;
    cycle / 8k depth / getter / revoked Proxy / over-wide still typed
    CEREBRAS_SCHEMA_UNBOUNDED with generateText never called

defect proof at the reviewed head
  git checkout -- plugins/plugin-openai/models/text.ts   (back to 4854c203 ordering)
  bun run vitest run __tests__/cerebras-native-tools-walk-bound.shape.test.ts -t "open-map"
  Tests  4 failed | 13 skipped (17)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no live provider call is made or changed. The regressions mock the `ai`
SDK and assert both that `generateText` is never reached on a rejected schema
and that the tool payload handed to it keeps the declared open map.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; the focused package suites
and the production-boundary suite are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Maintainer wire-boundary repair (exact `0330f6b0fbfc97e827263f85c8c4cf2d24f495f0`)

- Rebased the contributor series onto `develop` `8737a653e34ff0f5d3a39e591c30cbf4848a9ae2`.
- `deepToWellFormedUnicode` now rejects enumerable accessors without invocation and translates revoked/hostile reflection into typed `WELL_FORMED_UNSAFE_VALUE` failures with preserved causes. Cycles, depth, and visit overflow retain typed `WELL_FORMED_UNBOUNDED`.
- Real `normalizeNativeToolsForCall` coverage proves legal annotation values remain opaque through the schema pre-pass; real `handleTextSmall` coverage proves getter, revoked Proxy, cycle, and over-depth annotation values reject with zero `generateText`/`streamText` dispatch.
- Pinned Bun 1.3.14: core focused 73/73; plugin-openai real-path focused 25/25; core and plugin-openai typecheck clean; core and plugin-openai builds clean; six touched files Biome clean; `git diff --check` clean.

## Maintainer sanitizer-keyword parity repair (exact `e8210d7cd101e7a95badcc7dfb2ee284c7be66d8`)

- Rebased the complete contributor/maintainer series onto `develop` `9edb8e24017b4675669e79ea6560b38a19aa8ec5`.
- Core now exports the canonical schema array/map/mixed-map/single keyword tables and the OpenAI sanitizer consumes those exact tables, covering `prefixItems`, `dependentSchemas`, `dependencies`, `additionalProperties`, `unevaluated*`, `contentSchema`, and `additionalItems`.
- Record-argument reverse mapping now keeps conditional instance paths, targets the exact tuple slot for `prefixItems`, and supports wildcard values nested under schema-valued `additionalProperties`.
- Real `normalizeNativeToolsForCall` plus `restoreRecordArgToolCalls` regressions cover `dependentSchemas`, two distinct `prefixItems` slots, nested `additionalProperties`, and canonical-table parity.
- Pinned Bun 1.3.14 exact-head receipts: core focused 47/47; plugin-openai 8-file production lane 176/176; core and plugin-openai typecheck clean; touched Biome and `git diff --check` clean. Pre-rebase source-identical builds: core runtime/browser/edge/testing plus declarations and packed consumers clean; plugin-openai node/browser/declarations clean.

## Final freshness rebase (exact `414df2036fc0feaf856d9a5d66232bb0a480c18d`)

- Rebased without conflicts onto `origin/develop@3eab135f4e9498d1d84c4931f39bac87b966cd51`.
- The complete binary patch and all six changed source/test blobs are byte-identical to independently reviewed `e8210d7cd101e7a95badcc7dfb2ee284c7be66d8`; `cmp` of pre/post-rebase binary diffs and `git diff --check` both exit 0.
- No behavior changed after the independent source review; the prior exact-source focused/type/build/Biome receipts remain applicable. Final exact-head acceptance requires only the independent base/delta freshness confirmation.

## Known gaps / failures

- `bun run verify` does not reach a clean exit in this local tree, and both
  failures observed are outside this PR's diff (which is confined to
  `packages/core/src/runtime/schema-compat.ts` + its test and
  `plugins/plugin-openai` text.ts + its test):
  - this head: `@elizaos/plugin-maps#typecheck`,
    `test/scenarios/maps.share-coordinate.scenario.ts(10,8): error TS2307`
    ("Cannot find module '@elizaos/scenario-runner/scenario-assertions'") —
    `packages/scenario-runner/dist` is not built in this checkout, so the
    subpath export cannot resolve. A local build-artifact ordering issue.
  - previous head `fb67e329`: `@elizaos/shared#typecheck`,
    `packages/shared/src/sandbox-registry.test.ts(177,24): error TS2769`. That
    file is untouched here and was last changed by `4e656c361b4f`, already an
    ancestor of this PR's base `f19633d775`.
  Both touched packages typecheck and lint clean on their own
  (`bun run --cwd packages/core typecheck`,
  `bun run --cwd plugins/plugin-openai typecheck`, biome check: all exit 0).
- No live Cerebras API call: the fork has no Cerebras credential in this
  environment, so provider behavior is proven against the mocked `ai` SDK at the
  real `normalizeNativeToolsForCall` / `handleTextSmall` boundary rather than on
  the wire.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is
  inline.
- Hosted checks: `gh pr checks 23159` reports "no checks reported on the
  `fix/hunt-next-18` branch" at this head — fork pull requests need a maintainer
  to approve the workflow run before any hosted job starts. The transcript above
  is the local run; happy to re-post hosted results once the workflows are
  approved.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-only]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-eliza"} -->
