### PR TITLE
feat(integrations): add native Notion and Dropbox plugin adapters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1731,6 +1731,21 @@
         "react-dom": "^19.0.0",
       },
     },
+    "plugins/plugin-dropbox": {
+      "name": "@elizaos/plugin-dropbox",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-google-workspace": "workspace:*",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.8",
+        "@types/node": "^25.6.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10",
+      },
+    },
     "plugins/plugin-elizacloud": {
       "name": "@elizaos/plugin-elizacloud",
       "version": "2.0.3-beta.7",
@@ -2708,6 +2723,21 @@
       },
       "peerDependencies": {
         "react-dom": "^19.0.0",
+      },
+    },
+    "plugins/plugin-notion": {
+      "name": "@elizaos/plugin-notion",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-google-workspace": "workspace:*",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.8",
+        "@types/node": "^25.6.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10",
       },
     },
     "plugins/plugin-openai": {
@@ -4094,6 +4124,8 @@
 
     "@elizaos/plugin-documents": ["@elizaos/plugin-documents@workspace:plugins/plugin-documents"],
 
+    "@elizaos/plugin-dropbox": ["@elizaos/plugin-dropbox@workspace:plugins/plugin-dropbox"],
+
     "@elizaos/plugin-elizacloud": ["@elizaos/plugin-elizacloud@workspace:plugins/plugin-elizacloud"],
 
     "@elizaos/plugin-embeddings": ["@elizaos/plugin-embeddings@workspace:plugins/plugin-embeddings"],
@@ -4143,6 +4175,8 @@
     "@elizaos/plugin-native-settings": ["@elizaos/plugin-native-settings@workspace:plugins/plugin-native-settings"],
 
     "@elizaos/plugin-notes": ["@elizaos/plugin-notes@workspace:plugins/plugin-notes"],
+
+    "@elizaos/plugin-notion": ["@elizaos/plugin-notion@workspace:plugins/plugin-notion"],
 
     "@elizaos/plugin-openai": ["@elizaos/plugin-openai@workspace:plugins/plugin-openai"],
 

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -1509,6 +1509,86 @@
       }
     },
     {
+      "id": "dropbox",
+      "name": "Dropbox",
+      "description": "Dropbox connector for file listing, search, text reads, uploads, temporary links, and citation deep links. Uses PKCE offline OAuth; local mode accepts a generated access token.",
+      "npmName": "@elizaos/plugin-dropbox",
+      "version": "2.0.0-beta.0",
+      "source": "bundled",
+      "tags": [
+        "dropbox",
+        "files",
+        "storage",
+        "documents",
+        "connector",
+        "productivity"
+      ],
+      "config": {
+        "DROPBOX_CLIENT_ID": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "App Key",
+          "help": "Dropbox app key (OAuth client ID). Not needed when using Eliza Cloud OAuth.",
+          "advanced": true
+        },
+        "DROPBOX_CLIENT_SECRET": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "App Secret",
+          "help": "Dropbox app secret (OAuth client secret). Not needed when using Eliza Cloud OAuth.",
+          "advanced": true
+        },
+        "DROPBOX_REDIRECT_URI": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "OAuth Redirect URI",
+          "help": "Redirect URI registered on the Dropbox app.",
+          "advanced": true
+        },
+        "DROPBOX_ACCESS_TOKEN": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "Access Token",
+          "help": "Local BYO access token for self-hosted mode. Short-lived tokens without a refresh token stop working when they expire.",
+          "advanced": false
+        }
+      },
+      "render": {
+        "visible": true,
+        "pinTo": [],
+        "style": "setup-panel",
+        "icon": "FolderOpen",
+        "group": "connector",
+        "groupOrder": 1,
+        "actions": ["enable", "configure", "setup-guide"]
+      },
+      "resources": {
+        "homepage": "https://github.com/elizaOS/eliza/tree/develop/plugins/plugin-dropbox#readme",
+        "repository": "https://github.com/elizaOS/eliza"
+      },
+      "dependsOn": [],
+      "channels": [],
+      "shortIds": [],
+      "kind": "connector",
+      "subtype": "other",
+      "auth": {
+        "kind": "oauth",
+        "credentialKeys": ["DROPBOX_ACCESS_TOKEN"]
+      },
+      "accounts": {
+        "owner": {
+          "supported": true,
+          "authKind": "oauth-cloud",
+          "credentialKeys": [],
+          "notes": "The user's Dropbox account, connected via PKCE offline OAuth with read scopes by default and an explicit write-scope escalation."
+        }
+      }
+    },
+    {
       "id": "elizacloud",
       "name": "Elizacloud",
       "description": "elizaOS plugin to connect with elizaOS Cloud services",
@@ -3850,6 +3930,79 @@
       "auth": {
         "kind": "token",
         "credentialKeys": []
+      }
+    },
+    {
+      "id": "notion",
+      "name": "Notion",
+      "description": "Notion connector for workspace search, page reads with citation deep links, page creation, and appends. Uses workspace-bound OAuth; local mode accepts an internal integration token.",
+      "npmName": "@elizaos/plugin-notion",
+      "version": "2.0.0-beta.0",
+      "source": "bundled",
+      "tags": ["notion", "notes", "documents", "connector", "productivity"],
+      "config": {
+        "NOTION_CLIENT_ID": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "OAuth Client ID",
+          "help": "Notion public-integration OAuth client ID. Not needed when using Eliza Cloud OAuth.",
+          "advanced": true
+        },
+        "NOTION_CLIENT_SECRET": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "OAuth Client Secret",
+          "help": "Notion public-integration OAuth client secret. Not needed when using Eliza Cloud OAuth.",
+          "advanced": true
+        },
+        "NOTION_REDIRECT_URI": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "OAuth Redirect URI",
+          "help": "Redirect URI registered on the Notion integration.",
+          "advanced": true
+        },
+        "NOTION_TOKEN": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "Internal Integration Token",
+          "help": "Local BYO internal-integration token for self-hosted mode. The integration only sees pages shared with it.",
+          "advanced": false
+        }
+      },
+      "render": {
+        "visible": true,
+        "pinTo": [],
+        "style": "setup-panel",
+        "icon": "FileText",
+        "group": "connector",
+        "groupOrder": 1,
+        "actions": ["enable", "configure", "setup-guide"]
+      },
+      "resources": {
+        "homepage": "https://github.com/elizaOS/eliza/tree/develop/plugins/plugin-notion#readme",
+        "repository": "https://github.com/elizaOS/eliza"
+      },
+      "dependsOn": [],
+      "channels": [],
+      "shortIds": [],
+      "kind": "connector",
+      "subtype": "other",
+      "auth": {
+        "kind": "oauth",
+        "credentialKeys": ["NOTION_TOKEN"]
+      },
+      "accounts": {
+        "owner": {
+          "supported": true,
+          "authKind": "oauth-cloud",
+          "credentialKeys": [],
+          "notes": "The user's Notion workspace, connected via OAuth. The grant is scoped to exactly the pages and databases the user shares with the connection inside Notion's consent UI."
+        }
       }
     },
     {

--- a/plugins/plugin-dropbox/AGENTS.md
+++ b/plugins/plugin-dropbox/AGENTS.md
@@ -1,0 +1,56 @@
+# @elizaos/plugin-dropbox
+
+Native Dropbox provider adapter. Projects a connected Dropbox account into the
+files/documents capabilities: folder listing, search, text-file reads, uploads,
+and deep links. Registers `DropboxService` (`runtime.getService("dropbox")`)
+and a ConnectorAccountManager provider for the PKCE offline OAuth flow. No MCP
+runtime is involved; this plugin speaks the Dropbox API v2 directly over fetch.
+
+## Architecture
+
+- `src/client.ts` — fetch-based API v2 client. RPC endpoints go to the api
+  host; `download`/`upload` go to the content host with `Dropbox-API-Arg`
+  headers (non-ASCII escaped). All upstream failures become typed
+  `ElizaError`s (`DROPBOX_AUTH_EXPIRED`, `DROPBOX_RATE_LIMITED`,
+  `DROPBOX_NOT_FOUND`, `DROPBOX_MALFORMED_RESPONSE`,
+  `DROPBOX_UPSTREAM_FAILURE`, `DROPBOX_INVALID_REQUEST`). File limitation UX:
+  `downloadText` refuses binary (`DROPBOX_FILE_NOT_TEXT`) and oversized
+  (`DROPBOX_FILE_TOO_LARGE`) files instead of returning garbage — callers
+  offer `getTemporaryLink` instead. `ELIZA_MOCK_DROPBOX_BASE` /
+  `ELIZA_MOCK_DROPBOX_CONTENT_BASE` override base URLs for protocol-faithful
+  mock servers.
+- `src/credential-resolver.ts` — account → live bearer token. Order: BYO
+  `DROPBOX_ACCESS_TOKEN` setting (local mode, account id `default`/`local`),
+  then metadata credential refs, storage records, vault refs. Dropbox access
+  tokens are short-lived: the resolver runs the OAuth refresh grant when the
+  stored expiry is within the skew window and caches the refreshed token in
+  memory. A rejected refresh surfaces as `DROPBOX_AUTH_EXPIRED`.
+- `src/connector-account-provider.ts` — PKCE `token_access_type=offline`
+  OAuth. Default scopes are the read set (`account_info.read`,
+  `files.metadata.read`, `files.content.read`) plus the explicit write
+  escalation pair (`files.metadata.write`, `files.content.write`); callers may
+  narrow via `scopes`, and unrecognized or empty selections fail closed.
+  Token sets are persisted as durable credential refs via the shared
+  `persistConnectorCredentialRefs` helper
+  (`@elizaos/plugin-google-workspace/connector-credential-refs`) — never in
+  account metadata.
+- `src/service.ts` / `src/index.ts` — `DropboxService` and the plugin entry.
+
+## Invariants
+
+- Every entry carries a deterministic `dropbox.com` deep link (folder browse
+  or file preview) for citations.
+- List/search/read is the default posture; `upload` is the explicit write
+  surface, `mode: "add"` by default so accidental overwrites fail.
+- Tokens never appear in account metadata, logs, or error contexts.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-dropbox test
+bun run --cwd plugins/plugin-dropbox typecheck
+bun run --cwd plugins/plugin-dropbox lint:check
+```
+
+Tests use deterministic protocol-faithful fakes (request handlers serving real
+wire shapes), not mocks of the client under test.

--- a/plugins/plugin-dropbox/CLAUDE.md
+++ b/plugins/plugin-dropbox/CLAUDE.md
@@ -1,0 +1,56 @@
+# @elizaos/plugin-dropbox
+
+Native Dropbox provider adapter. Projects a connected Dropbox account into the
+files/documents capabilities: folder listing, search, text-file reads, uploads,
+and deep links. Registers `DropboxService` (`runtime.getService("dropbox")`)
+and a ConnectorAccountManager provider for the PKCE offline OAuth flow. No MCP
+runtime is involved; this plugin speaks the Dropbox API v2 directly over fetch.
+
+## Architecture
+
+- `src/client.ts` — fetch-based API v2 client. RPC endpoints go to the api
+  host; `download`/`upload` go to the content host with `Dropbox-API-Arg`
+  headers (non-ASCII escaped). All upstream failures become typed
+  `ElizaError`s (`DROPBOX_AUTH_EXPIRED`, `DROPBOX_RATE_LIMITED`,
+  `DROPBOX_NOT_FOUND`, `DROPBOX_MALFORMED_RESPONSE`,
+  `DROPBOX_UPSTREAM_FAILURE`, `DROPBOX_INVALID_REQUEST`). File limitation UX:
+  `downloadText` refuses binary (`DROPBOX_FILE_NOT_TEXT`) and oversized
+  (`DROPBOX_FILE_TOO_LARGE`) files instead of returning garbage — callers
+  offer `getTemporaryLink` instead. `ELIZA_MOCK_DROPBOX_BASE` /
+  `ELIZA_MOCK_DROPBOX_CONTENT_BASE` override base URLs for protocol-faithful
+  mock servers.
+- `src/credential-resolver.ts` — account → live bearer token. Order: BYO
+  `DROPBOX_ACCESS_TOKEN` setting (local mode, account id `default`/`local`),
+  then metadata credential refs, storage records, vault refs. Dropbox access
+  tokens are short-lived: the resolver runs the OAuth refresh grant when the
+  stored expiry is within the skew window and caches the refreshed token in
+  memory. A rejected refresh surfaces as `DROPBOX_AUTH_EXPIRED`.
+- `src/connector-account-provider.ts` — PKCE `token_access_type=offline`
+  OAuth. Default scopes are the read set (`account_info.read`,
+  `files.metadata.read`, `files.content.read`) plus the explicit write
+  escalation pair (`files.metadata.write`, `files.content.write`); callers may
+  narrow via `scopes`, and unrecognized or empty selections fail closed.
+  Token sets are persisted as durable credential refs via the shared
+  `persistConnectorCredentialRefs` helper
+  (`@elizaos/plugin-google-workspace/connector-credential-refs`) — never in
+  account metadata.
+- `src/service.ts` / `src/index.ts` — `DropboxService` and the plugin entry.
+
+## Invariants
+
+- Every entry carries a deterministic `dropbox.com` deep link (folder browse
+  or file preview) for citations.
+- List/search/read is the default posture; `upload` is the explicit write
+  surface, `mode: "add"` by default so accidental overwrites fail.
+- Tokens never appear in account metadata, logs, or error contexts.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-dropbox test
+bun run --cwd plugins/plugin-dropbox typecheck
+bun run --cwd plugins/plugin-dropbox lint:check
+```
+
+Tests use deterministic protocol-faithful fakes (request handlers serving real
+wire shapes), not mocks of the client under test.

--- a/plugins/plugin-dropbox/README.md
+++ b/plugins/plugin-dropbox/README.md
@@ -1,0 +1,30 @@
+# @elizaos/plugin-dropbox
+
+Native Dropbox adapter for elizaOS agents: folder listing, search, text reads,
+uploads, temporary links, and citation deep links — no MCP runtime required.
+
+## Usage
+
+```ts
+import { dropboxPlugin, DropboxService } from "@elizaos/plugin-dropbox";
+
+const dropbox = runtime.getService<DropboxService>("dropbox");
+const page = await dropbox.search({ accountId: "default", query: "invoice" });
+```
+
+## Configuration
+
+Managed mode (Cloud OAuth or self-hosted app):
+
+- `DROPBOX_CLIENT_ID`, `DROPBOX_CLIENT_SECRET`, `DROPBOX_REDIRECT_URI` — the
+  app registered at https://www.dropbox.com/developers/apps with scoped access
+  (`account_info.read`, `files.metadata.read/write`,
+  `files.content.read/write`) and the redirect URI registered.
+
+Local/self-hosted BYO mode:
+
+- `DROPBOX_ACCESS_TOKEN` — a generated access token; used for account id
+  `default`. Short-lived tokens without a refresh token stop working when they
+  expire.
+
+See `CLAUDE.md` for architecture, error codes, and validation commands.

--- a/plugins/plugin-dropbox/biome.json
+++ b/plugins/plugin-dropbox/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "root": false,
+  "files": {
+    "includes": ["src/**", "__tests__/**", "build.ts", "vitest.config.ts"]
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "style": {},
+      "complexity": {
+        "noCommaOperator": "off",
+        "useLiteralKeys": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentWidth": 2,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  }
+}

--- a/plugins/plugin-dropbox/build.ts
+++ b/plugins/plugin-dropbox/build.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-dropbox. tsc-only (non-bundled) plugin: the
+ * shared driver cleans dist then runs `tsc --project tsconfig.json --noCheck`
+ * via the empty-targets path.
+ */
+import { buildPlugin } from "../plugin-build";
+
+await buildPlugin({
+  name: "@elizaos/plugin-dropbox",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
+});

--- a/plugins/plugin-dropbox/package.json
+++ b/plugins/plugin-dropbox/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "@elizaos/plugin-dropbox",
+  "version": "2.0.3-beta.7",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": ["registry-entry.json", "dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build.ts",
+    "test": "vitest run",
+    "test:watch": "vitest --config vitest.config.ts",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-google-workspace": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.8",
+    "@types/node": "^25.6.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "eliza": {
+    "platforms": ["node"],
+    "runtime": "node"
+  },
+  "agentConfig": {
+    "pluginParameters": {
+      "DROPBOX_CLIENT_ID": {
+        "type": "string",
+        "description": "Dropbox app key (OAuth client ID)",
+        "required": false,
+        "sensitive": false
+      },
+      "DROPBOX_CLIENT_SECRET": {
+        "type": "string",
+        "description": "Dropbox app secret (OAuth client secret)",
+        "required": false,
+        "sensitive": true
+      },
+      "DROPBOX_REDIRECT_URI": {
+        "type": "string",
+        "description": "Dropbox OAuth redirect URI registered on the app",
+        "required": false,
+        "sensitive": false
+      },
+      "DROPBOX_ACCESS_TOKEN": {
+        "type": "string",
+        "description": "Local BYO access token (self-hosted mode)",
+        "required": false,
+        "sensitive": true
+      }
+    }
+  }
+}

--- a/plugins/plugin-dropbox/registry-entry.json
+++ b/plugins/plugin-dropbox/registry-entry.json
@@ -1,0 +1,84 @@
+{
+  "id": "dropbox",
+  "name": "Dropbox",
+  "description": "Dropbox connector for file listing, search, text reads, uploads, temporary links, and citation deep links. Uses PKCE offline OAuth; local mode accepts a generated access token.",
+  "npmName": "@elizaos/plugin-dropbox",
+  "version": "2.0.0-beta.0",
+  "source": "bundled",
+  "tags": [
+    "dropbox",
+    "files",
+    "storage",
+    "documents",
+    "connector",
+    "productivity"
+  ],
+  "config": {
+    "DROPBOX_CLIENT_ID": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "App Key",
+      "help": "Dropbox app key (OAuth client ID). Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "DROPBOX_CLIENT_SECRET": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "App Secret",
+      "help": "Dropbox app secret (OAuth client secret). Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "DROPBOX_REDIRECT_URI": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "OAuth Redirect URI",
+      "help": "Redirect URI registered on the Dropbox app.",
+      "advanced": true
+    },
+    "DROPBOX_ACCESS_TOKEN": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "Access Token",
+      "help": "Local BYO access token for self-hosted mode. Short-lived tokens without a refresh token stop working when they expire.",
+      "advanced": false
+    }
+  },
+  "render": {
+    "visible": true,
+    "pinTo": [],
+    "style": "setup-panel",
+    "icon": "FolderOpen",
+    "group": "connector",
+    "groupOrder": 1,
+    "actions": [
+      "enable",
+      "configure",
+      "setup-guide"
+    ]
+  },
+  "resources": {
+    "homepage": "https://github.com/elizaOS/eliza/tree/develop/plugins/plugin-dropbox#readme",
+    "repository": "https://github.com/elizaOS/eliza"
+  },
+  "dependsOn": [],
+  "kind": "connector",
+  "subtype": "other",
+  "auth": {
+    "kind": "oauth",
+    "credentialKeys": [
+      "DROPBOX_ACCESS_TOKEN"
+    ]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The user's Dropbox account, connected via PKCE offline OAuth with read scopes by default and an explicit write-scope escalation."
+    }
+  }
+}

--- a/plugins/plugin-dropbox/src/__tests__/client.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/client.test.ts
@@ -1,0 +1,319 @@
+/**
+ * DropboxClient contract tests against a deterministic, protocol-faithful fake
+ * Dropbox API v2 (real RPC/content wire shapes served through an injected
+ * fetch). Covers success, designed-empty, cursor pagination
+ * (list_folder/continue and search/continue_v2), expired auth, rate limiting,
+ * 409 path errors, malformed upstream data, upstream failure, the text-read
+ * limitation UX (binary and oversized refusals), uploads, and deep links.
+ */
+import type { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  DROPBOX_MAX_TEXT_BYTES,
+  DropboxClient,
+  dropboxApiArg,
+  dropboxDeepLink,
+} from "../client.js";
+import type { DropboxCredentialResolver } from "../types.js";
+
+const resolver: DropboxCredentialResolver = {
+  getCredential: async () => ({ accessToken: "sl.test_token" }),
+};
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+  rawBody: BodyInit | null | undefined;
+}
+
+function fakeDropbox(
+  handler: (request: RecordedRequest) => {
+    status: number;
+    body: unknown;
+    headers?: Record<string, string>;
+    raw?: BodyInit;
+  }
+): { fetchImpl: typeof fetch; requests: RecordedRequest[] } {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const headers = Object.fromEntries(
+      Object.entries((init?.headers as Record<string, string>) ?? {}).map(([k, v]) => [
+        k.toLowerCase(),
+        v,
+      ])
+    );
+    const request: RecordedRequest = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers,
+      body:
+        typeof init?.body === "string" && headers["content-type"]?.includes("json")
+          ? JSON.parse(init.body)
+          : undefined,
+      rawBody: init?.body,
+    };
+    requests.push(request);
+    const result = handler(request);
+    if (result.raw !== undefined) {
+      return new Response(result.raw, { status: result.status, headers: result.headers });
+    }
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { "Content-Type": "application/json", ...result.headers },
+    });
+  };
+  return { fetchImpl, requests };
+}
+
+function fileEntry(name: string, path: string, extra: Record<string, unknown> = {}) {
+  return {
+    ".tag": "file",
+    id: `id:${name}`,
+    name,
+    path_lower: path.toLowerCase(),
+    path_display: path,
+    size: 128,
+    client_modified: "2026-08-01T00:00:00Z",
+    server_modified: "2026-08-02T00:00:00Z",
+    content_hash: "abc123",
+    ...extra,
+  };
+}
+
+function client(fetchImpl: typeof fetch): DropboxClient {
+  return new DropboxClient(resolver, {
+    apiBaseUrl: "https://api.dropbox.test",
+    contentBaseUrl: "https://content.dropbox.test",
+    fetchImpl,
+  });
+}
+
+describe("DropboxClient.listFolder", () => {
+  it("lists a folder with bearer auth and maps entries with deep links", async () => {
+    const { fetchImpl, requests } = fakeDropbox(() => ({
+      status: 200,
+      body: {
+        entries: [
+          fileEntry("q3.pdf", "/Reports/q3.pdf"),
+          {
+            ".tag": "folder",
+            id: "id:folder",
+            name: "Archive",
+            path_lower: "/reports/archive",
+            path_display: "/Reports/Archive",
+          },
+        ],
+        cursor: "cursor-a",
+        has_more: false,
+      },
+    }));
+    const page = await client(fetchImpl).listFolder({ accountId: "acct", path: "/Reports" });
+    expect(requests[0].url).toBe("https://api.dropbox.test/2/files/list_folder");
+    expect(requests[0].headers.authorization).toBe("Bearer sl.test_token");
+    expect((requests[0].body as { path: string }).path).toBe("/Reports");
+    expect(page.entries).toHaveLength(2);
+    expect(page.entries[0].kind).toBe("file");
+    expect(page.entries[0].url).toBe("https://www.dropbox.com/home/Reports?preview=q3.pdf");
+    expect(page.entries[1].kind).toBe("folder");
+    expect(page.entries[1].url).toBe("https://www.dropbox.com/home/Reports/Archive");
+  });
+
+  it("continues with the cursor endpoint when a cursor is supplied", async () => {
+    const { fetchImpl, requests } = fakeDropbox(() => ({
+      status: 200,
+      body: { entries: [], cursor: null, has_more: false },
+    }));
+    const page = await client(fetchImpl).listFolder({ accountId: "acct", cursor: "cursor-a" });
+    expect(requests[0].url).toBe("https://api.dropbox.test/2/files/list_folder/continue");
+    expect((requests[0].body as { cursor: string }).cursor).toBe("cursor-a");
+    expect(page.entries).toEqual([]);
+  });
+
+  it("maps 401 to DROPBOX_AUTH_EXPIRED even with a non-JSON body", async () => {
+    const { fetchImpl } = fakeDropbox(() => ({
+      status: 401,
+      raw: "Error in call to API function: invalid access token",
+    }));
+    const error = await client(fetchImpl)
+      .listFolder({ accountId: "acct" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_AUTH_EXPIRED");
+  });
+
+  it("maps 429 with a retry_after body to DROPBOX_RATE_LIMITED", async () => {
+    const { fetchImpl } = fakeDropbox(() => ({
+      status: 429,
+      body: {
+        error_summary: "too_many_requests/",
+        error: { reason: { ".tag": "too_many_requests" }, retry_after: 30 },
+      },
+    }));
+    const error = await client(fetchImpl)
+      .listFolder({ accountId: "acct" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_RATE_LIMITED");
+    expect((error as ElizaError).context?.retryAfterSeconds).toBe(30);
+  });
+
+  it("maps a 409 path not_found to DROPBOX_NOT_FOUND", async () => {
+    const { fetchImpl } = fakeDropbox(() => ({
+      status: 409,
+      body: {
+        error_summary: "path/not_found/..",
+        error: { ".tag": "path", path: { ".tag": "not_found" } },
+      },
+    }));
+    const error = await client(fetchImpl)
+      .getMetadata({ accountId: "acct", path: "/missing" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_NOT_FOUND");
+  });
+
+  it("maps 5xx to DROPBOX_UPSTREAM_FAILURE and rejects malformed success bodies", async () => {
+    const down = fakeDropbox(() => ({ status: 503, raw: "upstream down" }));
+    const e1 = await client(down.fetchImpl)
+      .listFolder({ accountId: "acct" })
+      .catch((e: unknown) => e);
+    expect((e1 as ElizaError).code).toBe("DROPBOX_UPSTREAM_FAILURE");
+
+    const malformed = fakeDropbox(() => ({ status: 200, body: { cursor: "x" } }));
+    const e2 = await client(malformed.fetchImpl)
+      .listFolder({ accountId: "acct" })
+      .catch((e: unknown) => e);
+    expect((e2 as ElizaError).code).toBe("DROPBOX_MALFORMED_RESPONSE");
+  });
+});
+
+describe("DropboxClient.search", () => {
+  it("searches then continues via search/continue_v2 with the returned cursor", async () => {
+    const { fetchImpl, requests } = fakeDropbox((request) => {
+      if (request.url.endsWith("/2/files/search_v2")) {
+        return {
+          status: 200,
+          body: {
+            matches: [{ metadata: { ".tag": "metadata", metadata: fileEntry("a.txt", "/a.txt") } }],
+            cursor: "search-cursor",
+            has_more: true,
+          },
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          matches: [{ metadata: { ".tag": "metadata", metadata: fileEntry("b.txt", "/b.txt") } }],
+          cursor: null,
+          has_more: false,
+        },
+      };
+    });
+    const c = client(fetchImpl);
+    const first = await c.search({ accountId: "acct", query: "txt" });
+    expect(first.hasMore).toBe(true);
+    expect(first.entries[0].name).toBe("a.txt");
+    const second = await c.search({ accountId: "acct", query: "txt", cursor: first.cursor ?? "" });
+    expect(requests[1].url).toBe("https://api.dropbox.test/2/files/search/continue_v2");
+    expect(second.entries[0].name).toBe("b.txt");
+    expect(second.hasMore).toBe(false);
+  });
+
+  it("returns a designed-empty result when nothing matches", async () => {
+    const { fetchImpl } = fakeDropbox(() => ({
+      status: 200,
+      body: { matches: [], has_more: false },
+    }));
+    const page = await client(fetchImpl).search({ accountId: "acct", query: "nothing" });
+    expect(page.entries).toEqual([]);
+    expect(page.cursor).toBeNull();
+  });
+});
+
+describe("DropboxClient content endpoints", () => {
+  it("downloads UTF-8 text through the content host with Dropbox-API-Arg", async () => {
+    const { fetchImpl, requests } = fakeDropbox((request) => {
+      if (request.url.includes("get_metadata")) {
+        return { status: 200, body: fileEntry("notes.md", "/notes.md", { size: 11 }) };
+      }
+      return { status: 200, raw: "hello world" };
+    });
+    const result = await client(fetchImpl).downloadText({ accountId: "acct", path: "/notes.md" });
+    expect(result.text).toBe("hello world");
+    expect(requests[1].url).toBe("https://content.dropbox.test/2/files/download");
+    expect(JSON.parse(requests[1].headers["dropbox-api-arg"])).toEqual({ path: "/notes.md" });
+  });
+
+  it("refuses binary content with DROPBOX_FILE_NOT_TEXT", async () => {
+    const { fetchImpl } = fakeDropbox((request) => {
+      if (request.url.includes("get_metadata")) {
+        return { status: 200, body: fileEntry("app.bin", "/app.bin", { size: 4 }) };
+      }
+      return { status: 200, raw: new Uint8Array([0x00, 0x01, 0x02, 0x03]) };
+    });
+    const error = await client(fetchImpl)
+      .downloadText({ accountId: "acct", path: "/app.bin" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_FILE_NOT_TEXT");
+  });
+
+  it("refuses oversized files before downloading", async () => {
+    const { fetchImpl, requests } = fakeDropbox(() => ({
+      status: 200,
+      body: fileEntry("big.log", "/big.log", { size: DROPBOX_MAX_TEXT_BYTES + 1 }),
+    }));
+    const error = await client(fetchImpl)
+      .downloadText({ accountId: "acct", path: "/big.log" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_FILE_TOO_LARGE");
+    expect(requests).toHaveLength(1);
+  });
+
+  it("uploads bytes with mode and returns the mapped entry", async () => {
+    const { fetchImpl, requests } = fakeDropbox(() => ({
+      status: 200,
+      body: { ...fileEntry("out.txt", "/out.txt"), ".tag": undefined },
+    }));
+    const entry = await client(fetchImpl).upload({
+      accountId: "acct",
+      path: "/out.txt",
+      content: "data",
+      mode: "overwrite",
+    });
+    const arg = JSON.parse(requests[0].headers["dropbox-api-arg"]) as { mode: string };
+    expect(arg.mode).toBe("overwrite");
+    expect(requests[0].headers["content-type"]).toBe("application/octet-stream");
+    expect(entry.name).toBe("out.txt");
+    expect(entry.kind).toBe("file");
+  });
+
+  it("returns the temporary link and rejects a linkless payload", async () => {
+    const good = fakeDropbox(() => ({
+      status: 200,
+      body: { metadata: fileEntry("a.txt", "/a.txt"), link: "https://dl.dropbox.test/tmp/a" },
+    }));
+    await expect(
+      client(good.fetchImpl).getTemporaryLink({ accountId: "acct", path: "/a.txt" })
+    ).resolves.toBe("https://dl.dropbox.test/tmp/a");
+
+    const bad = fakeDropbox(() => ({ status: 200, body: { metadata: {} } }));
+    const error = await client(bad.fetchImpl)
+      .getTemporaryLink({ accountId: "acct", path: "/a.txt" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_MALFORMED_RESPONSE");
+  });
+});
+
+describe("helpers", () => {
+  it("escapes non-ASCII in Dropbox-API-Arg", () => {
+    expect(dropboxApiArg({ path: "/résumé.txt" })).not.toMatch(/[^\x20-\x7e]/);
+    expect(JSON.parse(dropboxApiArg({ path: "/résumé.txt" }))).toEqual({ path: "/résumé.txt" });
+  });
+
+  it("builds browse links for folders and preview links for files", () => {
+    expect(dropboxDeepLink("/A B/c.txt", "file")).toBe(
+      "https://www.dropbox.com/home/A%20B?preview=c.txt"
+    );
+    expect(dropboxDeepLink("/A B", "folder")).toBe("https://www.dropbox.com/home/A%20B");
+    expect(dropboxDeepLink("", "folder")).toBe("https://www.dropbox.com/home");
+  });
+});

--- a/plugins/plugin-dropbox/src/__tests__/client.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/client.test.ts
@@ -268,6 +268,90 @@ describe("DropboxClient content endpoints", () => {
     expect(requests).toHaveLength(1);
   });
 
+  it("accepts the exact text cap without reading a max+1 byte", async () => {
+    const bytes = new Uint8Array(DROPBOX_MAX_TEXT_BYTES).fill(0x61);
+    const { fetchImpl } = fakeDropbox((request) => {
+      if (request.url.includes("get_metadata")) {
+        return {
+          status: 200,
+          body: fileEntry("exact.txt", "/exact.txt", { size: DROPBOX_MAX_TEXT_BYTES }),
+        };
+      }
+      return { status: 200, raw: bytes };
+    });
+    const result = await client(fetchImpl).downloadText({ accountId: "acct", path: "/exact.txt" });
+    expect(result.text).toHaveLength(DROPBOX_MAX_TEXT_BYTES);
+  });
+
+  it("cancels a dishonest max+1 stream and reports DROPBOX_FILE_TOO_LARGE", async () => {
+    let cancelled = false;
+    const fetchImpl: typeof fetch = async (input) => {
+      if (String(input).includes("get_metadata")) {
+        return new Response(
+          JSON.stringify(fileEntry("dishonest.txt", "/dishonest.txt", { size: 1 })),
+          { status: 200 }
+        );
+      }
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(DROPBOX_MAX_TEXT_BYTES + 1).fill(0x61));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "Content-Length": "1" } });
+    };
+    const error = await client(fetchImpl)
+      .downloadText({ accountId: "acct", path: "/dishonest.txt" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_FILE_TOO_LARGE");
+    expect(cancelled).toBe(true);
+  });
+
+  it("cancels a stalled download at the body deadline", async () => {
+    let cancelled = false;
+    const fetchImpl: typeof fetch = async (input) => {
+      if (String(input).includes("get_metadata")) {
+        return new Response(JSON.stringify(fileEntry("stalled.txt", "/stalled.txt", { size: 1 })), {
+          status: 200,
+        });
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 200 }
+      );
+    };
+    const c = new DropboxClient(resolver, {
+      apiBaseUrl: "https://api.dropbox.test",
+      contentBaseUrl: "https://content.dropbox.test",
+      fetchImpl,
+      timeoutMs: 5,
+    });
+    const error = await c
+      .downloadText({ accountId: "acct", path: "/stalled.txt" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_UPSTREAM_FAILURE");
+    expect(cancelled).toBe(true);
+  });
+
+  it("rejects malformed UTF-8 as non-text", async () => {
+    const { fetchImpl } = fakeDropbox((request) => {
+      if (request.url.includes("get_metadata")) {
+        return { status: 200, body: fileEntry("bad.txt", "/bad.txt", { size: 2 }) };
+      }
+      return { status: 200, raw: new Uint8Array([0xc3, 0x28]) };
+    });
+    const error = await client(fetchImpl)
+      .downloadText({ accountId: "acct", path: "/bad.txt" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("DROPBOX_FILE_NOT_TEXT");
+  });
+
   it("uploads bytes with mode and returns the mapped entry", async () => {
     const { fetchImpl, requests } = fakeDropbox(() => ({
       status: 200,

--- a/plugins/plugin-dropbox/src/__tests__/connector-account-provider.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/connector-account-provider.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Dropbox connector-account-provider contract tests. Uses a real in-memory
+ * ConnectorAccountManager-shaped fake plus protocol-faithful fake token and
+ * identity endpoints via injected fetch. Covers PKCE offline OAuth start,
+ * scope normalization (read default + write escalation, unrecognized and
+ * empty-scope failures), callback success with durable credential-ref
+ * persistence, failed exchange, and invalid payloads.
+ */
+import type {
+  ConnectorAccount,
+  ConnectorAccountManager,
+  ConnectorOAuthCallbackRequest,
+  ConnectorOAuthStartRequest,
+  IAgentRuntime,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  createDropboxConnectorAccountProvider,
+  DROPBOX_READ_SCOPES,
+  DROPBOX_WRITE_SCOPES,
+} from "../connector-account-provider.js";
+
+function fakeRuntime(settings: Record<string, string>) {
+  const vaultStore = new Map<string, string>();
+  const runtime = {
+    agentId: "agent-1",
+    getSetting: (key: string) => settings[key],
+    getService: (type: string) =>
+      type === "vault"
+        ? {
+            set: async (key: string, value: string) => {
+              vaultStore.set(key, value);
+            },
+          }
+        : null,
+  } as unknown as IAgentRuntime;
+  return { runtime, vaultStore };
+}
+
+function fakeManager() {
+  const accounts = new Map<string, ConnectorAccount>();
+  const credentialRefs: Array<Record<string, unknown>> = [];
+  const storage = {
+    listAccounts: async (provider: string) =>
+      [...accounts.values()].filter((account) => account.provider === provider),
+    getAccount: async (_provider: string, id: string) => accounts.get(id) ?? null,
+    upsertAccount: async (account: ConnectorAccount) => {
+      accounts.set(account.id, account);
+      return account;
+    },
+    deleteAccount: async (_provider: string, id: string) => {
+      accounts.delete(id);
+    },
+    setConnectorAccountCredentialRef: async (params: Record<string, unknown>) => {
+      credentialRefs.push(params);
+    },
+  };
+  const manager = {
+    getStorage: () => storage,
+    getAccount: async (provider: string, id: string) => storage.getAccount(provider, id),
+    listAccounts: async (provider: string) => storage.listAccounts(provider),
+    upsertAccount: async (
+      provider: string,
+      patch: Record<string, unknown>,
+      accountId?: string
+    ): Promise<ConnectorAccount> => {
+      const id = accountId ?? `acct-${accounts.size + 1}`;
+      const account = { ...(accounts.get(id) ?? {}), ...patch, id, provider } as ConnectorAccount;
+      accounts.set(id, account);
+      return account;
+    },
+  } as unknown as ConnectorAccountManager;
+  return { manager, accounts, credentialRefs };
+}
+
+const SETTINGS = {
+  DROPBOX_CLIENT_ID: "app-key",
+  DROPBOX_CLIENT_SECRET: "app-secret",
+  DROPBOX_REDIRECT_URI: "https://agent.example/oauth/dropbox/callback",
+};
+
+function startRequest(scopes?: string[]): ConnectorOAuthStartRequest {
+  return {
+    scopes,
+    flow: { state: "state-xyz" },
+    metadata: {},
+  } as unknown as ConnectorOAuthStartRequest;
+}
+
+function callbackRequest(code: string | undefined): ConnectorOAuthCallbackRequest {
+  return {
+    code,
+    flow: {
+      state: "state-xyz",
+      redirectUri: SETTINGS.DROPBOX_REDIRECT_URI,
+      codeVerifier: "verifier-1",
+      metadata: { redirectUri: SETTINGS.DROPBOX_REDIRECT_URI },
+    },
+  } as unknown as ConnectorOAuthCallbackRequest;
+}
+
+describe("Dropbox OAuth start", () => {
+  it("builds a PKCE offline authorization URL with the default read+write scopes", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createDropboxConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    const result = await provider.startOAuth?.(startRequest(), manager);
+    const url = new URL(result?.authUrl ?? "");
+    expect(url.origin + url.pathname).toBe("https://www.dropbox.com/oauth2/authorize");
+    expect(url.searchParams.get("token_access_type")).toBe("offline");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(result?.codeVerifier).toBeTruthy();
+    const scope = url.searchParams.get("scope")?.split(" ") ?? [];
+    for (const expected of [...DROPBOX_READ_SCOPES, ...DROPBOX_WRITE_SCOPES]) {
+      expect(scope).toContain(expected);
+    }
+  });
+
+  it("narrows to a read-only grant when only read scopes are requested", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createDropboxConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    const result = await provider.startOAuth?.(
+      startRequest(["files.metadata.read", "files.content.read"]),
+      manager
+    );
+    const scope = new URL(result?.authUrl ?? "").searchParams.get("scope")?.split(" ") ?? [];
+    expect(scope).toContain("files.metadata.read");
+    expect(scope).toContain("account_info.read");
+    expect(scope).not.toContain("files.content.write");
+  });
+
+  it("fails closed on unrecognized or empty scope selections", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createDropboxConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    await expect(provider.startOAuth?.(startRequest(["sharing.write"]), manager)).rejects.toThrow(
+      /not recognized/
+    );
+    await expect(provider.startOAuth?.(startRequest([]), manager)).rejects.toThrow(
+      /at least one recognized scope/
+    );
+  });
+
+  it("fails closed when client settings are missing", async () => {
+    const { runtime } = fakeRuntime({});
+    const provider = createDropboxConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    await expect(provider.startOAuth?.(startRequest(), manager)).rejects.toThrow(
+      /DROPBOX_CLIENT_ID/
+    );
+  });
+});
+
+describe("Dropbox OAuth callback", () => {
+  it("exchanges the code with the verifier, records identity and scopes, and persists a durable token set", async () => {
+    const { runtime, vaultStore } = fakeRuntime(SETTINGS);
+    const requests: Array<{ url: string; body: string }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      requests.push({ url, body: String(init?.body ?? "") });
+      if (url.endsWith("/oauth2/token")) {
+        return new Response(
+          JSON.stringify({
+            access_token: "sl.short_lived",
+            expires_in: 14_400,
+            token_type: "bearer",
+            refresh_token: "rt-durable",
+            scope: "account_info.read files.metadata.read files.content.read",
+            account_id: "dbid:abc",
+            uid: "12345",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          account_id: "dbid:abc",
+          email: "ada@acme.test",
+          name: { display_name: "Ada Lovelace" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const provider = createDropboxConnectorAccountProvider(runtime, { fetchImpl });
+    const { manager, credentialRefs } = fakeManager();
+
+    const result = await provider.completeOAuth?.(callbackRequest("auth-code"), manager);
+
+    const tokenBody = new URLSearchParams(requests[0].body);
+    expect(tokenBody.get("grant_type")).toBe("authorization_code");
+    expect(tokenBody.get("code_verifier")).toBe("verifier-1");
+    expect(tokenBody.get("client_id")).toBe("app-key");
+
+    expect(result?.account.status).toBe("connected");
+    expect(result?.account.externalId).toBe("dbid:abc");
+    expect(result?.account.label).toBe("Ada Lovelace");
+    const metadata = result?.account.metadata as Record<string, unknown>;
+    expect(metadata.grantedScopes).toEqual([
+      "account_info.read",
+      "files.metadata.read",
+      "files.content.read",
+    ]);
+    expect(metadata.hasRefreshToken).toBe(true);
+    // Tokens never land in account metadata — only durable refs.
+    expect(JSON.stringify(metadata)).not.toContain("sl.short_lived");
+    expect(JSON.stringify(metadata)).not.toContain("rt-durable");
+    expect(credentialRefs).toHaveLength(1);
+    const persisted = [...vaultStore.values()][0];
+    expect(persisted).toContain("sl.short_lived");
+    expect(persisted).toContain("rt-durable");
+  });
+
+  it("rejects a callback without an authorization code", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createDropboxConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    await expect(provider.completeOAuth?.(callbackRequest(undefined), manager)).rejects.toThrow(
+      /authorization code/
+    );
+  });
+
+  it("surfaces a failed exchange and an invalid token payload", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const failing = createDropboxConnectorAccountProvider(runtime, {
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+    });
+    const { manager, accounts } = fakeManager();
+    await expect(failing.completeOAuth?.(callbackRequest("bad"), manager)).rejects.toThrow(
+      /token exchange failed with 400/
+    );
+    expect(accounts.size).toBe(0);
+
+    const invalid = createDropboxConnectorAccountProvider(runtime, {
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ token_type: "bearer" }), { status: 200 }),
+    });
+    await expect(invalid.completeOAuth?.(callbackRequest("code"), manager)).rejects.toThrow(
+      /invalid payload/
+    );
+  });
+});

--- a/plugins/plugin-dropbox/src/__tests__/credential-resolver.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/credential-resolver.test.ts
@@ -1,0 +1,163 @@
+/**
+ * DefaultDropboxCredentialResolver contract tests over a real in-memory
+ * connector-account manager fake and a protocol-faithful fake token endpoint.
+ * Covers BYO local token, fresh stored tokens, expiry-driven refresh with
+ * in-memory caching, refresh rejection (revoked grant), unconfigured client
+ * credentials, and missing-credential failure paths.
+ */
+import type { ConnectorAccount, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { DefaultDropboxCredentialResolver } from "../credential-resolver.js";
+
+function runtimeWith(options: {
+  settings?: Record<string, string>;
+  accounts?: ConnectorAccount[];
+}): IAgentRuntime {
+  const accounts = options.accounts ?? [];
+  const manager = {
+    registerProvider: () => undefined,
+    evaluatePolicy: async () => ({ allowed: true }),
+    getAccount: async (_provider: string, id: string) =>
+      accounts.find((account) => account.id === id) ?? null,
+    listAccounts: async () => accounts,
+    getStorage: () => ({
+      listAccounts: async () => accounts,
+      getAccount: async (_provider: string, id: string) =>
+        accounts.find((account) => account.id === id) ?? null,
+      upsertAccount: async (account: ConnectorAccount) => account,
+      deleteAccount: async () => undefined,
+    }),
+  };
+  return {
+    agentId: "agent-1",
+    getSetting: (key: string) => options.settings?.[key],
+    getService: (type: string) => (type === "connector_account" ? manager : null),
+  } as unknown as IAgentRuntime;
+}
+
+function accountWithTokens(tokens: Record<string, unknown>): ConnectorAccount {
+  return {
+    id: "acct-1",
+    provider: "dropbox",
+    role: "OWNER",
+    purpose: ["drive"],
+    accessGate: "open",
+    status: "connected",
+    metadata: {
+      credentialRefs: [{ credentialType: "oauth.tokens", value: JSON.stringify(tokens) }],
+    },
+  } as ConnectorAccount;
+}
+
+const CLIENT_SETTINGS = {
+  DROPBOX_CLIENT_ID: "app-key",
+  DROPBOX_CLIENT_SECRET: "app-secret",
+};
+
+describe("DefaultDropboxCredentialResolver", () => {
+  it("uses the BYO DROPBOX_ACCESS_TOKEN for the local default account", async () => {
+    const resolver = new DefaultDropboxCredentialResolver(
+      runtimeWith({ settings: { DROPBOX_ACCESS_TOKEN: "sl.byo" } })
+    );
+    await expect(resolver.getCredential({ accountId: "default" })).resolves.toEqual({
+      accessToken: "sl.byo",
+    });
+  });
+
+  it("returns a stored token that is still fresh without refreshing", async () => {
+    const now = 1_000_000_000_000;
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error("refresh must not be called for a fresh token");
+    };
+    const resolver = new DefaultDropboxCredentialResolver(
+      runtimeWith({
+        settings: CLIENT_SETTINGS,
+        accounts: [
+          accountWithTokens({
+            access_token: "sl.fresh",
+            refresh_token: "rt-1",
+            expiry_date: now + 3_600_000,
+            account_id: "dbid:one",
+          }),
+        ],
+      }),
+      { fetchImpl, now: () => now }
+    );
+    const credential = await resolver.getCredential({ accountId: "acct-1" });
+    expect(credential.accessToken).toBe("sl.fresh");
+    expect(credential.dropboxAccountId).toBe("dbid:one");
+  });
+
+  it("refreshes an expired token via the OAuth refresh grant and caches it", async () => {
+    const now = 1_000_000_000_000;
+    const refreshCalls: string[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      refreshCalls.push(String(init?.body));
+      return new Response(JSON.stringify({ access_token: "sl.refreshed", expires_in: 14_400 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    const resolver = new DefaultDropboxCredentialResolver(
+      runtimeWith({
+        settings: CLIENT_SETTINGS,
+        accounts: [
+          accountWithTokens({
+            access_token: "sl.stale",
+            refresh_token: "rt-1",
+            expiry_date: now - 1,
+          }),
+        ],
+      }),
+      { fetchImpl, now: () => now }
+    );
+    const first = await resolver.getCredential({ accountId: "acct-1" });
+    const second = await resolver.getCredential({ accountId: "acct-1" });
+    expect(first.accessToken).toBe("sl.refreshed");
+    expect(second.accessToken).toBe("sl.refreshed");
+    expect(refreshCalls).toHaveLength(1);
+    const body = new URLSearchParams(refreshCalls[0]);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt-1");
+    expect(body.get("client_id")).toBe("app-key");
+  });
+
+  it("surfaces a rejected refresh as DROPBOX_AUTH_EXPIRED", async () => {
+    const now = 1_000_000_000_000;
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 });
+    const resolver = new DefaultDropboxCredentialResolver(
+      runtimeWith({
+        settings: CLIENT_SETTINGS,
+        accounts: [accountWithTokens({ refresh_token: "rt-revoked", expiry_date: now - 1 })],
+      }),
+      { fetchImpl, now: () => now }
+    );
+    await expect(resolver.getCredential({ accountId: "acct-1" })).rejects.toThrow(
+      /refresh failed with 400/
+    );
+  });
+
+  it("fails closed when a refresh is needed but client credentials are missing", async () => {
+    const now = 1_000_000_000_000;
+    const resolver = new DefaultDropboxCredentialResolver(
+      runtimeWith({
+        accounts: [accountWithTokens({ refresh_token: "rt-1", expiry_date: now - 1 })],
+      }),
+      { now: () => now }
+    );
+    await expect(resolver.getCredential({ accountId: "acct-1" })).rejects.toThrow(
+      /DROPBOX_CLIENT_ID/
+    );
+  });
+
+  it("fails with account-not-found and missing-credential errors", async () => {
+    const resolver = new DefaultDropboxCredentialResolver(runtimeWith({}));
+    await expect(resolver.getCredential({ accountId: "missing" })).rejects.toThrow(/not found/);
+
+    const empty = new DefaultDropboxCredentialResolver(
+      runtimeWith({ accounts: [accountWithTokens({})] })
+    );
+    await expect(empty.getCredential({ accountId: "acct-1" })).rejects.toThrow(/no token material/);
+  });
+});

--- a/plugins/plugin-dropbox/src/bounded-response.ts
+++ b/plugins/plugin-dropbox/src/bounded-response.ts
@@ -1,0 +1,98 @@
+/**
+ * Reads untrusted HTTP response bodies with a hard allocation limit and one
+ * deadline covering the complete stream. The reader is cancelled as soon as
+ * the limit or deadline is crossed so rejected bodies are not drained.
+ */
+export interface BoundedResponseErrors {
+  tooLarge(declaredBytes: number | null): Error;
+  timedOut(): Error;
+  readFailed(cause: unknown): Error;
+}
+
+export async function readBoundedResponse(
+  response: Response,
+  maxBytes: number,
+  timeoutMs: number,
+  errors: BoundedResponseErrors
+): Promise<Uint8Array> {
+  const declaredBytes = parseContentLength(response.headers.get("Content-Length"));
+  if (declaredBytes !== null && declaredBytes > maxBytes) {
+    cancelBody(response.body);
+    throw errors.tooLarge(declaredBytes);
+  }
+
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      cancelReader(reader);
+      throw errors.timedOut();
+    }
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await readBeforeDeadline(reader, remainingMs);
+    } catch (cause) {
+      cancelReader(reader);
+      if (cause instanceof BodyDeadlineError) throw errors.timedOut();
+      throw errors.readFailed(cause);
+    }
+    if (result.done) break;
+    total += result.value.byteLength;
+    if (total > maxBytes) {
+      cancelReader(reader);
+      throw errors.tooLarge(declaredBytes);
+    }
+    chunks.push(result.value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function readBeforeDeadline(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  remainingMs: number
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new BodyDeadlineError()), remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+class BodyDeadlineError extends Error {}
+
+function parseContentLength(value: string | null): number | null {
+  if (value === null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function cancelBody(body: ReadableStream<Uint8Array> | null): void {
+  if (!body) return;
+  body.cancel().catch(() => {
+    // error-policy:J6 response rejection is already authoritative; cancellation is teardown only.
+  });
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  reader.cancel().catch(() => {
+    // error-policy:J6 response rejection is already authoritative; cancellation is teardown only.
+  });
+}

--- a/plugins/plugin-dropbox/src/client.ts
+++ b/plugins/plugin-dropbox/src/client.ts
@@ -15,6 +15,7 @@
  * garbage, so callers can point the user at the temporary link instead.
  */
 import { ElizaError } from "@elizaos/core";
+import { readBoundedResponse } from "./bounded-response.js";
 import type {
   DropboxAccountRef,
   DropboxCredentialResolver,
@@ -30,6 +31,11 @@ export const DROPBOX_DEFAULT_CONTENT_BASE = "https://content.dropboxapi.com";
 export const DROPBOX_FETCH_TIMEOUT_MS = 30_000;
 /** Refuse to decode files larger than this as text (protects model context). */
 export const DROPBOX_MAX_TEXT_BYTES = 1_000_000;
+/** Dropbox's single-request upload endpoint accepts at most 150 MB. */
+export const DROPBOX_MAX_UPLOAD_BYTES = 150_000_000;
+
+const DROPBOX_MAX_JSON_BYTES = 4_000_000;
+const DROPBOX_MAX_ERROR_BYTES = 64_000;
 
 const MAX_PAGE_SIZE = 1000;
 
@@ -145,19 +151,38 @@ export class DropboxClient {
       signal: AbortSignal.timeout(this.timeoutMs),
     });
     if (!response.ok) {
-      throw await dropboxHttpError(response, {
-        accountId: params.accountId,
-        path: "/2/files/download",
-      });
+      throw await dropboxHttpError(
+        response,
+        { accountId: params.accountId, path: "/2/files/download" },
+        this.timeoutMs
+      );
     }
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.length > DROPBOX_MAX_TEXT_BYTES || looksBinary(bytes)) {
+    const bytes = await readDropboxBody(
+      response,
+      DROPBOX_MAX_TEXT_BYTES,
+      params.path,
+      this.timeoutMs,
+      { tooLargeCode: "DROPBOX_FILE_TOO_LARGE" }
+    );
+    if (looksBinary(bytes)) {
       throw new ElizaError(
         `DropboxClient: ${params.path} does not decode as text. Use getTemporaryLink instead.`,
         { code: "DROPBOX_FILE_NOT_TEXT", context: { path: params.path, bytes: bytes.length } }
       );
     }
-    return { entry, text: new TextDecoder("utf-8", { fatal: false }).decode(bytes) };
+    try {
+      return { entry, text: new TextDecoder("utf-8", { fatal: true }).decode(bytes) };
+    } catch (cause) {
+      // error-policy:J3 invalid UTF-8 is an explicit non-text result, never replacement text.
+      throw new ElizaError(
+        `DropboxClient: ${params.path} is not valid UTF-8 text. Use getTemporaryLink instead.`,
+        {
+          code: "DROPBOX_FILE_NOT_TEXT",
+          context: { path: params.path, bytes: bytes.length },
+          cause: cause instanceof Error ? cause : undefined,
+        }
+      );
+    }
   }
 
   async upload(params: DropboxUploadInput): Promise<DropboxEntry> {
@@ -166,6 +191,15 @@ export class DropboxClient {
       typeof params.content === "string"
         ? new TextEncoder().encode(params.content)
         : params.content;
+    if (bytes.byteLength > DROPBOX_MAX_UPLOAD_BYTES) {
+      throw new ElizaError(
+        `DropboxClient: upload is ${bytes.byteLength} bytes, larger than the ${DROPBOX_MAX_UPLOAD_BYTES}-byte single-request cap.`,
+        {
+          code: "DROPBOX_FILE_TOO_LARGE",
+          context: { path: params.path, bytes: bytes.byteLength, cap: DROPBOX_MAX_UPLOAD_BYTES },
+        }
+      );
+    }
     // Copy into a plain ArrayBuffer-backed Blob so BodyInit accepts it
     // regardless of the source view's underlying buffer type.
     const body = new Blob([bytes.slice()]);
@@ -185,12 +219,18 @@ export class DropboxClient {
       signal: AbortSignal.timeout(this.timeoutMs),
     });
     if (!response.ok) {
-      throw await dropboxHttpError(response, {
-        accountId: params.accountId,
-        path: "/2/files/upload",
-      });
+      throw await dropboxHttpError(
+        response,
+        { accountId: params.accountId, path: "/2/files/upload" },
+        this.timeoutMs
+      );
     }
-    const payload = await parseJsonRecord(response, "/2/files/upload", params.accountId);
+    const payload = await parseJsonRecord(
+      response,
+      "/2/files/upload",
+      params.accountId,
+      this.timeoutMs
+    );
     return mapEntry({ ".tag": "file", ...payload });
   }
 
@@ -222,24 +262,34 @@ export class DropboxClient {
       signal: AbortSignal.timeout(this.timeoutMs),
     });
     if (!response.ok) {
-      throw await dropboxHttpError(response, { accountId: account.accountId, path });
+      throw await dropboxHttpError(
+        response,
+        { accountId: account.accountId, path },
+        this.timeoutMs
+      );
     }
-    return parseJsonRecord(response, path, account.accountId);
+    return parseJsonRecord(response, path, account.accountId, this.timeoutMs);
   }
 }
 
 async function parseJsonRecord(
   response: Response,
   path: string,
-  accountId: string
+  accountId: string,
+  timeoutMs: number
 ): Promise<JsonRecord> {
-  const parsed: unknown = await response.json().catch((cause: unknown) => {
+  const bytes = await readDropboxBody(response, DROPBOX_MAX_JSON_BYTES, path, timeoutMs);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch (cause) {
+    // error-policy:J3 the success body is untrusted and must be valid bounded UTF-8 JSON.
     throw new ElizaError("DropboxClient: Dropbox returned a non-JSON success body.", {
       code: "DROPBOX_MALFORMED_RESPONSE",
       context: { path, accountId },
       cause: cause instanceof Error ? cause : undefined,
     });
-  });
+  }
   if (!isRecord(parsed)) {
     throw new ElizaError("DropboxClient: Dropbox returned a non-object success body.", {
       code: "DROPBOX_MALFORMED_RESPONSE",
@@ -251,11 +301,23 @@ async function parseJsonRecord(
 
 async function dropboxHttpError(
   response: Response,
-  context: { accountId: string; path: string }
+  context: { accountId: string; path: string },
+  timeoutMs: number
 ): Promise<ElizaError> {
   // error-policy:J3 the upstream error body is untrusted; an unparseable body
   // degrades to an empty record and the HTTP status still drives the code.
-  const bodyText = await response.text().catch(() => "");
+  let bodyBytes: Uint8Array = new Uint8Array();
+  try {
+    bodyBytes = await readDropboxBody(response, DROPBOX_MAX_ERROR_BYTES, context.path, timeoutMs);
+  } catch {
+    // error-policy:J3 malformed, stalled, or oversized error bodies are ignored; status is authoritative.
+  }
+  let bodyText = "";
+  try {
+    bodyText = new TextDecoder("utf-8", { fatal: true }).decode(bodyBytes);
+  } catch {
+    // error-policy:J3 malformed error text is ignored; HTTP status remains authoritative.
+  }
   let body: JsonRecord = {};
   try {
     const parsed: unknown = JSON.parse(bodyText);
@@ -316,6 +378,33 @@ async function dropboxHttpError(
   return new ElizaError(`DropboxClient: Dropbox request failed with status ${response.status}.`, {
     code: "DROPBOX_UPSTREAM_FAILURE",
     context: base,
+  });
+}
+
+async function readDropboxBody(
+  response: Response,
+  maxBytes: number,
+  path: string,
+  timeoutMs: number,
+  options: { tooLargeCode?: string } = {}
+): Promise<Uint8Array> {
+  return readBoundedResponse(response, maxBytes, timeoutMs, {
+    tooLarge: (declaredBytes) =>
+      new ElizaError("DropboxClient: Dropbox response exceeded the permitted body size.", {
+        code: options.tooLargeCode ?? "DROPBOX_MALFORMED_RESPONSE",
+        context: { path, cap: maxBytes, declaredBytes },
+      }),
+    timedOut: () =>
+      new ElizaError("DropboxClient: timed out while reading the Dropbox response body.", {
+        code: "DROPBOX_UPSTREAM_FAILURE",
+        context: { path, timeoutMs },
+      }),
+    readFailed: (cause) =>
+      new ElizaError("DropboxClient: failed while reading the Dropbox response body.", {
+        code: "DROPBOX_UPSTREAM_FAILURE",
+        context: { path },
+        cause: cause instanceof Error ? cause : undefined,
+      }),
   });
 }
 

--- a/plugins/plugin-dropbox/src/client.ts
+++ b/plugins/plugin-dropbox/src/client.ts
@@ -1,0 +1,432 @@
+/**
+ * Fetch-based Dropbox API v2 client behind the service. RPC endpoints
+ * (list_folder, list_folder/continue, search_v2, search/continue_v2,
+ * get_metadata, get_temporary_link) go to the api host; content endpoints
+ * (download, upload) go to the content host with `Dropbox-API-Arg` headers.
+ * Every upstream failure is translated into a typed `ElizaError`
+ * (`DROPBOX_AUTH_EXPIRED`, `DROPBOX_RATE_LIMITED`, `DROPBOX_NOT_FOUND`,
+ * `DROPBOX_MALFORMED_RESPONSE`, `DROPBOX_UPSTREAM_FAILURE`, …) so callers
+ * branch on codes, never on HTTP details. Base URLs are overridable via
+ * `ELIZA_MOCK_DROPBOX_BASE` / `ELIZA_MOCK_DROPBOX_CONTENT_BASE` for
+ * protocol-faithful mock servers in tests.
+ *
+ * File limitation UX: `downloadText` refuses binary-looking or oversized files
+ * with `DROPBOX_FILE_NOT_TEXT` / `DROPBOX_FILE_TOO_LARGE` instead of returning
+ * garbage, so callers can point the user at the temporary link instead.
+ */
+import { ElizaError } from "@elizaos/core";
+import type {
+  DropboxAccountRef,
+  DropboxCredentialResolver,
+  DropboxEntry,
+  DropboxFileText,
+  DropboxListPage,
+  DropboxUploadInput,
+} from "./types.js";
+
+export const DROPBOX_DEFAULT_API_BASE = "https://api.dropboxapi.com";
+export const DROPBOX_DEFAULT_CONTENT_BASE = "https://content.dropboxapi.com";
+/** Maximum time allowed for one Dropbox API request. */
+export const DROPBOX_FETCH_TIMEOUT_MS = 30_000;
+/** Refuse to decode files larger than this as text (protects model context). */
+export const DROPBOX_MAX_TEXT_BYTES = 1_000_000;
+
+const MAX_PAGE_SIZE = 1000;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface DropboxClientOptions {
+  apiBaseUrl?: string;
+  contentBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export class DropboxClient {
+  private readonly apiBase: string;
+  private readonly contentBase: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly credentialResolver: DropboxCredentialResolver,
+    options: DropboxClientOptions = {}
+  ) {
+    this.apiBase = (
+      options.apiBaseUrl ??
+      process.env.ELIZA_MOCK_DROPBOX_BASE ??
+      DROPBOX_DEFAULT_API_BASE
+    ).replace(/\/$/, "");
+    this.contentBase = (
+      options.contentBaseUrl ??
+      process.env.ELIZA_MOCK_DROPBOX_CONTENT_BASE ??
+      process.env.ELIZA_MOCK_DROPBOX_BASE ??
+      DROPBOX_DEFAULT_CONTENT_BASE
+    ).replace(/\/$/, "");
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.timeoutMs = options.timeoutMs ?? DROPBOX_FETCH_TIMEOUT_MS;
+  }
+
+  async listFolder(
+    params: DropboxAccountRef & { path?: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage> {
+    const payload = params.cursor
+      ? await this.rpc(params, "/2/files/list_folder/continue", { cursor: params.cursor })
+      : await this.rpc(params, "/2/files/list_folder", {
+          path: params.path ?? "",
+          limit: normalizedPageSize(params.limit),
+          recursive: false,
+          include_deleted: false,
+        });
+    return {
+      entries: readArray(payload, "entries").map(mapEntry),
+      cursor: readNullableString(payload, "cursor"),
+      hasMore: payload.has_more === true,
+    };
+  }
+
+  async search(
+    params: DropboxAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage> {
+    const payload = params.cursor
+      ? await this.rpc(params, "/2/files/search/continue_v2", { cursor: params.cursor })
+      : await this.rpc(params, "/2/files/search_v2", {
+          query: params.query,
+          options: { max_results: Math.min(normalizedPageSize(params.limit), 100) },
+        });
+    const matches = readArray(payload, "matches");
+    const entries: DropboxEntry[] = [];
+    for (const match of matches) {
+      const metadata = asRecord(asRecord(match.metadata)?.metadata);
+      if (metadata) {
+        entries.push(mapEntry(metadata));
+      }
+    }
+    return {
+      entries,
+      cursor: readNullableString(payload, "cursor"),
+      hasMore: payload.has_more === true,
+    };
+  }
+
+  async getMetadata(params: DropboxAccountRef & { path: string }): Promise<DropboxEntry> {
+    const payload = await this.rpc(params, "/2/files/get_metadata", {
+      path: params.path,
+      include_deleted: false,
+    });
+    return mapEntry(payload);
+  }
+
+  async downloadText(params: DropboxAccountRef & { path: string }): Promise<DropboxFileText> {
+    const entry = await this.getMetadata(params);
+    if (entry.kind !== "file") {
+      throw new ElizaError(`DropboxClient: ${params.path} is a ${entry.kind}, not a file.`, {
+        code: "DROPBOX_NOT_A_FILE",
+        context: { path: params.path, kind: entry.kind },
+      });
+    }
+    if (typeof entry.size === "number" && entry.size > DROPBOX_MAX_TEXT_BYTES) {
+      throw new ElizaError(
+        `DropboxClient: ${params.path} is ${entry.size} bytes, larger than the ${DROPBOX_MAX_TEXT_BYTES}-byte text read cap. Use getTemporaryLink instead.`,
+        {
+          code: "DROPBOX_FILE_TOO_LARGE",
+          context: { path: params.path, size: entry.size, cap: DROPBOX_MAX_TEXT_BYTES },
+        }
+      );
+    }
+
+    const credential = await this.credentialResolver.getCredential(params);
+    const response = await this.fetchImpl(`${this.contentBase}/2/files/download`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${credential.accessToken}`,
+        "Dropbox-API-Arg": dropboxApiArg({ path: params.path }),
+      },
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!response.ok) {
+      throw await dropboxHttpError(response, {
+        accountId: params.accountId,
+        path: "/2/files/download",
+      });
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.length > DROPBOX_MAX_TEXT_BYTES || looksBinary(bytes)) {
+      throw new ElizaError(
+        `DropboxClient: ${params.path} does not decode as text. Use getTemporaryLink instead.`,
+        { code: "DROPBOX_FILE_NOT_TEXT", context: { path: params.path, bytes: bytes.length } }
+      );
+    }
+    return { entry, text: new TextDecoder("utf-8", { fatal: false }).decode(bytes) };
+  }
+
+  async upload(params: DropboxUploadInput): Promise<DropboxEntry> {
+    const credential = await this.credentialResolver.getCredential(params);
+    const bytes =
+      typeof params.content === "string"
+        ? new TextEncoder().encode(params.content)
+        : params.content;
+    // Copy into a plain ArrayBuffer-backed Blob so BodyInit accepts it
+    // regardless of the source view's underlying buffer type.
+    const body = new Blob([bytes.slice()]);
+    const response = await this.fetchImpl(`${this.contentBase}/2/files/upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${credential.accessToken}`,
+        "Content-Type": "application/octet-stream",
+        "Dropbox-API-Arg": dropboxApiArg({
+          path: params.path,
+          mode: params.mode ?? "add",
+          autorename: false,
+          mute: true,
+        }),
+      },
+      body,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!response.ok) {
+      throw await dropboxHttpError(response, {
+        accountId: params.accountId,
+        path: "/2/files/upload",
+      });
+    }
+    const payload = await parseJsonRecord(response, "/2/files/upload", params.accountId);
+    return mapEntry({ ".tag": "file", ...payload });
+  }
+
+  async getTemporaryLink(params: DropboxAccountRef & { path: string }): Promise<string> {
+    const payload = await this.rpc(params, "/2/files/get_temporary_link", { path: params.path });
+    const link = readNullableString(payload, "link");
+    if (!link) {
+      throw new ElizaError("DropboxClient: get_temporary_link response is missing the link.", {
+        code: "DROPBOX_MALFORMED_RESPONSE",
+        context: { path: params.path },
+      });
+    }
+    return link;
+  }
+
+  private async rpc(
+    account: DropboxAccountRef,
+    path: string,
+    body: JsonRecord
+  ): Promise<JsonRecord> {
+    const credential = await this.credentialResolver.getCredential(account);
+    const response = await this.fetchImpl(`${this.apiBase}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${credential.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!response.ok) {
+      throw await dropboxHttpError(response, { accountId: account.accountId, path });
+    }
+    return parseJsonRecord(response, path, account.accountId);
+  }
+}
+
+async function parseJsonRecord(
+  response: Response,
+  path: string,
+  accountId: string
+): Promise<JsonRecord> {
+  const parsed: unknown = await response.json().catch((cause: unknown) => {
+    throw new ElizaError("DropboxClient: Dropbox returned a non-JSON success body.", {
+      code: "DROPBOX_MALFORMED_RESPONSE",
+      context: { path, accountId },
+      cause: cause instanceof Error ? cause : undefined,
+    });
+  });
+  if (!isRecord(parsed)) {
+    throw new ElizaError("DropboxClient: Dropbox returned a non-object success body.", {
+      code: "DROPBOX_MALFORMED_RESPONSE",
+      context: { path, accountId, bodyType: typeof parsed },
+    });
+  }
+  return parsed;
+}
+
+async function dropboxHttpError(
+  response: Response,
+  context: { accountId: string; path: string }
+): Promise<ElizaError> {
+  // error-policy:J3 the upstream error body is untrusted; an unparseable body
+  // degrades to an empty record and the HTTP status still drives the code.
+  const bodyText = await response.text().catch(() => "");
+  let body: JsonRecord = {};
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (isRecord(parsed)) body = parsed;
+  } catch {
+    // 409/429 bodies are JSON; auth failures can be plain text.
+  }
+  const errorTag = errorTagOf(body);
+  const summary = typeof body.error_summary === "string" ? body.error_summary : undefined;
+  const base = { ...context, status: response.status, errorTag, summary };
+
+  if (response.status === 401) {
+    return new ElizaError(
+      "DropboxClient: access token is invalid, expired, or revoked; refresh or reconnect the Dropbox account.",
+      { code: "DROPBOX_AUTH_EXPIRED", context: base }
+    );
+  }
+  if (response.status === 403) {
+    return new ElizaError("DropboxClient: access denied for this resource.", {
+      code: "DROPBOX_FORBIDDEN",
+      context: base,
+    });
+  }
+  if (response.status === 429) {
+    const retryAfterBody = asRecord(body.error)?.retry_after;
+    return new ElizaError("DropboxClient: rate limited by Dropbox; retry after the given delay.", {
+      code: "DROPBOX_RATE_LIMITED",
+      context: {
+        ...base,
+        retryAfterSeconds:
+          typeof retryAfterBody === "number"
+            ? retryAfterBody
+            : parseRetryAfter(response.headers.get("Retry-After")),
+      },
+    });
+  }
+  if (response.status === 409) {
+    if (summary?.includes("not_found") || errorTag === "path" || errorTag === "path_lookup") {
+      const pathTag = pathErrorTag(body);
+      if (pathTag === "not_found" || summary?.includes("not_found")) {
+        return new ElizaError("DropboxClient: path not found.", {
+          code: "DROPBOX_NOT_FOUND",
+          context: base,
+        });
+      }
+    }
+    return new ElizaError(
+      `DropboxClient: request conflicted: ${summary ?? errorTag ?? "unknown endpoint error"}`,
+      { code: "DROPBOX_INVALID_REQUEST", context: base }
+    );
+  }
+  if (response.status === 400) {
+    return new ElizaError(
+      `DropboxClient: request rejected: ${summary ?? (bodyText.slice(0, 200) || "bad input")}`,
+      { code: "DROPBOX_INVALID_REQUEST", context: base }
+    );
+  }
+  return new ElizaError(`DropboxClient: Dropbox request failed with status ${response.status}.`, {
+    code: "DROPBOX_UPSTREAM_FAILURE",
+    context: base,
+  });
+}
+
+function errorTagOf(body: JsonRecord): string | undefined {
+  const error = asRecord(body.error);
+  const tag = error?.[".tag"];
+  return typeof tag === "string" ? tag : undefined;
+}
+
+function pathErrorTag(body: JsonRecord): string | undefined {
+  const error = asRecord(body.error);
+  const path = asRecord(error?.path) ?? asRecord(error?.path_lookup);
+  const tag = path?.[".tag"];
+  return typeof tag === "string" ? tag : undefined;
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function normalizedPageSize(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 100;
+  }
+  return Math.min(Math.trunc(value), MAX_PAGE_SIZE);
+}
+
+/** Dropbox-API-Arg must be ASCII-safe; non-ASCII is escaped per Dropbox docs. */
+export function dropboxApiArg(value: JsonRecord): string {
+  return JSON.stringify(value).replace(
+    /[\u007f-\uffff]/g,
+    (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`
+  );
+}
+
+function looksBinary(bytes: Uint8Array): boolean {
+  const sample = bytes.subarray(0, Math.min(bytes.length, 8192));
+  for (const byte of sample) {
+    if (byte === 0) return true;
+  }
+  return false;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function readArray(payload: JsonRecord, key: string): JsonRecord[] {
+  const value = payload[key];
+  if (!Array.isArray(value)) {
+    throw new ElizaError(`DropboxClient: Dropbox response is missing the "${key}" array.`, {
+      code: "DROPBOX_MALFORMED_RESPONSE",
+      context: { key, valueType: typeof value },
+    });
+  }
+  return value.filter(isRecord);
+}
+
+function readNullableString(payload: JsonRecord, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function mapEntry(item: JsonRecord): DropboxEntry {
+  const tag = item[".tag"];
+  const kind = tag === "folder" ? "folder" : tag === "deleted" ? "deleted" : "file";
+  const name = typeof item.name === "string" ? item.name : "";
+  const pathLower = typeof item.path_lower === "string" ? item.path_lower : "";
+  const pathDisplay = typeof item.path_display === "string" ? item.path_display : pathLower;
+  if (!name || (!pathLower && kind !== "deleted")) {
+    throw new ElizaError("DropboxClient: Dropbox entry is missing its name or path.", {
+      code: "DROPBOX_MALFORMED_RESPONSE",
+      context: { kind, hasName: Boolean(name), hasPath: Boolean(pathLower) },
+    });
+  }
+  return {
+    kind,
+    id: typeof item.id === "string" ? item.id : "",
+    name,
+    pathLower,
+    pathDisplay,
+    url: dropboxDeepLink(pathDisplay, kind),
+    size: typeof item.size === "number" ? item.size : undefined,
+    clientModified: typeof item.client_modified === "string" ? item.client_modified : undefined,
+    serverModified: typeof item.server_modified === "string" ? item.server_modified : undefined,
+    contentHash: typeof item.content_hash === "string" ? item.content_hash : undefined,
+  };
+}
+
+/** Deterministic dropbox.com deep link: folders browse in /home, files preview. */
+export function dropboxDeepLink(pathDisplay: string, kind: DropboxEntry["kind"]): string {
+  if (!pathDisplay) return "https://www.dropbox.com/home";
+  const encoded = pathDisplay
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  if (kind === "folder") {
+    return `https://www.dropbox.com/home${encoded}`;
+  }
+  const lastSlash = pathDisplay.lastIndexOf("/");
+  const parent = pathDisplay.slice(0, Math.max(lastSlash, 0));
+  const file = pathDisplay.slice(lastSlash + 1);
+  const encodedParent = parent
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `https://www.dropbox.com/home${encodedParent}?preview=${encodeURIComponent(file)}`;
+}

--- a/plugins/plugin-dropbox/src/connector-account-provider.ts
+++ b/plugins/plugin-dropbox/src/connector-account-provider.ts
@@ -1,0 +1,400 @@
+/**
+ * Dropbox ConnectorAccountManager provider. Bridges plugin-dropbox to the core
+ * ConnectorAccountManager so the generic HTTP CRUD + OAuth surface can list,
+ * create, patch, delete, and run the OAuth flow for Dropbox accounts.
+ *
+ * Dropbox OAuth uses PKCE and `token_access_type=offline`, so a completed
+ * grant yields a short-lived access token plus a refresh token; the credential
+ * resolver owns refresh. The default requested scopes are the read set plus
+ * the explicit write escalation scope pair — callers may pass `scopes` to
+ * narrow or widen, and the granted scope string is recorded on the account.
+ */
+import { createHash, randomBytes } from "node:crypto";
+import {
+  type ConnectorAccount,
+  type ConnectorAccountManager,
+  type ConnectorAccountPatch,
+  type ConnectorAccountProvider,
+  type ConnectorOAuthCallbackRequest,
+  type ConnectorOAuthCallbackResult,
+  type ConnectorOAuthStartRequest,
+  type ConnectorOAuthStartResult,
+  ElizaError,
+  type IAgentRuntime,
+  logger,
+} from "@elizaos/core";
+import { persistConnectorCredentialRefs } from "@elizaos/plugin-google-workspace/connector-credential-refs";
+import { DROPBOX_SERVICE_NAME } from "./types.js";
+
+export const DROPBOX_AUTHORIZATION_ENDPOINT = "https://www.dropbox.com/oauth2/authorize";
+export const DROPBOX_TOKEN_ENDPOINT = "https://api.dropboxapi.com/oauth2/token";
+export const DROPBOX_CURRENT_ACCOUNT_ENDPOINT =
+  "https://api.dropboxapi.com/2/users/get_current_account";
+/** Maximum time allowed for one Dropbox OAuth or identity request. */
+export const DROPBOX_OAUTH_FETCH_TIMEOUT_MS = 15_000;
+
+/** Read-default scope set; write scopes are the explicit escalation. */
+export const DROPBOX_READ_SCOPES = [
+  "account_info.read",
+  "files.metadata.read",
+  "files.content.read",
+] as const;
+export const DROPBOX_WRITE_SCOPES = ["files.metadata.write", "files.content.write"] as const;
+
+interface DropboxTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type?: string;
+  refresh_token?: string;
+  scope?: string;
+  account_id?: string;
+  team_id?: string;
+  uid?: string;
+}
+
+interface DropboxIdentity {
+  account_id?: string;
+  email?: string;
+  name?: { display_name?: string };
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readClientConfig(runtime: IAgentRuntime): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} {
+  const clientId = nonEmptyString(runtime.getSetting?.("DROPBOX_CLIENT_ID"));
+  const clientSecret = nonEmptyString(runtime.getSetting?.("DROPBOX_CLIENT_SECRET"));
+  const redirectUri = nonEmptyString(runtime.getSetting?.("DROPBOX_REDIRECT_URI"));
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new ElizaError(
+      "Dropbox OAuth requires DROPBOX_CLIENT_ID, DROPBOX_CLIENT_SECRET, and DROPBOX_REDIRECT_URI to be configured.",
+      { code: "DROPBOX_OAUTH_NOT_CONFIGURED", severity: "fatal" }
+    );
+  }
+  return { clientId, clientSecret, redirectUri };
+}
+
+function normalizeRequestedScopes(scopes: readonly string[] | undefined): string[] {
+  if (scopes === undefined) {
+    return [...DROPBOX_READ_SCOPES, ...DROPBOX_WRITE_SCOPES];
+  }
+  const known = new Set<string>([...DROPBOX_READ_SCOPES, ...DROPBOX_WRITE_SCOPES]);
+  const requested = new Set<string>();
+  for (const scope of scopes) {
+    const trimmed = scope.trim();
+    if (!trimmed) continue;
+    if (!known.has(trimmed)) {
+      throw new ElizaError(`Dropbox OAuth scope is not recognized: ${trimmed}`, {
+        code: "DROPBOX_OAUTH_SCOPE_UNRECOGNIZED",
+        context: { scope: trimmed },
+        severity: "fatal",
+      });
+    }
+    requested.add(trimmed);
+  }
+  if (requested.size === 0) {
+    throw new ElizaError("Dropbox OAuth requires at least one recognized scope.", {
+      code: "DROPBOX_OAUTH_SCOPE_REQUIRED",
+      context: { scopes: [...scopes] },
+      severity: "fatal",
+    });
+  }
+  requested.add("account_info.read");
+  return [...requested];
+}
+
+export async function exchangeDropboxAuthorizationCode(
+  args: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    code: string;
+    codeVerifier?: string;
+  },
+  fetchImpl: typeof fetch = globalThis.fetch,
+  tokenEndpoint: string = DROPBOX_TOKEN_ENDPOINT,
+  timeoutMs: number = DROPBOX_OAUTH_FETCH_TIMEOUT_MS
+): Promise<DropboxTokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+  });
+  if (args.codeVerifier) {
+    params.set("code_verifier", args.codeVerifier);
+  }
+  const response = await fetchImpl(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new ElizaError(`Dropbox token exchange failed with ${response.status}.`, {
+      code: "DROPBOX_OAUTH_TOKEN_EXCHANGE_FAILED",
+      context: { status: response.status, body: body.slice(0, 500) },
+      severity: "fatal",
+    });
+  }
+  const parsed = (await response.json()) as DropboxTokenResponse;
+  if (!nonEmptyString(parsed?.access_token) || !Number.isFinite(parsed?.expires_in)) {
+    throw new ElizaError("Dropbox token exchange returned an invalid payload.", {
+      code: "DROPBOX_OAUTH_TOKEN_PAYLOAD_INVALID",
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
+
+async function fetchDropboxIdentity(
+  accessToken: string,
+  fetchImpl: typeof fetch,
+  endpoint: string
+): Promise<DropboxIdentity> {
+  const response = await fetchImpl(endpoint, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(DROPBOX_OAUTH_FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new ElizaError(`Dropbox identity request failed with ${response.status}.`, {
+      code: "DROPBOX_OAUTH_IDENTITY_FAILED",
+      context: { status: response.status },
+      severity: "fatal",
+    });
+  }
+  const parsed = (await response.json()) as DropboxIdentity;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ElizaError("Dropbox identity returned an invalid payload.", {
+      code: "DROPBOX_OAUTH_IDENTITY_INVALID",
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
+
+/**
+ * Build the Dropbox ConnectorAccountProvider: account CRUD adapters plus the
+ * PKCE offline OAuth flow that records account identity and granted scopes
+ * and persists the token set (access + refresh) as a durable credential ref.
+ */
+export function createDropboxConnectorAccountProvider(
+  runtime: IAgentRuntime,
+  options: {
+    fetchImpl?: typeof fetch;
+    tokenEndpoint?: string;
+    identityEndpoint?: string;
+  } = {}
+): ConnectorAccountProvider {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const tokenEndpoint = options.tokenEndpoint ?? DROPBOX_TOKEN_ENDPOINT;
+  const identityEndpoint = options.identityEndpoint ?? DROPBOX_CURRENT_ACCOUNT_ENDPOINT;
+  return {
+    provider: DROPBOX_SERVICE_NAME,
+    label: "Dropbox",
+
+    listAccounts: async (manager: ConnectorAccountManager): Promise<ConnectorAccount[]> => {
+      return manager.getStorage().listAccounts(DROPBOX_SERVICE_NAME);
+    },
+
+    createAccount: async (input: ConnectorAccountPatch, _manager: ConnectorAccountManager) => {
+      return {
+        ...input,
+        provider: DROPBOX_SERVICE_NAME,
+        role: input.role ?? "OWNER",
+        purpose: input.purpose ?? ["drive"],
+        accessGate: input.accessGate ?? "open",
+        status: input.status ?? "pending",
+      };
+    },
+
+    patchAccount: async (
+      _accountId: string,
+      patch: ConnectorAccountPatch,
+      _manager: ConnectorAccountManager
+    ) => {
+      return { ...patch, provider: DROPBOX_SERVICE_NAME };
+    },
+
+    deleteAccount: async (_accountId: string, _manager: ConnectorAccountManager): Promise<void> => {
+      // Credential cleanup is the credential store's responsibility; the
+      // manager removes the account row after this resolves.
+    },
+
+    startOAuth: async (
+      request: ConnectorOAuthStartRequest,
+      _manager: ConnectorAccountManager
+    ): Promise<ConnectorOAuthStartResult> => {
+      const config = readClientConfig(runtime);
+      const scopes = normalizeRequestedScopes(request.scopes);
+      const codeVerifier = randomBytes(64).toString("base64url");
+      const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+      const params = new URLSearchParams({
+        client_id: config.clientId,
+        redirect_uri: config.redirectUri,
+        response_type: "code",
+        state: request.flow.state,
+        token_access_type: "offline",
+        scope: scopes.join(" "),
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+      });
+      return {
+        authUrl: `${DROPBOX_AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+        redirectUri: config.redirectUri,
+        codeVerifier,
+        metadata: {
+          ...request.metadata,
+          requestedScopes: scopes,
+          redirectUri: config.redirectUri,
+        },
+      };
+    },
+
+    completeOAuth: async (
+      request: ConnectorOAuthCallbackRequest,
+      manager: ConnectorAccountManager
+    ): Promise<ConnectorOAuthCallbackResult> => {
+      const code = nonEmptyString(request.code);
+      if (!code) {
+        throw new ElizaError("Dropbox OAuth callback is missing an authorization code.", {
+          code: "DROPBOX_OAUTH_CODE_MISSING",
+          severity: "fatal",
+        });
+      }
+      const config = readClientConfig(runtime);
+      const redirectUri =
+        nonEmptyString(request.flow.redirectUri) ??
+        nonEmptyString(
+          (request.flow.metadata as Record<string, unknown> | undefined)?.redirectUri
+        ) ??
+        config.redirectUri;
+
+      const tokens = await exchangeDropboxAuthorizationCode(
+        {
+          clientId: config.clientId,
+          clientSecret: config.clientSecret,
+          redirectUri,
+          code,
+          codeVerifier: request.flow.codeVerifier,
+        },
+        fetchImpl,
+        tokenEndpoint
+      );
+
+      let externalId = nonEmptyString(tokens.account_id);
+      let identity: DropboxIdentity = {};
+      // Identity enrichment is required when the token payload omits
+      // account_id; otherwise it only adds display name/email.
+      if (!externalId) {
+        identity = await fetchDropboxIdentity(tokens.access_token, fetchImpl, identityEndpoint);
+        externalId = nonEmptyString(identity.account_id);
+      } else {
+        // error-policy:J4 display metadata is optional; a failed identity call
+        // degrades to an account labeled "Dropbox" while the grant stands.
+        identity = await fetchDropboxIdentity(
+          tokens.access_token,
+          fetchImpl,
+          identityEndpoint
+        ).catch(() => ({}));
+      }
+      if (!externalId) {
+        throw new ElizaError("Dropbox OAuth response did not include an account id.", {
+          code: "DROPBOX_OAUTH_IDENTITY_MISSING",
+          severity: "fatal",
+        });
+      }
+
+      const grantedScopes = nonEmptyString(tokens.scope)?.split(/\s+/).filter(Boolean) ?? [];
+      const displayName = nonEmptyString(identity.name?.display_name);
+      const email = nonEmptyString(identity.email);
+      const expiresAt = Date.now() + tokens.expires_in * 1000;
+      const oauthCredentialVersion = String(Date.now());
+      const accountMetadata = {
+        email: email ?? null,
+        name: displayName ?? null,
+        teamId: nonEmptyString(tokens.team_id) ?? null,
+        grantedScopes,
+        hasRefreshToken: Boolean(tokens.refresh_token),
+        expiresAt,
+        oauthCredentialVersion,
+      };
+
+      const pendingAccount = await manager.upsertAccount(
+        DROPBOX_SERVICE_NAME,
+        {
+          provider: DROPBOX_SERVICE_NAME,
+          role: "OWNER",
+          purpose: ["drive"],
+          accessGate: "open",
+          status: "pending",
+          externalId,
+          displayHandle: email ?? displayName,
+          label: displayName ?? email ?? "Dropbox",
+          metadata: accountMetadata,
+        },
+        request.flow.accountId
+      );
+
+      const credentialPersist = await persistConnectorCredentialRefs({
+        runtime,
+        manager,
+        provider: DROPBOX_SERVICE_NAME,
+        accountIdForRef: pendingAccount.id,
+        storageAccountId: pendingAccount.id,
+        caller: "plugin-dropbox",
+        credentials: [
+          {
+            credentialType: "oauth.tokens",
+            value: JSON.stringify({
+              access_token: tokens.access_token,
+              ...(tokens.refresh_token ? { refresh_token: tokens.refresh_token } : {}),
+              token_type: tokens.token_type ?? "bearer",
+              scope: grantedScopes.join(" "),
+              account_id: externalId,
+              expiry_date: expiresAt,
+            }),
+            expiresAt,
+            metadata: {
+              provider: DROPBOX_SERVICE_NAME,
+              hasRefreshToken: Boolean(tokens.refresh_token),
+            },
+          },
+        ],
+      });
+
+      logger.info(
+        { src: "plugin:dropbox:connector", externalId, grantedScopes },
+        "Dropbox OAuth completed"
+      );
+
+      return {
+        account: {
+          ...pendingAccount,
+          id: pendingAccount.id,
+          provider: DROPBOX_SERVICE_NAME,
+          status: "connected",
+          metadata: {
+            ...accountMetadata,
+            credentialRefs: credentialPersist.refs,
+            credentialRefStorage: {
+              vaultAvailable: credentialPersist.vaultAvailable,
+              storageAvailable: credentialPersist.storageAvailable,
+            },
+          },
+        },
+        flow: { status: "completed" },
+      };
+    },
+  };
+}

--- a/plugins/plugin-dropbox/src/credential-resolver.ts
+++ b/plugins/plugin-dropbox/src/credential-resolver.ts
@@ -1,0 +1,376 @@
+/**
+ * `DefaultDropboxCredentialResolver` — turns a stored Dropbox connector account
+ * into a live bearer token. Resolution order: explicit BYO
+ * `DROPBOX_ACCESS_TOKEN` setting (local/self-hosted mode, `accountId`
+ * "default" or "local"), then the connector account's credential refs
+ * (metadata-embedded values first, then connector-account storage records,
+ * then vault refs read through the runtime's credential store / vault /
+ * secrets services).
+ *
+ * Dropbox access tokens are short-lived: when the stored token set carries an
+ * expiry within the refresh skew and a refresh token, the resolver performs the
+ * OAuth refresh grant against the token endpoint (mock-overridable via
+ * `ELIZA_MOCK_DROPBOX_BASE`) and caches the refreshed token in memory until it
+ * expires. A refresh rejection surfaces as `DROPBOX_AUTH_EXPIRED` so callers
+ * prompt for reconnection instead of retrying forever.
+ */
+import {
+  CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
+  type ConnectorAccount,
+  ElizaError,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+} from "@elizaos/core";
+import {
+  DROPBOX_SERVICE_NAME,
+  type DropboxAccountRef,
+  type DropboxCredentialResolver,
+  type DropboxResolvedCredential,
+} from "./types.js";
+
+const BYO_TOKEN_SETTING = "DROPBOX_ACCESS_TOKEN";
+const BYO_ACCOUNT_IDS = new Set(["default", "local"]);
+const TOKEN_CREDENTIAL_TYPES = [
+  "oauth.tokens",
+  "oauth.access_token",
+  "oauth.accessToken",
+  "access_token",
+  "accessToken",
+];
+/** Refresh this long before the recorded expiry to absorb clock skew. */
+const REFRESH_SKEW_MS = 60_000;
+export const DROPBOX_TOKEN_ENDPOINT_PATH = "/oauth2/token";
+const DROPBOX_DEFAULT_API_BASE = "https://api.dropboxapi.com";
+
+type JsonRecord = Record<string, unknown>;
+
+interface CredentialRefRecord {
+  credentialType: string;
+  value?: string | null;
+  token?: string | null;
+  secret?: string | null;
+  vaultRef?: string | null;
+}
+
+interface DropboxTokenSet {
+  accessToken?: string;
+  refreshToken?: string;
+  expiryDate?: number;
+  dropboxAccountId?: string;
+}
+
+export interface DefaultDropboxCredentialResolverOptions {
+  fetchImpl?: typeof fetch;
+  tokenEndpoint?: string;
+  now?: () => number;
+}
+
+export class DefaultDropboxCredentialResolver implements DropboxCredentialResolver {
+  private readonly fetchImpl: typeof fetch;
+  private readonly tokenEndpoint: string;
+  private readonly now: () => number;
+  private readonly refreshed = new Map<string, { accessToken: string; expiryDate: number }>();
+
+  constructor(
+    private readonly runtime?: IAgentRuntime | null,
+    options: DefaultDropboxCredentialResolverOptions = {}
+  ) {
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.tokenEndpoint =
+      options.tokenEndpoint ??
+      `${(process.env.ELIZA_MOCK_DROPBOX_BASE ?? DROPBOX_DEFAULT_API_BASE).replace(/\/$/, "")}${DROPBOX_TOKEN_ENDPOINT_PATH}`;
+    this.now = options.now ?? Date.now;
+  }
+
+  async getCredential(request: DropboxAccountRef): Promise<DropboxResolvedCredential> {
+    const byoToken = nonEmptyString(this.runtime?.getSetting?.(BYO_TOKEN_SETTING));
+    if (byoToken && BYO_ACCOUNT_IDS.has(request.accountId)) {
+      return { accessToken: byoToken };
+    }
+
+    const account = await this.getAccount(request.accountId);
+    if (!account) {
+      throw new ElizaError(
+        `DefaultDropboxCredentialResolver: Dropbox account ${request.accountId} was not found` +
+          " and no DROPBOX_ACCESS_TOKEN is configured for local mode.",
+        { code: "DROPBOX_ACCOUNT_NOT_FOUND", context: { accountId: request.accountId } }
+      );
+    }
+    if (account.status !== "connected") {
+      throw new ElizaError(
+        `DefaultDropboxCredentialResolver: Dropbox account ${request.accountId} is ${account.status}, not connected.`,
+        {
+          code: "DROPBOX_ACCOUNT_NOT_CONNECTED",
+          context: { accountId: request.accountId, status: account.status },
+        }
+      );
+    }
+
+    const tokenSet = await this.resolveTokenSet(account);
+    if (!tokenSet.accessToken && !tokenSet.refreshToken) {
+      throw new ElizaError(
+        `DefaultDropboxCredentialResolver: no token material is stored for Dropbox account ${request.accountId}.`,
+        { code: "DROPBOX_CREDENTIAL_MISSING", context: { accountId: request.accountId } }
+      );
+    }
+
+    const cached = this.refreshed.get(account.id);
+    if (cached && cached.expiryDate - REFRESH_SKEW_MS > this.now()) {
+      return { accessToken: cached.accessToken, dropboxAccountId: tokenSet.dropboxAccountId };
+    }
+
+    const expired =
+      typeof tokenSet.expiryDate === "number" &&
+      tokenSet.expiryDate - REFRESH_SKEW_MS <= this.now();
+    if ((expired || !tokenSet.accessToken) && tokenSet.refreshToken) {
+      const refreshedToken = await this.refreshAccessToken(account, tokenSet.refreshToken);
+      this.refreshed.set(account.id, refreshedToken);
+      return {
+        accessToken: refreshedToken.accessToken,
+        dropboxAccountId: tokenSet.dropboxAccountId,
+      };
+    }
+    if (!tokenSet.accessToken) {
+      throw new ElizaError(
+        `DefaultDropboxCredentialResolver: Dropbox account ${request.accountId} has no usable access token.`,
+        { code: "DROPBOX_CREDENTIAL_MISSING", context: { accountId: request.accountId } }
+      );
+    }
+    return { accessToken: tokenSet.accessToken, dropboxAccountId: tokenSet.dropboxAccountId };
+  }
+
+  clearCache(accountId?: string): void {
+    if (accountId) {
+      this.refreshed.delete(accountId);
+    } else {
+      this.refreshed.clear();
+    }
+  }
+
+  private async refreshAccessToken(
+    account: ConnectorAccount,
+    refreshToken: string
+  ): Promise<{ accessToken: string; expiryDate: number }> {
+    const clientId = nonEmptyString(this.runtime?.getSetting?.("DROPBOX_CLIENT_ID"));
+    const clientSecret = nonEmptyString(this.runtime?.getSetting?.("DROPBOX_CLIENT_SECRET"));
+    if (!clientId || !clientSecret) {
+      throw new ElizaError(
+        "DefaultDropboxCredentialResolver: a Dropbox refresh token is available, but DROPBOX_CLIENT_ID and DROPBOX_CLIENT_SECRET are not configured for token refresh.",
+        { code: "DROPBOX_OAUTH_NOT_CONFIGURED", context: { accountId: account.id } }
+      );
+    }
+    const response = await this.fetchImpl(this.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }).toString(),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      throw new ElizaError(
+        `DefaultDropboxCredentialResolver: Dropbox token refresh failed with ${response.status}; reconnect the account.`,
+        {
+          code: "DROPBOX_AUTH_EXPIRED",
+          context: { accountId: account.id, status: response.status },
+        }
+      );
+    }
+    const parsed = (await response.json().catch(() => null)) as {
+      access_token?: string;
+      expires_in?: number;
+    } | null;
+    const accessToken = nonEmptyString(parsed?.access_token);
+    if (!accessToken || typeof parsed?.expires_in !== "number") {
+      throw new ElizaError(
+        "DefaultDropboxCredentialResolver: Dropbox token refresh returned an invalid payload.",
+        { code: "DROPBOX_MALFORMED_RESPONSE", context: { accountId: account.id } }
+      );
+    }
+    return { accessToken, expiryDate: this.now() + parsed.expires_in * 1000 };
+  }
+
+  private async getAccount(accountId: string): Promise<ConnectorAccount | null> {
+    const manager = this.runtime ? getConnectorAccountManager(this.runtime) : null;
+    if (!manager) return null;
+    const direct = await manager.getAccount(DROPBOX_SERVICE_NAME, accountId);
+    if (direct) return direct;
+    if (BYO_ACCOUNT_IDS.has(accountId)) {
+      const connected = (await manager.listAccounts(DROPBOX_SERVICE_NAME)).filter(
+        (account) => account.status === "connected"
+      );
+      if (connected.length === 1) return connected[0];
+    }
+    return null;
+  }
+
+  private async resolveTokenSet(account: ConnectorAccount): Promise<DropboxTokenSet> {
+    const merged: DropboxTokenSet = {};
+    for (const record of credentialRecordsFromMetadata(account.metadata)) {
+      mergeTokenSet(merged, await this.valueFromRecord(record));
+    }
+    if (!merged.accessToken && !merged.refreshToken) {
+      for (const record of await this.loadStorageRecords(account.id)) {
+        mergeTokenSet(merged, await this.valueFromRecord(record));
+      }
+    }
+    return merged;
+  }
+
+  private async loadStorageRecords(accountId: string): Promise<CredentialRefRecord[]> {
+    const storage = this.resolveStorage();
+    if (!storage) return [];
+    if (typeof storage.listConnectorAccountCredentialRefs === "function") {
+      return storage.listConnectorAccountCredentialRefs({ accountId });
+    }
+    if (typeof storage.getConnectorAccountCredentialRef !== "function") return [];
+    const records: CredentialRefRecord[] = [];
+    for (const credentialType of TOKEN_CREDENTIAL_TYPES) {
+      const record = await storage.getConnectorAccountCredentialRef({ accountId, credentialType });
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  private resolveStorage(): {
+    listConnectorAccountCredentialRefs?: (params: {
+      accountId: string;
+    }) => Promise<CredentialRefRecord[]>;
+    getConnectorAccountCredentialRef?: (params: {
+      accountId: string;
+      credentialType: string;
+    }) => Promise<CredentialRefRecord | null>;
+  } | null {
+    if (!this.runtime) return null;
+    const service = safelyGetService(this.runtime, CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE);
+    if (isStorageLike(service)) return service;
+    const manager = getConnectorAccountManager(this.runtime);
+    const storage = manager?.getStorage();
+    return isStorageLike(storage) ? storage : null;
+  }
+
+  private async valueFromRecord(record: CredentialRefRecord): Promise<string | undefined> {
+    if (
+      !TOKEN_CREDENTIAL_TYPES.some((t) => t.toLowerCase() === record.credentialType.toLowerCase())
+    ) {
+      return undefined;
+    }
+    return (
+      nonEmptyString(record.value) ??
+      nonEmptyString(record.token) ??
+      nonEmptyString(record.secret) ??
+      (record.vaultRef ? await this.readVaultRef(record.vaultRef) : undefined)
+    );
+  }
+
+  private async readVaultRef(vaultRef: string): Promise<string | undefined> {
+    if (!this.runtime) return undefined;
+    for (const serviceType of ["connector-credential-store", "vault", "secrets"]) {
+      const service = safelyGetService(this.runtime, serviceType) as {
+        reveal?: (key: string, caller?: string) => Promise<string> | string;
+        get?: (
+          key: string,
+          options?: { reveal?: boolean; caller?: string } | JsonRecord
+        ) => Promise<string | null> | string | null;
+      } | null;
+      if (!service) continue;
+      // error-policy:J4 an individual store missing/failing this ref is an
+      // expected miss; the caller reports CREDENTIAL_MISSING when all miss.
+      try {
+        if (typeof service.reveal === "function") {
+          const value = nonEmptyString(await service.reveal(vaultRef, "plugin-dropbox"));
+          if (value) return value;
+        } else if (typeof service.get === "function") {
+          const value = nonEmptyString(
+            await service.get(vaultRef, { reveal: true, caller: "plugin-dropbox" })
+          );
+          if (value) return value;
+        }
+      } catch {
+        // continue to the next reader
+      }
+    }
+    return undefined;
+  }
+}
+
+function mergeTokenSet(target: DropboxTokenSet, raw: string | undefined): void {
+  if (!raw) return;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    target.accessToken ??= trimmed;
+    return;
+  }
+  // error-policy:J3 a persisted token-set that fails to parse contributes
+  // nothing rather than fabricating credentials from a broken blob.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return;
+  const record = parsed as JsonRecord;
+  target.accessToken ??= nonEmptyString(record.access_token) ?? nonEmptyString(record.accessToken);
+  target.refreshToken ??=
+    nonEmptyString(record.refresh_token) ?? nonEmptyString(record.refreshToken);
+  target.dropboxAccountId ??= nonEmptyString(record.account_id) ?? nonEmptyString(record.accountId);
+  if (target.expiryDate === undefined) {
+    const expiry = record.expiry_date ?? record.expiryDate ?? record.expires_at;
+    if (typeof expiry === "number" && Number.isFinite(expiry)) {
+      target.expiryDate = expiry;
+    }
+  }
+}
+
+function credentialRecordsFromMetadata(metadata: unknown): CredentialRefRecord[] {
+  const record =
+    metadata !== null && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as JsonRecord)
+      : undefined;
+  const refs = record?.credentialRefs;
+  if (!Array.isArray(refs)) return [];
+  return refs.filter(
+    (ref): ref is CredentialRefRecord =>
+      ref !== null &&
+      typeof ref === "object" &&
+      !Array.isArray(ref) &&
+      typeof (ref as JsonRecord).credentialType === "string"
+  );
+}
+
+function safelyGetService(runtime: IAgentRuntime, serviceType: string): unknown {
+  // error-policy:J4 a missing optional storage/vault service is a designed
+  // absence; resolution continues down the fallback chain.
+  try {
+    return runtime.getService(serviceType);
+  } catch {
+    return null;
+  }
+}
+
+function isStorageLike(value: unknown): value is {
+  listConnectorAccountCredentialRefs?: (params: {
+    accountId: string;
+  }) => Promise<CredentialRefRecord[]>;
+  getConnectorAccountCredentialRef?: (params: {
+    accountId: string;
+    credentialType: string;
+  }) => Promise<CredentialRefRecord | null>;
+} {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as JsonRecord;
+  return (
+    typeof candidate.listConnectorAccountCredentialRefs === "function" ||
+    typeof candidate.getConnectorAccountCredentialRef === "function"
+  );
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/plugins/plugin-dropbox/src/index.ts
+++ b/plugins/plugin-dropbox/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Plugin entry for @elizaos/plugin-dropbox: re-exports every public symbol and
+ * defines `dropboxPlugin`. The plugin registers `DropboxService` (folder
+ * listing, search, and text reads by default; uploads as explicit writes) and
+ * at init attaches the Dropbox connector-account provider to the runtime's
+ * ConnectorAccountManager so the generic connector HTTP routes can manage
+ * accounts and drive the PKCE offline OAuth flow. It registers no actions or
+ * providers of its own; domain plugins invoke the service directly.
+ */
+import type { IAgentRuntime, Plugin } from "@elizaos/core";
+import { getConnectorAccountManager, logger } from "@elizaos/core";
+import { createDropboxConnectorAccountProvider } from "./connector-account-provider.js";
+import { DropboxService } from "./service.js";
+import { DROPBOX_SERVICE_NAME } from "./types.js";
+
+export * from "./client.js";
+export * from "./connector-account-provider.js";
+export * from "./credential-resolver.js";
+export * from "./types.js";
+export { DropboxService };
+
+export const dropboxPlugin: Plugin = {
+  name: DROPBOX_SERVICE_NAME,
+  description:
+    "Dropbox integration for file listing, search, text reads, uploads, and deep links with PKCE offline OAuth",
+  services: [DropboxService],
+  actions: [],
+  providers: [],
+  tests: [],
+
+  init: async (_config: Record<string, string>, runtime: IAgentRuntime): Promise<void> => {
+    // error-policy:J4 a runtime without a ConnectorAccountManager (minimal
+    // hosts, BYO-token local mode) still gets the service; only managed OAuth
+    // account CRUD is unavailable and that absence is logged.
+    try {
+      const manager = getConnectorAccountManager(runtime);
+      manager.registerProvider(createDropboxConnectorAccountProvider(runtime));
+    } catch (err) {
+      logger.warn(
+        {
+          src: "plugin:dropbox",
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to register Dropbox provider with ConnectorAccountManager"
+      );
+    }
+  },
+};
+
+export default dropboxPlugin;

--- a/plugins/plugin-dropbox/src/service.ts
+++ b/plugins/plugin-dropbox/src/service.ts
@@ -1,0 +1,86 @@
+/**
+ * `DropboxService` — the sole runtime service and single entry point for the
+ * plugin. Wraps `DropboxClient` and delegates every `IDropboxService` method.
+ * Retrieved via `runtime.getService("dropbox")`. Credential resolution defaults
+ * to `DefaultDropboxCredentialResolver` but can be swapped (constructor option
+ * or `setCredentialResolver`) for tests.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger, Service } from "@elizaos/core";
+import { DropboxClient, type DropboxClientOptions } from "./client.js";
+import { DefaultDropboxCredentialResolver } from "./credential-resolver.js";
+import {
+  DROPBOX_SERVICE_NAME,
+  type DropboxAccountRef,
+  type DropboxCredentialResolver,
+  type DropboxEntry,
+  type DropboxFileText,
+  type DropboxListPage,
+  type DropboxUploadInput,
+  type IDropboxService,
+} from "./types.js";
+
+export interface DropboxServiceOptions {
+  credentialResolver?: DropboxCredentialResolver;
+  clientOptions?: DropboxClientOptions;
+}
+
+export class DropboxService extends Service implements IDropboxService {
+  static serviceType = DROPBOX_SERVICE_NAME;
+
+  capabilityDescription =
+    "Dropbox service for listing, searching, reading, uploading, and deep-linking files";
+
+  private client: DropboxClient;
+  private readonly clientOptions: DropboxClientOptions;
+
+  constructor(runtime?: IAgentRuntime, options: DropboxServiceOptions = {}) {
+    super(runtime);
+    this.clientOptions = options.clientOptions ?? {};
+    this.client = new DropboxClient(
+      options.credentialResolver ?? new DefaultDropboxCredentialResolver(runtime),
+      this.clientOptions
+    );
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<DropboxService> {
+    logger.info("Starting Dropbox plugin");
+    return new DropboxService(runtime);
+  }
+
+  setCredentialResolver(credentialResolver: DropboxCredentialResolver): void {
+    this.client = new DropboxClient(credentialResolver, this.clientOptions);
+  }
+
+  async stop(): Promise<void> {
+    logger.info("Stopping Dropbox plugin");
+  }
+
+  listFolder(
+    params: DropboxAccountRef & { path?: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage> {
+    return this.client.listFolder(params);
+  }
+
+  search(
+    params: DropboxAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage> {
+    return this.client.search(params);
+  }
+
+  getMetadata(params: DropboxAccountRef & { path: string }): Promise<DropboxEntry> {
+    return this.client.getMetadata(params);
+  }
+
+  downloadText(params: DropboxAccountRef & { path: string }): Promise<DropboxFileText> {
+    return this.client.downloadText(params);
+  }
+
+  upload(params: DropboxUploadInput): Promise<DropboxEntry> {
+    return this.client.upload(params);
+  }
+
+  getTemporaryLink(params: DropboxAccountRef & { path: string }): Promise<string> {
+    return this.client.getTemporaryLink(params);
+  }
+}

--- a/plugins/plugin-dropbox/src/types.ts
+++ b/plugins/plugin-dropbox/src/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Domain contracts for the Dropbox provider adapter. Every service method is
+ * account-scoped (`DropboxAccountRef`), listings and search results carry a
+ * deterministic dropbox.com deep link for citations, and credential resolution
+ * is pluggable via `DropboxCredentialResolver` (Dropbox access tokens are
+ * short-lived, so the resolver owns refresh).
+ */
+
+export const DROPBOX_SERVICE_NAME = "dropbox";
+
+/** All Dropbox API calls are account-scoped; there is no single-account shortcut. */
+export interface DropboxAccountRef {
+  accountId: string;
+}
+
+export interface DropboxResolvedCredential {
+  accessToken: string;
+  dropboxAccountId?: string;
+}
+
+export interface DropboxCredentialResolver {
+  getCredential(request: DropboxAccountRef): Promise<DropboxResolvedCredential>;
+}
+
+export interface DropboxEntry {
+  /** "file" | "folder" | "deleted" per the wire `.tag`. */
+  kind: "file" | "folder" | "deleted";
+  id: string;
+  name: string;
+  /** Lower-cased canonical path, e.g. "/reports/q3.pdf". */
+  pathLower: string;
+  pathDisplay: string;
+  /** dropbox.com browse deep link for citations. */
+  url: string;
+  size?: number;
+  clientModified?: string;
+  serverModified?: string;
+  contentHash?: string;
+}
+
+export interface DropboxListPage {
+  entries: DropboxEntry[];
+  cursor: string | null;
+  hasMore: boolean;
+}
+
+export interface DropboxFileText {
+  entry: DropboxEntry;
+  /** UTF-8 decoded content. Only offered for text-like files under the size cap. */
+  text: string;
+}
+
+export interface DropboxUploadInput extends DropboxAccountRef {
+  /** Absolute destination path, e.g. "/notes/today.md". */
+  path: string;
+  content: string | Uint8Array;
+  /** "add" fails on conflict; "overwrite" replaces. Defaults to "add". */
+  mode?: "add" | "overwrite";
+}
+
+export interface IDropboxService {
+  listFolder(
+    params: DropboxAccountRef & { path?: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage>;
+  search(
+    params: DropboxAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<DropboxListPage>;
+  getMetadata(params: DropboxAccountRef & { path: string }): Promise<DropboxEntry>;
+  downloadText(params: DropboxAccountRef & { path: string }): Promise<DropboxFileText>;
+  upload(params: DropboxUploadInput): Promise<DropboxEntry>;
+  getTemporaryLink(params: DropboxAccountRef & { path: string }): Promise<string>;
+}

--- a/plugins/plugin-dropbox/tsconfig.json
+++ b/plugins/plugin-dropbox/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/plugins/plugin-dropbox/vitest.config.ts
+++ b/plugins/plugin-dropbox/vitest.config.ts
@@ -1,0 +1,16 @@
+/** Runs Dropbox plugin source tests against real workspace packages with deterministic fetch mocks. */
+import { defineConfig } from "vitest/config";
+import { buildWorkspaceSourceAliases } from "../../packages/scripts/vitest/source-aliases.ts";
+
+const workspaceAliases = buildWorkspaceSourceAliases();
+
+export default defineConfig({
+  resolve: {
+    alias: workspaceAliases,
+  },
+  test: {
+    alias: workspaceAliases,
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**", "**/*.live.test.ts", "**/*.e2e.test.ts"],
+  },
+});

--- a/plugins/plugin-notion/AGENTS.md
+++ b/plugins/plugin-notion/AGENTS.md
@@ -1,0 +1,49 @@
+# @elizaos/plugin-notion
+
+Native Notion provider adapter. Projects a connected Notion workspace into the
+notes/documents capabilities: workspace search, page reads (flattened block
+plain text with citation deep links), page creation, and paragraph appends.
+Registers `NotionService` (`runtime.getService("notion")`) and a
+ConnectorAccountManager provider for the workspace-bound OAuth flow. No MCP
+runtime is involved; this plugin speaks the Notion REST API (2022-06-28)
+directly over fetch.
+
+## Architecture
+
+- `src/client.ts` — fetch-based REST client. All upstream failures become
+  typed `ElizaError`s (`NOTION_AUTH_EXPIRED`, `NOTION_RATE_LIMITED`,
+  `NOTION_NOT_FOUND`, `NOTION_MALFORMED_RESPONSE`, `NOTION_UPSTREAM_FAILURE`,
+  `NOTION_INVALID_REQUEST`); callers branch on `code`, never on HTTP details.
+  `ELIZA_MOCK_NOTION_BASE` overrides the base URL for protocol-faithful mock
+  servers.
+- `src/credential-resolver.ts` — account → bearer token. Order: BYO
+  `NOTION_TOKEN` setting (local mode, account id `default`/`local`), then
+  metadata credential refs, then connector-account storage records, then vault
+  refs. Notion tokens do not expire; revocation surfaces as
+  `NOTION_AUTH_EXPIRED` and requires reconnecting.
+- `src/connector-account-provider.ts` — OAuth start/complete. Notion has no
+  PKCE, no refresh tokens, and no incremental scopes; access is scoped by what
+  the user shares with the connection in Notion's consent UI. Tokens are
+  persisted as durable credential refs via the shared
+  `persistConnectorCredentialRefs` helper
+  (`@elizaos/plugin-google-workspace/connector-credential-refs`) — never in
+  account metadata.
+- `src/service.ts` / `src/index.ts` — `NotionService` and the plugin entry.
+
+## Invariants
+
+- Every read result carries the canonical `notion.so` URL for citations.
+- Search/read is the default posture; `createPage`/`appendToPage` are the
+  explicit write surface.
+- Tokens never appear in account metadata, logs, or error contexts.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-notion test
+bun run --cwd plugins/plugin-notion typecheck
+bun run --cwd plugins/plugin-notion lint:check
+```
+
+Tests use deterministic protocol-faithful fakes (request handlers serving real
+wire shapes), not mocks of the client under test.

--- a/plugins/plugin-notion/CLAUDE.md
+++ b/plugins/plugin-notion/CLAUDE.md
@@ -1,0 +1,49 @@
+# @elizaos/plugin-notion
+
+Native Notion provider adapter. Projects a connected Notion workspace into the
+notes/documents capabilities: workspace search, page reads (flattened block
+plain text with citation deep links), page creation, and paragraph appends.
+Registers `NotionService` (`runtime.getService("notion")`) and a
+ConnectorAccountManager provider for the workspace-bound OAuth flow. No MCP
+runtime is involved; this plugin speaks the Notion REST API (2022-06-28)
+directly over fetch.
+
+## Architecture
+
+- `src/client.ts` — fetch-based REST client. All upstream failures become
+  typed `ElizaError`s (`NOTION_AUTH_EXPIRED`, `NOTION_RATE_LIMITED`,
+  `NOTION_NOT_FOUND`, `NOTION_MALFORMED_RESPONSE`, `NOTION_UPSTREAM_FAILURE`,
+  `NOTION_INVALID_REQUEST`); callers branch on `code`, never on HTTP details.
+  `ELIZA_MOCK_NOTION_BASE` overrides the base URL for protocol-faithful mock
+  servers.
+- `src/credential-resolver.ts` — account → bearer token. Order: BYO
+  `NOTION_TOKEN` setting (local mode, account id `default`/`local`), then
+  metadata credential refs, then connector-account storage records, then vault
+  refs. Notion tokens do not expire; revocation surfaces as
+  `NOTION_AUTH_EXPIRED` and requires reconnecting.
+- `src/connector-account-provider.ts` — OAuth start/complete. Notion has no
+  PKCE, no refresh tokens, and no incremental scopes; access is scoped by what
+  the user shares with the connection in Notion's consent UI. Tokens are
+  persisted as durable credential refs via the shared
+  `persistConnectorCredentialRefs` helper
+  (`@elizaos/plugin-google-workspace/connector-credential-refs`) — never in
+  account metadata.
+- `src/service.ts` / `src/index.ts` — `NotionService` and the plugin entry.
+
+## Invariants
+
+- Every read result carries the canonical `notion.so` URL for citations.
+- Search/read is the default posture; `createPage`/`appendToPage` are the
+  explicit write surface.
+- Tokens never appear in account metadata, logs, or error contexts.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-notion test
+bun run --cwd plugins/plugin-notion typecheck
+bun run --cwd plugins/plugin-notion lint:check
+```
+
+Tests use deterministic protocol-faithful fakes (request handlers serving real
+wire shapes), not mocks of the client under test.

--- a/plugins/plugin-notion/README.md
+++ b/plugins/plugin-notion/README.md
@@ -1,0 +1,28 @@
+# @elizaos/plugin-notion
+
+Native Notion adapter for elizaOS agents: workspace search, page reads with
+citation deep links, page creation, and appends — no MCP runtime required.
+
+## Usage
+
+```ts
+import { notionPlugin, NotionService } from "@elizaos/plugin-notion";
+
+const notion = runtime.getService<NotionService>("notion");
+const page = await notion.search({ accountId: "default", query: "roadmap" });
+```
+
+## Configuration
+
+Managed mode (Cloud OAuth or self-hosted public integration):
+
+- `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_REDIRECT_URI` — the
+  public integration registered at https://www.notion.so/my-integrations with
+  the redirect URI added under OAuth settings.
+
+Local/self-hosted BYO mode:
+
+- `NOTION_TOKEN` — an internal integration token; used for account id
+  `default`. The integration only sees pages explicitly shared with it.
+
+See `CLAUDE.md` for architecture, error codes, and validation commands.

--- a/plugins/plugin-notion/biome.json
+++ b/plugins/plugin-notion/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "root": false,
+  "files": {
+    "includes": ["src/**", "__tests__/**", "build.ts", "vitest.config.ts"]
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "style": {},
+      "complexity": {
+        "noCommaOperator": "off",
+        "useLiteralKeys": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentWidth": 2,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  }
+}

--- a/plugins/plugin-notion/build.ts
+++ b/plugins/plugin-notion/build.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-notion. tsc-only (non-bundled) plugin: the
+ * shared driver cleans dist then runs `tsc --project tsconfig.json --noCheck`
+ * via the empty-targets path.
+ */
+import { buildPlugin } from "../plugin-build";
+
+await buildPlugin({
+  name: "@elizaos/plugin-notion",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
+});

--- a/plugins/plugin-notion/package.json
+++ b/plugins/plugin-notion/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "@elizaos/plugin-notion",
+  "version": "2.0.3-beta.7",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": ["registry-entry.json", "dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build.ts",
+    "test": "vitest run",
+    "test:watch": "vitest --config vitest.config.ts",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-google-workspace": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.8",
+    "@types/node": "^25.6.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "eliza": {
+    "platforms": ["node"],
+    "runtime": "node"
+  },
+  "agentConfig": {
+    "pluginParameters": {
+      "NOTION_CLIENT_ID": {
+        "type": "string",
+        "description": "Notion public-integration OAuth client ID",
+        "required": false,
+        "sensitive": false
+      },
+      "NOTION_CLIENT_SECRET": {
+        "type": "string",
+        "description": "Notion public-integration OAuth client secret",
+        "required": false,
+        "sensitive": true
+      },
+      "NOTION_REDIRECT_URI": {
+        "type": "string",
+        "description": "Notion OAuth redirect URI registered on the integration",
+        "required": false,
+        "sensitive": false
+      },
+      "NOTION_TOKEN": {
+        "type": "string",
+        "description": "Local BYO internal-integration token (self-hosted mode)",
+        "required": false,
+        "sensitive": true
+      }
+    }
+  }
+}

--- a/plugins/plugin-notion/registry-entry.json
+++ b/plugins/plugin-notion/registry-entry.json
@@ -1,0 +1,83 @@
+{
+  "id": "notion",
+  "name": "Notion",
+  "description": "Notion connector for workspace search, page reads with citation deep links, page creation, and appends. Uses workspace-bound OAuth; local mode accepts an internal integration token.",
+  "npmName": "@elizaos/plugin-notion",
+  "version": "2.0.0-beta.0",
+  "source": "bundled",
+  "tags": [
+    "notion",
+    "notes",
+    "documents",
+    "connector",
+    "productivity"
+  ],
+  "config": {
+    "NOTION_CLIENT_ID": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "OAuth Client ID",
+      "help": "Notion public-integration OAuth client ID. Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "NOTION_CLIENT_SECRET": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "OAuth Client Secret",
+      "help": "Notion public-integration OAuth client secret. Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "NOTION_REDIRECT_URI": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "OAuth Redirect URI",
+      "help": "Redirect URI registered on the Notion integration.",
+      "advanced": true
+    },
+    "NOTION_TOKEN": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "Internal Integration Token",
+      "help": "Local BYO internal-integration token for self-hosted mode. The integration only sees pages shared with it.",
+      "advanced": false
+    }
+  },
+  "render": {
+    "visible": true,
+    "pinTo": [],
+    "style": "setup-panel",
+    "icon": "FileText",
+    "group": "connector",
+    "groupOrder": 1,
+    "actions": [
+      "enable",
+      "configure",
+      "setup-guide"
+    ]
+  },
+  "resources": {
+    "homepage": "https://github.com/elizaOS/eliza/tree/develop/plugins/plugin-notion#readme",
+    "repository": "https://github.com/elizaOS/eliza"
+  },
+  "dependsOn": [],
+  "kind": "connector",
+  "subtype": "other",
+  "auth": {
+    "kind": "oauth",
+    "credentialKeys": [
+      "NOTION_TOKEN"
+    ]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The user's Notion workspace, connected via OAuth. The grant is scoped to exactly the pages and databases the user shares with the connection inside Notion's consent UI."
+    }
+  }
+}

--- a/plugins/plugin-notion/src/__tests__/client.test.ts
+++ b/plugins/plugin-notion/src/__tests__/client.test.ts
@@ -182,6 +182,27 @@ describe("NotionClient.search", () => {
     expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
   });
 
+  it("rejects an oversized declared success body before draining it", async () => {
+    let cancelled = false;
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{}"));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 200, headers: { "Content-Length": "4000001" } }
+      );
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
+    expect(cancelled).toBe(true);
+  });
+
   it("rejects an object result missing its id or url", async () => {
     const { fetchImpl } = fakeNotion(() => ({
       status: 200,

--- a/plugins/plugin-notion/src/__tests__/client.test.ts
+++ b/plugins/plugin-notion/src/__tests__/client.test.ts
@@ -1,0 +1,307 @@
+/**
+ * NotionClient contract tests against a deterministic, protocol-faithful fake
+ * Notion API (real 2022-06-28 wire shapes served through an injected fetch).
+ * Covers success, designed-empty, cursor pagination, expired/revoked auth,
+ * rate limiting with Retry-After, malformed upstream data, upstream failure,
+ * and write-path request shapes. No network access; the fake is a request
+ * handler, not a mock of the client under test.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { NOTION_API_VERSION, NotionClient } from "../client.js";
+import type { NotionCredentialResolver } from "../types.js";
+
+const resolver: NotionCredentialResolver = {
+  getCredential: async () => ({ accessToken: "secret_test_token" }),
+};
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function fakeNotion(
+  handler: (request: RecordedRequest) => {
+    status: number;
+    body: unknown;
+    headers?: Record<string, string>;
+  }
+): { fetchImpl: typeof fetch; requests: RecordedRequest[] } {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const request: RecordedRequest = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: Object.fromEntries(
+        Object.entries((init?.headers as Record<string, string>) ?? {}).map(([k, v]) => [
+          k.toLowerCase(),
+          v,
+        ])
+      ),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+    };
+    requests.push(request);
+    const result = handler(request);
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { "Content-Type": "application/json", ...result.headers },
+    });
+  };
+  return { fetchImpl, requests };
+}
+
+function page(id: string, title: string): Record<string, unknown> {
+  return {
+    object: "page",
+    id,
+    created_time: "2026-08-01T00:00:00.000Z",
+    last_edited_time: "2026-08-02T00:00:00.000Z",
+    archived: false,
+    url: `https://www.notion.so/${title.replace(/\s/g, "-")}-${id.replace(/-/g, "")}`,
+    parent: { type: "workspace", workspace: true },
+    properties: {
+      Name: {
+        id: "title",
+        type: "title",
+        title: [{ type: "text", plain_text: title, text: { content: title } }],
+      },
+    },
+  };
+}
+
+function client(fetchImpl: typeof fetch): NotionClient {
+  return new NotionClient(resolver, { baseUrl: "https://notion.test", fetchImpl });
+}
+
+describe("NotionClient.search", () => {
+  it("sends the bearer token, API version, and query, and maps results with deep links", async () => {
+    const { fetchImpl, requests } = fakeNotion(() => ({
+      status: 200,
+      body: {
+        object: "list",
+        results: [page("11111111-2222-3333-4444-555555555555", "Q3 Plan")],
+        next_cursor: null,
+        has_more: false,
+      },
+    }));
+    const result = await client(fetchImpl).search({ accountId: "acct", query: "plan" });
+
+    expect(requests[0].url).toBe("https://notion.test/v1/search");
+    expect(requests[0].headers.authorization).toBe("Bearer secret_test_token");
+    expect(requests[0].headers["notion-version"]).toBe(NOTION_API_VERSION);
+    expect((requests[0].body as { query: string }).query).toBe("plan");
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].title).toBe("Q3 Plan");
+    expect(result.results[0].url).toContain("https://www.notion.so/");
+    expect(result.results[0].parentType).toBe("workspace");
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("returns a designed-empty page when nothing matches", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 200,
+      body: { object: "list", results: [], next_cursor: null, has_more: false },
+    }));
+    const result = await client(fetchImpl).search({ accountId: "acct", query: "nothing" });
+    expect(result.results).toEqual([]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("passes the cursor through and surfaces the next one", async () => {
+    const { fetchImpl, requests } = fakeNotion((request) => {
+      const cursor = (request.body as { start_cursor?: string }).start_cursor;
+      return {
+        status: 200,
+        body: {
+          object: "list",
+          results: [page("11111111-2222-3333-4444-555555555555", cursor ? "Second" : "First")],
+          next_cursor: cursor ? null : "cursor-2",
+          has_more: !cursor,
+        },
+      };
+    });
+    const c = client(fetchImpl);
+    const first = await c.search({ accountId: "acct", query: "q" });
+    expect(first.hasMore).toBe(true);
+    expect(first.nextCursor).toBe("cursor-2");
+    const second = await c.search({ accountId: "acct", query: "q", cursor: "cursor-2" });
+    expect((requests[1].body as { start_cursor: string }).start_cursor).toBe("cursor-2");
+    expect(second.results[0].title).toBe("Second");
+    expect(second.hasMore).toBe(false);
+  });
+
+  it("maps 401 to NOTION_AUTH_EXPIRED", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 401,
+      body: {
+        object: "error",
+        status: 401,
+        code: "unauthorized",
+        message: "API token is invalid.",
+      },
+    }));
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("NOTION_AUTH_EXPIRED");
+  });
+
+  it("maps 429 to NOTION_RATE_LIMITED with the Retry-After delay", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 429,
+      headers: { "Retry-After": "17" },
+      body: { object: "error", status: 429, code: "rate_limited", message: "Rate limited." },
+    }));
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_RATE_LIMITED");
+    expect((error as ElizaError).context?.retryAfterSeconds).toBe(17);
+  });
+
+  it("maps 5xx to NOTION_UPSTREAM_FAILURE", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 503,
+      body: { object: "error", status: 503, code: "service_unavailable", message: "down" },
+    }));
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_UPSTREAM_FAILURE");
+  });
+
+  it("rejects a malformed success body missing the results array", async () => {
+    const { fetchImpl } = fakeNotion(() => ({ status: 200, body: { object: "list" } }));
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
+  });
+
+  it("rejects an object result missing its id or url", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 200,
+      body: {
+        object: "list",
+        results: [{ object: "page", id: "x" }],
+        next_cursor: null,
+        has_more: false,
+      },
+    }));
+    const error = await client(fetchImpl)
+      .search({ accountId: "acct", query: "q" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
+  });
+});
+
+describe("NotionClient.getPageContent", () => {
+  it("flattens paginated block children to plain text and reports unsupported types", async () => {
+    const pageId = "11111111-2222-3333-4444-555555555555";
+    const { fetchImpl, requests } = fakeNotion((request) => {
+      if (request.url.includes("/v1/pages/")) {
+        return { status: 200, body: page(pageId, "Doc") };
+      }
+      const isSecond = request.url.includes("start_cursor=blocks-2");
+      return {
+        status: 200,
+        body: {
+          object: "list",
+          results: isSecond
+            ? [
+                {
+                  object: "block",
+                  type: "to_do",
+                  to_do: { rich_text: [{ plain_text: "ship it" }], checked: true },
+                },
+                { object: "block", type: "image", image: {} },
+              ]
+            : [
+                {
+                  object: "block",
+                  type: "heading_1",
+                  heading_1: { rich_text: [{ plain_text: "Title" }] },
+                },
+                {
+                  object: "block",
+                  type: "paragraph",
+                  paragraph: { rich_text: [{ plain_text: "Body text" }] },
+                },
+              ],
+          next_cursor: isSecond ? null : "blocks-2",
+          has_more: !isSecond,
+        },
+      };
+    });
+    const content = await client(fetchImpl).getPageContent({ accountId: "acct", pageId });
+    expect(content.plainText).toBe("Title\nBody text\n[x] ship it");
+    expect(content.unsupportedBlockTypes).toEqual(["image"]);
+    expect(content.url).toContain("notion.so");
+    // page read + two block pages
+    expect(requests).toHaveLength(3);
+  });
+});
+
+describe("NotionClient writes", () => {
+  it("creates a page under a parent with title and paragraph children", async () => {
+    const { fetchImpl, requests } = fakeNotion(() => ({
+      status: 200,
+      body: page("99999999-2222-3333-4444-555555555555", "New Page"),
+    }));
+    const created = await client(fetchImpl).createPage({
+      accountId: "acct",
+      parentPageId: "parent-1",
+      title: "New Page",
+      content: "line one\nline two",
+    });
+    const body = requests[0].body as {
+      parent: { page_id: string };
+      children: Array<{ paragraph: { rich_text: Array<{ text: { content: string } }> } }>;
+    };
+    expect(body.parent.page_id).toBe("parent-1");
+    expect(body.children).toHaveLength(2);
+    expect(body.children[1].paragraph.rich_text[0].text.content).toBe("line two");
+    expect(created.title).toBe("New Page");
+  });
+
+  it("surfaces validation_error rejections as NOTION_INVALID_REQUEST", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 400,
+      body: {
+        object: "error",
+        status: 400,
+        code: "validation_error",
+        message: "parent.page_id should be a valid uuid",
+      },
+    }));
+    const error = await client(fetchImpl)
+      .createPage({ accountId: "acct", parentPageId: "nope", title: "x" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_INVALID_REQUEST");
+  });
+
+  it("appends paragraphs with PATCH to block children", async () => {
+    const { fetchImpl, requests } = fakeNotion(() => ({
+      status: 200,
+      body: { object: "list", results: [], next_cursor: null, has_more: false },
+    }));
+    await client(fetchImpl).appendToPage({ accountId: "acct", pageId: "p-1", content: "note" });
+    expect(requests[0].method).toBe("PATCH");
+    expect(requests[0].url).toBe("https://notion.test/v1/blocks/p-1/children");
+  });
+
+  it("maps 404 (not shared with the connection) to NOTION_NOT_FOUND", async () => {
+    const { fetchImpl } = fakeNotion(() => ({
+      status: 404,
+      body: { object: "error", status: 404, code: "object_not_found", message: "Could not find" },
+    }));
+    const error = await client(fetchImpl)
+      .getPage({ accountId: "acct", pageId: "missing" })
+      .catch((e: unknown) => e);
+    expect((error as ElizaError).code).toBe("NOTION_NOT_FOUND");
+  });
+});

--- a/plugins/plugin-notion/src/__tests__/connector-account-provider.test.ts
+++ b/plugins/plugin-notion/src/__tests__/connector-account-provider.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Notion connector-account-provider contract tests. Uses a real in-memory
+ * ConnectorAccountManager-shaped fake (storage-backed upsert) plus a
+ * protocol-faithful fake token endpoint via injected fetch — the system under
+ * test is the real provider. Covers OAuth start URL shape, callback success
+ * with credential-ref persistence via the shared connector-credential-refs
+ * helper, missing-code, failed exchange, invalid payload, and unconfigured
+ * client settings.
+ */
+import type {
+  ConnectorAccount,
+  ConnectorAccountManager,
+  ConnectorOAuthCallbackRequest,
+  ConnectorOAuthStartRequest,
+  IAgentRuntime,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  createNotionConnectorAccountProvider,
+  NOTION_TOKEN_ENDPOINT,
+} from "../connector-account-provider.js";
+
+function fakeRuntime(settings: Record<string, string>, services: Record<string, unknown> = {}) {
+  const vaultStore = new Map<string, string>();
+  const refs: Array<Record<string, unknown>> = [];
+  const runtime = {
+    agentId: "agent-1",
+    getSetting: (key: string) => settings[key],
+    getService: (type: string) => {
+      if (type in services) return services[type];
+      if (type === "vault") {
+        return {
+          set: async (key: string, value: string) => {
+            vaultStore.set(key, value);
+          },
+        };
+      }
+      return null;
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, vaultStore, refs };
+}
+
+function fakeManager() {
+  const accounts = new Map<string, ConnectorAccount>();
+  const credentialRefs: Array<Record<string, unknown>> = [];
+  const storage = {
+    listAccounts: async (provider: string) =>
+      [...accounts.values()].filter((account) => account.provider === provider),
+    getAccount: async (_provider: string, id: string) => accounts.get(id) ?? null,
+    upsertAccount: async (account: ConnectorAccount) => {
+      accounts.set(account.id, account);
+      return account;
+    },
+    deleteAccount: async (_provider: string, id: string) => {
+      accounts.delete(id);
+    },
+    setConnectorAccountCredentialRef: async (params: Record<string, unknown>) => {
+      credentialRefs.push(params);
+    },
+  };
+  const manager = {
+    getStorage: () => storage,
+    getAccount: async (provider: string, id: string) => storage.getAccount(provider, id),
+    listAccounts: async (provider: string) => storage.listAccounts(provider),
+    upsertAccount: async (
+      provider: string,
+      patch: Record<string, unknown>,
+      accountId?: string
+    ): Promise<ConnectorAccount> => {
+      const id = accountId ?? `acct-${accounts.size + 1}`;
+      const account = { ...(accounts.get(id) ?? {}), ...patch, id, provider } as ConnectorAccount;
+      accounts.set(id, account);
+      return account;
+    },
+  } as unknown as ConnectorAccountManager;
+  return { manager, accounts, credentialRefs };
+}
+
+const SETTINGS = {
+  NOTION_CLIENT_ID: "client-id",
+  NOTION_CLIENT_SECRET: "client-secret",
+  NOTION_REDIRECT_URI: "https://agent.example/oauth/notion/callback",
+};
+
+function startRequest(): ConnectorOAuthStartRequest {
+  return {
+    flow: { state: "state-123" },
+    metadata: {},
+  } as unknown as ConnectorOAuthStartRequest;
+}
+
+function callbackRequest(code: string | undefined): ConnectorOAuthCallbackRequest {
+  return {
+    code,
+    flow: {
+      state: "state-123",
+      redirectUri: SETTINGS.NOTION_REDIRECT_URI,
+      metadata: { redirectUri: SETTINGS.NOTION_REDIRECT_URI },
+    },
+  } as unknown as ConnectorOAuthCallbackRequest;
+}
+
+describe("Notion OAuth start", () => {
+  it("builds the authorization URL with owner=user and no PKCE", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createNotionConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    const result = await provider.startOAuth?.(startRequest(), manager);
+    const url = new URL(result?.authUrl ?? "");
+    expect(url.origin + url.pathname).toBe("https://api.notion.com/v1/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("client-id");
+    expect(url.searchParams.get("owner")).toBe("user");
+    expect(url.searchParams.get("state")).toBe("state-123");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(result?.codeVerifier).toBeUndefined();
+  });
+
+  it("fails closed when client settings are missing", async () => {
+    const { runtime } = fakeRuntime({});
+    const provider = createNotionConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    await expect(provider.startOAuth?.(startRequest(), manager)).rejects.toThrow(
+      /NOTION_CLIENT_ID/
+    );
+  });
+});
+
+describe("Notion OAuth callback", () => {
+  it("exchanges the code with Basic auth, records workspace identity, and persists a durable credential ref", async () => {
+    const { runtime, vaultStore } = fakeRuntime(SETTINGS);
+    const tokenRequests: Array<{ url: string; auth: string | undefined; body: unknown }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      tokenRequests.push({
+        url: String(input),
+        auth: (init?.headers as Record<string, string>)?.Authorization,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      });
+      return new Response(
+        JSON.stringify({
+          access_token: "secret_notion_token",
+          bot_id: "bot-1",
+          workspace_id: "ws-1",
+          workspace_name: "Acme Workspace",
+          workspace_icon: null,
+          owner: {
+            type: "user",
+            user: { id: "u-1", name: "Ada", person: { email: "ada@acme.test" } },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const provider = createNotionConnectorAccountProvider(runtime, { fetchImpl });
+    const { manager, credentialRefs } = fakeManager();
+
+    const result = await provider.completeOAuth?.(callbackRequest("auth-code"), manager);
+
+    expect(tokenRequests[0].url).toBe(NOTION_TOKEN_ENDPOINT);
+    expect(tokenRequests[0].auth).toBe(
+      `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`
+    );
+    expect((tokenRequests[0].body as { grant_type: string }).grant_type).toBe("authorization_code");
+
+    expect(result?.account.status).toBe("connected");
+    expect(result?.account.externalId).toBe("ws-1");
+    expect(result?.account.label).toBe("Acme Workspace");
+    const metadata = result?.account.metadata as Record<string, unknown>;
+    expect(metadata.workspaceId).toBe("ws-1");
+    // The raw token never lands in account metadata — only refs.
+    expect(JSON.stringify(metadata)).not.toContain("secret_notion_token");
+    expect(credentialRefs).toHaveLength(1);
+    expect(credentialRefs[0].credentialType).toBe("oauth.tokens");
+    const persisted = [...vaultStore.values()];
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toContain("secret_notion_token");
+  });
+
+  it("rejects a callback without an authorization code", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createNotionConnectorAccountProvider(runtime);
+    const { manager } = fakeManager();
+    await expect(provider.completeOAuth?.(callbackRequest(undefined), manager)).rejects.toThrow(
+      /authorization code/
+    );
+  });
+
+  it("surfaces a failed token exchange without marking anything connected", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 });
+    const provider = createNotionConnectorAccountProvider(runtime, { fetchImpl });
+    const { manager, accounts } = fakeManager();
+    await expect(provider.completeOAuth?.(callbackRequest("bad"), manager)).rejects.toThrow(
+      /token exchange failed with 400/
+    );
+    expect(accounts.size).toBe(0);
+  });
+
+  it("rejects a token payload without an access token", async () => {
+    const { runtime } = fakeRuntime(SETTINGS);
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({ workspace_id: "ws-1" }), { status: 200 });
+    const provider = createNotionConnectorAccountProvider(runtime, { fetchImpl });
+    const { manager } = fakeManager();
+    await expect(provider.completeOAuth?.(callbackRequest("code"), manager)).rejects.toThrow(
+      /invalid payload/
+    );
+  });
+});

--- a/plugins/plugin-notion/src/__tests__/credential-resolver.test.ts
+++ b/plugins/plugin-notion/src/__tests__/credential-resolver.test.ts
@@ -1,0 +1,159 @@
+/**
+ * DefaultNotionCredentialResolver contract tests over a real in-memory
+ * connector-account manager fake. Covers BYO local token, metadata-embedded
+ * token-set refs, vault-ref reads, "default" single-account resolution,
+ * not-found, not-connected, and missing-credential failure paths.
+ */
+import type { ConnectorAccount, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { accessTokenFromValue, DefaultNotionCredentialResolver } from "../credential-resolver.js";
+
+function runtimeWith(options: {
+  settings?: Record<string, string>;
+  accounts?: ConnectorAccount[];
+  vault?: Record<string, string>;
+}): IAgentRuntime {
+  const accounts = options.accounts ?? [];
+  const manager = {
+    registerProvider: () => undefined,
+    evaluatePolicy: async () => ({ allowed: true }),
+    getAccount: async (_provider: string, id: string) =>
+      accounts.find((account) => account.id === id) ?? null,
+    listAccounts: async () => accounts,
+    getStorage: () => ({
+      listAccounts: async () => accounts,
+      getAccount: async (_provider: string, id: string) =>
+        accounts.find((account) => account.id === id) ?? null,
+      upsertAccount: async (account: ConnectorAccount) => account,
+      deleteAccount: async () => undefined,
+    }),
+  };
+  return {
+    agentId: "agent-1",
+    getSetting: (key: string) => options.settings?.[key],
+    getService: (type: string) => {
+      if (type === "connector_account") return manager;
+      if (type === "vault" && options.vault) {
+        return { get: async (key: string) => options.vault?.[key] ?? null };
+      }
+      return null;
+    },
+    getConnectorAccountManager: () => manager,
+  } as unknown as IAgentRuntime;
+}
+
+function account(overrides: Partial<ConnectorAccount>): ConnectorAccount {
+  return {
+    id: "acct-1",
+    provider: "notion",
+    role: "OWNER",
+    purpose: ["drive"],
+    accessGate: "open",
+    status: "connected",
+    ...overrides,
+  } as ConnectorAccount;
+}
+
+describe("DefaultNotionCredentialResolver", () => {
+  it("uses the BYO NOTION_TOKEN for the local default account", async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({ settings: { NOTION_TOKEN: "ntn_local" } })
+    );
+    const credential = await resolver.getCredential({ accountId: "default" });
+    expect(credential.accessToken).toBe("ntn_local");
+  });
+
+  it("reads a metadata-embedded token-set credential ref", async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({
+        accounts: [
+          account({
+            metadata: {
+              workspaceId: "ws-1",
+              credentialRefs: [
+                {
+                  credentialType: "oauth.tokens",
+                  value: JSON.stringify({ access_token: "ntn_from_metadata" }),
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    );
+    const credential = await resolver.getCredential({ accountId: "acct-1" });
+    expect(credential.accessToken).toBe("ntn_from_metadata");
+    expect(credential.workspaceId).toBe("ws-1");
+  });
+
+  it("resolves a vaultRef through the vault service", async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({
+        vault: {
+          "connector.agent-1.notion.acct-1.oauth_tokens": JSON.stringify({
+            access_token: "ntn_from_vault",
+          }),
+        },
+        accounts: [
+          account({
+            metadata: {
+              credentialRefs: [
+                {
+                  credentialType: "oauth.tokens",
+                  vaultRef: "connector.agent-1.notion.acct-1.oauth_tokens",
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    );
+    const credential = await resolver.getCredential({ accountId: "acct-1" });
+    expect(credential.accessToken).toBe("ntn_from_vault");
+  });
+
+  it('resolves "default" to the sole connected account', async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({
+        accounts: [
+          account({
+            metadata: {
+              credentialRefs: [{ credentialType: "oauth.tokens", value: "ntn_sole" }],
+            },
+          }),
+        ],
+      })
+    );
+    const credential = await resolver.getCredential({ accountId: "default" });
+    expect(credential.accessToken).toBe("ntn_sole");
+  });
+
+  it("fails with NOTION_ACCOUNT_NOT_FOUND for an unknown account", async () => {
+    const resolver = new DefaultNotionCredentialResolver(runtimeWith({}));
+    await expect(resolver.getCredential({ accountId: "missing" })).rejects.toThrow(/not found/);
+  });
+
+  it("fails when the account is not connected", async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({ accounts: [account({ status: "revoked" })] })
+    );
+    await expect(resolver.getCredential({ accountId: "acct-1" })).rejects.toThrow(/revoked/);
+  });
+
+  it("fails with a missing-credential error when no token material exists", async () => {
+    const resolver = new DefaultNotionCredentialResolver(
+      runtimeWith({ accounts: [account({ metadata: {} })] })
+    );
+    await expect(resolver.getCredential({ accountId: "acct-1" })).rejects.toThrow(
+      /no access token/
+    );
+  });
+});
+
+describe("accessTokenFromValue", () => {
+  it("passes raw tokens through and extracts JSON token sets", () => {
+    expect(accessTokenFromValue("ntn_raw")).toBe("ntn_raw");
+    expect(accessTokenFromValue(JSON.stringify({ access_token: "ntn_json" }))).toBe("ntn_json");
+    expect(accessTokenFromValue(JSON.stringify({ other: true }))).toBeUndefined();
+  });
+});

--- a/plugins/plugin-notion/src/bounded-response.ts
+++ b/plugins/plugin-notion/src/bounded-response.ts
@@ -1,0 +1,97 @@
+/**
+ * Reads untrusted HTTP response bodies with a hard allocation limit and one
+ * deadline covering the complete stream. The reader is cancelled as soon as
+ * the limit or deadline is crossed so rejected bodies are not drained.
+ */
+export interface BoundedResponseErrors {
+  tooLarge(declaredBytes: number | null): Error;
+  timedOut(): Error;
+  readFailed(cause: unknown): Error;
+}
+
+export async function readBoundedResponse(
+  response: Response,
+  maxBytes: number,
+  timeoutMs: number,
+  errors: BoundedResponseErrors
+): Promise<Uint8Array> {
+  const declaredBytes = parseContentLength(response.headers.get("Content-Length"));
+  if (declaredBytes !== null && declaredBytes > maxBytes) {
+    cancelBody(response.body);
+    throw errors.tooLarge(declaredBytes);
+  }
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      cancelReader(reader);
+      throw errors.timedOut();
+    }
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await readBeforeDeadline(reader, remainingMs);
+    } catch (cause) {
+      cancelReader(reader);
+      if (cause instanceof BodyDeadlineError) throw errors.timedOut();
+      throw errors.readFailed(cause);
+    }
+    if (result.done) break;
+    total += result.value.byteLength;
+    if (total > maxBytes) {
+      cancelReader(reader);
+      throw errors.tooLarge(declaredBytes);
+    }
+    chunks.push(result.value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function readBeforeDeadline(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  remainingMs: number
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new BodyDeadlineError()), remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+class BodyDeadlineError extends Error {}
+
+function parseContentLength(value: string | null): number | null {
+  if (value === null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function cancelBody(body: ReadableStream<Uint8Array> | null): void {
+  if (!body) return;
+  body.cancel().catch(() => {
+    // error-policy:J6 response rejection is already authoritative; cancellation is teardown only.
+  });
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  reader.cancel().catch(() => {
+    // error-policy:J6 response rejection is already authoritative; cancellation is teardown only.
+  });
+}

--- a/plugins/plugin-notion/src/client.ts
+++ b/plugins/plugin-notion/src/client.ts
@@ -1,0 +1,362 @@
+/**
+ * Fetch-based Notion REST client (API version 2022-06-28) behind the service.
+ * Speaks the real wire protocol — search with cursor pagination, page reads,
+ * paginated block-children reads flattened to plain text, page creation, and
+ * paragraph appends — and translates every upstream failure into a typed
+ * `ElizaError` (`NOTION_AUTH_EXPIRED`, `NOTION_RATE_LIMITED`,
+ * `NOTION_MALFORMED_RESPONSE`, `NOTION_UPSTREAM_FAILURE`, …) so callers branch
+ * on codes, never on HTTP details. The base URL is overridable via
+ * `ELIZA_MOCK_NOTION_BASE` for protocol-faithful mock servers in tests.
+ */
+import { ElizaError } from "@elizaos/core";
+import type {
+  NotionAccountRef,
+  NotionAppendInput,
+  NotionCreatePageInput,
+  NotionCredentialResolver,
+  NotionObjectSummary,
+  NotionPageContent,
+  NotionSearchPage,
+} from "./types.js";
+
+export const NOTION_API_VERSION = "2022-06-28";
+export const NOTION_DEFAULT_BASE_URL = "https://api.notion.com";
+/** Maximum time allowed for one Notion API request. */
+export const NOTION_FETCH_TIMEOUT_MS = 20_000;
+
+const MAX_PAGE_SIZE = 100;
+/** Cap block-children pagination so one pathological page cannot spin forever. */
+const MAX_CONTENT_PAGES = 20;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface NotionClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export class NotionClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly credentialResolver: NotionCredentialResolver,
+    options: NotionClientOptions = {}
+  ) {
+    this.baseUrl = (
+      options.baseUrl ??
+      process.env.ELIZA_MOCK_NOTION_BASE ??
+      NOTION_DEFAULT_BASE_URL
+    ).replace(/\/$/, "");
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.timeoutMs = options.timeoutMs ?? NOTION_FETCH_TIMEOUT_MS;
+  }
+
+  async search(
+    params: NotionAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<NotionSearchPage> {
+    const body: JsonRecord = {
+      query: params.query,
+      page_size: normalizedPageSize(params.limit),
+      sort: { direction: "descending", timestamp: "last_edited_time" },
+    };
+    if (params.cursor) {
+      body.start_cursor = params.cursor;
+    }
+    const payload = await this.request(params, "POST", "/v1/search", body);
+    const results = readArray(payload, "results").map(mapObjectSummary);
+    return {
+      results,
+      nextCursor: readNullableString(payload, "next_cursor"),
+      hasMore: payload.has_more === true,
+    };
+  }
+
+  async getPage(params: NotionAccountRef & { pageId: string }): Promise<NotionObjectSummary> {
+    const payload = await this.request(
+      params,
+      "GET",
+      `/v1/pages/${encodeURIComponent(params.pageId)}`
+    );
+    return mapObjectSummary(payload);
+  }
+
+  async getPageContent(params: NotionAccountRef & { pageId: string }): Promise<NotionPageContent> {
+    const page = await this.getPage(params);
+    const lines: string[] = [];
+    const unsupported = new Set<string>();
+    let cursor: string | null = null;
+    for (let fetched = 0; fetched < MAX_CONTENT_PAGES; fetched += 1) {
+      const query = cursor
+        ? `?page_size=${MAX_PAGE_SIZE}&start_cursor=${encodeURIComponent(cursor)}`
+        : `?page_size=${MAX_PAGE_SIZE}`;
+      const payload = await this.request(
+        params,
+        "GET",
+        `/v1/blocks/${encodeURIComponent(params.pageId)}/children${query}`
+      );
+      for (const block of readArray(payload, "results")) {
+        const text = blockPlainText(block);
+        if (text !== null) {
+          if (text.length > 0) lines.push(text);
+        } else {
+          unsupported.add(typeof block.type === "string" ? block.type : "unknown");
+        }
+      }
+      cursor = payload.has_more === true ? readNullableString(payload, "next_cursor") : null;
+      if (!cursor) break;
+    }
+    return {
+      id: page.id,
+      title: page.title,
+      url: page.url,
+      plainText: lines.join("\n"),
+      unsupportedBlockTypes: [...unsupported].sort(),
+    };
+  }
+
+  async createPage(params: NotionCreatePageInput): Promise<NotionObjectSummary> {
+    const body: JsonRecord = {
+      parent: { page_id: params.parentPageId },
+      properties: {
+        title: { title: [{ type: "text", text: { content: params.title } }] },
+      },
+    };
+    if (params.content) {
+      body.children = paragraphBlocks(params.content);
+    }
+    const payload = await this.request(params, "POST", "/v1/pages", body);
+    return mapObjectSummary(payload);
+  }
+
+  async appendToPage(params: NotionAppendInput): Promise<void> {
+    await this.request(
+      params,
+      "PATCH",
+      `/v1/blocks/${encodeURIComponent(params.pageId)}/children`,
+      { children: paragraphBlocks(params.content) }
+    );
+  }
+
+  private async request(
+    account: NotionAccountRef,
+    method: "GET" | "POST" | "PATCH",
+    path: string,
+    body?: JsonRecord
+  ): Promise<JsonRecord> {
+    const credential = await this.credentialResolver.getCredential(account);
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${credential.accessToken}`,
+        "Notion-Version": NOTION_API_VERSION,
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+
+    if (!response.ok) {
+      throw await notionHttpError(response, { accountId: account.accountId, path });
+    }
+
+    const parsed: unknown = await response.json().catch((cause: unknown) => {
+      throw new ElizaError("NotionClient: Notion returned a non-JSON success body.", {
+        code: "NOTION_MALFORMED_RESPONSE",
+        context: { path, accountId: account.accountId },
+        cause: cause instanceof Error ? cause : undefined,
+      });
+    });
+    if (!isRecord(parsed)) {
+      throw new ElizaError("NotionClient: Notion returned a non-object success body.", {
+        code: "NOTION_MALFORMED_RESPONSE",
+        context: { path, accountId: account.accountId, bodyType: typeof parsed },
+      });
+    }
+    return parsed;
+  }
+}
+
+async function notionHttpError(
+  response: Response,
+  context: { accountId: string; path: string }
+): Promise<ElizaError> {
+  // error-policy:J3 the upstream error body is untrusted; an unparseable body
+  // degrades to an empty record and the HTTP status still drives the code.
+  const body: JsonRecord = await response
+    .json()
+    .then((value: unknown) => (isRecord(value) ? value : {}))
+    .catch(() => ({}));
+  const upstreamCode = typeof body.code === "string" ? body.code : undefined;
+  const upstreamMessage = typeof body.message === "string" ? body.message : undefined;
+  const base = { ...context, status: response.status, upstreamCode, upstreamMessage };
+
+  if (response.status === 401) {
+    return new ElizaError(
+      "NotionClient: access token is invalid, expired, or revoked; reconnect the Notion account.",
+      { code: "NOTION_AUTH_EXPIRED", context: base }
+    );
+  }
+  if (response.status === 403) {
+    return new ElizaError(
+      "NotionClient: the integration does not have access to this resource; share it with the connection in Notion.",
+      { code: "NOTION_FORBIDDEN", context: base }
+    );
+  }
+  if (response.status === 404) {
+    return new ElizaError("NotionClient: resource not found or not shared with the connection.", {
+      code: "NOTION_NOT_FOUND",
+      context: base,
+    });
+  }
+  if (response.status === 429) {
+    return new ElizaError("NotionClient: rate limited by Notion; retry after the given delay.", {
+      code: "NOTION_RATE_LIMITED",
+      context: { ...base, retryAfterSeconds: parseRetryAfter(response.headers.get("Retry-After")) },
+    });
+  }
+  if (response.status === 400 && upstreamCode === "validation_error") {
+    return new ElizaError(`NotionClient: request rejected: ${upstreamMessage ?? "invalid input"}`, {
+      code: "NOTION_INVALID_REQUEST",
+      context: base,
+    });
+  }
+  return new ElizaError(`NotionClient: Notion request failed with status ${response.status}.`, {
+    code: "NOTION_UPSTREAM_FAILURE",
+    context: base,
+  });
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function normalizedPageSize(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 25;
+  }
+  return Math.min(Math.trunc(value), MAX_PAGE_SIZE);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readArray(payload: JsonRecord, key: string): JsonRecord[] {
+  const value = payload[key];
+  if (!Array.isArray(value)) {
+    throw new ElizaError(`NotionClient: Notion response is missing the "${key}" array.`, {
+      code: "NOTION_MALFORMED_RESPONSE",
+      context: { key, valueType: typeof value },
+    });
+  }
+  return value.filter(isRecord);
+}
+
+function readNullableString(payload: JsonRecord, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function mapObjectSummary(item: JsonRecord): NotionObjectSummary {
+  const object = item.object === "database" ? "database" : "page";
+  const id = typeof item.id === "string" ? item.id : "";
+  const url = typeof item.url === "string" ? item.url : "";
+  if (!id || !url) {
+    throw new ElizaError("NotionClient: Notion object is missing its id or url.", {
+      code: "NOTION_MALFORMED_RESPONSE",
+      context: { object, hasId: Boolean(id), hasUrl: Boolean(url) },
+    });
+  }
+  return {
+    id,
+    object,
+    title: extractTitle(item),
+    url,
+    lastEditedTime: typeof item.last_edited_time === "string" ? item.last_edited_time : "",
+    createdTime: typeof item.created_time === "string" ? item.created_time : "",
+    archived: item.archived === true,
+    parentType: parentType(item.parent),
+  };
+}
+
+function parentType(parent: unknown): NotionObjectSummary["parentType"] {
+  if (!isRecord(parent) || typeof parent.type !== "string") return "unknown";
+  switch (parent.type) {
+    case "workspace":
+    case "page_id":
+    case "database_id":
+    case "block_id":
+      return parent.type;
+    default:
+      return "unknown";
+  }
+}
+
+function extractTitle(item: JsonRecord): string {
+  // Databases carry `title` at the top level; pages nest it inside the
+  // property whose value type is "title" (property name varies per database).
+  if (Array.isArray(item.title)) {
+    return richTextPlain(item.title);
+  }
+  if (isRecord(item.properties)) {
+    for (const property of Object.values(item.properties)) {
+      if (isRecord(property) && property.type === "title" && Array.isArray(property.title)) {
+        return richTextPlain(property.title);
+      }
+    }
+  }
+  return "";
+}
+
+function richTextPlain(spans: unknown[]): string {
+  return spans
+    .filter(isRecord)
+    .map((span) => (typeof span.plain_text === "string" ? span.plain_text : ""))
+    .join("");
+}
+
+const TEXT_BLOCK_TYPES = new Set([
+  "paragraph",
+  "heading_1",
+  "heading_2",
+  "heading_3",
+  "bulleted_list_item",
+  "numbered_list_item",
+  "to_do",
+  "quote",
+  "callout",
+  "toggle",
+  "code",
+]);
+
+/** Returns the block's plain text, or null when the block type is unsupported. */
+function blockPlainText(block: JsonRecord): string | null {
+  const type = typeof block.type === "string" ? block.type : "";
+  if (!TEXT_BLOCK_TYPES.has(type)) {
+    return type === "divider" ? "" : null;
+  }
+  const payload = block[type];
+  if (!isRecord(payload) || !Array.isArray(payload.rich_text)) {
+    return "";
+  }
+  const text = richTextPlain(payload.rich_text);
+  if (type === "to_do") {
+    return `${payload.checked === true ? "[x]" : "[ ]"} ${text}`;
+  }
+  return text;
+}
+
+function paragraphBlocks(content: string): JsonRecord[] {
+  return content.split("\n").map((line) => ({
+    object: "block",
+    type: "paragraph",
+    paragraph: {
+      rich_text: line.length > 0 ? [{ type: "text", text: { content: line } }] : [],
+    },
+  }));
+}

--- a/plugins/plugin-notion/src/client.ts
+++ b/plugins/plugin-notion/src/client.ts
@@ -9,6 +9,7 @@
  * `ELIZA_MOCK_NOTION_BASE` for protocol-faithful mock servers in tests.
  */
 import { ElizaError } from "@elizaos/core";
+import { readBoundedResponse } from "./bounded-response.js";
 import type {
   NotionAccountRef,
   NotionAppendInput,
@@ -23,6 +24,9 @@ export const NOTION_API_VERSION = "2022-06-28";
 export const NOTION_DEFAULT_BASE_URL = "https://api.notion.com";
 /** Maximum time allowed for one Notion API request. */
 export const NOTION_FETCH_TIMEOUT_MS = 20_000;
+
+const NOTION_MAX_JSON_BYTES = 4_000_000;
+const NOTION_MAX_ERROR_BYTES = 64_000;
 
 const MAX_PAGE_SIZE = 100;
 /** Cap block-children pagination so one pathological page cannot spin forever. */
@@ -159,16 +163,16 @@ export class NotionClient {
     });
 
     if (!response.ok) {
-      throw await notionHttpError(response, { accountId: account.accountId, path });
+      throw await notionHttpError(response, { accountId: account.accountId, path }, this.timeoutMs);
     }
 
-    const parsed: unknown = await response.json().catch((cause: unknown) => {
-      throw new ElizaError("NotionClient: Notion returned a non-JSON success body.", {
-        code: "NOTION_MALFORMED_RESPONSE",
-        context: { path, accountId: account.accountId },
-        cause: cause instanceof Error ? cause : undefined,
-      });
-    });
+    const parsed = await parseNotionJson(
+      response,
+      path,
+      account.accountId,
+      NOTION_MAX_JSON_BYTES,
+      this.timeoutMs
+    );
     if (!isRecord(parsed)) {
       throw new ElizaError("NotionClient: Notion returned a non-object success body.", {
         code: "NOTION_MALFORMED_RESPONSE",
@@ -181,14 +185,24 @@ export class NotionClient {
 
 async function notionHttpError(
   response: Response,
-  context: { accountId: string; path: string }
+  context: { accountId: string; path: string },
+  timeoutMs: number
 ): Promise<ElizaError> {
   // error-policy:J3 the upstream error body is untrusted; an unparseable body
   // degrades to an empty record and the HTTP status still drives the code.
-  const body: JsonRecord = await response
-    .json()
-    .then((value: unknown) => (isRecord(value) ? value : {}))
-    .catch(() => ({}));
+  let body: JsonRecord = {};
+  try {
+    const parsed = await parseNotionJson(
+      response,
+      context.path,
+      context.accountId,
+      NOTION_MAX_ERROR_BYTES,
+      timeoutMs
+    );
+    if (isRecord(parsed)) body = parsed;
+  } catch {
+    // error-policy:J3 malformed or oversized error bodies are ignored; status remains authoritative.
+  }
   const upstreamCode = typeof body.code === "string" ? body.code : undefined;
   const upstreamMessage = typeof body.message === "string" ? body.message : undefined;
   const base = { ...context, status: response.status, upstreamCode, upstreamMessage };
@@ -227,6 +241,43 @@ async function notionHttpError(
     code: "NOTION_UPSTREAM_FAILURE",
     context: base,
   });
+}
+
+async function parseNotionJson(
+  response: Response,
+  path: string,
+  accountId: string,
+  maxBytes: number,
+  timeoutMs: number
+): Promise<unknown> {
+  const bytes = await readBoundedResponse(response, maxBytes, timeoutMs, {
+    tooLarge: (declaredBytes) =>
+      new ElizaError("NotionClient: Notion response exceeded the permitted body size.", {
+        code: "NOTION_MALFORMED_RESPONSE",
+        context: { path, accountId, cap: maxBytes, declaredBytes },
+      }),
+    timedOut: () =>
+      new ElizaError("NotionClient: timed out while reading the Notion response body.", {
+        code: "NOTION_UPSTREAM_FAILURE",
+        context: { path, accountId, timeoutMs },
+      }),
+    readFailed: (cause) =>
+      new ElizaError("NotionClient: failed while reading the Notion response body.", {
+        code: "NOTION_UPSTREAM_FAILURE",
+        context: { path, accountId },
+        cause: cause instanceof Error ? cause : undefined,
+      }),
+  });
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch (cause) {
+    // error-policy:J3 the response is untrusted and must be valid bounded UTF-8 JSON.
+    throw new ElizaError("NotionClient: Notion returned a non-JSON success body.", {
+      code: "NOTION_MALFORMED_RESPONSE",
+      context: { path, accountId },
+      cause: cause instanceof Error ? cause : undefined,
+    });
+  }
 }
 
 function parseRetryAfter(value: string | null): number | null {

--- a/plugins/plugin-notion/src/connector-account-provider.ts
+++ b/plugins/plugin-notion/src/connector-account-provider.ts
@@ -1,0 +1,291 @@
+/**
+ * Notion ConnectorAccountManager provider. Bridges plugin-notion to the core
+ * ConnectorAccountManager so the generic HTTP CRUD + OAuth surface can list,
+ * create, patch, delete, and run the OAuth flow for Notion workspaces.
+ *
+ * Notion public-integration OAuth has no PKCE, no refresh tokens, and no
+ * incremental scopes: the grant covers exactly the pages/databases the user
+ * shares with the connection, selected inside Notion's own consent UI. Each
+ * completed grant is bound to one workspace; workspace identity (id, name,
+ * icon) is recorded on the account so deterministic code can select accounts.
+ */
+import {
+  type ConnectorAccount,
+  type ConnectorAccountManager,
+  type ConnectorAccountPatch,
+  type ConnectorAccountProvider,
+  type ConnectorOAuthCallbackRequest,
+  type ConnectorOAuthCallbackResult,
+  type ConnectorOAuthStartRequest,
+  type ConnectorOAuthStartResult,
+  ElizaError,
+  type IAgentRuntime,
+  logger,
+} from "@elizaos/core";
+import { persistConnectorCredentialRefs } from "@elizaos/plugin-google-workspace/connector-credential-refs";
+import { NOTION_SERVICE_NAME } from "./types.js";
+
+export const NOTION_AUTHORIZATION_ENDPOINT = "https://api.notion.com/v1/oauth/authorize";
+export const NOTION_TOKEN_ENDPOINT = "https://api.notion.com/v1/oauth/token";
+/** Maximum time allowed for the Notion token exchange request. */
+export const NOTION_OAUTH_FETCH_TIMEOUT_MS = 15_000;
+
+interface NotionTokenResponse {
+  access_token: string;
+  bot_id?: string;
+  workspace_id?: string;
+  workspace_name?: string | null;
+  workspace_icon?: string | null;
+  owner?: {
+    type?: string;
+    user?: {
+      id?: string;
+      name?: string | null;
+      person?: { email?: string };
+    };
+  };
+  duplicated_template_id?: string | null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readClientConfig(runtime: IAgentRuntime): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} {
+  const clientId = nonEmptyString(runtime.getSetting?.("NOTION_CLIENT_ID"));
+  const clientSecret = nonEmptyString(runtime.getSetting?.("NOTION_CLIENT_SECRET"));
+  const redirectUri = nonEmptyString(runtime.getSetting?.("NOTION_REDIRECT_URI"));
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new ElizaError(
+      "Notion OAuth requires NOTION_CLIENT_ID, NOTION_CLIENT_SECRET, and NOTION_REDIRECT_URI to be configured.",
+      { code: "NOTION_OAUTH_NOT_CONFIGURED", severity: "fatal" }
+    );
+  }
+  return { clientId, clientSecret, redirectUri };
+}
+
+export async function exchangeNotionAuthorizationCode(
+  args: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    code: string;
+  },
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = NOTION_OAUTH_FETCH_TIMEOUT_MS
+): Promise<NotionTokenResponse> {
+  const basic = Buffer.from(`${args.clientId}:${args.clientSecret}`).toString("base64");
+  const response = await fetchImpl(NOTION_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code: args.code,
+      redirect_uri: args.redirectUri,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new ElizaError(`Notion token exchange failed with ${response.status}.`, {
+      code: "NOTION_OAUTH_TOKEN_EXCHANGE_FAILED",
+      context: { status: response.status, body: body.slice(0, 500) },
+      severity: "fatal",
+    });
+  }
+  const parsed = (await response.json()) as NotionTokenResponse;
+  if (!nonEmptyString(parsed?.access_token)) {
+    throw new ElizaError("Notion token exchange returned an invalid payload.", {
+      code: "NOTION_OAUTH_TOKEN_PAYLOAD_INVALID",
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
+
+/**
+ * Build the Notion ConnectorAccountProvider: account CRUD adapters plus the
+ * authorization-code OAuth flow that records workspace identity and persists
+ * the workspace-bound access token as a durable credential ref.
+ */
+export function createNotionConnectorAccountProvider(
+  runtime: IAgentRuntime,
+  options: { fetchImpl?: typeof fetch } = {}
+): ConnectorAccountProvider {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  return {
+    provider: NOTION_SERVICE_NAME,
+    label: "Notion",
+
+    listAccounts: async (manager: ConnectorAccountManager): Promise<ConnectorAccount[]> => {
+      return manager.getStorage().listAccounts(NOTION_SERVICE_NAME);
+    },
+
+    createAccount: async (input: ConnectorAccountPatch, _manager: ConnectorAccountManager) => {
+      return {
+        ...input,
+        provider: NOTION_SERVICE_NAME,
+        role: input.role ?? "OWNER",
+        purpose: input.purpose ?? ["drive"],
+        accessGate: input.accessGate ?? "open",
+        status: input.status ?? "pending",
+      };
+    },
+
+    patchAccount: async (
+      _accountId: string,
+      patch: ConnectorAccountPatch,
+      _manager: ConnectorAccountManager
+    ) => {
+      return { ...patch, provider: NOTION_SERVICE_NAME };
+    },
+
+    deleteAccount: async (_accountId: string, _manager: ConnectorAccountManager): Promise<void> => {
+      // Credential cleanup is the credential store's responsibility; the
+      // manager removes the account row after this resolves.
+    },
+
+    startOAuth: async (
+      request: ConnectorOAuthStartRequest,
+      _manager: ConnectorAccountManager
+    ): Promise<ConnectorOAuthStartResult> => {
+      const config = readClientConfig(runtime);
+      const params = new URLSearchParams({
+        client_id: config.clientId,
+        redirect_uri: config.redirectUri,
+        response_type: "code",
+        owner: "user",
+        state: request.flow.state,
+      });
+      return {
+        authUrl: `${NOTION_AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+        redirectUri: config.redirectUri,
+        metadata: {
+          ...request.metadata,
+          redirectUri: config.redirectUri,
+        },
+      };
+    },
+
+    completeOAuth: async (
+      request: ConnectorOAuthCallbackRequest,
+      manager: ConnectorAccountManager
+    ): Promise<ConnectorOAuthCallbackResult> => {
+      const code = nonEmptyString(request.code);
+      if (!code) {
+        throw new ElizaError("Notion OAuth callback is missing an authorization code.", {
+          code: "NOTION_OAUTH_CODE_MISSING",
+          severity: "fatal",
+        });
+      }
+      const config = readClientConfig(runtime);
+      const redirectUri =
+        nonEmptyString(request.flow.redirectUri) ??
+        nonEmptyString(
+          (request.flow.metadata as Record<string, unknown> | undefined)?.redirectUri
+        ) ??
+        config.redirectUri;
+
+      const tokens = await exchangeNotionAuthorizationCode(
+        {
+          clientId: config.clientId,
+          clientSecret: config.clientSecret,
+          redirectUri,
+          code,
+        },
+        fetchImpl
+      );
+
+      const workspaceId = nonEmptyString(tokens.workspace_id);
+      const externalId = workspaceId ?? nonEmptyString(tokens.bot_id);
+      if (!externalId) {
+        throw new ElizaError("Notion OAuth response did not include a workspace or bot id.", {
+          code: "NOTION_OAUTH_IDENTITY_MISSING",
+          severity: "fatal",
+        });
+      }
+      const workspaceName = nonEmptyString(tokens.workspace_name);
+      const ownerName = nonEmptyString(tokens.owner?.user?.name);
+      const ownerEmail = nonEmptyString(tokens.owner?.user?.person?.email);
+      const oauthCredentialVersion = String(Date.now());
+      const accountMetadata = {
+        workspaceId: workspaceId ?? null,
+        workspaceName: workspaceName ?? null,
+        workspaceIcon: nonEmptyString(tokens.workspace_icon) ?? null,
+        botId: nonEmptyString(tokens.bot_id) ?? null,
+        ownerName: ownerName ?? null,
+        ownerEmail: ownerEmail ?? null,
+        oauthCredentialVersion,
+      };
+
+      const pendingAccount = await manager.upsertAccount(
+        NOTION_SERVICE_NAME,
+        {
+          provider: NOTION_SERVICE_NAME,
+          role: "OWNER",
+          purpose: ["drive"],
+          accessGate: "open",
+          status: "pending",
+          externalId,
+          displayHandle: workspaceName ?? ownerEmail,
+          label: workspaceName ?? "Notion",
+          metadata: accountMetadata,
+        },
+        request.flow.accountId
+      );
+
+      const credentialPersist = await persistConnectorCredentialRefs({
+        runtime,
+        manager,
+        provider: NOTION_SERVICE_NAME,
+        accountIdForRef: pendingAccount.id,
+        storageAccountId: pendingAccount.id,
+        caller: "plugin-notion",
+        credentials: [
+          {
+            credentialType: "oauth.tokens",
+            value: JSON.stringify({
+              access_token: tokens.access_token,
+              token_type: "Bearer",
+              workspace_id: workspaceId ?? null,
+              bot_id: nonEmptyString(tokens.bot_id) ?? null,
+            }),
+            metadata: { provider: NOTION_SERVICE_NAME, hasRefreshToken: false },
+          },
+        ],
+      });
+
+      logger.info(
+        { src: "plugin:notion:connector", externalId, workspaceName: workspaceName ?? null },
+        "Notion OAuth completed"
+      );
+
+      return {
+        account: {
+          ...pendingAccount,
+          id: pendingAccount.id,
+          provider: NOTION_SERVICE_NAME,
+          status: "connected",
+          metadata: {
+            ...accountMetadata,
+            credentialRefs: credentialPersist.refs,
+            credentialRefStorage: {
+              vaultAvailable: credentialPersist.vaultAvailable,
+              storageAvailable: credentialPersist.storageAvailable,
+            },
+          },
+        },
+        flow: { status: "completed" },
+      };
+    },
+  };
+}

--- a/plugins/plugin-notion/src/credential-resolver.ts
+++ b/plugins/plugin-notion/src/credential-resolver.ts
@@ -1,0 +1,264 @@
+/**
+ * `DefaultNotionCredentialResolver` — turns a stored Notion connector account
+ * into a bearer token. Resolution order: explicit BYO `NOTION_TOKEN` setting
+ * (local/self-hosted mode, `accountId` "default" or "local"), then the
+ * connector account's credential refs (metadata-embedded values first, then
+ * connector-account storage records, then vault refs read through the runtime's
+ * credential store / vault / secrets services). Notion access tokens do not
+ * expire, so there is no refresh path; a revoked token surfaces as
+ * `NOTION_AUTH_EXPIRED` from the client and requires re-connecting.
+ */
+import {
+  CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
+  type ConnectorAccount,
+  ElizaError,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+} from "@elizaos/core";
+import {
+  NOTION_SERVICE_NAME,
+  type NotionAccountRef,
+  type NotionCredentialResolver,
+  type NotionResolvedCredential,
+} from "./types.js";
+
+const BYO_TOKEN_SETTING = "NOTION_TOKEN";
+const BYO_ACCOUNT_IDS = new Set(["default", "local"]);
+const TOKEN_CREDENTIAL_TYPES = [
+  "oauth.tokens",
+  "oauth.access_token",
+  "oauth.accessToken",
+  "access_token",
+  "accessToken",
+];
+
+type JsonRecord = Record<string, unknown>;
+
+interface CredentialRefRecord {
+  credentialType: string;
+  value?: string | null;
+  token?: string | null;
+  secret?: string | null;
+  vaultRef?: string | null;
+}
+
+export class DefaultNotionCredentialResolver implements NotionCredentialResolver {
+  constructor(private readonly runtime?: IAgentRuntime | null) {}
+
+  async getCredential(request: NotionAccountRef): Promise<NotionResolvedCredential> {
+    const byoToken = this.readSetting(BYO_TOKEN_SETTING);
+    if (byoToken && BYO_ACCOUNT_IDS.has(request.accountId)) {
+      return { accessToken: byoToken };
+    }
+
+    const account = await this.getAccount(request.accountId);
+    if (!account) {
+      throw new ElizaError(
+        `DefaultNotionCredentialResolver: Notion account ${request.accountId} was not found` +
+          " and no NOTION_TOKEN is configured for local mode.",
+        { code: "NOTION_ACCOUNT_NOT_FOUND", context: { accountId: request.accountId } }
+      );
+    }
+    if (account.status !== "connected") {
+      throw new ElizaError(
+        `DefaultNotionCredentialResolver: Notion account ${request.accountId} is ${account.status}, not connected.`,
+        {
+          code: "NOTION_ACCOUNT_NOT_CONNECTED",
+          context: { accountId: request.accountId, status: account.status },
+        }
+      );
+    }
+
+    const accessToken = await this.resolveAccessToken(account);
+    if (!accessToken) {
+      throw new ElizaError(
+        `DefaultNotionCredentialResolver: no access token is stored for Notion account ${request.accountId}.`,
+        { code: "NOTION_CREDENTIAL_MISSING", context: { accountId: request.accountId } }
+      );
+    }
+
+    const metadata = asRecord(account.metadata);
+    return {
+      accessToken,
+      workspaceId: readString(metadata, "workspaceId"),
+      botId: readString(metadata, "botId"),
+    };
+  }
+
+  private async getAccount(accountId: string): Promise<ConnectorAccount | null> {
+    const manager = this.runtime ? getConnectorAccountManager(this.runtime) : null;
+    if (!manager) return null;
+    const direct = await manager.getAccount(NOTION_SERVICE_NAME, accountId);
+    if (direct) return direct;
+    if (BYO_ACCOUNT_IDS.has(accountId)) {
+      const connected = (await manager.listAccounts(NOTION_SERVICE_NAME)).filter(
+        (account) => account.status === "connected"
+      );
+      if (connected.length === 1) return connected[0];
+    }
+    return null;
+  }
+
+  private async resolveAccessToken(account: ConnectorAccount): Promise<string | undefined> {
+    for (const record of credentialRecordsFromMetadata(account.metadata)) {
+      const token = await this.tokenFromRecord(record);
+      if (token) return token;
+    }
+    for (const record of await this.loadStorageRecords(account.id)) {
+      const token = await this.tokenFromRecord(record);
+      if (token) return token;
+    }
+    return undefined;
+  }
+
+  private async loadStorageRecords(accountId: string): Promise<CredentialRefRecord[]> {
+    const storage = this.resolveStorage();
+    if (!storage) return [];
+    if (typeof storage.listConnectorAccountCredentialRefs === "function") {
+      return storage.listConnectorAccountCredentialRefs({ accountId });
+    }
+    if (typeof storage.getConnectorAccountCredentialRef !== "function") return [];
+    const records: CredentialRefRecord[] = [];
+    for (const credentialType of TOKEN_CREDENTIAL_TYPES) {
+      const record = await storage.getConnectorAccountCredentialRef({ accountId, credentialType });
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  private resolveStorage(): {
+    listConnectorAccountCredentialRefs?: (params: {
+      accountId: string;
+    }) => Promise<CredentialRefRecord[]>;
+    getConnectorAccountCredentialRef?: (params: {
+      accountId: string;
+      credentialType: string;
+    }) => Promise<CredentialRefRecord | null>;
+  } | null {
+    if (!this.runtime) return null;
+    const service = safelyGetService(this.runtime, CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE);
+    if (isRecordLike(service)) return service;
+    const manager = getConnectorAccountManager(this.runtime);
+    const storage = manager?.getStorage();
+    return isRecordLike(storage) ? storage : null;
+  }
+
+  private async tokenFromRecord(record: CredentialRefRecord): Promise<string | undefined> {
+    if (
+      !TOKEN_CREDENTIAL_TYPES.some((t) => t.toLowerCase() === record.credentialType.toLowerCase())
+    ) {
+      return undefined;
+    }
+    const raw =
+      nonEmptyString(record.value) ??
+      nonEmptyString(record.token) ??
+      nonEmptyString(record.secret) ??
+      (record.vaultRef ? await this.readVaultRef(record.vaultRef) : undefined);
+    if (!raw) return undefined;
+    return accessTokenFromValue(raw);
+  }
+
+  private async readVaultRef(vaultRef: string): Promise<string | undefined> {
+    if (!this.runtime) return undefined;
+    for (const serviceType of ["connector-credential-store", "vault", "secrets"]) {
+      const service = safelyGetService(this.runtime, serviceType) as {
+        reveal?: (key: string, caller?: string) => Promise<string> | string;
+        get?: (
+          key: string,
+          options?: { reveal?: boolean; caller?: string } | JsonRecord
+        ) => Promise<string | null> | string | null;
+      } | null;
+      if (!service) continue;
+      // error-policy:J4 an individual store missing/failing this ref is an
+      // expected miss; the caller reports CREDENTIAL_MISSING when all miss.
+      try {
+        if (typeof service.reveal === "function") {
+          const value = nonEmptyString(await service.reveal(vaultRef, "plugin-notion"));
+          if (value) return value;
+        } else if (typeof service.get === "function") {
+          const value = nonEmptyString(
+            await service.get(vaultRef, { reveal: true, caller: "plugin-notion" })
+          );
+          if (value) return value;
+        }
+      } catch {
+        // continue to the next reader
+      }
+    }
+    return undefined;
+  }
+
+  private readSetting(key: string): string | undefined {
+    return nonEmptyString(this.runtime?.getSetting?.(key));
+  }
+}
+
+/** Extracts the access token whether the value is raw or a persisted token-set JSON. */
+export function accessTokenFromValue(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{")) return trimmed;
+  // error-policy:J3 a persisted token-set that fails to parse is treated as a
+  // raw token rather than fabricating credentials from a broken blob.
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (isRecordValue(parsed)) {
+      return nonEmptyString(parsed.access_token) ?? nonEmptyString(parsed.accessToken);
+    }
+  } catch {
+    return trimmed;
+  }
+  return undefined;
+}
+
+function credentialRecordsFromMetadata(metadata: unknown): CredentialRefRecord[] {
+  const refs = asRecord(metadata)?.credentialRefs;
+  if (!Array.isArray(refs)) return [];
+  return refs.filter(
+    (ref): ref is CredentialRefRecord =>
+      isRecordValue(ref) && typeof ref.credentialType === "string"
+  );
+}
+
+function safelyGetService(runtime: IAgentRuntime, serviceType: string): unknown {
+  // error-policy:J4 a missing optional storage/vault service is a designed
+  // absence; resolution continues down the fallback chain.
+  try {
+    return runtime.getService(serviceType);
+  } catch {
+    return null;
+  }
+}
+
+function isRecordLike(value: unknown): value is {
+  listConnectorAccountCredentialRefs?: (params: {
+    accountId: string;
+  }) => Promise<CredentialRefRecord[]>;
+  getConnectorAccountCredentialRef?: (params: {
+    accountId: string;
+    credentialType: string;
+  }) => Promise<CredentialRefRecord | null>;
+} {
+  return (
+    isRecordValue(value) &&
+    (typeof value.listConnectorAccountCredentialRefs === "function" ||
+      typeof value.getConnectorAccountCredentialRef === "function")
+  );
+}
+
+function isRecordValue(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return isRecordValue(value) ? value : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readString(record: JsonRecord | undefined, key: string): string | undefined {
+  return record ? nonEmptyString(record[key]) : undefined;
+}

--- a/plugins/plugin-notion/src/index.ts
+++ b/plugins/plugin-notion/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Plugin entry for @elizaos/plugin-notion: re-exports every public symbol and
+ * defines `notionPlugin`. The plugin registers `NotionService` (workspace
+ * search/read by default, page creation and appends as explicit writes) and at
+ * init attaches the Notion connector-account provider to the runtime's
+ * ConnectorAccountManager so the generic connector HTTP routes can manage
+ * accounts and drive the workspace-bound OAuth flow. It registers no actions
+ * or providers of its own; domain plugins invoke the service directly.
+ */
+import type { IAgentRuntime, Plugin } from "@elizaos/core";
+import { getConnectorAccountManager, logger } from "@elizaos/core";
+import { createNotionConnectorAccountProvider } from "./connector-account-provider.js";
+import { NotionService } from "./service.js";
+import { NOTION_SERVICE_NAME } from "./types.js";
+
+export * from "./client.js";
+export * from "./connector-account-provider.js";
+export * from "./credential-resolver.js";
+export * from "./types.js";
+export { NotionService };
+
+export const notionPlugin: Plugin = {
+  name: NOTION_SERVICE_NAME,
+  description:
+    "Notion integration for workspace search, page reads, page creation, and appends with workspace-bound OAuth",
+  services: [NotionService],
+  actions: [],
+  providers: [],
+  tests: [],
+
+  init: async (_config: Record<string, string>, runtime: IAgentRuntime): Promise<void> => {
+    // error-policy:J4 a runtime without a ConnectorAccountManager (minimal
+    // hosts, BYO-token local mode) still gets the service; only managed OAuth
+    // account CRUD is unavailable and that absence is logged.
+    try {
+      const manager = getConnectorAccountManager(runtime);
+      manager.registerProvider(createNotionConnectorAccountProvider(runtime));
+    } catch (err) {
+      logger.warn(
+        {
+          src: "plugin:notion",
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to register Notion provider with ConnectorAccountManager"
+      );
+    }
+  },
+};
+
+export default notionPlugin;

--- a/plugins/plugin-notion/src/service.ts
+++ b/plugins/plugin-notion/src/service.ts
@@ -1,0 +1,81 @@
+/**
+ * `NotionService` — the sole runtime service and single entry point for the
+ * plugin. Wraps `NotionClient` and delegates every `INotionService` method.
+ * Retrieved via `runtime.getService("notion")`. Credential resolution defaults
+ * to `DefaultNotionCredentialResolver` but can be swapped (constructor option
+ * or `setCredentialResolver`) for tests.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger, Service } from "@elizaos/core";
+import { NotionClient, type NotionClientOptions } from "./client.js";
+import { DefaultNotionCredentialResolver } from "./credential-resolver.js";
+import {
+  type INotionService,
+  NOTION_SERVICE_NAME,
+  type NotionAccountRef,
+  type NotionAppendInput,
+  type NotionCreatePageInput,
+  type NotionCredentialResolver,
+  type NotionObjectSummary,
+  type NotionPageContent,
+  type NotionSearchPage,
+} from "./types.js";
+
+export interface NotionServiceOptions {
+  credentialResolver?: NotionCredentialResolver;
+  clientOptions?: NotionClientOptions;
+}
+
+export class NotionService extends Service implements INotionService {
+  static serviceType = NOTION_SERVICE_NAME;
+
+  capabilityDescription =
+    "Notion workspace service for searching, reading, creating, and appending to shared pages";
+
+  private client: NotionClient;
+  private readonly clientOptions: NotionClientOptions;
+
+  constructor(runtime?: IAgentRuntime, options: NotionServiceOptions = {}) {
+    super(runtime);
+    this.clientOptions = options.clientOptions ?? {};
+    this.client = new NotionClient(
+      options.credentialResolver ?? new DefaultNotionCredentialResolver(runtime),
+      this.clientOptions
+    );
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<NotionService> {
+    logger.info("Starting Notion plugin");
+    return new NotionService(runtime);
+  }
+
+  setCredentialResolver(credentialResolver: NotionCredentialResolver): void {
+    this.client = new NotionClient(credentialResolver, this.clientOptions);
+  }
+
+  async stop(): Promise<void> {
+    logger.info("Stopping Notion plugin");
+  }
+
+  search(
+    params: NotionAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<NotionSearchPage> {
+    return this.client.search(params);
+  }
+
+  getPage(params: NotionAccountRef & { pageId: string }): Promise<NotionObjectSummary> {
+    return this.client.getPage(params);
+  }
+
+  getPageContent(params: NotionAccountRef & { pageId: string }): Promise<NotionPageContent> {
+    return this.client.getPageContent(params);
+  }
+
+  createPage(params: NotionCreatePageInput): Promise<NotionObjectSummary> {
+    return this.client.createPage(params);
+  }
+
+  appendToPage(params: NotionAppendInput): Promise<void> {
+    return this.client.appendToPage(params);
+  }
+}

--- a/plugins/plugin-notion/src/types.ts
+++ b/plugins/plugin-notion/src/types.ts
@@ -1,0 +1,77 @@
+/**
+ * Domain contracts for the Notion provider adapter. Every service method is
+ * account-scoped (`NotionAccountRef`), read results carry the canonical Notion
+ * deep link (`url`) so downstream surfaces can cite sources, and credential
+ * resolution is pluggable via `NotionCredentialResolver` so tests and hosts can
+ * substitute their own token source.
+ */
+
+export const NOTION_SERVICE_NAME = "notion";
+
+/** All Notion API calls are account-scoped; there is no single-account shortcut. */
+export interface NotionAccountRef {
+  accountId: string;
+}
+
+export interface NotionResolvedCredential {
+  accessToken: string;
+  /** Workspace the token is bound to, when known (recorded at OAuth time). */
+  workspaceId?: string;
+  botId?: string;
+}
+
+export interface NotionCredentialResolver {
+  getCredential(request: NotionAccountRef): Promise<NotionResolvedCredential>;
+}
+
+/** Search / list result item: a page or database with its citation deep link. */
+export interface NotionObjectSummary {
+  id: string;
+  object: "page" | "database";
+  title: string;
+  /** Canonical notion.so deep link for citations. */
+  url: string;
+  lastEditedTime: string;
+  createdTime: string;
+  archived: boolean;
+  parentType: "workspace" | "page_id" | "database_id" | "block_id" | "unknown";
+}
+
+export interface NotionSearchPage {
+  results: NotionObjectSummary[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export interface NotionPageContent {
+  id: string;
+  title: string;
+  url: string;
+  /** Flattened plain text of the page's supported block types, one block per line. */
+  plainText: string;
+  /** Block types present on the page that the adapter cannot render as text. */
+  unsupportedBlockTypes: string[];
+}
+
+export interface NotionCreatePageInput extends NotionAccountRef {
+  parentPageId: string;
+  title: string;
+  /** Paragraph content; split on newlines into paragraph blocks. */
+  content?: string;
+}
+
+export interface NotionAppendInput extends NotionAccountRef {
+  pageId: string;
+  /** Paragraph content; split on newlines into paragraph blocks. */
+  content: string;
+}
+
+export interface INotionService {
+  search(
+    params: NotionAccountRef & { query: string; cursor?: string; limit?: number }
+  ): Promise<NotionSearchPage>;
+  getPage(params: NotionAccountRef & { pageId: string }): Promise<NotionObjectSummary>;
+  getPageContent(params: NotionAccountRef & { pageId: string }): Promise<NotionPageContent>;
+  createPage(params: NotionCreatePageInput): Promise<NotionObjectSummary>;
+  appendToPage(params: NotionAppendInput): Promise<void>;
+}

--- a/plugins/plugin-notion/tsconfig.json
+++ b/plugins/plugin-notion/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/plugins/plugin-notion/vitest.config.ts
+++ b/plugins/plugin-notion/vitest.config.ts
@@ -1,0 +1,16 @@
+/** Runs Notion plugin source tests against real workspace packages with deterministic fetch mocks. */
+import { defineConfig } from "vitest/config";
+import { buildWorkspaceSourceAliases } from "../../packages/scripts/vitest/source-aliases.ts";
+
+const workspaceAliases = buildWorkspaceSourceAliases();
+
+export default defineConfig({
+  resolve: {
+    alias: workspaceAliases,
+  },
+  test: {
+    alias: workspaceAliases,
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**", "**/*.live.test.ts", "**/*.e2e.test.ts"],
+  },
+});


### PR DESCRIPTION
## Current exact-head status (2026-08-20)

Exact head: `cea81230d97aeb7c9d39fad3f25627274163356f` rebased onto current `origin/develop`.

Source review blockers repaired: all successful JSON and provider error bodies are bounded; Dropbox downloads enforce the 1 MB limit during streaming even with absent/dishonest `Content-Length`; rejected bodies are cancelled immediately; one deadline covers the full body; malformed UTF-8 is rejected; and uploads enforce Dropbox’s 150 MB single-request cap before Blob construction/copying.

Validated on the exact head:
- Dropbox: 3 files, 32/32 tests; typecheck and lint clean.
- Notion: 3 files, 28/28 tests; typecheck and lint clean.
- `check:agents-claude`: 158 pairs byte-identical.
- Root `bun run verify` reached workspace lint and failed only on unchanged `plugins/plugin-bluebubbles/src/accounts.test.ts` import ordering; the owned package checks above are green.

The PR remains draft. Real Notion and Dropbox sandbox accounts/OAuth credentials were unavailable, so the required live OAuth/read/write evidence has not been captured. No claim of real-provider evidence is made.

---

Fixes #19899

## What

Adds two first-party provider adapter plugins, modeled on the `plugin-google-workspace` connector pattern, projecting Notion and Dropbox into the notes/documents/files capabilities. Both speak the provider REST APIs directly over fetch — no MCP runtime, per the parent epic (#19877) architecture.

### `@elizaos/plugin-notion`
- `NotionClient` (API 2022-06-28): workspace search with cursor pagination, page reads, paginated block-children reads flattened to plain text (with unsupported-block-type reporting), page creation, paragraph appends. Every read result carries the canonical `notion.so` deep link for citations.
- Typed error surface: `NOTION_AUTH_EXPIRED` / `NOTION_FORBIDDEN` / `NOTION_NOT_FOUND` / `NOTION_RATE_LIMITED` (+`retryAfterSeconds`) / `NOTION_INVALID_REQUEST` / `NOTION_MALFORMED_RESPONSE` / `NOTION_UPSTREAM_FAILURE` — callers branch on codes, never HTTP details.
- OAuth: workspace-bound authorization-code flow (`owner=user`, Basic-auth token exchange — Notion has no PKCE, refresh tokens, or incremental scopes; access is scoped by what the user shares with the connection inside Notion's consent UI). Workspace identity (id/name/icon/owner) is recorded on the account for deterministic account selection.
- Credential resolution: BYO `NOTION_TOKEN` (local/self-hosted mode) → metadata credential refs → connector-account storage → vault refs.

### `@elizaos/plugin-dropbox`
- `DropboxClient` (API v2): `list_folder`(+`/continue`), `search_v2`(+`search/continue_v2`), `get_metadata`, `download`/`upload` via the content host with ASCII-escaped `Dropbox-API-Arg`, `get_temporary_link`. Deterministic `dropbox.com` deep links (folder browse / file preview) on every entry for citations.
- File limitation UX: `downloadText` refuses binary (`DROPBOX_FILE_NOT_TEXT`) and oversized (`DROPBOX_FILE_TOO_LARGE`, 1 MB cap, checked before download) files instead of returning garbage — callers offer `getTemporaryLink` instead. Uploads default to `mode: "add"` so accidental overwrites fail.
- OAuth: PKCE + `token_access_type=offline`. Default scope set = read scopes (`account_info.read`, `files.metadata.read`, `files.content.read`) plus the explicit write-escalation pair (`files.metadata.write`, `files.content.write`); caller-supplied scopes are normalized, unrecognized/empty selections fail closed; granted scopes are recorded on the account.
- Credential resolution adds refresh handling for Dropbox's short-lived tokens: refresh grant with a skew window, in-memory caching per account, refresh rejection surfaced as `DROPBOX_AUTH_EXPIRED`.

### Shared
- Durable token persistence reuses the provider-agnostic `persistConnectorCredentialRefs` helper (subpath import from `@elizaos/plugin-google-workspace/connector-credential-refs`) — tokens land in the vault/credential store as refs, never in account metadata, logs, or error contexts (asserted by tests).
- Both plugins register a `Service` (`runtime.getService("notion"|"dropbox")`) and a `ConnectorAccountProvider` at init; runtimes without a ConnectorAccountManager still get the service in BYO local mode.
- `registry-entry.json` for both, aggregated into `packages/registry/src/first-party/generated.json` via `generate:first-party`.
- Per-plugin `CLAUDE.md`/`AGENTS.md` (byte-identical, parity gate green) and `README.md`.
- Mock base-URL overrides (`ELIZA_MOCK_NOTION_BASE`, `ELIZA_MOCK_DROPBOX_BASE`, `ELIZA_MOCK_DROPBOX_CONTENT_BASE`) for protocol-faithful mock servers.

## Tests

Deterministic protocol-faithful fakes (request handlers serving real wire shapes through injected fetch — not mocks of the system under test), per the parent epic's CI baseline:

- **plugin-notion: 27 tests** — search success/designed-empty/cursor pagination, 401/429(+Retry-After)/404/5xx/validation_error mapping, malformed bodies, paginated block flattening, create/append request shapes, OAuth start/complete (Basic auth, workspace identity, credential-ref persistence, token-never-in-metadata), resolver BYO/metadata/vault/default-account/not-found/not-connected/missing-credential paths.
- **plugin-dropbox: 28 tests** — list/continue and search/continue_v2 pagination, designed-empty, 401 with a non-JSON body, 429 with body `retry_after`, 409 path `not_found`, 5xx, malformed bodies, download/upload wire shapes, binary/oversize refusals, temporary links, `Dropbox-API-Arg` escaping, deep links, OAuth PKCE start + scope-normalization failures, callback persistence and secrecy assertions, resolver refresh/caching/rejection/unconfigured paths.

```
plugin-notion:  Test Files 3 passed · Tests 27 passed
plugin-dropbox: Test Files 3 passed · Tests 28 passed
typecheck: clean (both) · lint:check: clean (both) · build: clean (both)
check:agents-claude: PASS (156 pairs byte-identical)
fix-deps:check: OK (147 workspace packages)
ensure-plugin-test-conventions:check: PASS
registry generate:first-party --check: up to date
audit:test-lane-membership: every test-bearing package accounted for
```

## Human-only remainder

Managed/production enablement needs provider app registration (documented in each plugin README):

- **Notion**: create a public integration at notion.so/my-integrations, register the redirect URI, set `NOTION_CLIENT_ID` / `NOTION_CLIENT_SECRET` / `NOTION_REDIRECT_URI` (Cloud credential broker in managed mode). Local mode: `NOTION_TOKEN` internal-integration token.
- **Dropbox**: create a scoped app at dropbox.com/developers/apps with `account_info.read`, `files.metadata.read/write`, `files.content.read/write` and the redirect URI; set `DROPBOX_CLIENT_ID` / `DROPBOX_CLIENT_SECRET` / `DROPBOX_REDIRECT_URI`. Local mode: `DROPBOX_ACCESS_TOKEN`.
- Real sandbox-account exercise per `CONTRIBUTING.md` requires those credentials and gates promotion/release of the managed integrations, not this scaffolding-plus-contract-tests landing.

No UI changes; app visual audit N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)