### PR TITLE
feat(identity): add canonical authority foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3002,6 +3002,7 @@
         "@electric-sql/pglite": "^0.4.0",
         "@electric-sql/pglite-sync": "0.5.6",
         "@neondatabase/serverless": "^1.1.0",
+        "@noble/hashes": "2.2.0",
         "drizzle-orm": "0.45.2",
         "pg": "^8.23.0",
         "uuid": "^14.0.0",

--- a/packages/core/src/roles.resolution.test.ts
+++ b/packages/core/src/roles.resolution.test.ts
@@ -22,6 +22,7 @@ type FakeRuntimeOptions = {
 	entities?: Record<string, Entity>;
 	relationships?: Relationship[];
 	ownerBindingEvaluation?: OwnerBindingEvaluation;
+	canonicalPrincipalId?: UUID;
 };
 
 function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
@@ -35,6 +36,17 @@ function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
 		getService: () =>
 			options.ownerBindingEvaluation
 				? {
+						resolveCanonicalPrincipal: async () => ({
+							agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+							requestedPrincipalId: SENDER_ID as UUID,
+							canonicalPrincipalId:
+								options.canonicalPrincipalId ??
+								(options.ownerBindingEvaluation?.decision === "bound"
+									? options.ownerBindingEvaluation.actorCanonicalPrincipalId
+									: (SENDER_ID as UUID)),
+							redirectIds: [],
+							generation: 1,
+						}),
 						evaluateOwnerBinding: async () => options.ownerBindingEvaluation,
 					}
 				: null,
@@ -121,6 +133,23 @@ describe("resolveEntityRole — connector identity binding (owner pairing)", () 
 		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
 	});
 
+	it("rejects a bound result for a different canonical actor", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			canonicalPrincipalId: SENDER_ID as UUID,
+			ownerBindingEvaluation: {
+				decision: "bound",
+				actorCanonicalPrincipalId: OWNER_ID as UUID,
+				ownerPrincipalId: OWNER_ID as UUID,
+				claimId: "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID,
+				ownerBindingId: "binding-1",
+				generation: 1,
+				reason: "verified_owner_binding",
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
 	it("grants OWNER when the sender entity's stable platform id matches the owner entity's", async () => {
 		// This is exactly the state the OWNER_BIND_VERIFY pairing flow writes:
 		// the verified snowflake recorded on the owner entity's metadata.
@@ -174,12 +203,12 @@ describe("resolveEntityRole — confirmed identity links (merge engine)", () => 
 		} as Relationship;
 	}
 
-	it("a confirmed identity link to the owner does not confer authority", async () => {
+	it("preserves confirmed-link authority until the canonical service is installed", async () => {
 		const runtime = makeRuntime({
 			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
 			relationships: [identityLink("confirmed")],
 		});
-		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("OWNER");
 	});
 
 	it("an unconfirmed identity link grants nothing", async () => {

--- a/packages/core/src/roles.resolution.test.ts
+++ b/packages/core/src/roles.resolution.test.ts
@@ -3,13 +3,14 @@
  * decide whether a connector-originated sender (Discord/Telegram/…) is the app
  * owner. Driven over a deterministic fake runtime (no DB, no live model):
  * configured-owner identity, connector-identity matching against the owner
- * entity's metadata (the owner-pairing bridge), confirmed identity links, the
+ * entity's verified pairing metadata, non-authoritative identity links, the
  * connector-admin whitelist ceiling (ADMIN, never OWNER), and the fail-closed
  * defaults for unlinked strangers and stale world OWNER grants.
  */
 import { describe, expect, it } from "vitest";
 import { type RolesWorldMetadata, resolveEntityRole } from "./roles.ts";
 import type { Entity, IAgentRuntime, Relationship, UUID } from "./types";
+import type { OwnerBindingEvaluation } from "./types/identity";
 
 const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 const SENDER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
@@ -20,6 +21,7 @@ type FakeRuntimeOptions = {
 	settings?: Record<string, string>;
 	entities?: Record<string, Entity>;
 	relationships?: Relationship[];
+	ownerBindingEvaluation?: OwnerBindingEvaluation;
 };
 
 function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
@@ -30,6 +32,13 @@ function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
 		getSetting: (key: string) => settings[key],
 		getEntityById: async (id: UUID) => entities[id] ?? null,
 		getRelationships: async () => options.relationships ?? [],
+		getService: () =>
+			options.ownerBindingEvaluation
+				? {
+						evaluateOwnerBinding: async () => options.ownerBindingEvaluation,
+					}
+				: null,
+		reportError: () => undefined,
 	} as unknown as IAgentRuntime;
 }
 
@@ -39,7 +48,12 @@ function ownerEntity(discordId: string): Entity {
 		names: ["Owner"],
 		agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
 		metadata: {
-			discord: { id: discordId, userId: discordId, username: "owner" },
+			discord: {
+				id: discordId,
+				userId: discordId,
+				username: "owner",
+				ownerBindVerifiedAt: 1,
+			},
 		},
 	};
 }
@@ -76,6 +90,37 @@ describe("resolveEntityRole — configured canonical owner", () => {
 });
 
 describe("resolveEntityRole — connector identity binding (owner pairing)", () => {
+	it("grants OWNER from a verified canonical identity-service decision", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			ownerBindingEvaluation: {
+				decision: "bound",
+				actorCanonicalPrincipalId: OWNER_ID as UUID,
+				ownerPrincipalId: OWNER_ID as UUID,
+				claimId: "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID,
+				ownerBindingId: "binding-1",
+				generation: 1,
+				reason: "verified_owner_binding",
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("OWNER");
+	});
+
+	it("does not fall back when the identity service is unavailable", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: {
+				[OWNER_ID]: ownerEntity(OWNER_DISCORD_ID),
+				[SENDER_ID]: senderEntity(OWNER_DISCORD_ID, "owner"),
+			},
+			ownerBindingEvaluation: {
+				decision: "unavailable",
+				reason: "read_failed",
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
 	it("grants OWNER when the sender entity's stable platform id matches the owner entity's", async () => {
 		// This is exactly the state the OWNER_BIND_VERIFY pairing flow writes:
 		// the verified snowflake recorded on the owner entity's metadata.
@@ -129,12 +174,12 @@ describe("resolveEntityRole — confirmed identity links (merge engine)", () => 
 		} as Relationship;
 	}
 
-	it("a confirmed identity link to the owner inherits OWNER", async () => {
+	it("a confirmed identity link to the owner does not confer authority", async () => {
 		const runtime = makeRuntime({
 			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
 			relationships: [identityLink("confirmed")],
 		});
-		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("OWNER");
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
 	});
 
 	it("an unconfirmed identity link grants nothing", async () => {

--- a/packages/core/src/roles.resolution.test.ts
+++ b/packages/core/src/roles.resolution.test.ts
@@ -23,6 +23,9 @@ type FakeRuntimeOptions = {
 	relationships?: Relationship[];
 	ownerBindingEvaluation?: OwnerBindingEvaluation;
 	canonicalPrincipalId?: UUID;
+	canonicalAgentId?: UUID;
+	canonicalRequestedPrincipalId?: UUID;
+	canonicalGeneration?: number;
 };
 
 function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
@@ -37,15 +40,18 @@ function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
 			options.ownerBindingEvaluation
 				? {
 						resolveCanonicalPrincipal: async () => ({
-							agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
-							requestedPrincipalId: SENDER_ID as UUID,
+							agentId:
+								options.canonicalAgentId ??
+								("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID),
+							requestedPrincipalId:
+								options.canonicalRequestedPrincipalId ?? (SENDER_ID as UUID),
 							canonicalPrincipalId:
 								options.canonicalPrincipalId ??
 								(options.ownerBindingEvaluation?.decision === "bound"
 									? options.ownerBindingEvaluation.actorCanonicalPrincipalId
 									: (SENDER_ID as UUID)),
 							redirectIds: [],
-							generation: 1,
+							generation: options.canonicalGeneration ?? 1,
 						}),
 						evaluateOwnerBinding: async () => options.ownerBindingEvaluation,
 					}
@@ -146,6 +152,52 @@ describe("resolveEntityRole — connector identity binding (owner pairing)", () 
 				generation: 1,
 				reason: "verified_owner_binding",
 			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
+	const boundToOwner: OwnerBindingEvaluation = {
+		decision: "bound",
+		actorCanonicalPrincipalId: OWNER_ID as UUID,
+		ownerPrincipalId: OWNER_ID as UUID,
+		claimId: "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID,
+		ownerBindingId: "binding-1",
+		generation: 1,
+		reason: "verified_owner_binding",
+	};
+
+	it("rejects a canonical resolution echoed for a different agent", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			canonicalAgentId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID,
+			ownerBindingEvaluation: boundToOwner,
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
+	it("rejects a canonical resolution echoed for a different requested actor", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			canonicalRequestedPrincipalId: OWNER_ID as UUID,
+			ownerBindingEvaluation: boundToOwner,
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
+	it("rejects a binding evaluated at a different generation than the canonical read", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			canonicalGeneration: 2,
+			ownerBindingEvaluation: boundToOwner,
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+
+	it("rejects a malformed negative canonical generation", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			canonicalGeneration: -1,
+			ownerBindingEvaluation: { ...boundToOwner, generation: -1 },
 		});
 		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
 	});

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -585,7 +585,9 @@ describe("connector metadata is registry-driven, not Discord-special-cased (#120
 				if (id === ownerEntityId || id === senderEntityId) {
 					return {
 						id,
-						metadata: { telegram: { id: "telegram-owner" } },
+						metadata: {
+							telegram: { id: "telegram-owner", ownerBindVerifiedAt: 1 },
+						},
 					};
 				}
 				return null;

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -522,12 +522,24 @@ async function resolveIdentityOwnerBinding(
 			runtime.agentId,
 			entityId,
 		);
+		// The canonical read must echo exactly the request it resolved; a
+		// misrouted response for another agent or actor must not authorize.
+		if (
+			canonical.agentId !== runtime.agentId ||
+			canonical.requestedPrincipalId !== entityId ||
+			!Number.isSafeInteger(canonical.generation) ||
+			canonical.generation < 0
+		) {
+			return false;
+		}
 		const evaluation = await service.evaluateOwnerBinding({
 			agentId: runtime.agentId,
 			actorPrincipalId: entityId,
 			candidateOwnerPrincipalIds: ownerIds,
 			purpose: "role_resolution",
 		});
+		// Both reads must observe the same identity-graph generation; a merge
+		// or split between the two awaits invalidates the binding decision.
 		return (
 			evaluation.decision === "bound" &&
 			evaluation.actorCanonicalPrincipalId === canonical.canonicalPrincipalId &&
@@ -537,9 +549,11 @@ async function resolveIdentityOwnerBinding(
 			typeof evaluation.ownerBindingId === "string" &&
 			evaluation.ownerBindingId.length > 0 &&
 			Number.isSafeInteger(evaluation.generation) &&
-			evaluation.generation >= 0
+			evaluation.generation === canonical.generation
 		);
 	} catch (error) {
+		// error-policy:J4 authority read failure is reported and degrades to a
+		// fail-closed non-owner decision instead of falling back to weaker paths.
 		runtime.reportError("Roles.evaluateOwnerBinding", error, { entityId });
 		return false;
 	}

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -4,8 +4,8 @@
  * and the resolution that turns a sender + world into an effective role. A role
  * is merged here from four sources — an explicit grant stored on world metadata
  * (`roles`/`roleSources`), the configured or world-recorded canonical owner, a
- * connector-admin whitelist match on a stable platform id, and verified owner
- * bindings from the canonical identity authority. `canModifyRole`
+ * connector-admin whitelist match on a stable platform id, and identity
+ * evidence selected by the active authority cutover state. `canModifyRole`
  * is the privilege-escalation gate (OWNER may change anyone; ADMIN only
  * strictly-lower ranks and never grants OWNER); `hasRoleAccess` is the read-time
  * gate callers use to admit or deny an action.
@@ -456,16 +456,6 @@ function connectorIdentityMatches(
 		if (!leftConnector || !rightConnector) {
 			continue;
 		}
-		const verifiedAt = rightConnector.ownerBindVerifiedAt;
-		if (
-			(typeof verifiedAt !== "number" ||
-				!Number.isFinite(verifiedAt) ||
-				verifiedAt <= 0) &&
-			(typeof verifiedAt !== "string" || verifiedAt.trim().length === 0)
-		) {
-			continue;
-		}
-
 		for (const field of CONNECTOR_STABLE_ID_FIELDS) {
 			const leftValue = leftConnector[field];
 			const rightValue = rightConnector[field];
@@ -482,6 +472,40 @@ function connectorIdentityMatches(
 	return false;
 }
 
+async function getConfirmedLinkedEntityIds(
+	runtime: IAgentRuntime,
+	entityId: string,
+): Promise<string[]> {
+	if (typeof runtime.getRelationships !== "function") return [];
+
+	try {
+		const relationships = await runtime.getRelationships({
+			entityIds: [entityId as UUID],
+			tags: ["identity_link"],
+		});
+		const linkedIds = new Set<string>();
+		for (const relationship of relationships) {
+			const metadata = asRecord(relationship.metadata);
+			if (metadata?.status !== "confirmed") continue;
+			if (relationship.sourceEntityId === entityId) {
+				linkedIds.add(relationship.targetEntityId);
+			}
+			if (relationship.targetEntityId === entityId) {
+				linkedIds.add(relationship.sourceEntityId);
+			}
+		}
+		return [...linkedIds];
+	} catch (error) {
+		// error-policy:J2 identity links participate in the pre-cutover
+		// authorization path, so a failed read must not become an empty result.
+		throw new ElizaError("Failed to load confirmed identity links", {
+			code: "IDENTITY_LINK_QUERY_FAILED",
+			cause: error,
+			context: { entityId },
+		});
+	}
+}
+
 async function resolveIdentityOwnerBinding(
 	runtime: IAgentRuntime,
 	entityId: UUID,
@@ -494,6 +518,10 @@ async function resolveIdentityOwnerBinding(
 	if (!service) return null;
 
 	try {
+		const canonical = await service.resolveCanonicalPrincipal(
+			runtime.agentId,
+			entityId,
+		);
 		const evaluation = await service.evaluateOwnerBinding({
 			agentId: runtime.agentId,
 			actorPrincipalId: entityId,
@@ -502,6 +530,7 @@ async function resolveIdentityOwnerBinding(
 		});
 		return (
 			evaluation.decision === "bound" &&
+			evaluation.actorCanonicalPrincipalId === canonical.canonicalPrincipalId &&
 			ownerIds.includes(evaluation.ownerPrincipalId) &&
 			validateUuid(evaluation.actorCanonicalPrincipalId) !== null &&
 			validateUuid(evaluation.claimId) !== null &&
@@ -544,6 +573,9 @@ async function resolveOwnershipRole(
 		ownerIds as UUID[],
 	);
 	if (verifiedBinding !== null) return verifiedBinding ? "OWNER" : null;
+
+	const linkedIds = await getConfirmedLinkedEntityIds(runtime, entityId);
+	if (ownerIds.some((ownerId) => linkedIds.includes(ownerId))) return "OWNER";
 
 	for (const ownerId of ownerIds) {
 		const ownerMetadata = await getEntityMetadata(runtime, ownerId);
@@ -717,7 +749,7 @@ async function resolveExplicitGrantedRole(
 	options?: ResolveEntityRoleOptions,
 ): Promise<{
 	role: RoleName;
-	source: "manual";
+	source: "manual" | "linked_manual";
 } | null> {
 	const directRole = getEntityRole(metadata, entityId);
 	const directSource = await resolveStoredRoleSource(
@@ -730,7 +762,29 @@ async function resolveExplicitGrantedRole(
 		return { role: directRole, source: "manual" };
 	}
 
-	return null;
+	const identityService =
+		typeof runtime.getService === "function"
+			? runtime.getService<IdentityResolutionService>(
+					ServiceType.IDENTITY_RESOLUTION,
+				)
+			: null;
+	if (identityService) return null;
+
+	const linkedIds = await getConfirmedLinkedEntityIds(runtime, entityId);
+	let bestRole: RoleName | null = null;
+	for (const linkedEntityId of linkedIds) {
+		const linkedRole = getEntityRole(metadata, linkedEntityId);
+		if (linkedRole === "GUEST") continue;
+		const linkedSource = await resolveStoredRoleSource(
+			runtime,
+			metadata,
+			linkedEntityId,
+		);
+		if (linkedSource !== "manual") continue;
+		if (!bestRole || ROLE_RANK[linkedRole] > ROLE_RANK[bestRole])
+			bestRole = linkedRole;
+	}
+	return bestRole ? { role: bestRole, source: "linked_manual" } : null;
 }
 
 export function getLiveEntityMetadataFromMessage(
@@ -840,7 +894,7 @@ export async function checkSenderPrivateAccess(
 	canManageRoles: boolean;
 	hasPrivateAccess: boolean;
 	accessRole: RoleName | null;
-	accessSource: "owner" | "manual" | null;
+	accessSource: "owner" | "manual" | "linked_manual" | null;
 } | null> {
 	const resolved = await resolveWorldForMessage(runtime, message);
 	if (!resolved) return null;

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -4,8 +4,8 @@
  * and the resolution that turns a sender + world into an effective role. A role
  * is merged here from four sources — an explicit grant stored on world metadata
  * (`roles`/`roleSources`), the configured or world-recorded canonical owner, a
- * connector-admin whitelist match on a stable platform id, and confirmed
- * identity links that let a linked entity inherit the owner/grant. `canModifyRole`
+ * connector-admin whitelist match on a stable platform id, and verified owner
+ * bindings from the canonical identity authority. `canModifyRole`
  * is the privilege-escalation gate (OWNER may change anyone; ADMIN only
  * strictly-lower ranks and never grants OWNER); `hasRoleAccess` is the read-time
  * gate callers use to admit or deny an action.
@@ -30,12 +30,14 @@ import { createUniqueUuid } from "./entities";
 import { ElizaError } from "./errors.ts";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
+import type { IdentityResolutionService } from "./types/identity";
 import {
 	MESSAGE_SOURCE_AGENT_GREETING,
 	MESSAGE_SOURCE_CLIENT_CHAT,
 	MESSAGE_SOURCE_CODING_AGENT,
 	MESSAGE_SOURCE_SUB_AGENT,
 } from "./types/message-source";
+import { ServiceType } from "./types/service";
 import { formatError } from "./utils/format-error";
 import { asRecordOrUndefined as asRecord } from "./utils/type-guards";
 import { validateUuid } from "./utils.ts";
@@ -454,6 +456,15 @@ function connectorIdentityMatches(
 		if (!leftConnector || !rightConnector) {
 			continue;
 		}
+		const verifiedAt = rightConnector.ownerBindVerifiedAt;
+		if (
+			(typeof verifiedAt !== "number" ||
+				!Number.isFinite(verifiedAt) ||
+				verifiedAt <= 0) &&
+			(typeof verifiedAt !== "string" || verifiedAt.trim().length === 0)
+		) {
+			continue;
+		}
 
 		for (const field of CONNECTOR_STABLE_ID_FIELDS) {
 			const leftValue = leftConnector[field];
@@ -471,59 +482,37 @@ function connectorIdentityMatches(
 	return false;
 }
 
-async function hasConfirmedIdentityLink(
+async function resolveIdentityOwnerBinding(
 	runtime: IAgentRuntime,
-	entityId: string,
-	ownerId: string,
-): Promise<boolean> {
-	const linkedIds = await getConfirmedLinkedEntityIds(runtime, entityId);
-	return linkedIds.includes(ownerId);
-}
-
-async function getConfirmedLinkedEntityIds(
-	runtime: IAgentRuntime,
-	entityId: string,
-): Promise<string[]> {
-	if (typeof runtime.getRelationships !== "function") {
-		return [];
-	}
+	entityId: UUID,
+	ownerIds: readonly UUID[],
+): Promise<boolean | null> {
+	if (typeof runtime.getService !== "function") return null;
+	const service = runtime.getService<IdentityResolutionService>(
+		ServiceType.IDENTITY_RESOLUTION,
+	);
+	if (!service) return null;
 
 	try {
-		const relationships = await runtime.getRelationships({
-			entityIds: [entityId as UUID],
-			tags: ["identity_link"],
+		const evaluation = await service.evaluateOwnerBinding({
+			agentId: runtime.agentId,
+			actorPrincipalId: entityId,
+			candidateOwnerPrincipalIds: ownerIds,
+			purpose: "role_resolution",
 		});
-
-		const linkedIds = new Set<string>();
-		for (const relationship of relationships) {
-			const metadata = asRecord(relationship.metadata);
-			if (metadata?.status !== "confirmed") {
-				continue;
-			}
-
-			if (
-				relationship.sourceEntityId === entityId &&
-				typeof relationship.targetEntityId === "string"
-			) {
-				linkedIds.add(relationship.targetEntityId);
-			}
-			if (
-				relationship.targetEntityId === entityId &&
-				typeof relationship.sourceEntityId === "string"
-			) {
-				linkedIds.add(relationship.sourceEntityId);
-			}
-		}
-
-		return [...linkedIds];
+		return (
+			evaluation.decision === "bound" &&
+			ownerIds.includes(evaluation.ownerPrincipalId) &&
+			validateUuid(evaluation.actorCanonicalPrincipalId) !== null &&
+			validateUuid(evaluation.claimId) !== null &&
+			typeof evaluation.ownerBindingId === "string" &&
+			evaluation.ownerBindingId.length > 0 &&
+			Number.isSafeInteger(evaluation.generation) &&
+			evaluation.generation >= 0
+		);
 	} catch (error) {
-		// error-policy:J2 identity links participate in authorization; preserve
-		// lookup context instead of treating a failed read as no links.
-		throw new ElizaError("Failed to load confirmed identity links", {
-			code: "IDENTITY_LINK_QUERY_FAILED",
-			cause: error,
-			context: { entityId },
-		});
+		runtime.reportError("Roles.evaluateOwnerBinding", error, { entityId });
+		return false;
 	}
 }
 
@@ -547,11 +536,16 @@ async function resolveOwnershipRole(
 		if (ownerId === entityId) {
 			return "OWNER";
 		}
+	}
 
-		if (await hasConfirmedIdentityLink(runtime, entityId, ownerId)) {
-			return "OWNER";
-		}
+	const verifiedBinding = await resolveIdentityOwnerBinding(
+		runtime,
+		entityId as UUID,
+		ownerIds as UUID[],
+	);
+	if (verifiedBinding !== null) return verifiedBinding ? "OWNER" : null;
 
+	for (const ownerId of ownerIds) {
 		const ownerMetadata = await getEntityMetadata(runtime, ownerId);
 		if (!ownerMetadata) {
 			continue;
@@ -723,7 +717,7 @@ async function resolveExplicitGrantedRole(
 	options?: ResolveEntityRoleOptions,
 ): Promise<{
 	role: RoleName;
-	source: "manual" | "linked_manual";
+	source: "manual";
 } | null> {
 	const directRole = getEntityRole(metadata, entityId);
 	const directSource = await resolveStoredRoleSource(
@@ -736,28 +730,7 @@ async function resolveExplicitGrantedRole(
 		return { role: directRole, source: "manual" };
 	}
 
-	const linkedIds = await getConfirmedLinkedEntityIds(runtime, entityId);
-	let bestRole: RoleName | null = null;
-
-	for (const linkedEntityId of linkedIds) {
-		const linkedRole = getEntityRole(metadata, linkedEntityId);
-		if (linkedRole === "GUEST") {
-			continue;
-		}
-		const linkedSource = await resolveStoredRoleSource(
-			runtime,
-			metadata,
-			linkedEntityId,
-		);
-		if (linkedSource !== "manual") {
-			continue;
-		}
-		if (!bestRole || ROLE_RANK[linkedRole] > ROLE_RANK[bestRole]) {
-			bestRole = linkedRole;
-		}
-	}
-
-	return bestRole ? { role: bestRole, source: "linked_manual" } : null;
+	return null;
 }
 
 export function getLiveEntityMetadataFromMessage(
@@ -867,7 +840,7 @@ export async function checkSenderPrivateAccess(
 	canManageRoles: boolean;
 	hasPrivateAccess: boolean;
 	accessRole: RoleName | null;
-	accessSource: "owner" | "manual" | "linked_manual" | null;
+	accessSource: "owner" | "manual" | null;
 } | null> {
 	const resolved = await resolveWorldForMessage(runtime, message);
 	if (!resolved) return null;

--- a/packages/core/src/schemas/identity-authority.test.ts
+++ b/packages/core/src/schemas/identity-authority.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Verifies the portable identity schema preserves account scope, immutable
+ * attribution, generation fencing, and reversible redirect history.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	identityAuthorityStateSchema,
+	identityCanonicalRedirectSchema,
+	identityClaimSchema,
+	identityMergeConfirmationSchema,
+	identityMergeJournalSchema,
+} from "./identity-authority";
+
+describe("portable identity authority schemas", () => {
+	it("allows historical claims while uniquely fencing active scoped subjects", () => {
+		const active =
+			identityClaimSchema.indexes.identity_claim_active_scope_subject_unique;
+		expect(active?.isUnique).toBe(true);
+		expect(active?.where).toBe("status IN ('active', 'disputed')");
+		expect(identityClaimSchema.columns.connector_account_id?.type).toBe("uuid");
+		expect(
+			identityClaimSchema.foreignKeys.fk_identity_claim_owner_binding?.onDelete,
+		).toBe("restrict");
+	});
+
+	it("fences every mutation with a durable generation and exact replay key", () => {
+		expect(identityAuthorityStateSchema.columns.generation?.notNull).toBe(true);
+		expect(
+			identityMergeJournalSchema.uniqueConstraints
+				.identity_merge_journal_idempotency_unique?.columns,
+		).toEqual(["agent_id", "operation", "idempotency_key"]);
+		expect(identityMergeJournalSchema.columns.request_digest?.notNull).toBe(
+			true,
+		);
+		expect(identityMergeJournalSchema.columns.actor_principal_id?.notNull).toBe(
+			true,
+		);
+	});
+
+	it("binds a bounded confirmation to the exact plan and generation", () => {
+		expect(identityMergeConfirmationSchema.columns.plan_digest?.notNull).toBe(
+			true,
+		);
+		expect(
+			identityMergeConfirmationSchema.columns.expected_generation?.notNull,
+		).toBe(true);
+		expect(
+			identityMergeConfirmationSchema.indexes
+				.identity_merge_confirmation_active_unique?.where,
+		).toBe("status = 'active'");
+	});
+
+	it("retains versioned, journal-backed redirects without deleting principals", () => {
+		expect(
+			identityCanonicalRedirectSchema.uniqueConstraints
+				.identity_canonical_redirect_version_unique?.columns,
+		).toEqual(["agent_id", "source_principal_id", "version"]);
+		expect(
+			identityCanonicalRedirectSchema.foreignKeys
+				.fk_identity_canonical_redirect_source?.onDelete,
+		).toBe("restrict");
+		expect(
+			identityCanonicalRedirectSchema.foreignKeys
+				.fk_identity_canonical_redirect_journal?.onDelete,
+		).toBe("restrict");
+	});
+});

--- a/packages/core/src/schemas/identity-authority.test.ts
+++ b/packages/core/src/schemas/identity-authority.test.ts
@@ -17,7 +17,7 @@ describe("portable identity authority schemas", () => {
 		const active =
 			identityClaimSchema.indexes.identity_claim_active_scope_subject_unique;
 		expect(active?.isUnique).toBe(true);
-		expect(active?.where).toBe("status IN ('active', 'disputed')");
+		expect(active?.where).toBe("status = 'active'");
 		expect(identityClaimSchema.columns.connector_account_id?.type).toBe("uuid");
 		expect(
 			identityClaimSchema.foreignKeys.fk_identity_claim_owner_binding?.onDelete,
@@ -46,9 +46,9 @@ describe("portable identity authority schemas", () => {
 			identityMergeConfirmationSchema.columns.expected_generation?.notNull,
 		).toBe(true);
 		expect(
-			identityMergeConfirmationSchema.indexes
-				.identity_merge_confirmation_active_unique?.where,
-		).toBe("status = 'active'");
+			identityMergeConfirmationSchema.uniqueConstraints
+				.identity_merge_confirmation_journal_unique?.columns,
+		).toEqual(["agent_id", "journal_id"]);
 	});
 
 	it("retains versioned, journal-backed redirects without deleting principals", () => {

--- a/packages/core/src/schemas/identity-authority.ts
+++ b/packages/core/src/schemas/identity-authority.ts
@@ -120,7 +120,7 @@ export const identityClaimSchema: SchemaTable = {
 				{ expression: "external_subject_id", isExpression: false },
 			],
 			isUnique: true,
-			where: "status IN ('active', 'disputed')",
+			where: "status = 'active'",
 		},
 		identity_claim_principal_idx: {
 			name: "identity_claim_principal_idx",
@@ -151,8 +151,8 @@ export const identityClaimSchema: SchemaTable = {
 			name: "fk_identity_claim_principal",
 			tableFrom: "identity_claims",
 			tableTo: "entities",
-			columnsFrom: ["principal_entity_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["principal_entity_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -160,8 +160,8 @@ export const identityClaimSchema: SchemaTable = {
 			name: "fk_identity_claim_connector_account",
 			tableFrom: "identity_claims",
 			tableTo: "connector_accounts",
-			columnsFrom: ["connector_account_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["connector_account_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -211,7 +211,7 @@ export const identityAuthorityStateSchema: SchemaTable = {
 		},
 		generation: {
 			name: "generation",
-			type: "integer",
+			type: "bigint",
 			notNull: true,
 			default: 0,
 		},
@@ -279,9 +279,19 @@ export const identityMergeJournalSchema: SchemaTable = {
 			type: "text",
 			notNull: true,
 		},
+		commit_idempotency_key: {
+			name: "commit_idempotency_key",
+			type: "text",
+		},
+		commit_request_digest: {
+			name: "commit_request_digest",
+			type: "text",
+		},
+		plan_digest: { name: "plan_digest", type: "text", notNull: true },
+		expires_at: { name: "expires_at", type: "timestamp", notNull: true },
 		expected_generation: {
 			name: "expected_generation",
-			type: "integer",
+			type: "bigint",
 			notNull: true,
 		},
 		source_principal_ids: {
@@ -316,6 +326,15 @@ export const identityMergeJournalSchema: SchemaTable = {
 			columns: [{ expression: "parent_journal_id", isExpression: false }],
 			isUnique: false,
 		},
+		identity_merge_journal_commit_idempotency_unique: {
+			name: "identity_merge_journal_commit_idempotency_unique",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "commit_idempotency_key", isExpression: false },
+			],
+			isUnique: true,
+			where: "commit_idempotency_key IS NOT NULL",
+		},
 	},
 	foreignKeys: {
 		fk_identity_merge_journal_agent: agentForeignKey(
@@ -326,8 +345,8 @@ export const identityMergeJournalSchema: SchemaTable = {
 			name: "fk_identity_merge_journal_parent",
 			tableFrom: "identity_merge_journal",
 			tableTo: "identity_merge_journal",
-			columnsFrom: ["parent_journal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["parent_journal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -335,8 +354,8 @@ export const identityMergeJournalSchema: SchemaTable = {
 			name: "fk_identity_merge_journal_actor",
 			tableFrom: "identity_merge_journal",
 			tableTo: "entities",
-			columnsFrom: ["actor_principal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["actor_principal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -344,8 +363,8 @@ export const identityMergeJournalSchema: SchemaTable = {
 			name: "fk_identity_merge_journal_canonical",
 			tableFrom: "identity_merge_journal",
 			tableTo: "entities",
-			columnsFrom: ["canonical_principal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["canonical_principal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -355,6 +374,10 @@ export const identityMergeJournalSchema: SchemaTable = {
 		identity_merge_journal_idempotency_unique: {
 			name: "identity_merge_journal_idempotency_unique",
 			columns: ["agent_id", "operation", "idempotency_key"],
+		},
+		identity_merge_journal_id_agent_unique: {
+			name: "identity_merge_journal_id_agent_unique",
+			columns: ["id", "agent_id"],
 		},
 	},
 	checkConstraints: {
@@ -366,6 +389,14 @@ export const identityMergeJournalSchema: SchemaTable = {
 			name: "identity_merge_journal_status_check",
 			value:
 				"status IN ('planned', 'committed', 'completed', 'reverted', 'failed')",
+		},
+		identity_merge_journal_generation_check: {
+			name: "identity_merge_journal_generation_check",
+			value: "expected_generation >= 0",
+		},
+		identity_merge_journal_expiry_check: {
+			name: "identity_merge_journal_expiry_check",
+			value: "expires_at > created_at",
 		},
 	},
 };
@@ -391,7 +422,7 @@ export const identityMergeConfirmationSchema: SchemaTable = {
 		plan_digest: { name: "plan_digest", type: "text", notNull: true },
 		expected_generation: {
 			name: "expected_generation",
-			type: "integer",
+			type: "bigint",
 			notNull: true,
 		},
 		status: {
@@ -410,15 +441,6 @@ export const identityMergeConfirmationSchema: SchemaTable = {
 		consumed_at: { name: "consumed_at", type: "timestamp" },
 	},
 	indexes: {
-		identity_merge_confirmation_active_unique: {
-			name: "identity_merge_confirmation_active_unique",
-			columns: [
-				{ expression: "agent_id", isExpression: false },
-				{ expression: "journal_id", isExpression: false },
-			],
-			isUnique: true,
-			where: "status = 'active'",
-		},
 		identity_merge_confirmation_expiry_idx: {
 			name: "identity_merge_confirmation_expiry_idx",
 			columns: [
@@ -437,8 +459,8 @@ export const identityMergeConfirmationSchema: SchemaTable = {
 			name: "fk_identity_merge_confirmation_journal",
 			tableFrom: "identity_merge_confirmations",
 			tableTo: "identity_merge_journal",
-			columnsFrom: ["journal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["journal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -446,14 +468,19 @@ export const identityMergeConfirmationSchema: SchemaTable = {
 			name: "fk_identity_merge_confirmation_actor",
 			tableFrom: "identity_merge_confirmations",
 			tableTo: "entities",
-			columnsFrom: ["actor_principal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["actor_principal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
 	},
 	compositePrimaryKeys: {},
-	uniqueConstraints: {},
+	uniqueConstraints: {
+		identity_merge_confirmation_journal_unique: {
+			name: "identity_merge_confirmation_journal_unique",
+			columns: ["agent_id", "journal_id"],
+		},
+	},
 	checkConstraints: {
 		identity_merge_confirmation_status_check: {
 			name: "identity_merge_confirmation_status_check",
@@ -462,6 +489,15 @@ export const identityMergeConfirmationSchema: SchemaTable = {
 		identity_merge_confirmation_generation_check: {
 			name: "identity_merge_confirmation_generation_check",
 			value: "expected_generation >= 0",
+		},
+		identity_merge_confirmation_time_check: {
+			name: "identity_merge_confirmation_time_check",
+			value: "expires_at > confirmed_at",
+		},
+		identity_merge_confirmation_consumed_check: {
+			name: "identity_merge_confirmation_consumed_check",
+			value:
+				"(status = 'consumed' AND consumed_at IS NOT NULL) OR (status <> 'consumed' AND consumed_at IS NULL)",
 		},
 	},
 };
@@ -493,7 +529,7 @@ export const identityCanonicalRedirectSchema: SchemaTable = {
 			type: "uuid",
 			notNull: true,
 		},
-		version: { name: "version", type: "integer", notNull: true },
+		version: { name: "version", type: "bigint", notNull: true },
 		status: {
 			name: "status",
 			type: "text",
@@ -527,6 +563,15 @@ export const identityCanonicalRedirectSchema: SchemaTable = {
 			],
 			isUnique: false,
 		},
+		identity_redirect_journal_idx: {
+			name: "identity_redirect_journal_idx",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "merge_journal_id", isExpression: false },
+				{ expression: "status", isExpression: false },
+			],
+			isUnique: false,
+		},
 	},
 	foreignKeys: {
 		fk_identity_canonical_redirect_agent: agentForeignKey(
@@ -537,8 +582,8 @@ export const identityCanonicalRedirectSchema: SchemaTable = {
 			name: "fk_identity_canonical_redirect_source",
 			tableFrom: "identity_canonical_redirects",
 			tableTo: "entities",
-			columnsFrom: ["source_principal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["source_principal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -546,8 +591,8 @@ export const identityCanonicalRedirectSchema: SchemaTable = {
 			name: "fk_identity_canonical_redirect_target",
 			tableFrom: "identity_canonical_redirects",
 			tableTo: "entities",
-			columnsFrom: ["canonical_principal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["canonical_principal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},
@@ -555,8 +600,8 @@ export const identityCanonicalRedirectSchema: SchemaTable = {
 			name: "fk_identity_canonical_redirect_journal",
 			tableFrom: "identity_canonical_redirects",
 			tableTo: "identity_merge_journal",
-			columnsFrom: ["merge_journal_id"],
-			columnsTo: ["id"],
+			columnsFrom: ["merge_journal_id", "agent_id"],
+			columnsTo: ["id", "agent_id"],
 			onDelete: "restrict",
 			schemaTo: "",
 		},

--- a/packages/core/src/schemas/identity-authority.ts
+++ b/packages/core/src/schemas/identity-authority.ts
@@ -1,0 +1,585 @@
+/**
+ * Portable descriptors for the canonical identity authority: account-scoped
+ * claims, generation fencing, durable confirmations, reversible merge/split
+ * journals, and non-destructive redirects. Adapters materialize these tables
+ * without making authorization depend on lossy entity rewrites.
+ */
+
+import type { SchemaTable } from "../types/schema.ts";
+
+const agentForeignKey = (
+	name: string,
+	tableFrom: string,
+): SchemaTable["foreignKeys"][string] => ({
+	name,
+	tableFrom,
+	tableTo: "agents",
+	columnsFrom: ["agent_id"],
+	columnsTo: ["id"],
+	onDelete: "cascade",
+	schemaTo: "",
+});
+
+export const identityClaimSchema: SchemaTable = {
+	name: "identity_claims",
+	schema: "",
+	columns: {
+		id: {
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "gen_random_uuid()",
+		},
+		agent_id: { name: "agent_id", type: "uuid", notNull: true },
+		principal_entity_id: {
+			name: "principal_entity_id",
+			type: "uuid",
+			notNull: true,
+		},
+		namespace: { name: "namespace", type: "text", notNull: true },
+		connector_id: { name: "connector_id", type: "text", notNull: true },
+		connector_account_id: {
+			name: "connector_account_id",
+			type: "uuid",
+			notNull: true,
+		},
+		external_subject_id: {
+			name: "external_subject_id",
+			type: "text",
+			notNull: true,
+		},
+		handle: { name: "handle", type: "text" },
+		display_name: { name: "display_name", type: "text" },
+		verification: {
+			name: "verification",
+			type: "text",
+			notNull: true,
+			default: "'unverified'",
+		},
+		owner_binding_id: { name: "owner_binding_id", type: "text" },
+		status: {
+			name: "status",
+			type: "text",
+			notNull: true,
+			default: "'active'",
+		},
+		confidence: {
+			name: "confidence",
+			type: "real",
+			notNull: true,
+			default: 0,
+		},
+		provenance: {
+			name: "provenance",
+			type: "jsonb",
+			notNull: true,
+			default: "'{}'::jsonb",
+		},
+		evidence: {
+			name: "evidence",
+			type: "jsonb",
+			notNull: true,
+			default: "'{}'::jsonb",
+		},
+		first_seen_at: {
+			name: "first_seen_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		last_seen_at: {
+			name: "last_seen_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		verified_at: { name: "verified_at", type: "timestamp" },
+		revoked_at: { name: "revoked_at", type: "timestamp" },
+		created_at: {
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		updated_at: {
+			name: "updated_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+	},
+	indexes: {
+		identity_claim_active_scope_subject_unique: {
+			name: "identity_claim_active_scope_subject_unique",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "namespace", isExpression: false },
+				{ expression: "connector_id", isExpression: false },
+				{ expression: "connector_account_id", isExpression: false },
+				{ expression: "external_subject_id", isExpression: false },
+			],
+			isUnique: true,
+			where: "status IN ('active', 'disputed')",
+		},
+		identity_claim_principal_idx: {
+			name: "identity_claim_principal_idx",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "principal_entity_id", isExpression: false },
+			],
+			isUnique: false,
+		},
+		identity_claim_lookup_idx: {
+			name: "identity_claim_lookup_idx",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "namespace", isExpression: false },
+				{ expression: "connector_id", isExpression: false },
+				{ expression: "connector_account_id", isExpression: false },
+				{ expression: "external_subject_id", isExpression: false },
+			],
+			isUnique: false,
+		},
+	},
+	foreignKeys: {
+		fk_identity_claim_agent: agentForeignKey(
+			"fk_identity_claim_agent",
+			"identity_claims",
+		),
+		fk_identity_claim_principal: {
+			name: "fk_identity_claim_principal",
+			tableFrom: "identity_claims",
+			tableTo: "entities",
+			columnsFrom: ["principal_entity_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_claim_connector_account: {
+			name: "fk_identity_claim_connector_account",
+			tableFrom: "identity_claims",
+			tableTo: "connector_accounts",
+			columnsFrom: ["connector_account_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_claim_owner_binding: {
+			name: "fk_identity_claim_owner_binding",
+			tableFrom: "identity_claims",
+			tableTo: "auth_owner_bindings",
+			columnsFrom: ["owner_binding_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+	},
+	compositePrimaryKeys: {},
+	uniqueConstraints: {},
+	checkConstraints: {
+		identity_claim_verification_check: {
+			name: "identity_claim_verification_check",
+			value:
+				"verification IN ('unverified', 'observed', 'verified', 'owner_bound')",
+		},
+		identity_claim_status_check: {
+			name: "identity_claim_status_check",
+			value: "status IN ('active', 'revoked', 'superseded', 'disputed')",
+		},
+		identity_claim_confidence_check: {
+			name: "identity_claim_confidence_check",
+			value: "confidence >= 0 AND confidence <= 1",
+		},
+		identity_claim_owner_binding_check: {
+			name: "identity_claim_owner_binding_check",
+			value:
+				"verification <> 'owner_bound' OR (owner_binding_id IS NOT NULL AND verified_at IS NOT NULL)",
+		},
+	},
+};
+
+export const identityAuthorityStateSchema: SchemaTable = {
+	name: "identity_authority_state",
+	schema: "",
+	columns: {
+		agent_id: {
+			name: "agent_id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+		},
+		generation: {
+			name: "generation",
+			type: "integer",
+			notNull: true,
+			default: 0,
+		},
+		updated_at: {
+			name: "updated_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+	},
+	indexes: {},
+	foreignKeys: {
+		fk_identity_authority_state_agent: agentForeignKey(
+			"fk_identity_authority_state_agent",
+			"identity_authority_state",
+		),
+	},
+	compositePrimaryKeys: {},
+	uniqueConstraints: {},
+	checkConstraints: {
+		identity_authority_state_generation_check: {
+			name: "identity_authority_state_generation_check",
+			value: "generation >= 0",
+		},
+	},
+};
+
+export const identityMergeJournalSchema: SchemaTable = {
+	name: "identity_merge_journal",
+	schema: "",
+	columns: {
+		id: {
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "gen_random_uuid()",
+		},
+		agent_id: { name: "agent_id", type: "uuid", notNull: true },
+		operation: { name: "operation", type: "text", notNull: true },
+		status: {
+			name: "status",
+			type: "text",
+			notNull: true,
+			default: "'planned'",
+		},
+		parent_journal_id: { name: "parent_journal_id", type: "uuid" },
+		actor_principal_id: {
+			name: "actor_principal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		canonical_principal_id: {
+			name: "canonical_principal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		idempotency_key: {
+			name: "idempotency_key",
+			type: "text",
+			notNull: true,
+		},
+		request_digest: {
+			name: "request_digest",
+			type: "text",
+			notNull: true,
+		},
+		expected_generation: {
+			name: "expected_generation",
+			type: "integer",
+			notNull: true,
+		},
+		source_principal_ids: {
+			name: "source_principal_ids",
+			type: "jsonb",
+			notNull: true,
+		},
+		plan: { name: "plan", type: "jsonb", notNull: true },
+		before_state: { name: "before_state", type: "jsonb", notNull: true },
+		result: { name: "result", type: "jsonb" },
+		reason: { name: "reason", type: "text", notNull: true },
+		created_at: {
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		committed_at: { name: "committed_at", type: "timestamp" },
+		completed_at: { name: "completed_at", type: "timestamp" },
+	},
+	indexes: {
+		identity_merge_journal_agent_status_idx: {
+			name: "identity_merge_journal_agent_status_idx",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "status", isExpression: false },
+			],
+			isUnique: false,
+		},
+		identity_merge_journal_parent_idx: {
+			name: "identity_merge_journal_parent_idx",
+			columns: [{ expression: "parent_journal_id", isExpression: false }],
+			isUnique: false,
+		},
+	},
+	foreignKeys: {
+		fk_identity_merge_journal_agent: agentForeignKey(
+			"fk_identity_merge_journal_agent",
+			"identity_merge_journal",
+		),
+		fk_identity_merge_journal_parent: {
+			name: "fk_identity_merge_journal_parent",
+			tableFrom: "identity_merge_journal",
+			tableTo: "identity_merge_journal",
+			columnsFrom: ["parent_journal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_merge_journal_actor: {
+			name: "fk_identity_merge_journal_actor",
+			tableFrom: "identity_merge_journal",
+			tableTo: "entities",
+			columnsFrom: ["actor_principal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_merge_journal_canonical: {
+			name: "fk_identity_merge_journal_canonical",
+			tableFrom: "identity_merge_journal",
+			tableTo: "entities",
+			columnsFrom: ["canonical_principal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+	},
+	compositePrimaryKeys: {},
+	uniqueConstraints: {
+		identity_merge_journal_idempotency_unique: {
+			name: "identity_merge_journal_idempotency_unique",
+			columns: ["agent_id", "operation", "idempotency_key"],
+		},
+	},
+	checkConstraints: {
+		identity_merge_journal_operation_check: {
+			name: "identity_merge_journal_operation_check",
+			value: "operation IN ('merge', 'split')",
+		},
+		identity_merge_journal_status_check: {
+			name: "identity_merge_journal_status_check",
+			value:
+				"status IN ('planned', 'committed', 'completed', 'reverted', 'failed')",
+		},
+	},
+};
+
+export const identityMergeConfirmationSchema: SchemaTable = {
+	name: "identity_merge_confirmations",
+	schema: "",
+	columns: {
+		id: {
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "gen_random_uuid()",
+		},
+		agent_id: { name: "agent_id", type: "uuid", notNull: true },
+		journal_id: { name: "journal_id", type: "uuid", notNull: true },
+		actor_principal_id: {
+			name: "actor_principal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		plan_digest: { name: "plan_digest", type: "text", notNull: true },
+		expected_generation: {
+			name: "expected_generation",
+			type: "integer",
+			notNull: true,
+		},
+		status: {
+			name: "status",
+			type: "text",
+			notNull: true,
+			default: "'active'",
+		},
+		confirmed_at: {
+			name: "confirmed_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		expires_at: { name: "expires_at", type: "timestamp", notNull: true },
+		consumed_at: { name: "consumed_at", type: "timestamp" },
+	},
+	indexes: {
+		identity_merge_confirmation_active_unique: {
+			name: "identity_merge_confirmation_active_unique",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "journal_id", isExpression: false },
+			],
+			isUnique: true,
+			where: "status = 'active'",
+		},
+		identity_merge_confirmation_expiry_idx: {
+			name: "identity_merge_confirmation_expiry_idx",
+			columns: [
+				{ expression: "status", isExpression: false },
+				{ expression: "expires_at", isExpression: false },
+			],
+			isUnique: false,
+		},
+	},
+	foreignKeys: {
+		fk_identity_merge_confirmation_agent: agentForeignKey(
+			"fk_identity_merge_confirmation_agent",
+			"identity_merge_confirmations",
+		),
+		fk_identity_merge_confirmation_journal: {
+			name: "fk_identity_merge_confirmation_journal",
+			tableFrom: "identity_merge_confirmations",
+			tableTo: "identity_merge_journal",
+			columnsFrom: ["journal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_merge_confirmation_actor: {
+			name: "fk_identity_merge_confirmation_actor",
+			tableFrom: "identity_merge_confirmations",
+			tableTo: "entities",
+			columnsFrom: ["actor_principal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+	},
+	compositePrimaryKeys: {},
+	uniqueConstraints: {},
+	checkConstraints: {
+		identity_merge_confirmation_status_check: {
+			name: "identity_merge_confirmation_status_check",
+			value: "status IN ('active', 'consumed', 'expired', 'revoked')",
+		},
+		identity_merge_confirmation_generation_check: {
+			name: "identity_merge_confirmation_generation_check",
+			value: "expected_generation >= 0",
+		},
+	},
+};
+
+export const identityCanonicalRedirectSchema: SchemaTable = {
+	name: "identity_canonical_redirects",
+	schema: "",
+	columns: {
+		id: {
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "gen_random_uuid()",
+		},
+		agent_id: { name: "agent_id", type: "uuid", notNull: true },
+		source_principal_id: {
+			name: "source_principal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		canonical_principal_id: {
+			name: "canonical_principal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		merge_journal_id: {
+			name: "merge_journal_id",
+			type: "uuid",
+			notNull: true,
+		},
+		version: { name: "version", type: "integer", notNull: true },
+		status: {
+			name: "status",
+			type: "text",
+			notNull: true,
+			default: "'active'",
+		},
+		created_at: {
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		},
+		superseded_at: { name: "superseded_at", type: "timestamp" },
+	},
+	indexes: {
+		identity_canonical_redirect_active_unique: {
+			name: "identity_canonical_redirect_active_unique",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "source_principal_id", isExpression: false },
+			],
+			isUnique: true,
+			where: "status = 'active'",
+		},
+		identity_canonical_redirect_target_idx: {
+			name: "identity_canonical_redirect_target_idx",
+			columns: [
+				{ expression: "agent_id", isExpression: false },
+				{ expression: "canonical_principal_id", isExpression: false },
+				{ expression: "status", isExpression: false },
+			],
+			isUnique: false,
+		},
+	},
+	foreignKeys: {
+		fk_identity_canonical_redirect_agent: agentForeignKey(
+			"fk_identity_canonical_redirect_agent",
+			"identity_canonical_redirects",
+		),
+		fk_identity_canonical_redirect_source: {
+			name: "fk_identity_canonical_redirect_source",
+			tableFrom: "identity_canonical_redirects",
+			tableTo: "entities",
+			columnsFrom: ["source_principal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_canonical_redirect_target: {
+			name: "fk_identity_canonical_redirect_target",
+			tableFrom: "identity_canonical_redirects",
+			tableTo: "entities",
+			columnsFrom: ["canonical_principal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+		fk_identity_canonical_redirect_journal: {
+			name: "fk_identity_canonical_redirect_journal",
+			tableFrom: "identity_canonical_redirects",
+			tableTo: "identity_merge_journal",
+			columnsFrom: ["merge_journal_id"],
+			columnsTo: ["id"],
+			onDelete: "restrict",
+			schemaTo: "",
+		},
+	},
+	compositePrimaryKeys: {},
+	uniqueConstraints: {
+		identity_canonical_redirect_version_unique: {
+			name: "identity_canonical_redirect_version_unique",
+			columns: ["agent_id", "source_principal_id", "version"],
+		},
+	},
+	checkConstraints: {
+		identity_canonical_redirect_status_check: {
+			name: "identity_canonical_redirect_status_check",
+			value: "status IN ('active', 'superseded', 'reverted')",
+		},
+		identity_canonical_redirect_distinct_check: {
+			name: "identity_canonical_redirect_distinct_check",
+			value: "source_principal_id <> canonical_principal_id",
+		},
+		identity_canonical_redirect_version_check: {
+			name: "identity_canonical_redirect_version_check",
+			value: "version > 0",
+		},
+	},
+};

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -95,7 +95,7 @@ export {
 
 /**
  * Type for the object returned by buildBaseTables().
- * Represents all 25 core database tables as ORM table objects.
+ * Represents all 20 portable core database tables as ORM table objects.
  */
 export interface BaseTables {
 	agent: unknown;
@@ -105,11 +105,6 @@ export interface BaseTables {
 	component: unknown;
 	embedding: unknown;
 	entity: unknown;
-	identityAuthorityState: unknown;
-	identityCanonicalRedirect: unknown;
-	identityClaim: unknown;
-	identityMergeConfirmation: unknown;
-	identityMergeJournal: unknown;
 	log: unknown;
 	memory: unknown;
 	message: unknown;
@@ -126,7 +121,7 @@ export interface BaseTables {
 }
 
 /**
- * Factory: build all 25 base tables using the given dialect adapter and buildTable function.
+ * Factory: build all 20 base tables using the given dialect adapter and buildTable function.
  *
  * This is the single source of truth for the elizaOS data model. Plugins
  * import this function and pass their dialect adapter (pgAdapter, mysqlAdapter)
@@ -136,7 +131,7 @@ export interface BaseTables {
  *
  * @param buildTable - The buildTable function from the plugin
  * @param adapter - The dialect-specific adapter (pgAdapter or mysqlAdapter).
- * @returns An object with all 25 tables, keyed by camelCase name.
+ * @returns An object with all 20 tables, keyed by camelCase name.
  */
 export function buildBaseTables(
 	buildTable: BuildTableFn,
@@ -150,17 +145,6 @@ export function buildBaseTables(
 		component: buildTable(componentSchema, adapter),
 		embedding: buildTable(embeddingSchema, adapter),
 		entity: buildTable(entitySchema, adapter),
-		identityAuthorityState: buildTable(identityAuthorityStateSchema, adapter),
-		identityCanonicalRedirect: buildTable(
-			identityCanonicalRedirectSchema,
-			adapter,
-		),
-		identityClaim: buildTable(identityClaimSchema, adapter),
-		identityMergeConfirmation: buildTable(
-			identityMergeConfirmationSchema,
-			adapter,
-		),
-		identityMergeJournal: buildTable(identityMergeJournalSchema, adapter),
 		log: buildTable(logSchema, adapter),
 		memory: buildTable(memorySchema, adapter),
 		message: buildTable(messageSchema, adapter),

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -36,6 +36,13 @@ export type {
 	FactCandidateStatus,
 } from "./entity-identity.ts";
 
+import {
+	identityAuthorityStateSchema,
+	identityCanonicalRedirectSchema,
+	identityClaimSchema,
+	identityMergeConfirmationSchema,
+	identityMergeJournalSchema,
+} from "./identity-authority.ts";
 import { logSchema } from "./log.ts";
 import { memorySchema } from "./memory.ts";
 import { messageSchema } from "./message.ts";
@@ -62,6 +69,11 @@ export {
 	entityMergeCandidateSchema,
 	entitySchema,
 	factCandidateSchema,
+	identityAuthorityStateSchema,
+	identityCanonicalRedirectSchema,
+	identityClaimSchema,
+	identityMergeConfirmationSchema,
+	identityMergeJournalSchema,
 	logSchema,
 	// Advanced memory schemas
 	longTermMemories,
@@ -83,7 +95,7 @@ export {
 
 /**
  * Type for the object returned by buildBaseTables().
- * Represents all 20 core database tables as ORM table objects.
+ * Represents all 25 core database tables as ORM table objects.
  */
 export interface BaseTables {
 	agent: unknown;
@@ -93,6 +105,11 @@ export interface BaseTables {
 	component: unknown;
 	embedding: unknown;
 	entity: unknown;
+	identityAuthorityState: unknown;
+	identityCanonicalRedirect: unknown;
+	identityClaim: unknown;
+	identityMergeConfirmation: unknown;
+	identityMergeJournal: unknown;
 	log: unknown;
 	memory: unknown;
 	message: unknown;
@@ -109,7 +126,7 @@ export interface BaseTables {
 }
 
 /**
- * Factory: build all 20 base tables using the given dialect adapter and buildTable function.
+ * Factory: build all 25 base tables using the given dialect adapter and buildTable function.
  *
  * This is the single source of truth for the elizaOS data model. Plugins
  * import this function and pass their dialect adapter (pgAdapter, mysqlAdapter)
@@ -119,7 +136,7 @@ export interface BaseTables {
  *
  * @param buildTable - The buildTable function from the plugin
  * @param adapter - The dialect-specific adapter (pgAdapter or mysqlAdapter).
- * @returns An object with all 20 tables, keyed by camelCase name.
+ * @returns An object with all 25 tables, keyed by camelCase name.
  */
 export function buildBaseTables(
 	buildTable: BuildTableFn,
@@ -133,6 +150,17 @@ export function buildBaseTables(
 		component: buildTable(componentSchema, adapter),
 		embedding: buildTable(embeddingSchema, adapter),
 		entity: buildTable(entitySchema, adapter),
+		identityAuthorityState: buildTable(identityAuthorityStateSchema, adapter),
+		identityCanonicalRedirect: buildTable(
+			identityCanonicalRedirectSchema,
+			adapter,
+		),
+		identityClaim: buildTable(identityClaimSchema, adapter),
+		identityMergeConfirmation: buildTable(
+			identityMergeConfirmationSchema,
+			adapter,
+		),
+		identityMergeJournal: buildTable(identityMergeJournalSchema, adapter),
 		log: buildTable(logSchema, adapter),
 		memory: buildTable(memorySchema, adapter),
 		message: buildTable(messageSchema, adapter),

--- a/packages/core/src/types/identity.test.ts
+++ b/packages/core/src/types/identity.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Verifies the public identity-authority vocabulary and runtime service key
+ * through deterministic contract assertions.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	IDENTITY_AUTHORITY_CONTRACT_VERSION,
+	IDENTITY_CLAIM_STATUSES,
+	IDENTITY_CLAIM_VERIFICATIONS,
+	IDENTITY_MERGE_OPERATIONS,
+	IDENTITY_MERGE_STATUSES,
+	IDENTITY_REDIRECT_STATUSES,
+	IdentityResolutionService,
+} from "./identity";
+import { ServiceType } from "./service";
+
+describe("identity authority contract", () => {
+	it("keeps the mutation vocabulary closed and versioned", () => {
+		expect(IDENTITY_AUTHORITY_CONTRACT_VERSION).toBe(1);
+		expect(IDENTITY_CLAIM_VERIFICATIONS).toEqual([
+			"unverified",
+			"observed",
+			"verified",
+			"owner_bound",
+		]);
+		expect(IDENTITY_CLAIM_STATUSES).toEqual([
+			"active",
+			"revoked",
+			"superseded",
+			"disputed",
+		]);
+		expect(IDENTITY_MERGE_OPERATIONS).toEqual(["merge", "split"]);
+		expect(IDENTITY_MERGE_STATUSES).toEqual([
+			"planned",
+			"committed",
+			"completed",
+			"reverted",
+			"failed",
+		]);
+		expect(IDENTITY_REDIRECT_STATUSES).toEqual([
+			"active",
+			"superseded",
+			"reverted",
+		]);
+	});
+
+	it("registers one canonical runtime service name", () => {
+		expect(ServiceType.IDENTITY_RESOLUTION).toBe("identity_resolution");
+		expect(IdentityResolutionService.serviceType).toBe(
+			ServiceType.IDENTITY_RESOLUTION,
+		);
+	});
+});

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -1,0 +1,278 @@
+/**
+ * Canonical identity-resolution contracts shared by runtime entities,
+ * connector accounts, authorization, delivery, and relationship consumers.
+ * Identity mutations preserve source principals and evidence; callers resolve
+ * through versioned redirects instead of rewriting or deleting history.
+ */
+
+import type { JsonObject, UUID } from "./primitives";
+import { Service, ServiceType } from "./service";
+
+export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1 as const;
+export const PRINCIPAL_KINDS = [
+	"person",
+	"agent",
+	"service",
+	"organization",
+	"unknown",
+] as const;
+export type PrincipalKind = (typeof PRINCIPAL_KINDS)[number];
+export const IDENTITY_CLAIM_VERIFICATIONS = [
+	"unverified",
+	"observed",
+	"verified",
+	"owner_bound",
+] as const;
+export type IdentityClaimVerification =
+	(typeof IDENTITY_CLAIM_VERIFICATIONS)[number];
+export const IDENTITY_CLAIM_STATUSES = [
+	"active",
+	"revoked",
+	"superseded",
+	"disputed",
+] as const;
+export type IdentityClaimStatus = (typeof IDENTITY_CLAIM_STATUSES)[number];
+export const IDENTITY_REDIRECT_STATUSES = [
+	"active",
+	"superseded",
+	"reverted",
+] as const;
+export type IdentityCanonicalRedirectStatus =
+	(typeof IDENTITY_REDIRECT_STATUSES)[number];
+export const IDENTITY_MERGE_OPERATIONS = ["merge", "split"] as const;
+export type IdentityMergeOperation = (typeof IDENTITY_MERGE_OPERATIONS)[number];
+export const IDENTITY_MERGE_STATUSES = [
+	"planned",
+	"committed",
+	"completed",
+	"reverted",
+	"failed",
+] as const;
+export type IdentityMergeStatus = (typeof IDENTITY_MERGE_STATUSES)[number];
+
+export interface Principal {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	kind: PrincipalKind;
+	displayName: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+/** The scoped-subject tuple identifies at most one principal. */
+export interface IdentityClaim {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	principalEntityId: UUID;
+	namespace: string;
+	connectorId: string;
+	connectorAccountId: UUID;
+	externalSubjectId: string;
+	handle: string | null;
+	displayName: string | null;
+	verification: IdentityClaimVerification;
+	status: IdentityClaimStatus;
+	confidence: number;
+	/** Only this separately verified binding can confer owner authority. */
+	ownerBindingId: string | null;
+	provenance: JsonObject;
+	evidence: JsonObject;
+	firstSeenAt: string;
+	lastSeenAt: string;
+	verifiedAt: string | null;
+	revokedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface IdentityClaimScope {
+	agentId: UUID;
+	namespace: string;
+	connectorId: string;
+	connectorAccountId: UUID;
+	externalSubjectId: string;
+}
+
+export interface IdentityCluster {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	agentId: UUID;
+	canonicalPrincipalId: UUID;
+	principalIds: readonly UUID[];
+	claims: readonly IdentityClaim[];
+	generation: number;
+	readAt: string;
+}
+
+export interface IdentityCanonicalResolution {
+	agentId: UUID;
+	requestedPrincipalId: UUID;
+	canonicalPrincipalId: UUID;
+	redirectIds: readonly UUID[];
+	generation: number;
+}
+
+export interface IdentityCanonicalRedirect {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	sourcePrincipalId: UUID;
+	canonicalPrincipalId: UUID;
+	mergeJournalId: UUID;
+	version: number;
+	status: IdentityCanonicalRedirectStatus;
+	createdAt: string;
+	supersededAt: string | null;
+}
+
+export interface IdentityAffectedReference {
+	consumer: string;
+	referenceType: string;
+	referenceId: string;
+	principalId: UUID;
+	resolution: "redirect_safe" | "projection_repair_required";
+}
+
+export interface IdentityClaimConflict {
+	claimIds: readonly UUID[];
+	reason: "owner_binding" | "scoped_subject" | "verification";
+	details: JsonObject;
+}
+
+export interface IdentityMergePlan {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	operation: IdentityMergeOperation;
+	canonicalPrincipalId: UUID;
+	sourcePrincipalIds: readonly UUID[];
+	parentJournalId: UUID | null;
+	expectedGeneration: number;
+	affectedReferences: readonly IdentityAffectedReference[];
+	conflictingClaims: readonly IdentityClaimConflict[];
+	createdAt: string;
+	expiresAt: string;
+}
+
+export interface IdentityMergeResult {
+	canonicalPrincipalId: UUID;
+	preservedPrincipalIds: readonly UUID[];
+	redirectIds: readonly UUID[];
+	repairedConsumers: readonly string[];
+	pendingConsumers: readonly string[];
+	generation: number;
+}
+
+export interface MergeJournal {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	operation: IdentityMergeOperation;
+	status: IdentityMergeStatus;
+	parentJournalId: UUID | null;
+	actorPrincipalId: UUID;
+	canonicalPrincipalId: UUID;
+	sourcePrincipalIds: readonly UUID[];
+	plan: IdentityMergePlan;
+	beforeState: JsonObject;
+	result: IdentityMergeResult | null;
+	reason: string;
+	createdAt: string;
+	committedAt: string | null;
+	completedAt: string | null;
+}
+
+export interface ProposeIdentityMergeRequest {
+	agentId: UUID;
+	canonicalPrincipalId: UUID;
+	sourcePrincipalIds: readonly UUID[];
+	actorPrincipalId: UUID;
+	reason: string;
+	idempotencyKey: string;
+	requestDigest: string;
+}
+
+export interface ConfirmIdentityMergeRequest {
+	agentId: UUID;
+	planId: UUID;
+	expectedGeneration: number;
+	actorPrincipalId: UUID;
+}
+
+export interface IdentityMergeConfirmation {
+	id: UUID;
+	agentId: UUID;
+	planId: UUID;
+	expectedGeneration: number;
+	actorPrincipalId: UUID;
+	confirmedAt: string;
+	expiresAt: string;
+}
+
+export interface CommitIdentityMergeRequest {
+	agentId: UUID;
+	planId: UUID;
+	confirmationId: UUID;
+	expectedGeneration: number;
+	actorPrincipalId: UUID;
+	idempotencyKey: string;
+	requestDigest: string;
+}
+
+export interface SplitIdentityRequest {
+	agentId: UUID;
+	parentJournalId: UUID;
+	principalIds: readonly UUID[];
+	expectedGeneration: number;
+	actorPrincipalId: UUID;
+	reason: string;
+	idempotencyKey: string;
+	requestDigest: string;
+}
+
+export interface IdentityJournalPage {
+	items: readonly MergeJournal[];
+	nextCursor: string | null;
+}
+
+/** Single runtime authority for identity reads and reversible mutations. */
+export abstract class IdentityResolutionService extends Service {
+	static override readonly serviceType = ServiceType.IDENTITY_RESOLUTION;
+	public readonly capabilityDescription =
+		"Resolves canonical principals and performs reversible identity mutations.";
+
+	abstract resolveCanonicalPrincipal(
+		agentId: UUID,
+		principalId: UUID,
+	): Promise<IdentityCanonicalResolution>;
+	abstract resolveClaim(
+		scope: IdentityClaimScope,
+	): Promise<IdentityClaim | null>;
+	abstract getCluster(
+		agentId: UUID,
+		principalId: UUID,
+	): Promise<IdentityCluster | null>;
+	abstract proposeMerge(
+		request: ProposeIdentityMergeRequest,
+	): Promise<IdentityMergePlan>;
+	abstract confirmMerge(
+		request: ConfirmIdentityMergeRequest,
+	): Promise<IdentityMergeConfirmation>;
+	abstract commitMerge(
+		request: CommitIdentityMergeRequest,
+	): Promise<MergeJournal>;
+	abstract split(request: SplitIdentityRequest): Promise<MergeJournal>;
+	abstract getJournal(
+		agentId: UUID,
+		journalId: UUID,
+	): Promise<MergeJournal | null>;
+	abstract listRedirects(
+		agentId: UUID,
+		principalId: UUID,
+	): Promise<readonly IdentityCanonicalRedirect[]>;
+	abstract listJournal(
+		agentId: UUID,
+		options: { limit: number; cursor: string | null },
+	): Promise<IdentityJournalPage>;
+}

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -113,6 +113,36 @@ export interface IdentityCanonicalResolution {
 	generation: number;
 }
 
+export interface EvaluateOwnerBindingRequest {
+	agentId: UUID;
+	actorPrincipalId: UUID;
+	candidateOwnerPrincipalIds: readonly UUID[];
+	purpose:
+		| "role_resolution"
+		| "connector_account"
+		| "sensitive_request"
+		| "delivery";
+}
+
+export type OwnerBindingEvaluation =
+	| {
+			decision: "bound";
+			actorCanonicalPrincipalId: UUID;
+			ownerPrincipalId: UUID;
+			claimId: UUID;
+			ownerBindingId: string;
+			generation: number;
+			reason: "verified_owner_binding";
+	  }
+	| {
+			decision: "not_bound";
+			reason: "no_active_binding" | "revoked" | "disputed" | "wrong_owner";
+	  }
+	| {
+			decision: "unavailable";
+			reason: "not_implemented" | "service_unavailable" | "read_failed";
+	  };
+
 export interface IdentityCanonicalRedirect {
 	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
 	id: UUID;
@@ -142,6 +172,7 @@ export interface IdentityClaimConflict {
 
 export interface IdentityMergePlan {
 	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	/** The durable planned merge-journal row identifier. */
 	id: UUID;
 	agentId: UUID;
 	operation: IdentityMergeOperation;
@@ -206,8 +237,11 @@ export interface IdentityMergeConfirmation {
 	planId: UUID;
 	expectedGeneration: number;
 	actorPrincipalId: UUID;
+	planDigest: string;
+	status: "active" | "consumed" | "expired" | "revoked";
 	confirmedAt: string;
 	expiresAt: string;
+	consumedAt: string | null;
 }
 
 export interface CommitIdentityMergeRequest {
@@ -246,6 +280,14 @@ export abstract class IdentityResolutionService extends Service {
 		agentId: UUID,
 		principalId: UUID,
 	): Promise<IdentityCanonicalResolution>;
+	abstract resolveForDisplay(
+		agentId: UUID,
+		principalId: UUID,
+	): Promise<IdentityCanonicalResolution>;
+	abstract resolveForDataAccess(
+		agentId: UUID,
+		principalId: UUID,
+	): Promise<IdentityCanonicalResolution>;
 	abstract resolveClaim(
 		scope: IdentityClaimScope,
 	): Promise<IdentityClaim | null>;
@@ -253,6 +295,14 @@ export abstract class IdentityResolutionService extends Service {
 		agentId: UUID,
 		principalId: UUID,
 	): Promise<IdentityCluster | null>;
+	abstract resolveVerifiedDeliveryClaims(
+		agentId: UUID,
+		principalId: UUID,
+		connectorAccountId?: UUID,
+	): Promise<readonly IdentityClaim[]>;
+	abstract evaluateOwnerBinding(
+		request: EvaluateOwnerBindingRequest,
+	): Promise<OwnerBindingEvaluation>;
 	abstract proposeMerge(
 		request: ProposeIdentityMergeRequest,
 	): Promise<IdentityMergePlan>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -37,6 +37,7 @@ export * from "./environment";
 export * from "./evaluator";
 export * from "./events";
 export * from "./hook";
+export * from "./identity";
 export * from "./interactions";
 export * from "./memory";
 export * from "./memory-storage";

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -53,6 +53,7 @@ export interface ServiceTypeRegistry {
 	SCREEN_CAPTURE: "screen_capture";
 	DOCUMENTS: "documents";
 	RELATIONSHIPS: "relationships";
+	IDENTITY_RESOLUTION: "identity_resolution";
 	FOLLOW_UP: "follow_up";
 	TRAJECTORIES: "trajectories";
 	SWARM_COORDINATOR: "SWARM_COORDINATOR";
@@ -160,6 +161,7 @@ export const ServiceType = {
 	SCREEN_CAPTURE: "screen_capture",
 	DOCUMENTS: "documents",
 	RELATIONSHIPS: "relationships",
+	IDENTITY_RESOLUTION: "identity_resolution",
 	FOLLOW_UP: "follow_up",
 	TRAJECTORIES: "trajectories",
 	SWARM_COORDINATOR: "SWARM_COORDINATOR",

--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -87,6 +87,7 @@
     "test:live": "bun run test:e2e"
   },
   "dependencies": {
+    "@noble/hashes": "2.2.0",
     "@electric-sql/client": "1.0.14",
     "@electric-sql/experimental": "1.0.14",
     "@electric-sql/pglite": "^0.4.0",

--- a/plugins/plugin-sql/src/__tests__/identity-authority-schema.test.ts
+++ b/plugins/plugin-sql/src/__tests__/identity-authority-schema.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Deterministically verifies the relational invariants for canonical identity
+ * claims, reversible merge journals, and non-destructive redirects.
+ */
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import {
+  identityAuthorityStateTable,
+  identityCanonicalRedirectTable,
+  identityClaimTable,
+  identityMergeConfirmationTable,
+  identityMergeJournalTable,
+} from "../schema/identityAuthority";
+
+describe("canonical identity authority schema", () => {
+  it("account-scopes one external subject and separates OWNER binding", () => {
+    const config = getTableConfig(identityClaimTable);
+
+    expect(config.name).toBe("identity_claims");
+    expect(config.indexes.map((entry) => entry.config.name)).toContain(
+      "identity_claim_active_scope_subject_unique"
+    );
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "identity_claim_verification_check",
+        "identity_claim_status_check",
+        "identity_claim_confidence_check",
+        "identity_claim_owner_binding_check",
+      ])
+    );
+    expect(config.columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "agent_id",
+        "principal_entity_id",
+        "connector_id",
+        "connector_account_id",
+        "external_subject_id",
+        "owner_binding_id",
+      ])
+    );
+  });
+
+  it("retains merge and split plans with lineage and before-state", () => {
+    const config = getTableConfig(identityMergeJournalTable);
+
+    expect(config.name).toBe("identity_merge_journal");
+    expect(config.columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "operation",
+        "status",
+        "parent_journal_id",
+        "idempotency_key",
+        "request_digest",
+        "expected_generation",
+        "actor_principal_id",
+        "canonical_principal_id",
+        "source_principal_ids",
+        "plan",
+        "before_state",
+        "result",
+      ])
+    );
+    expect(config.foreignKeys).toHaveLength(4);
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "identity_merge_journal_operation_check",
+        "identity_merge_journal_status_check",
+      ])
+    );
+  });
+
+  it("persists authority generation and bounded confirmation state", () => {
+    const state = getTableConfig(identityAuthorityStateTable);
+    const confirmation = getTableConfig(identityMergeConfirmationTable);
+
+    expect(state.columns.map((column) => column.name)).toContain("generation");
+    expect(confirmation.columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "journal_id",
+        "plan_digest",
+        "expected_generation",
+        "expires_at",
+        "consumed_at",
+      ])
+    );
+    expect(confirmation.foreignKeys).toHaveLength(3);
+  });
+
+  it("keeps versioned redirects and forbids self-canonicalization", () => {
+    const config = getTableConfig(identityCanonicalRedirectTable);
+
+    expect(config.name).toBe("identity_canonical_redirects");
+    expect(config.uniqueConstraints.map((constraint) => constraint.name)).toContain(
+      "identity_canonical_redirect_version_unique"
+    );
+    expect(config.foreignKeys).toHaveLength(4);
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "identity_canonical_redirect_status_check",
+        "identity_canonical_redirect_distinct_check",
+        "identity_canonical_redirect_version_check",
+      ])
+    );
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
@@ -5,11 +5,15 @@
 
 import type { UUID } from "@elizaos/core";
 import { and, eq, inArray, sql } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { authIdentityTable } from "../../schema/authIdentity";
+import { authOwnerBindingTable } from "../../schema/authOwnerBinding";
+import { connectorAccountsTable } from "../../schema/connectorAccounts";
 import { entityTable } from "../../schema/entity";
 import {
   identityAuthorityStateTable,
   identityCanonicalRedirectTable,
+  identityClaimTable,
   identityMergeConfirmationTable,
   identityMergeJournalTable,
 } from "../../schema/identityAuthority";
@@ -33,21 +37,35 @@ describe("SQL identity authority", () => {
   const sourceD = crypto.randomUUID() as UUID;
   const sourceE = crypto.randomUUID() as UUID;
   const sourceF = crypto.randomUUID() as UUID;
+  const ownerPrincipalId = crypto.randomUUID() as UUID;
+  const configuredOwnerAliasId = crypto.randomUUID() as UUID;
 
   beforeAll(async () => {
     const setup = await createIsolatedTestDatabase("identity-authority-real");
     cleanup = setup.cleanup;
     db = setup.adapter.getDatabase() as DrizzleDatabase;
     agentId = setup.testAgentId;
-    service = new SqlIdentityResolutionService(setup.runtime);
-    await db.insert(entityTable).values(
-      [actorId, canonicalId, sourceA, sourceB, sourceC, sourceD, sourceE, sourceF].map((id) => ({
-        id,
-        agentId,
-        names: [id],
-        metadata: {},
-      }))
+    const getSetting = setup.runtime.getSetting.bind(setup.runtime);
+    vi.spyOn(setup.runtime, "getSetting").mockImplementation((key) =>
+      key === "ELIZA_INSTANCE_ID" ? "identity-authority-test" : getSetting(key)
     );
+    service = new SqlIdentityResolutionService(setup.runtime);
+    await db
+      .insert(entityTable)
+      .values(
+        [
+          actorId,
+          canonicalId,
+          sourceA,
+          sourceB,
+          sourceC,
+          sourceD,
+          sourceE,
+          sourceF,
+          ownerPrincipalId,
+          configuredOwnerAliasId,
+        ].map((id) => ({ id, agentId, names: [id], metadata: {} }))
+      );
   });
 
   afterAll(async () => {
@@ -85,6 +103,10 @@ describe("SQL identity authority", () => {
     };
     const commitDigest = computeIdentityRequestDigest("commit-merge", commitValue);
     const committed = await service.commitMerge({ ...commitValue, requestDigest: commitDigest });
+    await db
+      .update(identityMergeJournalTable)
+      .set({ expiresAt: new Date() })
+      .where(eq(identityMergeJournalTable.id, plan.id));
     const replayed = await service.commitMerge({ ...commitValue, requestDigest: commitDigest });
     expect(replayed).toEqual(committed);
     expect((await service.resolveForDataAccess(agentId, sourceA)).canonicalPrincipalId).toBe(
@@ -287,5 +309,128 @@ describe("SQL identity authority", () => {
       .where(eq(identityMergeJournalTable.id, plan.id));
     expect(journalAfter?.status).toBe("planned");
     expect(journalAfter?.commitIdempotencyKey).toBeNull();
+  });
+
+  it("requires a live same-instance account and canonicalizes configured owners", async () => {
+    const identityId = crypto.randomUUID();
+    const bindingId = crypto.randomUUID();
+    const accountId = crypto.randomUUID() as UUID;
+    await db.insert(authIdentityTable).values({
+      id: identityId,
+      kind: "owner",
+      displayName: "Owner",
+      createdAt: Date.now(),
+    });
+    await db.insert(authOwnerBindingTable).values({
+      id: bindingId,
+      identityId,
+      connector: "discord",
+      externalId: "owner-subject",
+      displayHandle: "owner",
+      instanceId: "identity-authority-test",
+      verifiedAt: Date.now(),
+    });
+    await db.insert(connectorAccountsTable).values({
+      id: accountId,
+      agentId,
+      provider: "discord",
+      accountKey: "owner-account",
+      externalId: "owner-subject",
+      ownerBindingId: bindingId,
+      accessGate: "owner_binding",
+      status: "connected",
+    });
+    await db.insert(identityClaimTable).values({
+      agentId,
+      principalEntityId: ownerPrincipalId,
+      namespace: "connector_subject",
+      connectorId: "discord",
+      connectorAccountId: accountId,
+      externalSubjectId: "owner-subject",
+      verification: "owner_bound",
+      ownerBindingId: bindingId,
+      status: "active",
+      confidence: 1,
+      verifiedAt: new Date(),
+    });
+
+    await db
+      .update(connectorAccountsTable)
+      .set({ status: "disabled" })
+      .where(eq(connectorAccountsTable.id, accountId));
+    await expect(
+      service.evaluateOwnerBinding({
+        agentId,
+        actorPrincipalId: ownerPrincipalId,
+        candidateOwnerPrincipalIds: [ownerPrincipalId],
+        purpose: "role_resolution",
+      })
+    ).resolves.toEqual({ decision: "not_bound", reason: "no_active_binding" });
+    await db
+      .update(connectorAccountsTable)
+      .set({ status: "connected" })
+      .where(eq(connectorAccountsTable.id, accountId));
+
+    const [state] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    const proposalValue = {
+      agentId,
+      canonicalPrincipalId: ownerPrincipalId,
+      sourcePrincipalIds: [configuredOwnerAliasId],
+      actorPrincipalId: actorId,
+      reason: "configured owner alias",
+      idempotencyKey: "proposal-owner-alias",
+    };
+    const plan = await service.proposeMerge({
+      ...proposalValue,
+      requestDigest: computeIdentityRequestDigest("propose-merge", proposalValue),
+    });
+    const confirmation = await service.confirmMerge({
+      agentId,
+      planId: plan.id,
+      expectedGeneration: state?.generation ?? -1,
+      actorPrincipalId: actorId,
+    });
+    const commitValue = {
+      agentId,
+      planId: plan.id,
+      confirmationId: confirmation.id,
+      expectedGeneration: state?.generation ?? -1,
+      actorPrincipalId: actorId,
+      idempotencyKey: "commit-owner-alias",
+    };
+    await service.commitMerge({
+      ...commitValue,
+      requestDigest: computeIdentityRequestDigest("commit-merge", commitValue),
+    });
+
+    await expect(
+      service.evaluateOwnerBinding({
+        agentId,
+        actorPrincipalId: ownerPrincipalId,
+        candidateOwnerPrincipalIds: [configuredOwnerAliasId],
+        purpose: "role_resolution",
+      })
+    ).resolves.toMatchObject({
+      decision: "bound",
+      actorCanonicalPrincipalId: ownerPrincipalId,
+      ownerPrincipalId: configuredOwnerAliasId,
+      ownerBindingId: bindingId,
+    });
+
+    await db
+      .update(authOwnerBindingTable)
+      .set({ instanceId: "foreign-instance" })
+      .where(eq(authOwnerBindingTable.id, bindingId));
+    await expect(
+      service.evaluateOwnerBinding({
+        agentId,
+        actorPrincipalId: ownerPrincipalId,
+        candidateOwnerPrincipalIds: [configuredOwnerAliasId],
+        purpose: "role_resolution",
+      })
+    ).resolves.toEqual({ decision: "not_bound", reason: "no_active_binding" });
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Exercises the production SQL identity authority against a real migrated
+ * PGlite database, proving durable merge, replay, split, and tenant fencing.
+ */
+
+import type { UUID } from "@elizaos/core";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { entityTable } from "../../schema/entity";
+import {
+  identityAuthorityStateTable,
+  identityCanonicalRedirectTable,
+  identityMergeConfirmationTable,
+  identityMergeJournalTable,
+} from "../../schema/identityAuthority";
+import {
+  computeIdentityRequestDigest,
+  SqlIdentityResolutionService,
+} from "../../services/sql-identity-resolution";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+describe("SQL identity authority", () => {
+  let cleanup: () => Promise<void>;
+  let db: DrizzleDatabase;
+  let service: SqlIdentityResolutionService;
+  let agentId: UUID;
+  const actorId = crypto.randomUUID() as UUID;
+  const canonicalId = crypto.randomUUID() as UUID;
+  const sourceA = crypto.randomUUID() as UUID;
+  const sourceB = crypto.randomUUID() as UUID;
+  const sourceC = crypto.randomUUID() as UUID;
+  const sourceD = crypto.randomUUID() as UUID;
+  const sourceE = crypto.randomUUID() as UUID;
+  const sourceF = crypto.randomUUID() as UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("identity-authority-real");
+    cleanup = setup.cleanup;
+    db = setup.adapter.getDatabase() as DrizzleDatabase;
+    agentId = setup.testAgentId;
+    service = new SqlIdentityResolutionService(setup.runtime);
+    await db.insert(entityTable).values(
+      [actorId, canonicalId, sourceA, sourceB, sourceC, sourceD, sourceE, sourceF].map((id) => ({
+        id,
+        agentId,
+        names: [id],
+        metadata: {},
+      }))
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup?.();
+  });
+
+  it("merges non-destructively, replays exactly, then splits one source", async () => {
+    const proposalKey = "proposal-1";
+    const proposalValue = {
+      agentId,
+      canonicalPrincipalId: canonicalId,
+      sourcePrincipalIds: [sourceA, sourceB],
+      actorPrincipalId: actorId,
+      reason: "verified same person",
+      idempotencyKey: proposalKey,
+    };
+    const requestDigest = computeIdentityRequestDigest("propose-merge", proposalValue);
+    const plan = await service.proposeMerge({ ...proposalValue, requestDigest });
+    expect(plan.expectedGeneration).toBe(0);
+
+    const confirmation = await service.confirmMerge({
+      agentId,
+      planId: plan.id,
+      expectedGeneration: 0,
+      actorPrincipalId: actorId,
+    });
+    const commitKey = "commit-1";
+    const commitValue = {
+      agentId,
+      planId: plan.id,
+      confirmationId: confirmation.id,
+      expectedGeneration: 0,
+      actorPrincipalId: actorId,
+      idempotencyKey: commitKey,
+    };
+    const commitDigest = computeIdentityRequestDigest("commit-merge", commitValue);
+    const committed = await service.commitMerge({ ...commitValue, requestDigest: commitDigest });
+    const replayed = await service.commitMerge({ ...commitValue, requestDigest: commitDigest });
+    expect(replayed).toEqual(committed);
+    expect((await service.resolveForDataAccess(agentId, sourceA)).canonicalPrincipalId).toBe(
+      canonicalId
+    );
+    expect((await service.resolveForDataAccess(agentId, sourceB)).canonicalPrincipalId).toBe(
+      canonicalId
+    );
+
+    const sourceRows = await db
+      .select({ id: entityTable.id })
+      .from(entityTable)
+      .where(and(eq(entityTable.agentId, agentId), eq(entityTable.id, sourceA)));
+    expect(sourceRows).toHaveLength(1);
+    const [stateAfterMerge] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    expect(stateAfterMerge?.generation).toBe(1);
+
+    const splitKey = "split-1";
+    const splitValue = {
+      agentId,
+      parentJournalId: plan.id,
+      principalIds: [sourceA],
+      expectedGeneration: 1,
+      actorPrincipalId: actorId,
+      reason: "verified distinct person",
+      idempotencyKey: splitKey,
+    };
+    const splitDigest = computeIdentityRequestDigest("split", splitValue);
+    const split = await service.split({ ...splitValue, requestDigest: splitDigest });
+    const splitReplay = await service.split({ ...splitValue, requestDigest: splitDigest });
+    expect(splitReplay).toEqual(split);
+    expect((await service.resolveCanonicalPrincipal(agentId, sourceA)).canonicalPrincipalId).toBe(
+      sourceA
+    );
+    expect((await service.resolveCanonicalPrincipal(agentId, sourceB)).canonicalPrincipalId).toBe(
+      canonicalId
+    );
+
+    const [stateAfterSplit] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    expect(stateAfterSplit?.generation).toBe(2);
+    expect(await db.select().from(identityCanonicalRedirectTable)).toHaveLength(2);
+    expect(await db.select().from(identityMergeJournalTable)).toHaveLength(2);
+    const [consumed] = await db.select().from(identityMergeConfirmationTable);
+    expect(consumed?.status).toBe("consumed");
+  });
+
+  it("rejects foreign runtime tenants before reading", async () => {
+    const foreignAgentId = crypto.randomUUID() as UUID;
+    await expect(service.resolveCanonicalPrincipal(foreignAgentId, sourceA)).rejects.toMatchObject({
+      code: "IDENTITY_TENANT_MISMATCH",
+    });
+  });
+
+  it("serializes concurrent commits at one generation without partial writes", async () => {
+    const [state] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    const generation = state?.generation ?? -1;
+    const prepare = async (sourcePrincipalId: UUID, suffix: string) => {
+      const proposalValue = {
+        agentId,
+        canonicalPrincipalId: canonicalId,
+        sourcePrincipalIds: [sourcePrincipalId],
+        actorPrincipalId: actorId,
+        reason: `concurrent-${suffix}`,
+        idempotencyKey: `proposal-${suffix}`,
+      };
+      const plan = await service.proposeMerge({
+        ...proposalValue,
+        requestDigest: computeIdentityRequestDigest("propose-merge", proposalValue),
+      });
+      const confirmation = await service.confirmMerge({
+        agentId,
+        planId: plan.id,
+        expectedGeneration: generation,
+        actorPrincipalId: actorId,
+      });
+      const commitValue = {
+        agentId,
+        planId: plan.id,
+        confirmationId: confirmation.id,
+        expectedGeneration: generation,
+        actorPrincipalId: actorId,
+        idempotencyKey: `commit-${suffix}`,
+      };
+      return {
+        request: {
+          ...commitValue,
+          requestDigest: computeIdentityRequestDigest("commit-merge", commitValue),
+        },
+      };
+    };
+
+    const left = await prepare(sourceC, "left");
+    const right = await prepare(sourceD, "right");
+    const outcomes = await Promise.allSettled([
+      service.commitMerge(left.request),
+      service.commitMerge(right.request),
+    ]);
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    const [after] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    expect(after?.generation).toBe(generation + 1);
+
+    const active = await db
+      .select()
+      .from(identityCanonicalRedirectTable)
+      .where(
+        and(
+          eq(identityCanonicalRedirectTable.agentId, agentId),
+          eq(identityCanonicalRedirectTable.status, "active")
+        )
+      );
+    expect(
+      active.filter((row) => row.sourcePrincipalId === sourceC || row.sourcePrincipalId === sourceD)
+    ).toHaveLength(1);
+  });
+
+  it("rolls back confirmation, redirects, journal, and generation on a database fault", async () => {
+    const [state] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    const generation = state?.generation ?? -1;
+    const proposalValue = {
+      agentId,
+      canonicalPrincipalId: canonicalId,
+      sourcePrincipalIds: [sourceE, sourceF],
+      actorPrincipalId: actorId,
+      reason: "forced rollback proof",
+      idempotencyKey: "proposal-rollback",
+    };
+    const plan = await service.proposeMerge({
+      ...proposalValue,
+      requestDigest: computeIdentityRequestDigest("propose-merge", proposalValue),
+    });
+    const confirmation = await service.confirmMerge({
+      agentId,
+      planId: plan.id,
+      expectedGeneration: generation,
+      actorPrincipalId: actorId,
+    });
+    const commitValue = {
+      agentId,
+      planId: plan.id,
+      confirmationId: confirmation.id,
+      expectedGeneration: generation,
+      actorPrincipalId: actorId,
+      idempotencyKey: "commit-rollback",
+    };
+    await db.execute(
+      sql.raw(
+        `ALTER TABLE identity_canonical_redirects ADD CONSTRAINT identity_test_forced_rollback CHECK (source_principal_id <> '${sourceF}'::uuid)`
+      )
+    );
+    try {
+      await expect(
+        service.commitMerge({
+          ...commitValue,
+          requestDigest: computeIdentityRequestDigest("commit-merge", commitValue),
+        })
+      ).rejects.toBeDefined();
+    } finally {
+      await db.execute(
+        sql.raw(
+          "ALTER TABLE identity_canonical_redirects DROP CONSTRAINT identity_test_forced_rollback"
+        )
+      );
+    }
+
+    const [after] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    expect(after?.generation).toBe(generation);
+    expect(
+      await db
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(inArray(identityCanonicalRedirectTable.sourcePrincipalId, [sourceE, sourceF]))
+    ).toHaveLength(0);
+    const [confirmationAfter] = await db
+      .select()
+      .from(identityMergeConfirmationTable)
+      .where(eq(identityMergeConfirmationTable.id, confirmation.id));
+    expect(confirmationAfter?.status).toBe("active");
+    const [journalAfter] = await db
+      .select()
+      .from(identityMergeJournalTable)
+      .where(eq(identityMergeJournalTable.id, plan.id));
+    expect(journalAfter?.status).toBe("planned");
+    expect(journalAfter?.commitIdempotencyKey).toBeNull();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
@@ -138,8 +138,10 @@ describe("SQL identity authority", () => {
       idempotencyKey: splitKey,
     };
     const splitDigest = computeIdentityRequestDigest("split", splitValue);
-    const split = await service.split({ ...splitValue, requestDigest: splitDigest });
-    const splitReplay = await service.split({ ...splitValue, requestDigest: splitDigest });
+    const [split, splitReplay] = await Promise.all([
+      service.split({ ...splitValue, requestDigest: splitDigest }),
+      service.split({ ...splitValue, requestDigest: splitDigest }),
+    ]);
     expect(splitReplay).toEqual(split);
     expect((await service.resolveCanonicalPrincipal(agentId, sourceA)).canonicalPrincipalId).toBe(
       sourceA
@@ -419,6 +421,75 @@ describe("SQL identity authority", () => {
       ownerPrincipalId: configuredOwnerAliasId,
       ownerBindingId: bindingId,
     });
+
+    const conflictingPrincipalId = crypto.randomUUID() as UUID;
+    const conflictingIdentityId = crypto.randomUUID();
+    const conflictingBindingId = crypto.randomUUID();
+    const conflictingAccountId = crypto.randomUUID() as UUID;
+    await db.insert(entityTable).values({
+      id: conflictingPrincipalId,
+      agentId,
+      names: ["Conflicting owner"],
+      metadata: {},
+    });
+    await db.insert(authIdentityTable).values({
+      id: conflictingIdentityId,
+      kind: "owner",
+      displayName: "Conflicting owner",
+      createdAt: Date.now(),
+    });
+    await db.insert(authOwnerBindingTable).values({
+      id: conflictingBindingId,
+      identityId: conflictingIdentityId,
+      connector: "telegram",
+      externalId: "conflicting-owner-subject",
+      displayHandle: "conflicting-owner",
+      instanceId: "identity-authority-test",
+      verifiedAt: Date.now(),
+    });
+    await db.insert(connectorAccountsTable).values({
+      id: conflictingAccountId,
+      agentId,
+      provider: "telegram",
+      accountKey: "conflicting-owner-account",
+      externalId: "conflicting-owner-subject",
+      ownerBindingId: conflictingBindingId,
+      accessGate: "owner_binding",
+      status: "connected",
+    });
+    await db.insert(identityClaimTable).values({
+      agentId,
+      principalEntityId: conflictingPrincipalId,
+      namespace: "connector_subject",
+      connectorId: "telegram",
+      connectorAccountId: conflictingAccountId,
+      externalSubjectId: "conflicting-owner-subject",
+      verification: "owner_bound",
+      ownerBindingId: conflictingBindingId,
+      status: "active",
+      confidence: 1,
+      verifiedAt: new Date(),
+    });
+    const [conflictState] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    const conflictProposalValue = {
+      agentId,
+      canonicalPrincipalId: configuredOwnerAliasId,
+      sourcePrincipalIds: [conflictingPrincipalId],
+      actorPrincipalId: actorId,
+      reason: "must inspect canonical aliases",
+      idempotencyKey: "proposal-owner-alias-conflict",
+    };
+    const conflictPlan = await service.proposeMerge({
+      ...conflictProposalValue,
+      requestDigest: computeIdentityRequestDigest("propose-merge", conflictProposalValue),
+    });
+    expect(conflictPlan.expectedGeneration).toBe(conflictState?.generation);
+    expect(conflictPlan.conflictingClaims).toEqual(
+      expect.arrayContaining([expect.objectContaining({ reason: "owner_binding" })])
+    );
 
     await db
       .update(authOwnerBindingTable)

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -28,7 +28,6 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
@@ -115,7 +114,11 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access (PGlite WASM in browser).",
   priority: 0,
   schema: schema,
-  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
+  // Identity authority is exported for explicit hosts and integration tests,
+  // but remains cutover-gated until owner claims are backfilled. Registering
+  // it early would make role resolution prefer an empty authority over the
+  // verified owner-pairing compatibility path.
+  services: [AdvancedMemoryStorageService],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     logger.info({ src: "plugin:sql" }, "plugin-sql (browser) init starting");

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -28,6 +28,7 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
@@ -114,7 +115,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access (PGlite WASM in browser).",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService],
+  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     logger.info({ src: "plugin:sql" }, "plugin-sql (browser) init starting");
@@ -195,4 +196,8 @@ export type {
 } from "./pglite/manager-cache";
 export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export {
+  computeIdentityRequestDigest,
+  SqlIdentityResolutionService,
+} from "./services/sql-identity-resolution";
 export type { DrizzleDatabase } from "./types";

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -53,6 +53,7 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { stringToUuid } from "./utils/string-to-uuid";
 import { resolvePgliteDir } from "./utils.node.ts";
 
@@ -179,7 +180,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService],
+  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(
@@ -254,6 +255,10 @@ export {
   uninstallRLS,
 } from "./rls";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export {
+  computeIdentityRequestDigest,
+  SqlIdentityResolutionService,
+} from "./services/sql-identity-resolution";
 
 /**
  * Query the live Electric Sync status from the global PGliteClientManager

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -53,7 +53,6 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { stringToUuid } from "./utils/string-to-uuid";
 import { resolvePgliteDir } from "./utils.node.ts";
 
@@ -180,7 +179,11 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
+  // Identity authority is exported for explicit hosts and integration tests,
+  // but remains cutover-gated until owner claims are backfilled. Registering
+  // it early would make role resolution prefer an empty authority over the
+  // verified owner-pairing compatibility path.
+  services: [AdvancedMemoryStorageService],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -53,7 +53,6 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { resolvePgliteDir } from "./utils";
 import { stringToUuid } from "./utils/string-to-uuid";
 
@@ -175,7 +174,11 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
+  // Identity authority is exported for explicit hosts and integration tests,
+  // but remains cutover-gated until owner claims are backfilled. Registering
+  // it early would make role resolution prefer an empty authority over the
+  // verified owner-pairing compatibility path.
+  services: [AdvancedMemoryStorageService],
   init: async (_, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -53,6 +53,7 @@ import {
 } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { resolvePgliteDir } from "./utils";
 import { stringToUuid } from "./utils/string-to-uuid";
 
@@ -174,7 +175,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService],
+  services: [SqlIdentityResolutionService, AdvancedMemoryStorageService],
   init: async (_, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(
@@ -265,6 +266,10 @@ export {
 } from "./rls";
 export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export {
+  computeIdentityRequestDigest,
+  SqlIdentityResolutionService,
+} from "./services/sql-identity-resolution";
 export * from "./types";
 export { schema };
 

--- a/plugins/plugin-sql/src/schema/connectorAccounts.ts
+++ b/plugins/plugin-sql/src/schema/connectorAccounts.ts
@@ -23,6 +23,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -65,6 +66,7 @@ export const connectorAccountsTable = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).default(sql`now()`).notNull(),
   },
   (table) => [
+    unique("connector_accounts_id_agent_unique").on(table.id, table.agentId),
     uniqueIndex("connector_accounts_agent_provider_account_key_uniq")
       .on(table.agentId, table.provider, table.accountKey)
       .where(sql`${table.deletedAt} IS NULL`),

--- a/plugins/plugin-sql/src/schema/identityAuthority.ts
+++ b/plugins/plugin-sql/src/schema/identityAuthority.ts
@@ -1,0 +1,291 @@
+/**
+ * Durable canonical-identity authority tables for account-scoped claims,
+ * non-destructive principal redirects, and reversible merge/split journals.
+ * These tables preserve identity provenance independently from legacy entity
+ * metadata while keeping OWNER authority tied to an explicit binding.
+ */
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  real,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { agentTable } from "./agent";
+import { authOwnerBindingTable } from "./authOwnerBinding";
+import { connectorAccountsTable } from "./connectorAccounts";
+import { entityTable } from "./entity";
+
+export const identityClaimTable = pgTable(
+  "identity_claims",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id").notNull(),
+    principalEntityId: uuid("principal_entity_id").notNull(),
+    namespace: text("namespace").notNull(),
+    connectorId: text("connector_id").notNull(),
+    connectorAccountId: uuid("connector_account_id").notNull(),
+    externalSubjectId: text("external_subject_id").notNull(),
+    handle: text("handle"),
+    displayName: text("display_name"),
+    verification: text("verification").notNull().default("unverified"),
+    ownerBindingId: text("owner_binding_id"),
+    status: text("status").notNull().default("active"),
+    confidence: real("confidence").notNull().default(0),
+    provenance: jsonb("provenance")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    evidence: jsonb("evidence")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull().default(sql`now()`),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().default(sql`now()`),
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    uniqueIndex("identity_claim_active_scope_subject_unique")
+      .on(
+        table.agentId,
+        table.namespace,
+        table.connectorId,
+        table.connectorAccountId,
+        table.externalSubjectId
+      )
+      .where(sql`${table.status} IN ('active', 'disputed')`),
+    index("identity_claim_principal_idx").on(table.agentId, table.principalEntityId),
+    index("identity_claim_lookup_idx").on(
+      table.agentId,
+      table.namespace,
+      table.connectorId,
+      table.connectorAccountId,
+      table.externalSubjectId
+    ),
+    index("identity_claim_status_idx").on(table.agentId, table.status),
+    foreignKey({
+      name: "fk_identity_claim_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_identity_claim_principal",
+      columns: [table.principalEntityId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_claim_connector_account",
+      columns: [table.connectorAccountId],
+      foreignColumns: [connectorAccountsTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_claim_owner_binding",
+      columns: [table.ownerBindingId],
+      foreignColumns: [authOwnerBindingTable.id],
+    }).onDelete("restrict"),
+    check(
+      "identity_claim_verification_check",
+      sql`${table.verification} IN ('unverified', 'observed', 'verified', 'owner_bound')`
+    ),
+    check(
+      "identity_claim_status_check",
+      sql`${table.status} IN ('active', 'revoked', 'superseded', 'disputed')`
+    ),
+    check(
+      "identity_claim_confidence_check",
+      sql`${table.confidence} >= 0 AND ${table.confidence} <= 1`
+    ),
+    check(
+      "identity_claim_owner_binding_check",
+      sql`${table.verification} <> 'owner_bound' OR (${table.ownerBindingId} IS NOT NULL AND ${table.verifiedAt} IS NOT NULL)`
+    ),
+  ]
+);
+
+export const identityAuthorityStateTable = pgTable(
+  "identity_authority_state",
+  {
+    agentId: uuid("agent_id").primaryKey().notNull(),
+    generation: integer("generation").notNull().default(0),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    foreignKey({
+      name: "fk_identity_authority_state_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    check("identity_authority_state_generation_check", sql`${table.generation} >= 0`),
+  ]
+);
+
+export const identityMergeJournalTable = pgTable(
+  "identity_merge_journal",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id").notNull(),
+    operation: text("operation").notNull(),
+    status: text("status").notNull().default("planned"),
+    parentJournalId: uuid("parent_journal_id"),
+    actorPrincipalId: uuid("actor_principal_id").notNull(),
+    canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestDigest: text("request_digest").notNull(),
+    expectedGeneration: integer("expected_generation").notNull(),
+    sourcePrincipalIds: jsonb("source_principal_ids").$type<string[]>().notNull(),
+    plan: jsonb("plan").$type<Record<string, unknown>>().notNull(),
+    beforeState: jsonb("before_state").$type<Record<string, unknown>>().notNull(),
+    result: jsonb("result").$type<Record<string, unknown>>(),
+    reason: text("reason").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+    committedAt: timestamp("committed_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("identity_merge_journal_agent_status_idx").on(table.agentId, table.status),
+    index("identity_merge_journal_canonical_idx").on(table.agentId, table.canonicalPrincipalId),
+    index("identity_merge_journal_parent_idx").on(table.parentJournalId),
+    unique("identity_merge_journal_idempotency_unique").on(
+      table.agentId,
+      table.operation,
+      table.idempotencyKey
+    ),
+    foreignKey({
+      name: "fk_identity_merge_journal_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_identity_merge_journal_parent",
+      columns: [table.parentJournalId],
+      foreignColumns: [table.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_merge_journal_actor",
+      columns: [table.actorPrincipalId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_merge_journal_canonical",
+      columns: [table.canonicalPrincipalId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    check("identity_merge_journal_operation_check", sql`${table.operation} IN ('merge', 'split')`),
+    check(
+      "identity_merge_journal_status_check",
+      sql`${table.status} IN ('planned', 'committed', 'completed', 'reverted', 'failed')`
+    ),
+  ]
+);
+
+export const identityMergeConfirmationTable = pgTable(
+  "identity_merge_confirmations",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id").notNull(),
+    journalId: uuid("journal_id").notNull(),
+    actorPrincipalId: uuid("actor_principal_id").notNull(),
+    planDigest: text("plan_digest").notNull(),
+    expectedGeneration: integer("expected_generation").notNull(),
+    status: text("status").notNull().default("active"),
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }).notNull().default(sql`now()`),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("identity_merge_confirmation_active_unique")
+      .on(table.agentId, table.journalId)
+      .where(sql`${table.status} = 'active'`),
+    index("identity_merge_confirmation_expiry_idx").on(table.status, table.expiresAt),
+    foreignKey({
+      name: "fk_identity_merge_confirmation_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_identity_merge_confirmation_journal",
+      columns: [table.journalId],
+      foreignColumns: [identityMergeJournalTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_merge_confirmation_actor",
+      columns: [table.actorPrincipalId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    check(
+      "identity_merge_confirmation_status_check",
+      sql`${table.status} IN ('active', 'consumed', 'expired', 'revoked')`
+    ),
+    check("identity_merge_confirmation_generation_check", sql`${table.expectedGeneration} >= 0`),
+  ]
+);
+
+export const identityCanonicalRedirectTable = pgTable(
+  "identity_canonical_redirects",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id").notNull(),
+    sourcePrincipalId: uuid("source_principal_id").notNull(),
+    canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
+    mergeJournalId: uuid("merge_journal_id").notNull(),
+    version: integer("version").notNull(),
+    status: text("status").notNull().default("active"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+    supersededAt: timestamp("superseded_at", { withTimezone: true }),
+  },
+  (table) => [
+    unique("identity_canonical_redirect_version_unique").on(
+      table.agentId,
+      table.sourcePrincipalId,
+      table.version
+    ),
+    uniqueIndex("identity_canonical_redirect_active_unique")
+      .on(table.agentId, table.sourcePrincipalId)
+      .where(sql`${table.status} = 'active'`),
+    index("identity_canonical_redirect_target_idx").on(
+      table.agentId,
+      table.canonicalPrincipalId,
+      table.status
+    ),
+    foreignKey({
+      name: "fk_identity_canonical_redirect_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_identity_canonical_redirect_source",
+      columns: [table.sourcePrincipalId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_canonical_redirect_target",
+      columns: [table.canonicalPrincipalId],
+      foreignColumns: [entityTable.id],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_canonical_redirect_journal",
+      columns: [table.mergeJournalId],
+      foreignColumns: [identityMergeJournalTable.id],
+    }).onDelete("restrict"),
+    check(
+      "identity_canonical_redirect_status_check",
+      sql`${table.status} IN ('active', 'superseded', 'reverted')`
+    ),
+    check(
+      "identity_canonical_redirect_distinct_check",
+      sql`${table.sourcePrincipalId} <> ${table.canonicalPrincipalId}`
+    ),
+    check("identity_canonical_redirect_version_check", sql`${table.version} > 0`),
+  ]
+);

--- a/plugins/plugin-sql/src/schema/identityAuthority.ts
+++ b/plugins/plugin-sql/src/schema/identityAuthority.ts
@@ -6,10 +6,10 @@
  */
 import { sql } from "drizzle-orm";
 import {
+  bigint,
   check,
   foreignKey,
   index,
-  integer,
   jsonb,
   pgTable,
   real,
@@ -64,7 +64,7 @@ export const identityClaimTable = pgTable(
         table.connectorAccountId,
         table.externalSubjectId
       )
-      .where(sql`${table.status} IN ('active', 'disputed')`),
+      .where(sql`${table.status} = 'active'`),
     index("identity_claim_principal_idx").on(table.agentId, table.principalEntityId),
     index("identity_claim_lookup_idx").on(
       table.agentId,
@@ -81,13 +81,13 @@ export const identityClaimTable = pgTable(
     }).onDelete("cascade"),
     foreignKey({
       name: "fk_identity_claim_principal",
-      columns: [table.principalEntityId],
-      foreignColumns: [entityTable.id],
+      columns: [table.principalEntityId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_claim_connector_account",
-      columns: [table.connectorAccountId],
-      foreignColumns: [connectorAccountsTable.id],
+      columns: [table.connectorAccountId, table.agentId],
+      foreignColumns: [connectorAccountsTable.id, connectorAccountsTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_claim_owner_binding",
@@ -117,7 +117,7 @@ export const identityAuthorityStateTable = pgTable(
   "identity_authority_state",
   {
     agentId: uuid("agent_id").primaryKey().notNull(),
-    generation: integer("generation").notNull().default(0),
+    generation: bigint("generation", { mode: "number" }).notNull().default(0),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
   },
   (table) => [
@@ -142,7 +142,11 @@ export const identityMergeJournalTable = pgTable(
     canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
     idempotencyKey: text("idempotency_key").notNull(),
     requestDigest: text("request_digest").notNull(),
-    expectedGeneration: integer("expected_generation").notNull(),
+    commitIdempotencyKey: text("commit_idempotency_key"),
+    commitRequestDigest: text("commit_request_digest"),
+    planDigest: text("plan_digest").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    expectedGeneration: bigint("expected_generation", { mode: "number" }).notNull(),
     sourcePrincipalIds: jsonb("source_principal_ids").$type<string[]>().notNull(),
     plan: jsonb("plan").$type<Record<string, unknown>>().notNull(),
     beforeState: jsonb("before_state").$type<Record<string, unknown>>().notNull(),
@@ -156,11 +160,15 @@ export const identityMergeJournalTable = pgTable(
     index("identity_merge_journal_agent_status_idx").on(table.agentId, table.status),
     index("identity_merge_journal_canonical_idx").on(table.agentId, table.canonicalPrincipalId),
     index("identity_merge_journal_parent_idx").on(table.parentJournalId),
+    uniqueIndex("identity_merge_journal_commit_idempotency_unique")
+      .on(table.agentId, table.commitIdempotencyKey)
+      .where(sql`${table.commitIdempotencyKey} IS NOT NULL`),
     unique("identity_merge_journal_idempotency_unique").on(
       table.agentId,
       table.operation,
       table.idempotencyKey
     ),
+    unique("identity_merge_journal_id_agent_unique").on(table.id, table.agentId),
     foreignKey({
       name: "fk_identity_merge_journal_agent",
       columns: [table.agentId],
@@ -168,24 +176,26 @@ export const identityMergeJournalTable = pgTable(
     }).onDelete("cascade"),
     foreignKey({
       name: "fk_identity_merge_journal_parent",
-      columns: [table.parentJournalId],
-      foreignColumns: [table.id],
+      columns: [table.parentJournalId, table.agentId],
+      foreignColumns: [table.id, table.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_merge_journal_actor",
-      columns: [table.actorPrincipalId],
-      foreignColumns: [entityTable.id],
+      columns: [table.actorPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_merge_journal_canonical",
-      columns: [table.canonicalPrincipalId],
-      foreignColumns: [entityTable.id],
+      columns: [table.canonicalPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     check("identity_merge_journal_operation_check", sql`${table.operation} IN ('merge', 'split')`),
     check(
       "identity_merge_journal_status_check",
       sql`${table.status} IN ('planned', 'committed', 'completed', 'reverted', 'failed')`
     ),
+    check("identity_merge_journal_generation_check", sql`${table.expectedGeneration} >= 0`),
+    check("identity_merge_journal_expiry_check", sql`${table.expiresAt} > ${table.createdAt}`),
   ]
 );
 
@@ -197,16 +207,14 @@ export const identityMergeConfirmationTable = pgTable(
     journalId: uuid("journal_id").notNull(),
     actorPrincipalId: uuid("actor_principal_id").notNull(),
     planDigest: text("plan_digest").notNull(),
-    expectedGeneration: integer("expected_generation").notNull(),
+    expectedGeneration: bigint("expected_generation", { mode: "number" }).notNull(),
     status: text("status").notNull().default("active"),
     confirmedAt: timestamp("confirmed_at", { withTimezone: true }).notNull().default(sql`now()`),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     consumedAt: timestamp("consumed_at", { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex("identity_merge_confirmation_active_unique")
-      .on(table.agentId, table.journalId)
-      .where(sql`${table.status} = 'active'`),
+    unique("identity_merge_confirmation_journal_unique").on(table.agentId, table.journalId),
     index("identity_merge_confirmation_expiry_idx").on(table.status, table.expiresAt),
     foreignKey({
       name: "fk_identity_merge_confirmation_agent",
@@ -215,19 +223,24 @@ export const identityMergeConfirmationTable = pgTable(
     }).onDelete("cascade"),
     foreignKey({
       name: "fk_identity_merge_confirmation_journal",
-      columns: [table.journalId],
-      foreignColumns: [identityMergeJournalTable.id],
+      columns: [table.journalId, table.agentId],
+      foreignColumns: [identityMergeJournalTable.id, identityMergeJournalTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_merge_confirmation_actor",
-      columns: [table.actorPrincipalId],
-      foreignColumns: [entityTable.id],
+      columns: [table.actorPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     check(
       "identity_merge_confirmation_status_check",
       sql`${table.status} IN ('active', 'consumed', 'expired', 'revoked')`
     ),
     check("identity_merge_confirmation_generation_check", sql`${table.expectedGeneration} >= 0`),
+    check("identity_merge_confirmation_time_check", sql`${table.expiresAt} > ${table.confirmedAt}`),
+    check(
+      "identity_merge_confirmation_consumed_check",
+      sql`(${table.status} = 'consumed' AND ${table.consumedAt} IS NOT NULL) OR (${table.status} <> 'consumed' AND ${table.consumedAt} IS NULL)`
+    ),
   ]
 );
 
@@ -239,7 +252,7 @@ export const identityCanonicalRedirectTable = pgTable(
     sourcePrincipalId: uuid("source_principal_id").notNull(),
     canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
     mergeJournalId: uuid("merge_journal_id").notNull(),
-    version: integer("version").notNull(),
+    version: bigint("version", { mode: "number" }).notNull(),
     status: text("status").notNull().default("active"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
     supersededAt: timestamp("superseded_at", { withTimezone: true }),
@@ -258,6 +271,7 @@ export const identityCanonicalRedirectTable = pgTable(
       table.canonicalPrincipalId,
       table.status
     ),
+    index("identity_redirect_journal_idx").on(table.agentId, table.mergeJournalId, table.status),
     foreignKey({
       name: "fk_identity_canonical_redirect_agent",
       columns: [table.agentId],
@@ -265,18 +279,18 @@ export const identityCanonicalRedirectTable = pgTable(
     }).onDelete("cascade"),
     foreignKey({
       name: "fk_identity_canonical_redirect_source",
-      columns: [table.sourcePrincipalId],
-      foreignColumns: [entityTable.id],
+      columns: [table.sourcePrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_canonical_redirect_target",
-      columns: [table.canonicalPrincipalId],
-      foreignColumns: [entityTable.id],
+      columns: [table.canonicalPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
     foreignKey({
       name: "fk_identity_canonical_redirect_journal",
-      columns: [table.mergeJournalId],
-      foreignColumns: [identityMergeJournalTable.id],
+      columns: [table.mergeJournalId, table.agentId],
+      foreignColumns: [identityMergeJournalTable.id, identityMergeJournalTable.agentId],
     }).onDelete("restrict"),
     check(
       "identity_canonical_redirect_status_check",

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -34,6 +34,13 @@ export {
   entityMergeCandidateTable,
   factCandidateTable,
 } from "./entityIdentity";
+export {
+  identityAuthorityStateTable,
+  identityCanonicalRedirectTable,
+  identityClaimTable,
+  identityMergeConfirmationTable,
+  identityMergeJournalTable,
+} from "./identityAuthority";
 export { logTable } from "./log";
 export { longTermMemories } from "./longTermMemories";
 export { memoryTable } from "./memory";

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.test.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Deterministic contract tests for identity mutation request digests. Database
+ * transaction, rollback, restart, and race behavior is covered by the real
+ * PGlite integration lane rather than mocks of the SQL authority.
+ */
+import { describe, expect, it } from "vitest";
+import { computeIdentityRequestDigest } from "./sql-identity-resolution";
+
+describe("computeIdentityRequestDigest", () => {
+  it("is stable across object-key and principal-set order", () => {
+    const first = computeIdentityRequestDigest("propose-merge", {
+      agentId: "agent",
+      sourcePrincipalIds: ["a", "b"],
+      reason: "same",
+    });
+    const reordered = computeIdentityRequestDigest("propose-merge", {
+      reason: "same",
+      sourcePrincipalIds: ["a", "b"],
+      agentId: "agent",
+    });
+    const changed = computeIdentityRequestDigest("propose-merge", {
+      agentId: "agent",
+      sourcePrincipalIds: ["b", "a"],
+      reason: "same",
+    });
+    expect(reordered).toBe(first);
+    expect(changed).toBe(first);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("domain-separates proposal, commit, and split", () => {
+    const payload = { agentId: "agent", idempotencyKey: "same" };
+    expect(
+      new Set([
+        computeIdentityRequestDigest("propose-merge", payload),
+        computeIdentityRequestDigest("commit-merge", payload),
+        computeIdentityRequestDigest("split", payload),
+      ])
+    ).toHaveLength(3);
+  });
+});

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.ts
@@ -390,6 +390,11 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
     request: Parameters<IdentityResolutionService["evaluateOwnerBinding"]>[0]
   ): Promise<OwnerBindingEvaluation> {
     this.assertAgent(request.agentId);
+    const instanceSetting = this.runtime.getSetting("ELIZA_INSTANCE_ID");
+    const instanceId = typeof instanceSetting === "string" ? instanceSetting.trim() : "";
+    if (instanceId.length === 0) {
+      return { decision: "unavailable", reason: "service_unavailable" };
+    }
     const cluster = await this.getCluster(request.agentId, request.actorPrincipalId);
     if (!cluster) return { decision: "not_bound", reason: "no_active_binding" };
     const ownerClaim = cluster.claims.find(
@@ -399,11 +404,25 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
         claim.ownerBindingId !== null
     );
     if (!ownerClaim) return { decision: "not_bound", reason: "no_active_binding" };
-    if (!request.candidateOwnerPrincipalIds.includes(cluster.canonicalPrincipalId)) {
+    const candidateResolutions = await Promise.all(
+      request.candidateOwnerPrincipalIds.map(async (candidateOwnerPrincipalId) => ({
+        configured: candidateOwnerPrincipalId,
+        resolved: await this.resolveCanonicalPrincipal(request.agentId, candidateOwnerPrincipalId),
+      }))
+    );
+    const matchedOwner = candidateResolutions.find(
+      ({ resolved }) => resolved.canonicalPrincipalId === cluster.canonicalPrincipalId
+    );
+    if (!matchedOwner) {
       return { decision: "not_bound", reason: "wrong_owner" };
     }
     const [account] = await this.db
-      .select({ ownerBindingId: connectorAccountsTable.ownerBindingId })
+      .select({
+        ownerBindingId: connectorAccountsTable.ownerBindingId,
+        provider: connectorAccountsTable.provider,
+        status: connectorAccountsTable.status,
+        deletedAt: connectorAccountsTable.deletedAt,
+      })
       .from(connectorAccountsTable)
       .where(
         and(
@@ -417,6 +436,7 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
       .select({
         connector: authOwnerBindingTable.connector,
         externalId: authOwnerBindingTable.externalId,
+        instanceId: authOwnerBindingTable.instanceId,
         verifiedAt: authOwnerBindingTable.verifiedAt,
       })
       .from(authOwnerBindingTable)
@@ -425,8 +445,12 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
     if (
       !account ||
       !binding ||
+      account.deletedAt !== null ||
+      account.status !== "connected" ||
+      account.provider !== ownerClaim.connectorId ||
       binding.connector !== ownerClaim.connectorId ||
       binding.externalId !== ownerClaim.externalSubjectId ||
+      binding.instanceId !== instanceId ||
       binding.verifiedAt <= 0
     ) {
       return { decision: "not_bound", reason: "no_active_binding" };
@@ -434,7 +458,7 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
     return {
       decision: "bound",
       actorCanonicalPrincipalId: cluster.canonicalPrincipalId,
-      ownerPrincipalId: cluster.canonicalPrincipalId,
+      ownerPrincipalId: matchedOwner.configured,
       claimId: ownerClaim.id,
       ownerBindingId: ownerClaim.ownerBindingId as string,
       generation: cluster.generation,
@@ -727,12 +751,6 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
       if (journal?.operation !== "merge") {
         fail("IDENTITY_PLAN_NOT_COMMITTABLE", "Merge plan is not committable.");
       }
-      if (
-        journal.expiresAt <= new Date() ||
-        journal.planDigest !== digest("elizaos:identity:merge-plan:v1", mapJournal(journal).plan)
-      ) {
-        fail("IDENTITY_PLAN_EXPIRED", "Merge plan expired or its digest changed.");
-      }
       if (journal.status === "committed" || journal.status === "completed") {
         if (
           journal.commitIdempotencyKey === request.idempotencyKey &&
@@ -741,6 +759,12 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
           return mapJournal(journal);
         }
         fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Merge was already committed by another request.");
+      }
+      if (
+        journal.expiresAt <= new Date() ||
+        journal.planDigest !== digest("elizaos:identity:merge-plan:v1", mapJournal(journal).plan)
+      ) {
+        fail("IDENTITY_PLAN_EXPIRED", "Merge plan expired or its digest changed.");
       }
       if (journal.status !== "planned") {
         fail("IDENTITY_PLAN_NOT_COMMITTABLE", "Merge plan is not committable.");

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.ts
@@ -540,7 +540,14 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
       if (expanded.size === 0) {
         fail("IDENTITY_ALREADY_CANONICAL", "All requested principals already resolve canonically.");
       }
-      const clusterIds = [canonical, ...expanded];
+      const canonicalAliases = new Set<UUID>();
+      for (const redirect of redirects) {
+        const sourcePrincipalId = redirect.sourcePrincipalId as UUID;
+        if (follow(sourcePrincipalId, redirects).canonical === canonical) {
+          canonicalAliases.add(sourcePrincipalId);
+        }
+      }
+      const clusterIds = [canonical, ...canonicalAliases, ...expanded];
       const claims = await tx
         .select()
         .from(identityClaimTable)
@@ -1041,6 +1048,23 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
         .limit(1);
       if (parent?.operation !== "merge" || !["committed", "completed"].includes(parent.status)) {
         fail("IDENTITY_SPLIT_PARENT_INVALID", "Split parent is not a committed merge.");
+      }
+      const [replayed] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.agentId, request.agentId),
+            eq(identityMergeJournalTable.operation, "split"),
+            eq(identityMergeJournalTable.idempotencyKey, request.idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (replayed) {
+        if (replayed.requestDigest !== request.requestDigest) {
+          fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Split key was reused.");
+        }
+        return mapJournal(replayed);
       }
       const parentSources = new Set(asUuidArray(parent.sourcePrincipalIds, "parent.sources"));
       if (!principalIds.every((id) => parentSources.has(id))) {

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.ts
@@ -313,7 +313,7 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
           eq(identityClaimTable.connectorId, scope.connectorId),
           eq(identityClaimTable.connectorAccountId, scope.connectorAccountId),
           eq(identityClaimTable.externalSubjectId, scope.externalSubjectId),
-          inArray(identityClaimTable.status, ["active", "disputed"])
+          eq(identityClaimTable.status, "active")
         )
       )
       .limit(1);
@@ -555,16 +555,44 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
         (claim) => claim.verification === "owner_bound" && claim.ownerBindingId
       );
       const ownerBindings = new Set(ownerClaims.map((claim) => claim.ownerBindingId));
-      const conflictingClaims: IdentityClaimConflict[] =
-        ownerBindings.size > 1
-          ? [
-              {
-                claimIds: ownerClaims.map((claim) => claim.id as UUID),
-                reason: "owner_binding",
-                details: { ownerBindingIds: [...ownerBindings] },
-              },
-            ]
-          : [];
+      const conflictingClaims: IdentityClaimConflict[] = [];
+      if (ownerBindings.size > 1) {
+        conflictingClaims.push({
+          claimIds: ownerClaims.map((claim) => claim.id as UUID),
+          reason: "owner_binding",
+          details: { ownerBindingIds: [...ownerBindings] },
+        });
+      }
+      const claimsByScope = new Map<string, typeof claims>();
+      for (const claim of claims) {
+        const key = [
+          claim.namespace,
+          claim.connectorId,
+          claim.connectorAccountId,
+          claim.externalSubjectId,
+        ].join("\u0000");
+        const scoped = claimsByScope.get(key) ?? [];
+        scoped.push(claim);
+        claimsByScope.set(key, scoped);
+      }
+      for (const scoped of claimsByScope.values()) {
+        const principals = new Set(scoped.map((claim) => claim.principalEntityId));
+        if (principals.size > 1) {
+          conflictingClaims.push({
+            claimIds: scoped.map((claim) => claim.id as UUID),
+            reason: "scoped_subject",
+            details: { principalEntityIds: [...principals] },
+          });
+        }
+        const disputed = scoped.filter((claim) => claim.status === "disputed");
+        if (disputed.length > 0) {
+          conflictingClaims.push({
+            claimIds: disputed.map((claim) => claim.id as UUID),
+            reason: "verification",
+            details: { status: "disputed" },
+          });
+        }
+      }
       const now = new Date();
       const journalId = newId();
       const plan: IdentityMergePlan = {
@@ -591,36 +619,64 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
             principalId: claim.principalEntityId as UUID,
             resolution: "redirect_safe" as const,
           })),
+          ...PENDING_CONSUMERS.flatMap((consumer) =>
+            [...expanded].map((principalId) => ({
+              consumer,
+              referenceType: "principal_projection",
+              referenceId: principalId,
+              principalId,
+              resolution: "projection_repair_required" as const,
+            }))
+          ),
         ],
         conflictingClaims,
         createdAt: iso(now),
         expiresAt: iso(new Date(now.getTime() + PLAN_TTL_MS)),
       };
       const planDigest = digest("elizaos:identity:merge-plan:v1", plan);
-      await tx.insert(identityMergeJournalTable).values({
-        id: journalId,
-        agentId: request.agentId,
-        operation: "merge",
-        status: "planned",
-        actorPrincipalId: request.actorPrincipalId,
-        canonicalPrincipalId: canonical,
-        idempotencyKey: request.idempotencyKey,
-        requestDigest: request.requestDigest,
-        planDigest,
-        expiresAt: new Date(plan.expiresAt),
-        expectedGeneration: state.generation,
-        sourcePrincipalIds: [...expanded].sort(),
-        plan: toDbObject(plan),
-        beforeState: toDbObject({
-          generation: state.generation,
-          redirects: redirects
-            .filter((row) => clusterIds.includes(row.sourcePrincipalId as UUID))
-            .map(mapRedirect),
-          claims: claims.map(mapClaim),
-        }),
-        reason: request.reason,
-      });
-      return plan;
+      const inserted = await tx
+        .insert(identityMergeJournalTable)
+        .values({
+          id: journalId,
+          agentId: request.agentId,
+          operation: "merge",
+          status: "planned",
+          actorPrincipalId: request.actorPrincipalId,
+          canonicalPrincipalId: canonical,
+          idempotencyKey: request.idempotencyKey,
+          requestDigest: request.requestDigest,
+          planDigest,
+          expiresAt: new Date(plan.expiresAt),
+          expectedGeneration: state.generation,
+          sourcePrincipalIds: [...expanded].sort(),
+          plan: toDbObject(plan),
+          beforeState: toDbObject({
+            generation: state.generation,
+            redirects: redirects
+              .filter((row) => clusterIds.includes(row.sourcePrincipalId as UUID))
+              .map(mapRedirect),
+            claims: claims.map(mapClaim),
+          }),
+          reason: request.reason,
+        })
+        .onConflictDoNothing()
+        .returning();
+      if (inserted[0]) return plan;
+      const [winner] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.agentId, request.agentId),
+            eq(identityMergeJournalTable.operation, "merge"),
+            eq(identityMergeJournalTable.idempotencyKey, request.idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (!winner || winner.requestDigest !== request.requestDigest) {
+        fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Proposal idempotency key was reused.");
+      }
+      return mapJournal(winner).plan;
     });
   }
 
@@ -700,17 +756,54 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
       }
       const id = newId();
       const expiresAt = new Date(now.getTime() + CONFIRMATION_TTL_MS);
-      await tx.insert(identityMergeConfirmationTable).values({
-        id,
-        agentId: request.agentId,
-        journalId: request.planId,
-        actorPrincipalId: request.actorPrincipalId,
-        planDigest,
-        expectedGeneration: request.expectedGeneration,
-        status: "active",
-        confirmedAt: now,
-        expiresAt,
-      });
+      const inserted = await tx
+        .insert(identityMergeConfirmationTable)
+        .values({
+          id,
+          agentId: request.agentId,
+          journalId: request.planId,
+          actorPrincipalId: request.actorPrincipalId,
+          planDigest,
+          expectedGeneration: request.expectedGeneration,
+          status: "active",
+          confirmedAt: now,
+          expiresAt,
+        })
+        .onConflictDoNothing()
+        .returning();
+      if (!inserted[0]) {
+        const [winner] = await tx
+          .select()
+          .from(identityMergeConfirmationTable)
+          .where(
+            and(
+              eq(identityMergeConfirmationTable.agentId, request.agentId),
+              eq(identityMergeConfirmationTable.journalId, request.planId),
+              eq(identityMergeConfirmationTable.status, "active")
+            )
+          )
+          .limit(1);
+        if (
+          !winner ||
+          winner.actorPrincipalId !== request.actorPrincipalId ||
+          winner.expectedGeneration !== request.expectedGeneration ||
+          winner.planDigest !== planDigest
+        ) {
+          fail("IDENTITY_CONFIRMATION_CONFLICT", "Active confirmation does not match.");
+        }
+        return {
+          id: winner.id as UUID,
+          agentId: request.agentId,
+          planId: request.planId,
+          expectedGeneration: winner.expectedGeneration,
+          actorPrincipalId: winner.actorPrincipalId as UUID,
+          planDigest: winner.planDigest,
+          status: "active",
+          confirmedAt: iso(winner.confirmedAt),
+          expiresAt: iso(winner.expiresAt),
+          consumedAt: null,
+        };
+      }
       return {
         id,
         agentId: request.agentId,
@@ -992,27 +1085,48 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
         expiresAt: iso(expiresAt),
       };
       const planDigest = digest("elizaos:identity:merge-plan:v1", plan);
-      await tx.insert(identityMergeJournalTable).values({
-        id: journalId,
-        agentId: request.agentId,
-        operation: "split",
-        status: "planned",
-        parentJournalId: request.parentJournalId,
-        actorPrincipalId: request.actorPrincipalId,
-        canonicalPrincipalId: parent.canonicalPrincipalId,
-        idempotencyKey: request.idempotencyKey,
-        requestDigest: request.requestDigest,
-        planDigest,
-        expiresAt,
-        expectedGeneration: request.expectedGeneration,
-        sourcePrincipalIds: principalIds,
-        plan: toDbObject(plan),
-        beforeState: toDbObject({
-          generation: request.expectedGeneration,
-          redirects: active.map(mapRedirect),
-        }),
-        reason: request.reason,
-      });
+      const inserted = await tx
+        .insert(identityMergeJournalTable)
+        .values({
+          id: journalId,
+          agentId: request.agentId,
+          operation: "split",
+          status: "planned",
+          parentJournalId: request.parentJournalId,
+          actorPrincipalId: request.actorPrincipalId,
+          canonicalPrincipalId: parent.canonicalPrincipalId,
+          idempotencyKey: request.idempotencyKey,
+          requestDigest: request.requestDigest,
+          planDigest,
+          expiresAt,
+          expectedGeneration: request.expectedGeneration,
+          sourcePrincipalIds: principalIds,
+          plan: toDbObject(plan),
+          beforeState: toDbObject({
+            generation: request.expectedGeneration,
+            redirects: active.map(mapRedirect),
+          }),
+          reason: request.reason,
+        })
+        .onConflictDoNothing()
+        .returning();
+      if (!inserted[0]) {
+        const [winner] = await tx
+          .select()
+          .from(identityMergeJournalTable)
+          .where(
+            and(
+              eq(identityMergeJournalTable.agentId, request.agentId),
+              eq(identityMergeJournalTable.operation, "split"),
+              eq(identityMergeJournalTable.idempotencyKey, request.idempotencyKey)
+            )
+          )
+          .limit(1);
+        if (!winner || winner.requestDigest !== request.requestDigest) {
+          fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Split key was reused.");
+        }
+        return mapJournal(winner);
+      }
       const bumped = await tx
         .update(identityAuthorityStateTable)
         .set({ generation: sql`${identityAuthorityStateTable.generation} + 1`, updatedAt: now })

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.ts
@@ -1,0 +1,1113 @@
+/**
+ * SQL-backed canonical identity authority. Merge and split serialize through
+ * the per-agent generation row and commit journal, confirmation consumption,
+ * and versioned redirects in one transaction. Source entities and claims are
+ * immutable inputs; consumer projections follow redirects and repair later.
+ */
+import {
+  type CommitIdentityMergeRequest,
+  ElizaError,
+  type IAgentRuntime,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  type IdentityCanonicalRedirect,
+  type IdentityCanonicalResolution,
+  type IdentityClaim,
+  type IdentityClaimConflict,
+  type IdentityClaimScope,
+  type IdentityCluster,
+  type IdentityJournalPage,
+  type IdentityMergeConfirmation,
+  type IdentityMergePlan,
+  IdentityResolutionService,
+  type JsonObject,
+  type MergeJournal,
+  type OwnerBindingEvaluation,
+  type ProposeIdentityMergeRequest,
+  type Service,
+  type SplitIdentityRequest,
+  type UUID,
+} from "@elizaos/core";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { authOwnerBindingTable } from "../schema/authOwnerBinding";
+import { connectorAccountsTable } from "../schema/connectorAccounts";
+import { entityTable } from "../schema/entity";
+import {
+  identityAuthorityStateTable,
+  identityCanonicalRedirectTable,
+  identityClaimTable,
+  identityMergeConfirmationTable,
+  identityMergeJournalTable,
+} from "../schema/identityAuthority";
+import { type DrizzleDatabase, getDb } from "../types";
+
+const PLAN_TTL_MS = 15 * 60_000;
+const CONFIRMATION_TTL_MS = 5 * 60_000;
+const MAX_JOURNAL_PAGE = 100;
+const PENDING_CONSUMERS = Object.freeze([
+  "runtime-relationships",
+  "contacts",
+  "lifeops",
+  "roles",
+  "message",
+  "notifications",
+  "document-acls",
+]);
+
+type JournalRow = typeof identityMergeJournalTable.$inferSelect;
+type RedirectRow = typeof identityCanonicalRedirectTable.$inferSelect;
+type ClaimRow = typeof identityClaimTable.$inferSelect;
+
+function fail(code: string, message: string, context: Record<string, unknown> = {}): never {
+  throw new ElizaError(message, { code, context, severity: "fatal" });
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (typeof value !== "object") {
+    return fail("IDENTITY_DIGEST_INVALID", "Identity digest input is not JSON.");
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function digest(domain: string, value: unknown): string {
+  const bytes = sha256(new TextEncoder().encode(`${domain}\n${stableJson(value)}`));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function canonicalizeIdentityRequest(
+  operation: "propose-merge" | "commit-merge" | "split",
+  value: JsonObject
+): JsonObject {
+  const normalized: JsonObject = { ...value };
+  const setField = operation === "propose-merge" ? "sourcePrincipalIds" : "principalIds";
+  const candidate = normalized[setField];
+  if (operation !== "commit-merge" && Array.isArray(candidate)) {
+    normalized[setField] = [...candidate].sort((left, right) =>
+      String(left).localeCompare(String(right))
+    );
+  }
+  return normalized;
+}
+
+export function computeIdentityRequestDigest(
+  operation: "propose-merge" | "commit-merge" | "split",
+  value: JsonObject
+): string {
+  return digest(`elizaos:identity:${operation}:v1`, canonicalizeIdentityRequest(operation, value));
+}
+
+function assertRequestDigest(
+  actual: string,
+  operation: Parameters<typeof computeIdentityRequestDigest>[0],
+  value: JsonObject
+): void {
+  if (actual !== computeIdentityRequestDigest(operation, value)) {
+    fail(
+      "IDENTITY_REQUEST_DIGEST_MISMATCH",
+      "Identity request digest does not match the request.",
+      {
+        operation,
+      }
+    );
+  }
+}
+
+function newId(): UUID {
+  return globalThis.crypto.randomUUID() as UUID;
+}
+function iso(value: Date): string {
+  return value.toISOString();
+}
+function toDbObject(value: unknown): Record<string, unknown> {
+  return JSON.parse(stableJson(value)) as Record<string, unknown>;
+}
+function asJsonObject(value: unknown, field: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return fail("IDENTITY_PERSISTED_JSON_INVALID", `Persisted ${field} is invalid.`, { field });
+  }
+  return value as JsonObject;
+}
+function asUuidArray(value: unknown, field: string): UUID[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    return fail("IDENTITY_PERSISTED_JSON_INVALID", `Persisted ${field} is invalid.`, { field });
+  }
+  return value as UUID[];
+}
+
+function mapClaim(row: ClaimRow): IdentityClaim {
+  return {
+    contractVersion: 1,
+    id: row.id as UUID,
+    agentId: row.agentId as UUID,
+    principalEntityId: row.principalEntityId as UUID,
+    namespace: row.namespace,
+    connectorId: row.connectorId,
+    connectorAccountId: row.connectorAccountId as UUID,
+    externalSubjectId: row.externalSubjectId,
+    handle: row.handle,
+    displayName: row.displayName,
+    verification: row.verification as IdentityClaim["verification"],
+    status: row.status as IdentityClaim["status"],
+    confidence: row.confidence,
+    ownerBindingId: row.ownerBindingId,
+    provenance: asJsonObject(row.provenance, "claim.provenance"),
+    evidence: asJsonObject(row.evidence, "claim.evidence"),
+    firstSeenAt: iso(row.firstSeenAt),
+    lastSeenAt: iso(row.lastSeenAt),
+    verifiedAt: row.verifiedAt ? iso(row.verifiedAt) : null,
+    revokedAt: row.revokedAt ? iso(row.revokedAt) : null,
+    createdAt: iso(row.createdAt),
+    updatedAt: iso(row.updatedAt),
+  };
+}
+
+function mapRedirect(row: RedirectRow): IdentityCanonicalRedirect {
+  return {
+    contractVersion: 1,
+    id: row.id as UUID,
+    agentId: row.agentId as UUID,
+    sourcePrincipalId: row.sourcePrincipalId as UUID,
+    canonicalPrincipalId: row.canonicalPrincipalId as UUID,
+    mergeJournalId: row.mergeJournalId as UUID,
+    version: row.version,
+    status: row.status as IdentityCanonicalRedirect["status"],
+    createdAt: iso(row.createdAt),
+    supersededAt: row.supersededAt ? iso(row.supersededAt) : null,
+  };
+}
+
+function mapJournal(row: JournalRow): MergeJournal {
+  return {
+    contractVersion: IDENTITY_AUTHORITY_CONTRACT_VERSION,
+    id: row.id as UUID,
+    agentId: row.agentId as UUID,
+    operation: row.operation as MergeJournal["operation"],
+    status: row.status as MergeJournal["status"],
+    parentJournalId: row.parentJournalId as UUID | null,
+    actorPrincipalId: row.actorPrincipalId as UUID,
+    canonicalPrincipalId: row.canonicalPrincipalId as UUID,
+    sourcePrincipalIds: asUuidArray(row.sourcePrincipalIds, "journal.sourcePrincipalIds"),
+    plan: asJsonObject(row.plan, "journal.plan") as unknown as IdentityMergePlan,
+    beforeState: asJsonObject(row.beforeState, "journal.beforeState"),
+    result: row.result
+      ? (asJsonObject(row.result, "journal.result") as unknown as MergeJournal["result"])
+      : null,
+    reason: row.reason,
+    createdAt: iso(row.createdAt),
+    committedAt: row.committedAt ? iso(row.committedAt) : null,
+    completedAt: row.completedAt ? iso(row.completedAt) : null,
+  };
+}
+
+function follow(
+  principalId: UUID,
+  redirects: readonly RedirectRow[]
+): { canonical: UUID; ids: UUID[] } {
+  const bySource = new Map(
+    redirects.filter((row) => row.status === "active").map((row) => [row.sourcePrincipalId, row])
+  );
+  const seen = new Set<UUID>();
+  const ids: UUID[] = [];
+  let current = principalId;
+  while (bySource.has(current)) {
+    if (seen.has(current)) {
+      fail("IDENTITY_REDIRECT_CYCLE", "Canonical redirect cycle detected.", { principalId });
+    }
+    seen.add(current);
+    const redirect = bySource.get(current);
+    if (!redirect) break;
+    ids.push(redirect.id as UUID);
+    current = redirect.canonicalPrincipalId as UUID;
+  }
+  return { canonical: current, ids };
+}
+
+export class SqlIdentityResolutionService extends IdentityResolutionService {
+  static override readonly serviceType = IdentityResolutionService.serviceType;
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new SqlIdentityResolutionService(runtime);
+    if (!service.db) {
+      fail(
+        "IDENTITY_SQL_ADAPTER_REQUIRED",
+        "SQL identity authority requires a Drizzle-backed adapter."
+      );
+    }
+    return service;
+  }
+
+  async stop(): Promise<void> {}
+
+  private get db(): DrizzleDatabase {
+    return getDb(this.runtime.adapter);
+  }
+
+  private assertAgent(agentId: UUID): void {
+    if (agentId !== this.runtime.agentId) {
+      fail("IDENTITY_TENANT_MISMATCH", "Identity request is outside this runtime tenant.", {
+        agentId,
+      });
+    }
+  }
+
+  async resolveCanonicalPrincipal(
+    agentId: UUID,
+    principalId: UUID
+  ): Promise<IdentityCanonicalResolution> {
+    this.assertAgent(agentId);
+    const [states, redirects] = await Promise.all([
+      this.db
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, agentId))
+        .limit(1),
+      this.db
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, agentId),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        ),
+    ]);
+    const resolved = follow(principalId, redirects);
+    return {
+      agentId,
+      requestedPrincipalId: principalId,
+      canonicalPrincipalId: resolved.canonical,
+      redirectIds: resolved.ids,
+      generation: states[0]?.generation ?? 0,
+    };
+  }
+
+  async resolveForDisplay(agentId: UUID, principalId: UUID): Promise<IdentityCanonicalResolution> {
+    return this.resolveCanonicalPrincipal(agentId, principalId);
+  }
+
+  async resolveForDataAccess(
+    agentId: UUID,
+    principalId: UUID
+  ): Promise<IdentityCanonicalResolution> {
+    return this.resolveCanonicalPrincipal(agentId, principalId);
+  }
+
+  async resolveClaim(scope: IdentityClaimScope): Promise<IdentityClaim | null> {
+    this.assertAgent(scope.agentId);
+    const [row] = await this.db
+      .select()
+      .from(identityClaimTable)
+      .where(
+        and(
+          eq(identityClaimTable.agentId, scope.agentId),
+          eq(identityClaimTable.namespace, scope.namespace),
+          eq(identityClaimTable.connectorId, scope.connectorId),
+          eq(identityClaimTable.connectorAccountId, scope.connectorAccountId),
+          eq(identityClaimTable.externalSubjectId, scope.externalSubjectId),
+          inArray(identityClaimTable.status, ["active", "disputed"])
+        )
+      )
+      .limit(1);
+    return row ? mapClaim(row) : null;
+  }
+
+  async getCluster(agentId: UUID, principalId: UUID): Promise<IdentityCluster | null> {
+    this.assertAgent(agentId);
+    const [entity] = await this.db
+      .select({ id: entityTable.id })
+      .from(entityTable)
+      .where(and(eq(entityTable.agentId, agentId), eq(entityTable.id, principalId)))
+      .limit(1);
+    if (!entity) return null;
+    const [states, redirects] = await Promise.all([
+      this.db
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, agentId))
+        .limit(1),
+      this.db
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, agentId),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        ),
+    ]);
+    const canonical = follow(principalId, redirects).canonical;
+    const principalIds = new Set<UUID>([canonical]);
+    for (const redirect of redirects) {
+      if (follow(redirect.sourcePrincipalId as UUID, redirects).canonical === canonical) {
+        principalIds.add(redirect.sourcePrincipalId as UUID);
+      }
+    }
+    const claims = await this.db
+      .select()
+      .from(identityClaimTable)
+      .where(
+        and(
+          eq(identityClaimTable.agentId, agentId),
+          inArray(identityClaimTable.principalEntityId, [...principalIds])
+        )
+      );
+    return {
+      contractVersion: 1,
+      agentId,
+      canonicalPrincipalId: canonical,
+      principalIds: [...principalIds].sort(),
+      claims: claims.map(mapClaim),
+      generation: states[0]?.generation ?? 0,
+      readAt: new Date().toISOString(),
+    };
+  }
+
+  async resolveVerifiedDeliveryClaims(
+    agentId: UUID,
+    principalId: UUID,
+    connectorAccountId?: UUID
+  ): Promise<readonly IdentityClaim[]> {
+    const cluster = await this.getCluster(agentId, principalId);
+    if (!cluster) return [];
+    return cluster.claims.filter(
+      (claim) =>
+        claim.status === "active" &&
+        (claim.verification === "verified" || claim.verification === "owner_bound") &&
+        (connectorAccountId === undefined || claim.connectorAccountId === connectorAccountId)
+    );
+  }
+
+  async evaluateOwnerBinding(
+    request: Parameters<IdentityResolutionService["evaluateOwnerBinding"]>[0]
+  ): Promise<OwnerBindingEvaluation> {
+    this.assertAgent(request.agentId);
+    const cluster = await this.getCluster(request.agentId, request.actorPrincipalId);
+    if (!cluster) return { decision: "not_bound", reason: "no_active_binding" };
+    const ownerClaim = cluster.claims.find(
+      (claim) =>
+        claim.status === "active" &&
+        claim.verification === "owner_bound" &&
+        claim.ownerBindingId !== null
+    );
+    if (!ownerClaim) return { decision: "not_bound", reason: "no_active_binding" };
+    if (!request.candidateOwnerPrincipalIds.includes(cluster.canonicalPrincipalId)) {
+      return { decision: "not_bound", reason: "wrong_owner" };
+    }
+    const [account] = await this.db
+      .select({ ownerBindingId: connectorAccountsTable.ownerBindingId })
+      .from(connectorAccountsTable)
+      .where(
+        and(
+          eq(connectorAccountsTable.id, ownerClaim.connectorAccountId),
+          eq(connectorAccountsTable.agentId, request.agentId),
+          eq(connectorAccountsTable.ownerBindingId, ownerClaim.ownerBindingId as string)
+        )
+      )
+      .limit(1);
+    const [binding] = await this.db
+      .select({
+        connector: authOwnerBindingTable.connector,
+        externalId: authOwnerBindingTable.externalId,
+        verifiedAt: authOwnerBindingTable.verifiedAt,
+      })
+      .from(authOwnerBindingTable)
+      .where(eq(authOwnerBindingTable.id, ownerClaim.ownerBindingId as string))
+      .limit(1);
+    if (
+      !account ||
+      !binding ||
+      binding.connector !== ownerClaim.connectorId ||
+      binding.externalId !== ownerClaim.externalSubjectId ||
+      binding.verifiedAt <= 0
+    ) {
+      return { decision: "not_bound", reason: "no_active_binding" };
+    }
+    return {
+      decision: "bound",
+      actorCanonicalPrincipalId: cluster.canonicalPrincipalId,
+      ownerPrincipalId: cluster.canonicalPrincipalId,
+      claimId: ownerClaim.id,
+      ownerBindingId: ownerClaim.ownerBindingId as string,
+      generation: cluster.generation,
+      reason: "verified_owner_binding",
+    };
+  }
+
+  async proposeMerge(request: ProposeIdentityMergeRequest): Promise<IdentityMergePlan> {
+    this.assertAgent(request.agentId);
+    const sourceIds = [...new Set(request.sourcePrincipalIds)].sort();
+    if (sourceIds.length === 0 || sourceIds.includes(request.canonicalPrincipalId)) {
+      fail(
+        "IDENTITY_MERGE_INPUT_INVALID",
+        "Merge requires distinct canonical and source principals."
+      );
+    }
+    assertRequestDigest(request.requestDigest, "propose-merge", {
+      agentId: request.agentId,
+      canonicalPrincipalId: request.canonicalPrincipalId,
+      sourcePrincipalIds: sourceIds,
+      actorPrincipalId: request.actorPrincipalId,
+      reason: request.reason,
+      idempotencyKey: request.idempotencyKey,
+    });
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.agentId, request.agentId),
+            eq(identityMergeJournalTable.operation, "merge"),
+            eq(identityMergeJournalTable.idempotencyKey, request.idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (existing) {
+        if (existing.requestDigest !== request.requestDigest) {
+          fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Proposal idempotency key was reused.");
+        }
+        return mapJournal(existing).plan;
+      }
+      await tx
+        .insert(identityAuthorityStateTable)
+        .values({ agentId: request.agentId })
+        .onConflictDoNothing();
+      const [state] = await tx
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, request.agentId))
+        .limit(1);
+      if (!state) return fail("IDENTITY_STATE_MISSING", "Identity authority state is missing.");
+      const ids = [request.canonicalPrincipalId, ...sourceIds, request.actorPrincipalId];
+      const entities = await tx
+        .select({ id: entityTable.id })
+        .from(entityTable)
+        .where(and(eq(entityTable.agentId, request.agentId), inArray(entityTable.id, ids)));
+      if (new Set(entities.map((row) => row.id)).size !== new Set(ids).size) {
+        fail("IDENTITY_PRINCIPAL_NOT_FOUND", "Every merge principal and actor must exist.");
+      }
+      const redirects = await tx
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, request.agentId),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        );
+      const canonical = follow(request.canonicalPrincipalId, redirects).canonical;
+      const roots = new Set(sourceIds.map((id) => follow(id, redirects).canonical));
+      roots.delete(canonical);
+      const expanded = new Set<UUID>(roots);
+      for (const redirect of redirects) {
+        if (roots.has(follow(redirect.sourcePrincipalId as UUID, redirects).canonical)) {
+          expanded.add(redirect.sourcePrincipalId as UUID);
+        }
+      }
+      if (expanded.size === 0) {
+        fail("IDENTITY_ALREADY_CANONICAL", "All requested principals already resolve canonically.");
+      }
+      const clusterIds = [canonical, ...expanded];
+      const claims = await tx
+        .select()
+        .from(identityClaimTable)
+        .where(
+          and(
+            eq(identityClaimTable.agentId, request.agentId),
+            inArray(identityClaimTable.principalEntityId, clusterIds),
+            inArray(identityClaimTable.status, ["active", "disputed"])
+          )
+        );
+      const ownerClaims = claims.filter(
+        (claim) => claim.verification === "owner_bound" && claim.ownerBindingId
+      );
+      const ownerBindings = new Set(ownerClaims.map((claim) => claim.ownerBindingId));
+      const conflictingClaims: IdentityClaimConflict[] =
+        ownerBindings.size > 1
+          ? [
+              {
+                claimIds: ownerClaims.map((claim) => claim.id as UUID),
+                reason: "owner_binding",
+                details: { ownerBindingIds: [...ownerBindings] },
+              },
+            ]
+          : [];
+      const now = new Date();
+      const journalId = newId();
+      const plan: IdentityMergePlan = {
+        contractVersion: 1,
+        id: journalId,
+        agentId: request.agentId,
+        operation: "merge",
+        canonicalPrincipalId: canonical,
+        sourcePrincipalIds: [...expanded].sort(),
+        parentJournalId: null,
+        expectedGeneration: state.generation,
+        affectedReferences: [
+          ...[...expanded].map((id) => ({
+            consumer: "identity-canonical-redirects",
+            referenceType: "principal",
+            referenceId: id,
+            principalId: id,
+            resolution: "redirect_safe" as const,
+          })),
+          ...claims.map((claim) => ({
+            consumer: "identity-claims",
+            referenceType: "claim",
+            referenceId: claim.id,
+            principalId: claim.principalEntityId as UUID,
+            resolution: "redirect_safe" as const,
+          })),
+        ],
+        conflictingClaims,
+        createdAt: iso(now),
+        expiresAt: iso(new Date(now.getTime() + PLAN_TTL_MS)),
+      };
+      const planDigest = digest("elizaos:identity:merge-plan:v1", plan);
+      await tx.insert(identityMergeJournalTable).values({
+        id: journalId,
+        agentId: request.agentId,
+        operation: "merge",
+        status: "planned",
+        actorPrincipalId: request.actorPrincipalId,
+        canonicalPrincipalId: canonical,
+        idempotencyKey: request.idempotencyKey,
+        requestDigest: request.requestDigest,
+        planDigest,
+        expiresAt: new Date(plan.expiresAt),
+        expectedGeneration: state.generation,
+        sourcePrincipalIds: [...expanded].sort(),
+        plan: toDbObject(plan),
+        beforeState: toDbObject({
+          generation: state.generation,
+          redirects: redirects
+            .filter((row) => clusterIds.includes(row.sourcePrincipalId as UUID))
+            .map(mapRedirect),
+          claims: claims.map(mapClaim),
+        }),
+        reason: request.reason,
+      });
+      return plan;
+    });
+  }
+
+  async confirmMerge(
+    request: Parameters<IdentityResolutionService["confirmMerge"]>[0]
+  ): Promise<IdentityMergeConfirmation> {
+    this.assertAgent(request.agentId);
+    return this.db.transaction(async (tx) => {
+      const [journal] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.id, request.planId),
+            eq(identityMergeJournalTable.agentId, request.agentId)
+          )
+        )
+        .for("update")
+        .limit(1);
+      if (journal?.operation !== "merge" || journal.status !== "planned") {
+        fail("IDENTITY_PLAN_NOT_CONFIRMABLE", "Merge plan is not confirmable.");
+      }
+      const plan = mapJournal(journal).plan;
+      const now = new Date();
+      if (Date.parse(plan.expiresAt) <= now.getTime()) {
+        fail("IDENTITY_PLAN_EXPIRED", "Merge plan expired.");
+      }
+      if (
+        journal.actorPrincipalId !== request.actorPrincipalId ||
+        journal.expectedGeneration !== request.expectedGeneration
+      ) {
+        fail("IDENTITY_CONFIRMATION_MISMATCH", "Confirmation does not match the plan.");
+      }
+      const [state] = await tx
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, request.agentId))
+        .limit(1);
+      if (!state || state.generation !== request.expectedGeneration) {
+        fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed after planning.");
+      }
+      const planDigest = digest("elizaos:identity:merge-plan:v1", plan);
+      const [active] = await tx
+        .select()
+        .from(identityMergeConfirmationTable)
+        .where(
+          and(
+            eq(identityMergeConfirmationTable.agentId, request.agentId),
+            eq(identityMergeConfirmationTable.journalId, request.planId),
+            eq(identityMergeConfirmationTable.status, "active")
+          )
+        )
+        .limit(1);
+      if (active && active.expiresAt > now) {
+        if (
+          active.actorPrincipalId !== request.actorPrincipalId ||
+          active.expectedGeneration !== request.expectedGeneration ||
+          active.planDigest !== planDigest
+        ) {
+          fail("IDENTITY_CONFIRMATION_CONFLICT", "Active confirmation does not match.");
+        }
+        return {
+          id: active.id as UUID,
+          agentId: request.agentId,
+          planId: request.planId,
+          expectedGeneration: active.expectedGeneration,
+          actorPrincipalId: active.actorPrincipalId as UUID,
+          planDigest: active.planDigest,
+          status: "active",
+          confirmedAt: iso(active.confirmedAt),
+          expiresAt: iso(active.expiresAt),
+          consumedAt: null,
+        };
+      }
+      if (active) {
+        fail("IDENTITY_CONFIRMATION_EXPIRED", "Merge confirmation expired; create a new plan.");
+      }
+      const id = newId();
+      const expiresAt = new Date(now.getTime() + CONFIRMATION_TTL_MS);
+      await tx.insert(identityMergeConfirmationTable).values({
+        id,
+        agentId: request.agentId,
+        journalId: request.planId,
+        actorPrincipalId: request.actorPrincipalId,
+        planDigest,
+        expectedGeneration: request.expectedGeneration,
+        status: "active",
+        confirmedAt: now,
+        expiresAt,
+      });
+      return {
+        id,
+        agentId: request.agentId,
+        planId: request.planId,
+        expectedGeneration: request.expectedGeneration,
+        actorPrincipalId: request.actorPrincipalId,
+        planDigest,
+        status: "active",
+        confirmedAt: iso(now),
+        expiresAt: iso(expiresAt),
+        consumedAt: null,
+      };
+    });
+  }
+
+  async commitMerge(request: CommitIdentityMergeRequest): Promise<MergeJournal> {
+    this.assertAgent(request.agentId);
+    assertRequestDigest(request.requestDigest, "commit-merge", {
+      agentId: request.agentId,
+      planId: request.planId,
+      confirmationId: request.confirmationId,
+      expectedGeneration: request.expectedGeneration,
+      actorPrincipalId: request.actorPrincipalId,
+      idempotencyKey: request.idempotencyKey,
+    });
+    return this.db.transaction(async (tx) => {
+      const [journal] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.id, request.planId),
+            eq(identityMergeJournalTable.agentId, request.agentId)
+          )
+        )
+        .for("update")
+        .limit(1);
+      if (journal?.operation !== "merge") {
+        fail("IDENTITY_PLAN_NOT_COMMITTABLE", "Merge plan is not committable.");
+      }
+      if (
+        journal.expiresAt <= new Date() ||
+        journal.planDigest !== digest("elizaos:identity:merge-plan:v1", mapJournal(journal).plan)
+      ) {
+        fail("IDENTITY_PLAN_EXPIRED", "Merge plan expired or its digest changed.");
+      }
+      if (journal.status === "committed" || journal.status === "completed") {
+        if (
+          journal.commitIdempotencyKey === request.idempotencyKey &&
+          journal.commitRequestDigest === request.requestDigest
+        ) {
+          return mapJournal(journal);
+        }
+        fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Merge was already committed by another request.");
+      }
+      if (journal.status !== "planned") {
+        fail("IDENTITY_PLAN_NOT_COMMITTABLE", "Merge plan is not committable.");
+      }
+      const [sameKey] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.agentId, request.agentId),
+            eq(identityMergeJournalTable.commitIdempotencyKey, request.idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (sameKey) fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Commit key was reused.");
+      const plan = mapJournal(journal).plan;
+      if (plan.conflictingClaims.length > 0) {
+        fail("IDENTITY_CLAIM_CONFLICT", "Merge plan contains unresolved claim conflicts.");
+      }
+      const now = new Date();
+      const [confirmation] = await tx
+        .select()
+        .from(identityMergeConfirmationTable)
+        .where(
+          and(
+            eq(identityMergeConfirmationTable.id, request.confirmationId),
+            eq(identityMergeConfirmationTable.agentId, request.agentId),
+            eq(identityMergeConfirmationTable.journalId, request.planId),
+            eq(identityMergeConfirmationTable.status, "active")
+          )
+        )
+        .for("update")
+        .limit(1);
+      if (
+        !confirmation ||
+        confirmation.expiresAt <= now ||
+        confirmation.actorPrincipalId !== request.actorPrincipalId ||
+        confirmation.expectedGeneration !== request.expectedGeneration ||
+        confirmation.planDigest !== digest("elizaos:identity:merge-plan:v1", plan)
+      ) {
+        fail("IDENTITY_CONFIRMATION_INVALID", "Merge confirmation is stale or mismatched.");
+      }
+      const consumed = await tx
+        .update(identityMergeConfirmationTable)
+        .set({ status: "consumed", consumedAt: now })
+        .where(
+          and(
+            eq(identityMergeConfirmationTable.id, confirmation.id),
+            eq(identityMergeConfirmationTable.status, "active")
+          )
+        )
+        .returning();
+      if (consumed.length !== 1) {
+        fail("IDENTITY_CONFIRMATION_CONSUMED", "Merge confirmation was consumed.");
+      }
+      const bumped = await tx
+        .update(identityAuthorityStateTable)
+        .set({
+          generation: sql`${identityAuthorityStateTable.generation} + 1`,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(identityAuthorityStateTable.agentId, request.agentId),
+            eq(identityAuthorityStateTable.generation, request.expectedGeneration)
+          )
+        )
+        .returning();
+      if (!bumped[0]) {
+        fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed after confirmation.");
+      }
+      const sourceIds = [...plan.sourcePrincipalIds];
+      await tx
+        .update(identityCanonicalRedirectTable)
+        .set({ status: "superseded", supersededAt: now })
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, request.agentId),
+            inArray(identityCanonicalRedirectTable.sourcePrincipalId, sourceIds),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        );
+      const redirectIds: UUID[] = [];
+      for (const sourcePrincipalId of sourceIds) {
+        const [latest] = await tx
+          .select({ version: identityCanonicalRedirectTable.version })
+          .from(identityCanonicalRedirectTable)
+          .where(
+            and(
+              eq(identityCanonicalRedirectTable.agentId, request.agentId),
+              eq(identityCanonicalRedirectTable.sourcePrincipalId, sourcePrincipalId)
+            )
+          )
+          .orderBy(desc(identityCanonicalRedirectTable.version))
+          .limit(1);
+        const id = newId();
+        redirectIds.push(id);
+        await tx.insert(identityCanonicalRedirectTable).values({
+          id,
+          agentId: request.agentId,
+          sourcePrincipalId,
+          canonicalPrincipalId: plan.canonicalPrincipalId,
+          mergeJournalId: journal.id,
+          version: (latest?.version ?? 0) + 1,
+          status: "active",
+          createdAt: now,
+        });
+      }
+      const result = {
+        canonicalPrincipalId: plan.canonicalPrincipalId,
+        preservedPrincipalIds: [plan.canonicalPrincipalId, ...sourceIds],
+        redirectIds,
+        repairedConsumers: ["identity-canonical-redirects"],
+        pendingConsumers: [...PENDING_CONSUMERS],
+        generation: bumped[0].generation,
+      };
+      const [updated] = await tx
+        .update(identityMergeJournalTable)
+        .set({
+          status: "committed",
+          commitIdempotencyKey: request.idempotencyKey,
+          commitRequestDigest: request.requestDigest,
+          result: toDbObject(result),
+          committedAt: now,
+        })
+        .where(
+          and(
+            eq(identityMergeJournalTable.id, journal.id),
+            eq(identityMergeJournalTable.status, "planned")
+          )
+        )
+        .returning();
+      if (!updated) return fail("IDENTITY_COMMIT_RACE", "Merge journal changed during commit.");
+      return mapJournal(updated);
+    });
+  }
+
+  async split(request: SplitIdentityRequest): Promise<MergeJournal> {
+    this.assertAgent(request.agentId);
+    const principalIds = [...new Set(request.principalIds)].sort();
+    if (principalIds.length === 0) {
+      fail("IDENTITY_SPLIT_INPUT_INVALID", "Split requires at least one principal.");
+    }
+    assertRequestDigest(request.requestDigest, "split", {
+      agentId: request.agentId,
+      parentJournalId: request.parentJournalId,
+      principalIds,
+      expectedGeneration: request.expectedGeneration,
+      actorPrincipalId: request.actorPrincipalId,
+      reason: request.reason,
+      idempotencyKey: request.idempotencyKey,
+    });
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.agentId, request.agentId),
+            eq(identityMergeJournalTable.operation, "split"),
+            eq(identityMergeJournalTable.idempotencyKey, request.idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (existing) {
+        if (existing.requestDigest !== request.requestDigest) {
+          fail("IDENTITY_IDEMPOTENCY_CONFLICT", "Split key was reused.");
+        }
+        return mapJournal(existing);
+      }
+      const [parent] = await tx
+        .select()
+        .from(identityMergeJournalTable)
+        .where(
+          and(
+            eq(identityMergeJournalTable.id, request.parentJournalId),
+            eq(identityMergeJournalTable.agentId, request.agentId)
+          )
+        )
+        .for("update")
+        .limit(1);
+      if (parent?.operation !== "merge" || !["committed", "completed"].includes(parent.status)) {
+        fail("IDENTITY_SPLIT_PARENT_INVALID", "Split parent is not a committed merge.");
+      }
+      const parentSources = new Set(asUuidArray(parent.sourcePrincipalIds, "parent.sources"));
+      if (!principalIds.every((id) => parentSources.has(id))) {
+        fail("IDENTITY_SPLIT_SCOPE_INVALID", "Split principals are outside the parent merge.");
+      }
+      const active = await tx
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, request.agentId),
+            inArray(identityCanonicalRedirectTable.sourcePrincipalId, principalIds),
+            eq(identityCanonicalRedirectTable.mergeJournalId, request.parentJournalId),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        )
+        .for("update");
+      if (active.length !== principalIds.length) {
+        fail("IDENTITY_SPLIT_STALE", "A principal no longer uses the parent redirect.");
+      }
+      const now = new Date();
+      const journalId = newId();
+      const expiresAt = new Date(now.getTime() + PLAN_TTL_MS);
+      const plan: IdentityMergePlan = {
+        contractVersion: 1,
+        id: journalId,
+        agentId: request.agentId,
+        operation: "split",
+        canonicalPrincipalId: parent.canonicalPrincipalId as UUID,
+        sourcePrincipalIds: principalIds,
+        parentJournalId: request.parentJournalId,
+        expectedGeneration: request.expectedGeneration,
+        affectedReferences: active.map((row) => ({
+          consumer: "identity-canonical-redirects",
+          referenceType: "redirect",
+          referenceId: row.id,
+          principalId: row.sourcePrincipalId as UUID,
+          resolution: "redirect_safe",
+        })),
+        conflictingClaims: [],
+        createdAt: iso(now),
+        expiresAt: iso(expiresAt),
+      };
+      const planDigest = digest("elizaos:identity:merge-plan:v1", plan);
+      await tx.insert(identityMergeJournalTable).values({
+        id: journalId,
+        agentId: request.agentId,
+        operation: "split",
+        status: "planned",
+        parentJournalId: request.parentJournalId,
+        actorPrincipalId: request.actorPrincipalId,
+        canonicalPrincipalId: parent.canonicalPrincipalId,
+        idempotencyKey: request.idempotencyKey,
+        requestDigest: request.requestDigest,
+        planDigest,
+        expiresAt,
+        expectedGeneration: request.expectedGeneration,
+        sourcePrincipalIds: principalIds,
+        plan: toDbObject(plan),
+        beforeState: toDbObject({
+          generation: request.expectedGeneration,
+          redirects: active.map(mapRedirect),
+        }),
+        reason: request.reason,
+      });
+      const bumped = await tx
+        .update(identityAuthorityStateTable)
+        .set({ generation: sql`${identityAuthorityStateTable.generation} + 1`, updatedAt: now })
+        .where(
+          and(
+            eq(identityAuthorityStateTable.agentId, request.agentId),
+            eq(identityAuthorityStateTable.generation, request.expectedGeneration)
+          )
+        )
+        .returning();
+      if (!bumped[0])
+        return fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed before split.");
+      await tx
+        .update(identityCanonicalRedirectTable)
+        .set({ status: "reverted", supersededAt: now })
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, request.agentId),
+            inArray(
+              identityCanonicalRedirectTable.id,
+              active.map((row) => row.id)
+            ),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        );
+      const result = {
+        canonicalPrincipalId: parent.canonicalPrincipalId as UUID,
+        preservedPrincipalIds: [parent.canonicalPrincipalId as UUID, ...principalIds],
+        redirectIds: active.map((row) => row.id as UUID),
+        repairedConsumers: ["identity-canonical-redirects"],
+        pendingConsumers: [...PENDING_CONSUMERS],
+        generation: bumped[0].generation,
+      };
+      const [updated] = await tx
+        .update(identityMergeJournalTable)
+        .set({ status: "committed", result: toDbObject(result), committedAt: now })
+        .where(eq(identityMergeJournalTable.id, journalId))
+        .returning();
+      if (!updated) return fail("IDENTITY_SPLIT_COMMIT_FAILED", "Split did not commit.");
+      return mapJournal(updated);
+    });
+  }
+
+  async getJournal(agentId: UUID, journalId: UUID): Promise<MergeJournal | null> {
+    this.assertAgent(agentId);
+    const [row] = await this.db
+      .select()
+      .from(identityMergeJournalTable)
+      .where(
+        and(
+          eq(identityMergeJournalTable.agentId, agentId),
+          eq(identityMergeJournalTable.id, journalId)
+        )
+      )
+      .limit(1);
+    return row ? mapJournal(row) : null;
+  }
+
+  async listRedirects(
+    agentId: UUID,
+    principalId: UUID
+  ): Promise<readonly IdentityCanonicalRedirect[]> {
+    this.assertAgent(agentId);
+    const rows = await this.db
+      .select()
+      .from(identityCanonicalRedirectTable)
+      .where(
+        and(
+          eq(identityCanonicalRedirectTable.agentId, agentId),
+          or(
+            eq(identityCanonicalRedirectTable.sourcePrincipalId, principalId),
+            eq(identityCanonicalRedirectTable.canonicalPrincipalId, principalId)
+          )
+        )
+      )
+      .orderBy(desc(identityCanonicalRedirectTable.version));
+    return rows.map(mapRedirect);
+  }
+
+  async listJournal(
+    agentId: UUID,
+    options: { limit: number; cursor: string | null }
+  ): Promise<IdentityJournalPage> {
+    this.assertAgent(agentId);
+    const limit = Math.min(MAX_JOURNAL_PAGE, Math.max(1, Math.trunc(options.limit)));
+    let cursorDate: Date | null = null;
+    let cursorId: UUID | null = null;
+    if (options.cursor) {
+      const splitAt = options.cursor.indexOf("|");
+      cursorDate = new Date(options.cursor.slice(0, splitAt));
+      cursorId = options.cursor.slice(splitAt + 1) as UUID;
+      if (splitAt < 1 || !Number.isFinite(cursorDate.getTime()) || !cursorId) {
+        fail("IDENTITY_CURSOR_INVALID", "Journal cursor is invalid.");
+      }
+    }
+    const predicate =
+      cursorDate && cursorId
+        ? and(
+            eq(identityMergeJournalTable.agentId, agentId),
+            or(
+              lt(identityMergeJournalTable.createdAt, cursorDate),
+              and(
+                eq(identityMergeJournalTable.createdAt, cursorDate),
+                lt(identityMergeJournalTable.id, cursorId)
+              )
+            )
+          )
+        : eq(identityMergeJournalTable.agentId, agentId);
+    const rows = await this.db
+      .select()
+      .from(identityMergeJournalTable)
+      .where(predicate)
+      .orderBy(desc(identityMergeJournalTable.createdAt), desc(identityMergeJournalTable.id))
+      .limit(limit + 1);
+    const page = rows.slice(0, limit);
+    const last = page.at(-1);
+    return {
+      items: page.map(mapJournal),
+      nextCursor: rows.length > limit && last ? `${iso(last.createdAt)}|${last.id}` : null,
+    };
+  }
+}


### PR DESCRIPTION
# Relates to

Foundation slice of #23099. This PR deliberately does not close the issue; claim lifecycle/backfill, authenticated merge entrypoints, legacy cluster cutover, and LifeOps/MESSAGE consumer migration remain follow-up slices.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install` and focused package/build/real-database checks were run after sync.
- [x] A reviewer can inspect the migrated real-PGlite artifacts through the integration assertions below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop 0.148.0-alpha.15`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e8bfd8830e51b2bfb40bc214e8544c2549553985:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `40b04ccf80`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It reached the workspace Turbo lane, then stopped on pre-existing Biome errors in `plugins/plugin-bluebubbles/src/accounts.test.ts` and `plugins/plugin-bluebubbles/src/service.ts`; this branch does not touch those files.

# Risks

Medium, security-sensitive foundation. It adds durable identity tables and a transactional service export, and changes role resolution so generic confirmed relationship edges no longer grant OWNER or inherit manual private-access roles. The new SQL authority is intentionally not registered in the plugin service list until owner claims are backfilled, preventing an empty projection from demoting currently paired owners.

# Background

## What does this PR do?

- Defines the versioned core identity vocabulary: account-scoped claims, canonical redirects, merge/split plans, confirmations, journals, delivery resolution, and discriminated owner-binding decisions.
- Adds portable schema descriptors and real Drizzle tables with composite tenant FKs, immutable journal evidence, generation fencing, phase-specific idempotency, and active-only scoped-claim uniqueness.
- Implements a SQL identity service using one real Drizzle transaction for confirm/commit/split, preserving source principals and claims rather than destructively rewriting them.
- Removes generic confirmed `identity_link` inheritance from OWNER and manual private-access role resolution. The temporary compatibility path accepts only connector IDs carrying the verified owner-pairing marker.
- Hardens owner evaluation to require a connected, non-deleted account, matching connector, matching external subject, matching runtime instance, and a verified binding. Configured owner aliases are canonicalized.
- Keeps the service exported but cutover-gated until claim lifecycle/backfill and authenticated merge consumers land.

## What kind of change is this?

Feature foundation plus security hardening; non-breaking public additions, with intentionally stricter privilege resolution for generic relationship links.

# Documentation changes needed?

No public product behavior is enabled in this slice. The contracts are documented in source; operator/user documentation belongs with the later cutover PR.

# Testing

## Where should a reviewer start?

Start with `packages/core/src/types/identity.ts`, `plugins/plugin-sql/src/schema/identityAuthority.ts`, `plugins/plugin-sql/src/services/sql-identity-resolution.ts`, and the real test `plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core typecheck
bun run --cwd packages/core test -- src/types/identity.test.ts src/schemas/identity-authority.test.ts src/roles.resolution.test.ts src/roles.test.ts
bun run --cwd plugins/plugin-sql typecheck
bun run --cwd plugins/plugin-sql lint:check
bun run --cwd plugins/plugin-sql test -- __tests__/identity-authority-schema.test.ts services/sql-identity-resolution.test.ts
cd plugins/plugin-sql/src
bun run test:real:files -- __tests__/integration/identity-authority.real.test.ts __tests__/migration/initialization.real.test.ts
```

Observed post-rebase result: 68 core tests, 6 SQL focused tests, 5 real identity tests, and 9 real migration tests passed. Core Node/browser/edge builds and the SQL plugin build also passed.

# Evidence Gate

<!-- evidence-head:fc78140fc164e688bc9804aa3dcde6ab46c2c919 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - real migrated PGlite execution results are documented in the detailed testing section above; no hosted backend route is enabled in this foundation slice.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, action, or evaluator path is enabled by this slice.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the real-PGlite inspection scope and exact passing counts are documented in the detailed testing section above; no separate domain artifact was produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR does not change a live model path.

## Backend + frontend logs

The real database test output records runtime migration, 203 SQL statements applied, merge/split execution, forced rollback, and successful assertions. Frontend logs are N/A because no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

- Root `bun run verify` is blocked outside this diff by existing Biome failures in `plugin-bluebubbles`; package-owned lint/typecheck/tests pass.
- PostgreSQL and browser-PGlite execution evidence are not included yet; the service remains unregistered, so this PR does not claim production cutover.
- Claim mutation/backfill, authenticated proposal confirmation, projection repair, legacy relationship clustering, LifeOps, and MESSAGE consumer migration remain explicit follow-up work under #23099.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop 0.148.0-alpha.15
Contribution skill revision: elizaOS/eliza@e8bfd8830e51b2bfb40bc214e8544c2549553985:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [identity-authority-foundation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop 0.148.0-alpha.15","skill_revision":"elizaOS/eliza@e8bfd8830e51b2bfb40bc214e8544c2549553985:packages/skills/skills/contribute-to-eliza"} -->


