### PR TITLE
feat(plugin-maps): build the routed /maps web view

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -252,6 +252,7 @@
         "@elizaos/plugin-calendar": "workspace:*",
         "@elizaos/plugin-contacts": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",
+        "@elizaos/plugin-maps": "workspace:*",
         "@elizaos/plugin-messages": "workspace:*",
         "@elizaos/plugin-native-settings": "workspace:*",
         "@elizaos/plugin-notes": "workspace:*",
@@ -2101,6 +2102,8 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/ui": "workspace:*",
+        "react": "^19.0.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -2109,10 +2112,17 @@
         "@elizaos/plugin-sql": "workspace:*",
         "@elizaos/scenario-runner": "workspace:*",
         "@types/node": "^25.0.6",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
+        "react-dom": "^19.0.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
+        "vite": "^8.0.0",
         "vitest": "^4.0.17",
+      },
+      "peerDependencies": {
+        "react-dom": "^19.0.0",
       },
     },
     "plugins/plugin-matrix": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -203,6 +203,7 @@
     "@elizaos/plugin-calendar": "workspace:*",
     "@elizaos/plugin-contacts": "workspace:*",
     "@elizaos/plugin-elizacloud": "workspace:*",
+    "@elizaos/plugin-maps": "workspace:*",
     "@elizaos/plugin-messages": "workspace:*",
     "@elizaos/plugin-native-settings": "workspace:*",
     "@elizaos/plugin-personal-assistant": "workspace:*",

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -34,6 +34,7 @@ const SCAN_ROOTS = [
 const EXPECTED_SIDE_EFFECT_MODULES = [
   "@elizaos/plugin-calendar#register",
   "@elizaos/plugin-contacts#register",
+  "@elizaos/plugin-maps#register",
   "@elizaos/plugin-native-settings#register",
   "@elizaos/plugin-notes#register",
   "@elizaos/plugin-personal-assistant#register",

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -72,7 +72,6 @@ import type {
   SandboxStartResponse,
   SandboxWindowInfo,
 } from "./client-types";
-import { desktopHttpTransportForUrl } from "./desktop-http-transport";
 import {
   DEFAULT_DIRECT_CLOUD_APP_BASE_URL,
   DEFAULT_DIRECT_CLOUD_BASE_URL,
@@ -80,7 +79,6 @@ import {
   resolveDirectCloudAuthApiBase,
   resolveDirectCloudWebBase,
 } from "./direct-cloud-endpoints";
-import { fetchAgentTransport } from "./transport";
 
 // ---------------------------------------------------------------------------
 // Module-level constants

--- a/plugins/plugin-maps/AGENTS.md
+++ b/plugins/plugin-maps/AGENTS.md
@@ -17,7 +17,12 @@ saved places, safe sharing, and navigation handoffs.
   Do not add another file store, scheduler, or identity graph.
 - Native coordinates may be supplied by `@elizaos/capacitor-location`, but this
   package does not request device permissions or read device location itself.
-- Google Maps/Routes integration and rendered maps UI belong to later issues.
+- The routed `/maps` web view renders the server-owned snapshot (providers,
+  attribution, saved places) plus provider reads through the shared
+  view-capability broker. View capabilities are read-only by design; saved-place
+  writes stay on the promoted `MAPS_SAVE` action so runtime receipt settlement
+  is never bypassed. Google Maps/Routes provider integration belongs to the
+  managed adapter issue.
 
 ## Public surface
 
@@ -37,6 +42,13 @@ saved places, safe sharing, and navigation handoffs.
   desired state is current.
 - Missing action inputs return a canonical form interaction and set
   `awaitingUserInput`; they never fabricate coordinates or places.
+- The `/maps` view ships as `dist/views/bundle.js` (`MapsView`), registers the
+  app-shell page via `src/register.ts` (`elizaos.appRegister`), serves
+  `GET /api/maps/state`, and declares `MAPS_VIEW_CAPABILITIES` dispatched by
+  `serverInteract` in `src/interact.ts`. `view-contract.ts` is the shared zod
+  transport contract and must stay free of runtime imports. Adapters may
+  declare an `attribution` line; the view must display it. Loading,
+  designed-empty, error, offline, and provider-unavailable render distinctly.
 
 ## Commands
 

--- a/plugins/plugin-maps/CLAUDE.md
+++ b/plugins/plugin-maps/CLAUDE.md
@@ -17,7 +17,12 @@ saved places, safe sharing, and navigation handoffs.
   Do not add another file store, scheduler, or identity graph.
 - Native coordinates may be supplied by `@elizaos/capacitor-location`, but this
   package does not request device permissions or read device location itself.
-- Google Maps/Routes integration and rendered maps UI belong to later issues.
+- The routed `/maps` web view renders the server-owned snapshot (providers,
+  attribution, saved places) plus provider reads through the shared
+  view-capability broker. View capabilities are read-only by design; saved-place
+  writes stay on the promoted `MAPS_SAVE` action so runtime receipt settlement
+  is never bypassed. Google Maps/Routes provider integration belongs to the
+  managed adapter issue.
 
 ## Public surface
 
@@ -37,6 +42,13 @@ saved places, safe sharing, and navigation handoffs.
   desired state is current.
 - Missing action inputs return a canonical form interaction and set
   `awaitingUserInput`; they never fabricate coordinates or places.
+- The `/maps` view ships as `dist/views/bundle.js` (`MapsView`), registers the
+  app-shell page via `src/register.ts` (`elizaos.appRegister`), serves
+  `GET /api/maps/state`, and declares `MAPS_VIEW_CAPABILITIES` dispatched by
+  `serverInteract` in `src/interact.ts`. `view-contract.ts` is the shared zod
+  transport contract and must stay free of runtime imports. Adapters may
+  declare an `attribution` line; the view must display it. Loading,
+  designed-empty, error, offline, and provider-unavailable render distinctly.
 
 ## Commands
 

--- a/plugins/plugin-maps/package.json
+++ b/plugins/plugin-maps/package.json
@@ -42,8 +42,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "bun run build:js && bun run build:types",
+    "build": "bun run build:js && bun run build:views && bun run build:types",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
+    "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "build:types": "tsc6 --noCheck -p tsconfig.build.json",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "test": "vitest run --config vitest.config.ts",
@@ -55,9 +56,18 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "@elizaos/ui": "workspace:*",
+    "react": "^19.0.0",
     "zod": "^4.4.3"
   },
+  "peerDependencies": {
+    "react-dom": "^19.0.0"
+  },
   "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vite": "^8.0.0",
     "@electric-sql/pglite": "^0.4.5",
     "@elizaos/cloud-test-mocks": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",
@@ -76,6 +86,7 @@
     "pluginParameters": {}
   },
   "elizaos": {
+    "appRegister": "register",
     "app": {
       "displayName": "Maps",
       "category": "productivity"

--- a/plugins/plugin-maps/src/adapter.ts
+++ b/plugins/plugin-maps/src/adapter.ts
@@ -30,6 +30,8 @@ export interface MapsProviderAdapter {
   readonly id: string;
   readonly connectionId: string;
   readonly supportsCrossProviderRoutes?: boolean;
+  /** Provider-mandated attribution line the routed view must display. */
+  readonly attribution?: string;
   searchPlaces(request: PlaceSearchRequest): Promise<PlacePage>;
   getPlace(providerPlaceId: string): Promise<PlaceRef | null>;
   planRoute(request: RoutePlanRequest): Promise<RoutePlan>;

--- a/plugins/plugin-maps/src/capabilities.ts
+++ b/plugins/plugin-maps/src/capabilities.ts
@@ -1,0 +1,93 @@
+/**
+ * Planner-visible capabilities for the routed /maps view. Every declaration
+ * maps one-to-one to the read-only dispatch table in `interact.ts`; writes stay
+ * on the promoted MAPS_SAVE action so runtime receipt settlement is never
+ * bypassed through the view broker.
+ */
+
+import type { ViewCapability, ViewCapabilityParameter } from "@elizaos/core";
+
+const QUERY_PARAM: ViewCapabilityParameter = {
+  type: "string",
+  description: "Free-text place search query, e.g. a name, address, or kind.",
+  required: true,
+  minLength: 1,
+  maxLength: 500,
+  pattern: "\\S",
+};
+
+const PLACE_ID_PARAM: ViewCapabilityParameter = {
+  type: "string",
+  description: "Opaque provider place id from a prior search or saved place.",
+  required: true,
+  minLength: 1,
+  maxLength: 512,
+};
+
+const LATITUDE_PARAM: ViewCapabilityParameter = {
+  type: "number",
+  description: "Latitude in decimal degrees.",
+  minimum: -90,
+  maximum: 90,
+};
+
+const LONGITUDE_PARAM: ViewCapabilityParameter = {
+  type: "number",
+  description: "Longitude in decimal degrees.",
+  minimum: -180,
+  maximum: 180,
+};
+
+export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
+  {
+    id: "get-maps-state",
+    description:
+      "Read the current maps snapshot: registered providers, their required attribution, and the owner's saved places.",
+  },
+  {
+    id: "search-places",
+    description:
+      "Search the active maps provider for places, optionally biased near a coordinate, with cursor pagination.",
+    params: {
+      query: QUERY_PARAM,
+      latitude: LATITUDE_PARAM,
+      longitude: LONGITUDE_PARAM,
+      cursor: {
+        type: "string",
+        description: "Opaque pagination cursor from a prior search page.",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      limit: {
+        type: "integer",
+        description: "Maximum results per page, from 1 to 100.",
+        minimum: 1,
+        maximum: 100,
+      },
+    },
+  },
+  {
+    id: "get-place",
+    description: "Read one place's details by its provider place id.",
+    params: { placeId: PLACE_ID_PARAM },
+  },
+  {
+    id: "plan-route-alternatives",
+    description:
+      "Plan routes between two known places across every travel mode (drive, walk, bicycle, transit), reporting each mode's route or its explicit failure.",
+    params: {
+      originPlaceId: {
+        ...PLACE_ID_PARAM,
+        description: "Provider place id of the route origin.",
+      },
+      destinationPlaceId: {
+        ...PLACE_ID_PARAM,
+        description: "Provider place id of the route destination.",
+      },
+    },
+  },
+  {
+    id: "get-saved-places",
+    description: "List the owner's durable saved places.",
+  },
+];

--- a/plugins/plugin-maps/src/import-meta-env.ts
+++ b/plugins/plugin-maps/src/import-meta-env.ts
@@ -1,0 +1,19 @@
+/**
+ * Vite-style `import.meta.env` visibility for the `@elizaos/ui` sources this
+ * package type-checks through its tsconfig path mapping. Type-only global
+ * augmentation; the runtime plugin itself never reads `import.meta.env`.
+ * A plain module rather than a declaration file because plugin src trees
+ * gitignore generated `.d.ts` outputs.
+ */
+
+declare global {
+  interface ImportMetaEnv {
+    readonly [key: string]: string | boolean | undefined;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
+export {};

--- a/plugins/plugin-maps/src/index.ts
+++ b/plugins/plugin-maps/src/index.ts
@@ -1,9 +1,13 @@
-/** Exports the maps plugin, contracts, service, adapter, store, and actions. */
+/** Exports the maps plugin, contracts, service, adapter, store, views, and actions. */
 
 export * from "./action.js";
 export * from "./adapter.js";
+export * from "./capabilities.js";
 export * from "./errors.js";
+export * from "./interact.js";
 export { default, mapsPlugin } from "./plugin.js";
+export * from "./routes.js";
 export * from "./service.js";
 export * from "./store.js";
 export * from "./types.js";
+export * from "./view-state.js";

--- a/plugins/plugin-maps/src/interact.test.ts
+++ b/plugins/plugin-maps/src/interact.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Exercises the /maps view broker against a real AgentRuntime, a real
+ * MapsService, and a deterministic in-memory provider adapter — the fixture
+ * data path the routed view renders in audits, independent of live APIs.
+ * Covers success, designed-empty, invalid input, pagination, provider
+ * unavailability, auth expiry, rate limiting, partial route alternatives,
+ * malformed provider data, and unknown capabilities.
+ */
+
+import {
+  AgentRuntime,
+  createCharacter,
+  InMemoryDatabaseAdapter,
+  type UUID,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MapsProviderAdapter } from "./adapter.js";
+import { MapsError } from "./errors.js";
+import { serverInteract } from "./interact.js";
+import { MAPS_SERVICE_TYPE, MapsService } from "./service.js";
+import type { PlacePage, PlaceRef } from "./types.js";
+import { buildMapsViewSnapshot, mapsViewSnapshotSchema } from "./view-state.js";
+
+const AGENT_ID = "11111111-1111-4111-a111-111111111111" as UUID;
+const OWNER_ID = "22222222-2222-4222-a222-222222222222" as UUID;
+
+const pier: PlaceRef = {
+  provider: "fixture-maps",
+  providerPlaceId: "pier-1",
+  name: "Santa Monica Pier",
+  coordinates: { latitude: 34.0092, longitude: -118.4973 },
+  formattedAddress: "200 Santa Monica Pier",
+  categories: ["landmark"],
+};
+const cafe: PlaceRef = {
+  ...pier,
+  providerPlaceId: "cafe-1",
+  name: "Harbor Cafe",
+  coordinates: { latitude: 34.0101, longitude: -118.4931 },
+  categories: ["cafe"],
+};
+
+function fixtureAdapter(
+  overrides: Partial<MapsProviderAdapter> = {},
+): MapsProviderAdapter {
+  return {
+    id: "fixture-maps",
+    connectionId: "conn_fixture1234567890",
+    attribution: "Map data © Fixture Maps contributors",
+    async searchPlaces(request): Promise<PlacePage> {
+      if (request.query === "empty") return { places: [], nextCursor: null };
+      if (request.cursor === "page-2") {
+        return { places: [cafe], nextCursor: null };
+      }
+      return { places: [pier], nextCursor: "page-2" };
+    },
+    async getPlace(id) {
+      if (id === pier.providerPlaceId) return pier;
+      if (id === cafe.providerPlaceId) return cafe;
+      return null;
+    },
+    async planRoute(request) {
+      if (request.travelMode === "transit") {
+        throw new MapsError("Transit routing is not offered here.", {
+          code: "MAPS_PROVIDER_REJECTED",
+        });
+      }
+      return {
+        provider: "fixture-maps",
+        routeId: `route-${request.travelMode}`,
+        origin: request.origin,
+        destination: request.destination,
+        travelMode: request.travelMode,
+        distanceMeters: 2_400,
+        durationSeconds: 900,
+        warnings: [],
+      };
+    },
+    ...overrides,
+  };
+}
+
+describe("maps view serverInteract", () => {
+  let runtime: AgentRuntime;
+  let service: MapsService;
+
+  beforeEach(() => {
+    runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      character: createCharacter({
+        name: "Maps View Test",
+        settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+      }),
+      adapter: new InMemoryDatabaseAdapter(),
+      disableBasicCapabilities: true,
+      logLevel: "fatal",
+    });
+    service = new MapsService(runtime);
+    service.registerAdapter(fixtureAdapter(), true);
+    vi.spyOn(runtime, "getService").mockImplementation((serviceType) =>
+      serviceType === MAPS_SERVICE_TYPE ? service : null,
+    );
+  });
+
+  it("returns a schema-valid snapshot with providers and saved places", async () => {
+    const result = await serverInteract("get-maps-state", undefined, {
+      runtime,
+    });
+    expect(result.success).toBe(true);
+    const snapshot = mapsViewSnapshotSchema.parse(result.data);
+    expect(snapshot.providerAvailable).toBe(true);
+    expect(snapshot.providers).toEqual([
+      {
+        id: "fixture-maps",
+        attribution: "Map data © Fixture Maps contributors",
+        isDefault: true,
+      },
+    ]);
+    expect(snapshot.savedPlaces).toEqual({ status: "ok", places: [] });
+  });
+
+  it("reports saved places unavailable without a configured owner", async () => {
+    const anonymousRuntime = new AgentRuntime({
+      agentId: AGENT_ID,
+      character: createCharacter({ name: "No Owner" }),
+      adapter: new InMemoryDatabaseAdapter(),
+      disableBasicCapabilities: true,
+      logLevel: "fatal",
+    });
+    const snapshot = await buildMapsViewSnapshot(anonymousRuntime, service);
+    expect(snapshot.savedPlaces.status).toBe("unavailable");
+  });
+
+  it("searches places and pages with the returned cursor", async () => {
+    const first = await serverInteract(
+      "search-places",
+      { query: "pier" },
+      { runtime },
+    );
+    expect(first.success).toBe(true);
+    const firstPage = first.data as PlacePage;
+    expect(firstPage.places.map((place) => place.name)).toEqual([
+      "Santa Monica Pier",
+    ]);
+    expect(firstPage.nextCursor).toBe("page-2");
+
+    const second = await serverInteract(
+      "search-places",
+      { query: "pier", cursor: "page-2" },
+      { runtime },
+    );
+    const secondPage = second.data as PlacePage;
+    expect(secondPage.places.map((place) => place.name)).toEqual([
+      "Harbor Cafe",
+    ]);
+    expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it("returns designed-empty search results distinctly from errors", async () => {
+    const result = await serverInteract(
+      "search-places",
+      { query: "empty" },
+      { runtime },
+    );
+    expect(result.success).toBe(true);
+    expect((result.data as PlacePage).places).toEqual([]);
+    expect(result.text).toBe("No places matched that search.");
+  });
+
+  it("rejects invalid input as an explicit failure result", async () => {
+    for (const params of [
+      {},
+      { query: "  " },
+      { query: "pier", latitude: 12 },
+      { query: "pier", latitude: 400, longitude: 0 },
+      { query: "pier", limit: 2.5 },
+      { query: "pier", bogus: true },
+    ]) {
+      const result = await serverInteract("search-places", params, {
+        runtime,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe("MAPS_INVALID_INPUT");
+    }
+  });
+
+  it("fails explicitly when no provider adapter is registered", async () => {
+    service.unregisterAdapter("fixture-maps");
+    const result = await serverInteract(
+      "search-places",
+      { query: "pier" },
+      { runtime },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("MAPS_PROVIDER_UNAVAILABLE");
+  });
+
+  it("translates provider auth expiry and rate limiting into failure results", async () => {
+    for (const code of ["MAPS_AUTH_EXPIRED", "MAPS_RATE_LIMITED"] as const) {
+      service.unregisterAdapter("fixture-maps");
+      service.registerAdapter(
+        fixtureAdapter({
+          async searchPlaces() {
+            throw new MapsError("Provider refused the request.", { code });
+          },
+        }),
+        true,
+      );
+      const result = await serverInteract(
+        "search-places",
+        { query: "pier" },
+        { runtime },
+      );
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe(code);
+    }
+  });
+
+  it("rethrows systemic provider-spoofing failures to the route boundary", async () => {
+    service.unregisterAdapter("fixture-maps");
+    service.registerAdapter(
+      fixtureAdapter({
+        async searchPlaces() {
+          return {
+            places: [{ ...pier, provider: "spoofed-provider" }],
+            nextCursor: null,
+          };
+        },
+      }),
+      true,
+    );
+    await expect(
+      serverInteract("search-places", { query: "pier" }, { runtime }),
+    ).rejects.toMatchObject({ code: "MAPS_MALFORMED_RESPONSE" });
+  });
+
+  it("reads one place and reports missing ids as not found", async () => {
+    const found = await serverInteract(
+      "get-place",
+      { placeId: "pier-1" },
+      { runtime },
+    );
+    expect(found.success).toBe(true);
+    expect((found.data as { place: PlaceRef }).place.name).toBe(
+      "Santa Monica Pier",
+    );
+
+    const missing = await serverInteract(
+      "get-place",
+      { placeId: "nowhere" },
+      { runtime },
+    );
+    expect(missing.success).toBe(false);
+    expect(missing.error?.code).toBe("MAPS_NOT_FOUND");
+  });
+
+  it("plans route alternatives with explicit per-mode failures", async () => {
+    const result = await serverInteract(
+      "plan-route-alternatives",
+      { originPlaceId: "pier-1", destinationPlaceId: "cafe-1" },
+      { runtime },
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      alternatives: Array<{ travelMode: string; status: string }>;
+    };
+    expect(data.alternatives.map((a) => [a.travelMode, a.status])).toEqual([
+      ["drive", "ok"],
+      ["walk", "ok"],
+      ["bicycle", "ok"],
+      ["transit", "error"],
+    ]);
+  });
+
+  it("fails plan-route-alternatives when every mode fails", async () => {
+    service.unregisterAdapter("fixture-maps");
+    service.registerAdapter(
+      fixtureAdapter({
+        async planRoute() {
+          throw new MapsError("Routing is down.", {
+            code: "MAPS_PROVIDER_FAILURE",
+          });
+        },
+      }),
+      true,
+    );
+    const result = await serverInteract(
+      "plan-route-alternatives",
+      { originPlaceId: "pier-1", destinationPlaceId: "cafe-1" },
+      { runtime },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("MAPS_PROVIDER_FAILURE");
+  });
+
+  it("rejects unknown capabilities and a missing runtime", async () => {
+    await expect(
+      serverInteract("format-disk", {}, { runtime }),
+    ).rejects.toMatchObject({ code: "MAPS_UNKNOWN_CAPABILITY" });
+    const result = await serverInteract("get-maps-state");
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("MAPS_PROVIDER_UNAVAILABLE");
+  });
+});

--- a/plugins/plugin-maps/src/interact.ts
+++ b/plugins/plugin-maps/src/interact.ts
@@ -1,0 +1,368 @@
+/**
+ * Server interaction broker for the routed /maps view. Every capability in
+ * `capabilities.ts` dispatches here against the owning runtime's MapsService,
+ * so the mounted view, the planner, and chat share one read path. All
+ * capabilities are read-only by design: saved-place writes stay on the
+ * promoted MAPS_SAVE action, which the runtime settles with effect receipts.
+ *
+ * Expected domain failures (invalid input, provider unavailable, auth expiry,
+ * rate limiting, not found) become explicit `success: false` results the view
+ * renders as a distinct error state; systemic failures propagate to the shared
+ * route boundary.
+ */
+
+import {
+  ElizaError,
+  type IAgentRuntime,
+  isElizaError,
+  toElizaError,
+} from "@elizaos/core";
+import { getMapsService, type MapsService } from "./service.js";
+import type {
+  Coordinates,
+  PlacePage,
+  PlaceRef,
+  SavedPlace,
+  TravelMode,
+} from "./types.js";
+import { travelModeSchema } from "./types.js";
+import {
+  buildMapsViewSnapshot,
+  type MapsViewSnapshot,
+  type RouteAlternative,
+} from "./view-state.js";
+
+export interface MapsInteractResult {
+  success: boolean;
+  text: string;
+  data?: unknown;
+  error?: { code: string; message: string };
+}
+
+const EXPECTED_FAILURE_CODES = new Set([
+  "MAPS_INVALID_INPUT",
+  "MAPS_PROVIDER_UNAVAILABLE",
+  "MAPS_NOT_FOUND",
+  "MAPS_AUTH_EXPIRED",
+  "MAPS_AUTH_REVOKED",
+  "MAPS_RATE_LIMITED",
+]);
+
+const ROUTE_MODES: readonly TravelMode[] = travelModeSchema.options;
+
+function paramsRecord(value: unknown): Record<string, unknown> {
+  if (value === undefined) return {};
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ElizaError("Capability params must be a JSON object.", {
+      code: "MAPS_INVALID_INPUT",
+      context: { field: "params" },
+      severity: "ephemeral",
+    });
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertOnlyParams(
+  params: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const allowedKeys = new Set(allowed);
+  const unknownKey = Object.keys(params).find((key) => !allowedKeys.has(key));
+  if (unknownKey) {
+    throw new ElizaError(
+      `Capability params contain unsupported field "${unknownKey}".`,
+      {
+        code: "MAPS_INVALID_INPUT",
+        context: { field: unknownKey },
+        severity: "ephemeral",
+      },
+    );
+  }
+}
+
+function requiredString(
+  params: Record<string, unknown>,
+  field: string,
+  maxLength: number,
+): string {
+  const value = params[field];
+  if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
+    throw new ElizaError(
+      `Capability parameter "${field}" must be a nonblank string of at most ${maxLength} characters.`,
+      {
+        code: "MAPS_INVALID_INPUT",
+        context: { field },
+        severity: "ephemeral",
+      },
+    );
+  }
+  return value;
+}
+
+function optionalNear(
+  params: Record<string, unknown>,
+): Coordinates | undefined {
+  const hasLatitude = Object.hasOwn(params, "latitude");
+  const hasLongitude = Object.hasOwn(params, "longitude");
+  if (!hasLatitude && !hasLongitude) return undefined;
+  if (!hasLatitude || !hasLongitude) {
+    throw new ElizaError(
+      "search-places requires latitude and longitude together.",
+      {
+        code: "MAPS_INVALID_INPUT",
+        context: { fields: ["latitude", "longitude"] },
+        severity: "ephemeral",
+      },
+    );
+  }
+  const { latitude, longitude } = params;
+  if (typeof latitude !== "number" || typeof longitude !== "number") {
+    throw new ElizaError("Coordinates must be numbers in decimal degrees.", {
+      code: "MAPS_INVALID_INPUT",
+      context: { fields: ["latitude", "longitude"] },
+      severity: "ephemeral",
+    });
+  }
+  return { latitude, longitude };
+}
+
+function summarizePlaces(page: PlacePage): string {
+  if (page.places.length === 0) return "No places matched that search.";
+  const names = page.places.slice(0, 5).map((place) => place.name);
+  const more =
+    page.places.length > names.length
+      ? ` and ${page.places.length - names.length} more`
+      : "";
+  return `Found ${page.places.length} places: ${names.join(", ")}${more}.`;
+}
+
+async function resolvePlace(
+  service: MapsService,
+  placeId: string,
+  field: string,
+): Promise<PlaceRef> {
+  const place = await service.getPlace(placeId);
+  if (!place) {
+    throw new ElizaError(`No place exists for ${field} "${placeId}".`, {
+      code: "MAPS_NOT_FOUND",
+      context: { field, placeId },
+      severity: "ephemeral",
+    });
+  }
+  return place;
+}
+
+async function planAlternatives(
+  service: MapsService,
+  origin: PlaceRef,
+  destination: PlaceRef,
+): Promise<RouteAlternative[]> {
+  const alternatives: RouteAlternative[] = [];
+  for (const travelMode of ROUTE_MODES) {
+    try {
+      const route = await service.planRoute({
+        origin,
+        destination,
+        travelMode,
+      });
+      alternatives.push({ travelMode, status: "ok", route });
+    } catch (error) {
+      // error-policy:J4 an unsupported or failing travel mode renders as an
+      // explicit per-mode error row; it never hides the modes that did resolve.
+      const normalized = isElizaError(error)
+        ? error
+        : toElizaError(error, "MAPS_PROVIDER_FAILURE");
+      alternatives.push({
+        travelMode,
+        status: "error",
+        code: normalized.code,
+        message: normalized.message,
+      });
+    }
+  }
+  return alternatives;
+}
+
+function summarizeAlternatives(alternatives: RouteAlternative[]): string {
+  const resolved = alternatives.filter(
+    (alternative) => alternative.status === "ok",
+  );
+  if (resolved.length === 0) return "No travel mode produced a route.";
+  return `Planned ${resolved.length} route ${
+    resolved.length === 1 ? "alternative" : "alternatives"
+  }: ${resolved
+    .map(
+      (alternative) =>
+        `${alternative.travelMode} ${(alternative.route.distanceMeters / 1000).toFixed(1)} km in ${Math.round(alternative.route.durationSeconds / 60)} min`,
+    )
+    .join("; ")}.`;
+}
+
+function summarizeSavedPlaces(places: SavedPlace[]): string {
+  if (places.length === 0) return "No places are saved yet.";
+  return `Saved places: ${places
+    .slice(0, 8)
+    .map((saved) => saved.label)
+    .join(", ")}${places.length > 8 ? ` and ${places.length - 8} more` : ""}.`;
+}
+
+function summarizeSnapshot(snapshot: MapsViewSnapshot): string {
+  const providerText = snapshot.providerAvailable
+    ? `Providers: ${snapshot.providers.map((provider) => provider.id).join(", ")}.`
+    : "No maps provider is connected.";
+  const savedText =
+    snapshot.savedPlaces.status === "ok"
+      ? `${snapshot.savedPlaces.places.length} saved ${
+          snapshot.savedPlaces.places.length === 1 ? "place" : "places"
+        }.`
+      : snapshot.savedPlaces.reason;
+  return `${providerText} ${savedText}`;
+}
+
+async function dispatchCapability(
+  runtime: IAgentRuntime,
+  service: MapsService,
+  capability: string,
+  paramsValue?: Record<string, unknown>,
+): Promise<MapsInteractResult> {
+  const params = paramsRecord(paramsValue);
+  if (capability === "get-maps-state") {
+    assertOnlyParams(params, []);
+    const snapshot = await buildMapsViewSnapshot(runtime, service);
+    return { success: true, text: summarizeSnapshot(snapshot), data: snapshot };
+  }
+  if (capability === "search-places") {
+    assertOnlyParams(params, [
+      "query",
+      "latitude",
+      "longitude",
+      "cursor",
+      "limit",
+    ]);
+    const near = optionalNear(params);
+    const cursor = Object.hasOwn(params, "cursor")
+      ? requiredString(params, "cursor", 2_048)
+      : undefined;
+    const limit = params.limit;
+    if (
+      limit !== undefined &&
+      (typeof limit !== "number" || !Number.isInteger(limit))
+    ) {
+      throw new ElizaError("search-places limit must be an integer.", {
+        code: "MAPS_INVALID_INPUT",
+        context: { field: "limit" },
+        severity: "ephemeral",
+      });
+    }
+    const page = await service.searchPlaces({
+      query: requiredString(params, "query", 500),
+      ...(near ? { near } : {}),
+      ...(cursor ? { cursor } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    return { success: true, text: summarizePlaces(page), data: page };
+  }
+  if (capability === "get-place") {
+    assertOnlyParams(params, ["placeId"]);
+    const place = await resolvePlace(
+      service,
+      requiredString(params, "placeId", 512),
+      "placeId",
+    );
+    return {
+      success: true,
+      text: `${place.name}${place.formattedAddress ? ` — ${place.formattedAddress}` : ""}.`,
+      data: { place },
+    };
+  }
+  if (capability === "plan-route-alternatives") {
+    assertOnlyParams(params, ["originPlaceId", "destinationPlaceId"]);
+    const origin = await resolvePlace(
+      service,
+      requiredString(params, "originPlaceId", 512),
+      "originPlaceId",
+    );
+    const destination = await resolvePlace(
+      service,
+      requiredString(params, "destinationPlaceId", 512),
+      "destinationPlaceId",
+    );
+    const alternatives = await planAlternatives(service, origin, destination);
+    if (!alternatives.some((alternative) => alternative.status === "ok")) {
+      const firstFailure = alternatives.find(
+        (alternative) => alternative.status === "error",
+      );
+      return {
+        success: false,
+        text: "No travel mode produced a route between those places.",
+        data: { origin, destination, alternatives },
+        error: {
+          code: firstFailure?.code ?? "MAPS_PROVIDER_FAILURE",
+          message: firstFailure?.message ?? "No travel mode produced a route.",
+        },
+      };
+    }
+    return {
+      success: true,
+      text: summarizeAlternatives(alternatives),
+      data: { origin, destination, alternatives },
+    };
+  }
+  if (capability === "get-saved-places") {
+    assertOnlyParams(params, []);
+    const snapshot = await buildMapsViewSnapshot(runtime, service);
+    if (snapshot.savedPlaces.status === "unavailable") {
+      return {
+        success: false,
+        text: snapshot.savedPlaces.reason,
+        error: {
+          code: "MAPS_PROVIDER_UNAVAILABLE",
+          message: snapshot.savedPlaces.reason,
+        },
+      };
+    }
+    return {
+      success: true,
+      text: summarizeSavedPlaces(snapshot.savedPlaces.places),
+      data: { places: snapshot.savedPlaces.places },
+    };
+  }
+  throw new ElizaError(`Maps does not support capability "${capability}".`, {
+    code: "MAPS_UNKNOWN_CAPABILITY",
+    context: { capability },
+    severity: "ephemeral",
+  });
+}
+
+export async function serverInteract(
+  capability: string,
+  params?: Record<string, unknown>,
+  context?: { runtime?: IAgentRuntime },
+): Promise<MapsInteractResult> {
+  try {
+    if (!context?.runtime) {
+      throw new ElizaError(
+        "Maps interaction requires an owning runtime service.",
+        { code: "MAPS_PROVIDER_UNAVAILABLE", severity: "ephemeral" },
+      );
+    }
+    return await dispatchCapability(
+      context.runtime,
+      getMapsService(context.runtime),
+      capability,
+      params,
+    );
+  } catch (error) {
+    // error-policy:J1 expected capability input and provider failures become
+    // explicit false results; systemic failures reach the shared route boundary.
+    const normalized = isElizaError(error)
+      ? error
+      : toElizaError(error, "MAPS_INTERACT_FAILED");
+    if (!EXPECTED_FAILURE_CODES.has(normalized.code)) throw normalized;
+    return {
+      success: false,
+      text: normalized.message,
+      error: { code: normalized.code, message: normalized.message },
+    };
+  }
+}

--- a/plugins/plugin-maps/src/plugin.ts
+++ b/plugins/plugin-maps/src/plugin.ts
@@ -1,8 +1,14 @@
-/** Registers the maps service and discoverable maps action family. */
+/**
+ * Registers the maps service, the discoverable maps action family, and the
+ * routed /maps web view with its read-only capability broker.
+ */
 
 import type { Plugin } from "@elizaos/core";
 import { promoteSubactionsToActions } from "@elizaos/core";
 import { bindPromotedMapsSaveHandler, mapsAction } from "./action.js";
+import { MAPS_VIEW_CAPABILITIES } from "./capabilities.js";
+import { serverInteract } from "./interact.js";
+import { mapsRoutes } from "./routes.js";
 import { MapsService } from "./service.js";
 
 const promotedMapsActions = promoteSubactionsToActions(mapsAction);
@@ -26,6 +32,37 @@ export const mapsPlugin: Plugin = {
     "Provider-neutral place search, routes, saved places, sharing, and navigation handoffs.",
   services: [MapsService],
   actions: [...promotedMapsActions],
+  routes: mapsRoutes,
+  views: [
+    {
+      id: "maps",
+      label: "Maps",
+      roleGate: { minRole: "OWNER" },
+      description:
+        "Place search, route alternatives, and the owner's saved places on a rendered map.",
+      icon: "Map",
+      path: "/maps",
+      order: 930,
+      viewKind: "release",
+      modalities: ["gui"],
+      tags: ["maps", "places", "directions", "routes", "navigation"],
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "MapsView",
+      surface: { header: "fullscreen" },
+      relatedActions: [
+        "MAPS",
+        "MAPS_PLACE",
+        "MAPS_ROUTE",
+        "MAPS_SAVE",
+        "MAPS_SHARE",
+        "MAPS_NAVIGATE",
+      ],
+      capabilities: MAPS_VIEW_CAPABILITIES,
+      serverInteract,
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+  ],
 };
 
 export default mapsPlugin;

--- a/plugins/plugin-maps/src/register.ts
+++ b/plugins/plugin-maps/src/register.ts
@@ -1,0 +1,24 @@
+/**
+ * Statically registers the routed /maps page with the app shell.
+ *
+ * Native clients prohibit remotely supplied JavaScript, so the renderer is a
+ * lazy chunk in the signed app bundle while the runtime plugin supplies only
+ * metadata, capabilities, and durable state.
+ */
+
+import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+
+registerAppShellPage({
+  id: "maps",
+  pluginId: "@elizaos/plugin-maps",
+  label: "Maps",
+  icon: "Map",
+  path: "/maps",
+  order: 930,
+  viewKind: "release",
+  surface: { header: "fullscreen" },
+  loader: () =>
+    import("./views/MapsView.tsx").then((module) => ({
+      default: module.MapsView,
+    })),
+});

--- a/plugins/plugin-maps/src/routes.ts
+++ b/plugins/plugin-maps/src/routes.ts
@@ -1,0 +1,57 @@
+/**
+ * Authenticated state boundary for the routed /maps view. Reads return the
+ * validated snapshot DTO; interaction goes through the shared view-capability
+ * broker so the mounted view and chat never grow parallel transports.
+ */
+
+import { isElizaError, type Route, toElizaError } from "@elizaos/core";
+import { getMapsService } from "./service.js";
+import { buildMapsViewSnapshot } from "./view-state.js";
+
+export const mapsRoutes: Route[] = [
+  {
+    type: "GET",
+    name: "maps-state",
+    path: "/api/maps/state",
+    rawPath: true,
+    modes: ["local", "local-only", "cloud", "remote"],
+    modeReason:
+      "Maps provider registration and saved places are owned by the active runtime in every supported topology",
+    routeHandler: async (context) => {
+      try {
+        return {
+          status: 200,
+          body: {
+            success: true,
+            data: await buildMapsViewSnapshot(
+              context.runtime,
+              getMapsService(context.runtime),
+            ),
+          },
+        };
+      } catch (error) {
+        // error-policy:J1 boundary translation — this authenticated HTTP
+        // boundary reports systemic failures and never fabricates an empty
+        // snapshot.
+        const normalized = isElizaError(error)
+          ? error
+          : toElizaError(error, "MAPS_ROUTE_FAILED");
+        context.runtime.reportError("MapsRoutes", normalized, {
+          method: context.method,
+          path: context.path,
+        });
+        return {
+          status:
+            normalized.code === "MAPS_PROVIDER_UNAVAILABLE" ||
+            normalized.code === "MAPS_STORAGE_FAILURE"
+              ? 503
+              : 500,
+          body: {
+            success: false,
+            error: { code: normalized.code, message: normalized.message },
+          },
+        };
+      }
+    },
+  },
+];

--- a/plugins/plugin-maps/src/service.ts
+++ b/plugins/plugin-maps/src/service.ts
@@ -23,6 +23,13 @@ import {
 
 export const MAPS_SERVICE_TYPE = "maps";
 
+export interface MapsProviderDescription {
+  id: string;
+  /** Provider-mandated attribution line, or null when the adapter has none. */
+  attribution: string | null;
+  isDefault: boolean;
+}
+
 export interface MapsHandoff {
   kind: "share" | "navigate";
   uri: string;
@@ -163,6 +170,18 @@ export class MapsService extends Service {
 
   listAdapters(): readonly string[] {
     return [...this.adapters.keys()];
+  }
+
+  /**
+   * Registered providers as the routed view renders them: id, required
+   * attribution line when the adapter declares one, and default selection.
+   */
+  describeProviders(): readonly MapsProviderDescription[] {
+    return [...this.adapters.values()].map((adapter) => ({
+      id: adapter.id,
+      attribution: adapter.attribution ?? null,
+      isDefault: adapter.id === this.defaultAdapterId,
+    }));
   }
 
   async searchPlaces(

--- a/plugins/plugin-maps/src/view-contract.ts
+++ b/plugins/plugin-maps/src/view-contract.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared zod contract for the routed /maps view transport. This module is
+ * bundled into the browser view, so it must stay free of runtime imports —
+ * only zod and the domain type schemas. The server-side snapshot producer
+ * lives in `view-state.ts`.
+ */
+
+import * as z from "zod";
+import {
+  routePlanSchema,
+  savedPlaceSchema,
+  travelModeSchema,
+} from "./types.js";
+
+export const mapsViewProviderSchema = z
+  .object({
+    id: z.string().min(1).max(64),
+    attribution: z.string().min(1).max(500).nullable(),
+    isDefault: z.boolean(),
+  })
+  .strict();
+
+export const mapsSavedPlacesStateSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("ok"),
+      places: z.array(savedPlaceSchema).max(100),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      reason: z.string().min(1).max(500),
+    })
+    .strict(),
+]);
+
+export const mapsViewSnapshotSchema = z
+  .object({
+    providers: z.array(mapsViewProviderSchema).max(32),
+    /** True only when a default adapter can serve search and route reads. */
+    providerAvailable: z.boolean(),
+    savedPlaces: mapsSavedPlacesStateSchema,
+  })
+  .strict();
+
+/**
+ * One per-travel-mode outcome from `plan-route-alternatives`. A mode the
+ * provider cannot serve is an explicit error entry, never a silently missing
+ * row, so the view can render partial availability truthfully.
+ */
+export const routeAlternativeSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      travelMode: travelModeSchema,
+      status: z.literal("ok"),
+      route: routePlanSchema,
+    })
+    .strict(),
+  z
+    .object({
+      travelMode: travelModeSchema,
+      status: z.literal("error"),
+      code: z.string().min(1).max(120),
+      message: z.string().min(1).max(1_000),
+    })
+    .strict(),
+]);
+
+export type MapsViewProvider = z.infer<typeof mapsViewProviderSchema>;
+export type MapsSavedPlacesState = z.infer<typeof mapsSavedPlacesStateSchema>;
+export type MapsViewSnapshot = z.infer<typeof mapsViewSnapshotSchema>;
+export type RouteAlternative = z.infer<typeof routeAlternativeSchema>;

--- a/plugins/plugin-maps/src/view-state.ts
+++ b/plugins/plugin-maps/src/view-state.ts
@@ -1,0 +1,48 @@
+/**
+ * Server-side producer for the routed /maps view snapshot. Builds the DTO from
+ * the registered provider adapters and the owner's durable saved places; the
+ * validated shape itself lives in `view-contract.ts`, which both the server
+ * broker and the browser bundle share. Saved places are owner-scoped: when no
+ * canonical owner entity is configured, the snapshot carries an explicit
+ * unavailable state instead of a healthy-looking empty collection.
+ */
+
+import { type IAgentRuntime, resolveCanonicalOwnerId } from "@elizaos/core";
+import type { MapsService } from "./service.js";
+import type {
+  MapsSavedPlacesState,
+  MapsViewSnapshot,
+} from "./view-contract.js";
+
+export type {
+  MapsSavedPlacesState,
+  MapsViewProvider,
+  MapsViewSnapshot,
+  RouteAlternative,
+} from "./view-contract.js";
+export {
+  mapsSavedPlacesStateSchema,
+  mapsViewProviderSchema,
+  mapsViewSnapshotSchema,
+  routeAlternativeSchema,
+} from "./view-contract.js";
+
+export async function buildMapsViewSnapshot(
+  runtime: IAgentRuntime,
+  service: MapsService,
+): Promise<MapsViewSnapshot> {
+  const providers = service.describeProviders();
+  const ownerEntityId = resolveCanonicalOwnerId(runtime);
+  const savedPlaces: MapsSavedPlacesState = ownerEntityId
+    ? { status: "ok", places: await service.listSavedPlaces(ownerEntityId) }
+    : {
+        status: "unavailable",
+        reason:
+          "Saved places require a configured owner entity for this agent.",
+      };
+  return {
+    providers: [...providers],
+    providerAvailable: providers.length > 0,
+    savedPlaces,
+  };
+}

--- a/plugins/plugin-maps/src/views/MapsView.test.tsx
+++ b/plugins/plugin-maps/src/views/MapsView.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Component coverage for the routed /maps surface: loading, transport-error,
+ * offline, provider-unavailable, designed-empty search, results with category
+ * filters, place details, route alternatives with explicit per-mode failures,
+ * saved places, and attribution. The state hook and broker transport are
+ * mocked; the deterministic fixture shapes match the shared zod contract.
+ *
+ * @vitest-environment jsdom
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PlacePage, PlaceRef } from "../types.js";
+import type { MapsViewSnapshot } from "../view-contract.js";
+import type { MapsViewState } from "./useMapsViewState.js";
+
+const stateHook = vi.hoisted(() => vi.fn());
+const transport = vi.hoisted(() => ({
+  searchPlaces: vi.fn(),
+  planRouteAlternatives: vi.fn(),
+}));
+
+vi.mock("./useMapsViewState.js", () => ({
+  useMapsViewState: stateHook,
+}));
+
+vi.mock("./mapsData.js", () => ({
+  searchPlaces: transport.searchPlaces,
+  planRouteAlternatives: transport.planRouteAlternatives,
+  getPlace: vi.fn(),
+  fetchMapsState: vi.fn(),
+  MAPS_STATE_UPDATED_EVENT: "maps:state-updated",
+  MAPS_UPDATED_EVENT: "view:maps:updated",
+}));
+
+import { MapsView } from "./MapsView.js";
+
+const pier: PlaceRef = {
+  provider: "fixture-maps",
+  providerPlaceId: "pier-1",
+  name: "Santa Monica Pier",
+  coordinates: { latitude: 34.0092, longitude: -118.4973 },
+  formattedAddress: "200 Santa Monica Pier",
+  categories: ["landmark"],
+};
+const cafe: PlaceRef = {
+  ...pier,
+  providerPlaceId: "cafe-1",
+  name: "Harbor Cafe",
+  coordinates: { latitude: 34.0101, longitude: -118.4931 },
+  formattedAddress: "12 Harbor Way",
+  categories: ["cafe"],
+};
+
+function snapshot(overrides: Partial<MapsViewSnapshot> = {}): MapsViewSnapshot {
+  return {
+    providers: [
+      {
+        id: "fixture-maps",
+        attribution: "Map data © Fixture Maps contributors",
+        isDefault: true,
+      },
+    ],
+    providerAvailable: true,
+    savedPlaces: { status: "ok", places: [] },
+    ...overrides,
+  };
+}
+
+function hookState(overrides: Partial<MapsViewState> = {}): MapsViewState {
+  return {
+    snapshot: snapshot(),
+    loading: false,
+    error: null,
+    offline: false,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function page(places: PlaceRef[], nextCursor: string | null = null): PlacePage {
+  return { places, nextCursor };
+}
+
+async function searchFor(query: string): Promise<void> {
+  fireEvent.change(screen.getByLabelText("Search places"), {
+    target: { value: query },
+  });
+  fireEvent.submit(screen.getByTestId("maps-search-form"));
+  await waitFor(() => expect(transport.searchPlaces).toHaveBeenCalled());
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("MapsView", () => {
+  it("renders the loading phase before any snapshot arrives", () => {
+    stateHook.mockReturnValue(hookState({ snapshot: null, loading: true }));
+    render(<MapsView />);
+    expect(screen.getByTestId("maps-loading")).toBeTruthy();
+    expect(screen.queryByTestId("maps-map-pane")).toBeNull();
+  });
+
+  it("renders a transport error distinctly from empty state", () => {
+    stateHook.mockReturnValue(
+      hookState({
+        snapshot: null,
+        error: "Maps could not reach the local agent.",
+      }),
+    );
+    render(<MapsView />);
+    expect(screen.getByTestId("maps-error").textContent).toContain(
+      "could not reach",
+    );
+    expect(screen.queryByTestId("maps-empty")).toBeNull();
+  });
+
+  it("shows the offline banner and disables search while offline", () => {
+    stateHook.mockReturnValue(hookState({ offline: true }));
+    render(<MapsView />);
+    expect(screen.getByTestId("maps-offline")).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Search places") as HTMLInputElement).disabled,
+    ).toBe(true);
+  });
+
+  it("renders an explicit provider-unavailable state", () => {
+    stateHook.mockReturnValue(
+      hookState({
+        snapshot: snapshot({ providers: [], providerAvailable: false }),
+      }),
+    );
+    render(<MapsView />);
+    expect(screen.getByTestId("maps-provider-unavailable")).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Search places") as HTMLInputElement).disabled,
+    ).toBe(true);
+  });
+
+  it("renders designed-empty results after a search with no matches", async () => {
+    stateHook.mockReturnValue(hookState());
+    transport.searchPlaces.mockResolvedValue(page([]));
+    render(<MapsView />);
+    await searchFor("empty");
+    await waitFor(() => expect(screen.getByTestId("maps-empty")).toBeTruthy());
+    expect(screen.queryByTestId("maps-search-error")).toBeNull();
+  });
+
+  it("renders a search failure as a distinct error state", async () => {
+    stateHook.mockReturnValue(hookState());
+    transport.searchPlaces.mockRejectedValue(new Error("Rate limited."));
+    render(<MapsView />);
+    await searchFor("pier");
+    await waitFor(() =>
+      expect(screen.getByTestId("maps-search-error").textContent).toContain(
+        "Rate limited.",
+      ),
+    );
+    expect(screen.queryByTestId("maps-empty")).toBeNull();
+  });
+
+  it("lists results, plots markers, and filters by category", async () => {
+    stateHook.mockReturnValue(hookState());
+    transport.searchPlaces.mockResolvedValue(page([pier, cafe]));
+    render(<MapsView />);
+    await searchFor("santa monica");
+    await waitFor(() =>
+      expect(screen.getByTestId("maps-results").textContent).toContain(
+        "Harbor Cafe",
+      ),
+    );
+    expect(screen.getAllByTestId("maps-marker")).toHaveLength(2);
+    expect(screen.getByTestId("maps-attribution").textContent).toContain(
+      "Fixture Maps contributors",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "cafe" }));
+    expect(screen.getByTestId("maps-results").textContent).not.toContain(
+      "Santa Monica Pier",
+    );
+    expect(screen.getAllByTestId("maps-marker")).toHaveLength(1);
+  });
+
+  it("shows place details and route alternatives with explicit mode failures", async () => {
+    stateHook.mockReturnValue(hookState());
+    transport.searchPlaces.mockResolvedValue(page([pier, cafe]));
+    transport.planRouteAlternatives.mockResolvedValue({
+      origin: pier,
+      destination: cafe,
+      alternatives: [
+        {
+          travelMode: "drive",
+          status: "ok",
+          route: {
+            provider: "fixture-maps",
+            routeId: "route-drive",
+            origin: pier,
+            destination: cafe,
+            travelMode: "drive",
+            distanceMeters: 2_400,
+            durationSeconds: 900,
+            warnings: ["Toll road."],
+          },
+        },
+        {
+          travelMode: "transit",
+          status: "error",
+          code: "MAPS_PROVIDER_REJECTED",
+          message: "Transit routing is not offered here.",
+        },
+      ],
+    });
+    render(<MapsView />);
+    await searchFor("santa monica");
+    await waitFor(() => screen.getByTestId("maps-results"));
+
+    fireEvent.click(
+      within(screen.getByTestId("maps-results")).getByText("Santa Monica Pier"),
+    );
+    expect(screen.getByTestId("maps-place-details").textContent).toContain(
+      "200 Santa Monica Pier",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Set as origin" }));
+
+    fireEvent.click(
+      within(screen.getByTestId("maps-results")).getByText("Harbor Cafe"),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Routes from Santa Monica Pier/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("maps-route-alternatives")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("maps-route-drive").textContent).toContain(
+      "2.4 km",
+    );
+    expect(screen.getByTestId("maps-route-transit").textContent).toContain(
+      "unavailable: Transit routing is not offered here.",
+    );
+    expect(screen.getByTestId("maps-route-polyline")).toBeTruthy();
+  });
+
+  it("renders saved places, their designed-empty state, and unavailability", () => {
+    stateHook.mockReturnValue(
+      hookState({
+        snapshot: snapshot({
+          savedPlaces: {
+            status: "ok",
+            places: [
+              {
+                id: "66666666-6666-4666-a666-666666666666",
+                ownerEntityId: "22222222-2222-4222-a222-222222222222",
+                place: pier,
+                label: "Weekend spot",
+                createdAt: "2026-08-01T00:00:00.000Z",
+                updatedAt: "2026-08-01T00:00:00.000Z",
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    const { unmount } = render(<MapsView />);
+    expect(screen.getByTestId("maps-saved-places").textContent).toContain(
+      "Weekend spot",
+    );
+    unmount();
+
+    stateHook.mockReturnValue(
+      hookState({
+        snapshot: snapshot({
+          savedPlaces: { status: "unavailable", reason: "No owner entity." },
+        }),
+      }),
+    );
+    render(<MapsView />);
+    expect(screen.getByTestId("maps-saved-unavailable").textContent).toContain(
+      "No owner entity.",
+    );
+  });
+});

--- a/plugins/plugin-maps/src/views/MapsView.tsx
+++ b/plugins/plugin-maps/src/views/MapsView.tsx
@@ -1,0 +1,788 @@
+/**
+ * Routed /maps surface: responsive map and list panes over the authoritative
+ * server snapshot, with place search, category filters, place details, route
+ * alternatives across every travel mode, saved places, and provider
+ * attribution. All reads dispatch through the shared view-capability broker;
+ * saved-place writes stay on the promoted MAPS_SAVE chat action.
+ *
+ * Loading, designed-empty, transport-error, offline, and provider-unavailable
+ * are distinct renders — nothing degrades into a healthy-looking blank map.
+ */
+
+import { type FormEvent, Fragment, useMemo, useState } from "react";
+import type { PlacePage, PlaceRef, RoutePlan } from "../types.js";
+import type { RouteAlternative } from "../view-contract.js";
+import { decodePolyline, projectToViewBox } from "./geometry.js";
+import {
+  planRouteAlternatives,
+  type RouteAlternativesData,
+  searchPlaces,
+} from "./mapsData.js";
+import { useMapsViewState } from "./useMapsViewState.js";
+import {
+  ACCENT,
+  BUTTON_STYLE,
+  ERROR_PANEL_STYLE,
+  FIELD_STYLE,
+  GLASS_PANEL_STYLE,
+  PRIMARY_BUTTON_STYLE,
+  SECONDARY_TEXT_STYLE,
+  VIEW_ROOT_STYLE,
+  VIEW_SCROLL_STYLE,
+  ViewState,
+} from "./viewPrimitives.js";
+
+type SearchPhase =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; page: PlacePage; appended: PlaceRef[] };
+
+type RoutePhase =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; result: RouteAlternativesData };
+
+const MAP_WIDTH = 100;
+const MAP_HEIGHT = 62;
+const MAP_PADDING = 8;
+
+function placeKey(place: PlaceRef): string {
+  return `${place.provider}:${place.providerPlaceId}`;
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error && cause.message.trim()
+    ? cause.message
+    : "Maps could not reach the local agent.";
+}
+
+function formatDistance(distanceMeters: number): string {
+  return distanceMeters >= 1_000
+    ? `${(distanceMeters / 1_000).toFixed(1)} km`
+    : `${distanceMeters} m`;
+}
+
+function formatDuration(durationSeconds: number): string {
+  const minutes = Math.round(durationSeconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  return `${Math.floor(minutes / 60)} h ${minutes % 60} min`;
+}
+
+function _routePath(route: RoutePlan): ReturnType<typeof projectToViewBox> {
+  const points = route.encodedPolyline
+    ? decodePolyline(route.encodedPolyline)
+    : [route.origin.coordinates, route.destination.coordinates];
+  return projectToViewBox(points, MAP_WIDTH, MAP_HEIGHT, MAP_PADDING);
+}
+
+function MapPane({
+  places,
+  selected,
+  route,
+  onSelect,
+}: {
+  places: readonly PlaceRef[];
+  selected: PlaceRef | null;
+  route: RoutePlan | null;
+  onSelect: (place: PlaceRef) => void;
+}) {
+  const coordinates = useMemo(() => {
+    const all = places.map((place) => place.coordinates);
+    if (route) {
+      all.push(
+        ...(route.encodedPolyline
+          ? decodePolyline(route.encodedPolyline)
+          : [route.origin.coordinates, route.destination.coordinates]),
+      );
+    }
+    return all;
+  }, [places, route]);
+  const projected = useMemo(
+    () => projectToViewBox(coordinates, MAP_WIDTH, MAP_HEIGHT, MAP_PADDING),
+    [coordinates],
+  );
+  const markerPoints = projected.slice(0, places.length);
+  const routePoints = route ? projected.slice(places.length) : [];
+  return (
+    <figure
+      aria-label={
+        places.length === 0
+          ? "Map with no plotted places"
+          : `Map plotting ${places.length} ${places.length === 1 ? "place" : "places"}`
+      }
+      data-testid="maps-map-pane"
+      style={{ ...GLASS_PANEL_STYLE, margin: 0, padding: 10, minWidth: 0 }}
+    >
+      <svg
+        role="img"
+        aria-label={
+          places.length === 0
+            ? "Empty map canvas"
+            : `Map markers for ${places.map((place) => place.name).join(", ")}`
+        }
+        viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
+        style={{ display: "block", width: "100%", height: "auto" }}
+      >
+        <rect
+          x={0}
+          y={0}
+          width={MAP_WIDTH}
+          height={MAP_HEIGHT}
+          rx={4}
+          fill="color-mix(in srgb, var(--bg, #080808) 82%, transparent)"
+        />
+        {[1, 2, 3].map((line) => (
+          <Fragment key={line}>
+            <line
+              x1={0}
+              x2={MAP_WIDTH}
+              y1={(MAP_HEIGHT / 4) * line}
+              y2={(MAP_HEIGHT / 4) * line}
+              stroke="rgba(255,255,255,.06)"
+              strokeWidth={0.3}
+            />
+            <line
+              y1={0}
+              y2={MAP_HEIGHT}
+              x1={(MAP_WIDTH / 4) * line}
+              x2={(MAP_WIDTH / 4) * line}
+              stroke="rgba(255,255,255,.06)"
+              strokeWidth={0.3}
+            />
+          </Fragment>
+        ))}
+        {routePoints.length >= 2 ? (
+          <polyline
+            data-testid="maps-route-polyline"
+            points={routePoints
+              .map((point) => `${point.x},${point.y}`)
+              .join(" ")}
+            fill="none"
+            stroke={ACCENT}
+            strokeWidth={1.4}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : null}
+        {places.map((place, index) => {
+          const point = markerPoints[index];
+          if (!point) return null;
+          const isSelected = selected
+            ? placeKey(selected) === placeKey(place)
+            : false;
+          return (
+            // biome-ignore lint/a11y/useSemanticElements: SVG markers cannot be <button>; role+tabIndex+key handler provide the control semantics.
+            <circle
+              key={placeKey(place)}
+              data-testid="maps-marker"
+              role="button"
+              aria-label={`Select ${place.name} on the map`}
+              tabIndex={0}
+              cx={point.x}
+              cy={point.y}
+              r={isSelected ? 2.6 : 1.8}
+              fill={isSelected ? ACCENT : "rgba(255,255,255,.72)"}
+              stroke={isSelected ? "rgba(255,255,255,.85)" : "transparent"}
+              strokeWidth={0.4}
+              style={{ cursor: "pointer" }}
+              onClick={() => onSelect(place)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(place);
+                }
+              }}
+            >
+              <title>{place.name}</title>
+            </circle>
+          );
+        })}
+      </svg>
+      {places.length === 0 ? (
+        <figcaption style={{ ...SECONDARY_TEXT_STYLE, padding: "8px 4px 2px" }}>
+          Search for places to plot them here.
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+function RouteAlternativeRow({
+  alternative,
+  active,
+  onSelect,
+}: {
+  alternative: RouteAlternative;
+  active: boolean;
+  onSelect: (route: RoutePlan) => void;
+}) {
+  if (alternative.status === "error") {
+    return (
+      <li
+        data-testid={`maps-route-${alternative.travelMode}`}
+        style={{ ...SECONDARY_TEXT_STYLE, listStyle: "none" }}
+      >
+        <span style={{ fontWeight: 650, textTransform: "capitalize" }}>
+          {alternative.travelMode}
+        </span>
+        {" — unavailable: "}
+        {alternative.message}
+      </li>
+    );
+  }
+  const { route } = alternative;
+  return (
+    <li style={{ listStyle: "none" }}>
+      <button
+        type="button"
+        data-testid={`maps-route-${alternative.travelMode}`}
+        aria-pressed={active}
+        onClick={() => onSelect(route)}
+        style={{
+          ...BUTTON_STYLE,
+          width: "100%",
+          justifyContent: "space-between",
+          ...(active
+            ? { background: ACCENT, color: "var(--accent-foreground, #fff)" }
+            : {}),
+        }}
+      >
+        <span style={{ textTransform: "capitalize" }}>
+          {alternative.travelMode}
+        </span>
+        <span>
+          {formatDistance(route.distanceMeters)} ·{" "}
+          {formatDuration(route.durationSeconds)}
+        </span>
+      </button>
+      {route.warnings.length > 0 ? (
+        <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 4 }}>
+          {route.warnings.join(" ")}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+export function MapsView() {
+  const { snapshot, loading, error, offline, refresh } = useMapsViewState();
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState<SearchPhase>({ phase: "idle" });
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [selected, setSelected] = useState<PlaceRef | null>(null);
+  const [routeOrigin, setRouteOrigin] = useState<PlaceRef | null>(null);
+  const [routes, setRoutes] = useState<RoutePhase>({ phase: "idle" });
+  const [activeRoute, setActiveRoute] = useState<RoutePlan | null>(null);
+
+  const providerAvailable = snapshot?.providerAvailable === true;
+  const searchDisabled = offline || !providerAvailable;
+
+  const results = useMemo<PlaceRef[]>(() => {
+    if (search.phase !== "ready") return [];
+    return [...search.page.places, ...search.appended];
+  }, [search]);
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>();
+    for (const place of results) {
+      for (const category of place.categories) unique.add(category);
+    }
+    return [...unique].sort();
+  }, [results]);
+
+  const visiblePlaces = useMemo(
+    () =>
+      categoryFilter
+        ? results.filter((place) => place.categories.includes(categoryFilter))
+        : results,
+    [results, categoryFilter],
+  );
+
+  const runSearch = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed || searchDisabled) return;
+    setSearch({ phase: "loading" });
+    setCategoryFilter(null);
+    try {
+      const page = await searchPlaces({ query: trimmed });
+      setSearch({ phase: "ready", page, appended: [] });
+    } catch (cause) {
+      // error-policy:J4 a failed search renders as a distinct error state.
+      setSearch({ phase: "error", message: errorMessage(cause) });
+    }
+  };
+
+  const loadMore = async () => {
+    if (search.phase !== "ready" || !search.page.nextCursor) return;
+    const current = search;
+    try {
+      const nextPage = await searchPlaces({
+        query: query.trim(),
+        cursor: current.page.nextCursor ?? undefined,
+      });
+      setSearch({
+        phase: "ready",
+        page: { ...nextPage, places: current.page.places },
+        appended: [...current.appended, ...nextPage.places],
+      });
+    } catch (cause) {
+      // error-policy:J4 pagination failure keeps loaded results and reports.
+      setSearch({ phase: "error", message: errorMessage(cause) });
+    }
+  };
+
+  const planRoutes = async (destination: PlaceRef) => {
+    if (!routeOrigin) return;
+    setRoutes({ phase: "loading" });
+    setActiveRoute(null);
+    try {
+      const result = await planRouteAlternatives({
+        originPlaceId: routeOrigin.providerPlaceId,
+        destinationPlaceId: destination.providerPlaceId,
+      });
+      setRoutes({ phase: "ready", result });
+      const firstResolved = result.alternatives.find(
+        (alternative) => alternative.status === "ok",
+      );
+      setActiveRoute(
+        firstResolved && firstResolved.status === "ok"
+          ? firstResolved.route
+          : null,
+      );
+    } catch (cause) {
+      // error-policy:J4 route failure renders as a distinct error state.
+      setRoutes({ phase: "error", message: errorMessage(cause) });
+    }
+  };
+
+  const selectPlace = (place: PlaceRef) => {
+    setSelected(place);
+    setRoutes({ phase: "idle" });
+    setActiveRoute(null);
+  };
+
+  const savedPlaces = snapshot?.savedPlaces ?? null;
+  const attribution = snapshot?.providers ?? [];
+
+  return (
+    <main
+      aria-busy={loading}
+      aria-label="Maps"
+      data-testid="maps-view"
+      style={VIEW_ROOT_STYLE}
+    >
+      <div data-testid="maps-scroll-region" style={VIEW_SCROLL_STYLE}>
+        {offline ? (
+          <div
+            role="status"
+            data-testid="maps-offline"
+            style={{
+              ...GLASS_PANEL_STYLE,
+              marginBottom: 12,
+              padding: 12,
+              boxShadow: `inset 0 0 0 1px ${ACCENT}, 0 18px 48px rgba(0,0,0,.20)`,
+            }}
+          >
+            You're offline. Showing the last loaded maps data; search and
+            routing are paused until the connection returns.
+          </div>
+        ) : null}
+        {snapshot === null ? (
+          <ViewState
+            loading={loading}
+            error={error}
+            empty={false}
+            emptyTitle=""
+            emptyBody=""
+          />
+        ) : (
+          <Fragment>
+            {error ? (
+              <div
+                role="alert"
+                style={{ ...ERROR_PANEL_STYLE, marginBottom: 12 }}
+              >
+                {error}
+                <button
+                  type="button"
+                  onClick={() => void refresh()}
+                  style={{ ...BUTTON_STYLE, marginInlineStart: 10 }}
+                >
+                  Retry
+                </button>
+              </div>
+            ) : null}
+            {!providerAvailable ? (
+              <div
+                data-testid="maps-provider-unavailable"
+                style={{ ...GLASS_PANEL_STYLE, marginBottom: 12, padding: 16 }}
+              >
+                <p style={{ margin: 0, fontWeight: 650 }}>
+                  No maps provider is connected
+                </p>
+                <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 6 }}>
+                  Connect a maps provider to search places and plan routes.
+                  Saved places remain available below.
+                </p>
+              </div>
+            ) : null}
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns:
+                  "repeat(auto-fit, minmax(min(100%, 340px), 1fr))",
+                gap: 12,
+                minWidth: 0,
+              }}
+            >
+              <section aria-label="Map and search" style={{ minWidth: 0 }}>
+                <form
+                  onSubmit={runSearch}
+                  aria-label="Place search"
+                  data-testid="maps-search-form"
+                  style={{ display: "flex", gap: 8, marginBottom: 12 }}
+                >
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search places…"
+                    aria-label="Search places"
+                    disabled={searchDisabled}
+                    style={FIELD_STYLE}
+                  />
+                  <button
+                    type="submit"
+                    disabled={searchDisabled || !query.trim()}
+                    style={PRIMARY_BUTTON_STYLE}
+                  >
+                    Search
+                  </button>
+                </form>
+                <MapPane
+                  places={visiblePlaces}
+                  selected={selected}
+                  route={activeRoute}
+                  onSelect={selectPlace}
+                />
+                {attribution.length > 0 ? (
+                  <p
+                    data-testid="maps-attribution"
+                    style={{
+                      ...SECONDARY_TEXT_STYLE,
+                      marginTop: 8,
+                      fontSize: 11,
+                    }}
+                  >
+                    {attribution
+                      .map(
+                        (provider) =>
+                          provider.attribution ?? `Data: ${provider.id}`,
+                      )
+                      .join(" · ")}
+                  </p>
+                ) : null}
+              </section>
+              <section aria-label="Results and details" style={{ minWidth: 0 }}>
+                {search.phase === "loading" ? (
+                  <div
+                    aria-live="polite"
+                    data-testid="maps-search-loading"
+                    style={{ ...GLASS_PANEL_STYLE, padding: 14 }}
+                  >
+                    <p style={SECONDARY_TEXT_STYLE}>Searching…</p>
+                  </div>
+                ) : null}
+                {search.phase === "error" ? (
+                  <div
+                    role="alert"
+                    data-testid="maps-search-error"
+                    style={ERROR_PANEL_STYLE}
+                  >
+                    {search.message}
+                  </div>
+                ) : null}
+                {search.phase === "ready" && results.length === 0 ? (
+                  <ViewState
+                    loading={false}
+                    error={null}
+                    empty
+                    emptyTitle="No places matched"
+                    emptyBody="Try a broader search term."
+                  />
+                ) : null}
+                {results.length > 0 ? (
+                  <Fragment>
+                    {categories.length > 0 ? (
+                      <fieldset
+                        aria-label="Filter by category"
+                        style={{
+                          display: "flex",
+                          flexWrap: "wrap",
+                          gap: 6,
+                          margin: "0 0 10px",
+                          padding: 0,
+                          border: "none",
+                        }}
+                      >
+                        <button
+                          type="button"
+                          aria-pressed={categoryFilter === null}
+                          onClick={() => setCategoryFilter(null)}
+                          style={{
+                            ...BUTTON_STYLE,
+                            minHeight: 32,
+                            ...(categoryFilter === null
+                              ? {
+                                  background: ACCENT,
+                                  color: "var(--accent-foreground, #fff)",
+                                }
+                              : {}),
+                          }}
+                        >
+                          All
+                        </button>
+                        {categories.map((category) => (
+                          <button
+                            key={category}
+                            type="button"
+                            aria-pressed={categoryFilter === category}
+                            onClick={() =>
+                              setCategoryFilter(
+                                categoryFilter === category ? null : category,
+                              )
+                            }
+                            style={{
+                              ...BUTTON_STYLE,
+                              minHeight: 32,
+                              ...(categoryFilter === category
+                                ? {
+                                    background: ACCENT,
+                                    color: "var(--accent-foreground, #fff)",
+                                  }
+                                : {}),
+                            }}
+                          >
+                            {category}
+                          </button>
+                        ))}
+                      </fieldset>
+                    ) : null}
+                    <ul
+                      aria-label="Search results"
+                      data-testid="maps-results"
+                      style={{
+                        margin: 0,
+                        padding: 0,
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      {visiblePlaces.map((place) => (
+                        <li key={placeKey(place)} style={{ listStyle: "none" }}>
+                          <button
+                            type="button"
+                            aria-pressed={
+                              selected
+                                ? placeKey(selected) === placeKey(place)
+                                : false
+                            }
+                            onClick={() => selectPlace(place)}
+                            style={{
+                              ...BUTTON_STYLE,
+                              width: "100%",
+                              justifyContent: "flex-start",
+                              textAlign: "start",
+                              flexDirection: "column",
+                              alignItems: "flex-start",
+                              gap: 2,
+                              ...(selected &&
+                              placeKey(selected) === placeKey(place)
+                                ? {
+                                    boxShadow: `inset 0 0 0 1.5px ${ACCENT}`,
+                                  }
+                                : {}),
+                            }}
+                          >
+                            <span style={{ fontWeight: 650 }}>
+                              {place.name}
+                            </span>
+                            {place.formattedAddress ? (
+                              <span style={{ ...SECONDARY_TEXT_STYLE }}>
+                                {place.formattedAddress}
+                              </span>
+                            ) : null}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                    {search.phase === "ready" && search.page.nextCursor ? (
+                      <button
+                        type="button"
+                        onClick={() => void loadMore()}
+                        style={{ ...BUTTON_STYLE, marginTop: 10 }}
+                      >
+                        More results
+                      </button>
+                    ) : null}
+                  </Fragment>
+                ) : null}
+                {selected ? (
+                  <article
+                    aria-label={`Details for ${selected.name}`}
+                    data-testid="maps-place-details"
+                    style={{ ...GLASS_PANEL_STYLE, marginTop: 12, padding: 16 }}
+                  >
+                    <h2 style={{ margin: 0, fontSize: 16 }}>{selected.name}</h2>
+                    {selected.formattedAddress ? (
+                      <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 4 }}>
+                        {selected.formattedAddress}
+                      </p>
+                    ) : null}
+                    <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 4 }}>
+                      {selected.coordinates.latitude.toFixed(5)},{" "}
+                      {selected.coordinates.longitude.toFixed(5)} ·{" "}
+                      {selected.provider}
+                    </p>
+                    {selected.categories.length > 0 ? (
+                      <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 4 }}>
+                        {selected.categories.join(" · ")}
+                      </p>
+                    ) : null}
+                    <div
+                      style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 8,
+                        marginTop: 12,
+                      }}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setRouteOrigin(selected)}
+                        style={BUTTON_STYLE}
+                      >
+                        Set as origin
+                      </button>
+                      <button
+                        type="button"
+                        disabled={
+                          !routeOrigin ||
+                          placeKey(routeOrigin) === placeKey(selected) ||
+                          offline
+                        }
+                        onClick={() => void planRoutes(selected)}
+                        style={PRIMARY_BUTTON_STYLE}
+                      >
+                        {routeOrigin
+                          ? `Routes from ${routeOrigin.name}`
+                          : "Pick an origin first"}
+                      </button>
+                    </div>
+                    {routes.phase === "loading" ? (
+                      <p
+                        aria-live="polite"
+                        data-testid="maps-routes-loading"
+                        style={{ ...SECONDARY_TEXT_STYLE, marginTop: 10 }}
+                      >
+                        Planning routes…
+                      </p>
+                    ) : null}
+                    {routes.phase === "error" ? (
+                      <div
+                        role="alert"
+                        data-testid="maps-routes-error"
+                        style={{ ...ERROR_PANEL_STYLE, marginTop: 10 }}
+                      >
+                        {routes.message}
+                      </div>
+                    ) : null}
+                    {routes.phase === "ready" ? (
+                      <ul
+                        aria-label="Route alternatives"
+                        data-testid="maps-route-alternatives"
+                        style={{
+                          margin: "10px 0 0",
+                          padding: 0,
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        {routes.result.alternatives.map((alternative) => (
+                          <RouteAlternativeRow
+                            key={alternative.travelMode}
+                            alternative={alternative}
+                            active={
+                              alternative.status === "ok" &&
+                              activeRoute?.routeId === alternative.route.routeId
+                            }
+                            onSelect={setActiveRoute}
+                          />
+                        ))}
+                      </ul>
+                    ) : null}
+                  </article>
+                ) : null}
+                <section
+                  aria-label="Saved places"
+                  data-testid="maps-saved-places"
+                  style={{ ...GLASS_PANEL_STYLE, marginTop: 12, padding: 16 }}
+                >
+                  <h2 style={{ margin: 0, fontSize: 15 }}>Saved places</h2>
+                  {savedPlaces === null ? null : savedPlaces.status ===
+                    "unavailable" ? (
+                    <p
+                      data-testid="maps-saved-unavailable"
+                      style={{ ...SECONDARY_TEXT_STYLE, marginTop: 8 }}
+                    >
+                      {savedPlaces.reason}
+                    </p>
+                  ) : savedPlaces.places.length === 0 ? (
+                    <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 8 }}>
+                      Nothing saved yet. Ask your agent in chat to save a place.
+                    </p>
+                  ) : (
+                    <ul
+                      style={{
+                        margin: "8px 0 0",
+                        padding: 0,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      {savedPlaces.places.map((saved) => (
+                        <li key={saved.id} style={{ listStyle: "none" }}>
+                          <button
+                            type="button"
+                            onClick={() => selectPlace(saved.place)}
+                            style={{
+                              ...BUTTON_STYLE,
+                              width: "100%",
+                              justifyContent: "space-between",
+                            }}
+                          >
+                            <span style={{ fontWeight: 650 }}>
+                              {saved.label}
+                            </span>
+                            <span style={SECONDARY_TEXT_STYLE}>
+                              {saved.place.name}
+                            </span>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              </section>
+            </div>
+          </Fragment>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default MapsView;

--- a/plugins/plugin-maps/src/views/geometry.test.ts
+++ b/plugins/plugin-maps/src/views/geometry.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Deterministic unit coverage for polyline decoding and viewBox projection —
+ * pure functions, no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { decodePolyline, projectToViewBox } from "./geometry.js";
+
+describe("decodePolyline", () => {
+  it("decodes the canonical Google example", () => {
+    expect(decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@")).toEqual([
+      { latitude: 38.5, longitude: -120.2 },
+      { latitude: 40.7, longitude: -120.95 },
+      { latitude: 43.252, longitude: -126.453 },
+    ]);
+  });
+
+  it("returns an empty path for an empty string", () => {
+    expect(decodePolyline("")).toEqual([]);
+  });
+
+  it("throws on truncated input instead of yielding a partial path", () => {
+    expect(() => decodePolyline("_p~iF")).toThrow(/truncated/);
+  });
+
+  it("throws on characters outside the polyline alphabet", () => {
+    expect(() => decodePolyline("!!")).toThrow(/invalid character/);
+  });
+});
+
+describe("projectToViewBox", () => {
+  it("maps the bounding box corners onto the padded viewBox", () => {
+    const projected = projectToViewBox(
+      [
+        { latitude: 0, longitude: 0 },
+        { latitude: 10, longitude: 20 },
+      ],
+      100,
+      60,
+      10,
+    );
+    // North (higher latitude) renders toward the top of the SVG.
+    expect(projected).toEqual([
+      { x: 10, y: 50 },
+      { x: 90, y: 10 },
+    ]);
+  });
+
+  it("centers a single point instead of dividing by a zero span", () => {
+    expect(
+      projectToViewBox([{ latitude: 5, longitude: 5 }], 100, 60, 10),
+    ).toEqual([{ x: 50, y: 30 }]);
+  });
+
+  it("returns an empty projection for no points", () => {
+    expect(projectToViewBox([], 100, 60, 10)).toEqual([]);
+  });
+});

--- a/plugins/plugin-maps/src/views/geometry.ts
+++ b/plugins/plugin-maps/src/views/geometry.ts
@@ -1,0 +1,81 @@
+/**
+ * Deterministic client-side map geometry: Google encoded-polyline decoding and
+ * equirectangular projection of coordinates into an SVG viewBox. Pure functions
+ * with no provider or DOM dependencies so the rendered map pane is exactly
+ * reproducible in tests and audits.
+ */
+
+import type { Coordinates } from "../types.js";
+
+/**
+ * Decodes a Google encoded polyline (precision 1e-5) into coordinates.
+ * Malformed input throws instead of yielding a silently truncated path.
+ */
+export function decodePolyline(encoded: string): Coordinates[] {
+  const points: Coordinates[] = [];
+  let index = 0;
+  let latitude = 0;
+  let longitude = 0;
+  const readDelta = (): number => {
+    let result = 0;
+    let shift = 0;
+    let byte: number;
+    do {
+      if (index >= encoded.length) {
+        throw new Error("Encoded polyline is truncated.");
+      }
+      byte = encoded.charCodeAt(index++) - 63;
+      if (byte < 0 || byte > 63) {
+        throw new Error("Encoded polyline contains an invalid character.");
+      }
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    return result & 1 ? ~(result >> 1) : result >> 1;
+  };
+  while (index < encoded.length) {
+    latitude += readDelta();
+    longitude += readDelta();
+    points.push({ latitude: latitude / 1e5, longitude: longitude / 1e5 });
+  }
+  return points;
+}
+
+export interface ProjectedPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * Projects coordinates into a width x height viewBox with uniform padding,
+ * preserving relative geometry. A single point (or identical points) lands at
+ * the center rather than dividing by a zero-sized span.
+ */
+export function projectToViewBox(
+  points: readonly Coordinates[],
+  width: number,
+  height: number,
+  padding: number,
+): ProjectedPoint[] {
+  if (points.length === 0) return [];
+  const latitudes = points.map((point) => point.latitude);
+  const longitudes = points.map((point) => point.longitude);
+  const minLat = Math.min(...latitudes);
+  const maxLat = Math.max(...latitudes);
+  const minLng = Math.min(...longitudes);
+  const maxLng = Math.max(...longitudes);
+  const latSpan = maxLat - minLat;
+  const lngSpan = maxLng - minLng;
+  const innerWidth = width - padding * 2;
+  const innerHeight = height - padding * 2;
+  return points.map((point) => ({
+    x:
+      lngSpan === 0
+        ? width / 2
+        : padding + ((point.longitude - minLng) / lngSpan) * innerWidth,
+    y:
+      latSpan === 0
+        ? height / 2
+        : padding + ((maxLat - point.latitude) / latSpan) * innerHeight,
+  }));
+}

--- a/plugins/plugin-maps/src/views/index.ts
+++ b/plugins/plugin-maps/src/views/index.ts
@@ -1,0 +1,11 @@
+/** Public exports for the /maps browser bundle and local registration. */
+
+export { MapsView } from "./MapsView.js";
+export {
+  fetchMapsState,
+  getPlace,
+  MAPS_STATE_UPDATED_EVENT,
+  MAPS_UPDATED_EVENT,
+  planRouteAlternatives,
+  searchPlaces,
+} from "./mapsData.js";

--- a/plugins/plugin-maps/src/views/maps-view-bundle.ts
+++ b/plugins/plugin-maps/src/views/maps-view-bundle.ts
@@ -1,0 +1,3 @@
+/** Standalone bundle entry for the routed /maps view. */
+
+export { MapsView } from "./MapsView.js";

--- a/plugins/plugin-maps/src/views/mapsData.test.ts
+++ b/plugins/plugin-maps/src/views/mapsData.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Verifies the browser transport parses only valid route and broker envelopes,
+ * and rejects malformed JSON, error envelopes, broker failures, and
+ * schema-invalid payloads instead of fabricating healthy state. The CSRF fetch
+ * client is mocked; every payload shape matches the real transports.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PlaceRef } from "../types.js";
+
+const fetchWithCsrf = vi.hoisted(() => vi.fn());
+
+vi.mock("@elizaos/ui/api/csrf-client", () => ({ fetchWithCsrf }));
+
+import {
+  fetchMapsState,
+  planRouteAlternatives,
+  searchPlaces,
+} from "./mapsData.js";
+
+const pier: PlaceRef = {
+  provider: "fixture-maps",
+  providerPlaceId: "pier-1",
+  name: "Santa Monica Pier",
+  coordinates: { latitude: 34.0092, longitude: -118.4973 },
+  categories: ["landmark"],
+};
+
+function response(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchMapsState", () => {
+  it("parses a schema-valid snapshot envelope", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(200, {
+        success: true,
+        data: {
+          providers: [
+            { id: "fixture-maps", attribution: null, isDefault: true },
+          ],
+          providerAvailable: true,
+          savedPlaces: { status: "ok", places: [] },
+        },
+      }),
+    );
+    const snapshot = await fetchMapsState();
+    expect(snapshot.providerAvailable).toBe(true);
+    expect(fetchWithCsrf).toHaveBeenCalledWith(
+      "/api/maps/state",
+      expect.anything(),
+    );
+  });
+
+  it("rejects a schema-invalid snapshot instead of rendering it", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(200, { success: true, data: { providers: "nope" } }),
+    );
+    await expect(fetchMapsState()).rejects.toThrow(/invalid state snapshot/);
+  });
+
+  it("surfaces structured route errors with their code", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(503, {
+        success: false,
+        error: { code: "MAPS_PROVIDER_UNAVAILABLE", message: "No provider." },
+      }),
+    );
+    await expect(fetchMapsState()).rejects.toMatchObject({
+      message: "No provider.",
+      cause: "MAPS_PROVIDER_UNAVAILABLE",
+    });
+  });
+
+  it("rejects malformed JSON with the parser cause preserved", async () => {
+    fetchWithCsrf.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("bad json");
+      },
+    } as unknown as Response);
+    await expect(fetchMapsState()).rejects.toThrow(/malformed JSON/);
+  });
+});
+
+describe("broker capabilities", () => {
+  it("parses a successful search broker envelope", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(200, {
+        requestId: "req-1",
+        success: true,
+        result: {
+          success: true,
+          text: "ok",
+          data: { places: [pier], nextCursor: null },
+        },
+      }),
+    );
+    const page = await searchPlaces({ query: "pier" });
+    expect(page.places[0]?.name).toBe("Santa Monica Pier");
+  });
+
+  it("throws the broker failure text for an unsuccessful capability", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(200, {
+        requestId: "req-2",
+        success: true,
+        result: {
+          success: false,
+          text: "No maps provider adapter is available.",
+          error: { code: "MAPS_PROVIDER_UNAVAILABLE", message: "n/a" },
+        },
+      }),
+    );
+    await expect(searchPlaces({ query: "pier" })).rejects.toThrow(
+      /No maps provider adapter is available/,
+    );
+  });
+
+  it("rejects schema-invalid route alternatives", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      response(200, {
+        requestId: "req-3",
+        success: true,
+        result: { success: true, text: "ok", data: { alternatives: [] } },
+      }),
+    );
+    await expect(
+      planRouteAlternatives({
+        originPlaceId: "pier-1",
+        destinationPlaceId: "cafe-1",
+      }),
+    ).rejects.toThrow(/invalid route alternatives result/);
+  });
+});

--- a/plugins/plugin-maps/src/views/mapsData.ts
+++ b/plugins/plugin-maps/src/views/mapsData.ts
@@ -1,0 +1,183 @@
+/**
+ * Browser-side transport and validation for the routed /maps view. The server
+ * owns provider registration, search, routing, and saved places; this module
+ * accepts only the authenticated route envelopes and the zod contracts shared
+ * with the plugin before exposing anything to React.
+ */
+
+import { fetchWithCsrf } from "@elizaos/ui/api/csrf-client";
+import * as z from "zod";
+import { MAPS_VIEW_CAPABILITIES } from "../capabilities.js";
+import {
+  type PlacePage,
+  type PlaceRef,
+  placePageSchema,
+  placeRefSchema,
+} from "../types.js";
+import {
+  type MapsViewSnapshot,
+  mapsViewSnapshotSchema,
+  type RouteAlternative,
+  routeAlternativeSchema,
+} from "../view-contract.js";
+
+export const MAPS_STATE_UPDATED_EVENT = "maps:state-updated";
+export const MAPS_UPDATED_EVENT = "view:maps:updated";
+
+const MAPS_CAPABILITY_IDS = new Set(MAPS_VIEW_CAPABILITIES.map(({ id }) => id));
+
+const routeAlternativesDataSchema = z
+  .object({
+    origin: placeRefSchema,
+    destination: placeRefSchema,
+    alternatives: z.array(routeAlternativeSchema).min(1).max(8),
+  })
+  .strict();
+
+export type RouteAlternativesData = z.infer<typeof routeAlternativesDataSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseErrorEnvelope(value: unknown, status: number): Error {
+  if (isRecord(value) && typeof value.error === "string") {
+    return new Error(value.error);
+  }
+  if (
+    isRecord(value) &&
+    value.success === false &&
+    isRecord(value.error) &&
+    typeof value.error.code === "string" &&
+    typeof value.error.message === "string"
+  ) {
+    return new Error(value.error.message, { cause: value.error.code });
+  }
+  return new Error(`Maps request failed with HTTP ${status}.`);
+}
+
+function parseBrokerFailure(value: Record<string, unknown>): Error {
+  if (typeof value.error === "string" && value.error.trim()) {
+    return new Error(value.error);
+  }
+  if (
+    isRecord(value.result) &&
+    value.result.success === false &&
+    typeof value.result.text === "string" &&
+    value.result.text.trim()
+  ) {
+    const code = isRecord(value.result.error)
+      ? value.result.error.code
+      : undefined;
+    return new Error(value.result.text, {
+      ...(typeof code === "string" ? { cause: code } : {}),
+    });
+  }
+  return new Error("Maps returned an invalid broker failure result.");
+}
+
+function parseBrokerData(value: unknown): unknown {
+  if (
+    !isRecord(value) ||
+    typeof value.requestId !== "string" ||
+    value.requestId.trim().length === 0 ||
+    typeof value.success !== "boolean"
+  ) {
+    throw new Error("Maps returned an invalid broker envelope.");
+  }
+  if (!value.success) {
+    throw parseBrokerFailure(value);
+  }
+  if (!isRecord(value.result) || value.result.success !== true) {
+    throw parseBrokerFailure(value);
+  }
+  return value.result.data;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (cause) {
+    // error-policy:J2 retain the parser cause at the authenticated API boundary.
+    throw new Error("Maps returned malformed JSON.", { cause });
+  }
+}
+
+function validated<T>(schema: z.ZodType<T>, value: unknown, what: string): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Maps returned an invalid ${what}.`, {
+      cause: parsed.error,
+    });
+  }
+  return parsed.data;
+}
+
+export async function fetchMapsState(): Promise<MapsViewSnapshot> {
+  const response = await fetchWithCsrf("/api/maps/state", {
+    headers: { Accept: "application/json" },
+  });
+  const value = await readJson(response);
+  if (!response.ok) {
+    throw parseErrorEnvelope(value, response.status);
+  }
+  if (!isRecord(value) || value.success !== true || !("data" in value)) {
+    throw new Error("Maps returned an invalid success envelope.");
+  }
+  return validated(mapsViewSnapshotSchema, value.data, "state snapshot");
+}
+
+async function interact(
+  capability: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  if (!MAPS_CAPABILITY_IDS.has(capability)) {
+    throw new Error(`Maps does not support capability "${capability}".`);
+  }
+  const response = await fetchWithCsrf("/api/views/maps/interact", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ capability, ...(params ? { params } : {}) }),
+  });
+  const value = await readJson(response);
+  if (!response.ok) {
+    throw parseErrorEnvelope(value, response.status);
+  }
+  return parseBrokerData(value);
+}
+
+export async function searchPlaces(params: {
+  query: string;
+  latitude?: number;
+  longitude?: number;
+  cursor?: string;
+  limit?: number;
+}): Promise<PlacePage> {
+  return validated(
+    placePageSchema,
+    await interact("search-places", params),
+    "place page",
+  );
+}
+
+export async function getPlace(placeId: string): Promise<PlaceRef> {
+  const data = await interact("get-place", { placeId });
+  if (!isRecord(data)) throw new Error("Maps returned an invalid place.");
+  return validated(placeRefSchema, data.place, "place");
+}
+
+export async function planRouteAlternatives(params: {
+  originPlaceId: string;
+  destinationPlaceId: string;
+}): Promise<RouteAlternativesData> {
+  return validated(
+    routeAlternativesDataSchema,
+    await interact("plan-route-alternatives", params),
+    "route alternatives result",
+  );
+}
+
+export type { MapsViewSnapshot, PlacePage, PlaceRef, RouteAlternative };

--- a/plugins/plugin-maps/src/views/useMapsViewState.ts
+++ b/plugins/plugin-maps/src/views/useMapsViewState.ts
@@ -1,0 +1,107 @@
+/**
+ * Synchronizes the mounted /maps view with the server-owned snapshot and
+ * tracks browser connectivity. Loading, error, offline, and designed-empty are
+ * four distinguishable phases: a broken transport or lost network never renders
+ * as an empty map.
+ */
+
+import { useViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MapsViewSnapshot } from "../view-contract.js";
+import {
+  fetchMapsState,
+  MAPS_STATE_UPDATED_EVENT,
+  MAPS_UPDATED_EVENT,
+} from "./mapsData.js";
+
+export interface MapsViewState {
+  snapshot: MapsViewSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  offline: boolean;
+  refresh: () => Promise<void>;
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error && cause.message.trim()
+    ? cause.message
+    : "Maps could not reach the local agent.";
+}
+
+export function useMapsViewState(): MapsViewState {
+  const [snapshot, setSnapshot] = useState<MapsViewSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [offline, setOffline] = useState(
+    typeof navigator !== "undefined" && navigator.onLine === false,
+  );
+  const mounted = useRef(true);
+  const refreshGeneration = useRef(0);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const generation = ++refreshGeneration.current;
+    if (mounted.current) {
+      setLoading(true);
+      setError(null);
+    }
+    try {
+      const next = await fetchMapsState();
+      if (mounted.current && generation === refreshGeneration.current) {
+        setSnapshot(next);
+      }
+    } catch (cause) {
+      // error-policy:J4 render transport failure distinctly from empty state.
+      if (mounted.current && generation === refreshGeneration.current) {
+        setError(errorMessage(cause));
+      }
+    } finally {
+      if (mounted.current && generation === refreshGeneration.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useViewEvent(MAPS_STATE_UPDATED_EVENT, () => {
+    void refresh();
+  }, [refresh]);
+  useViewEvent(MAPS_UPDATED_EVENT, () => {
+    void refresh();
+  }, [refresh]);
+  useViewEvent(VIEW_EVENTS.VIEW_REFRESH, () => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      if (mounted.current) setOffline(false);
+      void refresh();
+    };
+    const handleOffline = () => {
+      if (mounted.current) setOffline(true);
+    };
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
+    };
+  }, [refresh]);
+
+  return { snapshot, loading, error, offline, refresh };
+}

--- a/plugins/plugin-maps/src/views/viewPrimitives.tsx
+++ b/plugins/plugin-maps/src/views/viewPrimitives.tsx
@@ -1,0 +1,148 @@
+/**
+ * Bundle-local styles and phase components for the /maps surface. Inline
+ * material styles keep the dynamic view bundle self-contained; loading,
+ * designed-empty, and error render as three visibly different states.
+ */
+
+import type { CSSProperties, ReactNode } from "react";
+
+export const ACCENT = "var(--accent, #ff6a1f)";
+
+export const VIEW_ROOT_STYLE: CSSProperties = {
+  boxSizing: "border-box",
+  position: "relative",
+  width: "100%",
+  height: "100%",
+  minHeight: 0,
+  overflow: "hidden",
+  color: "var(--txt, #f5f5f5)",
+  fontFamily: "inherit",
+};
+
+export const VIEW_SCROLL_STYLE: CSSProperties = {
+  boxSizing: "border-box",
+  position: "absolute",
+  inset: 0,
+  minWidth: 0,
+  minHeight: 0,
+  overflowX: "hidden",
+  overflowY: "auto",
+  overscrollBehavior: "contain",
+  padding: "clamp(8px, 2.4vw, 24px)",
+  paddingTop: "calc(clamp(8px, 2.4vw, 24px) + var(--safe-area-top, 0px))",
+  paddingBottom:
+    "calc(clamp(8px, 2.4vw, 24px) + var(--eliza-chat-clearance, 5.25rem))",
+  paddingInlineEnd:
+    "calc(clamp(8px, 2.4vw, 24px) + var(--eliza-chat-side-clearance, 0px))",
+  color: "var(--txt, #f5f5f5)",
+  fontFamily: "inherit",
+};
+
+export const GLASS_PANEL_STYLE: CSSProperties = {
+  boxSizing: "border-box",
+  border: "none",
+  borderRadius: 20,
+  background:
+    "color-mix(in srgb, var(--card, rgba(16,16,16,.88)) 76%, transparent)",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,.10), 0 18px 48px rgba(0,0,0,.20)",
+  backdropFilter: "blur(24px) saturate(145%)",
+  WebkitBackdropFilter: "blur(24px) saturate(145%)",
+};
+
+export const FIELD_STYLE: CSSProperties = {
+  boxSizing: "border-box",
+  width: "100%",
+  minHeight: 44,
+  border: "none",
+  borderRadius: 12,
+  padding: "10px 12px",
+  background: "color-mix(in srgb, var(--bg, #080808) 78%, transparent)",
+  color: "var(--txt, #f5f5f5)",
+  font: "inherit",
+  fontSize: 14,
+  lineHeight: 1.45,
+  boxShadow: "inset 0 0 0 1px rgba(255,255,255,.10)",
+};
+
+export const SECONDARY_TEXT_STYLE: CSSProperties = {
+  margin: 0,
+  color: "var(--muted, rgba(255,255,255,.58))",
+  fontSize: 13,
+  lineHeight: 1.45,
+};
+
+export const BUTTON_STYLE: CSSProperties = {
+  boxSizing: "border-box",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 7,
+  minHeight: 40,
+  border: "none",
+  borderRadius: 12,
+  padding: "8px 12px",
+  background:
+    "color-mix(in srgb, var(--surface, rgba(255,255,255,.08)) 86%, transparent)",
+  color: "var(--txt, #f5f5f5)",
+  font: "inherit",
+  fontSize: 13,
+  fontWeight: 650,
+  cursor: "pointer",
+};
+
+export const PRIMARY_BUTTON_STYLE: CSSProperties = {
+  ...BUTTON_STYLE,
+  background: ACCENT,
+  color: "var(--accent-foreground, #fff)",
+};
+
+export const ERROR_PANEL_STYLE: CSSProperties = {
+  ...GLASS_PANEL_STYLE,
+  padding: 14,
+  color: "var(--status-danger, #ff857a)",
+};
+
+export function ViewState({
+  loading,
+  error,
+  empty,
+  emptyTitle,
+  emptyBody,
+}: {
+  loading: boolean;
+  error: string | null;
+  empty: boolean;
+  emptyTitle: string;
+  emptyBody: string;
+}): ReactNode {
+  if (loading) {
+    return (
+      <div
+        aria-live="polite"
+        data-testid="maps-loading"
+        style={{ ...GLASS_PANEL_STYLE, padding: 18 }}
+      >
+        <p style={{ ...SECONDARY_TEXT_STYLE }}>Loading maps…</p>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div role="alert" data-testid="maps-error" style={ERROR_PANEL_STYLE}>
+        {error}
+      </div>
+    );
+  }
+  if (empty) {
+    return (
+      <div
+        data-testid="maps-empty"
+        style={{ ...GLASS_PANEL_STYLE, padding: 18 }}
+      >
+        <p style={{ margin: 0, fontWeight: 650 }}>{emptyTitle}</p>
+        <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 6 }}>{emptyBody}</p>
+      </div>
+    );
+  }
+  return null;
+}

--- a/plugins/plugin-maps/tsconfig.build.json
+++ b/plugins/plugin-maps/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
 }

--- a/plugins/plugin-maps/tsconfig.json
+++ b/plugins/plugin-maps/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": false,
+    "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
@@ -20,9 +21,16 @@
       "@elizaos/cloud-test-mocks": [
         "../../packages/cloud/test-mocks/src/index.ts"
       ],
-      "@elizaos/cloud-test-mocks/*": ["../../packages/cloud/test-mocks/src/*"]
+      "@elizaos/cloud-test-mocks/*": ["../../packages/cloud/test-mocks/src/*"],
+      "@elizaos/ui": ["../../packages/ui/src/index.ts"],
+      "@elizaos/ui/*": ["../../packages/ui/src/*"]
     }
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "vitest.config.ts"
+  ],
   "exclude": []
 }

--- a/plugins/plugin-maps/vite.config.views.ts
+++ b/plugins/plugin-maps/vite.config.views.ts
@@ -1,0 +1,10 @@
+/** Builds the /maps dynamic-view bundle. */
+import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
+
+export default createViewBundleConfig({
+  packageName: "@elizaos/plugin-maps",
+  viewId: "maps",
+  entry: "./src/views/maps-view-bundle.ts",
+  outDir: "dist/views",
+  componentExport: "MapsView",
+});

--- a/plugins/plugin-maps/vitest.config.ts
+++ b/plugins/plugin-maps/vitest.config.ts
@@ -11,7 +11,7 @@ const root = path.resolve(
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}", "test/**/*.test.ts"],
   },
   resolve: {
     conditions: ["node"],
@@ -23,6 +23,14 @@ export default defineConfig({
       {
         find: /^@elizaos\/core\/(.+)$/,
         replacement: path.join(root, "packages/core/src/$1"),
+      },
+      {
+        find: /^@elizaos\/ui\/(.+)$/,
+        replacement: path.join(root, "packages/ui/src/$1"),
+      },
+      {
+        find: /^@elizaos\/ui$/,
+        replacement: path.join(root, "packages/ui/src/index.ts"),
       },
       {
         find: /^@elizaos\/cloud-routing$/,


### PR DESCRIPTION
Fixes #19890

## What

Builds the routed `/maps` web view for `@elizaos/plugin-maps`, following the established plugin-notes view architecture:

- **View declaration + app-shell registration** — `mapsPlugin.views` declares the `maps` view (`/maps`, OWNER role gate, `dist/views/bundle.js`, `MapsView` export, MAPS action affinity); `src/register.ts` + `elizaos.appRegister` register the lazy page in the signed app bundle, discovered by the manifest scan (expected-list test updated, `@elizaos/plugin-maps` added as an app workspace dep).
- **Read-only capability broker** — `MAPS_VIEW_CAPABILITIES` (`get-maps-state`, `search-places`, `get-place`, `plan-route-alternatives`, `get-saved-places`) dispatch through `serverInteract` against the real `MapsService`. Saved-place writes stay on the promoted `MAPS_SAVE` action so receipt settlement is never bypassed. Expected domain failures (invalid input, provider unavailable, not found, auth expired/revoked, rate limited) become explicit `success: false` results; systemic failures propagate to the route boundary.
- **State boundary** — `GET /api/maps/state` returns the validated snapshot DTO (providers with required attribution, provider availability, owner-scoped saved places). A missing owner entity is an explicit `unavailable` state, never a healthy-looking empty list.
- **Shared zod contract** — `src/view-contract.ts` (runtime-import-free) is parsed by both the server producer and the browser transport, so malformed payloads are rejected instead of rendered.
- **Browser bundle** — responsive map/list grid; deterministic SVG map pane (polyline decode + equirectangular viewBox projection); place details; route alternatives across all four travel modes with explicit per-mode failure rows; category filter chips; cursor pagination; saved places; attribution footer. Orange accent only. Keyboard/screen-reader coverage: labelled search form, aria-pressed filters/results, focusable SVG markers with Enter/Space activation, role=alert errors, aria-live loading.
- **Distinct states** — loading, designed-empty, transport error, offline (online/offline listeners pause search/routing), and provider-unavailable each render differently.
- **Adapter surface (additive)** — optional `MapsProviderAdapter.attribution`, `MapsService.describeProviders()`.
- **Unblocking fix** — removed duplicate `desktopHttpTransportForUrl`/`fetchAgentTransport` imports in `packages/ui/src/api/client-cloud.ts` (TS2300 on develop) that failed every plugin typecheck that path-maps `@elizaos/ui`.

## Verification

- `bun run --cwd plugins/plugin-maps test` — 7 files, **71 passed** (includes new `interact.test.ts` real-runtime broker suite over a deterministic fixture adapter: success, empty, invalid input, pagination, provider unavailable, auth expiry, rate limit, provider spoofing rethrow, partial/total route failure, unknown capability; `MapsView.test.tsx` 9 component states; `mapsData.test.ts` transport envelope/schema rejection; `geometry.test.ts` polyline + projection).
- `bun run --cwd plugins/plugin-maps typecheck` — clean.
- `bun run --cwd plugins/plugin-maps lint:check` — clean.
- `bun run --cwd plugins/plugin-maps build` — JS + views bundle (`dist/views/bundle.js`) + types build.
- `packages/app` `plugin-registrations.test.ts` — 9 passed with the new `@elizaos/plugin-maps#register` entry.

## Notes / remainder

- Live rendered-map imagery and the managed Google Maps/Routes adapter are owned by sibling issue #19889; this view renders deterministic provider data through the neutral adapter seam and shows an explicit provider-unavailable state until an adapter registers.
- App visual audit (`bun run --cwd packages/app audit:app`) capture review on the running app is the human-attended evidence step; the view was built strictly on the repo's audited view primitives/conventions (notes surface) and all states are covered by component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)